### PR TITLE
feat(integrations): self-serve admin UI + encrypted connector secrets (Option B)

### DIFF
--- a/app/api/v1/integrations/route.ts
+++ b/app/api/v1/integrations/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { errorResponse } from "@/lib/api/schemas";
+import { audit } from "@/lib/api/audit";
+import { getEnabledIntegrationsWithSecrets } from "@/lib/integrations/manage";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/v1/integrations — the ingestion sidecar pulls its team's enabled integrations
+ * (config + DECRYPTED secret) authenticated by its connector API key. The only path that
+ * emits plaintext connector secrets; every fetch is audited (`integrations.read`). Admins
+ * manage integrations in the dashboard (Admin → Integrations).
+ */
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+
+  const supabase = adminClient();
+  if (!(await rateLimit(supabase, `${auth.apiKeyId}:integrations:get`, 60))) {
+    return errorResponse("rate_limited", "60/min per key", 429);
+  }
+
+  try {
+    const integrations = await getEnabledIntegrationsWithSecrets(supabase, auth.teamId);
+    await audit(supabase, {
+      team_id: auth.teamId,
+      actor_kind: "api_key",
+      member_id: auth.memberId,
+      api_key_id: auth.apiKeyId,
+      action: "integrations.read",
+      meta: { count: integrations.length, types: integrations.map((i) => i.type) },
+    });
+    // Never echo the connector key; secrets are returned to the authenticated sidecar only.
+    return Response.json({ integrations });
+  } catch (e) {
+    return errorResponse("internal", e instanceof Error ? e.message : "failed", 500);
+  }
+}

--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -1,0 +1,121 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverClient } from "@/lib/supabase/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  upsertIntegration,
+  setIntegrationSecret,
+  setIntegrationStatus,
+  deleteIntegration,
+} from "@/lib/integrations/manage";
+import { IntegrationConfigError, type IntegrationType } from "@/lib/api/schemas";
+
+async function requireAdmin(teamSlug: string) {
+  const supabase = await serverClient();
+  const user = await getSessionUser();
+  if (!user) return null;
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+  const { data: me } = await supabase
+    .from("members")
+    .select("id, role")
+    .eq("team_id", team.id)
+    .eq("auth_user_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+  if (me?.role !== "admin") return null;
+  return { teamId: team.id, myMemberId: me.id as string };
+}
+
+function toList(raw: string): string[] {
+  return raw.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);
+}
+
+/** Map a single "selection" field to the per-type NON-SECRET config shape (validated downstream). */
+function buildConfig(type: IntegrationType, selection: string): Record<string, unknown> {
+  const list = toList(selection);
+  switch (type) {
+    case "slack": return { channelIds: list };
+    case "github": return { repos: list };
+    case "granola": return { matchKeywords: list };
+    case "wise": return list[0] ? { profileId: list[0] } : {};
+    case "linear": return list[0] ? { projectId: list[0] } : {};
+    case "plane": return list[0] ? { projectId: list[0] } : {};
+    default: return {};
+  }
+}
+
+export async function saveIntegration(
+  teamSlug: string,
+  form: { type: IntegrationType; name: string; selection: string; secret: string }
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  const name = form.name.trim();
+  if (!name) return { ok: false, error: "name is required" };
+  const auth = { teamId: ctx.teamId, memberId: ctx.myMemberId };
+  try {
+    const { id } = await upsertIntegration(adminClient(), auth, {
+      type: form.type,
+      name,
+      config: buildConfig(form.type, form.selection),
+      status: "enabled",
+    });
+    if (form.secret) await setIntegrationSecret(adminClient(), auth, id, form.secret);
+  } catch (e) {
+    if (e instanceof IntegrationConfigError) return { ok: false, error: e.message };
+    return { ok: false, error: e instanceof Error ? e.message : "could not save integration" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}
+
+export async function toggleIntegration(
+  teamSlug: string,
+  id: string,
+  status: "enabled" | "disabled"
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    await setIntegrationStatus(adminClient(), { teamId: ctx.teamId, memberId: ctx.myMemberId }, id, status);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not update" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}
+
+export async function rotateSecret(
+  teamSlug: string,
+  id: string,
+  secret: string
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  if (!secret) return { ok: false, error: "secret is required" };
+  try {
+    await setIntegrationSecret(adminClient(), { teamId: ctx.teamId, memberId: ctx.myMemberId }, id, secret);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not rotate" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}
+
+export async function removeIntegration(
+  teamSlug: string,
+  id: string
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    await deleteIntegration(adminClient(), { teamId: ctx.teamId, memberId: ctx.myMemberId }, id);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not delete" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}

--- a/app/t/[team]/admin/integrations/page.tsx
+++ b/app/t/[team]/admin/integrations/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { adminClient } from "@/lib/supabase/admin";
+import { listIntegrations } from "@/lib/integrations/read";
+import { IntegrationsManager, type IntegrationRow } from "@/components/admin/integrations-manager";
+
+export const metadata: Metadata = { title: "Integrations" };
+
+/**
+ * Admin → Integrations. Manage ingestion integrations (type + non-secret selection + an
+ * encrypted secret). The /admin subtree is admin-gated by the layout. Reads use the
+ * service-role client (already past the admin gate) so `hasSecret` is derivable; the secret
+ * value is never sent to the browser. The sidecar pulls these via GET /api/v1/integrations.
+ */
+export default async function IntegrationsPage({ params }: { params: Promise<{ team: string }> }) {
+  const { team: teamSlug } = await params;
+  const supabase = adminClient();
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  const integrations = (await listIntegrations(supabase, team.id)) as IntegrationRow[];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h1 className="text-xl font-semibold text-ink">Integrations</h1>
+        <p className="mt-1 text-sm text-ink-secondary">
+          Connect sources for the ingestion sidecar (Slack, GitHub, Notion, …). The selection
+          (channels/repos) and an encrypted secret are stored here; the sidecar fetches enabled
+          integrations to run ingestion. Secrets are stored encrypted and never shown again.
+        </p>
+      </div>
+      <IntegrationsManager teamSlug={teamSlug} integrations={integrations} />
+    </div>
+  );
+}

--- a/components/admin/admin-tabs.tsx
+++ b/components/admin/admin-tabs.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 const TABS = [
   { slug: "members", label: "Members" },
   { slug: "keys", label: "API keys" },
+  { slug: "integrations", label: "Integrations" },
   { slug: "audit", label: "Audit log" },
 ];
 

--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Plug, Plus, Trash2, KeyRound } from "lucide-react";
+import {
+  saveIntegration,
+  toggleIntegration,
+  rotateSecret,
+  removeIntegration,
+} from "@/app/t/[team]/admin/integrations/actions";
+
+type IntegrationType = "github" | "granola" | "slack" | "wise" | "linear" | "plane";
+
+export interface IntegrationRow {
+  id: string;
+  type: IntegrationType;
+  name: string;
+  config: Record<string, unknown>;
+  status: "enabled" | "disabled";
+  hasSecret: boolean;
+}
+
+const TYPES: IntegrationType[] = ["slack", "github", "granola", "linear", "plane", "wise"];
+
+// What the single "selection" field means per type (hint text + how config renders back).
+const SELECTION_HINT: Record<IntegrationType, string> = {
+  slack: "channel IDs (comma-separated)",
+  github: "repos owner/name (comma-separated)",
+  granola: "match keywords (comma-separated)",
+  linear: "project ID",
+  plane: "project ID",
+  wise: "profile ID",
+};
+
+function summarizeConfig(type: IntegrationType, config: Record<string, unknown>): string {
+  const arr = (k: string) => (Array.isArray(config[k]) ? (config[k] as string[]) : []);
+  if (type === "slack") return `${arr("channelIds").length} channel(s)`;
+  if (type === "github") return `${arr("repos").length} repo(s)`;
+  if (type === "granola") return `${arr("matchKeywords").length} keyword(s)`;
+  return Object.values(config)[0] ? String(Object.values(config)[0]) : "—";
+}
+
+export function IntegrationsManager({
+  teamSlug,
+  integrations,
+}: {
+  teamSlug: string;
+  integrations: IntegrationRow[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<{ type: IntegrationType; name: string; selection: string; secret: string }>({
+    type: "slack",
+    name: "",
+    selection: "",
+    secret: "",
+  });
+
+  function run(fn: () => Promise<{ ok: boolean; error?: string }>) {
+    setError(null);
+    startTransition(async () => {
+      const res = await fn();
+      if (!res.ok) setError(res.error ?? "something went wrong");
+      else router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          run(async () => {
+            const res = await saveIntegration(teamSlug, form);
+            if (res.ok) setForm({ type: form.type, name: "", selection: "", secret: "" });
+            return res;
+          });
+        }}
+        className="prism-card flex flex-col gap-3 p-4"
+      >
+        <p className="flex items-center gap-2 text-sm font-medium text-ink">
+          <Plus className="size-4 text-violet" /> Add an integration
+        </p>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <select
+            value={form.type}
+            onChange={(e) => setForm({ ...form, type: e.target.value as IntegrationType })}
+            className="prism-input"
+          >
+            {TYPES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          <input
+            className="prism-input"
+            placeholder="name (e.g. eng-slack)"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            required
+          />
+        </div>
+        <input
+          className="prism-input"
+          placeholder={SELECTION_HINT[form.type]}
+          value={form.selection}
+          onChange={(e) => setForm({ ...form, selection: e.target.value })}
+        />
+        <input
+          className="prism-input"
+          type="password"
+          autoComplete="off"
+          placeholder="secret token (e.g. xoxb-… for Slack) — stored encrypted, never shown again"
+          value={form.secret}
+          onChange={(e) => setForm({ ...form, secret: e.target.value })}
+        />
+        <button type="submit" disabled={pending} className="btn-prism justify-center">
+          <Plug className="size-4" /> Save integration
+        </button>
+        {error ? <p className="text-sm text-red">{error}</p> : null}
+      </form>
+
+      {integrations.length === 0 ? (
+        <p className="text-sm text-ink-tertiary">No integrations yet. Add one above.</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {integrations.map((i) => (
+            <div key={i.id} className="prism-card flex flex-wrap items-center gap-3 px-4 py-3">
+              <span className="rounded-full bg-violet/10 px-2 py-0.5 font-mono text-xs text-violet">{i.type}</span>
+              <span className="font-medium text-ink">{i.name}</span>
+              <span className="text-xs text-ink-tertiary">
+                {summarizeConfig(i.type, i.config)}
+                {i.hasSecret ? " · secret set" : " · no secret"}
+              </span>
+              <div className="ml-auto flex items-center gap-2">
+                <button
+                  onClick={() => run(() => toggleIntegration(teamSlug, i.id, i.status === "enabled" ? "disabled" : "enabled"))}
+                  disabled={pending}
+                  className={`rounded-lg border px-3 py-1 text-xs font-medium ${
+                    i.status === "enabled"
+                      ? "border-violet/40 bg-violet/10 text-violet"
+                      : "border-border-default text-ink-tertiary"
+                  }`}
+                >
+                  {i.status === "enabled" ? "Enabled" : "Disabled"}
+                </button>
+                <button
+                  onClick={() => {
+                    const s = window.prompt(`New secret for ${i.name}:`);
+                    if (s) run(() => rotateSecret(teamSlug, i.id, s));
+                  }}
+                  disabled={pending}
+                  className="rounded-lg border border-border-default p-1.5 text-ink-secondary hover:text-ink"
+                  aria-label="Rotate secret"
+                >
+                  <KeyRound className="size-4" />
+                </button>
+                <button
+                  onClick={() => {
+                    if (window.confirm(`Delete integration "${i.name}"?`)) run(() => removeIntegration(teamSlug, i.id));
+                  }}
+                  disabled={pending}
+                  className="rounded-lg border border-border-default p-1.5 text-ink-secondary hover:text-red"
+                  aria-label="Delete integration"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,7 @@ Reason from this table, not from a random call site.
 | Git-author aliases | `member_emails` (+ `members.github_login`/`avatar_url`) | `lib/admin/*` + GitHub sync (`lib/codebases/github`) | `lib/codebases/ingest` (author→member), dashboard | team-scoped `unique(team_id,email)`; one alias → one member |
 | Sessions (postgres) | `auth_users`, `auth_tokens` | `lib/auth/pg-*` | `getSessionUser` | signed httpOnly cookie |
 | Rate limits | `rate_limits` | `rate_limit_hit` rpc | — | service-role only |
+| Integrations | `integrations` | **`lib/integrations/manage` only** (single-writer guarded; admin actions) | Admin → Integrations page (`lib/integrations/read`); `GET /api/v1/integrations` (sidecar) | `config` is NON-secret (per-type allowlist + secret-key rejection); the connector secret is **encrypted at rest** in `secret_ciphertext` (`lib/secrets`, AES-256-GCM), plaintext only on the connector-key read path (audited); admin-gated writes; postgres-only |
 | Codebase analytics | `codebases`, `code_metrics`, `code_contributions`, `github_issues` | **`lib/codebases/ingest` only** (single-writer guarded; via `POST /api/v1/codebases`) | codebases pages, `lib/metrics/codebases` | team-tier only; **app-code gate** (`lib/codebases/visibility` + guard) — no RLS backstop |
 
 ## System context
@@ -272,8 +273,9 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/okf-bundle` — OKF link graph (tier-filtered, link redaction)
 - `POST /api/v1/actions` — request a policy-gated action (Organ 4)
 - `POST /api/v1/codebases` — ingest a codebase scan (raw metrics; team-tier key only, audited)
+- `GET /api/v1/integrations` — sidecar pulls enabled integrations + decrypted secrets (connector key; audited)
 - `POST /api/dashboard/query` — same query pipeline, session-authenticated
-- `POST /api/auth/login` — postgres-mode magic-link request (invite-only; always `{ok:true}`)
+- `POST /api/auth/login` — postgres-mode direct passwordless sign-in (invite-only; 403 if unknown)
 <!-- /drift:routes -->
 
 ### Database tables

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -258,5 +258,8 @@ export const integrationInputSchema = z.object({
   name: z.string().min(1).max(120),
   config: z.unknown().optional(),
   status: z.enum(INTEGRATION_STATUSES).optional(),
+  // Connector secret (e.g. a Slack `xoxb-` token). Stored ENCRYPTED, never in `config`.
+  // Omit to leave an existing secret unchanged; provide to set/rotate it.
+  secret: z.string().min(1).max(8192).optional(),
 });
 export type IntegrationInput = z.infer<typeof integrationInputSchema>;

--- a/lib/integrations/manage.ts
+++ b/lib/integrations/manage.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { audit } from "@/lib/api/audit";
+import { encryptSecret, decryptSecret } from "@/lib/secrets/crypto";
 import {
   validateIntegrationConfig,
   type IntegrationInput,
@@ -99,6 +100,66 @@ export async function deleteIntegration(
     target_type: "integration",
     target_id: id,
   });
+}
+
+/**
+ * Set/rotate an integration's connector secret (Option B: stored ENCRYPTED in the brain).
+ * Team-scoped write of the dedicated `secret_ciphertext` column — never `config`, so the
+ * config secret-key rejection is untouched. Audits that a secret was set (keys/flags only,
+ * never the value).
+ */
+export async function setIntegrationSecret(
+  supabase: SupabaseClient,
+  auth: IntegrationAuth,
+  id: string,
+  secret: string
+): Promise<void> {
+  const { error } = await supabase
+    .from("integrations")
+    .update({ secret_ciphertext: encryptSecret(secret), updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("team_id", auth.teamId);
+  if (error) throw new Error(`integration secret update failed: ${error.message}`);
+  await audit(supabase, {
+    team_id: auth.teamId,
+    actor_kind: "member",
+    member_id: auth.memberId,
+    action: "integration.secret_set",
+    target_type: "integration",
+    target_id: id,
+    meta: { secretSet: true }, // never the value
+  });
+}
+
+export interface IntegrationWithSecret {
+  id: string;
+  type: IntegrationType;
+  name: string;
+  config: Record<string, unknown>;
+  secret: string | null;
+}
+
+/**
+ * The sidecar read path: enabled integrations for a team with DECRYPTED secrets. Call ONLY
+ * from the connector-key-authenticated endpoint (GET /api/v1/integrations) — never a page.
+ */
+export async function getEnabledIntegrationsWithSecrets(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<IntegrationWithSecret[]> {
+  const { data, error } = await supabase
+    .from("integrations")
+    .select("id, type, name, config, secret_ciphertext")
+    .eq("team_id", teamId)
+    .eq("status", "enabled");
+  if (error) throw new Error(`load integrations failed: ${error.message}`);
+  return (data ?? []).map((r) => ({
+    id: r.id as string,
+    type: r.type as IntegrationType,
+    name: r.name as string,
+    config: (r.config as Record<string, unknown>) ?? {},
+    secret: r.secret_ciphertext ? decryptSecret(r.secret_ciphertext as string) : null,
+  }));
 }
 
 /** Re-exported for callers that branch on type without importing schemas directly. */

--- a/lib/integrations/read.ts
+++ b/lib/integrations/read.ts
@@ -1,0 +1,40 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { IntegrationType } from "@/lib/api/schemas";
+
+/**
+ * Integration reads for UI/admin surfaces. METADATA only — never the secret value (only
+ * `hasSecret`). Team-scoped; callers (admin pages/actions) gate on role. The privileged
+ * decrypt read used by the sidecar lives in manage.ts (getEnabledIntegrationsWithSecrets).
+ */
+
+export interface IntegrationMeta {
+  id: string;
+  type: IntegrationType;
+  name: string;
+  config: Record<string, unknown>;
+  status: "enabled" | "disabled";
+  hasSecret: boolean;
+  createdAt: string;
+}
+
+export async function listIntegrations(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<IntegrationMeta[]> {
+  const { data, error } = await supabase
+    .from("integrations")
+    .select("id, type, name, config, status, secret_ciphertext, created_at")
+    .eq("team_id", teamId)
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(`list integrations failed: ${error.message}`);
+  return (data ?? []).map((r) => ({
+    id: r.id as string,
+    type: r.type as IntegrationType,
+    name: r.name as string,
+    config: (r.config as Record<string, unknown>) ?? {},
+    status: r.status as "enabled" | "disabled",
+    hasSecret: r.secret_ciphertext != null,
+    createdAt: r.created_at as string,
+  }));
+}

--- a/lib/secrets/crypto.test.ts
+++ b/lib/secrets/crypto.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { randomBytes } from "node:crypto";
+import { encryptSecret, decryptSecret, generateSecretsKey } from "@/lib/secrets/crypto";
+
+const KEY = randomBytes(32);
+
+describe("connector secret crypto (AES-256-GCM)", () => {
+  it("round-trips plaintext", () => {
+    const token = "xoxb-1234567890-abcdefABCDEF";
+    expect(decryptSecret(encryptSecret(token, KEY), KEY)).toBe(token);
+  });
+
+  it("produces a different ciphertext each time (random IV)", () => {
+    expect(encryptSecret("same", KEY)).not.toBe(encryptSecret("same", KEY));
+  });
+
+  it("fails to decrypt with the wrong key", () => {
+    const blob = encryptSecret("secret", KEY);
+    expect(() => decryptSecret(blob, randomBytes(32))).toThrow();
+  });
+
+  it("detects tampering (auth tag)", () => {
+    const blob = encryptSecret("secret", KEY);
+    const buf = Buffer.from(blob, "base64");
+    buf[buf.length - 1] ^= 0xff; // flip a ciphertext bit
+    expect(() => decryptSecret(buf.toString("base64"), KEY)).toThrow();
+  });
+
+  it("rejects a malformed/too-short blob", () => {
+    expect(() => decryptSecret("AAAA", KEY)).toThrow();
+  });
+
+  it("generateSecretsKey yields a 32-byte base64 key", () => {
+    expect(Buffer.from(generateSecretsKey(), "base64").length).toBe(32);
+  });
+});

--- a/lib/secrets/crypto.ts
+++ b/lib/secrets/crypto.ts
@@ -1,0 +1,58 @@
+import "server-only";
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+/**
+ * Symmetric encryption for connector secrets at rest (Integrations settings). AES-256-GCM:
+ * authenticated, so tampering with the stored ciphertext is detected on decrypt. The key
+ * comes from the server-only `SECRETS_KEY` env (32 bytes, base64 or hex) — never the client.
+ * Stored blob layout (base64): iv(12) || authTag(16) || ciphertext.
+ */
+
+const IV_LEN = 12; // GCM standard nonce
+const TAG_LEN = 16;
+const KEY_LEN = 32; // AES-256
+
+/** Resolve the 32-byte key from `SECRETS_KEY` (base64 or hex). Throws if unusable. */
+export function secretsKey(): Buffer {
+  const raw = process.env.SECRETS_KEY;
+  if (!raw) {
+    throw new Error("SECRETS_KEY is required to store/read connector secrets (32 bytes, base64 or hex).");
+  }
+  const key = decodeKey(raw);
+  if (key.length !== KEY_LEN) {
+    throw new Error(`SECRETS_KEY must decode to ${KEY_LEN} bytes (got ${key.length}).`);
+  }
+  return key;
+}
+
+function decodeKey(raw: string): Buffer {
+  const trimmed = raw.trim();
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) return Buffer.from(trimmed, "hex");
+  return Buffer.from(trimmed, "base64");
+}
+
+/** Encrypt plaintext → base64(iv|tag|ciphertext). `key` defaults to SECRETS_KEY. */
+export function encryptSecret(plaintext: string, key: Buffer = secretsKey()): string {
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ct]).toString("base64");
+}
+
+/** Decrypt a base64(iv|tag|ciphertext) blob. Throws on a bad key or tampered data. */
+export function decryptSecret(blob: string, key: Buffer = secretsKey()): string {
+  const buf = Buffer.from(blob, "base64");
+  if (buf.length < IV_LEN + TAG_LEN) throw new Error("ciphertext too short / malformed");
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+  const ct = buf.subarray(IV_LEN + TAG_LEN);
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+}
+
+/** Generate a fresh base64 SECRETS_KEY (for provisioning a deployment). */
+export function generateSecretsKey(): string {
+  return randomBytes(KEY_LEN).toString("base64");
+}

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -468,19 +468,20 @@ create table if not exists github_issues (
 create index if not exists github_issues_codebase_state_idx
   on github_issues (codebase_id, state, updated_at desc);
 
--- Integration selections (Wave 1 framework). Holds NON-SECRET selection/config only —
--- e.g. which repos to scan, which Slack channels to ingest, a Linear/Plane project slug.
--- Secrets (tokens) live in the sidecar's env/connections.yaml and are merged locally by
--- (type, name); the brain never stores them. POSTGRES-ONLY: no RLS is defined here, so tier/
--- role isolation is enforced in app code (lib/integrations/read.ts) — there is no DB backstop.
--- No updated_at trigger exists in this schema; the single writer (lib/integrations/manage.ts)
--- must set updated_at = now() explicitly on update.
+-- Integration selections. `config` holds NON-SECRET selection only (repos, channels, project
+-- slugs); the per-type allowlist + secret-key rejection (lib/api/schemas) keep secrets OUT of
+-- config. The connector secret (Slack/GitHub/… token) lives ENCRYPTED in `secret_ciphertext`
+-- (AES-256-GCM via lib/secrets) so admins set it self-serve in the dashboard; plaintext is only
+-- produced on the connector-key read path (GET /api/v1/integrations, audited). POSTGRES-ONLY:
+-- no RLS — tier/role isolation is in app code. Single writer: lib/integrations/manage.ts (sets
+-- updated_at explicitly; no trigger).
 create table if not exists integrations (
   id uuid primary key default gen_random_uuid(),
   team_id uuid not null references teams(id) on delete cascade,
   type text not null check (type in ('github','granola','slack','wise','linear','plane')),
   name text not null,
   config jsonb not null default '{}',
+  secret_ciphertext text,                 -- AES-256-GCM blob (base64); null if no secret set
   status text not null default 'enabled' check (status in ('enabled','disabled')),
   created_by uuid references members(id) on delete set null,
   created_at timestamptz not null default now(),
@@ -488,3 +489,5 @@ create table if not exists integrations (
   unique (team_id, type, name)
 );
 create index if not exists integrations_team_type_idx on integrations (team_id, type);
+-- Additive column for existing deployments (idempotent rollout via `npm run pg:schema`).
+alter table integrations add column if not exists secret_ciphertext text;

--- a/test/datamechanics/integrations-secret.datamechanics.test.ts
+++ b/test/datamechanics/integrations-secret.datamechanics.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  upsertIntegration,
+  setIntegrationSecret,
+  setIntegrationStatus,
+  getEnabledIntegrationsWithSecrets,
+} from "@/lib/integrations/manage";
+import { listIntegrations } from "@/lib/integrations/read";
+import { db, seedTeam } from "./helpers";
+
+// Spec (Option B): the connector secret is stored ENCRYPTED in `integrations.secret_ciphertext`,
+// metadata reads never expose it, the sidecar read path decrypts it, and a config-only upsert
+// must NOT wipe an existing secret. Verified to the observable outcome on real Postgres.
+
+function auth(teamId: string, memberId: string) {
+  return { teamId, memberId };
+}
+
+describe("integrations secret (real Postgres)", () => {
+  it("encrypts the secret at rest; metadata never exposes it; sidecar read decrypts", async () => {
+    const seed = await seedTeam();
+    const a = auth(seed.teamId, seed.memberId);
+    const token = "xoxb-REAL-slack-token-abc123";
+
+    const { id } = await upsertIntegration(db(), a, {
+      type: "slack", name: "eng-slack", config: { channelIds: ["C1", "C2"] },
+    });
+    await setIntegrationSecret(db(), a, id, token);
+
+    // Raw row: ciphertext present and NOT the plaintext.
+    const { data: raw } = await db()
+      .from("integrations").select("secret_ciphertext").eq("id", id).maybeSingle();
+    expect(raw!.secret_ciphertext).toBeTruthy();
+    expect(raw!.secret_ciphertext).not.toContain(token);
+
+    // Admin metadata list: hasSecret true, never the value.
+    const list = await listIntegrations(db(), seed.teamId);
+    expect(list[0].hasSecret).toBe(true);
+    expect(JSON.stringify(list)).not.toContain(token);
+
+    // Sidecar read path decrypts.
+    const enabled = await getEnabledIntegrationsWithSecrets(db(), seed.teamId);
+    expect(enabled[0].secret).toBe(token);
+    expect(enabled[0].config).toEqual({ channelIds: ["C1", "C2"] });
+  });
+
+  it("a config-only upsert preserves the existing secret", async () => {
+    const seed = await seedTeam();
+    const a = auth(seed.teamId, seed.memberId);
+    const { id } = await upsertIntegration(db(), a, { type: "slack", name: "s", config: { channelIds: ["C1"] } });
+    await setIntegrationSecret(db(), a, id, "keep-me");
+
+    // Re-upsert same (type,name) with new config, no secret touched.
+    await upsertIntegration(db(), a, { type: "slack", name: "s", config: { channelIds: ["C1", "C9"] } });
+
+    const enabled = await getEnabledIntegrationsWithSecrets(db(), seed.teamId);
+    expect(enabled[0].secret).toBe("keep-me"); // not wiped by the config upsert
+    expect(enabled[0].config).toEqual({ channelIds: ["C1", "C9"] });
+  });
+
+  it("disabled integrations are excluded from the sidecar read path", async () => {
+    const seed = await seedTeam();
+    const a = auth(seed.teamId, seed.memberId);
+    const { id } = await upsertIntegration(db(), a, { type: "github", name: "g", config: { repos: ["o/r"] } });
+    await setIntegrationSecret(db(), a, id, "ghp_x");
+    await setIntegrationStatus(db(), a, id, "disabled");
+    expect(await getEnabledIntegrationsWithSecrets(db(), seed.teamId)).toHaveLength(0);
+  });
+});

--- a/test/datamechanics/setup.ts
+++ b/test/datamechanics/setup.ts
@@ -5,6 +5,7 @@ import { Client } from "pg";
 // before each test. One dedicated connection (separate from the app's pool) so
 // truncation can't deadlock against in-flight adapter queries.
 const DATA_TABLES = [
+  "integrations",
   "actions",
   "approval_requests",
   "policies",

--- a/vitest.datamechanics.config.ts
+++ b/vitest.datamechanics.config.ts
@@ -20,6 +20,8 @@ if (!databaseTestUrl) {
 process.env.DB_BACKEND = "postgres";
 process.env.NEXT_PUBLIC_DB_BACKEND = "postgres";
 process.env.DATABASE_URL = databaseTestUrl;
+// Fixed test key for integration-secret crypto (lib/secrets); not a real secret.
+process.env.SECRETS_KEY ??= Buffer.alloc(32, 7).toString("base64");
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Implements **Option B** as an *extension of main's merged `integrations` framework* (not a duplicate table). Admins manage integrations in the dashboard; the connector secret is stored **AES-256-GCM encrypted** in the brain and the sidecar pulls config + decrypted secret from `GET /api/v1/integrations`.

- `integrations.secret_ciphertext` column (canonical schema; additive, postgres-only). Config stays non-secret — the per-type allowlist + secret-key rejection are untouched; the secret lives in its own encrypted column.
- `lib/integrations/manage.ts`: `setIntegrationSecret` (encrypt; audits a flag, never the value) + `getEnabledIntegrationsWithSecrets` (decrypt; sidecar path). `lib/integrations/read.ts`: admin metadata list (hasSecret only).
- Admin → Integrations page + nav tab + server actions (admin-gated; secret write-only; config-only upsert preserves the secret).
- `lib/secrets` AES-256-GCM keyed by `SECRETS_KEY` (KMS-swap is a later hardening, not a redesign).

Tests: unit 104/104 (incl 6 crypto), data-mechanics 46/46 (incl 3: encrypted-at-rest+metadata-hides+sidecar-decrypts, config-upsert preserves secret, disabled excluded). tsc clean, drift green.

Prereq for prod (after merge): set `SECRETS_KEY` on Railway + `npm run pg:schema` (adds the column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)