### PR TITLE
Pluggable local/cloud LLM + reranker for the Team Brain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# ── Supabase (required) ──────────────────────────────────────────────────────
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# ── LLM provider: CLOUD (default) ────────────────────────────────────────────
+# Leave LLM_BASE_URL unset to answer queries with the Anthropic cloud API.
+ANTHROPIC_API_KEY=
+
+# ── LLM provider: LOCAL (optional) ───────────────────────────────────────────
+# Set LLM_BASE_URL to stream answers from a local OpenAI-compatible endpoint
+# (Ollama, Hermes, llama.cpp, LM Studio) instead of Anthropic. Cost is $0.
+# When set, ANTHROPIC_API_KEY is ignored. See docs/PROVIDERS.md.
+# LLM_BASE_URL=http://localhost:11434/v1
+# LLM_MODEL=llama3.1-8b-64k:latest          # any model your endpoint serves
+# OPENAI_API_KEY=local                       # placeholder; most local servers ignore it
+
+# ── Retrieval reranker (optional, local or cloud) ────────────────────────────
+# Reorders retrieved sources by cross-encoder relevance before the LLM sees
+# them. Local default = a llama-server --reranking instance (Qwen3-Reranker).
+# Point at a hosted endpoint (Cohere/Voyage/ZeroEntropy wire shape) for cloud.
+# Unset = keep Postgres ranking order.
+# RERANK_URL=http://localhost:8081/v1/rerank
+# RERANK_MODEL=qwen3-reranker-0.6b
+# RERANK_TOKEN=                              # bearer token for hosted rerankers
+# RERANK_TIMEOUT_MS=4000
+
+# ── External retrieval augmentation (optional, advanced) ─────────────────────
+# Merge extra sources from an external retrieval service (e.g. a GBrain adapter
+# or a cloud retrieval API). Contract: POST {query,limit,tier} -> {sources:[...]}.
+# Unset = Postgres-only retrieval. See docs/PROVIDERS.md.
+# RETRIEVAL_AUGMENT_URL=http://localhost:8791/retrieve
+# RETRIEVAL_AUGMENT_TOKEN=
+# RETRIEVAL_AUGMENT_LIMIT=6
+# RETRIEVAL_AUGMENT_TIMEOUT_MS=3000

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ query over the team's shared memory.
 ## Stack
 
 Next.js 16 (App Router) · Supabase (Postgres + Auth, **RLS default-deny on
-every table**) · Claude API (`claude-opus-4-8`) for query · Tailwind v4 with
-Prism Light tokens. Self-host portable: plain SQL migrations, Postgres-backed
-rate limiting, no Vercel-only dependencies.
+every table**) · **pluggable LLM** for query — Anthropic by default, or any
+local OpenAI-compatible endpoint (Ollama/Hermes/llama.cpp), plus an optional
+local/cloud reranker (see [docs/PROVIDERS.md](docs/PROVIDERS.md)) · Tailwind v4
+with Prism Light tokens. Self-host portable: plain SQL migrations,
+Postgres-backed rate limiting, no Vercel-only dependencies.
 
 ## Architecture in one paragraph
 
@@ -40,6 +42,12 @@ cp .env.example .env.local     # fill from `supabase status -o env` + your Anthr
 npx tsx --conditions react-server scripts/seed-demo.ts   # demo team + Northwind + Veridian graph
 npm run dev
 ```
+
+**Run it local or cloud.** By default queries use the Anthropic API. To answer
+fully on-machine ($0), set `LLM_BASE_URL` (and optionally a local `RERANK_URL`)
+in `.env.local` — no rebuild. See **[docs/PROVIDERS.md](docs/PROVIDERS.md)** for
+every switch, and **[docs/LOCAL_AI_WORKSTATION.md](docs/LOCAL_AI_WORKSTATION.md)**
+to stand up the whole local stack (Ollama + Hermes + llm-wiki + GBrain).
 
 The seed prints a demo API key once. Use it from a contributor repo:
 

--- a/docs/LOCAL_AI_WORKSTATION.md
+++ b/docs/LOCAL_AI_WORKSTATION.md
@@ -1,0 +1,153 @@
+# Local AI Workstation
+
+A private, self-hosted AI stack on a single machine (built/tested on macOS /
+Apple Silicon), with the Team Brain as the team-facing query layer. Every layer
+can run **fully locally** or fall back to **cloud** — see
+[PROVIDERS.md](./PROVIDERS.md) for the brain's provider switches.
+
+```
+            ┌────────────────────────── your machine ──────────────────────────┐
+ any device │  Hermes Agent (local agent)         aios-team-brain (Next.js)     │
+ over   ───▶│     │                                   │                         │
+ Tailscale  │     ▼                                   ├─ LLM ──┐                 │
+            │  Ollama  ◀──────── OpenAI /v1 ──────────┤        ▼                 │
+            │   (local model, e.g. llama3.1 / qwen3)  │   llama.cpp reranker     │
+            │                                         │        ▲   (/v1/rerank)  │
+            │  llm-wiki (~/wiki, markdown)            └─ retrieval ──┘           │
+            │  GBrain (~/.gbrain, embeddings + brain) ─ local nomic-embed-text   │
+            └───────────────────────────────────────────────────────────────────┘
+```
+
+Each component is independent — adopt only the layers you want.
+
+## Prerequisites
+
+- macOS 13+ on Apple Silicon (Linux works for most pieces too).
+- **RAM matters.** A 7–8B model at 64k context ≈ 13 GB; a 35B reasoning model
+  ≈ 21–25 GB. On 32–36 GB, prefer an 8B as the everyday driver. Watch memory
+  with `ollama ps` and `memory_pressure`.
+- Tools: `git`, `node 20+`, `ollama`, `bun` (for GBrain), `brew` (for llama.cpp),
+  and `tailscale` (for the private gateway).
+
+---
+
+## 1. Ollama + a local model
+
+```bash
+# pull a model; ensure it advertises >=64k context if you'll drive Hermes with it
+ollama pull llama3.1:8b
+# many models default to a small context — pin it with a Modelfile:
+printf 'FROM llama3.1:8b\nPARAMETER num_ctx 65536\n' > Modelfile.64k
+ollama create llama3.1-8b-64k -f Modelfile.64k
+ollama run llama3.1-8b-64k "hello"   # verify it loads without swapping
+```
+
+> Tip: if you updated the Ollama app but `ollama --version` shows a different
+> server vs client version, **restart the Ollama daemon** — a stale daemon
+> ignores `num_ctx` and can over-allocate context (OOM). Some quant formats
+> (e.g. MLX/nvfp4) ignore `num_ctx` entirely and load at native context; cap
+> usage at the *client* layer instead (Hermes `context_length`, or the brain's
+> own prompt budget).
+
+## 2. Hermes Agent (local agent + private gateway)
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.zshrc
+hermes model        # choose "Custom Endpoint": http://localhost:11434/v1, model = your 64k model
+hermes              # chat, served entirely by the local model
+```
+
+**Private gateway (reach it from any device, no public exposure):** put the
+dashboard on the tailnet. The cleanest, cert-free way is to bind it to the
+Tailscale IP directly (loopback-trust, so no login; tailnet is the boundary):
+
+```bash
+tailscale up
+hermes dashboard --insecure --host <your-tailscale-ip> --port 9119 --no-open
+# then browse http://<your-tailscale-ip>:9119/ from any device on your tailnet
+```
+
+(For always-on, wrap it in a `launchctl` LaunchAgent — see **Persistence**.)
+
+## 3. llm-wiki (knowledge layer)
+
+Hermes ships a built-in `llm-wiki` skill (`hermes skills list`). Or use the
+upstream [`nvk/llm-wiki`](https://github.com/nvk/llm-wiki) `AGENTS.md` with any
+agent. Wikis live as plain markdown in `~/wiki/` (Obsidian-compatible). Ask the
+agent to "initialize my wiki and add a page about X" — a capable model
+(8B+ for tool-driven file ops) will scaffold and maintain it.
+
+## 4. GBrain (memory/retrieval + local reranker)
+
+```bash
+bun install -g github:garrytan/gbrain
+gbrain init --pglite                                   # local Postgres-in-WASM
+gbrain apply-migrations --yes && gbrain doctor
+
+# use LOCAL embeddings (default auto-detect picks cloud OpenAI — override it):
+ollama pull nomic-embed-text
+gbrain reinit-pglite --embedding-model ollama:nomic-embed-text --embedding-dimensions 768
+gbrain import ~/wiki/                                   # index your wiki, locally
+
+# LOCAL cross-encoder reranker (use the ggml-org GGUF — community ones can score garbage):
+brew install llama.cpp
+llama-server -hf ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF \
+  --alias qwen3-reranker-0.6b --reranking --pooling rank --port 8081
+gbrain config set search.reranker.model llama-server-reranker:qwen3-reranker-0.6b
+gbrain config set search.reranker.enabled true
+gbrain config set provider_base_urls.llama-server-reranker http://localhost:8081/v1
+```
+
+Expose GBrain to Hermes over MCP, **pruned to a lean toolset** so it doesn't
+crowd a local model's context window:
+
+```bash
+printf 'Y\n' | hermes mcp add gbrain --command "$(command -v gbrain)" --args serve
+# then in ~/.hermes/config.yaml under mcp_servers.gbrain, add:
+#   tools:
+#     include: [query, search, recall, get_page, put_page, list_pages]
+```
+
+## 5. Team Brain integration
+
+The brain (`aios-team-brain`) is a Next.js app. Point its **LLM** and
+**reranker** at your local services via env — full reference in
+[PROVIDERS.md](./PROVIDERS.md):
+
+```bash
+# .env.local
+LLM_BASE_URL=http://localhost:11434/v1
+LLM_MODEL=llama3.1-8b-64k:latest
+RERANK_URL=http://localhost:8081/v1/rerank
+RERANK_MODEL=qwen3-reranker-0.6b
+```
+
+```bash
+npm run dev      # dashboard query + `aios query` now run on the local model, $0
+```
+
+Unset `LLM_BASE_URL` / `RERANK_URL` to use cloud Anthropic + Postgres ranking —
+the same code path, no rebuild. The `aios` CLI is unchanged; it just POSTs to the
+brain, so pointing the brain local makes `aios query` local end-to-end.
+
+---
+
+## Persistence (always-on)
+
+Long-running local services (Hermes dashboard, the reranker) survive reboots via
+user LaunchAgents in `~/Library/LaunchAgents/`. Pattern: `RunAtLoad` +
+`KeepAlive` (KeepAlive retries until the Tailscale interface is up). Load with
+`launchctl bootstrap gui/$(id -u) <plist>`; check with `launchctl print`.
+
+## Local vs cloud at a glance
+
+| Layer | Local | Cloud |
+|-------|-------|-------|
+| Agent | Hermes + Ollama | Hermes + hosted model |
+| Brain LLM | `LLM_BASE_URL` → Ollama | `ANTHROPIC_API_KEY` |
+| Embeddings | `ollama:nomic-embed-text` | `openai:text-embedding-3-large` |
+| Reranker | `llama-server` Qwen3-Reranker | Cohere / Voyage / ZeroEntropy |
+| Storage | PGLite / local Postgres | Supabase / hosted Postgres |
+
+Mix freely — each layer is an independent switch.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1,0 +1,139 @@
+# AI Providers — local or cloud
+
+The Team Brain answers queries with an LLM and orders its evidence with an
+optional reranker. **Both are configurable, and both default to cloud-free.**
+You can run the whole query path on your own machine, on cloud APIs, or mix the
+two — purely through environment variables. No code changes.
+
+There are three independent knobs:
+
+| Knob | Env | Default (unset) | Local option | Cloud option |
+|------|-----|-----------------|--------------|--------------|
+| **Answering LLM** | `LLM_BASE_URL` | Anthropic (`ANTHROPIC_API_KEY`) | Ollama / Hermes / llama.cpp | any OpenAI-compatible API |
+| **Reranker** | `RERANK_URL` | off (Postgres order) | `llama-server --reranking` | Cohere / Voyage / ZeroEntropy |
+| **Extra retrieval** | `RETRIEVAL_AUGMENT_URL` | off (Postgres only) | GBrain adapter | hosted retrieval API |
+
+Everything degrades safely: if a local/cloud endpoint is unreachable or times
+out, the brain falls back (LLM → error surfaced; reranker/augmentation → skipped)
+rather than breaking the query.
+
+---
+
+## 1. Answering LLM
+
+### Cloud (default)
+Set `ANTHROPIC_API_KEY` and leave `LLM_BASE_URL` unset. Queries use
+`claude-opus-4-8` with prompt caching and usage/cost accounting.
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### Local
+Set `LLM_BASE_URL` to any OpenAI-compatible `/v1` endpoint. `ANTHROPIC_API_KEY`
+is then ignored, and reported cost is `$0`.
+
+```bash
+LLM_BASE_URL=http://localhost:11434/v1     # Ollama
+LLM_MODEL=llama3.1-8b-64k:latest           # any model the endpoint serves
+OPENAI_API_KEY=local                        # placeholder; Ollama ignores it
+```
+
+Works with **Ollama**, **Hermes Agent**, **llama.cpp `llama-server`**, **LM Studio**,
+**vLLM** — anything exposing `POST /v1/chat/completions`.
+
+Notes:
+- The brain prompt is summarize-from-sources, so a fast 7–8B instruct model
+  (e.g. `llama3.1:8b`) is a good default. A reasoning model also works —
+  `streamAnswer` strips `<think>…</think>` spans so answers stay clean.
+- Whatever model you name in `LLM_MODEL` must already be available on the
+  endpoint (e.g. `ollama pull` / loaded in LM Studio).
+
+Implementation: `lib/query/claude.ts` (`streamAnswer` → `streamLocal`). Both
+paths yield the same `{delta}/{done}` stream, so the SSE API routes are unchanged.
+
+---
+
+## 2. Reranker (recommended)
+
+A cross-encoder reranker reorders the retrieved sources by true relevance before
+the LLM sees them, so the most relevant source is cited as `[S1]`. This noticeably
+improves answer quality on larger brains. It's optional and off by default.
+
+### Local
+Run a `llama-server` reranking instance and point the brain at it:
+
+```bash
+# one-time: install llama.cpp (brew install llama.cpp) then run the reranker
+llama-server -hf ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF \
+  --alias qwen3-reranker-0.6b --reranking --pooling rank --port 8081
+
+# brain env
+RERANK_URL=http://localhost:8081/v1/rerank
+RERANK_MODEL=qwen3-reranker-0.6b
+```
+
+### Cloud
+Point `RERANK_URL` at any endpoint speaking the ZeroEntropy/llama.cpp rerank
+wire shape (`POST {model, query, documents[]}` → `{results:[{index, relevance_score}]}`):
+
+```bash
+RERANK_URL=https://api.your-rerank-provider.com/v1/rerank
+RERANK_MODEL=rerank-2
+RERANK_TOKEN=...        # sent as Authorization: Bearer
+```
+
+Implementation: `lib/query/retrieve.ts` (`rerankSources`). Timeout
+`RERANK_TIMEOUT_MS` (default 4000ms); on any failure the Postgres order is kept.
+
+---
+
+## 3. External retrieval augmentation (advanced)
+
+By default the brain retrieves from its own Postgres (full-text + graph). You can
+merge in extra sources from an external retrieval service — for example a local
+[GBrain](https://github.com/garrytan/gbrain) brain via a small adapter, or a
+hosted retrieval API.
+
+```bash
+RETRIEVAL_AUGMENT_URL=http://localhost:8791/retrieve
+RETRIEVAL_AUGMENT_TOKEN=...           # optional bearer
+RETRIEVAL_AUGMENT_LIMIT=6
+```
+
+**Contract** (vendor-neutral):
+
+```
+POST {RETRIEVAL_AUGMENT_URL}
+  → body: { "query": string, "limit": number, "tier": "team"|"external" }
+  ← 200:  { "sources": [ { "path": string, "text": string,
+                           "score"?: number, "project"?: string, "kind"?: string } ] }
+```
+
+Returned sources are merged after the Postgres hits (deduped by `path`, same
+context budget) and then reranked if a reranker is configured. Timeout
+`RETRIEVAL_AUGMENT_TIMEOUT_MS` (default 3000ms); on any failure the brain uses
+Postgres-only retrieval. Implementation: `lib/query/retrieve.ts`
+(`fetchAugmentedSources`).
+
+---
+
+## Recipes
+
+**Fully local (private, $0 inference):**
+```bash
+LLM_BASE_URL=http://localhost:11434/v1
+LLM_MODEL=llama3.1-8b-64k:latest
+RERANK_URL=http://localhost:8081/v1/rerank
+RERANK_MODEL=qwen3-reranker-0.6b
+```
+
+**Fully cloud (default):**
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+# (LLM_BASE_URL / RERANK_URL unset)
+```
+
+**Hybrid (local LLM, cloud rerank, or vice-versa):** set each knob independently.
+
+Switching is just env + a restart — no rebuild.

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -6,6 +6,11 @@ import type { RetrievedContext } from "./retrieve";
  * Thin adapter around the Claude API so a future agent backend (e.g. Hermes)
  * is a one-module swap. Stable cached system prefix; numbered sources;
  * question last (keeps the cacheable prefix stable per team).
+ *
+ * Backend selection is env-driven:
+ *   - LLM_BASE_URL set  → stream from a local OpenAI-compatible endpoint
+ *     (Ollama / Hermes / llama.cpp). LLM_MODEL picks the model; cost is $0.
+ *   - LLM_BASE_URL unset → the original Anthropic path (unchanged).
  */
 
 const MODEL = "claude-opus-4-8";
@@ -13,6 +18,10 @@ const MODEL = "claude-opus-4-8";
 const INPUT_PER_TOKEN = 5 / 1_000_000;
 const OUTPUT_PER_TOKEN = 25 / 1_000_000;
 const CACHE_READ_PER_TOKEN = 0.5 / 1_000_000;
+
+// Local OpenAI-compatible backend (Ollama/Hermes). Unset → cloud Anthropic.
+const LLM_BASE_URL = process.env.LLM_BASE_URL;
+const LLM_MODEL = process.env.LLM_MODEL ?? "llama3.1-8b-64k:latest";
 
 const SYSTEM_PROMPT = `You are the Team Brain — the shared memory and coordination assistant for a team using AIOS.
 
@@ -37,14 +46,20 @@ export async function* streamAnswer(
   | { type: "delta"; text: string }
   | { type: "done"; usage: QueryUsage }
 > {
-  const client = new Anthropic();
-
   const sourcesBlock = ctx.sources
     .map(
       (s) =>
         `<source id="${s.sid}" project="${s.project}" path="${s.path}" kind="${s.kind}" synced="${s.synced_at}">\n${s.text}\n</source>`
     )
     .join("\n\n");
+
+  // Local OpenAI-compatible backend (Ollama/Hermes) — fully on-machine, $0.
+  if (LLM_BASE_URL) {
+    yield* streamLocal(ctx.structured, sourcesBlock, question);
+    return;
+  }
+
+  const client = new Anthropic();
 
   const stream = client.messages.stream({
     model: MODEL,
@@ -88,6 +103,111 @@ export async function* streamAnswer(
       output_tokens: u.output_tokens ?? 0,
       cache_read_tokens: u.cache_read_input_tokens ?? 0,
       cost_usd: Math.round(cost * 100000) / 100000,
+    },
+  };
+}
+
+/**
+ * Stream from a local OpenAI-compatible chat endpoint (Ollama/Hermes/llama.cpp).
+ * Same `delta`/`done` contract as the Anthropic path; cost is always $0.
+ * Strips any `<think>…</think>` reasoning spans so the Team Brain answer stays
+ * clean even when LLM_MODEL points at a reasoning model.
+ */
+async function* streamLocal(
+  structured: string,
+  sourcesBlock: string,
+  question: string
+): AsyncGenerator<
+  | { type: "delta"; text: string }
+  | { type: "done"; usage: QueryUsage }
+> {
+  const userContent =
+    `<structured_context>\n${structured}\n</structured_context>\n\n` +
+    `${sourcesBlock || "<no document sources matched>"}\n\n` +
+    `Question: ${question}`;
+
+  const res = await fetch(`${LLM_BASE_URL!.replace(/\/$/, "")}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY ?? "local"}`,
+    },
+    body: JSON.stringify({
+      model: LLM_MODEL,
+      max_tokens: 4096,
+      stream: true,
+      stream_options: { include_usage: true },
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: userContent },
+      ],
+    }),
+  });
+
+  if (!res.ok || !res.body) {
+    throw new Error(`local LLM ${LLM_MODEL} @ ${LLM_BASE_URL}: ${res.status} ${await res.text().catch(() => "")}`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let inThink = false;
+  let prompt = 0;
+  let completion = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+    for (const line of lines) {
+      const t = line.trim();
+      if (!t.startsWith("data:")) continue;
+      const data = t.slice(5).trim();
+      if (data === "[DONE]") continue;
+      let j: {
+        choices?: { delta?: { content?: string } }[];
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+      };
+      try {
+        j = JSON.parse(data);
+      } catch {
+        continue;
+      }
+      if (j.usage) {
+        prompt = j.usage.prompt_tokens ?? prompt;
+        completion = j.usage.completion_tokens ?? completion;
+      }
+      let piece: string = j.choices?.[0]?.delta?.content ?? "";
+      if (!piece) continue;
+      // Drop <think>…</think> reasoning spans (token-by-token aware).
+      let out = "";
+      while (piece.length) {
+        if (inThink) {
+          const end = piece.indexOf("</think>");
+          if (end === -1) { piece = ""; break; }
+          piece = piece.slice(end + 8);
+          inThink = false;
+        } else {
+          const start = piece.indexOf("<think>");
+          if (start === -1) { out += piece; piece = ""; break; }
+          out += piece.slice(0, start);
+          piece = piece.slice(start + 7);
+          inThink = true;
+        }
+      }
+      if (out) yield { type: "delta", text: out };
+    }
+  }
+
+  yield {
+    type: "done",
+    usage: {
+      input_tokens: prompt,
+      output_tokens: completion,
+      cache_read_tokens: 0,
+      cost_usd: 0,
     },
   };
 }

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -19,6 +19,99 @@ export type RetrievedContext = {
 const MAX_SOURCE_CHARS = 8_000;
 const MAX_TOTAL_CHARS = 160_000; // ~40k tokens context cap
 
+// Optional external retrieval augmentation (e.g. a local GBrain adapter or a
+// cloud retrieval service). Vendor-neutral HTTP contract:
+//   POST { query, limit, tier } -> { sources: [{ path, text, score?, project?, kind? }] }
+// Unset → Postgres-only retrieval (the default; works with local OR cloud LLMs).
+const RETRIEVAL_AUGMENT_URL = process.env.RETRIEVAL_AUGMENT_URL;
+const RETRIEVAL_AUGMENT_TOKEN = process.env.RETRIEVAL_AUGMENT_TOKEN;
+const RETRIEVAL_AUGMENT_TIMEOUT_MS = Number(process.env.RETRIEVAL_AUGMENT_TIMEOUT_MS ?? 3000);
+const RETRIEVAL_AUGMENT_LIMIT = Number(process.env.RETRIEVAL_AUGMENT_LIMIT ?? 6);
+
+// Optional cross-encoder reranker (ZeroEntropy/llama.cpp/Cohere wire shape):
+//   POST { model, query, documents: string[] } -> { results: [{ index, relevance_score }] }
+// Local default: a llama-server --reranking instance (e.g. Qwen3-Reranker).
+// Cloud: point at a hosted rerank endpoint. Unset → keep Postgres order.
+const RERANK_URL = process.env.RERANK_URL;
+const RERANK_MODEL = process.env.RERANK_MODEL ?? "qwen3-reranker-0.6b";
+const RERANK_TIMEOUT_MS = Number(process.env.RERANK_TIMEOUT_MS ?? 4000);
+const RERANK_TOKEN = process.env.RERANK_TOKEN; // bearer for hosted rerankers
+
+type AugmentHit = { path?: string; text?: string; score?: number; project?: string; kind?: string };
+
+/**
+ * Reorder sources by cross-encoder relevance. Best-effort: on timeout/error/
+ * misconfig it returns the input order unchanged. sids are reassigned so the
+ * most relevant source is S1 (keeps the LLM's citations stable & meaningful).
+ */
+async function rerankSources(question: string, sources: Source[]): Promise<Source[]> {
+  if (!RERANK_URL || sources.length < 2) return sources;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), RERANK_TIMEOUT_MS);
+  try {
+    const res = await fetch(RERANK_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(RERANK_TOKEN ? { Authorization: `Bearer ${RERANK_TOKEN}` } : {}),
+      },
+      body: JSON.stringify({
+        model: RERANK_MODEL,
+        query: question,
+        documents: sources.map((s) => s.text),
+      }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return sources;
+    const data = (await res.json()) as { results?: { index: number; relevance_score: number }[] };
+    if (!Array.isArray(data.results) || !data.results.length) return sources;
+    const ordered = [...data.results]
+      .sort((a, b) => b.relevance_score - a.relevance_score)
+      .map((r) => sources[r.index])
+      .filter(Boolean);
+    // Append any sources the reranker omitted, preserving them.
+    for (const s of sources) if (!ordered.includes(s)) ordered.push(s);
+    return ordered.map((s, i) => ({ ...s, sid: `S${i + 1}` }));
+  } catch {
+    return sources; // degrade gracefully to the Postgres order
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Best-effort augmentation from an external retrieval service. Never throws:
+ * on timeout/error/misconfig it returns [] so the brain falls back to its
+ * Postgres retrieval. This is the seam that makes retrieval source pluggable
+ * (local GBrain via the adapter, or any cloud retrieval endpoint).
+ */
+async function fetchAugmentedSources(
+  question: string,
+  tier: "team" | "external"
+): Promise<AugmentHit[]> {
+  if (!RETRIEVAL_AUGMENT_URL) return [];
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), RETRIEVAL_AUGMENT_TIMEOUT_MS);
+  try {
+    const res = await fetch(RETRIEVAL_AUGMENT_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(RETRIEVAL_AUGMENT_TOKEN ? { Authorization: `Bearer ${RETRIEVAL_AUGMENT_TOKEN}` } : {}),
+      },
+      body: JSON.stringify({ query: question, limit: RETRIEVAL_AUGMENT_LIMIT, tier }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { sources?: AugmentHit[] };
+    return Array.isArray(data.sources) ? data.sources : [];
+  } catch {
+    return []; // timeout or network error → degrade to Postgres-only
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /**
  * Tier-filtered retrieval: FTS top-12 + always-include structured context
  * (recent decisions, open/blocked tasks, projects, compact graph digest)
@@ -31,9 +124,6 @@ export async function retrieve(
   question: string,
   projectSlug?: string | null
 ): Promise<RetrievedContext> {
-  const tierFilter = (q: ReturnType<SupabaseClient["from"]>["select"] extends never ? never : any) =>
-    tier === "external" ? q.eq("access", "external") : q;
-
   // 1. FTS over items
   let fts = supabase
     .from("items")
@@ -74,6 +164,29 @@ export async function retrieve(
       path: hit.path,
       kind: hit.kind,
       synced_at: hit.synced_at,
+      text,
+    });
+  }
+
+  // 2b. Optional external retrieval augmentation (GBrain adapter / cloud service).
+  // Merged after Postgres hits, deduped by path, same char budget. No-op + safe
+  // fallback when RETRIEVAL_AUGMENT_URL is unset or the call fails.
+  const seenPaths = new Set(sources.map((s) => s.path));
+  for (const hit of await fetchAugmentedSources(question, tier)) {
+    const text = (hit.text || "").slice(0, MAX_SOURCE_CHARS);
+    if (!text) continue;
+    const path = hit.path || `gbrain:${n}`;
+    if (seenPaths.has(path)) continue;
+    seenPaths.add(path);
+    if (total + text.length > MAX_TOTAL_CHARS) break;
+    total += text.length;
+    sources.push({
+      sid: `S${n++}`,
+      item_id: null,
+      project: hit.project ?? "",
+      path,
+      kind: hit.kind ?? "brain",
+      synced_at: "",
       text,
     });
   }
@@ -144,5 +257,9 @@ export async function retrieve(
     ...(rels ?? []).map((r) => `- ${r.from_id} ${r.relationship_type} ${r.to_id}`),
   ].join("\n");
 
-  return { sources, structured };
+  // 4. Optional cross-encoder rerank (local llama-server or cloud). No-op when
+  // RERANK_URL is unset; reorders so the most relevant source is cited first.
+  const ranked = await rerankSources(question, sources);
+
+  return { sources: ranked, structured };
 }


### PR DESCRIPTION
Make the query path provider-agnostic and configurable via env, with safe fallbacks and **no rebuild** to switch local↔cloud.

## What changed
- **LLM** (`lib/query/claude.ts`): `streamAnswer()` delegates to a new `streamLocal()` when `LLM_BASE_URL` is set — streams from any OpenAI-compatible endpoint (Ollama/Hermes/llama.cpp) via `fetch`, strips `<think>` spans, cost $0. Anthropic path unchanged when unset. Same `{delta}/{done}` contract, so the SSE routes are untouched.
- **Retrieval** (`lib/query/retrieve.ts`):
  - Optional cross-encoder **rerank** (`RERANK_URL`) — local `llama-server` or cloud Cohere/Voyage/ZeroEntropy wire shape. Reorders sources so the most relevant is cited `[S1]`.
  - Optional external **source augmentation** (`RETRIEVAL_AUGMENT_URL`) — vendor-neutral `POST {query,limit,tier} -> {sources}` contract.
  - Both best-effort with timeouts; degrade to Postgres-only on any failure. Removed dead `tierFilter`.
- **Docs**: `docs/PROVIDERS.md` (every local/cloud switch + recipes), `docs/LOCAL_AI_WORKSTATION.md` (full local stack: Ollama + Hermes + llm-wiki + GBrain), documented `.env.example` (now tracked), README pointers.

## Config matrix
| Knob | Env | Local | Cloud / default |
|---|---|---|---|
| Answering LLM | `LLM_BASE_URL` | Ollama/Hermes/llama.cpp | Anthropic |
| Reranker | `RERANK_URL` | llama-server Qwen3-Reranker | Cohere/Voyage/ZeroEntropy |
| Extra sources | `RETRIEVAL_AUGMENT_URL` | GBrain adapter | hosted retrieval API |

## Verification
- `tsc --noEmit` and `eslint` clean on changed files.
- Local LLM stream validated against the live endpoint (deltas + usage + correct `[S1]` citations).
- Rerank wire-contract validated against a live `llama-server` reranker (relevant doc 1.0 vs 0.0001, reorders correctly).
- Full app e2e (Supabase + dashboard query) not run in this PR — defaults to the unchanged Anthropic path when the local env vars are unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)