### PR TITLE
feat(pm-sync): reactive auto-projection of task writes (brain-api v1.2 Phase 2)

### DIFF
--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -1,15 +1,34 @@
 "use server";
 
+import { after } from "next/server";
+
 import { serverClient } from "@/lib/supabase/server";
+import { adminClient } from "@/lib/supabase/admin";
 import { currentMember } from "@/lib/auth/guard";
 import { uiRowKey, isUniqueViolation } from "@/lib/ids";
+import { normalizeTaskPriority } from "@/lib/api/schemas";
+import { projectTaskByIdAfterWrite } from "@/lib/pm-sync";
 import { TASK_STATUSES, type Task, type TaskStatus } from "@/components/kanban/types";
 
 /**
  * Backend-agnostic task mutations initiated from the Kanban board. In supabase
  * mode these also satisfy RLS; in postgres mode the currentMember() guard is
  * the access control. (Browser → server action so no PostgREST is needed.)
+ *
+ * Reactive projection (brain-api v1.2 Phase 2): each successful write schedules a single-row
+ * projection into the team's primary PM tool via `after()` (runs after the response). It loads the
+ * full task row inside the callback and NEVER fails the user action — on error it only records
+ * `task_pm_links.last_error`. UI writes always schedule (they bypass the push-path changed-rows
+ * guard); the engine's projection_fingerprint skip prevents a redundant provider write.
  */
+
+// Schedule the fire-and-forget projection. adminClient() needs no request context (gone by the time
+// the callback runs); the helper swallows every error so projection can't fail the action.
+function scheduleProjection(taskId: string) {
+  after(async () => {
+    await projectTaskByIdAfterWrite(adminClient(), taskId);
+  });
+}
 
 export interface NewTaskInput {
   teamId: string;
@@ -39,7 +58,9 @@ export async function moveTaskAction(
     .from("tasks")
     .update({ status, updated_at: new Date().toISOString() })
     .eq("id", taskId);
-  return error ? { ok: false, error: error.message } : { ok: true };
+  if (error) return { ok: false, error: error.message };
+  scheduleProjection(taskId);
+  return { ok: true };
 }
 
 export async function createTaskAction(
@@ -73,9 +94,75 @@ export async function createTaskAction(
         "id, row_key, title, assignee, status, sprint, due_date, origin, project_id, updated_at"
       )
       .single();
-    if (!error && data) return { ok: true, task: data as Task };
+    if (!error && data) {
+      scheduleProjection((data as Task).id);
+      return { ok: true, task: data as Task };
+    }
     if (attempt === 0 && isUniqueViolation(error?.message)) continue;
     return { ok: false, error: error?.message ?? "could not create task" };
   }
   return { ok: false, error: "could not create task" };
+}
+
+export interface UpdateTaskInput {
+  taskId: string;
+  title?: string;
+  sprint?: string;
+  dueDate?: string | null;
+  parentRowKey?: string | null;
+  labels?: string[];
+  priority?: string;
+  body?: string;
+}
+
+/**
+ * Edit a task's projectable fields from the dashboard (brain-api v1.2). Partial — only provided keys
+ * are written, so a title-only edit never clobbers labels. Schedules projection on success.
+ * (Kanban UI wiring lands in Phase 4; this action + its projection trigger ship now.)
+ */
+export async function updateTaskAction(
+  input: UpdateTaskInput
+): Promise<{ ok: boolean; error?: string }> {
+  if (!input.taskId) return { ok: false, error: "taskId required" };
+  const supabase = await serverClient();
+  const { data: task } = await supabase
+    .from("tasks")
+    .select("team_id, project_id, row_key")
+    .eq("id", input.taskId)
+    .maybeSingle();
+  if (!task) return { ok: false, error: "task not found" };
+  const row = task as { team_id: string; project_id: string; row_key: string | null };
+  const me = await currentMember(row.team_id);
+  if (!me) return { ok: false, error: "not a member of this team" };
+
+  // Parent integrity (when provided + non-empty): reject self-parent; require the parent to exist in
+  // the same (team, project). Full cycle detection is deferred to Phase 4's richer CRUD — the
+  // projection engine's visiting-guard prevents any runtime loop meanwhile.
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (input.title !== undefined) update.title = input.title;
+  if (input.sprint !== undefined) update.sprint = input.sprint;
+  if (input.dueDate !== undefined) update.due_date = input.dueDate || null;
+  if (input.labels !== undefined) update.labels = input.labels;
+  if (input.priority !== undefined) update.priority = normalizeTaskPriority(input.priority);
+  if (input.body !== undefined) update.body = input.body;
+  if (input.parentRowKey !== undefined) {
+    const parent = (input.parentRowKey ?? "").trim();
+    if (parent) {
+      if (parent === row.row_key) return { ok: false, error: "a task cannot be its own parent" };
+      const { data: parentRow } = await supabase
+        .from("tasks")
+        .select("id")
+        .eq("team_id", row.team_id)
+        .eq("project_id", row.project_id)
+        .eq("row_key", parent)
+        .maybeSingle();
+      if (!parentRow) return { ok: false, error: `parent "${parent}" not found in project` };
+    }
+    update.parent_row_key = parent || null;
+  }
+
+  const { error } = await supabase.from("tasks").update(update).eq("id", input.taskId);
+  if (error) return { ok: false, error: error.message };
+  scheduleProjection(input.taskId);
+  return { ok: true };
 }

--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server";
+import { NextRequest, after } from "next/server";
 import { adminClient } from "@/lib/supabase/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/api/rate-limit";
@@ -9,6 +9,7 @@ import {
   IngestValidationError,
 } from "@/lib/api/schemas";
 import { ingestItem } from "@/lib/ingest";
+import { projectChangedTasksAfterWrite } from "@/lib/pm-sync";
 
 export const runtime = "nodejs";
 
@@ -60,7 +61,30 @@ export async function POST(req: NextRequest) {
 
   try {
     const result = await ingestItem(supabase, auth, parsed.data, tier);
-    return Response.json(result, { status: result.status === "created" ? 201 : 200 });
+
+    // Reactive auto-projection (brain-api v1.2 Phase 2): on a task push that actually changed
+    // projected fields, schedule a bounded projection of ONLY the changed rows into the team's
+    // primary PM tool — after the response, never failing/blocking the push. Fire-and-forget; the
+    // helper swallows all errors. work-events keeps its own inline projection (unchanged).
+    if (
+      parsed.data.kind === "task" &&
+      result.status !== "unchanged" &&
+      result.projectId &&
+      (result.changedTaskRowKeys?.length ?? 0) > 0
+    ) {
+      const teamId = auth.teamId;
+      const projectId = result.projectId;
+      const rowKeys = result.changedTaskRowKeys!;
+      after(async () => {
+        await projectChangedTasksAfterWrite(adminClient(), teamId, projectId, rowKeys);
+      });
+    }
+
+    // Strip the internal scheduling hints — the HTTP wire format stays { status, id }.
+    return Response.json(
+      { status: result.status, id: result.id },
+      { status: result.status === "created" ? 201 : 200 }
+    );
   } catch (e) {
     // Client validation failures (e.g. a bad task row or a parent-integrity violation) are 422,
     // not 500 — the CLI needs a structured signal to fix the markdown and retry.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,6 +188,18 @@ the work-events done path calls `projectTask` (creating the link/item if missing
 remains as a thin state-only delegate. Assignees and inbound/two-way reconciliation are deferred
 (Phase 5 uses `provider_seen_status` to detect divergence).
 
+**Reactive triggers (brain-api v1.2 Phase 2).** Projection is no longer manual-only. Task UI
+writes — `createTaskAction` / `moveTaskAction` / the new `updateTaskAction` (title/sprint/due/
+parent/labels/priority/body) — schedule a single-row `projectTask` via `next/server`'s `after()`
+(`lib/pm-sync/after-write.ts: projectTaskByIdAfterWrite`). Sync **pushes** (`POST /api/v1/items`,
+task kind) schedule `projectChangedTasksAfterWrite` for **only the rows whose projected fields
+changed this push** — `lib/ingest` computes the changed set by diffing the projectable columns
+(title/status/sprint/priority/labels/parent — not assignee/due/body) against a pre-upsert snapshot
+(`lib/ingest/projectable-diff.ts`), so an unchanged backlog never re-projects. These callbacks run
+**after** the response and **never fail** the originating action/push — on error they only record
+`task_pm_links.last_error`; the `projection_fingerprint` skip keeps them from re-writing the board.
+The manual `projectBoardAction` and the inline work-events projection remain.
+
 **Legacy seed scripts (being retired).** The backlog was originally authored in
 `scripts/aios-backlog.mjs` and pushed by `npm run plane:backlog` / `npm run linear:backlog`
 (idempotent by `external_id` / the `aios-ext:` marker). The projection engine supersedes these;
@@ -294,11 +306,16 @@ guard enforces it, it's named.
 - **Append-only audit.** `audit_log` has a trigger that blocks UPDATE/DELETE.
 - **The brain is the source of truth; the PM board is a one-way projection.** The `tasks` table is
   canonical (v1.2: hierarchy + `body`). The brain projects task create/update/state into the single
-  `teams.primary_pm_provider` board (Plane/Linear) — never the reverse in v1. A merged-work event
-  still marks the matching task done first; provider failures are recorded on
-  `task_pm_links.last_error` and surfaced in Admin → PM sync, never rolling the task back. Inbound
-  PM→brain reconciliation (two-way) is deferred (Phase 5); v1 only records `provider_seen_status` so
-  divergence is detectable.
+  `teams.primary_pm_provider` board (Plane/Linear) — never the reverse in v1. Projection fires both
+  **manually** (admin "Project board now") and **reactively** (v1.2 Phase 2): task UI writes
+  (`create`/`move`/`updateTaskAction`) and changed-row pushes (`POST /api/v1/items`) schedule it via
+  `after()` — bounded to the rows whose projected fields changed, run after the response, and never
+  failing the user action (errors → `task_pm_links.last_error` only; `projection_fingerprint` skips
+  redundant writes). A merged-work event still marks the matching task done first; provider failures
+  are surfaced in Admin → PM sync, never rolling the task back. Inbound PM→brain reconciliation
+  (two-way) is deferred (Phase 5); v1 only records `provider_seen_status` so divergence is detectable.
+  (Rows removed from a push are diff-deleted in `tasks` but **not** deleted from the PM board in
+  Phase 2 — PM deletion-on-diff is a later phase.)
 - **`key_hash` is column-revoked** from client roles; API secrets are sha256-at-rest, shown once.
 - **Migration replay.** 14-digit timestamp prefixes, unique, lexical == chronological.
   *Guards:* `test/guards/migrations-numbering.test.ts` + `npm run db:test:up` (migrates from zero).

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -10,6 +10,11 @@ import {
   IngestValidationError,
 } from "@/lib/api/schemas";
 import { audit } from "@/lib/api/audit";
+import {
+  effectiveProjectable,
+  projectableChanged,
+  type ProjectableSnapshot,
+} from "@/lib/ingest/projectable-diff";
 
 /**
  * The ONLY write path for synced content. Runs with the service role (bypasses
@@ -20,13 +25,24 @@ import { audit } from "@/lib/api/audit";
  *   3. upsert item; version on body change
  *   4. rows[] → diff-sync by row_key; never delete origin='ui' task rows
  *   5. access 'client' → 'external' (handled by caller); 'admin' → 422 (caller)
+ *
+ * For task items, returns `projectId` + `changedTaskRowKeys` (the row_keys whose *projected* fields
+ * changed this push) so the route can schedule a bounded reactive projection via `after()`. These
+ * are internal scheduling hints — the route strips them from the HTTP response (wire format unchanged).
  */
+export interface IngestResult {
+  status: "created" | "updated" | "unchanged";
+  id: string;
+  projectId?: string;
+  changedTaskRowKeys?: string[];
+}
+
 export async function ingestItem(
   supabase: SupabaseClient,
   auth: { teamId: string; memberId: string; apiKeyId: string },
   payload: ItemPayload,
   access: "team" | "external"
-): Promise<{ status: "created" | "updated" | "unchanged"; id: string }> {
+): Promise<IngestResult> {
   // 1. project
   const { data: project, error: projErr } = await supabase
     .from("projects")
@@ -57,7 +73,8 @@ export async function ingestItem(
       action: "item.unchanged", target_type: "item", target_id: existing.id,
       meta: { path: payload.path },
     });
-    return { status: "unchanged", id: existing.id };
+    // No projection on an unchanged push (the route also guards status !== "unchanged").
+    return { status: "unchanged", id: existing.id, projectId: project.id };
   }
 
   // Validate task rows before mutating items so a 422 never leaves a revised item/version behind.
@@ -110,9 +127,10 @@ export async function ingestItem(
   // markdown table diff-deletes its synced rows. `now` (the item's synced_at) is used as
   // the row updated_at, so a freshly-synced row is NOT mistaken for "edited after sync"
   // by the writeback (which would otherwise re-emit a just-written-back UI row forever).
+  let changedTaskRowKeys: string[] | undefined;
   if (payload.rows && (payload.kind === "task" || payload.kind === "decision")) {
     if (payload.kind === "task") {
-      await materializeTasks(
+      changedTaskRowKeys = await materializeTasks(
         supabase,
         auth.teamId,
         project.id,
@@ -133,7 +151,7 @@ export async function ingestItem(
     meta: { path: payload.path, kind: payload.kind, access, rows: payload.rows?.length ?? 0 },
   });
 
-  return { status: existing ? "updated" : "created", id: itemId };
+  return { status: existing ? "updated" : "created", id: itemId, projectId: project.id, changedTaskRowKeys };
 }
 
 type TaskRow = NonNullable<ReturnType<typeof taskRowSchema.safeParse>["data"]>;
@@ -207,12 +225,40 @@ async function materializeTasks(
   itemId: string,
   rows: TaskRow[],
   syncedAt: string
-) {
+): Promise<string[]> {
   const incomingKeys = new Set(rows.map((r) => r.row_key));
   const parentOf = (r: TaskRow) => (r.parent ?? "").trim();
 
+  // Snapshot the incoming rows' projectable columns BEFORE the upsert loop, so we can detect which
+  // rows' projected fields changed this push (bounded reactive projection — see projectable-diff).
+  const snapshotByKey = new Map<string, ProjectableSnapshot>();
+  if (incomingKeys.size) {
+    const { data: before } = await supabase
+      .from("tasks")
+      .select("row_key, title, status, sprint, priority, labels, parent_row_key")
+      .eq("team_id", teamId)
+      .eq("project_id", projectId)
+      .not("row_key", "is", null);
+    for (const t of before ?? []) {
+      if (!t.row_key || !incomingKeys.has(t.row_key)) continue;
+      snapshotByKey.set(t.row_key, {
+        title: t.title ?? "",
+        status: t.status ?? "backlog",
+        sprint: t.sprint ?? "",
+        priority: t.priority || "none",
+        labels: t.labels ?? [],
+        parent_row_key: t.parent_row_key ?? null,
+      });
+    }
+  }
+  const changed: string[] = [];
+
   for (const row of rows) {
     const { status, raw_status } = normalizeTaskStatus(row.status || "");
+    // Projected-field change detection (title/status/sprint/priority/labels/parent only). A new row
+    // (no snapshot) is always "changed"; assignee/due/body changes never trigger projection.
+    const snapshot = snapshotByKey.get(row.row_key) ?? null;
+    if (projectableChanged(snapshot, effectiveProjectable(row, snapshot))) changed.push(row.row_key);
     // `body` is dashboard/DB-only and `parent`/`labels`/`priority` are optional v1.2 fields: each is
     // written ONLY when the row carries the key, so a six-column push preserves them on update and
     // falls back to DB defaults on insert. (A present-but-empty value is authoritative — it clears.)
@@ -282,6 +328,10 @@ async function materializeTasks(
       await supabase.from("tasks").update({ parent_row_key: null }).eq("id", t.id);
     }
   }
+
+  // The row_keys whose projected fields changed this push. The route projects only these (the
+  // after() callback reloads each row's final DB state, so a parent later nulled above is reflected).
+  return changed;
 }
 
 async function materializeDecisions(

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -251,14 +251,14 @@ async function materializeTasks(
       });
     }
   }
-  const changed: string[] = [];
+  const changed = new Set<string>();
 
   for (const row of rows) {
     const { status, raw_status } = normalizeTaskStatus(row.status || "");
     // Projected-field change detection (title/status/sprint/priority/labels/parent only). A new row
     // (no snapshot) is always "changed"; assignee/due/body changes never trigger projection.
     const snapshot = snapshotByKey.get(row.row_key) ?? null;
-    if (projectableChanged(snapshot, effectiveProjectable(row, snapshot))) changed.push(row.row_key);
+    if (projectableChanged(snapshot, effectiveProjectable(row, snapshot))) changed.add(row.row_key);
     // `body` is dashboard/DB-only and `parent`/`labels`/`priority` are optional v1.2 fields: each is
     // written ONLY when the row carries the key, so a six-column push preserves them on update and
     // falls back to DB defaults on insert. (A present-but-empty value is authoritative — it clears.)
@@ -326,12 +326,15 @@ async function materializeTasks(
     const parent = (t.parent_row_key ?? "").trim();
     if (parent && survivors.has(t.row_key!) && !survivors.has(parent)) {
       await supabase.from("tasks").update({ parent_row_key: null }).eq("id", t.id);
+      // Nulling a dangling parent IS a projected-field change (the child must un-nest on the board),
+      // but it happens after the snapshot diff — so flag it here or reactive projection would miss it.
+      if (t.row_key) changed.add(t.row_key);
     }
   }
 
   // The row_keys whose projected fields changed this push. The route projects only these (the
-  // after() callback reloads each row's final DB state, so a parent later nulled above is reflected).
-  return changed;
+  // after() callback reloads each row's final DB state, so a parent nulled above is reflected).
+  return [...changed];
 }
 
 async function materializeDecisions(

--- a/lib/ingest/projectable-diff.ts
+++ b/lib/ingest/projectable-diff.ts
@@ -1,0 +1,72 @@
+import { normalizeTaskStatus, normalizeTaskPriority } from "@/lib/api/schemas";
+
+/**
+ * Changed-rows detection for the reactive push path. A sync push must re-project ONLY the rows whose
+ * *projected* fields changed — so an unchanged backlog never re-projects on every push (bounded; no
+ * board spam). The projected field set the engine writes to the PM tool is:
+ *
+ *   title · normalized status · sprint · priority · labels · parent_row_key
+ *
+ * Notably NOT: `assignee` / `due_date` (never projected) and `body` (dashboard/DB-only on the push
+ * path — `tasks.body` is owned by the dashboard, not the markdown table). A push that only flips
+ * `due_date` or whose body/content_sha256 changed but projected columns didn't ⇒ no projection.
+ */
+export interface ProjectableSnapshot {
+  title: string;
+  status: string; // normalized task_status
+  sprint: string;
+  priority: string; // normalized: none | low | medium | high | urgent
+  labels: string[];
+  parent_row_key: string | null;
+}
+
+// The subset of a parsed task row this predicate reads. Presence of `parent`/`labels`/`priority`
+// keys mirrors materializeTasks' partial-write rule: absent key ⇒ the stored value is preserved.
+export interface IncomingProjectableRow {
+  title: string;
+  status?: string | null;
+  sprint?: string | null;
+  parent?: string | null;
+  labels?: string[];
+  priority?: string | null;
+}
+
+function sameLabels(a: string[], b: string[]): boolean {
+  const sa = [...a].map((l) => l.trim()).filter(Boolean).sort();
+  const sb = [...b].map((l) => l.trim()).filter(Boolean).sort();
+  return sa.length === sb.length && sa.every((v, i) => v === sb[i]);
+}
+
+// Compute the post-upsert projectable values, applying the SAME partial-write rules as
+// materializeTasks: a key present in the push is authoritative (even when empty → clears); a key
+// absent falls back to the stored snapshot value. `snapshot` is null for a brand-new row.
+export function effectiveProjectable(
+  row: IncomingProjectableRow,
+  snapshot: ProjectableSnapshot | null
+): ProjectableSnapshot {
+  return {
+    title: row.title,
+    status: normalizeTaskStatus(row.status || "").status,
+    sprint: row.sprint ?? "",
+    priority: "priority" in row ? normalizeTaskPriority(row.priority) : snapshot?.priority || "none",
+    labels: "labels" in row ? row.labels ?? [] : snapshot?.labels ?? [],
+    parent_row_key:
+      "parent" in row ? (row.parent ?? "").trim() || null : snapshot?.parent_row_key ?? null,
+  };
+}
+
+// True when the row's projected fields changed (or the row is brand-new, i.e. no snapshot).
+export function projectableChanged(
+  snapshot: ProjectableSnapshot | null,
+  effective: ProjectableSnapshot
+): boolean {
+  if (!snapshot) return true;
+  return !(
+    snapshot.title === effective.title &&
+    snapshot.status === effective.status &&
+    snapshot.sprint === effective.sprint &&
+    (snapshot.priority || "none") === effective.priority &&
+    (snapshot.parent_row_key ?? null) === (effective.parent_row_key ?? null) &&
+    sameLabels(snapshot.labels ?? [], effective.labels ?? [])
+  );
+}

--- a/lib/pm-sync/after-write.ts
+++ b/lib/pm-sync/after-write.ts
@@ -60,7 +60,7 @@ export async function projectChangedTasksAfterWrite(
   if (!rowKeys.length) return [];
   try {
     const primary = await resolvePrimaryProvider(supabase, teamId);
-    if (primary.provider === null || primary.integration === null) return [];
+    if (primary.provider === null) return []; // no PM tool configured → nothing to project or surface
 
     const { data } = await supabase
       .from("tasks")
@@ -70,6 +70,15 @@ export async function projectChangedTasksAfterWrite(
       .in("row_key", rowKeys);
     const rows = ((data ?? []) as ProjectionTaskRow[]).filter((r) => r.row_key);
     if (!rows.length) return [];
+
+    // Provider configured but its integration is missing/secret-less: record the error on each
+    // changed row's link (parity with single-row projectTask) so Admin → PM sync surfaces it,
+    // instead of failing silently. No bootstrap is reachable here, so don't take the batch path.
+    if (primary.integration === null) {
+      const reports: ProjectionReport[] = [];
+      for (const row of rows) reports.push(await projectTask(supabase, row, { primary, fetchImpl: opts.fetchImpl }));
+      return reports;
+    }
 
     return await projectRows(supabase, primary, rows, { fetchImpl: opts.fetchImpl });
   } catch {

--- a/lib/pm-sync/after-write.ts
+++ b/lib/pm-sync/after-write.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  projectTask,
+  projectRows,
+  resolvePrimaryProvider,
+  PROJECTION_TASK_COLS,
+  type ProjectionReport,
+  type ProjectionTaskRow,
+} from "@/lib/pm-sync/project";
+
+/**
+ * Fire-and-forget projection for the reactive write paths (UI server actions + the changed-rows push
+ * tail). These run INSIDE a `next/server` `after()` callback — after the response is sent — so they
+ * must NEVER throw: a projection failure must not fail the user action / push.
+ *
+ * `projectTask` already catches *adapter* errors internally and records `task_pm_links.last_error`;
+ * the outer try/catch here is the safety net for `ensureLink` / primary-resolution DB errors. Both
+ * helpers take the service-role `adminClient()` (no request context needed in the callback) and an
+ * injectable `fetchImpl` so tests stub the provider — no live PM calls in CI.
+ */
+
+// Load a task by id with the canonical projection column set (shared with the engine). Missing row
+// (e.g. deleted between the write and the after() callback) → null.
+async function loadTaskById(supabase: SupabaseClient, taskId: string): Promise<ProjectionTaskRow | null> {
+  const { data } = await supabase.from("tasks").select(PROJECTION_TASK_COLS).eq("id", taskId).maybeSingle();
+  return (data as ProjectionTaskRow | null) ?? null;
+}
+
+// Project a single task (by id) into the team's primary PM tool. Used by createTaskAction /
+// moveTaskAction / updateTaskAction via after(). Always single-row — the UI bypasses the push-path
+// changed-rows guard (Decision 3) and the engine's fingerprint skip prevents a redundant write.
+export async function projectTaskByIdAfterWrite(
+  supabase: SupabaseClient,
+  taskId: string,
+  opts: { fetchImpl?: typeof fetch } = {}
+): Promise<ProjectionReport | null> {
+  try {
+    const row = await loadTaskById(supabase, taskId);
+    if (!row) return null;
+    return await projectTask(supabase, row, { fetchImpl: opts.fetchImpl });
+  } catch {
+    // Swallow — projection must never surface as a user-action failure.
+    return null;
+  }
+}
+
+// Project a bounded set of changed rows (by row_key) after a sync push. Mirrors projectAllTasks batch
+// semantics — prepare once, parent-before-child, shared resolved map, synced-only throttle — but
+// scoped to the rows whose projected fields changed this push.
+export async function projectChangedTasksAfterWrite(
+  supabase: SupabaseClient,
+  teamId: string,
+  projectId: string,
+  rowKeys: string[],
+  opts: { fetchImpl?: typeof fetch } = {}
+): Promise<ProjectionReport[]> {
+  if (!rowKeys.length) return [];
+  try {
+    const primary = await resolvePrimaryProvider(supabase, teamId);
+    if (primary.provider === null || primary.integration === null) return [];
+
+    const { data } = await supabase
+      .from("tasks")
+      .select(PROJECTION_TASK_COLS)
+      .eq("team_id", teamId)
+      .eq("project_id", projectId)
+      .in("row_key", rowKeys);
+    const rows = ((data ?? []) as ProjectionTaskRow[]).filter((r) => r.row_key);
+    if (!rows.length) return [];
+
+    return await projectRows(supabase, primary, rows, { fetchImpl: opts.fetchImpl });
+  } catch {
+    return [];
+  }
+}

--- a/lib/pm-sync/index.ts
+++ b/lib/pm-sync/index.ts
@@ -7,6 +7,7 @@ import type { PmProvider } from "@/lib/pm-sync/provider";
 
 export { projectTask, projectAllTasks } from "@/lib/pm-sync/project";
 export type { ProjectionReport, ProjectionTaskRow } from "@/lib/pm-sync/project";
+export { projectTaskByIdAfterWrite, projectChangedTasksAfterWrite } from "@/lib/pm-sync/after-write";
 
 export interface TaskForPmSync {
   id: string;

--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -131,6 +131,11 @@ function toProjectable(row: ProjectionTaskRow, parentResourceId: string | null):
 const LINK_COLS =
   "id, team_id, project_id, task_id, row_key, provider, provider_resource_id, provider_external_source, provider_external_id, provider_url, projection_fingerprint, last_projected_status, provider_seen_status";
 
+// The exact `tasks` columns that hydrate a ProjectionTaskRow. Named explicitly (the pg adapter
+// rejects "*") and shared by every loader so the projected shape can't drift between call sites.
+export const PROJECTION_TASK_COLS =
+  "id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key";
+
 // Get-or-create the task_pm_links row for (team, project, row_key, provider).
 async function ensureLink(
   supabase: SupabaseClient,
@@ -201,7 +206,7 @@ async function loadTaskByRowKey(
 ): Promise<ProjectionTaskRow | null> {
   const { data } = await supabase
     .from("tasks")
-    .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key")
+    .select(PROJECTION_TASK_COLS)
     .eq("team_id", teamId)
     .eq("project_id", projectId)
     .eq("row_key", rowKey)
@@ -291,7 +296,7 @@ export async function projectTask(
 
 // Order rows parent-before-child (epics first). Rows whose parent is missing/cyclic are still
 // emitted (projectTask reports the failure) so the batch never silently drops them.
-function topoOrder(rows: ProjectionTaskRow[]): ProjectionTaskRow[] {
+export function topoOrder(rows: ProjectionTaskRow[]): ProjectionTaskRow[] {
   const byKey = new Map(rows.map((r) => [r.row_key, r]));
   const ordered: ProjectionTaskRow[] = [];
   const placed = new Set<string>();
@@ -317,28 +322,17 @@ export interface ProjectAllOptions {
   throttleMs?: number;
 }
 
-// Server-side replacement for `npm run plane:backlog` / `linear:backlog`: project the whole board
-// for a (team, project). ~80 rows × 1 provider ≈ ~90s with the throttle. Continues on per-row
-// failure and returns a per-row report.
-export async function projectAllTasks(
+// Shared batch projector: prefetch the provider bootstrap ONCE (labels/states/items), then project
+// the rows parent-before-child sharing a single `resolved` map, paying the ~1 req/s throttle only on
+// rows that actually wrote. Both `projectAllTasks` (whole board) and the reactive changed-rows path
+// reuse this so the prepare/order/throttle semantics can't drift apart.
+export async function projectRows(
   supabase: SupabaseClient,
-  teamId: string,
-  projectId: string,
+  primary: ResolvedPrimary,
+  rows: ProjectionTaskRow[],
   opts: ProjectAllOptions = {}
-): Promise<{ provider: PmProvider | null; reports: ProjectionReport[]; reason?: string }> {
-  const primary = await resolvePrimaryProvider(supabase, teamId);
-  if (primary.provider === null || primary.integration === null) {
-    return { provider: primary.provider, reports: [], reason: primary.reason };
-  }
-
-  const { data: taskRows } = await supabase
-    .from("tasks")
-    .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key")
-    .eq("team_id", teamId)
-    .eq("project_id", projectId)
-    .not("row_key", "is", null);
-  const rows = ((taskRows ?? []) as ProjectionTaskRow[]).filter((r) => r.row_key);
-  if (!rows.length) return { provider: primary.provider, reports: [] };
+): Promise<ProjectionReport[]> {
+  if (!rows.length) return [];
 
   // Prefetch once: ensure all labels exist + cache states/items/issues for the run.
   const allLabels = Array.from(new Set(rows.flatMap((r) => r.labels ?? []).filter(Boolean)));
@@ -363,5 +357,32 @@ export async function projectAllTasks(
     // Only pay the throttle when we actually wrote to the provider.
     if (report.status === "synced") await sleep(throttleMs);
   }
+  return reports;
+}
+
+// Server-side replacement for `npm run plane:backlog` / `linear:backlog`: project the whole board
+// for a (team, project). ~80 rows × 1 provider ≈ ~90s with the throttle. Continues on per-row
+// failure and returns a per-row report.
+export async function projectAllTasks(
+  supabase: SupabaseClient,
+  teamId: string,
+  projectId: string,
+  opts: ProjectAllOptions = {}
+): Promise<{ provider: PmProvider | null; reports: ProjectionReport[]; reason?: string }> {
+  const primary = await resolvePrimaryProvider(supabase, teamId);
+  if (primary.provider === null || primary.integration === null) {
+    return { provider: primary.provider, reports: [], reason: primary.reason };
+  }
+
+  const { data: taskRows } = await supabase
+    .from("tasks")
+    .select(PROJECTION_TASK_COLS)
+    .eq("team_id", teamId)
+    .eq("project_id", projectId)
+    .not("row_key", "is", null);
+  const rows = ((taskRows ?? []) as ProjectionTaskRow[]).filter((r) => r.row_key);
+  if (!rows.length) return { provider: primary.provider, reports: [] };
+
+  const reports = await projectRows(supabase, primary, rows, opts);
   return { provider: primary.provider, reports };
 }

--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -58,8 +58,10 @@ export interface ProjectionReport {
 export interface ProjectTaskOptions {
   statusOnly?: boolean;
   fetchImpl?: typeof fetch;
-  // Resolved once by projectAllTasks and threaded through to avoid re-resolution per row.
-  primary?: ResolvedPrimary;
+  // Resolved once by the orchestrator and threaded through to avoid re-resolution per row. Accepts
+  // any resolution (incl. provider-known-but-integration-missing) so projectTask still records the
+  // missing_integration error on the link instead of re-resolving.
+  primary?: PrimaryResolution;
   bootstrap?: unknown;
   // Map of row_key → already-projected provider resource id (parent-first ordering).
   resolved?: Map<string, string>;

--- a/test/datamechanics/helpers.ts
+++ b/test/datamechanics/helpers.ts
@@ -49,7 +49,7 @@ export async function seedTeam(): Promise<Seed> {
 export async function ingest(
   seed: Seed,
   over: Partial<ItemPayload> & { body: string; path: string; access: "team" | "external" }
-): Promise<{ status: string; id: string }> {
+): Promise<{ status: string; id: string; projectId?: string; changedTaskRowKeys?: string[] }> {
   const payload: ItemPayload = {
     project: "acme",
     kind: "deliverable",

--- a/test/datamechanics/reactive-projection.datamechanics.test.ts
+++ b/test/datamechanics/reactive-projection.datamechanics.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+import { projectTaskByIdAfterWrite, projectChangedTasksAfterWrite } from "@/lib/pm-sync";
+import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+
+// Spec (brain-api v1.2 Phase 2): reactive projection of task writes into the primary PM tool.
+// Verified to the observable outcome on real Postgres, with a mutation-counting stub `fetchImpl`
+// (the linearMock pattern from test/pm-sync-adapters.test.ts) — NO live Linear calls in CI.
+
+// ── Linear stub: routes GraphQL by operation, records mutations, mints distinct issue ids ──────────
+function linearMock(opts: { issues?: unknown[]; labels?: unknown[] } = {}) {
+  const mutations: { name: string; variables: { [k: string]: unknown } }[] = [];
+  let n = 0;
+  const states = [
+    { id: "ls-backlog", name: "Backlog", type: "backlog" },
+    { id: "ls-todo", name: "Todo", type: "unstarted" },
+    { id: "ls-started", name: "In Progress", type: "started" },
+    { id: "ls-done", name: "Done", type: "completed" },
+  ];
+  const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+    const { query, variables } = JSON.parse(String(init?.body));
+    if (query.includes("ProjectionBootstrap")) {
+      return Response.json({ data: { team: { states: { nodes: states }, labels: { nodes: opts.labels ?? [] } } } });
+    }
+    if (query.includes("ProjectionIssues")) {
+      return Response.json({ data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: opts.issues ?? [] } } } });
+    }
+    const name = query.match(/mutation (\w+)/)?.[1] ?? query.match(/query (\w+)/)?.[1] ?? "op";
+    if (query.includes("mutation")) mutations.push({ name, variables });
+    if (query.includes("issueCreate")) {
+      const id = `li-${++n}`;
+      return Response.json({ data: { issueCreate: { success: true, issue: { id, identifier: `AIO-${n}`, url: `https://linear.app/${id}` } } } });
+    }
+    if (query.includes("issueUpdate")) {
+      return Response.json({ data: { issueUpdate: { success: true, issue: { id: variables.id, identifier: "AIO-1", url: "https://linear.app/AIO-1" } } } });
+    }
+    if (query.includes("issueLabelCreate")) {
+      return Response.json({ data: { issueLabelCreate: { issueLabel: { id: `label-${++n}` } } } });
+    }
+    return Response.json({ data: {} });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations };
+}
+
+async function seedLinearPrimary(seed: Seed) {
+  await db().from("teams").update({ primary_pm_provider: "linear" }).eq("id", seed.teamId);
+  const auth = { teamId: seed.teamId, memberId: seed.memberId };
+  const { id } = await upsertIntegration(db(), auth, { type: "linear", name: "linear", config: { teamId: "team-uuid" } });
+  await setIntegrationSecret(db(), auth, id, "lin_api_x");
+}
+
+// Push a tasks.md item. `salt` keeps content_sha256 unique so each push re-materializes (mirrors a
+// real edited tasks.md); the row fields drive the projected columns.
+const pushTasks = (seed: Seed, salt: string, rows: Record<string, unknown>[]) =>
+  ingest(seed, {
+    kind: "task",
+    path: "3-log/tasks.md",
+    body: `${salt}\n` + rows.map((r) => `| ${r.row_key} | ${r.title} | ${r.parent ?? ""} | ${r.due ?? ""} |`).join("\n"),
+    access: "team",
+    rows,
+  } as never);
+
+async function projectIdOf(teamId: string): Promise<string> {
+  const { data } = await db().from("projects").select("id").eq("team_id", teamId).eq("slug", "acme").single();
+  return (data as { id: string }).id;
+}
+async function taskIdOf(teamId: string, rowKey: string): Promise<string> {
+  const { data } = await db().from("tasks").select("id").eq("team_id", teamId).eq("row_key", rowKey).single();
+  return (data as { id: string }).id;
+}
+async function linkOf(teamId: string, rowKey: string) {
+  const { data } = await db()
+    .from("task_pm_links")
+    .select("provider, provider_external_id, provider_resource_id, projection_fingerprint, last_error")
+    .eq("team_id", teamId)
+    .eq("row_key", rowKey)
+    .maybeSingle();
+  return data as {
+    provider: string;
+    provider_external_id: string;
+    provider_resource_id: string | null;
+    projection_fingerprint: string | null;
+    last_error: string | null;
+  } | null;
+}
+
+describe("reactive projection — single task write (real Postgres)", () => {
+  it("a task with no PM column auto-creates a link + projects (create path)", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    await pushTasks(seed, "v1", [{ row_key: "P0", title: "Solo task" }]);
+    const taskId = await taskIdOf(seed.teamId, "P0");
+
+    const { fetchImpl, mutations } = linearMock();
+    const report = await projectTaskByIdAfterWrite(db(), taskId, { fetchImpl });
+
+    expect(report?.status).toBe("synced");
+    const link = await linkOf(seed.teamId, "P0");
+    expect(link).toMatchObject({ provider: "linear", provider_external_id: "P0", provider_resource_id: "li-1" });
+    expect(link?.projection_fingerprint).toBeTruthy();
+    expect(mutations.some((m) => m.name === "CreateIssue")).toBe(true);
+  });
+
+  it("a projection failure does NOT throw and only records last_error", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    await pushTasks(seed, "v1", [{ row_key: "P0", title: "x" }]);
+    const taskId = await taskIdOf(seed.teamId, "P0");
+
+    const failing = vi.fn(async () => {
+      throw new Error("linear down");
+    }) as unknown as typeof fetch;
+
+    // The helper must RESOLVE (never reject) so the originating user action stays successful.
+    const report = await projectTaskByIdAfterWrite(db(), taskId, { fetchImpl: failing });
+    expect(report?.status).toBe("failed");
+
+    const link = await linkOf(seed.teamId, "P0");
+    expect(link?.last_error).toBeTruthy();
+    expect(link?.provider_resource_id).toBeNull(); // nothing was created
+  });
+
+  it("a second projection of an unchanged task makes ZERO provider writes (fingerprint skip)", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    await pushTasks(seed, "v1", [{ row_key: "P0", title: "x" }]);
+    const taskId = await taskIdOf(seed.teamId, "P0");
+
+    const first = linearMock();
+    await projectTaskByIdAfterWrite(db(), taskId, { fetchImpl: first.fetchImpl });
+
+    const second = linearMock();
+    const report = await projectTaskByIdAfterWrite(db(), taskId, { fetchImpl: second.fetchImpl });
+
+    expect(report?.status).toBe("skipped");
+    expect(second.mutations.length).toBe(0);
+    expect(second.fetchImpl).not.toHaveBeenCalled(); // short-circuited before any round-trip
+  });
+});
+
+describe("reactive projection — changed-rows batch (real Postgres)", () => {
+  it("projects parent before child so the child carries the epic's resource id", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    await pushTasks(seed, "v1", [
+      { row_key: "E", title: "Epic" },
+      { row_key: "C", title: "Child", parent: "E" },
+    ]);
+    const projectId = await projectIdOf(seed.teamId);
+
+    const { fetchImpl, mutations } = linearMock();
+    // Pass the row_keys child-first to prove topo-order projects the epic first regardless.
+    const reports = await projectChangedTasksAfterWrite(db(), seed.teamId, projectId, ["C", "E"], { fetchImpl });
+
+    expect(reports.length).toBe(2);
+    expect(reports.every((r) => r.status === "synced")).toBe(true);
+
+    const creates = mutations.filter((m) => m.name === "CreateIssue");
+    const titleOf = (m: { variables: { [k: string]: unknown } }) => (m.variables.input as { title: string }).title;
+    const parentOf = (m: { variables: { [k: string]: unknown } }) => (m.variables.input as { parentId: string | null }).parentId;
+    const epicCreate = creates.find((c) => titleOf(c) === "Epic");
+    const childCreate = creates.find((c) => titleOf(c) === "Child");
+
+    expect(epicCreate).toBeTruthy();
+    expect(childCreate).toBeTruthy();
+    const epicLink = await linkOf(seed.teamId, "E");
+    expect(epicLink?.provider_resource_id).toBe("li-1"); // epic created first
+    expect(parentOf(childCreate!)).toBe(epicLink?.provider_resource_id); // child nested under it
+  });
+});
+
+describe("materialize changed-rows detection (real Postgres)", () => {
+  it("ingestItem returns only the row_keys whose projected fields changed", async () => {
+    const seed = await seedTeam();
+    // Push 1: two brand-new rows → both changed.
+    let res = await pushTasks(seed, "v1", [
+      { row_key: "E", title: "Epic" },
+      { row_key: "C", title: "Child", parent: "E" },
+    ]);
+    expect(new Set(res.changedTaskRowKeys)).toEqual(new Set(["E", "C"]));
+
+    // Push 2: identical projected values, different body (content_sha differs) → nothing projected.
+    res = await pushTasks(seed, "v2-body-only", [
+      { row_key: "E", title: "Epic" },
+      { row_key: "C", title: "Child", parent: "E" },
+    ]);
+    expect(res.changedTaskRowKeys).toEqual([]);
+
+    // Push 3: rename only C → exactly [C].
+    res = await pushTasks(seed, "v3", [
+      { row_key: "E", title: "Epic" },
+      { row_key: "C", title: "Child RENAMED", parent: "E" },
+    ]);
+    expect(res.changedTaskRowKeys).toEqual(["C"]);
+
+    // Push 4: change only E's due_date (not a projected field) → nothing projected.
+    res = await pushTasks(seed, "v4", [
+      { row_key: "E", title: "Epic", due: "2030-01-01" },
+      { row_key: "C", title: "Child RENAMED", parent: "E" },
+    ]);
+    expect(res.changedTaskRowKeys).toEqual([]);
+  });
+});

--- a/test/datamechanics/reactive-projection.datamechanics.test.ts
+++ b/test/datamechanics/reactive-projection.datamechanics.test.ts
@@ -200,4 +200,42 @@ describe("materialize changed-rows detection (real Postgres)", () => {
     ]);
     expect(res.changedTaskRowKeys).toEqual([]);
   });
+
+  it("flags a child whose dangling parent is nulled by an epic diff-delete", async () => {
+    const seed = await seedTeam();
+    await pushTasks(seed, "v1", [
+      { row_key: "E", title: "Epic" },
+      { row_key: "C", title: "Child", parent: "E" },
+    ]);
+    // Push drops the epic E but keeps C (still referencing E) → C.parent_row_key is nulled AFTER the
+    // pre-upsert snapshot diff. C's projected parent changed (E → null), so it must still be flagged.
+    const res = await pushTasks(seed, "v2", [{ row_key: "C", title: "Child", parent: "E" }]);
+    expect(res.changedTaskRowKeys).toContain("C");
+    const { data } = await db()
+      .from("tasks")
+      .select("parent_row_key")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "C")
+      .single();
+    expect((data as { parent_row_key: string | null }).parent_row_key).toBeNull();
+  });
+});
+
+describe("reactive projection — missing integration (real Postgres)", () => {
+  it("records missing_integration on each changed row's link (observability parity)", async () => {
+    const seed = await seedTeam();
+    // Primary provider configured, but NO integration enabled → the push path must still surface the
+    // failure on the link (not return silently), matching single-row projectTask.
+    await db().from("teams").update({ primary_pm_provider: "linear" }).eq("id", seed.teamId);
+    await pushTasks(seed, "v1", [{ row_key: "P0", title: "x" }]);
+    const projectId = await projectIdOf(seed.teamId);
+
+    const reports = await projectChangedTasksAfterWrite(db(), seed.teamId, projectId, ["P0"]);
+    expect(reports).toEqual([
+      expect.objectContaining({ row_key: "P0", provider: "linear", status: "missing_integration" }),
+    ]);
+    const link = await linkOf(seed.teamId, "P0");
+    expect(link?.last_error).toBeTruthy();
+    expect(link?.provider_external_id).toBe("P0");
+  });
 });

--- a/test/projectable-diff.test.ts
+++ b/test/projectable-diff.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  effectiveProjectable,
+  projectableChanged,
+  type ProjectableSnapshot,
+} from "@/lib/ingest/projectable-diff";
+
+// Spec: the reactive push path re-projects ONLY rows whose projected fields changed. Projected set is
+// title · normalized status · sprint · priority · labels · parent_row_key — NOT assignee/due/body.
+
+const snap = (over: Partial<ProjectableSnapshot> = {}): ProjectableSnapshot => ({
+  title: "T",
+  status: "backlog",
+  sprint: "",
+  priority: "none",
+  labels: [],
+  parent_row_key: null,
+  ...over,
+});
+
+describe("projectable-diff (changed-rows predicate)", () => {
+  it("a brand-new row (no snapshot) is always changed", () => {
+    expect(projectableChanged(null, effectiveProjectable({ title: "x" }, null))).toBe(true);
+  });
+
+  it("identical projected values are unchanged (a due/assignee-only edit never trips this)", () => {
+    const s = snap({ title: "x", status: "ready" });
+    // Six-col push re-emits title/status with the same values; due_date/assignee aren't in the set.
+    expect(projectableChanged(s, effectiveProjectable({ title: "x", status: "ready" }, s))).toBe(false);
+  });
+
+  it("a title change is changed", () => {
+    const s = snap({ title: "old" });
+    expect(projectableChanged(s, effectiveProjectable({ title: "new" }, s))).toBe(true);
+  });
+
+  it("a status change is changed (normalized)", () => {
+    const s = snap({ status: "backlog" });
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", status: "In Progress" }, s))).toBe(true);
+  });
+
+  it("a label reorder is NOT a change (order-independent)", () => {
+    const s = snap({ labels: ["a", "b"] });
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", labels: ["b", "a"] }, s))).toBe(false);
+  });
+
+  it("a label add IS a change", () => {
+    const s = snap({ labels: ["a"] });
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", labels: ["a", "c"] }, s))).toBe(true);
+  });
+
+  it("a priority alias that resolves to the same value is unchanged", () => {
+    const s = snap({ priority: "urgent" });
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", priority: "critical" }, s))).toBe(false);
+  });
+
+  it("a real priority change is changed", () => {
+    const s = snap({ priority: "high" });
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", priority: "low" }, s))).toBe(true);
+  });
+
+  it("absent partial keys preserve the snapshot (no change)", () => {
+    const s = snap({ title: "T", labels: ["a"], priority: "high", parent_row_key: "E" });
+    const eff = effectiveProjectable({ title: "T" }, s); // six-col push: no labels/priority/parent keys
+    expect(eff.labels).toEqual(["a"]);
+    expect(eff.priority).toBe("high");
+    expect(eff.parent_row_key).toBe("E");
+    expect(projectableChanged(s, eff)).toBe(false);
+  });
+
+  it("a present-but-empty parent clears it (change)", () => {
+    const s = snap({ parent_row_key: "E" });
+    const eff = effectiveProjectable({ title: "T", parent: "" }, s);
+    expect(eff.parent_row_key).toBeNull();
+    expect(projectableChanged(s, eff)).toBe(true);
+  });
+
+  it("a parent re-point is changed", () => {
+    const s = snap({ parent_row_key: "E1" });
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", parent: "E2" }, s))).toBe(true);
+  });
+
+  it("a null-priority snapshot vs an absent priority key is unchanged (none ≡ null)", () => {
+    const s = snap({ priority: "none" });
+    expect(projectableChanged(s, effectiveProjectable({ title: "T" }, s))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Phase 2 of the brain→PM projection: task writes now **auto-project** to the primary PM tool (Linear) — the board updates without the manual "Project board now" button. Bounded (only changed rows), non-blocking (runs after the response via `after()`), and non-failing (a projection error never fails the user action).

Phases 0/1 shipped the projection engine + manual trigger; this adds the reactive layer on top. **Internal brain behavior only — no `brain-api.md` contract change.**

## Changes

- **`app/actions/tasks.ts`** — `createTaskAction` / `moveTaskAction` and a **new `updateTaskAction`** (title/sprint/due/parent/labels/priority/body) schedule a single-row projection via `next/server` `after()` (first use in the repo). The callback loads the full row with `adminClient()` (no request context needed) and only records `task_pm_links.last_error` on failure. (Kanban UI wiring for `updateTaskAction` is deferred to Phase 4.)
- **`lib/ingest`** — `materializeTasks` diffs each row's **projected** fields (title/status/sprint/priority/labels/parent — *not* assignee/due/body) against a pre-upsert snapshot and returns the changed `row_key`s; `ingestItem` surfaces `{ projectId, changedTaskRowKeys }`. New pure predicate in `lib/ingest/projectable-diff.ts`.
- **`app/api/v1/items`** — on a task push that changed projected fields, schedule `projectChangedTasksAfterWrite` for **only** the changed rows, after the response. Guards: `kind === "task" && status !== "unchanged" && changedTaskRowKeys.length > 0`. The HTTP wire format stays `{ status, id }` (hints stripped).
- **`lib/pm-sync/after-write.ts`** (new) — error-swallowing fire-and-forget helpers. The batch helper reuses the now-exported `topoOrder` + a new shared `projectRows` (prepare-once, parent-first, shared `resolved` map, synced-only throttle) so batch semantics can't drift from `projectAllTasks`.
- **`docs/ARCHITECTURE.md`** — §1 PM-sync flow + the one-way-projection invariant record the reactive triggers and the Phase-2 deferral of PM deletion-on-diff-delete.

## Tests (all `fetchImpl`-stubbed — no live PM calls in CI)

- **Unit (+12):** `projectable-diff` predicate — new row, title/status/label/priority/parent changes, label-reorder no-op, priority-alias no-op, absent-key preservation, due/assignee-only no-op.
- **Data-mechanics (+5, real Postgres):** auto-link + create on a no-PM-column task; **projection failure does not throw**, only writes `last_error`; **second projection = zero provider writes** (mutation count 0, fingerprint skip); **parent-before-child** ordering (child carries the epic's resource id); `ingestItem` changed-rows detection (body-only / due-only → empty; rename → exactly that key).

## Verification

| Gate | Result |
|---|---|
| `npm test` (unit) | ✅ 165 passed |
| `npm run test:datamechanics` | ✅ 94 passed |
| `npm run test:http` (real socket + build) | ✅ 9 passed |
| `npx tsc --noEmit` | ✅ clean |
| `npm run lint` | ✅ 0 errors (1 pre-existing warning, untouched file) |
| `npm run check:docs` | ✅ in sync |

No schema change → no `pg:schema`; deploy is automatic on merge (Railway).

## Ops effect (once merged + deployed)

- Create/move/update task writes and changed-row pushes auto-project to Linear. The changed-rows guard + `projection_fingerprint` skip prevent board spam.
- **Deferred:** rows removed from a push are diff-deleted in `tasks` but **not** removed from the Linear board in Phase 2 (PM deletion-on-diff is a later phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core task ingest, server actions, and external PM API calls asynchronously; failures are isolated but can cause brain/Linear drift until retried or manually projected.
> 
> **Overview**
> Adds **brain-api v1.2 Phase 2**: task writes automatically project to the team’s primary PM tool (e.g. Linear) without relying on manual “Project board now,” while keeping the public ingest API response as `{ status, id }`.
> 
> **Reactive triggers** use `next/server` `after()` so projection runs after the HTTP/action response and never fails the caller—errors only land on `task_pm_links.last_error`. Kanban **create/move** and a new **`updateTaskAction`** (partial edits + basic parent checks) each schedule single-row projection via `projectTaskByIdAfterWrite`. **`POST /api/v1/items`** (task pushes) schedules **`projectChangedTasksAfterWrite`** only for rows whose **projected** fields changed.
> 
> **Bounded push path:** `lib/ingest/projectable-diff.ts` diffs title/status/sprint/priority/labels/parent (not assignee/due/body); `ingestItem` returns internal `projectId` / `changedTaskRowKeys` that the route strips from JSON. **`lib/pm-sync/after-write.ts`** swallows errors; **`projectRows`** is extracted so full-board and changed-row batches share prepare/topo/throttle semantics with `projectAllTasks`.
> 
> Docs note reactive triggers and that diff-deleted tasks are **not** removed from the PM board in Phase 2. New unit and Postgres data-mechanics tests cover the diff predicate, fingerprint skip, failure non-throw, and parent-before-child ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dfcfc58e1c0cd31a12a15b6584085d58048ea87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks now automatically synchronize to project management tools after creation, updates, or moves
  * Item ingestion intelligently detects and syncs only fields that have changed, reducing unnecessary API calls

* **Documentation**
  * Updated architecture guide to explain reactive synchronization behavior and field change detection

* **Tests**
  * Added comprehensive tests for reactive synchronization workflows and change detection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->