### PR TITLE
ci(scan-on-merge): scan agent-readiness on merge to main

### DIFF
--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -1,0 +1,50 @@
+name: scan-on-merge
+
+# Keep the codebase's agent-readiness fresh: on every merge to main, scan this repo with the
+# ingestion scanner and push the result (full raw metrics + readiness) to the Team Brain.
+# The scan is read-only against the repo and idempotent on the brain (keyed by head_sha).
+#
+# Required repo secrets (until set, the job logs "skipping" and exits 0 — never red):
+#   BRAIN_URL     — e.g. https://aios-team-brain-production.up.railway.app
+#   AIOS_TEAM     — team slug (e.g. aios)
+#   AIOS_API_KEY  — a TEAM-TIER api key (codebase scans are team-tier; keep it least-privilege)
+# GITHUB_TOKEN is the built-in token (read access to this repo for stars/issues metadata).
+
+on:
+  push:
+    branches: [main]
+
+# One scan at a time; newer pushes supersede in-flight ones.
+concurrency:
+  group: scan-on-merge
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: codebase readiness scan → brain
+    runs-on: ubuntu-latest
+    if: github.repository == 'AIOS-alpha/aios-team-brain'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history — the scanner reads the commit window
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the ingestion scanner
+        run: pip install -e ingestion
+
+      - name: Scan this repo into the brain
+        env:
+          BRAIN_URL: ${{ secrets.BRAIN_URL }}
+          AIOS_TEAM: ${{ secrets.AIOS_TEAM }}
+          AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$AIOS_API_KEY" ] || [ -z "$BRAIN_URL" ] || [ -z "$AIOS_TEAM" ]; then
+            echo "scan secrets not configured (BRAIN_URL/AIOS_TEAM/AIOS_API_KEY) — skipping."
+            exit 0
+          fi
+          aios-ingest scan --path . --slug aios-team-brain --full-name "$GITHUB_REPOSITORY"

--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -5,9 +5,10 @@ name: scan-on-merge
 # The scan is read-only against the repo and idempotent on the brain (keyed by head_sha).
 #
 # Required repo secrets (until set, the job logs "skipping" and exits 0 — never red):
-#   BRAIN_URL     — e.g. https://aios-team-brain-production.up.railway.app
-#   AIOS_TEAM     — team slug (e.g. aios)
-#   AIOS_API_KEY  — a TEAM-TIER api key (codebase scans are team-tier; keep it least-privilege)
+#   AIOS_BRAIN_URL — e.g. https://aios-team-brain-production.up.railway.app
+#   AIOS_TEAM      — team slug (e.g. aios)
+#   AIOS_API_KEY   — a TEAM-TIER api key (codebase scans are team-tier; keep it least-privilege)
+# (These already exist for the aios-work-sync workflow; the scanner reads BRAIN_URL, mapped below.)
 # GITHUB_TOKEN is the built-in token (read access to this repo for stars/issues metadata).
 
 on:
@@ -38,7 +39,7 @@ jobs:
 
       - name: Scan this repo into the brain
         env:
-          BRAIN_URL: ${{ secrets.BRAIN_URL }}
+          BRAIN_URL: ${{ secrets.AIOS_BRAIN_URL }}
           AIOS_TEAM: ${{ secrets.AIOS_TEAM }}
           AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
On every merge to `main`, scan this repo with the in-repo ingestion scanner and push a **full** scan (raw metrics + readiness) to the Team Brain — keeping the Codebases dashboard fresh instead of relying on manual scans.

- Read-only against the repo, idempotent on the brain (keyed by `head_sha`), `fetch-depth: 0` for the commit window, built-in `GITHUB_TOKEN` for fresh stars/issues (no clobber).
- **Guarded**: if `BRAIN_URL` / `AIOS_TEAM` / `AIOS_API_KEY` aren't set, the job logs "skipping" and exits 0 — safe to merge before secrets exist.

## ⚙️ Needs secrets before it does anything
Add repo secrets: `BRAIN_URL`, `AIOS_TEAM`, and a **team-tier** `AIOS_API_KEY`. (I can mint the key + set the secrets if you authorize — see the chat.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with read-only repo access and idempotent brain uploads; no application runtime or auth logic is modified.
> 
> **Overview**
> Adds a **`scan-on-merge`** GitHub Actions workflow that runs on every push to **`main`** (only on `AIOS-alpha/aios-team-brain`). It checks out full git history, installs the in-repo **`ingestion`** package, and runs **`aios-ingest scan`** to push a full readiness scan to the Team Brain so the Codebases dashboard stays current without manual scans.
> 
> The job uses **`concurrency`** with cancel-in-progress so only the latest merge is scanned. It reuses **`AIOS_BRAIN_URL`**, **`AIOS_TEAM`**, and **`AIOS_API_KEY`** (mapped to **`BRAIN_URL`** for the CLI) plus **`GITHUB_TOKEN`** for repo metadata. If any of the brain secrets are missing, it logs a skip and exits **0** so merges stay green before secrets are configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a29e7790bf0e08de407091c43177ae30ffe757a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new automated readiness scan workflow that runs on every push to the main branch.
  * The scan performs necessary setup, uses required credentials from environment variables, and supports safe skipping when credentials are missing (exits without failing).
  * Added run coordination so only one scan runs at a time, cancelling any in-progress run when a newer push occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->