### PR TITLE
feat(ci): CI architecture doc, CodeRabbit, CODEOWNERS, PR template, Dependabot, code-reviewer agent

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -49,9 +49,17 @@ You are the AIOS Team Brain Code Reviewer. You review pull requests after CI has
 # CI check status
 gh pr checks <PR_NUMBER> --repo AIOS-alpha/aios-team-brain
 
-# All bot comments
+# Bot issue comments (walkthrough summaries)
 gh api repos/AIOS-alpha/aios-team-brain/issues/<PR_NUMBER>/comments \
-  --jq '[.[] | select(.user.login | test("cursor|coderabbit")) | {user: .user.login, body: .body}]'
+  --jq '[.[] | select(.user.login | test("cursor|coderabbit")) | {user: .user.login, body: .body, created_at: .created_at}]'
+
+# Bot inline diff comments — Bugbot and CodeRabbit post findings here, not in issue comments
+gh api repos/AIOS-alpha/aios-team-brain/pulls/<PR_NUMBER>/comments \
+  --jq '[.[] | select(.user.login | test("cursor|coderabbit")) | {user: .user.login, path: .path, line: .line, body: .body}]'
+
+# Bot PR reviews (submitted review objects)
+gh api repos/AIOS-alpha/aios-team-brain/pulls/<PR_NUMBER>/reviews \
+  --jq '[.[] | select(.user.login | test("cursor|coderabbit")) | {user: .user.login, state: .state, body: .body}]'
 
 # PR diff
 gh pr diff <PR_NUMBER> --repo AIOS-alpha/aios-team-brain

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,84 @@
+---
+name: code-reviewer
+description: AIOS Team Brain code reviewer. Use when Opus builder opens a PR and wait-for-bots has confirmed bot reviews are ready. Reads CI results and all bot comments, then produces a structured finding list the builder can act on.
+tools: Bash, Read
+---
+
+You are the AIOS Team Brain Code Reviewer. You review pull requests after CI has run and async bot reviews (Cursor Bugbot, CodeRabbit) have posted their comments.
+
+## Your job
+
+1. Read the CI check results for the PR.
+2. Read all `cursor[bot]` and `coderabbitai[bot]` comments from the PR.
+3. Read the diff yourself.
+4. Produce a **structured finding list** — do not just summarize the bots. Add your own analysis with AIOS-specific rules they don't know.
+
+## AIOS Team Brain invariants to check
+
+**Sync contract (critical):**
+- `docs/brain-api.md` is pinned at v1.2. Any change to routes, request/response shape, or auth must bump the version. Flag any API change that doesn't.
+- The brain rejects `admin`-tier content at the boundary (422). No code path should expose admin-tier data to team-tier callers.
+
+**Docs drift (required by CI):**
+- New `app/api/**/route.ts` routes must appear in the `<!-- drift:routes -->` block of `docs/ARCHITECTURE.md`.
+- New `postgres/schema.sql` tables must appear in `<!-- drift:tables -->`.
+- New `ingestion/aios_ingest/sources/registry.py` sources must appear in `<!-- drift:sources -->`.
+- If CI `docs-drift` job failed, call it out explicitly.
+
+**Test tiers:**
+- Persistence and RLS changes must have a `test/datamechanics/**/*.datamechanics.test.ts` test using the real Postgres test DB. No mocks for this tier.
+- Unit tests (`test/**/*.test.ts`) must not import from `test/datamechanics/`.
+- Python ingest changes need a `pytest` test.
+
+**Access tier vocabulary:**
+- Canonical tiers: `admin` (never syncs), `team` (syncs to brain), `external` (syncs outward).
+- Friendly aliases `private`→admin, `client`/`company`→external are normalized on push — don't introduce new aliases.
+
+**PR hygiene:**
+- PR body must include `AIOS-Work: <KEY>` for `aios-work-sync` to close the Plane ticket. Flag if missing.
+- No secrets, tokens, or API keys in the diff.
+
+**Stack conventions:**
+- Next.js App Router (`app/`), not Pages Router.
+- Vitest for tests — not Jest.
+- Postgres backend uses `postgres/schema.sql` as the canonical schema; do not introduce ad-hoc table creation.
+
+## How to gather inputs
+
+```bash
+# CI check status
+gh pr checks <PR_NUMBER> --repo AIOS-alpha/aios-team-brain
+
+# All bot comments
+gh api repos/AIOS-alpha/aios-team-brain/issues/<PR_NUMBER>/comments \
+  --jq '[.[] | select(.user.login | test("cursor|coderabbit")) | {user: .user.login, body: .body}]'
+
+# PR diff
+gh pr diff <PR_NUMBER> --repo AIOS-alpha/aios-team-brain
+```
+
+## Output format
+
+Return findings as a structured list. Be concise — the builder needs to act on this, not read an essay.
+
+```
+## CI Status
+[PASS|FAIL] docs-drift
+[PASS|FAIL] brain-tests
+[PASS|FAIL] datamechanics-tests
+[PASS|FAIL] ingestion-tests
+
+## Bot Findings (synthesized)
+[severity] file:line — description (source: Bugbot|CodeRabbit)
+
+## AIOS Rule Violations
+[severity] description — rule violated
+
+## Verdict
+[CLEAR|BLOCKED]
+If BLOCKED: bullet list of what must be fixed before merge.
+```
+
+Severity levels: `Critical` (blocks merge), `High` (blocks merge), `Medium` (should fix), `Low` (nice to have).
+
+If there are no Critical or High findings, end with `BUGBOT_CLEAR` on its own line.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,52 @@
+version: "2"
+language: "en-US"
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  path_filters:
+    - "!.next/**"
+    - "!ingestion/.venv/**"
+    - "!ingestion/**/*.pyc"
+    - "!coverage/**"
+    - "!node_modules/**"
+    - "!*.lock"
+
+  path_instructions:
+    - path: "app/api/**"
+      instructions: |
+        Check that every new route is documented in the <!-- drift:routes --> block of
+        docs/ARCHITECTURE.md. Flag if not.
+    - path: "postgres/schema.sql"
+      instructions: |
+        Check that every new table is documented in the <!-- drift:tables --> block of
+        docs/ARCHITECTURE.md. Flag if not.
+    - path: "ingestion/**"
+      instructions: |
+        Check that any new ingest source is registered in sources/registry.py and
+        documented in the <!-- drift:sources --> block of docs/ARCHITECTURE.md.
+    - path: "lib/**"
+      instructions: |
+        Verify tier access: functions that return data must filter by the caller's
+        access tier (admin/team/external). The brain rejects admin-tier at the API
+        boundary (422) — never expose admin content to team-tier callers.
+    - path: "**/*.test.ts"
+      instructions: |
+        Tests should be spec-first. datamechanics tests must use the real Postgres
+        test DB (DATABASE_TEST_URL) — no mocks for persistence or RLS checks.
+
+  finishing_touches:
+    docstrings: false
+
+chat:
+  auto_reply: true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# AIOS Team Brain — code owners
+# All PRs require review from core team.
+* @AIOS-alpha/core
+
+# Sync contract — extra scrutiny for API changes
+docs/brain-api.md @AIOS-alpha/core
+app/api/ @AIOS-alpha/core
+postgres/schema.sql @AIOS-alpha/core

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "pip"
+    directory: "/ingestion"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## What & Why
+
+<!-- One paragraph: what changed and why. -->
+
+## Work item
+
+<!-- Link this PR to a Plane item so aios-work-sync closes it on merge. -->
+AIOS-Work: <!-- e.g. AIOS-123 -->
+
+## Checklist
+
+- [ ] `node scripts/check-docs-drift.mjs` passes locally (or no routes/tables/sources changed)
+- [ ] Unit tests pass: `npm test`
+- [ ] Datamechanics tests pass if persistence changed: `npm run test:datamechanics:local`
+- [ ] Ingestion tests pass if Python changed: `cd ingestion && pytest -q`
+- [ ] `brain-api.md` version bumped if sync protocol changed
+- [ ] No secrets or admin-tier content in diff
+
+## Bot review summary
+
+<!-- After Bugbot + CodeRabbit post, paste a one-line summary of their findings here,
+     or write "no blocking findings." Helps reviewers scan quickly. -->

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -1,0 +1,136 @@
+# CI/CD Architecture — AIOS Team Brain
+
+## Overview
+
+This document describes the full CI/CD pipeline for `aios-team-brain`, including automated tests, async bot reviews, and how the multi-agent dev loop integrates with GitHub.
+
+---
+
+## Pipeline Diagram
+
+```mermaid
+flowchart TD
+    subgraph AgentLoop["Multi-Agent Dev Loop (local)"]
+        A1[Opus — Planner\nCreates spec / Plane issue] --> A2[Codex — Critic\nReviews plan]
+        A2 --> A3[Opus — Planner\nFinalizes plan]
+        A3 --> A4[Opus — Builder\nImplements, commits\nopens PR via gh]
+        A4 -->|wait-for-bots.mjs\npoll every 30s ≤10 min| A4W{Bots landed?}
+        A4W -->|yes| A5[AIOS Code Reviewer\nReads CI + Bugbot\n+ CodeRabbit findings]
+        A4W -->|timeout| A5
+        A5 -->|findings| A4
+        A5 -->|clear| MERGE[Human approves\n+ merges]
+    end
+
+    subgraph GitHubActions["GitHub Actions — triggered on PR open/push"]
+        B1["docs-drift\ncheck-docs-drift.mjs\nRoutes · Tables · Sources"]
+        B2["brain-tests\nvitest unit\npure logic + contract guards"]
+        B3["datamechanics-tests\nvitest + real Postgres 16\nRLS · persistence · access control"]
+        B4["ingestion-tests\npytest\nPython ingest pipeline"]
+        B5["aios-work-sync\nPOST /api/v1/work-events\ncloses Plane ticket on merge"]
+    end
+
+    subgraph BotReviews["Async Bot Reviews — GitHub Apps"]
+        C1["Cursor Bugbot\nGeneral LLM review\n1–5 min after PR opens"]
+        C2["CodeRabbit\nWalkthrough + inline\n~2 min after PR opens"]
+        C3["Cursor Security Reviewer\nSecurity-focused analysis\n~2–5 min after PR opens"]
+    end
+
+    subgraph GitHubPR["GitHub PR"]
+        D1["Checks tab\nCI pass/fail per job"]
+        D2["Conversation tab\nBot inline comments"]
+        D3["Security tab\n(SAST — not yet wired)"]
+    end
+
+    A4 -->|gh pr create| GitHubPR
+    GitHubPR --> GitHubActions
+    GitHubPR --> BotReviews
+    GitHubActions --> D1
+    BotReviews --> D2
+    MERGE --> B5
+```
+
+---
+
+## GitHub Actions Workflows
+
+### `ci.yml` — required gate on every PR and push to `main`
+
+| Job | What it runs | Blocks merge? |
+|---|---|---|
+| `docs-drift` | `node scripts/check-docs-drift.mjs` — validates routes, tables, sources against `docs/ARCHITECTURE.md` markers | Yes |
+| `brain-tests` | `npm test` — vitest unit tests (pure logic, parse/format, contract guards) | Yes |
+| `datamechanics-tests` | `npm run test:datamechanics` against real Postgres 16 (port 5434) — RLS, persistence, access control | Yes |
+| `ingestion-tests` | `pytest -q` inside `ingestion/` — Python ingest pipeline | Yes |
+
+All four must pass for a PR to merge (enforced via branch protection).
+
+### `aios-work-sync.yml` — fires on merge to `main`
+
+Extracts `AIOS-Work: <KEY>` from the PR title/body and POSTs a merge event to `/api/v1/work-events`. This closes the matching Plane work item automatically.
+
+**Required secrets:** `AIOS_BRAIN_URL`, `AIOS_API_KEY`, `AIOS_TEAM`
+
+---
+
+## Async Bot Reviews
+
+These run outside GitHub Actions and post comments to the PR conversation. They are not required checks — they are signals for the Code Reviewer agent.
+
+| Bot | GitHub user | Typical delay | What it covers |
+|---|---|---|---|
+| Cursor Bugbot | `cursor[bot]` | 1–5 min | General logic, naming, patterns |
+| CodeRabbit | `coderabbitai[bot]` | ~2 min | Walkthrough summary + inline suggestions |
+| Cursor Security Reviewer | `cursor[bot]` | 2–5 min | Auth, injection, secrets, access control |
+
+**Polling:** The builder agent runs `scripts/wait-for-bots.mjs --pr <n> --repo AIOS-alpha/aios-team-brain` after opening a PR. It blocks until `cursor[bot]` and `coderabbitai[bot]` have both posted, then prints a summary before the Code Reviewer agent runs.
+
+---
+
+## Local Development Hooks
+
+| Hook | When | What |
+|---|---|---|
+| `.githooks/pre-push` | Every `git push` | Runs `check-docs-drift.mjs` — blocks push if docs are out of sync |
+
+Installed automatically via `npm prepare` → `git config core.hooksPath .githooks`.
+
+---
+
+## Docs Drift Guard
+
+Three surfaces are machine-validated to stay in sync with `docs/ARCHITECTURE.md`:
+
+- **Routes** — derived from `app/api/**/route.ts` HTTP method exports
+- **Tables** — derived from `postgres/schema.sql`
+- **Sources** — derived from `ingestion/aios_ingest/sources/registry.py`
+
+If you add an API route, table, or ingest source, update the corresponding `<!-- drift:* -->` block in `docs/ARCHITECTURE.md` in the same PR. The pre-push hook and CI both enforce this.
+
+---
+
+## Branch Protection (required — verify in GitHub Settings)
+
+Repo: `AIOS-alpha/aios-team-brain` → Settings → Branches → `main`
+
+- [x] Require status checks: `docs-drift`, `brain-tests`, `datamechanics-tests`, `ingestion-tests`
+- [x] Require branches to be up to date before merging
+- [x] Dismiss stale reviews on new pushes
+- [x] Require review from code owners (CODEOWNERS)
+
+---
+
+## Optimized Agent Pipeline Sequencing
+
+```
+1. Opus (Planner)  → creates spec from Plane issue
+2. Codex (Critic)  → reviews plan, requests changes
+3. Opus (Planner)  → finalizes, hands off to builder
+4. Opus (Builder)  → implements, commits, opens PR
+5.                   GitHub Actions CI fires (parallel jobs)
+6.                   Cursor Bugbot + CodeRabbit fire async
+7. wait-for-bots   → polls every 30s until both bots have posted (≤10 min)
+8. Code Reviewer   → reads CI status + all bot comments → structured findings
+9. Opus (Builder)  → addresses findings, pushes fix commits if needed
+10. Human          → approves + merges
+11.                  aios-work-sync fires → Plane ticket closed
+```

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -82,7 +82,14 @@ These run outside GitHub Actions and post comments to the PR conversation. They 
 | CodeRabbit | `coderabbitai[bot]` | ~2 min | Walkthrough summary + inline suggestions |
 | Cursor Security Reviewer | `cursor[bot]` | 2–5 min | Auth, injection, secrets, access control |
 
-**Polling:** The builder agent runs `scripts/wait-for-bots.mjs --pr <n> --repo AIOS-alpha/aios-team-brain` after opening a PR. It blocks until `cursor[bot]` and `coderabbitai[bot]` have both posted, then prints a summary before the Code Reviewer agent runs.
+**Polling:** The builder agent runs `wait-for-bots.mjs` from the `aios-workspace` repo, passing `--repo` explicitly to target any AIOS-alpha repo:
+
+```bash
+node /path/to/aios-workspace/scripts/wait-for-bots.mjs \
+  --pr <n> --repo AIOS-alpha/aios-team-brain
+```
+
+The script lives only in `aios-workspace` (not duplicated here) — it is a shared cross-repo tool. It blocks until `cursor[bot]` and `coderabbitai[bot]` have both posted substantive feedback after the latest push (rate-limit stubs and pre-push comments are rejected), then prints a summary before the Code Reviewer agent runs.
 
 ---
 


### PR DESCRIPTION
## What & Why

Documents the full CI/CD pipeline architecture and adds the missing infrastructure to make the multi-agent dev loop (Opus planner → Codex reviewer → Opus builder → code-reviewer agent) reliable and well-guarded.

AIOS-Work: <!-- fill in -->

## Changes

- `docs/CI-ARCHITECTURE.md` — full Mermaid diagram of GitHub Actions jobs, async bot reviews (Bugbot, CodeRabbit, Security Reviewer), and the optimized pipeline sequencing
- `.coderabbit.yaml` — configures CodeRabbit to flag docs-drift, tier access violations, and brain-api.md contract drift
- `.github/CODEOWNERS` — routes all PRs to @AIOS-alpha/core; extra scrutiny on brain-api.md, app/api/, schema.sql
- `.github/pull_request_template.md` — standardizes PR body with AIOS-Work key field for aios-work-sync
- `.github/dependabot.yml` — weekly npm + pip + GitHub Actions dependency updates
- `.claude/agents/code-reviewer.md` — AIOS-aware code reviewer subagent that reads CI + Bugbot + CodeRabbit findings and applies brain-specific rules

## Checklist

- [x] No routes/tables/sources changed — docs-drift N/A
- [x] No secrets in diff
- [x] brain-api.md unchanged

## Bot review summary

(awaiting bot reviews)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and GitHub/config-only changes; no API, schema, or application logic modified.
> 
> **Overview**
> Adds **CI/CD documentation and repo guardrails** so the multi-agent loop (builder → `wait-for-bots` → code-reviewer) lines up with GitHub Actions and async bot reviews.
> 
> **`docs/CI-ARCHITECTURE.md`** documents the pipeline: four blocking `ci.yml` jobs, merge-time `aios-work-sync`, Bugbot/CodeRabbit/Security Reviewer, pre-push docs drift, branch protection, and agent sequencing.
> 
> **`.coderabbit.yaml`** turns on auto-review on `main` with path-specific rules (docs drift for routes/tables/sources, tier access in `lib/**`, datamechanics test expectations).
> 
> **`.github/CODEOWNERS`** requires `@AIOS-alpha/core` on all PRs and extra ownership on `brain-api.md`, `app/api/`, and `schema.sql`.
> 
> **`.github/pull_request_template.md`** standardizes PR bodies with **`AIOS-Work:`** for Plane closure and a checklist aligned with CI.
> 
> **`.github/dependabot.yml`** schedules weekly npm, pip (`ingestion/`), and GitHub Actions updates.
> 
> **`.claude/agents/code-reviewer.md`** defines an AIOS-aware reviewer subagent that pulls CI + bot comments via `gh`, applies brain invariants (sync contract, docs drift, test tiers, PR hygiene), and outputs a structured verdict including `BUGBOT_CLEAR` when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd5f00192365d47d8760f00df0b429fa2712054. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->