### PR TITLE
M4 (brain): team blueprint kind + role-gated publish + Team Tools page

### DIFF
--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -36,6 +36,11 @@ export async function POST(req: NextRequest) {
     return errorResponse("payload_too_large", "body exceeds 1 MB", 413);
   }
 
+  // Only a lead/admin may publish the team blueprint (which tools the team uses).
+  if (parsed.data.kind === "blueprint" && auth.memberRole !== "admin" && auth.memberRole !== "lead") {
+    return errorResponse("forbidden", "only a team lead or admin can publish the team blueprint", 403);
+  }
+
   const tier = normalizeTier(parsed.data.access);
   if (parsed.data.access === "admin" || parsed.data.access === "private") {
     return errorResponse(

--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -62,6 +62,7 @@ export default async function TeamLayout({
     { icon: "decisions", label: "Decisions", href: `${base}/decisions` },
     { icon: "library", label: "Library", href: `${base}/library` },
     { icon: "skills", label: "Skills", href: `${base}/skills` },
+    { icon: "teamtools", label: "Team tools", href: `${base}/team-tools` },
     { icon: "query", label: "Query", href: `${base}/query` },
   ];
   if (me.role === "admin") {

--- a/app/t/[team]/team-tools/page.tsx
+++ b/app/t/[team]/team-tools/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import { Blocks } from "lucide-react";
+import { serverClient } from "@/lib/supabase/server";
+import { EmptyState } from "@/components/empty-state";
+import { timeAgo } from "@/components/format";
+
+export const metadata: Metadata = { title: "Team Tools" };
+
+type BlueprintItem = { body: string | null; actor: string; updated_at: string; frontmatter: Record<string, unknown> | null };
+type Connector = { enabled?: boolean; name?: string; transport?: string; instance?: Record<string, string> };
+
+export default async function TeamToolsPage({ params }: { params: Promise<{ team: string }> }) {
+  const { team: teamSlug } = await params;
+  const supabase = await serverClient();
+
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  // Latest published blueprint for the team (RLS already scopes to readable items).
+  const { data } = await supabase
+    .from("items")
+    .select("body, actor, updated_at, frontmatter")
+    .eq("team_id", team.id)
+    .eq("kind", "blueprint")
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const bp = data as BlueprintItem | null;
+
+  let connectors: Array<[string, Connector]> = [];
+  let publishedBy = bp?.actor || "";
+  if (bp?.body) {
+    try {
+      const parsed = JSON.parse(bp.body) as { connectors?: Record<string, Connector>; published_by?: string };
+      connectors = Object.entries(parsed.connectors || {}).filter(([, c]) => c.enabled);
+      publishedBy = parsed.published_by || publishedBy;
+    } catch { /* malformed blueprint */ }
+  }
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-5">
+      <div>
+        <h1 className="text-2xl font-semibold text-ink">Team tools</h1>
+        <p className="mt-1 text-sm text-ink-secondary">
+          The integrations your team uses. Each person connects these in their own workspace with
+          their own credentials — keys never leave their machine, and are never sent here.
+        </p>
+      </div>
+
+      {connectors.length === 0 ? (
+        <EmptyState
+          icon={Blocks}
+          title="No team tools published yet"
+          action="A team lead publishes the tool set from their AIOS Workspace (Team tab → Publish). It'll appear here for everyone to connect."
+        />
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {connectors.map(([id, c]) => (
+              <div key={id} className="prism-card flex flex-col gap-2 px-4 py-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium text-ink">{c.name || id}</span>
+                  {c.transport ? <span className="text-[11px] uppercase tracking-wider text-ink-tertiary">{c.transport === "skill" ? "direct API" : c.transport}</span> : null}
+                </div>
+                {c.instance && Object.keys(c.instance).length > 0 && (
+                  <p className="break-all font-mono text-[11px] text-ink-tertiary">
+                    {Object.values(c.instance).join(" · ")}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+          <p className="text-[11px] text-ink-tertiary">
+            {connectors.length} tool{connectors.length === 1 ? "" : "s"}
+            {publishedBy ? ` · published by @${publishedBy}` : ""}
+            {bp ? ` · ${timeAgo(bp.updated_at)}` : ""}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/team-nav.tsx
+++ b/components/team-nav.tsx
@@ -11,6 +11,7 @@ import {
   ListTodo,
   Shield,
   Sparkles,
+  Wrench,
 } from "lucide-react";
 
 const ICONS = {
@@ -20,6 +21,7 @@ const ICONS = {
   decisions: Gavel,
   library: Library,
   skills: Blocks,
+  teamtools: Wrench,
   query: Sparkles,
   admin: Shield,
 } as const;

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -7,6 +7,7 @@ export type ApiAuth = {
   teamId: string;
   memberId: string;
   memberTier: "team" | "external";
+  memberRole: "admin" | "lead" | "member";
   apiKeyId: string;
   actorHandle: string;
 };
@@ -39,7 +40,7 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
 
   const { data: key } = await supabase
     .from("api_keys")
-    .select("id, team_id, member_id, key_hash, revoked_at, members(actor_handle, tier, status), teams(slug)")
+    .select("id, team_id, member_id, key_hash, revoked_at, members(actor_handle, tier, status, role), teams(slug)")
     .eq("key_id", keyId)
     .maybeSingle();
 
@@ -51,7 +52,7 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
     return fail("bad_secret");
   }
 
-  const member = key.members as unknown as { actor_handle: string; tier: "team" | "external"; status: string };
+  const member = key.members as unknown as { actor_handle: string; tier: "team" | "external"; status: string; role: "admin" | "lead" | "member" };
   if (member?.status !== "active") return fail("member_not_active");
 
   const team = key.teams as unknown as { slug: string };
@@ -71,6 +72,7 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
     teamId: key.team_id,
     memberId: key.member_id,
     memberTier: member.tier,
+    memberRole: member.role,
     apiKeyId: key.id,
     actorHandle: member.actor_handle,
   };

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -30,7 +30,7 @@ export const decisionRowSchema = z.object({
 export const itemPayloadSchema = z.object({
   project: z.string().min(1).max(120),
   path: z.string().min(1).max(500),
-  kind: z.enum(["deliverable", "transcript", "decision", "task", "artifact", "skill"]),
+  kind: z.enum(["deliverable", "transcript", "decision", "task", "artifact", "skill", "blueprint"]),
   content_sha256: z.string().regex(/^[a-f0-9]{64}$/),
   actor: z.string().max(120).optional().default(""),
   access: z.string(),

--- a/supabase/migrations/20260615060245_add_blueprint_kind.sql
+++ b/supabase/migrations/20260615060245_add_blueprint_kind.sql
@@ -1,0 +1,5 @@
+-- Add 'blueprint' to item_kind: a team lead publishes one blueprint item per team
+-- (which integrations the team uses + non-secret instance config) that ICs pull to get
+-- a guided connect-checklist. No secrets are ever stored in a blueprint. See
+-- docs/brain-api.md (blueprint kind). Precedent: 20260614052740_add_skill_kind.sql.
+alter type item_kind add value if not exists 'blueprint';


### PR DESCRIPTION
Brain side of **M4** (team-lead blueprint → ICs get a guided checklist). Rebased onto the latest `main` (Chetan's Organs 2/4/6 + middleware→proxy).

## What
- **Migration** `add_blueprint_kind`: adds `blueprint` to `item_kind`. A lead publishes one blueprint item per team (which integrations the team uses + non-secret instance config like the Jira site URL); ICs pull it. **No secrets are ever stored in a blueprint.**
- **`lib/api/schemas.ts`**: accept `kind: "blueprint"`.
- **`lib/api/auth.ts`**: expose `memberRole`; **`app/api/v1/items` POST rejects `kind=blueprint` from non-lead/admin (403)** — only a team lead/admin can publish the tool set.
- **`app/t/[team]/team-tools/`**: read-only dashboard page rendering the published blueprint (enabled tools + instance URLs + `published_by`), tier-filtered via RLS. New "Team tools" nav item.

## Verified
- My files typecheck. (The 4 remaining `tsc` errors are missing `recharts`/`vitest` deps in the newly-merged code, pre-existing.)
- Pairs with the workspace PR (AIOS-alpha/aios-workspace#m4-team-blueprint): lead publishes from the cockpit Team tab; ICs pull a checklist.
- Blueprint item: `project:_team` (ingest auto-creates), `path:.aios/blueprint.json`, `access:team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)