### PR TITLE
docs(pm): reflect Linear as the PM tool of choice (Plane retired)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@
 
 ## Work item
 
-<!-- Link this PR to a Plane item so aios-work-sync closes it on merge. -->
-AIOS-Work: <!-- e.g. AIOS-123 -->
+<!-- Link this PR to a Linear issue so aios-work-sync closes it on merge. -->
+AIOS-Work: <!-- e.g. AIO-72 -->
 
 ## Checklist
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,7 +151,7 @@ flowchart LR
   ST[("sqlite: cursors + watch channels")] -.-> T2
 ```
 
-### PM progression loop — merged work → done in Plane/Linear
+### PM progression loop — merged work → done in the primary PM tool (Linear)
 
 ```mermaid
 flowchart LR
@@ -161,8 +161,8 @@ flowchart LR
   EVT --> TASKS[("tasks.status = done")]
   EVT --> LINKS[("task_pm_links")]
   LINKS --> PMS["lib/pm-sync provider adapter"]
-  PMS --> PLANE["Plane work item completed state"]
-  PMS --> LINEAR["Linear completed workflow state"]
+  PMS --> LINEAR["Linear completed workflow state (primary)"]
+  PMS --> PLANE["Plane completed state (legacy adapter)"]
   EVT --> UNRES["unresolved work_events for admin reconciliation"]
 ```
 
@@ -192,6 +192,12 @@ remains as a thin state-only delegate. Assignees and inbound/two-way reconciliat
 `scripts/aios-backlog.mjs` and pushed by `npm run plane:backlog` / `npm run linear:backlog`
 (idempotent by `external_id` / the `aios-ext:` marker). The projection engine supersedes these;
 they are removed once the live backlog is migrated (brain-api v1.2 Phase 3).
+
+**PM tool decision (resolved).** The Plane-vs-Linear bake-off (backlog epic W2.4) is settled —
+**Linear is the chosen PM tool** (more adoption + better compatibility), and
+`teams.primary_pm_provider` is set to `linear`. The Plane adapter and the `npm run plane:backlog`
+/ `--sync-status` mirror are legacy/reference-only; the runtime projection path stays
+provider-neutral (both adapters still exist).
 
 ### Action layer (Organ 4) — policy-gated execution
 

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -11,7 +11,7 @@ This document describes the full CI/CD pipeline for `aios-team-brain`, including
 ```mermaid
 flowchart TD
     subgraph AgentLoop["Multi-Agent Dev Loop (local)"]
-        A1[Opus — Planner\nCreates spec / Plane issue] --> A2[Codex — Critic\nReviews plan]
+        A1[Opus — Planner\nCreates spec / Linear issue] --> A2[Codex — Critic\nReviews plan]
         A2 --> A3[Opus — Planner\nFinalizes plan]
         A3 --> A4[Opus — Builder\nImplements, commits\nopens PR via gh]
         A4 -->|wait-for-bots.mjs\npoll every 30s ≤10 min| A4W{Bots landed?}
@@ -27,7 +27,7 @@ flowchart TD
         B3["datamechanics-tests\nvitest + real Postgres 16\nRLS · persistence · access control"]
         B4["http-tests (advisory)\nnext build + test:http\nreal socket · route runtime"]
         B5["ingestion-tests\npytest\nPython ingest pipeline"]
-        B6["aios-work-sync\nPOST /api/v1/work-events\ncloses Plane ticket on merge"]
+        B6["aios-work-sync\nPOST /api/v1/work-events\ncloses Linear issue on merge"]
     end
 
     subgraph BotReviews["Async Bot Reviews — GitHub Apps"]
@@ -68,7 +68,7 @@ The four required jobs (`docs-drift`, `brain-tests`, `datamechanics-tests`, `ing
 
 ### `aios-work-sync.yml` — fires on merge to `main`
 
-Extracts `AIOS-Work: <KEY>` from the PR title/body and POSTs a merge event to `/api/v1/work-events`. This closes the matching Plane work item automatically.
+Extracts `AIOS-Work: <KEY>` from the PR title/body and POSTs a merge event to `/api/v1/work-events`. This closes the matching issue in the team's primary PM tool automatically — currently **Linear** (the brain projects the merge event to whichever provider `teams.primary_pm_provider` names; the sync path itself is provider-neutral).
 
 **Required secrets:** `AIOS_BRAIN_URL`, `AIOS_API_KEY`, `AIOS_TEAM`
 
@@ -132,7 +132,7 @@ Repo: `AIOS-alpha/aios-team-brain` → Settings → Branches → `main`
 ## Optimized Agent Pipeline Sequencing
 
 ```
-1. Opus (Planner)  → creates spec from Plane issue
+1. Opus (Planner)  → creates spec from Linear issue
 2. Codex (Critic)  → reviews plan, requests changes
 3. Opus (Planner)  → finalizes, hands off to builder
 4. Opus (Builder)  → implements, commits, opens PR
@@ -142,5 +142,5 @@ Repo: `AIOS-alpha/aios-team-brain` → Settings → Branches → `main`
 8. Code Reviewer   → reads CI status + all bot comments → structured findings
 9. Opus (Builder)  → addresses findings, pushes fix commits if needed
 10. Human          → approves + merges
-11.                  aios-work-sync fires → Plane ticket closed
+11.                  aios-work-sync fires → Linear issue closed
 ```


### PR DESCRIPTION
## What & Why

The Plane-vs-Linear bake-off is **resolved — Linear is the PM tool of choice** (more adoption + better compatibility/integrations), and `teams.primary_pm_provider` is set to `linear`. This updates the **live-flow docs** so they stop saying "Plane" where the system now acts on Linear. Documentation only — no code or workflow changes.

## Changes

- **`docs/CI-ARCHITECTURE.md`** — `aios-work-sync` now described as closing the team's primary PM issue (**Linear**); pipeline diagram node + numbered sequence reworded Plane→Linear. Noted that the sync path itself is provider-neutral (projects to whatever `teams.primary_pm_provider` names).
- **`.github/pull_request_template.md`** — "Link this PR to a **Linear issue**" (example `AIO-72`).
- **`docs/ARCHITECTURE.md`** — PM progression loop heading + diagram name Linear as primary; the Plane adapter node is marked legacy; the bake-off prose records the resolution. The provider-neutral capability descriptions (`lib/pm-sync`, `teams.primary_pm_provider`) are left intact since both adapters still exist in code.

## Out of scope (intentionally)

- `docs/agent-handoffs.md` — a historical log of past agent handoff prompts where those epics were genuinely tracked in Plane at the time; rewriting it would be revisionist.

## Verification

- `npm run check:docs` → green (prose edits don't touch the machine-guarded drift blocks) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only edits to architecture and PR template; no runtime, schema, or CI workflow changes.
> 
> **Overview**
> **Documentation-only** update after the W2.4 bake-off: **Linear is the chosen PM tool** (`teams.primary_pm_provider` = `linear`); runtime `lib/pm-sync` and workflows are unchanged.
> 
> The **PR template** now tells contributors to link **`AIOS-Work`** to a **Linear** issue (example `AIO-72`) instead of Plane.
> 
> **`docs/ARCHITECTURE.md`** renames the PM progression loop around the **primary PM tool (Linear)**, puts **Linear** first in the diagram and marks **Plane** as a **legacy adapter**, and states that `npm run plane:backlog` / `--sync-status` mirroring are **reference-only** while the merge → work-events → PM sync path stays **provider-neutral**.
> 
> **`docs/CI-ARCHITECTURE.md`** describes **`aios-work-sync`** and the agent pipeline as closing the **Linear** issue on merge, with a note that projection follows **`primary_pm_provider`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1004ae4596eeb47bf5c54ee5b255e9782f574652. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR template to reference Linear issue links
  * Updated architecture documentation to reflect Linear as the primary project management tool
  * Updated CI/CD documentation to reference Linear for automatic work-item closure on merge

<!-- end of auto-generated comment: release notes by coderabbit.ai -->