### PR TITLE
fix(api+rollout): 422 on unknown member handle; additive postgres migration path (W2.1 follow-ups)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,12 @@ bash scripts/e2e.sh    # system-level integration: seed → push → materialize
 - **Schema:** canonical = `postgres/schema.sql` (idempotent; `npm run pg:schema` loads it and is the
   prod rollout step against Railway). `supabase/migrations/` is the **legacy/derived** RLS schema, used
   only when `DB_BACKEND=supabase`; its `migrations-numbering` guard is now legacy-scoped.
+- **Adding a COLUMN to an existing table:** `schema.sql` is `create … if not exists`, so editing the
+  `create table` body is a **no-op on a DB that already has the table** — prod keeps the old shape.
+  Put the `alter table … add column if not exists` in **`postgres/migrations/`** (applied by
+  `pg:schema` after `schema.sql`, in filename order) **and** mirror it into `schema.sql` for
+  from-zero. See `postgres/migrations/README.md`. (A brand-new table needs no migration —
+  `create table if not exists` in `schema.sql` covers it.)
 - **Deploy:** Postgres on Railway (self-host portable). After a merge, run `npm run pg:schema` against
   prod for any schema change, and **confirm the platform started a new build** (CI webhooks can be
   silently dropped); re-trigger if the latest deploy predates the merge.

--- a/app/api/v1/costs/route.ts
+++ b/app/api/v1/costs/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { adminClient } from "@/lib/supabase/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/api/rate-limit";
-import { usageCostPayloadSchema, errorResponse } from "@/lib/api/schemas";
+import { usageCostPayloadSchema, errorResponse, IngestValidationError } from "@/lib/api/schemas";
 import { ingestUsageCost } from "@/lib/costs/ingest";
 
 export const runtime = "nodejs";
@@ -41,6 +41,11 @@ export async function POST(req: NextRequest) {
     const result = await ingestUsageCost(supabase, auth, parsed.data);
     return Response.json({ status: "ok", ...result }, { status: 201 });
   } catch (e) {
+    // An unknown member handle is a client input error (the caller sent a handle the team
+    // doesn't have), not a brain fault — surface 422 so the CLI gets a structured signal.
+    if (e instanceof IngestValidationError) {
+      return errorResponse("invalid_payload", e.message, 422);
+    }
     return errorResponse("internal", e instanceof Error ? e.message : "cost ingest failed", 500);
   }
 }

--- a/app/api/v1/metrics/route.ts
+++ b/app/api/v1/metrics/route.ts
@@ -2,7 +2,11 @@ import { NextRequest } from "next/server";
 import { adminClient } from "@/lib/supabase/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/api/rate-limit";
-import { maturitySnapshotPayloadSchema, errorResponse } from "@/lib/api/schemas";
+import {
+  maturitySnapshotPayloadSchema,
+  errorResponse,
+  IngestValidationError,
+} from "@/lib/api/schemas";
 import { ingestMaturitySnapshot } from "@/lib/metrics/individual-maturity-ingest";
 
 export const runtime = "nodejs";
@@ -42,6 +46,10 @@ export async function POST(req: NextRequest) {
     const result = await ingestMaturitySnapshot(supabase, auth, parsed.data);
     return Response.json({ status: "ok", ...result }, { status: 201 });
   } catch (e) {
+    // Unknown member handle = client input error → 422, not a 500 brain fault.
+    if (e instanceof IngestValidationError) {
+      return errorResponse("invalid_payload", e.message, 422);
+    }
     return errorResponse("internal", e instanceof Error ? e.message : "snapshot ingest failed", 500);
   }
 }

--- a/lib/costs/ingest.ts
+++ b/lib/costs/ingest.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { UsageCostPayload } from "@/lib/api/schemas";
+import { IngestValidationError, type UsageCostPayload } from "@/lib/api/schemas";
 import { buildIdentityMap, resolveMember } from "@/lib/identity/resolve";
 import { audit } from "@/lib/api/audit";
 
@@ -17,7 +17,7 @@ export async function ingestUsageCost(
   if (payload.member) {
     const map = await buildIdentityMap(supabase, auth.teamId);
     const resolved = resolveMember(map, { key: payload.member });
-    if (!resolved) throw new Error(`unknown member handle '${payload.member}'`);
+    if (!resolved) throw new IngestValidationError(`unknown member handle '${payload.member}'`);
     memberId = resolved;
   }
 

--- a/lib/metrics/individual-maturity-ingest.ts
+++ b/lib/metrics/individual-maturity-ingest.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { MaturitySnapshotPayload } from "@/lib/api/schemas";
+import { IngestValidationError, type MaturitySnapshotPayload } from "@/lib/api/schemas";
 import { buildIdentityMap, resolveMember } from "@/lib/identity/resolve";
 import { audit } from "@/lib/api/audit";
 import { placement, type AemPlacement } from "@/lib/metrics/individual-maturity";
@@ -23,7 +23,7 @@ export async function ingestMaturitySnapshot(
   if (payload.member) {
     const map = await buildIdentityMap(supabase, auth.teamId);
     const resolved = resolveMember(map, { key: payload.member });
-    if (!resolved) throw new Error(`unknown member handle '${payload.member}'`);
+    if (!resolved) throw new IngestValidationError(`unknown member handle '${payload.member}'`);
     memberId = resolved;
   }
 

--- a/postgres/migrations/20260622180100_maturity_cost_totals.sql
+++ b/postgres/migrations/20260622180100_maturity_cost_totals.sql
@@ -1,0 +1,9 @@
+-- W2.1 additive delta for the postgres target: daily token + cost totals on AEM snapshots.
+-- `agentic_maturity_snapshots` already exists in prod, so the matching `create table if not
+-- exists` in postgres/schema.sql is a no-op there — these columns only land via this ALTER.
+-- Idempotent (add column if not exists); also mirrored into postgres/schema.sql for from-zero.
+alter table agentic_maturity_snapshots
+  add column if not exists total_cost_usd numeric(12, 5) not null default 0,
+  add column if not exists input_tokens bigint not null default 0,
+  add column if not exists output_tokens bigint not null default 0,
+  add column if not exists cache_read_tokens bigint not null default 0;

--- a/postgres/migrations/README.md
+++ b/postgres/migrations/README.md
@@ -1,0 +1,20 @@
+# postgres/migrations — additive deltas for the deployed `postgres` target
+
+`postgres/schema.sql` is the canonical, idempotent schema, but it expresses every object
+with `create table if not exists` / `create index if not exists`. That makes it safe to
+re-run on a **fresh** database, but it is a **no-op on an existing table** — so adding a
+column to a table that already exists in prod is silently skipped by `npm run pg:schema`.
+
+This directory holds the additive deltas `schema.sql` cannot express on an existing DB:
+`alter table … add column if not exists`, backfills, new constraints, etc. `npm run pg:schema`
+loads `schema.sql` first, then applies every file here in **lexical filename order**.
+
+Rules:
+- **Idempotent only.** Use `add column if not exists`, `create index if not exists`,
+  guarded `do $$ … $$` blocks. Files are replayed on every rollout and in the
+  migrate-from-zero test (`npm run db:test:up`), so a non-idempotent file will break CI.
+- **Name as `YYYYMMDDHHMMSS_short_description.sql`** (matches `supabase/migrations/`).
+- **Mirror the change into `postgres/schema.sql`** so a from-zero load still produces the
+  same shape — the file here is only what an *existing* DB needs to catch up.
+- This is the `DB_BACKEND=postgres` (Railway) rollout path. `supabase/migrations/` remains
+  the legacy supabase-only schema.

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -10,6 +10,10 @@
 --     runs on a stock Postgres (e.g. Railway) with no extra extensions
 --
 -- Idempotent: safe to re-run. Load with `npm run pg:schema`.
+-- NOTE: every object below is `create … if not exists`, so editing a `create table` body does
+-- NOT alter a table that already exists in a deployed DB. To ADD A COLUMN, also add an idempotent
+-- `alter table … add column if not exists` to `postgres/migrations/` (pg:schema applies those
+-- after this file). See `postgres/migrations/README.md`.
 -- ───────────────────────────────────────────────────────────────────────────
 
 create extension if not exists citext;

--- a/scripts/pg-load-schema.ts
+++ b/scripts/pg-load-schema.ts
@@ -1,8 +1,15 @@
 /**
- * Load postgres/schema.sql into the database at DATABASE_URL.
+ * Load postgres/schema.sql into the database at DATABASE_URL, then apply every additive
+ * delta in postgres/migrations/ (in lexical filename order).
+ *
+ * schema.sql is `create … if not exists` throughout, so it is a no-op on an EXISTING table —
+ * it cannot add a column to a table prod already has. postgres/migrations/ holds the idempotent
+ * `alter table … add column if not exists` deltas that catch an existing DB up. Both are
+ * idempotent, so this is safe to re-run and is the prod rollout step (`npm run pg:schema`).
+ *
  * Usage: DATABASE_URL=postgres://… npx tsx scripts/pg-load-schema.ts
  */
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { Client } from "pg";
 
@@ -10,7 +17,8 @@ async function main() {
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error("DATABASE_URL is required");
 
-  const sql = readFileSync(path.join(process.cwd(), "postgres", "schema.sql"), "utf8");
+  const pgDir = path.join(process.cwd(), "postgres");
+  const sql = readFileSync(path.join(pgDir, "schema.sql"), "utf8");
   const useSsl =
     /\bsslmode=require\b/.test(url) ||
     process.env.PGSSL === "require" ||
@@ -24,6 +32,18 @@ async function main() {
   try {
     await client.query(sql);
     console.log("✓ postgres/schema.sql loaded");
+
+    // Additive deltas that `create … if not exists` can't apply to an existing table.
+    const migDir = path.join(pgDir, "migrations");
+    const files = existsSync(migDir)
+      ? readdirSync(migDir)
+          .filter((f) => f.endsWith(".sql"))
+          .sort()
+      : [];
+    for (const f of files) {
+      await client.query(readFileSync(path.join(migDir, f), "utf8"));
+      console.log(`✓ postgres/migrations/${f} applied`);
+    }
   } finally {
     await client.end();
   }

--- a/test/datamechanics/external-costs.datamechanics.test.ts
+++ b/test/datamechanics/external-costs.datamechanics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ingestUsageCost } from "@/lib/costs/ingest";
 import { getExternalCosts } from "@/lib/metrics/external-costs";
+import { IngestValidationError } from "@/lib/api/schemas";
 import { db, seedTeam } from "./helpers";
 
 describe("usage_costs ingest + read (W2.1)", () => {
@@ -71,5 +72,21 @@ describe("usage_costs ingest + read (W2.1)", () => {
     });
     expect(view.totals.cost_usd).toBeCloseTo(61.5, 2);
     expect(view.totals.events).toBe(36);
+  });
+
+  it("rejects an unknown member handle as a client error (→ route 422, not 500)", async () => {
+    const seed = await seedTeam();
+    const auth = { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: "test-key" };
+
+    await expect(
+      ingestUsageCost(db(), auth, {
+        member: "nobody-here",
+        date: "2026-06-22",
+        provider: "cursor",
+        source: "dashboard-api",
+        project: "",
+        cost_usd: 1,
+      })
+    ).rejects.toBeInstanceOf(IngestValidationError);
   });
 });


### PR DESCRIPTION
Two follow-ups surfaced while rolling W2.1 (#62) to production.

## 1. `500 → 422` on an unknown member handle
`POST /api/v1/costs` and `POST /api/v1/metrics` both threw a plain `Error` when `payload.member` resolved to no team member, which the route catch-all turned into `500 internal`. That's a client input error. Both ingests now throw `IngestValidationError` (the existing `/api/v1/items` convention) and both routes map it to `422 invalid_payload`, so the CLI gets a structured "bad handle" signal instead of a brain-fault.

Repro before this PR: `aios analyze --push` with `AIOS_MEMBER=<handle the brain doesn't have>` → `500 internal: unknown member handle '…'`.

- `lib/costs/ingest.ts`, `lib/metrics/individual-maturity-ingest.ts` — throw `IngestValidationError`
- `app/api/v1/costs/route.ts`, `app/api/v1/metrics/route.ts` — map it to 422
- Data-mechanics test asserting the typed error (real Postgres)

## 2. Additive-column rollout path for the `postgres` target
`npm run pg:schema` loads `schema.sql`, which is `create … if not exists` throughout — so editing a `create table` body is a **no-op on a table prod already has**. During the #62 rollout the new `usage_costs` table was created fine, but the four W2.1 cost/token columns on the **pre-existing** `agentic_maturity_snapshots` were silently skipped (had to be applied by hand).

- New `postgres/migrations/` dir for idempotent additive deltas (`alter table … add column if not exists`)
- `pg-load-schema.ts` applies `schema.sql`, then every `postgres/migrations/*.sql` in filename order
- Moved the maturity-columns ALTER there (mirrored in `schema.sql` for from-zero)
- Documented the column-add rule: `CLAUDE.md` §6, `schema.sql` header, `postgres/migrations/README.md`

`npm run db:test:up` (migrate-from-zero) is the idempotency/replay guard — it now loads schema.sql then the migration, both clean.

## Verification
- `npm test` 153 ✓ · external-costs data-mechanics 3 ✓ (incl. new 422 case) · `npm run check:docs` ✓ · eslint + tsc clean
- Note: prod already has the columns (applied manually during the #62 rollout); this PR just makes that delta replayable and codifies the path. No new prod schema step required on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: HTTP status mapping for a known client error and idempotent schema rollout plumbing; no auth or tier logic changes.
> 
> **Overview**
> **API behavior:** `POST /api/v1/costs` and `POST /api/v1/metrics` now treat an unresolved `payload.member` as **`invalid_payload` (422)** by throwing **`IngestValidationError`** from the cost and maturity ingests and mapping it in the routes—the same pattern as **`/api/v1/items`**—so CLI pushes get a client error instead of a **500**.
> 
> **Postgres rollout:** Introduces **`postgres/migrations/`** for idempotent **`ALTER … ADD COLUMN`** deltas that **`schema.sql`** cannot apply on tables that already exist. **`scripts/pg-load-schema.ts`** runs **`schema.sql`** then sorted **`*.sql`** migrations; docs in **`CLAUDE.md`**, **`postgres/schema.sql`**, and **`postgres/migrations/README.md`** spell out mirroring changes into **`schema.sql`** for from-zero. The first migration adds W2.1 cost/token columns on **`agentic_maturity_snapshots`**.
> 
> A data-mechanics test asserts **`IngestValidationError`** for a bad member handle on cost ingest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096f8e58f0949dac8ba8f4a76f42b1c05e4ac752. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->