### PR TITLE
fix(codebases): reject sparse scan pushes (don't let a partial push zero a row)

### DIFF
--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -70,20 +70,24 @@ export const codeMetricsSchema = z.object({
   head_sha: z.string().min(1).max(64),
   window_days: z.number().int().positive().max(3650).optional().default(90),
   scanned_at: z.string().nullable().optional(),
-  loc: z.number().int().nonnegative().optional().default(0),
-  files: z.number().int().nonnegative().optional().default(0),
-  commits_window: z.number().int().nonnegative().optional().default(0),
-  ai_commits_window: z.number().int().nonnegative().optional().default(0),
-  additions_window: z.number().int().nonnegative().optional().default(0),
-  deletions_window: z.number().int().nonnegative().optional().default(0),
+  // Core raw-scan fields are REQUIRED — a partial/sparse push (e.g. a readiness-only payload)
+  // is rejected at the boundary (422) instead of upserting a row that zeroes existing analytics
+  // (code_metrics upserts on (codebase_id, head_sha) and REPLACES the row). The ingestion
+  // scanner (`aios-ingest scan`) always sends the full block; readiness fields stay optional.
+  loc: z.number().int().nonnegative(),
+  files: z.number().int().nonnegative(),
+  commits_window: z.number().int().nonnegative(),
+  ai_commits_window: z.number().int().nonnegative(),
+  additions_window: z.number().int().nonnegative(),
+  deletions_window: z.number().int().nonnegative(),
   test_coverage_pct: z.number().min(0).max(100).nullable().optional().default(null),
-  recent_commits: z.array(z.record(z.string(), z.unknown())).optional().default([]),
-  // explicit scaffolding inputs
-  has_claude_md: z.boolean().optional().default(false),
-  has_agents_md: z.boolean().optional().default(false),
-  agents_md_count: z.number().int().nonnegative().optional().default(0),
-  skills_count: z.number().int().nonnegative().optional().default(0),
-  commands_count: z.number().int().nonnegative().optional().default(0),
+  recent_commits: z.array(z.record(z.string(), z.unknown())),
+  // explicit scaffolding inputs (required)
+  has_claude_md: z.boolean(),
+  has_agents_md: z.boolean(),
+  agents_md_count: z.number().int().nonnegative(),
+  skills_count: z.number().int().nonnegative(),
+  commands_count: z.number().int().nonnegative(),
   // cadence inputs (used to compute cadence_score; not persisted raw)
   active_days: z.number().int().nonnegative().optional().default(0),
   days_since_last_commit: z.number().int().nonnegative().nullable().optional().default(null),

--- a/test/codebase-readiness-schema.test.ts
+++ b/test/codebase-readiness-schema.test.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
+import { fullMetrics } from "@/test/fixtures/codebase-scan";
 
 // Spec: the scan boundary must reject malformed AEM agent-readiness so bad scanner
 // output can't become permanent analytics — level is the fixed L0..L5 ladder, and a
 // pillar can never report more checks passed than exist. Readiness stays fully optional
-// (older scanners that omit it keep working).
+// (older scanners that omit it keep working). The core raw-scan fields are REQUIRED so a
+// sparse readiness-only push is rejected (can't zero out an existing rich row on upsert).
 
 function payload(metrics: Record<string, unknown>) {
   return {
     codebase: { slug: "acme-api", full_name: "acme/api", open_issues: 0 },
-    metrics: { head_sha: "a".repeat(40), window_days: 90, commits_window: 1, ai_commits_window: 0, ...metrics },
+    metrics: { ...fullMetrics(), ...metrics },
     contributions: [],
     issues: [],
   };
@@ -44,5 +46,33 @@ describe("codebaseScanPayloadSchema — readiness validation", () => {
       payload({ readiness_level: "L2", readiness_pillars: { testing: { passed: 5, total: 2 } } })
     );
     expect(r.success).toBe(false);
+  });
+
+  it("rejects a SPARSE metrics payload (readiness-only, missing the raw-scan block)", () => {
+    // This is the shape the old `aios assess-codebase --push` sent — it must be rejected so
+    // it can't upsert a row that zeroes the existing commits/loc/recent_commits analytics.
+    const r = codebaseScanPayloadSchema.safeParse({
+      codebase: { slug: "acme-api", full_name: "acme/api", open_issues: 0 },
+      metrics: {
+        head_sha: "a".repeat(40),
+        has_claude_md: true,
+        skills_count: 3,
+        readiness_level: "L3",
+        readiness_pct: 67,
+      },
+      contributions: [],
+      issues: [],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a full metrics payload (the ingestion scanner's shape)", () => {
+    const r = codebaseScanPayloadSchema.safeParse({
+      codebase: { slug: "acme-api", full_name: "acme/api", open_issues: 0 },
+      metrics: fullMetrics(),
+      contributions: [],
+      issues: [],
+    });
+    expect(r.success).toBe(true);
   });
 });

--- a/test/datamechanics/codebase-identity.datamechanics.test.ts
+++ b/test/datamechanics/codebase-identity.datamechanics.test.ts
@@ -6,16 +6,14 @@ import { addAuthorAlias } from "@/lib/admin/aliases";
 import { createMember } from "@/lib/admin/members";
 import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
 import { db, seedTeam } from "./helpers";
+import { fullMetrics } from "@/test/fixtures/codebase-scan";
 
 const NOREPLY = "123+john@users.noreply.github.com";
 
 function scan(slug: string, contributions: { author_key: string; author_email: string; day: string; commits: number }[]) {
   return codebaseScanPayloadSchema.parse({
     codebase: { slug, full_name: `acme/${slug}`, open_issues: 0 },
-    metrics: {
-      head_sha: "a".repeat(40), window_days: 90, commits_window: 8, ai_commits_window: 8,
-      active_days: 3, days_since_last_commit: 1,
-    },
+    metrics: fullMetrics({ commits_window: 8, ai_commits_window: 8, active_days: 3 }),
     contributions,
     issues: [],
   });

--- a/test/datamechanics/codebase-readiness.datamechanics.test.ts
+++ b/test/datamechanics/codebase-readiness.datamechanics.test.ts
@@ -4,6 +4,7 @@ import { ingestCodebaseScan } from "@/lib/codebases/ingest";
 import { getCodebaseDetail, getCodebaseSummaries } from "@/lib/metrics/codebases";
 import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
 import { db, seedTeam } from "./helpers";
+import { fullMetrics } from "@/test/fixtures/codebase-scan";
 
 // Spec: the scanner scores AEM agent-readiness (scanner-side, against the canonical
 // rubric) and pushes it on the metrics payload; the brain persists it verbatim and
@@ -13,13 +14,10 @@ import { db, seedTeam } from "./helpers";
 function scanWithReadiness(slug: string) {
   return codebaseScanPayloadSchema.parse({
     codebase: { slug, full_name: `acme/${slug}`, open_issues: 0 },
-    metrics: {
+    metrics: fullMetrics({
       head_sha: "b".repeat(40),
-      window_days: 90,
       commits_window: 4,
       ai_commits_window: 2,
-      active_days: 2,
-      days_since_last_commit: 1,
       readiness_level: "L3",
       readiness_pct: 67,
       readiness_pillars: {
@@ -27,7 +25,7 @@ function scanWithReadiness(slug: string) {
         docs: { passed: 2, total: 3 },
       },
       readiness_rubric_version: "1.0.0",
-    },
+    }),
     contributions: [],
     issues: [],
   });

--- a/test/datamechanics/codebases-isolation.datamechanics.test.ts
+++ b/test/datamechanics/codebases-isolation.datamechanics.test.ts
@@ -28,6 +28,8 @@ function buildScan(over: {
       files: 300,
       commits_window: 100,
       ai_commits_window: 60,
+      additions_window: 5000,
+      deletions_window: 1200,
       test_coverage_pct: 70,
       has_claude_md: true,
       has_agents_md: true,

--- a/test/datamechanics/route-tier-guards.datamechanics.test.ts
+++ b/test/datamechanics/route-tier-guards.datamechanics.test.ts
@@ -5,6 +5,7 @@ import { POST as codebasesPOST } from "@/app/api/v1/codebases/route";
 import { POST as metricsPOST } from "@/app/api/v1/metrics/route";
 import { issueApiKey } from "@/lib/admin/keys";
 import { db, seedTeam, type Seed } from "./helpers";
+import { fullMetrics } from "@/test/fixtures/codebase-scan";
 
 // The route handlers are the SOLE tier gate for codebase + maturity analytics
 // (POSTGRES-ONLY, no RLS backstop). The lib-level datamechanics tests cover the
@@ -61,8 +62,13 @@ function post(
   return route(req);
 }
 
-// Minimal bodies that satisfy the schemas (only the required fields).
-const scanBody = () => ({ codebase: { slug: "guard-repo" }, metrics: { head_sha: "a".repeat(40) } });
+// A full scan body (the schema requires the core raw-metrics block).
+const scanBody = () => ({ codebase: { slug: "guard-repo" }, metrics: fullMetrics() });
+// A sparse readiness-only body (the shape the old assess-codebase --push sent).
+const sparseScanBody = () => ({
+  codebase: { slug: "guard-repo" },
+  metrics: { head_sha: "a".repeat(40), readiness_level: "L3", readiness_pct: 50 },
+});
 const metricsBody = () => ({ date: "2026-06-19", signals: {} });
 
 describe("route tier guards (real handlers, real Postgres)", () => {
@@ -77,6 +83,13 @@ describe("route tier guards (real handlers, real Postgres)", () => {
     const denied = await post(codebasesPOST, CB_URL, ext.key, seed.teamSlug, scanBody());
     expect(denied.status).toBe(403);
     expect((await denied.json()).error.code).toBe("forbidden_tier");
+  });
+
+  it("codebases: a sparse (readiness-only) scan is rejected 422, not silently persisted", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const res = await post(codebasesPOST, CB_URL, team.key, seed.teamSlug, sparseScanBody());
+    expect(res.status).toBe(422);
   });
 
   it("metrics: team key 201, external key 403 forbidden_tier", async () => {

--- a/test/datamechanics/team-maturity.datamechanics.test.ts
+++ b/test/datamechanics/team-maturity.datamechanics.test.ts
@@ -4,6 +4,7 @@ import { ingestCodebaseScan } from "@/lib/codebases/ingest";
 import { getTeamMaturity } from "@/lib/metrics/maturity";
 import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
 import { db, seedTeam } from "./helpers";
+import { fullMetrics } from "@/test/fixtures/codebase-scan";
 
 // Spec: the team rollup aggregates per-repo agent-readiness into "% at L3+" and is
 // team-tier only (no leak to external), reusing the codebase choke-point.
@@ -11,13 +12,12 @@ import { db, seedTeam } from "./helpers";
 function scan(slug: string, level: string, pct: number) {
   return codebaseScanPayloadSchema.parse({
     codebase: { slug, full_name: `acme/${slug}`, open_issues: 0 },
-    metrics: {
+    metrics: fullMetrics({
       head_sha: "c".repeat(40),
-      window_days: 90,
       readiness_level: level,
       readiness_pct: pct,
       readiness_rubric_version: "1.0.0",
-    },
+    }),
     contributions: [],
     issues: [],
   });

--- a/test/fixtures/codebase-scan.ts
+++ b/test/fixtures/codebase-scan.ts
@@ -1,0 +1,26 @@
+// Shared builder for a FULL codebase-scan metrics block. The /api/v1/codebases schema
+// requires the core raw-scan fields (so a sparse readiness-only push is rejected at the
+// boundary — see lib/api/schemas.ts), so tests must send a complete block. Spread overrides
+// for the fields a given test cares about.
+export function fullMetrics(overrides: Record<string, unknown> = {}) {
+  return {
+    head_sha: "a".repeat(40),
+    window_days: 90,
+    loc: 1000,
+    files: 50,
+    commits_window: 4,
+    ai_commits_window: 2,
+    additions_window: 100,
+    deletions_window: 20,
+    test_coverage_pct: null,
+    recent_commits: [],
+    has_claude_md: false,
+    has_agents_md: false,
+    agents_md_count: 0,
+    skills_count: 0,
+    commands_count: 0,
+    active_days: 2,
+    days_since_last_commit: 1,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## What

`POST /api/v1/codebases` upserts `code_metrics` on `(codebase_id, head_sha)` and **replaces** the row. A sparse/partial push (e.g. a readiness-only payload) would zero out existing `commits_window`/`loc`/`recent_commits`/scaffolding analytics. This makes the core raw-scan fields **required** in `codeMetricsSchema`, so a sparse payload is rejected at the boundary (**422**) instead of silently corrupting the row.

This is the Team Brain half of a two-PR change. The aios-workspace PR removes the only sparse client (`aios assess-codebase --push`) and updates the pinned `brain-api.md` contract.

## Changes

- **`lib/api/schemas.ts`** — `loc`, `files`, `commits_window`, `ai_commits_window`, `additions_window`, `deletions_window`, `recent_commits`, `has_claude_md`, `has_agents_md`, `agents_md_count`, `skills_count`, `commands_count` → **required**. `test_coverage_pct`, `window_days`, cadence inputs, and **readiness fields stay optional**.
- **`test/fixtures/codebase-scan.ts`** — shared `fullMetrics()` builder so a future required-field add touches one place; updated the lenient test builders that relied on defaults.
- **Guards:** unit (`codebase-readiness-schema.test.ts`: sparse readiness-only → reject; full → accept) + data-mechanics (`route-tier-guards`: a sparse codebases push returns **422**).

## Compatibility

The ingestion scanner (`aios-ingest scan`) always sends the full block → unaffected. The only sparse client (`assess-codebase --push`) is removed in the paired workspace PR. **Order: merge/deploy this *after* that PR removes `--push`**, so nothing legit starts 422-ing.

Validation-layer only — **no `postgres/schema.sql` change**, so no `pg:schema` migration; deploy is a normal build.

## Verification
- ✅ `tsc --noEmit` · ✅ unit 125 · ✅ data-mechanics 58 (incl. route sparse→422) · ✅ docs drift · ✅ lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)