### PR TITLE
feat(pm-sync): inbound divergence detection (brain-api v1.2 Phase 5, surface-only)

### DIFF
--- a/app/t/[team]/admin/pm-sync/actions.ts
+++ b/app/t/[team]/admin/pm-sync/actions.ts
@@ -8,6 +8,7 @@ import { getSessionUser } from "@/lib/auth/session";
 import { resolveIntegrationsAdmin } from "@/lib/integrations/read";
 import { audit } from "@/lib/api/audit";
 import { projectAllTasks, type ProjectionReport } from "@/lib/pm-sync";
+import { reconcileProviderState, type DivergenceRow } from "@/lib/pm-sync/reconcile";
 
 async function requireAdmin(teamSlug: string) {
   const supabase = await serverClient();
@@ -66,4 +67,40 @@ export async function projectBoardAction(teamSlug: string): Promise<ProjectBoard
 
   revalidatePath(`/t/${teamSlug}/admin/pm-sync`);
   return { ok: true, provider, counts, reports };
+}
+
+export interface ReconcileResultDto {
+  ok: boolean;
+  error?: string;
+  provider?: string | null;
+  seenUpdated?: number;
+  divergences?: DivergenceRow[];
+}
+
+/**
+ * "Check for divergence" — inbound reconcile pass (brain-api v1.2 Phase 5). Admins only; audited.
+ * Reads the primary PM tool's CURRENT state for each linked task, records `provider_seen_status`,
+ * and surfaces items whose provider state has drifted from the brain's `last_projected_status`.
+ * SURFACE-ONLY: brain wins — it never writes back to the brain or the board.
+ */
+export async function reconcileDivergenceAction(teamSlug: string): Promise<ReconcileResultDto> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+
+  const db = adminClient();
+  const result = await reconcileProviderState(db, ctx.teamId);
+  if (result.provider === null) return { ok: false, error: result.reason ?? "no primary PM provider configured" };
+
+  await audit(db, {
+    team_id: ctx.teamId,
+    actor_kind: "member",
+    member_id: ctx.myMemberId,
+    action: "team.reconcile_divergence",
+    target_type: "team",
+    target_id: ctx.teamId,
+    meta: { provider: result.provider, seenUpdated: result.seenUpdated, divergences: result.divergences.length },
+  });
+
+  revalidatePath(`/t/${teamSlug}/admin/pm-sync`);
+  return { ok: true, provider: result.provider, seenUpdated: result.seenUpdated, divergences: result.divergences };
 }

--- a/app/t/[team]/admin/pm-sync/page.tsx
+++ b/app/t/[team]/admin/pm-sync/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { serverClient } from "@/lib/supabase/server";
+import { isDiverged } from "@/lib/pm-sync/reconcile";
 import { ProjectBoardButton } from "./project-board-button";
+import { ReconcileButton } from "./reconcile-button";
 
 export const metadata: Metadata = { title: "PM sync" };
 
@@ -14,7 +16,7 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
     .maybeSingle();
   if (!team) return null;
 
-  const [{ data: unresolved }, { data: failedLinks }] = await Promise.all([
+  const [{ data: unresolved }, { data: failedLinks }, { data: seenLinks }] = await Promise.all([
     supabase
       .from("work_events")
       .select("row_key, repo, merged_sha, pr_url, pr_title, error, created_at")
@@ -29,7 +31,27 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
       .not("last_error", "is", null)
       .order("updated_at", { ascending: false })
       .limit(50),
+    // Inbound divergence (Phase 5): links the reconcile pass has recorded a provider_seen_status on.
+    // Divergence is computed in JS (the pg adapter can't compare two columns in a filter).
+    supabase
+      .from("task_pm_links")
+      .select("row_key, provider, provider_url, last_projected_status, provider_seen_status, updated_at")
+      .eq("team_id", team.id)
+      .not("provider_seen_status", "is", null)
+      .order("updated_at", { ascending: false })
+      .limit(200),
   ]);
+
+  const divergences = (
+    (seenLinks ?? []) as {
+      row_key: string;
+      provider: string;
+      provider_url: string | null;
+      last_projected_status: string | null;
+      provider_seen_status: string | null;
+      updated_at: string;
+    }[]
+  ).filter(isDiverged);
 
   return (
     <div className="flex flex-col gap-5">
@@ -44,6 +66,48 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
             teamSlug={teamSlug}
             primaryProvider={(team as { primary_pm_provider: string | null }).primary_pm_provider}
           />
+        </div>
+      </section>
+
+      <section className="prism-card p-4" data-section="inbound-divergence">
+        <h2 className="text-lg font-semibold text-ink">Inbound divergence</h2>
+        <p className="mt-1 text-sm text-ink-secondary">
+          Tasks whose state in the PM tool has drifted from what the brain last projected. The brain
+          is the source of truth — this is <span className="font-medium text-ink">surface-only</span>,
+          shown for a human to pull; it is never written back automatically.
+        </p>
+        <div className="mt-4">
+          <ReconcileButton
+            teamSlug={teamSlug}
+            primaryProvider={(team as { primary_pm_provider: string | null }).primary_pm_provider}
+          />
+        </div>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-left text-xs uppercase tracking-wider text-ink-tertiary">
+              <tr>
+                <th className="py-2 pr-4 font-medium">Key</th>
+                <th className="py-2 pr-4 font-medium">Provider</th>
+                <th className="py-2 pr-4 font-medium">Brain projected</th>
+                <th className="py-2 pr-4 font-medium">Seen in tool</th>
+              </tr>
+            </thead>
+            <tbody>
+              {divergences.map((d) => (
+                <tr key={`${d.provider}-${d.row_key}`} data-divergence={d.row_key} className="border-t border-border-subtle">
+                  <td className="py-2 pr-4 font-mono text-xs">{d.row_key}</td>
+                  <td className="py-2 pr-4">
+                    {d.provider_url ? <a className="text-violet" href={d.provider_url}>{d.provider}</a> : d.provider}
+                  </td>
+                  <td className="py-2 pr-4 text-ink-secondary">{d.last_projected_status}</td>
+                  <td className="py-2 pr-4 font-medium text-amber-700">{d.provider_seen_status}</td>
+                </tr>
+              ))}
+              {divergences.length === 0 ? (
+                <tr><td colSpan={4} className="py-4 text-ink-tertiary">No divergence detected.</td></tr>
+              ) : null}
+            </tbody>
+          </table>
         </div>
       </section>
 

--- a/app/t/[team]/admin/pm-sync/reconcile-button.tsx
+++ b/app/t/[team]/admin/pm-sync/reconcile-button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { reconcileDivergenceAction, type ReconcileResultDto } from "./actions";
+
+/**
+ * "Check for divergence" — triggers the inbound reconcile pass (brain-api v1.2 Phase 5). Reads the
+ * primary PM tool's current state and surfaces drift on the table below. Surface-only: it never
+ * writes back to the brain or the board. The page revalidates so the divergence list refreshes.
+ */
+export function ReconcileButton({ teamSlug, primaryProvider }: { teamSlug: string; primaryProvider: string | null }) {
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<ReconcileResultDto | null>(null);
+
+  function run() {
+    setResult(null);
+    startTransition(async () => {
+      setResult(await reconcileDivergenceAction(teamSlug));
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={run}
+          disabled={pending || !primaryProvider}
+          className="rounded-md border border-violet/50 px-3 py-1.5 text-sm font-medium text-violet disabled:opacity-60"
+        >
+          {pending ? "Checking…" : "Check for divergence"}
+        </button>
+        {!primaryProvider ? (
+          <span className="text-sm text-ink-tertiary">Set a primary PM tool first.</span>
+        ) : null}
+      </div>
+
+      {result && !pending ? (
+        result.ok ? (
+          <div className="rounded-md border border-emerald/40 bg-emerald/10 px-3 py-2 text-sm">
+            <p className="font-medium text-emerald">✓ Checked {result.provider}</p>
+            <p className="mt-0.5 text-ink-secondary">
+              {(result.divergences ?? []).length} diverged · {result.seenUpdated ?? 0} state{result.seenUpdated === 1 ? "" : "s"} updated
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-md border border-red/40 bg-red/10 px-3 py-2 text-sm">
+            <p className="font-medium text-red">Reconcile failed</p>
+            <p className="mt-0.5 text-ink-secondary">{result.error}</p>
+          </div>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,8 +187,18 @@ membership. A `projection_fingerprint` on the link skips a provider round-trip w
 changed (a second `projectAllTasks` run does zero writes). The admin **"Project board now"**
 button (`projectBoardAction`, admin-gated + audited) on the pm-sync page triggers a full run;
 the work-events done path calls `projectTask` (creating the link/item if missing). `moveToDone`
-remains as a thin state-only delegate. Assignees and inbound/two-way reconciliation are deferred
-(Phase 5 uses `provider_seen_status` to detect divergence).
+remains as a thin state-only delegate. Assignee projection is deferred.
+
+**Inbound divergence detection (brain-api v1.2 Phase 5, surface-only).** The reconcile pass
+(`lib/pm-sync/reconcile.ts: reconcileProviderState`) reads the primary tool's CURRENT workflow
+state for every linked task (adapter `fetchSeenStates` — read-only), records it on
+`task_pm_links.provider_seen_status`, and surfaces any item whose state has drifted from the brain's
+`last_projected_status`. It is **SURFACE-ONLY (brain wins)**: it never mutates the provider and never
+changes brain `tasks.status` — the only write is `provider_seen_status`, and only when it changed
+(so a second pass does zero writes — idempotent). The admin **"Check for divergence"** button
+(`reconcileDivergenceAction`, admin-gated + audited) runs it; the PM-sync page renders the divergence
+list read-only from stored state (`isDiverged`). Conflict policy is fixed at brain-wins: drift is
+shown for a human to pull, never silently applied. Two-way write-back remains out of scope.
 
 **Reactive triggers (brain-api v1.2 Phase 2).** Projection is no longer manual-only. Task UI
 writes — `createTaskAction` / `moveTaskAction` / the new `updateTaskAction` (title/sprint/due/
@@ -328,8 +338,10 @@ guard enforces it, it's named.
   `after()` — bounded to the rows whose projected fields changed, run after the response, and never
   failing the user action (errors → `task_pm_links.last_error` only; `projection_fingerprint` skips
   redundant writes). A merged-work event still marks the matching task done first; provider failures
-  are surfaced in Admin → PM sync, never rolling the task back. Inbound PM→brain reconciliation
-  (two-way) is deferred (Phase 5); v1 only records `provider_seen_status` so divergence is detectable.
+  are surfaced in Admin → PM sync, never rolling the task back. Inbound PM→brain divergence is
+  **detected and surfaced** (Phase 5, `reconcileProviderState`): drift between the tool's state and
+  `last_projected_status` is recorded on `provider_seen_status` and shown on the PM-sync page —
+  surface-only, brain wins, never written back. Two-way write-back remains out of scope.
   (Rows removed from a push are diff-deleted in `tasks` but **not** deleted from the PM board in
   Phase 2 — PM deletion-on-diff is a later phase.)
 - **`key_hash` is column-revoked** from client roles; API secrets are sha256-at-rest, shown once.

--- a/lib/pm-sync/linear.ts
+++ b/lib/pm-sync/linear.ts
@@ -8,6 +8,7 @@ import {
   requireString,
   sameLabelSet,
   type DesiredState,
+  type FetchSeenStatesInput,
   type PmAdapter,
   type PrepareInput,
   type ProviderSyncInput,
@@ -218,6 +219,19 @@ export const linearAdapter: PmAdapter = {
     const ctx = linearCtx({ integration, fetchImpl });
     const teamId = requireString(ctx.teamIdConfig, "Linear teamId (config.teamId) for projection");
     return buildBootstrap(ctx, teamId);
+  },
+
+  // Phase 5 inbound reconcile: list every issue once and return resource id → current state NAME.
+  // Read-only (reuses the projection bootstrap queries; performs no mutations).
+  async fetchSeenStates({ integration, fetchImpl }: FetchSeenStatesInput): Promise<Map<string, string>> {
+    const ctx = linearCtx({ integration, fetchImpl });
+    const teamId = requireString(ctx.teamIdConfig, "Linear teamId (config.teamId) for reconcile");
+    const boot = await buildBootstrap(ctx, teamId);
+    const seen = new Map<string, string>();
+    for (const [id, issue] of boot.issuesById) {
+      if (issue.state?.name) seen.set(id, issue.state.name);
+    }
+    return seen;
   },
 
   async upsertWorkItem({ task, link, integration, desiredFingerprint, statusOnly, bootstrap, fetchImpl }: UpsertWorkItemInput): Promise<UpsertWorkItemResult> {

--- a/lib/pm-sync/provider.ts
+++ b/lib/pm-sync/provider.ts
@@ -89,6 +89,11 @@ export interface PrepareInput {
   fetchImpl?: typeof fetch;
 }
 
+export interface FetchSeenStatesInput {
+  integration: IntegrationWithSecret;
+  fetchImpl?: typeof fetch;
+}
+
 export interface PmAdapter {
   provider: PmProvider;
   // Optional per-run prefetch: returns an opaque provider bootstrap (states/labels/items/modules)
@@ -96,6 +101,10 @@ export interface PmAdapter {
   prepare?(input: PrepareInput): Promise<unknown>;
   upsertWorkItem(input: UpsertWorkItemInput): Promise<UpsertWorkItemResult>;
   moveToDone(input: ProviderSyncInput): Promise<ProviderSyncResult>;
+  // Inbound reconciliation (brain-api v1.2 Phase 5): read the CURRENT provider workflow-state NAME
+  // for every projected item, keyed by provider resource id. Read-only — never mutates the provider.
+  // Optional: a provider without an implementation simply has no divergence detection.
+  fetchSeenStates?(input: FetchSeenStatesInput): Promise<Map<string, string>>;
 }
 
 // status → desired provider state. Both providers share five workflow groups; `blocked` has no

--- a/lib/pm-sync/reconcile.ts
+++ b/lib/pm-sync/reconcile.ts
@@ -1,0 +1,124 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { linearAdapter } from "@/lib/pm-sync/linear";
+import { planeAdapter } from "@/lib/pm-sync/plane";
+import { resolvePrimaryProvider } from "@/lib/pm-sync/project";
+import type { PmAdapter, PmProvider } from "@/lib/pm-sync/provider";
+
+/**
+ * Inbound divergence detection (brain-api v1.2 Phase 5).
+ *
+ * The brain is the source of truth and projects one-way into the primary PM tool. This pass closes
+ * the observability loop the other direction: it reads the provider's CURRENT workflow state for
+ * each projected item, records it on `task_pm_links.provider_seen_status`, and SURFACES any item
+ * whose provider state has diverged from the brain's `last_projected_status`.
+ *
+ * Hard invariant — SURFACE-ONLY (brain wins):
+ *   • never mutates the provider (no PATCH / no state write back to the board);
+ *   • never changes brain `tasks.status` (or any task field);
+ *   • the only write is `task_pm_links.provider_seen_status`, and only when it actually changed
+ *     (so a second pass over an unchanged board performs ZERO writes — idempotent).
+ *
+ * Conflict policy is fixed at "brain wins": divergence is logged/surfaced on the PM-sync page for a
+ * human to pull, never silently applied. Live provider reads use an injectable `fetchImpl` (tests
+ * stub it; no live PM calls in CI).
+ */
+
+const ADAPTERS: Record<PmProvider, PmAdapter> = { plane: planeAdapter, linear: linearAdapter };
+
+// The link columns reconcile reads. Named explicitly — the pg adapter (prod) rejects a bare "*".
+const LINK_COLS = "id, row_key, provider, provider_resource_id, last_projected_status, provider_seen_status";
+
+interface ReconcileLink {
+  id: string;
+  row_key: string;
+  provider: PmProvider;
+  provider_resource_id: string | null;
+  last_projected_status: string | null;
+  provider_seen_status: string | null;
+}
+
+export interface DivergenceRow {
+  row_key: string;
+  provider: PmProvider;
+  last_projected_status: string | null;
+  provider_seen_status: string | null;
+}
+
+export interface ReconcileResult {
+  provider: PmProvider | null;
+  // Count of links whose provider_seen_status was (re)written this pass — 0 on an idempotent re-run.
+  seenUpdated: number;
+  divergences: DivergenceRow[];
+  reason?: string;
+}
+
+// Pure: a link is diverged when both sides are known and the provider's current state differs from
+// what the brain last projected. Shared by the engine and the read-only PM-sync page render.
+export function isDiverged(link: {
+  last_projected_status: string | null;
+  provider_seen_status: string | null;
+}): boolean {
+  return (
+    !!link.provider_seen_status &&
+    !!link.last_projected_status &&
+    link.provider_seen_status !== link.last_projected_status
+  );
+}
+
+export async function reconcileProviderState(
+  supabase: SupabaseClient,
+  teamId: string,
+  opts: { fetchImpl?: typeof fetch } = {}
+): Promise<ReconcileResult> {
+  const primary = await resolvePrimaryProvider(supabase, teamId);
+  if (primary.provider === null || primary.integration === null) {
+    return { provider: primary.provider, seenUpdated: 0, divergences: [], reason: primary.reason };
+  }
+  const adapter = ADAPTERS[primary.provider];
+  if (!adapter.fetchSeenStates) {
+    return { provider: primary.provider, seenUpdated: 0, divergences: [], reason: `${primary.provider} has no inbound reconcile support` };
+  }
+
+  const { data } = await supabase
+    .from("task_pm_links")
+    .select(LINK_COLS)
+    .eq("team_id", teamId)
+    .eq("provider", primary.provider)
+    .not("provider_resource_id", "is", null);
+  const links = ((data ?? []) as ReconcileLink[]).filter((l) => l.provider_resource_id);
+  if (!links.length) return { provider: primary.provider, seenUpdated: 0, divergences: [] };
+
+  // One read of the provider's current states (resource id → state name). Read-only.
+  const seenByResource = await adapter.fetchSeenStates({ integration: primary.integration, fetchImpl: opts.fetchImpl });
+
+  let seenUpdated = 0;
+  const divergences: DivergenceRow[] = [];
+  for (const link of links) {
+    const seen = seenByResource.get(link.provider_resource_id!) ?? null;
+    if (seen === null) continue; // provider has no state for this item (e.g. deleted) — leave as-is
+
+    // Persist the seen state ONLY when it changed — keeps a re-run write-free (idempotent).
+    if (seen !== link.provider_seen_status) {
+      await supabase
+        .from("task_pm_links")
+        .update({ provider_seen_status: seen, updated_at: new Date().toISOString() })
+        .eq("id", link.id);
+      seenUpdated += 1;
+    }
+
+    // Surface divergence from the brain's last projection — using the freshly-seen value.
+    if (isDiverged({ last_projected_status: link.last_projected_status, provider_seen_status: seen })) {
+      divergences.push({
+        row_key: link.row_key,
+        provider: link.provider,
+        last_projected_status: link.last_projected_status,
+        provider_seen_status: seen,
+      });
+    }
+  }
+
+  return { provider: primary.provider, seenUpdated, divergences };
+}

--- a/test/datamechanics/reconcile-divergence.datamechanics.test.ts
+++ b/test/datamechanics/reconcile-divergence.datamechanics.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { reconcileProviderState } from "@/lib/pm-sync/reconcile";
+import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
+import { db, seedTeam, type Seed } from "./helpers";
+
+// Spec (brain-api v1.2 Phase 5): inbound divergence detection. A reconcile pass reads the provider's
+// CURRENT workflow state, records it on `task_pm_links.provider_seen_status`, and SURFACES divergence
+// when that state ≠ `last_projected_status`. It is SURFACE-ONLY: it must never mutate the provider
+// (brain wins) and never change brain `tasks.status` (brain is the source of truth). Verified to the
+// observable outcome on real Postgres with a mutation-counting Linear stub — no live calls in CI.
+
+// ── Linear stub: ProjectionBootstrap (states/labels) + ProjectionIssues (current issue states) ──────
+function linearMock(issues: unknown[]) {
+  const mutations: { name: string }[] = [];
+  const states = [
+    { id: "ls-backlog", name: "Backlog", type: "backlog" },
+    { id: "ls-todo", name: "Todo", type: "unstarted" },
+    { id: "ls-started", name: "In Progress", type: "started" },
+    { id: "ls-done", name: "Done", type: "completed" },
+  ];
+  const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+    const { query } = JSON.parse(String(init?.body));
+    if (query.includes("ProjectionBootstrap")) {
+      return Response.json({ data: { team: { states: { nodes: states }, labels: { nodes: [] } } } });
+    }
+    if (query.includes("ProjectionIssues")) {
+      return Response.json({ data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: issues } } } });
+    }
+    if (query.includes("mutation")) mutations.push({ name: query.match(/mutation (\w+)/)?.[1] ?? "op" });
+    return Response.json({ data: {} });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations };
+}
+
+async function seedLinearPrimary(seed: Seed) {
+  await db().from("teams").update({ primary_pm_provider: "linear" }).eq("id", seed.teamId);
+  const auth = { teamId: seed.teamId, memberId: seed.memberId };
+  const { id } = await upsertIntegration(db(), auth, { type: "linear", name: "linear", config: { teamId: "team-uuid" } });
+  await setIntegrationSecret(db(), auth, id, "lin_api_x");
+}
+
+async function seedProject(teamId: string): Promise<string> {
+  const { data } = await db().from("projects").insert({ team_id: teamId, slug: `p-${randomUUID().slice(0, 6)}`, name: "Proj" }).select("id").single();
+  return (data as { id: string }).id;
+}
+
+// A linked, already-projected task: the engine previously set last_projected_status; the issue now
+// lives at `resourceId` on Linear.
+async function seedLinkedTask(seed: Seed, projectId: string, rowKey: string, resourceId: string, lastProjected: string) {
+  const { data: task } = await db()
+    .from("tasks")
+    .insert({ team_id: seed.teamId, project_id: projectId, row_key: rowKey, title: rowKey, status: "backlog", origin: "ui" })
+    .select("id")
+    .single();
+  const taskId = (task as { id: string }).id;
+  await db().from("task_pm_links").insert({
+    team_id: seed.teamId,
+    project_id: projectId,
+    task_id: taskId,
+    row_key: rowKey,
+    provider: "linear",
+    provider_external_id: rowKey,
+    provider_external_source: "aios-backlog",
+    provider_resource_id: resourceId,
+    provider_url: `https://linear.app/${resourceId}`,
+    last_projected_status: lastProjected,
+    provider_seen_status: null,
+  });
+  return taskId;
+}
+
+async function readLink(teamId: string, rowKey: string) {
+  const { data } = await db()
+    .from("task_pm_links")
+    .select("provider_seen_status, last_projected_status, updated_at")
+    .eq("team_id", teamId)
+    .eq("row_key", rowKey)
+    .single();
+  return data as { provider_seen_status: string | null; last_projected_status: string | null; updated_at: string };
+}
+
+async function readTaskStatus(taskId: string): Promise<string> {
+  const { data } = await db().from("tasks").select("status").eq("id", taskId).single();
+  return (data as { status: string }).status;
+}
+
+describe("reconcileProviderState — inbound divergence (real Postgres)", () => {
+  it("surfaces divergence + records provider_seen_status, WITHOUT touching brain status or the board", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    // Brain last projected "Backlog"; someone moved the Linear issue to "Done".
+    const taskId = await seedLinkedTask(seed, project, "P0", "li-1", "Backlog");
+
+    const { fetchImpl, mutations } = linearMock([{ id: "li-1", state: { id: "ls-done", name: "Done", type: "completed" } }]);
+    const result = await reconcileProviderState(db(), seed.teamId, { fetchImpl });
+
+    expect(result.provider).toBe("linear");
+    expect(result.divergences).toEqual([
+      expect.objectContaining({ row_key: "P0", provider: "linear", last_projected_status: "Backlog", provider_seen_status: "Done" }),
+    ]);
+    // provider_seen_status persisted.
+    expect((await readLink(seed.teamId, "P0")).provider_seen_status).toBe("Done");
+    // SURFACE-ONLY: brain status unchanged + ZERO provider mutations (never writes back to the board).
+    expect(await readTaskStatus(taskId)).toBe("backlog");
+    expect(mutations.length).toBe(0);
+  });
+
+  it("no-op when the provider state equals last_projected_status (not flagged)", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    await seedLinkedTask(seed, project, "P0", "li-1", "Backlog");
+
+    const { fetchImpl, mutations } = linearMock([{ id: "li-1", state: { id: "ls-backlog", name: "Backlog", type: "backlog" } }]);
+    const result = await reconcileProviderState(db(), seed.teamId, { fetchImpl });
+
+    expect(result.divergences).toEqual([]); // equal → no divergence
+    expect((await readLink(seed.teamId, "P0")).provider_seen_status).toBe("Backlog"); // still recorded as seen
+    expect(mutations.length).toBe(0);
+  });
+
+  it("is idempotent — a second pass makes ZERO writes (seenUpdated=0, updated_at frozen)", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    await seedLinkedTask(seed, project, "P0", "li-1", "Backlog");
+
+    const first = linearMock([{ id: "li-1", state: { id: "ls-done", name: "Done", type: "completed" } }]);
+    const r1 = await reconcileProviderState(db(), seed.teamId, { fetchImpl: first.fetchImpl });
+    expect(r1.seenUpdated).toBe(1);
+    const afterFirst = await readLink(seed.teamId, "P0");
+
+    const second = linearMock([{ id: "li-1", state: { id: "ls-done", name: "Done", type: "completed" } }]);
+    const r2 = await reconcileProviderState(db(), seed.teamId, { fetchImpl: second.fetchImpl });
+    expect(r2.seenUpdated).toBe(0); // nothing changed → no DB write
+    expect(second.mutations.length).toBe(0);
+    // The divergence is still surfaced (read from stored state), but the row was not re-written.
+    expect(r2.divergences.length).toBe(1);
+    expect(new Date((await readLink(seed.teamId, "P0")).updated_at).getTime()).toBe(
+      new Date(afterFirst.updated_at).getTime()
+    );
+  });
+
+  it("no primary provider → clean no-op report (nothing to reconcile)", async () => {
+    const seed = await seedTeam();
+    const { fetchImpl } = linearMock([]);
+    const result = await reconcileProviderState(db(), seed.teamId, { fetchImpl });
+    expect(result.provider).toBeNull();
+    expect(result.divergences).toEqual([]);
+    expect(result.seenUpdated).toBe(0);
+  });
+});

--- a/test/http/pm-sync-divergence.http.test.ts
+++ b/test/http/pm-sync-divergence.http.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { BASE_URL, db, seedTeam, type Seed } from "./http-helpers";
+
+// Spec (brain-api v1.2 Phase 5): the admin PM-sync page server-renders the inbound-divergence list —
+// tasks whose state in the PM tool has drifted from the brain's last_projected_status. Proven over a
+// real socket (HTTP 200) with an admin session. Divergence is read from stored provider_seen_status
+// (a prior reconcile pass populated it) — no live PM call on render.
+
+async function seedAdmin(seed: Seed): Promise<string> {
+  const email = `admin-${randomUUID().slice(0, 8)}@test.local`;
+  const { error } = await db().from("members").insert({
+    team_id: seed.teamId,
+    email,
+    display_name: "Admin",
+    actor_handle: `admin-${randomUUID().slice(0, 8)}`,
+    role: "admin",
+    tier: "team",
+    status: "active",
+  });
+  if (error) throw new Error(`admin seed failed: ${error.message}`);
+  return email;
+}
+
+async function login(email: string): Promise<string> {
+  const res = await fetch(`${BASE_URL}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+  if (res.status !== 200) throw new Error(`login failed: ${res.status}`);
+  const cookie = (res.headers.get("set-cookie") ?? "").split(";")[0];
+  if (!cookie.startsWith("aios_session=")) throw new Error("no session cookie");
+  return cookie;
+}
+
+async function seedDivergedLink(seed: Seed) {
+  const { data: project } = await db().from("projects").insert({ team_id: seed.teamId, slug: `p-${randomUUID().slice(0, 6)}`, name: "Proj" }).select("id").single();
+  const projectId = (project as { id: string }).id;
+  const { data: task } = await db()
+    .from("tasks")
+    .insert({ team_id: seed.teamId, project_id: projectId, row_key: "DIV-1", title: "Diverged task", status: "backlog", origin: "ui" })
+    .select("id")
+    .single();
+  await db().from("task_pm_links").insert({
+    team_id: seed.teamId,
+    project_id: projectId,
+    task_id: (task as { id: string }).id,
+    row_key: "DIV-1",
+    provider: "linear",
+    provider_external_id: "DIV-1",
+    provider_external_source: "aios-backlog",
+    provider_resource_id: "li-div",
+    provider_url: "https://linear.app/issue/DIV",
+    last_projected_status: "Backlog", // brain projected Backlog…
+    provider_seen_status: "Done", // …but the reconcile pass saw Done → divergence
+  });
+}
+
+describe("GET /t/{team}/admin/pm-sync (HTTP) — inbound divergence list", () => {
+  it("server-renders the divergence row (brain vs tool) for an admin (200)", async () => {
+    const seed = await seedTeam();
+    const email = await seedAdmin(seed);
+    const cookie = await login(email);
+    await seedDivergedLink(seed);
+
+    const res = await fetch(`${BASE_URL}/t/${seed.teamSlug}/admin/pm-sync`, { headers: { cookie }, cache: "no-store" });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain("Inbound divergence");
+    expect(html).toContain('data-divergence="DIV-1"');
+    // Both sides of the drift are rendered: what the brain projected vs what the tool now shows.
+    expect(html).toContain("Backlog");
+    expect(html).toContain("Done");
+    expect(html).toContain("Check for divergence");
+  });
+
+  it("shows the empty state when nothing has diverged", async () => {
+    const seed = await seedTeam();
+    const email = await seedAdmin(seed);
+    const cookie = await login(email);
+
+    const res = await fetch(`${BASE_URL}/t/${seed.teamSlug}/admin/pm-sync`, { headers: { cookie }, cache: "no-store" });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("No divergence detected");
+  });
+});


### PR DESCRIPTION
## Phase 5 — Inbound divergence detection (brain-api v1.2)

Closes the observability loop in the PM→brain direction **without** breaking brain-wins. The brain still projects one-way; this pass only *detects and surfaces* drift.

### What changed
- **`lib/pm-sync/reconcile.ts` → `reconcileProviderState`**: reads the primary tool's **current** workflow state per linked task (new **read-only** adapter method `fetchSeenStates`, implemented for Linear by reusing `buildBootstrap`), records it on `task_pm_links.provider_seen_status`, and surfaces any item whose state diverged from `last_projected_status`.
- **SURFACE-ONLY (brain wins)**: never mutates the provider, never changes brain `tasks.status`. The only write is `provider_seen_status`, and only when it changed — so a **second pass does zero writes** (idempotent).
- **Admin "Check for divergence"** button (`reconcileDivergenceAction`, admin-gated + audited) runs the pass; the PM-sync page renders the divergence list **read-only** from stored state (`isDiverged`). Conflict policy fixed at brain-wins; two-way write-back stays out of scope.

### Tests (spec-derived, RED before the feature)
- `test/datamechanics/reconcile-divergence.datamechanics.test.ts` (4) — surfaces divergence + sets `provider_seen_status` while leaving brain status **and** the board untouched (zero provider mutations); no-op when equal; idempotent (2nd pass zero writes); clean no-op with no primary provider. Real Postgres + stubbed `fetch`.
- `test/http/pm-sync-divergence.http.test.ts` (2) — the admin page server-renders the divergence row (brain vs tool) over a real socket (HTTP 200); empty-state otherwise.

### Local bar (all green)
unit **165** · data-mechanics **112** · http **13** · ingestion pytest **95** · eslint · `tsc --noEmit` · `check:docs`. `docs/ARCHITECTURE.md` updated in the same PR.

### Assumptions locked
- Divergence is computed in JS from stored `provider_seen_status` vs `last_projected_status` (the pg adapter can't compare two columns in a filter); the page render makes **no live PM call**.
- `fetchSeenStates` is an **optional** adapter method — a provider without it simply has no divergence detection (Plane is retired, so only Linear implements it).
- Comparison is by provider **state name** (what `last_projected_status` already stores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New admin action performs live PM API reads and updates `task_pm_links`; mistakes could mis-report drift but the design explicitly avoids brain or provider writes.
> 
> **Overview**
> Adds **Phase 5 inbound divergence detection** so admins can see when the primary PM tool’s workflow state no longer matches what the brain last projected—without changing brain tasks or writing back to the board.
> 
> **`reconcileProviderState`** (`lib/pm-sync/reconcile.ts`) loads linked tasks for the team’s primary provider, calls a new read-only adapter hook **`fetchSeenStates`** (Linear implements it via existing bootstrap/issue listing), updates **`task_pm_links.provider_seen_status`** only when the seen name changed, and returns rows where **`provider_seen_status` ≠ `last_projected_status`** (`isDiverged`). **`reconcileDivergenceAction`** wires this for admins with audit + page revalidation; **`ReconcileButton`** triggers it from Admin → PM sync.
> 
> The PM-sync page gains an **Inbound divergence** section: table of brain vs tool state from stored columns (divergence filtered in JS), plus empty state when none. **`docs/ARCHITECTURE.md`** documents surface-only brain-wins policy. Tests cover reconcile invariants (no provider mutations, idempotency) and HTTP rendering of the divergence list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb2b8831ad3bd8c287f8cef0cbfa8af21c7ff425. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->