### PR TITLE
feat(integrations): admin settings for connector secrets (encrypted)

### DIFF
--- a/app/api/v1/connections/route.ts
+++ b/app/api/v1/connections/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { errorResponse } from "@/lib/api/schemas";
+import { audit } from "@/lib/api/audit";
+import { getEnabledConnectionsWithSecrets } from "@/lib/connections";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/v1/connections — the ingestion sidecar pulls its enabled connections (with
+ * DECRYPTED secrets) for its team, authenticated by its connector API key. This is the only
+ * path that emits plaintext connector secrets; every fetch is audited (`connections.read`).
+ * Admins manage the connections in the dashboard (Admin → Integrations).
+ */
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+
+  const supabase = adminClient();
+  if (!(await rateLimit(supabase, `${auth.apiKeyId}:connections:get`, 60))) {
+    return errorResponse("rate_limited", "60/min per key", 429);
+  }
+
+  try {
+    const connections = await getEnabledConnectionsWithSecrets(supabase, auth.teamId);
+    await audit(supabase, {
+      team_id: auth.teamId,
+      actor_kind: "api_key",
+      member_id: auth.memberId,
+      api_key_id: auth.apiKeyId,
+      action: "connections.read",
+      meta: { count: connections.length, sources: connections.map((c) => c.source) },
+    });
+    return Response.json({ connections });
+  } catch (e) {
+    return errorResponse("internal", e instanceof Error ? e.message : "failed", 500);
+  }
+}

--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -1,0 +1,111 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverClient } from "@/lib/supabase/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  createConnection,
+  updateConnection,
+  deleteConnection,
+} from "@/lib/connections";
+
+/** Verify the caller is an active admin of the team; returns ids or null. */
+async function requireAdmin(teamSlug: string) {
+  const supabase = await serverClient();
+  const user = await getSessionUser();
+  if (!user) return null;
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+  const { data: me } = await supabase
+    .from("members")
+    .select("id, role")
+    .eq("team_id", team.id)
+    .eq("auth_user_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+  if (me?.role !== "admin") return null;
+  return { teamId: team.id, myMemberId: me.id };
+}
+
+/** Split a comma/newline-separated list into trimmed non-empty tokens. */
+function toList(raw: string): string[] {
+  return raw.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);
+}
+
+export async function addConnection(
+  teamSlug: string,
+  form: { source: string; name: string; channels: string; secret: string }
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  const name = form.name.trim();
+  if (!name) return { ok: false, error: "name is required" };
+  const config: Record<string, unknown> = {};
+  const channels = toList(form.channels);
+  if (channels.length) config.channel_ids = channels;
+  try {
+    // Service-role client: writes the encrypted secret column (revoked from clients in
+    // supabase mode; no RLS in postgres mode). lib/connections encrypts before insert.
+    await createConnection(adminClient(), {
+      teamId: ctx.teamId,
+      source: form.source,
+      name,
+      config,
+      secret: form.secret || null,
+      createdBy: ctx.myMemberId,
+    });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not save connection" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}
+
+export async function setConnectionEnabled(
+  teamSlug: string,
+  id: string,
+  enabled: boolean
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    await updateConnection(adminClient(), { teamId: ctx.teamId, id, enabled });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not update" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}
+
+export async function rotateConnectionSecret(
+  teamSlug: string,
+  id: string,
+  secret: string
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  if (!secret) return { ok: false, error: "secret is required" };
+  try {
+    await updateConnection(adminClient(), { teamId: ctx.teamId, id, secret });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not rotate" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}
+
+export async function removeConnection(
+  teamSlug: string,
+  id: string
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    await deleteConnection(adminClient(), ctx.teamId, id);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not delete" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}

--- a/app/t/[team]/admin/integrations/page.tsx
+++ b/app/t/[team]/admin/integrations/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import { adminClient } from "@/lib/supabase/admin";
+import { listConnections } from "@/lib/connections";
+import { ConnectionsManager, type ConnectionRow } from "@/components/admin/connections-manager";
+
+export const metadata: Metadata = { title: "Integrations" };
+
+/**
+ * Admin → Integrations. Manage ingestion connections (source + config + an encrypted secret).
+ * The whole /admin subtree is admin-gated by the layout. Reads use the service-role client
+ * (already past the admin gate) so `hasSecret` is derivable; the secret value is never sent
+ * to the browser — only `hasSecret`. The ingestion sidecar pulls these via GET /api/v1/connections.
+ */
+export default async function IntegrationsPage({ params }: { params: Promise<{ team: string }> }) {
+  const { team: teamSlug } = await params;
+  const supabase = adminClient();
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  const connections: ConnectionRow[] = (await listConnections(supabase, team.id)).map((c) => ({
+    id: c.id,
+    source: c.source,
+    name: c.name,
+    config: c.config,
+    enabled: c.enabled,
+    hasSecret: c.hasSecret,
+  }));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h1 className="text-xl font-semibold text-ink">Integrations</h1>
+        <p className="mt-1 text-sm text-ink-secondary">
+          Connect sources for the ingestion sidecar (Slack, GitHub, Notion, …). Secrets are stored
+          encrypted and never shown again; the sidecar fetches enabled connections to run ingestion.
+        </p>
+      </div>
+      <ConnectionsManager teamSlug={teamSlug} connections={connections} />
+    </div>
+  );
+}

--- a/components/admin/admin-tabs.tsx
+++ b/components/admin/admin-tabs.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 const TABS = [
   { slug: "members", label: "Members" },
   { slug: "keys", label: "API keys" },
+  { slug: "integrations", label: "Integrations" },
   { slug: "audit", label: "Audit log" },
 ];
 

--- a/components/admin/connections-manager.tsx
+++ b/components/admin/connections-manager.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Plug, Plus, Trash2, KeyRound } from "lucide-react";
+import {
+  addConnection,
+  setConnectionEnabled,
+  rotateConnectionSecret,
+  removeConnection,
+} from "@/app/t/[team]/admin/integrations/actions";
+
+export interface ConnectionRow {
+  id: string;
+  source: string;
+  name: string;
+  config: Record<string, unknown>;
+  enabled: boolean;
+  hasSecret: boolean;
+}
+
+const SOURCES = ["slack", "github", "notion", "gdrive", "confluence", "linear", "web"];
+
+export function ConnectionsManager({
+  teamSlug,
+  connections,
+}: {
+  teamSlug: string;
+  connections: ConnectionRow[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({ source: "slack", name: "", channels: "", secret: "" });
+
+  function run(fn: () => Promise<{ ok: boolean; error?: string }>) {
+    setError(null);
+    startTransition(async () => {
+      const res = await fn();
+      if (!res.ok) setError(res.error ?? "something went wrong");
+      else router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Add form */}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          run(async () => {
+            const res = await addConnection(teamSlug, form);
+            if (res.ok) setForm({ source: "slack", name: "", channels: "", secret: "" });
+            return res;
+          });
+        }}
+        className="prism-card flex flex-col gap-3 p-4"
+      >
+        <p className="flex items-center gap-2 text-sm font-medium text-ink">
+          <Plus className="size-4 text-violet" /> Add a connection
+        </p>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <select
+            value={form.source}
+            onChange={(e) => setForm({ ...form, source: e.target.value })}
+            className="prism-input"
+          >
+            {SOURCES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <input
+            className="prism-input"
+            placeholder="name (e.g. eng-slack)"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            required
+          />
+        </div>
+        <input
+          className="prism-input"
+          placeholder="channel IDs / paths (comma-separated, optional)"
+          value={form.channels}
+          onChange={(e) => setForm({ ...form, channels: e.target.value })}
+        />
+        <input
+          className="prism-input"
+          type="password"
+          autoComplete="off"
+          placeholder="secret token (e.g. xoxb-… for Slack) — stored encrypted"
+          value={form.secret}
+          onChange={(e) => setForm({ ...form, secret: e.target.value })}
+        />
+        <button type="submit" disabled={pending} className="btn-prism justify-center">
+          <Plug className="size-4" /> Save connection
+        </button>
+        {error ? <p className="text-sm text-red">{error}</p> : null}
+      </form>
+
+      {/* List */}
+      {connections.length === 0 ? (
+        <p className="text-sm text-ink-tertiary">No connections yet. Add one above.</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {connections.map((c) => (
+            <div key={c.id} className="prism-card flex flex-wrap items-center gap-3 px-4 py-3">
+              <span className="rounded-full bg-violet/10 px-2 py-0.5 font-mono text-xs text-violet">
+                {c.source}
+              </span>
+              <span className="font-medium text-ink">{c.name}</span>
+              <span className="text-xs text-ink-tertiary">
+                {Array.isArray(c.config.channel_ids)
+                  ? `${(c.config.channel_ids as string[]).length} channel(s)`
+                  : ""}
+                {c.hasSecret ? " · secret set" : " · no secret"}
+              </span>
+              <div className="ml-auto flex items-center gap-2">
+                <button
+                  onClick={() => run(() => setConnectionEnabled(teamSlug, c.id, !c.enabled))}
+                  disabled={pending}
+                  className={`rounded-lg border px-3 py-1 text-xs font-medium ${
+                    c.enabled
+                      ? "border-violet/40 bg-violet/10 text-violet"
+                      : "border-border-default text-ink-tertiary"
+                  }`}
+                >
+                  {c.enabled ? "Enabled" : "Disabled"}
+                </button>
+                <button
+                  onClick={() => {
+                    const s = window.prompt(`New secret for ${c.name}:`);
+                    if (s) run(() => rotateConnectionSecret(teamSlug, c.id, s));
+                  }}
+                  disabled={pending}
+                  className="rounded-lg border border-border-default p-1.5 text-ink-secondary hover:text-ink"
+                  aria-label="Rotate secret"
+                >
+                  <KeyRound className="size-4" />
+                </button>
+                <button
+                  onClick={() => {
+                    if (window.confirm(`Delete connection "${c.name}"?`))
+                      run(() => removeConnection(teamSlug, c.id));
+                  }}
+                  disabled={pending}
+                  className="rounded-lg border border-border-default p-1.5 text-ink-secondary hover:text-red"
+                  aria-label="Delete connection"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,7 @@ Reason from this table, not from a random call site.
 | Git-author aliases | `member_emails` (+ `members.github_login`/`avatar_url`) | `lib/admin/*` + GitHub sync (`lib/codebases/github`) | `lib/codebases/ingest` (author→member), dashboard | team-scoped `unique(team_id,email)`; one alias → one member |
 | Sessions (postgres) | `auth_users`, `auth_tokens` | `lib/auth/pg-*` | `getSessionUser` | signed httpOnly cookie |
 | Rate limits | `rate_limits` | `rate_limit_hit` rpc | — | service-role only |
+| Connections (integrations) | `connections` | **`lib/connections` only** (single-writer guarded) | Admin → Integrations page; `GET /api/v1/connections` (sidecar) | secret **encrypted at rest** (`lib/secrets`, AES-256-GCM); plaintext only on the connector-key read path (audited); admin-gated writes |
 | Codebase analytics | `codebases`, `code_metrics`, `code_contributions`, `github_issues` | **`lib/codebases/ingest` only** (single-writer guarded; via `POST /api/v1/codebases`) | codebases pages, `lib/metrics/codebases` | team-tier only; **app-code gate** (`lib/codebases/visibility` + guard) — no RLS backstop |
 
 ## System context
@@ -270,8 +271,9 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/okf-bundle` — OKF link graph (tier-filtered, link redaction)
 - `POST /api/v1/actions` — request a policy-gated action (Organ 4)
 - `POST /api/v1/codebases` — ingest a codebase scan (raw metrics; team-tier key only, audited)
+- `GET /api/v1/connections` — sidecar pulls enabled connections + decrypted secrets (connector key; audited)
 - `POST /api/dashboard/query` — same query pipeline, session-authenticated
-- `POST /api/auth/login` — postgres-mode magic-link request (invite-only; always `{ok:true}`)
+- `POST /api/auth/login` — postgres-mode direct passwordless sign-in (invite-only; 403 if unknown)
 <!-- /drift:routes -->
 
 ### Database tables
@@ -280,7 +282,8 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 `auth_users` · `auth_tokens` · `teams` · `members` · `api_keys` · `audit_log` · `rate_limits` ·
 `projects` · `items` · `item_versions` · `tasks` · `decisions` · `graph_entities` ·
 `graph_relationships` · `query_log` · `policies` · `approval_requests` · `actions` ·
-`codebases` · `code_metrics` · `code_contributions` · `github_issues` · `member_emails`
+`codebases` · `code_metrics` · `code_contributions` · `github_issues` · `member_emails` ·
+`connections`
 <!-- /drift:tables -->
 
 ### Ingestion sources

--- a/lib/connections/index.ts
+++ b/lib/connections/index.ts
@@ -1,0 +1,150 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { encryptSecret, decryptSecret } from "@/lib/secrets/crypto";
+
+/**
+ * Ingestion connections (Integrations settings) — the SOLE writer of the `connections`
+ * table. Secrets are encrypted at rest (lib/secrets); plaintext only crosses this boundary
+ * on input (set*) and on the sidecar read path (getEnabledConnectionsWithSecrets). Metadata
+ * reads never include the secret. Team-scoped throughout.
+ */
+
+export interface ConnectionMeta {
+  id: string;
+  source: string;
+  name: string;
+  config: Record<string, unknown>;
+  enabled: boolean;
+  hasSecret: boolean;
+  createdAt: string;
+}
+
+export interface ConnectionWithSecret {
+  source: string;
+  name: string;
+  config: Record<string, unknown>;
+  secret: string | null;
+  enabled: boolean;
+}
+
+type Row = {
+  id: string;
+  source: string;
+  name: string;
+  config: Record<string, unknown> | null;
+  enabled: boolean;
+  secret_ciphertext: string | null;
+  created_at: string;
+};
+
+/** List a team's connections as METADATA only — never returns the secret. */
+export async function listConnections(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<ConnectionMeta[]> {
+  const { data, error } = await supabase
+    .from("connections")
+    .select("id, source, name, config, enabled, secret_ciphertext, created_at")
+    .eq("team_id", teamId)
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(`list connections failed: ${error.message}`);
+  return (data ?? []).map((r: Row) => ({
+    id: r.id,
+    source: r.source,
+    name: r.name,
+    config: r.config ?? {},
+    enabled: r.enabled,
+    hasSecret: r.secret_ciphertext != null,
+    createdAt: r.created_at,
+  }));
+}
+
+export async function createConnection(
+  supabase: SupabaseClient,
+  args: {
+    teamId: string;
+    source: string;
+    name: string;
+    config?: Record<string, unknown>;
+    secret?: string | null;
+    createdBy?: string | null;
+  }
+): Promise<{ id: string }> {
+  const secret_ciphertext =
+    args.secret != null && args.secret !== "" ? encryptSecret(args.secret) : null;
+  const { data, error } = await supabase
+    .from("connections")
+    .insert({
+      team_id: args.teamId,
+      source: args.source,
+      name: args.name,
+      config: args.config ?? {},
+      secret_ciphertext,
+      created_by: args.createdBy ?? null,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`create connection failed: ${error?.message}`);
+  return { id: data.id };
+}
+
+export async function updateConnection(
+  supabase: SupabaseClient,
+  args: {
+    teamId: string;
+    id: string;
+    config?: Record<string, unknown>;
+    enabled?: boolean;
+    /** Provide to rotate the secret; omit (undefined) to leave it unchanged. */
+    secret?: string;
+  }
+): Promise<void> {
+  const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (args.config !== undefined) patch.config = args.config;
+  if (args.enabled !== undefined) patch.enabled = args.enabled;
+  if (args.secret !== undefined && args.secret !== "") {
+    patch.secret_ciphertext = encryptSecret(args.secret);
+  }
+  const { error } = await supabase
+    .from("connections")
+    .update(patch)
+    .eq("team_id", args.teamId)
+    .eq("id", args.id);
+  if (error) throw new Error(`update connection failed: ${error.message}`);
+}
+
+export async function deleteConnection(
+  supabase: SupabaseClient,
+  teamId: string,
+  id: string
+): Promise<void> {
+  const { error } = await supabase
+    .from("connections")
+    .delete()
+    .eq("team_id", teamId)
+    .eq("id", id);
+  if (error) throw new Error(`delete connection failed: ${error.message}`);
+}
+
+/**
+ * The sidecar read path: enabled connections with DECRYPTED secrets. Only call from the
+ * connector-key-authenticated endpoint (GET /api/v1/connections), never from a page.
+ */
+export async function getEnabledConnectionsWithSecrets(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<ConnectionWithSecret[]> {
+  const { data, error } = await supabase
+    .from("connections")
+    .select("source, name, config, enabled, secret_ciphertext")
+    .eq("team_id", teamId)
+    .eq("enabled", true);
+  if (error) throw new Error(`load connections failed: ${error.message}`);
+  return (data ?? []).map((r: Omit<Row, "id" | "created_at">) => ({
+    source: r.source,
+    name: r.name,
+    config: r.config ?? {},
+    enabled: r.enabled,
+    secret: r.secret_ciphertext ? decryptSecret(r.secret_ciphertext) : null,
+  }));
+}

--- a/lib/secrets/crypto.test.ts
+++ b/lib/secrets/crypto.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { randomBytes } from "node:crypto";
+import { encryptSecret, decryptSecret, generateSecretsKey } from "@/lib/secrets/crypto";
+
+const KEY = randomBytes(32);
+
+describe("connector secret crypto (AES-256-GCM)", () => {
+  it("round-trips plaintext", () => {
+    const token = "xoxb-1234567890-abcdefABCDEF";
+    expect(decryptSecret(encryptSecret(token, KEY), KEY)).toBe(token);
+  });
+
+  it("produces a different ciphertext each time (random IV)", () => {
+    expect(encryptSecret("same", KEY)).not.toBe(encryptSecret("same", KEY));
+  });
+
+  it("fails to decrypt with the wrong key", () => {
+    const blob = encryptSecret("secret", KEY);
+    expect(() => decryptSecret(blob, randomBytes(32))).toThrow();
+  });
+
+  it("detects tampering (auth tag)", () => {
+    const blob = encryptSecret("secret", KEY);
+    const buf = Buffer.from(blob, "base64");
+    buf[buf.length - 1] ^= 0xff; // flip a ciphertext bit
+    expect(() => decryptSecret(buf.toString("base64"), KEY)).toThrow();
+  });
+
+  it("rejects a malformed/too-short blob", () => {
+    expect(() => decryptSecret("AAAA", KEY)).toThrow();
+  });
+
+  it("generateSecretsKey yields a 32-byte base64 key", () => {
+    expect(Buffer.from(generateSecretsKey(), "base64").length).toBe(32);
+  });
+});

--- a/lib/secrets/crypto.ts
+++ b/lib/secrets/crypto.ts
@@ -1,0 +1,58 @@
+import "server-only";
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+/**
+ * Symmetric encryption for connector secrets at rest (Integrations settings). AES-256-GCM:
+ * authenticated, so tampering with the stored ciphertext is detected on decrypt. The key
+ * comes from the server-only `SECRETS_KEY` env (32 bytes, base64 or hex) — never the client.
+ * Stored blob layout (base64): iv(12) || authTag(16) || ciphertext.
+ */
+
+const IV_LEN = 12; // GCM standard nonce
+const TAG_LEN = 16;
+const KEY_LEN = 32; // AES-256
+
+/** Resolve the 32-byte key from `SECRETS_KEY` (base64 or hex). Throws if unusable. */
+export function secretsKey(): Buffer {
+  const raw = process.env.SECRETS_KEY;
+  if (!raw) {
+    throw new Error("SECRETS_KEY is required to store/read connector secrets (32 bytes, base64 or hex).");
+  }
+  const key = decodeKey(raw);
+  if (key.length !== KEY_LEN) {
+    throw new Error(`SECRETS_KEY must decode to ${KEY_LEN} bytes (got ${key.length}).`);
+  }
+  return key;
+}
+
+function decodeKey(raw: string): Buffer {
+  const trimmed = raw.trim();
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) return Buffer.from(trimmed, "hex");
+  return Buffer.from(trimmed, "base64");
+}
+
+/** Encrypt plaintext → base64(iv|tag|ciphertext). `key` defaults to SECRETS_KEY. */
+export function encryptSecret(plaintext: string, key: Buffer = secretsKey()): string {
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ct]).toString("base64");
+}
+
+/** Decrypt a base64(iv|tag|ciphertext) blob. Throws on a bad key or tampered data. */
+export function decryptSecret(blob: string, key: Buffer = secretsKey()): string {
+  const buf = Buffer.from(blob, "base64");
+  if (buf.length < IV_LEN + TAG_LEN) throw new Error("ciphertext too short / malformed");
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+  const ct = buf.subarray(IV_LEN + TAG_LEN);
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+}
+
+/** Generate a fresh base64 SECRETS_KEY (for provisioning a deployment). */
+export function generateSecretsKey(): string {
+  return randomBytes(KEY_LEN).toString("base64");
+}

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -461,3 +461,22 @@ create table if not exists github_issues (
 );
 create index if not exists github_issues_codebase_state_idx
   on github_issues (codebase_id, state, updated_at desc);
+
+-- Ingestion connections (Integrations settings). Holds per-team connector config and an
+-- ENCRYPTED secret (AES-256-GCM via lib/secrets) — the plaintext token never lives in the
+-- DB. Admins manage these in the dashboard; the ingestion sidecar pulls enabled connections
+-- (with decrypted secrets) from GET /api/v1/connections. Sole writer: lib/connections.
+create table if not exists connections (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  source text not null,                         -- 'slack' | 'github' | 'notion' | ...
+  name text not null,                           -- human label, unique per team
+  config jsonb not null default '{}',           -- NON-secret config (channel_ids, etc.)
+  secret_ciphertext text,                       -- AES-256-GCM blob (base64); null if none
+  enabled boolean not null default true,
+  created_by uuid references members(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (team_id, name)
+);
+create index if not exists connections_team_idx on connections (team_id, source);

--- a/supabase/migrations/20260619120000_connections.sql
+++ b/supabase/migrations/20260619120000_connections.sql
@@ -1,0 +1,44 @@
+-- 0008 (legacy supabase mode) ingestion connections for the Integrations settings page.
+-- Canonical schema is postgres/schema.sql; this mirrors it for DB_BACKEND=supabase.
+-- Holds an ENCRYPTED secret (AES-256-GCM via lib/secrets) — never plaintext. RLS: admins
+-- manage; the secret_ciphertext column is revoked from clients (like api_keys.key_hash),
+-- so even an admin select can't read it back — only the service role (sidecar endpoint) can.
+
+create table connections (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  source text not null,
+  name text not null,
+  config jsonb not null default '{}',
+  secret_ciphertext text,
+  enabled boolean not null default true,
+  created_by uuid references members(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (team_id, name)
+);
+create index connections_team_idx on connections (team_id, source);
+
+alter table connections enable row level security;
+
+create policy connections_admin_select on connections for select
+  to authenticated
+  using (team_id in (select private.my_team_ids()) and private.my_role(team_id) = 'admin');
+
+create policy connections_admin_insert on connections for insert
+  to authenticated
+  with check (private.my_role(team_id) = 'admin');
+
+create policy connections_admin_update on connections for update
+  to authenticated
+  using (private.my_role(team_id) = 'admin')
+  with check (private.my_role(team_id) = 'admin');
+
+create policy connections_admin_delete on connections for delete
+  to authenticated
+  using (private.my_role(team_id) = 'admin');
+
+-- The encrypted secret is never readable by client roles (defense in depth atop encryption).
+revoke select (secret_ciphertext) on connections from authenticated;
+revoke insert (secret_ciphertext) on connections from authenticated;
+revoke update (secret_ciphertext) on connections from authenticated;

--- a/test/datamechanics/connections.datamechanics.test.ts
+++ b/test/datamechanics/connections.datamechanics.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  createConnection,
+  listConnections,
+  updateConnection,
+  getEnabledConnectionsWithSecrets,
+} from "@/lib/connections";
+import { db, seedTeam } from "./helpers";
+
+// Spec: connector secrets are stored ENCRYPTED, metadata reads never expose them, and the
+// sidecar read path decrypts them. Verified to the observable outcome on real Postgres.
+
+describe("connections store (real Postgres)", () => {
+  it("encrypts the secret at rest; metadata lists hasSecret but never the value", async () => {
+    const seed = await seedTeam();
+    const token = "xoxb-REAL-slack-token-abc123";
+    await createConnection(db(), {
+      teamId: seed.teamId, source: "slack", name: "eng-slack",
+      config: { channel_ids: ["C1", "C2"] }, secret: token,
+    });
+
+    // Raw row: ciphertext present and NOT the plaintext.
+    const { data: raw } = await db()
+      .from("connections").select("secret_ciphertext").eq("team_id", seed.teamId).maybeSingle();
+    expect(raw!.secret_ciphertext).toBeTruthy();
+    expect(raw!.secret_ciphertext).not.toContain(token);
+
+    // Metadata list: hasSecret true, config preserved, no plaintext/ciphertext leaked.
+    const list = await listConnections(db(), seed.teamId);
+    expect(list).toHaveLength(1);
+    expect(list[0].hasSecret).toBe(true);
+    expect(list[0].config).toEqual({ channel_ids: ["C1", "C2"] });
+    expect(JSON.stringify(list[0])).not.toContain(token);
+  });
+
+  it("the sidecar read path decrypts the secret back to plaintext", async () => {
+    const seed = await seedTeam();
+    const token = "xoxb-round-trip";
+    await createConnection(db(), { teamId: seed.teamId, source: "slack", name: "s", secret: token });
+
+    const enabled = await getEnabledConnectionsWithSecrets(db(), seed.teamId);
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0].secret).toBe(token);
+  });
+
+  it("disabled connections are excluded from the sidecar read path", async () => {
+    const seed = await seedTeam();
+    const { id } = await createConnection(db(), {
+      teamId: seed.teamId, source: "notion", name: "n", secret: "secret_xyz",
+    });
+    await updateConnection(db(), { teamId: seed.teamId, id, enabled: false });
+    expect(await getEnabledConnectionsWithSecrets(db(), seed.teamId)).toHaveLength(0);
+  });
+
+  it("update rotates the secret only when provided", async () => {
+    const seed = await seedTeam();
+    const { id } = await createConnection(db(), {
+      teamId: seed.teamId, source: "slack", name: "rot", secret: "old-token",
+    });
+    await updateConnection(db(), { teamId: seed.teamId, id, config: { channel_ids: ["X"] } });
+    expect((await getEnabledConnectionsWithSecrets(db(), seed.teamId))[0].secret).toBe("old-token");
+    await updateConnection(db(), { teamId: seed.teamId, id, secret: "new-token" });
+    expect((await getEnabledConnectionsWithSecrets(db(), seed.teamId))[0].secret).toBe("new-token");
+  });
+});

--- a/test/guards/single-writer-connections.test.ts
+++ b/test/guards/single-writer-connections.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Single-writer guard for the `connections` table (Integrations settings). It holds the
+ * encrypted connector secrets, so only `lib/connections` may write it — that module owns
+ * encryption-on-write and the decrypt-on-read path. This fails the build if any other file
+ * inserts/updates/upserts/deletes `connections`, so a future surface can't bypass the
+ * encryption boundary. (Reads — `.select` — are fine.)
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCAN_DIRS = ["app", "lib", "scripts"];
+const OWNER = join("lib", "connections");
+const WRITE_RE = /from\(\s*["']connections["']\s*\)\s*\.\s*(insert|update|upsert|delete)\b/g;
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+function offenders(): string[] {
+  const hits: string[] = [];
+  for (const d of SCAN_DIRS) {
+    for (const file of walk(join(ROOT, d))) {
+      const rel = file.slice(ROOT.length + 1);
+      if (rel.startsWith(OWNER)) continue;
+      if (rel.endsWith(".test.ts") || rel.includes("fake-supabase")) continue;
+      const src = readFileSync(file, "utf8");
+      for (const m of src.matchAll(WRITE_RE)) hits.push(`${rel}: .from("connections").${m[1]}(`);
+    }
+  }
+  return hits.sort();
+}
+
+describe("single-writer: connections", () => {
+  it("only lib/connections writes the connections table", () => {
+    const violations = offenders();
+    expect(
+      violations,
+      `connections written outside lib/connections (the encryption-owning writer):\n${violations.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("the matcher discriminates (non-vacuity)", () => {
+    const W = () => new RegExp(WRITE_RE.source, "g");
+    expect(W().test('supabase.from("connections").insert(rec)')).toBe(true);
+    expect(W().test('supabase.from("connections").select("id")')).toBe(false);
+  });
+});

--- a/vitest.datamechanics.config.ts
+++ b/vitest.datamechanics.config.ts
@@ -20,6 +20,8 @@ if (!databaseTestUrl) {
 process.env.DB_BACKEND = "postgres";
 process.env.NEXT_PUBLIC_DB_BACKEND = "postgres";
 process.env.DATABASE_URL = databaseTestUrl;
+// Fixed test key for connector-secret crypto (lib/secrets); not a real secret.
+process.env.SECRETS_KEY ??= Buffer.alloc(32, 7).toString("base64");
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Self-serve **Admin → Integrations** page so admins set connector credentials (Slack token, etc.) in the dashboard instead of editing Railway env vars. Secrets are **AES-256-GCM encrypted at rest**; the ingestion sidecar pulls enabled connections (with decrypted secrets) from `GET /api/v1/connections` using its connector API key (audited).

- `connections` table (canonical `postgres/schema.sql` + legacy supabase migration with admin RLS + secret-column revoke)
- `lib/secrets` AES-256-GCM (keyed by `SECRETS_KEY`); `lib/connections` is the sole writer (single-writer guard); metadata reads never expose the secret
- Admin page + server actions (admin-gated); secrets write-only in the UI
- Tests: unit 83/83 (incl 6 crypto), data-mechanics 32/32 (incl 4 connections: encrypted-at-rest, list hides secret, decrypt round-trip, disabled excluded, rotate)

Prereq for prod (rolled out after merge): set `SECRETS_KEY` env + create the `connections` table (`pg:schema`).

Verified: tsc clean, drift green, all tiers green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)