### PR TITLE
ci(railway): auto-apply schema migrations on deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare": "git config core.hooksPath .githooks || true",
     "dev:seed": "set -a; . ./.env.local; set +a; npx tsx --conditions react-server scripts/seed-demo.ts",
     "dev:login": "set -a; . ./.env.local; set +a; npx tsx scripts/dev-login.ts",
-    "pg:schema": "npx tsx scripts/pg-load-schema.ts",
+    "pg:schema": "node scripts/pg-load-schema.mjs",
     "admin": "npx tsx --conditions react-server scripts/admin.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "preDeployCommand": "npm run pg:schema"
+  }
+}

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -81,7 +81,7 @@ async function main() {
   if (cmd === "help" || flags.help) return console.log(USAGE);
 
   if (cmd === "pg:schema") {
-    execFileSync("npx", ["tsx", "scripts/pg-load-schema.ts"], { stdio: "inherit" });
+    execFileSync("node", ["scripts/pg-load-schema.mjs"], { stdio: "inherit" });
     return;
   }
 

--- a/scripts/pg-load-schema.mjs
+++ b/scripts/pg-load-schema.mjs
@@ -1,13 +1,14 @@
 /**
- * Load postgres/schema.sql into the database at DATABASE_URL, then apply every additive
- * delta in postgres/migrations/ (in lexical filename order).
+ * Load postgres/schema.sql into the database at DATABASE_URL, then apply every additive delta in
+ * postgres/migrations/ (in lexical filename order). Both are idempotent, so this is safe to re-run
+ * and is the prod rollout step for schema changes (`npm run pg:schema`).
  *
- * schema.sql is `create … if not exists` throughout, so it is a no-op on an EXISTING table —
- * it cannot add a column to a table prod already has. postgres/migrations/ holds the idempotent
- * `alter table … add column if not exists` deltas that catch an existing DB up. Both are
- * idempotent, so this is safe to re-run and is the prod rollout step (`npm run pg:schema`).
+ * Pure node + the `pg` runtime dependency (NO tsx) so it runs in the pruned production image — it
+ * is the Railway pre-deploy hook (railway.json `deploy.preDeployCommand`), so every deploy
+ * self-applies pending migrations before the new app version goes live. A failure here aborts the
+ * release rather than shipping app code ahead of its schema.
  *
- * Usage: DATABASE_URL=postgres://… npx tsx scripts/pg-load-schema.ts
+ * Usage: DATABASE_URL=postgres://… node scripts/pg-load-schema.mjs
  */
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import path from "node:path";
@@ -33,12 +34,9 @@ async function main() {
     await client.query(sql);
     console.log("✓ postgres/schema.sql loaded");
 
-    // Additive deltas that `create … if not exists` can't apply to an existing table.
     const migDir = path.join(pgDir, "migrations");
     const files = existsSync(migDir)
-      ? readdirSync(migDir)
-          .filter((f) => f.endsWith(".sql"))
-          .sort()
+      ? readdirSync(migDir).filter((f) => f.endsWith(".sql")).sort()
       : [];
     for (const f of files) {
       await client.query(readFileSync(path.join(migDir, f), "utf8"));


### PR DESCRIPTION
## Summary
Makes schema migrations **self-applying on deploy** so app code can never ship ahead of its database schema again (the bug behind the recent `integrations_type_check` violation when setting an OpenAI key).

## What
- **`railway.json`** — `deploy.preDeployCommand: "npm run pg:schema"`. Railway runs this in the deploy container **before** the new version goes live, with the service's `DATABASE_URL`. A migration failure **aborts the release** rather than shipping a schema-ahead app.
- **Pure-node loader** — ported `scripts/pg-load-schema.ts` → `scripts/pg-load-schema.mjs` (uses only the `pg` runtime dep, no `tsx`, which is a devDependency and may be pruned from the production image). `pg:schema` and `scripts/admin.ts` now call the `.mjs`; the `.ts` is removed.

`pg:schema` is idempotent (`create … if not exists` + `add … if not exists`), so re-running every deploy is a safe no-op when there's nothing new.

## Why this is safe in the prod image
`next.config` does not use `output: standalone` and there's no custom build config, so railpack ships the full `/app` (the `postgres/*.sql` files) and `node_modules` incl. `pg` — both confirmed present.

## Test plan
- [x] `npm run db:test:up` runs the new `.mjs` loader against a fresh DB (schema + both migrations apply from zero).
- [x] `tsc`, `eslint` clean.
- [ ] Post-merge: confirm the Railway deploy log shows the pre-deploy `pg:schema` step running.
