### PR TITLE
fix(pm-sync): clearer projection success state + "Reason" column

### DIFF
--- a/app/t/[team]/admin/pm-sync/page.tsx
+++ b/app/t/[team]/admin/pm-sync/page.tsx
@@ -59,7 +59,7 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
                 <th className="py-2 pr-4 font-medium">Key</th>
                 <th className="py-2 pr-4 font-medium">PR</th>
                 <th className="py-2 pr-4 font-medium">Repo</th>
-                <th className="py-2 pr-4 font-medium">Error</th>
+                <th className="py-2 pr-4 font-medium">Reason</th>
               </tr>
             </thead>
             <tbody>
@@ -70,7 +70,7 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
                     {e.pr_url ? <a className="text-violet" href={e.pr_url}>{e.pr_title || e.pr_url}</a> : e.pr_title || "—"}
                   </td>
                   <td className="py-2 pr-4 text-ink-secondary">{e.repo}</td>
-                  <td className="py-2 pr-4 text-red">{e.error || "unresolved"}</td>
+                  <td className="py-2 pr-4 text-ink-secondary">{e.error || "unresolved"}</td>
                 </tr>
               ))}
               {(unresolved ?? []).length === 0 ? (

--- a/app/t/[team]/admin/pm-sync/project-board-button.tsx
+++ b/app/t/[team]/admin/pm-sync/project-board-button.tsx
@@ -4,6 +4,14 @@ import { useState, useTransition } from "react";
 
 import { projectBoardAction, type ProjectBoardResult } from "./actions";
 
+function summarize(counts: Record<string, number> | undefined): { synced: number; skipped: number; other: number; total: number } {
+  const c = counts ?? {};
+  const synced = c.synced ?? 0;
+  const skipped = c.skipped ?? 0;
+  const total = Object.values(c).reduce((a, b) => a + b, 0);
+  return { synced, skipped, other: total - synced - skipped, total };
+}
+
 export function ProjectBoardButton({ teamSlug, primaryProvider }: { teamSlug: string; primaryProvider: string | null }) {
   const [pending, startTransition] = useTransition();
   const [result, setResult] = useState<ProjectBoardResult | null>(null);
@@ -15,9 +23,11 @@ export function ProjectBoardButton({ teamSlug, primaryProvider }: { teamSlug: st
     });
   }
 
+  const s = result?.ok ? summarize(result.counts) : null;
+
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-3">
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <button
           type="button"
           onClick={run}
@@ -29,17 +39,27 @@ export function ProjectBoardButton({ teamSlug, primaryProvider }: { teamSlug: st
         <span className="text-sm text-ink-secondary">
           Primary PM tool: <span className="font-medium text-ink">{primaryProvider ?? "not set"}</span>
         </span>
+        {pending ? (
+          <span className="text-sm text-ink-tertiary">Projecting the full board — this can take up to ~90s.</span>
+        ) : null}
       </div>
-      {result ? (
+
+      {result && !pending ? (
         result.ok ? (
-          <p className="text-sm text-ink-secondary">
-            Projected to <span className="font-medium text-ink">{result.provider}</span>:{" "}
-            {Object.entries(result.counts ?? {})
-              .map(([k, v]) => `${v} ${k}`)
-              .join(" · ") || "no rows"}
-          </p>
+          <div className="rounded-md border border-emerald/40 bg-emerald/10 px-3 py-2 text-sm">
+            <p className="font-medium text-emerald">✓ Projection complete — {result.provider}</p>
+            <p className="mt-0.5 text-ink-secondary">
+              {s!.total} task{s!.total === 1 ? "" : "s"}: <span className="font-medium text-ink">{s!.synced} updated</span>
+              {" · "}
+              {s!.skipped} already in sync
+              {s!.other > 0 ? ` · ${s!.other} other` : ""}
+            </p>
+          </div>
         ) : (
-          <p className="text-sm text-red">{result.error}</p>
+          <div className="rounded-md border border-red/40 bg-red/10 px-3 py-2 text-sm">
+            <p className="font-medium text-red">Projection failed</p>
+            <p className="mt-0.5 text-ink-secondary">{result.error}</p>
+          </div>
         )
       ) : null}
     </div>


### PR DESCRIPTION
UX polish on `/t/[team]/admin/pm-sync`, from feedback on the first live projection (66 skipped · 5 synced, which succeeded but gave only a quiet one-line result and no completion cue).

- **"Project board now" success state** — prominent banner: `✓ Projection complete — linear` with `71 tasks: 5 updated · 66 already in sync`, plus a "this can take up to ~90s" hint while running. Failures get a matching red banner.
- **"Error" → "Reason" column** in the *Unresolved merge events* table, with neutral (non-red) text — "no matching row" is an informational reason, not an error. The *Provider sync failures* table keeps its red **Error** column (those are genuine failures).

No schema/route/contract changes. ✅ tsc · eslint · check:docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes on the pm-sync admin page; no API, schema, or projection logic changes.
> 
> **Overview**
> Polishes **PM sync** admin UX so successful board projections feel finished and unresolved merges read as informational.
> 
> **Project board now** shows a ~90s hint while projecting, then a green **Projection complete** banner with provider name and human-readable totals (updated vs already in sync, plus any other count buckets). Failures use a matching red banner instead of plain text.
> 
> In **Unresolved merge events**, the last column is renamed **Error → Reason** and styled with neutral text instead of red, while **Provider sync failures** still uses a red **Error** column for real sync failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc3cf2efb3476beb15548782cba4e3e3442c6b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated "Unresolved merge events" table by replacing "Error" column header with "Reason" and applying secondary text styling
  * Enhanced project board sync operation UI with improved pending state messaging and restructured success/failure status display showing task counts and sync breakdown

<!-- end of auto-generated comment: release notes by coderabbit.ai -->