### PR TITLE
feat: adopt @aios-alpha/design 0.3.0 (off-white + effects)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,11 +84,12 @@ h3 {
   background: var(--gradient-prism);
 }
 
-/* Frosted nav / sidebar layer */
+/* Frosted nav / sidebar layer — liquid-glass tokens (mode-aware, 0.3.0) */
 .frosted {
-  background: var(--color-surface-nav);
-  backdrop-filter: blur(20px) saturate(1.2);
-  -webkit-backdrop-filter: blur(20px) saturate(1.2);
+  background: var(--aios-glass-bg);
+  border-color: var(--aios-glass-border);
+  backdrop-filter: var(--aios-blur-glass-strong) saturate(1.2);
+  -webkit-backdrop-filter: var(--aios-blur-glass-strong) saturate(1.2);
 }
 
 /* Cards: flat at rest, violet-tinted glow on hover — never black shadows. */
@@ -96,6 +97,8 @@ h3 {
   background: var(--color-surface-card);
   border: 1px solid var(--color-border-subtle);
   border-radius: 0.75rem;
+  /* subtle mode-aware resting elevation (0.3.0 effects layer) */
+  box-shadow: var(--aios-shadow-glow-card);
   transition: all 0.3s ease;
 }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -25,7 +25,7 @@ export default async function LoginPage({
       <div className="relative w-full max-w-sm">
         <div className="bg-gradient-prism rounded-2xl p-[1px]">
           <div className="rounded-2xl bg-surface-inset px-8 py-10">
-            <p className="font-display text-sm font-semibold uppercase tracking-[0.15em] text-gradient-prism">
+            <p className="font-display text-sm uppercase tracking-[0.15em] text-gradient-prism">
               Team Brain
             </p>
             <h1 className="mt-2 text-2xl font-semibold text-ink">Sign in</h1>

--- a/app/t/[team]/codebases/[slug]/contributors/[author]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/contributors/[author]/page.tsx
@@ -74,7 +74,7 @@ export default async function ContributorPage({
               </span>
             )}
             <div>
-              <h1 className="font-display text-2xl font-semibold text-ink">{c.name}</h1>
+              <h1 className="font-display text-2xl text-ink">{c.name}</h1>
               <div className="mt-0.5 flex items-center gap-3 text-xs text-ink-tertiary">
                 {c.github_login ? (
                   <a

--- a/app/t/[team]/codebases/[slug]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/page.tsx
@@ -55,7 +55,7 @@ export default async function CodebaseDetailPage({
         </Link>
         <div className="mt-2 flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <h1 className="font-display text-2xl font-semibold text-ink">{cb.slug}</h1>
+            <h1 className="font-display text-2xl text-ink">{cb.slug}</h1>
             {cb.full_name ? (
               <a
                 href={`https://github.com/${cb.full_name}`}

--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -90,10 +90,10 @@ export default async function TeamLayout({
     <div className="flex min-h-dvh flex-1 bg-surface-raised">
       <aside className="frosted sticky top-0 flex h-dvh w-60 shrink-0 flex-col border-r border-border-subtle px-4 py-6">
         <div className="mb-8 px-3">
-          <p className="font-display text-[11px] font-semibold uppercase tracking-[0.18em] text-gradient-prism">
+          <p className="font-display text-[11px] uppercase tracking-[0.18em] text-gradient-prism">
             Team Brain
           </p>
-          <h2 className="mt-1 truncate font-display text-lg font-semibold text-ink" title={team.name}>
+          <h2 className="mt-1 truncate font-display text-lg text-ink" title={team.name}>
             {team.name}
           </h2>
         </div>

--- a/app/t/[team]/maturity/page.tsx
+++ b/app/t/[team]/maturity/page.tsx
@@ -75,7 +75,7 @@ export default async function MaturityPage({
               <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-ink-tertiary">
                 Repos at L3+ (agent-ready)
               </p>
-              <p className="mt-1 font-display text-4xl font-semibold text-gradient-prism">
+              <p className="mt-1 font-display text-4xl text-gradient-prism">
                 {m.pctAtL3Plus}%
               </p>
               <p className="mt-1 text-xs text-ink-secondary">

--- a/app/t/[team]/people/[handle]/page.tsx
+++ b/app/t/[team]/people/[handle]/page.tsx
@@ -64,7 +64,7 @@ export default async function PersonPage({
               </span>
             )}
             <div>
-              <h1 className="font-display text-2xl font-semibold text-ink">{p.name}</h1>
+              <h1 className="font-display text-2xl text-ink">{p.name}</h1>
               <div className="mt-0.5 flex items-center gap-3 text-xs text-ink-tertiary">
                 <span className="capitalize">{p.role}</span>
                 {p.github_login ? (

--- a/app/t/[team]/projects/page.tsx
+++ b/app/t/[team]/projects/page.tsx
@@ -57,7 +57,7 @@ export default async function ProjectsPage({ params }: { params: Promise<{ team:
               className="prism-card prism-card-hover flex flex-col gap-3 px-5 py-5"
             >
               <div>
-                <h2 className="font-display text-lg font-semibold text-ink">{p.name || p.slug}</h2>
+                <h2 className="font-display text-lg text-ink">{p.name || p.slug}</h2>
                 <p className="font-mono text-xs text-ink-tertiary">{p.slug}</p>
               </div>
               <div className="mt-auto flex items-center gap-4 text-xs text-ink-secondary">

--- a/components/codebases/codebase-card.tsx
+++ b/components/codebases/codebase-card.tsx
@@ -13,7 +13,7 @@ export function CodebaseCard({ teamSlug, cb }: { teamSlug: string; cb: CodebaseS
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <h2 className="truncate font-display text-lg font-semibold text-ink">{cb.slug}</h2>
+          <h2 className="truncate font-display text-lg text-ink">{cb.slug}</h2>
           <p className="truncate font-mono text-xs text-ink-tertiary">{cb.full_name || cb.slug}</p>
         </div>
         <ScoreRing value={cb.agentic_score} label="agentic" />

--- a/components/dashboard/agents-placeholder.tsx
+++ b/components/dashboard/agents-placeholder.tsx
@@ -15,7 +15,7 @@ export function AgentsPlaceholder() {
           </div>
         </div>
         <div>
-          <h2 className="font-display text-base font-semibold text-ink">Agent workstations</h2>
+          <h2 className="font-display text-base text-ink">Agent workstations</h2>
           <p className="mt-0.5 max-w-md text-sm text-ink-secondary">
             Spawn permissioned agents to claim tasks from the board and act under your team&apos;s
             policy. Coming soon.

--- a/components/dashboard/ask-brain.tsx
+++ b/components/dashboard/ask-brain.tsx
@@ -19,7 +19,7 @@ export function AskBrain({ teamSlug, teamName }: { teamSlug: string; teamName: s
       <div className="rounded-2xl bg-surface-inset px-5 py-5 sm:px-6 sm:py-6">
         <div className="mb-4 flex items-center gap-2">
           <Sparkles className="size-4 text-violet" />
-          <h2 className="font-display text-lg font-semibold text-ink">
+          <h2 className="font-display text-lg text-ink">
             Ask {teamName}&apos;s brain
           </h2>
         </div>

--- a/components/dashboard/kpi-stat.tsx
+++ b/components/dashboard/kpi-stat.tsx
@@ -18,7 +18,7 @@ export function KpiStat({ kpi }: { kpi: Kpi }) {
         {kpi.label}
       </p>
       <div className="flex items-end justify-between gap-2">
-        <span className="font-display text-2xl font-semibold leading-none text-ink">
+        <span className="font-display text-2xl leading-none text-ink">
           {kpi.value}
         </span>
         <span className={accent}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "aios-team-brain",
       "version": "0.1.0",
       "dependencies": {
-        "@aios-alpha/design": "^0.2.1",
-        "@aios-alpha/ui": "^0.2.1",
+        "@aios-alpha/design": "^0.3.0",
+        "@aios-alpha/ui": "^0.3.0",
         "@anthropic-ai/sdk": "^0.105.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -47,18 +47,18 @@
       }
     },
     "node_modules/@aios-alpha/design": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@aios-alpha/design/-/design-0.2.1.tgz",
-      "integrity": "sha512-BljGQdicgNqp9BNggoCFDolwSD+Q6r4KBAMDqEqfXxd2HLYP0rT2+ManlCoG+JK4RChCvg1bF1/GeGPgSQ5P2Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aios-alpha/design/-/design-0.3.0.tgz",
+      "integrity": "sha512-EfOL11d/5VUbpdjPxXOXbChC3mxUVX5qfO+J6faYNBLJPORps8YyQwfLraAg00SLqVi1voS7gtqPcYutXRkGKw==",
       "license": "MIT",
       "dependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "node_modules/@aios-alpha/ui": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@aios-alpha/ui/-/ui-0.2.1.tgz",
-      "integrity": "sha512-WdFGb+z+X8KAHkvxDDo2+uDay+XjOiaBJ3Kw6BKDdSu3gcUzX31yULfFQkTyDctw62lgCu80GX/5p5L3/267DA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aios-alpha/ui/-/ui-0.3.0.tgz",
+      "integrity": "sha512-0tiJvPJ8DAYCZJzodHuwaMzni3VyZBO7JNBuuuasW6IUc46B5QYSPoxKtgvihk1zfhxBglHDYUrZQOlGAHf9bg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "test:http:local": "npm run build && DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.http.config.ts"
   },
   "dependencies": {
-    "@aios-alpha/design": "^0.2.1",
-    "@aios-alpha/ui": "^0.2.1",
+    "@aios-alpha/design": "^0.3.0",
+    "@aios-alpha/ui": "^0.3.0",
     "@anthropic-ai/sdk": "^0.105.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
Bumps the team-brain dashboard to `@aios-alpha/design@^0.3.0` + `@aios-alpha/ui@^0.3.0` (Editorial Minimal + new effects layer: eased off-white, card glow, liquid glass). Published `0.3.0` is live on npm.

This is a **clean version bump, not a rebuild** — every legacy `--aios-*` token name the existing `app/globals.css` mapping depends on still exists in 0.3.0, so the alias layer resolves unchanged.

## Changes
- **`package.json` / lockfile:** `@aios-alpha/design` and `@aios-alpha/ui` `^0.2.1 → ^0.3.0`; `npm install` refreshed the lockfile (both resolve to `0.3.0`).
- **Off-white canvas:** `--aios-bg` is now `#fafaf8` and flows in automatically via the existing `--color-surface-base: var(--aios-bg)` map. No hex vendored.
- **Effects layer (subtle, mode-aware, 1–2 line maps):**
  - `.frosted` nav/sidebar → liquid-glass tokens (`--aios-glass-bg`, `--aios-glass-border`, `--aios-blur-glass-strong`).
  - `.prism-card` resting elevation → `--aios-shadow-glow-card`.
- **Instrument Serif is weight-400 only:** dropped `font-semibold` from every `font-display` (serif) element across 11 surfaces (dashboard cards, KPIs, ask-brain, codebase/project/people/maturity headings, sidebar, login) so the serif no longer faux-bolds. Instrument Sans body weights left untouched. `body` already sets `font-synthesis: none`.

## Verification
- `npm run build` (Next.js / Turbopack): **compiled successfully**, all routes generated. (The only warning is a pre-existing, unrelated optional `@e2b/code-interpreter` dynamic-import notice — not from this change. Build needs no live DB.)
- `npm run lint`: clean.
- Compiled CSS bundle references the 0.3.0 tokens: off-white `#fafaf8`, `--aios-shadow-glow-card`, `--aios-glass-bg`, `--aios-blur-glass-strong`.

⚠️ **Visual dual-mode verification recommended.** Only the build + compiled-token presence were confirmed here; the dashboard needs Supabase/Postgres to run fully, so a reviewer should eyeball light + dark (off-white canvas, frosted nav glass, card elevation, serif headings at 400) in a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and dependency-only changes with no auth, API, or data logic; recommend a quick light/dark UI pass for glass, card shadow, and off-white canvas.
> 
> **Overview**
> Upgrades **`@aios-alpha/design`** and **`@aios-alpha/ui`** from **0.2.1 → 0.3.0** so the dashboard picks up Editorial Minimal 0.3 (eased off-white canvas via existing `--aios-bg` → `--color-surface-base` mapping) without changing the legacy token alias layer.
> 
> **`app/globals.css`** wires the new effects tokens: **`.frosted`** nav/sidebar now uses liquid-glass (`--aios-glass-bg`, `--aios-glass-border`, `--aios-blur-glass-strong`) instead of the old nav surface + fixed blur; **`.prism-card`** gets resting elevation from **`--aios-shadow-glow-card`**.
> 
> Across **11 UI surfaces**, **`font-semibold`** is removed from **`font-display`** (Instrument Serif) headings and labels so serif text stays at weight 400 and avoids faux-bold; sans **`font-semibold`** on stats and page titles is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54fcc5c6b76e8bba55c56ceb53cc65c882185ee3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined navigation, sidebar, cards, and dashboard headings with a more polished, consistent visual treatment.
  * Updated several page titles and stats to use lighter typography and improved spacing/contrast.
  * Enhanced card and frosted-surface styling for a more modern glass-like look.

* **Chores**
  * Updated shared UI/design dependencies to the latest compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->