### PR TITLE
feat(pm): mirror the AIOS backlog into Linear (Plane-vs-Linear bake-off)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,8 +177,11 @@ projected into each PM tool by a seed script that shares that data:
 `npm run plane:backlog` (Plane: epics + sub-issues + Wave modules, idempotent by
 `external_id`) and `npm run linear:backlog` (Linear-native: a Project per Wave,
 epics as parent issues, chunks as sub-issues, idempotent by an `aios-ext:` marker
-in each issue description). Both read `LINEAR_API_KEY`/`PLANE_API_KEY` from the
-workspace `.env` via dotenvx and support `--dry-run`. This is the Plane-vs-Linear
+in each issue description). `npm run linear:backlog -- --sync-status` additionally
+reconciles each Linear issue's workflow state from its Plane counterpart (matched by
+the shared ext key, mapped by state group) so "done in Plane" shows as "done in
+Linear". Both read `LINEAR_API_KEY`/`PLANE_API_KEY` (+ optional `LINEAR_TEAM`) from
+the workspace `.env` via dotenvx and support `--dry-run`. This is the Plane-vs-Linear
 bake-off substrate (backlog epic W2.4); the runtime write-back loop above is
 unchanged and provider-neutral.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,6 +171,17 @@ lives only in `integrations.secret_ciphertext` and is decrypted on the server-si
 sync path. Provider failures update `task_pm_links.last_error` and the task remains
 done — PM drift is visible, not allowed to roll back completed code work.
 
+**Seeding/mirroring the board (one-way, idempotent).** The backlog itself is
+authored once in `scripts/aios-backlog.mjs` (the single source of truth) and
+projected into each PM tool by a seed script that shares that data:
+`npm run plane:backlog` (Plane: epics + sub-issues + Wave modules, idempotent by
+`external_id`) and `npm run linear:backlog` (Linear-native: a Project per Wave,
+epics as parent issues, chunks as sub-issues, idempotent by an `aios-ext:` marker
+in each issue description). Both read `LINEAR_API_KEY`/`PLANE_API_KEY` from the
+workspace `.env` via dotenvx and support `--dry-run`. This is the Plane-vs-Linear
+bake-off substrate (backlog epic W2.4); the runtime write-back loop above is
+unchanged and provider-neutral.
+
 ### Action layer (Organ 4) — policy-gated execution
 
 ```mermaid

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,9 +175,9 @@ done — PM drift is visible, not allowed to roll back completed code work.
 authored once in `scripts/aios-backlog.mjs` (the single source of truth) and
 projected into each PM tool by a seed script that shares that data:
 `npm run plane:backlog` (Plane: epics + sub-issues + Wave modules, idempotent by
-`external_id`) and `npm run linear:backlog` (Linear-native: a Project per Wave,
-epics as parent issues, chunks as sub-issues, idempotent by an `aios-ext:` marker
-in each issue description). `npm run linear:backlog -- --sync-status` additionally
+`external_id`) and `npm run linear:backlog` (Linear-native: a saved View per Wave
+filtered by the wave label, epics as parent issues, chunks as sub-issues, idempotent
+by an `aios-ext:` + `source: aios-backlog` marker in each issue description). `npm run linear:backlog -- --sync-status` additionally
 reconciles each Linear issue's workflow state from its Plane counterpart (matched by
 the shared ext key, mapped by state group) so "done in Plane" shows as "done in
 Linear". Both read `LINEAR_API_KEY`/`PLANE_API_KEY` (+ optional `LINEAR_TEAM`) from

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "coverage": "vitest run --coverage",
     "check:docs": "node scripts/check-docs-drift.mjs",
     "plane:backlog": "npx --yes @dotenvx/dotenvx run -f ../aios-workspace/.env -- node scripts/plane-backlog.mjs",
+    "linear:backlog": "npx --yes @dotenvx/dotenvx run -f ../aios-workspace/.env -- node scripts/linear-backlog.mjs",
     "pm:backfill": "npx tsx --conditions react-server scripts/pm-sync-backfill.ts",
     "test:setup": "bash scripts/dev-test-setup.sh",
     "db:test:up": "docker compose -f compose.test.yml up -d --wait && DATABASE_URL=postgres://app:app@localhost:5434/app_test npm run pg:schema",

--- a/scripts/aios-backlog.mjs
+++ b/scripts/aios-backlog.mjs
@@ -7,7 +7,7 @@
  *
  * Consumed by:
  *   - scripts/plane-backlog.mjs   → seeds Plane (epics + sub-issues + Wave modules)
- *   - scripts/linear-backlog.mjs  → mirrors into Linear (Wave projects + parent/sub issues)
+ *   - scripts/linear-backlog.mjs  → mirrors into Linear (Wave views + parent/sub issues)
  *
  * Keep this file data-only so both seeds stay in lock-step — edit the backlog here once.
  */

--- a/scripts/aios-backlog.mjs
+++ b/scripts/aios-backlog.mjs
@@ -1,0 +1,151 @@
+/**
+ * Single source of truth for the AIOS remaining-work backlog.
+ *
+ * One epic per feature; sub-issues = chunks. Each item carries a stable `ext` key
+ * (e.g. "P0", "F3.1") used for idempotency by the PM seed scripts, a `wave`
+ * (WAVE1/WAVE2), a `priority`, and `labels`.
+ *
+ * Consumed by:
+ *   - scripts/plane-backlog.mjs   → seeds Plane (epics + sub-issues + Wave modules)
+ *   - scripts/linear-backlog.mjs  → mirrors into Linear (Wave projects + parent/sub issues)
+ *
+ * Keep this file data-only so both seeds stay in lock-step — edit the backlog here once.
+ */
+
+export const WAVE1 = "Wave 1 — MVP";
+export const WAVE2 = "Wave 2 — Later";
+export const LABELS = ["wave-1", "wave-2", "foundation", "brain", "sidecar", "ops", "integration", "design", "migration"];
+
+// description helper — backlog descriptions are authored as HTML paragraphs (Plane wants
+// description_html). Linear strips this back to plain text via plain() in linear-backlog.mjs.
+export const p = (s) => `<p>${s}</p>`;
+
+// ── backlog: one epic per feature, sub-issues = chunks ────────────────────────
+export const BACKLOG = [
+  { ext: "P0", name: "P0 — Plane integration (MCP + seed)", wave: WAVE1, priority: "high",
+    labels: ["integration", "wave-1"], desc: p("Stand up Plane as a real integration: official MCP server (durable/agentic) + idempotent REST seed of this backlog under the AIOS project."),
+    subs: [
+      { ext: "P0.1", name: "Register official Plane MCP server", desc: p("claude mcp add --transport http plane https://mcp.plane.so/http/mcp (OAuth). Confirm tools listable. Fallback: uvx plane-mcp-server (user scope).") },
+      { ext: "P0.2", name: "Idempotent REST seed script", desc: p("scripts/plane-backlog.mjs: discover AIOS project, ensure Wave modules + labels, create epics+sub-issues with external_id idempotency, throttle ≤60/min. npm plane:backlog.") },
+      { ext: "P0.3", name: "Record Plane integration in brain integrations table", desc: p("After F5: integrations row type=plane, config={workspaceSlug:'aios-alpha', projectId}. Substrate for W2.4 plane ingestion source.") },
+      { ext: "P0.4", name: "Verify backlog structure + idempotent re-run", desc: p("Confirm epics+sub-issues with parents/modules/labels; re-run seed → all skipped (no duplicates).") },
+    ] },
+
+  { ext: "F3", name: "F3 — Integrations auth surfaces + contract bump", wave: WAVE1, priority: "high",
+    labels: ["foundation", "brain", "wave-1"], desc: p("Two auth surfaces for the integrations framework without touching the pinned /api/v1 write contract."),
+    subs: [
+      { ext: "F3.1", name: "Dashboard session-auth write (server action)", desc: p("Server action / app/api/dashboard/integrations/route.ts → lib/integrations/manage.ts; admin-gated like admin/layout.tsx. No /api/v1 write surface.") },
+      { ext: "F3.2", name: "GET /api/v1/integrations (sidecar read)", desc: p("API-key auth; returns NON-SECRET selections for the team. The documented contract the sidecar consumes.") },
+      { ext: "F3.3", name: "Version brain-api.md + drift:routes", desc: p("Add the new read endpoint to aios-workspace/docs/brain-api.md FIRST, then docs/ARCHITECTURE.md drift:routes; npm run check:docs green. dep: F3.2") },
+      { ext: "F3.4", name: "Data-mechanics: admin-only write + scoped read", desc: p("Non-admin write → 403; API-key read returns only non-secret fields, team-scoped. dep: F3.1,F3.2") },
+    ] },
+
+  { ext: "F4", name: "F4 — Sidecar consumes selections", wave: WAVE1, priority: "high",
+    labels: ["sidecar", "wave-1"], desc: p("Close the 'table does nothing' gap: the ingestion engine merges brain-side selections with local secrets. dep: F3"),
+    subs: [
+      { ext: "F4.1", name: "engine.py + brain_client.py merge", desc: p("Fetch GET /api/v1/integrations; merge with local secrets by (type,name) — selection from brain, tokens local.") },
+      { ext: "F4.2", name: "connections.yaml.example + backward-compat", desc: p("Document; when selection-fetch unconfigured, behave exactly as today.") },
+      { ext: "F4.3", name: "Python tests: merge + backward-compat", desc: p("Merge precedence; unconfigured = current behavior.") },
+    ] },
+
+  { ext: "F5", name: "F5 — Admin Integrations UI + tier guards", wave: WAVE1, priority: "high",
+    labels: ["foundation", "brain", "wave-1"], desc: p("Admin-gated Integrations surface + per-table tier/role guards (no RLS backstop on postgres). dep: F3"),
+    subs: [
+      { ext: "F5.1", name: "Admin tab + integrations page", desc: p("components/admin/admin-tabs.tsx entry + app/t/[team]/admin/integrations/page.tsx (admin gate).") },
+      { ext: "F5.2", name: "lib/integrations/read.ts scoped reads", desc: p("Role/tier-scoped read helper for the integrations surface.") },
+      { ext: "F5.3", name: "integrations-tier-filter guard test", desc: p("test/guards/integrations-tier-filter.test.ts modeled on codebases-tier-filter.") },
+      { ext: "F5.4", name: "Supabase fail-closed notice", desc: p("Under DB_BACKEND=supabase, surface shows 'not available on legacy backend'.") },
+      { ext: "F5.5", name: "Data-mechanics: persistence + tier isolation", desc: p("Real-PG: integrations persist; external tier cannot read admin config.") },
+    ] },
+
+  { ext: "W1.1", name: "W1.1 — Granola → decisions (sanitized, consented)", wave: WAVE1, priority: "high",
+    labels: ["sidecar", "integration", "wave-1"], desc: p("Ingest Granola meetings as decision rows only — NO verbatim transcript synced team-tier."),
+    subs: [
+      { ext: "W1.1.1", name: "granola.py source + registry + drift", desc: p("ingestion/aios_ingest/sources/granola.py implements Source; register in registry.py; drift:sources += granola.") },
+      { ext: "W1.1.2", name: "Privacy gate: allowlist + consent", desc: p("Meeting allowlist (AIOS keyword / John+Chetan participants) + per-note consent; no verbatim team-tier transcript.") },
+      { ext: "W1.1.3", name: "Reuse granola-digest pull/parse", desc: p("Transcripts pulled to workspace (admin-tier, local) only.") },
+      { ext: "W1.1.4", name: "Wire transcript-decisions flow", desc: p("transcript-decisions workflow → human-reviewed decision rows → decision-log.md → aios push → materializeDecisions.") },
+      { ext: "W1.1.5", name: "Python tests (mocked pagination/rate-limit)", desc: p("Registry + normalize + mocked API pagination & rate-limit.") },
+    ] },
+
+  { ext: "W1.2", name: "W1.2 — Token + cost per member (brain spend)", wave: WAVE1, priority: "high",
+    labels: ["brain", "wave-1"], desc: p("Per-member LLM cost from query_log (built on the shipped scopeQueryLog fix + shared identity resolver)."),
+    subs: [
+      { ext: "W1.2.1", name: "lib/metrics/members.ts getPerMemberCosts", desc: p("Role-scoped aggregation of query_log via scopeQueryLog; admins team-wide, others self.") },
+      { ext: "W1.2.2", name: "Admin usage page", desc: p("app/t/[team]/admin/usage/page.tsx (admin-only) reusing contributor-table + charts.") },
+      { ext: "W1.2.3", name: "Throughput-vs-cost primitive", desc: p("Join code_contributions (via shared resolver) × query_log spend → $ per AI commit / contributor.") },
+      { ext: "W1.2.4", name: "Tier/role guard + data-mechanics", desc: p("Guard test + real-PG aggregation test.") },
+    ] },
+
+  { ext: "W1.3", name: "W1.3 — GitHub native UI (selection + manual scan)", wave: WAVE1, priority: "high",
+    labels: ["brain", "wave-1"], desc: p("Dashboard repo selection + member linking, reusing the code-only GitHub integration. No server-triggered scan in Wave 1. dep: F5"),
+    subs: [
+      { ext: "W1.3.1", name: "Repo selection persisted to integrations", desc: p("type=github, config.repos; reuse lib/codebases/github.ts.") },
+      { ext: "W1.3.2", name: "Member → GitHub linking UI", desc: p("Reuse linkGithub.") },
+      { ext: "W1.3.3", name: "Scan freshness + manual scan panel", desc: p("Show last-scan SHA vs main HEAD + documented manual aios-ingest command. Selection consumed by sidecar (F4).") },
+      { ext: "W1.3.4", name: "Respect canSeeCodebases (team-tier)", desc: p("lib/codebases/visibility.ts gate.") },
+    ] },
+
+  { ext: "W1.4", name: "W1.4 — Ops hardening (Sentry, CodeRabbit, BugBot)", wave: WAVE1, priority: "high",
+    labels: ["ops", "wave-1"], desc: p("Error logging + AI code review for the OSS repos."),
+    subs: [
+      { ext: "W1.4.1", name: "Sentry @sentry/nextjs ≥10.13 (Turbopack)", desc: p("instrumentation-client.ts, sentry.server/edge.config.ts, onRequestError in instrumentation.ts, app/global-error.tsx, withSentryConfig; DSN+token via env.") },
+      { ext: "W1.4.2", name: "CodeRabbit GitHub App on public repos", desc: p("Free for public repos; no org-admin friction.") },
+      { ext: "W1.4.3", name: "Fix Cursor BugBot org-app approval", desc: p("Approve Cursor app at AIOS-alpha → Third-party Access (manual; John is owner).") },
+      { ext: "W1.4.4", name: "Sentry smoke test", desc: p("Client + server error → events + source maps resolve.") },
+    ] },
+
+  { ext: "W2.1", name: "W2.1 — External AI cost (usage_costs)", wave: WAVE2, priority: "medium",
+    labels: ["brain", "wave-2"], desc: p("Per-member external provider spend (Anthropic/Cursor seats + API). dep: W1.2"),
+    subs: [
+      { ext: "W2.1.1", name: "usage_costs schema + FK registry + drift", desc: p("{team_id, member_id, provider, period, input_tokens, output_tokens, cost_usd, source}.") },
+      { ext: "W2.1.2", name: "lib/costs/ingest.ts single writer + guard", desc: p("Only writer for usage_costs.") },
+      { ext: "W2.1.3", name: "Anthropic Usage/Cost API source", desc: p("+ Enterprise Analytics per-user if available.") },
+      { ext: "W2.1.4", name: "Cursor Admin API source (/teams/spend)", desc: p("Per-seat USD + tokens.") },
+      { ext: "W2.1.5", name: "Identity resolve + retention + tier guard", desc: p("Shared resolver; 13-month retention; tier guard; merge into usage page.") },
+    ] },
+
+  { ext: "W2.2", name: "W2.2 — Slack bidirectional", wave: WAVE2, priority: "medium",
+    labels: ["sidecar", "integration", "wave-2"], desc: p("Pull allowlisted channels into the brain; push digests + /ask-brain."),
+    subs: [
+      { ext: "W2.2.1", name: "Slack source + Events API (allowlisted)", desc: p("slack.py exists; Events API for allowlisted channels.") },
+      { ext: "W2.2.2", name: "Push digests via incoming webhook", desc: p("Decisions / daily digest.") },
+      { ext: "W2.2.3", name: "/ask-brain slash command", desc: p("→ lib/query/retrieve.ts.") },
+      { ext: "W2.2.4", name: "Privacy allowlist + app manifest", desc: p("Like Granola; minimal Slack app manifest.") },
+    ] },
+
+  { ext: "W2.3", name: "W2.3 — Wise Business finance", wave: WAVE2, priority: "medium",
+    labels: ["sidecar", "wave-2"], desc: p("Cash/runway view from Wise Business; secrets local."),
+    subs: [
+      { ext: "W2.3.1", name: "wise.py source (OAuth2)", desc: p("OAuth2 user token; balances + transactions.") },
+      { ext: "W2.3.2", name: "finance_snapshots table + writer + guard", desc: p("Single writer + tier guard + FK registry.") },
+      { ext: "W2.3.3", name: "Cash/runway dashboard tile", desc: p("Operating financials tile.") },
+    ] },
+
+  { ext: "W2.4", name: "W2.4 — PM bake-off: Linear + Plane → brain", wave: WAVE2, priority: "medium",
+    labels: ["integration", "wave-2"], desc: p("Ingest both Linear and Plane issues/cycles INTO the brain; compare; pick. Closes the loop with P0."),
+    subs: [
+      { ext: "W2.4.1", name: "Configure linear source", desc: p("Existing linear source → ingest issues/cycles.") },
+      { ext: "W2.4.2", name: "Add plane.py source", desc: p("Ingest AIOS work items/cycles back into the brain.") },
+      { ext: "W2.4.3", name: "Brain overlay: link issues ↔ decisions", desc: p("Link issues ↔ decisions/deliverables.") },
+      { ext: "W2.4.4", name: "Comparison writeup → pick", desc: p("Linear vs Plane decision.") },
+    ] },
+
+  { ext: "W2.5", name: "W2.5 — Pencil design system", wave: WAVE2, priority: "low",
+    labels: ["design", "wave-2"], desc: p("Shared agentic design system with W3C design tokens."),
+    subs: [
+      { ext: "W2.5.1", name: "W3C DTCG tokens", desc: p("design/*.tokens.json.") },
+      { ext: "W2.5.2", name: "Style Dictionary → tokens.css", desc: p("For Tailwind v4.") },
+      { ext: "W2.5.3", name: "pencil MCP edits .pen + sync", desc: p("Two-way sync of tokens.") },
+      { ext: "W2.5.4", name: "Shared design-library docs", desc: p("Usage across contributors/clients.") },
+    ] },
+
+  { ext: "W2.6", name: "W2.6 — connector→integration rename (blueprint migration)", wave: WAVE2, priority: "low",
+    labels: ["migration", "wave-2"], desc: p("Versioned, backward-compatible rename — connectors is live blueprint JSON across repos."),
+    subs: [
+      { ext: "W2.6.1", name: "Bump blueprint schema version", desc: p("New version field.") },
+      { ext: "W2.6.2", name: "Backward-compatible reader", desc: p("Accept both connectors + integrations keys.") },
+      { ext: "W2.6.3", name: "Migrate published blueprints", desc: p("In-place migration.") },
+      { ext: "W2.6.4", name: "brain-api.md + team-tools update", desc: p("Doc + UI.") },
+    ] },
+];

--- a/scripts/linear-backlog.mjs
+++ b/scripts/linear-backlog.mjs
@@ -2,19 +2,21 @@
 /**
  * Idempotent mirror of the AIOS remaining-work backlog into Linear.
  *
- * Linear-native mapping (decided with John): each Wave becomes a Linear PROJECT, each epic
- * becomes a parent ISSUE inside its wave's project, and each chunk becomes a SUB-ISSUE.
+ * Linear-native mapping (decided with John): each Wave becomes a team CUSTOM VIEW (filtered by
+ * the wave label), each epic becomes a parent ISSUE, and each chunk becomes a SUB-ISSUE.
  * The backlog data is shared verbatim with scripts/plane-backlog.mjs via scripts/aios-backlog.mjs,
  * so the Plane board and the Linear board stay in lock-step.
  *
- *   Wave 1 — MVP    →  Linear project "AIOS — Wave 1 (MVP)"
- *   Wave 2 — Later  →  Linear project "AIOS — Wave 2 (Later)"
+ *   Wave 1 — MVP    →  custom view "AIOS — Wave 1 (MVP)" (label wave-1)
+ *   Wave 2 — Later  →  custom view "AIOS — Wave 2 (Later)" (label wave-2)
  *     epic  P0      →  parent issue  "P0 — Plane integration (MCP + seed)"
  *       chunk P0.1  →  sub-issue     "Register official Plane MCP server"
  *
  * Idempotency: Linear has no Plane-style external_id, so each created issue carries a stable
  * footer marker `aios-ext: <ext>` in its description (ext = P0, P0.1, …). Re-runs read that
  * marker off existing issues and skip anything already present — safe to run repeatedly.
+ * Re-runs do not update titles, descriptions, labels, or parent links when the backlog changes;
+ * edit issues in Linear/Plane or delete and re-seed if you need a full refresh.
  *
  * Auth/config from env (read at runtime — never hard-coded):
  *   LINEAR_API_KEY  (required)  → header Authorization: <raw personal key>  (NOT a Bearer token)
@@ -31,7 +33,8 @@
  *   npx --yes @dotenvx/dotenvx run -f ../aios-workspace/.env -- node scripts/linear-backlog.mjs
  *   # or: npm run linear:backlog
  *
- * Flags: --dry-run (no writes; print plan)   --verbose   --team <key>
+ * Flags: --dry-run (no writes; print plan; with --sync-status, plan state changes only)
+ *        --verbose   --team <key>
  *        --sync-status (after seeding, set each Linear issue's state from its Plane counterpart)
  */
 
@@ -47,18 +50,26 @@ const SYNC_STATUS = process.argv.includes("--sync-status");
 const teamFlagIdx = process.argv.indexOf("--team");
 const TEAM_WANT = (teamFlagIdx !== -1 ? process.argv[teamFlagIdx + 1] : process.env.LINEAR_TEAM || "").trim();
 
-// Wave module → Linear project name.
-const PROJECT_NAME = {
+// Wave → saved view name + filter label (issues already carry wave-1 / wave-2 labels).
+const VIEW_NAME = {
   [WAVE1]: "AIOS — Wave 1 (MVP)",
   [WAVE2]: "AIOS — Wave 2 (Later)",
+};
+const WAVE_LABEL = {
+  [WAVE1]: "wave-1",
+  [WAVE2]: "wave-2",
 };
 
 // Stable per-issue idempotency marker, embedded in the issue description.
 const EXT_SOURCE = "aios-backlog";
 const extMarker = (ext) => `aios-ext: ${ext} · source: ${EXT_SOURCE}`;
-const EXT_RE = /aios-ext:\s*([A-Za-z0-9._-]+)/;
+const EXT_RE = /aios-ext:\s*([A-Za-z0-9._-]+)\s*[·•]\s*source:\s*aios-backlog\b/;
+const parseExt = (description) => {
+  const m = String(description || "").match(EXT_RE);
+  return m ? m[1] : null;
+};
 
-if (!API_KEY && !DRY) {
+if (!API_KEY && (!DRY || SYNC_STATUS)) {
   console.error("LINEAR_API_KEY is not set. Run via: npx @dotenvx/dotenvx run -f ../aios-workspace/.env -- node scripts/linear-backlog.mjs");
   process.exit(1);
 }
@@ -84,8 +95,9 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // ── GraphQL transport: light throttle + 429 backoff ───────────────────────────
 const MIN_INTERVAL = 150; // ms between requests; Linear allows ~1500 req/hr for personal keys
+const MAX_429_RETRIES = 8;
 let lastReq = 0;
-async function gql(query, variables, attempt = 0) {
+async function gql(query, variables, attempt = 0, rateLimitAttempt = 0) {
   const now = Date.now();
   const wait = Math.max(0, MIN_INTERVAL - (now - lastReq));
   if (wait) await sleep(wait);
@@ -99,20 +111,21 @@ async function gql(query, variables, attempt = 0) {
     });
   } catch (err) {
     // network blip — retry a few times before giving up
-    if (attempt < 4) { console.warn(`  network error (${err.message}); retry ${attempt + 1}/4`); await sleep(1000 * (attempt + 1)); return gql(query, variables, attempt + 1); }
+    if (attempt < 4) { console.warn(`  network error (${err.message}); retry ${attempt + 1}/4`); await sleep(1000 * (attempt + 1)); return gql(query, variables, attempt + 1, rateLimitAttempt); }
     throw err;
   }
   if (res.status === 429) {
+    if (rateLimitAttempt >= MAX_429_RETRIES) throw new Error(`Linear rate-limited after ${MAX_429_RETRIES} retries`);
     const retry = Number(res.headers.get("Retry-After") || 5) * 1000;
-    console.warn(`  rate-limited; backing off ${retry}ms`);
+    console.warn(`  rate-limited; backing off ${retry}ms (${rateLimitAttempt + 1}/${MAX_429_RETRIES})`);
     await sleep(retry);
-    return gql(query, variables, attempt);
+    return gql(query, variables, attempt, rateLimitAttempt + 1);
   }
   if (res.status >= 500 && attempt < 4) {
     // transient Linear gateway error (502/503/504) — back off and retry
     console.warn(`  Linear HTTP ${res.status}; retry ${attempt + 1}/4`);
     await sleep(1000 * (attempt + 1));
-    return gql(query, variables, attempt + 1);
+    return gql(query, variables, attempt + 1, rateLimitAttempt);
   }
   const json = await res.json().catch(() => null);
   if (!res.ok || !json || json.errors) {
@@ -138,18 +151,23 @@ async function resolveTeam() {
   throw new Error(`Multiple Linear teams — set LINEAR_TEAM (or --team) to one of: ${teams.map((t) => `${t.key} (${t.name})`).join(", ")}`);
 }
 
-async function teamProjects(teamId) {
-  const data = await gql(`query($id: String!) { team(id: $id) { projects(first: 250) { nodes { id name } } } }`, { id: teamId });
-  return data.team.projects.nodes;
+async function teamCustomViews(teamId) {
+  const data = await gql(`query { customViews(first: 250) { nodes { id name team { id } } } }`);
+  return data.customViews.nodes.filter((v) => v.team?.id === teamId);
 }
 
-async function createProject(teamId, name) {
+async function createCustomView(teamId, name, labelName) {
   const data = await gql(
-    `mutation($input: ProjectCreateInput!) { projectCreate(input: $input) { success project { id name } } }`,
-    { input: { name, teamIds: [teamId], description: `Mirror of the AIOS ${name.includes("Wave 1") ? WAVE1 : WAVE2} backlog (see Plane workspace aios-alpha / project AIOS).` }
-  });
-  if (!data.projectCreate.success) throw new Error(`projectCreate failed for ${name}`);
-  return data.projectCreate.project;
+    `mutation($input: CustomViewCreateInput!) { customViewCreate(input: $input) { success customView { id name } } }`,
+    { input: {
+      name,
+      teamId,
+      filterData: { labels: { name: { eq: labelName } } },
+      description: `AIOS backlog mirror — issues labeled ${labelName} (see Plane workspace aios-alpha / project AIOS).`,
+    } }
+  );
+  if (!data.customViewCreate.success) throw new Error(`customViewCreate failed for ${name}`);
+  return data.customViewCreate.customView;
 }
 
 async function teamLabels(teamId) {
@@ -184,8 +202,8 @@ async function existingByExt(teamId) {
     );
     const conn = data.team.issues;
     for (const node of conn.nodes) {
-      const m = (node.description || "").match(EXT_RE);
-      if (m) byExt.set(m[1], node.id);
+      const ext = parseExt(node.description);
+      if (ext) byExt.set(ext, node.id);
     }
     if (!conn.pageInfo.hasNextPage) break;
     after = conn.pageInfo.endCursor;
@@ -193,11 +211,10 @@ async function existingByExt(teamId) {
   return byExt;
 }
 
-async function createIssue({ teamId, title, description, priority, labelIds, projectId, parentId }) {
+async function createIssue({ teamId, title, description, priority, labelIds, parentId }) {
   const input = { teamId, title, description };
   if (priority) input.priority = priority;
   if (labelIds?.length) input.labelIds = labelIds;
-  if (projectId) input.projectId = projectId;
   if (parentId) input.parentId = parentId;
   const data = await gql(
     `mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id identifier } } }`,
@@ -258,7 +275,7 @@ async function planeExtGroups() {
   return byExt;
 }
 
-async function reconcileStatus(teamId) {
+async function reconcileStatus(teamId, { dryRun = false } = {}) {
   // Linear workflow states for the team.
   const sData = await gql(`query($id: String!) { team(id: $id) { states(first: 50) { nodes { id name type } } } }`, { id: teamId });
   const states = sData.team.states.nodes;
@@ -279,8 +296,8 @@ async function reconcileStatus(teamId) {
     );
     const conn = d.team.issues;
     for (const n of conn.nodes) {
-      const m = (n.description || "").match(EXT_RE);
-      if (m) current.set(m[1], { id: n.id, stateId: n.state?.id || null });
+      const ext = parseExt(n.description);
+      if (ext) current.set(ext, { id: n.id, stateId: n.state?.id || null });
     }
     if (!conn.pageInfo.hasNextPage) break;
     after = conn.pageInfo.endCursor;
@@ -294,25 +311,37 @@ async function reconcileStatus(teamId) {
     matched++;
     const target = stateForGroup(group);
     if (!target || target === issue.stateId) continue;
-    await setIssueState(issue.id, target);
     changed++;
+    if (dryRun) {
+      if (VERBOSE) console.log(`would  ${ext} → ${GROUP_PREFERRED[group]} (${group})`);
+      continue;
+    }
+    await setIssueState(issue.id, target);
     if (VERBOSE) console.log(`state  ${ext} → ${GROUP_PREFERRED[group]} (${group})`);
   }
-  console.log(`Status sync: ${changed} updated · ${matched - changed} already correct · ${missing} Plane item(s) not in Linear (e.g. pre-backlog history).`);
+  const prefix = dryRun ? "Status sync (dry-run)" : "Status sync";
+  console.log(`${prefix}: ${changed} ${dryRun ? "would update" : "updated"} · ${matched - changed} already correct · ${missing} Plane item(s) not in Linear (e.g. pre-backlog history).`);
 }
 
 // ── plan / run ────────────────────────────────────────────────────────────────
 async function main() {
   const totalItems = BACKLOG.length + BACKLOG.reduce((n, e) => n + e.subs.length, 0);
 
-  if (DRY) {
+  if (DRY && !SYNC_STATUS) {
     console.log(`Linear mirror plan (--dry-run): ${BACKLOG.length} epics + ${totalItems - BACKLOG.length} sub-issues = ${totalItems} issues`);
-    console.log(`Projects: "${PROJECT_NAME[WAVE1]}", "${PROJECT_NAME[WAVE2]}"  ·  team: ${TEAM_WANT || "(auto / single team)"}\n`);
+    console.log(`Views: "${VIEW_NAME[WAVE1]}" (${WAVE_LABEL[WAVE1]}), "${VIEW_NAME[WAVE2]}" (${WAVE_LABEL[WAVE2]})  ·  team: ${TEAM_WANT || "(auto / single team)"}\n`);
     for (const e of BACKLOG) {
-      console.log(`◆ [${PROJECT_NAME[e.wave]}] (${e.priority})  ${e.name}`);
+      console.log(`◆ [${VIEW_NAME[e.wave]}] (${e.priority})  ${e.name}`);
       for (const s of e.subs) console.log(`   └─ ${s.ext}  ${s.name}`);
     }
     console.log("\n--dry-run: no writes performed. Set LINEAR_API_KEY + LINEAR_TEAM and re-run without --dry-run.");
+    return;
+  }
+
+  if (DRY && SYNC_STATUS) {
+    const team = await resolveTeam();
+    console.log(`Team: ${team.name} (${team.key}) ${team.id}\n`);
+    await reconcileStatus(team.id, { dryRun: true });
     return;
   }
 
@@ -320,19 +349,15 @@ async function main() {
   const team = await resolveTeam();
   console.log(`Team: ${team.name} (${team.key}) ${team.id}`);
 
-  // 2. ensure wave projects
-  const existingProjects = await teamProjects(team.id);
-  const projectId = new Map(existingProjects.map((p) => [p.name, p.id]));
-  const waveProject = new Map();
+  // 2. ensure wave views (label-filtered saved views, not projects)
+  const existingViews = await teamCustomViews(team.id);
+  const viewId = new Map(existingViews.map((v) => [v.name, v.id]));
   for (const wave of [WAVE1, WAVE2]) {
-    const name = PROJECT_NAME[wave];
-    let id = projectId.get(name);
-    if (!id) {
-      const created = await createProject(team.id, name);
-      id = created.id;
-      console.log(`project + ${name}`);
-    }
-    waveProject.set(wave, id);
+    const name = VIEW_NAME[wave];
+    if (viewId.has(name)) continue;
+    const created = await createCustomView(team.id, name, WAVE_LABEL[wave]);
+    viewId.set(name, created.id);
+    console.log(`view + ${name} (label ${WAVE_LABEL[wave]})`);
   }
 
   // 3. ensure labels
@@ -362,7 +387,6 @@ async function main() {
       description: bodyFor(desc, ext),
       priority: mapPriority(priority),
       labelIds: (labels || []).map((n) => labelId.get(n)).filter(Boolean),
-      projectId: waveProject.get(wave),
       parentId,
     });
     byExt.set(ext, issue.id);

--- a/scripts/linear-backlog.mjs
+++ b/scripts/linear-backlog.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * Idempotent mirror of the AIOS remaining-work backlog into Linear.
+ *
+ * Linear-native mapping (decided with John): each Wave becomes a Linear PROJECT, each epic
+ * becomes a parent ISSUE inside its wave's project, and each chunk becomes a SUB-ISSUE.
+ * The backlog data is shared verbatim with scripts/plane-backlog.mjs via scripts/aios-backlog.mjs,
+ * so the Plane board and the Linear board stay in lock-step.
+ *
+ *   Wave 1 — MVP    →  Linear project "AIOS — Wave 1 (MVP)"
+ *   Wave 2 — Later  →  Linear project "AIOS — Wave 2 (Later)"
+ *     epic  P0      →  parent issue  "P0 — Plane integration (MCP + seed)"
+ *       chunk P0.1  →  sub-issue     "Register official Plane MCP server"
+ *
+ * Idempotency: Linear has no Plane-style external_id, so each created issue carries a stable
+ * footer marker `aios-ext: <ext>` in its description (ext = P0, P0.1, …). Re-runs read that
+ * marker off existing issues and skip anything already present — safe to run repeatedly.
+ *
+ * Auth/config from env (read at runtime — never hard-coded):
+ *   LINEAR_API_KEY  (required)  → header Authorization: <raw personal key>  (NOT a Bearer token)
+ *   LINEAR_TEAM     (optional)  → target team key or name (e.g. "AIOS" / "Engineering").
+ *                                 If unset and the account has exactly one team, that team is used.
+ *                                 May also be passed as `--team <key>`.
+ *
+ * Endpoint/auth verified against https://linear.app/developers (matches the shipped
+ * linear-direct skill): POST https://api.linear.app/graphql, Authorization: <api-key>.
+ *
+ * Run (decrypts the dotenvx-encrypted key from the workspace .env, same pattern as plane:backlog):
+ *   npx --yes @dotenvx/dotenvx run -f ../aios-workspace/.env -- node scripts/linear-backlog.mjs
+ *   # or: npm run linear:backlog
+ *
+ * Flags: --dry-run (no writes; print plan)   --verbose   --team <key>
+ */
+
+import { BACKLOG, WAVE1, WAVE2, LABELS } from "./aios-backlog.mjs";
+
+const API = "https://api.linear.app/graphql";
+const API_KEY = process.env.LINEAR_API_KEY;
+const DRY = process.argv.includes("--dry-run");
+const VERBOSE = process.argv.includes("--verbose");
+const teamFlagIdx = process.argv.indexOf("--team");
+const TEAM_WANT = (teamFlagIdx !== -1 ? process.argv[teamFlagIdx + 1] : process.env.LINEAR_TEAM || "").trim();
+
+// Wave module → Linear project name.
+const PROJECT_NAME = {
+  [WAVE1]: "AIOS — Wave 1 (MVP)",
+  [WAVE2]: "AIOS — Wave 2 (Later)",
+};
+
+// Stable per-issue idempotency marker, embedded in the issue description.
+const EXT_SOURCE = "aios-backlog";
+const extMarker = (ext) => `aios-ext: ${ext} · source: ${EXT_SOURCE}`;
+const EXT_RE = /aios-ext:\s*([A-Za-z0-9._-]+)/;
+
+if (!API_KEY && !DRY) {
+  console.error("LINEAR_API_KEY is not set. Run via: npx @dotenvx/dotenvx run -f ../aios-workspace/.env -- node scripts/linear-backlog.mjs");
+  process.exit(1);
+}
+
+// Plane priority words → Linear priority Int (0 none · 1 urgent · 2 high · 3 medium · 4 low).
+function mapPriority(word) {
+  switch ((word || "").toLowerCase()) {
+    case "high": return 2;
+    case "medium": return 3;
+    case "low": return 4;
+    default: return 0;
+  }
+}
+
+// Backlog descriptions are authored as <p>…</p> HTML (for Plane's description_html). Linear wants
+// markdown/plain text, so unwrap the single paragraph and append the idempotency marker.
+function bodyFor(htmlDesc, ext) {
+  const text = String(htmlDesc || "").replace(/^<p>/, "").replace(/<\/p>$/, "").trim();
+  return `${text}\n\n${extMarker(ext)}`;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── GraphQL transport: light throttle + 429 backoff ───────────────────────────
+const MIN_INTERVAL = 150; // ms between requests; Linear allows ~1500 req/hr for personal keys
+let lastReq = 0;
+async function gql(query, variables) {
+  const now = Date.now();
+  const wait = Math.max(0, MIN_INTERVAL - (now - lastReq));
+  if (wait) await sleep(wait);
+  lastReq = Date.now();
+  const res = await fetch(API, {
+    method: "POST",
+    headers: { Authorization: API_KEY, "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (res.status === 429) {
+    const retry = Number(res.headers.get("Retry-After") || 5) * 1000;
+    console.warn(`  rate-limited; backing off ${retry}ms`);
+    await sleep(retry);
+    return gql(query, variables);
+  }
+  const json = await res.json().catch(() => null);
+  if (!res.ok || !json || json.errors) {
+    const msg = json?.errors ? json.errors.map((e) => e.message).join("; ") : `HTTP ${res.status}`;
+    throw new Error(`Linear GraphQL error: ${msg}`);
+  }
+  if (VERBOSE) console.log(`  gql ok`);
+  return json.data;
+}
+
+// ── queries / mutations ───────────────────────────────────────────────────────
+async function resolveTeam() {
+  const data = await gql(`query { teams(first: 250) { nodes { id key name } } }`);
+  const teams = data.teams.nodes;
+  if (!teams.length) throw new Error("This Linear account has no teams.");
+  if (TEAM_WANT) {
+    const want = TEAM_WANT.toLowerCase();
+    const team = teams.find((t) => t.key.toLowerCase() === want || t.name.toLowerCase() === want);
+    if (!team) throw new Error(`Linear team "${TEAM_WANT}" not found. Available: ${teams.map((t) => `${t.key} (${t.name})`).join(", ")}`);
+    return team;
+  }
+  if (teams.length === 1) return teams[0];
+  throw new Error(`Multiple Linear teams — set LINEAR_TEAM (or --team) to one of: ${teams.map((t) => `${t.key} (${t.name})`).join(", ")}`);
+}
+
+async function teamProjects(teamId) {
+  const data = await gql(`query($id: String!) { team(id: $id) { projects(first: 250) { nodes { id name } } } }`, { id: teamId });
+  return data.team.projects.nodes;
+}
+
+async function createProject(teamId, name) {
+  const data = await gql(
+    `mutation($input: ProjectCreateInput!) { projectCreate(input: $input) { success project { id name } } }`,
+    { input: { name, teamIds: [teamId], description: `Mirror of the AIOS ${name.includes("Wave 1") ? WAVE1 : WAVE2} backlog (see Plane workspace aios-alpha / project AIOS).` }
+  });
+  if (!data.projectCreate.success) throw new Error(`projectCreate failed for ${name}`);
+  return data.projectCreate.project;
+}
+
+async function teamLabels(teamId) {
+  const data = await gql(`query($id: String!) { team(id: $id) { labels(first: 250) { nodes { id name } } } }`, { id: teamId });
+  return data.team.labels.nodes;
+}
+
+async function createLabel(teamId, name) {
+  const data = await gql(
+    `mutation($input: IssueLabelCreateInput!) { issueLabelCreate(input: $input) { success issueLabel { id name } } }`,
+    { input: { name, teamId } }
+  );
+  if (!data.issueLabelCreate.success) throw new Error(`issueLabelCreate failed for ${name}`);
+  return data.issueLabelCreate.issueLabel;
+}
+
+// All team issues (paginated) → map of ext-marker → issue id, for idempotency + parent linking.
+async function existingByExt(teamId) {
+  const byExt = new Map();
+  let after = null;
+  for (let i = 0; i < 100; i++) {
+    const data = await gql(
+      `query($id: String!, $after: String) {
+        team(id: $id) {
+          issues(first: 250, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes { id title description }
+          }
+        }
+      }`,
+      { id: teamId, after }
+    );
+    const conn = data.team.issues;
+    for (const node of conn.nodes) {
+      const m = (node.description || "").match(EXT_RE);
+      if (m) byExt.set(m[1], node.id);
+    }
+    if (!conn.pageInfo.hasNextPage) break;
+    after = conn.pageInfo.endCursor;
+  }
+  return byExt;
+}
+
+async function createIssue({ teamId, title, description, priority, labelIds, projectId, parentId }) {
+  const input = { teamId, title, description };
+  if (priority) input.priority = priority;
+  if (labelIds?.length) input.labelIds = labelIds;
+  if (projectId) input.projectId = projectId;
+  if (parentId) input.parentId = parentId;
+  const data = await gql(
+    `mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id identifier } } }`,
+    { input }
+  );
+  if (!data.issueCreate.success) throw new Error(`issueCreate failed for ${title}`);
+  return data.issueCreate.issue;
+}
+
+// ── plan / run ────────────────────────────────────────────────────────────────
+async function main() {
+  const totalItems = BACKLOG.length + BACKLOG.reduce((n, e) => n + e.subs.length, 0);
+
+  if (DRY) {
+    console.log(`Linear mirror plan (--dry-run): ${BACKLOG.length} epics + ${totalItems - BACKLOG.length} sub-issues = ${totalItems} issues`);
+    console.log(`Projects: "${PROJECT_NAME[WAVE1]}", "${PROJECT_NAME[WAVE2]}"  ·  team: ${TEAM_WANT || "(auto / single team)"}\n`);
+    for (const e of BACKLOG) {
+      console.log(`◆ [${PROJECT_NAME[e.wave]}] (${e.priority})  ${e.name}`);
+      for (const s of e.subs) console.log(`   └─ ${s.ext}  ${s.name}`);
+    }
+    console.log("\n--dry-run: no writes performed. Set LINEAR_API_KEY + LINEAR_TEAM and re-run without --dry-run.");
+    return;
+  }
+
+  // 1. team
+  const team = await resolveTeam();
+  console.log(`Team: ${team.name} (${team.key}) ${team.id}`);
+
+  // 2. ensure wave projects
+  const existingProjects = await teamProjects(team.id);
+  const projectId = new Map(existingProjects.map((p) => [p.name, p.id]));
+  const waveProject = new Map();
+  for (const wave of [WAVE1, WAVE2]) {
+    const name = PROJECT_NAME[wave];
+    let id = projectId.get(name);
+    if (!id) {
+      const created = await createProject(team.id, name);
+      id = created.id;
+      console.log(`project + ${name}`);
+    }
+    waveProject.set(wave, id);
+  }
+
+  // 3. ensure labels
+  const existingLabels = await teamLabels(team.id);
+  const labelId = new Map(existingLabels.map((l) => [l.name, l.id]));
+  for (const name of LABELS) {
+    if (labelId.has(name)) continue;
+    const created = await createLabel(team.id, name);
+    labelId.set(name, created.id);
+    console.log(`label + ${name}`);
+  }
+
+  // 4. idempotency index
+  const byExt = await existingByExt(team.id);
+
+  const stats = { created: 0, skipped: 0 };
+  async function ensureIssue({ ext, name, desc, priority, labels, wave, parentId }) {
+    const found = byExt.get(ext);
+    if (found) {
+      stats.skipped++;
+      if (VERBOSE) console.log(`skip   ${ext} (exists)`);
+      return found;
+    }
+    const issue = await createIssue({
+      teamId: team.id,
+      title: name,
+      description: bodyFor(desc, ext),
+      priority: mapPriority(priority),
+      labelIds: (labels || []).map((n) => labelId.get(n)).filter(Boolean),
+      projectId: waveProject.get(wave),
+      parentId,
+    });
+    byExt.set(ext, issue.id);
+    stats.created++;
+    console.log(`create ${ext}  ${issue.identifier}  ${name}`);
+    return issue.id;
+  }
+
+  // 5. epics (parent issues) then chunks (sub-issues)
+  for (const epic of BACKLOG) {
+    const epicId = await ensureIssue({ ext: epic.ext, name: epic.name, desc: epic.desc, priority: epic.priority, labels: epic.labels, wave: epic.wave });
+    for (const sub of epic.subs) {
+      await ensureIssue({ ext: sub.ext, name: sub.name, desc: sub.desc, priority: epic.priority, labels: epic.labels, wave: epic.wave, parentId: epicId });
+    }
+  }
+
+  console.log(`\nDone. created=${stats.created} skipped=${stats.skipped} (total ${totalItems}).`);
+}
+
+main().catch((e) => { console.error("FAILED:", e.message); process.exit(1); });

--- a/scripts/linear-backlog.mjs
+++ b/scripts/linear-backlog.mjs
@@ -18,9 +18,11 @@
  *
  * Auth/config from env (read at runtime — never hard-coded):
  *   LINEAR_API_KEY  (required)  → header Authorization: <raw personal key>  (NOT a Bearer token)
- *   LINEAR_TEAM     (optional)  → target team key or name (e.g. "AIOS" / "Engineering").
+ *   LINEAR_TEAM     (optional)  → target team key or name (e.g. "AIO" / "Engineering").
  *                                 If unset and the account has exactly one team, that team is used.
  *                                 May also be passed as `--team <key>`.
+ *   PLANE_API_KEY / PLANE_WORKSPACE_SLUG / PLANE_BASE_URL  (only for --sync-status; same env as
+ *                                 plane:backlog) → read Plane state groups to mirror onto Linear.
  *
  * Endpoint/auth verified against https://linear.app/developers (matches the shipped
  * linear-direct skill): POST https://api.linear.app/graphql, Authorization: <api-key>.
@@ -30,6 +32,7 @@
  *   # or: npm run linear:backlog
  *
  * Flags: --dry-run (no writes; print plan)   --verbose   --team <key>
+ *        --sync-status (after seeding, set each Linear issue's state from its Plane counterpart)
  */
 
 import { BACKLOG, WAVE1, WAVE2, LABELS } from "./aios-backlog.mjs";
@@ -38,6 +41,9 @@ const API = "https://api.linear.app/graphql";
 const API_KEY = process.env.LINEAR_API_KEY;
 const DRY = process.argv.includes("--dry-run");
 const VERBOSE = process.argv.includes("--verbose");
+// After seeding, reconcile each Linear issue's workflow state to match its Plane counterpart
+// (matched by the shared ext key) so "done in Plane" shows as "done in Linear". Needs PLANE_API_KEY.
+const SYNC_STATUS = process.argv.includes("--sync-status");
 const teamFlagIdx = process.argv.indexOf("--team");
 const TEAM_WANT = (teamFlagIdx !== -1 ? process.argv[teamFlagIdx + 1] : process.env.LINEAR_TEAM || "").trim();
 
@@ -79,21 +85,34 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 // ── GraphQL transport: light throttle + 429 backoff ───────────────────────────
 const MIN_INTERVAL = 150; // ms between requests; Linear allows ~1500 req/hr for personal keys
 let lastReq = 0;
-async function gql(query, variables) {
+async function gql(query, variables, attempt = 0) {
   const now = Date.now();
   const wait = Math.max(0, MIN_INTERVAL - (now - lastReq));
   if (wait) await sleep(wait);
   lastReq = Date.now();
-  const res = await fetch(API, {
-    method: "POST",
-    headers: { Authorization: API_KEY, "Content-Type": "application/json" },
-    body: JSON.stringify({ query, variables }),
-  });
+  let res;
+  try {
+    res = await fetch(API, {
+      method: "POST",
+      headers: { Authorization: API_KEY, "Content-Type": "application/json" },
+      body: JSON.stringify({ query, variables }),
+    });
+  } catch (err) {
+    // network blip — retry a few times before giving up
+    if (attempt < 4) { console.warn(`  network error (${err.message}); retry ${attempt + 1}/4`); await sleep(1000 * (attempt + 1)); return gql(query, variables, attempt + 1); }
+    throw err;
+  }
   if (res.status === 429) {
     const retry = Number(res.headers.get("Retry-After") || 5) * 1000;
     console.warn(`  rate-limited; backing off ${retry}ms`);
     await sleep(retry);
-    return gql(query, variables);
+    return gql(query, variables, attempt);
+  }
+  if (res.status >= 500 && attempt < 4) {
+    // transient Linear gateway error (502/503/504) — back off and retry
+    console.warn(`  Linear HTTP ${res.status}; retry ${attempt + 1}/4`);
+    await sleep(1000 * (attempt + 1));
+    return gql(query, variables, attempt + 1);
   }
   const json = await res.json().catch(() => null);
   if (!res.ok || !json || json.errors) {
@@ -188,6 +207,100 @@ async function createIssue({ teamId, title, description, priority, labelIds, pro
   return data.issueCreate.issue;
 }
 
+async function setIssueState(issueId, stateId) {
+  const data = await gql(
+    `mutation($id: String!, $input: IssueUpdateInput!) { issueUpdate(id: $id, input: $input) { success } }`,
+    { id: issueId, input: { stateId } }
+  );
+  if (!data.issueUpdate.success) throw new Error(`issueUpdate failed for ${issueId}`);
+}
+
+// ── status sync: mirror Plane state groups onto Linear workflow states ─────────
+// Plane and Linear share the same five workflow-state "groups"/"types", so we map by group
+// and prefer a same-named state, falling back to the first state of that type.
+const GROUP_TO_TYPE = { backlog: "backlog", unstarted: "unstarted", started: "started", completed: "completed", cancelled: "canceled" };
+const GROUP_PREFERRED = { backlog: "Backlog", unstarted: "Todo", started: "In Progress", completed: "Done", cancelled: "Canceled" };
+
+// Read Plane state groups for the AIOS backlog: returns Map(ext → group). Reuses the same env
+// and cursor-pagination shape as scripts/plane-backlog.mjs.
+async function planeExtGroups() {
+  const KEY = process.env.PLANE_API_KEY;
+  if (!KEY) throw new Error("--sync-status needs PLANE_API_KEY (same env as plane:backlog).");
+  const SLUG = process.env.PLANE_WORKSPACE_SLUG || "aios-alpha";
+  const BASE = (process.env.PLANE_BASE_URL || "https://api.plane.so").replace(/\/$/, "");
+  const h = { "X-API-Key": KEY, "Content-Type": "application/json" };
+  async function all(path) {
+    const out = []; let cursor = "100:0:0";
+    for (let i = 0; i < 100; i++) {
+      const sep = path.includes("?") ? "&" : "?";
+      const r = await fetch(`${BASE}/api/v1/workspaces/${SLUG}${path}${sep}per_page=100&cursor=${encodeURIComponent(cursor)}`, { headers: h });
+      if (!r.ok) throw new Error(`Plane ${path} → ${r.status}`);
+      const j = await r.json();
+      if (Array.isArray(j)) { out.push(...j); break; }
+      out.push(...(j.results || []));
+      if (!j.next_page_results || !j.next_cursor) break;
+      cursor = j.next_cursor;
+    }
+    return out;
+  }
+  const projects = await all("/projects/");
+  const project = process.env.PLANE_PROJECT_ID
+    ? projects.find((p) => p.id === process.env.PLANE_PROJECT_ID)
+    : projects.find((p) => p.identifier === "AIOS" || /(^|\b)AIOS\b/.test(p.name));
+  if (!project) throw new Error(`AIOS project not found in Plane workspace ${SLUG}`);
+  const states = await all(`/projects/${project.id}/states/`);
+  const groupOf = new Map(states.map((s) => [s.id, s.group]));
+  const items = await all(`/projects/${project.id}/work-items/`);
+  const byExt = new Map();
+  for (const it of items) {
+    if (it.external_source === "aios-backlog" && it.external_id) byExt.set(it.external_id, groupOf.get(it.state) || "unstarted");
+  }
+  return byExt;
+}
+
+async function reconcileStatus(teamId) {
+  // Linear workflow states for the team.
+  const sData = await gql(`query($id: String!) { team(id: $id) { states(first: 50) { nodes { id name type } } } }`, { id: teamId });
+  const states = sData.team.states.nodes;
+  const stateForGroup = (group) => {
+    const type = GROUP_TO_TYPE[group];
+    const ofType = states.filter((s) => s.type === type);
+    return ofType.find((s) => s.name === GROUP_PREFERRED[group])?.id || ofType[0]?.id || null;
+  };
+
+  // Current Linear issues (ext marker → {id, current stateId}).
+  const current = new Map();
+  let after = null;
+  for (let i = 0; i < 100; i++) {
+    const d = await gql(
+      `query($id: String!, $after: String) { team(id: $id) { issues(first: 250, after: $after) {
+        pageInfo { hasNextPage endCursor } nodes { id description state { id } } } } }`,
+      { id: teamId, after }
+    );
+    const conn = d.team.issues;
+    for (const n of conn.nodes) {
+      const m = (n.description || "").match(EXT_RE);
+      if (m) current.set(m[1], { id: n.id, stateId: n.state?.id || null });
+    }
+    if (!conn.pageInfo.hasNextPage) break;
+    after = conn.pageInfo.endCursor;
+  }
+
+  const planeGroups = await planeExtGroups();
+  let changed = 0, matched = 0, missing = 0;
+  for (const [ext, group] of planeGroups) {
+    const issue = current.get(ext);
+    if (!issue) { missing++; continue; }
+    matched++;
+    const target = stateForGroup(group);
+    if (!target || target === issue.stateId) continue;
+    await setIssueState(issue.id, target);
+    changed++;
+    if (VERBOSE) console.log(`state  ${ext} → ${GROUP_PREFERRED[group]} (${group})`);
+  }
+  console.log(`Status sync: ${changed} updated · ${matched - changed} already correct · ${missing} Plane item(s) not in Linear (e.g. pre-backlog history).`);
+}
+
 // ── plan / run ────────────────────────────────────────────────────────────────
 async function main() {
   const totalItems = BACKLOG.length + BACKLOG.reduce((n, e) => n + e.subs.length, 0);
@@ -267,6 +380,9 @@ async function main() {
   }
 
   console.log(`\nDone. created=${stats.created} skipped=${stats.skipped} (total ${totalItems}).`);
+
+  // 6. optional: mirror Plane state groups onto Linear (done-in-Plane → done-in-Linear).
+  if (SYNC_STATUS) await reconcileStatus(team.id);
 }
 
 main().catch((e) => { console.error("FAILED:", e.message); process.exit(1); });

--- a/scripts/plane-backlog.mjs
+++ b/scripts/plane-backlog.mjs
@@ -27,6 +27,9 @@
  * Flags: --dry-run (no writes; print plan)   --verbose
  */
 
+// Backlog is the single source of truth shared with scripts/linear-backlog.mjs.
+import { BACKLOG, WAVE1, WAVE2, LABELS } from "./aios-backlog.mjs";
+
 const API_KEY = process.env.PLANE_API_KEY;
 const SLUG = process.env.PLANE_WORKSPACE_SLUG || "aios-alpha";
 const BASE = (process.env.PLANE_BASE_URL || "https://api.plane.so").replace(/\/$/, "");
@@ -42,141 +45,6 @@ if (!API_KEY) {
   console.error("PLANE_API_KEY is not set. Run via: dotenvx run -f <workspace>/.env -- node scripts/plane-backlog.mjs");
   process.exit(1);
 }
-
-const WAVE1 = "Wave 1 — MVP";
-const WAVE2 = "Wave 2 — Later";
-const LABELS = ["wave-1", "wave-2", "foundation", "brain", "sidecar", "ops", "integration", "design", "migration"];
-
-// ── backlog: one epic per feature, sub-issues = chunks ────────────────────────
-const p = (s) => `<p>${s}</p>`;
-const BACKLOG = [
-  { ext: "P0", name: "P0 — Plane integration (MCP + seed)", wave: WAVE1, priority: "high",
-    labels: ["integration", "wave-1"], desc: p("Stand up Plane as a real integration: official MCP server (durable/agentic) + idempotent REST seed of this backlog under the AIOS project."),
-    subs: [
-      { ext: "P0.1", name: "Register official Plane MCP server", desc: p("claude mcp add --transport http plane https://mcp.plane.so/http/mcp (OAuth). Confirm tools listable. Fallback: uvx plane-mcp-server (user scope).") },
-      { ext: "P0.2", name: "Idempotent REST seed script", desc: p("scripts/plane-backlog.mjs: discover AIOS project, ensure Wave modules + labels, create epics+sub-issues with external_id idempotency, throttle ≤60/min. npm plane:backlog.") },
-      { ext: "P0.3", name: "Record Plane integration in brain integrations table", desc: p("After F5: integrations row type=plane, config={workspaceSlug:'aios-alpha', projectId}. Substrate for W2.4 plane ingestion source.") },
-      { ext: "P0.4", name: "Verify backlog structure + idempotent re-run", desc: p("Confirm epics+sub-issues with parents/modules/labels; re-run seed → all skipped (no duplicates).") },
-    ] },
-
-  { ext: "F3", name: "F3 — Integrations auth surfaces + contract bump", wave: WAVE1, priority: "high",
-    labels: ["foundation", "brain", "wave-1"], desc: p("Two auth surfaces for the integrations framework without touching the pinned /api/v1 write contract."),
-    subs: [
-      { ext: "F3.1", name: "Dashboard session-auth write (server action)", desc: p("Server action / app/api/dashboard/integrations/route.ts → lib/integrations/manage.ts; admin-gated like admin/layout.tsx. No /api/v1 write surface.") },
-      { ext: "F3.2", name: "GET /api/v1/integrations (sidecar read)", desc: p("API-key auth; returns NON-SECRET selections for the team. The documented contract the sidecar consumes.") },
-      { ext: "F3.3", name: "Version brain-api.md + drift:routes", desc: p("Add the new read endpoint to aios-workspace/docs/brain-api.md FIRST, then docs/ARCHITECTURE.md drift:routes; npm run check:docs green. dep: F3.2") },
-      { ext: "F3.4", name: "Data-mechanics: admin-only write + scoped read", desc: p("Non-admin write → 403; API-key read returns only non-secret fields, team-scoped. dep: F3.1,F3.2") },
-    ] },
-
-  { ext: "F4", name: "F4 — Sidecar consumes selections", wave: WAVE1, priority: "high",
-    labels: ["sidecar", "wave-1"], desc: p("Close the 'table does nothing' gap: the ingestion engine merges brain-side selections with local secrets. dep: F3"),
-    subs: [
-      { ext: "F4.1", name: "engine.py + brain_client.py merge", desc: p("Fetch GET /api/v1/integrations; merge with local secrets by (type,name) — selection from brain, tokens local.") },
-      { ext: "F4.2", name: "connections.yaml.example + backward-compat", desc: p("Document; when selection-fetch unconfigured, behave exactly as today.") },
-      { ext: "F4.3", name: "Python tests: merge + backward-compat", desc: p("Merge precedence; unconfigured = current behavior.") },
-    ] },
-
-  { ext: "F5", name: "F5 — Admin Integrations UI + tier guards", wave: WAVE1, priority: "high",
-    labels: ["foundation", "brain", "wave-1"], desc: p("Admin-gated Integrations surface + per-table tier/role guards (no RLS backstop on postgres). dep: F3"),
-    subs: [
-      { ext: "F5.1", name: "Admin tab + integrations page", desc: p("components/admin/admin-tabs.tsx entry + app/t/[team]/admin/integrations/page.tsx (admin gate).") },
-      { ext: "F5.2", name: "lib/integrations/read.ts scoped reads", desc: p("Role/tier-scoped read helper for the integrations surface.") },
-      { ext: "F5.3", name: "integrations-tier-filter guard test", desc: p("test/guards/integrations-tier-filter.test.ts modeled on codebases-tier-filter.") },
-      { ext: "F5.4", name: "Supabase fail-closed notice", desc: p("Under DB_BACKEND=supabase, surface shows 'not available on legacy backend'.") },
-      { ext: "F5.5", name: "Data-mechanics: persistence + tier isolation", desc: p("Real-PG: integrations persist; external tier cannot read admin config.") },
-    ] },
-
-  { ext: "W1.1", name: "W1.1 — Granola → decisions (sanitized, consented)", wave: WAVE1, priority: "high",
-    labels: ["sidecar", "integration", "wave-1"], desc: p("Ingest Granola meetings as decision rows only — NO verbatim transcript synced team-tier."),
-    subs: [
-      { ext: "W1.1.1", name: "granola.py source + registry + drift", desc: p("ingestion/aios_ingest/sources/granola.py implements Source; register in registry.py; drift:sources += granola.") },
-      { ext: "W1.1.2", name: "Privacy gate: allowlist + consent", desc: p("Meeting allowlist (AIOS keyword / John+Chetan participants) + per-note consent; no verbatim team-tier transcript.") },
-      { ext: "W1.1.3", name: "Reuse granola-digest pull/parse", desc: p("Transcripts pulled to workspace (admin-tier, local) only.") },
-      { ext: "W1.1.4", name: "Wire transcript-decisions flow", desc: p("transcript-decisions workflow → human-reviewed decision rows → decision-log.md → aios push → materializeDecisions.") },
-      { ext: "W1.1.5", name: "Python tests (mocked pagination/rate-limit)", desc: p("Registry + normalize + mocked API pagination & rate-limit.") },
-    ] },
-
-  { ext: "W1.2", name: "W1.2 — Token + cost per member (brain spend)", wave: WAVE1, priority: "high",
-    labels: ["brain", "wave-1"], desc: p("Per-member LLM cost from query_log (built on the shipped scopeQueryLog fix + shared identity resolver)."),
-    subs: [
-      { ext: "W1.2.1", name: "lib/metrics/members.ts getPerMemberCosts", desc: p("Role-scoped aggregation of query_log via scopeQueryLog; admins team-wide, others self.") },
-      { ext: "W1.2.2", name: "Admin usage page", desc: p("app/t/[team]/admin/usage/page.tsx (admin-only) reusing contributor-table + charts.") },
-      { ext: "W1.2.3", name: "Throughput-vs-cost primitive", desc: p("Join code_contributions (via shared resolver) × query_log spend → $ per AI commit / contributor.") },
-      { ext: "W1.2.4", name: "Tier/role guard + data-mechanics", desc: p("Guard test + real-PG aggregation test.") },
-    ] },
-
-  { ext: "W1.3", name: "W1.3 — GitHub native UI (selection + manual scan)", wave: WAVE1, priority: "high",
-    labels: ["brain", "wave-1"], desc: p("Dashboard repo selection + member linking, reusing the code-only GitHub integration. No server-triggered scan in Wave 1. dep: F5"),
-    subs: [
-      { ext: "W1.3.1", name: "Repo selection persisted to integrations", desc: p("type=github, config.repos; reuse lib/codebases/github.ts.") },
-      { ext: "W1.3.2", name: "Member → GitHub linking UI", desc: p("Reuse linkGithub.") },
-      { ext: "W1.3.3", name: "Scan freshness + manual scan panel", desc: p("Show last-scan SHA vs main HEAD + documented manual aios-ingest command. Selection consumed by sidecar (F4).") },
-      { ext: "W1.3.4", name: "Respect canSeeCodebases (team-tier)", desc: p("lib/codebases/visibility.ts gate.") },
-    ] },
-
-  { ext: "W1.4", name: "W1.4 — Ops hardening (Sentry, CodeRabbit, BugBot)", wave: WAVE1, priority: "high",
-    labels: ["ops", "wave-1"], desc: p("Error logging + AI code review for the OSS repos."),
-    subs: [
-      { ext: "W1.4.1", name: "Sentry @sentry/nextjs ≥10.13 (Turbopack)", desc: p("instrumentation-client.ts, sentry.server/edge.config.ts, onRequestError in instrumentation.ts, app/global-error.tsx, withSentryConfig; DSN+token via env.") },
-      { ext: "W1.4.2", name: "CodeRabbit GitHub App on public repos", desc: p("Free for public repos; no org-admin friction.") },
-      { ext: "W1.4.3", name: "Fix Cursor BugBot org-app approval", desc: p("Approve Cursor app at AIOS-alpha → Third-party Access (manual; John is owner).") },
-      { ext: "W1.4.4", name: "Sentry smoke test", desc: p("Client + server error → events + source maps resolve.") },
-    ] },
-
-  { ext: "W2.1", name: "W2.1 — External AI cost (usage_costs)", wave: WAVE2, priority: "medium",
-    labels: ["brain", "wave-2"], desc: p("Per-member external provider spend (Anthropic/Cursor seats + API). dep: W1.2"),
-    subs: [
-      { ext: "W2.1.1", name: "usage_costs schema + FK registry + drift", desc: p("{team_id, member_id, provider, period, input_tokens, output_tokens, cost_usd, source}.") },
-      { ext: "W2.1.2", name: "lib/costs/ingest.ts single writer + guard", desc: p("Only writer for usage_costs.") },
-      { ext: "W2.1.3", name: "Anthropic Usage/Cost API source", desc: p("+ Enterprise Analytics per-user if available.") },
-      { ext: "W2.1.4", name: "Cursor Admin API source (/teams/spend)", desc: p("Per-seat USD + tokens.") },
-      { ext: "W2.1.5", name: "Identity resolve + retention + tier guard", desc: p("Shared resolver; 13-month retention; tier guard; merge into usage page.") },
-    ] },
-
-  { ext: "W2.2", name: "W2.2 — Slack bidirectional", wave: WAVE2, priority: "medium",
-    labels: ["sidecar", "integration", "wave-2"], desc: p("Pull allowlisted channels into the brain; push digests + /ask-brain."),
-    subs: [
-      { ext: "W2.2.1", name: "Slack source + Events API (allowlisted)", desc: p("slack.py exists; Events API for allowlisted channels.") },
-      { ext: "W2.2.2", name: "Push digests via incoming webhook", desc: p("Decisions / daily digest.") },
-      { ext: "W2.2.3", name: "/ask-brain slash command", desc: p("→ lib/query/retrieve.ts.") },
-      { ext: "W2.2.4", name: "Privacy allowlist + app manifest", desc: p("Like Granola; minimal Slack app manifest.") },
-    ] },
-
-  { ext: "W2.3", name: "W2.3 — Wise Business finance", wave: WAVE2, priority: "medium",
-    labels: ["sidecar", "wave-2"], desc: p("Cash/runway view from Wise Business; secrets local."),
-    subs: [
-      { ext: "W2.3.1", name: "wise.py source (OAuth2)", desc: p("OAuth2 user token; balances + transactions.") },
-      { ext: "W2.3.2", name: "finance_snapshots table + writer + guard", desc: p("Single writer + tier guard + FK registry.") },
-      { ext: "W2.3.3", name: "Cash/runway dashboard tile", desc: p("Operating financials tile.") },
-    ] },
-
-  { ext: "W2.4", name: "W2.4 — PM bake-off: Linear + Plane → brain", wave: WAVE2, priority: "medium",
-    labels: ["integration", "wave-2"], desc: p("Ingest both Linear and Plane issues/cycles INTO the brain; compare; pick. Closes the loop with P0."),
-    subs: [
-      { ext: "W2.4.1", name: "Configure linear source", desc: p("Existing linear source → ingest issues/cycles.") },
-      { ext: "W2.4.2", name: "Add plane.py source", desc: p("Ingest AIOS work items/cycles back into the brain.") },
-      { ext: "W2.4.3", name: "Brain overlay: link issues ↔ decisions", desc: p("Link issues ↔ decisions/deliverables.") },
-      { ext: "W2.4.4", name: "Comparison writeup → pick", desc: p("Linear vs Plane decision.") },
-    ] },
-
-  { ext: "W2.5", name: "W2.5 — Pencil design system", wave: WAVE2, priority: "low",
-    labels: ["design", "wave-2"], desc: p("Shared agentic design system with W3C design tokens."),
-    subs: [
-      { ext: "W2.5.1", name: "W3C DTCG tokens", desc: p("design/*.tokens.json.") },
-      { ext: "W2.5.2", name: "Style Dictionary → tokens.css", desc: p("For Tailwind v4.") },
-      { ext: "W2.5.3", name: "pencil MCP edits .pen + sync", desc: p("Two-way sync of tokens.") },
-      { ext: "W2.5.4", name: "Shared design-library docs", desc: p("Usage across contributors/clients.") },
-    ] },
-
-  { ext: "W2.6", name: "W2.6 — connector→integration rename (blueprint migration)", wave: WAVE2, priority: "low",
-    labels: ["migration", "wave-2"], desc: p("Versioned, backward-compatible rename — connectors is live blueprint JSON across repos."),
-    subs: [
-      { ext: "W2.6.1", name: "Bump blueprint schema version", desc: p("New version field.") },
-      { ext: "W2.6.2", name: "Backward-compatible reader", desc: p("Accept both connectors + integrations keys.") },
-      { ext: "W2.6.3", name: "Migrate published blueprints", desc: p("In-place migration.") },
-      { ext: "W2.6.4", name: "brain-api.md + team-tools update", desc: p("Doc + UI.") },
-    ] },
-];
 
 // ── HTTP + throttle (≤60 req/min → ~1.05s/request) ────────────────────────────
 let lastReq = 0;


### PR DESCRIPTION
## What & why

We had Plane seeded as the AIOS board and a merged-to-`main` Plane+Linear PM-sync layer, but **no way to stand up a Linear board mirroring Plane** — so we couldn't actually trial Plane vs Linear. This adds that. (Backlog epic **W2.4 — PM bake-off**.)

## Changes

- **`scripts/aios-backlog.mjs`** — extract the backlog (14 epics + 57 sub-issues, with waves/priorities/labels) into a single source of truth shared by both seeds, so Plane and Linear can't drift.
- **`scripts/plane-backlog.mjs`** — now imports the shared backlog. No behavior change (dry-run is byte-identical: 71 items).
- **`scripts/linear-backlog.mjs`** + **`npm run linear:backlog`** — Linear-native mapping chosen by John:
  - a **Project per Wave** (`AIOS — Wave 1 (MVP)`, `AIOS — Wave 2 (Later)`)
  - **epics → parent issues**, **chunks → sub-issues**
  - priorities mapped to Linear's scale, labels mirrored, 429 backoff
  - **idempotent** via an `aios-ext:` marker in each issue description (Linear has no `external_id`)
- **`docs/ARCHITECTURE.md`** — document both seed scripts.

## GUI parity (already in place — verified, not changed)

Both connectors already surface in both GUIs: Team Brain `integrations` schema CHECK + admin manager + validator/tests cover `plane`/`linear`; the workspace catalog/descriptors list both as `available`. `integration-config.test.ts` is green (7/7); `check:docs` green.

## Verification (live)

Run against team `JE4 / Je4light`:
- `npm run linear:backlog` → **71 issues created** (JE4-89..JE4-159); Wave 1 project **41**, Wave 2 project **30**.
- Spot-check: epic `JE4-89` in correct project, priority **High**, labels `integration,wave-1`, **4 nested sub-issues**.
- **Re-run → `created=0 skipped=71`** (idempotency proven).
- John's pre-existing personal Linear projects untouched.

## How to run

```bash
npm run linear:backlog -- --dry-run   # plan only
npm run linear:backlog                # create/refresh the mirror
```
Reads `LINEAR_API_KEY` (+ optional `LINEAR_TEAM`) from `aios-workspace/.env` via dotenvx, same pattern as `plane:backlog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev/ops tooling and docs only; no runtime brain API, auth, or ingest paths change. Linear/Plane writes are opt-in CLI scripts using workspace API keys.
> 
> **Overview**
> Enables a **Plane-vs-Linear bake-off** by projecting the same remaining-work backlog into both PM tools from one data file.
> 
> **`scripts/aios-backlog.mjs`** centralizes the backlog (epics, chunks, waves, labels, stable `ext` keys). **`scripts/plane-backlog.mjs`** now imports it instead of inlining the list—Plane seed behavior is unchanged.
> 
> **`scripts/linear-backlog.mjs`** and **`npm run linear:backlog`** add an idempotent Linear mirror: wave **custom views** (label-filtered), epics as parent issues and chunks as sub-issues, labels/priorities mirrored, GraphQL throttling and 429 backoff. Idempotency uses an **`aios-ext:`** + **`source: aios-backlog`** footer in descriptions (Linear has no `external_id`); re-runs skip existing issues and do not refresh edited titles/descriptions. Optional **`--sync-status`** maps Plane workflow state groups onto Linear states by the shared `ext` key.
> 
> **`docs/ARCHITECTURE.md`** documents the one-way seed/mirror flow, dotenvx env vars, and `--dry-run` for both scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6b8be0ca8c5d15854ce673bc08a9f6fecea4ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linear backlog mirroring via `npm run linear:backlog`
  * Backlog seeding is idempotent and supports `--dry-run`
  * Introduced `--sync-status` to reconcile Linear issue workflow states to match Plane
* **Documentation**
  * Updated architecture documentation with the one-way, idempotent backlog seeding/mirroring approach and sync behavior
* **Refactor**
  * Centralized backlog configuration so both Plane and Linear seed processes stay consistent
<!-- end of auto-generated comment: release notes by coderabbit.ai -->