### PR TITLE
feat(codebases): surface functions + branches coverage (not just lines)

### DIFF
--- a/components/codebases/agentic-breakdown.tsx
+++ b/components/codebases/agentic-breakdown.tsx
@@ -113,7 +113,15 @@ export function AgenticBreakdownCard({ b }: { b: Breakdown }) {
         <Check2 ok={b.commands_count > 0} label={`${b.commands_count} commands`} />
         <Check2
           ok={b.test_coverage_pct != null}
-          label={b.test_coverage_pct == null ? "no coverage report" : `${b.test_coverage_pct}% coverage`}
+          label={b.test_coverage_pct == null ? "no coverage report" : `${b.test_coverage_pct}% lines`}
+        />
+        <Check2
+          ok={b.test_coverage_functions_pct != null}
+          label={b.test_coverage_functions_pct == null ? "no fn coverage" : `${b.test_coverage_functions_pct}% functions`}
+        />
+        <Check2
+          ok={b.test_coverage_branches_pct != null}
+          label={b.test_coverage_branches_pct == null ? "no branch coverage" : `${b.test_coverage_branches_pct}% branches`}
         />
       </div>
 

--- a/ingestion/aios_ingest/analyzers/codebase.py
+++ b/ingestion/aios_ingest/analyzers/codebase.py
@@ -219,35 +219,60 @@ def _count_loc(repo: Path, tracked: list[str]) -> int:
     return loc
 
 
-def _read_coverage(repo: Path) -> float | None:
-    """Read a committed coverage report if present (Istanbul json or lcov). Else None."""
+def _read_coverage(repo: Path) -> dict[str, float | None]:
+    """Read a committed coverage report if present (Istanbul json or lcov).
+
+    Returns {"lines", "functions", "branches"} percentages, each None when that
+    dimension isn't reported (or no report exists at all). `lines` is the headline
+    number; functions/branches are surfaced alongside it on the dashboard.
+    """
     import json
+
+    empty: dict[str, float | None] = {"lines": None, "functions": None, "branches": None}
 
     for rel in ("coverage/coverage-summary.json", "coverage-summary.json"):
         p = repo / rel
         if p.is_file():
             try:
-                data = json.loads(p.read_text())
-                pct = data.get("total", {}).get("lines", {}).get("pct")
-                if isinstance(pct, (int, float)):
-                    return float(pct)
+                total = json.loads(p.read_text()).get("total", {})
+
+                def _pct(key: str) -> float | None:
+                    v = total.get(key, {}).get("pct")
+                    return float(v) if isinstance(v, (int, float)) else None
+
+                if _pct("lines") is not None:
+                    return {"lines": _pct("lines"), "functions": _pct("functions"), "branches": _pct("branches")}
             except (ValueError, OSError):
                 pass
 
     lcov = repo / "coverage" / "lcov.info"
     if lcov.is_file():
         try:
-            hit = found = 0
+            # [hit, found] per dimension: L=lines, FN=functions, BR=branches.
+            counts = {"L": [0, 0], "FN": [0, 0], "BR": [0, 0]}
             for line in lcov.read_text().splitlines():
                 if line.startswith("LH:"):
-                    hit += int(line[3:])
+                    counts["L"][0] += int(line[3:])
                 elif line.startswith("LF:"):
-                    found += int(line[3:])
-            if found:
-                return round(100 * hit / found, 2)
+                    counts["L"][1] += int(line[3:])
+                elif line.startswith("FNH:"):
+                    counts["FN"][0] += int(line[4:])
+                elif line.startswith("FNF:"):
+                    counts["FN"][1] += int(line[4:])
+                elif line.startswith("BRH:"):
+                    counts["BR"][0] += int(line[4:])
+                elif line.startswith("BRF:"):
+                    counts["BR"][1] += int(line[4:])
+
+            def _ratio(k: str) -> float | None:
+                hit, found = counts[k]
+                return round(100 * hit / found, 2) if found else None
+
+            if counts["L"][1]:  # lines found → a real report
+                return {"lines": _ratio("L"), "functions": _ratio("FN"), "branches": _ratio("BR")}
         except (ValueError, OSError):
             pass
-    return None
+    return empty
 
 
 def _github_enrich(full_name: str, token: str | None) -> dict[str, Any]:
@@ -358,7 +383,7 @@ def _codebase_block(slug: str, full_name: str, meta: dict[str, Any]) -> dict[str
 def _metrics_block(
     git: dict[str, Any],
     scaff: dict[str, Any],
-    coverage: float | None,
+    coverage: dict[str, float | None] | None,
     head_sha: str,
     window_days: int,
     scanned_at: str | None = None,
@@ -368,6 +393,7 @@ def _metrics_block(
     # historical backfill) both yield the brain's schema-safe shape — level/pct/version
     # nullable, pillars defaults to {} (NOT nullable). Keeps the two paths byte-identical.
     r = readiness or {}
+    c = coverage or {}  # history backfill passes None (no coverage at past SHAs)
     block = {
         "head_sha": head_sha,
         "window_days": window_days,
@@ -377,7 +403,9 @@ def _metrics_block(
         "ai_commits_window": git["ai_commits_window"],
         "additions_window": git["additions_window"],
         "deletions_window": git["deletions_window"],
-        "test_coverage_pct": coverage,
+        "test_coverage_pct": c.get("lines"),
+        "test_coverage_functions_pct": c.get("functions"),
+        "test_coverage_branches_pct": c.get("branches"),
         "recent_commits": git["recent_commits"],
         "has_claude_md": scaff["has_claude_md"],
         "has_agents_md": scaff["has_agents_md"],

--- a/ingestion/tests/test_codebase_analyzer.py
+++ b/ingestion/tests/test_codebase_analyzer.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 from aios_ingest.analyzers.codebase import (
     _detect_scaffolding,
     _entries_under,
+    _read_coverage,
     analyze_history,
     analyze_repo,
 )
@@ -92,7 +93,33 @@ def test_no_github_token_means_no_issues(tmp_path, monkeypatch):
     _git(repo, "commit", "-m", "c1")
     payload = analyze_repo(str(repo), slug="x", full_name="org/x")
     assert payload["issues"] == []
-    assert payload["metrics"]["test_coverage_pct"] is None  # no committed report
+    m = payload["metrics"]
+    assert m["test_coverage_pct"] is None  # no committed report
+    assert m["test_coverage_functions_pct"] is None
+    assert m["test_coverage_branches_pct"] is None
+
+
+def test_read_coverage_istanbul_all_three(tmp_path):
+    """Istanbul coverage-summary.json yields lines/functions/branches percentages."""
+    cov = tmp_path / "coverage"
+    cov.mkdir()
+    (cov / "coverage-summary.json").write_text(
+        '{"total": {"lines": {"pct": 31.67}, "functions": {"pct": 34.33}, "branches": {"pct": 25.7}}}'
+    )
+    assert _read_coverage(tmp_path) == {"lines": 31.67, "functions": 34.33, "branches": 25.7}
+
+
+def test_read_coverage_lcov_all_three(tmp_path):
+    """LCOV lcov.info yields lines/functions/branches computed from hit/found totals."""
+    cov = tmp_path / "coverage"
+    cov.mkdir()
+    (cov / "lcov.info").write_text("\n".join(["LF:200", "LH:100", "FNF:40", "FNH:30", "BRF:50", "BRH:20", "end_of_record"]))
+    assert _read_coverage(tmp_path) == {"lines": 50.0, "functions": 75.0, "branches": 40.0}
+
+
+def test_read_coverage_none_when_absent(tmp_path):
+    """No report → all three None (so the scanner pushes nulls, not zeros)."""
+    assert _read_coverage(tmp_path) == {"lines": None, "functions": None, "branches": None}
 
 
 def test_live_scan_carries_scored_readiness(tmp_path):

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -90,6 +90,8 @@ export const codeMetricsSchema = z.object({
   additions_window: z.number().int().nonnegative(),
   deletions_window: z.number().int().nonnegative(),
   test_coverage_pct: z.number().min(0).max(100).nullable().optional().default(null),
+  test_coverage_functions_pct: z.number().min(0).max(100).nullable().optional().default(null),
+  test_coverage_branches_pct: z.number().min(0).max(100).nullable().optional().default(null),
   recent_commits: z.array(z.record(z.string(), z.unknown())),
   // explicit scaffolding inputs (required)
   has_claude_md: z.boolean(),

--- a/lib/codebases/ingest.ts
+++ b/lib/codebases/ingest.ts
@@ -83,6 +83,8 @@ export async function ingestCodebaseScan(
         additions_window: m.additions_window,
         deletions_window: m.deletions_window,
         test_coverage_pct: m.test_coverage_pct,
+        test_coverage_functions_pct: m.test_coverage_functions_pct,
+        test_coverage_branches_pct: m.test_coverage_branches_pct,
         // jsonb ARRAY column: the pg adapter only auto-casts plain objects to
         // ::jsonb, not arrays — stringify so Postgres parses it as jsonb (this
         // feature is postgres-only). Empty + non-empty both round-trip correctly.

--- a/lib/metrics/codebases.ts
+++ b/lib/metrics/codebases.ts
@@ -251,6 +251,8 @@ export interface AgenticBreakdown {
   skills_count: number;
   commands_count: number;
   test_coverage_pct: number | null;
+  test_coverage_functions_pct: number | null;
+  test_coverage_branches_pct: number | null;
   readiness_level: string | null;
   readiness_pct: number | null;
   readiness_pillars: Record<string, { passed: number; total: number }>;
@@ -339,7 +341,8 @@ export async function getCodebaseDetail(
   const METRIC_COLS =
     "scanned_at, agentic_score, health_score, ai_commit_ratio, test_coverage_score, " +
     "scaffolding_score, skill_breadth_score, cadence_score, issue_health, has_claude_md, " +
-    "has_agents_md, agents_md_count, skills_count, commands_count, test_coverage_pct, recent_commits, " +
+    "has_agents_md, agents_md_count, skills_count, commands_count, test_coverage_pct, " +
+    "test_coverage_functions_pct, test_coverage_branches_pct, recent_commits, " +
     "readiness_level, readiness_pct, readiness_pillars";
 
   const [metricsRes, contribRes, issuesRes, membersRes] = await Promise.all([
@@ -394,6 +397,10 @@ export async function getCodebaseDetail(
         commands_count: num(latest.commands_count as number),
         test_coverage_pct:
           latest.test_coverage_pct == null ? null : num(latest.test_coverage_pct as number),
+        test_coverage_functions_pct:
+          latest.test_coverage_functions_pct == null ? null : num(latest.test_coverage_functions_pct as number),
+        test_coverage_branches_pct:
+          latest.test_coverage_branches_pct == null ? null : num(latest.test_coverage_branches_pct as number),
         readiness_level: (latest.readiness_level as string | null) ?? null,
         readiness_pct: latest.readiness_pct == null ? null : num(latest.readiness_pct as number),
         readiness_pillars:

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -486,7 +486,9 @@ create table if not exists code_metrics (
   ai_commits_window integer not null default 0,
   additions_window integer not null default 0,
   deletions_window integer not null default 0,
-  test_coverage_pct numeric(5,2),                 -- null = no coverage report found
+  test_coverage_pct numeric(5,2),                 -- null = no coverage report found (lines %)
+  test_coverage_functions_pct numeric(5,2),       -- null = not reported
+  test_coverage_branches_pct numeric(5,2),        -- null = not reported
   recent_commits jsonb not null default '[]',     -- [{sha,author,ai,additions,deletions,committed_at,message}]
   -- explicit scaffolding inputs (named, not vague JSON → testable scoring)
   has_claude_md boolean not null default false,
@@ -520,6 +522,11 @@ alter table code_metrics add column if not exists readiness_level text;
 alter table code_metrics add column if not exists readiness_pct numeric(5,2);
 alter table code_metrics add column if not exists readiness_pillars jsonb not null default '{}';
 alter table code_metrics add column if not exists readiness_rubric_version text;
+
+-- Functions/branches coverage — added via alter so an already-deployed code_metrics
+-- gains them on `pg:schema` (the create-table above is a no-op once the table exists).
+alter table code_metrics add column if not exists test_coverage_functions_pct numeric(5,2);
+alter table code_metrics add column if not exists test_coverage_branches_pct numeric(5,2);
 
 -- Keep `npm run pg:schema` safe for existing deployments that created
 -- code_metrics before AEM readiness fields were added. The table declaration

--- a/test/datamechanics/codebases-isolation.datamechanics.test.ts
+++ b/test/datamechanics/codebases-isolation.datamechanics.test.ts
@@ -31,6 +31,8 @@ function buildScan(over: {
       additions_window: 5000,
       deletions_window: 1200,
       test_coverage_pct: 70,
+      test_coverage_functions_pct: 65,
+      test_coverage_branches_pct: 55,
       has_claude_md: true,
       has_agents_md: true,
       agents_md_count: 1,
@@ -132,6 +134,20 @@ describe("codebase scan idempotency (real Postgres)", () => {
     const { codebases } = await getCodebaseSummaries(db(), seed.teamId, "90d", "team");
     const row = codebases.find((c) => c.slug === slug);
     expect(row?.test_coverage_pct).toBe(20); // newest wins
+  });
+
+  it("persists and surfaces all three coverage dimensions (lines/functions/branches)", async () => {
+    const seed = await seedTeam();
+    const slug = `repo-${randomUUID().slice(0, 6)}`;
+    await ingestScan(seed, buildScan({ slug })); // 70 / 65 / 55
+
+    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    // Reading back through the real DB proves persistence AND the read mapping.
+    expect(detail?.breakdown).toMatchObject({
+      test_coverage_pct: 70,
+      test_coverage_functions_pct: 65,
+      test_coverage_branches_pct: 55,
+    });
   });
 
   it("contributions recompute + upsert by (author_key, day), and map to a member", async () => {

--- a/test/fixtures/codebase-scan.ts
+++ b/test/fixtures/codebase-scan.ts
@@ -13,6 +13,8 @@ export function fullMetrics(overrides: Record<string, unknown> = {}) {
     additions_window: 100,
     deletions_window: 20,
     test_coverage_pct: null,
+    test_coverage_functions_pct: null,
+    test_coverage_branches_pct: null,
     recent_commits: [],
     has_claude_md: false,
     has_agents_md: false,


### PR DESCRIPTION
## What

The Codebases dashboard tracked **one** coverage number (lines %). This captures and surfaces all three Istanbul/LCOV dimensions — **lines, functions, branches** — end to end, so the dashboard matches the `26/29/23` CI gate's three-way view.

## The vertical slice

**Scanner** (`ingestion/aios_ingest/analyzers/codebase.py`)
- `_read_coverage` returns `{lines, functions, branches}` (each `null` when not reported) — from Istanbul `total.{lines,functions,branches}.pct` and from LCOV (`FNF/FNH`, `BRF/BRH` alongside `LH/LF`).
- `_metrics_block` emits `test_coverage_functions_pct` / `test_coverage_branches_pct` and tolerates `None` (history backfill passes no coverage).
- New pytest cases: Istanbul trio, LCOV trio, none-when-absent.

**Brain**
- `codeMetricsSchema`: two new nullable fields. Unknown keys are stripped by Zod, so an **old** brain ignores them — safe rollout ordering.
- `postgres/schema.sql`: two `numeric(5,2)` columns in the create-table **and** via idempotent `alter table ... add column if not exists` (so `pg:schema` backfills the already-deployed `code_metrics`, mirroring the readiness columns).
- `lib/codebases/ingest.ts` persists them; `lib/metrics/codebases.ts` threads them into `AgenticBreakdown` + the detail `METRIC_COLS` select/mapping. **Scoring unchanged** — `coverageScore` still uses lines only; functions/branches are display-only.

**UI**
- The detail page's **breakdown card** now shows `lines / functions / branches` coverage. The list card, KPI band, and trend chart keep the headline **lines** % to avoid clutter.

## Verification (all local, green)

- Python: `pytest` 9/9 (incl. the new `_read_coverage` cases)
- `tsc --noEmit` clean · `eslint` clean (only a pre-existing unrelated warning)
- Unit: 153/153 (route-tier-guards uses the updated `fullMetrics` fixture)
- Data-mechanics: 92/92, incl. a **new** test proving all three persist and surface via `getCodebaseDetail`
- `check:docs` ✓ (table unchanged → drift guard only checks table names)

## ⚠️ Deploy ordering (additive migration)

After merge, **`npm run pg:schema` must run against prod _before_ the new brain writes these columns**, else the ingest insert hits a missing column. Sequence: apply schema → confirm Railway redeploys the brain → `scan-on-merge` pushes the new fields → dashboard fills in. I can run the schema step via `railway connect Postgres` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requires a schema migration before ingest writes new columns; otherwise inserts fail. Scoring and list/trend surfaces are unchanged, limiting behavioral risk.
> 
> **Overview**
> Extends codebase coverage from a single **lines** percentage to **lines, functions, and branches** across the scan → store → dashboard path, aligned with Istanbul/LCOV three-way reports.
> 
> The Python scanner’s `_read_coverage` now returns a dict (Istanbul `total.*.pct` or LCOV `LH/LF`, `FNH/FNF`, `BRH/BRF`) and `_metrics_block` maps those to `test_coverage_pct` (lines), `test_coverage_functions_pct`, and `test_coverage_branches_pct`. **Agentic/health scoring is unchanged** — `coverageScore` still uses lines only; the new fields are display metrics.
> 
> The brain adds nullable Zod fields, `code_metrics` columns (create + idempotent `ALTER`), ingest persistence, and `AgenticBreakdown` / detail reads. The codebase detail **agentic breakdown** card shows three check rows (lines / functions / branches); list KPIs and trends still headline lines %.
> 
> Tests cover Istanbul/LCOV parsing, absent reports, and a data-mechanics round-trip for all three dimensions. **Deploy:** run `pg:schema` before the new brain writes these columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cf1ba6393949f231f2c8eb5550e15a0004aff44. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->