### PR TITLE
feat(F3): integrations auth surfaces + contract bump

### DIFF
--- a/app/api/v1/integrations/route.ts
+++ b/app/api/v1/integrations/route.ts
@@ -4,15 +4,17 @@ import { authenticateApiKey } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/api/rate-limit";
 import { errorResponse } from "@/lib/api/schemas";
 import { audit } from "@/lib/api/audit";
-import { getEnabledIntegrationsWithSecrets } from "@/lib/integrations/manage";
+import { listEnabledIntegrationSelections } from "@/lib/integrations/read";
 
 export const runtime = "nodejs";
 
 /**
- * GET /api/v1/integrations — the ingestion sidecar pulls its team's enabled integrations
- * (config + DECRYPTED secret) authenticated by its connector API key. The only path that
- * emits plaintext connector secrets; every fetch is audited (`integrations.read`). Admins
- * manage integrations in the dashboard (Admin → Integrations).
+ * GET /api/v1/integrations — returns the authenticated team's ENABLED integration
+ * **selections** (type + name + non-secret config) for an API-key caller. It NEVER returns
+ * connector secrets or `secret_ciphertext`: the connector secret never crosses this HTTP
+ * boundary, even to a valid key. The in-process ingestion runner reads decrypted secrets
+ * directly (`lib/integrations/manage.getEnabledIntegrationsWithSecrets`), not over the API.
+ * Admins manage integrations in the dashboard (Admin → Integrations). Every read is audited.
  */
 export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
@@ -24,7 +26,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const integrations = await getEnabledIntegrationsWithSecrets(supabase, auth.teamId);
+    const integrations = await listEnabledIntegrationSelections(supabase, auth.teamId);
     await audit(supabase, {
       team_id: auth.teamId,
       actor_kind: "api_key",
@@ -33,7 +35,7 @@ export async function GET(req: NextRequest) {
       action: "integrations.read",
       meta: { count: integrations.length, types: integrations.map((i) => i.type) },
     });
-    // Never echo the connector key; secrets are returned to the authenticated sidecar only.
+    // Non-secret selections only — no token/secret/secret_ciphertext ever leaves here.
     return Response.json({ integrations });
   } catch (e) {
     return errorResponse("internal", e instanceof Error ? e.message : "failed", 500);

--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -11,23 +11,21 @@ import {
   deleteIntegration,
 } from "@/lib/integrations/manage";
 import { runSlackIngestion } from "@/lib/ingest/run";
+import { resolveIntegrationsAdmin } from "@/lib/integrations/read";
 import { IntegrationConfigError, type IntegrationType } from "@/lib/api/schemas";
 
+/**
+ * Session half of the admin gate: resolve the signed-in user, then delegate to the DB-level
+ * `resolveIntegrationsAdmin` (same role==="admin" + active-member check as the /admin layout).
+ * Returns null on any non-admin/unknown/wrong-team caller → every write action rejects.
+ */
 async function requireAdmin(teamSlug: string) {
   const supabase = await serverClient();
   const user = await getSessionUser();
   if (!user) return null;
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
-  if (!team) return null;
-  const { data: me } = await supabase
-    .from("members")
-    .select("id, role")
-    .eq("team_id", team.id)
-    .eq("auth_user_id", user.id)
-    .eq("status", "active")
-    .maybeSingle();
-  if (me?.role !== "admin") return null;
-  return { teamId: team.id, myMemberId: me.id as string };
+  const ctx = await resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+  if (!ctx) return null;
+  return { teamId: ctx.teamId, myMemberId: ctx.memberId };
 }
 
 function toList(raw: string): string[] {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Reason from this table, not from a random call site.
 | Git-author aliases | `member_emails` (+ `members.github_login`/`avatar_url`) | `lib/admin/*` + GitHub sync (`lib/codebases/github`) | `lib/codebases/ingest` (author→member), dashboard | team-scoped `unique(team_id,email)`; one alias → one member |
 | Sessions (postgres) | `auth_users`, `auth_tokens` | `lib/auth/pg-*` | `getSessionUser` | signed httpOnly cookie |
 | Rate limits | `rate_limits` | `rate_limit_hit` rpc | — | service-role only |
-| Integrations | `integrations` | **`lib/integrations/manage` only** (single-writer guarded; admin actions) | Admin → Integrations page (`lib/integrations/read`); `GET /api/v1/integrations` (sidecar) | `config` is NON-secret (per-type allowlist + secret-key rejection); the connector secret is **encrypted at rest** in `secret_ciphertext` (`lib/secrets`, AES-256-GCM), plaintext only on the connector-key read path (audited); admin-gated writes; postgres-only |
+| Integrations | `integrations` | **`lib/integrations/manage` only** (single-writer guarded; admin server actions) | Admin → Integrations page (`lib/integrations/read`); `GET /api/v1/integrations` (API-key, NON-secret selections); in-process Slack runner (`lib/ingest/run` via `manage.getEnabledIntegrationsWithSecrets`) | `config` is NON-secret (per-type allowlist + secret-key rejection); the connector secret is **encrypted at rest** in `secret_ciphertext` (`lib/secrets`, AES-256-GCM) and decrypted **only in-process** for the runner — it never leaves over HTTP, not even on the API-key read; writes admin-gated (`role==="admin"`, app-code, no RLS backstop — `resolveIntegrationsAdmin`); postgres-only |
 | Codebase analytics | `codebases`, `code_metrics`, `code_contributions`, `github_issues` | **`lib/codebases/ingest` only** (single-writer guarded; via `POST /api/v1/codebases`) | codebases pages, `lib/metrics/codebases` | team-tier only; **app-code gate** (`lib/codebases/visibility` + guard) — no RLS backstop. Brain derives `agentic_score`/`health_score`; AEM `readiness_*` is scored scanner-side (`ingestion/aios_ingest/analyzers/readiness.py`) and persisted verbatim |
 
 ## System context
@@ -273,7 +273,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/okf-bundle` — OKF link graph (tier-filtered, link redaction)
 - `POST /api/v1/actions` — request a policy-gated action (Organ 4)
 - `POST /api/v1/codebases` — ingest a codebase scan (raw metrics + scanner-scored AEM agent-readiness, persisted verbatim; team-tier key only, audited)
-- `GET /api/v1/integrations` — sidecar pulls enabled integrations + decrypted secrets (connector key; audited)
+- `GET /api/v1/integrations` — API-key read of a team's enabled integration selections; NON-SECRET only (no secret/secret_ciphertext), team-scoped, audited
 - `POST /api/v1/metrics` — ingest an AEM individual maturity daily snapshot (team-tier key only; brain recomputes canonical scores; audited)
 - `POST /api/dashboard/query` — same query pipeline, session-authenticated
 - `POST /api/auth/login` — postgres-mode direct passwordless sign-in (invite-only; 403 if unknown)

--- a/lib/integrations/read.ts
+++ b/lib/integrations/read.ts
@@ -38,3 +38,67 @@ export async function listIntegrations(
     createdAt: r.created_at as string,
   }));
 }
+
+/**
+ * Resolve a team-slug + auth-user into an admin write context, or null. This is the DB-level
+ * half of the dashboard's `requireAdmin` gate (the session lookup happens in the server action):
+ * it returns `{ teamId, memberId }` ONLY when the user is an `active`, `role==="admin"` member of
+ * the team — exactly the gate `app/t/[team]/admin/layout.tsx` applies. Any non-admin (member/lead),
+ * inactive, wrong-team, or unknown user resolves to null → the write is rejected. Tested on real
+ * Postgres (F3.4); there is no RLS backstop on the postgres target, so this app-code gate is the
+ * isolation.
+ */
+export async function resolveIntegrationsAdmin(
+  supabase: SupabaseClient,
+  teamSlug: string,
+  userId: string
+): Promise<{ teamId: string; memberId: string } | null> {
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+  const { data: me } = await supabase
+    .from("members")
+    .select("id, role")
+    .eq("team_id", team.id)
+    .eq("auth_user_id", userId)
+    .eq("status", "active")
+    .maybeSingle();
+  if (!me || me.role !== "admin") return null;
+  return { teamId: team.id as string, memberId: me.id as string };
+}
+
+/** A team's enabled integration selection — NON-SECRET fields only. */
+export interface IntegrationSelection {
+  id: string;
+  type: IntegrationType;
+  name: string;
+  config: Record<string, unknown>;
+  status: "enabled";
+}
+
+/**
+ * The API read path for `GET /api/v1/integrations`: a team's ENABLED integrations as
+ * NON-SECRET selections (type + name + config). It deliberately never selects, decrypts, or
+ * returns `secret_ciphertext` — the connector secret never crosses this HTTP boundary, even to
+ * an authenticated connector key. (The in-process Slack runner reads decrypted secrets directly
+ * via `manage.getEnabledIntegrationsWithSecrets`, never over HTTP.) Team-scoped: only the
+ * caller's `teamId` is returned.
+ */
+export async function listEnabledIntegrationSelections(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<IntegrationSelection[]> {
+  const { data, error } = await supabase
+    .from("integrations")
+    .select("id, type, name, config, status") // NOTE: no secret_ciphertext — by design
+    .eq("team_id", teamId)
+    .eq("status", "enabled")
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(`list integration selections failed: ${error.message}`);
+  return (data ?? []).map((r) => ({
+    id: r.id as string,
+    type: r.type as IntegrationType,
+    name: r.name as string,
+    config: (r.config as Record<string, unknown>) ?? {},
+    status: "enabled" as const,
+  }));
+}

--- a/test/datamechanics/integrations-auth.datamechanics.test.ts
+++ b/test/datamechanics/integrations-auth.datamechanics.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { loginByEmail } from "@/lib/auth/pg-login";
+import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
+import {
+  resolveIntegrationsAdmin,
+  listEnabledIntegrationSelections,
+} from "@/lib/integrations/read";
+import { db, seedTeam } from "./helpers";
+
+// F3.4 — spec-first, verified to the observable outcome on real Postgres.
+//
+// Two product invariants for the integrations auth surfaces:
+//  1. (F3.1 write gate) The dashboard write is admin-gated by the same role==="admin" check the
+//     /admin layout uses. A non-admin (member/lead) member must NOT resolve to a write context.
+//     There is no RLS backstop on the postgres target, so this app-code gate is the isolation.
+//  2. (F3.2 API read) GET /api/v1/integrations returns enabled selections as NON-SECRET fields
+//     only — never the connector secret / secret_ciphertext — and is team-scoped.
+
+function auth(teamId: string, memberId: string) {
+  return { teamId, memberId };
+}
+
+/** Insert a member with a known role + email, then force-link an auth user via the login path. */
+async function seedMemberWithAuth(
+  teamId: string,
+  role: "admin" | "lead" | "member",
+  email: string
+): Promise<{ memberId: string; userId: string }> {
+  const { data: m } = await db()
+    .from("members")
+    .insert({
+      team_id: teamId,
+      email,
+      display_name: role,
+      actor_handle: `${role}-${email.split("@")[0]}`,
+      role,
+      tier: "team",
+      status: "invited",
+    })
+    .select("id")
+    .single();
+  const user = await loginByEmail(email); // activates + links auth_user_id
+  if (!user) throw new Error("login link failed in seed");
+  return { memberId: m!.id as string, userId: user.id };
+}
+
+describe("integrations dashboard write gate (real Postgres)", () => {
+  it("an admin member resolves to a write context", async () => {
+    const seed = await seedTeam();
+    const admin = await seedMemberWithAuth(seed.teamId, "admin", "admin@f3.test");
+    const ctx = await resolveIntegrationsAdmin(db(), seed.teamSlug, admin.userId);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.teamId).toBe(seed.teamId);
+    expect(ctx!.memberId).toBe(admin.memberId);
+  });
+
+  it("a non-admin (member-role) is REJECTED — no write context", async () => {
+    const seed = await seedTeam();
+    const member = await seedMemberWithAuth(seed.teamId, "member", "member@f3.test");
+    expect(await resolveIntegrationsAdmin(db(), seed.teamSlug, member.userId)).toBeNull();
+  });
+
+  it("a lead-role member is REJECTED — admin-only, not lead", async () => {
+    const seed = await seedTeam();
+    const lead = await seedMemberWithAuth(seed.teamId, "lead", "lead@f3.test");
+    expect(await resolveIntegrationsAdmin(db(), seed.teamSlug, lead.userId)).toBeNull();
+  });
+
+  it("an admin of ANOTHER team cannot resolve against this team", async () => {
+    const teamA = await seedTeam();
+    const teamB = await seedTeam();
+    const adminB = await seedMemberWithAuth(teamB.teamId, "admin", "adminB@f3.test");
+    // Admin of B, querying A's slug → no membership in A → null.
+    expect(await resolveIntegrationsAdmin(db(), teamA.teamSlug, adminB.userId)).toBeNull();
+  });
+});
+
+describe("integrations API read — non-secret + team-scoped (real Postgres)", () => {
+  it("returns enabled selections with NO secret material, even when a secret is set", async () => {
+    const seed = await seedTeam();
+    const a = auth(seed.teamId, seed.memberId);
+    const token = "xoxb-SUPER-secret-token-zzz999";
+
+    const { id } = await upsertIntegration(db(), a, {
+      type: "slack",
+      name: "eng",
+      config: { channelIds: ["C1", "C2"] },
+    });
+    await setIntegrationSecret(db(), a, id, token);
+
+    const selections = await listEnabledIntegrationSelections(db(), seed.teamId);
+    expect(selections).toHaveLength(1);
+    const sel = selections[0];
+    expect(sel.type).toBe("slack");
+    expect(sel.name).toBe("eng");
+    expect(sel.config).toEqual({ channelIds: ["C1", "C2"] });
+
+    // Crown jewel: no secret, no ciphertext, no decrypted token anywhere in the payload.
+    const serialized = JSON.stringify(selections);
+    expect(serialized).not.toContain(token);
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("ciphertext");
+    expect(Object.keys(sel)).toEqual(["id", "type", "name", "config", "status"]);
+  });
+
+  it("excludes disabled integrations", async () => {
+    const seed = await seedTeam();
+    const a = auth(seed.teamId, seed.memberId);
+    await upsertIntegration(db(), a, {
+      type: "github",
+      name: "g",
+      config: { repos: ["o/r"] },
+      status: "disabled",
+    });
+    expect(await listEnabledIntegrationSelections(db(), seed.teamId)).toHaveLength(0);
+  });
+
+  it("is team-scoped: never returns another team's integrations", async () => {
+    const teamA = await seedTeam();
+    const teamB = await seedTeam();
+    await upsertIntegration(db(), auth(teamA.teamId, teamA.memberId), {
+      type: "slack",
+      name: "a-only",
+      config: { channelIds: ["CA"] },
+    });
+    await upsertIntegration(db(), auth(teamB.teamId, teamB.memberId), {
+      type: "slack",
+      name: "b-only",
+      config: { channelIds: ["CB"] },
+    });
+
+    const aSel = await listEnabledIntegrationSelections(db(), teamA.teamId);
+    expect(aSel.map((s) => s.name)).toEqual(["a-only"]);
+    const bSel = await listEnabledIntegrationSelections(db(), teamB.teamId);
+    expect(bSel.map((s) => s.name)).toEqual(["b-only"]);
+  });
+});


### PR DESCRIPTION
## EPIC F3 — Integrations auth surfaces + contract bump

Reconciled with the pre-existing `lib/integrations/manage.ts` (single writer) and the prior self-serve admin UI (PR #25). No duplication; the single-writer guard (`test/guards/single-writer-integrations.test.ts`) still holds.

### Sub-issues

**F3.1 — Dashboard session-auth WRITE (admin-gated)** ✅
The dashboard write surface already existed as admin server actions in `app/t/[team]/admin/integrations/actions.ts` (`saveIntegration`/`toggleIntegration`/`rotateSecret`/`removeIntegration`), all calling `lib/integrations/manage.ts`. Hardened the gate: `requireAdmin` now delegates to a new DB-level `resolveIntegrationsAdmin(supabase, teamSlug, userId)` in `lib/integrations/read.ts`, which applies the exact `role==="admin"` + active-member check from `app/t/[team]/admin/layout.tsx`. No new `/api/v1` write route.

**F3.2 — `GET /api/v1/integrations` (API-key auth) returns NON-SECRET only** ✅
Reworked the route to use the new `listEnabledIntegrationSelections()`, which selects only `id, type, name, config, status` — it never selects/decrypts/returns `secret_ciphertext` or any token. (The prior route returned decrypted secrets; that path is now dead surface — the in-process Slack runner reads decrypted secrets directly via `manage.getEnabledIntegrationsWithSecrets`, so secrets never cross the HTTP boundary even to a valid connector key.) API-key auth via `lib/api/auth.ts`; team-scoped; audited.

**F3.3 — Docs + contract** ✅
`docs/ARCHITECTURE.md`: updated the integrations source-of-truth row and the `drift:routes` entry for `GET /api/v1/integrations`. `npm run check:docs` passes. brain-api.md patch below (sibling repo not edited).

**F3.4 — Data-mechanics tests (real Postgres, spec-first / red-first)** ✅
`test/datamechanics/integrations-auth.datamechanics.test.ts` (7 tests). Proven red-first:
- removing the `role==="admin"` check → the member-role and lead-role rejection tests go red;
- making the read select+return `secret_ciphertext` → the non-secret read test goes red.
Covers: admin resolves; member/lead/other-team rejected; API read is non-secret + team-scoped + excludes disabled.

### Verification (all green)
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 123 passed (23 files), incl. single-writer-integrations guard
- `npm run check:docs` — routes/tables/sources in sync
- `npm run test:datamechanics` (real PG) — 64 passed (16 files), incl. the new 7

### brain-api.md patch — FOR A HUMAN TO APPLY in `aios-workspace/docs/brain-api.md`
Add the new read endpoint to the v1 surface (bump the contract version per the monorepo invariant):

```diff
+### `GET /api/v1/integrations`
+
+Returns the authenticated team's **enabled** integration *selections* — non-secret only.
+
+**Auth:** `Authorization: Bearer aios_<key_id>_<secret>` + `X-AIOS-Team: <slug-or-id>`
+(per-member API key; same scheme as the other v1 routes).
+
+**Request:** no body.
+
+**Response `200`:**
+```json
+{
+  "integrations": [
+    {
+      "id": "uuid",
+      "type": "slack",
+      "name": "eng",
+      "config": { "channelIds": ["C1", "C2"] },
+      "status": "enabled"
+    }
+  ]
+}
+```
+
+- `config` is the per-type **non-secret** selection (channels/repos/keywords/etc.).
+- The connector **secret is never returned** by this endpoint (no `secret`,
+  no `secret_ciphertext`). Secrets are stored encrypted at rest and decrypted
+  only in-process by the ingestion runner — they never cross the API boundary.
+- Results are **team-scoped** to the key's team; disabled integrations are omitted.
+
+**Errors:** `401` invalid key/team · `429` rate-limited (60/min/key).
```

### Notes for the human
- **Plane MCP not accessible** from this agent's context (only Jira/Confluence/GitHub/Linear tools were available). Could not move the epic to In Progress, flip F3.1–F3.4 to Done, or comment this PR URL on the epic — please do this manually.
- Apply the brain-api.md patch above in the `aios-workspace` repo and bump the contract version there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)