### PR TITLE
ci(scan-on-merge): generate coverage report before scanning

### DIFF
--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -4,6 +4,11 @@ name: scan-on-merge
 # ingestion scanner and push the result (full raw metrics + readiness) to the Team Brain.
 # The scan is read-only against the repo and idempotent on the brain (keyed by head_sha).
 #
+# We run `npm run coverage` first so a fresh coverage/coverage-summary.json exists for the
+# scanner's _read_coverage() to pick up — otherwise test_coverage_pct lands null and the
+# Codebases dashboard shows "no reports". The coverage GATE still lives in ci.yml; here it is
+# purely a metrics source, so a threshold miss must not block the scan (|| true).
+#
 # Required repo secrets (until set, the job logs "skipping" and exits 0 — never red):
 #   AIOS_BRAIN_URL — e.g. https://aios-team-brain-production.up.railway.app
 #   AIOS_TEAM      — team slug (e.g. aios)
@@ -29,6 +34,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history — the scanner reads the commit window
+
+      # Produce coverage/coverage-summary.json (lib/** lines pct) for the scanner to read.
+      # `|| true`: this is a metrics source, not a gate — never block the scan on coverage.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - name: Generate coverage report (metrics source for the scanner)
+        run: npm run coverage || true
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Why

`scan-on-merge` pushes codebase metrics to the brain on every merge to `main`, but it **never generated a coverage report** — so the scanner's `_read_coverage()` found no `coverage/coverage-summary.json` and `test_coverage_pct` landed **null on every scan**.

Confirmed against prod (`railway connect Postgres`):

| repo | scans | scans_with_coverage | latest_coverage_pct |
|---|---|---|---|
| aios-team-brain | 20 | **1** | **null** |

So the Codebases dashboard shows "**no reports**" for coverage and an empty coverage trend line — despite scanning fine otherwise (agentic 45.67, fresh today).

## Fix

Add a Node setup + `npm ci` + `npm run coverage` step **before** the Python scan, so a fresh `coverage/coverage-summary.json` (the `lib/**` lines pct) exists for the scanner to read. `|| true` keeps this a pure **metrics source** — the coverage **gate** still lives in `ci.yml`'s `brain-tests` job; a threshold miss here must never block the scan.

## Effect

After this merges, each `scan-on-merge` run pushes `test_coverage_pct` (currently **31.67%**), so the Codebases dashboard's "Avg coverage" KPI and the per-repo coverage **trend line** start populating — and keep climbing as the gate ratchets up.

## Verification

- Local: `npm run coverage` writes `coverage/coverage-summary.json` with `.total.lines.pct = 31.67` — exactly the file/field `_read_coverage` reads ✅
- `scan-on-merge.yml` parses as valid YAML ✅
- Runs only on `push: main` for `AIOS-alpha/aios-team-brain`; gracefully skips if scan secrets are unset ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with non-blocking coverage; no runtime, auth, or data-path changes.
> 
> **Overview**
> The **scan-on-merge** workflow now runs **Node 20**, **`npm ci`**, and **`npm run coverage`** (with **`|| true`**) **before** the Python ingestion scan, so **`coverage/coverage-summary.json`** exists when **`_read_coverage()`** runs.
> 
> That populates **`test_coverage_pct`** on brain pushes instead of leaving it **null**, which fixes empty **Codebases** coverage KPIs and trend lines. Comments clarify this step is only a **metrics source**—the coverage **gate** stays in **`ci.yml`**, and a failed coverage run must not block the scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a29cb3871b070a67043e2e37c6e5e9fccedebc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration scan workflow to generate coverage metrics earlier in the process, improving scan reliability and ensuring consistent data availability for analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->