### PR TITLE
feat(ingest): import Plane cycles as cycle:<name> labels

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,8 +215,10 @@ work-items **into** the brain as tasks, run in-process by `lib/ingest/run.ts: ru
 > starting `aios`) are **skipped** on import — the brain already owns that `row_key` in its real
 > project, so re-importing would duplicate (this preserves "brain wins"). Plane-native items import
 > fresh, keyed by `<IDENTIFIER>-<sequence_id>`. Sub-issue `parent` → `parent_row_key` (resolved only
-> within the imported set; a skipped/absent parent is nulled, never dangling), module → `sprint`,
-> labels/state/priority/assignee carried through. Imports stay at **team tier**; the runner does not
+> within the imported set; a skipped/absent parent is nulled, never dangling), module → `sprint`
+> (round-trip-consistent with pm-sync's "Wave" mapping), cycle → a namespaced `cycle:<name>` label
+> (iterations have no dedicated task column), labels/state/priority/assignee carried through. Imports
+> stay at **team tier**; the runner does not
 > populate `task_pm_links`, so an imported task is not re-projected back out.
 
 **Reactive triggers (brain-api v1.2 Phase 2).** Projection is no longer manual-only. Task UI

--- a/lib/ingest/sources/plane-normalize.ts
+++ b/lib/ingest/sources/plane-normalize.ts
@@ -53,8 +53,10 @@ export interface NormalizePlaneInput {
   labels?: { id: string; name: string }[];
   /** member id → display name (best-effort). */
   members?: Record<string, string>;
-  /** work-item id → module (epic) name. */
+  /** work-item id → module (epic) name. Maps to `sprint` (round-trip-consistent with pm-sync). */
   moduleByItem?: Record<string, string>;
+  /** work-item id → cycle (iteration) name. Maps to a namespaced `cycle:<name>` label. */
+  cycleByItem?: Record<string, string>;
   /** external_source values that mark a brain-projected round-tripper. Defaults to the aios markers. */
   aiosSources?: string[];
 }
@@ -111,6 +113,7 @@ export function normalizePlaneProject(input: NormalizePlaneInput): ItemPayload {
   const labelById = new Map((input.labels ?? []).map((l) => [l.id, l.name]));
   const members = input.members ?? {};
   const moduleByItem = input.moduleByItem ?? {};
+  const cycleByItem = input.cycleByItem ?? {};
 
   const identifier = input.projectIdentifier;
   const slugSeg = safeSegment(identifier || input.projectId.slice(0, 8)) || "project";
@@ -130,6 +133,10 @@ export function normalizePlaneProject(input: NormalizePlaneInput): ItemPayload {
     const labels = (it.labels ?? [])
       .map((id) => labelById.get(id))
       .filter((n): n is string => Boolean(n));
+    // Cycle (iteration) has no dedicated task column → carry it as a namespaced label so it survives
+    // and stays distinct from module→sprint. Cap at the row schema's 80-char label limit.
+    const cycle = cycleByItem[it.id];
+    if (cycle) labels.push(`cycle:${cycle}`.slice(0, 80));
     const assignee = (it.assignees ?? [])
       .map((id) => members[id] ?? id)
       .join(", ");

--- a/lib/ingest/sources/plane.ts
+++ b/lib/ingest/sources/plane.ts
@@ -21,6 +21,7 @@ export interface FetchedPlaneProject {
   labels: { id: string; name: string }[];
   members: Record<string, string>;
   moduleByItem: Record<string, string>;
+  cycleByItem: Record<string, string>;
 }
 
 /** Project's short identifier (e.g. "ENG") for stable, human-readable row_keys. Best-effort. */
@@ -98,14 +99,41 @@ async function fetchModuleByItem(conn: PlaneConnection): Promise<Record<string, 
   return out;
 }
 
+/** work-item id → cycle (iteration) name, by walking each cycle's issue membership. Best-effort. */
+async function fetchCycleByItem(conn: PlaneConnection): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  try {
+    const cycles = (await fetchAllPaged(conn, "/cycles/")) as { id: string; name?: string }[];
+    for (const cyc of cycles) {
+      if (!cyc.name) continue;
+      try {
+        const members = (await fetchAllPaged(conn, `/cycles/${cyc.id}/cycle-issues/`)) as {
+          issue?: string;
+          id?: string;
+        }[];
+        for (const ci of members) {
+          const issueId = ci.issue || ci.id;
+          if (issueId) out[issueId] = cyc.name;
+        }
+      } catch {
+        // one cycle's membership failed — skip it, keep the rest.
+      }
+    }
+  } catch {
+    // no cycle access — import without iteration grouping.
+  }
+  return out;
+}
+
 export async function fetchPlaneProject(conn: PlaneConnection): Promise<FetchedPlaneProject> {
-  const [items, states, labels, identifier, members, moduleByItem] = await Promise.all([
+  const [items, states, labels, identifier, members, moduleByItem, cycleByItem] = await Promise.all([
     fetchAllPaged(conn, "/work-items/") as Promise<PlaneWorkItemRaw[]>,
     fetchAllPaged(conn, "/states/") as Promise<PlaneState[]>,
     fetchAllPaged(conn, "/labels/") as Promise<{ id: string; name: string }[]>,
     fetchIdentifier(conn),
     fetchMembers(conn),
     fetchModuleByItem(conn),
+    fetchCycleByItem(conn),
   ]);
   return {
     projectId: conn.projectId,
@@ -117,5 +145,6 @@ export async function fetchPlaneProject(conn: PlaneConnection): Promise<FetchedP
     labels,
     members,
     moduleByItem,
+    cycleByItem,
   };
 }

--- a/test/datamechanics/plane-import.datamechanics.test.ts
+++ b/test/datamechanics/plane-import.datamechanics.test.ts
@@ -15,7 +15,11 @@ const STATES = [
   { id: "s-doing", name: "In Progress", group: "started" },
 ];
 
-function importPlane(seed: Seed, items: PlaneWorkItemRaw[]) {
+function importPlane(
+  seed: Seed,
+  items: PlaneWorkItemRaw[],
+  extra: { moduleByItem?: Record<string, string>; cycleByItem?: Record<string, string> } = {}
+) {
   const payload = normalizePlaneProject({
     projectId: "p-1",
     projectIdentifier: "ENG",
@@ -23,6 +27,7 @@ function importPlane(seed: Seed, items: PlaneWorkItemRaw[]) {
     baseUrl: "https://api.plane.so",
     states: STATES,
     items,
+    ...extra,
   });
   return ingest(seed, {
     project: payload.project,
@@ -101,6 +106,24 @@ describe("Plane import (data-mechanics)", () => {
     ]);
     expect(await tasksByKey(seed.teamId, "ENG-1")).toHaveLength(1);
     expect(await tasksByKey(seed.teamId, "ENG-2")).toHaveLength(0); // skipped
+  });
+
+  it("persists module → sprint and cycle → cycle:<name> label on the task row", async () => {
+    const seed = await seedTeam();
+    await importPlane(
+      seed,
+      [{ id: "wi-1", sequence_id: 1, name: "Task", state: "s-todo" }],
+      { moduleByItem: { "wi-1": "Auth epic" }, cycleByItem: { "wi-1": "Sprint 7" } }
+    );
+    const { data } = await db()
+      .from("tasks")
+      .select("sprint, labels")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "ENG-1")
+      .maybeSingle();
+    const row = data as { sprint: string; labels: string[] } | null;
+    expect(row?.sprint).toBe("Auth epic");
+    expect(row?.labels).toContain("cycle:Sprint 7");
   });
 
   it("writes imported Plane data at team tier (never external)", async () => {

--- a/test/ingest-plane-normalize.test.ts
+++ b/test/ingest-plane-normalize.test.ts
@@ -135,6 +135,28 @@ describe("normalizePlaneProject", () => {
     expect(row.sprint).toBe("Wave 1");
   });
 
+  it("maps Plane cycle → a namespaced label (cycle:<name>) alongside real labels", () => {
+    const p = normalizePlaneProject({
+      ...base,
+      cycleByItem: { "wi-1": "Sprint 7" },
+      items: [{ id: "wi-1", sequence_id: 6, name: "Task", state: "s-todo", labels: ["l-bug"] }],
+    });
+    const row = (p.rows as Record<string, unknown>[])[0];
+    expect(row.labels).toEqual(["bug", "cycle:Sprint 7"]);
+  });
+
+  it("keeps module → sprint and cycle → label independent (both preserved)", () => {
+    const p = normalizePlaneProject({
+      ...base,
+      moduleByItem: { "wi-1": "Auth epic" },
+      cycleByItem: { "wi-1": "Sprint 7" },
+      items: [{ id: "wi-1", sequence_id: 6, name: "Task", state: "s-todo" }],
+    });
+    const row = (p.rows as Record<string, unknown>[])[0];
+    expect(row.sprint).toBe("Auth epic"); // module → sprint (round-trip-consistent with pm-sync)
+    expect(row.labels).toEqual(["cycle:Sprint 7"]); // cycle → label
+  });
+
   it("honors a state NAMED like a brain status over its group (Blocked → blocked)", () => {
     const p = normalizePlaneProject({
       ...base,


### PR DESCRIPTION
Follow-up to #73 (Plane inbound import). Imports each work-item's **cycle** (iteration) membership.

## How
- `lib/ingest/sources/plane.ts` — `fetchCycleByItem` walks `/cycles/` + `/cycles/<id>/cycle-issues/` (best-effort, mirrors module fetch).
- `lib/ingest/sources/plane-normalize.ts` — carries each item's cycle as a namespaced **`cycle:<name>`** label (capped at the 80-char row-schema limit).

## Why a label (not `sprint`)
pm-sync already maps brain `sprint` ↔ Plane **module** ("Wave"), so `module → sprint` is kept for round-trip consistency. Cycles are inbound-only and have no dedicated task column, so they map to a distinct, namespaced label. **Non-breaking** — module behaviour is unchanged.

## Tests
- +2 normalize unit (cycle → label; module/cycle independence).
- +1 real-Postgres data-mechanics (sprint + `cycle:` label both persist to the task row).
- Full suites green: 174 unit, 6 plane data-mechanics. tsc + eslint clean, docs-drift in sync. `docs/ARCHITECTURE.md` updated.

No schema change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plane import now captures cycle and iteration information for tasks, representing them as namespaced labels in the format `cycle:<name>` in task metadata.

* **Documentation**
  * Updated architecture documentation to clarify cycle information mapping contract for Plane imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->