### PR TITLE
fix(pm-sync): explicit task_pm_links columns — prod pg adapter rejects "*" (Step 7 hotfix)

### DIFF
--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -126,6 +126,11 @@ function toProjectable(row: ProjectionTaskRow, parentResourceId: string | null):
   };
 }
 
+// Columns of task_pm_links the projection engine reads. The pg adapter (prod) rejects a bare
+// "*" column reference, so every select / insert-returning must name columns explicitly.
+const LINK_COLS =
+  "id, team_id, project_id, task_id, row_key, provider, provider_resource_id, provider_external_source, provider_external_id, provider_url, projection_fingerprint, last_projected_status, provider_seen_status";
+
 // Get-or-create the task_pm_links row for (team, project, row_key, provider).
 async function ensureLink(
   supabase: SupabaseClient,
@@ -135,7 +140,7 @@ async function ensureLink(
 ): Promise<TaskPmLink> {
   const { data: existing } = await supabase
     .from("task_pm_links")
-    .select("*")
+    .select(LINK_COLS)
     .eq("team_id", row.team_id)
     .eq("project_id", row.project_id)
     .eq("row_key", row.row_key)
@@ -153,7 +158,7 @@ async function ensureLink(
     provider_external_source: defaultSource,
     provider_url: "",
   };
-  const { data, error } = await supabase.from("task_pm_links").insert(insert).select("*").single();
+  const { data, error } = await supabase.from("task_pm_links").insert(insert).select(LINK_COLS).single();
   if (error) throw new Error(`create task PM link failed: ${error.message}`);
   return data as TaskPmLink;
 }

--- a/test/datamechanics/work-events.datamechanics.test.ts
+++ b/test/datamechanics/work-events.datamechanics.test.ts
@@ -124,4 +124,53 @@ describe("work events (real Postgres)", () => {
       .single();
     expect((link as { last_error: string }).last_error).toMatch(/plane integration/i);
   });
+
+  it("creates a PM link row when none exists yet (insert-returning path against real PG)", async () => {
+    const seed = await seedTeam();
+    // primary provider set, integration absent, and NO markdown PM column ⇒ no pre-existing link.
+    // The work-events done path must INSERT a task_pm_links row to record the error — this exercises
+    // ensureLink's insert-returning, which the prod pg adapter rejects with a bare "*" select.
+    await db().from("teams").update({ primary_pm_provider: "plane" }).eq("id", seed.teamId);
+    await ingest(seed, {
+      kind: "task",
+      path: "3-log/tasks.md",
+      body: "| ID | Task | Assignee | Status | Sprint | Due |\n| P7 | no pm column | alex | ready | | |",
+      access: "team",
+      rows: [{ row_key: "P7", title: "no pm column", status: "ready" }],
+    } as never);
+
+    const res = await ingestWorkEvent(
+      db(),
+      { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: "api-key" },
+      {
+        project: "acme",
+        event_kind: "merged",
+        repo: "AIOS-alpha/aios-team-brain",
+        merged_sha: "abcdef987654",
+        pr_url: "",
+        pr_title: "P7 done",
+        pr_body: "",
+        branch: "",
+        work_keys: ["P7"],
+        actor: "alex",
+      }
+    );
+
+    expect(await taskStatus("P7")).toBe("done");
+    expect(res.pm_sync).toEqual([
+      expect.objectContaining({ row_key: "P7", provider: "plane", status: "missing_integration" }),
+    ]);
+    // The link was created (not pre-existing) and carries the error.
+    const { data: link } = await db()
+      .from("task_pm_links")
+      .select("provider, provider_external_id, last_error")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "P7")
+      .single();
+    expect(link as { provider: string; provider_external_id: string; last_error: string }).toMatchObject({
+      provider: "plane",
+      provider_external_id: "P7",
+    });
+    expect((link as { last_error: string }).last_error).toMatch(/plane integration/i);
+  });
 });


### PR DESCRIPTION
## Problem
"Project board now" (and any projection that creates a new `task_pm_links` row) **500'd in production**:

```
[pg] insert task_pm_links: pg-adapter: unsupported column reference "*"
⨯ Error: create task PM link failed: pg-adapter: unsupported column reference "*"
```

`ensureLink` (lib/pm-sync/project.ts) used `.select("*")` for both the existing-link lookup and the insert-returning. The prod Postgres adapter (`lib/db/pg`) rejects a bare `"*"`. The Supabase client tolerates it, and the existing datamechanics test only exercised the path where a link already existed (insert never ran) — so it passed CI but broke in prod on the first real projection.

## Fix
- Replace both `"*"` with an explicit `LINK_COLS` list.
- Add a datamechanics test that drives the **INSERT** path (primary provider set, integration absent, no markdown PM column ⇒ `ensureLink` inserts a fresh link). **Verified non-vacuous**: it reproduces the exact prod error on the old code, passes with the fix.

## Checks
- ✅ 89 datamechanics (real Postgres, +1 new) · ✅ 153 unit · ✅ `tsc` · ✅ `eslint` · ✅ `check:docs`

Unblocks Phase 3 Step 7 (live projection to the Linear AIO board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow query-shape fix in PM link bookkeeping with regression coverage; no auth, payment, or broad behavioral changes beyond restoring the insert path in prod.
> 
> **Overview**
> **Fixes production 500s** when projection or work-events paths **create a new** `task_pm_links` row. The prod `lib/db/pg` query builder rejects a bare `"*"` column reference; `ensureLink` in `lib/pm-sync/project.ts` used `.select("*")` on both the existing-link lookup and insert-returning, which Supabase tolerated but prod did not.
> 
> The change introduces **`LINK_COLS`** (explicit column list the projection engine needs) and uses it in both selects. A new **datamechanics** case drives the **INSERT** path—primary PM set, no integration, no markdown PM column—so CI catches regressions that prior tests missed when only pre-existing links were exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b24db0705e9f78f3cc086f80614d1182089ab6d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->