### PR TITLE
fix(schema): upgrade code metrics readiness columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+.aios/
 
 # debug
 npm-debug.log*

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -425,6 +425,14 @@ create table if not exists code_metrics (
 create index if not exists code_metrics_codebase_time_idx on code_metrics (codebase_id, scanned_at desc);
 create index if not exists code_metrics_team_time_idx on code_metrics (team_id, scanned_at desc);
 
+-- Keep `npm run pg:schema` safe for existing deployments that created
+-- code_metrics before AEM readiness fields were added. The table declaration
+-- alone does not backfill new columns.
+alter table code_metrics add column if not exists readiness_level text;
+alter table code_metrics add column if not exists readiness_pct numeric(5,2);
+alter table code_metrics add column if not exists readiness_pillars jsonb not null default '{}';
+alter table code_metrics add column if not exists readiness_rubric_version text;
+
 -- Daily contribution aggregates, recomputed + upserted each scan over the window.
 -- author_key is stable (normalized email, or name when email absent); git history
 -- rarely carries a GitHub login. member_id maps to the roster when resolvable.


### PR DESCRIPTION
## Summary
- Add idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements for AEM readiness fields on `code_metrics`.
- Ignore local `.aios/` runtime state in the brain repo.
- Preserves the v1 `/api/v1/codebases` contract for existing Postgres deployments that already have `code_metrics`.

## Test plan
- `npm run check:docs`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run db:test:down && npm run db:test:up && npm run test:datamechanics:local`
- simulated old table: drop readiness columns, rerun `DATABASE_URL=... npm run pg:schema`, then `npm run test:datamechanics:local`
- ingestion suite in temp Python 3.12 venv: `pytest -q` (34 passed, 1 skipped)

Made with [Cursor](https://cursor.com)