### PR TITLE
feat(dashboard): hierarchical task CRUD + cycle guard (brain-api v1.2 Phase 4)

### DIFF
--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -136,8 +136,8 @@ export async function updateTaskAction(
   if (!me) return { ok: false, error: "not a member of this team" };
 
   // Parent integrity (when provided + non-empty): reject self-parent; require the parent to exist in
-  // the same (team, project). Full cycle detection is deferred to Phase 4's richer CRUD — the
-  // projection engine's visiting-guard prevents any runtime loop meanwhile.
+  // the same (team, project); and reject any re-parent that would close a cycle (the epic→sub graph
+  // must stay a forest — no PM sub-issue may become its own ancestor).
   const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
   if (input.title !== undefined) update.title = input.title;
   if (input.sprint !== undefined) update.sprint = input.sprint;
@@ -157,6 +157,26 @@ export async function updateTaskAction(
         .eq("row_key", parent)
         .maybeSingle();
       if (!parentRow) return { ok: false, error: `parent "${parent}" not found in project` };
+
+      // Cycle guard: walk ancestors up from the proposed parent over the project's current edges;
+      // reaching this row's own key means the new edge would form a loop. Bounded by the edge count
+      // so a pre-existing data cycle can't spin forever.
+      const { data: edgeRows } = await supabase
+        .from("tasks")
+        .select("row_key, parent_row_key")
+        .eq("team_id", row.team_id)
+        .eq("project_id", row.project_id);
+      const parentOf = new Map<string, string | null>();
+      for (const e of (edgeRows ?? []) as { row_key: string | null; parent_row_key: string | null }[]) {
+        if (e.row_key) parentOf.set(e.row_key, e.parent_row_key);
+      }
+      let cursor: string | null = parent;
+      for (let steps = 0; cursor && steps <= parentOf.size; steps++) {
+        if (cursor === row.row_key) {
+          return { ok: false, error: `re-parenting "${row.row_key}" under "${parent}" would create a cycle` };
+        }
+        cursor = parentOf.get(cursor) ?? null;
+      }
     }
     update.parent_row_key = parent || null;
   }

--- a/app/t/[team]/tasks/page.tsx
+++ b/app/t/[team]/tasks/page.tsx
@@ -3,6 +3,7 @@ import { ListTodo } from "lucide-react";
 import { serverClient } from "@/lib/supabase/server";
 import { getSessionUser } from "@/lib/auth/session";
 import { Board } from "@/components/kanban/board";
+import { TaskHierarchy } from "@/components/kanban/task-hierarchy";
 import { EmptyState } from "@/components/empty-state";
 import type { MemberOption, ProjectOption, Task } from "@/components/kanban/types";
 
@@ -21,34 +22,55 @@ export default async function TasksPage({ params }: { params: Promise<{ team: st
 
   const user = await getSessionUser();
 
-  const [{ data: tasks }, { data: projects }, { data: members }, { data: me }] = await Promise.all([
-    supabase
-      .from("tasks")
-      .select("id, row_key, title, assignee, status, sprint, due_date, origin, project_id, updated_at, task_pm_links(provider, provider_url, last_synced_status, last_error)")
-      .eq("team_id", team.id)
-      .order("updated_at", { ascending: false })
-      .limit(500),
-    supabase
-      .from("projects")
-      .select("id, slug, name")
-      .eq("team_id", team.id)
-      .order("slug"),
-    supabase
-      .from("members")
-      .select("id, display_name, actor_handle")
-      .eq("team_id", team.id)
-      .eq("status", "active")
-      .order("display_name"),
-    supabase
-      .from("members")
-      .select("id")
-      .eq("team_id", team.id)
-      .eq("auth_user_id", user?.id ?? "")
-      .eq("status", "active")
-      .maybeSingle(),
-  ]);
+  // PM links are fetched as a sibling query and grouped in JS rather than as an embedded resource:
+  // the pg adapter (the deployed backend) only supports to-many embeds as `(count)`, so a
+  // `task_pm_links(provider, ...)` embed silently returns no tasks. A separate named-column query
+  // works on both backends and keeps the per-task badge wiring intact.
+  const [{ data: tasks }, { data: links }, { data: projects }, { data: members }, { data: me }] =
+    await Promise.all([
+      supabase
+        .from("tasks")
+        .select("id, row_key, title, assignee, status, sprint, due_date, origin, project_id, updated_at, parent_row_key, labels, priority, body")
+        .eq("team_id", team.id)
+        .order("updated_at", { ascending: false })
+        .limit(500),
+      supabase
+        .from("task_pm_links")
+        .select("task_id, provider, provider_url, last_synced_status, last_error")
+        .eq("team_id", team.id),
+      supabase
+        .from("projects")
+        .select("id, slug, name")
+        .eq("team_id", team.id)
+        .order("slug"),
+      supabase
+        .from("members")
+        .select("id, display_name, actor_handle")
+        .eq("team_id", team.id)
+        .eq("status", "active")
+        .order("display_name"),
+      supabase
+        .from("members")
+        .select("id")
+        .eq("team_id", team.id)
+        .eq("auth_user_id", user?.id ?? "")
+        .eq("status", "active")
+        .maybeSingle(),
+    ]);
 
-  const taskRows = (tasks ?? []) as Task[];
+  type LinkRow = { task_id: string | null } & NonNullable<Task["task_pm_links"]>[number];
+  const linksByTask = new Map<string, NonNullable<Task["task_pm_links"]>>();
+  for (const l of (links ?? []) as LinkRow[]) {
+    if (!l.task_id) continue;
+    const { task_id, ...badge } = l;
+    const arr = linksByTask.get(task_id) ?? [];
+    arr.push(badge);
+    linksByTask.set(task_id, arr);
+  }
+  const taskRows = ((tasks ?? []) as Task[]).map((t) => ({
+    ...t,
+    task_pm_links: linksByTask.get(t.id) ?? [],
+  }));
 
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-5">
@@ -60,13 +82,16 @@ export default async function TasksPage({ params }: { params: Promise<{ team: st
           action="Tasks appear here when a synced tasks.md lands via aios push, or once a project exists you can create them with the New task button."
         />
       ) : (
-        <Board
-          teamId={team.id}
-          initialTasks={taskRows}
-          projects={(projects ?? []) as ProjectOption[]}
-          members={(members ?? []) as MemberOption[]}
-          myMemberId={me?.id ?? ""}
-        />
+        <>
+          <TaskHierarchy tasks={taskRows} />
+          <Board
+            teamId={team.id}
+            initialTasks={taskRows}
+            projects={(projects ?? []) as ProjectOption[]}
+            members={(members ?? []) as MemberOption[]}
+            myMemberId={me?.id ?? ""}
+          />
+        </>
       )}
     </div>
   );

--- a/components/kanban/edit-task-dialog.tsx
+++ b/components/kanban/edit-task-dialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, Pencil, X } from "lucide-react";
+import { updateTaskAction } from "@/app/actions/tasks";
+import { TASK_PRIORITIES, type Task } from "./types";
+
+export type ParentOption = { row_key: string; title: string };
+
+/**
+ * Dashboard hierarchical edit (brain-api v1.2 Phase 4). Edits the projectable fields — title,
+ * sprint, due, parent (epic), labels, priority, body — through `updateTaskAction`, which persists
+ * them and schedules reactive projection into the primary PM tool. `router.refresh()` re-renders the
+ * server hierarchy so the new grouping/badges show without a full reload.
+ */
+export function EditTaskButton({ task, parents }: { task: Task; parents: ParentOption[] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-md p-1 text-ink-tertiary hover:bg-surface-overlay hover:text-ink"
+        aria-label={`Edit ${task.title}`}
+      >
+        <Pencil className="size-3.5" />
+      </button>
+      {open ? <EditTaskDialog task={task} parents={parents} onClose={() => setOpen(false)} /> : null}
+    </>
+  );
+}
+
+function EditTaskDialog({
+  task,
+  parents,
+  onClose,
+}: {
+  task: Task;
+  parents: ParentOption[];
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const [title, setTitle] = useState(task.title);
+  const [sprint, setSprint] = useState(task.sprint ?? "");
+  const [due, setDue] = useState(task.due_date ? String(task.due_date).slice(0, 10) : "");
+  const [parent, setParent] = useState(task.parent_row_key ?? "");
+  const [labels, setLabels] = useState((task.labels ?? []).join(", "));
+  const [priority, setPriority] = useState(task.priority || "none");
+  const [body, setBody] = useState(task.body ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    const res = await updateTaskAction({
+      taskId: task.id,
+      title: title.trim(),
+      sprint,
+      dueDate: due || null,
+      parentRowKey: parent || null,
+      labels: labels.split(",").map((l) => l.trim()).filter(Boolean),
+      priority,
+      body,
+    });
+    setSaving(false);
+    if (!res.ok) {
+      setError(res.error ?? "Could not save the task.");
+      return;
+    }
+    onClose();
+    router.refresh();
+  }
+
+  // A task can't parent itself; epics offered exclude this row.
+  const parentChoices = parents.filter((p) => p.row_key !== task.row_key);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 px-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[0_12px_48px_rgba(124,58,237,0.16)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-ink">Edit task</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-ink-tertiary hover:bg-surface-overlay hover:text-ink"
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <form onSubmit={submit} className="flex flex-col gap-3">
+          <input
+            autoFocus
+            required
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Title"
+            className="prism-input"
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <select value={parent} onChange={(e) => setParent(e.target.value)} className="prism-input">
+              <option value="">No parent (epic)</option>
+              {parentChoices.map((p) => (
+                <option key={p.row_key} value={p.row_key}>
+                  {p.row_key} · {p.title}
+                </option>
+              ))}
+            </select>
+            <select value={priority} onChange={(e) => setPriority(e.target.value)} className="prism-input">
+              {TASK_PRIORITIES.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <input
+              value={sprint}
+              onChange={(e) => setSprint(e.target.value)}
+              placeholder="Sprint / Wave"
+              className="prism-input"
+            />
+            <input type="date" value={due} onChange={(e) => setDue(e.target.value)} className="prism-input" />
+          </div>
+          <input
+            value={labels}
+            onChange={(e) => setLabels(e.target.value)}
+            placeholder="Labels (comma-separated)"
+            className="prism-input"
+          />
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Description (dashboard-only; projected into the PM tool)"
+            rows={4}
+            className="prism-input resize-y"
+          />
+          {error ? <p className="text-sm text-red">{error}</p> : null}
+          <div className="mt-1 flex justify-end gap-2">
+            <button type="button" onClick={onClose} className="btn-ghost">
+              Cancel
+            </button>
+            <button type="submit" disabled={saving || !title.trim()} className="btn-prism">
+              {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/kanban/task-hierarchy.tsx
+++ b/components/kanban/task-hierarchy.tsx
@@ -1,0 +1,119 @@
+import { ExternalLink } from "lucide-react";
+import { STATUS_LABELS, type Task } from "./types";
+import { EditTaskButton, type ParentOption } from "./edit-task-dialog";
+
+/**
+ * Server-rendered task hierarchy (brain-api v1.2 Phase 4): epics with their children grouped beneath
+ * them, each row showing its primary-provider link + sync status. This is the brain's view of the
+ * board it projects — read here, edit via the per-row dialog (which calls `updateTaskAction`). Tasks
+ * whose `parent_row_key` is null (or points outside the loaded set) render as roots/epics.
+ */
+
+function PmLinks({ task }: { task: Task }) {
+  const links = task.task_pm_links ?? [];
+  if (!links.length) return <span className="text-xs text-ink-tertiary">no link</span>;
+  return (
+    <span className="flex flex-wrap items-center gap-2">
+      {links.map((l) => {
+        const label = `${l.provider}${l.last_synced_status ? `:${l.last_synced_status}` : ""}`;
+        const tone = l.last_error ? "text-red" : "text-emerald-700";
+        return l.provider_url ? (
+          <a
+            key={l.provider}
+            href={l.provider_url}
+            target="_blank"
+            rel="noreferrer"
+            className={`inline-flex items-center gap-1 text-xs font-medium ${tone} hover:underline`}
+            title={l.last_error || l.last_synced_status || "PM link"}
+          >
+            {label}
+            <ExternalLink className="size-3" />
+          </a>
+        ) : (
+          <span key={l.provider} className={`text-xs font-medium ${tone}`} title={l.last_error ?? undefined}>
+            {label}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+function TaskRow({ task, parents, isEpic }: { task: Task; parents: ParentOption[]; isEpic: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-border-subtle bg-surface-card px-3.5 py-2.5">
+      <div className="min-w-0 flex flex-wrap items-center gap-x-3 gap-y-1">
+        {task.row_key ? <span className="font-mono text-[11px] text-ink-tertiary">{task.row_key}</span> : null}
+        <span className={`truncate ${isEpic ? "text-sm font-semibold text-ink" : "text-sm text-ink"}`}>
+          {task.title}
+        </span>
+        <span className="text-[11px] uppercase tracking-wide text-ink-tertiary">{STATUS_LABELS[task.status]}</span>
+        {task.priority && task.priority !== "none" ? (
+          <span className="rounded bg-violet/10 px-1.5 py-0.5 text-[10px] font-medium text-violet">{task.priority}</span>
+        ) : null}
+        {(task.labels ?? []).map((label) => (
+          <span key={label} className="rounded bg-surface-overlay px-1.5 py-0.5 text-[10px] text-ink-secondary">
+            {label}
+          </span>
+        ))}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <PmLinks task={task} />
+        <EditTaskButton task={task} parents={parents} />
+      </div>
+    </div>
+  );
+}
+
+export function TaskHierarchy({ tasks }: { tasks: Task[] }) {
+  const byRowKey = new Map<string, Task>();
+  for (const t of tasks) if (t.row_key) byRowKey.set(t.row_key, t);
+
+  // Children grouped by parent row_key; a parent_row_key that points outside the loaded set is
+  // treated as a root (so nothing is silently hidden).
+  const childrenOf = new Map<string, Task[]>();
+  const roots: Task[] = [];
+  for (const t of tasks) {
+    const parentKey = t.parent_row_key ?? null;
+    if (parentKey && byRowKey.has(parentKey)) {
+      const arr = childrenOf.get(parentKey) ?? [];
+      arr.push(t);
+      childrenOf.set(parentKey, arr);
+    } else {
+      roots.push(t);
+    }
+  }
+
+  // Parent candidates for the edit dialog: any task with a row_key (a task can become a sub of any
+  // other; the action rejects self/cycle).
+  const parents: ParentOption[] = tasks
+    .filter((t): t is Task & { row_key: string } => Boolean(t.row_key))
+    .map((t) => ({ row_key: t.row_key, title: t.title }));
+
+  if (!tasks.length) return null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-ink-tertiary">Hierarchy</h2>
+      <div className="flex flex-col gap-3">
+        {roots.map((epic) => {
+          const kids = epic.row_key ? childrenOf.get(epic.row_key) ?? [] : [];
+          return (
+            <div key={epic.id} data-epic={epic.row_key ?? undefined} className="flex flex-col gap-1.5">
+              <TaskRow task={epic} parents={parents} isEpic={kids.length > 0} />
+              {kids.length ? (
+                <div className="ml-5 flex flex-col gap-1.5 border-l border-border-subtle pl-3">
+                  {kids.map((child) => (
+                    <div key={child.id} data-parent={epic.row_key ?? undefined}>
+                      <TaskRow task={child} parents={parents} isEpic={false} />
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/kanban/types.ts
+++ b/components/kanban/types.ts
@@ -1,6 +1,10 @@
 export const TASK_STATUSES = ["backlog", "ready", "in_progress", "blocked", "done"] as const;
 export type TaskStatus = (typeof TASK_STATUSES)[number];
 
+// Canonical priority words (postgres `task_priority`); mirrors normalizeTaskPriority's output set.
+export const TASK_PRIORITIES = ["none", "low", "medium", "high", "urgent"] as const;
+export type TaskPriority = (typeof TASK_PRIORITIES)[number];
+
 export const STATUS_LABELS: Record<TaskStatus, string> = {
   backlog: "Backlog",
   ready: "Ready",
@@ -20,6 +24,11 @@ export type Task = {
   origin: "sync" | "ui";
   project_id: string;
   updated_at: string;
+  // Hierarchy/board fields (brain-api v1.2). `body` is dashboard/DB-only.
+  parent_row_key?: string | null;
+  labels?: string[];
+  priority?: string;
+  body?: string;
   task_pm_links?: {
     provider: "plane" | "linear";
     provider_url: string;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -202,6 +202,18 @@ changed this push** — `lib/ingest` computes the changed set by diffing the pro
 `task_pm_links.last_error`; the `projection_fingerprint` skip keeps them from re-writing the board.
 The manual `projectBoardAction` and the inline work-events projection remain.
 
+**Dashboard hierarchical CRUD (brain-api v1.2 Phase 4).** The tasks page (`app/t/[team]/tasks`)
+is the second authoring surface alongside `aios push`. It **server-renders the hierarchy** —
+`components/kanban/task-hierarchy.tsx` groups sub-tasks under their epic (by `parent_row_key`) and
+shows each task's primary-provider link + sync status. Editing a task (`components/kanban/
+edit-task-dialog.tsx`) calls `updateTaskAction`, which writes the projectable fields and schedules
+the same reactive `after()` projection. `updateTaskAction` enforces **parent integrity** —
+self-parent, missing parent, and **cycle** (it walks the proposed parent's ancestor chain over the
+project's edges) are all rejected before the write. PM-link badges are loaded by a **sibling
+`task_pm_links` query grouped in JS**, not a PostgREST embed: the pg adapter only supports to-many
+embeds as `(count)`, so an embedded `task_pm_links(...)` select returns no rows on the postgres
+backend.
+
 **Seed scripts (retired, Phase 3).** The backlog was originally authored in a `BACKLOG`
 constant (`scripts/aios-backlog.mjs`) and one-way-pushed into the boards by
 `scripts/{plane,linear}-backlog.mjs` (+ `plane-views.mjs`, `pm-sync-backfill.ts`). The

--- a/test/datamechanics/task-update-action.datamechanics.test.ts
+++ b/test/datamechanics/task-update-action.datamechanics.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
+import { db, seedTeam, type Seed } from "./helpers";
+
+// Spec (brain-api v1.2 Phase 4): the dashboard `updateTaskAction` is the second authoring surface.
+// It must persist & round-trip ALL projectable fields, enforce parent integrity (missing/self/cycle),
+// and schedule reactive projection via `next/server`'s `after()`. Verified to the observable outcome
+// on real Postgres, with the after() callback captured and a mutation-counting Linear stub (no live
+// PM calls in CI). updateTaskAction itself depends on request-context modules (serverClient/auth/
+// after) — those three are mocked to the service-role test DB; the action's own logic runs unchanged.
+
+const h = vi.hoisted(() => ({
+  memberId: "",
+  afterCbs: [] as Array<() => Promise<void> | void>,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  serverClient: async () => (await import("@/lib/supabase/admin")).adminClient(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  currentMember: async () =>
+    h.memberId ? { id: h.memberId, role: "admin", tier: "team", userId: "u" } : null,
+}));
+vi.mock("next/server", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return { ...actual, after: (cb: () => Promise<void> | void) => h.afterCbs.push(cb) };
+});
+
+// Imported AFTER the mocks are registered (vi.mock is hoisted, so this is safe).
+const { updateTaskAction } = await import("@/app/actions/tasks");
+
+// ── Linear stub: routes GraphQL by operation, records mutations, mints issue ids ────────────────
+function linearMock() {
+  const mutations: { name: string }[] = [];
+  let n = 0;
+  const states = [
+    { id: "ls-backlog", name: "Backlog", type: "backlog" },
+    { id: "ls-todo", name: "Todo", type: "unstarted" },
+    { id: "ls-started", name: "In Progress", type: "started" },
+    { id: "ls-done", name: "Done", type: "completed" },
+  ];
+  const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+    const { query } = JSON.parse(String(init?.body));
+    if (query.includes("ProjectionBootstrap")) {
+      return Response.json({ data: { team: { states: { nodes: states }, labels: { nodes: [] } } } });
+    }
+    if (query.includes("ProjectionIssues")) {
+      return Response.json({ data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } } });
+    }
+    const name = query.match(/mutation (\w+)/)?.[1] ?? "op";
+    if (query.includes("mutation")) mutations.push({ name });
+    if (query.includes("issueCreate")) {
+      const id = `li-${++n}`;
+      return Response.json({ data: { issueCreate: { success: true, issue: { id, identifier: `AIO-${n}`, url: `https://linear.app/${id}` } } } });
+    }
+    if (query.includes("issueUpdate")) {
+      return Response.json({ data: { issueUpdate: { success: true, issue: { id: "li-x", identifier: "AIO-1", url: "https://linear.app/AIO-1" } } } });
+    }
+    return Response.json({ data: {} });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations };
+}
+
+async function seedLinearPrimary(seed: Seed) {
+  await db().from("teams").update({ primary_pm_provider: "linear" }).eq("id", seed.teamId);
+  const auth = { teamId: seed.teamId, memberId: seed.memberId };
+  const { id } = await upsertIntegration(db(), auth, { type: "linear", name: "linear", config: { teamId: "team-uuid" } });
+  await setIntegrationSecret(db(), auth, id, "lin_api_x");
+}
+
+async function seedProject(teamId: string): Promise<string> {
+  const { data } = await db()
+    .from("projects")
+    .insert({ team_id: teamId, slug: `p-${randomUUID().slice(0, 6)}`, name: "Proj" })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+async function seedTask(teamId: string, projectId: string, rowKey: string, over: Record<string, unknown> = {}): Promise<string> {
+  const { data } = await db()
+    .from("tasks")
+    .insert({ team_id: teamId, project_id: projectId, row_key: rowKey, title: rowKey, status: "backlog", origin: "ui", ...over })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+async function readTask(taskId: string) {
+  const { data } = await db()
+    .from("tasks")
+    .select("title, sprint, due_date, parent_row_key, labels, priority, body")
+    .eq("id", taskId)
+    .single();
+  return data as {
+    title: string;
+    sprint: string;
+    due_date: string | null;
+    parent_row_key: string | null;
+    labels: string[];
+    priority: string;
+    body: string;
+  };
+}
+
+beforeEach(() => {
+  h.memberId = "";
+  h.afterCbs = [];
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("updateTaskAction — persistence & round-trip (real Postgres)", () => {
+  it("persists every projectable field and reads them back", async () => {
+    const seed = await seedTeam();
+    h.memberId = seed.memberId;
+    const project = await seedProject(seed.teamId);
+    await seedTask(seed.teamId, project, "E1");
+    const childId = await seedTask(seed.teamId, project, "C1");
+
+    const res = await updateTaskAction({
+      taskId: childId,
+      title: "Child renamed",
+      sprint: "Wave 2",
+      dueDate: "2030-03-01",
+      parentRowKey: "E1",
+      labels: ["integration", "wave-2"],
+      priority: "critical", // normalizes → urgent
+      body: "dashboard-only description",
+    });
+    expect(res.ok).toBe(true);
+
+    const t = await readTask(childId);
+    expect(t.title).toBe("Child renamed");
+    expect(t.sprint).toBe("Wave 2");
+    const d = new Date(t.due_date as string); // pg adapter returns `date` cols as a local-midnight Date
+    expect([d.getFullYear(), d.getMonth() + 1, d.getDate()]).toEqual([2030, 3, 1]);
+    expect(t.parent_row_key).toBe("E1");
+    expect(t.labels).toEqual(["integration", "wave-2"]);
+    expect(t.priority).toBe("urgent");
+    expect(t.body).toBe("dashboard-only description");
+  });
+
+  it("is partial — a title-only edit never clobbers existing labels/priority", async () => {
+    const seed = await seedTeam();
+    h.memberId = seed.memberId;
+    const project = await seedProject(seed.teamId);
+    const id = await seedTask(seed.teamId, project, "T1", { labels: ["keep"], priority: "high" });
+
+    const res = await updateTaskAction({ taskId: id, title: "only title" });
+    expect(res.ok).toBe(true);
+    const t = await readTask(id);
+    expect(t.title).toBe("only title");
+    expect(t.labels).toEqual(["keep"]); // untouched
+    expect(t.priority).toBe("high"); // untouched
+  });
+});
+
+describe("updateTaskAction — parent integrity (real Postgres)", () => {
+  it("rejects a parent that does not resolve in the project", async () => {
+    const seed = await seedTeam();
+    h.memberId = seed.memberId;
+    const project = await seedProject(seed.teamId);
+    const id = await seedTask(seed.teamId, project, "C1");
+    const res = await updateTaskAction({ taskId: id, parentRowKey: "GHOST" });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/not found/);
+  });
+
+  it("rejects a self-parent", async () => {
+    const seed = await seedTeam();
+    h.memberId = seed.memberId;
+    const project = await seedProject(seed.teamId);
+    const id = await seedTask(seed.teamId, project, "A");
+    const res = await updateTaskAction({ taskId: id, parentRowKey: "A" });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/own parent/);
+  });
+
+  it("rejects a 2-node cycle (A is parent of B; re-parenting A under B closes the loop)", async () => {
+    const seed = await seedTeam();
+    h.memberId = seed.memberId;
+    const project = await seedProject(seed.teamId);
+    const aId = await seedTask(seed.teamId, project, "A");
+    // B is A's child (B.parent = A).
+    await seedTask(seed.teamId, project, "B", { parent_row_key: "A" });
+
+    // Now point A at B → A→B→A. Must be rejected as a cycle (not silently persisted).
+    const res = await updateTaskAction({ taskId: aId, parentRowKey: "B" });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/cycle/i);
+    // And the DB must be unchanged — A still has no parent.
+    expect((await readTask(aId)).parent_row_key).toBeNull();
+  });
+
+  it("rejects a 3-node cycle (A→B→C, re-parenting A under C)", async () => {
+    const seed = await seedTeam();
+    h.memberId = seed.memberId;
+    const project = await seedProject(seed.teamId);
+    const aId = await seedTask(seed.teamId, project, "A");
+    await seedTask(seed.teamId, project, "B", { parent_row_key: "A" });
+    await seedTask(seed.teamId, project, "C", { parent_row_key: "B" });
+
+    const res = await updateTaskAction({ taskId: aId, parentRowKey: "C" });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/cycle/i);
+  });
+
+  it("allows a legitimate re-parent that introduces no cycle", async () => {
+    const seed = await seedTeam();
+    h.memberId = seed.memberId;
+    const project = await seedProject(seed.teamId);
+    await seedTask(seed.teamId, project, "E1");
+    const cId = await seedTask(seed.teamId, project, "C1");
+    const res = await updateTaskAction({ taskId: cId, parentRowKey: "E1" });
+    expect(res.ok).toBe(true);
+    expect((await readTask(cId)).parent_row_key).toBe("E1");
+  });
+});
+
+describe("updateTaskAction — reactive projection via after() (real Postgres)", () => {
+  it("schedules a projection that fires projectTask (create path) when the after() callback runs", async () => {
+    const seed = await seedTeam();
+    h.memberId = seed.memberId;
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    const id = await seedTask(seed.teamId, project, "P0");
+
+    const { fetchImpl, mutations } = linearMock();
+    vi.stubGlobal("fetch", fetchImpl); // scheduleProjection's after() callback uses global fetch
+
+    const res = await updateTaskAction({ taskId: id, title: "edited via dashboard" });
+    expect(res.ok).toBe(true);
+    expect(h.afterCbs.length).toBe(1); // a projection was scheduled
+
+    // Run the scheduled work (as next/server would after the response is sent).
+    for (const cb of h.afterCbs) await cb();
+
+    expect(mutations.some((m) => m.name === "CreateIssue")).toBe(true);
+    const { data: link } = await db()
+      .from("task_pm_links")
+      .select("provider, provider_resource_id, projection_fingerprint")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "P0")
+      .maybeSingle();
+    expect(link).toMatchObject({ provider: "linear", provider_resource_id: "li-1" });
+    expect((link as { projection_fingerprint: string | null }).projection_fingerprint).toBeTruthy();
+  });
+});

--- a/test/http/tasks-page.http.test.ts
+++ b/test/http/tasks-page.http.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { BASE_URL, db, seedMemberEmail, seedTeam, type Seed } from "./http-helpers";
+
+// Spec (brain-api v1.2 Phase 4): the tasks dashboard server-renders the hierarchy — epics with their
+// children grouped beneath them — and shows each task's primary-provider link + sync status. This is
+// the only tier that proves the real Next server component renders over the wire (HTTP 200 + HTML).
+
+async function login(email: string): Promise<string> {
+  const res = await fetch(`${BASE_URL}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+  if (res.status !== 200) throw new Error(`login failed: ${res.status}`);
+  const setCookie = res.headers.get("set-cookie") ?? "";
+  const cookie = setCookie.split(";")[0]; // aios_session=<jwt>
+  if (!cookie.startsWith("aios_session=")) throw new Error(`no session cookie: ${setCookie}`);
+  return cookie;
+}
+
+async function seedProject(teamId: string): Promise<string> {
+  const { data } = await db()
+    .from("projects")
+    .insert({ team_id: teamId, slug: `p-${randomUUID().slice(0, 6)}`, name: "Proj" })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+async function seedTask(teamId: string, projectId: string, rowKey: string, over: Record<string, unknown> = {}): Promise<string> {
+  const { data } = await db()
+    .from("tasks")
+    .insert({ team_id: teamId, project_id: projectId, row_key: rowKey, title: rowKey, status: "backlog", origin: "ui", ...over })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+async function seedLink(seed: Seed, projectId: string, taskId: string, rowKey: string, over: Record<string, unknown>) {
+  const { error } = await db().from("task_pm_links").insert({
+    team_id: seed.teamId,
+    project_id: projectId,
+    task_id: taskId,
+    row_key: rowKey,
+    provider: "linear",
+    provider_external_id: rowKey,
+    provider_external_source: "aios-backlog",
+    provider_url: "",
+    ...over,
+  });
+  if (error) throw new Error(`seed link failed: ${error.message}`);
+}
+
+describe("GET /t/{team}/tasks (HTTP) — hierarchical render", () => {
+  it("server-renders epics with their children grouped and shows pm-link + sync status (200)", async () => {
+    const seed = await seedTeam();
+    const email = await seedMemberEmail(seed); // a known-email, team-tier member on this team
+    const cookie = await login(email);
+
+    const project = await seedProject(seed.teamId);
+    const epicId = await seedTask(seed.teamId, project, "EPIC-1", { title: "Wave 1 Foundations" });
+    const childId = await seedTask(seed.teamId, project, "SUB-1", { title: "Build the projector", parent_row_key: "EPIC-1", priority: "high", labels: ["integration"] });
+    await seedLink(seed, project, epicId, "EPIC-1", { provider_resource_id: "li-epic", provider_url: "https://linear.app/issue/EPIC", last_synced_status: "backlog" });
+    await seedLink(seed, project, childId, "SUB-1", { provider_resource_id: "li-sub", provider_url: "https://linear.app/issue/SUB", last_synced_status: "backlog" });
+
+    const res = await fetch(`${BASE_URL}/t/${seed.teamSlug}/tasks`, { headers: { cookie }, cache: "no-store" });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // Both titles render.
+    expect(html).toContain("Wave 1 Foundations");
+    expect(html).toContain("Build the projector");
+    // The child is grouped under its epic (a server-rendered grouping marker, not a flat list).
+    expect(html).toContain('data-parent="EPIC-1"');
+    expect(html).toContain('data-epic="EPIC-1"');
+    // Each task shows its primary-provider link + sync status.
+    expect(html).toContain("https://linear.app/issue/EPIC");
+    expect(html).toContain("https://linear.app/issue/SUB");
+    expect(html).toMatch(/linear/i);
+  });
+
+  it("redirects an unauthenticated request to the sign-in page (no task leak)", async () => {
+    const seed = await seedTeam();
+    const project = await seedProject(seed.teamId);
+    await seedTask(seed.teamId, project, "SECRET-1", { title: "Confidential epic" });
+
+    // No cookie → the /t/* proxy gate redirects to /login (fetch follows it). The protected
+    // content must never appear in the response.
+    const res = await fetch(`${BASE_URL}/t/${seed.teamSlug}/tasks`, { redirect: "manual" });
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/login");
+
+    const followed = await fetch(`${BASE_URL}/t/${seed.teamSlug}/tasks`);
+    const html = await followed.text();
+    expect(html).not.toContain("Confidential epic");
+  });
+});


### PR DESCRIPTION
## Phase 4 — Dashboard hierarchical CRUD (brain-api v1.2)

The tasks page becomes the **second authoring surface** for the brain→PM projection (alongside `aios push`).

### What changed
- **`updateTaskAction` parent integrity** now rejects self-parent, missing parent, **and cycles** (walks the proposed parent's ancestor chain over the project's edges) before writing. Cycle detection was explicitly deferred in Phase 2 — this closes it.
- **Server-rendered hierarchy**: `components/kanban/task-hierarchy.tsx` groups sub-tasks under their epic (`parent_row_key`) and shows each task's primary-provider link + sync status. Editing via `edit-task-dialog.tsx` calls `updateTaskAction`, which schedules the same reactive `after()` projection (title/sprint/due/parent/labels/priority/body).
- **Latent postgres-mode bug fixed**: PM-link badges are now loaded via a **sibling `task_pm_links` query grouped in JS** instead of a PostgREST embed. The pg adapter (deployed backend) only supports to-many embeds as `(count)`, so the prior `task_pm_links(...)` embed silently returned **zero tasks** on the tasks page in postgres mode.

### Tests (spec-derived, RED before the feature)
- `test/datamechanics/task-update-action.datamechanics.test.ts` (8) — persist + round-trip all fields, partial writes, parent integrity (missing/self/2-node + 3-node cycle), and `after()` firing `projectTask` with a stubbed `fetch`, on real Postgres.
- `test/http/tasks-page.http.test.ts` (2) — the page server-renders epics with children grouped + pm-link/status over a real socket (HTTP 200); an unauthenticated request redirects to `/login` with no task leak.

### Local bar (all green)
unit **165** · data-mechanics **108** · http **11** · ingestion pytest **95** · eslint · `tsc --noEmit` · `check:docs`. `docs/ARCHITECTURE.md` updated in the same PR.

### Assumptions locked
- The hierarchy renders as a server section **above** the existing interactive kanban Board (both kept); no removal of the board.
- PM-link badges read by sibling query (not adapter embed) — chosen over extending the pg adapter's to-many embed support to keep the change contained and avoid adapter risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task mutation validation and PM projection triggers on dashboard edits; cycle guard adds an extra per-reparent query. UI/data-loading change fixes a production postgres bug but alters how tasks page fetches links.
> 
> **Overview**
> Phase 4 makes the tasks dashboard a **second authoring surface** for brain→PM projection: a server-rendered **Hierarchy** section above the existing kanban board, with per-row edit and PM link badges.
> 
> **`updateTaskAction`** now rejects **parent cycles** (ancestor walk over the project’s `parent_row_key` edges), closing the guard that was deferred earlier; self-parent and missing parent checks remain.
> 
> The tasks page **loads PM links via a sibling `task_pm_links` query** grouped in JS instead of a PostgREST embed, fixing postgres mode where embedded to-many selects returned no tasks. Task queries also pull hierarchy fields (`parent_row_key`, labels, priority, body).
> 
> New UI: **`task-hierarchy.tsx`** (epic/child grouping, sync status) and **`edit-task-dialog.tsx`** (projectable fields → `updateTaskAction` + `router.refresh()`). Types gain `TASK_PRIORITIES` and optional hierarchy fields. **`docs/ARCHITECTURE.md`** documents Phase 4. Tests cover action persistence, cycle cases, `after()` projection, and HTTP hierarchy/auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d4fcc8a98c27c26ed36e5e538b1714f1ec3c896. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->