### PR TITLE
feat(tasks): brain half of v1.2 — hierarchy model, parent integrity, primary PM provider

### DIFF
--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -2,7 +2,12 @@ import { NextRequest } from "next/server";
 import { adminClient } from "@/lib/supabase/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/api/rate-limit";
-import { itemPayloadSchema, normalizeTier, errorResponse } from "@/lib/api/schemas";
+import {
+  itemPayloadSchema,
+  normalizeTier,
+  errorResponse,
+  IngestValidationError,
+} from "@/lib/api/schemas";
 import { ingestItem } from "@/lib/ingest";
 
 export const runtime = "nodejs";
@@ -57,6 +62,11 @@ export async function POST(req: NextRequest) {
     const result = await ingestItem(supabase, auth, parsed.data, tier);
     return Response.json(result, { status: result.status === "created" ? 201 : 200 });
   } catch (e) {
+    // Client validation failures (e.g. a bad task row or a parent-integrity violation) are 422,
+    // not 500 — the CLI needs a structured signal to fix the markdown and retry.
+    if (e instanceof IngestValidationError) {
+      return errorResponse("invalid_payload", e.message, 422);
+    }
     return errorResponse("internal", e instanceof Error ? e.message : "ingest failed", 500);
   }
 }

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -25,7 +25,9 @@ export async function GET(req: NextRequest) {
 
   const { data, error } = await supabase
     .from("tasks")
-    .select("row_key, title, assignee, status, sprint, due_date, origin, updated_at, projects(slug), items:source_item_id(synced_at)")
+    .select(
+      "row_key, title, assignee, status, sprint, due_date, parent_row_key, labels, priority, origin, updated_at, projects(slug), items:source_item_id(synced_at)"
+    )
     .eq("team_id", auth.teamId)
     .gt("updated_at", since)
     .not("row_key", "is", null)
@@ -39,7 +41,20 @@ export async function GET(req: NextRequest) {
     return synced ? new Date(t.updated_at) > new Date(synced) : false;
   });
 
-  const byProject = new Map<string, { row_key: string; title: string; assignee: string; status: string; sprint: string; due: string | null }[]>();
+  const byProject = new Map<
+    string,
+    {
+      row_key: string;
+      title: string;
+      assignee: string;
+      status: string;
+      sprint: string;
+      due: string | null;
+      parent: string | null;
+      labels: string[];
+      priority: string;
+    }[]
+  >();
   for (const t of uiChanged) {
     const slug = (t.projects as unknown as { slug: string })?.slug ?? "unknown";
     if (!byProject.has(slug)) byProject.set(slug, []);
@@ -50,6 +65,10 @@ export async function GET(req: NextRequest) {
       status: t.status,
       sprint: t.sprint,
       due: t.due_date,
+      // v1.2 hierarchy fields (body is intentionally excluded — dashboard/DB-only).
+      parent: t.parent_row_key ?? null,
+      labels: (t.labels as string[] | null) ?? [],
+      priority: t.priority ?? "none",
     });
   }
 

--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -13,6 +13,9 @@ import {
 import { runSlackIngestion } from "@/lib/ingest/run";
 import { resolveIntegrationsAdmin } from "@/lib/integrations/read";
 import { IntegrationConfigError, type IntegrationType } from "@/lib/api/schemas";
+import { audit } from "@/lib/api/audit";
+
+export type PrimaryPmProvider = "plane" | "linear" | null;
 
 /**
  * Session half of the admin gate: resolve the signed-in user, then delegate to the DB-level
@@ -160,6 +163,39 @@ export async function removeIntegration(
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not delete" };
   }
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}
+
+/**
+ * Choose the single PM tool the brain projects tasks into (brain-api v1.2). Admins only; audited.
+ * Pass `null` to clear it. The projection engine reads `teams.primary_pm_provider`; with it unset it
+ * no-ops (or falls back to the sole enabled PM integration).
+ */
+export async function setPrimaryPmProvider(
+  teamSlug: string,
+  provider: PrimaryPmProvider
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  if (provider !== null && provider !== "plane" && provider !== "linear") {
+    return { ok: false, error: "invalid provider" };
+  }
+  const db = adminClient();
+  const { error } = await db
+    .from("teams")
+    .update({ primary_pm_provider: provider })
+    .eq("id", ctx.teamId);
+  if (error) return { ok: false, error: error.message };
+  await audit(db, {
+    team_id: ctx.teamId,
+    actor_kind: "member",
+    member_id: ctx.myMemberId,
+    action: "team.primary_pm_provider_set",
+    target_type: "team",
+    target_id: ctx.teamId,
+    meta: { provider },
+  });
   revalidatePath(`/t/${teamSlug}/admin/integrations`);
   return { ok: true };
 }

--- a/app/t/[team]/admin/integrations/page.tsx
+++ b/app/t/[team]/admin/integrations/page.tsx
@@ -40,7 +40,11 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
   // Resolve the viewer's role on this team for the read gate (the layout already blocks non-admins).
   const sessionDb = await serverClient();
   const user = await getSessionUser();
-  const { data: team } = await sessionDb.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await sessionDb
+    .from("teams")
+    .select("id, primary_pm_provider")
+    .eq("slug", teamSlug)
+    .maybeSingle();
   if (!team) return null;
   const { data: me } = user
     ? await sessionDb
@@ -67,7 +71,11 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
           integrations to run ingestion. Secrets are stored encrypted and never shown again.
         </p>
       </div>
-      <IntegrationsManager teamSlug={teamSlug} integrations={integrations} />
+      <IntegrationsManager
+        teamSlug={teamSlug}
+        integrations={integrations}
+        primaryPmProvider={(team.primary_pm_provider as "plane" | "linear" | null) ?? null}
+      />
     </div>
   );
 }

--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -9,6 +9,8 @@ import {
   rotateSecret,
   removeIntegration,
   syncSlackNow,
+  setPrimaryPmProvider,
+  type PrimaryPmProvider,
 } from "@/app/t/[team]/admin/integrations/actions";
 
 type IntegrationType = "github" | "granola" | "slack" | "wise" | "linear" | "plane";
@@ -60,9 +62,11 @@ function summarizeConfig(type: IntegrationType, config: Record<string, unknown>)
 export function IntegrationsManager({
   teamSlug,
   integrations,
+  primaryPmProvider,
 }: {
   teamSlug: string;
   integrations: IntegrationRow[];
+  primaryPmProvider: PrimaryPmProvider;
 }) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -99,6 +103,41 @@ export function IntegrationsManager({
 
   return (
     <div className="flex flex-col gap-6">
+      <div className="prism-card flex flex-col gap-2 p-4">
+        <p className="flex items-center gap-2 text-sm font-medium text-ink">
+          <Plug className="size-4 text-violet" /> Primary PM tool
+        </p>
+        <p className="text-xs text-ink-secondary">
+          The single project-management tool the brain projects tasks into (epics, sub-issues,
+          status). The brain stays the source of truth; the chosen board is a downstream projection.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {(
+            [
+              { value: null, label: "None" },
+              { value: "plane", label: "Plane" },
+              { value: "linear", label: "Linear" },
+            ] as { value: PrimaryPmProvider; label: string }[]
+          ).map((opt) => {
+            const active = primaryPmProvider === opt.value;
+            return (
+              <button
+                key={opt.label}
+                type="button"
+                disabled={pending || active}
+                onClick={() => run(() => setPrimaryPmProvider(teamSlug, opt.value))}
+                className={`rounded-md border px-3 py-1.5 text-sm ${
+                  active
+                    ? "border-violet bg-violet/10 text-ink"
+                    : "border-ink/15 text-ink-secondary hover:border-ink/30"
+                }`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
       <form
         onSubmit={(e) => {
           e.preventDefault();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,8 +20,9 @@ Reason from this table, not from a random call site.
 | State | Store (table) | Writer | Readers | Tier/access enforcement |
 |---|---|---|---|---|
 | Synced content | `items`, `item_versions` | **`lib/ingest` only** (single-writer guarded) | dashboard pages, `/api/v1/items`, `lib/query/retrieve`, okf-bundle, metrics | supabase: RLS; postgres: app-code — API ✅, dashboard ✅ (`lib/auth/visibility` choke-point, guarded) |
-| Tasks | `tasks` | `lib/ingest` (sync rows) + `app/actions/tasks.ts` (UI; mints `ui-` row_key) + `lib/work-events` (merged-work completion) | dashboard, `/api/v1/tasks`, PM sync | team-scoped; `origin='ui'` rows survive sync diff |
-| Task PM links | `task_pm_links` | `lib/ingest` (optional task-row PM metadata) + PM backfill | dashboard task badges, `lib/pm-sync` | team-scoped; stores provider IDs/status only, never secrets |
+| Tasks | `tasks` | `lib/ingest` (sync rows) + `app/actions/tasks.ts` (UI; mints `ui-` row_key) + `lib/work-events` (merged-work completion) | dashboard, `/api/v1/tasks`, PM sync | team-scoped; `origin='ui'` rows survive sync diff; v1.2 hierarchy fields `parent_row_key`/`labels`/`priority` (parent integrity — exists + acyclic — enforced in `lib/ingest`); `body` is dashboard/DB-only (never in the markdown contract) |
+| Task PM links | `task_pm_links` | `lib/ingest` (optional task-row PM metadata) + PM backfill | dashboard task badges, `lib/pm-sync` | team-scoped; stores provider IDs/status only, never secrets; v1.2 adds `last_projected_status`/`projection_fingerprint` (skip-detection) + `provider_seen_status` (Phase 5 divergence) |
+| Primary PM provider | `teams.primary_pm_provider` | Admin → Integrations (`setPrimaryPmProvider`, admin-gated + audited) | `lib/pm-sync` projection | the single PM tool the brain projects into; null = projection no-ops / sole-enabled fallback |
 | Work events | `work_events` | `POST /api/v1/work-events` → `lib/work-events` | Admin → PM sync health | team-tier only; unresolved events are preserved for reconciliation |
 | Decisions | `decisions` | `lib/ingest` (sync rows) + `app/actions/decisions.ts` (UI; `source_item_id` NULL) | dashboard, `/api/v1/decisions` | team-scoped; UI rows (`source_item_id` NULL) never diff-deleted; writeback tier-scoped by `audience` |
 | Policy rules | `policies` | admin (role-gated) | `lib/policy.authorize` | role-gated (admin/lead) |
@@ -278,9 +279,13 @@ guard enforces it, it's named.
   per-channel) and a new tier/scope — a product feature, not covered by the current filter.
 - **`admin`/`private` tiers never reach the DB** — rejected with 422 at the API.
 - **Append-only audit.** `audit_log` has a trigger that blocks UPDATE/DELETE.
-- **PM sync is an effect, not the source of truth.** A merged-work event marks the matching
-  AIOS task done first. Plane/Linear failures are recorded on `task_pm_links.last_error` and
-  surfaced in Admin → PM sync; they never roll the task back.
+- **The brain is the source of truth; the PM board is a one-way projection.** The `tasks` table is
+  canonical (v1.2: hierarchy + `body`). The brain projects task create/update/state into the single
+  `teams.primary_pm_provider` board (Plane/Linear) — never the reverse in v1. A merged-work event
+  still marks the matching task done first; provider failures are recorded on
+  `task_pm_links.last_error` and surfaced in Admin → PM sync, never rolling the task back. Inbound
+  PM→brain reconciliation (two-way) is deferred (Phase 5); v1 only records `provider_seen_status` so
+  divergence is detectable.
 - **`key_hash` is column-revoked** from client roles; API secrets are sha256-at-rest, shown once.
 - **Migration replay.** 14-digit timestamp prefixes, unique, lexical == chronological.
   *Guards:* `test/guards/migrations-numbering.test.ts` + `npm run db:test:up` (migrates from zero).

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -302,6 +302,13 @@ const MAX_CONFIG_BYTES = 8 * 1024;
 /** Thrown when integration config is malformed/oversized/contains a secret-like key (→ 400). */
 export class IntegrationConfigError extends Error {}
 
+/**
+ * A client-side validation failure detected during ingest (e.g. a malformed task row or a
+ * task-hierarchy violation: missing/self/cyclic parent). The /api/v1/items route maps this to
+ * 422 invalid_payload so the CLI gets a structured "fix your markdown" signal, not a 500.
+ */
+export class IngestValidationError extends Error {}
+
 function collectKeys(value: unknown, out: string[] = []): string[] {
   if (value && typeof value === "object" && !Array.isArray(value)) {
     for (const [k, v] of Object.entries(value)) {

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -14,6 +14,12 @@ export const taskRowSchema = z.object({
   status: z.string().optional().default(""),
   sprint: z.string().optional().default(""),
   due: z.string().nullable().optional(),
+  // Hierarchy fields (brain-api v1.2, all optional). `parent` is the epic's row_key; `labels` is a
+  // string array; `priority` is sent verbatim and normalized server-side. `body` is intentionally
+  // absent — it is dashboard/DB-only and never travels through the contract.
+  parent: z.string().nullable().optional(),
+  labels: z.array(z.string().max(80)).max(50).optional(),
+  priority: z.string().max(20).nullable().optional(),
   pm_provider: z.enum(["plane", "linear"]).nullable().optional(),
   pm_external_id: z.string().max(200).nullable().optional(),
   pm_url: z.string().max(500).nullable().optional(),
@@ -226,6 +232,20 @@ export function normalizeTaskStatus(raw: string): {
     return { status: s as (typeof TASK_STATUSES)[number], raw_status: null };
   }
   return { status: "backlog", raw_status: raw };
+}
+
+export const TASK_PRIORITIES = ["none", "low", "medium", "high", "urgent"] as const;
+export type TaskPriority = (typeof TASK_PRIORITIES)[number];
+// Normalize a free-text priority to the allowed set. Unknown / empty → "none". Also accepts a few
+// common aliases (e.g. Plane's "urgent", Linear's numeric labels are mapped upstream).
+export function normalizeTaskPriority(raw: string | null | undefined): TaskPriority {
+  const s = (raw ?? "").trim().toLowerCase();
+  if ((TASK_PRIORITIES as readonly string[]).includes(s)) return s as TaskPriority;
+  if (s === "critical" || s === "p0" || s === "highest") return "urgent";
+  if (s === "p1") return "high";
+  if (s === "p2") return "medium";
+  if (s === "p3" || s === "p4") return "low";
+  return "none";
 }
 
 export function errorResponse(code: string, message: string, status: number) {

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -60,6 +60,17 @@ export async function ingestItem(
     return { status: "unchanged", id: existing.id };
   }
 
+  // Validate task rows before mutating items so a 422 never leaves a revised item/version behind.
+  let validatedTaskRows: TaskRow[] | undefined;
+  if (payload.rows && payload.kind === "task") {
+    validatedTaskRows = await parseAndValidateTaskRows(
+      supabase,
+      auth.teamId,
+      project.id,
+      payload.rows
+    );
+  }
+
   // 3. upsert item (+ version when body changed)
   const itemRecord = {
     team_id: auth.teamId,
@@ -101,7 +112,14 @@ export async function ingestItem(
   // by the writeback (which would otherwise re-emit a just-written-back UI row forever).
   if (payload.rows && (payload.kind === "task" || payload.kind === "decision")) {
     if (payload.kind === "task") {
-      await materializeTasks(supabase, auth.teamId, project.id, itemId, payload.rows, now);
+      await materializeTasks(
+        supabase,
+        auth.teamId,
+        project.id,
+        itemId,
+        validatedTaskRows!,
+        now
+      );
     } else {
       await materializeDecisions(supabase, auth.teamId, project.id, itemId, payload.rows, now);
     }
@@ -118,33 +136,28 @@ export async function ingestItem(
   return { status: existing ? "updated" : "created", id: itemId };
 }
 
-async function materializeTasks(
+type TaskRow = NonNullable<ReturnType<typeof taskRowSchema.safeParse>["data"]>;
+
+/** Parse + parent-integrity checks only (no writes). Called before item upsert so 422 is clean. */
+async function parseAndValidateTaskRows(
   supabase: SupabaseClient,
   teamId: string,
   projectId: string,
-  itemId: string,
-  rawRows: unknown[],
-  syncedAt: string
-) {
-  // Fail the whole push on any malformed task row — a silently-dropped row would otherwise be
-  // diff-deleted below (absent from incomingKeys), so a single bad cell could erase a real task.
+  rawRows: unknown[]
+): Promise<TaskRow[]> {
   const parsed = rawRows.map((r) => taskRowSchema.safeParse(r));
   const firstBad = parsed.find((r) => !r.success);
   if (firstBad && !firstBad.success) {
-    throw new IngestValidationError(`invalid task row: ${firstBad.error.issues[0]?.message ?? "bad shape"}`);
+    throw new IngestValidationError(
+      `invalid task row: ${firstBad.error.issues[0]?.message ?? "bad shape"}`
+    );
   }
   const rows = parsed.map((r) => r.data!);
 
-  const incomingKeys = new Set(rows.map((r) => r.row_key));
   const incomingByKey = new Map(rows.map((r) => [r.row_key, r]));
-  const parentOf = (r: (typeof rows)[number]) => (r.parent ?? "").trim();
+  const parentOf = (r: TaskRow) => (r.parent ?? "").trim();
 
-  // Parent integrity (brain-api v1.2): every parent must resolve within (team, project), and the
-  // combined graph (existing rows + this push) must be acyclic. Reject the whole push on violation
-  // so a bad hierarchy never lands half-applied or leaves orphan PM sub-issues downstream.
-  // Build the post-push parent map: existing parents, then overridden by incoming rows (only where
-  // a row carries the `parent` key — a six-column push leaves existing parents untouched).
-  const parentMap = new Map<string, string>(); // row_key -> parent row_key (non-empty)
+  const parentMap = new Map<string, string>();
   const existingKeys = new Set<string>();
   {
     const { data: existing } = await supabase
@@ -161,10 +174,10 @@ async function materializeTasks(
     }
   }
   for (const row of rows) {
-    if (!("parent" in row)) continue; // six-column row — does not change this row's parent
+    if (!("parent" in row)) continue;
     const parent = parentOf(row);
     if (!parent) {
-      parentMap.delete(row.row_key); // explicit clear (empty Parent cell)
+      parentMap.delete(row.row_key);
       continue;
     }
     if (parent === row.row_key) {
@@ -175,8 +188,6 @@ async function materializeTasks(
     }
     parentMap.set(row.row_key, parent);
   }
-  // Cycle detection over the combined graph (catches a cycle formed across two syncs, e.g. DB has
-  // B.parent=A and this push sets A.parent=B).
   for (const start of parentMap.keys()) {
     const seen = new Set<string>();
     let cur: string | undefined = start;
@@ -186,6 +197,19 @@ async function materializeTasks(
       cur = parentMap.get(cur);
     }
   }
+  return rows;
+}
+
+async function materializeTasks(
+  supabase: SupabaseClient,
+  teamId: string,
+  projectId: string,
+  itemId: string,
+  rows: TaskRow[],
+  syncedAt: string
+) {
+  const incomingKeys = new Set(rows.map((r) => r.row_key));
+  const parentOf = (r: TaskRow) => (r.parent ?? "").trim();
 
   for (const row of rows) {
     const { status, raw_status } = normalizeTaskStatus(row.status || "");

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -6,6 +6,7 @@ import {
   decisionRowSchema,
   normalizeTier,
   normalizeTaskStatus,
+  normalizeTaskPriority,
 } from "@/lib/api/schemas";
 import { audit } from "@/lib/api/audit";
 
@@ -130,9 +131,47 @@ async function materializeTasks(
     .map((r) => r.data!);
 
   const incomingKeys = new Set(rows.map((r) => r.row_key));
+  const incomingByKey = new Map(rows.map((r) => [r.row_key, r]));
+  const parentOf = (r: (typeof rows)[number]) => (r.parent ?? "").trim();
+
+  // Parent integrity (brain-api v1.2): every parent must resolve within (team, project), and the
+  // incoming graph must be acyclic. Reject the whole push on violation so a bad hierarchy never
+  // lands half-applied or leaves orphan PM sub-issues downstream.
+  const existingKeys = new Set<string>();
+  {
+    const { data: existing } = await supabase
+      .from("tasks")
+      .select("row_key")
+      .eq("team_id", teamId)
+      .eq("project_id", projectId)
+      .not("row_key", "is", null);
+    for (const t of existing ?? []) if (t.row_key) existingKeys.add(t.row_key);
+  }
+  for (const row of rows) {
+    const parent = parentOf(row);
+    if (!parent) continue;
+    if (parent === row.row_key) throw new Error(`task ${row.row_key}: parent cannot reference itself`);
+    if (!incomingByKey.has(parent) && !existingKeys.has(parent)) {
+      throw new Error(`task ${row.row_key}: parent "${parent}" not found in project`);
+    }
+  }
+  // Cycle detection within the incoming graph (follow parent links through this push).
+  for (const row of rows) {
+    const seen = new Set<string>();
+    let cur: string | undefined = row.row_key;
+    while (cur) {
+      if (seen.has(cur)) throw new Error(`task ${row.row_key}: parent cycle detected`);
+      seen.add(cur);
+      const node = incomingByKey.get(cur);
+      const p = node ? parentOf(node) : "";
+      cur = p || undefined;
+    }
+  }
 
   for (const row of rows) {
     const { status, raw_status } = normalizeTaskStatus(row.status || "");
+    // NOTE: `body` is intentionally NOT written here — it is dashboard/DB-only and must survive
+    // a sync push. Omitting it from the upsert preserves it on update and defaults to '' on insert.
     const { data: task, error } = await supabase.from("tasks").upsert(
       {
         team_id: teamId,
@@ -145,6 +184,9 @@ async function materializeTasks(
         raw_status,
         sprint: row.sprint ?? "",
         due_date: row.due || null,
+        parent_row_key: parentOf(row) || null,
+        labels: row.labels ?? [],
+        priority: normalizeTaskPriority(row.priority),
         origin: "sync",
         updated_at: syncedAt,
       },
@@ -175,13 +217,25 @@ async function materializeTasks(
   // diff-delete: sync-originated rows absent from this push; UI rows survive.
   const { data: current } = await supabase
     .from("tasks")
-    .select("id, row_key, origin")
+    .select("id, row_key, origin, parent_row_key")
     .eq("team_id", teamId)
     .eq("project_id", projectId)
     .not("row_key", "is", null);
+  const survivors = new Set<string>();
   for (const t of current ?? []) {
     if (t.origin === "sync" && t.row_key && !incomingKeys.has(t.row_key)) {
       await supabase.from("tasks").delete().eq("id", t.id);
+    } else if (t.row_key) {
+      survivors.add(t.row_key);
+    }
+  }
+  // No DB FK backs parent_row_key, so a deleted epic can leave a surviving child pointing at a
+  // now-missing parent. Null those dangling references so the brain stays internally consistent
+  // (the projection's topological sort errors on a missing parent).
+  for (const t of current ?? []) {
+    const parent = (t.parent_row_key ?? "").trim();
+    if (parent && survivors.has(t.row_key!) && !survivors.has(parent)) {
+      await supabase.from("tasks").update({ parent_row_key: null }).eq("id", t.id);
     }
   }
 }

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -7,6 +7,7 @@ import {
   normalizeTier,
   normalizeTaskStatus,
   normalizeTaskPriority,
+  IngestValidationError,
 } from "@/lib/api/schemas";
 import { audit } from "@/lib/api/audit";
 
@@ -125,73 +126,92 @@ async function materializeTasks(
   rawRows: unknown[],
   syncedAt: string
 ) {
-  const rows = rawRows
-    .map((r) => taskRowSchema.safeParse(r))
-    .filter((r) => r.success)
-    .map((r) => r.data!);
+  // Fail the whole push on any malformed task row — a silently-dropped row would otherwise be
+  // diff-deleted below (absent from incomingKeys), so a single bad cell could erase a real task.
+  const parsed = rawRows.map((r) => taskRowSchema.safeParse(r));
+  const firstBad = parsed.find((r) => !r.success);
+  if (firstBad && !firstBad.success) {
+    throw new IngestValidationError(`invalid task row: ${firstBad.error.issues[0]?.message ?? "bad shape"}`);
+  }
+  const rows = parsed.map((r) => r.data!);
 
   const incomingKeys = new Set(rows.map((r) => r.row_key));
   const incomingByKey = new Map(rows.map((r) => [r.row_key, r]));
   const parentOf = (r: (typeof rows)[number]) => (r.parent ?? "").trim();
 
   // Parent integrity (brain-api v1.2): every parent must resolve within (team, project), and the
-  // incoming graph must be acyclic. Reject the whole push on violation so a bad hierarchy never
-  // lands half-applied or leaves orphan PM sub-issues downstream.
+  // combined graph (existing rows + this push) must be acyclic. Reject the whole push on violation
+  // so a bad hierarchy never lands half-applied or leaves orphan PM sub-issues downstream.
+  // Build the post-push parent map: existing parents, then overridden by incoming rows (only where
+  // a row carries the `parent` key — a six-column push leaves existing parents untouched).
+  const parentMap = new Map<string, string>(); // row_key -> parent row_key (non-empty)
   const existingKeys = new Set<string>();
   {
     const { data: existing } = await supabase
       .from("tasks")
-      .select("row_key")
+      .select("row_key, parent_row_key")
       .eq("team_id", teamId)
       .eq("project_id", projectId)
       .not("row_key", "is", null);
-    for (const t of existing ?? []) if (t.row_key) existingKeys.add(t.row_key);
-  }
-  for (const row of rows) {
-    const parent = parentOf(row);
-    if (!parent) continue;
-    if (parent === row.row_key) throw new Error(`task ${row.row_key}: parent cannot reference itself`);
-    if (!incomingByKey.has(parent) && !existingKeys.has(parent)) {
-      throw new Error(`task ${row.row_key}: parent "${parent}" not found in project`);
+    for (const t of existing ?? []) {
+      if (!t.row_key) continue;
+      existingKeys.add(t.row_key);
+      const p = (t.parent_row_key ?? "").trim();
+      if (p) parentMap.set(t.row_key, p);
     }
   }
-  // Cycle detection within the incoming graph (follow parent links through this push).
   for (const row of rows) {
+    if (!("parent" in row)) continue; // six-column row — does not change this row's parent
+    const parent = parentOf(row);
+    if (!parent) {
+      parentMap.delete(row.row_key); // explicit clear (empty Parent cell)
+      continue;
+    }
+    if (parent === row.row_key) {
+      throw new IngestValidationError(`task ${row.row_key}: parent cannot reference itself`);
+    }
+    if (!incomingByKey.has(parent) && !existingKeys.has(parent)) {
+      throw new IngestValidationError(`task ${row.row_key}: parent "${parent}" not found in project`);
+    }
+    parentMap.set(row.row_key, parent);
+  }
+  // Cycle detection over the combined graph (catches a cycle formed across two syncs, e.g. DB has
+  // B.parent=A and this push sets A.parent=B).
+  for (const start of parentMap.keys()) {
     const seen = new Set<string>();
-    let cur: string | undefined = row.row_key;
+    let cur: string | undefined = start;
     while (cur) {
-      if (seen.has(cur)) throw new Error(`task ${row.row_key}: parent cycle detected`);
+      if (seen.has(cur)) throw new IngestValidationError(`task ${start}: parent cycle detected`);
       seen.add(cur);
-      const node = incomingByKey.get(cur);
-      const p = node ? parentOf(node) : "";
-      cur = p || undefined;
+      cur = parentMap.get(cur);
     }
   }
 
   for (const row of rows) {
     const { status, raw_status } = normalizeTaskStatus(row.status || "");
-    // NOTE: `body` is intentionally NOT written here — it is dashboard/DB-only and must survive
-    // a sync push. Omitting it from the upsert preserves it on update and defaults to '' on insert.
-    const { data: task, error } = await supabase.from("tasks").upsert(
-      {
-        team_id: teamId,
-        project_id: projectId,
-        source_item_id: itemId,
-        row_key: row.row_key,
-        title: row.title,
-        assignee: row.assignee ?? "",
-        status,
-        raw_status,
-        sprint: row.sprint ?? "",
-        due_date: row.due || null,
-        parent_row_key: parentOf(row) || null,
-        labels: row.labels ?? [],
-        priority: normalizeTaskPriority(row.priority),
-        origin: "sync",
-        updated_at: syncedAt,
-      },
-      { onConflict: "team_id,project_id,row_key" }
-    )
+    // `body` is dashboard/DB-only and `parent`/`labels`/`priority` are optional v1.2 fields: each is
+    // written ONLY when the row carries the key, so a six-column push preserves them on update and
+    // falls back to DB defaults on insert. (A present-but-empty value is authoritative — it clears.)
+    const upsertRow: Record<string, unknown> = {
+      team_id: teamId,
+      project_id: projectId,
+      source_item_id: itemId,
+      row_key: row.row_key,
+      title: row.title,
+      assignee: row.assignee ?? "",
+      status,
+      raw_status,
+      sprint: row.sprint ?? "",
+      due_date: row.due || null,
+      origin: "sync",
+      updated_at: syncedAt,
+    };
+    if ("parent" in row) upsertRow.parent_row_key = parentOf(row) || null;
+    if ("labels" in row) upsertRow.labels = row.labels ?? [];
+    if ("priority" in row) upsertRow.priority = normalizeTaskPriority(row.priority);
+    const { data: task, error } = await supabase
+      .from("tasks")
+      .upsert(upsertRow, { onConflict: "team_id,project_id,row_key" })
       .select("id")
       .single();
     if (error) throw new Error(`task row ${row.row_key}: ${error.message}`);

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -236,8 +236,8 @@ create table if not exists tasks (
   -- Hierarchy/board fields (brain-api v1.2). The brain is the source of truth that projects a
   -- structured board into the primary PM tool. parent_row_key is the epic's row_key, resolved
   -- within (team_id, project_id); integrity (exists, acyclic) is enforced in app code (lib/ingest
-  -- + the task server actions), not a DB FK. body is dashboard/DB-only — it never round-trips
-  -- through the markdown contract.
+  -- on the sync push), not a DB FK. body is dashboard/DB-only — it never round-trips through the
+  -- markdown contract.
   parent_row_key text,
   labels text[] not null default '{}',
   priority text not null default 'none' check (priority in ('none', 'low', 'medium', 'high', 'urgent')),

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -68,8 +68,18 @@ create table if not exists teams (
   id uuid primary key default gen_random_uuid(),
   slug text not null unique check (slug ~ '^[a-z0-9][a-z0-9-]*$'),
   name text not null,
+  -- The single PM tool the brain projects tasks into (brain-api v1.2). Null until an admin picks
+  -- one; projection no-ops (or uses the sole enabled PM integration) when unset.
+  primary_pm_provider text check (primary_pm_provider in ('plane', 'linear')),
   created_at timestamptz not null default now()
 );
+-- Additive column for existing deployments.
+alter table teams add column if not exists primary_pm_provider text;
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'teams_primary_pm_provider_check') then
+    alter table teams add constraint teams_primary_pm_provider_check check (primary_pm_provider in ('plane', 'linear'));
+  end if;
+end $$;
 
 create table if not exists members (
   id uuid primary key default gen_random_uuid(),
@@ -223,14 +233,36 @@ create table if not exists tasks (
   sprint text not null default '',
   due_date date,
   origin task_origin not null,
+  -- Hierarchy/board fields (brain-api v1.2). The brain is the source of truth that projects a
+  -- structured board into the primary PM tool. parent_row_key is the epic's row_key, resolved
+  -- within (team_id, project_id); integrity (exists, acyclic) is enforced in app code (lib/ingest
+  -- + the task server actions), not a DB FK. body is dashboard/DB-only — it never round-trips
+  -- through the markdown contract.
+  parent_row_key text,
+  labels text[] not null default '{}',
+  priority text not null default 'none' check (priority in ('none', 'low', 'medium', 'high', 'urgent')),
+  body text not null default '',
   created_by uuid references members(id) on delete set null,
   updated_at timestamptz not null default now(),
   created_at timestamptz not null default now()
 );
+-- Additive columns for existing deployments (idempotent rollout via `npm run pg:schema`).
+-- Run BEFORE any index that references them so an existing DB (where the column arrives via
+-- ALTER, because the table definition above is not re-run for an existing table) can build the index.
+alter table tasks add column if not exists parent_row_key text;
+alter table tasks add column if not exists labels text[] not null default '{}';
+alter table tasks add column if not exists priority text not null default 'none';
+alter table tasks add column if not exists body text not null default '';
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'tasks_priority_check') then
+    alter table tasks add constraint tasks_priority_check check (priority in ('none', 'low', 'medium', 'high', 'urgent'));
+  end if;
+end $$;
 create unique index if not exists tasks_row_key_uq on tasks (team_id, project_id, row_key);
 create index if not exists tasks_team_status_idx on tasks (team_id, status);
 create index if not exists tasks_team_assignee_idx on tasks (team_id, assignee);
 create index if not exists tasks_team_updated_idx on tasks (team_id, updated_at desc);
+create index if not exists tasks_team_parent_idx on tasks (team_id, project_id, parent_row_key);
 
 -- Links between AIOS task rows and the external PM tool selected by the team.
 -- AIOS remains the source of truth for row identity/status; this table records how
@@ -249,12 +281,22 @@ create table if not exists task_pm_links (
   last_synced_status text,
   last_synced_at timestamptz,
   last_error text,
+  -- Projection bookkeeping (brain-api v1.2). last_projected_status + projection_fingerprint let
+  -- the projection engine skip a provider write when nothing changed; provider_seen_status records
+  -- the last state observed on the provider so Phase 5 (inbound/two-way) can detect divergence.
+  last_projected_status text,
+  projection_fingerprint text,
+  provider_seen_status text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   unique (team_id, project_id, row_key, provider)
 );
 create index if not exists task_pm_links_task_idx on task_pm_links (task_id);
 create index if not exists task_pm_links_team_provider_idx on task_pm_links (team_id, provider);
+-- Additive columns for existing deployments.
+alter table task_pm_links add column if not exists last_projected_status text;
+alter table task_pm_links add column if not exists projection_fingerprint text;
+alter table task_pm_links add column if not exists provider_seen_status text;
 
 -- Observable work events from code repos. The initial event is "merged": after a PR
 -- lands on main, the matching task row moves to done and provider sync is attempted.

--- a/supabase/migrations/20260622120000_task_hierarchy.sql
+++ b/supabase/migrations/20260622120000_task_hierarchy.sql
@@ -1,0 +1,30 @@
+-- brain-api v1.2 — task hierarchy + primary PM provider + projection bookkeeping.
+-- Mirrors the additive changes in postgres/schema.sql (the canonical self-host target).
+-- All idempotent so it is safe on an already-migrated database.
+
+-- tasks: hierarchy/board fields. parent_row_key references the epic by row_key within
+-- (team_id, project_id); integrity is enforced in app code (lib/ingest + task server actions),
+-- not a DB FK. body is dashboard/DB-only and never round-trips through markdown.
+alter table tasks add column if not exists parent_row_key text;
+alter table tasks add column if not exists labels text[] not null default '{}';
+alter table tasks add column if not exists priority text not null default 'none';
+alter table tasks add column if not exists body text not null default '';
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'tasks_priority_check') then
+    alter table tasks add constraint tasks_priority_check check (priority in ('none', 'low', 'medium', 'high', 'urgent'));
+  end if;
+end $$;
+create index if not exists tasks_team_parent_idx on tasks (team_id, project_id, parent_row_key);
+
+-- teams: the single PM tool the brain projects into.
+alter table teams add column if not exists primary_pm_provider text;
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'teams_primary_pm_provider_check') then
+    alter table teams add constraint teams_primary_pm_provider_check check (primary_pm_provider in ('plane', 'linear'));
+  end if;
+end $$;
+
+-- task_pm_links: projection bookkeeping (skip-detection + Phase 5 divergence detection).
+alter table task_pm_links add column if not exists last_projected_status text;
+alter table task_pm_links add column if not exists projection_fingerprint text;
+alter table task_pm_links add column if not exists provider_seen_status text;

--- a/test/datamechanics/task-hierarchy.datamechanics.test.ts
+++ b/test/datamechanics/task-hierarchy.datamechanics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { db, ingest, seedTeam } from "./helpers";
+import { IngestValidationError } from "@/lib/api/schemas";
 
 // Spec (brain-api v1.2): materializeTasks persists the hierarchy fields, preserves the
 // dashboard-only `body` across a sync push, and enforces parent integrity (exists + acyclic).
@@ -9,7 +10,15 @@ const pushTasks = (seed: Awaited<ReturnType<typeof seedTeam>>, rows: Record<stri
   ingest(seed, {
     kind: "task",
     path: "3-log/tasks.md",
-    body: rows.map((r) => `| ${r.row_key} | ${r.title} |`).join("\n"),
+    // Serialize every field into the body so any change (incl. labels/priority/parent) shifts the
+    // content_sha256 — otherwise ingest short-circuits as "unchanged" and never re-materializes,
+    // exactly as a real tasks.md (whose columns carry these values) would.
+    body: rows
+      .map(
+        (r) =>
+          `| ${r.row_key} | ${r.title} | ${r.parent ?? ""} | ${JSON.stringify(r.labels ?? "")} | ${r.priority ?? ""} |`
+      )
+      .join("\n"),
     access: "team",
     rows,
   } as never);
@@ -46,6 +55,38 @@ describe("task hierarchy materialization (real Postgres)", () => {
     expect(sub?.priority).toBe("high");
   });
 
+  it("a six-column re-push preserves hierarchy fields (no clobber)", async () => {
+    const seed = await seedTeam();
+    // First push carries the v1.2 columns.
+    await pushTasks(seed, [
+      { row_key: "P0", title: "Epic", labels: ["integration", "wave-1"], priority: "high" },
+      { row_key: "P0.1", title: "Chunk", parent: "P0", labels: ["integration"], priority: "medium" },
+    ]);
+    // Second push is a plain SIX-COLUMN table (no parent/labels/priority keys at all) — still valid
+    // per brain-api v1.2. It must NOT reset the hierarchy to null/[]/none.
+    await pushTasks(seed, [
+      { row_key: "P0", title: "Epic renamed" },
+      { row_key: "P0.1", title: "Chunk renamed" },
+    ]);
+
+    const epic = await readTask(seed.teamId, "P0");
+    const sub = await readTask(seed.teamId, "P0.1");
+    expect(epic?.labels).toEqual(["integration", "wave-1"]); // preserved
+    expect(epic?.priority).toBe("high"); // preserved
+    expect(sub?.parent_row_key).toBe("P0"); // preserved
+    expect(sub?.priority).toBe("medium"); // preserved
+  });
+
+  it("a present-but-empty hierarchy cell IS authoritative (clears it)", async () => {
+    const seed = await seedTeam();
+    await pushTasks(seed, [{ row_key: "T-1", title: "x", labels: ["a"], priority: "high" }]);
+    // A push that includes the keys with empty values (the column exists, the cell is blank).
+    await pushTasks(seed, [{ row_key: "T-1", title: "x", parent: null, labels: [], priority: "" }]);
+    const t = await readTask(seed.teamId, "T-1");
+    expect(t?.labels).toEqual([]);
+    expect(t?.priority).toBe("none");
+  });
+
   it("preserves dashboard-authored `body` across a sync re-push", async () => {
     const seed = await seedTeam();
     await pushTasks(seed, [{ row_key: "T-1", title: "x" }]);
@@ -66,10 +107,10 @@ describe("task hierarchy materialization (real Postgres)", () => {
     ).rejects.toThrow(/parent "GHOST" not found/);
   });
 
-  it("rejects a self-parent and a parent cycle", async () => {
+  it("rejects a self-parent and a parent cycle (typed IngestValidationError → 422)", async () => {
     const seed = await seedTeam();
     await expect(pushTasks(seed, [{ row_key: "A", title: "a", parent: "A" }])).rejects.toThrow(
-      /cannot reference itself/
+      IngestValidationError
     );
     const seed2 = await seedTeam();
     await expect(
@@ -78,6 +119,31 @@ describe("task hierarchy materialization (real Postgres)", () => {
         { row_key: "B", title: "b", parent: "A" },
       ])
     ).rejects.toThrow(/cycle/);
+  });
+
+  it("rejects a cycle formed across two syncs (combined existing + incoming graph)", async () => {
+    const seed = await seedTeam();
+    // Sync 1: A is the epic, B is its child (B.parent = A).
+    await pushTasks(seed, [
+      { row_key: "A", title: "a" },
+      { row_key: "B", title: "b", parent: "A" },
+    ]);
+    // Sync 2: now point A at B → A→B→A cycle through the existing DB edge.
+    await expect(pushTasks(seed, [{ row_key: "A", title: "a", parent: "B" }])).rejects.toThrow(
+      /cycle/
+    );
+  });
+
+  it("fails the whole push on a malformed row (no partial apply)", async () => {
+    const seed = await seedTeam();
+    await expect(
+      pushTasks(seed, [
+        { row_key: "GOOD", title: "ok" },
+        { row_key: "BAD", title: "bad", labels: [1, 2] }, // non-string labels
+      ])
+    ).rejects.toThrow(IngestValidationError);
+    // The good row must NOT have landed — the push is all-or-nothing.
+    expect(await readTask(seed.teamId, "GOOD")).toBeNull();
   });
 
   it("nulls a dangling parent when the epic is diff-deleted", async () => {

--- a/test/datamechanics/task-hierarchy.datamechanics.test.ts
+++ b/test/datamechanics/task-hierarchy.datamechanics.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { POST as itemsPOST } from "@/app/api/v1/items/route";
+import { issueApiKey } from "@/lib/admin/keys";
 import { db, ingest, seedTeam } from "./helpers";
 import { IngestValidationError } from "@/lib/api/schemas";
 
@@ -144,6 +148,13 @@ describe("task hierarchy materialization (real Postgres)", () => {
     ).rejects.toThrow(IngestValidationError);
     // The good row must NOT have landed — the push is all-or-nothing.
     expect(await readTask(seed.teamId, "GOOD")).toBeNull();
+    // The item must NOT have been written either (validation runs before item upsert).
+    const { count } = await db()
+      .from("items")
+      .select("id", { count: "exact", head: true })
+      .eq("team_id", seed.teamId)
+      .eq("path", "3-log/tasks.md");
+    expect(count).toBe(0);
   });
 
   it("nulls a dangling parent when the epic is diff-deleted", async () => {
@@ -159,5 +170,77 @@ describe("task hierarchy materialization (real Postgres)", () => {
 
     expect(await readTask(seed.teamId, "E")).toBeNull(); // epic diff-deleted
     expect((await readTask(seed.teamId, "C"))?.parent_row_key).toBeNull(); // dangling parent cleared
+  });
+});
+
+const ITEMS_URL = "http://test/api/v1/items";
+
+function sha(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+async function issueTeamKey(seed: Awaited<ReturnType<typeof seedTeam>>) {
+  const { key, keyId } = await issueApiKey(db(), seed.teamId, seed.memberId, "team key");
+  const { data: row } = await db().from("api_keys").select("id").eq("key_id", keyId).single();
+  return { key, apiKeyId: (row as { id: string }).id };
+}
+
+function postItems(key: string, teamSlug: string, body: unknown) {
+  const req = new Request(ITEMS_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "X-AIOS-Team": teamSlug,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+  return itemsPOST(req);
+}
+
+describe("task hierarchy route guards (real handlers, real Postgres)", () => {
+  it("POST /items: a self-parent task row is 422 invalid_payload, not 500", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueTeamKey(seed);
+    const mdBody = "| A | a | A | | |";
+    const res = await postItems(key, seed.teamSlug, {
+      project: "acme",
+      path: "3-log/tasks.md",
+      kind: "task",
+      access: "team",
+      actor: "tester",
+      frontmatter: {},
+      body: mdBody,
+      content_sha256: sha(mdBody),
+      rows: [{ row_key: "A", title: "a", parent: "A" }],
+    });
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("invalid_payload");
+    expect(json.error.message).toMatch(/cannot reference itself/);
+  });
+
+  it("POST /items: a bad hierarchy push does not persist the item", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueTeamKey(seed);
+    const mdBody = "| C | child | GHOST | | |";
+    const res = await postItems(key, seed.teamSlug, {
+      project: "acme",
+      path: "3-log/tasks.md",
+      kind: "task",
+      access: "team",
+      actor: "tester",
+      frontmatter: {},
+      body: mdBody,
+      content_sha256: sha(mdBody),
+      rows: [{ row_key: "C", title: "child", parent: "GHOST" }],
+    });
+    expect(res.status).toBe(422);
+    const { count } = await db()
+      .from("items")
+      .select("id", { count: "exact", head: true })
+      .eq("team_id", seed.teamId)
+      .eq("path", "3-log/tasks.md");
+    expect(count).toBe(0);
   });
 });

--- a/test/datamechanics/task-hierarchy.datamechanics.test.ts
+++ b/test/datamechanics/task-hierarchy.datamechanics.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { db, ingest, seedTeam } from "./helpers";
+
+// Spec (brain-api v1.2): materializeTasks persists the hierarchy fields, preserves the
+// dashboard-only `body` across a sync push, and enforces parent integrity (exists + acyclic).
+// Verified to the observable outcome: the row read back from real Postgres.
+
+const pushTasks = (seed: Awaited<ReturnType<typeof seedTeam>>, rows: Record<string, unknown>[]) =>
+  ingest(seed, {
+    kind: "task",
+    path: "3-log/tasks.md",
+    body: rows.map((r) => `| ${r.row_key} | ${r.title} |`).join("\n"),
+    access: "team",
+    rows,
+  } as never);
+
+const readTask = async (teamId: string, rowKey: string) => {
+  const { data } = await db()
+    .from("tasks")
+    .select("parent_row_key, labels, priority, body, status")
+    .eq("team_id", teamId)
+    .eq("row_key", rowKey)
+    .maybeSingle();
+  return data as {
+    parent_row_key: string | null;
+    labels: string[];
+    priority: string;
+    body: string;
+    status: string;
+  } | null;
+};
+
+describe("task hierarchy materialization (real Postgres)", () => {
+  it("persists parent_row_key, labels, and normalized priority", async () => {
+    const seed = await seedTeam();
+    await pushTasks(seed, [
+      { row_key: "P0", title: "Epic", labels: ["integration", "wave-1"], priority: "critical" },
+      { row_key: "P0.1", title: "Chunk", parent: "P0", labels: ["integration"], priority: "high" },
+    ]);
+
+    const epic = await readTask(seed.teamId, "P0");
+    const sub = await readTask(seed.teamId, "P0.1");
+    expect(epic?.labels).toEqual(["integration", "wave-1"]);
+    expect(epic?.priority).toBe("urgent"); // "critical" → urgent
+    expect(sub?.parent_row_key).toBe("P0");
+    expect(sub?.priority).toBe("high");
+  });
+
+  it("preserves dashboard-authored `body` across a sync re-push", async () => {
+    const seed = await seedTeam();
+    await pushTasks(seed, [{ row_key: "T-1", title: "x" }]);
+    // Simulate a dashboard body edit.
+    await db().from("tasks").update({ body: "long dashboard description" }).eq("team_id", seed.teamId).eq("row_key", "T-1");
+
+    // Re-push the same row from markdown (no body in the contract).
+    await pushTasks(seed, [{ row_key: "T-1", title: "x updated" }]);
+
+    const t = await readTask(seed.teamId, "T-1");
+    expect(t?.body).toBe("long dashboard description"); // survived the sync push
+  });
+
+  it("rejects a push whose parent does not resolve", async () => {
+    const seed = await seedTeam();
+    await expect(
+      pushTasks(seed, [{ row_key: "C", title: "child", parent: "GHOST" }])
+    ).rejects.toThrow(/parent "GHOST" not found/);
+  });
+
+  it("rejects a self-parent and a parent cycle", async () => {
+    const seed = await seedTeam();
+    await expect(pushTasks(seed, [{ row_key: "A", title: "a", parent: "A" }])).rejects.toThrow(
+      /cannot reference itself/
+    );
+    const seed2 = await seedTeam();
+    await expect(
+      pushTasks(seed2, [
+        { row_key: "A", title: "a", parent: "B" },
+        { row_key: "B", title: "b", parent: "A" },
+      ])
+    ).rejects.toThrow(/cycle/);
+  });
+
+  it("nulls a dangling parent when the epic is diff-deleted", async () => {
+    const seed = await seedTeam();
+    await pushTasks(seed, [
+      { row_key: "E", title: "epic" },
+      { row_key: "C", title: "child", parent: "E" },
+    ]);
+    expect((await readTask(seed.teamId, "C"))?.parent_row_key).toBe("E");
+
+    // Second push: the epic E vanishes from tasks.md; the child C still references it.
+    await pushTasks(seed, [{ row_key: "C", title: "child", parent: "E" }]);
+
+    expect(await readTask(seed.teamId, "E")).toBeNull(); // epic diff-deleted
+    expect((await readTask(seed.teamId, "C"))?.parent_row_key).toBeNull(); // dangling parent cleared
+  });
+});

--- a/test/task-hierarchy-schema.test.ts
+++ b/test/task-hierarchy-schema.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { taskRowSchema, normalizeTaskPriority, TASK_PRIORITIES } from "@/lib/api/schemas";
+
+// Spec (brain-api v1.2): task rows gain optional parent/labels/priority; `body` is NOT a contract
+// field (dashboard/DB-only) and must be stripped from a pushed row. Priority normalizes to the
+// allowed set with a few common aliases.
+
+describe("normalizeTaskPriority", () => {
+  it("passes through the allowed set", () => {
+    for (const p of TASK_PRIORITIES) expect(normalizeTaskPriority(p)).toBe(p);
+  });
+  it("is case/space-insensitive", () => {
+    expect(normalizeTaskPriority(" High ")).toBe("high");
+    expect(normalizeTaskPriority("URGENT")).toBe("urgent");
+  });
+  it("maps common aliases", () => {
+    expect(normalizeTaskPriority("critical")).toBe("urgent");
+    expect(normalizeTaskPriority("p0")).toBe("urgent");
+    expect(normalizeTaskPriority("p1")).toBe("high");
+    expect(normalizeTaskPriority("p2")).toBe("medium");
+    expect(normalizeTaskPriority("p3")).toBe("low");
+  });
+  it("unknown / empty / null → none", () => {
+    expect(normalizeTaskPriority("")).toBe("none");
+    expect(normalizeTaskPriority(null)).toBe("none");
+    expect(normalizeTaskPriority(undefined)).toBe("none");
+    expect(normalizeTaskPriority("banana")).toBe("none");
+  });
+});
+
+describe("taskRowSchema (v1.2 hierarchy)", () => {
+  it("accepts parent / labels / priority", () => {
+    const r = taskRowSchema.parse({
+      row_key: "P0.1",
+      title: "Register MCP",
+      parent: "P0",
+      labels: ["integration", "wave-1"],
+      priority: "high",
+    });
+    expect(r.parent).toBe("P0");
+    expect(r.labels).toEqual(["integration", "wave-1"]);
+    expect(r.priority).toBe("high");
+  });
+
+  it("strips `body` — it is not a contract field", () => {
+    const r = taskRowSchema.parse({
+      row_key: "T-1",
+      title: "x",
+      body: "this should not survive",
+    } as Record<string, unknown>);
+    expect("body" in r).toBe(false);
+  });
+
+  it("omitting hierarchy fields is valid (six-column rows)", () => {
+    const r = taskRowSchema.parse({ row_key: "T-1", title: "x" });
+    expect(r.parent).toBeUndefined();
+    expect(r.labels).toBeUndefined();
+    expect(r.priority).toBeUndefined();
+  });
+
+  it("rejects a non-string label entry", () => {
+    expect(() => taskRowSchema.parse({ row_key: "T-1", title: "x", labels: [1, 2] })).toThrow();
+  });
+});


### PR DESCRIPTION
## What & why

**Phase 0 (brain side)** of making the **brain `tasks` table the source of truth** that projects a structured board into the primary PM tool. Implements the brain side of the **brain-api v1.2** contract landed in aios-workspace **#66**.

Tracking: Plane **PROJ-148** / Linear **AIO-73** (Phase 0). Depends on #66 (contract-first).

## Schema (`postgres/schema.sql` + `supabase/migrations/20260622120000_task_hierarchy.sql`)
Additive + idempotent — validated **from-zero** and via **ALTER on an existing DB** (the ALTERs run before the dependent index, so existing deployments build it cleanly).
- `tasks`: `parent_row_key`, `labels text[]`, `priority` (check `none|low|medium|high|urgent`), `body`.
- `teams`: `primary_pm_provider` (check `plane|linear`) — the single board the brain projects into.
- `task_pm_links`: `last_projected_status`, `projection_fingerprint` (skip-detection), `provider_seen_status` (Phase 5 divergence).

## Code
- `taskRowSchema` gains optional `parent`/`labels`/`priority`; `normalizeTaskPriority` (+ aliases). **`body` is not a contract field — stripped from pushed rows** (dashboard/DB-only).
- `materializeTasks`: persists the hierarchy fields; **parent integrity** (parent must resolve in `(team,project)`; rejects self/cycle); **preserves `body`** across a sync push (omitted from the upsert); **nulls a dangling `parent_row_key`** when an epic is diff-deleted.
- `GET /api/v1/tasks` writeback returns `parent`/`labels`/`priority` (body excluded).
- **Admin → Integrations**: "Primary PM tool" selector → `setPrimaryPmProvider` (admin-gated, audited) → `teams.primary_pm_provider`.
- `docs/ARCHITECTURE.md`: sources-of-truth rows (tasks / PM-links / primary provider) + the invariant rewritten to **brain-is-source-of-truth, one-way projection** (was "PM sync is an effect"); inbound/two-way called out as deferred (Phase 5).

## Verification
- **Schema**: `pg:schema` loads from-zero and on the pre-existing table; columns/index/check present.
- **Unit (8)**: `normalizeTaskPriority` (allowed set + aliases + unknown→none), `taskRowSchema` (accepts hierarchy, **strips body**, rejects bad labels).
- **Data-mechanics (5, real Postgres)**: persists parent/labels/normalized priority; **body preserved** across re-push; rejects missing parent / self / cycle; **dangling parent nulled** on epic delete.
- Full suites green: **147 unit · 82 data-mechanics**; `npm run check:docs` congruent; eslint clean; `tsc --noEmit` 0 errors.

## Not in this PR
The projection engine itself (`lib/pm-sync` `upsertWorkItem` + `projectAllTasks`, reactive triggers, "Project board now") is **Phase 1**. Until then the new columns are inert plumbing — no behavior change to the existing merge→done write-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the single-writer ingest path and task materialization with fail-whole-push parent validation; schema/API contract changes affect sync and pull clients, though runtime PM projection is not wired yet.
> 
> **Overview**
> **Phase 0 (brain side)** for brain-api **v1.2**: the `tasks` table becomes the canonical board model that will project one-way into a single PM tool (projection engine is later).
> 
> **Schema** (additive, idempotent in `postgres/schema.sql` + Supabase migration): `tasks` gains `parent_row_key`, `labels`, `priority`, and dashboard-only `body`; `teams.primary_pm_provider` (`plane` | `linear` | null); `task_pm_links` gains projection bookkeeping columns (`last_projected_status`, `projection_fingerprint`, `provider_seen_status`).
> 
> **Contract & ingest**: `taskRowSchema` adds optional `parent` / `labels` / `priority` and **`body` is excluded** from the markdown contract. `normalizeTaskPriority` maps aliases (e.g. critical → urgent). `materializeTasks` persists hierarchy fields, **rejects** missing/self/cyclic parents for the whole push, **omits `body` on upsert** so dashboard edits survive sync, and **clears dangling `parent_row_key`** when an epic is diff-deleted.
> 
> **API & admin**: `GET /api/v1/tasks` writeback includes `parent`, `labels`, and `priority` (not `body`). Admin → Integrations adds a **Primary PM tool** control via audited `setPrimaryPmProvider`.
> 
> **Docs & tests**: `ARCHITECTURE.md` updated for brain-as-source-of-truth and one-way projection. Unit and Postgres data-mechanics tests cover schema, priority normalization, parent rules, body preservation, and dangling-parent cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 706224135c342eaaa169f6dd35d801b9f0ffa801. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task hierarchy support: tasks can now store parent relationships, multiple labels, and normalized priority.
  * Integrations: added a “Primary PM tool” option to choose Plane, Linear, or None for the team.

* **Bug Fixes**
  * Task ingestion now validates hierarchy inputs and returns a clear **422 invalid payload** for malformed requests; hierarchy references are kept consistent when parent tasks are removed.

* **Documentation**
  * Architecture docs updated for v1.2 task hierarchy fields and the primary PM provider projection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->