### PR TITLE
feat(ingest): native TS Slack connector — in-process, one service

### DIFF
--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -10,6 +10,7 @@ import {
   setIntegrationStatus,
   deleteIntegration,
 } from "@/lib/integrations/manage";
+import { runSlackIngestion } from "@/lib/ingest/run";
 import { IntegrationConfigError, type IntegrationType } from "@/lib/api/schemas";
 
 async function requireAdmin(teamSlug: string) {
@@ -103,6 +104,29 @@ export async function rotateSecret(
   }
   revalidatePath(`/t/${teamSlug}/admin/integrations`);
   return { ok: true };
+}
+
+/**
+ * Run Slack ingestion now for this team (admins only). Pulls the configured
+ * channels through the in-app runner and reports a one-line summary. The
+ * scheduler also runs this on its interval; this is the on-demand trigger.
+ */
+export async function syncSlackNow(
+  teamSlug: string
+): Promise<{ ok: boolean; error?: string; message?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    const s = await runSlackIngestion({ teamId: ctx.teamId });
+    if (!s.ok && s.errors.length) return { ok: false, error: s.errors.join("; ") };
+    revalidatePath(`/t/${teamSlug}/admin/integrations`);
+    return {
+      ok: true,
+      message: `Synced ${s.channels} channel(s): +${s.created} new, ~${s.updated} updated, =${s.unchanged} unchanged.`,
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "sync failed" };
+  }
 }
 
 export async function removeIntegration(

--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Plug, Plus, Trash2, KeyRound } from "lucide-react";
+import { Plug, Plus, Trash2, KeyRound, RefreshCw } from "lucide-react";
 import {
   saveIntegration,
   toggleIntegration,
   rotateSecret,
   removeIntegration,
+  syncSlackNow,
 } from "@/app/t/[team]/admin/integrations/actions";
 
 type IntegrationType = "github" | "granola" | "slack" | "wise" | "linear" | "plane";
@@ -51,6 +52,20 @@ export function IntegrationsManager({
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  function syncSlack() {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const res = await syncSlackNow(teamSlug);
+      if (!res.ok) setError(res.error ?? "sync failed");
+      else {
+        setNotice(res.message ?? "Synced.");
+        router.refresh();
+      }
+    });
+  }
   const [form, setForm] = useState<{ type: IntegrationType; name: string; selection: string; secret: string }>({
     type: "slack",
     name: "",
@@ -121,6 +136,12 @@ export function IntegrationsManager({
         {error ? <p className="text-sm text-red">{error}</p> : null}
       </form>
 
+      {notice ? (
+        <p className="rounded-lg border border-emerald/30 bg-emerald/5 px-3 py-2 text-sm text-emerald-700">
+          {notice}
+        </p>
+      ) : null}
+
       {integrations.length === 0 ? (
         <p className="text-sm text-ink-tertiary">No integrations yet. Add one above.</p>
       ) : (
@@ -134,6 +155,16 @@ export function IntegrationsManager({
                 {i.hasSecret ? " · secret set" : " · no secret"}
               </span>
               <div className="ml-auto flex items-center gap-2">
+                {i.type === "slack" ? (
+                  <button
+                    onClick={syncSlack}
+                    disabled={pending}
+                    className="flex items-center gap-1.5 rounded-lg border border-violet/40 bg-violet/10 px-3 py-1 text-xs font-medium text-violet disabled:opacity-50"
+                    title="Pull this team's Slack channels into the brain now"
+                  >
+                    <RefreshCw className={`size-3.5 ${pending ? "animate-spin" : ""}`} /> Sync now
+                  </button>
+                ) : null}
                 <button
                   onClick={() => run(() => toggleIntegration(teamSlug, i.id, i.status === "enabled" ? "disabled" : "enabled"))}
                   disabled={pending}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,12 @@
+/**
+ * Next.js instrumentation hook — runs once when the server process boots.
+ * We use it to start the in-process ingestion poller so the brain self-schedules
+ * connector syncs inside the single Railway service (no separate cron worker).
+ */
+export async function register() {
+  // Only in the Node.js server runtime (not edge, not build).
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  if (process.env.INGEST_POLL_ENABLED === "false") return;
+  const { startIngestScheduler } = await import("@/lib/ingest/scheduler");
+  startIngestScheduler();
+}

--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -1,0 +1,157 @@
+import "server-only";
+import { randomUUID } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { adminClient } from "@/lib/supabase/admin";
+import { ingestItem } from "@/lib/ingest";
+import { SlackClient, fetchSlackChannel } from "./sources/slack";
+import { normalizeThread } from "./sources/slack-normalize";
+
+/**
+ * In-app ingestion runner — the TypeScript replacement for the Python sidecar's
+ * Slack path, running inside the brain (one Railway service). Reads each team's
+ * enabled Slack integration (`integrations.config.channelIds`, set from the
+ * dashboard — non-secret), pulls via the Slack Web API using SLACK_BOT_TOKEN,
+ * and writes through the existing `ingestItem` writer (dedup / version / audit).
+ *
+ * Idempotent (sha256 dedup) and single-flight per process.
+ */
+
+export interface IngestSummary {
+  ok: boolean;
+  integrations: number;
+  channels: number;
+  created: number;
+  updated: number;
+  unchanged: number;
+  errors: string[];
+  skipped?: boolean;
+}
+
+function slackToken(): string | null {
+  // Canonical is SLACK_BOT_TOKEN; tolerate the lowercase form some deployers set.
+  return process.env.SLACK_BOT_TOKEN ?? process.env.slack_bot_token ?? null;
+}
+
+interface IntegrationRow {
+  id: string;
+  team_id: string;
+  name: string;
+  config: { channelIds?: string[] } | null;
+}
+
+/** Find (or auto-provision) the per-team connector member used as the ingest actor. */
+async function resolveConnectorAuth(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<{ teamId: string; memberId: string; apiKeyId: string } | null> {
+  const { data: existing } = await supabase
+    .from("members")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("actor_handle", "slack-sync")
+    .maybeSingle();
+
+  let memberId = (existing as { id: string } | null)?.id;
+  if (!memberId) {
+    const { data: created } = await supabase
+      .from("members")
+      .upsert(
+        {
+          team_id: teamId,
+          email: "slack-sync@connector.local",
+          display_name: "Slack Sync",
+          actor_handle: "slack-sync",
+          role: "member",
+          tier: "team",
+          status: "active",
+        },
+        { onConflict: "team_id,actor_handle" }
+      )
+      .select("id")
+      .single();
+    memberId = (created as { id: string } | null)?.id;
+  }
+  if (!memberId) return null;
+
+  // api_key_id is recorded in the audit row (no FK); reuse one if present.
+  const { data: key } = await supabase
+    .from("api_keys")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("member_id", memberId)
+    .limit(1)
+    .maybeSingle();
+
+  return { teamId, memberId, apiKeyId: (key as { id: string } | null)?.id ?? randomUUID() };
+}
+
+let running = false;
+
+/** Run Slack ingestion for all enabled integrations (optionally one team). */
+export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise<IngestSummary> {
+  const empty: IngestSummary = {
+    ok: true,
+    integrations: 0,
+    channels: 0,
+    created: 0,
+    updated: 0,
+    unchanged: 0,
+    errors: [],
+  };
+  if (running) return { ...empty, skipped: true };
+  running = true;
+  try {
+    const token = slackToken();
+    if (!token) return { ...empty, ok: false, errors: ["SLACK_BOT_TOKEN not set"] };
+
+    const supabase = adminClient();
+    let q = supabase
+      .from("integrations")
+      .select("id, team_id, name, config")
+      .eq("type", "slack")
+      .eq("status", "enabled");
+    if (opts.teamId) q = q.eq("team_id", opts.teamId);
+    const { data: rows } = await q;
+    const integrations = (rows ?? []) as IntegrationRow[];
+
+    const summary: IngestSummary = { ...empty, integrations: integrations.length };
+    if (integrations.length === 0) return summary;
+
+    const client = new SlackClient(token);
+    const users = await client.usersMap(); // one workspace-wide pass, reused across channels
+
+    for (const integ of integrations) {
+      const channelIds = integ.config?.channelIds ?? [];
+      if (channelIds.length === 0) continue;
+      const auth = await resolveConnectorAuth(supabase, integ.team_id);
+      if (!auth) {
+        summary.errors.push(`team ${integ.team_id}: no connector member`);
+        continue;
+      }
+      for (const channelId of channelIds) {
+        summary.channels++;
+        try {
+          const channel = await fetchSlackChannel(client, channelId, { users, maxMessages: 300 });
+          for (const thread of channel.threads) {
+            const payload = normalizeThread(thread, {
+              channelId: channel.channelId,
+              channelName: channel.channelName,
+              users: channel.users,
+              project: "slack",
+            });
+            const res = await ingestItem(supabase, auth, payload, "team");
+            if (res.status === "created") summary.created++;
+            else if (res.status === "updated") summary.updated++;
+            else summary.unchanged++;
+          }
+        } catch (err) {
+          summary.errors.push(`${channelId}: ${err instanceof Error ? err.message : "fetch failed"}`);
+        }
+      }
+    }
+    summary.ok = summary.errors.length === 0;
+    return summary;
+  } finally {
+    running = false;
+  }
+}

--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -3,15 +3,18 @@ import { randomUUID } from "node:crypto";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { adminClient } from "@/lib/supabase/admin";
 import { ingestItem } from "@/lib/ingest";
+import { getEnabledIntegrationsWithSecrets } from "@/lib/integrations/manage";
 import { SlackClient, fetchSlackChannel } from "./sources/slack";
 import { normalizeThread } from "./sources/slack-normalize";
 
 /**
  * In-app ingestion runner — the TypeScript replacement for the Python sidecar's
- * Slack path, running inside the brain (one Railway service). Reads each team's
- * enabled Slack integration (`integrations.config.channelIds`, set from the
- * dashboard — non-secret), pulls via the Slack Web API using SLACK_BOT_TOKEN,
- * and writes through the existing `ingestItem` writer (dedup / version / audit).
+ * Slack path, running inside the brain (one Railway service). For each team's
+ * enabled Slack integration it reads the channel selection (`config.channelIds`)
+ * and the per-integration **encrypted token** (set in the dashboard, decrypted by
+ * getEnabledIntegrationsWithSecrets) — falling back to the SLACK_BOT_TOKEN env if
+ * no secret is stored — pulls via the Slack Web API, and writes through the
+ * existing `ingestItem` writer (dedup / version / audit).
  *
  * Idempotent (sha256 dedup) and single-flight per process.
  */
@@ -27,16 +30,21 @@ export interface IngestSummary {
   skipped?: boolean;
 }
 
-function slackToken(): string | null {
-  // Canonical is SLACK_BOT_TOKEN; tolerate the lowercase form some deployers set.
+function envSlackToken(): string | null {
+  // Fallback only — the per-integration encrypted secret is preferred.
+  // Canonical env name is SLACK_BOT_TOKEN; tolerate the lowercase form.
   return process.env.SLACK_BOT_TOKEN ?? process.env.slack_bot_token ?? null;
 }
 
-interface IntegrationRow {
-  id: string;
-  team_id: string;
-  name: string;
-  config: { channelIds?: string[] } | null;
+/** Distinct teams that have at least one enabled Slack integration. */
+async function teamsWithSlack(supabase: SupabaseClient): Promise<string[]> {
+  const { data } = await supabase
+    .from("integrations")
+    .select("team_id")
+    .eq("type", "slack")
+    .eq("status", "enabled");
+  const ids = (data ?? []).map((r) => (r as { team_id: string }).team_id);
+  return [...new Set(ids)];
 }
 
 /** Find (or auto-provision) the per-team connector member used as the ingest actor. */
@@ -101,51 +109,64 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
   if (running) return { ...empty, skipped: true };
   running = true;
   try {
-    const token = slackToken();
-    if (!token) return { ...empty, ok: false, errors: ["SLACK_BOT_TOKEN not set"] };
-
     const supabase = adminClient();
-    let q = supabase
-      .from("integrations")
-      .select("id, team_id, name, config")
-      .eq("type", "slack")
-      .eq("status", "enabled");
-    if (opts.teamId) q = q.eq("team_id", opts.teamId);
-    const { data: rows } = await q;
-    const integrations = (rows ?? []) as IntegrationRow[];
+    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithSlack(supabase);
+    const envToken = envSlackToken();
 
-    const summary: IngestSummary = { ...empty, integrations: integrations.length };
-    if (integrations.length === 0) return summary;
-
-    const client = new SlackClient(token);
-    const users = await client.usersMap(); // one workspace-wide pass, reused across channels
-
-    for (const integ of integrations) {
-      const channelIds = integ.config?.channelIds ?? [];
-      if (channelIds.length === 0) continue;
-      const auth = await resolveConnectorAuth(supabase, integ.team_id);
-      if (!auth) {
-        summary.errors.push(`team ${integ.team_id}: no connector member`);
+    const summary: IngestSummary = { ...empty };
+    for (const teamId of teamIds) {
+      let slackIntegrations;
+      try {
+        slackIntegrations = (await getEnabledIntegrationsWithSecrets(supabase, teamId)).filter(
+          (i) => i.type === "slack"
+        );
+      } catch (err) {
+        // e.g. SECRETS_KEY missing/wrong → can't decrypt this team's secrets.
+        summary.errors.push(`team ${teamId}: ${err instanceof Error ? err.message : "secret read failed"}`);
         continue;
       }
-      for (const channelId of channelIds) {
-        summary.channels++;
-        try {
-          const channel = await fetchSlackChannel(client, channelId, { users, maxMessages: 300 });
-          for (const thread of channel.threads) {
-            const payload = normalizeThread(thread, {
-              channelId: channel.channelId,
-              channelName: channel.channelName,
-              users: channel.users,
-              project: "slack",
-            });
-            const res = await ingestItem(supabase, auth, payload, "team");
-            if (res.status === "created") summary.created++;
-            else if (res.status === "updated") summary.updated++;
-            else summary.unchanged++;
+      if (slackIntegrations.length === 0) continue;
+      const auth = await resolveConnectorAuth(supabase, teamId);
+      if (!auth) {
+        summary.errors.push(`team ${teamId}: no connector member`);
+        continue;
+      }
+
+      for (const integ of slackIntegrations) {
+        summary.integrations++;
+        const token = integ.secret ?? envToken;
+        if (!token) {
+          summary.errors.push(
+            `integration "${integ.name}": no token — paste a bot token in the dashboard or set SLACK_BOT_TOKEN`
+          );
+          continue;
+        }
+        const channelIds = (integ.config.channelIds as string[] | undefined) ?? [];
+        if (channelIds.length === 0) continue;
+
+        const client = new SlackClient(token);
+        const users = await client.usersMap(); // one pass per integration token
+        for (const channelId of channelIds) {
+          summary.channels++;
+          try {
+            const channel = await fetchSlackChannel(client, channelId, { users, maxMessages: 300 });
+            for (const thread of channel.threads) {
+              const payload = normalizeThread(thread, {
+                channelId: channel.channelId,
+                channelName: channel.channelName,
+                users: channel.users,
+                project: "slack",
+              });
+              const res = await ingestItem(supabase, auth, payload, "team");
+              if (res.status === "created") summary.created++;
+              else if (res.status === "updated") summary.updated++;
+              else summary.unchanged++;
+            }
+          } catch (err) {
+            summary.errors.push(
+              `${channelId}: ${err instanceof Error ? err.message : "fetch failed"}`
+            );
           }
-        } catch (err) {
-          summary.errors.push(`${channelId}: ${err instanceof Error ? err.message : "fetch failed"}`);
         }
       }
     }

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -4,19 +4,16 @@ import { runSlackIngestion } from "./run";
 /**
  * In-process poller — the single-service alternative to a separate cron worker.
  * Started once from instrumentation.register() on server boot (Node runtime only).
- * Idle (never starts the interval) when SLACK_BOT_TOKEN is unset, so a fresh deploy
- * without Slack configured is silent.
+ * Config-driven: each tick syncs whatever Slack integrations are enabled (tokens
+ * come from the dashboard-stored encrypted secret or SLACK_BOT_TOKEN). A deploy
+ * with nothing configured polls cheaply and logs nothing. Opt out with
+ * INGEST_POLL_ENABLED=false.
  */
 
 let started = false;
 
 export function startIngestScheduler(): void {
   if (started) return;
-  const token = process.env.SLACK_BOT_TOKEN ?? process.env.slack_bot_token;
-  if (!token) {
-    console.info("[ingest] scheduler idle — SLACK_BOT_TOKEN not set");
-    return;
-  }
   started = true;
 
   const minutes = Number(process.env.INGEST_POLL_MINUTES ?? 30);

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -1,0 +1,44 @@
+import "server-only";
+import { runSlackIngestion } from "./run";
+
+/**
+ * In-process poller — the single-service alternative to a separate cron worker.
+ * Started once from instrumentation.register() on server boot (Node runtime only).
+ * Idle (never starts the interval) when SLACK_BOT_TOKEN is unset, so a fresh deploy
+ * without Slack configured is silent.
+ */
+
+let started = false;
+
+export function startIngestScheduler(): void {
+  if (started) return;
+  const token = process.env.SLACK_BOT_TOKEN ?? process.env.slack_bot_token;
+  if (!token) {
+    console.info("[ingest] scheduler idle — SLACK_BOT_TOKEN not set");
+    return;
+  }
+  started = true;
+
+  const minutes = Number(process.env.INGEST_POLL_MINUTES ?? 30);
+  const intervalMs = Math.max(1, minutes) * 60_000;
+
+  const tick = async () => {
+    try {
+      const s = await runSlackIngestion();
+      if (s.created || s.updated || s.errors.length) {
+        console.info(
+          `[ingest] slack: +${s.created} ~${s.updated} =${s.unchanged} ` +
+            `(${s.channels} channels, ${s.integrations} integrations)` +
+            (s.errors.length ? ` errors: ${s.errors.join("; ")}` : "")
+        );
+      }
+    } catch (err) {
+      console.error("[ingest] tick failed:", err instanceof Error ? err.message : err);
+    }
+  };
+
+  // Delay the first run so boot isn't blocked; then poll on the interval.
+  setTimeout(tick, 20_000).unref?.();
+  setInterval(tick, intervalMs).unref?.();
+  console.info(`[ingest] scheduler started — Slack every ${minutes}m`);
+}

--- a/lib/ingest/sources/slack-normalize.ts
+++ b/lib/ingest/sources/slack-normalize.ts
@@ -1,0 +1,78 @@
+import { createHash } from "node:crypto";
+import type { ItemPayload } from "@/lib/api/schemas";
+import type { FetchedThread, SlackMessage } from "./slack";
+
+/**
+ * Pure: a Slack thread (root + replies) → the brain's ItemPayload.
+ *   kind  = transcript
+ *   path  = slack/<channel>/<root-ts>.md   (one item per top-level message/thread)
+ *   body  = rendered markdown transcript (author · time · text, replies appended)
+ * Re-ingesting an unchanged thread is a no-op (sha256 dedup at the writer); a new
+ * reply changes the body → sha → a new version.
+ */
+
+export interface NormalizeOpts {
+  channelId: string;
+  channelName: string;
+  users: Record<string, string>;
+  project?: string; // brain project slug (default "slack")
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function safeSegment(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "channel";
+}
+
+function tsToIso(ts: string): string {
+  const ms = Math.round(parseFloat(ts) * 1000);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : "";
+}
+
+/** Resolve <@U123> mentions and <url|label> links to human-readable text. */
+function renderText(text: string, users: Record<string, string>): string {
+  return text
+    .replace(/<@([A-Z0-9]+)(\|[^>]+)?>/g, (_m, id: string) => `@${users[id] ?? id}`)
+    .replace(/<(https?:[^>|]+)\|([^>]+)>/g, (_m, url: string, label: string) => `${label} (${url})`)
+    .replace(/<(https?:[^>]+)>/g, (_m, url: string) => url);
+}
+
+function renderMessage(m: SlackMessage, opts: NormalizeOpts): string {
+  const author = (m.user && opts.users[m.user]) || m.user || "unknown";
+  const when = tsToIso(m.ts);
+  return `**${author}**${when ? ` · ${when}` : ""}\n\n${renderText(m.text ?? "", opts.users)}`;
+}
+
+export function normalizeThread(thread: FetchedThread, opts: NormalizeOpts): ItemPayload {
+  const { root, replies } = thread;
+  const channelSeg = safeSegment(opts.channelName || opts.channelId);
+
+  const parts = [renderMessage(root, opts)];
+  for (const r of replies) parts.push(renderMessage(r, opts));
+  const body = `# #${opts.channelName} — Slack thread\n\n${parts.join("\n\n---\n\n")}\n`;
+
+  const author = (root.user && opts.users[root.user]) || root.user || "";
+
+  return {
+    project: opts.project ?? "slack",
+    path: `slack/${channelSeg}/${root.ts}.md`,
+    kind: "transcript",
+    content_sha256: sha256(body),
+    actor: author,
+    access: "team",
+    frontmatter: {
+      source: "slack",
+      channel: opts.channelName,
+      channel_id: opts.channelId,
+      ts: root.ts,
+      thread_ts: root.thread_ts ?? root.ts,
+      author,
+      author_id: root.user ?? "",
+      source_ts: tsToIso(root.ts),
+      reply_count: replies.length,
+    },
+    body,
+  };
+}

--- a/lib/ingest/sources/slack.ts
+++ b/lib/ingest/sources/slack.ts
@@ -1,0 +1,159 @@
+import "server-only";
+
+/**
+ * Minimal Slack Web API client (raw fetch, no SDK) for the in-app ingestion
+ * runner. Read-only methods only: conversations.history/replies/info and a
+ * cached users.list for author display names. Bounded per run; pagination via
+ * response_metadata.next_cursor.
+ *
+ * Scopes the bot token needs: channels:history + channels:read (public),
+ * groups:history + groups:read (private), users:read (author names).
+ */
+
+const SLACK_API = "https://slack.com/api";
+
+export interface SlackMessage {
+  ts: string;
+  user?: string;
+  text?: string;
+  thread_ts?: string;
+  reply_count?: number;
+  subtype?: string;
+}
+
+export interface FetchedThread {
+  root: SlackMessage;
+  replies: SlackMessage[]; // excludes the root
+}
+
+export interface FetchedChannel {
+  channelId: string;
+  channelName: string;
+  threads: FetchedThread[];
+  /** user id → display name (best-effort) */
+  users: Record<string, string>;
+}
+
+export class SlackError extends Error {}
+
+export class SlackClient {
+  constructor(private readonly token: string) {}
+
+  private async call<T>(method: string, params: Record<string, string>): Promise<T> {
+    const url = `${SLACK_API}/${method}?${new URLSearchParams(params).toString()}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.token}` },
+    });
+    const json = (await res.json()) as { ok: boolean; error?: string } & T;
+    if (!json.ok) {
+      throw new SlackError(`slack ${method} failed: ${json.error ?? `HTTP ${res.status}`}`);
+    }
+    return json;
+  }
+
+  async channelName(channelId: string): Promise<string> {
+    try {
+      const r = await this.call<{ channel: { name?: string } }>("conversations.info", {
+        channel: channelId,
+      });
+      return r.channel.name ?? channelId;
+    } catch {
+      return channelId; // private channel without scope, or renamed — fall back to id
+    }
+  }
+
+  /** Paginated history, newest→oldest, capped at `max` messages. */
+  async history(channelId: string, max: number): Promise<SlackMessage[]> {
+    const out: SlackMessage[] = [];
+    let cursor: string | undefined;
+    while (out.length < max) {
+      const params: Record<string, string> = {
+        channel: channelId,
+        limit: String(Math.min(200, max - out.length)),
+      };
+      if (cursor) params.cursor = cursor;
+      const r = await this.call<{
+        messages: SlackMessage[];
+        response_metadata?: { next_cursor?: string };
+      }>("conversations.history", params);
+      out.push(...(r.messages ?? []));
+      cursor = r.response_metadata?.next_cursor || undefined;
+      if (!cursor) break;
+    }
+    return out;
+  }
+
+  /** Thread replies (excludes the root message). */
+  async replies(channelId: string, threadTs: string): Promise<SlackMessage[]> {
+    const r = await this.call<{ messages: SlackMessage[] }>("conversations.replies", {
+      channel: channelId,
+      ts: threadTs,
+    });
+    return (r.messages ?? []).filter((m) => m.ts !== threadTs);
+  }
+
+  /** All workspace users → id→name map (one paginated pass; best-effort). */
+  async usersMap(): Promise<Record<string, string>> {
+    const map: Record<string, string> = {};
+    let cursor: string | undefined;
+    try {
+      do {
+        const params: Record<string, string> = { limit: "200" };
+        if (cursor) params.cursor = cursor;
+        const r = await this.call<{
+          members: { id: string; name?: string; real_name?: string; profile?: { display_name?: string; real_name?: string } }[];
+          response_metadata?: { next_cursor?: string };
+        }>("users.list", params);
+        for (const u of r.members ?? []) {
+          map[u.id] =
+            u.profile?.display_name || u.profile?.real_name || u.real_name || u.name || u.id;
+        }
+        cursor = r.response_metadata?.next_cursor || undefined;
+      } while (cursor);
+    } catch {
+      // users:read not granted — fall back to ids at normalize time.
+    }
+    return map;
+  }
+}
+
+/** Keep only real human/bot messages with text (drop joins, topic changes, etc.). */
+function isContentMessage(m: SlackMessage): boolean {
+  if (!m.text || !m.text.trim()) return false;
+  // No subtype = a normal message. Allow bot_message; drop channel_join/leave/topic/etc.
+  return !m.subtype || m.subtype === "bot_message" || m.subtype === "thread_broadcast";
+}
+
+/**
+ * Fetch one channel into top-level threads (root message + its replies), capped
+ * at `maxMessages` roots. Each thread becomes one brain item at normalize time.
+ */
+export async function fetchSlackChannel(
+  client: SlackClient,
+  channelId: string,
+  opts: { maxMessages?: number; users?: Record<string, string> } = {}
+): Promise<FetchedChannel> {
+  const max = opts.maxMessages ?? 300;
+  const [channelName, users] = await Promise.all([
+    client.channelName(channelId),
+    opts.users ? Promise.resolve(opts.users) : client.usersMap(),
+  ]);
+
+  const history = await client.history(channelId, max);
+  // Top-level messages only (a reply has thread_ts !== ts). Roots keep their thread.
+  const roots = history.filter((m) => isContentMessage(m) && (!m.thread_ts || m.thread_ts === m.ts));
+
+  const threads: FetchedThread[] = [];
+  for (const root of roots) {
+    let replies: SlackMessage[] = [];
+    if (root.reply_count && root.reply_count > 0) {
+      try {
+        replies = (await client.replies(channelId, root.ts)).filter(isContentMessage);
+      } catch {
+        replies = [];
+      }
+    }
+    threads.push({ root, replies });
+  }
+  return { channelId, channelName, threads, users };
+}

--- a/test/ingest-slack-normalize.test.ts
+++ b/test/ingest-slack-normalize.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { normalizeThread, type NormalizeOpts } from "@/lib/ingest/sources/slack-normalize";
+import { itemPayloadSchema } from "@/lib/api/schemas";
+import type { FetchedThread } from "@/lib/ingest/sources/slack";
+
+const opts: NormalizeOpts = {
+  channelId: "C0B8V119G4D",
+  channelName: "eng",
+  users: { U1: "Alex", U2: "Riley" },
+  project: "slack",
+};
+
+describe("normalizeThread", () => {
+  it("maps a single message to a valid transcript ItemPayload", () => {
+    const thread: FetchedThread = {
+      root: { ts: "1718900000.000100", user: "U1", text: "shipping the dual-backend today" },
+      replies: [],
+    };
+    const p = normalizeThread(thread, opts);
+
+    // conforms to the brain contract
+    expect(() => itemPayloadSchema.parse(p)).not.toThrow();
+    expect(p.kind).toBe("transcript");
+    expect(p.path).toBe("slack/eng/1718900000.000100.md");
+    expect(p.content_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(p.actor).toBe("Alex");
+    expect(p.body).toContain("shipping the dual-backend today");
+    expect(p.frontmatter.channel_id).toBe("C0B8V119G4D");
+    expect(p.frontmatter.reply_count).toBe(0);
+  });
+
+  it("resolves @mentions and links, and appends thread replies", () => {
+    const thread: FetchedThread = {
+      root: { ts: "1718900100.000200", user: "U1", text: "hey <@U2> see <https://x.com|the doc>" },
+      replies: [{ ts: "1718900200.000300", user: "U2", text: "on it" }],
+    };
+    const p = normalizeThread(thread, opts);
+    expect(p.body).toContain("@Riley");
+    expect(p.body).toContain("the doc (https://x.com)");
+    expect(p.body).toContain("on it");
+    expect(p.frontmatter.reply_count).toBe(1);
+  });
+
+  it("is deterministic — same thread yields the same sha (dedup-stable)", () => {
+    const thread: FetchedThread = {
+      root: { ts: "1718900300.000400", user: "U1", text: "same" },
+      replies: [],
+    };
+    expect(normalizeThread(thread, opts).content_sha256).toBe(
+      normalizeThread(thread, opts).content_sha256
+    );
+  });
+
+  it("falls back to a safe path segment when the channel name is missing", () => {
+    const p = normalizeThread(
+      { root: { ts: "1.0", user: "U1", text: "x" }, replies: [] },
+      { ...opts, channelName: "" }
+    );
+    expect(p.path).toMatch(/^slack\/[a-z0-9_-]+\/1\.0\.md$/);
+  });
+});


### PR DESCRIPTION
Ports the Slack connector from the Python sidecar into the brain so ingestion runs inside the single Next.js Railway service. Config-driven and plug-and-play: an admin pastes the bot token in the **Integrations** UI (stored encrypted per PR #24), selects channel IDs, and the brain self-schedules a pull every 30 min (in-process via `instrumentation.ts`) plus a **Sync now** button.

## Pieces
- `lib/ingest/sources/slack.ts` — Slack Web API client (raw fetch; history/replies/info + cached users.list; pagination; bounded).
- `lib/ingest/sources/slack-normalize.ts` — pure thread→`ItemPayload` (kind `transcript`, path `slack/<chan>/<ts>.md`, sha256, @mention/link rendering). **Spec-tested.**
- `lib/ingest/run.ts` — orchestrator using `getEnabledIntegrationsWithSecrets` (decrypted per-integration token; `SLACK_BOT_TOKEN` env fallback) → existing `ingestItem` writer (dedup/version/audit). Idempotent, single-flight.
- `lib/ingest/scheduler.ts` + `instrumentation.ts` — in-process poller (Node runtime), `INGEST_POLL_MINUTES` default 30, opt out `INGEST_POLL_ENABLED=false`.
- Admin **Sync now** button + `syncSlackNow` action.

## Test plan
- [x] `tsc`, `eslint`, `next build` clean; normalize spec test green (4/4).
- [ ] Live: add Slack integration (channel `C0B8V119G4D` + token) → Sync now → transcripts appear in Library.

## Notes
- One-service goal met: no separate Python/cron service. Sidecar stays in-repo but is superseded for Slack.
- Needs `SECRETS_KEY` on the service to decrypt dashboard-stored tokens (already required by PR #24's admin UI).
- In-process scheduler: if Railway runs >1 replica, duplicate runs are harmless (sha dedup); a DB advisory lock is the follow-up if we scale out.