### PR TITLE
docs: DEVELOPMENT.md + CONTRIBUTING.md for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,4 +74,4 @@ changes bump the major version.
 Be kind and direct. This is real work for real teams — assume good faith, prefer the durable fix
 over the quick one, and leave the map (and the tests) better than you found them.
 
-Maintainer: John Dass — iamjohndass@pm.me
+Maintainer: John Ellison — john@john-ellison.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing — AIOS Team Brain
+
+Thanks for building AIOS. This file is the human checklist for landing a change in the brain. Get
+it running first with [`DEVELOPMENT.md`](DEVELOPMENT.md). The authoritative, agent-facing
+conventions are in [`AGENTS.md`](AGENTS.md) — read it; the rules below are the short version a
+reviewer will hold you to.
+
+## The five things that gate a PR
+
+1. **Work in a git worktree, never a feature branch in the primary checkout.** People work in the
+   primary checkout concurrently; committing feature work there collides with them. From the repo:
+   ```bash
+   git fetch origin
+   git worktree add -b feat/<short-task> ../aios-team-brain-<short-task> origin/main
+   cd ../aios-team-brain-<short-task>
+   ln -sfn ../aios-team-brain/node_modules node_modules   # share deps (or run npm install)
+   ```
+   Open the PR from the worktree branch; `git worktree remove <path>` after it merges.
+
+2. **Spec-first tests, in the right tier.** Write the assertion from what the product *should* do
+   (the brain-api contract, the tier intent, a scenario) — then run it. A spec-derived test that
+   goes red found a real gap. Don't write tests that read the implementation and assert what it
+   already does. Pick the tier that catches the failure mode (unit / data-mechanics / integration —
+   see [`DEVELOPMENT.md`](DEVELOPMENT.md#tests--which-tier-catches-what) and [`AGENTS.md` §4](AGENTS.md)).
+   Anything touching the DB or access control needs a **data-mechanics** test on real Postgres.
+
+3. **Update the architecture map in the same PR.** [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) is
+   the single fast reference for *where data lives, who writes it, who reads it*. Consult it before
+   building; update it after. If you add/remove an API route, a table, or an ingestion source, update
+   the `<!-- drift:* -->` blocks too or `npm run check:docs` (CI + the pre-push hook) fails.
+
+4. **Respect the single-writer + tier invariants — there is no RLS backstop on Postgres.** Each
+   sensitive table has exactly one legal writer module (e.g. `lib/ingest` for `items`,
+   `lib/integrations/manage` for `integrations`) guarded by a build-failing test; don't write around
+   it. Tier isolation (an `external`-tier principal never reads `team`/`admin` content; `admin`-tier
+   content never crosses the API — 422) is enforced **in app code** and guarded. New read surfaces
+   must add their own app-code gate + a guard test; new write paths must route through the owner.
+
+5. **Green before you open it.** Run, and paste the output in the PR:
+   ```bash
+   npm run lint
+   npm test                         # unit tier
+   npm run check:docs               # drift guard
+   npm run db:test:up && npm run test:datamechanics:local   # if you touched the DB / access
+   ```
+
+## The sync contract is pinned — don't drift it
+
+`aios-workspace/docs/brain-api.md` is the **pinned `/api/v1` contract** between the brain and the
+`aios` CLI. A protocol change is a *versioned* change in that file first — never a code change in
+one repo that silently diverges. Additive, gracefully-degrading changes stay in v1; breaking
+changes bump the major version.
+
+## Where to start
+
+- **Run it:** [`DEVELOPMENT.md`](DEVELOPMENT.md).
+- **Understand it:** [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §1 (the sources-of-truth table),
+  then the flow for the area you're changing.
+- **Conventions:** [`AGENTS.md`](AGENTS.md) (test tiers, the build loop, access-control stance).
+- **Pick something:** the GitHub issue tracker (look for `good first issue`), or ask a maintainer
+  which Wave/epic needs hands.
+
+## PR hygiene
+
+- Branch name: `feat/…`, `fix/…`, `docs/…`, `test/…`, `chore/…`.
+- Keep PRs small and single-purpose; describe the change and **paste verification output**.
+- Don't commit secrets (no real DSNs, tokens, or `.env*`). Don't add a Vercel-only dependency —
+  the brain is self-host portable (plain SQL schema, Postgres-backed rate limiting).
+- Label status honestly: ✅ done-and-verified / 🟡 partial / 🔴 blocked. Never claim done without
+  a green test or the observable outcome.
+
+## Code of conduct
+
+Be kind and direct. This is real work for real teams — assume good faith, prefer the durable fix
+over the quick one, and leave the map (and the tests) better than you found them.
+
+Maintainer: John Dass — iamjohndass@pm.me

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,118 @@
+# Development — AIOS Team Brain
+
+Get the brain running locally and know which command catches which failure. New here? Read this,
+then [`CONTRIBUTING.md`](CONTRIBUTING.md) for how to land a change. The deep map of where data
+lives is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md); the conventions an agent must follow are
+[`AGENTS.md`](AGENTS.md).
+
+## Prerequisites
+
+- **Node 20+** (Next.js 16 / App Router).
+- **Docker** — only for the ephemeral test Postgres (`npm run db:test:up`) and, if you don't have
+  a Postgres handy, for local dev too.
+- **git**, and (recommended) the `gh` CLI for PRs.
+- An **Anthropic API key** is *optional* for development — the dashboard, ingest, and all tests run
+  without it; only live NL queries need an LLM (cloud key or a local endpoint — see
+  [`docs/PROVIDERS.md`](docs/PROVIDERS.md)).
+
+## First run (Postgres backend — the default)
+
+```bash
+npm install
+cp .env.example .env.local
+```
+
+Edit `.env.local` and set, at minimum:
+
+```bash
+DB_BACKEND=postgres
+NEXT_PUBLIC_DB_BACKEND=postgres
+DATABASE_URL=postgres://app:app@localhost:5434/app_test   # see "Where do I get a DATABASE_URL?"
+AUTH_SECRET=<paste 32 random bytes — command below>
+APP_URL=http://localhost:3000
+# ANTHROPIC_API_KEY=sk-ant-...   # optional; only for live queries
+```
+
+Generate `AUTH_SECRET` (signs the session cookie in Postgres mode):
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+Then load the schema, seed demo data, and start the dev server:
+
+```bash
+npm run pg:schema     # load postgres/schema.sql (canonical, idempotent) into DATABASE_URL
+npm run dev:seed      # demo team (aios) + Northwind + Veridian graph
+npm run dev           # http://localhost:3000
+```
+
+Login is invite-only (magic link). For local dev, mint a session without email:
+
+```bash
+npm run dev:login     # prints a login link for the seeded admin
+```
+
+> **Where do I get a `DATABASE_URL`?** Easiest: reuse the test Postgres container —
+> `npm run db:test:up` starts one on `localhost:5434` (user/pass/db = `app`/`app`/`app_test`) and
+> loads the schema. Point `DATABASE_URL` at it as above. Or run your own
+> (`docker run -e POSTGRES_PASSWORD=app -e POSTGRES_USER=app -e POSTGRES_DB=app -p 5432:5432 postgres:16`)
+> and use `postgres://app:app@localhost:5432/app`. For a managed provider that requires TLS (e.g.
+> Railway) also set `PGSSL=require`.
+
+> **Legacy Supabase backend:** set `DB_BACKEND=supabase`, run `supabase start`, fill `.env.local`
+> from `supabase status -o env`, and `supabase db reset` to migrate. New work targets Postgres;
+> Supabase is opt-in and its migrations are legacy-scoped.
+
+## Tests — which tier catches what
+
+Put a spec-derived test in the tier that catches *its* failure mode (full rationale in
+[`AGENTS.md` §4](AGENTS.md)):
+
+| Tier | Command | Runs against | Catches |
+|---|---|---|---|
+| **unit** | `npm test` | nothing (pure) | parse/format, pure logic, **all drift/contract guards** |
+| **data-mechanics** | `npm run db:test:up` then `npm run test:datamechanics:local` | **real Postgres**, stubbed model | persistence & access: write→store→read, dedup, diff-sync, **tier isolation** |
+| **integration** | `bash scripts/e2e.sh` | API routes over a real DB + the cross-process sync loop | routing, auth, tier-422 |
+| **docs guard** | `npm run check:docs` | the doc drift blocks | a route/table/source added without updating `docs/ARCHITECTURE.md` |
+| **lint** | `npm run lint` | — | style/correctness lints |
+
+Notes:
+- The data-mechanics tier **requires `DATABASE_TEST_URL`** and refuses to fall back to a dev/prod
+  URL. Use `npm run test:datamechanics:local` (it sets the URL after `db:test:up`), never bare
+  `test:datamechanics` unless the env var is already set.
+- `npm run db:test:down` tears the container down. The container can stop between sessions — if a
+  data-mechanics run prints `ECONNREFUSED ...:5434`, just re-run `npm run db:test:up`.
+
+## Deploy / schema rollout
+
+Production is Postgres on Railway. After a merge that changes `postgres/schema.sql`, run
+`npm run pg:schema` against the prod `DATABASE_URL` and confirm the platform started a new build
+(CI webhooks can be dropped — re-trigger if the latest deploy predates the merge).
+
+## Giving a new contributor brain access (admins)
+
+People are invite-only; machines (the `aios` CLI / sidecar) use a per-member API key. To onboard
+someone, an admin runs (against the target `DATABASE_URL` — prod uses the Railway DB):
+
+```bash
+npm run admin -- create-member <email> --name "<Display Name>" --handle <actor-handle> --role member --team aios
+npm run admin -- issue-key <email> --name "<their-laptop>" --team aios
+# → prints aios_<key_id>_<secret> ONCE. Send it to them over a secure channel; it is sha256 at rest.
+npm run admin -- login-link <email> --team aios            # optional: a magic link to sign into the dashboard
+```
+
+`npm run admin -- list-members` / `list-keys` show the current state. The full contributor journey
+(scaffold a workspace → connect → first push → first PR) lives in the public docs under
+**Getting Started → Onboarding a contributor**.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `ECONNREFUSED 127.0.0.1:5434` in data-mechanics | the test container is down → `npm run db:test:up` |
+| data-mechanics refuses to run (`requires DATABASE_TEST_URL`) | use `npm run test:datamechanics:local` |
+| `relation "..." does not exist` / empty dashboard | schema/seed not loaded → `npm run pg:schema && npm run dev:seed` |
+| auth/cookie errors in Postgres mode | `AUTH_SECRET` unset in `.env.local` |
+| invite/magic links point at the wrong host | set `APP_URL` to your absolute base URL |
+| live query errors, everything else works | no LLM configured — set `ANTHROPIC_API_KEY` or `LLM_BASE_URL` ([`docs/PROVIDERS.md`](docs/PROVIDERS.md)) |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ npx tsx --conditions react-server scripts/seed-demo.ts   # demo team + Northwind
 npm run dev
 ```
 
+> **New contributor?** [`DEVELOPMENT.md`](DEVELOPMENT.md) is the full local-setup + test-tier walkthrough
+> (prereqs, `.env.local`, `AUTH_SECRET`, troubleshooting); [`CONTRIBUTING.md`](CONTRIBUTING.md) is the
+> PR checklist (worktrees, spec-first tests, the architecture-map loop). Start there.
+
 > Legacy Supabase backend: set `DB_BACKEND=supabase`, run `supabase start`, fill
 > `.env.local` from `supabase status -o env`, and `supabase db reset` to migrate.
 


### PR DESCRIPTION
Adds the two human-onboarding docs the brain was missing, so a new contributor (we're onboarding Abe) can clone, run it locally, and open a correct PR without reverse-engineering conventions from `AGENTS.md`.

## New
- **`DEVELOPMENT.md`** — local setup grounded in the real `.env.example` / `package.json`: prereqs (Node 20+, Docker), `.env.local` with `AUTH_SECRET` generation + "where do I get a `DATABASE_URL`" (reuse the `:5434` test container or run your own), `pg:schema` → `dev:seed` → `dev` → `dev:login`, the **test-tier table** (unit / data-mechanics / integration / docs-guard / lint — which command catches which failure), schema rollout, the **admin commands to provision a contributor** (`create-member` + `issue-key`), and a troubleshooting table (incl. the `ECONNREFUSED :5434` and `DATABASE_TEST_URL` gotchas).
- **`CONTRIBUTING.md`** — the five PR gates: worktrees (not feature branches in the primary checkout), spec-first tests in the right tier, the `docs/ARCHITECTURE.md` build loop + `check:docs`, single-writer + tier invariants (no RLS backstop on Postgres), and "green before you open it". Plus the pinned `brain-api.md` contract rule and PR hygiene.
- **`README.md`** — pointer to both from Local development.

Docs only — no code touched. Verified every internal link resolves.

Part of a 3-repo contributor-onboarding pass (workspace `GETTING-STARTED.md` + website expansion in sibling PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> Adds **human-facing onboarding docs** so new contributors can run the brain locally and open PRs without reverse-engineering **`AGENTS.md`**.
> 
> **`DEVELOPMENT.md`** documents Postgres-first local setup (`.env.local`, `AUTH_SECRET`, `DATABASE_URL` including the `:5434` test container), `pg:schema` → `dev:seed` → `dev` → `dev:login`, a **test-tier command table** (unit / data-mechanics / integration / docs guard / lint), schema rollout, **admin `create-member` / `issue-key`** provisioning, and a troubleshooting table.
> 
> **`CONTRIBUTING.md`** distills the **five PR gates**: git worktrees (not feature branches in the primary checkout), spec-first tests in the right tier, keeping **`docs/ARCHITECTURE.md`** and `check:docs` in sync, single-writer + tier invariants (no RLS backstop), and verification commands before opening a PR; it also covers the pinned **`brain-api.md`** contract and PR hygiene.
> 
> **`README.md`** gains a short **“New contributor?”** callout under Local development pointing to both files. Docs only — no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cbc4d78c7f6b804bf2f31b8544acbf28d4103de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Added detailed contribution guidelines, including an AIOS PR landing checklist and required verification expectations.
* Introduced a comprehensive local development guide covering prerequisites, environment setup, local login flow, test-tier commands, and troubleshooting.
* Updated the README to point new contributors to the full local setup and PR workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->