### PR TITLE
feat(api): GET /api/v1/me (member identity + role)

### DIFF
--- a/app/api/v1/me/route.ts
+++ b/app/api/v1/me/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { errorResponse } from "@/lib/api/schemas";
+
+export const runtime = "nodejs";
+
+// GET /api/v1/me — the authenticated member's identity + role + tier (no secrets).
+// Lets a client (e.g. the cockpit) tailor the UI — e.g. only leads/admins see the
+// team-blueprint publish surface.
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+  return Response.json({
+    actor: auth.actorHandle,
+    role: auth.memberRole,
+    tier: auth.memberTier,
+    team: auth.teamId,
+  });
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,6 +194,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/items` — tier-filtered, keyset-paginated pull
 - `GET /api/v1/items/:id` — single item fetch
 - `GET /api/v1/tasks` — dashboard task changes for `aios pull` writeback
+- `GET /api/v1/me` — authenticated member identity + role (drives client UI gating)
 - `POST /api/v1/query` — SSE grounded query (`delta`/`sources`/`done`)
 - `GET /api/v1/okf-bundle` — OKF link graph (tier-filtered, link redaction)
 - `POST /api/v1/actions` — request a policy-gated action (Organ 4)


### PR DESCRIPTION
Adds `GET /api/v1/me` → `{actor, role, tier, team}` for the caller's API key (no secrets). Lets the cockpit hide lead-only surfaces (the Team/blueprint publish tab) from members — matching the existing `kind=blueprint` 403 role-gate. Pairs with the workspace cockpit role-gate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)