### PR TITLE
fix(security): scope query_log reads per member

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -96,13 +96,14 @@ export default async function TeamHome({
 
   const { data: me } = await supabase
     .from("members")
-    .select("role, tier")
+    .select("id, role, tier")
     .eq("team_id", team.id)
     .eq("auth_user_id", user?.id ?? "")
     .eq("status", "active")
     .maybeSingle();
   const isAdmin = me?.role === "admin";
   const tier = ((me?.tier as "team" | "external" | undefined) ?? "external");
+  const memberId = (me?.id as string | undefined) ?? "";
 
   // Tier-filtered count (no RLS backstop in postgres mode).
   const { count: itemCount } = await visibleItems(
@@ -121,7 +122,7 @@ export default async function TeamHome({
 
   const [pulse, { data: activity }, { data: openTasks }, { data: commitments }, { data: decisions }] =
     await Promise.all([
-      getPulseMetrics(supabase, team.id, range, isAdmin),
+      getPulseMetrics(supabase, team.id, range, { isAdmin, memberId }),
       visibleItems(
         supabase
           .from("items")

--- a/app/t/[team]/query/page.tsx
+++ b/app/t/[team]/query/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { History } from "lucide-react";
 import { serverClient } from "@/lib/supabase/server";
+import { currentMember } from "@/lib/auth/guard";
+import { scopeQueryLog } from "@/lib/auth/visibility";
 import { QueryChat } from "@/components/query-chat";
 import { timeAgo, truncate } from "@/components/format";
 
@@ -24,13 +26,20 @@ export default async function QueryPage({
     .maybeSingle();
   if (!team) return null;
 
-  // RLS: members see their own queries; admins see the whole team's.
-  const { data: recent } = await supabase
-    .from("query_log")
-    .select("id, question, answer_preview, cost_usd, latency_ms, created_at")
-    .eq("team_id", team.id)
-    .order("created_at", { ascending: false })
-    .limit(10);
+  // No RLS in postgres mode: scope query_log in app code. Members see only their own queries;
+  // admins see the whole team's (scopeQueryLog, CLAUDE.md §5).
+  const me = await currentMember(team.id);
+  const { data: recent } = me
+    ? await scopeQueryLog(
+        supabase
+          .from("query_log")
+          .select("id, question, answer_preview, cost_usd, latency_ms, created_at")
+          .eq("team_id", team.id),
+        { isAdmin: me.role === "admin", memberId: me.id }
+      )
+        .order("created_at", { ascending: false })
+        .limit(10)
+    : { data: [] };
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-6">

--- a/lib/auth/visibility.ts
+++ b/lib/auth/visibility.ts
@@ -23,3 +23,23 @@ export function visibleItems<Q>(query: Q, tier: ViewerTier): Q {
 export function canSeeAccess(tier: ViewerTier, access: string): boolean {
   return tier === "team" || access === "external";
 }
+
+/**
+ * Role-scoped visibility for `query_log` reads (CLAUDE.md §5). `query_log` rows carry a
+ * `member_id`; in postgres mode there is NO RLS, so this app-code filter is the SOLE thing
+ * stopping a non-admin from reading the whole team's questions and `cost_usd`. Admins see the
+ * team-wide log; everyone else (lead, member) sees only their own rows. Route every dashboard
+ * `query_log` read through here — the query-log-visibility guard enforces it.
+ *
+ * `Q` is a free generic (no recursive constraint) so the supabase-js builder's deeply recursive
+ * type doesn't trigger TS2589; the `.eq` shape is asserted by a localized cast.
+ */
+export interface QueryLogViewer {
+  isAdmin: boolean;
+  memberId: string;
+}
+
+export function scopeQueryLog<Q>(query: Q, viewer: QueryLogViewer): Q {
+  if (viewer.isAdmin) return query;
+  return (query as { eq(column: string, value: string): Q }).eq("member_id", viewer.memberId);
+}

--- a/lib/codebases/ingest.ts
+++ b/lib/codebases/ingest.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { CodebaseScanPayload } from "@/lib/api/schemas";
 import { computeScores } from "@/lib/codebases/score";
+import { buildIdentityMap, resolveMember } from "@/lib/identity/resolve";
 import { audit } from "@/lib/api/audit";
 
 /**
@@ -102,26 +103,12 @@ export async function ingestCodebaseScan(
   // 4. contributions — map author → member, then recompute + upsert daily aggregates
   let contribCount = 0;
   if (payload.contributions.length) {
-    const memberId = await buildAuthorMap(supabase, auth.teamId);
+    const identityMap = await buildIdentityMap(supabase, auth.teamId);
     for (const row of payload.contributions) {
-      // Resolve to a roster member by exact email first. Only derive a handle from
-      // an email local-part when that email uses a domain already present in the
-      // roster; otherwise external contributors like alex@gmail.com could be
-      // misattributed to an internal actor_handle "alex".
-      const email = row.author_email.trim().toLowerCase();
-      const keyLc = row.author_key.trim().toLowerCase();
-      const [localPart, domain] = email.includes("@") ? email.split("@", 2) : ["", ""];
-      const handleFromTeamDomain =
-        localPart && domain && memberId.emailDomains.has(domain)
-          ? memberId.byHandle.get(localPart)
-          : undefined;
-      const explicitHandle = keyLc && !keyLc.includes("@") ? memberId.byHandle.get(keyLc) : undefined;
-      const mapped =
-        memberId.byEmail.get(email) ??
-        memberId.byEmail.get(keyLc) ??
-        handleFromTeamDomain ??
-        explicitHandle ??
-        null;
+      const mapped = resolveMember(identityMap, {
+        email: row.author_email,
+        key: row.author_key,
+      });
       const { error } = await supabase.from("code_contributions").upsert(
         {
           team_id: auth.teamId,
@@ -193,38 +180,4 @@ export async function ingestCodebaseScan(
     contributions: contribCount,
     issues: issueCount,
   };
-}
-
-/** Lookup tables mapping git author identity → member_id for the team. */
-async function buildAuthorMap(supabase: SupabaseClient, teamId: string) {
-  const { data } = await supabase
-    .from("members")
-    .select("id, email, actor_handle")
-    .eq("team_id", teamId);
-  const byEmail = new Map<string, string>();
-  const byHandle = new Map<string, string>();
-  const emailDomains = new Set<string>();
-  for (const r of (data ?? []) as { id: string; email: string | null; actor_handle: string | null }[]) {
-    if (r.email) {
-      const email = r.email.toLowerCase();
-      byEmail.set(email, r.id);
-      const domain = email.split("@", 2)[1];
-      if (domain) emailDomains.add(domain);
-    }
-    if (r.actor_handle) byHandle.set(r.actor_handle.toLowerCase(), r.id);
-  }
-
-  // Fold in explicit git-author aliases (e.g. GitHub noreply emails) as EXACT
-  // byEmail matches. Deliberately NOT added to emailDomains — alias domains like
-  // users.noreply.github.com are shared, so widening the handle heuristic with them
-  // would re-introduce cross-author misattribution (the bug PR #11 closed).
-  const { data: aliases } = await supabase
-    .from("member_emails")
-    .select("email, member_id")
-    .eq("team_id", teamId);
-  for (const a of (aliases ?? []) as { email: string; member_id: string }[]) {
-    if (a.email) byEmail.set(a.email.toLowerCase(), a.member_id);
-  }
-
-  return { byEmail, byHandle, emailDomains };
 }

--- a/lib/identity/resolve.ts
+++ b/lib/identity/resolve.ts
@@ -1,0 +1,98 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Shared identity resolution: git/provider author identity → roster `member_id` for a team.
+ * Extracted from lib/codebases/ingest.ts so codebase contributions AND per-member cost
+ * attribution (lib/metrics/members.ts, lib/costs/*) resolve identities the SAME way — one
+ * resolver, not two drifting copies. Uses the `member_emails` alias table for explicit
+ * git-author aliases (e.g. GitHub noreply emails).
+ */
+
+export interface IdentityMap {
+  /** lower-cased email (roster + aliases) → member_id, exact matches only */
+  byEmail: Map<string, string>;
+  /** lower-cased actor_handle → member_id */
+  byHandle: Map<string, string>;
+  /** email domains present in the roster (gates the local-part → handle heuristic) */
+  emailDomains: Set<string>;
+}
+
+export interface AuthorIdentity {
+  email?: string | null;
+  /** the source's author key (may be an email or a bare handle) */
+  key?: string | null;
+}
+
+/** Build lookup tables mapping author identity → member_id for the team. */
+export async function buildIdentityMap(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<IdentityMap> {
+  const { data } = await supabase
+    .from("members")
+    .select("id, email, actor_handle")
+    .eq("team_id", teamId);
+  const byEmail = new Map<string, string>();
+  const byHandle = new Map<string, string>();
+  const emailDomains = new Set<string>();
+  for (const r of (data ?? []) as {
+    id: string;
+    email: string | null;
+    actor_handle: string | null;
+  }[]) {
+    if (r.email) {
+      const email = r.email.toLowerCase();
+      byEmail.set(email, r.id);
+      const domain = email.split("@", 2)[1];
+      if (domain) emailDomains.add(domain);
+    }
+    if (r.actor_handle) byHandle.set(r.actor_handle.toLowerCase(), r.id);
+  }
+
+  // Fold in explicit git-author aliases (e.g. GitHub noreply emails) as EXACT byEmail matches.
+  // Deliberately NOT added to emailDomains — alias domains like users.noreply.github.com are
+  // shared, so widening the handle heuristic with them would re-introduce cross-author
+  // misattribution (the bug PR #11 closed).
+  const { data: aliases } = await supabase
+    .from("member_emails")
+    .select("email, member_id")
+    .eq("team_id", teamId);
+  for (const a of (aliases ?? []) as { email: string; member_id: string }[]) {
+    if (a.email) byEmail.set(a.email.toLowerCase(), a.member_id);
+  }
+
+  return { byEmail, byHandle, emailDomains };
+}
+
+/**
+ * Resolve one author identity to a roster member_id, or null. Exact email match first; only
+ * derive a handle from an email local-part when that email's domain is already in the roster
+ * (otherwise external contributors like alex@gmail.com could be misattributed to an internal
+ * actor_handle "alex"); then an explicit non-email handle key.
+ */
+export function resolveMember(map: IdentityMap, identity: AuthorIdentity): string | null {
+  const email = (identity.email ?? "").trim().toLowerCase();
+  const keyLc = (identity.key ?? "").trim().toLowerCase();
+  const [localPart, domain] = email.includes("@") ? email.split("@", 2) : ["", ""];
+  const handleFromTeamDomain =
+    localPart && domain && map.emailDomains.has(domain) ? map.byHandle.get(localPart) : undefined;
+  const explicitHandle = keyLc && !keyLc.includes("@") ? map.byHandle.get(keyLc) : undefined;
+  return (
+    map.byEmail.get(email) ??
+    map.byEmail.get(keyLc) ??
+    handleFromTeamDomain ??
+    explicitHandle ??
+    null
+  );
+}
+
+/** Convenience: build the map once and resolve a batch of identities to member_ids. */
+export async function resolveMembers(
+  supabase: SupabaseClient,
+  teamId: string,
+  identities: AuthorIdentity[]
+): Promise<(string | null)[]> {
+  const map = await buildIdentityMap(supabase, teamId);
+  return identities.map((id) => resolveMember(map, id));
+}

--- a/lib/metrics/pulse.ts
+++ b/lib/metrics/pulse.ts
@@ -1,11 +1,14 @@
 import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { rangeDays, type Range } from "./range";
+import { scopeQueryLog } from "@/lib/auth/visibility";
 
 /**
- * Range-aware dashboard metrics. Every read goes through the caller's
- * RLS-governed client, so tier/role filtering (e.g. query_log being member-
- * scoped for members and team-wide for admins) is enforced automatically.
+ * Range-aware dashboard metrics. In postgres mode there is NO RLS, so query_log row-level
+ * scoping is NOT automatic — it is applied here in app code via `scopeQueryLog`: members see
+ * only their own queries/spend, admins see the whole team's (CLAUDE.md §5). The items/tasks
+ * aggregates are team-wide counts shown only to a team-tier viewer (the home page gates the
+ * page on a tier-filtered item count first).
  *
  * Aggregation is done in JS over rows fetched within the window. That is fine
  * at MVP volumes; if the corpus grows large, move the day-bucketing into SQL
@@ -123,8 +126,9 @@ export async function getPulseMetrics(
   supabase: SupabaseClient,
   teamId: string,
   range: Range,
-  isAdmin: boolean
+  viewer: { isAdmin: boolean; memberId: string }
 ): Promise<PulseMetrics> {
+  const { isAdmin } = viewer;
   const days = rangeDays(range);
   const now = new Date();
   const windowStart = new Date(now.getTime() - days * 86_400_000);
@@ -143,13 +147,16 @@ export async function getPulseMetrics(
       .gte("synced_at", priorStart.toISOString())
       .order("synced_at", { ascending: false })
       .limit(10_000),
-    supabase
-      .from("query_log")
-      .select("cost_usd, created_at")
-      .eq("team_id", teamId)
-      .gte("created_at", priorStart.toISOString())
-      .order("created_at", { ascending: false })
-      .limit(10_000),
+    scopeQueryLog(
+      supabase
+        .from("query_log")
+        .select("cost_usd, created_at")
+        .eq("team_id", teamId)
+        .gte("created_at", priorStart.toISOString())
+        .order("created_at", { ascending: false })
+        .limit(10_000),
+      viewer
+    ),
     supabase
       .from("tasks")
       .select("status, updated_at")

--- a/test/datamechanics/query-log-visibility.datamechanics.test.ts
+++ b/test/datamechanics/query-log-visibility.datamechanics.test.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { scopeQueryLog } from "@/lib/auth/visibility";
+import { db, seedTeam } from "./helpers";
+
+// query_log row-level scoping (lib/auth/visibility.scopeQueryLog), verified to the observable
+// outcome on real Postgres (DB_BACKEND=postgres → no RLS). This is the SOLE enforcement that a
+// non-admin member cannot read another member's questions / cost_usd. Reproduces the bug the
+// page-level comment falsely claimed RLS handled.
+
+async function addMember(teamId: string, role: "admin" | "lead" | "member") {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: teamId,
+      email: `${randomUUID()}@test.local`,
+      display_name: `M-${role}`,
+      actor_handle: `actor-${randomUUID().slice(0, 8)}`,
+      role,
+      tier: "team",
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seed member failed: ${error?.message}`);
+  return data.id as string;
+}
+
+async function logQuery(teamId: string, memberId: string, question: string) {
+  const { error } = await db()
+    .from("query_log")
+    .insert({ team_id: teamId, member_id: memberId, question, answer_preview: "", cost_usd: 1.5 });
+  if (error) throw new Error(`seed query_log failed: ${error.message}`);
+}
+
+describe("scopeQueryLog() on real Postgres", () => {
+  it("a member sees only their own query_log rows; an admin sees the whole team's", async () => {
+    const seed = await seedTeam(); // memberId is a 'member'
+    const other = await addMember(seed.teamId, "member");
+    await logQuery(seed.teamId, seed.memberId, "my own question");
+    await logQuery(seed.teamId, other, "someone else's question");
+
+    const base = () =>
+      db().from("query_log").select("question, member_id").eq("team_id", seed.teamId);
+
+    // Non-admin member: only their own row, no leak of the other member's question/cost.
+    const { data: mine } = await scopeQueryLog(base(), {
+      isAdmin: false,
+      memberId: seed.memberId,
+    });
+    const myQuestions = (mine ?? []).map((r: { question: string }) => r.question);
+    expect(myQuestions).toContain("my own question");
+    expect(myQuestions).not.toContain("someone else's question"); // no leak, no RLS backstop
+
+    // Admin: team-wide visibility (non-vacuity — both rows are present in the table).
+    const { data: all } = await scopeQueryLog(base(), { isAdmin: true, memberId: seed.memberId });
+    const allQuestions = (all ?? []).map((r: { question: string }) => r.question);
+    expect(allQuestions).toContain("my own question");
+    expect(allQuestions).toContain("someone else's question");
+  });
+});

--- a/test/guards/query-log-visibility.test.ts
+++ b/test/guards/query-log-visibility.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * query_log row-scoping guard (CLAUDE.md §5). In postgres mode there is no RLS, so any read of
+ * `query_log` that renders to a viewer MUST scope rows in app code via `scopeQueryLog` — members
+ * see only their own questions/cost, admins see the team. This guard fails the build if a
+ * dashboard page or metrics module reads `query_log` without it, so the prior leak (a page that
+ * read the whole team's query_log behind a false "RLS handles it" comment) can't recur.
+ * A genuinely viewer-agnostic read (e.g. a cron aggregate) may opt out with `// query-scope-ok: <reason>`.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCAN_DIRS = [join(ROOT, "app", "t"), join(ROOT, "lib", "metrics")];
+const SCOPE = /scopeQueryLog\s*\(/;
+const READS_QUERY_LOG = /from\(\s*["']query_log["']\s*\)/;
+const OPT_OUT = /query-scope-ok:/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".tsx") || p.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+function offenders(): string[] {
+  const hits: string[] = [];
+  for (const dir of SCAN_DIRS) {
+    for (const file of walk(dir)) {
+      const src = readFileSync(file, "utf8");
+      if (!READS_QUERY_LOG.test(src)) continue;
+      if (OPT_OUT.test(src)) continue;
+      if (!SCOPE.test(src)) hits.push(file.slice(file.indexOf("aios-team-brain/") + "aios-team-brain/".length));
+    }
+  }
+  return hits.sort();
+}
+
+describe("query_log row-level visibility", () => {
+  it("every dashboard/metrics read of query_log scopes rows by member/role", () => {
+    const violations = offenders();
+    expect(
+      violations,
+      `Reads of query_log without scopeQueryLog (no RLS backstop in postgres mode):\n` +
+        `Route the read through scopeQueryLog() (or // query-scope-ok: <reason>):\n${violations.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("the matchers discriminate (non-vacuity)", () => {
+    expect(READS_QUERY_LOG.test('supabase.from("query_log").select("cost_usd")')).toBe(true);
+    expect(SCOPE.test("scopeQueryLog(q, { isAdmin, memberId })")).toBe(true);
+    expect(SCOPE.test('q.eq("team_id", t)')).toBe(false);
+  });
+});

--- a/test/identity-resolve.test.ts
+++ b/test/identity-resolve.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveMember, type IdentityMap } from "@/lib/identity/resolve";
+
+// Pure-logic spec for the shared identity resolver (lib/identity/resolve). Locks the
+// misattribution-prevention rules so codebase contributions and cost attribution stay aligned.
+
+function mapOf(): IdentityMap {
+  return {
+    byEmail: new Map([
+      ["jane@acme.com", "m-jane"],
+      ["jane@users.noreply.github.com", "m-jane"], // explicit alias
+    ]),
+    byHandle: new Map([
+      ["jane", "m-jane"],
+      ["bob", "m-bob"],
+    ]),
+    emailDomains: new Set(["acme.com"]),
+  };
+}
+
+describe("resolveMember()", () => {
+  it("matches an exact roster email", () => {
+    expect(resolveMember(mapOf(), { email: "Jane@Acme.com" })).toBe("m-jane");
+  });
+
+  it("matches an explicit git-author alias email", () => {
+    expect(resolveMember(mapOf(), { email: "jane@users.noreply.github.com" })).toBe("m-jane");
+  });
+
+  it("derives a handle from the local-part ONLY when the email domain is in the roster", () => {
+    expect(resolveMember(mapOf(), { email: "bob@acme.com" })).toBe("m-bob");
+  });
+
+  it("does NOT misattribute an external email whose local-part collides with a handle", () => {
+    // bob@gmail.com must not map to handle "bob" — gmail.com is not a roster domain.
+    expect(resolveMember(mapOf(), { email: "bob@gmail.com" })).toBeNull();
+  });
+
+  it("resolves an explicit non-email handle key", () => {
+    expect(resolveMember(mapOf(), { key: "bob" })).toBe("m-bob");
+  });
+
+  it("returns null for an unknown identity", () => {
+    expect(resolveMember(mapOf(), { email: "nobody@elsewhere.io", key: "ghost" })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Security fix: cross-member `query_log` leak

In **postgres mode there is no RLS**, but `app/t/[team]/query/page.tsx` and `lib/metrics/pulse.ts` both assumed an *"RLS-governed client"* and read `query_log` filtered only by `team_id`. Result: **any team member could read every other member's questions and per-query `cost_usd`** on the Query page and in the dashboard spend KPI.

### Fix
- Add `scopeQueryLog()` to the `lib/auth/visibility` choke-point: **admins** see the team-wide log; **everyone else** (lead, member) sees only their own rows.
- Apply it at both read sites; `getPulseMetrics` now takes `{ isAdmin, memberId }`.
- Delete the false "RLS handles it" comments.

### Also (Wave 0 prerequisite refactor)
- Extract the shared identity resolver into `lib/identity/resolve.ts` (`buildIdentityMap` / `resolveMember` / `resolveMembers`) out of the private `buildAuthorMap` in `lib/codebases/ingest.ts`, so codebase contributions **and** upcoming per-member cost attribution resolve git/provider identities the same way. **Pure refactor — behavior unchanged.**

### Tests (spec-first)
- 🔴→🟢 **data-mechanics** (real Postgres): a member cannot read another member's `query_log` row; an admin sees the whole team's.
- **Build-failing guard** (`test/guards/query-log-visibility.test.ts`): any read of `query_log` under `app/t` or `lib/metrics` must route through `scopeQueryLog` (or an explicit `// query-scope-ok:` opt-out), so the leak can't recur.
- **Unit spec** for `resolveMember()` (misattribution-prevention rules).
- Codebase-identity data-mechanics parity confirms the resolver extraction is a no-op.

### Verification
`tsc` clean · `eslint` clean · 83 unit tests · query_log data-mechanics test green on real Postgres · codebase-identity parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)