### PR TITLE
fix(granola): use john@john-ellison.com as maintainer participant identity

### DIFF
--- a/ingestion/aios_ingest/sources/granola.py
+++ b/ingestion/aios_ingest/sources/granola.py
@@ -51,7 +51,7 @@ _MAX_RETRIES = 5
 
 # Default privacy gate. AIOS-topic meetings or meetings with John/Chetan, AND consent.
 _DEFAULT_TOPICS = ("aios",)
-_DEFAULT_PARTICIPANTS = ("john", "chetan", "iamjohndass@pm.me")
+_DEFAULT_PARTICIPANTS = ("john", "chetan", "john@john-ellison.com")
 # A note is treated as consented if any of these markers is present.
 _CONSENT_TAGS = ("aios-consent", "consent", "share-decisions")
 _CONSENT_TITLE_TOKENS = ("[aios]", "[consent]")

--- a/ingestion/tests/test_granola.py
+++ b/ingestion/tests/test_granola.py
@@ -25,7 +25,7 @@ def _note(**kw):
         "id": "n1",
         "title": "AIOS planning",
         "created_at": "2026-06-14T10:00:00Z",
-        "participants": [{"name": "John Dass", "email": "iamjohndass@pm.me"}],
+        "participants": [{"name": "John Ellison", "email": "john@john-ellison.com"}],
         "tags": ["aios-consent"],
         "url": "https://granola.ai/notes/n1",
     }


### PR DESCRIPTION
Updates the granola privacy-gate default participant key + test fixture from the old `iamjohndass@pm.me` / "John Dass" to the canonical `john@john-ellison.com` / "John Ellison".

Why: participant-matching should key off John's current email. Part of the maintainer name/email sweep.

Tests: `test_granola.py` — 15 passed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only identity update in default config and tests; privacy-gate behavior is unchanged aside from which email matches John.
> 
> **Overview**
> Updates the Granola privacy gate’s default allowlist participant email from `iamjohndass@pm.me` to **`john@john-ellison.com`**, so participant matching uses John’s current address. The test `_note()` fixture is aligned to **John Ellison** / the same email.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 232290b53bfcdf56716373a37c248897a874a6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->