### PR TITLE
chore(dogfood): .claude/commands for team-brain

### DIFF
--- a/.claude/commands/scan-codebase.md
+++ b/.claude/commands/scan-codebase.md
@@ -1,0 +1,19 @@
+---
+description: Scan a repo's git history + scaffolding and push codebase metrics to the brain
+argument-hint: <local-path> <slug> [owner/repo]
+---
+
+Run the codebase analytics scanner for the repo at the path/slug in $ARGUMENTS and push the
+results to the brain. The brain computes the agentic/health scores from the raw metrics.
+
+Steps:
+1. If the repo has a coverage script, generate a fresh report first so coverage is real:
+   `(cd <local-path> && npm run coverage)` — if it errors or doesn't exist, continue (coverage
+   will be reported as null, not a failure).
+2. Run the scanner with a 12-week backfill so the trend populates:
+   `GITHUB_TOKEN=… aios-ingest scan --path <local-path> --slug <slug> --full-name <owner/repo> --backfill 12`
+   - Set `GITHUB_TOKEN` in the env (never as a flag) to enrich Issues/PRs + repo metadata.
+   - Requires `BRAIN_URL`, `AIOS_API_KEY`, `AIOS_TEAM` in the env (issue a key via the `admin` skill).
+3. Report the scanned counts (commits, AI-assisted, contributors, coverage, backfill points).
+
+Never print the API key or GitHub token.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,15 @@
+---
+description: Run the full verification suite (lint, unit, docs-drift, real-Postgres data-mechanics)
+---
+
+Run the Team Brain verification suite and report results concisely. Stop and surface
+the first failure with its output.
+
+1. `npm run lint`
+2. `npm run test` (unit tier — pure logic + drift/contract guards)
+3. `npm run check:docs` (architecture-map drift guard)
+4. `npm run db:test:up && npm run test:datamechanics` (real Postgres: persistence + tier
+   isolation), then `npm run db:test:down`
+
+Report pass/fail per step. If anything fails, show the failing test/output and propose a fix
+before re-running. Do not claim "done" unless every step is green.


### PR DESCRIPTION
**Stacked on #14.** Dogfoods the team-brain repo with real Claude Code slash-commands (which also raise its own "commands" sub-score honestly):
- `/.claude/commands/verify.md` — run the full lint + unit + docs-drift + real-Postgres data-mechanics suite.
- `/.claude/commands/scan-codebase.md` — run the analytics scanner (coverage + `--backfill 12`), secret-safe.

Scanner now reports team-brain: CLAUDE.md ✓, AGENTS.md ✓, 1 skill (admin), **2 commands**.

> aios-workspace dogfood (a real root `CLAUDE.md` + commands) is a **separate PR in that repo** (cross-repo, per plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)