### PR TITLE
fix(codebases): avoid external author handle misattribution

### DIFF
--- a/lib/codebases/ingest.ts
+++ b/lib/codebases/ingest.ts
@@ -104,16 +104,23 @@ export async function ingestCodebaseScan(
   if (payload.contributions.length) {
     const memberId = await buildAuthorMap(supabase, auth.teamId);
     for (const row of payload.contributions) {
-      // Resolve to a roster member by email first (author_key is usually the email),
-      // then by handle derived from the email local-part (e.g. alice@corp → "alice").
-      const email = row.author_email.toLowerCase();
-      const keyLc = row.author_key.toLowerCase();
-      const localPart = (email || keyLc).split("@")[0];
+      // Resolve to a roster member by exact email first. Only derive a handle from
+      // an email local-part when that email uses a domain already present in the
+      // roster; otherwise external contributors like alex@gmail.com could be
+      // misattributed to an internal actor_handle "alex".
+      const email = row.author_email.trim().toLowerCase();
+      const keyLc = row.author_key.trim().toLowerCase();
+      const [localPart, domain] = email.includes("@") ? email.split("@", 2) : ["", ""];
+      const handleFromTeamDomain =
+        localPart && domain && memberId.emailDomains.has(domain)
+          ? memberId.byHandle.get(localPart)
+          : undefined;
+      const explicitHandle = keyLc && !keyLc.includes("@") ? memberId.byHandle.get(keyLc) : undefined;
       const mapped =
         memberId.byEmail.get(email) ??
         memberId.byEmail.get(keyLc) ??
-        memberId.byHandle.get(localPart) ??
-        memberId.byHandle.get(keyLc) ??
+        handleFromTeamDomain ??
+        explicitHandle ??
         null;
       const { error } = await supabase.from("code_contributions").upsert(
         {
@@ -196,9 +203,15 @@ async function buildAuthorMap(supabase: SupabaseClient, teamId: string) {
     .eq("team_id", teamId);
   const byEmail = new Map<string, string>();
   const byHandle = new Map<string, string>();
+  const emailDomains = new Set<string>();
   for (const r of (data ?? []) as { id: string; email: string | null; actor_handle: string | null }[]) {
-    if (r.email) byEmail.set(r.email.toLowerCase(), r.id);
+    if (r.email) {
+      const email = r.email.toLowerCase();
+      byEmail.set(email, r.id);
+      const domain = email.split("@", 2)[1];
+      if (domain) emailDomains.add(domain);
+    }
     if (r.actor_handle) byHandle.set(r.actor_handle.toLowerCase(), r.id);
   }
-  return { byEmail, byHandle };
+  return { byEmail, byHandle, emailDomains };
 }

--- a/test/datamechanics/codebases-isolation.datamechanics.test.ts
+++ b/test/datamechanics/codebases-isolation.datamechanics.test.ts
@@ -56,6 +56,15 @@ async function memberEmail(memberId: string): Promise<string> {
   return (data as { email: string }).email;
 }
 
+async function memberIdentity(memberId: string): Promise<{ email: string; actor_handle: string }> {
+  const { data } = await db()
+    .from("members")
+    .select("email, actor_handle")
+    .eq("id", memberId)
+    .maybeSingle();
+  return data as { email: string; actor_handle: string };
+}
+
 describe("codebase tier isolation (real Postgres, no RLS backstop)", () => {
   it("external tier sees no codebases; team tier sees them", async () => {
     const seed = await seedTeam();
@@ -148,5 +157,54 @@ describe("codebase scan idempotency (real Postgres)", () => {
       .eq("codebase_id", res.codebase_id);
     expect((second.data ?? []).length).toBe(1);
     expect((second.data as { commits: number }[])[0].commits).toBe(8);
+  });
+
+  it("does not map an external contributor just because their email local-part matches a handle", async () => {
+    const seed = await seedTeam();
+    const slug = `repo-${randomUUID().slice(0, 6)}`;
+    const { actor_handle } = await memberIdentity(seed.memberId);
+    const externalEmail = `${actor_handle}@external.example`;
+
+    const res = await ingestScan(
+      seed,
+      buildScan({
+        slug,
+        contributions: [
+          { author_key: externalEmail, author_email: externalEmail, day: "2026-06-11", commits: 1 },
+        ],
+      })
+    );
+    const rows = await db()
+      .from("code_contributions")
+      .select("member_id")
+      .eq("codebase_id", res.codebase_id)
+      .eq("author_key", externalEmail);
+
+    expect((rows.data as { member_id: string | null }[])[0].member_id).toBeNull();
+  });
+
+  it("maps email local-part to handle only when the email uses a team roster domain", async () => {
+    const seed = await seedTeam();
+    const slug = `repo-${randomUUID().slice(0, 6)}`;
+    const { email, actor_handle } = await memberIdentity(seed.memberId);
+    const teamDomain = email.split("@")[1];
+    const teamDomainEmail = `${actor_handle}@${teamDomain}`;
+
+    const res = await ingestScan(
+      seed,
+      buildScan({
+        slug,
+        contributions: [
+          { author_key: teamDomainEmail, author_email: teamDomainEmail, day: "2026-06-12", commits: 1 },
+        ],
+      })
+    );
+    const rows = await db()
+      .from("code_contributions")
+      .select("member_id")
+      .eq("codebase_id", res.codebase_id)
+      .eq("author_key", teamDomainEmail);
+
+    expect((rows.data as { member_id: string | null }[])[0].member_id).toBe(seed.memberId);
   });
 });


### PR DESCRIPTION
## Summary
- Constrain author-to-member fallback mapping so email local-parts only map to actor handles for known team roster domains.
- Preserve exact email matching and explicit non-email handle matching.
- Add real-Postgres regression coverage for external-domain non-mapping and team-domain mapping.

## Test plan
- `npx tsc --noEmit`
- `npm run db:test:up`
- `npm run test:datamechanics:local -- test/datamechanics/codebases-isolation.datamechanics.test.ts`


Made with [Cursor](https://cursor.com)