### PR TITLE
feat(metrics): AEM individual-scope maturity ingest + dashboard

### DIFF
--- a/app/api/v1/metrics/route.ts
+++ b/app/api/v1/metrics/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { maturitySnapshotPayloadSchema, errorResponse } from "@/lib/api/schemas";
+import { ingestMaturitySnapshot } from "@/lib/metrics/individual-maturity-ingest";
+
+export const runtime = "nodejs";
+
+const MAX_PAYLOAD = 100_000; // 100 KB — one day's aggregate is tiny (ratios + counts)
+
+export async function POST(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+
+  // Agentic-maturity is team-tier only: an external-tier key may neither push nor read.
+  if (auth.memberTier !== "team") {
+    return errorResponse("forbidden_tier", "agentic-maturity metrics are team-tier only", 403);
+  }
+
+  const supabase = adminClient();
+  if (!(await rateLimit(supabase, `${auth.apiKeyId}:metrics:post`, 60))) {
+    return errorResponse("rate_limited", "60 snapshots/min per key", 429);
+  }
+
+  const len = parseInt(req.headers.get("content-length") || "0", 10);
+  if (len > MAX_PAYLOAD * 1.2) return errorResponse("payload_too_large", "max 100 KB", 413);
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return errorResponse("invalid_payload", "body must be JSON", 422);
+  }
+
+  const parsed = maturitySnapshotPayloadSchema.safeParse(json);
+  if (!parsed.success) {
+    return errorResponse("invalid_payload", parsed.error.issues[0]?.message ?? "invalid", 422);
+  }
+
+  try {
+    const result = await ingestMaturitySnapshot(supabase, auth, parsed.data);
+    return Response.json({ status: "ok", ...result }, { status: 201 });
+  } catch (e) {
+    return errorResponse("internal", e instanceof Error ? e.message : "snapshot ingest failed", 500);
+  }
+}

--- a/app/t/[team]/maturity/page.tsx
+++ b/app/t/[team]/maturity/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Gauge } from "lucide-react";
 import { isPostgresBackend } from "@/lib/db/backend";
 import { serverClient } from "@/lib/supabase/server";
@@ -50,6 +51,12 @@ export default async function MaturityPage({
           <p className="text-sm text-ink-secondary">
             How agent-ready the team&apos;s codebases are, scored against the AEM rubric.
           </p>
+          <Link
+            href={`/t/${teamSlug}/maturity/people`}
+            className="mt-1 inline-block text-sm text-ink-secondary underline-offset-2 hover:text-ink hover:underline"
+          >
+            View individual maturity (per-person, from agent sessions) →
+          </Link>
         </div>
         <RangeSelector value={range} />
       </div>

--- a/app/t/[team]/maturity/people/[handle]/page.tsx
+++ b/app/t/[team]/maturity/people/[handle]/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { isPostgresBackend } from "@/lib/db/backend";
+import { serverClient } from "@/lib/supabase/server";
+import { currentMember } from "@/lib/auth/guard";
+import { getMemberMaturity, AXIS_META, type AemAxes } from "@/lib/metrics/individual-maturity";
+import { MaturityRadar, type RadarDatum } from "@/components/charts/maturity-radar";
+import { MaturityTimeline } from "@/components/charts/maturity-timeline";
+
+export const metadata: Metadata = { title: "Member maturity" };
+
+function radarData(axes: AemAxes, team: AemAxes): RadarDatum[] {
+  return AXIS_META.map((a) => ({ axis: a.label, you: axes[a.key], team: team[a.key] }));
+}
+
+export default async function MemberMaturityPage({
+  params,
+}: {
+  params: Promise<{ team: string; handle: string }>;
+}) {
+  if (!isPostgresBackend()) return null;
+
+  const { team: teamSlug, handle } = await params;
+  const supabase = await serverClient();
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  const me = await currentMember(team.id);
+  if (!me) return null;
+
+  // Tier-gated read; external viewers and unknown handles → 404.
+  const data = await getMemberMaturity(supabase, team.id, handle, me.tier);
+  if (!data) notFound();
+
+  const { latest, timeline, teamAxes, prescription } = data;
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-5">
+      <Link href={`/t/${teamSlug}/maturity/people`} className="inline-flex items-center gap-1.5 text-sm text-ink-secondary hover:text-ink">
+        <ArrowLeft className="h-4 w-4" /> Individual Maturity
+      </Link>
+
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-ink">{data.name}</h1>
+          <p className="text-sm text-ink-secondary">
+            @{data.handle} · latest snapshot {latest.date}
+          </p>
+        </div>
+        <div className="text-right">
+          <div className="font-mono text-lg text-ink">{latest.spine}</div>
+          <div className="text-xs text-ink-subtle">overall {latest.overall.toFixed(2)}/4</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <MaturityRadar
+          data={radarData(latest.axes, teamAxes)}
+          primaryLabel={data.handle}
+          showTeam
+          title="Axes vs. team average"
+          hint="scored 0–4"
+        />
+        <MaturityTimeline data={timeline.map((t) => ({ date: t.date, overall: t.overall }))} />
+      </div>
+
+      <div className="card flex flex-col gap-2 p-5">
+        <h3 className="text-sm font-semibold text-ink">Next move</h3>
+        <p className="text-sm text-ink-secondary">
+          Weakest axis: <span className="font-medium text-ink">{AXIS_META.find((a) => a.key === latest.weakest)?.label}</span>.
+        </p>
+        <p className="text-sm text-ink-secondary">→ {prescription}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/t/[team]/maturity/people/page.tsx
+++ b/app/t/[team]/maturity/people/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Gauge } from "lucide-react";
+import { isPostgresBackend } from "@/lib/db/backend";
+import { serverClient } from "@/lib/supabase/server";
+import { currentMember } from "@/lib/auth/guard";
+import { getTeamMaturity, AXIS_META, type AemAxes } from "@/lib/metrics/individual-maturity";
+import { EmptyState } from "@/components/empty-state";
+import { MaturityRadar, type RadarDatum } from "@/components/charts/maturity-radar";
+
+export const metadata: Metadata = { title: "Individual Maturity" };
+
+const SPINE_ORDER = ["L1", "L2", "L3", "L4", "L5"];
+const SPINE_LABEL: Record<string, string> = {
+  L1: "Prompting", L2: "Prompt Eng", L3: "Context Eng", L4: "Agentic Eng", L5: "Orchestration",
+};
+
+function radarData(axes: AemAxes): RadarDatum[] {
+  return AXIS_META.map((a) => ({ axis: a.label, you: axes[a.key] }));
+}
+
+export default async function MaturityPage({ params }: { params: Promise<{ team: string }> }) {
+  // Maturity analytics live only on the postgres backend (canonical schema).
+  if (!isPostgresBackend()) return null;
+
+  const { team: teamSlug } = await params;
+  const supabase = await serverClient();
+  const { data: team } = await supabase.from("teams").select("id, name").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  const me = await currentMember(team.id);
+  if (!me) return null;
+
+  // Read helper enforces the team-tier gate (external → empty board).
+  const { members, teamAxes, spineDistribution, asOf } = await getTeamMaturity(supabase, team.id, me.tier);
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-5">
+      <div>
+        <h1 className="text-2xl font-semibold text-ink">Individual Maturity</h1>
+        <p className="text-sm text-ink-secondary">
+          Per-person AEM placement from local agent sessions (Claude Code · Codex · Cursor).
+          {asOf ? ` Latest snapshot ${asOf}.` : ""}
+        </p>
+      </div>
+
+      {members.length === 0 ? (
+        <EmptyState
+          icon={Gauge}
+          title="No maturity snapshots yet"
+          action="Snapshots appear after a teammate runs `aios analyze --push` from their workspace. Raw sessions stay on their machine — only daily aggregate scores are pushed."
+        />
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <MaturityRadar
+              data={radarData(teamAxes)}
+              primaryLabel="Team avg"
+              title="Team radar"
+              hint={`average across ${members.length} member(s)`}
+            />
+            <div className="card flex flex-col gap-3 p-5">
+              <h3 className="text-sm font-semibold text-ink">Spine distribution</h3>
+              <div className="flex flex-col gap-2">
+                {SPINE_ORDER.map((lvl) => {
+                  const n = spineDistribution[lvl] ?? 0;
+                  const pct = members.length ? Math.round((n / members.length) * 100) : 0;
+                  return (
+                    <div key={lvl} className="flex items-center gap-3 text-sm">
+                      <span className="w-8 font-mono text-ink">{lvl}</span>
+                      <span className="w-28 text-ink-secondary">{SPINE_LABEL[lvl]}</span>
+                      <div className="h-2 flex-1 overflow-hidden rounded-full bg-surface-sunken">
+                        <div className="h-full rounded-full bg-gradient-prism" style={{ width: `${pct}%` }} />
+                      </div>
+                      <span className="w-8 text-right tabular-nums text-ink-secondary">{n}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          <div className="card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border-subtle text-left text-xs uppercase tracking-wide text-ink-subtle">
+                  <th className="px-4 py-3 font-medium">Member</th>
+                  <th className="px-4 py-3 font-medium">Spine</th>
+                  <th className="px-4 py-3 font-medium">Overall</th>
+                  <th className="px-4 py-3 font-medium">Weakest axis</th>
+                  <th className="px-4 py-3 text-right font-medium">Tasks</th>
+                </tr>
+              </thead>
+              <tbody>
+                {members.map((m) => (
+                  <tr key={m.member_id} className="border-b border-border-subtle/50 last:border-0 hover:bg-surface-raised/50">
+                    <td className="px-4 py-3">
+                      <Link href={`/t/${teamSlug}/maturity/people/${m.handle}`} className="font-medium text-ink hover:text-gradient-prism">
+                        {m.name}
+                      </Link>
+                      <span className="ml-2 text-xs text-ink-subtle">@{m.handle}</span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="rounded-full bg-surface-sunken px-2 py-0.5 font-mono text-xs text-ink">{m.spine}</span>
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-ink-secondary">{m.overall.toFixed(2)}</td>
+                    <td className="px-4 py-3 text-ink-secondary">
+                      {AXIS_META.find((a) => a.key === m.weakest)?.label}
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums text-ink-secondary">{m.tasks}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/charts/maturity-radar.tsx
+++ b/components/charts/maturity-radar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Legend,
+  Tooltip,
+} from "recharts";
+import { PRISM, GRID_STROKE, TOOLTIP_STYLE } from "./palette";
+import { ChartCard } from "./chart-card";
+
+export type RadarDatum = { axis: string; you: number; team?: number };
+
+/**
+ * AEM 5-axis radar (scores 0–4). Optionally overlays a second series (e.g. the
+ * team average) for comparison on the member deep-dive.
+ */
+export function MaturityRadar({
+  data,
+  primaryLabel = "Score",
+  showTeam = false,
+  title = "Maturity radar",
+  hint = "axes scored 0–4",
+}: {
+  data: RadarDatum[];
+  primaryLabel?: string;
+  showTeam?: boolean;
+  title?: string;
+  hint?: string;
+}) {
+  return (
+    <ChartCard title={title} hint={hint} empty={data.length === 0}>
+      <ResponsiveContainer width="100%" height={300}>
+        <RadarChart data={data} outerRadius="72%">
+          <PolarGrid stroke={GRID_STROKE} />
+          <PolarAngleAxis dataKey="axis" tick={{ fill: "var(--color-ink-subtle)", fontSize: 11 }} />
+          <PolarRadiusAxis domain={[0, 4]} tickCount={5} tick={{ fill: "var(--color-ink-subtle)", fontSize: 10 }} />
+          {showTeam && (
+            <Radar name="Team avg" dataKey="team" stroke={PRISM.cyan} fill={PRISM.cyan} fillOpacity={0.12} strokeWidth={1.5} />
+          )}
+          <Radar name={primaryLabel} dataKey="you" stroke={PRISM.violet} fill={PRISM.violet} fillOpacity={0.3} strokeWidth={2} />
+          {showTeam && <Legend wrapperStyle={{ fontSize: 11 }} />}
+          <Tooltip contentStyle={TOOLTIP_STYLE} />
+        </RadarChart>
+      </ResponsiveContainer>
+    </ChartCard>
+  );
+}

--- a/components/charts/maturity-timeline.tsx
+++ b/components/charts/maturity-timeline.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import {
+  Line,
+  LineChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { AXIS_TICK, GRID_STROKE, PRISM, TOOLTIP_STYLE } from "./palette";
+import { ChartCard } from "./chart-card";
+
+export type TimelinePoint = { date: string; overall: number };
+
+/** Overall AEM score (0–4) over time — shows progression as the loop re-assesses. */
+export function MaturityTimeline({ data }: { data: TimelinePoint[] }) {
+  return (
+    <ChartCard title="Progression" hint="overall score over time" empty={data.length < 2}>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart data={data} margin={{ top: 4, right: 8, left: -24, bottom: 0 }}>
+          <CartesianGrid vertical={false} stroke={GRID_STROKE} />
+          <XAxis dataKey="date" tick={AXIS_TICK} tickLine={false} axisLine={false} minTickGap={28} />
+          <YAxis tick={AXIS_TICK} tickLine={false} axisLine={false} width={32} domain={[0, 4]} />
+          <Tooltip contentStyle={TOOLTIP_STYLE} />
+          <Line type="monotone" dataKey="overall" name="Overall" stroke={PRISM.violet} strokeWidth={1.75} dot={false} connectNulls />
+        </LineChart>
+      </ResponsiveContainer>
+    </ChartCard>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -274,6 +274,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `POST /api/v1/actions` — request a policy-gated action (Organ 4)
 - `POST /api/v1/codebases` — ingest a codebase scan (raw metrics; team-tier key only, audited)
 - `GET /api/v1/integrations` — sidecar pulls enabled integrations + decrypted secrets (connector key; audited)
+- `POST /api/v1/metrics` — ingest an AEM individual maturity daily snapshot (team-tier key only; brain recomputes canonical scores; audited)
 - `POST /api/dashboard/query` — same query pipeline, session-authenticated
 - `POST /api/auth/login` — postgres-mode direct passwordless sign-in (invite-only; 403 if unknown)
 <!-- /drift:routes -->
@@ -285,7 +286,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 `projects` · `items` · `item_versions` · `tasks` · `decisions` · `graph_entities` ·
 `graph_relationships` · `query_log` · `policies` · `approval_requests` · `actions` ·
 `codebases` · `code_metrics` · `code_contributions` · `github_issues` · `member_emails` ·
-`integrations`
+`integrations` · `agentic_maturity_snapshots`
 <!-- /drift:tables -->
 
 ### Ingestion sources

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -138,6 +138,41 @@ export const codebaseScanPayloadSchema = z.object({
 });
 export type CodebaseScanPayload = z.infer<typeof codebaseScanPayloadSchema>;
 
+// AEM individual-scope maturity signals (ratios + counts; the entire privacy
+// surface — no tool names, no branch, no cwd, no message text).
+export const aemSignalsSchema = z.object({
+  delegation_ratio: z.number().min(0).optional().default(0),
+  correction_loop_avg: z.number().min(0).optional().default(0),
+  error_rate: z.number().min(0).optional().default(0),
+  cost_per_task: z.number().min(0).optional().default(0),
+  tokens_per_task: z.number().min(0).optional().default(0),
+  cache_hit_rate: z.number().min(0).optional().default(0),
+  tool_diversity: z.number().min(0).optional().default(0),
+  verify_tool_rate: z.number().min(0).optional().default(0),
+  subagent_usage: z.number().min(0).optional().default(0),
+});
+
+export const maturitySnapshotPayloadSchema = z.object({
+  // optional; defaults to the authenticated key's member. A supplied handle must
+  // resolve to a member on the caller's team or the push is rejected.
+  member: z.string().max(120).nullable().optional(),
+  metric: z.string().max(60).optional().default("aem-individual"),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  window_days: z.number().int().positive().max(3650).optional().default(1),
+  signals: aemSignalsSchema,
+  // client-side provisional placement (persisted as provenance only)
+  provisional: z
+    .object({
+      spine: z.string().max(8).optional().default("L1"),
+      axes: z.record(z.string(), z.number()).optional().default({}),
+    })
+    .optional()
+    .default({ spine: "L1", axes: {} }),
+  sessions: z.number().int().nonnegative().optional().default(0),
+  tasks: z.number().int().nonnegative().optional().default(0),
+});
+export type MaturitySnapshotPayload = z.infer<typeof maturitySnapshotPayloadSchema>;
+
 export const querySchema = z.object({
   question: z.string().min(1).max(4000),
   project: z.string().nullable().optional(),

--- a/lib/metrics/individual-maturity-ingest.ts
+++ b/lib/metrics/individual-maturity-ingest.ts
@@ -1,0 +1,81 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { MaturitySnapshotPayload } from "@/lib/api/schemas";
+import { buildIdentityMap, resolveMember } from "@/lib/identity/resolve";
+import { audit } from "@/lib/api/audit";
+import { placement, type AemPlacement } from "@/lib/metrics/individual-maturity";
+
+/**
+ * The ONLY write path for `agentic_maturity_snapshots` (single-writer). The client
+ * (`aios analyze`) posts raw SIGNALS + a provisional placement; the canonical
+ * axis/Spine scores are recomputed HERE (lib/metrics/maturity.placement) so there
+ * is one scoring authority for team rollups. Idempotent on
+ * (team_id, member_id, snapshot_date, metric). Separated from the read helpers in
+ * maturity.ts so the maturity-tier-filter guard only polices reads.
+ */
+export async function ingestMaturitySnapshot(
+  supabase: SupabaseClient,
+  auth: { teamId: string; memberId: string; apiKeyId: string },
+  payload: MaturitySnapshotPayload
+): Promise<{ snapshot_id: string; member_id: string; canonical: AemPlacement }> {
+  // Resolve the member: an explicit handle must map to a team member; else self.
+  let memberId = auth.memberId;
+  if (payload.member) {
+    const map = await buildIdentityMap(supabase, auth.teamId);
+    const resolved = resolveMember(map, { key: payload.member });
+    if (!resolved) throw new Error(`unknown member handle '${payload.member}'`);
+    memberId = resolved;
+  }
+
+  const s = payload.signals;
+  const canonical = placement(s);
+
+  const { data, error } = await supabase
+    .from("agentic_maturity_snapshots")
+    .upsert(
+      {
+        team_id: auth.teamId,
+        member_id: memberId,
+        snapshot_date: payload.date,
+        metric: payload.metric,
+        window_days: payload.window_days,
+        delegation_ratio: s.delegation_ratio,
+        correction_loop_avg: s.correction_loop_avg,
+        error_rate: s.error_rate,
+        cost_per_task: s.cost_per_task,
+        tokens_per_task: s.tokens_per_task,
+        cache_hit_rate: s.cache_hit_rate,
+        tool_diversity: s.tool_diversity,
+        verify_tool_rate: s.verify_tool_rate,
+        subagent_usage: s.subagent_usage,
+        sessions: payload.sessions,
+        tasks: payload.tasks,
+        provisional_spine: payload.provisional.spine,
+        provisional_axes: JSON.stringify(payload.provisional.axes), // jsonb (postgres-only cast)
+        canonical_spine: canonical.spine,
+        canonical_verification: canonical.axes.verification,
+        canonical_context_hygiene: canonical.axes.context_hygiene,
+        canonical_autonomy: canonical.axes.autonomy,
+        canonical_learning: canonical.axes.learning,
+        canonical_cost_governance: canonical.axes.cost_governance,
+        canonical_overall: canonical.overall,
+      },
+      { onConflict: "team_id,member_id,snapshot_date,metric" }
+    )
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`maturity snapshot upsert failed: ${error?.message}`);
+
+  await audit(supabase, {
+    team_id: auth.teamId,
+    actor_kind: "api_key",
+    member_id: auth.memberId,
+    api_key_id: auth.apiKeyId,
+    action: "maturity.snapshot",
+    target_type: "member",
+    target_id: memberId,
+    meta: { date: payload.date, spine: canonical.spine, overall: canonical.overall, tasks: payload.tasks },
+  });
+
+  return { snapshot_id: data.id, member_id: memberId, canonical };
+}

--- a/lib/metrics/individual-maturity-visibility.ts
+++ b/lib/metrics/individual-maturity-visibility.ts
@@ -1,0 +1,17 @@
+import "server-only";
+import type { ViewerTier } from "@/lib/auth/visibility";
+
+/**
+ * Tier gate for agentic-maturity analytics (CLAUDE.md §5). Maturity intel is
+ * team-tier only — there is no per-row `access` column, so an `external`-tier
+ * viewer must see NOTHING. In postgres mode there is no RLS, so this app-code
+ * check is the SOLE enforcement; the maturity-tier-filter guard asserts every
+ * read helper in lib/metrics/maturity.ts routes through it.
+ */
+
+export type { ViewerTier };
+
+/** Whether a viewer of this tier may see any agentic-maturity analytics. */
+export function canSeeMaturity(tier: ViewerTier): boolean {
+  return tier === "team";
+}

--- a/lib/metrics/individual-maturity.test.ts
+++ b/lib/metrics/individual-maturity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { scoreAxes, spineLevel, placement, type AemSignals } from "./individual-maturity";
+
+// Spec-first: assertions derive from the AEM rubric (04-assessment-rubrics.md §1),
+// not from reading the implementation. The canonical brain scorer MUST agree with
+// the client scorer (scripts/analyze/aem.mjs) — these guard the shared thresholds
+// and the core rule: Spine is capped at L3 when Verification ≤ 1.
+
+const ZERO: AemSignals = {
+  delegation_ratio: 0, correction_loop_avg: 0, error_rate: 0, cost_per_task: 0,
+  tokens_per_task: 0, cache_hit_rate: 0, tool_diversity: 0, verify_tool_rate: 0,
+  subagent_usage: 0,
+};
+
+describe("AEM canonical scoring", () => {
+  it("scores all axes 0 for an empty signal set", () => {
+    expect(scoreAxes(ZERO)).toEqual({
+      verification: 0, context_hygiene: 0, autonomy: 0, learning: 0, cost_governance: 0,
+    });
+  });
+
+  it("verification reflects verify-tool rate bands", () => {
+    expect(scoreAxes({ ...ZERO, verify_tool_rate: 0.3 }).verification).toBe(4);
+    expect(scoreAxes({ ...ZERO, verify_tool_rate: 0.12 }).verification).toBe(3);
+    expect(scoreAxes({ ...ZERO, verify_tool_rate: 0.04 }).verification).toBe(2);
+    expect(scoreAxes({ ...ZERO, verify_tool_rate: 0 }).verification).toBe(0);
+  });
+
+  it("learning axis is capped at 3 (cross-session compounding is unobservable from logs)", () => {
+    expect(scoreAxes({ ...ZERO, tool_diversity: 50 }).learning).toBe(3);
+  });
+
+  it("cost & governance uses fresh-tokens-per-task inverted bands", () => {
+    expect(scoreAxes({ ...ZERO, tokens_per_task: 10_000 }).cost_governance).toBe(4);
+    expect(scoreAxes({ ...ZERO, tokens_per_task: 250_000 }).cost_governance).toBe(1);
+  });
+
+  // The core rule of the model.
+  it("GATE: caps Spine at L3 when verification ≤ 1, even with everything else strong", () => {
+    const strong: AemSignals = {
+      ...ZERO, verify_tool_rate: 0, cache_hit_rate: 0.8, delegation_ratio: 0.3,
+      subagent_usage: 0.5, tool_diversity: 8, tokens_per_task: 10_000,
+    };
+    const axes = scoreAxes(strong);
+    expect(axes.verification).toBe(0);
+    expect(spineLevel(axes, strong)).toBe("L3");
+  });
+
+  it("climbs past L3 once verification is present alongside autonomy", () => {
+    const strong: AemSignals = {
+      ...ZERO, verify_tool_rate: 0.3, cache_hit_rate: 0.8, delegation_ratio: 0.3,
+      subagent_usage: 0.5, tool_diversity: 8, tokens_per_task: 10_000,
+    };
+    const lvl = spineLevel(scoreAxes(strong), strong);
+    expect(["L4", "L5"]).toContain(lvl);
+  });
+
+  it("placement returns axes + spine + a 0–4 overall", () => {
+    const p = placement({ ...ZERO, verify_tool_rate: 0.3, cache_hit_rate: 0.6, tokens_per_task: 30_000 });
+    expect(p.spine).toMatch(/^L[1-5]$/);
+    expect(p.overall).toBeGreaterThanOrEqual(0);
+    expect(p.overall).toBeLessThanOrEqual(4);
+  });
+});

--- a/lib/metrics/individual-maturity.ts
+++ b/lib/metrics/individual-maturity.ts
@@ -1,0 +1,318 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { MaturitySnapshotPayload } from "@/lib/api/schemas";
+import { canSeeMaturity, type ViewerTier } from "@/lib/metrics/individual-maturity-visibility";
+
+/**
+ * Canonical AEM individual-scope scoring + the single write path for
+ * `agentic_maturity_snapshots`. The client (`scripts/analyze/aem.mjs`) computes a
+ * PROVISIONAL placement for its local report; the brain RECOMPUTES the canonical
+ * placement here from the pushed signals so team rollups have one authority. The
+ * thresholds below MUST stay in sync with aem.mjs (mirrored intentionally — there
+ * is no shared runtime between a Node CLI and this TS service).
+ *
+ * Maps to agentic-engineering-maturity/04-assessment-rubrics.md §1.
+ */
+
+export type AemSignals = MaturitySnapshotPayload["signals"];
+export type AemAxes = {
+  verification: number;
+  context_hygiene: number;
+  autonomy: number;
+  learning: number;
+  cost_governance: number;
+};
+export type AemPlacement = { axes: AemAxes; spine: string; overall: number };
+
+/** Axis order + labels for the radar (one source of truth for the UI). */
+export const AXIS_META: { key: keyof AemAxes; label: string }[] = [
+  { key: "verification", label: "Verification" },
+  { key: "context_hygiene", label: "Context hygiene" },
+  { key: "autonomy", label: "Autonomy / leash" },
+  { key: "learning", label: "Learning / compounding" },
+  { key: "cost_governance", label: "Cost & governance" },
+];
+
+/** Weakest axis → the next pattern to work on (mirrors the CLI report). */
+export const PRESCRIPTION: Record<keyof AemAxes, string> = {
+  verification: "B2 — give the agent a check it can run (tests/build) before you accept",
+  context_hygiene: "curate a CLAUDE.md and /clear between tasks; isolate exploration in subagents",
+  autonomy: "earn a longer leash: auto-accept low-risk actions behind a check",
+  learning: "feed corrections back into CLAUDE.md / build a reusable skill",
+  cost_governance: "tighten tokens-per-task: smaller fresh context, cheaper model tier",
+};
+
+/** First threshold whose `min` the value clears (bands sorted high→low). */
+function band(value: number, bands: [number, number][]): number {
+  for (const [min, score] of bands) if (value >= min) return score;
+  return 0;
+}
+
+// Verification: rate of verification-tool (shell) invocations — the agent running
+// checks it can act on. Coarse proxy (command bodies are intentionally invisible).
+export function scoreVerification(s: AemSignals): number {
+  return band(s.verify_tool_rate, [[0.25, 4], [0.12, 3], [0.04, 2], [0.005, 1]]);
+}
+// Context hygiene: prompt-cache hit rate (reuse of a maintained context).
+export function scoreContextHygiene(s: AemSignals): number {
+  return band(s.cache_hit_rate, [[0.7, 4], [0.5, 3], [0.3, 2], [0.05, 1]]);
+}
+// Autonomy / leash: delegation ratio + active permission management.
+export function scoreAutonomy(s: AemSignals): number {
+  const byDelegation = band(s.delegation_ratio, [[0.25, 4], [0.1, 3], [0.02, 2]]);
+  const floor = s.subagent_usage > 0 ? 1 : 0;
+  return Math.max(byDelegation, floor);
+}
+// Learning / compounding: tool-diversity proxy, CAPPED at 3 (logs can't observe
+// cross-session rule write-back).
+export function scoreLearning(s: AemSignals): number {
+  return Math.min(3, band(s.tool_diversity, [[6, 3], [3, 2], [1, 1]]));
+}
+// Cost & governance: fresh tokens per task (cache reads excluded), inverted bands.
+export function scoreCostGovernance(s: AemSignals): number {
+  if (s.tokens_per_task <= 0) return 0;
+  if (s.tokens_per_task <= 40_000) return 4;
+  if (s.tokens_per_task <= 90_000) return 3;
+  if (s.tokens_per_task <= 180_000) return 2;
+  return 1;
+}
+
+const VERIFICATION_GATE = 1; // cap Spine at L3 when verification ≤ this
+
+export function scoreAxes(s: AemSignals): AemAxes {
+  return {
+    verification: scoreVerification(s),
+    context_hygiene: scoreContextHygiene(s),
+    autonomy: scoreAutonomy(s),
+    learning: scoreLearning(s),
+    cost_governance: scoreCostGovernance(s),
+  };
+}
+
+/** Spine L1–L5 with the rubric's verification gate. Mirrors aem.mjs.spineLevel. */
+export function spineLevel(axes: AemAxes, s: AemSignals): string {
+  let level = 1;
+  if (axes.cost_governance >= 2 || axes.learning >= 1) level = 2;
+  if (axes.context_hygiene >= 2) level = 3;
+  if (axes.verification >= 2 && axes.autonomy >= 2) level = 4;
+  if (axes.autonomy >= 3 && axes.verification >= 3 && axes.learning >= 3 && s.subagent_usage >= 0.3) {
+    level = 5;
+  }
+  if (axes.verification <= VERIFICATION_GATE) level = Math.min(level, 3);
+  return `L${level}`;
+}
+
+export function placement(s: AemSignals): AemPlacement {
+  const axes = scoreAxes(s);
+  const overall = Math.round((Object.values(axes).reduce((a, b) => a + b, 0) / 5) * 100) / 100;
+  return { axes, spine: spineLevel(axes, s), overall };
+}
+
+// ── Dashboard reads (tier-gated; team-only, no RLS backstop) ─────────────────
+
+const AXIS_COLS = [
+  "canonical_verification", "canonical_context_hygiene", "canonical_autonomy",
+  "canonical_learning", "canonical_cost_governance",
+] as const;
+
+// Postgres `date` columns arrive as Date objects (at local midnight) via the pg
+// adapter; naive toISOString() is off-by-one. Format from local components, or
+// pass through an already-string value. Mirrors lib/metrics/codebases.dayStr.
+function dayStr(v: string | Date): string {
+  if (typeof v === "string") return v.slice(0, 10);
+  return `${v.getFullYear()}-${String(v.getMonth() + 1).padStart(2, "0")}-${String(v.getDate()).padStart(2, "0")}`;
+}
+
+type SnapshotRow = {
+  member_id: string;
+  snapshot_date: string | Date;
+  canonical_spine: string;
+  canonical_overall: number;
+  canonical_verification: number;
+  canonical_context_hygiene: number;
+  canonical_autonomy: number;
+  canonical_learning: number;
+  canonical_cost_governance: number;
+  tasks: number;
+  sessions: number;
+};
+
+function rowAxes(r: SnapshotRow): AemAxes {
+  return {
+    verification: Number(r.canonical_verification),
+    context_hygiene: Number(r.canonical_context_hygiene),
+    autonomy: Number(r.canonical_autonomy),
+    learning: Number(r.canonical_learning),
+    cost_governance: Number(r.canonical_cost_governance),
+  };
+}
+
+export type MemberMaturityCard = {
+  member_id: string;
+  handle: string;
+  name: string;
+  avatar_url: string | null;
+  date: string;
+  spine: string;
+  overall: number;
+  axes: AemAxes;
+  tasks: number;
+  weakest: keyof AemAxes;
+};
+
+export type TeamMaturity = {
+  asOf: string | null;
+  members: MemberMaturityCard[];
+  teamAxes: AemAxes;
+  spineDistribution: Record<string, number>;
+};
+
+function weakestOf(axes: AemAxes): keyof AemAxes {
+  return (Object.entries(axes) as [keyof AemAxes, number][]).sort((a, b) => a[1] - b[1])[0][0];
+}
+
+function averageAxes(rows: AemAxes[]): AemAxes {
+  const sum: AemAxes = { verification: 0, context_hygiene: 0, autonomy: 0, learning: 0, cost_governance: 0 };
+  for (const a of rows) for (const k of Object.keys(sum) as (keyof AemAxes)[]) sum[k] += a[k];
+  const n = rows.length || 1;
+  for (const k of Object.keys(sum) as (keyof AemAxes)[]) sum[k] = Math.round((sum[k] / n) * 100) / 100;
+  return sum;
+}
+
+/**
+ * Team view: each member's LATEST snapshot, the team-average axes (radar), and the
+ * Spine distribution. Team-tier only — an external viewer gets an empty board.
+ */
+export async function getTeamMaturity(
+  supabase: SupabaseClient,
+  teamId: string,
+  tier: ViewerTier
+): Promise<TeamMaturity> {
+  if (!canSeeMaturity(tier)) return { asOf: null, members: [], teamAxes: averageAxes([]), spineDistribution: {} };
+
+  const { data: snaps } = await supabase
+    .from("agentic_maturity_snapshots")
+    .select(
+      `member_id, snapshot_date, canonical_spine, canonical_overall, tasks, sessions, ${AXIS_COLS.join(", ")}`
+    )
+    .eq("team_id", teamId)
+    .eq("metric", "aem-individual")
+    .order("snapshot_date", { ascending: false });
+
+  const rows = (snaps ?? []) as unknown as SnapshotRow[];
+  // latest snapshot per member (rows already date-desc)
+  const latest = new Map<string, SnapshotRow>();
+  for (const r of rows) if (!latest.has(r.member_id)) latest.set(r.member_id, r);
+
+  const memberIds = [...latest.keys()];
+  const nameById = new Map<string, { handle: string; name: string; avatar: string | null }>();
+  if (memberIds.length) {
+    const { data: members } = await supabase
+      .from("members")
+      .select("id, actor_handle, display_name, avatar_url")
+      .in("id", memberIds);
+    for (const m of (members ?? []) as { id: string; actor_handle: string; display_name: string; avatar_url: string | null }[]) {
+      nameById.set(m.id, { handle: m.actor_handle, name: m.display_name, avatar: m.avatar_url });
+    }
+  }
+
+  const cards: MemberMaturityCard[] = [...latest.values()].map((r) => {
+    const axes = rowAxes(r);
+    const info = nameById.get(r.member_id);
+    return {
+      member_id: r.member_id,
+      handle: info?.handle ?? "unknown",
+      name: info?.name ?? "Unknown",
+      avatar_url: info?.avatar ?? null,
+      date: dayStr(r.snapshot_date),
+      spine: r.canonical_spine,
+      overall: Number(r.canonical_overall),
+      axes,
+      tasks: Number(r.tasks),
+      weakest: weakestOf(axes),
+    };
+  }).sort((a, b) => b.overall - a.overall);
+
+  const spineDistribution: Record<string, number> = {};
+  for (const c of cards) spineDistribution[c.spine] = (spineDistribution[c.spine] ?? 0) + 1;
+
+  return {
+    asOf: cards.length ? cards.map((c) => c.date).sort().at(-1)! : null,
+    members: cards,
+    teamAxes: averageAxes(cards.map((c) => c.axes)),
+    spineDistribution,
+  };
+}
+
+export type MemberTimelinePoint = { date: string } & AemAxes & { overall: number };
+export type MemberMaturity = {
+  handle: string;
+  name: string;
+  avatar_url: string | null;
+  latest: MemberMaturityCard;
+  timeline: MemberTimelinePoint[];
+  teamAxes: AemAxes;
+  prescription: string;
+};
+
+/**
+ * Member deep-dive: their snapshot timeline + latest placement + the team average
+ * (for the comparison radar) + the weakest-axis prescription. Team-tier only.
+ */
+export async function getMemberMaturity(
+  supabase: SupabaseClient,
+  teamId: string,
+  handle: string,
+  tier: ViewerTier
+): Promise<MemberMaturity | null> {
+  if (!canSeeMaturity(tier)) return null;
+
+  const { data: member } = await supabase
+    .from("members")
+    .select("id, actor_handle, display_name, avatar_url")
+    .eq("team_id", teamId)
+    .eq("actor_handle", handle)
+    .maybeSingle();
+  if (!member) return null;
+  const m = member as { id: string; actor_handle: string; display_name: string; avatar_url: string | null };
+
+  const { data: snaps } = await supabase
+    .from("agentic_maturity_snapshots")
+    .select(
+      `member_id, snapshot_date, canonical_spine, canonical_overall, tasks, sessions, ${AXIS_COLS.join(", ")}`
+    )
+    .eq("team_id", teamId)
+    .eq("member_id", m.id)
+    .eq("metric", "aem-individual")
+    .order("snapshot_date", { ascending: true });
+
+  const rows = (snaps ?? []) as unknown as SnapshotRow[];
+  if (!rows.length) return null;
+
+  const timeline: MemberTimelinePoint[] = rows.map((r) => ({
+    date: dayStr(r.snapshot_date),
+    overall: Number(r.canonical_overall),
+    ...rowAxes(r),
+  }));
+  const last = rows[rows.length - 1];
+  const axes = rowAxes(last);
+  const weakest = weakestOf(axes);
+  const latest: MemberMaturityCard = {
+    member_id: m.id, handle: m.actor_handle, name: m.display_name, avatar_url: m.avatar_url,
+    date: dayStr(last.snapshot_date), spine: last.canonical_spine, overall: Number(last.canonical_overall),
+    axes, tasks: Number(last.tasks), weakest,
+  };
+
+  // team average for the comparison overlay (reuse the team read, tier already checked)
+  const team = await getTeamMaturity(supabase, teamId, tier);
+
+  return {
+    handle: m.actor_handle,
+    name: m.display_name,
+    avatar_url: m.avatar_url,
+    latest,
+    timeline,
+    teamAxes: team.teamAxes,
+    prescription: PRESCRIPTION[weakest],
+  };
+}

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -474,6 +474,51 @@ create table if not exists github_issues (
 create index if not exists github_issues_codebase_state_idx
   on github_issues (codebase_id, state, updated_at desc);
 
+-- Agentic-maturity snapshots (AEM individual scope). One row per member per day,
+-- pushed by `aios analyze --push` from a member's LOCAL session logs (Claude/Codex/
+-- Cursor). Raw session content never leaves the machine — only the ratios + counts
+-- (the `signals`) and the scores below cross the boundary. The client sends its
+-- `provisional` placement; the brain RECOMPUTES the `canonical` axis/Spine scores
+-- from the signals (lib/metrics/individual-maturity) so team rollups have one authority.
+-- Team-tier only; POSTGRES-ONLY — no RLS backstop, app code is the tier gate.
+create table if not exists agentic_maturity_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  member_id uuid not null references members(id) on delete cascade,
+  snapshot_date date not null,
+  metric text not null default 'aem-individual',
+  window_days integer not null default 1,
+  -- raw signals (the entire privacy surface: ratios + counts, never content)
+  delegation_ratio numeric(6,4) not null default 0,
+  correction_loop_avg numeric(8,2) not null default 0,
+  error_rate numeric(6,4) not null default 0,
+  cost_per_task numeric(10,4) not null default 0,
+  tokens_per_task numeric(12,2) not null default 0,
+  cache_hit_rate numeric(6,4) not null default 0,
+  tool_diversity numeric(8,2) not null default 0,
+  verify_tool_rate numeric(6,4) not null default 0,
+  subagent_usage numeric(6,4) not null default 0,
+  sessions integer not null default 0,
+  tasks integer not null default 0,
+  -- client-side provisional placement (provenance; axes 0–4, spine L1–L5)
+  provisional_spine text not null default 'L1',
+  provisional_axes jsonb not null default '{}',
+  -- brain-recomputed canonical placement (the authority for rollups)
+  canonical_spine text not null default 'L1',
+  canonical_verification numeric(4,2) not null default 0,
+  canonical_context_hygiene numeric(4,2) not null default 0,
+  canonical_autonomy numeric(4,2) not null default 0,
+  canonical_learning numeric(4,2) not null default 0,
+  canonical_cost_governance numeric(4,2) not null default 0,
+  canonical_overall numeric(4,2) not null default 0,
+  created_at timestamptz not null default now(),
+  unique (team_id, member_id, snapshot_date, metric)
+);
+create index if not exists aem_snapshots_member_time_idx
+  on agentic_maturity_snapshots (member_id, snapshot_date desc);
+create index if not exists aem_snapshots_team_time_idx
+  on agentic_maturity_snapshots (team_id, snapshot_date desc);
+
 -- Integration selections. `config` holds NON-SECRET selection only (repos, channels, project
 -- slugs); the per-type allowlist + secret-key rejection (lib/api/schemas) keep secrets OUT of
 -- config. The connector secret (Slack/GitHub/… token) lives ENCRYPTED in `secret_ciphertext`

--- a/test/datamechanics/maturity-ingest.datamechanics.test.ts
+++ b/test/datamechanics/maturity-ingest.datamechanics.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { ingestMaturitySnapshot } from "@/lib/metrics/individual-maturity-ingest";
+import { createMember } from "@/lib/admin/members";
+import { maturitySnapshotPayloadSchema } from "@/lib/api/schemas";
+import { db, seedTeam } from "./helpers";
+
+// Spec-first, verified to the observable DB outcome: the brain recomputes canonical
+// AEM scores from pushed signals, the verification gate holds through persistence,
+// the snapshot is idempotent per (member, date), and member resolution is enforced.
+
+function snapshot(over: Record<string, unknown> = {}) {
+  return maturitySnapshotPayloadSchema.parse({
+    metric: "aem-individual",
+    date: "2026-06-18",
+    window_days: 1,
+    signals: {
+      delegation_ratio: 0.3, correction_loop_avg: 1.2, error_rate: 0.05,
+      cost_per_task: 0.4, tokens_per_task: 30_000, cache_hit_rate: 0.8,
+      tool_diversity: 8, verify_tool_rate: 0.3, subagent_usage: 0.5,
+    },
+    provisional: { spine: "L9-bogus", axes: { verification: 99 } }, // must NOT be trusted
+    sessions: 40, tasks: 130,
+    ...over,
+  });
+}
+
+async function ingest(seed: { teamId: string; memberId: string }, payload: ReturnType<typeof snapshot>) {
+  return ingestMaturitySnapshot(db(), { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: randomUUID() }, payload);
+}
+
+async function rowFor(teamId: string, memberId: string, date: string) {
+  const { data } = await db()
+    .from("agentic_maturity_snapshots")
+    .select("*")
+    .eq("team_id", teamId).eq("member_id", memberId).eq("snapshot_date", date)
+    .maybeSingle();
+  return data as Record<string, unknown> | null;
+}
+
+describe("agentic-maturity snapshot ingest (real Postgres)", () => {
+  it("persists raw signals + brain-recomputed canonical scores (ignoring client provisional)", async () => {
+    const seed = await seedTeam();
+    const res = await ingest(seed, snapshot());
+    expect(res.canonical.spine).toMatch(/^L[1-5]$/);
+
+    const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+    expect(row).not.toBeNull();
+    // raw signal stored
+    expect(Number(row!.cache_hit_rate)).toBeCloseTo(0.8, 4);
+    expect(Number(row!.tasks)).toBe(130);
+    // canonical recomputed by the brain (verify_tool_rate 0.3 → verification 4)
+    expect(Number(row!.canonical_verification)).toBe(4);
+    // provisional persisted verbatim as provenance, but NOT used as canonical
+    expect(row!.provisional_spine).toBe("L9-bogus");
+    expect(row!.canonical_spine).not.toBe("L9-bogus");
+  });
+
+  it("GATE through the DB: verification ≤ 1 caps canonical Spine at L3 even when else strong", async () => {
+    const seed = await seedTeam();
+    await ingest(seed, snapshot({
+      signals: {
+        delegation_ratio: 0.5, correction_loop_avg: 1, error_rate: 0,
+        cost_per_task: 0.1, tokens_per_task: 10_000, cache_hit_rate: 0.9,
+        tool_diversity: 10, verify_tool_rate: 0, subagent_usage: 0.6, // no verify tools
+      },
+    }));
+    const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+    expect(Number(row!.canonical_verification)).toBe(0);
+    expect(row!.canonical_spine).toBe("L3");
+  });
+
+  it("is idempotent per (member, date): re-push updates in place, no duplicate row", async () => {
+    const seed = await seedTeam();
+    await ingest(seed, snapshot({ tasks: 100 }));
+    await ingest(seed, snapshot({ tasks: 222 }));
+    const { data } = await db()
+      .from("agentic_maturity_snapshots")
+      .select("id")
+      .eq("team_id", seed.teamId).eq("member_id", seed.memberId).eq("snapshot_date", "2026-06-18");
+    expect((data as unknown[]).length).toBe(1);
+    const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+    expect(Number(row!.tasks)).toBe(222); // last write wins
+  });
+
+  it("an explicit member handle is resolved to that member; unknown handles are rejected", async () => {
+    const seed = await seedTeam();
+    const alex = await createMember(db(), seed.teamId, {
+      email: "alex@x.test", displayName: "Alex", actorHandle: "alex", role: "member",
+    });
+    const res = await ingest(seed, snapshot({ member: "alex" }));
+    expect(res.member_id).toBe(alex.id);
+
+    await expect(ingest(seed, snapshot({ member: "ghost" }))).rejects.toThrow(/unknown member/i);
+  });
+});

--- a/test/datamechanics/maturity-read.datamechanics.test.ts
+++ b/test/datamechanics/maturity-read.datamechanics.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { ingestMaturitySnapshot } from "@/lib/metrics/individual-maturity-ingest";
+import { getTeamMaturity, getMemberMaturity } from "@/lib/metrics/individual-maturity";
+import { createMember } from "@/lib/admin/members";
+import { maturitySnapshotPayloadSchema } from "@/lib/api/schemas";
+import { db, seedTeam } from "./helpers";
+
+// Spec-first, verified to the DB: the dashboard read layer aggregates latest
+// snapshots per member, builds the team radar + Spine distribution, exposes a
+// member timeline — and HARD-GATES external-tier viewers to nothing (no RLS).
+
+const DEFAULT_SIGNALS = {
+  delegation_ratio: 0.3, correction_loop_avg: 1, error_rate: 0,
+  cost_per_task: 0.4, tokens_per_task: 30_000, cache_hit_rate: 0.8,
+  tool_diversity: 8, verify_tool_rate: 0.3, subagent_usage: 0.5,
+};
+
+function snap(member: string, date: string, over: Record<string, unknown> = {}) {
+  return maturitySnapshotPayloadSchema.parse({
+    member, metric: "aem-individual", date, window_days: 1,
+    signals: DEFAULT_SIGNALS,
+    provisional: { spine: "L4", axes: {} },
+    sessions: 10, tasks: 50, ...over,
+  });
+}
+async function ingest(teamId: string, memberId: string, payload: ReturnType<typeof snap>) {
+  return ingestMaturitySnapshot(db(), { teamId, memberId, apiKeyId: randomUUID() }, payload);
+}
+
+describe("agentic-maturity dashboard reads (real Postgres)", () => {
+  it("team view aggregates each member's latest snapshot + Spine distribution", async () => {
+    const seed = await seedTeam();
+    const alex = await createMember(db(), seed.teamId, { email: "a@x.test", displayName: "Alex", actorHandle: "alex", role: "member" });
+    const sam = await createMember(db(), seed.teamId, { email: "s@x.test", displayName: "Sam", actorHandle: "sam", role: "member" });
+
+    // alex: two days — the later one (strong verify → L4+) must win over the earlier
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-17", { signals: { ...DEFAULT_SIGNALS, verify_tool_rate: 0 } }));
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-18"));
+    await ingest(seed.teamId, sam.id, snap("sam", "2026-06-18", { signals: { ...DEFAULT_SIGNALS, verify_tool_rate: 0 } }));
+
+    const team = await getTeamMaturity(db(), seed.teamId, "team");
+    expect(team.members.length).toBe(2);
+    const alexCard = team.members.find((m) => m.handle === "alex")!;
+    expect(alexCard.date).toBe("2026-06-18"); // latest wins
+    expect(alexCard.axes.verification).toBe(4);
+    // Sam was gated to L3 (verification 0); distribution reflects both members
+    const total = Object.values(team.spineDistribution).reduce((a, b) => a + b, 0);
+    expect(total).toBe(2);
+    expect(team.teamAxes.verification).toBeGreaterThan(0);
+  });
+
+  it("member deep-dive returns an ordered timeline + the latest placement", async () => {
+    const seed = await seedTeam();
+    const alex = await createMember(db(), seed.teamId, { email: "a@x.test", displayName: "Alex", actorHandle: "alex", role: "member" });
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-16"));
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-18"));
+
+    const m = await getMemberMaturity(db(), seed.teamId, "alex", "team");
+    expect(m).not.toBeNull();
+    expect(m!.timeline.map((t) => t.date)).toEqual(["2026-06-16", "2026-06-18"]); // ascending
+    expect(m!.latest.date).toBe("2026-06-18");
+    expect(m!.prescription).toBeTruthy();
+  });
+
+  it("GATE: an external-tier viewer sees an empty board and no member detail", async () => {
+    const seed = await seedTeam();
+    const alex = await createMember(db(), seed.teamId, { email: "a@x.test", displayName: "Alex", actorHandle: "alex", role: "member" });
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-18"));
+
+    const team = await getTeamMaturity(db(), seed.teamId, "external");
+    expect(team.members).toEqual([]);
+    expect(await getMemberMaturity(db(), seed.teamId, "alex", "external")).toBeNull();
+  });
+
+  it("an unknown handle returns null (not a crash)", async () => {
+    const seed = await seedTeam();
+    expect(await getMemberMaturity(db(), seed.teamId, "ghost", "team")).toBeNull();
+  });
+});

--- a/test/guards/maturity-tier-filter.test.ts
+++ b/test/guards/maturity-tier-filter.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Agentic-maturity tier-isolation guard (CLAUDE.md §5). Maturity analytics are
+ * team-tier only and there is NO RLS in postgres mode, so the app-code gate is the
+ * sole enforcement. The dashboard guard only watches `items`, so maturity reads
+ * need their own. This guard enforces:
+ *   (a) maturity dashboard PAGES never read the snapshots table directly — they go
+ *       through lib/metrics/maturity (so the gate can't be skipped per-page);
+ *   (b) every exported reader there applies the `canSeeMaturity(tier)` gate.
+ * The real proof is the data-mechanics isolation test; this fails fast in review.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const PAGES_DIR = join(ROOT, "app", "t");
+const HELPER = join(ROOT, "lib", "metrics", "individual-maturity.ts");
+const TABLE = /from\(\s*["']agentic_maturity_snapshots["']\s*\)/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".tsx") || p.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+describe("agentic-maturity tier isolation", () => {
+  it("dashboard pages never read the snapshots table directly (only via lib/metrics/maturity)", () => {
+    const offenders = walk(PAGES_DIR)
+      .filter((f) => TABLE.test(readFileSync(f, "utf8")))
+      .map((f) => f.slice(f.indexOf("app/")));
+    expect(
+      offenders,
+      `Pages read agentic_maturity_snapshots directly (no tier gate / no RLS backstop):\n${offenders.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("the read helper applies the canSeeMaturity tier gate", () => {
+    expect(readFileSync(HELPER, "utf8")).toMatch(/canSeeMaturity\s*\(/);
+  });
+
+  it("EVERY exported helper that reads the snapshots table gates on canSeeMaturity", () => {
+    const src = readFileSync(HELPER, "utf8");
+    const ungated = src
+      .split(/export async function /)
+      .slice(1)
+      .filter((chunk) => TABLE.test(chunk) && !/canSeeMaturity\s*\(/.test(chunk))
+      .map((chunk) => chunk.slice(0, chunk.indexOf("(")));
+    expect(
+      ungated,
+      `helper fn(s) read the snapshots table without a canSeeMaturity gate: ${ungated.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("the matcher discriminates (non-vacuity)", () => {
+    expect(TABLE.test('supabase.from("agentic_maturity_snapshots").select("x")')).toBe(true);
+    expect(TABLE.test('supabase.from("items").select("x")')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `POST /api/v1/metrics` — the **individual** counterpart to `/codebases` — ingesting a member's daily agentic-maturity aggregate from `aios analyze --push`, plus the dashboard to view it.

- The client sends raw **signals** + a **provisional** placement; the brain **recomputes the canonical** axis/Spine scores (`lib/metrics/maturity.placement`) so team rollups have one authority. It persists `signals`, `provisional`, and `canonical`.
- **Team-tier only** — `external`/`admin` rejected (403). There is no RLS backstop on the postgres target, so the app-code gate is the sole enforcement (CLAUDE.md §5).
- New `agentic_maturity_snapshots` table (one row per member per day, idempotent upsert).
- **Single-writer** ingest (`lib/metrics/maturity-ingest.ts`) + audit; **tier-gated reads** (`lib/metrics/maturity.ts`) behind `canSeeMaturity`, with a `test/guards/maturity-tier-filter.test.ts` guard.
- **Dashboard:** `/t/[team]/maturity` (team radar + Spine distribution + member table) and `/maturity/[handle]` (per-person radar vs team average, progression timeline, weakest-axis prescription).

## Paired PR (coupled)

Client + contract live in **aios-workspace#feat/aem-analyze** (`aios analyze`). Both build against the `POST /api/v1/metrics` section added to `docs/brain-api.md` there.

## How it was verified

- Full `tsc --noEmit`, `eslint`, and `next build` (both maturity routes compile).
- `scripts/check-docs-drift.mjs` green (route + table registered in `ARCHITECTURE.md`).
- Unit: `lib/metrics/maturity.test.ts` (scorer + verification gate).
- **Data-mechanics on real Postgres** (`test/datamechanics/maturity-{ingest,read}.datamechanics.test.ts`): canonical recompute, verification gate through persistence, idempotency, **external-tier isolation**, latest-per-member aggregation, date normalization.

> Deploy note: run `npm run pg:schema` against prod for the new table after merge.

---

## Reviewer prompt

Please focus your review on:

1. **Tier isolation (highest priority).** Maturity is team-only with no RLS. Confirm the route returns 403 for an `external` key and that **every** read in `lib/metrics/maturity.ts` routes through `canSeeMaturity` (the guard asserts this; try to add a read that bypasses it and confirm the guard fails). Verify the dashboard pages never touch the table directly.
2. **Single source of truth for scores.** The brain must IGNORE the client's `provisional` as authority and recompute `canonical` from `signals`. The data-mechanics test feeds a bogus `provisional.spine: "L9"` and asserts the stored canonical differs — confirm that's airtight.
3. **Scorer parity with the client.** `lib/metrics/maturity.ts` thresholds + the verification gate must match `aios-workspace/scripts/analyze/aem.mjs` exactly. Diff them.
4. **Single-writer + idempotency.** `agentic_maturity_snapshots` is upserted on `(team_id, member_id, snapshot_date, metric)`. Confirm re-push updates in place (no dup), and that `lib/metrics/maturity-ingest.ts` is the only writer.
5. **Member resolution.** A supplied `member` handle must resolve to a team member or reject; default is the authenticated key's member. Check `buildIdentityMap`/`resolveMember` usage.
6. **Next.js 16 / RSC boundaries.** Server-component pages reading the DB pass only serializable props to the `"use client"` recharts components. Confirm no client/server boundary smell and that the build's prerender step is happy.
7. **Date handling.** Postgres `date` columns return `Date` objects (off-by-one on naive `toISOString`); reads use a local-components `dayStr` helper. Verify that's correct across timezones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)