### PR TITLE
feat(plane): backlog seed CLI + Plane integration wiring

### DIFF
--- a/docs/agent-handoffs.md
+++ b/docs/agent-handoffs.md
@@ -1,0 +1,233 @@
+# AIOS — Parallel Agent Handoff Prompts
+
+Each prompt below is **self-contained**: copy one verbatim into a **fresh Claude Code session**.
+Every agent works in its **own git worktree** off `origin/main` (never the primary checkout) and
+tracks its progress on the **Plane** board (AIOS project) via the Plane MCP — that's the workflow
+we're testing.
+
+## Parallelization waves (respect dependencies)
+- **Wave A — start in parallel now (no cross-deps):** `F3`, `W1.1`, `W1.2`, `W1.4`
+- **Wave B — after `F3` merges:** `F4`, `F5`
+- **Wave C — after `F5` merges:** `W1.3`
+- Wave 2 epics (`W2.*`) come after Wave 1; generate their prompts the same way.
+
+## Shared caveats for parallel runs
+- **Worktrees:** name each uniquely — `../aios-team-brain-<epic>` (e.g. `-f3`, `-w1.1`).
+- **Shared test Postgres:** `npm run db:test:up` **resets** the shared DB on port 5434. Don't run it
+  concurrently from two agents. Either (a) one agent brings it up and others just run
+  `npm run test:datamechanics:local`, or (b) give an agent its own DB:
+  `docker compose -f compose.test.yml -p <epic> up -d` on a different port. Data-mechanics tests seed
+  random team ids, so they don't collide once the schema is loaded — only the reset step is destructive.
+- **Plane MCP** must be connected (user-scope `plane` server). If `/mcp` doesn't list it, restart the session.
+- Some `F3` scaffolding (encrypted-secret storage in `lib/integrations/manage.ts`) may already exist on
+  `main` — **read main first and reconcile**, don't blindly recreate.
+
+---
+
+## Common preamble (already embedded in each prompt below — shown once for reference)
+
+> You are a senior engineer on **AIOS Team Brain** (Next.js 16 App Router · React 19 · TypeScript ·
+> Postgres via `lib/db/pg`). **First, read** the root `/Users/iamjohndass/Projects/aios/CLAUDE.md`
+> (it MANDATES git worktrees — follow it), this repo's `CLAUDE.md` + `AGENTS.md`, and
+> `docs/ARCHITECTURE.md` §1. Then set up your worktree:
+> ```bash
+> cd /Users/iamjohndass/Projects/aios/aios-team-brain
+> git fetch origin
+> git worktree add -b feat/<epic> ../aios-team-brain-<epic> origin/main
+> cd ../aios-team-brain-<epic>
+> ln -sfn /Users/iamjohndass/Projects/aios/aios-team-brain/node_modules node_modules
+> ```
+> **Plane tracking (workspace `aios-alpha`, project `AIOS`, via the Plane MCP):** find the epic and its
+> sub-issues; move the epic to **In Progress** when you start; move each sub-issue to **Done** as you
+> finish it; when you open the PR, **comment the PR URL on the epic** and move it to In Review/Done.
+> **Engineering rules:** spec-first **red** tests (unit = parse/guards; data-mechanics = persistence/tier;
+> over a real DB); **single-writer + build-failing guard** for any new write surface; **tier/role
+> isolation is app-code only** (no RLS on postgres) — add a scoped read helper + guard test per new table;
+> update `docs/ARCHITECTURE.md` `drift:*` blocks in the same PR; **version
+> `aios-workspace/docs/brain-api.md` first** for any `/api/v1` or ingest-contract change.
+> **Verify before PR:** `npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run check:docs`, and (if you
+> touched persistence) `npm run db:test:up && npm run test:datamechanics:local`. **Open the PR from your
+> worktree branch against `main`.** Do all commits in the worktree, never the primary checkout.
+
+---
+
+## F3 — Integrations auth surfaces + contract bump  (Wave A)
+
+```
+You are a senior engineer on AIOS Team Brain (Next.js 16 App Router, React 19, TypeScript, Postgres via lib/db/pg). Read /Users/iamjohndass/Projects/aios/CLAUDE.md (it MANDATES git worktrees — follow it), this repo's CLAUDE.md + AGENTS.md, and docs/ARCHITECTURE.md §1 before coding.
+
+Set up your worktree:
+  cd /Users/iamjohndass/Projects/aios/aios-team-brain
+  git fetch origin
+  git worktree add -b feat/f3-integrations-auth ../aios-team-brain-f3 origin/main
+  cd ../aios-team-brain-f3
+  ln -sfn /Users/iamjohndass/Projects/aios/aios-team-brain/node_modules node_modules
+
+Track progress in Plane via the Plane MCP (workspace aios-alpha, project AIOS): find epic "F3 — Integrations auth surfaces + contract bump" and its sub-issues (F3.1–F3.4). Move the epic to In Progress now; move each sub-issue to Done as you complete it; comment the PR URL on the epic when you open it.
+
+OBJECTIVE: give the integrations framework two auth surfaces WITHOUT touching the pinned /api/v1 write contract. Note: lib/integrations/manage.ts already exists (single writer + config validation) and may already have encrypted-secret storage — read it on main first and reconcile; do not duplicate.
+
+SCOPE (sub-issues):
+- F3.1 Dashboard session-auth WRITE: a server action (or app/api/dashboard/integrations/route.ts, matching the existing app/api/dashboard/query session-auth pattern) that calls lib/integrations/manage.ts. Admin-gated exactly like app/t/[team]/admin/layout.tsx (role==="admin"). NO new /api/v1 write route.
+- F3.2 GET /api/v1/integrations (API-key auth via lib/api/auth.ts): returns the team's NON-SECRET selections only (never secrets). This is the documented contract the sidecar consumes.
+- F3.3 Version aios-workspace/docs/brain-api.md FIRST (add the new read endpoint, bump the version note), then add the route to docs/ARCHITECTURE.md drift:routes. npm run check:docs must pass.
+- F3.4 Tests: data-mechanics (real PG) — a non-admin dashboard write is rejected; the API-key read returns only non-secret fields and is team-scoped. Spec-first/red-first.
+
+CONSTRAINTS: single-writer stays lib/integrations/manage.ts; tier/role isolation is app-code (no RLS); secret-like keys must never appear in non-secret selections.
+
+VERIFY: npx tsc --noEmit; npm run lint; npm test; npm run check:docs; npm run db:test:up && npm run test:datamechanics:local. Then open a PR from feat/f3-integrations-auth against main and comment the link on the Plane epic.
+```
+
+## F4 — Sidecar consumes selections  (Wave B — after F3 merges)
+
+```
+You are a senior engineer on AIOS (the Python ingestion sidecar in aios-team-brain/ingestion + the brain). Read /Users/iamjohndass/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, docs/ARCHITECTURE.md §1, and the ingestion source pattern (ingestion/aios_ingest/sources/registry.py, engine.py, brain_client.py). Requires F3 (GET /api/v1/integrations) merged to main — confirm it exists before starting.
+
+Worktree:
+  cd /Users/iamjohndass/Projects/aios/aios-team-brain
+  git fetch origin
+  git worktree add -b feat/f4-sidecar-selections ../aios-team-brain-f4 origin/main
+  cd ../aios-team-brain-f4
+  ln -sfn /Users/iamjohndass/Projects/aios/aios-team-brain/node_modules node_modules
+
+Plane: epic "F4 — Sidecar consumes selections" (F4.1–F4.3). Epic → In Progress; sub-issues → Done as completed; comment PR on the epic.
+
+OBJECTIVE: close the "table does nothing" gap — the ingestion engine fetches brain-side NON-SECRET selections and merges them with LOCAL secrets.
+SCOPE:
+- F4.1 engine.py + brain_client.py: GET /api/v1/integrations; merge selections (repos, channel ids, project slug) with local secrets from env/connections.yaml keyed by (type, name). Selection from brain, tokens local — the brain NEVER stores secrets.
+- F4.2 connections.yaml.example note + docs. Backward-compatible: if selection-fetch isn't configured, behave exactly as today.
+- F4.3 Python tests: merge precedence + the backward-compat (unconfigured) path.
+
+VERIFY: run the ingestion Python tests; npm run check:docs if you touch ARCHITECTURE. PR from feat/f4-sidecar-selections → main; comment on the Plane epic.
+```
+
+## F5 — Admin Integrations UI + tier guards  (Wave B — after F3 merges)
+
+```
+You are a senior engineer on AIOS Team Brain. Read /Users/iamjohndass/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, docs/ARCHITECTURE.md §1 and §5 (tier isolation), and these existing patterns: components/admin/admin-tabs.tsx, app/t/[team]/admin/layout.tsx (admin gate), lib/auth/visibility.ts, test/guards/codebases-tier-filter.test.ts. Requires F3 merged.
+
+Worktree:
+  cd /Users/iamjohndass/Projects/aios/aios-team-brain
+  git fetch origin
+  git worktree add -b feat/f5-integrations-ui ../aios-team-brain-f5 origin/main
+  cd ../aios-team-brain-f5
+  ln -sfn /Users/iamjohndass/Projects/aios/aios-team-brain/node_modules node_modules
+
+Plane: epic "F5 — Admin Integrations UI + tier guards" (F5.1–F5.5). Epic → In Progress; sub-issues → Done; comment PR.
+
+OBJECTIVE: admin-gated Integrations surface + per-table tier/role guards (NO RLS backstop on postgres).
+SCOPE:
+- F5.1 Add {slug:"integrations",label:"Integrations"} to components/admin/admin-tabs.tsx + app/t/[team]/admin/integrations/page.tsx (inherits the admin-only gate). Calls the F3 server action to create/enable/disable integrations.
+- F5.2 lib/integrations/read.ts — role/tier-scoped reads for the surface.
+- F5.3 test/guards/integrations-tier-filter.test.ts modeled on codebases-tier-filter.test.ts (non-vacuous).
+- F5.4 Under DB_BACKEND=supabase: the surface fails closed with a "not available on legacy backend" notice (integrations is postgres-only).
+- F5.5 Data-mechanics: integrations persist; an external-tier viewer cannot read admin config.
+
+VERIFY: npx tsc --noEmit; npm run lint; npm test; npm run check:docs; npm run db:test:up && npm run test:datamechanics:local. PR from feat/f5-integrations-ui → main; comment on the Plane epic.
+```
+
+## W1.1 — Granola → decisions (sanitized, consented)  (Wave A)
+
+```
+You are a senior engineer on AIOS (the Python ingestion sidecar + the transcript→decision workflow). Read /Users/iamjohndass/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, the source pattern (ingestion/aios_ingest/sources/registry.py + base.py + an existing source like slack.py), and the existing granola-digest + transcript-decisions skills. There is already a granola-mcp server configured — reuse its pull/parse logic; do not re-write transcript fetching.
+
+Worktree:
+  cd /Users/iamjohndass/Projects/aios/aios-team-brain
+  git fetch origin
+  git worktree add -b feat/w1.1-granola ../aios-team-brain-w1.1 origin/main
+  cd ../aios-team-brain-w1.1
+  ln -sfn /Users/iamjohndass/Projects/aios/aios-team-brain/node_modules node_modules
+
+Plane: epic "W1.1 — Granola → decisions (sanitized, consented)" (W1.1.1–W1.1.5). Epic → In Progress; sub-issues → Done; comment PR.
+
+OBJECTIVE: ingest Granola meetings as DECISION ROWS ONLY — NO verbatim transcript synced team-tier. Privacy is the point.
+SCOPE:
+- W1.1.1 ingestion/aios_ingest/sources/granola.py implementing the Source protocol; register in registry.py; add `granola` to docs/ARCHITECTURE.md drift:sources.
+- W1.1.2 Privacy gate: a meeting ALLOWLIST (match "AIOS" topic or participants John/Chetan) + per-note consent. No verbatim transcript leaves admin-tier.
+- W1.1.3 Pull matching transcripts to the workspace (local, admin-tier) only — reuse granola-digest.
+- W1.1.4 Wire the transcript-decisions workflow: extract candidate decisions → HUMAN review → append to decision-log.md → aios push → materializeDecisions (lib/ingest) → decisions table.
+- W1.1.5 Python tests: registry wiring + normalize + MOCKED API pagination/rate-limit.
+
+VERIFY: ingestion Python tests; npm run check:docs (drift:sources). PR from feat/w1.1-granola → main; comment on the Plane epic.
+```
+
+## W1.2 — Token + cost per member (brain spend)  (Wave A)
+
+```
+You are a senior engineer on AIOS Team Brain. Read /Users/iamjohndass/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, and these SHIPPED pieces you build on: lib/auth/visibility.ts (scopeQueryLog — query_log is role-scoped), lib/identity/resolve.ts (shared identity resolver), lib/metrics/pulse.ts (JS day-bucketing pattern), and the codebases contributor-table/chart components.
+
+Worktree:
+  cd /Users/iamjohndass/Projects/aios/aios-team-brain
+  git fetch origin
+  git worktree add -b feat/w1.2-cost-per-member ../aios-team-brain-w1.2 origin/main
+  cd ../aios-team-brain-w1.2
+  ln -sfn /Users/iamjohndass/Projects/aios/aios-team-brain/node_modules node_modules
+
+Plane: epic "W1.2 — Token + cost per member (brain spend)" (W1.2.1–W1.2.4). Epic → In Progress; sub-issues → Done; comment PR.
+
+OBJECTIVE: per-member LLM cost from query_log (brain spend only; external providers are Wave 2).
+SCOPE:
+- W1.2.1 lib/metrics/members.ts getPerMemberCosts(client, teamId, range, {isAdmin, memberId}) aggregating query_log by member_id THROUGH scopeQueryLog (admins team-wide; others self).
+- W1.2.2 app/t/[team]/admin/usage/page.tsx (ADMIN-ONLY, under the admin layout) reusing the contributor-table + charts.
+- W1.2.3 Throughput-vs-cost: join code_contributions (mapped via lib/identity/resolve.ts) × query_log spend → "$ per AI commit / per contributor".
+- W1.2.4 Tier/role guard test + a data-mechanics aggregation test.
+
+VERIFY: npx tsc --noEmit; npm run lint; npm test; npm run db:test:up && npm run test:datamechanics:local. PR from feat/w1.2-cost-per-member → main; comment on the Plane epic.
+```
+
+## W1.3 — GitHub native UI (selection + manual scan)  (Wave C — after F5 merges)
+
+```
+You are a senior engineer on AIOS Team Brain. Read /Users/iamjohndass/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, and reuse (do NOT fork): lib/codebases/github.ts (fetchGithubUser/listOrgMembers/linkGithub), lib/codebases/ingest.ts (single writer), lib/codebases/visibility.ts (canSeeCodebases). Requires F5 (integrations UI) and F4 (sidecar consumes selections) merged. Heed memory codebase-scan-deploy-race.
+
+Worktree:
+  cd /Users/iamjohndass/Projects/aios/aios-team-brain
+  git fetch origin
+  git worktree add -b feat/w1.3-github-ui ../aios-team-brain-w1.3 origin/main
+  cd ../aios-team-brain-w1.3
+  ln -sfn /Users/iamjohndass/Projects/aios/aios-team-brain/node_modules node_modules
+
+Plane: epic "W1.3 — GitHub native UI (selection + manual scan)" (W1.3.1–W1.3.4). Epic → In Progress; sub-issues → Done; comment PR.
+
+OBJECTIVE: dashboard repo selection + member→GitHub linking on the Integrations surface. NO server-triggered scan in Wave 1 — selection persists and the sidecar consumes it; scans run via the documented aios-ingest CLI.
+SCOPE:
+- W1.3.1 Repo selection persisted to integrations (type=github, config.repos); reuse lib/codebases/github.ts.
+- W1.3.2 Member → GitHub login linking UI (reuse linkGithub).
+- W1.3.3 Show last-scan SHA vs main HEAD + a clearly-labelled "run a scan" panel documenting the aios-ingest command.
+- W1.3.4 Respect lib/codebases/visibility.ts (team-tier only).
+
+VERIFY: npx tsc --noEmit; npm run lint; npm test; npm run check:docs; data-mechanics if persistence touched. PR from feat/w1.3-github-ui → main; comment on the Plane epic.
+```
+
+## W1.4 — Ops hardening (Sentry, CodeRabbit, BugBot)  (Wave A)
+
+```
+You are a senior engineer on AIOS Team Brain (Next.js 16 + Turbopack). Read /Users/iamjohndass/Projects/aios/CLAUDE.md (MANDATES worktrees) and this repo's CLAUDE.md/AGENTS.md. AGENTS.md warns this Next.js has breaking changes — read node_modules/next/dist/docs as needed.
+
+Worktree:
+  cd /Users/iamjohndass/Projects/aios/aios-team-brain
+  git fetch origin
+  git worktree add -b feat/w1.4-ops ../aios-team-brain-w1.4 origin/main
+  cd ../aios-team-brain-w1.4
+  ln -sfn /Users/iamjohndass/Projects/aios/aios-team-brain/node_modules node_modules
+
+Plane: epic "W1.4 — Ops hardening (Sentry, CodeRabbit, BugBot)" (W1.4.1–W1.4.4). Epic → In Progress; sub-issues → Done; comment PR.
+
+OBJECTIVE: error logging + AI code review.
+SCOPE:
+- W1.4.1 Sentry: @sentry/nextjs >=10.13 (Turbopack source-map upload). Add instrumentation-client.ts, sentry.server.config.ts, sentry.edge.config.ts, onRequestError in instrumentation.ts, app/global-error.tsx (app root), withSentryConfig in next.config.ts. DSN + source-map auth token via env (.env.example entries; do NOT commit secrets). Confirm no custom webpack plugins (Turbopack ignores them).
+- W1.4.2 CodeRabbit: document installing the GitHub App on the public AIOS repos (free for public repos). This is a config/ops step — capture instructions in the PR.
+- W1.4.3 BugBot: document John (org owner) approving the Cursor app at AIOS-alpha → Settings → Third-party Access (manual).
+- W1.4.4 Sentry smoke: a client error and a server error both produce events with resolved source maps (note how to verify).
+
+VERIFY: npx tsc --noEmit; npm run lint; npm run build (Turbopack) succeeds with Sentry wired. PR from feat/w1.4-ops → main; comment on the Plane epic.
+```
+
+---
+
+## Wave 2 (generate full prompts the same way when ready)
+`W2.1` external AI cost (usage_costs table + Anthropic/Cursor sources) · `W2.2` Slack bidirectional ·
+`W2.3` Wise finance · `W2.4` PM bake-off (ingest Linear + Plane into the brain) · `W2.5` Pencil design
+system · `W2.6` connector→integration rename (versioned blueprint migration). Each has its epic +
+sub-issues already in Plane; reuse the common preamble, point at the epic, and list its sub-issues.
+```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "check:docs": "node scripts/check-docs-drift.mjs",
+    "plane:backlog": "npx --yes @dotenvx/dotenvx run -f ../aios-workspace/.env -- node scripts/plane-backlog.mjs",
     "test:setup": "bash scripts/dev-test-setup.sh",
     "db:test:up": "docker compose -f compose.test.yml up -d --wait && DATABASE_URL=postgres://app:app@localhost:5434/app_test npm run pg:schema",
     "db:test:down": "docker compose -f compose.test.yml down -v",

--- a/scripts/plane-backlog.mjs
+++ b/scripts/plane-backlog.mjs
@@ -26,6 +26,7 @@ const BASE = (process.env.PLANE_BASE_URL || "https://api.plane.so").replace(/\/$
 const EXTERNAL_SOURCE = "aios-backlog";
 const DRY = process.argv.includes("--dry-run");
 const VERBOSE = process.argv.includes("--verbose");
+const RESTATE = process.argv.includes("--restate"); // move all backlog items into the target state
 
 if (!API_KEY) {
   console.error("PLANE_API_KEY is not set. Run via: dotenvx run -f <workspace>/.env -- node scripts/plane-backlog.mjs");
@@ -218,6 +219,15 @@ async function main() {
   const proj = (p) => `/projects/${PID}${p}`;
   console.log(`Project: ${project.name} (${project.identifier}) ${PID}`);
 
+  // Target state — items land in "To Do" (unstarted), not the default "Backlog".
+  const states = await fetchAll(proj(`/states/`));
+  const want = (process.env.PLANE_STATE || "Todo").toLowerCase().replace(/\s+/g, "");
+  const todoState =
+    states.find((s) => s.name.toLowerCase().replace(/\s+/g, "") === want) ||
+    states.find((s) => s.group === "unstarted");
+  const stateId = todoState?.id || null;
+  if (stateId) console.log(`Target state: ${todoState.name} (${stateId})`);
+
   const totalItems = BACKLOG.length + BACKLOG.reduce((n, e) => n + e.subs.length, 0);
   console.log(`Backlog: ${BACKLOG.length} epics + ${totalItems - BACKLOG.length} sub-issues = ${totalItems} work items\n`);
   if (DRY) {
@@ -272,6 +282,7 @@ async function main() {
       external_source: EXTERNAL_SOURCE,
     };
     if (priority) body.priority = priority;
+    if (stateId) body.state = stateId; // new items start in "To Do", not Backlog
     if (labels?.length) body.labels = labels.map((n) => labelId.get(n)).filter(Boolean);
     if (parent) body.parent = parent;
     const created = await api("POST", proj(`/work-items/`), body);
@@ -301,6 +312,18 @@ async function main() {
       await api("POST", proj(`/modules/${mid}/module-issues/`), { issues: missing });
       console.log(`module ${wave} += ${missing.length} items`);
     }
+  }
+
+  // 7. optional: move all backlog items into the target state (one-off migration / fix).
+  // Only runs with --restate so a normal re-run never fights a board change a human made.
+  if (RESTATE && stateId) {
+    const all = await fetchAll(proj(`/work-items/`));
+    const targets = all.filter((x) => x.external_source === EXTERNAL_SOURCE && x.state !== stateId);
+    for (const it of targets) {
+      await api("PATCH", proj(`/work-items/${it.id}/`), { state: stateId });
+      console.log(`restate ${it.external_id || it.id} → ${todoState.name}`);
+    }
+    console.log(`restated ${targets.length} item(s) → ${todoState?.name}.`);
   }
 
   console.log(`\nDone. created=${stats.created} skipped=${stats.skipped} (total ${totalItems}).`);

--- a/scripts/plane-backlog.mjs
+++ b/scripts/plane-backlog.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * Idempotent seed of the AIOS remaining-work backlog into Plane.so.
+ *
+ * Creates one EPIC (parent work item) per feature and a SUB-ISSUE (child work item) per chunk,
+ * grouped into "Wave 1 — MVP" / "Wave 2 — Later" Modules, under the AIOS project. Every item
+ * carries a stable `external_id` (+ external_source="aios-backlog"); re-runs skip anything that
+ * already exists, so this is safe to run repeatedly as the plan evolves.
+ *
+ * Auth/config from env (read at runtime — never hard-coded):
+ *   PLANE_API_KEY        (required)  → header X-API-Key
+ *   PLANE_WORKSPACE_SLUG (default "aios-alpha")
+ *   PLANE_BASE_URL       (default "https://api.plane.so")
+ *   PLANE_PROJECT_ID     (optional; otherwise discovered by matching project identifier "AIOS")
+ *
+ * Run (decrypts the dotenvx-encrypted key from the workspace .env):
+ *   dotenvx run -f /Users/iamjohndass/Projects/aios/aios-workspace/.env -- node scripts/plane-backlog.mjs
+ *   # or: npm run plane:backlog   (wrapper does the same)
+ *
+ * Flags: --dry-run (no writes; print plan)   --verbose
+ */
+
+const API_KEY = process.env.PLANE_API_KEY;
+const SLUG = process.env.PLANE_WORKSPACE_SLUG || "aios-alpha";
+const BASE = (process.env.PLANE_BASE_URL || "https://api.plane.so").replace(/\/$/, "");
+const EXTERNAL_SOURCE = "aios-backlog";
+const DRY = process.argv.includes("--dry-run");
+const VERBOSE = process.argv.includes("--verbose");
+
+if (!API_KEY) {
+  console.error("PLANE_API_KEY is not set. Run via: dotenvx run -f <workspace>/.env -- node scripts/plane-backlog.mjs");
+  process.exit(1);
+}
+
+const WAVE1 = "Wave 1 — MVP";
+const WAVE2 = "Wave 2 — Later";
+const LABELS = ["wave-1", "wave-2", "foundation", "brain", "sidecar", "ops", "integration", "design", "migration"];
+
+// ── backlog: one epic per feature, sub-issues = chunks ────────────────────────
+const p = (s) => `<p>${s}</p>`;
+const BACKLOG = [
+  { ext: "P0", name: "P0 — Plane integration (MCP + seed)", wave: WAVE1, priority: "high",
+    labels: ["integration", "wave-1"], desc: p("Stand up Plane as a real integration: official MCP server (durable/agentic) + idempotent REST seed of this backlog under the AIOS project."),
+    subs: [
+      { ext: "P0.1", name: "Register official Plane MCP server", desc: p("claude mcp add --transport http plane https://mcp.plane.so/http/mcp (OAuth). Confirm tools listable. Fallback: uvx plane-mcp-server (user scope).") },
+      { ext: "P0.2", name: "Idempotent REST seed script", desc: p("scripts/plane-backlog.mjs: discover AIOS project, ensure Wave modules + labels, create epics+sub-issues with external_id idempotency, throttle ≤60/min. npm plane:backlog.") },
+      { ext: "P0.3", name: "Record Plane integration in brain integrations table", desc: p("After F5: integrations row type=plane, config={workspaceSlug:'aios-alpha', projectId}. Substrate for W2.4 plane ingestion source.") },
+      { ext: "P0.4", name: "Verify backlog structure + idempotent re-run", desc: p("Confirm epics+sub-issues with parents/modules/labels; re-run seed → all skipped (no duplicates).") },
+    ] },
+
+  { ext: "F3", name: "F3 — Integrations auth surfaces + contract bump", wave: WAVE1, priority: "high",
+    labels: ["foundation", "brain", "wave-1"], desc: p("Two auth surfaces for the integrations framework without touching the pinned /api/v1 write contract."),
+    subs: [
+      { ext: "F3.1", name: "Dashboard session-auth write (server action)", desc: p("Server action / app/api/dashboard/integrations/route.ts → lib/integrations/manage.ts; admin-gated like admin/layout.tsx. No /api/v1 write surface.") },
+      { ext: "F3.2", name: "GET /api/v1/integrations (sidecar read)", desc: p("API-key auth; returns NON-SECRET selections for the team. The documented contract the sidecar consumes.") },
+      { ext: "F3.3", name: "Version brain-api.md + drift:routes", desc: p("Add the new read endpoint to aios-workspace/docs/brain-api.md FIRST, then docs/ARCHITECTURE.md drift:routes; npm run check:docs green. dep: F3.2") },
+      { ext: "F3.4", name: "Data-mechanics: admin-only write + scoped read", desc: p("Non-admin write → 403; API-key read returns only non-secret fields, team-scoped. dep: F3.1,F3.2") },
+    ] },
+
+  { ext: "F4", name: "F4 — Sidecar consumes selections", wave: WAVE1, priority: "high",
+    labels: ["sidecar", "wave-1"], desc: p("Close the 'table does nothing' gap: the ingestion engine merges brain-side selections with local secrets. dep: F3"),
+    subs: [
+      { ext: "F4.1", name: "engine.py + brain_client.py merge", desc: p("Fetch GET /api/v1/integrations; merge with local secrets by (type,name) — selection from brain, tokens local.") },
+      { ext: "F4.2", name: "connections.yaml.example + backward-compat", desc: p("Document; when selection-fetch unconfigured, behave exactly as today.") },
+      { ext: "F4.3", name: "Python tests: merge + backward-compat", desc: p("Merge precedence; unconfigured = current behavior.") },
+    ] },
+
+  { ext: "F5", name: "F5 — Admin Integrations UI + tier guards", wave: WAVE1, priority: "high",
+    labels: ["foundation", "brain", "wave-1"], desc: p("Admin-gated Integrations surface + per-table tier/role guards (no RLS backstop on postgres). dep: F3"),
+    subs: [
+      { ext: "F5.1", name: "Admin tab + integrations page", desc: p("components/admin/admin-tabs.tsx entry + app/t/[team]/admin/integrations/page.tsx (admin gate).") },
+      { ext: "F5.2", name: "lib/integrations/read.ts scoped reads", desc: p("Role/tier-scoped read helper for the integrations surface.") },
+      { ext: "F5.3", name: "integrations-tier-filter guard test", desc: p("test/guards/integrations-tier-filter.test.ts modeled on codebases-tier-filter.") },
+      { ext: "F5.4", name: "Supabase fail-closed notice", desc: p("Under DB_BACKEND=supabase, surface shows 'not available on legacy backend'.") },
+      { ext: "F5.5", name: "Data-mechanics: persistence + tier isolation", desc: p("Real-PG: integrations persist; external tier cannot read admin config.") },
+    ] },
+
+  { ext: "W1.1", name: "W1.1 — Granola → decisions (sanitized, consented)", wave: WAVE1, priority: "high",
+    labels: ["sidecar", "integration", "wave-1"], desc: p("Ingest Granola meetings as decision rows only — NO verbatim transcript synced team-tier."),
+    subs: [
+      { ext: "W1.1.1", name: "granola.py source + registry + drift", desc: p("ingestion/aios_ingest/sources/granola.py implements Source; register in registry.py; drift:sources += granola.") },
+      { ext: "W1.1.2", name: "Privacy gate: allowlist + consent", desc: p("Meeting allowlist (AIOS keyword / John+Chetan participants) + per-note consent; no verbatim team-tier transcript.") },
+      { ext: "W1.1.3", name: "Reuse granola-digest pull/parse", desc: p("Transcripts pulled to workspace (admin-tier, local) only.") },
+      { ext: "W1.1.4", name: "Wire transcript-decisions flow", desc: p("transcript-decisions workflow → human-reviewed decision rows → decision-log.md → aios push → materializeDecisions.") },
+      { ext: "W1.1.5", name: "Python tests (mocked pagination/rate-limit)", desc: p("Registry + normalize + mocked API pagination & rate-limit.") },
+    ] },
+
+  { ext: "W1.2", name: "W1.2 — Token + cost per member (brain spend)", wave: WAVE1, priority: "high",
+    labels: ["brain", "wave-1"], desc: p("Per-member LLM cost from query_log (built on the shipped scopeQueryLog fix + shared identity resolver)."),
+    subs: [
+      { ext: "W1.2.1", name: "lib/metrics/members.ts getPerMemberCosts", desc: p("Role-scoped aggregation of query_log via scopeQueryLog; admins team-wide, others self.") },
+      { ext: "W1.2.2", name: "Admin usage page", desc: p("app/t/[team]/admin/usage/page.tsx (admin-only) reusing contributor-table + charts.") },
+      { ext: "W1.2.3", name: "Throughput-vs-cost primitive", desc: p("Join code_contributions (via shared resolver) × query_log spend → $ per AI commit / contributor.") },
+      { ext: "W1.2.4", name: "Tier/role guard + data-mechanics", desc: p("Guard test + real-PG aggregation test.") },
+    ] },
+
+  { ext: "W1.3", name: "W1.3 — GitHub native UI (selection + manual scan)", wave: WAVE1, priority: "high",
+    labels: ["brain", "wave-1"], desc: p("Dashboard repo selection + member linking, reusing the code-only GitHub integration. No server-triggered scan in Wave 1. dep: F5"),
+    subs: [
+      { ext: "W1.3.1", name: "Repo selection persisted to integrations", desc: p("type=github, config.repos; reuse lib/codebases/github.ts.") },
+      { ext: "W1.3.2", name: "Member → GitHub linking UI", desc: p("Reuse linkGithub.") },
+      { ext: "W1.3.3", name: "Scan freshness + manual scan panel", desc: p("Show last-scan SHA vs main HEAD + documented manual aios-ingest command. Selection consumed by sidecar (F4).") },
+      { ext: "W1.3.4", name: "Respect canSeeCodebases (team-tier)", desc: p("lib/codebases/visibility.ts gate.") },
+    ] },
+
+  { ext: "W1.4", name: "W1.4 — Ops hardening (Sentry, CodeRabbit, BugBot)", wave: WAVE1, priority: "high",
+    labels: ["ops", "wave-1"], desc: p("Error logging + AI code review for the OSS repos."),
+    subs: [
+      { ext: "W1.4.1", name: "Sentry @sentry/nextjs ≥10.13 (Turbopack)", desc: p("instrumentation-client.ts, sentry.server/edge.config.ts, onRequestError in instrumentation.ts, app/global-error.tsx, withSentryConfig; DSN+token via env.") },
+      { ext: "W1.4.2", name: "CodeRabbit GitHub App on public repos", desc: p("Free for public repos; no org-admin friction.") },
+      { ext: "W1.4.3", name: "Fix Cursor BugBot org-app approval", desc: p("Approve Cursor app at AIOS-alpha → Third-party Access (manual; John is owner).") },
+      { ext: "W1.4.4", name: "Sentry smoke test", desc: p("Client + server error → events + source maps resolve.") },
+    ] },
+
+  { ext: "W2.1", name: "W2.1 — External AI cost (usage_costs)", wave: WAVE2, priority: "medium",
+    labels: ["brain", "wave-2"], desc: p("Per-member external provider spend (Anthropic/Cursor seats + API). dep: W1.2"),
+    subs: [
+      { ext: "W2.1.1", name: "usage_costs schema + FK registry + drift", desc: p("{team_id, member_id, provider, period, input_tokens, output_tokens, cost_usd, source}.") },
+      { ext: "W2.1.2", name: "lib/costs/ingest.ts single writer + guard", desc: p("Only writer for usage_costs.") },
+      { ext: "W2.1.3", name: "Anthropic Usage/Cost API source", desc: p("+ Enterprise Analytics per-user if available.") },
+      { ext: "W2.1.4", name: "Cursor Admin API source (/teams/spend)", desc: p("Per-seat USD + tokens.") },
+      { ext: "W2.1.5", name: "Identity resolve + retention + tier guard", desc: p("Shared resolver; 13-month retention; tier guard; merge into usage page.") },
+    ] },
+
+  { ext: "W2.2", name: "W2.2 — Slack bidirectional", wave: WAVE2, priority: "medium",
+    labels: ["sidecar", "integration", "wave-2"], desc: p("Pull allowlisted channels into the brain; push digests + /ask-brain."),
+    subs: [
+      { ext: "W2.2.1", name: "Slack source + Events API (allowlisted)", desc: p("slack.py exists; Events API for allowlisted channels.") },
+      { ext: "W2.2.2", name: "Push digests via incoming webhook", desc: p("Decisions / daily digest.") },
+      { ext: "W2.2.3", name: "/ask-brain slash command", desc: p("→ lib/query/retrieve.ts.") },
+      { ext: "W2.2.4", name: "Privacy allowlist + app manifest", desc: p("Like Granola; minimal Slack app manifest.") },
+    ] },
+
+  { ext: "W2.3", name: "W2.3 — Wise Business finance", wave: WAVE2, priority: "medium",
+    labels: ["sidecar", "wave-2"], desc: p("Cash/runway view from Wise Business; secrets local."),
+    subs: [
+      { ext: "W2.3.1", name: "wise.py source (OAuth2)", desc: p("OAuth2 user token; balances + transactions.") },
+      { ext: "W2.3.2", name: "finance_snapshots table + writer + guard", desc: p("Single writer + tier guard + FK registry.") },
+      { ext: "W2.3.3", name: "Cash/runway dashboard tile", desc: p("Operating financials tile.") },
+    ] },
+
+  { ext: "W2.4", name: "W2.4 — PM bake-off: Linear + Plane → brain", wave: WAVE2, priority: "medium",
+    labels: ["integration", "wave-2"], desc: p("Ingest both Linear and Plane issues/cycles INTO the brain; compare; pick. Closes the loop with P0."),
+    subs: [
+      { ext: "W2.4.1", name: "Configure linear source", desc: p("Existing linear source → ingest issues/cycles.") },
+      { ext: "W2.4.2", name: "Add plane.py source", desc: p("Ingest AIOS work items/cycles back into the brain.") },
+      { ext: "W2.4.3", name: "Brain overlay: link issues ↔ decisions", desc: p("Link issues ↔ decisions/deliverables.") },
+      { ext: "W2.4.4", name: "Comparison writeup → pick", desc: p("Linear vs Plane decision.") },
+    ] },
+
+  { ext: "W2.5", name: "W2.5 — Pencil design system", wave: WAVE2, priority: "low",
+    labels: ["design", "wave-2"], desc: p("Shared agentic design system with W3C design tokens."),
+    subs: [
+      { ext: "W2.5.1", name: "W3C DTCG tokens", desc: p("design/*.tokens.json.") },
+      { ext: "W2.5.2", name: "Style Dictionary → tokens.css", desc: p("For Tailwind v4.") },
+      { ext: "W2.5.3", name: "pencil MCP edits .pen + sync", desc: p("Two-way sync of tokens.") },
+      { ext: "W2.5.4", name: "Shared design-library docs", desc: p("Usage across contributors/clients.") },
+    ] },
+
+  { ext: "W2.6", name: "W2.6 — connector→integration rename (blueprint migration)", wave: WAVE2, priority: "low",
+    labels: ["migration", "wave-2"], desc: p("Versioned, backward-compatible rename — connectors is live blueprint JSON across repos."),
+    subs: [
+      { ext: "W2.6.1", name: "Bump blueprint schema version", desc: p("New version field.") },
+      { ext: "W2.6.2", name: "Backward-compatible reader", desc: p("Accept both connectors + integrations keys.") },
+      { ext: "W2.6.3", name: "Migrate published blueprints", desc: p("In-place migration.") },
+      { ext: "W2.6.4", name: "brain-api.md + team-tools update", desc: p("Doc + UI.") },
+    ] },
+];
+
+// ── HTTP + throttle (≤60 req/min → ~1.05s/request) ────────────────────────────
+let lastReq = 0;
+async function api(method, path, body) {
+  const now = Date.now();
+  const wait = Math.max(0, 1050 - (now - lastReq));
+  if (wait) await new Promise((r) => setTimeout(r, wait));
+  lastReq = Date.now();
+  const res = await fetch(`${BASE}/api/v1/workspaces/${SLUG}${path}`, {
+    method,
+    headers: { "X-API-Key": API_KEY, "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (res.status === 429) {
+    const retry = Number(res.headers.get("Retry-After") || 5) * 1000;
+    console.warn(`  rate-limited; backing off ${retry}ms`);
+    await new Promise((r) => setTimeout(r, retry));
+    return api(method, path, body);
+  }
+  const text = await res.text();
+  let json;
+  try { json = text ? JSON.parse(text) : {}; } catch { json = { raw: text }; }
+  if (!res.ok) throw new Error(`${method} ${path} → ${res.status}: ${text.slice(0, 300)}`);
+  if (VERBOSE) console.log(`  ${method} ${path} → ${res.status}`);
+  return json;
+}
+
+async function fetchAll(path) {
+  // cursor pagination: ?cursor=value&per_page=100
+  const out = [];
+  let cursor = `100:0:0`;
+  for (let i = 0; i < 100; i++) {
+    const sep = path.includes("?") ? "&" : "?";
+    const page = await api("GET", `${path}${sep}per_page=100&cursor=${encodeURIComponent(cursor)}`);
+    out.push(...(page.results || []));
+    if (!page.next_page_results || !page.next_cursor) break;
+    cursor = page.next_cursor;
+  }
+  return out;
+}
+
+async function main() {
+  // 1. resolve project
+  const projects = await fetchAll(`/projects/`);
+  const project = process.env.PLANE_PROJECT_ID
+    ? projects.find((p) => p.id === process.env.PLANE_PROJECT_ID)
+    : projects.find((p) => p.identifier === "AIOS" || /(^|\b)AIOS\b/.test(p.name));
+  if (!project) throw new Error(`AIOS project not found in workspace ${SLUG}`);
+  const PID = project.id;
+  const proj = (p) => `/projects/${PID}${p}`;
+  console.log(`Project: ${project.name} (${project.identifier}) ${PID}`);
+
+  const totalItems = BACKLOG.length + BACKLOG.reduce((n, e) => n + e.subs.length, 0);
+  console.log(`Backlog: ${BACKLOG.length} epics + ${totalItems - BACKLOG.length} sub-issues = ${totalItems} work items\n`);
+  if (DRY) {
+    for (const e of BACKLOG) {
+      console.log(`◆ ${e.ext}  ${e.name}  [${e.wave}] (${e.priority})`);
+      for (const s of e.subs) console.log(`   └─ ${s.ext}  ${s.name}`);
+    }
+    console.log("\n--dry-run: no writes performed.");
+    return;
+  }
+
+  // 2. ensure labels
+  const existingLabels = await fetchAll(proj(`/labels/`));
+  const labelId = new Map(existingLabels.map((l) => [l.name, l.id]));
+  for (const name of LABELS) {
+    if (labelId.has(name)) continue;
+    const created = await api("POST", proj(`/labels/`), { name });
+    labelId.set(name, created.id);
+    console.log(`label + ${name}`);
+  }
+
+  // 3. ensure modules (waves)
+  const existingModules = await fetchAll(proj(`/modules/`));
+  const moduleId = new Map(existingModules.map((m) => [m.name, m.id]));
+  for (const name of [WAVE1, WAVE2]) {
+    if (moduleId.has(name)) continue;
+    const created = await api("POST", proj(`/modules/`), { name });
+    moduleId.set(name, created.id);
+    console.log(`module + ${name}`);
+  }
+
+  // 4. existing work items by external_id (idempotency)
+  const existingItems = await fetchAll(proj(`/work-items/`));
+  const byExt = new Map();
+  for (const it of existingItems) {
+    if (it.external_source === EXTERNAL_SOURCE && it.external_id) byExt.set(it.external_id, it.id);
+  }
+
+  const stats = { created: 0, skipped: 0 };
+  const moduleMembers = new Map([[WAVE1, []], [WAVE2, []]]);
+
+  async function ensureItem({ ext, name, desc, priority, labels, parent }) {
+    if (byExt.has(ext)) {
+      stats.skipped++;
+      if (VERBOSE) console.log(`skip   ${ext} (exists)`);
+      return byExt.get(ext);
+    }
+    const body = {
+      name,
+      description_html: desc || "",
+      external_id: ext,
+      external_source: EXTERNAL_SOURCE,
+    };
+    if (priority) body.priority = priority;
+    if (labels?.length) body.labels = labels.map((n) => labelId.get(n)).filter(Boolean);
+    if (parent) body.parent = parent;
+    const created = await api("POST", proj(`/work-items/`), body);
+    byExt.set(ext, created.id);
+    stats.created++;
+    console.log(`create ${ext}  ${name}`);
+    return created.id;
+  }
+
+  // 5. epics then sub-issues
+  for (const epic of BACKLOG) {
+    const epicId = await ensureItem({ ext: epic.ext, name: epic.name, desc: epic.desc, priority: epic.priority, labels: epic.labels });
+    moduleMembers.get(epic.wave).push(epicId);
+    for (const sub of epic.subs) {
+      const subId = await ensureItem({ ext: sub.ext, name: sub.name, desc: sub.desc, priority: epic.priority, labels: epic.labels, parent: epicId });
+      moduleMembers.get(epic.wave).push(subId);
+    }
+  }
+
+  // 6. assign items to their wave module (batch; only add missing)
+  for (const [wave, ids] of moduleMembers) {
+    if (!ids.length) continue;
+    const mid = moduleId.get(wave);
+    const present = new Set((await fetchAll(proj(`/modules/${mid}/module-issues/`))).map((mi) => mi.issue || mi.id));
+    const missing = ids.filter((id) => !present.has(id));
+    if (missing.length) {
+      await api("POST", proj(`/modules/${mid}/module-issues/`), { issues: missing });
+      console.log(`module ${wave} += ${missing.length} items`);
+    }
+  }
+
+  console.log(`\nDone. created=${stats.created} skipped=${stats.skipped} (total ${totalItems}).`);
+}
+
+main().catch((e) => { console.error("FAILED:", e.message); process.exit(1); });


### PR DESCRIPTION
## What

Wires **Plane.so** as a real integration and seeds the entire AIOS remaining-work backlog into it.

### Plane integration (MCP + CLI)
- **MCP server** registered in user config (`~/.claude.json`) — `https://mcp.plane.so/http/mcp` (HTTP/OAuth) for ongoing agentic/interactive use. Needs the browser OAuth handshake (`/mcp` → authenticate `plane`) to connect.
- **`scripts/plane-backlog.mjs`** — idempotent REST seed CLI (`npm run plane:backlog`). Discovers the AIOS project, ensures `Wave 1 — MVP` / `Wave 2 — Later` modules + labels, and creates the backlog.

### Backlog seeded (verified live)
**14 epics + 57 sub-issues = 71 work items** under the AIOS project, one epic per feature, sub-issues per chunk:
- **Wave 1 (41 items):** P0 Plane integration · F3 auth surfaces + contract · F4 sidecar selections · F5 admin UI + tier guards · W1.1 Granola→decisions · W1.2 token+cost per member · W1.3 GitHub UI · W1.4 ops (Sentry/CodeRabbit/BugBot)
- **Wave 2 (30 items):** W2.1 external AI cost · W2.2 Slack · W2.3 Wise finance · W2.4 PM bake-off (Linear+Plane→brain) · W2.5 Pencil design system · W2.6 connector→integration rename

### Idempotency & safety
- Every item carries `external_id` + `external_source=aios-backlog`. **Re-run verified: `created=0 skipped=71`** — safe to re-run as the plan evolves.
- Throttled to ≤60 req/min (Plane's limit).
- `PLANE_API_KEY` stays dotenvx-encrypted in `aios-workspace/.env`, read at runtime only, never committed, only sent to Plane.

## Verification
- Live seed: 71 created; API confirms 14 epics (no parent) + 57 sub-issues (with parent); Wave modules populated (41/30).
- Idempotent re-run: 0 created, 71 skipped.
- `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)