### PR TITLE
chore(codebases): cleanup follow-ups from PR #9 review

### DIFF
--- a/components/codebases/codebase-card.tsx
+++ b/components/codebases/codebase-card.tsx
@@ -2,24 +2,8 @@ import Link from "next/link";
 import { Star, CircleDot } from "lucide-react";
 import type { CodebaseSummary } from "@/lib/metrics/codebases";
 import { timeAgo } from "@/components/format";
+import { Sparkline } from "@/components/sparkline";
 import { ScoreRing } from "./score-ring";
-
-/** Inline sparkline (agentic score over the window), inherits color via currentColor. */
-function Spark({ data }: { data: number[] }) {
-  if (data.length < 2) return null;
-  const max = Math.max(...data, 1);
-  const w = 72;
-  const h = 22;
-  const step = w / (data.length - 1);
-  const points = data
-    .map((v, i) => `${(i * step).toFixed(1)},${(h - (v / max) * h).toFixed(1)}`)
-    .join(" ");
-  return (
-    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} className="overflow-visible text-violet" aria-hidden>
-      <polyline points={points} fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" opacity={0.85} />
-    </svg>
-  );
-}
 
 export function CodebaseCard({ teamSlug, cb }: { teamSlug: string; cb: CodebaseSummary }) {
   return (
@@ -46,7 +30,7 @@ export function CodebaseCard({ teamSlug, cb }: { teamSlug: string; cb: CodebaseS
           cov
         </span>
         <span className="ml-auto">
-          <Spark data={cb.spark} />
+          <Sparkline data={cb.spark} width={72} height={22} className="text-violet" />
         </span>
       </div>
 

--- a/components/dashboard/kpi-stat.tsx
+++ b/components/dashboard/kpi-stat.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import type { Kpi, KpiAccent } from "@/lib/metrics/pulse";
+import { Sparkline } from "@/components/sparkline";
 
 const ACCENT_TEXT: Record<KpiAccent, string> = {
   violet: "text-violet",
@@ -8,31 +9,6 @@ const ACCENT_TEXT: Record<KpiAccent, string> = {
   amber: "text-amber",
   emerald: "text-emerald",
 };
-
-/** Inline sparkline. Inherits color from the parent via currentColor. */
-function Sparkline({ data }: { data: number[] }) {
-  if (data.length < 2) return null;
-  const max = Math.max(...data, 1);
-  const w = 64;
-  const h = 20;
-  const step = w / (data.length - 1);
-  const points = data
-    .map((v, i) => `${(i * step).toFixed(1)},${(h - (v / max) * h).toFixed(1)}`)
-    .join(" ");
-  return (
-    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} className="overflow-visible" aria-hidden>
-      <polyline
-        points={points}
-        fill="none"
-        stroke="currentColor"
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-        strokeLinecap="round"
-        opacity={0.85}
-      />
-    </svg>
-  );
-}
 
 export function KpiStat({ kpi }: { kpi: Kpi }) {
   const accent = ACCENT_TEXT[kpi.accent];

--- a/components/sparkline.tsx
+++ b/components/sparkline.tsx
@@ -1,0 +1,41 @@
+/**
+ * Inline SVG sparkline. Inherits its color from the parent via `currentColor`
+ * (wrap in a colored span, or pass a text-* className). Server-safe (no hooks).
+ */
+export function Sparkline({
+  data,
+  width = 64,
+  height = 20,
+  className,
+}: {
+  data: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}) {
+  if (data.length < 2) return null;
+  const max = Math.max(...data, 1);
+  const step = width / (data.length - 1);
+  const points = data
+    .map((v, i) => `${(i * step).toFixed(1)},${(height - (v / max) * height).toFixed(1)}`)
+    .join(" ");
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={`overflow-visible${className ? ` ${className}` : ""}`}
+      aria-hidden
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        opacity={0.85}
+      />
+    </svg>
+  );
+}

--- a/ingestion/aios_ingest/analyzers/codebase.py
+++ b/ingestion/aios_ingest/analyzers/codebase.py
@@ -11,6 +11,7 @@ repo metadata (stars/forks/languages) and issues/PRs are enriched best-effort.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import subprocess
@@ -18,6 +19,8 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 # unit/record separators that won't appear in commit metadata
 _RS = "\x1e"
@@ -28,6 +31,7 @@ _CODE_EXT = {
     ".c", ".h", ".cpp", ".cs", ".sql", ".sh", ".mjs", ".cjs", ".svelte", ".vue",
 }
 _MAX_FILE_BYTES = 1_000_000  # skip giant/generated files when counting LOC
+_MAX_ISSUE_PAGES = 10  # GitHub issues pagination cap (1000 issues); logged if hit
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -246,25 +250,37 @@ def _github_enrich(full_name: str, token: str | None) -> dict[str, Any]:
             langs = gh.get(f"https://api.github.com/repos/{full_name}/languages").json()
             out["meta"]["languages"] = langs if isinstance(langs, dict) else {}
 
-            issues_resp = gh.get(
-                f"https://api.github.com/repos/{full_name}/issues",
-                params={"state": "all", "per_page": 100},
-            ).json()
-            issues = []
-            for it in issues_resp if isinstance(issues_resp, list) else []:
-                issues.append({
-                    "number": it["number"],
-                    "title": (it.get("title") or "")[:1000],
-                    "state": it.get("state", "open"),
-                    "is_pull_request": "pull_request" in it,
-                    "author_login": (it.get("user") or {}).get("login", ""),
-                    "assignee_login": (it.get("assignee") or {}).get("login", "") or "",
-                    "labels": [lb["name"] for lb in it.get("labels", []) if isinstance(lb, dict)],
-                    "comments": it.get("comments", 0),
-                    "url": it.get("html_url", ""),
-                    "opened_at": it.get("created_at"),
-                    "closed_at": it.get("closed_at"),
-                })
+            # Paginate so we don't silently truncate repos with >100 issues/PRs.
+            # Cap at _MAX_ISSUE_PAGES (logged) to bound API calls on huge repos.
+            issues: list[dict[str, Any]] = []
+            for page in range(1, _MAX_ISSUE_PAGES + 1):
+                batch = gh.get(
+                    f"https://api.github.com/repos/{full_name}/issues",
+                    params={"state": "all", "per_page": 100, "page": page},
+                ).json()
+                if not isinstance(batch, list) or not batch:
+                    break
+                for it in batch:
+                    issues.append({
+                        "number": it["number"],
+                        "title": (it.get("title") or "")[:1000],
+                        "state": it.get("state", "open"),
+                        "is_pull_request": "pull_request" in it,
+                        "author_login": (it.get("user") or {}).get("login", ""),
+                        "assignee_login": (it.get("assignee") or {}).get("login", "") or "",
+                        "labels": [lb["name"] for lb in it.get("labels", []) if isinstance(lb, dict)],
+                        "comments": it.get("comments", 0),
+                        "url": it.get("html_url", ""),
+                        "opened_at": it.get("created_at"),
+                        "closed_at": it.get("closed_at"),
+                    })
+                if len(batch) < 100:
+                    break
+            else:
+                log.warning(
+                    "issues truncated at %d pages (%d issues) for %s",
+                    _MAX_ISSUE_PAGES, len(issues), full_name,
+                )
             out["issues"] = issues
     except Exception:  # noqa: BLE001 — enrichment is best-effort; local git still wins
         return {}

--- a/lib/codebases/ingest.ts
+++ b/lib/codebases/ingest.ts
@@ -104,9 +104,16 @@ export async function ingestCodebaseScan(
   if (payload.contributions.length) {
     const memberId = await buildAuthorMap(supabase, auth.teamId);
     for (const row of payload.contributions) {
+      // Resolve to a roster member by email first (author_key is usually the email),
+      // then by handle derived from the email local-part (e.g. alice@corp → "alice").
+      const email = row.author_email.toLowerCase();
+      const keyLc = row.author_key.toLowerCase();
+      const localPart = (email || keyLc).split("@")[0];
       const mapped =
-        memberId.byEmail.get(row.author_email.toLowerCase()) ??
-        memberId.byHandle.get(row.author_key.toLowerCase()) ??
+        memberId.byEmail.get(email) ??
+        memberId.byEmail.get(keyLc) ??
+        memberId.byHandle.get(localPart) ??
+        memberId.byHandle.get(keyLc) ??
         null;
       const { error } = await supabase.from("code_contributions").upsert(
         {

--- a/lib/codebases/score.ts
+++ b/lib/codebases/score.ts
@@ -11,6 +11,8 @@
  * inputs so this stays testable. Weights live here and are meant to be tuned.
  */
 
+import { clamp, round } from "@/lib/num";
+
 export const AGENTIC_WEIGHTS = {
   ai_commit_ratio: 0.15,
   test_coverage_score: 0.25,
@@ -55,9 +57,6 @@ export interface ComputedScores {
   cadence_score: number;
   issue_health: number;
 }
-
-const clamp = (n: number, lo = 0, hi = 100) => Math.min(hi, Math.max(lo, n));
-const round2 = (n: number) => Math.round(n * 100) / 100;
 
 /** % of commits in the window that are AI-coauthored (heuristic; can saturate). */
 export function aiCommitRatio(i: ScanInputs): number {
@@ -118,13 +117,13 @@ export function computeScores(i: ScanInputs): ComputedScores {
     HEALTH_WEIGHTS.issue_health * issue_health;
 
   return {
-    agentic_score: round2(agentic_score),
-    health_score: round2(health_score),
-    ai_commit_ratio: round2(ai_commit_ratio),
-    test_coverage_score: round2(test_coverage_score),
-    scaffolding_score: round2(scaffolding_score),
-    skill_breadth_score: round2(skill_breadth_score),
-    cadence_score: round2(cadence_score),
-    issue_health: round2(issue_health),
+    agentic_score: round(agentic_score),
+    health_score: round(health_score),
+    ai_commit_ratio: round(ai_commit_ratio),
+    test_coverage_score: round(test_coverage_score),
+    scaffolding_score: round(scaffolding_score),
+    skill_breadth_score: round(skill_breadth_score),
+    cadence_score: round(cadence_score),
+    issue_health: round(issue_health),
   };
 }

--- a/lib/codebases/visibility.ts
+++ b/lib/codebases/visibility.ts
@@ -1,13 +1,17 @@
 import "server-only";
+import type { ViewerTier } from "@/lib/auth/visibility";
 
 /**
  * Tier gate for codebase analytics (CLAUDE.md §5). Codebase intel is team-tier only —
  * there is no per-row `access` column, so an `external`-tier viewer must see NOTHING.
  * In postgres mode there is no RLS, so this app-code check is the SOLE enforcement;
  * the codebases-tier-filter guard asserts every read helper routes through it.
+ *
+ * ViewerTier is owned by lib/auth/visibility (the canonical tier vocabulary); re-export
+ * it so callers here have one source of truth.
  */
 
-export type ViewerTier = "team" | "external";
+export type { ViewerTier };
 
 /** Whether a viewer of this tier may see any codebase analytics at all. */
 export function canSeeCodebases(tier: ViewerTier): boolean {

--- a/lib/metrics/codebases.ts
+++ b/lib/metrics/codebases.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Kpi } from "./pulse";
 import { rangeDays, type Range } from "./range";
 import { canSeeCodebases, type ViewerTier } from "@/lib/codebases/visibility";
+import { num, round } from "@/lib/num";
 
 /**
  * The ONLY read path for codebase analytics tables — pages must go through here,
@@ -40,8 +41,6 @@ type MetricRow = {
   test_coverage_pct: number | string | null;
   ai_commit_ratio: number | string;
 };
-
-const num = (v: number | string | null | undefined) => (v == null ? 0 : Number(v) || 0);
 
 export async function getCodebaseSummaries(
   supabase: SupabaseClient,
@@ -113,7 +112,7 @@ export async function getCodebaseSummaries(
 
 function avg(nums: number[]): number {
   if (!nums.length) return 0;
-  return Math.round((nums.reduce((a, b) => a + b, 0) / nums.length) * 10) / 10;
+  return round(nums.reduce((a, b) => a + b, 0) / nums.length, 1);
 }
 
 function teamKpis(s: CodebaseSummary[], range: Range): Kpi[] {

--- a/lib/num.ts
+++ b/lib/num.ts
@@ -1,0 +1,15 @@
+/** Shared numeric helpers for the metrics + scoring layer (client-safe; pure). */
+
+/** Clamp `n` into [lo, hi] (defaults to a 0–100 score range). */
+export const clamp = (n: number, lo = 0, hi = 100): number => Math.min(hi, Math.max(lo, n));
+
+/** Round to `dp` decimal places (default 2). */
+export const round = (n: number, dp = 2): number => {
+  const f = 10 ** dp;
+  return Math.round(n * f) / f;
+};
+
+/** Coerce a possibly-string Postgres numeric (supabase-js returns numerics as
+ * strings) to a number; null/undefined/NaN → 0. */
+export const num = (v: number | string | null | undefined): number =>
+  v == null ? 0 : Number(v) || 0;


### PR DESCRIPTION
Follow-up to #9 — pays down the low-severity cleanup items the review flagged. **No behavior change** to scoring or tier isolation; covered by the existing unit + data-mechanics suites.

## Changes
- **Dedupe `Sparkline`** → `components/sparkline.tsx` (parameterized width/height/className), used by both `kpi-stat` and `codebase-card` (was copy-pasted with slight variation).
- **Dedupe `ViewerTier`** → `lib/codebases/visibility` re-exports the canonical type from `lib/auth/visibility` instead of redeclaring it (one source of truth for the tier vocabulary).
- **Consolidate numeric helpers** → `lib/num.ts` (`clamp`/`round`/`num`); `score.ts` and `lib/metrics/codebases` use it instead of three local copies.
- **Paginate GitHub issues** in the scanner — was silently capped at 100; now bounded at 10 pages (1000 issues) and **logs when truncated**.
- **Tighten author→member mapping** — match by email, then by handle derived from the email local-part (`alice@corp` → `alice`). The old `byHandle(author_key)` compared a full email against `actor_handle` and never matched.

## Verification
- ✅ 75 unit (incl. score weights locked) · 12 data-mechanics on real Postgres · tsc 0 · lint clean (changed files) · `next build` passes · `check:docs` green · scanner `py_compile` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)