### PR TITLE
feat(ingest): native Plane inbound import (work-items → tasks)

### DIFF
--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -10,7 +10,7 @@ import {
   setIntegrationStatus,
   deleteIntegration,
 } from "@/lib/integrations/manage";
-import { runSlackIngestion } from "@/lib/ingest/run";
+import { runSlackIngestion, runPlaneIngestion } from "@/lib/ingest/run";
 import { resolveIntegrationsAdmin } from "@/lib/integrations/read";
 import { IntegrationConfigError, type IntegrationType } from "@/lib/api/schemas";
 import { audit } from "@/lib/api/audit";
@@ -146,6 +146,29 @@ export async function syncSlackNow(
     return {
       ok: true,
       message: `Synced ${s.channels} channel(s): +${s.created} new, ~${s.updated} updated, =${s.unchanged} unchanged.`,
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "sync failed" };
+  }
+}
+
+/**
+ * Run Plane ingestion now for this team (admins only). Imports the configured project's work-items
+ * into the brain (one dedicated task project per Plane project) and reports a one-line summary. The
+ * scheduler also runs this on its interval; this is the on-demand trigger.
+ */
+export async function syncPlaneNow(
+  teamSlug: string
+): Promise<{ ok: boolean; error?: string; message?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    const s = await runPlaneIngestion({ teamId: ctx.teamId });
+    if (!s.ok && s.errors.length) return { ok: false, error: s.errors.join("; ") };
+    revalidatePath(`/t/${teamSlug}/admin/integrations`);
+    return {
+      ok: true,
+      message: `Imported ${s.items} work-item(s) from ${s.projects} project(s): +${s.created} new, ~${s.updated} updated, =${s.unchanged} unchanged.`,
     };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "sync failed" };

--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -9,6 +9,7 @@ import {
   rotateSecret,
   removeIntegration,
   syncSlackNow,
+  syncPlaneNow,
   setPrimaryPmProvider,
   type PrimaryPmProvider,
 } from "@/app/t/[team]/admin/integrations/actions";
@@ -73,11 +74,11 @@ export function IntegrationsManager({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
-  function syncSlack() {
+  function syncNow(type: IntegrationType) {
     setError(null);
     setNotice(null);
     startTransition(async () => {
-      const res = await syncSlackNow(teamSlug);
+      const res = type === "plane" ? await syncPlaneNow(teamSlug) : await syncSlackNow(teamSlug);
       if (!res.ok) setError(res.error ?? "sync failed");
       else {
         setNotice(res.message ?? "Synced.");
@@ -209,12 +210,16 @@ export function IntegrationsManager({
                 {i.hasSecret ? " · secret set" : " · no secret"}
               </span>
               <div className="ml-auto flex items-center gap-2">
-                {i.type === "slack" ? (
+                {i.type === "slack" || i.type === "plane" ? (
                   <button
-                    onClick={syncSlack}
+                    onClick={() => syncNow(i.type)}
                     disabled={pending}
                     className="flex items-center gap-1.5 rounded-lg border border-violet/40 bg-violet/10 px-3 py-1 text-xs font-medium text-violet disabled:opacity-50"
-                    title="Pull this team's Slack channels into the brain now"
+                    title={
+                      i.type === "plane"
+                        ? "Import this Plane project's work-items into the brain now"
+                        : "Pull this team's Slack channels into the brain now"
+                    }
                   >
                     <RefreshCw className={`size-3.5 ${pending ? "animate-spin" : ""}`} /> Sync now
                   </button>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ Reason from this table, not from a random call site.
 | State | Store (table) | Writer | Readers | Tier/access enforcement |
 |---|---|---|---|---|
 | Synced content | `items`, `item_versions` | **`lib/ingest` only** (single-writer guarded) | dashboard pages, `/api/v1/items`, `lib/query/retrieve`, okf-bundle, metrics | supabase: RLS; postgres: app-code — API ✅, dashboard ✅ (`lib/auth/visibility` choke-point, guarded) |
-| Tasks | `tasks` | `lib/ingest` (sync rows) + `app/actions/tasks.ts` (UI; mints `ui-` row_key) + `lib/work-events` (merged-work completion) | dashboard, `/api/v1/tasks`, PM sync | team-scoped; `origin='ui'` rows survive sync diff; v1.2 hierarchy fields `parent_row_key`/`labels`/`priority` (parent integrity — exists + acyclic — enforced in `lib/ingest`); `body` is dashboard/DB-only (never in the markdown contract) |
+| Tasks | `tasks` | `lib/ingest` (sync rows — incl. inbound Plane import into a dedicated `plane-<id>` project) + `app/actions/tasks.ts` (UI; mints `ui-` row_key) + `lib/work-events` (merged-work completion) | dashboard, `/api/v1/tasks`, PM sync | team-scoped; `origin='ui'` rows survive sync diff; v1.2 hierarchy fields `parent_row_key`/`labels`/`priority` (parent integrity — exists + acyclic — enforced in `lib/ingest`); `body` is dashboard/DB-only (never in the markdown contract) |
 | Task PM links | `task_pm_links` | `lib/ingest` (optional task-row PM metadata) + PM backfill | dashboard task badges, `lib/pm-sync` | team-scoped; stores provider IDs/status only, never secrets; v1.2 adds `last_projected_status`/`projection_fingerprint` (skip-detection) + `provider_seen_status` (Phase 5 divergence) |
 | Primary PM provider | `teams.primary_pm_provider` | Admin → Integrations (`setPrimaryPmProvider`, admin-gated + audited) | `lib/pm-sync` projection | the single PM tool the brain projects into; null = projection no-ops / sole-enabled fallback |
 | Work events | `work_events` | `POST /api/v1/work-events` → `lib/work-events` | Admin → PM sync health | team-tier only; unresolved events are preserved for reconciliation |
@@ -33,7 +33,7 @@ Reason from this table, not from a random call site.
 | Git-author aliases | `member_emails` (+ `members.github_login`/`avatar_url`) | `lib/admin/*` + GitHub sync (`lib/codebases/github`) | `lib/codebases/ingest` (author→member), dashboard | team-scoped `unique(team_id,email)`; one alias → one member |
 | Sessions (postgres) | `auth_users`, `auth_tokens` | `lib/auth/pg-*` | `getSessionUser` | signed httpOnly cookie |
 | Rate limits | `rate_limits` | `rate_limit_hit` rpc | — | service-role only |
-| Integrations | `integrations` | **`lib/integrations/manage` only** (single-writer guarded; admin server actions) | Admin → Integrations page (`lib/integrations/read`, **admin-gated** `canManageIntegrations`); `GET /api/v1/integrations` (API-key, NON-secret selections via `manage.listEnabledIntegrationSelections`); in-process Slack runner (`lib/ingest/run` via `manage.getEnabledIntegrationsWithSecrets`) | `config` is NON-secret (per-type allowlist + secret-key rejection); the connector secret is **encrypted at rest** in `secret_ciphertext` (`lib/secrets`, AES-256-GCM) and decrypted **only in-process** for the runner — it never leaves over HTTP, not even on the API-key read. Admin-tier (no per-row `access` column): both writes (`resolveIntegrationsAdmin`) and the dashboard read (`canManageIntegrations`, in `lib/integrations/read`) are app-code gated on `role==="admin"` — no RLS backstop; guarded by `test/guards/integrations-tier-filter` + the data-mechanics tier test. The page fails closed under `DB_BACKEND=supabase`. postgres-only |
+| Integrations | `integrations` | **`lib/integrations/manage` only** (single-writer guarded; admin server actions) | Admin → Integrations page (`lib/integrations/read`, **admin-gated** `canManageIntegrations`); `GET /api/v1/integrations` (API-key, NON-secret selections via `manage.listEnabledIntegrationSelections`); in-process Slack + Plane runners (`lib/ingest/run` via `manage.getEnabledIntegrationsWithSecrets`) | `config` is NON-secret (per-type allowlist + secret-key rejection); the connector secret is **encrypted at rest** in `secret_ciphertext` (`lib/secrets`, AES-256-GCM) and decrypted **only in-process** for the runner — it never leaves over HTTP, not even on the API-key read. Admin-tier (no per-row `access` column): both writes (`resolveIntegrationsAdmin`) and the dashboard read (`canManageIntegrations`, in `lib/integrations/read`) are app-code gated on `role==="admin"` — no RLS backstop; guarded by `test/guards/integrations-tier-filter` + the data-mechanics tier test. The page fails closed under `DB_BACKEND=supabase`. postgres-only |
 | Codebase analytics | `codebases`, `code_metrics`, `code_contributions`, `github_issues` | **`lib/codebases/ingest` only** (single-writer guarded; via `POST /api/v1/codebases`) | codebases pages incl. Codebases → GitHub (scan freshness via `lib/metrics/codebases.getCodebaseFreshness` + live HEAD compare `lib/codebases/github.fetchRepoHeadSha`), `lib/metrics/codebases` | team-tier only; **app-code gate** (`lib/codebases/visibility` + guard) — no RLS backstop. Brain derives `agentic_score`/`health_score`; AEM `readiness_*` is scored scanner-side (`ingestion/aios_ingest/analyzers/readiness.py`) and persisted verbatim. W1.3 native UI: repo selection persists to `integrations` (type=github, admin); member→GitHub linking via `linkGithub` on Admin → Members (admin); **no server-triggered scan** — the GitHub surface documents the manual `aios-ingest scan` command and the sidecar consumes the selection (F4) |
 | Brain spend / usage meter | `query_log` (`cost_usd`, `input/output/cache_tokens`, `member_id`) | the query routes (`/api/v1/query`, `/api/dashboard/query`) — one row per answered question | `lib/metrics/pulse` (usage KPIs), `lib/metrics/members` (per-member cost + throughput-vs-cost, W1.2), Admin → Usage page | **role-scoped in app code** via `scopeQueryLog` (admins → team-wide; everyone else → own rows) — no RLS backstop in postgres; guarded by `test/guards/query-log-visibility`. Brain spend only |
 | External AI spend | `usage_costs` | **`lib/costs/ingest` only** (via `POST /api/v1/costs`) | `lib/metrics/external-costs`, Admin → Usage page | team-tier only; workstation pushes from `aios analyze --push` (Cursor dashboard USD + session-log estimates); idempotent on `(team, member, date, provider, source, project)` |
@@ -199,6 +199,25 @@ changes brain `tasks.status` — the only write is `provider_seen_status`, and o
 (`reconcileDivergenceAction`, admin-gated + audited) runs it; the PM-sync page renders the divergence
 list read-only from stored state (`isDiverged`). Conflict policy is fixed at brain-wins: drift is
 shown for a human to pull, never silently applied. Two-way write-back remains out of scope.
+
+**Inbound Plane import (Plane → brain, in-app runner).** The *opposite* direction from the
+projection engine: `lib/ingest/sources/plane.ts` + `plane-normalize.ts` pull a Plane project's
+work-items **into** the brain as tasks, run in-process by `lib/ingest/run.ts: runPlaneIngestion`
+(scheduler tick + the admin **"Sync now"** button on a Plane integration; actor = the auto-provisioned
+`plane-sync` connector member). It shares the low-level HTTP client with the outbound adapter via
+`lib/pm-sync/plane-client.ts`. Two invariants keep it from fighting the projection engine:
+> • **Dedicated brain project per Plane project** (`plane-<identifier>`). `materializeTasks`'
+> diff-delete is **project-wide**, so a Plane import must never share a project with CLI/UI tasks
+> or each run would delete the other's rows. Each import emits ONE `kind="task"` item whose `rows[]`
+> are the whole project, so a work-item removed in Plane diff-deletes from the brain — within that
+> project only.
+> • **One-directional, de-dupe over exclude.** Items the brain itself projected OUT (`external_source`
+> starting `aios`) are **skipped** on import — the brain already owns that `row_key` in its real
+> project, so re-importing would duplicate (this preserves "brain wins"). Plane-native items import
+> fresh, keyed by `<IDENTIFIER>-<sequence_id>`. Sub-issue `parent` → `parent_row_key` (resolved only
+> within the imported set; a skipped/absent parent is nulled, never dangling), module → `sprint`,
+> labels/state/priority/assignee carried through. Imports stay at **team tier**; the runner does not
+> populate `task_pm_links`, so an imported task is not re-projected back out.
 
 **Reactive triggers (brain-api v1.2 Phase 2).** Projection is no longer manual-only. Task UI
 writes — `createTaskAction` / `moveTaskAction` / the new `updateTaskAction` (title/sprint/due/

--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -6,6 +6,9 @@ import { ingestItem } from "@/lib/ingest";
 import { getEnabledIntegrationsWithSecrets } from "@/lib/integrations/manage";
 import { SlackClient, fetchSlackChannel } from "./sources/slack";
 import { normalizeThread } from "./sources/slack-normalize";
+import { fetchPlaneProject } from "./sources/plane";
+import { normalizePlaneProject } from "./sources/plane-normalize";
+import type { PlaneConnection } from "@/lib/pm-sync/plane-client";
 
 /**
  * In-app ingestion runner — the TypeScript replacement for the Python sidecar's
@@ -47,16 +50,23 @@ async function teamsWithSlack(supabase: SupabaseClient): Promise<string[]> {
   return [...new Set(ids)];
 }
 
-/** Find (or auto-provision) the per-team connector member used as the ingest actor. */
+interface ConnectorIdentity {
+  handle: string;
+  email: string;
+  displayName: string;
+}
+
+/** Find (or auto-provision) the per-team connector member used as a given source's ingest actor. */
 async function resolveConnectorAuth(
   supabase: SupabaseClient,
-  teamId: string
+  teamId: string,
+  identity: ConnectorIdentity
 ): Promise<{ teamId: string; memberId: string; apiKeyId: string } | null> {
   const { data: existing } = await supabase
     .from("members")
     .select("id")
     .eq("team_id", teamId)
-    .eq("actor_handle", "slack-sync")
+    .eq("actor_handle", identity.handle)
     .maybeSingle();
 
   let memberId = (existing as { id: string } | null)?.id;
@@ -66,9 +76,9 @@ async function resolveConnectorAuth(
       .upsert(
         {
           team_id: teamId,
-          email: "slack-sync@connector.local",
-          display_name: "Slack Sync",
-          actor_handle: "slack-sync",
+          email: identity.email,
+          display_name: identity.displayName,
+          actor_handle: identity.handle,
           role: "member",
           tier: "team",
           status: "active",
@@ -126,7 +136,11 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
         continue;
       }
       if (slackIntegrations.length === 0) continue;
-      const auth = await resolveConnectorAuth(supabase, teamId);
+      const auth = await resolveConnectorAuth(supabase, teamId, {
+        handle: "slack-sync",
+        email: "slack-sync@connector.local",
+        displayName: "Slack Sync",
+      });
       if (!auth) {
         summary.errors.push(`team ${teamId}: no connector member`);
         continue;
@@ -174,5 +188,122 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
     return summary;
   } finally {
     running = false;
+  }
+}
+
+// ── Plane inbound import ──────────────────────────────────────────────────────
+
+export interface PlaneIngestSummary {
+  ok: boolean;
+  integrations: number;
+  projects: number;
+  created: number;
+  updated: number;
+  unchanged: number;
+  /** Total work-items imported as task rows this run (after de-dupe). */
+  items: number;
+  errors: string[];
+  skipped?: boolean;
+}
+
+/** Distinct teams with at least one enabled Plane integration. */
+async function teamsWithPlane(supabase: SupabaseClient): Promise<string[]> {
+  const { data } = await supabase
+    .from("integrations")
+    .select("team_id")
+    .eq("type", "plane")
+    .eq("status", "enabled");
+  const ids = (data ?? []).map((r) => (r as { team_id: string }).team_id);
+  return [...new Set(ids)];
+}
+
+let planeRunning = false;
+
+/**
+ * Run Plane ingestion for all enabled Plane integrations (optionally one team). Each integration's
+ * project is imported into its OWN brain project (`plane-<identifier>`) as one kind="task" item;
+ * normalize de-dupes brain-projected round-trippers and the writer dedups unchanged boards.
+ */
+export async function runPlaneIngestion(opts: { teamId?: string } = {}): Promise<PlaneIngestSummary> {
+  const empty: PlaneIngestSummary = {
+    ok: true,
+    integrations: 0,
+    projects: 0,
+    created: 0,
+    updated: 0,
+    unchanged: 0,
+    items: 0,
+    errors: [],
+  };
+  if (planeRunning) return { ...empty, skipped: true };
+  planeRunning = true;
+  try {
+    const supabase = adminClient();
+    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithPlane(supabase);
+
+    const summary: PlaneIngestSummary = { ...empty };
+    for (const teamId of teamIds) {
+      let planeIntegrations;
+      try {
+        planeIntegrations = (await getEnabledIntegrationsWithSecrets(supabase, teamId)).filter(
+          (i) => i.type === "plane"
+        );
+      } catch (err) {
+        summary.errors.push(`team ${teamId}: ${err instanceof Error ? err.message : "secret read failed"}`);
+        continue;
+      }
+      if (planeIntegrations.length === 0) continue;
+      const auth = await resolveConnectorAuth(supabase, teamId, {
+        handle: "plane-sync",
+        email: "plane-sync@connector.local",
+        displayName: "Plane Sync",
+      });
+      if (!auth) {
+        summary.errors.push(`team ${teamId}: no connector member`);
+        continue;
+      }
+
+      for (const integ of planeIntegrations) {
+        summary.integrations++;
+        const apiKey = integ.secret;
+        const workspaceSlug = integ.config.workspaceSlug as string | undefined;
+        const projectId = integ.config.projectId as string | undefined;
+        if (!apiKey || !workspaceSlug || !projectId) {
+          summary.errors.push(
+            `integration "${integ.name}": needs an API key + workspaceSlug + projectId in the dashboard`
+          );
+          continue;
+        }
+        const conn: PlaneConnection = {
+          fetchImpl: fetch,
+          base: ((integ.config.baseUrl as string | undefined) || "https://api.plane.so").replace(/\/$/, ""),
+          apiKey,
+          workspaceSlug,
+          projectId,
+        };
+        // Round-tripper de-dupe also honors a custom configured externalSource.
+        const externalSource = integ.config.externalSource as string | undefined;
+        const aiosSources = [...new Set(["aios", "aios-backlog", ...(externalSource ? [externalSource] : [])])];
+
+        summary.projects++;
+        try {
+          const fetched = await fetchPlaneProject(conn);
+          const payload = normalizePlaneProject({ ...fetched, aiosSources });
+          summary.items += payload.rows?.length ?? 0;
+          const res = await ingestItem(supabase, auth, payload, "team");
+          if (res.status === "created") summary.created++;
+          else if (res.status === "updated") summary.updated++;
+          else summary.unchanged++;
+        } catch (err) {
+          summary.errors.push(
+            `integration "${integ.name}": ${err instanceof Error ? err.message : "import failed"}`
+          );
+        }
+      }
+    }
+    summary.ok = summary.errors.length === 0;
+    return summary;
+  } finally {
+    planeRunning = false;
   }
 }

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { runSlackIngestion } from "./run";
+import { runSlackIngestion, runPlaneIngestion } from "./run";
 
 /**
  * In-process poller — the single-service alternative to a separate cron worker.
@@ -30,12 +30,24 @@ export function startIngestScheduler(): void {
         );
       }
     } catch (err) {
-      console.error("[ingest] tick failed:", err instanceof Error ? err.message : err);
+      console.error("[ingest] slack tick failed:", err instanceof Error ? err.message : err);
+    }
+    try {
+      const p = await runPlaneIngestion();
+      if (p.created || p.updated || p.errors.length) {
+        console.info(
+          `[ingest] plane: +${p.created} ~${p.updated} =${p.unchanged} ` +
+            `(${p.items} items, ${p.projects} projects, ${p.integrations} integrations)` +
+            (p.errors.length ? ` errors: ${p.errors.join("; ")}` : "")
+        );
+      }
+    } catch (err) {
+      console.error("[ingest] plane tick failed:", err instanceof Error ? err.message : err);
     }
   };
 
   // Delay the first run so boot isn't blocked; then poll on the interval.
   setTimeout(tick, 20_000).unref?.();
   setInterval(tick, intervalMs).unref?.();
-  console.info(`[ingest] scheduler started — Slack every ${minutes}m`);
+  console.info(`[ingest] scheduler started — Slack + Plane every ${minutes}m`);
 }

--- a/lib/ingest/sources/plane-normalize.ts
+++ b/lib/ingest/sources/plane-normalize.ts
@@ -1,0 +1,177 @@
+import { createHash } from "node:crypto";
+import type { ItemPayload } from "@/lib/api/schemas";
+import { normalizeTaskStatus } from "@/lib/api/schemas";
+
+/**
+ * Pure: a Plane project's fetched work-items → ONE brain `kind="task"` ItemPayload
+ * whose `rows[]` diff-sync by a stable `row_key`.
+ *
+ * Design invariants (see docs/ARCHITECTURE.md, lib/ingest/index.ts):
+ *   • Dedicated brain project per Plane project (`plane-<identifier>`). The task
+ *     diff-delete in materializeTasks is PROJECT-WIDE, so Plane imports must never
+ *     share a project with CLI/UI tasks or each import would delete the others.
+ *   • One-directional (Plane → brain). Items the brain itself projected OUT to Plane
+ *     (external_source starting "aios") are de-duped (skipped): the brain already owns
+ *     that row_key in its real project, so re-importing would duplicate. This also
+ *     keeps the "brain wins, one-way out" pm-sync invariant intact.
+ *   • Org structure preserved: sub-issue parent → parent_row_key (resolved only within
+ *     the imported set; a parent that was skipped/absent is nulled, never dangling),
+ *     module → sprint (round-trip-consistent with pm-sync's sprint→module mapping),
+ *     labels/state/priority/assignee carried through.
+ *   • Deterministic output: rows are sorted and every projectable field is serialized
+ *     into the body, so re-importing an unchanged board is a true no-op at the writer
+ *     (sha256 dedup) while any real change shifts the sha.
+ */
+
+export interface PlaneState {
+  id: string;
+  name?: string;
+  group?: string; // backlog | unstarted | started | completed | cancelled
+}
+
+export interface PlaneWorkItemRaw {
+  id: string;
+  sequence_id?: number;
+  name?: string;
+  state?: string; // state id
+  priority?: string | null;
+  labels?: string[] | null; // label ids
+  assignees?: string[] | null; // member ids
+  parent?: string | null; // parent work-item id
+  external_id?: string | null;
+  external_source?: string | null;
+}
+
+export interface NormalizePlaneInput {
+  projectId: string;
+  /** Plane project's short identifier (e.g. "ENG") — drives the brain project slug + row_key prefix. */
+  projectIdentifier?: string;
+  workspaceSlug: string;
+  baseUrl: string;
+  items: PlaneWorkItemRaw[];
+  states: PlaneState[];
+  labels?: { id: string; name: string }[];
+  /** member id → display name (best-effort). */
+  members?: Record<string, string>;
+  /** work-item id → module (epic) name. */
+  moduleByItem?: Record<string, string>;
+  /** external_source values that mark a brain-projected round-tripper. Defaults to the aios markers. */
+  aiosSources?: string[];
+}
+
+export interface PlaneTaskRow {
+  row_key: string;
+  title: string;
+  status: string;
+  priority: string;
+  labels: string[];
+  assignee: string;
+  sprint: string;
+  parent?: string | null;
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function safeSegment(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+const GROUP_TO_STATUS: Record<string, string> = {
+  backlog: "backlog",
+  unstarted: "ready",
+  started: "in_progress",
+  completed: "done",
+  cancelled: "done", // terminal/closed; the brain has no distinct "cancelled"
+};
+
+/** A state literally NAMED like a brain status wins (e.g. a "Blocked" state in the started group); else map by group. */
+function planeStatus(stateName: string | undefined, group: string | undefined): string {
+  const byName = normalizeTaskStatus(stateName ?? "");
+  if (byName.raw_status === null && byName.status !== "backlog") return byName.status;
+  return GROUP_TO_STATUS[group ?? ""] ?? "backlog";
+}
+
+function isAiosOrigin(src: string | null | undefined, aiosSources: string[]): boolean {
+  if (!src) return false;
+  const s = src.toLowerCase();
+  return aiosSources.includes(src) || s.startsWith("aios");
+}
+
+function rowKeyFor(item: PlaneWorkItemRaw, identifier: string | undefined): string {
+  const prefix = (identifier && safeSegment(identifier).toUpperCase()) || "PLANE";
+  if (typeof item.sequence_id === "number") return `${prefix}-${item.sequence_id}`;
+  return `${prefix}-${item.id.slice(0, 8)}`;
+}
+
+export function normalizePlaneProject(input: NormalizePlaneInput): ItemPayload {
+  const aiosSources = input.aiosSources ?? ["aios", "aios-backlog"];
+  const stateById = new Map(input.states.map((s) => [s.id, s]));
+  const labelById = new Map((input.labels ?? []).map((l) => [l.id, l.name]));
+  const members = input.members ?? {};
+  const moduleByItem = input.moduleByItem ?? {};
+
+  const identifier = input.projectIdentifier;
+  const slugSeg = safeSegment(identifier || input.projectId.slice(0, 8)) || "project";
+  const project = `plane-${slugSeg}`;
+
+  // Included = everything except brain-projected round-trippers (de-dupe). Stable sort so re-import
+  // produces byte-identical output → a true no-op at the sha256 writer.
+  const included = input.items
+    .filter((it) => !isAiosOrigin(it.external_source, aiosSources))
+    .sort((a, b) => (a.sequence_id ?? 0) - (b.sequence_id ?? 0) || a.id.localeCompare(b.id));
+
+  // plane item id → row_key, for resolving sub-issue parents within the imported set only.
+  const idToRowKey = new Map(included.map((it) => [it.id, rowKeyFor(it, identifier)]));
+
+  const rows: PlaneTaskRow[] = included.map((it) => {
+    const st = it.state ? stateById.get(it.state) : undefined;
+    const labels = (it.labels ?? [])
+      .map((id) => labelById.get(id))
+      .filter((n): n is string => Boolean(n));
+    const assignee = (it.assignees ?? [])
+      .map((id) => members[id] ?? id)
+      .join(", ");
+    const row: PlaneTaskRow = {
+      row_key: rowKeyFor(it, identifier),
+      title: it.name?.trim() || "(untitled)",
+      status: planeStatus(st?.name, st?.group),
+      priority: (it.priority ?? "none") || "none",
+      labels,
+      assignee,
+      sprint: moduleByItem[it.id] ?? "",
+    };
+    if (it.parent) {
+      // Resolve only within the imported set; a parent that was skipped/absent is nulled (never dangling).
+      row.parent = idToRowKey.get(it.parent) ?? null;
+    }
+    return row;
+  });
+
+  // Serialize every projectable field so any change shifts the sha (writer never short-circuits a real change).
+  const lines = rows.map(
+    (r) =>
+      `| ${r.row_key} | ${r.title} | ${r.status} | ${r.priority} | ${r.sprint} | ${r.assignee} | ` +
+      `${JSON.stringify(r.labels)} | ${r.parent ?? ""} |`
+  );
+  const body = `# Plane import — ${input.workspaceSlug}/${slugSeg}\n\n${lines.join("\n")}\n`;
+
+  return {
+    project,
+    path: `plane/${slugSeg}/work-items.md`,
+    kind: "task",
+    content_sha256: sha256(body),
+    actor: "",
+    access: "team",
+    frontmatter: {
+      source: "plane",
+      workspace: input.workspaceSlug,
+      project_id: input.projectId,
+      identifier: identifier ?? "",
+      item_count: rows.length,
+    },
+    body,
+    rows,
+  };
+}

--- a/lib/ingest/sources/plane.ts
+++ b/lib/ingest/sources/plane.ts
@@ -1,0 +1,121 @@
+import "server-only";
+
+import { fetchAllPaged, planeApi, type PlaneConnection } from "@/lib/pm-sync/plane-client";
+import type { PlaneState, PlaneWorkItemRaw } from "./plane-normalize";
+
+/**
+ * Read-only Plane fetch for the inbound ingestion runner. Pulls a project's
+ * work-items plus the lookup tables normalize needs (states, labels, module/epic
+ * membership, member display names) via the shared low-level client. Every
+ * auxiliary lookup is best-effort: a missing scope/endpoint degrades gracefully
+ * (ids instead of names, empty module map) rather than aborting the import.
+ */
+
+export interface FetchedPlaneProject {
+  projectId: string;
+  projectIdentifier?: string;
+  workspaceSlug: string;
+  baseUrl: string;
+  items: PlaneWorkItemRaw[];
+  states: PlaneState[];
+  labels: { id: string; name: string }[];
+  members: Record<string, string>;
+  moduleByItem: Record<string, string>;
+}
+
+/** Project's short identifier (e.g. "ENG") for stable, human-readable row_keys. Best-effort. */
+async function fetchIdentifier(conn: PlaneConnection): Promise<string | undefined> {
+  try {
+    const proj = (await planeApi(
+      conn,
+      "GET",
+      `/api/v1/workspaces/${conn.workspaceSlug}/projects/${conn.projectId}/`
+    )) as { identifier?: string };
+    return proj.identifier || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Workspace member id → display name. Best-effort (needs member-read scope). */
+async function fetchMembers(conn: PlaneConnection): Promise<Record<string, string>> {
+  try {
+    const rows = (await planeApi(
+      conn,
+      "GET",
+      `/api/v1/workspaces/${conn.workspaceSlug}/members/`
+    )) as unknown;
+    const list = Array.isArray(rows)
+      ? rows
+      : (rows as { results?: unknown[] })?.results ?? [];
+    const map: Record<string, string> = {};
+    for (const m of list as {
+      member?: string;
+      id?: string;
+      display_name?: string;
+      first_name?: string;
+      last_name?: string;
+      email?: string;
+    }[]) {
+      const id = m.member || m.id;
+      if (!id) continue;
+      const name =
+        m.display_name ||
+        [m.first_name, m.last_name].filter(Boolean).join(" ").trim() ||
+        m.email ||
+        id;
+      map[id] = name;
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+/** work-item id → module (epic) name, by walking each module's issue membership. Best-effort. */
+async function fetchModuleByItem(conn: PlaneConnection): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  try {
+    const modules = (await fetchAllPaged(conn, "/modules/")) as { id: string; name?: string }[];
+    for (const mod of modules) {
+      if (!mod.name) continue;
+      try {
+        const members = (await fetchAllPaged(conn, `/modules/${mod.id}/module-issues/`)) as {
+          issue?: string;
+          id?: string;
+        }[];
+        for (const mi of members) {
+          const issueId = mi.issue || mi.id;
+          if (issueId) out[issueId] = mod.name;
+        }
+      } catch {
+        // one module's membership failed — skip it, keep the rest.
+      }
+    }
+  } catch {
+    // no module access — import without epic grouping.
+  }
+  return out;
+}
+
+export async function fetchPlaneProject(conn: PlaneConnection): Promise<FetchedPlaneProject> {
+  const [items, states, labels, identifier, members, moduleByItem] = await Promise.all([
+    fetchAllPaged(conn, "/work-items/") as Promise<PlaneWorkItemRaw[]>,
+    fetchAllPaged(conn, "/states/") as Promise<PlaneState[]>,
+    fetchAllPaged(conn, "/labels/") as Promise<{ id: string; name: string }[]>,
+    fetchIdentifier(conn),
+    fetchMembers(conn),
+    fetchModuleByItem(conn),
+  ]);
+  return {
+    projectId: conn.projectId,
+    projectIdentifier: identifier,
+    workspaceSlug: conn.workspaceSlug,
+    baseUrl: conn.base,
+    items,
+    states,
+    labels,
+    members,
+    moduleByItem,
+  };
+}

--- a/lib/pm-sync/plane-client.ts
+++ b/lib/pm-sync/plane-client.ts
@@ -1,0 +1,86 @@
+import "server-only";
+
+import { PmSyncError } from "@/lib/pm-sync/provider";
+
+/**
+ * Low-level Plane REST client shared by the OUTBOUND pm-sync projection
+ * (`lib/pm-sync/plane.ts`) and the INBOUND ingestion source
+ * (`lib/ingest/sources/plane.ts`). Connection-only: auth header, project-scoped
+ * path builder, cursor pagination, and 429 retry. No sync/ingest semantics live
+ * here — callers layer those on top of `PlaneConnection`.
+ */
+
+export interface PlaneConnection {
+  fetchImpl: typeof fetch;
+  base: string;
+  apiKey: string;
+  workspaceSlug: string;
+  projectId: string;
+}
+
+export async function readJson(res: Response): Promise<unknown> {
+  const text = await res.text();
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return { raw: text };
+  }
+}
+
+/** Plane list endpoints return either a bare array or a `{ results: [] }` envelope. */
+export function asArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === "object" && Array.isArray((value as { results?: unknown[] }).results)) {
+    return (value as { results: unknown[] }).results;
+  }
+  return [];
+}
+
+export async function planeApi(
+  conn: PlaneConnection,
+  method: string,
+  path: string,
+  body?: Record<string, unknown>
+): Promise<unknown> {
+  const url = `${conn.base}${path}`;
+  for (let attempt = 0; ; attempt++) {
+    const res = await conn.fetchImpl(url, {
+      method,
+      headers: { "X-API-Key": conn.apiKey, "Content-Type": "application/json" },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (res.status === 429 && attempt < 6) {
+      const retry = Number(res.headers.get("Retry-After") || 5) * 1000;
+      await new Promise((r) => setTimeout(r, retry));
+      continue;
+    }
+    const json = await readJson(res);
+    if (!res.ok) {
+      throw new PmSyncError(`Plane ${method} ${path} failed (${res.status}): ${JSON.stringify(json).slice(0, 300)}`);
+    }
+    return json;
+  }
+}
+
+export function projPath(conn: PlaneConnection, suffix: string): string {
+  return `/api/v1/workspaces/${conn.workspaceSlug}/projects/${conn.projectId}${suffix}`;
+}
+
+/** Walk a project-scoped list endpoint to completion (cursor pagination), capped at 100 pages. */
+export async function fetchAllPaged(conn: PlaneConnection, suffix: string): Promise<unknown[]> {
+  const out: unknown[] = [];
+  let cursor = "100:0:0";
+  for (let i = 0; i < 100; i++) {
+    const sep = suffix.includes("?") ? "&" : "?";
+    const page = await planeApi(conn, "GET", `${projPath(conn, suffix)}${sep}per_page=100&cursor=${encodeURIComponent(cursor)}`);
+    if (Array.isArray(page)) {
+      out.push(...page);
+      break;
+    }
+    out.push(...asArray(page));
+    const next = page && typeof page === "object" ? (page as { next_page_results?: boolean; next_cursor?: string }) : null;
+    if (!next?.next_page_results || !next.next_cursor) break;
+    cursor = next.next_cursor;
+  }
+  return out;
+}

--- a/lib/pm-sync/plane.ts
+++ b/lib/pm-sync/plane.ts
@@ -1,6 +1,12 @@
 import "server-only";
 
 import {
+  fetchAllPaged,
+  planeApi,
+  projPath,
+  type PlaneConnection,
+} from "@/lib/pm-sync/plane-client";
+import {
   desiredStateForStatus,
   htmlToPlainText,
   normalizeName,
@@ -43,29 +49,7 @@ interface PlaneBootstrap {
   moduleMembers: Map<string, Set<string>>; // moduleId → issue ids
 }
 
-async function readJson(res: Response): Promise<unknown> {
-  const text = await res.text();
-  try {
-    return text ? JSON.parse(text) : {};
-  } catch {
-    return { raw: text };
-  }
-}
-
-function asArray(value: unknown): unknown[] {
-  if (Array.isArray(value)) return value;
-  if (value && typeof value === "object" && Array.isArray((value as { results?: unknown[] }).results)) {
-    return (value as { results: unknown[] }).results;
-  }
-  return [];
-}
-
-interface PlaneCtx {
-  fetchImpl: typeof fetch;
-  base: string;
-  apiKey: string;
-  workspaceSlug: string;
-  projectId: string;
+interface PlaneCtx extends PlaneConnection {
   externalSource: string;
 }
 
@@ -80,49 +64,6 @@ function planeCtx(input: { integration: { config?: Record<string, unknown> | nul
   const externalSource =
     (config.externalSource as string | undefined) || input.link?.provider_external_source || "aios-backlog";
   return { fetchImpl: input.fetchImpl ?? fetch, base, apiKey, workspaceSlug, projectId, externalSource };
-}
-
-async function planeApi(ctx: PlaneCtx, method: string, path: string, body?: Record<string, unknown>): Promise<unknown> {
-  const url = `${ctx.base}${path}`;
-  for (let attempt = 0; ; attempt++) {
-    const res = await ctx.fetchImpl(url, {
-      method,
-      headers: { "X-API-Key": ctx.apiKey, "Content-Type": "application/json" },
-      body: body ? JSON.stringify(body) : undefined,
-    });
-    if (res.status === 429 && attempt < 6) {
-      const retry = Number(res.headers.get("Retry-After") || 5) * 1000;
-      await new Promise((r) => setTimeout(r, retry));
-      continue;
-    }
-    const json = await readJson(res);
-    if (!res.ok) {
-      throw new PmSyncError(`Plane ${method} ${path} failed (${res.status}): ${JSON.stringify(json).slice(0, 300)}`);
-    }
-    return json;
-  }
-}
-
-function projPath(ctx: PlaneCtx, suffix: string): string {
-  return `/api/v1/workspaces/${ctx.workspaceSlug}/projects/${ctx.projectId}${suffix}`;
-}
-
-async function fetchAllPaged(ctx: PlaneCtx, suffix: string): Promise<unknown[]> {
-  const out: unknown[] = [];
-  let cursor = "100:0:0";
-  for (let i = 0; i < 100; i++) {
-    const sep = suffix.includes("?") ? "&" : "?";
-    const page = await planeApi(ctx, "GET", `${projPath(ctx, suffix)}${sep}per_page=100&cursor=${encodeURIComponent(cursor)}`);
-    if (Array.isArray(page)) {
-      out.push(...page);
-      break;
-    }
-    out.push(...asArray(page));
-    const next = page && typeof page === "object" ? (page as { next_page_results?: boolean; next_cursor?: string }) : null;
-    if (!next?.next_page_results || !next.next_cursor) break;
-    cursor = next.next_cursor;
-  }
-  return out;
 }
 
 function extKey(source: string | null | undefined, ext: string | null | undefined): string {

--- a/test/datamechanics/plane-import.datamechanics.test.ts
+++ b/test/datamechanics/plane-import.datamechanics.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+import { normalizePlaneProject, type PlaneWorkItemRaw } from "@/lib/ingest/sources/plane-normalize";
+
+// Spec (Plane inbound import) verified to the observable outcome — rows read back from real Postgres:
+//   1. import materializes work-items as tasks in a DEDICATED brain project;
+//   2. re-importing an unchanged board is a no-op (sha dedup) and never duplicates a row;
+//   3. a work-item removed from Plane diff-deletes ONLY within the plane project — a CLI/UI task
+//      in another project is never touched (the diff-delete is project-wide, hence the isolation);
+//   4. aios round-trippers (external_source=aios) are de-duped (never materialized);
+//   5. imported Plane data is written at TEAM tier (never external).
+
+const STATES = [
+  { id: "s-todo", name: "Todo", group: "unstarted" },
+  { id: "s-doing", name: "In Progress", group: "started" },
+];
+
+function importPlane(seed: Seed, items: PlaneWorkItemRaw[]) {
+  const payload = normalizePlaneProject({
+    projectId: "p-1",
+    projectIdentifier: "ENG",
+    workspaceSlug: "acme",
+    baseUrl: "https://api.plane.so",
+    states: STATES,
+    items,
+  });
+  return ingest(seed, {
+    project: payload.project,
+    kind: "task",
+    path: payload.path,
+    body: payload.body,
+    access: "team",
+    rows: payload.rows,
+  } as never);
+}
+
+const tasksByKey = async (teamId: string, rowKey: string) => {
+  const { data } = await db()
+    .from("tasks")
+    .select("id, row_key, title, status, project_id, origin")
+    .eq("team_id", teamId)
+    .eq("row_key", rowKey);
+  return (data ?? []) as { id: string; row_key: string; title: string; status: string; project_id: string; origin: string }[];
+};
+
+describe("Plane import (data-mechanics)", () => {
+  it("materializes work-items as tasks in a dedicated plane project", async () => {
+    const seed = await seedTeam();
+    await importPlane(seed, [
+      { id: "wi-1", sequence_id: 1, name: "Build importer", state: "s-doing" },
+      { id: "wi-2", sequence_id: 2, name: "Write tests", state: "s-todo" },
+    ]);
+
+    const [t1] = await tasksByKey(seed.teamId, "ENG-1");
+    const [t2] = await tasksByKey(seed.teamId, "ENG-2");
+    expect(t1?.title).toBe("Build importer");
+    expect(t1?.status).toBe("in_progress");
+    expect(t2?.status).toBe("ready"); // "Todo" state, group "unstarted" → ready
+  });
+
+  it("re-importing an unchanged board is a no-op and never duplicates a row", async () => {
+    const seed = await seedTeam();
+    const items: PlaneWorkItemRaw[] = [{ id: "wi-1", sequence_id: 1, name: "Stable", state: "s-todo" }];
+    const first = await importPlane(seed, items);
+    const second = await importPlane(seed, items);
+    expect(first.status).toBe("created");
+    expect(second.status).toBe("unchanged");
+    expect(await tasksByKey(seed.teamId, "ENG-1")).toHaveLength(1);
+  });
+
+  it("a removed work-item diff-deletes within the plane project but never touches another project's tasks", async () => {
+    const seed = await seedTeam();
+    // A CLI-style task lives in its own project "acme" (origin=sync) — the at-risk bystander.
+    await ingest(seed, {
+      project: "acme",
+      kind: "task",
+      path: "3-log/tasks.md",
+      body: "| C-1 | CLI task |",
+      access: "team",
+      rows: [{ row_key: "C-1", title: "CLI task" }],
+    } as never);
+
+    await importPlane(seed, [
+      { id: "wi-1", sequence_id: 1, name: "Keep", state: "s-todo" },
+      { id: "wi-2", sequence_id: 2, name: "Drop", state: "s-todo" },
+    ]);
+    expect(await tasksByKey(seed.teamId, "ENG-2")).toHaveLength(1);
+
+    // ENG-2 removed from Plane → next import drops it from the plane project only.
+    await importPlane(seed, [{ id: "wi-1", sequence_id: 1, name: "Keep", state: "s-todo" }]);
+    expect(await tasksByKey(seed.teamId, "ENG-2")).toHaveLength(0); // diff-deleted
+    expect(await tasksByKey(seed.teamId, "ENG-1")).toHaveLength(1); // survivor
+    expect(await tasksByKey(seed.teamId, "C-1")).toHaveLength(1); // bystander UNTOUCHED
+  });
+
+  it("de-dupes aios round-trippers: external_source=aios items are never materialized", async () => {
+    const seed = await seedTeam();
+    await importPlane(seed, [
+      { id: "wi-native", sequence_id: 1, name: "Native", state: "s-todo" },
+      { id: "wi-rt", sequence_id: 2, name: "Round-tripper", state: "s-todo", external_source: "aios", external_id: "T-5" },
+    ]);
+    expect(await tasksByKey(seed.teamId, "ENG-1")).toHaveLength(1);
+    expect(await tasksByKey(seed.teamId, "ENG-2")).toHaveLength(0); // skipped
+  });
+
+  it("writes imported Plane data at team tier (never external)", async () => {
+    const seed = await seedTeam();
+    await importPlane(seed, [{ id: "wi-1", sequence_id: 1, name: "Task", state: "s-todo" }]);
+    const { data } = await db()
+      .from("items")
+      .select("access, path")
+      .eq("team_id", seed.teamId)
+      .eq("path", "plane/eng/work-items.md")
+      .maybeSingle();
+    expect((data as { access: string } | null)?.access).toBe("team");
+  });
+});

--- a/test/ingest-plane-normalize.test.ts
+++ b/test/ingest-plane-normalize.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { normalizePlaneProject, type NormalizePlaneInput } from "@/lib/ingest/sources/plane-normalize";
+import { itemPayloadSchema, taskRowSchema } from "@/lib/api/schemas";
+
+// Spec (Plane inbound import): a Plane project's work-items normalize to ONE kind="task"
+// ItemPayload whose rows diff-sync by a stable row_key. The import is one-directional
+// (Plane → brain): items the brain itself projected OUT to Plane (external_source="aios")
+// are de-duped (skipped) because the brain already owns that row_key in its real project.
+// Organizational structure is preserved: sub-issue parent → parent_row_key, module → sprint,
+// labels/priority/state/assignee carried through. Verified against the brain contract schema.
+
+const base: NormalizePlaneInput = {
+  projectId: "11111111-1111-1111-1111-111111111111",
+  projectIdentifier: "ENG",
+  workspaceSlug: "acme",
+  baseUrl: "https://api.plane.so",
+  states: [
+    { id: "s-backlog", name: "Backlog", group: "backlog" },
+    { id: "s-todo", name: "Todo", group: "unstarted" },
+    { id: "s-doing", name: "In Progress", group: "started" },
+    { id: "s-blocked", name: "Blocked", group: "started" },
+    { id: "s-done", name: "Done", group: "completed" },
+  ],
+  labels: [
+    { id: "l-bug", name: "bug" },
+    { id: "l-api", name: "api" },
+  ],
+  members: { u1: "Alex", u2: "Riley" },
+  moduleByItem: {},
+  items: [],
+};
+
+describe("normalizePlaneProject", () => {
+  it("maps a project to one valid kind=task ItemPayload in a dedicated brain project", () => {
+    const p = normalizePlaneProject({
+      ...base,
+      items: [
+        {
+          id: "wi-1",
+          sequence_id: 42,
+          name: "Ship dual-backend",
+          state: "s-doing",
+          priority: "high",
+          labels: ["l-api"],
+          assignees: ["u1"],
+        },
+      ],
+    });
+
+    expect(() => itemPayloadSchema.parse(p)).not.toThrow();
+    expect(p.kind).toBe("task");
+    // dedicated brain project, isolated from CLI/UI tasks (project-wide diff-delete safety)
+    expect(p.project).toBe("plane-eng");
+    expect(p.path).toBe("plane/eng/work-items.md");
+    expect(p.access).toBe("team");
+    expect(p.content_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(p.rows).toHaveLength(1);
+
+    const row = p.rows![0] as Record<string, unknown>;
+    expect(() => taskRowSchema.parse(row)).not.toThrow();
+    expect(row.row_key).toBe("ENG-42");
+    expect(row.title).toBe("Ship dual-backend");
+    expect(row.status).toBe("in_progress"); // state group "started"
+    expect(row.priority).toBe("high");
+    expect(row.labels).toEqual(["api"]); // label id → name
+    expect(row.assignee).toBe("Alex"); // assignee id → display name
+  });
+
+  it("de-dupes aios round-trippers: items stamped external_source=aios are skipped", () => {
+    const p = normalizePlaneProject({
+      ...base,
+      items: [
+        { id: "wi-native", sequence_id: 7, name: "Plane-native task", state: "s-todo" },
+        {
+          id: "wi-roundtrip",
+          sequence_id: 8,
+          name: "Brain task pushed to Plane",
+          state: "s-doing",
+          external_source: "aios",
+          external_id: "3-log/T-5",
+        },
+        {
+          id: "wi-roundtrip2",
+          sequence_id: 9,
+          name: "Legacy seed",
+          state: "s-doing",
+          external_source: "aios-backlog",
+          external_id: "T-9",
+        },
+      ],
+    });
+    const keys = (p.rows as Record<string, unknown>[]).map((r) => r.row_key);
+    expect(keys).toEqual(["ENG-7"]); // only the Plane-native item; aios-origin de-duped out
+  });
+
+  it("preserves sub-issue hierarchy: parent work-item → parent_row_key", () => {
+    const p = normalizePlaneProject({
+      ...base,
+      items: [
+        { id: "epic", sequence_id: 1, name: "Epic", state: "s-todo" },
+        { id: "child", sequence_id: 2, name: "Child", state: "s-todo", parent: "epic" },
+      ],
+    });
+    const child = (p.rows as Record<string, unknown>[]).find((r) => r.row_key === "ENG-2")!;
+    expect(child.parent).toBe("ENG-1");
+  });
+
+  it("nulls a parent that points at a skipped/absent item (no dangling reference → no 422)", () => {
+    const p = normalizePlaneProject({
+      ...base,
+      items: [
+        // parent was projected by the brain → skipped; the child must NOT keep a dangling parent
+        {
+          id: "epic",
+          sequence_id: 1,
+          name: "Epic",
+          state: "s-todo",
+          external_source: "aios",
+          external_id: "E-1",
+        },
+        { id: "child", sequence_id: 2, name: "Child", state: "s-todo", parent: "epic" },
+      ],
+    });
+    const child = (p.rows as Record<string, unknown>[]).find((r) => r.row_key === "ENG-2")!;
+    expect(child.parent ?? null).toBeNull();
+  });
+
+  it("maps Plane module → sprint (epic grouping, round-trip-consistent with pm-sync)", () => {
+    const p = normalizePlaneProject({
+      ...base,
+      moduleByItem: { "wi-1": "Wave 1" },
+      items: [{ id: "wi-1", sequence_id: 3, name: "Task", state: "s-todo" }],
+    });
+    const row = (p.rows as Record<string, unknown>[])[0];
+    expect(row.sprint).toBe("Wave 1");
+  });
+
+  it("honors a state NAMED like a brain status over its group (Blocked → blocked)", () => {
+    const p = normalizePlaneProject({
+      ...base,
+      items: [{ id: "wi-1", sequence_id: 4, name: "Stuck", state: "s-blocked" }],
+    });
+    expect((p.rows as Record<string, unknown>[])[0].status).toBe("blocked");
+  });
+
+  it("serializes projectable fields into the body so a changed field shifts content_sha256", () => {
+    const mk = (status: string) =>
+      normalizePlaneProject({
+        ...base,
+        items: [{ id: "wi-1", sequence_id: 5, name: "Task", state: status }],
+      });
+    const a = mk("s-todo");
+    const b = mk("s-doing");
+    expect(a.content_sha256).not.toBe(b.content_sha256); // status change is NOT a no-op at the writer
+  });
+});


### PR DESCRIPTION
## What
Adds a **Plane → brain** ingestion source: pulls a Plane project's work-items into the brain as tasks via the in-app runner (mirrors the Slack source). Closes the gap where `lib/pm-sync/plane.ts` only pushed *out* to Plane — nothing imported.

## How
- **`lib/pm-sync/plane-client.ts`** (new) — low-level Plane HTTP client (auth, pagination, 429 retry) extracted from the outbound adapter so import + pm-sync share one implementation.
- **`lib/ingest/sources/plane.ts`** (new) — read-only fetch: work-items + states + labels + modules(epics) + members.
- **`lib/ingest/sources/plane-normalize.ts`** (new) — pure: work-items → one `kind="task"` item with `rows[]`.
- **`lib/ingest/run.ts`** — `runPlaneIngestion`; **scheduler** tick; admin **"Sync now"** button + `syncPlaneNow`.

## Invariants (and why)
- **Dedicated brain project per Plane project** (`plane-<identifier>`). `materializeTasks`' diff-delete is **project-wide**, so imports must not share a project with CLI/UI tasks or each run would delete the other's rows. Proven by a data-mechanics bystander test.
- **One-directional, de-dupe over exclude.** Brain-projected round-trippers (`external_source` ~ `aios`) are skipped — the brain already owns that `row_key` (keeps "brain wins"). Plane-native items import as `<IDENT>-<sequence_id>`. Sub-issue parent → `parent_row_key` (dangling parent nulled), module → `sprint`, labels/state/priority/assignee carried through. Team tier; no `task_pm_links` writeback.

## Tests
- 7 normalize unit tests + 5 real-Postgres data-mechanics (cross-project diff-delete isolation, no-op re-import, dedupe, team-tier).
- Full suites green: 172 unit, 117 data-mechanics. tsc + eslint clean. docs-drift in sync. `docs/ARCHITECTURE.md` map updated.

## Not in scope
- **Plane cycles** (iterations/sprints) — follow-up PR. Only modules (epics→sprint) imported here.
- No schema change → no prod `pg:schema` step needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Plane integration support to the admin integrations panel with manual sync capability
  * "Sync now" button now supports both Slack and Plane integration types
  * Plane work items are imported as tasks in dedicated projects
  * Scheduled automatic ingestion now includes both Slack and Plane integrations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->