### PR TITLE
feat(F4): sidecar consumes brain integration selections

### DIFF
--- a/ingestion/aios_ingest/brain_client.py
+++ b/ingestion/aios_ingest/brain_client.py
@@ -111,6 +111,26 @@ class BrainClient:
             raise BrainError(resp.status_code, *_error_fields(resp))
         raise BrainError(429, "rate_limited", f"gave up after {_MAX_RETRIES} retries")
 
+    async def fetch_integration_selections(self) -> list[dict]:
+        """GET /api/v1/integrations → the team's ENABLED integration selections
+        (non-secret: type, name, config). Returns [] on 404 (older brain). Same auth
+        headers as push(). Raises BrainError on a definitive 4xx (other than 404)."""
+        url = f"{self._base}/api/v1/integrations"
+        for attempt in range(_MAX_RETRIES):
+            await self._limiter.acquire()
+            resp = await self._client.get(url, headers=self._headers)
+            if resp.status_code == 200:
+                return resp.json().get("integrations", [])
+            if resp.status_code == 404:
+                # Brain too old / route absent — backward-compat: no selections.
+                return []
+            if resp.status_code == 429 or resp.status_code >= 500:
+                backoff = _retry_after(resp) or min(2**attempt, 30)
+                await asyncio.sleep(backoff)
+                continue
+            raise BrainError(resp.status_code, *_error_fields(resp))
+        raise BrainError(429, "rate_limited", f"gave up after {_MAX_RETRIES} retries")
+
     async def push_codebase_scan(self, payload: dict) -> dict:
         """POST one codebase scan (RAW metrics) to /api/v1/codebases. The brain computes
         scores, audits, and upserts idempotently. Same retry policy as push()."""

--- a/ingestion/aios_ingest/cli.py
+++ b/ingestion/aios_ingest/cli.py
@@ -15,10 +15,36 @@ from typing import Any
 
 import click
 
-from .brain_client import BrainClient
+from .brain_client import BrainClient, BrainError
 from .config import BrainSettings, Connection, load_connections
 from .engine import run_connection
+from .selections import merge_selections
 from .sources import available_sources
+
+_TRUTHY = {"1", "true", "yes"}
+
+
+def _selections_enabled(flag: bool) -> bool:
+    """Effective opt-in: the CLI flag OR a truthy ``AIOS_BRAIN_SELECTIONS`` env var.
+    Default (flag False, env unset) is False so behavior is unchanged."""
+    if flag:
+        return True
+    return os.environ.get("AIOS_BRAIN_SELECTIONS", "").strip().lower() in _TRUTHY
+
+
+async def _apply_brain_selections(
+    settings: BrainSettings, conns: list[Connection]
+) -> list[Connection]:
+    """Fetch the brain's enabled selections and overlay them onto local connections.
+    Resilient: on any brain error, log and fall back to the local connections so a
+    selection-fetch failure never crashes a sync."""
+    try:
+        async with BrainClient(settings.base_url, settings.api_key, settings.team) as client:
+            remote = await client.fetch_integration_selections()
+    except BrainError as e:
+        click.echo(f"warning: brain selection fetch failed ({e}); using local connections")
+        return conns
+    return merge_selections(conns, remote)
 
 
 def _parse_opts(pairs: tuple[str, ...]) -> dict[str, Any]:
@@ -74,17 +100,29 @@ def backfill(source, opts, project, access, actor, since) -> None:
 @main.command()
 @click.option("--config", "config_path", required=True, help="connections.yaml path")
 @click.option("--only", default=None, help="run only the named connection")
-def sync(config_path, only) -> None:
+@click.option(
+    "--use-brain-selections/--no-use-brain-selections",
+    "use_brain_selections",
+    default=False,
+    help="overlay the brain's Admin → Integrations selections onto local connections "
+    "by (source, name); secrets stay local. Also enabled by AIOS_BRAIN_SELECTIONS=1.",
+)
+def sync(config_path, only, use_brain_selections) -> None:
     """Run all configured connections (or one with --only)."""
     settings = BrainSettings.from_env()
     conns = load_connections(config_path)
-    if only:
-        conns = [c for c in conns if c.name == only]
-        if not conns:
-            raise click.ClickException(f"no connection named '{only}'")
 
     async def run_all() -> None:
-        for conn in conns:
+        nonlocal conns
+        if _selections_enabled(use_brain_selections):
+            conns = await _apply_brain_selections(settings, conns)
+        # Apply --only AFTER the merge so brain selections are honored first.
+        run_conns = conns
+        if only:
+            run_conns = [c for c in conns if c.name == only]
+            if not run_conns:
+                raise click.ClickException(f"no connection named '{only}'")
+        for conn in run_conns:
             summary = await run_connection(settings, conn)
             click.echo(str(summary))
 

--- a/ingestion/aios_ingest/selections.py
+++ b/ingestion/aios_ingest/selections.py
@@ -1,0 +1,131 @@
+"""Merge brain-side integration *selections* onto local source connections.
+
+The brain stores per-team integration selections — which sources are enabled and
+their NON-SECRET config (channel ids, repos, keywords). The sidecar holds the
+secrets (tokens, signing secrets, api keys) locally in each connection's options.
+
+F4 overlays the brain's selection onto the matching local connection by
+``(type, name)`` so that an operator can change *what* a source ingests from the
+brain's Admin → Integrations UI, while the *secret* needed to run it always stays
+local. The brain rejects secret-like keys at write time, so a brain ``config`` can
+never contain a secret — merging it can therefore never overwrite a local secret.
+
+This module is pure (no I/O) so it is trivially testable.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any, Callable
+
+from .config import Connection
+
+log = logging.getLogger(__name__)
+
+
+def _translate_slack(config: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if "channelIds" in config:
+        out["channel_ids"] = list(config["channelIds"])
+    return out
+
+
+def _translate_github(config: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    repos = config.get("repos")
+    if repos:
+        if len(repos) > 1:
+            log.warning(
+                "github selection lists %d repos but the single-repo adapter "
+                "supports one; using the first (%s)",
+                len(repos),
+                repos[0],
+            )
+        out["repo"] = repos[0]
+    # empty / missing repos → emit nothing (keep the local repo selection)
+    return out
+
+
+def _translate_granola(config: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if "matchKeywords" in config:
+        out["topics"] = list(config["matchKeywords"])
+    if "participantEmails" in config:
+        out["participants"] = list(config["participantEmails"])
+    return out
+
+
+def _no_op(config: dict[str, Any]) -> dict[str, Any]:
+    # No consuming adapter field yet (linear teamId/projectId, plane, wise, notion).
+    # Translate to nothing so we never inject a key the adapter would reject.
+    # Adapter wiring for these selection fields is future work.
+    return {}
+
+
+# Dispatch by brain integration `type`. Defaults to a no-op so an unknown/unwired
+# type never injects keys that would make build_source() raise TypeError.
+_SELECTION_TRANSLATORS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
+    "slack": _translate_slack,
+    "github": _translate_github,
+    "granola": _translate_granola,
+    "linear": _no_op,
+    "plane": _no_op,
+    "wise": _no_op,
+    "notion": _no_op,
+}
+
+
+def _translate(integration_type: str, config: dict[str, Any]) -> dict[str, Any]:
+    translator = _SELECTION_TRANSLATORS.get(integration_type, _no_op)
+    return translator(config or {})
+
+
+def merge_selections(local: list[Connection], remote: list[dict]) -> list[Connection]:
+    """Overlay brain selections onto local connections by ``(type, name)``.
+
+    - For each local Connection, if a remote selection matches
+      (``remote['type'] == conn.source`` and ``remote['name'] == conn.name``),
+      produce a NEW Connection (``dataclasses.replace``) whose options are
+      ``{**conn.options, **translated_selection}``. The translated selection maps
+      the brain's camelCase config to the adapter's option keys; LOCAL SECRETS ARE
+      PRESERVED because the brain config has no secret keys.
+    - Local connections with no matching remote selection are returned unchanged
+      (backward compat).
+    - Remote selections with no matching local connection are SKIPPED (no local
+      secret → cannot run); they never become runnable connections.
+
+    Order of returned connections follows ``local``. Input objects are not mutated.
+    """
+    # Index remote selections by (type, name) for O(1) lookup.
+    by_key: dict[tuple[str, str], dict] = {}
+    for sel in remote:
+        key = (sel.get("type"), sel.get("name"))
+        by_key[key] = sel
+
+    merged: list[Connection] = []
+    matched_keys: set[tuple[str, str]] = set()
+    for conn in local:
+        key = (conn.source, conn.name)
+        sel = by_key.get(key)
+        if sel is None:
+            # No brain selection for this connection — leave it exactly as-is.
+            merged.append(conn)
+            continue
+        matched_keys.add(key)
+        translated = _translate(conn.source, sel.get("config") or {})
+        new_options = {**conn.options, **translated}
+        merged.append(dataclasses.replace(conn, options=new_options))
+
+    # Report remote selections that had no local connection (cannot run — no secret).
+    for sel in remote:
+        key = (sel.get("type"), sel.get("name"))
+        if key not in matched_keys:
+            log.info(
+                "brain selection %s/%s has no matching local connection — skipped "
+                "(no local secret to run it)",
+                sel.get("type"),
+                sel.get("name"),
+            )
+
+    return merged

--- a/ingestion/connections.yaml.example
+++ b/ingestion/connections.yaml.example
@@ -1,5 +1,18 @@
 # Named source connections for `aios-ingest sync` and the webhook app.
 # Secrets use ${ENV_VAR} references, expanded at load time — never inline secrets here.
+#
+# Brain selections (opt-in):
+#   When you run `aios-ingest sync --use-brain-selections` (or set
+#   AIOS_BRAIN_SELECTIONS=1), the sidecar fetches the team's enabled integration
+#   selections from the brain (Admin → Integrations) and OVERLAYS their non-secret
+#   selection — slack channel ids, github repos, granola keywords — onto the matching
+#   local connection. Matching is by (source == brain type) AND (name == brain name).
+#   The brain rejects secret-like keys at write time, so secrets ALWAYS stay local:
+#   the token / signing_secret / webhook_secret / api_key you set below via ${ENV_VAR}
+#   are preserved verbatim and never overwritten by a brain selection.
+#
+#   With the flag OFF (the default), there is NO brain call and behavior is exactly as
+#   the entries below describe — local options are used unchanged.
 connections:
   - name: eng-handbook
     source: github

--- a/ingestion/tests/test_brain_client.py
+++ b/ingestion/tests/test_brain_client.py
@@ -54,3 +54,50 @@ async def test_push_raises_brainerror_on_422():
 def test_rejects_non_aios_key():
     with pytest.raises(ValueError):
         BrainClient("http://brain", "badkey", "demo")
+
+
+async def test_fetch_integration_selections_parses_list_and_sends_auth():
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.method == "GET"
+        assert req.url.path == "/api/v1/integrations"
+        assert req.headers["authorization"] == "Bearer aios_abc_def"
+        assert req.headers["x-aios-team"] == "demo"
+        return httpx.Response(
+            200,
+            json={
+                "integrations": [
+                    {
+                        "id": "i1",
+                        "type": "slack",
+                        "name": "eng-slack",
+                        "config": {"channelIds": ["C1"]},
+                        "status": "enabled",
+                    }
+                ]
+            },
+        )
+
+    async with _client(httpx.MockTransport(handler)) as c:
+        sels = await c.fetch_integration_selections()
+    assert len(sels) == 1
+    assert sels[0]["type"] == "slack"
+    assert sels[0]["config"]["channelIds"] == ["C1"]
+
+
+async def test_fetch_integration_selections_returns_empty_on_404():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": {"code": "not_found", "message": "no route"}})
+
+    async with _client(httpx.MockTransport(handler)) as c:
+        sels = await c.fetch_integration_selections()
+    assert sels == []
+
+
+async def test_fetch_integration_selections_raises_on_definitive_4xx():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": {"code": "forbidden", "message": "nope"}})
+
+    async with _client(httpx.MockTransport(handler)) as c:
+        with pytest.raises(BrainError) as ei:
+            await c.fetch_integration_selections()
+    assert ei.value.status_code == 403

--- a/ingestion/tests/test_selections.py
+++ b/ingestion/tests/test_selections.py
@@ -1,0 +1,216 @@
+"""Spec tests for F4 — sidecar consumes brain selections.
+
+Derived from the F4 product contract, NOT from the current implementation:
+  1. Merge by (type, name): brain selection updates the matching local connection's
+     selection fields; the local connection supplies the secret/token.
+  2. Selection from brain, tokens local: brain config has no secret keys, so merging
+     can never overwrite a local secret.
+  3. Backward compatible: unconfigured → output equals local input, no brain call.
+"""
+
+import copy
+
+from aios_ingest.cli import _selections_enabled
+from aios_ingest.config import Connection
+from aios_ingest.selections import merge_selections
+from aios_ingest.sources.registry import build_source
+
+
+def _slack_conn() -> Connection:
+    return Connection(
+        name="eng-slack",
+        source="slack",
+        options={"token": "xoxb-LOCAL", "signing_secret": "s", "channel_ids": ["C_OLD"]},
+    )
+
+
+def _github_conn() -> Connection:
+    return Connection(
+        name="eng-handbook",
+        source="github",
+        options={"repo": "org/old", "token": "ghp-LOCAL", "webhook_secret": "wh"},
+    )
+
+
+def _granola_conn() -> Connection:
+    return Connection(
+        name="team-granola",
+        source="granola",
+        options={"api_key": "grn-LOCAL", "topics": ["old"], "participants": ["a@x.com"]},
+    )
+
+
+# --- 1 + 2: merge precedence + secrets preserved (slack) --------------------
+
+
+def test_slack_brain_channels_win_local_secrets_preserved():
+    remote = [
+        {
+            "id": "i1",
+            "type": "slack",
+            "name": "eng-slack",
+            "config": {"channelIds": ["C_NEW1", "C_NEW2"]},
+            "status": "enabled",
+        }
+    ]
+    merged = merge_selections([_slack_conn()], remote)
+    assert len(merged) == 1
+    opts = merged[0].options
+    # brain selection wins
+    assert opts["channel_ids"] == ["C_NEW1", "C_NEW2"]
+    # local secrets preserved verbatim
+    assert opts["token"] == "xoxb-LOCAL"
+    assert opts["signing_secret"] == "s"
+
+
+# --- github repos -> repo ---------------------------------------------------
+
+
+def test_github_single_repo_maps_and_preserves_secrets():
+    remote = [
+        {"type": "github", "name": "eng-handbook", "config": {"repos": ["org/a"]}, "status": "enabled"}
+    ]
+    merged = merge_selections([_github_conn()], remote)
+    opts = merged[0].options
+    assert opts["repo"] == "org/a"
+    assert opts["token"] == "ghp-LOCAL"
+    assert opts["webhook_secret"] == "wh"
+    # the camelCase `repos` list must NOT leak into options (build_source would crash)
+    assert "repos" not in opts
+
+
+def test_github_multi_repo_uses_first_and_no_repos_leak():
+    remote = [
+        {
+            "type": "github",
+            "name": "eng-handbook",
+            "config": {"repos": ["org/a", "org/b"]},
+            "status": "enabled",
+        }
+    ]
+    merged = merge_selections([_github_conn()], remote)
+    opts = merged[0].options
+    assert opts["repo"] == "org/a"
+    assert "repos" not in opts
+
+
+# --- granola mapping --------------------------------------------------------
+
+
+def test_granola_keywords_and_participants_map():
+    remote = [
+        {
+            "type": "granola",
+            "name": "team-granola",
+            "config": {"matchKeywords": ["aios", "brain"], "participantEmails": ["x@y.com"]},
+            "status": "enabled",
+        }
+    ]
+    merged = merge_selections([_granola_conn()], remote)
+    opts = merged[0].options
+    assert opts["topics"] == ["aios", "brain"]
+    assert opts["participants"] == ["x@y.com"]
+    assert opts["api_key"] == "grn-LOCAL"  # secret preserved
+
+
+# --- build_source compatibility: merged options are adapter-valid -----------
+
+
+def test_merged_slack_options_construct_without_typeerror():
+    remote = [
+        {"type": "slack", "name": "eng-slack", "config": {"channelIds": ["C1"]}, "status": "enabled"}
+    ]
+    conn = merge_selections([_slack_conn()], remote)[0]
+    src = build_source(conn.source, conn.options)  # must not raise TypeError
+    assert src is not None
+
+
+def test_merged_github_options_construct_without_typeerror():
+    remote = [
+        {"type": "github", "name": "eng-handbook", "config": {"repos": ["org/a"]}, "status": "enabled"}
+    ]
+    conn = merge_selections([_github_conn()], remote)[0]
+    src = build_source(conn.source, conn.options)  # must not raise TypeError
+    assert src is not None
+
+
+# --- unmatched remote skipped ----------------------------------------------
+
+
+def test_unmatched_remote_selection_is_skipped():
+    remote = [
+        {"type": "slack", "name": "no-such-local", "config": {"channelIds": ["C9"]}, "status": "enabled"}
+    ]
+    local = [_slack_conn()]
+    merged = merge_selections(local, remote)
+    # only the one local connection comes back; the orphan remote never becomes runnable
+    assert len(merged) == 1
+    assert merged[0].name == "eng-slack"
+    # and it was not affected by the unmatched remote
+    assert merged[0].options["channel_ids"] == ["C_OLD"]
+
+
+# --- unmatched local preserved ----------------------------------------------
+
+
+def test_unmatched_local_connection_returned_unchanged():
+    local = _slack_conn()
+    before = copy.deepcopy(local.options)
+    merged = merge_selections([local], [])
+    assert merged[0].options == before
+
+
+# --- backward compat / unconfigured ----------------------------------------
+
+
+def test_empty_remote_returns_equivalent_connections_without_mutation():
+    local = [_slack_conn(), _github_conn()]
+    snapshot = [copy.deepcopy(c.options) for c in local]
+    merged = merge_selections(local, [])
+    assert len(merged) == 2
+    for m, original_opts in zip(merged, snapshot):
+        assert m.options == original_opts
+    # originals not mutated (new objects via dataclasses.replace when matched; here
+    # unmatched are returned as-is, but their options must remain unchanged)
+    for c, original_opts in zip(local, snapshot):
+        assert c.options == original_opts
+
+
+def test_matched_merge_does_not_mutate_input_options():
+    local = _slack_conn()
+    remote = [
+        {"type": "slack", "name": "eng-slack", "config": {"channelIds": ["C_NEW"]}, "status": "enabled"}
+    ]
+    merged = merge_selections([local], remote)
+    # the original connection's options must be untouched (function returns a new object)
+    assert local.options["channel_ids"] == ["C_OLD"]
+    assert merged[0].options["channel_ids"] == ["C_NEW"]
+    assert merged[0] is not local
+
+
+def test_selections_enabled_default_false(monkeypatch):
+    monkeypatch.delenv("AIOS_BRAIN_SELECTIONS", raising=False)
+    assert _selections_enabled(False) is False
+    assert _selections_enabled(True) is True
+
+
+def test_selections_enabled_honors_env(monkeypatch):
+    monkeypatch.setenv("AIOS_BRAIN_SELECTIONS", "1")
+    assert _selections_enabled(False) is True
+    monkeypatch.setenv("AIOS_BRAIN_SELECTIONS", "true")
+    assert _selections_enabled(False) is True
+    monkeypatch.setenv("AIOS_BRAIN_SELECTIONS", "no")
+    assert _selections_enabled(False) is False
+
+
+def test_unwired_type_translates_to_no_op():
+    # linear/plane/wise/notion have no consuming adapter field yet — must not inject
+    # keys the adapter would reject.
+    local = Connection(name="lin", source="linear", options={"api_key": "lin-LOCAL"})
+    remote = [
+        {"type": "linear", "name": "lin", "config": {"teamId": "T1", "projectId": "P1"}, "status": "enabled"}
+    ]
+    merged = merge_selections([local], remote)
+    assert merged[0].options == {"api_key": "lin-LOCAL"}
+    # constructs cleanly (only api_key passed)
+    assert build_source("linear", merged[0].options) is not None


### PR DESCRIPTION
Implements **F4 — Sidecar consumes selections** (Plane AIOS-18). Closes the "table does nothing" gap: the ingestion sidecar can fetch the team's enabled integration selections from the brain and overlay their **non-secret** config onto local connections by `(type, name)` — **selection from brain, tokens local**.

## What changed (`ingestion/`)
- **`brain_client.py`** — `fetch_integration_selections()` → `GET /api/v1/integrations`. Same auth headers + rate-limiter + retry/backoff as `push()`. `404 → []` (older brain, backward-compat); other definitive 4xx → `BrainError`.
- **`selections.py`** (new, pure/no-I/O) — `merge_selections(local, remote)`. Matches by `(source==type, name)`; overlays a per-type translation of the brain's camelCase config onto the adapter's option keys. Local secrets are preserved; unmatched remote selections are skipped (no local secret → cannot run); unmatched local connections pass through unchanged; inputs are never mutated.
- **`cli.py`** — opt-in `sync --use-brain-selections` (or `AIOS_BRAIN_SELECTIONS=1`), **default OFF** so behavior is exactly as today. `--only` applies after the merge; a fetch failure falls back to local connections (never crashes a sync).
- **`connections.yaml.example`** — documents the opt-in and the secrets-stay-local guarantee.

### Merge translation (camelCase brain config → adapter option)
| type | brain config | → adapter option | notes |
|---|---|---|---|
| slack | `channelIds` | `channel_ids` | |
| github | `repos` | `repo` | 1→first; >1→first + warning; empty→no-op |
| granola | `matchKeywords`,`participantEmails` | `topics`,`participants` | |
| linear/plane/wise/notion | (any) | `{}` | no consuming adapter field yet — future wiring |

Only keys the adapter accepts are emitted, so `build_source(**options)` never gets a rejected kwarg.

## Invariants
- **Selection from brain, tokens local.** The brain rejects secret-like keys at write time, so a brain `config` can never carry a secret — merging it can never overwrite a local `token`/`signing_secret`/`webhook_secret`/`api_key`. A test asserts this directly.
- **Backward compatible.** Flag OFF (default) ⇒ no brain call, `load_connections()` output used unchanged.

## Tests (spec-derived, `pytest`)
Merge precedence (slack), secrets-preserved, github 1/N-repo mapping + no `repos` leak, granola mapping, `build_source` compatibility, unmatched-remote-skipped, unmatched-local-unchanged, no-mutation/backward-compat, `_selections_enabled` flag-or-env, and the client fetch (200 parse + auth headers, 404→[], 403→raise).

```
$ python -m pytest -q
87 passed, 1 skipped in 2.62s   # the skip is pre-existing/unrelated
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When enabled, sync scope (channels, repos, filters) follows brain UI config and mismatched names are silently ignored; default-off and error fallback limit blast radius.
> 
> **Overview**
> Adds **opt-in** support for driving ingestion *what-to-sync* from the brain’s Admin → Integrations UI while **credentials stay in local** `connections.yaml`.
> 
> `BrainClient` gains `fetch_integration_selections()` (`GET /api/v1/integrations`) with the same auth, rate limiting, and retries as `push()`; **404 returns `[]`** for older brains.
> 
> New pure `merge_selections()` matches brain rows to local connections by **`(type/source, name)`**, translates camelCase config into adapter option keys (e.g. Slack `channelIds`, GitHub `repos` → `repo`, Granola keywords/participants), and **overlays** onto local options without mutating inputs. Orphan brain selections without a local connection are skipped; fetch failures in sync **warn and fall back** to local config.
> 
> `aios-ingest sync` adds `--use-brain-selections` / `AIOS_BRAIN_SELECTIONS=1` (**default off**); `--only` runs **after** the merge. Example config and spec-style tests cover merge precedence, secret preservation, and client behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df47e736d32b186bc438dfc418796d307876ce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added brain selections overlay support to `sync` command via `--use-brain-selections` flag or `AIOS_BRAIN_SELECTIONS` environment variable to merge remote integration settings with local connections.
  * Local secret fields (API keys, tokens) are always preserved and never overwritten.

* **Documentation**
  * Added documentation explaining brain selections behavior and configuration.

* **Tests**
  * Added comprehensive test coverage for selection merging and brain integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->