### PR TITLE
ci(coverage): enforce lib/** coverage floor in brain-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm test
+      # Coverage gate: thresholds in vitest.config.ts (lib/** scope). Fails the job
+      # if coverage drops below the floor. Ratchet thresholds up as tests improve.
+      - run: npm run coverage
 
   datamechanics-tests:
     name: Data-mechanics tests (real Postgres)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,15 @@ export default defineConfig({
       reporter: ["text-summary", "json-summary"],
       reportsDirectory: "coverage",
       include: ["lib/**"],
+      // Merge gate: floor ≈ (baseline − 2pts) off the lib/** baseline
+      // (lines 28.18 / functions 31.92 / branches 25.12). vitest exits non-zero
+      // below these, so `npm run coverage` in CI blocks regressions. Ratchet up as
+      // lib/** test coverage improves — never lower to make a red build pass.
+      thresholds: {
+        lines: 26,
+        functions: 29,
+        branches: 23,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## What

Adds a coverage gate to the `brain-tests` CI job. `npm run coverage` now runs after `npm test`, and `vitest.config.ts` carries thresholds, so a coverage regression fails the build.

## Baseline & thresholds

Current `lib/**` coverage (the unit-tested core, the existing coverage scope):

| Metric | Baseline | Threshold (floor) |
|---|---|---|
| Lines | 28.18% (509/1806) | **26** |
| Functions | 31.92% (121/379) | **29** |
| Branches | 25.12% (403/1604) | **23** |

Floor ≈ baseline − 2pts. Scope unchanged (`lib/**`); ratchet upward as tests improve — never lower to make a red build pass.

## Verification

- `npm run coverage` → exit 0 at 26/29/23 ✅
- Non-vacuous check: bumping `lines` to 29 (above the 28.18 baseline) makes `npm run coverage` exit non-zero with `ERROR: Coverage for lines (28.18%) does not meet global threshold (29%)` ✅
- `npm run check:docs` → green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-config only; no runtime, auth, or production behavior changes.
> 
> **Overview**
> The **brain-tests** job runs **`npm run coverage`** after **`npm test`**, so coverage is checked on every PR/push to `main`.
> 
> **`vitest.config.ts`** adds global coverage **thresholds** for the existing **`lib/**`** scope: **26%** lines, **29%** functions, **23%** branches (roughly baseline minus 2 points). Vitest fails when coverage drops below those floors; comments document ratcheting thresholds up over time, not lowering them to unblock CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636fc5672dcb5c34d38c2a6c86fe46115d252131. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added code coverage validation to the CI pipeline with enforced minimum thresholds for lines, functions, and branches, ensuring consistent code quality standards are maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->