### PR TITLE
fix(next16): migrate middleware.ts → proxy.ts

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   let response = NextResponse.next({ request });
 
   const supabase = createServerClient(


### PR DESCRIPTION
Next.js 16 renamed the `middleware` file convention to `proxy`. Renames the file (`git mv`) and the exported function (`middleware` → `proxy`); `config`/matcher and the `@supabase/ssr` session-refresh logic are unchanged. Clears the deprecation warning.

Verified against the in-repo `node_modules/next/dist/docs` (Next 16.2.9) and the Vercel nextjs skill. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)