### PR TITLE
feat(test): add HTTP integration test tier (real socket + Next runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,38 @@ jobs:
       - run: DATABASE_URL="$DATABASE_TEST_URL" npm run pg:schema
       - run: npm run test:datamechanics
 
+  http-tests:
+    name: Integration tests (HTTP)
+    runs-on: ubuntu-latest
+    # Advisory until 5 consecutive green runs on main, then drop this line and add
+    # http-tests to branch protection (see docs/CI-ARCHITECTURE.md).
+    continue-on-error: true
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app
+          POSTGRES_DB: app_test
+        ports: ["5434:5432"]
+        options: >-
+          --health-cmd "pg_isready -U app -d app_test"
+          --health-interval 2s --health-timeout 3s --health-retries 30
+    env:
+      # Both the test process (seeding via lib/ingest) and the spawned next server read this.
+      DATABASE_TEST_URL: postgres://app:app@localhost:5434/app_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: DATABASE_URL="$DATABASE_TEST_URL" npm run pg:schema
+      # Production build first; global-setup spawns `next start` against .next.
+      - run: npm run build
+      - run: npm run test:http
+
   ingestion-tests:
     name: Ingestion tests (pytest)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Put a spec-derived test in the tier that catches *its* failure mode:
 |---|---|---|
 | **unit** (`vitest.config.ts`) | nothing (pure) | parse/format boundaries, pure logic, **all drift/contract guards** |
 | **data-mechanics** (`vitest.datamechanics.config.ts`) | **real Postgres, stubbed model** | persistence & access: write→store→read, dedup, diff-sync, tier isolation |
-| **integration** | API route handlers over a real DB + the system-level `scripts/e2e.sh` | routing, auth, tier-422, the cross-process sync loop |
+| **integration** (`vitest.http.config.ts`, `npm run test:http`) | the API over a **real socket** (`next start` + real Postgres) + the system-level `scripts/e2e.sh` | routing, auth, tier-422, cookies/headers, the JSON wire format, the cross-process sync loop |
 | **eval** *(not built)* | real model API | model judgment (grounded-answer quality) — exercised live in `e2e.sh` step 9 |
 
 Mental model: **unit = parse/guards · data-mechanics = persistence + access · integration =

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -25,8 +25,9 @@ flowchart TD
         B1["docs-drift\ncheck-docs-drift.mjs\nRoutes · Tables · Sources"]
         B2["brain-tests\nvitest unit\npure logic + contract guards"]
         B3["datamechanics-tests\nvitest + real Postgres 16\nRLS · persistence · access control"]
-        B4["ingestion-tests\npytest\nPython ingest pipeline"]
-        B5["aios-work-sync\nPOST /api/v1/work-events\ncloses Plane ticket on merge"]
+        B4["http-tests (advisory)\nnext build + test:http\nreal socket · route runtime"]
+        B5["ingestion-tests\npytest\nPython ingest pipeline"]
+        B6["aios-work-sync\nPOST /api/v1/work-events\ncloses Plane ticket on merge"]
     end
 
     subgraph BotReviews["Async Bot Reviews — GitHub Apps"]
@@ -46,7 +47,7 @@ flowchart TD
     GitHubPR --> BotReviews
     GitHubActions --> D1
     BotReviews --> D2
-    MERGE --> B5
+    MERGE --> B6
 ```
 
 ---
@@ -60,9 +61,10 @@ flowchart TD
 | `docs-drift` | `node scripts/check-docs-drift.mjs` — validates routes, tables, sources against `docs/ARCHITECTURE.md` markers | Yes |
 | `brain-tests` | `npm test` — vitest unit tests (pure logic, parse/format, contract guards) | Yes |
 | `datamechanics-tests` | `npm run test:datamechanics` against real Postgres 16 (port 5434) — RLS, persistence, access control | Yes |
+| `http-tests` | `npm run build` + `npm run test:http` — the API over a real socket against Postgres 16: TCP fetch, the Next.js route runtime (cookies/headers), JSON wire format | No (advisory) |
 | `ingestion-tests` | `pytest -q` inside `ingestion/` — Python ingest pipeline | Yes |
 
-All four must pass for a PR to merge (enforced via branch protection).
+The four required jobs (`docs-drift`, `brain-tests`, `datamechanics-tests`, `ingestion-tests`) must pass for a PR to merge (enforced via branch protection). `http-tests` runs `continue-on-error` (advisory) until it proves stable — see Branch Protection below.
 
 ### `aios-work-sync.yml` — fires on merge to `main`
 
@@ -120,6 +122,7 @@ If you add an API route, table, or ingest source, update the corresponding `<!--
 Repo: `AIOS-alpha/aios-team-brain` → Settings → Branches → `main`
 
 - [x] Require status checks: `docs-drift`, `brain-tests`, `datamechanics-tests`, `ingestion-tests`
+- [ ] `http-tests` — currently advisory (`continue-on-error`). Graduate to required after 5 consecutive green runs on `main`: drop `continue-on-error` in `ci.yml` and add it to this list.
 - [x] Require branches to be up to date before merging
 - [x] Dismiss stale reviews on new pushes
 - [x] Require review from code owners (CODEOWNERS)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "db:test:up": "docker compose -f compose.test.yml up -d --wait && DATABASE_URL=postgres://app:app@localhost:5434/app_test npm run pg:schema",
     "db:test:down": "docker compose -f compose.test.yml down -v",
     "test:datamechanics": "vitest run --config vitest.datamechanics.config.ts",
-    "test:datamechanics:local": "DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.datamechanics.config.ts"
+    "test:datamechanics:local": "DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.datamechanics.config.ts",
+    "test:http": "vitest run --config vitest.http.config.ts",
+    "test:http:local": "npm run build && DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.http.config.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.1",

--- a/test/http/auth.http.test.ts
+++ b/test/http/auth.http.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { BASE_URL, issueKeyFor, keyHeaders, seedMemberEmail, seedTeam } from "./http-helpers";
+
+// HTTP auth edges that the in-process tier can't reach: the login route sets a
+// real Set-Cookie session, and /api/v1/me round-trips Bearer + X-AIOS-Team headers.
+
+describe("POST /api/auth/login (HTTP)", () => {
+  it("rejects an unknown email with 403", async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: `nobody-${randomUUID().slice(0, 8)}@nope.test` }),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("not_recognized");
+  });
+
+  it("signs in a known member with 200 + a session cookie", async () => {
+    const seed = await seedTeam();
+    const email = await seedMemberEmail(seed);
+
+    const res = await fetch(`${BASE_URL}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+    expect(res.headers.get("set-cookie") ?? "").toContain("aios_session");
+  });
+});
+
+describe("GET /api/v1/me (HTTP)", () => {
+  it("returns the caller's role/tier for a valid API key", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(`${BASE_URL}/api/v1/me`, { headers: keyHeaders(key, seed.teamSlug) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ role: "member", tier: "team", team: seed.teamId });
+    expect(typeof body.actor).toBe("string");
+  });
+
+  it("rejects an invalid API key with 401", async () => {
+    const seed = await seedTeam();
+    const res = await fetch(`${BASE_URL}/api/v1/me`, {
+      headers: keyHeaders("aios_deadbeef_notarealsecret", seed.teamSlug),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/test/http/global-setup.ts
+++ b/test/http/global-setup.ts
@@ -1,0 +1,70 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { BASE_URL, HTTP_TEST_PORT as PORT } from "./server-url";
+
+// One production Next.js server for the whole HTTP suite. We boot `next start`
+// (not `next dev`) so tests hit the real production runtime, and against a
+// prebuilt .next so there's no first-request compile flakiness. The server and
+// the test process share the test Postgres (DATABASE_TEST_URL), so seeding done
+// in-process (lib/ingest helpers) is visible to the server over HTTP.
+
+async function waitForReady(): Promise<void> {
+  // Matches scripts/e2e.sh: an unauthenticated GET /api/v1/items returns 401 once
+  // the route runtime is live. Poll until then (≤30s).
+  for (let i = 0; i < 30; i++) {
+    try {
+      const res = await fetch(`${BASE_URL}/api/v1/items`);
+      if (res.status === 401) return;
+    } catch {
+      // connection refused while the server is still binding — keep polling
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`HTTP tier: server at ${BASE_URL} never became ready (no 401 on /api/v1/items)`);
+}
+
+export default async function setup(): Promise<() => Promise<void>> {
+  if (!existsSync(resolve(".next/BUILD_ID"))) {
+    throw new Error(
+      "HTTP tier: no production build found (.next/BUILD_ID missing). " +
+        "Run `npm run build` first, or use `npm run test:http:local` which builds for you."
+    );
+  }
+
+  const nextBin = resolve("node_modules/.bin/next");
+  const server: ChildProcess = spawn(nextBin, ["start", "-p", PORT], {
+    // Inherit the backend/secret env pinned in vitest.http.config.ts; PORT is also
+    // honored by `next start`. detached so we can kill the whole process group.
+    env: { ...process.env, PORT },
+    stdio: ["ignore", "inherit", "inherit"],
+    detached: true,
+  });
+
+  server.on("error", (err) => {
+    throw new Error(`HTTP tier: failed to spawn next start — ${err.message}`);
+  });
+
+  try {
+    await waitForReady();
+  } catch (e) {
+    if (server.pid) {
+      try {
+        process.kill(-server.pid, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+    throw e;
+  }
+
+  return async () => {
+    if (server.pid) {
+      try {
+        process.kill(-server.pid, "SIGTERM");
+      } catch {
+        /* already gone */
+      }
+    }
+  };
+}

--- a/test/http/http-helpers.ts
+++ b/test/http/http-helpers.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "node:crypto";
+import { issueApiKey } from "@/lib/admin/keys";
+import { db, seedTeam, type Seed } from "../datamechanics/helpers";
+import { BASE_URL } from "./server-url";
+
+// Shared helpers for the HTTP tier. Seeding reuses the data-mechanics helpers
+// (same test DB the server reads); requests go over a real socket to BASE_URL.
+
+export { BASE_URL };
+export { db, seedTeam, type Seed };
+
+/**
+ * Issue an API key for the seeded team member (tier=team) or for a fresh
+ * external-tier member on the same team. Mirrors `issueKeyFor` in
+ * route-tier-guards.datamechanics.test.ts so the two tiers stay consistent.
+ */
+export async function issueKeyFor(seed: Seed, tier: "team" | "external"): Promise<{ key: string }> {
+  let memberId = seed.memberId;
+  if (tier === "external") {
+    const { data, error } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `ext-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "External",
+        actor_handle: `ext-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "external",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`external member seed failed: ${error?.message}`);
+    memberId = (data as { id: string }).id;
+  }
+  const { key } = await issueApiKey(db(), seed.teamId, memberId, `${tier} key`);
+  return { key };
+}
+
+/** Seed a member with a known email under the seeded team (for login tests). */
+export async function seedMemberEmail(seed: Seed): Promise<string> {
+  const email = `login-${randomUUID().slice(0, 8)}@test.local`;
+  const { error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      email,
+      display_name: "Login Member",
+      actor_handle: `login-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+    });
+  if (error) throw new Error(`login member seed failed: ${error.message}`);
+  return email;
+}
+
+/** Standard auth headers for an API-key request. */
+export function keyHeaders(key: string, teamSlug: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${key}`,
+    "X-AIOS-Team": teamSlug,
+    "Content-Type": "application/json",
+  };
+}

--- a/test/http/items.http.test.ts
+++ b/test/http/items.http.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { sha } from "../datamechanics/helpers";
+import { BASE_URL, db, issueKeyFor, keyHeaders, seedTeam } from "./http-helpers";
+
+// HTTP edge of POST/GET /api/v1/items — the cross-the-wire path the in-process
+// data-mechanics tier bypasses. Closes the gap previously covered only by the
+// bash `scripts/e2e.sh`: the admin-tier 422 and the GET tier filter over a real socket.
+
+const ITEMS = `${BASE_URL}/api/v1/items`;
+
+function itemBody(over: Record<string, unknown> = {}) {
+  const body = (over.body as string) ?? "hello world";
+  return {
+    project: "acme",
+    path: "2-work/deliverable.md",
+    kind: "deliverable",
+    access: "team",
+    actor: "tester",
+    frontmatter: {},
+    body,
+    content_sha256: sha(body),
+    ...over,
+  };
+}
+
+describe("POST /api/v1/items (HTTP)", () => {
+  it("persists a team item and returns 201", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(ITEMS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(itemBody({ path: "2-work/created.md" })),
+    });
+    expect(res.status).toBe(201);
+
+    const { data } = await db()
+      .from("items")
+      .select("path, access")
+      .eq("team_id", seed.teamId)
+      .eq("path", "2-work/created.md")
+      .single();
+    expect(data).toMatchObject({ path: "2-work/created.md", access: "team" });
+  });
+
+  it("rejects admin-tier content with 422 forbidden_tier", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(ITEMS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(itemBody({ access: "admin", path: "5-personal/secret.md" })),
+    });
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("forbidden_tier");
+
+    // And it must NOT have been persisted.
+    const { data } = await db()
+      .from("items")
+      .select("id")
+      .eq("team_id", seed.teamId)
+      .eq("path", "5-personal/secret.md")
+      .maybeSingle();
+    expect(data).toBeNull();
+  });
+});
+
+describe("GET /api/v1/items (HTTP) — tier filter over the wire", () => {
+  it("a team key sees team+external items; an external key sees only external", async () => {
+    const seed = await seedTeam();
+    const { key: teamKey } = await issueKeyFor(seed, "team");
+
+    // Seed one team and one external item over HTTP (a team key may publish either).
+    for (const [path, access] of [
+      ["2-work/team-only.md", "team"],
+      ["4-shared/client-facing.md", "external"],
+    ] as const) {
+      const r = await fetch(ITEMS, {
+        method: "POST",
+        headers: keyHeaders(teamKey, seed.teamSlug),
+        body: JSON.stringify(itemBody({ path, access, body: path })),
+      });
+      expect(r.status).toBe(201);
+    }
+
+    const teamView = await fetch(ITEMS, { headers: keyHeaders(teamKey, seed.teamSlug) });
+    expect(teamView.status).toBe(200);
+    const teamPaths = (await teamView.json()).items.map((i: { path: string }) => i.path);
+    expect(teamPaths).toEqual(
+      expect.arrayContaining(["2-work/team-only.md", "4-shared/client-facing.md"])
+    );
+
+    const { key: extKey } = await issueKeyFor(seed, "external");
+    const extView = await fetch(ITEMS, { headers: keyHeaders(extKey, seed.teamSlug) });
+    expect(extView.status).toBe(200);
+    const extItems = (await extView.json()).items as { path: string; access: string }[];
+    expect(extItems.every((i) => i.access === "external")).toBe(true);
+    expect(extItems.map((i) => i.path)).not.toContain("2-work/team-only.md");
+  });
+});

--- a/test/http/server-url.ts
+++ b/test/http/server-url.ts
@@ -1,0 +1,10 @@
+// Single source of truth for the HTTP tier's server URL, imported by both the
+// server (global-setup) and the clients (test files) so they always agree.
+//
+// NOTE: do NOT use process.env.BASE_URL — Vite reserves that name and sets it to
+// its base path ("/"), which would clobber any value we put there. We derive the
+// URL from HTTP_TEST_PORT (a plain numeric override, default 3010) instead.
+const PORT = /^\d+$/.test(process.env.HTTP_TEST_PORT ?? "") ? process.env.HTTP_TEST_PORT! : "3010";
+
+export const HTTP_TEST_PORT = PORT;
+export const BASE_URL = `http://127.0.0.1:${PORT}`;

--- a/test/http/work-events.http.test.ts
+++ b/test/http/work-events.http.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { ingest } from "../datamechanics/helpers";
+import { BASE_URL, db, issueKeyFor, keyHeaders, seedTeam } from "./http-helpers";
+
+// HTTP edge of POST /api/v1/work-events: the route the merge-sync GitHub Action
+// (aios-work-sync.yml) calls to close a task. We assert the HTTP contract and the
+// DB outcome (task → done) — not Plane closure (the seeded task has no pm_links,
+// so pm_sync is a no-op and makes no external call).
+
+const WORK_EVENTS = `${BASE_URL}/api/v1/work-events`;
+
+async function seedTask(seed: Awaited<ReturnType<typeof seedTeam>>, rowKey: string) {
+  await ingest(seed, {
+    kind: "task",
+    path: "3-log/tasks.md",
+    body: `| ID | Task | Assignee | Status |\n| ${rowKey} | build it | alex | in_progress |`,
+    access: "team",
+    rows: [{ row_key: rowKey, title: "build it", status: "in_progress" }],
+  } as never);
+}
+
+function eventPayload(rowKey: string) {
+  return {
+    project: "acme",
+    event_kind: "merged",
+    repo: "AIOS-alpha/aios-team-brain",
+    merged_sha: "abc123456789",
+    pr_url: "https://example.test/pr/1",
+    pr_title: `${rowKey} build it`,
+    work_keys: [rowKey],
+    actor: "alex",
+  };
+}
+
+describe("POST /api/v1/work-events (HTTP)", () => {
+  it("applies a merge event and marks the matching task done", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+    await seedTask(seed, "W1.2.1");
+
+    const res = await fetch(WORK_EVENTS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(eventPayload("W1.2.1")),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.applied).toEqual([{ row_key: "W1.2.1", task_id: body.applied[0]?.task_id }]);
+    expect(body.unresolved).toEqual([]);
+    // The task has no PM link, so sync is a no-op (status "no_link") — no external call.
+    expect(body.pm_sync).toEqual([{ provider: null, row_key: "W1.2.1", status: "no_link" }]);
+
+    const { data } = await db()
+      .from("tasks")
+      .select("status")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "W1.2.1")
+      .single();
+    expect((data as { status: string }).status).toBe("done");
+  });
+
+  it("rejects an external-tier key with 403 (work events are team-tier only)", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "external");
+
+    const res = await fetch(WORK_EVENTS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(eventPayload("W1.2.1")),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("forbidden_tier");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,15 @@ export default defineConfig({
     environment: "node",
     include: ["**/*.test.ts"],
     // Data-mechanics tests need a real DB; they run via vitest.datamechanics.config.ts.
-    exclude: ["node_modules/**", "ingestion/**", ".next/**", ".claude/worktrees/**", "test/datamechanics/**"],
+    // HTTP integration tests need a running server; they run via vitest.http.config.ts.
+    exclude: [
+      "node_modules/**",
+      "ingestion/**",
+      ".next/**",
+      ".claude/worktrees/**",
+      "test/datamechanics/**",
+      "test/http/**",
+    ],
     // `npm run coverage` writes coverage/coverage-summary.json — the codebase scanner
     // reads total.lines.pct from it. Scoped to lib/** (the unit-tested core) for a
     // representative number rather than diluting with untested UI.

--- a/vitest.http.config.ts
+++ b/vitest.http.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+// Integration (HTTP) tier: spec-derived tests that exercise the API over a REAL
+// socket against a production Next.js server (`next start`) + the real test
+// Postgres. This is the only tier that crosses the wire — TCP fetch, the Next
+// route runtime (middleware, cookies, headers), and the JSON wire format — which
+// the in-process data-mechanics tier (it imports route handlers directly) cannot.
+
+// No-prod-fallback guard (same contract as the data-mechanics tier): refuse to run
+// without the dedicated test DB. Both this process (seeding via lib/ingest) and the
+// spawned server talk to it.
+const databaseTestUrl = process.env.DATABASE_TEST_URL;
+if (!databaseTestUrl) {
+  throw new Error(
+    "Integration (HTTP) tier requires DATABASE_TEST_URL (the dedicated test Postgres). " +
+      "Refusing to run — never fall back to a prod/dev URL. " +
+      "Use `npm run test:http:local` (it builds, then sets it after `npm run db:test:up`)."
+  );
+}
+
+// Pin the backend for this process (the seed helpers run the real app code) AND,
+// by inheritance through spawn, for the server child started in global-setup.
+process.env.DB_BACKEND = "postgres";
+process.env.NEXT_PUBLIC_DB_BACKEND = "postgres";
+process.env.DATABASE_URL = databaseTestUrl;
+// Fixed test key for integration-secret crypto (lib/secrets); not a real secret.
+process.env.SECRETS_KEY ??= Buffer.alloc(32, 7).toString("base64");
+// The login route signs sessions with AUTH_SECRET (lib/auth/pg-session requires >=16 chars).
+process.env.AUTH_SECRET ??= "http-tier-test-secret-not-for-production";
+// Server port override (default 3010 — see test/http/server-url.ts, which derives
+// the URL both the server and clients use). We avoid process.env.BASE_URL: Vite
+// reserves that name and pins it to "/".
+process.env.HTTP_TEST_PORT ??= "3010";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/http/**/*.http.test.ts"],
+    // Boot one production server for the whole suite (not per file).
+    globalSetup: ["test/http/global-setup.ts"],
+    // Reuse the data-mechanics per-test truncation (TRUNCATE ... CASCADE clears the
+    // same shared DB the server reads from).
+    setupFiles: ["test/datamechanics/setup.ts"],
+    fileParallelism: false, // shared DB + single server → serialize files
+    hookTimeout: 60_000, // server boot + readiness headroom
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./", import.meta.url)),
+      "server-only": fileURLToPath(new URL("./test/stubs/empty.ts", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## What

Adds the **integration (HTTP) test tier** — the API exercised over a real TCP socket against a production `next start` server + the real test Postgres. This is the only tier that crosses the wire: TCP fetch, the Next.js route runtime (cookies/headers), and the JSON wire format — which the in-process `datamechanics` tier (it imports route handlers directly) cannot reach.

## Coverage (closes gaps previously only in bash `scripts/e2e.sh`)

| File | Asserts |
|---|---|
| `items.http.test.ts` | POST happy path → 201 + row in DB · **admin-tier POST → 422 `forbidden_tier`** (and not persisted) · GET tier filter over HTTP (external key sees only `external`) |
| `auth.http.test.ts` | login unknown → 403 · known member → 200 + `Set-Cookie aios_session` · `/api/v1/me` Bearer+`X-AIOS-Team` → 200 `{role,tier}` · invalid key → 401 |
| `work-events.http.test.ts` | merge event → 201 + matched task `status='done'` (linkless `pm_sync` no-op, no external call) · external-tier key → 403 (team-tier only) |

## Mechanics

- `vitest.http.config.ts` mirrors `vitest.datamechanics.config.ts` (the `DATABASE_TEST_URL` no-prod-fallback guard, postgres backend, `SECRETS_KEY`/`AUTH_SECRET`), reuses the data-mechanics per-test truncation, serializes files, and boots **one** server via `globalSetup`.
- `test/http/global-setup.ts` spawns `next start` against a prebuilt `.next`, probes `GET /api/v1/items` for 401 readiness (same signal as `e2e.sh`), and tears the server down.
- Server URL derives from `HTTP_TEST_PORT` (`test/http/server-url.ts`) — **not** `process.env.BASE_URL`, which Vite reserves and pins to `/`.
- Seeding reuses `seedTeam`/`db`/`ingest` (data-mechanics helpers) + `issueApiKey` (`lib/admin/keys.ts`); requests go over real `fetch`.
- Unit tier excludes `test/http/**`; new `test:http` / `test:http:local` scripts.
- CI: new **advisory** `http-tests` job (`continue-on-error` until 5 consecutive green runs on `main`, then graduate per `docs/CI-ARCHITECTURE.md`).
- Docs: `CI-ARCHITECTURE.md` jobs table + diagram + branch-protection note; `CLAUDE.md` §4 integration row.

## Verification

- `npm run test:http:local` → green: fresh build → boot → 9/9 tests → teardown ✅
- `npm test` does **not** collect `test/http/**` (unit tier unchanged: 28 files / 147 tests) ✅
- `npm run check:docs` green; `eslint` clean (no new findings) ✅
- Server torn down (port clear after run); `.next` gitignored ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test harness, npm scripts, and advisory CI; production application code is untouched.
> 
> **Overview**
> Introduces a new **integration (HTTP)** Vitest tier that hits the API over a real TCP socket against **`next start`** and the dedicated test Postgres—covering cookies, headers, and JSON wire behavior that in-process data-mechanics tests skip.
> 
> **`vitest.http.config.ts`** mirrors the data-mechanics DB guard, reuses per-test DB truncation, serializes files, and boots one server via **`test/http/global-setup.ts`** (requires a prebuilt `.next`). **`test:http`** / **`test:http:local`** scripts are added; the unit config **excludes** `test/http/**`. New specs assert login/`/api/v1/me`, items POST/GET tier rules, and **`/api/v1/work-events`** (including merge → task `done`).
> 
> CI gains an **advisory** **`http-tests`** job (`build` + `test:http`, `continue-on-error` until graduation). **`CLAUDE.md`** and **`docs/CI-ARCHITECTURE.md`** document the tier and branch-protection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 610e7c9965d720b24657bd10648728613cdce174. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->