### PR TITLE
feat(pm-sync): brain→PM projection engine (brain-api v1.2 Phase 1)

### DIFF
--- a/app/t/[team]/admin/pm-sync/actions.ts
+++ b/app/t/[team]/admin/pm-sync/actions.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { serverClient } from "@/lib/supabase/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { getSessionUser } from "@/lib/auth/session";
+import { resolveIntegrationsAdmin } from "@/lib/integrations/read";
+import { audit } from "@/lib/api/audit";
+import { projectAllTasks, type ProjectionReport } from "@/lib/pm-sync";
+
+async function requireAdmin(teamSlug: string) {
+  const supabase = await serverClient();
+  const user = await getSessionUser();
+  if (!user) return null;
+  const ctx = await resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+  if (!ctx) return null;
+  return { teamId: ctx.teamId, myMemberId: ctx.memberId };
+}
+
+export interface ProjectBoardResult {
+  ok: boolean;
+  error?: string;
+  provider?: string | null;
+  counts?: Record<string, number>;
+  reports?: ProjectionReport[];
+}
+
+/**
+ * "Project board now" — full projection of the team's tasks into its primary PM tool (brain-api
+ * v1.2). Admins only; audited. Runs `projectAllTasks` for every project the team owns and reports
+ * per-row outcomes. Idempotent: a second run reports all `skipped` (zero provider writes).
+ */
+export async function projectBoardAction(teamSlug: string): Promise<ProjectBoardResult> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+
+  const db = adminClient();
+  const { data: projects, error: projErr } = await db.from("projects").select("id").eq("team_id", ctx.teamId);
+  if (projErr) return { ok: false, error: projErr.message };
+
+  const reports: ProjectionReport[] = [];
+  let provider: string | null = null;
+  let reason: string | undefined;
+  for (const p of projects ?? []) {
+    const res = await projectAllTasks(db, ctx.teamId, (p as { id: string }).id);
+    provider = res.provider;
+    if (res.reason) reason = res.reason;
+    reports.push(...res.reports);
+  }
+
+  if (!provider && reason) return { ok: false, error: reason };
+
+  const counts: Record<string, number> = {};
+  for (const r of reports) counts[r.status] = (counts[r.status] ?? 0) + 1;
+
+  await audit(db, {
+    team_id: ctx.teamId,
+    actor_kind: "member",
+    member_id: ctx.myMemberId,
+    action: "team.project_board",
+    target_type: "team",
+    target_id: ctx.teamId,
+    meta: { provider, counts },
+  });
+
+  revalidatePath(`/t/${teamSlug}/admin/pm-sync`);
+  return { ok: true, provider, counts, reports };
+}

--- a/app/t/[team]/admin/pm-sync/page.tsx
+++ b/app/t/[team]/admin/pm-sync/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { serverClient } from "@/lib/supabase/server";
+import { ProjectBoardButton } from "./project-board-button";
 
 export const metadata: Metadata = { title: "PM sync" };
 
@@ -8,7 +9,7 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
   const supabase = await serverClient();
   const { data: team } = await supabase
     .from("teams")
-    .select("id")
+    .select("id, primary_pm_provider")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
@@ -32,6 +33,20 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
 
   return (
     <div className="flex flex-col gap-5">
+      <section className="prism-card p-4">
+        <h2 className="text-lg font-semibold text-ink">Project board</h2>
+        <p className="mt-1 text-sm text-ink-secondary">
+          The brain is the source of truth. This projects every task into the primary PM tool
+          (create/update/state, one-way, brain wins). Re-running is idempotent — unchanged rows are skipped.
+        </p>
+        <div className="mt-4">
+          <ProjectBoardButton
+            teamSlug={teamSlug}
+            primaryProvider={(team as { primary_pm_provider: string | null }).primary_pm_provider}
+          />
+        </div>
+      </section>
+
       <section className="prism-card p-4">
         <h2 className="text-lg font-semibold text-ink">Unresolved merge events</h2>
         <p className="mt-1 text-sm text-ink-secondary">

--- a/app/t/[team]/admin/pm-sync/project-board-button.tsx
+++ b/app/t/[team]/admin/pm-sync/project-board-button.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { projectBoardAction, type ProjectBoardResult } from "./actions";
+
+export function ProjectBoardButton({ teamSlug, primaryProvider }: { teamSlug: string; primaryProvider: string | null }) {
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<ProjectBoardResult | null>(null);
+
+  function run() {
+    setResult(null);
+    startTransition(async () => {
+      setResult(await projectBoardAction(teamSlug));
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={run}
+          disabled={pending}
+          className="rounded-md bg-violet px-3 py-1.5 text-sm font-medium text-white disabled:opacity-60"
+        >
+          {pending ? "Projecting…" : "Project board now"}
+        </button>
+        <span className="text-sm text-ink-secondary">
+          Primary PM tool: <span className="font-medium text-ink">{primaryProvider ?? "not set"}</span>
+        </span>
+      </div>
+      {result ? (
+        result.ok ? (
+          <p className="text-sm text-ink-secondary">
+            Projected to <span className="font-medium text-ink">{result.provider}</span>:{" "}
+            {Object.entries(result.counts ?? {})
+              .map(([k, v]) => `${v} ${k}`)
+              .join(" · ") || "no rows"}
+          </p>
+        ) : (
+          <p className="text-sm text-red">{result.error}</p>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -172,19 +172,26 @@ lives only in `integrations.secret_ciphertext` and is decrypted on the server-si
 sync path. Provider failures update `task_pm_links.last_error` and the task remains
 done — PM drift is visible, not allowed to roll back completed code work.
 
-**Seeding/mirroring the board (one-way, idempotent).** The backlog itself is
-authored once in `scripts/aios-backlog.mjs` (the single source of truth) and
-projected into each PM tool by a seed script that shares that data:
-`npm run plane:backlog` (Plane: epics + sub-issues + Wave modules, idempotent by
-`external_id`) and `npm run linear:backlog` (Linear-native: a saved View per Wave
-filtered by the wave label, epics as parent issues, chunks as sub-issues, idempotent
-by an `aios-ext:` + `source: aios-backlog` marker in each issue description). `npm run linear:backlog -- --sync-status` additionally
-reconciles each Linear issue's workflow state from its Plane counterpart (matched by
-the shared ext key, mapped by state group) so "done in Plane" shows as "done in
-Linear". Both read `LINEAR_API_KEY`/`PLANE_API_KEY` (+ optional `LINEAR_TEAM`) from
-the workspace `.env` via dotenvx and support `--dry-run`. This is the Plane-vs-Linear
-bake-off substrate (backlog epic W2.4); the runtime write-back loop above is
-unchanged and provider-neutral.
+**Full projection engine (brain → PM, one-way, brain wins).** As of brain-api v1.2 the
+`tasks` table is the source of truth that **projects** a structured board into the team's
+single `teams.primary_pm_provider`. `lib/pm-sync/project.ts` owns this:
+`projectTask()` upserts one task (resolving its epic parent first, then the work item),
+and `projectAllTasks()` projects a whole `(team, project)` in topological order with a
+~1 req/s throttle — the server-side replacement for the seed scripts. Each adapter's
+`upsertWorkItem()` **adopts-or-creates** (Plane by `external_id` across
+`["aios-backlog","aios"]`; Linear by the `aios-ext: <row_key> · source: …` footer marker),
+then **brain-wins PATCHes** title/body/state/priority/labels/parent and Plane Wave-module
+membership. A `projection_fingerprint` on the link skips a provider round-trip when nothing
+changed (a second `projectAllTasks` run does zero writes). The admin **"Project board now"**
+button (`projectBoardAction`, admin-gated + audited) on the pm-sync page triggers a full run;
+the work-events done path calls `projectTask` (creating the link/item if missing). `moveToDone`
+remains as a thin state-only delegate. Assignees and inbound/two-way reconciliation are deferred
+(Phase 5 uses `provider_seen_status` to detect divergence).
+
+**Legacy seed scripts (being retired).** The backlog was originally authored in
+`scripts/aios-backlog.mjs` and pushed by `npm run plane:backlog` / `npm run linear:backlog`
+(idempotent by `external_id` / the `aios-ext:` marker). The projection engine supersedes these;
+they are removed once the live backlog is migrated (brain-api v1.2 Phase 3).
 
 ### Action layer (Organ 4) — policy-gated execution
 

--- a/lib/pm-sync/index.ts
+++ b/lib/pm-sync/index.ts
@@ -1,15 +1,12 @@
 import "server-only";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { getEnabledIntegrationsWithSecrets, type IntegrationWithSecret } from "@/lib/integrations/manage";
-import { linearAdapter } from "@/lib/pm-sync/linear";
-import { planeAdapter } from "@/lib/pm-sync/plane";
-import type { PmAdapter, PmProvider, ProviderSyncResult, TaskPmLink } from "@/lib/pm-sync/provider";
 
-const ADAPTERS: Record<PmProvider, PmAdapter> = {
-  plane: planeAdapter,
-  linear: linearAdapter,
-};
+import { projectTask, type ProjectionReport, type ProjectionTaskRow } from "@/lib/pm-sync/project";
+import type { PmProvider } from "@/lib/pm-sync/provider";
+
+export { projectTask, projectAllTasks } from "@/lib/pm-sync/project";
+export type { ProjectionReport, ProjectionTaskRow } from "@/lib/pm-sync/project";
 
 export interface TaskForPmSync {
   id: string;
@@ -25,38 +22,28 @@ export interface TaskPmSyncReport {
   error?: string;
 }
 
-async function updateLinkSuccess(
-  supabase: SupabaseClient,
-  link: TaskPmLink,
-  result: ProviderSyncResult
-) {
-  await supabase
-    .from("task_pm_links")
-    .update({
-      provider_resource_id: result.providerResourceId ?? link.provider_resource_id,
-      provider_url: result.providerUrl ?? link.provider_url ?? "",
-      last_synced_status: result.syncedStatus ?? "done",
-      last_synced_at: new Date().toISOString(),
-      last_error: null,
-      updated_at: new Date().toISOString(),
-    })
-    .eq("id", link.id);
+export function projectionToSyncReport(report: ProjectionReport): TaskPmSyncReport {
+  return { row_key: report.row_key, provider: report.provider, status: mapStatus(report.status), error: report.error };
 }
 
-async function updateLinkError(supabase: SupabaseClient, link: TaskPmLink, error: string) {
-  await supabase
-    .from("task_pm_links")
-    .update({ last_error: error.slice(0, 1000), updated_at: new Date().toISOString() })
-    .eq("id", link.id);
+function mapStatus(status: ProjectionReport["status"]): TaskPmSyncReport["status"] {
+  switch (status) {
+    case "synced":
+    case "skipped":
+    case "failed":
+      return status;
+    case "no_row_key":
+      return "no_link";
+    case "no_primary_provider":
+    case "missing_integration":
+      return "missing_integration";
+    default:
+      return "failed";
+  }
 }
 
-function chooseIntegration(
-  integrations: IntegrationWithSecret[],
-  provider: PmProvider
-): IntegrationWithSecret | null {
-  return integrations.find((i) => i.type === provider && i.secret) ?? null;
-}
-
+// Back-compat wrapper retained for the work-events report shape. Loads the full task row and
+// delegates to the projection engine in statusOnly mode (reconcile workflow state only).
 export async function syncTaskPmLinks(
   supabase: SupabaseClient,
   task: TaskForPmSync,
@@ -64,37 +51,13 @@ export async function syncTaskPmLinks(
 ): Promise<TaskPmSyncReport[]> {
   if (!task.row_key) return [{ row_key: "", provider: null, status: "no_link" }];
 
-  const { data, error } = await supabase
-    .from("task_pm_links")
-    .select("*")
-    .eq("team_id", task.team_id)
-    .eq("project_id", task.project_id)
-    .eq("row_key", task.row_key);
-  if (error) throw new Error(`load task PM links failed: ${error.message}`);
+  const { data } = await supabase
+    .from("tasks")
+    .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key")
+    .eq("id", task.id)
+    .maybeSingle();
+  if (!data) return [{ row_key: task.row_key, provider: null, status: "no_link" }];
 
-  const links = (data ?? []) as TaskPmLink[];
-  if (!links.length) return [{ row_key: task.row_key, provider: null, status: "no_link" }];
-
-  const integrations = await getEnabledIntegrationsWithSecrets(supabase, task.team_id);
-  const reports: TaskPmSyncReport[] = [];
-  for (const link of links) {
-    const provider = link.provider;
-    const integration = chooseIntegration(integrations, provider);
-    if (!integration) {
-      const message = `${provider} integration is not enabled or has no secret`;
-      await updateLinkError(supabase, link, message);
-      reports.push({ row_key: link.row_key, provider, status: "missing_integration", error: message });
-      continue;
-    }
-    try {
-      const result = await ADAPTERS[provider].moveToDone({ link, integration, fetchImpl: opts.fetchImpl });
-      await updateLinkSuccess(supabase, link, result);
-      reports.push({ row_key: link.row_key, provider, status: result.status });
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "PM sync failed";
-      await updateLinkError(supabase, link, message);
-      reports.push({ row_key: link.row_key, provider, status: "failed", error: message });
-    }
-  }
-  return reports;
+  const report = await projectTask(supabase, data as ProjectionTaskRow, { statusOnly: true, fetchImpl: opts.fetchImpl });
+  return [{ row_key: report.row_key, provider: report.provider, status: mapStatus(report.status), error: report.error }];
 }

--- a/lib/pm-sync/linear.ts
+++ b/lib/pm-sync/linear.ts
@@ -1,22 +1,71 @@
 import "server-only";
 
 import {
+  desiredStateForStatus,
   normalizeName,
   PmSyncError,
+  priorityToLinearInt,
   requireString,
+  sameLabelSet,
+  type DesiredState,
   type PmAdapter,
+  type PrepareInput,
   type ProviderSyncInput,
   type ProviderSyncResult,
+  type StateGroup,
+  type UpsertWorkItemInput,
+  type UpsertWorkItemResult,
 } from "@/lib/pm-sync/provider";
 
 type LinearGraphqlResponse<T> = { data?: T; errors?: { message: string }[] };
+type LinearState = { id: string; name: string; type: string };
+type LinearLabel = { id: string; name: string };
+type LinearIssue = {
+  id: string;
+  identifier?: string;
+  url?: string;
+  title?: string;
+  description?: string | null;
+  priority?: number | null;
+  parent?: { id: string } | null;
+  state?: { id: string; name?: string; type?: string } | null;
+  labels?: { nodes: LinearLabel[] } | null;
+  team?: { id: string } | null;
+};
 
-async function graphql<T>(
-  fetchImpl: typeof fetch,
-  apiKey: string,
-  query: string,
-  variables: Record<string, unknown>
-): Promise<T> {
+interface LinearBootstrap {
+  teamId: string;
+  states: LinearState[];
+  labels: Map<string, string>; // name → id
+  issuesByExt: Map<string, LinearIssue>; // row_key → issue
+  issuesById: Map<string, LinearIssue>;
+}
+
+// Plane↔Linear share five groups; Linear state.type uses "canceled" (one l).
+const GROUP_TO_TYPE: Record<StateGroup, string> = {
+  backlog: "backlog",
+  unstarted: "unstarted",
+  started: "started",
+  completed: "completed",
+  cancelled: "canceled",
+};
+
+const EXT_RE = /aios-ext:\s*([A-Za-z0-9._-]+)\s*[·•]\s*source:\s*([A-Za-z0-9._-]+)/;
+const extMarker = (rowKey: string, source: string) => `aios-ext: ${rowKey} · source: ${source}`;
+function parseExt(description: string | null | undefined): string | null {
+  const m = String(description ?? "").match(EXT_RE);
+  return m ? m[1] : null;
+}
+// Body that Linear stores = plain text + the idempotency footer. Strip the footer to compare to tasks.body.
+function withFooter(body: string, rowKey: string, source: string): string {
+  const text = (body ?? "").trim();
+  return `${text}\n\n${extMarker(rowKey, source)}`;
+}
+function stripFooter(description: string | null | undefined): string {
+  return String(description ?? "").replace(EXT_RE, "").trim();
+}
+
+async function graphql<T>(fetchImpl: typeof fetch, apiKey: string, query: string, variables: Record<string, unknown>): Promise<T> {
   const res = await fetchImpl("https://api.linear.app/graphql", {
     method: "POST",
     headers: { Authorization: apiKey, "Content-Type": "application/json" },
@@ -30,28 +79,109 @@ async function graphql<T>(
   return json.data;
 }
 
-async function resolveIssue(
-  fetchImpl: typeof fetch,
-  apiKey: string,
-  id: string
-): Promise<{ id: string; identifier: string; url?: string; team: { id: string }; state?: { id: string; name: string; type: string } }> {
+interface LinearCtx {
+  fetchImpl: typeof fetch;
+  apiKey: string;
+  externalSource: string;
+  teamIdConfig?: string;
+}
+
+function linearCtx(input: { integration: { config?: Record<string, unknown> | null; secret: string | null }; link?: { provider_external_source?: string } | null; fetchImpl?: typeof fetch }): LinearCtx {
+  const config = input.integration.config ?? {};
+  const apiKey = requireString(input.integration.secret, "Linear API key");
+  const externalSource = (config.externalSource as string | undefined) || input.link?.provider_external_source || "aios-backlog";
+  return { fetchImpl: input.fetchImpl ?? fetch, apiKey, externalSource, teamIdConfig: config.teamId as string | undefined };
+}
+
+function resolveStateByGroup(states: LinearState[], desired: DesiredState): LinearState {
+  const type = GROUP_TO_TYPE[desired.group];
+  const ofType = states.filter((s) => s.type === type);
+  const wantName = normalizeName(desired.preferredName);
+  const named = ofType.find((s) => normalizeName(s.name) === wantName) || states.find((s) => normalizeName(s.name) === wantName && desired.group === "started");
+  const target = named || ofType[0];
+  if (!target?.id) throw new PmSyncError(`Linear workflow state not found for group=${desired.group}`);
+  return target;
+}
+
+async function buildBootstrap(ctx: LinearCtx, teamId: string): Promise<LinearBootstrap> {
   const data = await graphql<{
-    issue: {
-      id: string;
-      identifier: string;
-      url?: string;
-      team: { id: string };
-      state?: { id: string; name: string; type: string };
+    team: {
+      states: { nodes: LinearState[] };
+      labels: { nodes: LinearLabel[] };
     } | null;
   }>(
-    fetchImpl,
-    apiKey,
-    `query IssueForPmSync($id: String!) {
-      issue(id: $id) {
-        id identifier url
-        team { id }
-        state { id name type }
+    ctx.fetchImpl,
+    ctx.apiKey,
+    `query ProjectionBootstrap($teamId: String!) {
+      team(id: $teamId) {
+        states(first: 100) { nodes { id name type } }
+        labels(first: 250) { nodes { id name } }
       }
+    }`,
+    { teamId }
+  );
+  const states = data.team?.states.nodes ?? [];
+  const labels = new Map<string, string>((data.team?.labels.nodes ?? []).map((l) => [l.name, l.id]));
+
+  const issuesByExt = new Map<string, LinearIssue>();
+  const issuesById = new Map<string, LinearIssue>();
+  type IssuesPage = { team: { issues: { pageInfo: { hasNextPage: boolean; endCursor: string }; nodes: LinearIssue[] } } | null };
+  let after: string | null = null;
+  for (let i = 0; i < 100; i++) {
+    const page: IssuesPage = await graphql<IssuesPage>(
+      ctx.fetchImpl,
+      ctx.apiKey,
+      `query ProjectionIssues($teamId: String!, $after: String) {
+        team(id: $teamId) {
+          issues(first: 250, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes { id identifier url title description priority parent { id } state { id name type } labels { nodes { id name } } team { id } }
+          }
+        }
+      }`,
+      { teamId, after }
+    );
+    const conn = page.team?.issues;
+    if (!conn) break;
+    for (const issue of conn.nodes) {
+      issuesById.set(issue.id, issue);
+      const ext = parseExt(issue.description);
+      if (ext) issuesByExt.set(ext, issue);
+    }
+    if (!conn.pageInfo.hasNextPage) break;
+    after = conn.pageInfo.endCursor;
+  }
+  return { teamId, states, labels, issuesByExt, issuesById };
+}
+
+async function ensureLabelIds(ctx: LinearCtx, boot: LinearBootstrap, names: string[]): Promise<string[]> {
+  const ids: string[] = [];
+  for (const name of names) {
+    if (!name) continue;
+    let id = boot.labels.get(name);
+    if (!id) {
+      const data = await graphql<{ issueLabelCreate: { issueLabel: { id: string } } }>(
+        ctx.fetchImpl,
+        ctx.apiKey,
+        `mutation CreateLabel($name: String!, $teamId: String!) {
+          issueLabelCreate(input: { name: $name, teamId: $teamId }) { issueLabel { id } }
+        }`,
+        { name, teamId: boot.teamId }
+      );
+      id = data.issueLabelCreate.issueLabel.id;
+      boot.labels.set(name, id);
+    }
+    ids.push(id);
+  }
+  return ids;
+}
+
+async function resolveIssueLite(ctx: LinearCtx, id: string): Promise<LinearIssue> {
+  const data = await graphql<{ issue: LinearIssue | null }>(
+    ctx.fetchImpl,
+    ctx.apiKey,
+    `query IssueForPmSync($id: String!) {
+      issue(id: $id) { id identifier url team { id } state { id name type } }
     }`,
     { id }
   );
@@ -59,65 +189,154 @@ async function resolveIssue(
   return data.issue;
 }
 
-async function resolveDoneState(
-  fetchImpl: typeof fetch,
-  apiKey: string,
-  teamId: string,
-  preferredName?: string
-): Promise<{ id: string; name: string }> {
-  const data = await graphql<{
-    team: { states: { nodes: { id: string; name: string; type: string; position?: number }[] } } | null;
-  }>(
-    fetchImpl,
-    apiKey,
+async function resolveStatesForTeam(ctx: LinearCtx, teamId: string): Promise<LinearState[]> {
+  const data = await graphql<{ team: { states: { nodes: LinearState[] } } | null }>(
+    ctx.fetchImpl,
+    ctx.apiKey,
     `query TeamDoneStates($teamId: String!) {
-      team(id: $teamId) {
-        states(filter: { type: { eq: "completed" } }) {
-          nodes { id name type position }
-        }
-      }
+      team(id: $teamId) { states(first: 100) { nodes { id name type } } }
     }`,
     { teamId }
   );
-  const states = data.team?.states.nodes ?? [];
-  const normalized = preferredName ? normalizeName(preferredName) : "";
-  const byName = normalized ? states.find((s) => normalizeName(s.name) === normalized) : null;
-  const done = states.find((s) => normalizeName(s.name) === "done");
-  const target = byName || done || states[0];
-  if (!target?.id) throw new PmSyncError("Linear completed workflow state not found");
-  return target;
+  return data.team?.states.nodes ?? [];
+}
+
+function linearIssueMatches(issue: LinearIssue, desired: { title: string; stateId: string; priority: number; labelIds: string[]; parent: string | null; body: string }): boolean {
+  if ((issue.title ?? "") !== desired.title) return false;
+  if ((issue.state?.id ?? "") !== desired.stateId) return false;
+  if ((issue.priority ?? 0) !== desired.priority) return false;
+  if ((issue.parent?.id ?? null) !== desired.parent) return false;
+  if (!sameLabelSet((issue.labels?.nodes ?? []).map((l) => l.id), desired.labelIds)) return false;
+  if (stripFooter(issue.description) !== desired.body.trim()) return false;
+  return true;
 }
 
 export const linearAdapter: PmAdapter = {
   provider: "linear",
-  async moveToDone({ link, integration, fetchImpl = fetch }: ProviderSyncInput): Promise<ProviderSyncResult> {
-    const apiKey = requireString(integration.secret, "Linear API key");
-    const issueRef = link.provider_resource_id || link.provider_external_id;
-    const issue = await resolveIssue(fetchImpl, apiKey, issueRef);
-    const config = integration.config ?? {};
-    const teamId = (config.teamId as string | undefined) || issue.team.id;
-    const doneState = await resolveDoneState(fetchImpl, apiKey, teamId, config.doneStateName as string | undefined);
 
-    if (issue.state?.id !== doneState.id) {
-      await graphql(
-        fetchImpl,
-        apiKey,
-        `mutation CompleteIssue($id: String!, $stateId: String!) {
-          issueUpdate(id: $id, input: { stateId: $stateId }) {
-            success
-            issue { id identifier url state { id name type } }
-          }
+  async prepare({ integration, fetchImpl }: PrepareInput): Promise<LinearBootstrap> {
+    const ctx = linearCtx({ integration, fetchImpl });
+    const teamId = requireString(ctx.teamIdConfig, "Linear teamId (config.teamId) for projection");
+    return buildBootstrap(ctx, teamId);
+  },
+
+  async upsertWorkItem({ task, link, integration, desiredFingerprint, statusOnly, bootstrap, fetchImpl }: UpsertWorkItemInput): Promise<UpsertWorkItemResult> {
+    const ctx = linearCtx({ integration, link, fetchImpl });
+    const desired = desiredStateForStatus(task.status);
+
+    // statusOnly: resolve the issue (by resource id) and reconcile only its workflow state.
+    if (statusOnly) {
+      if (!link) throw new PmSyncError("Linear statusOnly upsert requires an existing link");
+      const ref = link.provider_resource_id || link.provider_external_id;
+      const issue = await resolveIssueLite(ctx, ref);
+      const teamId = ctx.teamIdConfig || issue.team?.id;
+      if (!teamId) throw new PmSyncError("Linear team could not be resolved for statusOnly upsert");
+      const states = await resolveStatesForTeam(ctx, teamId);
+      const state = resolveStateByGroup(states, desired);
+      const changed = issue.state?.id !== state.id;
+      if (changed) {
+        await graphql(
+          ctx.fetchImpl,
+          ctx.apiKey,
+          `mutation SetIssueState($id: String!, $stateId: String!) {
+            issueUpdate(id: $id, input: { stateId: $stateId }) { success issue { id } }
+          }`,
+          { id: issue.id, stateId: state.id }
+        );
+      }
+      return {
+        provider: "linear",
+        status: changed ? "synced" : "skipped",
+        providerResourceId: issue.id,
+        providerUrl: issue.url || link.provider_url || "",
+        externalSource: ctx.externalSource,
+        syncedStatus: state.name,
+        fingerprint: desiredFingerprint,
+      };
+    }
+
+    const teamId = requireString(ctx.teamIdConfig, "Linear teamId (config.teamId) for projection");
+    const boot = (bootstrap as LinearBootstrap | undefined) ?? (await buildBootstrap(ctx, teamId));
+    const state = resolveStateByGroup(boot.states, desired);
+    const labelIds = await ensureLabelIds(ctx, boot, task.labels);
+    const priority = priorityToLinearInt(task.priority);
+    const parent = task.parentResourceId ?? null;
+    const description = withFooter(task.body, task.row_key, ctx.externalSource);
+    const desiredFields = { title: task.title, stateId: state.id, priority, labelIds, parent, body: task.body };
+
+    // Adopt-or-create: resource id wins, else the footer marker carrying the row_key.
+    const existing = (link?.provider_resource_id ? boot.issuesById.get(link.provider_resource_id) : undefined) || boot.issuesByExt.get(task.row_key);
+
+    let issue: LinearIssue;
+    let mutated = false;
+    if (existing?.id) {
+      issue = existing;
+      if (!linearIssueMatches(issue, desiredFields)) {
+        const data = await graphql<{ issueUpdate: { issue: LinearIssue } }>(
+          ctx.fetchImpl,
+          ctx.apiKey,
+          `mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
+            issueUpdate(id: $id, input: $input) { success issue { id identifier url } }
+          }`,
+          { id: issue.id, input: { title: task.title, description, stateId: state.id, priority, labelIds, parentId: parent } }
+        );
+        issue = { ...issue, ...data.issueUpdate.issue, state: { id: state.id }, priority, labels: { nodes: labelIds.map((id) => ({ id, name: "" })) }, parent: parent ? { id: parent } : null, title: task.title, description };
+        boot.issuesById.set(issue.id, issue);
+        mutated = true;
+      }
+    } else {
+      const data = await graphql<{ issueCreate: { issue: LinearIssue } }>(
+        ctx.fetchImpl,
+        ctx.apiKey,
+        `mutation CreateIssue($input: IssueCreateInput!) {
+          issueCreate(input: $input) { success issue { id identifier url } }
         }`,
-        { id: issue.id, stateId: doneState.id }
+        { input: { teamId, title: task.title, description, stateId: state.id, priority, labelIds, parentId: parent } }
       );
+      issue = { ...data.issueCreate.issue, description, title: task.title };
+      boot.issuesById.set(issue.id, issue);
+      boot.issuesByExt.set(task.row_key, issue);
+      mutated = true;
     }
 
     return {
       provider: "linear",
-      status: issue.state?.id === doneState.id ? "skipped" : "synced",
+      status: mutated ? "synced" : "skipped",
+      providerResourceId: issue.id,
+      providerUrl: issue.url || link?.provider_url || "",
+      parentResourceId: issue.id,
+      externalSource: ctx.externalSource,
+      syncedStatus: state.name,
+      fingerprint: desiredFingerprint,
+    };
+  },
+
+  // Thin delegate: reconcile only the workflow state of an already-linked issue to "done".
+  async moveToDone({ link, integration, fetchImpl }: ProviderSyncInput): Promise<ProviderSyncResult> {
+    const ctx = linearCtx({ integration, link, fetchImpl });
+    const ref = link.provider_resource_id || link.provider_external_id;
+    const issue = await resolveIssueLite(ctx, ref);
+    const teamId = ctx.teamIdConfig || issue.team?.id;
+    if (!teamId) throw new PmSyncError("Linear team could not be resolved");
+    const states = await resolveStatesForTeam(ctx, teamId);
+    const state = resolveStateByGroup(states, desiredStateForStatus("done"));
+    const changed = issue.state?.id !== state.id;
+    if (changed) {
+      await graphql(
+        ctx.fetchImpl,
+        ctx.apiKey,
+        `mutation CompleteIssue($id: String!, $stateId: String!) {
+          issueUpdate(id: $id, input: { stateId: $stateId }) { success issue { id identifier url state { id name type } } }
+        }`,
+        { id: issue.id, stateId: state.id }
+      );
+    }
+    return {
+      provider: "linear",
+      status: changed ? "synced" : "skipped",
       providerResourceId: issue.id,
       providerUrl: issue.url,
-      syncedStatus: doneState.name,
+      syncedStatus: state.name,
     };
   },
 };

--- a/lib/pm-sync/linear.ts
+++ b/lib/pm-sync/linear.ts
@@ -304,7 +304,7 @@ export const linearAdapter: PmAdapter = {
       status: mutated ? "synced" : "skipped",
       providerResourceId: issue.id,
       providerUrl: issue.url || link?.provider_url || "",
-      parentResourceId: issue.id,
+      parentResourceId: parent,
       externalSource: ctx.externalSource,
       syncedStatus: state.name,
       fingerprint: desiredFingerprint,

--- a/lib/pm-sync/plane.ts
+++ b/lib/pm-sync/plane.ts
@@ -330,7 +330,7 @@ export const planeAdapter: PmAdapter = {
       status: mutated ? "synced" : "skipped",
       providerResourceId: item.id,
       providerUrl: link?.provider_url || "",
-      parentResourceId: item.id,
+      parentResourceId: parent,
       externalSource: ctx.externalSource,
       syncedStatus: state.id,
       fingerprint: desiredFingerprint,

--- a/lib/pm-sync/plane.ts
+++ b/lib/pm-sync/plane.ts
@@ -1,22 +1,47 @@
 import "server-only";
 
 import {
+  desiredStateForStatus,
+  htmlToPlainText,
   normalizeName,
+  plainTextToHtml,
   PmSyncError,
   requireString,
+  sameLabelSet,
+  type DesiredState,
   type PmAdapter,
+  type PrepareInput,
   type ProviderSyncInput,
   type ProviderSyncResult,
+  type UpsertWorkItemInput,
+  type UpsertWorkItemResult,
 } from "@/lib/pm-sync/provider";
 
 type PlaneState = { id: string; name: string; group?: string };
+type PlaneModule = { id: string; name?: string };
+type PlaneLabel = { id: string; name: string };
 type PlaneWorkItem = {
   id: string;
   name?: string;
+  description_html?: string | null;
   state?: string;
+  priority?: string | null;
+  labels?: string[] | null;
+  parent?: string | null;
   external_id?: string | null;
   external_source?: string | null;
 };
+
+// Opaque per-run prefetch shared across a projectAllTasks batch. Module memberships are filled in
+// lazily (only for the waves actually projected) and cached here by reference.
+interface PlaneBootstrap {
+  states: PlaneState[];
+  items: Map<string, PlaneWorkItem>; // by id
+  itemsByExt: Map<string, PlaneWorkItem>; // by `${external_source}::${external_id}`
+  labelIds: Map<string, string>; // name → id
+  moduleIds: Map<string, string>; // name → id
+  moduleMembers: Map<string, Set<string>>; // moduleId → issue ids
+}
 
 async function readJson(res: Response): Promise<unknown> {
   const text = await res.text();
@@ -27,26 +52,6 @@ async function readJson(res: Response): Promise<unknown> {
   }
 }
 
-async function planeApi(
-  fetchImpl: typeof fetch,
-  base: string,
-  apiKey: string,
-  method: string,
-  path: string,
-  body?: Record<string, unknown>
-): Promise<unknown> {
-  const res = await fetchImpl(`${base}${path}`, {
-    method,
-    headers: { "X-API-Key": apiKey, "Content-Type": "application/json" },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  const json = await readJson(res);
-  if (!res.ok) {
-    throw new PmSyncError(`Plane ${method} ${path} failed (${res.status}): ${JSON.stringify(json).slice(0, 300)}`);
-  }
-  return json;
-}
-
 function asArray(value: unknown): unknown[] {
   if (Array.isArray(value)) return value;
   if (value && typeof value === "object" && Array.isArray((value as { results?: unknown[] }).results)) {
@@ -55,19 +60,64 @@ function asArray(value: unknown): unknown[] {
   return [];
 }
 
-async function fetchAllWorkItems(
-  fetchImpl: typeof fetch,
-  base: string,
-  apiKey: string,
-  workspaceSlug: string,
-  projectId: string
-): Promise<PlaneWorkItem[]> {
-  const out: PlaneWorkItem[] = [];
+interface PlaneCtx {
+  fetchImpl: typeof fetch;
+  base: string;
+  apiKey: string;
+  workspaceSlug: string;
+  projectId: string;
+  externalSource: string;
+}
+
+function planeCtx(input: { integration: { config?: Record<string, unknown> | null; secret: string | null }; link?: { provider_external_source?: string } | null; fetchImpl?: typeof fetch }): PlaneCtx {
+  const config = input.integration.config ?? {};
+  const apiKey = requireString(input.integration.secret, "Plane API key");
+  const base = requireString((config.baseUrl as string | undefined) || "https://api.plane.so", "Plane base URL").replace(/\/$/, "");
+  const workspaceSlug = requireString(config.workspaceSlug, "Plane workspaceSlug");
+  const projectId = requireString(config.projectId, "Plane projectId");
+  // Default to "aios-backlog" for back-compat with the seeded board (the seed wrote that source);
+  // a fresh integration can override via config.externalSource.
+  const externalSource =
+    (config.externalSource as string | undefined) || input.link?.provider_external_source || "aios-backlog";
+  return { fetchImpl: input.fetchImpl ?? fetch, base, apiKey, workspaceSlug, projectId, externalSource };
+}
+
+async function planeApi(ctx: PlaneCtx, method: string, path: string, body?: Record<string, unknown>): Promise<unknown> {
+  const url = `${ctx.base}${path}`;
+  for (let attempt = 0; ; attempt++) {
+    const res = await ctx.fetchImpl(url, {
+      method,
+      headers: { "X-API-Key": ctx.apiKey, "Content-Type": "application/json" },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (res.status === 429 && attempt < 6) {
+      const retry = Number(res.headers.get("Retry-After") || 5) * 1000;
+      await new Promise((r) => setTimeout(r, retry));
+      continue;
+    }
+    const json = await readJson(res);
+    if (!res.ok) {
+      throw new PmSyncError(`Plane ${method} ${path} failed (${res.status}): ${JSON.stringify(json).slice(0, 300)}`);
+    }
+    return json;
+  }
+}
+
+function projPath(ctx: PlaneCtx, suffix: string): string {
+  return `/api/v1/workspaces/${ctx.workspaceSlug}/projects/${ctx.projectId}${suffix}`;
+}
+
+async function fetchAllPaged(ctx: PlaneCtx, suffix: string): Promise<unknown[]> {
+  const out: unknown[] = [];
   let cursor = "100:0:0";
   for (let i = 0; i < 100; i++) {
-    const path = `/api/v1/workspaces/${workspaceSlug}/projects/${projectId}/work-items/?per_page=100&cursor=${encodeURIComponent(cursor)}`;
-    const page = await planeApi(fetchImpl, base, apiKey, "GET", path);
-    out.push(...(asArray(page) as PlaneWorkItem[]));
+    const sep = suffix.includes("?") ? "&" : "?";
+    const page = await planeApi(ctx, "GET", `${projPath(ctx, suffix)}${sep}per_page=100&cursor=${encodeURIComponent(cursor)}`);
+    if (Array.isArray(page)) {
+      out.push(...page);
+      break;
+    }
+    out.push(...asArray(page));
     const next = page && typeof page === "object" ? (page as { next_page_results?: boolean; next_cursor?: string }) : null;
     if (!next?.next_page_results || !next.next_cursor) break;
     cursor = next.next_cursor;
@@ -75,76 +125,228 @@ async function fetchAllWorkItems(
   return out;
 }
 
-async function resolveDoneState(
-  fetchImpl: typeof fetch,
-  base: string,
-  apiKey: string,
-  workspaceSlug: string,
-  projectId: string,
-  preferredName?: string
-): Promise<PlaneState> {
-  const states = asArray(
-    await planeApi(
-      fetchImpl,
-      base,
-      apiKey,
-      "GET",
-      `/api/v1/workspaces/${workspaceSlug}/projects/${projectId}/states/`
-    )
-  ) as PlaneState[];
-  const normalized = preferredName ? normalizeName(preferredName) : "";
-  const byName = normalized ? states.find((s) => normalizeName(s.name) === normalized) : null;
-  const completed = states.find((s) => s.group === "completed");
-  const done = states.find((s) => normalizeName(s.name) === "done");
-  const target = byName || done || completed;
-  if (!target?.id) throw new PmSyncError("Plane completed state not found");
+function extKey(source: string | null | undefined, ext: string | null | undefined): string {
+  return `${source ?? ""}::${ext ?? ""}`;
+}
+
+function resolveStateByGroup(states: PlaneState[], desired: DesiredState): PlaneState {
+  const wantName = normalizeName(desired.preferredName);
+  const ofGroup = states.filter((s) => s.group === desired.group);
+  const named = states.find((s) => normalizeName(s.name) === wantName);
+  // Prefer a state literally named like the desired (so a configured "Blocked" wins), else the
+  // first state in the target group.
+  const target = (named && (named.group === desired.group || desired.group === "started") ? named : null) || ofGroup[0] || named;
+  if (!target?.id) throw new PmSyncError(`Plane state not found for group=${desired.group}`);
   return target;
+}
+
+function indexItems(itemsRaw: PlaneWorkItem[]): { items: Map<string, PlaneWorkItem>; itemsByExt: Map<string, PlaneWorkItem> } {
+  const items = new Map<string, PlaneWorkItem>();
+  const itemsByExt = new Map<string, PlaneWorkItem>();
+  for (const it of itemsRaw) {
+    items.set(it.id, it);
+    if (it.external_id) itemsByExt.set(extKey(it.external_source, it.external_id), it);
+  }
+  return { items, itemsByExt };
+}
+
+// Lite prefetch for the status-only / moveToDone paths: states + items only (no labels/modules),
+// so a caller that just moves state never needs label/module endpoints.
+async function buildLiteBootstrap(ctx: PlaneCtx): Promise<PlaneBootstrap> {
+  const [statesRaw, itemsRaw] = await Promise.all([fetchAllPaged(ctx, "/states/"), fetchAllPaged(ctx, "/work-items/")]);
+  const { items, itemsByExt } = indexItems(itemsRaw as PlaneWorkItem[]);
+  return { states: statesRaw as PlaneState[], items, itemsByExt, labelIds: new Map(), moduleIds: new Map(), moduleMembers: new Map() };
+}
+
+async function buildBootstrap(ctx: PlaneCtx, labels: string[]): Promise<PlaneBootstrap> {
+  const [statesRaw, itemsRaw, labelsRaw, modulesRaw] = await Promise.all([
+    fetchAllPaged(ctx, "/states/"),
+    fetchAllPaged(ctx, "/work-items/"),
+    fetchAllPaged(ctx, "/labels/"),
+    fetchAllPaged(ctx, "/modules/"),
+  ]);
+  const { items, itemsByExt } = indexItems(itemsRaw as PlaneWorkItem[]);
+  const labelIds = new Map<string, string>((labelsRaw as PlaneLabel[]).map((l) => [l.name, l.id]));
+  const moduleIds = new Map<string, string>((modulesRaw as PlaneModule[]).filter((m) => m.name).map((m) => [m.name as string, m.id]));
+
+  // Ensure requested labels exist (create missing once per run).
+  for (const name of labels) {
+    if (!name || labelIds.has(name)) continue;
+    const created = (await planeApi(ctx, "POST", projPath(ctx, "/labels/"), { name })) as PlaneLabel;
+    labelIds.set(name, created.id);
+  }
+  return { states: statesRaw as PlaneState[], items, itemsByExt, labelIds, moduleIds, moduleMembers: new Map() };
+}
+
+async function ensureLabelIds(ctx: PlaneCtx, boot: PlaneBootstrap, names: string[]): Promise<string[]> {
+  const ids: string[] = [];
+  for (const name of names) {
+    if (!name) continue;
+    let id = boot.labelIds.get(name);
+    if (!id) {
+      const created = (await planeApi(ctx, "POST", projPath(ctx, "/labels/"), { name })) as PlaneLabel;
+      id = created.id;
+      boot.labelIds.set(name, id);
+    }
+    ids.push(id);
+  }
+  return ids;
+}
+
+async function ensureModuleMembership(ctx: PlaneCtx, boot: PlaneBootstrap, waveName: string, itemId: string): Promise<void> {
+  const name = waveName.trim();
+  if (!name) return;
+  let moduleId = boot.moduleIds.get(name);
+  if (!moduleId) {
+    const created = (await planeApi(ctx, "POST", projPath(ctx, "/modules/"), { name })) as PlaneModule;
+    moduleId = created.id;
+    boot.moduleIds.set(name, moduleId);
+  }
+  let members = boot.moduleMembers.get(moduleId);
+  if (!members) {
+    const rows = (await fetchAllPaged(ctx, `/modules/${moduleId}/module-issues/`)) as { issue?: string; id?: string }[];
+    members = new Set(rows.map((m) => m.issue || m.id).filter(Boolean) as string[]);
+    boot.moduleMembers.set(moduleId, members);
+  }
+  if (!members.has(itemId)) {
+    await planeApi(ctx, "POST", projPath(ctx, `/modules/${moduleId}/module-issues/`), { issues: [itemId] });
+    members.add(itemId);
+  }
+}
+
+// Does the adopted Plane item already match the desired projection? (avoids a redundant PATCH,
+// preserves seeded descriptions on first adoption.)
+function planeItemMatches(item: PlaneWorkItem, desired: { name: string; stateId: string; priority: string; labelIds: string[]; parent: string | null; body: string }): boolean {
+  if ((item.name ?? "") !== desired.name) return false;
+  if ((item.state ?? "") !== desired.stateId) return false;
+  if ((item.priority ?? "none") !== desired.priority) return false;
+  if ((item.parent ?? null) !== desired.parent) return false;
+  if (!sameLabelSet(item.labels ?? [], desired.labelIds)) return false;
+  if (htmlToPlainText(item.description_html) !== desired.body.trim()) return false;
+  return true;
+}
+
+async function patchStateOnly(ctx: PlaneCtx, boot: PlaneBootstrap, link: { provider_resource_id: string | null; provider_external_id: string }, desired: DesiredState): Promise<{ item: PlaneWorkItem; stateId: string; changed: boolean }> {
+  const item =
+    (link.provider_resource_id ? boot.items.get(link.provider_resource_id) : undefined) ||
+    boot.itemsByExt.get(extKey(ctx.externalSource, link.provider_external_id)) ||
+    boot.itemsByExt.get(extKey("aios", link.provider_external_id));
+  if (!item?.id) {
+    throw new PmSyncError(`Plane work item not found for external_source=${ctx.externalSource} external_id=${link.provider_external_id}`);
+  }
+  const state = resolveStateByGroup(boot.states, desired);
+  const changed = item.state !== state.id;
+  if (changed) {
+    await planeApi(ctx, "PATCH", projPath(ctx, `/work-items/${item.id}/`), { state: state.id });
+    item.state = state.id;
+  }
+  return { item, stateId: state.id, changed };
 }
 
 export const planeAdapter: PmAdapter = {
   provider: "plane",
-  async moveToDone({ link, integration, fetchImpl = fetch }: ProviderSyncInput): Promise<ProviderSyncResult> {
-    const config = integration.config ?? {};
-    const apiKey = requireString(integration.secret, "Plane API key");
-    const base = requireString((config.baseUrl as string | undefined) || "https://api.plane.so", "Plane base URL").replace(/\/$/, "");
-    const workspaceSlug = requireString(config.workspaceSlug, "Plane workspaceSlug");
-    const projectId = requireString(config.projectId, "Plane projectId");
-    const externalSource = (config.externalSource as string | undefined) || link.provider_external_source || "aios";
-    const doneState = await resolveDoneState(
-      fetchImpl,
-      base,
-      apiKey,
-      workspaceSlug,
-      projectId,
-      config.doneStateName as string | undefined
-    );
 
-    const items = await fetchAllWorkItems(fetchImpl, base, apiKey, workspaceSlug, projectId);
-    const item =
-      (link.provider_resource_id ? items.find((it) => it.id === link.provider_resource_id) : null) ||
-      items.find((it) => it.external_id === link.provider_external_id && it.external_source === externalSource);
-    if (!item?.id) {
-      throw new PmSyncError(
-        `Plane work item not found for external_source=${externalSource} external_id=${link.provider_external_id}`
-      );
+  async prepare({ integration, labels = [], fetchImpl }: PrepareInput): Promise<PlaneBootstrap> {
+    const ctx = planeCtx({ integration, fetchImpl });
+    return buildBootstrap(ctx, labels);
+  },
+
+  async upsertWorkItem({ task, link, integration, desiredFingerprint, statusOnly, bootstrap, fetchImpl }: UpsertWorkItemInput): Promise<UpsertWorkItemResult> {
+    const ctx = planeCtx({ integration, link, fetchImpl });
+    const boot =
+      (bootstrap as PlaneBootstrap | undefined) ?? (statusOnly ? await buildLiteBootstrap(ctx) : await buildBootstrap(ctx, task.labels));
+    const desired = desiredStateForStatus(task.status);
+
+    // statusOnly: only reconcile workflow state; never touch title/body/labels/priority/parent.
+    if (statusOnly) {
+      if (!link) throw new PmSyncError("Plane statusOnly upsert requires an existing link");
+      const { item, stateId, changed } = await patchStateOnly(ctx, boot, link, desired);
+      return {
+        provider: "plane",
+        status: changed ? "synced" : "skipped",
+        providerResourceId: item.id,
+        providerUrl: link.provider_url || "",
+        externalSource: ctx.externalSource,
+        syncedStatus: stateId,
+        fingerprint: desiredFingerprint,
+      };
     }
 
-    if (item.state !== doneState.id) {
-      await planeApi(
-        fetchImpl,
-        base,
-        apiKey,
-        "PATCH",
-        `/api/v1/workspaces/${workspaceSlug}/projects/${projectId}/work-items/${item.id}/`,
-        { state: doneState.id }
-      );
+    // Adopt-or-create. Resource id wins; else match external_id across legacy + current sources.
+    const existing =
+      (link?.provider_resource_id ? boot.items.get(link.provider_resource_id) : undefined) ||
+      boot.itemsByExt.get(extKey(ctx.externalSource, task.row_key)) ||
+      boot.itemsByExt.get(extKey("aios", task.row_key)) ||
+      boot.itemsByExt.get(extKey("aios-backlog", task.row_key));
+
+    const state = resolveStateByGroup(boot.states, desired);
+    const labelIds = await ensureLabelIds(ctx, boot, task.labels);
+    const priority = task.priority || "none";
+    const parent = task.parentResourceId ?? null;
+    const desiredFields = { name: task.title, stateId: state.id, priority, labelIds, parent, body: task.body };
+
+    let item: PlaneWorkItem;
+    let mutated = false;
+    if (existing?.id) {
+      item = existing;
+      if (!planeItemMatches(item, desiredFields)) {
+        const patched = (await planeApi(ctx, "PATCH", projPath(ctx, `/work-items/${item.id}/`), {
+          name: task.title,
+          description_html: plainTextToHtml(task.body),
+          state: state.id,
+          priority,
+          labels: labelIds,
+          parent,
+        })) as PlaneWorkItem;
+        item = { ...item, ...patched, labels: labelIds, state: state.id, priority, parent, name: task.title, description_html: plainTextToHtml(task.body) };
+        boot.items.set(item.id, item);
+        mutated = true;
+      }
+    } else {
+      item = (await planeApi(ctx, "POST", projPath(ctx, "/work-items/"), {
+        name: task.title,
+        description_html: plainTextToHtml(task.body),
+        external_id: task.row_key,
+        external_source: ctx.externalSource,
+        state: state.id,
+        priority,
+        labels: labelIds,
+        ...(parent ? { parent } : {}),
+      })) as PlaneWorkItem;
+      boot.items.set(item.id, item);
+      boot.itemsByExt.set(extKey(ctx.externalSource, task.row_key), item);
+      mutated = true;
+    }
+
+    // Wave module membership (idempotent add).
+    if (task.sprint) {
+      const before = mutated;
+      await ensureModuleMembership(ctx, boot, task.sprint, item.id);
+      mutated = before || mutated;
     }
 
     return {
       provider: "plane",
-      status: item.state === doneState.id ? "skipped" : "synced",
+      status: mutated ? "synced" : "skipped",
       providerResourceId: item.id,
-      syncedStatus: doneState.name,
+      providerUrl: link?.provider_url || "",
+      parentResourceId: item.id,
+      externalSource: ctx.externalSource,
+      syncedStatus: state.id,
+      fingerprint: desiredFingerprint,
+    };
+  },
+
+  // Thin delegate: reconcile only the workflow state of an already-linked item to "done".
+  async moveToDone({ link, integration, fetchImpl }: ProviderSyncInput): Promise<ProviderSyncResult> {
+    const ctx = planeCtx({ integration, link, fetchImpl });
+    const boot = await buildLiteBootstrap(ctx);
+    const { item, stateId, changed } = await patchStateOnly(ctx, boot, link, desiredStateForStatus("done"));
+    return {
+      provider: "plane",
+      status: changed ? "synced" : "skipped",
+      providerResourceId: item.id,
+      syncedStatus: (boot.states.find((s) => s.id === stateId)?.name) ?? stateId,
     };
   },
 };

--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -72,6 +72,13 @@ export interface ResolvedPrimary {
   integration: IntegrationWithSecret;
 }
 
+// Resolution outcomes: ready (provider + integration), provider-known-but-integration-missing
+// (still link + record the error for the pm-sync surface), or unresolved (true no-op).
+export type PrimaryResolution =
+  | ResolvedPrimary
+  | { provider: PmProvider; integration: null; reason: string }
+  | { provider: null; reason: string };
+
 const PROVIDERS: PmProvider[] = ["plane", "linear"];
 
 function chooseIntegration(integrations: IntegrationWithSecret[], provider: PmProvider): IntegrationWithSecret | null {
@@ -83,7 +90,7 @@ function chooseIntegration(integrations: IntegrationWithSecret[], provider: PmPr
 export async function resolvePrimaryProvider(
   supabase: SupabaseClient,
   teamId: string
-): Promise<ResolvedPrimary | { provider: null; reason: string }> {
+): Promise<PrimaryResolution> {
   const integrations = await getEnabledIntegrationsWithSecrets(supabase, teamId);
   const { data: team } = await supabase.from("teams").select("primary_pm_provider").eq("id", teamId).maybeSingle();
   const configured = (team?.primary_pm_provider as PmProvider | null) ?? null;
@@ -91,7 +98,9 @@ export async function resolvePrimaryProvider(
   if (configured) {
     const integration = chooseIntegration(integrations, configured);
     if (!integration) {
-      return { provider: null, reason: `primary provider "${configured}" has no enabled integration/secret` };
+      // Target is known but its integration is absent/secret-less: callers still record the
+      // failure on the link (observability parity with pre-v1.2 markdown-link sync).
+      return { provider: configured, integration: null, reason: `${configured} integration is not enabled or has no secret` };
     }
     return { provider: configured, integration };
   }
@@ -204,9 +213,16 @@ export async function projectTask(
 ): Promise<ProjectionReport> {
   if (!row.row_key) return { row_key: "", provider: null, status: "no_row_key" };
 
-  const primary = opts.primary ?? (await resolvePrimaryProvider(supabase, row.team_id));
-  if (!("integration" in primary)) {
+  const primary: PrimaryResolution = opts.primary ?? (await resolvePrimaryProvider(supabase, row.team_id));
+  if (primary.provider === null) {
     return { row_key: row.row_key, provider: null, status: "no_primary_provider", error: primary.reason };
+  }
+  if (primary.integration === null) {
+    // Provider is known but its integration is missing — create/find the link and record the
+    // error on it so the pm-sync failure surface shows it, then report missing_integration.
+    const link = await ensureLink(supabase, row, primary.provider, "aios-backlog");
+    await persistError(supabase, link, primary.reason);
+    return { row_key: row.row_key, provider: primary.provider, status: "missing_integration", error: primary.reason };
   }
   const { provider, integration } = primary;
   const adapter = ADAPTERS[provider];
@@ -306,8 +322,8 @@ export async function projectAllTasks(
   opts: ProjectAllOptions = {}
 ): Promise<{ provider: PmProvider | null; reports: ProjectionReport[]; reason?: string }> {
   const primary = await resolvePrimaryProvider(supabase, teamId);
-  if (!("integration" in primary)) {
-    return { provider: null, reports: [], reason: primary.reason };
+  if (primary.provider === null || primary.integration === null) {
+    return { provider: primary.provider, reports: [], reason: primary.reason };
   }
 
   const { data: taskRows } = await supabase

--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -1,0 +1,346 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { getEnabledIntegrationsWithSecrets, type IntegrationWithSecret } from "@/lib/integrations/manage";
+import { linearAdapter } from "@/lib/pm-sync/linear";
+import { planeAdapter } from "@/lib/pm-sync/plane";
+import {
+  projectionFingerprint,
+  type PmAdapter,
+  type PmProvider,
+  type ProjectableTask,
+  type TaskPmLink,
+  type TaskStatusValue,
+  type UpsertWorkItemResult,
+} from "@/lib/pm-sync/provider";
+
+const ADAPTERS: Record<PmProvider, PmAdapter> = { plane: planeAdapter, linear: linearAdapter };
+
+// ~1 req/s throttle between provider-writing tasks (reused from the seed scripts). Injectable so
+// tests run instantly.
+const DEFAULT_THROTTLE_MS = 1000;
+const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// The brain-canonical task row the engine projects. Loaded from `tasks`.
+export interface ProjectionTaskRow {
+  id: string;
+  team_id: string;
+  project_id: string;
+  row_key: string;
+  title: string;
+  status: TaskStatusValue;
+  sprint: string;
+  priority: string;
+  labels: string[];
+  body: string;
+  parent_row_key: string | null;
+}
+
+export type ProjectionStatus =
+  | "synced"
+  | "skipped"
+  | "no_row_key"
+  | "no_primary_provider"
+  | "missing_integration"
+  | "missing_parent"
+  | "cycle"
+  | "failed";
+
+export interface ProjectionReport {
+  row_key: string;
+  provider: PmProvider | null;
+  status: ProjectionStatus;
+  providerResourceId?: string | null;
+  error?: string;
+}
+
+export interface ProjectTaskOptions {
+  statusOnly?: boolean;
+  fetchImpl?: typeof fetch;
+  // Resolved once by projectAllTasks and threaded through to avoid re-resolution per row.
+  primary?: ResolvedPrimary;
+  bootstrap?: unknown;
+  // Map of row_key → already-projected provider resource id (parent-first ordering).
+  resolved?: Map<string, string>;
+  // Guards against parent cycles when projecting a single task's parent chain inline.
+  visiting?: Set<string>;
+}
+
+export interface ResolvedPrimary {
+  provider: PmProvider;
+  integration: IntegrationWithSecret;
+}
+
+const PROVIDERS: PmProvider[] = ["plane", "linear"];
+
+function chooseIntegration(integrations: IntegrationWithSecret[], provider: PmProvider): IntegrationWithSecret | null {
+  return integrations.find((i) => i.type === provider && i.secret) ?? null;
+}
+
+// Resolve the team's projection target: its configured primary_pm_provider, or — if unset — the
+// sole enabled PM integration. Ambiguous/none → null (caller no-ops with a clear report).
+export async function resolvePrimaryProvider(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<ResolvedPrimary | { provider: null; reason: string }> {
+  const integrations = await getEnabledIntegrationsWithSecrets(supabase, teamId);
+  const { data: team } = await supabase.from("teams").select("primary_pm_provider").eq("id", teamId).maybeSingle();
+  const configured = (team?.primary_pm_provider as PmProvider | null) ?? null;
+
+  if (configured) {
+    const integration = chooseIntegration(integrations, configured);
+    if (!integration) {
+      return { provider: null, reason: `primary provider "${configured}" has no enabled integration/secret` };
+    }
+    return { provider: configured, integration };
+  }
+
+  const enabled = PROVIDERS.filter((p) => chooseIntegration(integrations, p));
+  if (enabled.length === 1) {
+    return { provider: enabled[0], integration: chooseIntegration(integrations, enabled[0])! };
+  }
+  if (enabled.length === 0) return { provider: null, reason: "no enabled PM integration" };
+  return { provider: null, reason: "multiple PM integrations enabled but teams.primary_pm_provider is unset" };
+}
+
+function toProjectable(row: ProjectionTaskRow, parentResourceId: string | null): ProjectableTask {
+  return {
+    row_key: row.row_key,
+    title: row.title,
+    body: row.body ?? "",
+    status: row.status,
+    priority: row.priority || "none",
+    labels: row.labels ?? [],
+    sprint: row.sprint ?? "",
+    parentResourceId,
+  };
+}
+
+// Get-or-create the task_pm_links row for (team, project, row_key, provider).
+async function ensureLink(
+  supabase: SupabaseClient,
+  row: ProjectionTaskRow,
+  provider: PmProvider,
+  defaultSource: string
+): Promise<TaskPmLink> {
+  const { data: existing } = await supabase
+    .from("task_pm_links")
+    .select("*")
+    .eq("team_id", row.team_id)
+    .eq("project_id", row.project_id)
+    .eq("row_key", row.row_key)
+    .eq("provider", provider)
+    .maybeSingle();
+  if (existing) return existing as TaskPmLink;
+
+  const insert = {
+    team_id: row.team_id,
+    project_id: row.project_id,
+    task_id: row.id,
+    row_key: row.row_key,
+    provider,
+    provider_external_id: row.row_key,
+    provider_external_source: defaultSource,
+    provider_url: "",
+  };
+  const { data, error } = await supabase.from("task_pm_links").insert(insert).select("*").single();
+  if (error) throw new Error(`create task PM link failed: ${error.message}`);
+  return data as TaskPmLink;
+}
+
+async function persistSuccess(
+  supabase: SupabaseClient,
+  link: TaskPmLink,
+  result: UpsertWorkItemResult,
+  fingerprint: string
+) {
+  const now = new Date().toISOString();
+  await supabase
+    .from("task_pm_links")
+    .update({
+      provider_resource_id: result.providerResourceId,
+      provider_url: result.providerUrl || link.provider_url || "",
+      provider_external_source: result.externalSource || link.provider_external_source,
+      last_synced_status: result.syncedStatus ?? null,
+      last_synced_at: now,
+      last_projected_status: result.syncedStatus ?? null,
+      projection_fingerprint: fingerprint,
+      last_error: null,
+      updated_at: now,
+    })
+    .eq("id", link.id);
+}
+
+async function persistError(supabase: SupabaseClient, link: TaskPmLink, message: string) {
+  await supabase
+    .from("task_pm_links")
+    .update({ last_error: message.slice(0, 1000), updated_at: new Date().toISOString() })
+    .eq("id", link.id);
+}
+
+async function loadTaskByRowKey(
+  supabase: SupabaseClient,
+  teamId: string,
+  projectId: string,
+  rowKey: string
+): Promise<ProjectionTaskRow | null> {
+  const { data } = await supabase
+    .from("tasks")
+    .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key")
+    .eq("team_id", teamId)
+    .eq("project_id", projectId)
+    .eq("row_key", rowKey)
+    .maybeSingle();
+  return (data as ProjectionTaskRow | null) ?? null;
+}
+
+// Project one task into the team's primary PM tool. Resolves the parent first (so the provider
+// sub-issue link exists), upserts the work item, and persists the link bookkeeping. Brain-wins.
+export async function projectTask(
+  supabase: SupabaseClient,
+  row: ProjectionTaskRow,
+  opts: ProjectTaskOptions = {}
+): Promise<ProjectionReport> {
+  if (!row.row_key) return { row_key: "", provider: null, status: "no_row_key" };
+
+  const primary = opts.primary ?? (await resolvePrimaryProvider(supabase, row.team_id));
+  if (!("integration" in primary)) {
+    return { row_key: row.row_key, provider: null, status: "no_primary_provider", error: primary.reason };
+  }
+  const { provider, integration } = primary;
+  const adapter = ADAPTERS[provider];
+  const defaultSource = (integration.config?.externalSource as string | undefined) || "aios-backlog";
+
+  // Resolve the parent's provider resource id (parent-first). In a batch this comes from the
+  // resolved map; for a standalone projection we project the parent inline (cycle-guarded).
+  let parentResourceId: string | null = null;
+  if (!opts.statusOnly && row.parent_row_key) {
+    const resolved = opts.resolved;
+    if (resolved?.has(row.parent_row_key)) {
+      parentResourceId = resolved.get(row.parent_row_key) ?? null;
+    } else {
+      const visiting = opts.visiting ?? new Set<string>();
+      if (visiting.has(row.row_key)) {
+        return { row_key: row.row_key, provider, status: "cycle", error: `parent cycle at ${row.row_key}` };
+      }
+      visiting.add(row.row_key);
+      const parentRow = await loadTaskByRowKey(supabase, row.team_id, row.project_id, row.parent_row_key);
+      if (!parentRow) {
+        return { row_key: row.row_key, provider, status: "missing_parent", error: `parent ${row.parent_row_key} not found` };
+      }
+      const parentReport = await projectTask(supabase, parentRow, { ...opts, visiting });
+      if (parentReport.status === "failed" || parentReport.status === "cycle" || parentReport.status === "missing_parent") {
+        return { row_key: row.row_key, provider, status: parentReport.status, error: `parent ${row.parent_row_key}: ${parentReport.error ?? parentReport.status}` };
+      }
+      parentResourceId = parentReport.providerResourceId ?? null;
+    }
+  }
+
+  const link = await ensureLink(supabase, row, provider, defaultSource);
+  const task = toProjectable(row, parentResourceId);
+  const fingerprint = projectionFingerprint(task, parentResourceId);
+
+  // Fingerprint short-circuit: a known provider resource id + unchanged fingerprint ⇒ zero
+  // provider round-trips (guarantees a second projectAllTasks run does no writes).
+  if (!opts.statusOnly && link.provider_resource_id && link.projection_fingerprint === fingerprint) {
+    opts.resolved?.set(row.row_key, link.provider_resource_id);
+    return { row_key: row.row_key, provider, status: "skipped", providerResourceId: link.provider_resource_id };
+  }
+
+  try {
+    const result = await adapter.upsertWorkItem({
+      task,
+      link,
+      integration,
+      desiredFingerprint: fingerprint,
+      statusOnly: opts.statusOnly,
+      bootstrap: opts.bootstrap,
+      fetchImpl: opts.fetchImpl,
+    });
+    await persistSuccess(supabase, link, result, fingerprint);
+    opts.resolved?.set(row.row_key, result.providerResourceId);
+    return { row_key: row.row_key, provider, status: result.status, providerResourceId: result.providerResourceId };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "projection failed";
+    await persistError(supabase, link, message);
+    return { row_key: row.row_key, provider, status: "failed", error: message };
+  }
+}
+
+// Order rows parent-before-child (epics first). Rows whose parent is missing/cyclic are still
+// emitted (projectTask reports the failure) so the batch never silently drops them.
+function topoOrder(rows: ProjectionTaskRow[]): ProjectionTaskRow[] {
+  const byKey = new Map(rows.map((r) => [r.row_key, r]));
+  const ordered: ProjectionTaskRow[] = [];
+  const placed = new Set<string>();
+  const visiting = new Set<string>();
+  const place = (row: ProjectionTaskRow) => {
+    if (placed.has(row.row_key) || visiting.has(row.row_key)) return;
+    visiting.add(row.row_key);
+    const parentKey = (row.parent_row_key ?? "").trim();
+    if (parentKey && byKey.has(parentKey)) place(byKey.get(parentKey)!);
+    visiting.delete(row.row_key);
+    if (!placed.has(row.row_key)) {
+      placed.add(row.row_key);
+      ordered.push(row);
+    }
+  };
+  for (const row of rows) place(row);
+  return ordered;
+}
+
+export interface ProjectAllOptions {
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  throttleMs?: number;
+}
+
+// Server-side replacement for `npm run plane:backlog` / `linear:backlog`: project the whole board
+// for a (team, project). ~80 rows × 1 provider ≈ ~90s with the throttle. Continues on per-row
+// failure and returns a per-row report.
+export async function projectAllTasks(
+  supabase: SupabaseClient,
+  teamId: string,
+  projectId: string,
+  opts: ProjectAllOptions = {}
+): Promise<{ provider: PmProvider | null; reports: ProjectionReport[]; reason?: string }> {
+  const primary = await resolvePrimaryProvider(supabase, teamId);
+  if (!("integration" in primary)) {
+    return { provider: null, reports: [], reason: primary.reason };
+  }
+
+  const { data: taskRows } = await supabase
+    .from("tasks")
+    .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key")
+    .eq("team_id", teamId)
+    .eq("project_id", projectId)
+    .not("row_key", "is", null);
+  const rows = ((taskRows ?? []) as ProjectionTaskRow[]).filter((r) => r.row_key);
+  if (!rows.length) return { provider: primary.provider, reports: [] };
+
+  // Prefetch once: ensure all labels exist + cache states/items/issues for the run.
+  const allLabels = Array.from(new Set(rows.flatMap((r) => r.labels ?? []).filter(Boolean)));
+  const adapter = ADAPTERS[primary.provider];
+  const bootstrap = adapter.prepare
+    ? await adapter.prepare({ integration: primary.integration, labels: allLabels, fetchImpl: opts.fetchImpl })
+    : undefined;
+
+  const sleep = opts.sleep ?? realSleep;
+  const throttleMs = opts.throttleMs ?? DEFAULT_THROTTLE_MS;
+  const resolved = new Map<string, string>();
+  const reports: ProjectionReport[] = [];
+
+  for (const row of topoOrder(rows)) {
+    const report = await projectTask(supabase, row, {
+      primary,
+      bootstrap,
+      resolved,
+      fetchImpl: opts.fetchImpl,
+    });
+    reports.push(report);
+    // Only pay the throttle when we actually wrote to the provider.
+    if (report.status === "synced") await sleep(throttleMs);
+  }
+  return { provider: primary.provider, reports };
+}

--- a/lib/pm-sync/provider.ts
+++ b/lib/pm-sync/provider.ts
@@ -1,8 +1,15 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
+
 import type { IntegrationWithSecret } from "@/lib/integrations/manage";
 
 export type PmProvider = "plane" | "linear";
+
+// Canonical task status values (postgres `task_status` enum). The projection engine maps these
+// onto provider workflow-state "groups" (Plane state `group` / Linear state `type`).
+export type TaskStatusValue = "backlog" | "ready" | "in_progress" | "blocked" | "done";
+export type StateGroup = "backlog" | "unstarted" | "started" | "completed" | "cancelled";
 
 export interface TaskPmLink {
   id: string;
@@ -15,6 +22,11 @@ export interface TaskPmLink {
   provider_external_source: string;
   provider_external_id: string;
   provider_url: string;
+  // Projection bookkeeping (brain-api v1.2). Present on rows loaded for projection; the legacy
+  // moveToDone path may omit them.
+  projection_fingerprint?: string | null;
+  last_projected_status?: string | null;
+  provider_seen_status?: string | null;
 }
 
 export interface ProviderSyncResult {
@@ -31,9 +43,145 @@ export interface ProviderSyncInput {
   fetchImpl?: typeof fetch;
 }
 
+// ── Projection (brain → PM, brain-wins, one-way) ───────────────────────────────
+
+// The brain-canonical shape of a task the engine projects into the primary PM tool. `body` is
+// plain text (Postgres-canonical); each adapter wraps/sends it natively. `parentResourceId` is the
+// already-projected provider id of the epic (resolved by the orchestrator, parent-first).
+export interface ProjectableTask {
+  row_key: string;
+  title: string;
+  body: string;
+  status: TaskStatusValue;
+  priority: string; // normalized: none | low | medium | high | urgent
+  labels: string[];
+  sprint: string; // Wave name → Plane module membership ("" = none)
+  parentResourceId?: string | null;
+}
+
+export interface UpsertWorkItemInput {
+  task: ProjectableTask;
+  link: TaskPmLink | null;
+  integration: IntegrationWithSecret;
+  // The orchestrator-computed desired fingerprint; the adapter echoes it back for persistence.
+  desiredFingerprint: string;
+  // statusOnly: only reconcile workflow state (used by moveToDone / done transitions). Never
+  // touches title/body/labels/priority/parent so a partial caller can't blank fields.
+  statusOnly?: boolean;
+  // Optional per-run prefetch (states/labels/items) shared across a projectAllTasks batch.
+  bootstrap?: unknown;
+  fetchImpl?: typeof fetch;
+}
+
+export interface UpsertWorkItemResult extends ProviderSyncResult {
+  providerResourceId: string;
+  providerUrl: string;
+  parentResourceId?: string | null;
+  // The external_source actually used (persisted onto task_pm_links.provider_external_source).
+  externalSource: string;
+  fingerprint: string;
+}
+
+export interface PrepareInput {
+  integration: IntegrationWithSecret;
+  // Label names to ensure exist before the batch runs (created once, then reused).
+  labels?: string[];
+  fetchImpl?: typeof fetch;
+}
+
 export interface PmAdapter {
   provider: PmProvider;
+  // Optional per-run prefetch: returns an opaque provider bootstrap (states/labels/items/modules)
+  // the orchestrator passes back into each upsertWorkItem to avoid re-listing per task.
+  prepare?(input: PrepareInput): Promise<unknown>;
+  upsertWorkItem(input: UpsertWorkItemInput): Promise<UpsertWorkItemResult>;
   moveToDone(input: ProviderSyncInput): Promise<ProviderSyncResult>;
+}
+
+// status → desired provider state. Both providers share five workflow groups; `blocked` has no
+// native group, so it maps to `started` unless a state literally named "Blocked" exists (UX caveat).
+export interface DesiredState {
+  group: StateGroup;
+  preferredName: string;
+}
+
+export function desiredStateForStatus(status: string): DesiredState {
+  switch (status) {
+    case "ready":
+      return { group: "unstarted", preferredName: "Todo" };
+    case "in_progress":
+      return { group: "started", preferredName: "In Progress" };
+    case "blocked":
+      return { group: "started", preferredName: "Blocked" };
+    case "done":
+      return { group: "completed", preferredName: "Done" };
+    case "backlog":
+    default:
+      return { group: "backlog", preferredName: "Backlog" };
+  }
+}
+
+// Plane stores priority as the same word set we use; Linear uses Int (0 none·1 urgent·2 high·3 med·4 low).
+export function priorityToLinearInt(priority: string): number {
+  switch (priority) {
+    case "urgent":
+      return 1;
+    case "high":
+      return 2;
+    case "medium":
+      return 3;
+    case "low":
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+// Deterministic hash of everything the engine would write. Equal fingerprint + a known provider
+// resource id ⇒ the orchestrator can skip the provider round-trip entirely (zero mutations).
+export function projectionFingerprint(
+  task: ProjectableTask,
+  parentResourceId: string | null | undefined
+): string {
+  const payload = JSON.stringify({
+    title: task.title ?? "",
+    body: task.body ?? "",
+    labels: [...(task.labels ?? [])].map((l) => l.trim()).filter(Boolean).sort(),
+    priority: task.priority || "none",
+    parent: parentResourceId ?? "",
+    sprint: task.sprint ?? "",
+    group: desiredStateForStatus(task.status).group,
+  });
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+// Strip the single-paragraph HTML wrapper providers/seed use, back to the plain text we store in
+// tasks.body — so an adopted item whose description already matches produces no description write.
+export function htmlToPlainText(html: string | null | undefined): string {
+  return String(html ?? "")
+    .replace(/<\/p>\s*<p>/gi, "\n\n")
+    .replace(/<\/?p>/gi, "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .trim();
+}
+
+// Wrap plain-text body as Plane description_html. Empty body → "" (never a stray "<p></p>").
+export function plainTextToHtml(text: string | null | undefined): string {
+  const trimmed = String(text ?? "").trim();
+  if (!trimmed) return "";
+  return trimmed
+    .split(/\n{2,}/)
+    .map((p) => `<p>${p.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\n/g, "<br>")}</p>`)
+    .join("");
+}
+
+export function sameLabelSet(a: string[], b: string[]): boolean {
+  const sa = [...new Set(a)].sort();
+  const sb = [...new Set(b)].sort();
+  return sa.length === sb.length && sa.every((v, i) => v === sb[i]);
 }
 
 export class PmSyncError extends Error {

--- a/lib/work-events/ingest.ts
+++ b/lib/work-events/ingest.ts
@@ -4,7 +4,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { audit } from "@/lib/api/audit";
 import type { WorkEventPayload } from "@/lib/api/schemas";
 import { extractWorkKeys } from "@/lib/pm-sync/work-keys";
-import { syncTaskPmLinks, type TaskPmSyncReport } from "@/lib/pm-sync";
+import { projectTask, projectionToSyncReport, type ProjectionTaskRow, type TaskPmSyncReport } from "@/lib/pm-sync";
 
 export interface WorkEventAuth {
   teamId: string;
@@ -125,7 +125,17 @@ export async function ingestWorkEvent(
     });
 
     if (opts.syncPm !== false) {
-      pm_sync.push(...(await syncTaskPmLinks(supabase, found, { fetchImpl: opts.fetchImpl })));
+      // Full projection (not done-only): load the now-done task row and project it through the
+      // upsert path so a task with no pre-existing link/item still gets created + linked.
+      const { data: fullRow } = await supabase
+        .from("tasks")
+        .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key")
+        .eq("id", found.id)
+        .maybeSingle();
+      if (fullRow) {
+        const report = await projectTask(supabase, fullRow as ProjectionTaskRow, { fetchImpl: opts.fetchImpl });
+        pm_sync.push(projectionToSyncReport(report));
+      }
     }
   }
 

--- a/test/datamechanics/work-events.datamechanics.test.ts
+++ b/test/datamechanics/work-events.datamechanics.test.ts
@@ -84,6 +84,9 @@ describe("work events (real Postgres)", () => {
 
   it("records provider sync errors on the PM link without losing task completion", async () => {
     const seed = await seedTeam();
+    // v1.2: projection targets the team's primary PM tool. Declare it so the work-events done path
+    // knows the intended provider even though no integration is enabled (→ missing_integration).
+    await db().from("teams").update({ primary_pm_provider: "plane" }).eq("id", seed.teamId);
     await ingest(seed, {
       kind: "task",
       path: "3-log/tasks.md",

--- a/test/pm-sync-adapters.test.ts
+++ b/test/pm-sync-adapters.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { linearAdapter } from "@/lib/pm-sync/linear";
 import { planeAdapter } from "@/lib/pm-sync/plane";
+import { projectionFingerprint, plainTextToHtml, type ProjectableTask, type TaskPmLink } from "@/lib/pm-sync/provider";
 import type { IntegrationWithSecret } from "@/lib/integrations/manage";
-import type { TaskPmLink } from "@/lib/pm-sync/provider";
 
 const link: TaskPmLink = {
   id: "link-1",
@@ -17,50 +17,225 @@ const link: TaskPmLink = {
   provider_url: "",
 };
 
-describe("Plane PM adapter", () => {
-  it("resolves a completed state and patches the linked work item", async () => {
-    const bodies: string[] = [];
-    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url.endsWith("/states/")) {
-        return Response.json([{ id: "done-state", name: "DONE", group: "completed" }]);
-      }
-      if (url.includes("/work-items/?")) {
-        return Response.json({ results: [{ id: "wi-1", external_id: "P0", external_source: "aios-backlog", state: "todo-state" }] });
-      }
-      if (url.endsWith("/work-items/wi-1/")) {
-        bodies.push(String(init?.body));
-        return Response.json({ id: "wi-1" });
-      }
-      return Response.json({}, { status: 404 });
-    }) as unknown as typeof fetch;
+const planeIntegration = {
+  id: "int-1",
+  type: "plane",
+  name: "plane",
+  secret: "plane-key",
+  config: { workspaceSlug: "aios", projectId: "plane-project" },
+} as IntegrationWithSecret;
 
-    const result = await planeAdapter.moveToDone({
+const PLANE_STATES = [
+  { id: "st-backlog", name: "Backlog", group: "backlog" },
+  { id: "st-todo", name: "Todo", group: "unstarted" },
+  { id: "st-started", name: "In Progress", group: "started" },
+  { id: "st-done", name: "Done", group: "completed" },
+];
+
+// A routing Plane fetch mock. `items` seeds GET /work-items/. Records mutation calls.
+function planeMock(opts: { items?: unknown[]; labels?: { id: string; name: string }[]; modules?: { id: string; name: string }[]; moduleIssues?: Record<string, unknown[]> } = {}) {
+  const mutations: { method: string; path: string; body: { [k: string]: unknown } | undefined }[] = [];
+  let newId = 0;
+  const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const path = url.replace(/^https?:\/\/[^/]+/, "").split("?")[0];
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    if (method === "GET") {
+      if (path.endsWith("/states/")) return Response.json(PLANE_STATES);
+      if (path.endsWith("/work-items/")) return Response.json({ results: opts.items ?? [] });
+      if (path.endsWith("/labels/")) return Response.json(opts.labels ?? []);
+      if (path.endsWith("/modules/")) return Response.json(opts.modules ?? []);
+      if (path.includes("/module-issues/")) {
+        const mid = path.split("/modules/")[1].split("/")[0];
+        return Response.json((opts.moduleIssues ?? {})[mid] ?? []);
+      }
+    }
+    mutations.push({ method, path, body });
+    if (method === "POST" && path.endsWith("/work-items/")) return Response.json({ id: `new-${++newId}`, ...body });
+    if (method === "POST" && path.endsWith("/labels/")) return Response.json({ id: `label-${++newId}`, name: body?.name });
+    if (method === "POST" && path.endsWith("/modules/")) return Response.json({ id: `module-${++newId}`, name: body?.name });
+    return Response.json({ id: `ok-${++newId}`, ...(body ?? {}) });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations };
+}
+
+function projectable(over: Partial<ProjectableTask> = {}): ProjectableTask {
+  return { row_key: "P0", title: "Epic title", body: "Do the thing", status: "ready", priority: "none", labels: [], sprint: "", parentResourceId: null, ...over };
+}
+
+describe("Plane projection — upsertWorkItem", () => {
+  it("adopts a seeded aios-backlog item that already matches and writes nothing", async () => {
+    const task = projectable();
+    const { fetchImpl, mutations } = planeMock({
+      items: [
+        {
+          id: "wi-existing",
+          name: "Epic title",
+          description_html: plainTextToHtml("Do the thing"),
+          state: "st-todo",
+          priority: "none",
+          labels: [],
+          parent: null,
+          external_id: "P0",
+          external_source: "aios-backlog",
+        },
+      ],
+    });
+
+    const result = await planeAdapter.upsertWorkItem({
+      task,
       link,
-      integration: {
-        id: "int-1",
-        type: "plane",
-        name: "plane",
-        secret: "plane-key",
-        config: { workspaceSlug: "aios", projectId: "plane-project", doneStateName: "DONE" },
-      } as IntegrationWithSecret,
+      integration: planeIntegration,
+      desiredFingerprint: projectionFingerprint(task, null),
       fetchImpl,
     });
 
+    expect(result.status).toBe("skipped");
+    expect(result.providerResourceId).toBe("wi-existing");
+    expect(mutations).toHaveLength(0); // zero provider writes
+  });
+
+  it("creates a new item with external_id + external_source and ensures labels", async () => {
+    const task = projectable({ row_key: "P1", title: "Chunk", labels: ["wave-1"] });
+    const { fetchImpl, mutations } = planeMock({ items: [] });
+
+    const result = await planeAdapter.upsertWorkItem({
+      task,
+      link: { ...link, row_key: "P1", provider_external_id: "P1" },
+      integration: planeIntegration,
+      desiredFingerprint: projectionFingerprint(task, null),
+      fetchImpl,
+    });
+
+    expect(result.status).toBe("synced");
+    expect(result.externalSource).toBe("aios-backlog");
+    const created = mutations.find((m) => m.method === "POST" && m.path.endsWith("/work-items/"));
+    expect(created?.body).toMatchObject({ external_id: "P1", external_source: "aios-backlog", state: "st-todo" });
+    expect(mutations.some((m) => m.path.endsWith("/labels/") && m.method === "POST")).toBe(true);
+  });
+
+  it("adds the item to its Wave module", async () => {
+    const task = projectable({ row_key: "P2", sprint: "Wave 1 — MVP" });
+    const { fetchImpl, mutations } = planeMock({ items: [] });
+
+    await planeAdapter.upsertWorkItem({
+      task,
+      link: { ...link, row_key: "P2", provider_external_id: "P2" },
+      integration: planeIntegration,
+      desiredFingerprint: projectionFingerprint(task, null),
+      fetchImpl,
+    });
+
+    expect(mutations.some((m) => m.method === "POST" && m.path.endsWith("/modules/"))).toBe(true);
+    expect(mutations.some((m) => m.path.includes("/module-issues/") && m.method === "POST")).toBe(true);
+  });
+
+  it("moveToDone (back-compat) patches only the state", async () => {
+    const { fetchImpl, mutations } = planeMock({
+      items: [{ id: "wi-1", external_id: "P0", external_source: "aios-backlog", state: "st-todo" }],
+    });
+    const result = await planeAdapter.moveToDone({ link, integration: planeIntegration, fetchImpl });
     expect(result).toMatchObject({ provider: "plane", status: "synced", providerResourceId: "wi-1" });
-    expect(JSON.parse(bodies[0])).toEqual({ state: "done-state" });
+    const patch = mutations.find((m) => m.method === "PATCH");
+    expect(patch?.body).toEqual({ state: "st-done" });
+    expect(mutations.filter((m) => m.method !== "GET")).toHaveLength(1); // state only
   });
 });
 
-describe("Linear PM adapter", () => {
-  it("updates an issue to the team's completed workflow state", async () => {
+// ── Linear ─────────────────────────────────────────────────────────────────────
+
+const linearIntegration = {
+  id: "int-2",
+  type: "linear",
+  name: "linear",
+  secret: "lin_api_x",
+  config: { teamId: "team-uuid" },
+} as IntegrationWithSecret;
+
+function linearMock(opts: { issues?: unknown[]; states?: unknown[]; labels?: unknown[] } = {}) {
+  const mutations: { name: string; variables: { [k: string]: unknown } }[] = [];
+  const states = opts.states ?? [
+    { id: "ls-todo", name: "Todo", type: "unstarted" },
+    { id: "ls-started", name: "In Progress", type: "started" },
+    { id: "ls-done", name: "Done", type: "completed" },
+  ];
+  const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+    const { query, variables } = JSON.parse(String(init?.body));
+    if (query.includes("ProjectionBootstrap")) {
+      return Response.json({ data: { team: { states: { nodes: states }, labels: { nodes: opts.labels ?? [] } } } });
+    }
+    if (query.includes("ProjectionIssues")) {
+      return Response.json({ data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: opts.issues ?? [] } } } });
+    }
+    const name = query.match(/mutation (\w+)/)?.[1] ?? query.match(/query (\w+)/)?.[1] ?? "op";
+    if (query.includes("mutation")) mutations.push({ name, variables });
+    if (query.includes("issueCreate")) return Response.json({ data: { issueCreate: { success: true, issue: { id: "new-issue", identifier: "AIO-9", url: "https://linear.app/AIO-9" } } } });
+    if (query.includes("issueUpdate")) return Response.json({ data: { issueUpdate: { success: true, issue: { id: variables.id, identifier: "AIO-1", url: "https://linear.app/AIO-1" } } } });
+    if (query.includes("issueLabelCreate")) return Response.json({ data: { issueLabelCreate: { issueLabel: { id: "new-label" } } } });
+    return Response.json({ data: {} });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations };
+}
+
+describe("Linear projection — upsertWorkItem", () => {
+  it("adopts an issue by its aios-ext footer marker and updates on divergence", async () => {
+    const task = projectable({ row_key: "P0", title: "New title" });
+    const { fetchImpl, mutations } = linearMock({
+      issues: [
+        {
+          id: "issue-existing",
+          identifier: "AIO-1",
+          url: "https://linear.app/AIO-1",
+          title: "Old title",
+          description: "Do the thing\n\naios-ext: P0 · source: aios-backlog",
+          priority: 0,
+          parent: null,
+          state: { id: "ls-todo", name: "Todo", type: "unstarted" },
+          labels: { nodes: [] },
+          team: { id: "team-uuid" },
+        },
+      ],
+    });
+
+    const result = await linearAdapter.upsertWorkItem({
+      task,
+      link: { ...link, provider: "linear" },
+      integration: linearIntegration,
+      desiredFingerprint: projectionFingerprint(task, null),
+      fetchImpl,
+    });
+
+    expect(result.status).toBe("synced");
+    expect(result.providerResourceId).toBe("issue-existing");
+    const update = mutations.find((m) => m.name === "UpdateIssue");
+    expect(update).toBeTruthy();
+    expect((update?.variables as { input: { title: string } }).input.title).toBe("New title");
+  });
+
+  it("creates a new issue with the footer marker when none is adopted", async () => {
+    const task = projectable({ row_key: "P3", title: "Fresh" });
+    const { fetchImpl, mutations } = linearMock({ issues: [] });
+
+    const result = await linearAdapter.upsertWorkItem({
+      task,
+      link: { ...link, provider: "linear", row_key: "P3", provider_external_id: "P3" },
+      integration: linearIntegration,
+      desiredFingerprint: projectionFingerprint(task, null),
+      fetchImpl,
+    });
+
+    expect(result.status).toBe("synced");
+    const create = mutations.find((m) => m.name === "CreateIssue");
+    expect((create?.variables as { input: { description: string } }).input.description).toContain("aios-ext: P3 · source: aios-backlog");
+  });
+
+  it("moveToDone (back-compat) moves an issue to the completed state", async () => {
     const queries: string[] = [];
     const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body));
       queries.push(body.query);
       if (body.query.includes("IssueForPmSync")) {
-        return Response.json({
-          data: { issue: { id: "issue-uuid", identifier: "ENG-123", url: "https://linear.app/ENG-123", team: { id: "team-uuid" }, state: { id: "todo", name: "Todo", type: "unstarted" } } },
-        });
+        return Response.json({ data: { issue: { id: "issue-uuid", identifier: "ENG-123", url: "https://linear.app/ENG-123", team: { id: "team-uuid" }, state: { id: "todo", name: "Todo", type: "unstarted" } } } });
       }
       if (body.query.includes("TeamDoneStates")) {
         return Response.json({ data: { team: { states: { nodes: [{ id: "done", name: "Done", type: "completed" }] } } } });
@@ -70,17 +245,21 @@ describe("Linear PM adapter", () => {
 
     const result = await linearAdapter.moveToDone({
       link: { ...link, provider: "linear", provider_external_source: "linear", provider_external_id: "ENG-123" },
-      integration: {
-        id: "int-1",
-        type: "linear",
-        name: "linear",
-        secret: "lin_api_x",
-        config: {},
-      } as IntegrationWithSecret,
+      integration: { id: "int-1", type: "linear", name: "linear", secret: "lin_api_x", config: {} } as IntegrationWithSecret,
       fetchImpl,
     });
 
     expect(result).toMatchObject({ provider: "linear", status: "synced", providerResourceId: "issue-uuid" });
     expect(queries.some((q) => q.includes("issueUpdate"))).toBe(true);
+  });
+});
+
+describe("projectionFingerprint", () => {
+  it("is stable across label order and changes when a field changes", () => {
+    const a = projectionFingerprint(projectable({ labels: ["x", "y"] }), null);
+    const b = projectionFingerprint(projectable({ labels: ["y", "x"] }), null);
+    expect(a).toBe(b);
+    expect(projectionFingerprint(projectable({ title: "different" }), null)).not.toBe(a);
+    expect(projectionFingerprint(projectable(), "parent-id")).not.toBe(a);
   });
 });


### PR DESCRIPTION
## What

Phase 1 of the brain→PM projection (brain-api v1.2). Makes the brain `tasks` table the source of truth that **projects** a structured board into the team's single `teams.primary_pm_provider` — one-way, brain wins — replacing the JS seed scripts (`plane:backlog` / `linear:backlog`).

Plan: `~/.claude/plans/earlier-i-had-an-joyful-fox.md` · tracking PROJ-149 / AIO-74. Builds on Phase 0 (#44, merged).

## Changes

- **`lib/pm-sync/provider.ts`** — `ProjectableTask`, `upsertWorkItem` on `PmAdapter`, `projectionFingerprint` (order-stable hash of title/body/labels/priority/parent/state), `desiredStateForStatus` (`backlog→backlog`, `ready→unstarted`, `in_progress`/`blocked→started`, `done→completed`), html/priority helpers.
- **`lib/pm-sync/plane.ts` / `linear.ts`** — `prepare()` per-run prefetch + `ensureLabels`; `upsertWorkItem()`: **adopt-or-create** (Plane by `external_id` across `["aios-backlog","aios"]`; Linear by the `aios-ext: <row_key> · source: …` footer marker), **brain-wins** update of title/body/state/priority/labels/parent, **Plane Wave-module** membership, and field + fingerprint **skip**. `moveToDone` kept as a thin state-only delegate.
- **`lib/pm-sync/project.ts`** (new) — `projectTask` (parent-first, auto-creates the link, fingerprint short-circuit → zero provider writes) + `projectAllTasks` (topological order, ~1 req/s throttle, continue-on-failure, per-row report). Server-side replacement for the seed scripts.
- **`lib/pm-sync/index.ts`** — `syncTaskPmLinks` → thin wrapper over `projectTask`.
- **`lib/work-events/ingest.ts`** — done path does a **full** projection (creates link/item if missing), not done-only.
- **admin pm-sync page** — "Project board now" button + `projectBoardAction` (admin-gated, audited).
- **`docs/ARCHITECTURE.md`** — PM-sync prose rewritten to the full-projection model.

## Tests / checks

- 8 adapter + fingerprint unit tests (adopt / create / **skip = zero writes** / Wave-module / Linear footer / back-compat `moveToDone`).
- ✅ 153 unit tests · ✅ `eslint` · ✅ `tsc --noEmit` · ✅ `check:docs`.

## Deferred (not in this PR)

- **Phase 2** — reactive `after()` triggers + real-Postgres data-mechanics tests (second-run-zero-writes, parent integrity).
- **Phase 3** — live backlog migration + retiring the seed scripts. Decision recorded: **primary provider = Linear**.

## ⚠️ Prod prerequisites surfaced while prepping Phase 3

- Prod Railway Postgres is **missing the v1.2 columns** (`teams.primary_pm_provider`, `tasks.body`, etc.) — `npm run pg:schema` was never run against prod after #44 merged.
- No **Linear integration** is enabled in prod (only Plane); brain `tasks` has 1 row (backlog not yet materialized).

These don't affect this PR but gate the Phase 3 go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Admin-triggered and merge-path writes mutate external PM boards at scale (secrets, rate limits, partial failures); behavior change on work-events is broader than state-only sync, though idempotency and error recording on links limit blast radius.
> 
> **Overview**
> Introduces **brain-api v1.2 Phase 1**: `tasks` becomes the one-way source of truth that **projects** into the team’s `teams.primary_pm_provider` (Plane or Linear), replacing the old per-link “move to done” loop and legacy seed scripts.
> 
> **`lib/pm-sync/project.ts`** adds `projectTask` / `projectAllTasks` — parent-first ordering, auto `task_pm_links`, **`projection_fingerprint` skip** (repeat runs can do zero provider writes), ~1 req/s throttle, and per-row reports. **`provider.ts`** defines `ProjectableTask`, `upsertWorkItem`, status→workflow-group mapping, and fingerprinting. **Plane/Linear adapters** grow `prepare()` prefetch plus adopt-or-create **`upsertWorkItem`** (brain-wins fields; Plane wave modules; Linear `aios-ext` footer).
> 
> **Work-events** now runs **full** `projectTask` after marking done (can create link/item if missing). **`syncTaskPmLinks`** is a thin wrapper that still uses **status-only** projection for back-compat. **Admin PM sync** gets **“Project board now”** (`projectBoardAction`, admin + audit). **ARCHITECTURE.md** documents the projection model vs retiring seed scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d6d1a50ba5903aa650824aadb95c78ece50f23. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Project board” section to the PM sync admin page with an on-demand button to sync all tasks to the team’s primary PM provider.
  * Sync now uses the new projection-based engine (Plane + Linear) and returns a summary including the selected provider and per-row counts.
* **Bug Fixes**
  * Improved PM-sync on work events to project the full task details while still preserving task completion and recording provider errors on the PM link.
* **Documentation**
  * Updated architecture documentation to describe the new full projection workflow and how the project board run operates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->