### PR TITLE
feat(auth): direct passwordless email sign-in (postgres mode)

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { isPostgresBackend } from "@/lib/db/backend";
-import { issueMagicToken } from "@/lib/auth/pg-login";
-import { sendMagicLink } from "@/lib/auth/mailer";
+import { loginByEmail } from "@/lib/auth/pg-login";
+import { signSession, SESSION_COOKIE, sessionCookieOptions } from "@/lib/auth/pg-session";
 
 export const runtime = "nodejs";
 
@@ -12,10 +12,12 @@ const schema = z.object({
 });
 
 /**
- * Magic-link request for the postgres backend (supabase mode uses the client
- * SDK directly). Invite-only: a token is only issued for emails that already
- * have a member row, but the response is always `{ ok: true }` so the endpoint
- * doesn't reveal which emails exist.
+ * Direct (passwordless) sign-in for the postgres backend. Invite-only: if the email is a
+ * recognized non-disabled member we set the signed session cookie immediately; otherwise we
+ * reject with 403. No email round-trip / magic link.
+ *
+ * SECURITY: trusts the submitted email with no ownership proof — fine only for this
+ * invite-only, self-hosted instance with a known member list. See lib/auth/pg-login.loginByEmail.
  */
 export async function POST(req: NextRequest) {
   if (!isPostgresBackend()) {
@@ -35,10 +37,13 @@ export async function POST(req: NextRequest) {
   const nextParam = parsed.data.next ?? "/";
   const safeNext = nextParam.startsWith("/") && !nextParam.startsWith("//") ? nextParam : "/";
 
-  const raw = await issueMagicToken(email, safeNext);
-  if (raw) {
-    const origin = req.headers.get("origin") ?? new URL(req.url).origin;
-    await sendMagicLink(email, `${origin}/auth/confirm?token=${raw}`);
+  const user = await loginByEmail(email);
+  if (!user) {
+    // Not a recognized member — invite-only.
+    return NextResponse.json({ error: "not_recognized" }, { status: 403 });
   }
-  return NextResponse.json({ ok: true });
+
+  const res = NextResponse.json({ ok: true, redirect: safeNext });
+  res.cookies.set(SESSION_COOKIE, await signSession(user), sessionCookieOptions());
+  return res;
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { LoginForm } from "@/components/login-form";
+import { publicDbBackend } from "@/lib/db/backend";
 
 export const metadata: Metadata = { title: "Sign in" };
 
@@ -29,7 +30,9 @@ export default async function LoginPage({
             </p>
             <h1 className="mt-2 text-2xl font-semibold text-ink">Sign in</h1>
             <p className="mt-1 mb-6 text-sm text-ink-secondary">
-              We&apos;ll email you a one-time magic link.
+              {publicDbBackend() === "postgres"
+                ? "Enter your work email to sign in."
+                : "We'll email you a one-time magic link."}
             </p>
             {error === "invalid_link" ? (
               <p className="mb-4 rounded-lg border border-red/30 bg-red/5 px-3 py-2 text-sm text-red">

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -16,7 +16,8 @@ export function LoginForm({ next }: { next?: string }) {
     setState("sending");
     setError("");
 
-    // Postgres backend: request a magic link from our own endpoint.
+    // Postgres backend: direct (passwordless) sign-in — recognized members are logged in
+    // immediately; unknown emails are rejected (invite-only).
     if (publicDbBackend() === "postgres") {
       try {
         const res = await fetch("/api/auth/login", {
@@ -24,11 +25,17 @@ export function LoginForm({ next }: { next?: string }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ email, next }),
         });
-        if (!res.ok) throw new Error(`request failed (${res.status})`);
-        setState("sent");
+        if (res.status === 403) {
+          setState("error");
+          setError("That email isn't recognized. Team Brain is invite-only — ask your admin to add you.");
+          return;
+        }
+        if (!res.ok) throw new Error(`sign-in failed (${res.status})`);
+        const data = (await res.json()) as { redirect?: string };
+        window.location.href = data.redirect || next || "/";
       } catch (err) {
         setState("error");
-        setError(err instanceof Error ? err.message : "could not send link");
+        setError(err instanceof Error ? err.message : "could not sign in");
       }
       return;
     }
@@ -83,7 +90,7 @@ export function LoginForm({ next }: { next?: string }) {
         ) : (
           <Send className="size-4" />
         )}
-        Send magic link
+        {publicDbBackend() === "postgres" ? "Sign in" : "Send magic link"}
       </button>
       {state === "error" ? <p className="text-sm text-red">{error}</p> : null}
     </form>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,8 +78,11 @@ flowchart LR
 
 Two principals, one tier model:
 
-- **Humans** — magic-link / OAuth, invite-only. Dashboard reads go through **RLS**
-  (`private.my_*` SECURITY DEFINER helpers anchor every policy to `auth.uid()`).
+- **Humans** — invite-only. In the **postgres** target, sign-in is **direct passwordless**:
+  POST `/api/auth/login` with a recognized member email → signed session cookie (no email
+  round-trip; unknown emails 403). Trusts the email with no ownership proof — acceptable only
+  for this self-hosted, small known-member instance (`lib/auth/pg-login.loginByEmail`). In the
+  legacy **supabase** mode, magic-link / OAuth via Supabase Auth.
 - **Machines** — per-member API key `aios_<key_id>_<secret>` (sha256 at rest, shown
   once). Sync writes use the **service role** and bypass RLS — confined to `lib/ingest`
   and audited on every write.

--- a/lib/auth/pg-login.ts
+++ b/lib/auth/pg-login.ts
@@ -39,6 +39,31 @@ export async function emailHasMember(email: string): Promise<boolean> {
   return (rows[0]?.n ?? 0) > 0;
 }
 
+/**
+ * Direct (passwordless) login. If the email belongs to a non-disabled member, ensure the
+ * auth user, **force-link** the member to it (and activate if invited), and return the
+ * session user. Returns null if the email is not a recognized member (caller rejects).
+ *
+ * SECURITY NOTE: this trusts the submitted email with NO ownership proof — anyone who knows
+ * a registered email can sign in. Acceptable only for an invite-only, self-hosted instance
+ * with a small known member list (the explicit product choice here). Re-introduce magic-link
+ * verification (issueMagicToken/redeemMagicToken below) to harden later.
+ */
+export async function loginByEmail(email: string): Promise<SessionUser | null> {
+  if (!(await emailHasMember(email))) return null;
+  const id = await ensureAuthUser(email);
+  // Force-link so the session subject always matches members.auth_user_id (handles rows
+  // seeded active with a different/empty auth_user_id), and activate invited rows.
+  await runSql(
+    `update members
+        set auth_user_id = $1,
+            status = case when status = 'invited' then 'active' else status end
+      where email = $2 and status <> 'disabled'`,
+    [id, email]
+  );
+  return { id, email };
+}
+
 /** Issue a magic-link token, or null if the email has no member (invite-only).
  * `ttlMinutes` defaults to the login TTL; admin-minted links may pass a longer one. */
 export async function issueMagicToken(

--- a/test/datamechanics/login.datamechanics.test.ts
+++ b/test/datamechanics/login.datamechanics.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { loginByEmail } from "@/lib/auth/pg-login";
+import { db, seedTeam } from "./helpers";
+
+// Spec: direct (passwordless) login is invite-only. An email with a non-disabled member
+// signs in (and is force-linked + activated); anything else is rejected. Verified to the
+// observable outcome — the members row read back from real Postgres.
+
+describe("loginByEmail (real Postgres, invite-only)", () => {
+  it("rejects an email with no member", async () => {
+    await seedTeam();
+    expect(await loginByEmail("stranger@nowhere.test")).toBeNull();
+  });
+
+  it("rejects a disabled member", async () => {
+    const seed = await seedTeam();
+    const email = "gone@test.local";
+    await db().from("members").insert({
+      team_id: seed.teamId, email, display_name: "Gone",
+      actor_handle: "gone", role: "member", tier: "team", status: "disabled",
+    });
+    expect(await loginByEmail(email)).toBeNull();
+  });
+
+  it("signs in a recognized member, force-links the auth user, activates invited", async () => {
+    const seed = await seedTeam();
+    const email = "invitee@test.local";
+    await db().from("members").insert({
+      team_id: seed.teamId, email, display_name: "Invitee",
+      actor_handle: "invitee", role: "member", tier: "team", status: "invited",
+    });
+
+    const user = await loginByEmail(email);
+    expect(user).not.toBeNull();
+    expect(user!.email).toBe(email);
+
+    // Outcome in the DB: activated + linked to the same auth user the session carries.
+    const { data } = await db()
+      .from("members")
+      .select("auth_user_id, status")
+      .eq("email", email)
+      .maybeSingle();
+    expect(data!.status).toBe("active");
+    expect(data!.auth_user_id).toBe(user!.id);
+  });
+});


### PR DESCRIPTION
Replaces the magic-link email step (no SMTP in prod → login was dead) with **direct passwordless sign-in**: a recognized member email signs in immediately; unknown emails 403 (invite-only). `loginByEmail` force-links the auth user so the session subject always matches the member. 3 spec-first data-mechanics tests (reject unknown / reject disabled / activate+link invited). Security tradeoff (no email-ownership proof) documented; acceptable for this invite-only self-hosted instance.

Verified: data-mechanics 28/28, unit 75/75, tsc clean, drift green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)