### PR TITLE
feat(admin): admin CLI + audited shared primitives

### DIFF
--- a/.claude/skills/admin/SKILL.md
+++ b/.claude/skills/admin/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: admin
+description: >
+  Team Brain admin operations from the terminal — create members, mint one-time
+  login links, issue/revoke API keys, list members/keys, load the Postgres schema
+  (and, once landed, map git-author aliases, sync GitHub profiles, and run scans).
+  Use when asked to provision a user, get someone a login link, issue an API key,
+  or do team-brain admin DB work. Requires a Postgres DATABASE_URL.
+---
+
+# Team Brain admin
+
+A thin wrapper over `scripts/admin.ts` (which reuses the audited primitives in
+`lib/admin/*` — it never re-implements auth/key logic, and every credential/alias
+mutation is written to `audit_log`).
+
+## Running
+
+Local / dev / test DB:
+
+```bash
+DATABASE_URL=postgres://… npm run admin -- <command> [args] [--flags]
+# or: npx tsx --conditions react-server scripts/admin.ts <command> …
+```
+
+Production (Railway — injects the public DB URL; the secret never appears in argv):
+
+```bash
+railway run -s Postgres bash -lc \
+  'DATABASE_URL=$DATABASE_PUBLIC_URL npx tsx --conditions react-server scripts/admin.ts <command> …'
+```
+
+## Commands
+
+- `create-member <email> --name <n> --handle <h> [--role admin|lead|member] [--team <slug>] [--upsert]`
+- `login-link <email> [--team <slug>] [--ttl-min <n>] [--base-url <url> | env BRAIN_URL]` — one-time link
+- `issue-key <member-email> [--name <n>] [--team <slug>]` — prints the key **once**
+- `revoke-key <api-key-uuid> [--team <slug>]`
+- `list-members [--team <slug>]` · `list-keys [--team <slug>]`
+- `pg:schema` — load `postgres/schema.sql` (idempotent)
+
+Default team is `demo`.
+
+## Secret hygiene (IMPORTANT)
+
+- API keys and login tokens print to stdout **once**. Treat them as credentials:
+  hand them to the user, do **not** echo them back, paste them into chat, or store them.
+- Provide GitHub tokens via the **`GITHUB_TOKEN` env var** (or stdin), never a `--token`
+  flag (it would leak into shell history / process lists). Never print the token.

--- a/app/t/[team]/admin/actions.ts
+++ b/app/t/[team]/admin/actions.ts
@@ -1,10 +1,11 @@
 "use server";
 
-import { createHash, randomBytes } from "node:crypto";
 import { revalidatePath } from "next/cache";
 import { serverClient } from "@/lib/supabase/server";
 import { adminClient } from "@/lib/supabase/admin";
 import { getSessionUser } from "@/lib/auth/session";
+import { createMember } from "@/lib/admin/members";
+import { issueApiKey as issueApiKeyPrimitive, revokeApiKey as revokeApiKeyPrimitive } from "@/lib/admin/keys";
 
 /** Verify the caller is an active admin of the team; returns ids or null. */
 async function requireAdmin(teamSlug: string) {
@@ -35,17 +36,21 @@ export async function inviteMember(
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
 
-  // RLS-governed insert (members_admin_insert policy enforces this server-side too)
-  const supabase = await serverClient();
-  const { error } = await supabase.from("members").insert({
-    team_id: ctx.teamId,
-    email: form.email.trim().toLowerCase(),
-    display_name: form.displayName.trim(),
-    actor_handle: form.actorHandle.trim().toLowerCase(),
-    role: form.role,
-    status: "invited",
-  });
-  if (error) return { ok: false, error: error.message };
+  try {
+    await createMember(
+      adminClient(),
+      ctx.teamId,
+      {
+        email: form.email,
+        displayName: form.displayName,
+        actorHandle: form.actorHandle,
+        role: form.role,
+      },
+      { actor: { kind: "member", memberId: ctx.myMemberId } }
+    );
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "create failed" };
+  }
   revalidatePath(`/t/${teamSlug}/admin/members`);
   return { ok: true };
 }
@@ -58,33 +63,15 @@ export async function issueApiKey(
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
 
-  // The secret is generated server-side and only its sha256 is stored —
-  // key_hash is column-revoked from authenticated clients, so this uses the
-  // admin client (the one sanctioned write path for hashes).
-  const keyId = randomBytes(6).toString("hex");
-  const secret = randomBytes(32).toString("base64url");
-  const admin = adminClient();
-  const { error } = await admin.from("api_keys").insert({
-    team_id: ctx.teamId,
-    member_id: memberId,
-    key_id: keyId,
-    key_hash: createHash("sha256").update(secret).digest("hex"),
-    name: name.trim() || "unnamed key",
-  });
-  if (error) return { ok: false, error: error.message };
-
-  await admin.from("audit_log").insert({
-    team_id: ctx.teamId,
-    actor_kind: "member",
-    member_id: ctx.myMemberId,
-    action: "api_key.issued",
-    target_type: "api_key",
-    target_id: keyId,
-    meta: { for_member: memberId },
-  });
-
-  revalidatePath(`/t/${teamSlug}/admin/keys`);
-  return { ok: true, key: `aios_${keyId}_${secret}` };
+  try {
+    const { key } = await issueApiKeyPrimitive(adminClient(), ctx.teamId, memberId, name, {
+      actor: { kind: "member", memberId: ctx.myMemberId },
+    });
+    revalidatePath(`/t/${teamSlug}/admin/keys`);
+    return { ok: true, key };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "issue failed" };
+  }
 }
 
 export async function revokeApiKey(
@@ -94,22 +81,13 @@ export async function revokeApiKey(
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
 
-  const supabase = await serverClient(); // RLS: api_keys_admin_update
-  const { error } = await supabase
-    .from("api_keys")
-    .update({ revoked_at: new Date().toISOString() })
-    .eq("id", apiKeyId);
-  if (error) return { ok: false, error: error.message };
-
-  const admin = adminClient();
-  await admin.from("audit_log").insert({
-    team_id: ctx.teamId,
-    actor_kind: "member",
-    member_id: ctx.myMemberId,
-    action: "api_key.revoked",
-    target_type: "api_key",
-    target_id: apiKeyId,
-  });
-  revalidatePath(`/t/${teamSlug}/admin/keys`);
-  return { ok: true };
+  try {
+    await revokeApiKeyPrimitive(adminClient(), ctx.teamId, apiKeyId, {
+      actor: { kind: "member", memberId: ctx.myMemberId },
+    });
+    revalidatePath(`/t/${teamSlug}/admin/keys`);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "revoke failed" };
+  }
 }

--- a/lib/admin/keys.ts
+++ b/lib/admin/keys.ts
@@ -1,0 +1,63 @@
+import "server-only";
+import { createHash, randomBytes } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { audit } from "@/lib/api/audit";
+import type { ActorContext } from "./members";
+
+/**
+ * Shared admin primitive: issue / revoke API keys. The secret is generated here
+ * and only its sha256 is stored (key_hash); the raw `aios_<id>_<secret>` is
+ * returned ONCE and never persisted. Service-role client; caller does authz.
+ */
+export async function issueApiKey(
+  admin: SupabaseClient,
+  teamId: string,
+  memberId: string,
+  name: string,
+  opts: { actor?: ActorContext } = {}
+): Promise<{ key: string; keyId: string }> {
+  const keyId = randomBytes(6).toString("hex");
+  const secret = randomBytes(32).toString("base64url");
+  const { error } = await admin.from("api_keys").insert({
+    team_id: teamId,
+    member_id: memberId,
+    key_id: keyId,
+    key_hash: createHash("sha256").update(secret).digest("hex"),
+    name: name.trim() || "unnamed key",
+  });
+  if (error) throw new Error(`issue key failed: ${error.message}`);
+
+  await audit(admin, {
+    team_id: teamId,
+    actor_kind: opts.actor?.kind ?? "system",
+    member_id: opts.actor?.memberId ?? null,
+    action: "api_key.issued",
+    target_type: "api_key",
+    target_id: keyId,
+    meta: { for_member: memberId },
+  });
+  return { key: `aios_${keyId}_${secret}`, keyId };
+}
+
+export async function revokeApiKey(
+  admin: SupabaseClient,
+  teamId: string,
+  apiKeyId: string,
+  opts: { actor?: ActorContext } = {}
+): Promise<void> {
+  const { error } = await admin
+    .from("api_keys")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", apiKeyId)
+    .eq("team_id", teamId);
+  if (error) throw new Error(`revoke key failed: ${error.message}`);
+
+  await audit(admin, {
+    team_id: teamId,
+    actor_kind: opts.actor?.kind ?? "system",
+    member_id: opts.actor?.memberId ?? null,
+    action: "api_key.revoked",
+    target_type: "api_key",
+    target_id: apiKeyId,
+  });
+}

--- a/lib/admin/login.ts
+++ b/lib/admin/login.ts
@@ -1,0 +1,36 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { issueMagicToken } from "@/lib/auth/pg-login";
+import { audit } from "@/lib/api/audit";
+import type { ActorContext } from "./members";
+
+/**
+ * Shared admin primitive: mint a magic-link login token for an existing member
+ * (invite-only — issueMagicToken returns null if the email has no member). Returns
+ * the raw token and, when a base URL is given, the ready-to-click confirm URL.
+ * The raw token is a credential: surface once, never log it.
+ */
+export async function issueLoginLink(
+  admin: SupabaseClient,
+  teamId: string,
+  email: string,
+  opts: { nextPath?: string; ttlMinutes?: number; baseUrl?: string; actor?: ActorContext } = {}
+): Promise<{ token: string | null; url: string | null }> {
+  const e = email.trim().toLowerCase();
+  const raw = await issueMagicToken(e, opts.nextPath ?? "/", opts.ttlMinutes);
+  if (!raw) return { token: null, url: null };
+
+  await audit(admin, {
+    team_id: teamId,
+    actor_kind: opts.actor?.kind ?? "system",
+    member_id: opts.actor?.memberId ?? null,
+    action: "login_link.issued",
+    target_type: "member",
+    meta: { email: e, ttl_minutes: opts.ttlMinutes ?? null },
+  });
+
+  const url = opts.baseUrl
+    ? `${opts.baseUrl.replace(/\/$/, "")}/auth/confirm?token=${raw}`
+    : null;
+  return { token: raw, url };
+}

--- a/lib/admin/members.ts
+++ b/lib/admin/members.ts
@@ -1,0 +1,59 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { audit } from "@/lib/api/audit";
+
+/**
+ * Shared admin primitive: create (or upsert) a member. Used by the admin server
+ * action (UI) and the admin CLI so there's one audited write path. Authorization
+ * is the caller's responsibility (the action gates via requireAdmin; the CLI is a
+ * service-role/system actor). Always runs on the service-role client.
+ */
+export interface MemberInput {
+  email: string;
+  displayName: string;
+  actorHandle: string;
+  role: "admin" | "lead" | "member";
+  tier?: "team" | "external";
+}
+
+export interface ActorContext {
+  kind?: "member" | "system";
+  memberId?: string | null;
+}
+
+export async function createMember(
+  admin: SupabaseClient,
+  teamId: string,
+  input: MemberInput,
+  opts: { upsert?: boolean; actor?: ActorContext } = {}
+): Promise<{ id: string; status: string }> {
+  const email = input.email.trim().toLowerCase();
+  // `status` is intentionally omitted so the column default ('invited') applies on
+  // insert while an existing member's status is preserved on upsert-conflict.
+  const row = {
+    team_id: teamId,
+    email,
+    display_name: input.displayName.trim(),
+    actor_handle: input.actorHandle.trim().toLowerCase(),
+    role: input.role,
+    tier: input.tier ?? "team",
+  };
+
+  const builder = opts.upsert
+    ? admin.from("members").upsert(row, { onConflict: "team_id,email" })
+    : admin.from("members").insert({ ...row, status: "invited" });
+
+  const { data, error } = await builder.select("id, status").single();
+  if (error || !data) throw new Error(`create member failed: ${error?.message}`);
+
+  await audit(admin, {
+    team_id: teamId,
+    actor_kind: opts.actor?.kind ?? "system",
+    member_id: opts.actor?.memberId ?? null,
+    action: "member.created",
+    target_type: "member",
+    target_id: data.id,
+    meta: { email, role: input.role, upsert: Boolean(opts.upsert) },
+  });
+  return { id: data.id, status: data.status };
+}

--- a/lib/auth/pg-login.ts
+++ b/lib/auth/pg-login.ts
@@ -39,12 +39,17 @@ export async function emailHasMember(email: string): Promise<boolean> {
   return (rows[0]?.n ?? 0) > 0;
 }
 
-/** Issue a magic-link token, or null if the email has no member (invite-only). */
-export async function issueMagicToken(email: string, nextPath: string): Promise<string | null> {
+/** Issue a magic-link token, or null if the email has no member (invite-only).
+ * `ttlMinutes` defaults to the login TTL; admin-minted links may pass a longer one. */
+export async function issueMagicToken(
+  email: string,
+  nextPath: string,
+  ttlMinutes: number = TOKEN_TTL_MIN
+): Promise<string | null> {
   if (!(await emailHasMember(email))) return null;
   const raw = randomBytes(32).toString("base64url");
   const hash = createHash("sha256").update(raw).digest("hex");
-  const expires = new Date(Date.now() + TOKEN_TTL_MIN * 60_000).toISOString();
+  const expires = new Date(Date.now() + ttlMinutes * 60_000).toISOString();
   await runSql(
     `insert into auth_tokens (token_hash, email, next_path, expires_at)
      values ($1, $2, $3, $4)`,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:seed": "set -a; . ./.env.local; set +a; npx tsx --conditions react-server scripts/seed-demo.ts",
     "dev:login": "set -a; . ./.env.local; set +a; npx tsx scripts/dev-login.ts",
     "pg:schema": "npx tsx scripts/pg-load-schema.ts",
+    "admin": "npx tsx --conditions react-server scripts/admin.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "check:docs": "node scripts/check-docs-drift.mjs",

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -1,0 +1,156 @@
+/**
+ * Team Brain admin CLI. Runs against any Postgres `DATABASE_URL` (local/dev/test,
+ * or prod via `railway run`). Reuses the audited primitives in lib/admin/* — it
+ * does NOT re-implement auth/key/SQL logic. Secrets (API keys, login tokens) print
+ * ONCE and are never logged elsewhere; GITHUB_TOKEN is read from env/stdin only.
+ *
+ * Run:  npx tsx --conditions react-server scripts/admin.ts <command> [args] [--flags]
+ * Prod: railway run -s Postgres bash -lc \
+ *         'DATABASE_URL=$DATABASE_PUBLIC_URL npx tsx --conditions react-server scripts/admin.ts <cmd>'
+ */
+import { execFileSync } from "node:child_process";
+import { adminClient } from "@/lib/supabase/admin";
+import { createMember } from "@/lib/admin/members";
+import { issueApiKey, revokeApiKey } from "@/lib/admin/keys";
+import { issueLoginLink } from "@/lib/admin/login";
+
+type Flags = Record<string, string | boolean>;
+
+function parseArgs(argv: string[]): { cmd: string; positionals: string[]; flags: Flags } {
+  const [cmd = "help", ...rest] = argv;
+  const positionals: string[] = [];
+  const flags: Flags = {};
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = rest[i + 1];
+      if (next === undefined || next.startsWith("--")) flags[key] = true;
+      else {
+        flags[key] = next;
+        i++;
+      }
+    } else positionals.push(a);
+  }
+  return { cmd, positionals, flags };
+}
+
+function die(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+async function resolveTeam(admin: ReturnType<typeof adminClient>, slug: string) {
+  const { data } = await admin.from("teams").select("id, slug").eq("slug", slug).maybeSingle();
+  if (!data) die(`no team '${slug}'`);
+  return data as { id: string; slug: string };
+}
+
+const USAGE = `Team Brain admin CLI — commands:
+  create-member <email> --name <n> --handle <h> [--role admin|lead|member] [--team <slug>] [--upsert]
+  login-link <email> [--team <slug>] [--ttl-min <n>] [--base-url <url> | env BRAIN_URL]
+  issue-key <member-email> [--name <n>] [--team <slug>]
+  revoke-key <api-key-uuid> [--team <slug>]
+  list-members [--team <slug>]
+  list-keys [--team <slug>]
+  pg:schema                              # load postgres/schema.sql (idempotent)
+Defaults: --team demo. Requires DATABASE_URL (postgres).`;
+
+async function memberIdByEmail(admin: ReturnType<typeof adminClient>, teamId: string, email: string) {
+  const { data } = await admin
+    .from("members")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("email", email.trim().toLowerCase())
+    .maybeSingle();
+  return (data as { id: string } | null)?.id ?? null;
+}
+
+async function main() {
+  const { cmd, positionals, flags } = parseArgs(process.argv.slice(2));
+  if (cmd === "help" || flags.help) return console.log(USAGE);
+
+  if (cmd === "pg:schema") {
+    execFileSync("npx", ["tsx", "scripts/pg-load-schema.ts"], { stdio: "inherit" });
+    return;
+  }
+
+  if (!process.env.DATABASE_URL) die("DATABASE_URL is required");
+  const admin = adminClient();
+  const teamSlug = (flags.team as string) || "demo";
+
+  switch (cmd) {
+    case "create-member": {
+      const email = positionals[0] || die("usage: create-member <email> --name <n> --handle <h>");
+      const team = await resolveTeam(admin, teamSlug);
+      const res = await createMember(
+        admin,
+        team.id,
+        {
+          email,
+          displayName: (flags.name as string) || email.split("@")[0],
+          actorHandle: (flags.handle as string) || email.split("@")[0],
+          role: ((flags.role as string) || "member") as "admin" | "lead" | "member",
+          tier: (flags.tier as "team" | "external") || "team",
+        },
+        { upsert: Boolean(flags.upsert) }
+      );
+      console.log(`✓ member ${email} (${res.id}) status=${res.status} on team ${team.slug}`);
+      break;
+    }
+    case "login-link": {
+      const email = positionals[0] || die("usage: login-link <email>");
+      const team = await resolveTeam(admin, teamSlug);
+      const baseUrl = (flags["base-url"] as string) || process.env.BRAIN_URL || "";
+      const { token, url } = await issueLoginLink(admin, team.id, email, {
+        nextPath: `/t/${team.slug}`,
+        ttlMinutes: flags["ttl-min"] ? Number(flags["ttl-min"]) : 60,
+        baseUrl,
+      });
+      if (!token) die(`no member for ${email} (invite-only) — run create-member first`);
+      console.log(url ? `✓ one-time login link (expires soon):\n${url}` : `✓ token (append to /auth/confirm?token=): ${token}`);
+      break;
+    }
+    case "issue-key": {
+      const email = positionals[0] || die("usage: issue-key <member-email> [--name <n>]");
+      const team = await resolveTeam(admin, teamSlug);
+      const memberId = (await memberIdByEmail(admin, team.id, email)) || die(`no member ${email}`);
+      const { key } = await issueApiKey(admin, team.id, memberId, (flags.name as string) || "cli key");
+      console.log(`✓ API key (shown once — store it now):\n${key}`);
+      break;
+    }
+    case "revoke-key": {
+      const id = positionals[0] || die("usage: revoke-key <api-key-uuid>");
+      const team = await resolveTeam(admin, teamSlug);
+      await revokeApiKey(admin, team.id, id);
+      console.log(`✓ revoked key ${id}`);
+      break;
+    }
+    case "list-members": {
+      const team = await resolveTeam(admin, teamSlug);
+      const { data } = await admin
+        .from("members")
+        .select("email, actor_handle, role, tier, status")
+        .eq("team_id", team.id)
+        .order("created_at");
+      console.table(data ?? []);
+      break;
+    }
+    case "list-keys": {
+      const team = await resolveTeam(admin, teamSlug);
+      const { data } = await admin
+        .from("api_keys")
+        .select("id, key_id, name, last_used_at, revoked_at")
+        .eq("team_id", team.id)
+        .order("created_at");
+      console.table(data ?? []);
+      break;
+    }
+    default:
+      die(`unknown command '${cmd}'\n\n${USAGE}`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => die(e instanceof Error ? e.message : String(e)));

--- a/test/datamechanics/admin.datamechanics.test.ts
+++ b/test/datamechanics/admin.datamechanics.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import { createMember } from "@/lib/admin/members";
+import { issueApiKey, revokeApiKey } from "@/lib/admin/keys";
+import { issueLoginLink } from "@/lib/admin/login";
+import { db, seedTeam } from "./helpers";
+
+// Admin primitives against real Postgres: the CLI is a thin dispatcher over these,
+// so this is the meaningful smoke test. Asserts credential hashing (raw secret never
+// stored), idempotent upsert, invite-only login links, and audit-log writes.
+
+describe("admin primitives (real Postgres)", () => {
+  it("create-member: inserts; upsert is idempotent + audited", async () => {
+    const seed = await seedTeam();
+    const a = await createMember(db(), seed.teamId, {
+      email: "NewAdmin@x.test",
+      displayName: "New Admin",
+      actorHandle: "newadmin",
+      role: "admin",
+    });
+    expect(a.status).toBe("invited");
+
+    const b = await createMember(
+      db(),
+      seed.teamId,
+      { email: "newadmin@x.test", displayName: "Renamed", actorHandle: "newadmin", role: "admin" },
+      { upsert: true }
+    );
+    expect(b.id).toBe(a.id); // same member (email is citext-unique per team)
+
+    const { data: rows } = await db()
+      .from("members")
+      .select("id")
+      .eq("team_id", seed.teamId)
+      .eq("email", "newadmin@x.test");
+    expect((rows ?? []).length).toBe(1);
+  });
+
+  it("issue-key: returns aios_<id>_<secret>; stores only sha256(secret); revoke works", async () => {
+    const seed = await seedTeam();
+    const { key, keyId } = await issueApiKey(db(), seed.teamId, seed.memberId, "test key");
+    expect(key.startsWith(`aios_${keyId}_`)).toBe(true);
+
+    const secret = key.split("_").slice(2).join("_");
+    const { data: row } = await db()
+      .from("api_keys")
+      .select("id, key_hash")
+      .eq("key_id", keyId)
+      .maybeSingle();
+    const stored = row as { id: string; key_hash: string };
+    // crown jewel: only the hash is persisted, never the raw secret
+    expect(stored.key_hash).toBe(createHash("sha256").update(secret).digest("hex"));
+    expect(stored.key_hash).not.toContain(secret);
+
+    await revokeApiKey(db(), seed.teamId, stored.id);
+    const { data: after } = await db()
+      .from("api_keys")
+      .select("revoked_at")
+      .eq("id", stored.id)
+      .maybeSingle();
+    expect((after as { revoked_at: string | null }).revoked_at).not.toBeNull();
+  });
+
+  it("login-link: mints a token for a member (hash stored), null for a non-member", async () => {
+    const seed = await seedTeam();
+    await createMember(db(), seed.teamId, {
+      email: "loginme@x.test",
+      displayName: "Login Me",
+      actorHandle: "loginme",
+      role: "member",
+    });
+    const ok = await issueLoginLink(db(), seed.teamId, "loginme@x.test", {
+      baseUrl: "https://brain.test",
+      nextPath: `/t/${seed.teamSlug}`,
+      ttlMinutes: 60,
+    });
+    expect(ok.token).toBeTruthy();
+    expect(ok.url).toContain("/auth/confirm?token=");
+    const { data: tok } = await db()
+      .from("auth_tokens")
+      .select("token_hash")
+      .eq("email", "loginme@x.test")
+      .maybeSingle();
+    expect((tok as { token_hash: string }).token_hash).toBe(
+      createHash("sha256").update(ok.token as string).digest("hex")
+    );
+
+    // invite-only: unknown email yields no token
+    const none = await issueLoginLink(db(), seed.teamId, "stranger@x.test", {});
+    expect(none.token).toBeNull();
+  });
+
+  it("writes audit rows for member/key/login operations", async () => {
+    const seed = await seedTeam();
+    const m = await createMember(db(), seed.teamId, {
+      email: "audit@x.test",
+      displayName: "Audit",
+      actorHandle: "audit",
+      role: "member",
+    });
+    const { keyId } = await issueApiKey(db(), seed.teamId, m.id, "k");
+    void keyId;
+    await issueLoginLink(db(), seed.teamId, "audit@x.test", {});
+
+    const { data: audits } = await db()
+      .from("audit_log")
+      .select("action")
+      .eq("team_id", seed.teamId);
+    const actions = new Set((audits ?? []).map((a) => (a as { action: string }).action));
+    expect(actions.has("member.created")).toBe(true);
+    expect(actions.has("api_key.issued")).toBe(true);
+    expect(actions.has("login_link.issued")).toBe(true);
+  });
+});


### PR DESCRIPTION
First of the Codebases v1.1 series. Replaces hand-written one-off SQL (e.g. the manual user-creation earlier) with a reusable, **audited** admin path shared by the UI and a CLI.

## What
- **`lib/admin/{members,keys,login}.ts`** — shared, service-role primitives (caller does authz):
  - `createMember` (insert or idempotent upsert)
  - `issueApiKey`/`revokeApiKey` — `aios_<id>_<secret>`, **sha256-at-rest**, raw secret returned **once**
  - `issueLoginLink` — wraps `lib/auth/pg-login` `issueMagicToken` (invite-only), returns a confirm URL
  - every mutation writes `audit_log`
- **`app/t/[team]/admin/actions.ts`** — refactored to call the primitives (one path for UI + CLI; no duplicated auth/key logic, addressing the reviewer's blocker).
- **`lib/auth/pg-login.ts`** — `issueMagicToken` gains an optional `ttlMinutes` (backward-compatible).
- **`scripts/admin.ts`** — tsx CLI: `create-member`, `login-link`, `issue-key`, `revoke-key`, `list-members`, `list-keys`, `pg:schema`. Runs against any `DATABASE_URL` (local/dev/test or prod via `railway run`).
- **`.claude/skills/admin/SKILL.md`** — thin wrapper; documents prod invocation + **secret hygiene** (`GITHUB_TOKEN` via env/stdin only; never echo keys/tokens).

## Verification
- ✅ tsc 0 · lint clean · 75 unit · `check:docs` green
- ✅ 18 data-mechanics on real Postgres incl. **4 new admin tests**: key storage is **sha256-only** (raw secret never persisted), upsert idempotent, login links invite-only with hashed tokens, audit rows written
- ✅ End-to-end CLI smoke (create/list/issue/login) on the test DB

Net-new commands; no behavior change to existing flows beyond the action refactor (same audit actions preserved). Identity (`add-author-alias`, `sync-github`) and `scan`/`backfill` land in PR2/PR3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)