### PR TITLE
W1.1 — Granola → decisions (sanitized, consented)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -292,8 +292,15 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 ### Ingestion sources
 
 <!-- drift:sources -->
-`github` · `slack` · `notion` · `gdrive` · `confluence` · `linear` · `web` · `local` · `radar`
+`github` · `slack` · `notion` · `gdrive` · `confluence` · `linear` · `web` · `local` · `radar` · `granola`
 <!-- /drift:sources -->
+
+> **`granola` privacy invariant:** Granola is the one source that must **never** sync
+> verbatim transcript team-tier. Its `fetch()` team-push path emits metadata-only meeting
+> *markers* (`kind=artifact`, `transcript_synced:false`), behind an allowlist + per-note
+> consent gate; full transcripts are written to the local workspace at **admin tier only**
+> and decisions reach the `decisions` table solely through the human-reviewed
+> decision-log.md → `aios push` → `materializeDecisions` flow. See `docs/GRANOLA.md`.
 
 ## Docs drift guard
 

--- a/docs/GRANOLA.md
+++ b/docs/GRANOLA.md
@@ -1,0 +1,112 @@
+# Granola → decisions (sanitized, consented)
+
+**The hard rule: Granola meetings ingest as DECISION ROWS ONLY. No verbatim transcript is
+ever synced team-tier. Privacy is the point.**
+
+Granola records meeting transcripts. We want the *decisions* a meeting produced in the
+team brain — never the raw audio/text. This is enforced by separating the connector's two
+paths (one automatic + privacy-safe, one local-only) and by keeping the decision
+extraction step **human-reviewed**, not automatic.
+
+## The two connector paths (`ingestion/aios_ingest/sources/granola.py`)
+
+| Path | Trigger | Tier | Body content |
+|------|---------|------|--------------|
+| `fetch()` | `aios-ingest sync` (team-push) | **team** | metadata-only **meeting marker** (title, date, participants, Granola link) — **no transcript text** |
+| `pull_transcripts(dest)` | local workspace tooling | **admin (local file only)** | full transcript, written to the workspace, **never pushed** |
+
+`fetch()` items use `kind = artifact` (deliberately **not** `transcript`) so nothing in the
+team-push payload can carry verbatim speech. The marker frontmatter records
+`transcript_synced: false`.
+
+### The privacy gate (both paths)
+
+A meeting is processed only if **both** hold:
+
+1. **Allowlist** — its title mentions an allowlist topic (default `AIOS`) **or** a
+   participant matches the allowlist (default John / Chetan, by name or email).
+2. **Per-note consent** — the note carries a consent marker: a `consent: true` field, a
+   tag/label in `{aios-consent, consent, share-decisions}`, or a title token `[aios]` /
+   `[consent]`.
+
+Without consent the meeting is dropped **entirely** — not even a metadata marker leaves the
+machine. Topics/participants/consent-requirement are configurable per connection
+(`topics`, `participants`, `require_consent`).
+
+## Official API (mocked in tests; never hit live in CI)
+
+```
+GET https://public-api.granola.ai/v1/notes?limit=&cursor=&created_after=
+GET https://public-api.granola.ai/v1/notes/{id}?include=transcript
+Authorization: Bearer grn_…            rate limit ~300 req/min (429 → Retry-After honored)
+```
+
+The key is supplied as `${GRANOLA_API_KEY}` via `connections.yaml` options and is never
+logged. Cursor pagination + 429 backoff are handled in the adapter.
+
+## End-to-end flow: transcript → reviewed decisions → brain
+
+The decision extraction is **human/skill-driven**, not automatic. The connector never
+writes a decision row on its own; that would defeat the consent model.
+
+```mermaid
+flowchart LR
+  G[Granola API] -->|pull_transcripts<br/>allowlist+consent| W[workspace 1-inbox/transcripts<br/>tier: admin, LOCAL ONLY]
+  W -->|transcript-decisions skill| H{Human review}
+  H -->|approved decisions| DL[3-log/decision-log.md<br/>decision table rows]
+  DL -->|aios push| API[POST /api/v1/items<br/>kind=decision + rows]
+  API --> MAT[lib/ingest materializeDecisions]
+  MAT --> DB[(decisions table)]
+  DB --> DASH[dashboard + /api/v1/decisions]
+  G -.->|aios-ingest sync<br/>metadata marker only| API2[POST /api/v1/items<br/>kind=artifact, NO transcript]
+```
+
+Step by step:
+
+1. **Pull (local, admin-tier).** `pull_transcripts()` writes allowlisted + consented
+   transcripts into the workspace (`1-inbox/transcripts/`, frontmatter `access: admin`).
+   These files **never** enter the team-push path; the brain's `/api/v1/items` rejects
+   `admin`/`private` tier with 422 anyway, so even an accidental push is blocked at the
+   boundary.
+2. **Extract + HUMAN review.** The workspace `transcript-decisions` skill proposes
+   candidate decisions from the local transcript. A human reviews/edits them — this is the
+   consent checkpoint for *what specifically* becomes shared knowledge.
+3. **Record.** Approved decisions are appended as rows to `3-log/decision-log.md`
+   (the decision table: `row_key, title, decided_at, rationale, decided_by, impact,
+   tier, audience` — see `ItemPayload.DecisionRow`).
+4. **Push.** `aios push` sends `decision-log.md` as an `ItemPayload` (`kind = decision`,
+   `rows = [...]`) to `POST /api/v1/items`.
+5. **Materialize.** `lib/ingest` `materializeDecisions` diff-syncs those rows into the
+   `decisions` table (by `row_key`; UI-authored rows survive). They then appear on the
+   dashboard and via `GET /api/v1/decisions` (tier-scoped by `audience`).
+
+The optional `aios-ingest sync` of the Granola connection (step shown dashed) only adds a
+privacy-safe **meeting marker** to the brain so the meeting is discoverable — it carries no
+transcript and is independent of the decision-row flow.
+
+## Configure a connection
+
+```yaml
+# ingestion/connections.yaml
+connections:
+  - name: granola-aios
+    source: granola
+    access: team             # markers only; transcripts are admin-tier and local
+    project: aios
+    actor: granola-sync
+    options:
+      api_key: ${GRANOLA_API_KEY}
+      topics: AIOS            # comma-separated allowed
+      participants: john,chetan
+      require_consent: true   # NEVER set false for shared/team runs
+```
+
+## Why this is safe
+
+- Team-push path emits `kind=artifact` with `transcript_synced: false` — **structurally
+  cannot** carry verbatim transcript (guarded by `test_fetch_yields_marker_without_transcript_text`).
+- Transcripts are `access: admin` and only ever written to a local file; the brain 422s
+  admin-tier at `/api/v1/items`.
+- Un-consented meetings are dropped before any I/O leaves the machine (guarded by
+  `test_fetch_drops_unconsented_meetings`).
+- Decision rows are human-reviewed before they exist — the connector never authors them.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -60,6 +60,7 @@ expire. Cursors and channel state live in a local sqlite file (`--state-db`).
 |--------|--------------|--------|----------|
 | Slack / meeting notes | `transcript` | `slack/<channel>/<ts>.md` | per-connection (default `team`) |
 | Drive / Notion / Confluence / GitHub | `deliverable` | `<source>/<external-id>.md` | per-connection |
+| Granola (meeting **marker**) | `artifact` | `granola/<note-id>.md` | `team` — **no transcript**; see [docs/GRANOLA.md](../docs/GRANOLA.md) |
 
 Provenance (`source`, `source_id`, `source_url`, `author`, `source_ts`) is stored in the
 item's `frontmatter`. Re-reads of unchanged content are no-ops (sha256 dedup at the brain).

--- a/ingestion/aios_ingest/sources/granola.py
+++ b/ingestion/aios_ingest/sources/granola.py
@@ -1,0 +1,319 @@
+"""Granola source — meetings in, decisions out (NO verbatim transcript team-tier).
+
+Privacy is the whole point of this adapter. Granola records meeting transcripts; we
+must never sync that verbatim audio/text to the team tier. So this source does two
+distinct, deliberately-separated things:
+
+1. ``fetch()`` (the team-push path used by ``aios-ingest sync``) yields **metadata-only
+   meeting markers** — title, date, participants, the Granola permalink — for meetings
+   that pass the privacy gate. It NEVER puts transcript text in the body. The actual
+   decisions are extracted by a HUMAN-reviewed skill (transcript-decisions) into
+   ``3-log/decision-log.md`` and reach the brain as decision rows via ``aios push`` →
+   ``materializeDecisions`` (see docs/GRANOLA.md). This adapter does not auto-extract
+   decisions; doing so unreviewed would defeat the consent model.
+2. ``pull_transcripts(dest_dir)`` writes the **full transcript** to a LOCAL workspace
+   folder at **admin tier** only. These files never enter the team-push path; they exist
+   so the human extractor has source material on their own machine.
+
+The privacy gate (``_allowed``):
+- ALLOWLIST: a meeting must either mention an allowlist topic (default ``"AIOS"``) in its
+  title, or include an allowlist participant (default John / Chetan) by name or email.
+- CONSENT: a meeting must additionally carry a per-note consent marker (a tag/label, a
+  ``consent`` flag, or an opt-in title token like ``[aios]``). Absent consent, the meeting
+  is dropped entirely — not even a metadata marker leaves the machine.
+
+Both gates must pass. The gate is applied identically to the team-push path and the local
+transcript pull, so an un-consented meeting's transcript is never even written locally
+under the connector's automation.
+
+Official public API (https://docs.granola.ai/introduction), mocked in tests:
+    GET https://public-api.granola.ai/v1/notes?limit=&cursor=&created_after=
+    GET https://public-api.granola.ai/v1/notes/{id}?include=transcript
+    Authorization: Bearer grn_…   ·   rate limit ~300 req/min (429 → Retry-After)
+
+Pull-only (no webhook). The API key arrives via ``options`` (a ``${GRANOLA_API_KEY}`` env
+reference in connections.yaml) and is never logged.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Iterator
+
+import httpx
+
+from ..normalize import RawDoc
+from .base import PullOnlySource, Source
+
+_API = "https://public-api.granola.ai/v1"
+_MAX_RETRIES = 5
+
+# Default privacy gate. AIOS-topic meetings or meetings with John/Chetan, AND consent.
+_DEFAULT_TOPICS = ("aios",)
+_DEFAULT_PARTICIPANTS = ("john", "chetan", "iamjohndass@pm.me")
+# A note is treated as consented if any of these markers is present.
+_CONSENT_TAGS = ("aios-consent", "consent", "share-decisions")
+_CONSENT_TITLE_TOKENS = ("[aios]", "[consent]")
+
+
+def _pick(obj: Any, *keys: str) -> Any:
+    for k in keys:
+        if isinstance(obj, dict) and obj.get(k) is not None:
+            return obj[k]
+    return None
+
+
+def _participant_strings(note: dict[str, Any]) -> list[str]:
+    """Flatten Granola's people/attendees/participants into lowercased name+email tokens."""
+    raw = note.get("participants") or note.get("attendees") or note.get("people") or []
+    out: list[str] = []
+    for p in raw:
+        if isinstance(p, str):
+            out.append(p.lower())
+        elif isinstance(p, dict):
+            for v in (p.get("name"), p.get("email"), p.get("displayName")):
+                if v:
+                    out.append(str(v).lower())
+    return out
+
+
+def _tags(note: dict[str, Any]) -> list[str]:
+    raw = note.get("tags") or note.get("labels") or []
+    out: list[str] = []
+    for t in raw:
+        if isinstance(t, str):
+            out.append(t.lower())
+        elif isinstance(t, dict):
+            v = t.get("name") or t.get("label") or t.get("value")
+            if v:
+                out.append(str(v).lower())
+    return out
+
+
+class GranolaSource(PullOnlySource, Source):
+    name = "granola"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = _API,
+        topics: list[str] | str | None = None,
+        participants: list[str] | str | None = None,
+        require_consent: bool = True,
+        timeout: float = 30.0,
+        page_size: int = 100,
+    ):
+        if not api_key:
+            raise ValueError("granola source needs an `api_key` (set GRANOLA_API_KEY)")
+        self._key = api_key
+        self._base = base_url.rstrip("/")
+        self._topics = _as_lower_list(topics, _DEFAULT_TOPICS)
+        self._participants = _as_lower_list(participants, _DEFAULT_PARTICIPANTS)
+        # CLI `--opt require_consent=false` arrives as a string.
+        self._require_consent = _as_bool(require_consent)
+        self._timeout = float(timeout)
+        self._page_size = min(int(page_size), 100)
+
+    # ── HTTP with rate-limit (429) backoff ───────────────────────────────────
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._key}", "Accept": "application/json"}
+
+    def _get(
+        self, http: httpx.Client, url: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        resp: httpx.Response | None = None
+        for attempt in range(_MAX_RETRIES):
+            resp = http.get(url, params=params, headers=self._headers)
+            if resp.status_code == 429:
+                # ~300/min limit. Honor Retry-After; otherwise exponential backoff.
+                retry_after = resp.headers.get("Retry-After")
+                if retry_after and retry_after.replace(".", "", 1).isdigit():
+                    delay = float(retry_after)
+                else:
+                    delay = 2.0 ** attempt
+                time.sleep(delay)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+        raise httpx.HTTPStatusError(
+            "granola: exhausted retries on persistent 429 (rate limited)",
+            request=httpx.Request("GET", url),
+            response=resp,  # type: ignore[arg-type]
+        )
+
+    def _list_notes(self, http: httpx.Client, since: str | None) -> Iterator[dict[str, Any]]:
+        cursor: str | None = None
+        while True:
+            params: dict[str, Any] = {"limit": self._page_size}
+            if since:
+                params["created_after"] = since
+            if cursor:
+                params["cursor"] = cursor
+            page = self._get(http, f"{self._base}/notes", params=params)
+            items = _pick(page, "data", "notes", "items") or (page if isinstance(page, list) else [])
+            for n in items:
+                yield n
+            cursor = _pick(page, "next_cursor", "cursor") or _pick(
+                _pick(page, "pagination") or {}, "next_cursor"
+            )
+            if not cursor:
+                return
+
+    # ── privacy gate ─────────────────────────────────────────────────────────
+    def _allowed(self, note: dict[str, Any]) -> bool:
+        title = (_pick(note, "title", "name") or "").lower()
+        people = _participant_strings(note)
+        topic_hit = any(t in title for t in self._topics)
+        people_hit = any(any(p in person for p in self._participants) for person in people)
+        if not (topic_hit or people_hit):
+            return False
+        return self._consented(note)
+
+    def _consented(self, note: dict[str, Any]) -> bool:
+        if not self._require_consent:
+            return True
+        if _as_bool(note.get("consent")):
+            return True
+        tags = _tags(note)
+        if any(c in tags for c in _CONSENT_TAGS):
+            return True
+        title = (_pick(note, "title", "name") or "").lower()
+        return any(tok in title for tok in _CONSENT_TITLE_TOKENS)
+
+    # ── team-push path: METADATA-ONLY markers, never transcript text ──────────
+    def fetch(self, *, since: str | None = None) -> Iterator[RawDoc]:
+        with httpx.Client(timeout=self._timeout) as http:
+            for note in self._list_notes(http, since):
+                if not self._allowed(note):
+                    continue
+                yield self._marker(note)
+
+    def _marker(self, note: dict[str, Any]) -> RawDoc:
+        """A privacy-safe meeting marker. Body intentionally carries NO transcript text —
+        only metadata + a pointer back to Granola for the human reviewer."""
+        nid = str(_pick(note, "id", "note_id", "uuid") or "")
+        title = _pick(note, "title", "name") or "Untitled meeting"
+        created = _pick(note, "created_at", "created", "createdAt") or None
+        url = _pick(note, "url", "permalink", "html_url")
+        people = list(_participant_strings(note))
+        body = (
+            f"Granola meeting **{title}**"
+            + (f" ({str(created)[:10]})" if created else "")
+            + ".\n\nThis is a privacy-safe marker — the verbatim transcript is NOT synced. "
+            "Decisions are extracted by a human-reviewed workflow into the decision log. "
+            "See docs/GRANOLA.md."
+        )
+        return RawDoc(
+            source=self.name,
+            external_id=nid or (title if isinstance(title, str) else "untitled"),
+            body=body,
+            title=str(title),
+            url=str(url) if url else None,
+            source_ts=str(created) if created else None,
+            kind="artifact",  # NOT "transcript" — there is no transcript in the body
+            access="team",
+            extra_frontmatter={
+                "granola": True,
+                "meeting": True,
+                "participants": ", ".join(people),
+                "transcript_synced": False,
+            },
+        )
+
+    # ── local-only path: full transcript to an ADMIN-tier workspace folder ────
+    def pull_transcripts(self, dest_dir: str, *, since: str | None = None) -> list[str]:
+        """Write full transcripts for allowlisted+consented meetings to ``dest_dir``
+        (a LOCAL admin-tier workspace folder). Returns the written paths. These files are
+        never pushed team-tier; they feed the human transcript-decisions workflow only."""
+        os.makedirs(dest_dir, exist_ok=True)
+        written: list[str] = []
+        with httpx.Client(timeout=self._timeout) as http:
+            for note in self._list_notes(http, since):
+                if not self._allowed(note):
+                    continue
+                nid = str(_pick(note, "id", "note_id", "uuid") or "")
+                if not nid:
+                    continue
+                full = self._get(
+                    http, f"{self._base}/notes/{nid}", params={"include": "transcript"}
+                )
+                text = _transcript_text(full)
+                title = _pick(full, "title", "name") or _pick(note, "title", "name") or "untitled"
+                created = (
+                    _pick(full, "created_at", "created", "createdAt")
+                    or _pick(note, "created_at")
+                    or ""
+                )
+                fname = f"{str(created)[:10] or 'undated'}-{_slug(title)}.md"
+                path = os.path.join(dest_dir, fname)
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(_admin_transcript_md(nid, str(title), str(created), text))
+                written.append(path)
+        return written
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+def _as_lower_list(value: list[str] | str | None, default: tuple[str, ...]) -> list[str]:
+    if value is None:
+        return list(default)
+    if isinstance(value, str):
+        value = [v.strip() for v in value.split(",") if v.strip()]
+    return [v.lower() for v in value]
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+def _slug(s: Any) -> str:
+    out = "".join(c if c.isalnum() else "-" for c in str(s or "untitled").lower())
+    return "-".join(part for part in out.split("-") if part)[:60] or "untitled"
+
+
+def _transcript_text(note: dict[str, Any]) -> str:
+    t = note.get("transcript")
+    if not t:
+        # some payloads inline segments at the top level
+        t = note.get("segments")
+    if not t:
+        return ""
+    if isinstance(t, str):
+        return t
+    if isinstance(t, dict):
+        if isinstance(t.get("text"), str):
+            return t["text"]
+        if isinstance(t.get("segments"), list):
+            t = t["segments"]
+    if isinstance(t, list):
+        lines = []
+        for seg in t:
+            if isinstance(seg, dict):
+                speaker = seg.get("speaker") or seg.get("source") or ""
+                txt = seg.get("text") or ""
+                lines.append(f"{speaker + ': ' if speaker else ''}{txt}")
+            elif isinstance(seg, str):
+                lines.append(seg)
+        return "\n".join(lines)
+    return ""
+
+
+def _admin_transcript_md(nid: str, title: str, created: str, text: str) -> str:
+    return (
+        "---\n"
+        "type: transcript\n"
+        "source: granola\n"
+        f"granola_id: {nid}\n"
+        f"created: {created}\n"
+        "access: admin            # LOCAL ONLY — never pushed team-tier (privacy)\n"
+        "status: ingested\n"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"{text or '(no transcript available)'}\n"
+    )

--- a/ingestion/aios_ingest/sources/registry.py
+++ b/ingestion/aios_ingest/sources/registry.py
@@ -12,6 +12,7 @@ from .base import Source
 from .confluence import ConfluenceSource
 from .gdrive import GoogleDriveSource
 from .github import GithubSource
+from .granola import GranolaSource
 from .linear import LinearSource
 from .local import LocalSource
 from .notion import NotionSource
@@ -31,6 +32,7 @@ _REGISTRY: dict[str, Builder] = {
     "web": WebSource,
     "local": LocalSource,
     "radar": RadarSource,
+    "granola": GranolaSource,
 }
 
 

--- a/ingestion/connections.example.yaml
+++ b/ingestion/connections.example.yaml
@@ -28,3 +28,19 @@ connections:
         - https://github.com/anthropics/claude-code/releases.atom
         - https://hnrss.org/newest?q=Claude+Code&points=50
       max_entries_per_feed: 50
+
+  # ── Granola meetings → decisions (sanitized, consented) ───────────────────────
+  # HARD RULE: meetings ingest as DECISION ROWS ONLY. The sync path below pushes a
+  # privacy-safe metadata MARKER (kind=artifact, NO transcript). Verbatim transcripts
+  # are pulled to the LOCAL workspace at admin-tier and never synced. Decisions reach
+  # the brain only after HUMAN review via decision-log.md + `aios push`. See docs/GRANOLA.md.
+  - name: granola-aios
+    source: granola
+    access: team            # markers only — transcripts stay admin-tier and local
+    project: aios
+    actor: granola-sync
+    options:
+      api_key: ${GRANOLA_API_KEY}   # grn_… ; resolved from env, never committed
+      topics: AIOS                  # allowlist: title topic match (comma-separated)
+      participants: john,chetan     # allowlist: participant name/email match
+      require_consent: true         # per-note consent gate — NEVER false for team runs

--- a/ingestion/tests/test_granola.py
+++ b/ingestion/tests/test_granola.py
@@ -1,0 +1,218 @@
+"""Granola source — offline tests.
+
+Spec-derived (CLAUDE.md §2): the hard product rule is *NO verbatim transcript synced
+team-tier; meetings ingest as decision rows only, behind an allowlist + per-note consent*.
+These tests assert that contract directly, plus the registry wiring, RawDoc normalization,
+and mocked API pagination + 429 rate-limit behavior (no live API).
+"""
+
+import httpx
+import pytest
+
+from aios_ingest.normalize import NormalizeConfig, normalize
+from aios_ingest.sources import available_sources, build_source
+from aios_ingest.sources.granola import GranolaSource
+
+_REAL_CLIENT = httpx.Client  # captured before any monkeypatch rebinds httpx.Client
+
+
+def _mock_client_factory(handler):
+    return lambda **kw: _REAL_CLIENT(transport=httpx.MockTransport(handler))
+
+
+def _note(**kw):
+    base = {
+        "id": "n1",
+        "title": "AIOS planning",
+        "created_at": "2026-06-14T10:00:00Z",
+        "participants": [{"name": "John Dass", "email": "iamjohndass@pm.me"}],
+        "tags": ["aios-consent"],
+        "url": "https://granola.ai/notes/n1",
+    }
+    base.update(kw)
+    return base
+
+
+# ── registry wiring (W1.1.1) ──────────────────────────────────────────────────
+def test_registry_includes_granola():
+    assert "granola" in available_sources()
+    assert isinstance(build_source("granola", {"api_key": "grn_x"}), GranolaSource)
+
+
+def test_missing_api_key_raises():
+    with pytest.raises(ValueError):
+        build_source("granola", {"api_key": ""})
+
+
+# ── privacy gate: allowlist + consent (W1.1.2) ─────────────────────────────────
+def test_gate_allows_aios_topic_with_consent():
+    src = GranolaSource(api_key="grn_x")
+    assert src._allowed(_note(title="AIOS roadmap", participants=[], tags=["consent"]))
+
+
+def test_gate_allows_allowlisted_participant_with_consent():
+    src = GranolaSource(api_key="grn_x")
+    n = _note(title="Weekly sync", participants=[{"name": "Chetan"}], tags=["share-decisions"])
+    assert src._allowed(n)
+
+
+def test_gate_blocks_offtopic_meeting():
+    src = GranolaSource(api_key="grn_x")
+    n = _note(title="Dentist appointment", participants=[{"name": "Bob"}], tags=["consent"])
+    assert not src._allowed(n)
+
+
+def test_gate_blocks_allowlisted_meeting_without_consent():
+    # On-topic / right people, but NO consent marker → dropped entirely.
+    src = GranolaSource(api_key="grn_x")
+    n = _note(title="AIOS planning", tags=[], consent=None)
+    n.pop("tags")
+    assert not src._allowed(n)
+
+
+def test_consent_via_title_token():
+    src = GranolaSource(api_key="grn_x")
+    assert src._allowed(_note(title="AIOS sync [aios]", tags=[]))
+
+
+def test_require_consent_false_skips_consent_check():
+    src = GranolaSource(api_key="grn_x", require_consent=False)
+    assert src._allowed(_note(title="AIOS planning", tags=[]))
+
+
+# ── team-push path emits METADATA-ONLY markers, NEVER transcript (W1.1.2) ──────
+def test_fetch_yields_marker_without_transcript_text(monkeypatch):
+    transcript_secret = "SECRET VERBATIM SPEECH that must never sync"
+    page = {"data": [_note(transcript=transcript_secret)], "next_cursor": None}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        # The team-push path must NEVER call the transcript endpoint.
+        assert "include=transcript" not in str(req.url)
+        assert req.url.path.endswith("/v1/notes")
+        return httpx.Response(200, json=page)
+
+    monkeypatch.setattr(httpx, "Client", _mock_client_factory(handler))
+    docs = list(GranolaSource(api_key="grn_x").fetch())
+    assert len(docs) == 1
+    d = docs[0]
+    assert d.source == "granola"
+    assert d.access == "team"
+    assert d.kind == "artifact"  # NOT "transcript"
+    assert transcript_secret not in d.body  # the hard rule
+    assert d.external_id == "n1"
+    assert d.extra_frontmatter["transcript_synced"] is False
+
+
+def test_fetch_drops_unconsented_meetings(monkeypatch):
+    page = {
+        "data": [
+            _note(id="ok", title="AIOS sync", tags=["consent"]),
+            _note(id="nope", title="AIOS sync", tags=[]),  # no consent
+            _note(id="offtopic", title="Lunch", participants=[{"name": "Stranger"}], tags=["consent"]),
+        ],
+        "next_cursor": None,
+    }
+    monkeypatch.setattr(
+        httpx, "Client", _mock_client_factory(lambda req: httpx.Response(200, json=page))
+    )
+    docs = list(GranolaSource(api_key="grn_x").fetch())
+    assert [d.external_id for d in docs] == ["ok"]
+
+
+# ── pagination (W1.1.5) ─────────────────────────────────────────────────────────
+def test_fetch_paginates_with_cursor(monkeypatch):
+    pages = [
+        {"data": [_note(id="a", title="AIOS a", tags=["consent"])], "next_cursor": "c1"},
+        {"data": [_note(id="b", title="AIOS b", tags=["consent"])], "next_cursor": None},
+    ]
+    seen_cursors = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        cursor = dict(req.url.params).get("cursor")
+        seen_cursors.append(cursor)
+        return httpx.Response(200, json=pages[len(seen_cursors) - 1])
+
+    monkeypatch.setattr(httpx, "Client", _mock_client_factory(handler))
+    docs = list(GranolaSource(api_key="grn_x").fetch())
+    assert [d.external_id for d in docs] == ["a", "b"]
+    assert seen_cursors == [None, "c1"]  # second request carried the cursor
+
+
+# ── rate-limit 429 backoff (W1.1.5) ─────────────────────────────────────────────
+def test_429_then_success_retries(monkeypatch):
+    calls = {"n": 0}
+    page = {"data": [_note(title="AIOS x", tags=["consent"])], "next_cursor": None}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, headers={"Retry-After": "0"}, json={"error": "rate"})
+        return httpx.Response(200, json=page)
+
+    monkeypatch.setattr(httpx, "Client", _mock_client_factory(handler))
+    sleeps = []
+    monkeypatch.setattr("aios_ingest.sources.granola.time.sleep", lambda s: sleeps.append(s))
+
+    docs = list(GranolaSource(api_key="grn_x").fetch())
+    assert len(docs) == 1
+    assert calls["n"] == 2  # retried after the 429
+    assert sleeps == [0.0]  # honored Retry-After
+
+
+def test_persistent_429_raises(monkeypatch):
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        _mock_client_factory(lambda req: httpx.Response(429, json={"error": "rate"})),
+    )
+    monkeypatch.setattr("aios_ingest.sources.granola.time.sleep", lambda s: None)
+    with pytest.raises(httpx.HTTPStatusError):
+        list(GranolaSource(api_key="grn_x").fetch())
+
+
+# ── local-only transcript pull is ADMIN-tier and never team-pushed (W1.1.3) ────
+def test_pull_transcripts_writes_admin_tier_local_files(monkeypatch, tmp_path):
+    list_page = {"data": [_note(id="n1", title="AIOS planning", tags=["consent"])], "next_cursor": None}
+    full = _note(
+        id="n1",
+        title="AIOS planning",
+        transcript=[
+            {"speaker": "John", "text": "We will ship Wave A first."},
+            {"speaker": "Chetan", "text": "Agreed."},
+        ],
+    )
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if "include=transcript" in str(req.url) or "/v1/notes/n1" in req.url.path:
+            return httpx.Response(200, json=full)
+        return httpx.Response(200, json=list_page)
+
+    monkeypatch.setattr(httpx, "Client", _mock_client_factory(handler))
+    dest = tmp_path / "transcripts"
+    written = GranolaSource(api_key="grn_x").pull_transcripts(str(dest))
+    assert len(written) == 1
+    content = (dest / written[0].split("/")[-1]).read_text(encoding="utf-8") \
+        if "/" in written[0] else open(written[0]).read()
+    assert "access: admin" in content  # LOCAL only — never team-tier
+    assert "We will ship Wave A first." in content  # full transcript lives locally only
+    assert "John: We will ship Wave A first." in content
+
+
+# ── normalization of the marker into an ItemPayload (W1.1.5) ────────────────────
+def test_marker_normalizes_to_team_artifact_item(monkeypatch):
+    page = {"data": [_note(id="Note 1", title="AIOS planning")], "next_cursor": None}
+    monkeypatch.setattr(
+        httpx, "Client", _mock_client_factory(lambda req: httpx.Response(200, json=page))
+    )
+    raw = next(iter(GranolaSource(api_key="grn_x").fetch()))
+    item = normalize(raw, NormalizeConfig(default_project="aios", actor="granola-sync"))
+    assert item.kind == "artifact"
+    assert item.access == "team"
+    assert item.path == "granola/note-1.md"  # slugified, stable
+    assert item.project == "aios"
+    assert item.frontmatter["transcript_synced"] is False
+    assert item.frontmatter["source"] == "granola"
+    # identical re-read hashes identically (dedupe-safe)
+    raw2 = next(iter(GranolaSource(api_key="grn_x").fetch()))
+    item2 = normalize(raw2, NormalizeConfig(default_project="aios", actor="granola-sync"))
+    assert item.content_sha256 == item2.content_sha256


### PR DESCRIPTION
## EPIC W1.1 — Granola → decisions (sanitized, consented)

**Hard rule honored: Granola meetings ingest as DECISION ROWS ONLY. No verbatim transcript is ever synced team-tier.** Privacy is the point.

### What's here
- **W1.1.1 — Source adapter.** `ingestion/aios_ingest/sources/granola.py` implements the `Source` protocol (pull-only), registered in `registry.py`. Talks to the official public API — `GET /v1/notes` (cursor pagination), `GET /v1/notes/{id}?include=transcript`, `Authorization: Bearer grn_…`, ~300/min rate limit with `Retry-After`/exponential 429 backoff. Added `granola` to `docs/ARCHITECTURE.md` `drift:sources` (`npm run check:docs` green — 10 sources).
- **W1.1.2 — Privacy gate.** Allowlist (title mentions `AIOS` topic **OR** participant matches John/Chetan by name/email) **AND** per-note consent (a `consent` flag, a `{aios-consent, consent, share-decisions}` tag, or an `[aios]`/`[consent]` title token). Both must pass or the meeting is dropped before any I/O. The team-push `fetch()` emits **metadata-only meeting markers** (`kind=artifact`, `transcript_synced:false`) — structurally cannot carry verbatim transcript.
- **W1.1.3 — Transcripts local-only.** `pull_transcripts(dest)` writes full transcripts to a LOCAL workspace folder at **admin tier** (`access: admin` frontmatter); never pushed (the brain 422s admin at `/api/v1/items` anyway).
- **W1.1.4 — Flow wired/documented.** `docs/GRANOLA.md`: transcript → `transcript-decisions` skill → **human review** → `3-log/decision-log.md` decision rows → `aios push` → `materializeDecisions` → `decisions` table. The connector never auto-authors decisions (consent model). Connections example + README mapping table updated; ARCHITECTURE gets a privacy-invariant note.
- **W1.1.5 — Tests.** `ingestion/tests/test_granola.py`: registry wiring, gate allow/deny + consent variants, no-transcript marker assertion, MOCKED pagination + 429-retry + persistent-429 raise, admin-tier transcript pull, RawDoc→ItemPayload normalization. No live API.

### Verification
- `uv run --extra dev pytest` → **70 passed, 2 skipped** (skips = radar feedparser extra, unrelated).
- `npm run check:docs` → green; `sources: 10 in sync`. Pre-push docs guard passed.

### Notes for the human
- Plane MCP was **not accessible** in this environment, so the epic/sub-issue status moves and the PR-URL comment were not performed — please move epic W1.1 → In Progress, W1.1.1–W1.1.5 → Done, and drop this PR link on the epic manually.
- Secrets: `GRANOLA_API_KEY` (`grn_…`) is resolved from env via `${GRANOLA_API_KEY}` in `connections.yaml`; nothing committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)