### PR TITLE
fix: un-stale http work-events test + .coderabbit.yaml schema error

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -46,7 +46,8 @@ reviews:
         test DB (DATABASE_TEST_URL) — no mocks for persistence or RLS checks.
 
   finishing_touches:
-    docstrings: false
+    docstrings:
+      enabled: false
 
 chat:
   auto_reply: true

--- a/test/http/work-events.http.test.ts
+++ b/test/http/work-events.http.test.ts
@@ -48,8 +48,11 @@ describe("POST /api/v1/work-events (HTTP)", () => {
     expect(body.status).toBe("ok");
     expect(body.applied).toEqual([{ row_key: "W1.2.1", task_id: body.applied[0]?.task_id }]);
     expect(body.unresolved).toEqual([]);
-    // The task has no PM link, so sync is a no-op (status "no_link") — no external call.
-    expect(body.pm_sync).toEqual([{ provider: null, row_key: "W1.2.1", status: "no_link" }]);
+    // The done path runs the brain→PM projection engine (lib/pm-sync/project). The test
+    // team has no enabled PM integration, so projection reports missing_integration and
+    // makes no external call — the task is still completed (asserted below).
+    expect(body.pm_sync).toHaveLength(1);
+    expect(body.pm_sync[0]).toMatchObject({ row_key: "W1.2.1", status: "missing_integration" });
 
     const { data } = await db()
       .from("tasks")


### PR DESCRIPTION
Two post-merge fixes, both surfaced by the CI/review tooling now live on `main`.

## 1. `http-tests` (advisory) is red on `main`

The work-events HTTP test (#57) asserted the **pre-#55** `pm_sync` shape — `{ provider: null, status: "no_link" }`. But #55's projection engine changed the `/work-events` done path to project into the team's primary PM tool. With no enabled integration in the test DB, it now returns `{ status: "missing_integration", error: "no enabled PM integration" }`.

#57's CI passed because it branched off the older `main` (no #55); the clash only appeared once both landed — **exactly the cross-PR interaction this tier exists to catch.** Fix asserts the real observable outcome: the task still completes, and projection reports `missing_integration` (no external call made).

## 2. `.coderabbit.yaml` fails schema validation

CodeRabbit was rejecting the config (*"expected object, received boolean"*) and **silently falling back to defaults — ignoring all `path_instructions`.** Cause: `reviews.finishing_touches.docstrings` must be an object. Changed `docstrings: false` → `docstrings: { enabled: false }`.

> Note: this fixes the *config* so your instructions load. CodeRabbit also reported the org is **out of review credits / rate-limited**, which is a separate billing item — reviews won't run until that's resolved regardless of this fix.

## Verification

- `npm run test:http:local` → 9/9 green against current `main` ✅
- `.coderabbit.yaml` parses; `finishing_touches.docstrings = { enabled: false }` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CodeRabbit config only; no production API or auth behavior changes.
> 
> **Overview**
> Updates the **POST /work-events** HTTP test so `pm_sync` expectations match the post–#55 brain→PM projection path: when the seeded team has no enabled integration, the API reports **`missing_integration`** (still one entry per work key) while the task is marked **done**.
> 
> Fixes **`.coderabbit.yaml`** so `reviews.finishing_touches.docstrings` is `{ enabled: false }` instead of a bare boolean, restoring schema validation and loading of **`path_instructions`** instead of silent defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 187dc4aa67305f79d76976043cf01219bcf3b9dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file format for code review settings.
  * Updated test assertions for work event handling to reflect changes in API response expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->