### PR TITLE
feat(aem): codebase readiness, team maturity rollup, radar ingestion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,5 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v5
-      - run: uv pip install --system -e '.[dev]'
+      - run: uv pip install --system -e '.[dev,radar]'
       - run: pytest -q

--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -81,6 +81,7 @@ export default async function TeamLayout({
   ];
   if (isPostgresBackend()) {
     items.push({ icon: "codebases", label: "Codebases", href: `${base}/codebases` });
+    items.push({ icon: "maturity", label: "Maturity", href: `${base}/maturity` });
   }
   items.push({ icon: "query", label: "Query", href: `${base}/query` });
   items.push({ label: "Settings", children: settingsChildren });

--- a/app/t/[team]/maturity/page.tsx
+++ b/app/t/[team]/maturity/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from "next";
+import { Gauge } from "lucide-react";
+import { isPostgresBackend } from "@/lib/db/backend";
+import { serverClient } from "@/lib/supabase/server";
+import { currentMember } from "@/lib/auth/guard";
+import { getTeamMaturity, type ReadinessLevel } from "@/lib/metrics/maturity";
+import { parseRange } from "@/lib/metrics/range";
+import { EmptyState } from "@/components/empty-state";
+import { RangeSelector } from "@/components/dashboard/range-selector";
+
+export const metadata: Metadata = { title: "Agentic Maturity" };
+
+const LEVELS: ReadinessLevel[] = ["L0", "L1", "L2", "L3", "L4", "L5"];
+const LEVEL_NAME: Record<ReadinessLevel, string> = {
+  L0: "Pre-functional",
+  L1: "Functional",
+  L2: "Structured",
+  L3: "Agent-ready",
+  L4: "Measured",
+  L5: "Self-improving",
+};
+
+export default async function MaturityPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ team: string }>;
+  searchParams: Promise<{ range?: string }>;
+}) {
+  if (!isPostgresBackend()) return null;
+
+  const { team: teamSlug } = await params;
+  const range = parseRange((await searchParams).range);
+  const supabase = await serverClient();
+
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  const me = await currentMember(team.id);
+  if (!me) return null;
+
+  // Tier gate lives in getTeamMaturity → getCodebaseSummaries (team-only).
+  const m = await getTeamMaturity(supabase, team.id, range, me.tier);
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-5">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-ink">Agentic Maturity</h1>
+          <p className="text-sm text-ink-secondary">
+            How agent-ready the team&apos;s codebases are, scored against the AEM rubric.
+          </p>
+        </div>
+        <RangeSelector value={range} />
+      </div>
+
+      {m.reposScored === 0 ? (
+        <EmptyState
+          icon={Gauge}
+          title="No agent-readiness scores yet"
+          action="Run `aios assess-codebase --push` from a workspace (or POST a scan with readiness fields to /api/v1/codebases) to populate the maturity rollup."
+        />
+      ) : (
+        <>
+          {/* Headline */}
+          <div className="prism-card flex flex-wrap items-end gap-8 px-6 py-5">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-ink-tertiary">
+                Repos at L3+ (agent-ready)
+              </p>
+              <p className="mt-1 font-display text-4xl font-semibold text-gradient-prism">
+                {m.pctAtL3Plus}%
+              </p>
+              <p className="mt-1 text-xs text-ink-secondary">
+                {m.atL3Plus} of {m.reposScored} scored {m.reposScored === 1 ? "repo" : "repos"}
+              </p>
+            </div>
+            {/* Level distribution */}
+            <div className="flex flex-1 items-end gap-2">
+              {LEVELS.map((lvl) => {
+                const n = m.distribution[lvl];
+                const max = Math.max(...LEVELS.map((l) => m.distribution[l]), 1);
+                return (
+                  <div key={lvl} className="flex flex-1 flex-col items-center gap-1" title={LEVEL_NAME[lvl]}>
+                    <span className="text-[11px] text-ink-secondary">{n || ""}</span>
+                    <div
+                      className={`w-full rounded-t ${Number(lvl[1]) >= 3 ? "bg-violet/60" : "bg-white/15"}`}
+                      style={{ height: `${8 + (n / max) * 56}px` }}
+                    />
+                    <span className="font-mono text-[10px] text-ink-tertiary">{lvl}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Worst-first list — the "what to level up next" queue */}
+          <div className="prism-card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border-subtle text-left text-[11px] uppercase tracking-wide text-ink-tertiary">
+                  <th className="px-5 py-3 font-semibold">Repo</th>
+                  <th className="px-5 py-3 font-semibold">Level</th>
+                  <th className="px-5 py-3 font-semibold">Checks passed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {m.repos.map((r) => (
+                  <tr key={r.slug} className="border-b border-border-subtle/50 last:border-0">
+                    <td className="px-5 py-3 font-medium text-ink">{r.slug}</td>
+                    <td className="px-5 py-3">
+                      <span className="font-mono text-ink-secondary">
+                        {r.level} {r.level ? `· ${LEVEL_NAME[r.level]}` : ""}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3 text-ink-secondary">{r.pct == null ? "—" : `${r.pct}%`}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/codebases/codebase-card.tsx
+++ b/components/codebases/codebase-card.tsx
@@ -29,6 +29,14 @@ export function CodebaseCard({ teamSlug, cb }: { teamSlug: string; cb: CodebaseS
           </span>{" "}
           cov
         </span>
+        {cb.readiness_level ? (
+          <span
+            title={`AEM agent-readiness${cb.readiness_pct == null ? "" : ` — ${cb.readiness_pct}% of checks`}`}
+            className="inline-flex items-center rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5 font-mono text-[10px] font-semibold text-ink-secondary"
+          >
+            {cb.readiness_level} ready
+          </span>
+        ) : null}
         <span className="ml-auto">
           <Sparkline data={cb.spark} width={72} height={22} className="text-violet" />
         </span>

--- a/components/team-nav.tsx
+++ b/components/team-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import {
   Blocks,
   FolderKanban,
+  Gauge,
   Gavel,
   GitBranch,
   Home,
@@ -23,6 +24,7 @@ const ICONS = {
   library: Library,
   skills: Blocks,
   codebases: GitBranch,
+  maturity: Gauge,
   teamtools: Wrench,
   query: Sparkles,
   admin: Shield,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -289,7 +289,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 ### Ingestion sources
 
 <!-- drift:sources -->
-`github` · `slack` · `notion` · `gdrive` · `confluence` · `linear` · `web` · `local`
+`github` · `slack` · `notion` · `gdrive` · `confluence` · `linear` · `web` · `local` · `radar`
 <!-- /drift:sources -->
 
 ## Docs drift guard

--- a/docs/RADAR.md
+++ b/docs/RADAR.md
@@ -1,0 +1,60 @@
+# Agentic Engineering Radar
+
+The radar continuously mines the best practicing agentic engineers into the brain, then
+curated insights are promoted to the public wiki. It is the freshness engine behind the
+AEM pattern library (`agentic-engineering-maturity/` at the monorepo root, published at
+`/agentic` on the website).
+
+## Tiers — the public + team split
+
+| Layer | Tier | Where | What |
+|---|---|---|---|
+| **Staging** | `team` | brain `items` (kind `artifact`, source `radar`) | Every new feed entry, raw + summarized. Internal only. |
+| **Public wiki** | `external` | `aios-website/src/content/docs/agentic/reading.mdx` | Only *curated, approved* insights. A deliberate human/agent act. |
+
+The radar ingestion source (`ingestion/aios_ingest/sources/radar.py`) **only ever writes
+team tier**. It never produces `external`/`admin`. Promotion to the public wiki is a
+separate, deliberate step — nothing reaches the public site automatically. This mirrors
+the workspace spine philosophy: content is promoted, never auto-published.
+
+## Pipeline
+
+```
+watchlist.json feeds (RSS/Atom · GitHub releases.atom · hnrss)
+        │  aios-ingest schedule --config connections.yaml
+        ▼
+RadarSource.fetch → RawDoc(kind=artifact, access=team) → POST /api/v1/items
+        │  (dedupe-safe by permalink → content sha256)
+        ▼
+brain `items` (team tier)  ── queryable via /api/v1/query, "what did the radar surface?"
+        │  curation: human/agent reviews, scores actionability, maps to an AEM pattern
+        ▼  (deliberate promotion)
+aios-website /agentic/reading  (external tier, public)
+```
+
+## Run it
+
+```bash
+cd ingestion
+uv pip install -e '.[radar]'                 # feedparser
+cp connections.example.yaml connections.yaml # edit feeds / set AIOS_WATCHLIST_PATH
+export BRAIN_URL=... AIOS_API_KEY=... AIOS_TEAM=...
+aios-ingest backfill --source radar --opt watchlist_path=../../agentic-engineering-maturity/rubric/watchlist.json
+# or run on a schedule (every 6h):
+aios-ingest schedule --config connections.yaml --poll-interval 21600
+```
+
+## Promotion (staging → public)
+
+Promotion is intentionally manual/curated — the radar's value is selection, not volume
+(guarding against the "slopacalypse"). To promote an item:
+
+1. Review the team-tier radar artifacts (dashboard or `aios query`).
+2. For a keeper: write a one-line entry under the right section of
+   `aios-website/src/content/docs/agentic/reading.mdx`, linking the source and noting the
+   reusable technique (and which AEM pattern it informs).
+3. If it's a genuinely new technique, also propose a pattern addition to
+   `agentic-engineering-maturity/01-pattern-library.md` (canonical) — the website mirrors it.
+
+The root `/docs-sync` skill audits that the public wiki hasn't drifted from the canonical
+framework.

--- a/ingestion/aios_ingest/normalize.py
+++ b/ingestion/aios_ingest/normalize.py
@@ -25,6 +25,7 @@ DEFAULT_KIND_BY_SOURCE: dict[str, ItemKind] = {
     "github": "deliverable",
     "web": "deliverable",
     "local": "deliverable",
+    "radar": "artifact",
 }
 
 _SLUG_OK = re.compile(r"[^a-z0-9/_.-]+")

--- a/ingestion/aios_ingest/sources/radar.py
+++ b/ingestion/aios_ingest/sources/radar.py
@@ -1,0 +1,134 @@
+"""Radar source — the Agentic Engineering Radar.
+
+Mines the best practicing agentic engineers into the brain (team-tier) by pulling
+their public RSS/Atom feeds, GitHub `releases.atom` feeds, and Hacker News keyword
+feeds (hnrss). Each feed entry becomes one `RawDoc` (kind ``artifact``, access
+``team``) keyed by its permalink, so re-pulling is dedupe-safe via the brain's
+content sha256.
+
+Curated, high-signal items are later promoted to the public wiki — a deliberate human
+act (see docs/agentic radar promotion), never automatic. This source only fills the
+team-tier staging layer.
+
+The feed list is data: pass it inline via ``feeds`` (a list of URLs) or point
+``watchlist_path`` at a watchlist JSON (the monorepo-canonical
+``agentic-engineering-maturity/rubric/watchlist.json`` shape) and the source pulls its
+``feeds[].url`` + ``githubReleaseFeeds[].url`` + ``hnQueries[].url``.
+
+Pull-only. Needs the 'radar' extra (feedparser).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Iterator
+
+import httpx
+
+from ..normalize import RawDoc
+from .base import MissingExtraError, PullOnlySource, Source
+
+
+def _feeds_from_watchlist(path: str) -> list[str]:
+    with open(path, encoding="utf-8") as fh:
+        wl = json.load(fh)
+    urls: list[str] = []
+    for key in ("feeds", "githubReleaseFeeds", "hnQueries"):
+        for entry in wl.get(key, []):
+            url = entry.get("url") if isinstance(entry, dict) else entry
+            if url:
+                urls.append(url)
+    return urls
+
+
+def _struct_to_iso(parsed) -> str | None:
+    """feedparser's *_parsed time.struct_time → ISO8601 (UTC), or None."""
+    if not parsed:
+        return None
+    import calendar
+    from datetime import datetime, timezone
+
+    try:
+        return datetime.fromtimestamp(calendar.timegm(parsed), tz=timezone.utc).isoformat()
+    except (ValueError, OverflowError, TypeError):
+        return None
+
+
+class RadarSource(PullOnlySource, Source):
+    name = "radar"
+
+    def __init__(
+        self,
+        *,
+        feeds: list[str] | None = None,
+        watchlist_path: str | None = None,
+        timeout: float = 30.0,
+        max_entries_per_feed: int = 50,
+    ):
+        # feeds may arrive as a comma-separated string via the CLI `--opt feeds=a,b`.
+        if isinstance(feeds, str):
+            feeds = [u.strip() for u in feeds.split(",") if u.strip()]
+        urls = list(feeds or [])
+        if watchlist_path:
+            urls.extend(_feeds_from_watchlist(watchlist_path))
+        # de-dupe, preserve order
+        seen: set[str] = set()
+        self._urls = [u for u in urls if not (u in seen or seen.add(u))]
+        if not self._urls:
+            raise ValueError("radar source needs `feeds` or a `watchlist_path` with feeds")
+        # CLI `--opt` values arrive as strings — coerce the numerics.
+        self._timeout = float(timeout)
+        self._max = int(max_entries_per_feed)
+
+    def fetch(self, *, since: str | None = None) -> Iterator[RawDoc]:
+        try:
+            import feedparser  # type: ignore
+        except ImportError:
+            raise MissingExtraError("radar", "feedparser") from None
+
+        with httpx.Client(timeout=self._timeout, follow_redirects=True) as http:
+            for feed_url in self._urls:
+                try:
+                    resp = http.get(feed_url, headers={"User-Agent": "aios-radar/1.0"})
+                except httpx.HTTPError:
+                    continue
+                if resp.status_code != 200:
+                    continue
+                parsed = feedparser.parse(resp.content)
+                feed_title = (parsed.feed or {}).get("title") if hasattr(parsed, "feed") else None
+
+                for entry in (parsed.entries or [])[: self._max]:
+                    link = entry.get("link") or entry.get("id")
+                    if not link:
+                        continue
+                    ts = _struct_to_iso(entry.get("published_parsed") or entry.get("updated_parsed"))
+                    # cursor filter: skip entries at/older than `since` when both are known
+                    if since and ts and ts <= since:
+                        continue
+
+                    title = (entry.get("title") or "").strip() or None
+                    author = (entry.get("author") or "").strip() or feed_title or None
+                    summary = entry.get("summary") or ""
+                    if not summary and entry.get("content"):
+                        summary = entry["content"][0].get("value", "")
+
+                    body = "\n\n".join(
+                        part for part in (f"# {title}" if title else "", link, summary.strip()) if part
+                    )
+
+                    yield RawDoc(
+                        source=self.name,
+                        external_id=link,
+                        body=body,
+                        title=title,
+                        url=link,
+                        author=author,
+                        source_ts=ts,
+                        kind="artifact",
+                        access="team",
+                        extra_frontmatter={
+                            "radar": True,
+                            "feed": feed_url,
+                            "feed_title": feed_title,
+                        },
+                    )

--- a/ingestion/aios_ingest/sources/registry.py
+++ b/ingestion/aios_ingest/sources/registry.py
@@ -15,6 +15,7 @@ from .github import GithubSource
 from .linear import LinearSource
 from .local import LocalSource
 from .notion import NotionSource
+from .radar import RadarSource
 from .slack import SlackSource
 from .web import WebSource
 
@@ -29,6 +30,7 @@ _REGISTRY: dict[str, Builder] = {
     "linear": LinearSource,
     "web": WebSource,
     "local": LocalSource,
+    "radar": RadarSource,
 }
 
 

--- a/ingestion/connections.example.yaml
+++ b/ingestion/connections.example.yaml
@@ -1,0 +1,30 @@
+# Example ingestion connections. Copy to connections.yaml and edit.
+#   aios-ingest sync --config connections.yaml
+#   aios-ingest schedule --config connections.yaml --poll-interval 21600   # every 6h
+#
+# Secrets in `options` use ${ENV_VAR} and are expanded from the environment.
+
+connections:
+  # ── Agentic Engineering Radar ────────────────────────────────────────────────
+  # Mines the best practicing agentic engineers into the brain as team-tier artifacts.
+  # Curated items are later promoted to the public wiki (a deliberate human act —
+  # see docs/RADAR.md). The radar source only fills the team-tier staging layer.
+  - name: agentic-radar
+    source: radar
+    access: team            # NEVER external/admin — staging stays internal until promoted
+    project: agentic-radar
+    actor: radar-sync
+    options:
+      # Option A — point at the canonical watchlist JSON (recommended; one source of truth):
+      #   the monorepo file agentic-engineering-maturity/rubric/watchlist.json, or a copy.
+      watchlist_path: ${AIOS_WATCHLIST_PATH}
+      # Option B — inline feeds (use instead of, or in addition to, watchlist_path):
+      feeds:
+        - https://simonwillison.net/atom/everything/
+        - https://lucumr.pocoo.org/feed.atom
+        - https://ghuntley.com/rss/
+        - https://registerspill.thorstenball.com/feed
+        - https://www.latent.space/feed
+        - https://github.com/anthropics/claude-code/releases.atom
+        - https://hnrss.org/newest?q=Claude+Code&points=50
+      max_entries_per_feed: 50

--- a/ingestion/pyproject.toml
+++ b/ingestion/pyproject.toml
@@ -23,6 +23,7 @@ slack = ["llama-index-readers-slack>=0.1"]
 gdrive = ["llama-index-readers-google>=0.1"]
 notion = ["llama-index-readers-notion>=0.1"]
 confluence = ["llama-index-readers-confluence>=0.1"]
+radar = ["feedparser>=6.0"]
 docs = ["unstructured>=0.13"]
 all = [
   "llama-index-readers-github>=0.1",
@@ -30,6 +31,7 @@ all = [
   "llama-index-readers-google>=0.1",
   "llama-index-readers-notion>=0.1",
   "llama-index-readers-confluence>=0.1",
+  "feedparser>=6.0",
   "unstructured>=0.13",
 ]
 dev = ["pytest>=8", "pytest-asyncio>=0.23", "respx>=0.21", "pip-licenses>=5"]

--- a/ingestion/tests/test_radar.py
+++ b/ingestion/tests/test_radar.py
@@ -3,6 +3,11 @@
 import json
 
 import httpx
+import pytest
+
+# RadarSource.fetch() needs the 'radar' extra (feedparser). Skip cleanly if a bare
+# '.[dev]' env runs these; CI installs '.[dev,radar]' so they actually run there.
+pytest.importorskip("feedparser")
 
 from aios_ingest.sources.radar import RadarSource, _feeds_from_watchlist, _struct_to_iso
 

--- a/ingestion/tests/test_radar.py
+++ b/ingestion/tests/test_radar.py
@@ -1,0 +1,84 @@
+"""Radar source — offline tests (feed parsing, cursor filter, watchlist loading)."""
+
+import json
+
+import httpx
+
+from aios_ingest.sources.radar import RadarSource, _feeds_from_watchlist, _struct_to_iso
+
+ATOM = """<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Engineer</title>
+  <entry>
+    <title>Agentic coding tips</title>
+    <link href="https://example.com/posts/agentic-tips"/>
+    <id>https://example.com/posts/agentic-tips</id>
+    <updated>2026-06-10T12:00:00Z</updated>
+    <author><name>Jane Dev</name></author>
+    <summary>Use a check the agent can run.</summary>
+  </entry>
+  <entry>
+    <title>Older post</title>
+    <link href="https://example.com/posts/old"/>
+    <id>https://example.com/posts/old</id>
+    <updated>2026-01-01T00:00:00Z</updated>
+    <summary>Stale.</summary>
+  </entry>
+</feed>
+"""
+
+
+def _mock_get(monkeypatch, body: str, status: int = 200):
+    def fake_get(self, url, headers=None):
+        return httpx.Response(status, content=body.encode(), request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+
+
+def test_fetch_yields_team_tier_artifacts(monkeypatch):
+    _mock_get(monkeypatch, ATOM)
+    src = RadarSource(feeds=["https://example.com/feed.atom"])
+    docs = list(src.fetch())
+    assert len(docs) == 2
+    d = docs[0]
+    assert d.source == "radar"
+    assert d.kind == "artifact"
+    assert d.access == "team"  # never external/admin — staging is team-tier
+    assert d.external_id == "https://example.com/posts/agentic-tips"
+    assert d.author == "Jane Dev"
+    assert "check the agent can run" in d.body
+    assert d.extra_frontmatter["radar"] is True
+
+
+def test_since_cursor_filters_old_entries(monkeypatch):
+    _mock_get(monkeypatch, ATOM)
+    src = RadarSource(feeds=["https://example.com/feed.atom"])
+    docs = list(src.fetch(since="2026-03-01T00:00:00+00:00"))
+    # only the June entry survives the cursor
+    assert [d.external_id for d in docs] == ["https://example.com/posts/agentic-tips"]
+
+
+def test_non_200_feed_is_skipped(monkeypatch):
+    _mock_get(monkeypatch, "nope", status=503)
+    src = RadarSource(feeds=["https://example.com/feed.atom"])
+    assert list(src.fetch()) == []
+
+
+def test_watchlist_loading(tmp_path):
+    wl = {
+        "feeds": [{"url": "https://a.com/feed"}],
+        "githubReleaseFeeds": [{"url": "https://github.com/o/r/releases.atom"}],
+        "hnQueries": [{"url": "https://hnrss.org/newest?q=x"}],
+    }
+    p = tmp_path / "watchlist.json"
+    p.write_text(json.dumps(wl))
+    urls = _feeds_from_watchlist(str(p))
+    assert urls == [
+        "https://a.com/feed",
+        "https://github.com/o/r/releases.atom",
+        "https://hnrss.org/newest?q=x",
+    ]
+
+
+def test_struct_to_iso_handles_none():
+    assert _struct_to_iso(None) is None

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -87,6 +87,15 @@ export const codeMetricsSchema = z.object({
   // cadence inputs (used to compute cadence_score; not persisted raw)
   active_days: z.number().int().nonnegative().optional().default(0),
   days_since_last_commit: z.number().int().nonnegative().nullable().optional().default(null),
+  // AEM agent-readiness — scored scanner-side against the canonical rubric
+  // (agentic-engineering-maturity/rubric/agent-readiness.json); the brain persists as-is.
+  readiness_level: z.string().max(8).nullable().optional().default(null),
+  readiness_pct: z.number().min(0).max(100).nullable().optional().default(null),
+  readiness_pillars: z
+    .record(z.string(), z.object({ passed: z.number().int().nonnegative(), total: z.number().int().nonnegative() }))
+    .optional()
+    .default({}),
+  readiness_rubric_version: z.string().max(32).nullable().optional().default(null),
 });
 
 export const codeContributionSchema = z.object({

--- a/lib/codebases/ingest.ts
+++ b/lib/codebases/ingest.ts
@@ -92,6 +92,11 @@ export async function ingestCodebaseScan(
         agents_md_count: m.agents_md_count,
         skills_count: m.skills_count,
         commands_count: m.commands_count,
+        // AEM agent-readiness — scored scanner-side; persisted as-is (jsonb object auto-casts).
+        readiness_level: m.readiness_level,
+        readiness_pct: m.readiness_pct,
+        readiness_pillars: m.readiness_pillars,
+        readiness_rubric_version: m.readiness_rubric_version,
         ...scores,
       },
       { onConflict: "codebase_id,head_sha" }
@@ -169,6 +174,7 @@ export async function ingestCodebaseScan(
       head_sha: m.head_sha,
       agentic_score: scores.agentic_score,
       health_score: scores.health_score,
+      readiness_level: m.readiness_level,
       contributions: contribCount,
       issues: issueCount,
     },

--- a/lib/metrics/codebases.ts
+++ b/lib/metrics/codebases.ts
@@ -25,6 +25,8 @@ export interface CodebaseSummary {
   health_score: number;
   test_coverage_pct: number | null;
   ai_commit_ratio: number;
+  readiness_level: string | null; // AEM agent-readiness level (L0..L5), null = not scored
+  readiness_pct: number | null;
   spark: number[]; // agentic_score over the window
 }
 
@@ -40,6 +42,8 @@ type MetricRow = {
   health_score: number | string;
   test_coverage_pct: number | string | null;
   ai_commit_ratio: number | string;
+  readiness_level: string | null;
+  readiness_pct: number | string | null;
 };
 
 export async function getCodebaseSummaries(
@@ -60,7 +64,7 @@ export async function getCodebaseSummaries(
       .order("last_scan_at", { ascending: false, nullsFirst: false }),
     supabase
       .from("code_metrics")
-      .select("codebase_id, scanned_at, agentic_score, health_score, test_coverage_pct, ai_commit_ratio")
+      .select("codebase_id, scanned_at, agentic_score, health_score, test_coverage_pct, ai_commit_ratio, readiness_level, readiness_pct")
       .eq("team_id", teamId)
       .gte("scanned_at", windowStart)
       // DESC + limit keeps the NEWEST points (ascending+limit would drop them at scale).
@@ -102,6 +106,8 @@ export async function getCodebaseSummaries(
       health_score: num(latest?.health_score),
       test_coverage_pct: latest?.test_coverage_pct == null ? null : num(latest.test_coverage_pct),
       ai_commit_ratio: num(latest?.ai_commit_ratio),
+      readiness_level: latest?.readiness_level ?? null,
+      readiness_pct: latest?.readiness_pct == null ? null : num(latest.readiness_pct),
       // chronological for the sparkline (series is newest-first)
       spark: series.map((s) => num(s.agentic_score)).reverse(),
     };
@@ -183,6 +189,9 @@ export interface AgenticBreakdown {
   skills_count: number;
   commands_count: number;
   test_coverage_pct: number | null;
+  readiness_level: string | null;
+  readiness_pct: number | null;
+  readiness_pillars: Record<string, { passed: number; total: number }>;
 }
 
 export interface TrendPoint {
@@ -268,7 +277,8 @@ export async function getCodebaseDetail(
   const METRIC_COLS =
     "scanned_at, agentic_score, health_score, ai_commit_ratio, test_coverage_score, " +
     "scaffolding_score, skill_breadth_score, cadence_score, issue_health, has_claude_md, " +
-    "has_agents_md, agents_md_count, skills_count, commands_count, test_coverage_pct, recent_commits";
+    "has_agents_md, agents_md_count, skills_count, commands_count, test_coverage_pct, recent_commits, " +
+    "readiness_level, readiness_pct, readiness_pillars";
 
   const [metricsRes, contribRes, issuesRes, membersRes] = await Promise.all([
     supabase
@@ -322,6 +332,10 @@ export async function getCodebaseDetail(
         commands_count: num(latest.commands_count as number),
         test_coverage_pct:
           latest.test_coverage_pct == null ? null : num(latest.test_coverage_pct as number),
+        readiness_level: (latest.readiness_level as string | null) ?? null,
+        readiness_pct: latest.readiness_pct == null ? null : num(latest.readiness_pct as number),
+        readiness_pillars:
+          (latest.readiness_pillars as Record<string, { passed: number; total: number }>) ?? {},
       }
     : null;
 

--- a/lib/metrics/maturity.ts
+++ b/lib/metrics/maturity.ts
@@ -1,0 +1,77 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Range } from "./range";
+import type { ViewerTier } from "@/lib/codebases/visibility";
+import { getCodebaseSummaries } from "./codebases";
+
+/**
+ * Team-level Agentic Engineering Maturity rollup, derived from per-repo agent-readiness
+ * (AEM codebase scope). Reuses the codebase-summaries choke-point, so it inherits the
+ * team-tier gate — an external viewer gets an empty rollup, no leak path. There is no
+ * RLS backstop on postgres; the gate in getCodebaseSummaries is the sole enforcement.
+ *
+ * Headline org metric: % of scored repos at L3+ ("agent-ready" or better).
+ */
+
+const LEVEL_ORDER = ["L0", "L1", "L2", "L3", "L4", "L5"] as const;
+export type ReadinessLevel = (typeof LEVEL_ORDER)[number];
+
+export interface RepoReadiness {
+  slug: string;
+  level: ReadinessLevel | null;
+  pct: number | null;
+}
+
+export interface TeamMaturity {
+  reposTotal: number; // repos with any scan
+  reposScored: number; // repos with a readiness level
+  atL3Plus: number; // count scored at L3 or better
+  pctAtL3Plus: number; // headline metric (0 when none scored)
+  distribution: Record<ReadinessLevel, number>;
+  repos: RepoReadiness[]; // scored repos, worst-first (drives the "what to fix" list)
+}
+
+function rank(level: string | null): number {
+  const i = level ? LEVEL_ORDER.indexOf(level as ReadinessLevel) : -1;
+  return i; // -1 = unscored
+}
+
+export async function getTeamMaturity(
+  supabase: SupabaseClient,
+  teamId: string,
+  range: Range,
+  tier: ViewerTier
+): Promise<TeamMaturity> {
+  const empty: TeamMaturity = {
+    reposTotal: 0,
+    reposScored: 0,
+    atL3Plus: 0,
+    pctAtL3Plus: 0,
+    distribution: { L0: 0, L1: 0, L2: 0, L3: 0, L4: 0, L5: 0 },
+    repos: [],
+  };
+
+  const { codebases } = await getCodebaseSummaries(supabase, teamId, range, tier);
+  if (!codebases.length) return empty;
+
+  const distribution = { ...empty.distribution };
+  const scored: RepoReadiness[] = [];
+  for (const cb of codebases) {
+    if (cb.readiness_level && LEVEL_ORDER.includes(cb.readiness_level as ReadinessLevel)) {
+      distribution[cb.readiness_level as ReadinessLevel]++;
+      scored.push({ slug: cb.slug, level: cb.readiness_level as ReadinessLevel, pct: cb.readiness_pct });
+    }
+  }
+
+  const atL3Plus = scored.filter((r) => rank(r.level) >= LEVEL_ORDER.indexOf("L3")).length;
+  scored.sort((a, b) => rank(a.level) - rank(b.level)); // worst-first
+
+  return {
+    reposTotal: codebases.length,
+    reposScored: scored.length,
+    atL3Plus,
+    pctAtL3Plus: scored.length ? Math.round((atL3Plus / scored.length) * 100) : 0,
+    distribution,
+    repos: scored,
+  };
+}

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -413,6 +413,12 @@ create table if not exists code_metrics (
   skill_breadth_score numeric(5,2) not null default 0,
   cadence_score numeric(5,2) not null default 0,
   issue_health numeric(5,2) not null default 0,
+  -- AEM agent-readiness (rubric-scored scanner-side; the brain only persists the result.
+  -- canonical rubric: agentic-engineering-maturity/rubric/agent-readiness.json)
+  readiness_level text,                            -- L0..L5, null = not scored
+  readiness_pct numeric(5,2),                      -- % of all rubric checks passed
+  readiness_pillars jsonb not null default '{}',   -- { pillarKey: {passed,total} }
+  readiness_rubric_version text,                   -- which rubric version produced the score
   created_at timestamptz not null default now(),
   unique (codebase_id, head_sha)
 );

--- a/test/datamechanics/codebase-readiness.datamechanics.test.ts
+++ b/test/datamechanics/codebase-readiness.datamechanics.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { ingestCodebaseScan } from "@/lib/codebases/ingest";
+import { getCodebaseDetail, getCodebaseSummaries } from "@/lib/metrics/codebases";
+import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
+import { db, seedTeam } from "./helpers";
+
+// Spec: the scanner scores AEM agent-readiness (scanner-side, against the canonical
+// rubric) and pushes it on the metrics payload; the brain persists it verbatim and
+// surfaces it on both the codebase summary (list) and detail (breakdown). These are
+// new code_metrics columns with no RLS backstop — assert the observable DB outcome.
+
+function scanWithReadiness(slug: string) {
+  return codebaseScanPayloadSchema.parse({
+    codebase: { slug, full_name: `acme/${slug}`, open_issues: 0 },
+    metrics: {
+      head_sha: "b".repeat(40),
+      window_days: 90,
+      commits_window: 4,
+      ai_commits_window: 2,
+      active_days: 2,
+      days_since_last_commit: 1,
+      readiness_level: "L3",
+      readiness_pct: 67,
+      readiness_pillars: {
+        testing: { passed: 2, total: 2 },
+        docs: { passed: 2, total: 3 },
+      },
+      readiness_rubric_version: "1.0.0",
+    },
+    contributions: [],
+    issues: [],
+  });
+}
+
+describe("codebase agent-readiness persistence (real Postgres)", () => {
+  it("round-trips readiness through ingest → summary + detail breakdown", async () => {
+    const seed = await seedTeam();
+    const slug = `repo-${randomUUID().slice(0, 6)}`;
+
+    await ingestCodebaseScan(
+      db(),
+      { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: randomUUID() },
+      scanWithReadiness(slug)
+    );
+
+    // Summary (list view) carries level + pct.
+    const { codebases } = await getCodebaseSummaries(db(), seed.teamId, "90d", "team");
+    const summary = codebases.find((c) => c.slug === slug);
+    expect(summary?.readiness_level).toBe("L3");
+    expect(summary?.readiness_pct).toBe(67);
+
+    // Detail breakdown carries the per-pillar map too.
+    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    expect(detail?.breakdown?.readiness_level).toBe("L3");
+    expect(detail?.breakdown?.readiness_pct).toBe(67);
+    expect(detail?.breakdown?.readiness_pillars?.testing).toEqual({ passed: 2, total: 2 });
+  });
+
+  it("readiness is team-tier only — an external viewer never sees it", async () => {
+    const seed = await seedTeam();
+    const slug = `repo-${randomUUID().slice(0, 6)}`;
+    await ingestCodebaseScan(
+      db(),
+      { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: randomUUID() },
+      scanWithReadiness(slug)
+    );
+
+    // The codebase-analytics choke-point returns empty for external — no leak path.
+    const { codebases } = await getCodebaseSummaries(db(), seed.teamId, "90d", "external");
+    expect(codebases.length).toBe(0);
+    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "external");
+    expect(detail).toBeNull();
+  });
+});

--- a/test/datamechanics/team-maturity.datamechanics.test.ts
+++ b/test/datamechanics/team-maturity.datamechanics.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { ingestCodebaseScan } from "@/lib/codebases/ingest";
+import { getTeamMaturity } from "@/lib/metrics/maturity";
+import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
+import { db, seedTeam } from "./helpers";
+
+// Spec: the team rollup aggregates per-repo agent-readiness into "% at L3+" and is
+// team-tier only (no leak to external), reusing the codebase choke-point.
+
+function scan(slug: string, level: string, pct: number) {
+  return codebaseScanPayloadSchema.parse({
+    codebase: { slug, full_name: `acme/${slug}`, open_issues: 0 },
+    metrics: {
+      head_sha: "c".repeat(40),
+      window_days: 90,
+      readiness_level: level,
+      readiness_pct: pct,
+      readiness_rubric_version: "1.0.0",
+    },
+    contributions: [],
+    issues: [],
+  });
+}
+
+describe("team maturity rollup (real Postgres)", () => {
+  it("computes % of repos at L3+ and lists worst-first", async () => {
+    const seed = await seedTeam();
+    const auth = { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: randomUUID() };
+    const a = `repo-${randomUUID().slice(0, 6)}`;
+    const b = `repo-${randomUUID().slice(0, 6)}`;
+    await ingestCodebaseScan(db(), auth, scan(a, "L4", 80)); // agent-ready+
+    await ingestCodebaseScan(db(), auth, scan(b, "L1", 40)); // not ready
+
+    const m = await getTeamMaturity(db(), seed.teamId, "90d", "team");
+    expect(m.reposScored).toBe(2);
+    expect(m.atL3Plus).toBe(1);
+    expect(m.pctAtL3Plus).toBe(50);
+    expect(m.distribution.L4).toBe(1);
+    expect(m.distribution.L1).toBe(1);
+    // worst-first: L1 repo leads the "what to fix" queue
+    expect(m.repos[0].slug).toBe(b);
+  });
+
+  it("is team-tier only — external viewer gets an empty rollup", async () => {
+    const seed = await seedTeam();
+    const auth = { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: randomUUID() };
+    await ingestCodebaseScan(db(), auth, scan(`repo-${randomUUID().slice(0, 6)}`, "L4", 80));
+
+    const m = await getTeamMaturity(db(), seed.teamId, "90d", "external");
+    expect(m.reposScored).toBe(0);
+    expect(m.pctAtL3Plus).toBe(0);
+    expect(m.repos).toEqual([]);
+  });
+});


### PR DESCRIPTION
Team Brain side of the **Agentic Engineering Maturity (AEM)** system.

## What's in it
- **Codebase agent-readiness** — `code_metrics` gains `readiness_*` columns; the scan payload + `ingestCodebaseScan` persist a rubric score computed scanner-side; surfaced on the Codebases card/detail (team-tier gated). Contract documented in `aios-workspace/docs/brain-api.md` (additive v1).
- **Team maturity rollup** — `lib/metrics/maturity.ts` (% repos at L3+, distribution, worst-first) + `/t/[team]/maturity` page + nav. Tier-gated via the codebase choke-point.
- **Radar ingestion** — `ingestion/sources/radar.py` pulls RSS/Atom + GitHub `releases.atom` + hnrss into team-tier artifacts (dedupe-safe). `radar` extra (feedparser), `connections.example.yaml`, `docs/RADAR.md` (team→public promotion split).

## Verification
- `tsc` clean · `eslint` clean · `check:docs` green (9 sources, drift updated)
- 98 unit tests · 39 ingestion tests (incl. 5 radar) · data-mechanics: readiness round-trip + team-maturity rollup, both proving **tier isolation** (external sees nothing)
- **Live backfill proven**: 42 real artifacts from 14 feeds pushed via `/api/v1/items`, all `access=team`, re-run idempotent (42 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)