### PR TITLE
feat(graph): project all ingestions + blend graph facts into the query box

### DIFF
--- a/graphiti/README.md
+++ b/graphiti/README.md
@@ -2,9 +2,11 @@
 
 Graphiti is a temporal knowledge-graph engine. We run it **locally / self-hosted** (it never
 mixes into the TS codebase — the brain calls its REST API). It sits **downstream of the brain**:
-the brain's connectors fill `items`/`tasks`/`decisions`; `lib/graph` *projects* those rows into
-Graphiti as episodes; a tier-scoped query endpoint searches it. This is a parallel path next to
-the existing `graph_entities`/`graph_relationships` + `/api/v1/query` — not a replacement.
+the brain's connectors fill `items` (ALL ingestions: Slack transcripts, deliverables, decisions,
+tasks, artifacts); `lib/graph` *projects* those rows into Graphiti as episodes; the standalone
+`/api/v1/graph-query` endpoint searches it, AND `lib/query/retrieve` blends Graphiti's temporal
+facts into the main AI query box's context (tier-scoped, best-effort). Graphiti complements the
+existing `graph_entities`/`graph_relationships` digest — not a replacement.
 
 ## Run it
 ```bash
@@ -38,5 +40,7 @@ Extraction quality depends on structured-output support. Start with a strong clo
 model (Ollama via `OPENAI_BASE_URL`) trades quality/speed for privacy — swap via env, no code change.
 
 ## Status
-Phase 1: Slack transcripts → episodes, one team, bounded backfill. Validate the graph before
+Phase 2: ALL content-bearing item kinds (transcript/deliverable/decision/task/artifact) → episodes,
+projected on a schedule, and blended into the main query box. Bounded per run (`GRAPH_PROJECT_LIMIT`);
+a backlog beyond one run still needs cursor pagination. Earlier: Phase 1 was Slack transcripts only. Validate the graph before
 wiring Linear/Plane (those land in the brain via other work; the projector reads them downstream).

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -5,16 +5,32 @@ import { GraphitiClient, type GraphEpisode } from "./graphiti-client";
 import { episodeGroupId, type AccessTier } from "./group";
 
 /**
- * Brain → Graphiti projector. Reads already-normalized, tier-tagged rows from the brain
- * (Phase 1: Slack transcripts in `items`) and pushes them to Graphiti as episodes. The
- * SOLE writer of `graph_episodes` (the idempotency-state table) — single-writer guarded.
+ * Brain → Graphiti projector. Reads already-normalized, tier-tagged rows from the brain (`items` —
+ * ALL ingestions: Slack transcripts, GitHub/Notion/Drive deliverables, decisions, tasks, …) and
+ * pushes them to Graphiti as episodes. The SOLE writer of `graph_episodes` (the idempotency-state
+ * table) — single-writer guarded.
  *
- * Idempotent: re-projecting an unchanged row is a no-op (matched by content hash); changed
- * content re-pushes (Graphiti's temporal model supersedes the old fact). Source of truth stays
- * the brain; Graphiti is a downstream projection.
+ * Idempotent: re-projecting an unchanged row is a no-op (matched by content hash); changed content
+ * re-pushes (Graphiti's temporal model supersedes the old fact). Source of truth stays the brain;
+ * Graphiti is a downstream projection.
  */
 
 const SOURCE_TABLE = "items";
+
+/** Item kinds worth projecting as graph episodes — content-bearing knowledge, not raw config.
+ * `skill`/`blueprint` are configuration manifests, not events/knowledge, so they're excluded. */
+export const PROJECTABLE_KINDS = ["transcript", "deliverable", "decision", "task", "artifact"] as const;
+
+/** Human label per kind for the episode's source description (provenance the LLM extractor sees). */
+const KIND_LABEL: Record<string, string> = {
+  transcript: "Transcript",
+  deliverable: "Document",
+  decision: "Decision",
+  task: "Task",
+  artifact: "Artifact",
+  skill: "Skill",
+  blueprint: "Blueprint",
+};
 
 export interface ProjectSummary {
   scanned: number;
@@ -24,6 +40,7 @@ export interface ProjectSummary {
 
 type ItemRow = {
   id: string;
+  kind: string;
   access: AccessTier;
   body: string | null;
   path: string;
@@ -35,36 +52,47 @@ function sha(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
-/** Episode content + provenance from a Slack-transcript item. */
+/** Episode content + provenance from an item, labeled by kind. */
 function toEpisode(item: ItemRow): GraphEpisode {
   const fm = item.frontmatter ?? {};
   const title = typeof fm.title === "string" ? fm.title : undefined;
   const url = typeof fm.source_url === "string" ? fm.source_url : undefined;
   const ts = typeof fm.source_ts === "string" ? fm.source_ts : item.synced_at; // when it happened
+  const label = KIND_LABEL[item.kind] ?? "Item";
   return {
     content: item.body ?? "",
     timestamp: ts,
-    sourceDescription: `Slack thread — ${title ?? item.path}${url ? ` (${url})` : ""}`,
+    sourceDescription: `${label} — ${title ?? item.path}${url ? ` (${url})` : ""}`,
     name: `${SOURCE_TABLE}:${item.id}`,
   };
 }
 
 /**
- * Project this team's Slack transcripts into Graphiti. `since` (ISO) bounds the backfill;
- * `limit` caps a single run (episodes are LLM-extracted on Graphiti's side — keep runs bounded).
+ * Project this team's items into Graphiti. `kinds` selects which item kinds to project (default:
+ * PROJECTABLE_KINDS — all content-bearing ingestions). `since` (ISO) bounds the backfill; `limit`
+ * caps a single run (episodes are LLM-extracted on Graphiti's side — keep runs bounded). Rows with
+ * an empty body are skipped (nothing to extract).
  */
-export async function projectSlackToGraph(
+export async function projectItemsToGraph(
   supabase: SupabaseClient,
-  args: { teamId: string; teamSlug: string; client?: GraphitiClient; since?: string; limit?: number }
+  args: {
+    teamId: string;
+    teamSlug: string;
+    client?: GraphitiClient;
+    kinds?: readonly string[];
+    since?: string;
+    limit?: number;
+  }
 ): Promise<ProjectSummary> {
   const client = args.client ?? new GraphitiClient();
   const limit = args.limit ?? 50;
+  const kinds = args.kinds ?? PROJECTABLE_KINDS;
 
   let q = supabase
     .from("items")
-    .select("id, access, body, path, synced_at, frontmatter")
+    .select("id, kind, access, body, path, synced_at, frontmatter")
     .eq("team_id", args.teamId)
-    .eq("kind", "transcript")
+    .in("kind", kinds as string[])
     .order("synced_at", { ascending: true })
     .limit(limit);
   if (args.since) q = q.gt("synced_at", args.since);
@@ -76,6 +104,10 @@ export async function projectSlackToGraph(
   let skipped = 0;
   for (const item of rows) {
     const episode = toEpisode(item);
+    if (!episode.content.trim()) {
+      skipped++;
+      continue; // nothing to extract
+    }
     const contentSha = sha(episode.content);
 
     const { data: existing } = await supabase
@@ -108,4 +140,12 @@ export async function projectSlackToGraph(
   }
 
   return { scanned: rows.length, projected, skipped };
+}
+
+/** Back-compat: project only Slack transcripts. Prefer `projectItemsToGraph` (all ingestions). */
+export async function projectSlackToGraph(
+  supabase: SupabaseClient,
+  args: { teamId: string; teamSlug: string; client?: GraphitiClient; since?: string; limit?: number }
+): Promise<ProjectSummary> {
+  return projectItemsToGraph(supabase, { ...args, kinds: ["transcript"] });
 }

--- a/lib/graph/run.ts
+++ b/lib/graph/run.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { adminClient } from "@/lib/supabase/admin";
 import { GraphitiClient } from "./graphiti-client";
-import { projectSlackToGraph } from "./project";
+import { projectItemsToGraph } from "./project";
 
 /**
  * Graph-projection runner — the on-ramp that actually drives `projectSlackToGraph` (which is
@@ -64,7 +64,7 @@ export async function runGraphProjection(opts?: {
 
   for (const t of teams) {
     try {
-      const s = await projectSlackToGraph(supabase, {
+      const s = await projectItemsToGraph(supabase, {
         teamId: t.id,
         teamSlug: t.slug,
         client,

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -1,5 +1,7 @@
 import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { GraphitiClient, type GraphFact } from "@/lib/graph/graphiti-client";
+import { visibleGroupIds } from "@/lib/graph/group";
 
 export type Source = {
   sid: string; // S1, S2…
@@ -112,10 +114,36 @@ async function fetchAugmentedSources(
   }
 }
 
+// Graphiti graph-memory blend (temporal knowledge graph over ALL ingestions). Best-effort:
+// tier-scoped via group_ids, short timeout, never throws — a clean [] when GRAPHITI_URL is unset
+// or the call fails, so retrieval degrades to Postgres-only. Facts join the structured digest.
+const GRAPH_FACTS_LIMIT = Number(process.env.GRAPH_QUERY_FACTS ?? 12);
+const GRAPH_QUERY_TIMEOUT_MS = Number(process.env.GRAPH_QUERY_TIMEOUT_MS ?? 4000);
+
+async function fetchGraphFacts(
+  supabase: SupabaseClient,
+  teamId: string,
+  tier: "team" | "external",
+  question: string
+): Promise<GraphFact[]> {
+  const client = new GraphitiClient({ timeoutMs: GRAPH_QUERY_TIMEOUT_MS });
+  if (!client.configured) return [];
+  try {
+    const { data: team } = await supabase.from("teams").select("slug").eq("id", teamId).maybeSingle();
+    const slug = (team as { slug: string } | null)?.slug;
+    if (!slug) return [];
+    const groupIds = visibleGroupIds(slug, tier);
+    return await client.search(question, groupIds, GRAPH_FACTS_LIMIT);
+  } catch {
+    return []; // degrade to Postgres-only retrieval
+  }
+}
+
 /**
  * Tier-filtered retrieval: FTS top-12 + always-include structured context
- * (recent decisions, open/blocked tasks, projects, compact graph digest)
- * + 5 most recently synced items. All queries respect the caller's tier.
+ * (recent decisions, open/blocked tasks, projects, compact graph digest, and
+ * Graphiti temporal facts) + 5 most recently synced items. All queries respect
+ * the caller's tier.
  */
 export async function retrieve(
   supabase: SupabaseClient,
@@ -124,6 +152,9 @@ export async function retrieve(
   question: string,
   projectSlug?: string | null
 ): Promise<RetrievedContext> {
+  // Kick off the Graphiti graph-memory search concurrently with Postgres retrieval.
+  const graphFactsP = fetchGraphFacts(supabase, teamId, tier, question);
+
   // 1. FTS over items
   let fts = supabase
     .from("items")
@@ -257,9 +288,23 @@ export async function retrieve(
     ...(rels ?? []).map((r) => `- ${r.from_id} ${r.relationship_type} ${r.to_id}`),
   ].join("\n");
 
+  // 3b. Blend in Graphiti temporal facts (graph memory over all ingestions), if any.
+  const graphFacts = await graphFactsP;
+  const structuredWithGraph = graphFacts.length
+    ? structured +
+      "\n\n" +
+      [
+        "## Graph memory (temporal facts — entity/relationship knowledge across all ingestions)",
+        ...graphFacts.map(
+          (f) =>
+            `- ${f.fact}${f.valid_at ? ` (valid ${f.valid_at.slice(0, 10)})` : ""}${f.invalid_at ? " [SUPERSEDED]" : ""}`
+        ),
+      ].join("\n")
+    : structured;
+
   // 4. Optional cross-encoder rerank (local llama-server or cloud). No-op when
   // RERANK_URL is unset; reorders so the most relevant source is cited first.
   const ranked = await rerankSources(question, sources);
 
-  return { sources: ranked, structured };
+  return { sources: ranked, structured: structuredWithGraph };
 }

--- a/test/datamechanics/graph-project.datamechanics.test.ts
+++ b/test/datamechanics/graph-project.datamechanics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GraphitiClient, GraphEpisode } from "@/lib/graph/graphiti-client";
-import { projectSlackToGraph } from "@/lib/graph/project";
+import { projectSlackToGraph, projectItemsToGraph } from "@/lib/graph/project";
 import { runGraphProjection } from "@/lib/graph/run";
 import { db, ingest, seedTeam } from "./helpers";
 
@@ -74,6 +74,26 @@ describe("Slack → Graphiti projector (real Postgres, mocked Graphiti)", () => 
     const res = await projectSlackToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(again) });
     expect(again.pushes).toHaveLength(1); // changed content re-pushed
     expect(res.projected).toBe(1);
+  });
+});
+
+// All ingestions (not just Slack) feed the graph: projectItemsToGraph projects every content-bearing
+// kind and excludes config kinds (skill/blueprint). Verified on real Postgres with a mocked Graphiti.
+describe("projectItemsToGraph — all ingestions (real Postgres, mocked Graphiti)", () => {
+  it("projects all content kinds and excludes config kinds (skill)", async () => {
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    await ingest(seed, { kind: "transcript", path: "slack/eng/1.md", body: "slack thread", access: "team" });
+    await ingest(seed, { kind: "deliverable", path: "notion/spec.md", body: "product spec", access: "team" });
+    await ingest(seed, { kind: "decision", path: "decisions/d1.md", body: "we chose postgres", access: "team" });
+    await ingest(seed, { kind: "task", path: "tasks/t1.md", body: "ship the graph", access: "team" });
+    await ingest(seed, { kind: "skill", path: "skills/s.md", body: "skill manifest", access: "team" }); // excluded
+
+    const fake = new FakeGraphiti();
+    const res = await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    expect(res.projected).toBe(4); // transcript + deliverable + decision + task; skill excluded
+    expect(fake.pushes).toHaveLength(4);
   });
 });
 


### PR DESCRIPTION
## Summary
Makes the AI query box answer from the **unified context base** you described — **all ingestions** (Slack + everything in `items`) **fed into Graphiti**, and **Graphiti's temporal facts blended into the query box**. Phase 2 on top of the now-deployed Graphiti stack.

## What
1. **Project all ingestions (not just Slack).** Generalized the projector to `projectItemsToGraph` over all content-bearing kinds — `transcript / deliverable / decision / task / artifact` (`skill`/`blueprint` excluded as config, not knowledge). Kind-aware episode source descriptions; empty bodies skipped. `projectSlackToGraph` kept as a back-compat wrapper. The scheduler + admin "Project to graph" now project everything.
2. **Blend Graphiti into the main query.** `lib/query/retrieve` now fires a **tier-scoped** Graphiti `/search` (`visibleGroupIds`) concurrently with Postgres retrieval and appends the temporal facts (with `valid_at` / `[SUPERSEDED]`) to the structured context the LLM sees. **Best-effort**: short timeout, never throws, clean no-op when `GRAPHITI_URL` is unset → Postgres-only retrieval unchanged.

## Live status (deployed this session)
Graphiti + Neo4j are **running on Railway** (new services), `GRAPHITI_URL` wired on the brain, and projection verified end-to-end: a graph query returned correct temporal facts (e.g. *"John Ellison invited Abe Isleem to become a contributor… access to Linear and the roadmap"*, `valid_at 2026-06-23`). After this merges, the **query box** itself will include those facts in its answers.

## Test plan
- [x] `tsc`, `eslint`, **206 unit**, **data-mechanics** (real Postgres: all-kinds projection + skill exclusion + idempotency), docs-drift, `next build` — all green.
- [ ] Post-merge: ask the query box a relationship/temporal question and confirm it cites graph facts.

## Notes
- Tier isolation holds: graph search is scoped to the group_ids the caller's tier may see (Graphiti has no native tiering — `group_id` encodes team+tier; sole isolation per CLAUDE.md §5).
- Per-run projection is still bounded by `GRAPH_PROJECT_LIMIT`; a backlog beyond one run needs cursor pagination (tracked follow-up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Graph projection now includes more content types beyond transcripts, improving coverage of team knowledge in the graph.
  - Query results can now include relevant temporal facts from graph memory alongside existing context.

- **Bug Fixes**
  - Empty projected content is now skipped more reliably.
  - Graph-based context is fetched safely in the background and won’t block results if unavailable.

- **Documentation**
  - Updated the project status and integration overview to reflect the expanded graph workflow and current rollout phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->