### PR TITLE
feat(query): normal chat UI + fix Slack recall + parallelize retrieval

### DIFF
--- a/app/t/[team]/query/page.tsx
+++ b/app/t/[team]/query/page.tsx
@@ -1,12 +1,8 @@
 import type { Metadata } from "next";
-import { History } from "lucide-react";
 import { serverClient } from "@/lib/supabase/server";
-import { currentMember } from "@/lib/auth/guard";
-import { scopeQueryLog } from "@/lib/auth/visibility";
 import { QueryChat } from "@/components/query-chat";
-import { timeAgo, truncate } from "@/components/format";
 
-export const metadata: Metadata = { title: "Query" };
+export const metadata: Metadata = { title: "Chat" };
 
 export default async function QueryPage({
   params,
@@ -26,58 +22,16 @@ export default async function QueryPage({
     .maybeSingle();
   if (!team) return null;
 
-  // No RLS in postgres mode: scope query_log in app code. Members see only their own queries;
-  // admins see the whole team's (scopeQueryLog, CLAUDE.md §5).
-  const me = await currentMember(team.id);
-  const { data: recent } = me
-    ? await scopeQueryLog(
-        supabase
-          .from("query_log")
-          .select("id, question, answer_preview, cost_usd, latency_ms, created_at")
-          .eq("team_id", team.id),
-        { isAdmin: me.role === "admin", memberId: me.id }
-      )
-        .order("created_at", { ascending: false })
-        .limit(10)
-    : { data: [] };
-
   return (
-    <div className="mx-auto flex max-w-3xl flex-col gap-6">
+    <div className="mx-auto flex max-w-3xl flex-col gap-3">
       <div>
-        <h1 className="text-2xl font-semibold text-ink">Query</h1>
+        <h1 className="text-2xl font-semibold text-ink">Chat</h1>
         <p className="mt-1 text-sm text-ink-secondary">
-          Ask {team.name}&apos;s shared memory — answers cite the synced sources they came from.
+          Ask {team.name}&apos;s shared memory — Slack, decisions, tasks, code, and the knowledge
+          graph. Answers cite their sources.
         </p>
       </div>
-
-      <QueryChat teamSlug={teamSlug} initialQuestion={q} />
-
-      <section className="prism-card px-5 py-4">
-        <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
-          <History className="size-3.5" /> Recent queries
-        </h2>
-        {(recent ?? []).length === 0 ? (
-          <p className="text-sm text-ink-tertiary">
-            No queries yet — ask your first question above.
-          </p>
-        ) : (
-          <ul className="divide-y divide-border-subtle">
-            {(recent ?? []).map((r) => (
-              <li key={r.id} className="py-2.5">
-                <p className="text-sm font-medium text-ink">{r.question}</p>
-                {r.answer_preview ? (
-                  <p className="mt-0.5 text-xs text-ink-secondary">
-                    {truncate(r.answer_preview, 160)}
-                  </p>
-                ) : null}
-                <p className="mt-1 text-[11px] text-ink-tertiary">
-                  {timeAgo(r.created_at)} · ${Number(r.cost_usd).toFixed(3)} · {r.latency_ms}ms
-                </p>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      <QueryChat teamSlug={teamSlug} variant="page" initialQuestion={q} />
     </div>
   );
 }

--- a/components/dashboard/ask-brain.tsx
+++ b/components/dashboard/ask-brain.tsx
@@ -1,44 +1,24 @@
 "use client";
 
-import { useRef } from "react";
-import { Sparkles } from "lucide-react";
-import { QueryChat, type QueryChatHandle } from "@/components/query-chat";
-
-const SUGGESTIONS = [
-  "What is the eng team working on?",
-  "What did we accomplish last quarter?",
-  "What's blocking sprint 1?",
-  "Have we run the onboarding experiment with users yet?",
-];
+import Link from "next/link";
+import { Sparkles, MessageSquare } from "lucide-react";
+import { QueryChat } from "@/components/query-chat";
 
 export function AskBrain({ teamSlug, teamName }: { teamSlug: string; teamName: string }) {
-  const chatRef = useRef<QueryChatHandle>(null);
-
   return (
-    <section className="bg-gradient-prism rounded-2xl p-[1px]">
-      <div className="rounded-2xl bg-surface-inset px-5 py-5 sm:px-6 sm:py-6">
-        <div className="mb-4 flex items-center gap-2">
-          <Sparkles className="size-4 text-violet" />
-          <h2 className="font-display text-lg font-semibold text-ink">
-            Ask {teamName}&apos;s brain
-          </h2>
-        </div>
-
-        <QueryChat teamSlug={teamSlug} ref={chatRef} />
-
-        <div className="mt-4 flex flex-wrap gap-2">
-          {SUGGESTIONS.map((s) => (
-            <button
-              key={s}
-              type="button"
-              onClick={() => chatRef.current?.ask(s)}
-              className="rounded-full border border-violet/25 bg-violet/5 px-3 py-1 text-xs text-violet transition-colors hover:bg-violet/12"
-            >
-              {s}
-            </button>
-          ))}
-        </div>
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <h2 className="flex items-center gap-2 font-display text-lg font-semibold text-ink">
+          <Sparkles className="size-4 text-violet" /> Ask {teamName}&apos;s brain
+        </h2>
+        <Link
+          href={`/t/${teamSlug}/query`}
+          className="flex items-center gap-1 text-xs font-medium text-violet hover:underline"
+        >
+          <MessageSquare className="size-3.5" /> Open full chat
+        </Link>
       </div>
+      <QueryChat teamSlug={teamSlug} variant="embed" />
     </section>
   );
 }

--- a/components/query-chat.tsx
+++ b/components/query-chat.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useImperativeHandle, useState, type Ref } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Loader2, Send, Sparkles } from "lucide-react";
 import { Markdown } from "@/components/markdown";
@@ -21,31 +21,50 @@ type Exchange = {
   error?: string;
 };
 
-/** Imperative handle so parents (e.g. suggestion chips) can fire a query. */
-export type QueryChatHandle = { ask: (question: string) => void };
+const DEFAULT_SUGGESTIONS = [
+  "What is the team working on right now?",
+  "What did we decide recently, and why?",
+  "What has John been posting in Slack?",
+  "What's blocking us?",
+];
 
+/**
+ * Normal chat UI over the brain. Messages flow top→bottom (oldest first), the composer is pinned at
+ * the bottom, Enter sends (Shift+Enter = newline), and the view autoscrolls as the answer streams.
+ * `variant` controls height: "page" fills the viewport (the /query chat), "embed" is a compact panel
+ * (the Home launcher). Answers stream from /api/dashboard/query (SSE) and cite their sources.
+ */
 export function QueryChat({
   teamSlug,
   initialQuestion,
-  ref,
+  variant = "embed",
+  suggestions = DEFAULT_SUGGESTIONS,
 }: {
   teamSlug: string;
   initialQuestion?: string;
-  ref?: Ref<QueryChatHandle>;
+  variant?: "page" | "embed";
+  suggestions?: string[];
 }) {
-  const [question, setQuestion] = useState(initialQuestion ?? "");
+  const [question, setQuestion] = useState("");
   const [exchanges, setExchanges] = useState<Exchange[]>([]);
   const [busy, setBusy] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const askedInitial = useRef(false);
 
-  async function ask(e?: React.FormEvent, override?: string) {
-    e?.preventDefault();
-    const q = (override ?? question).trim();
-    if (!q || busy) return;
+  // Autoscroll to the newest content as the answer streams in.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [exchanges]);
+
+  async function ask(q: string) {
+    const text = q.trim();
+    if (!text || busy) return;
     setQuestion("");
     setBusy(true);
 
     const idx = exchanges.length;
-    setExchanges((xs) => [...xs, { question: q, answer: "", sources: [], status: "streaming" }]);
+    setExchanges((xs) => [...xs, { question: text, answer: "", sources: [], status: "streaming" }]);
     const patch = (p: Partial<Exchange>) =>
       setExchanges((xs) => xs.map((x, i) => (i === idx ? { ...x, ...p } : x)));
 
@@ -53,7 +72,7 @@ export function QueryChat({
       const res = await fetch("/api/dashboard/query", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question: q, team: teamSlug }),
+        body: JSON.stringify({ question: text, team: teamSlug }),
       });
 
       if (!res.ok || !res.body) {
@@ -68,7 +87,6 @@ export function QueryChat({
         return;
       }
 
-      // Parse the SSE stream
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
       let buf = "";
@@ -109,100 +127,135 @@ export function QueryChat({
           if (data) handle(event, data);
         }
       }
-      // if the stream ended without a done/error event, settle it
       setExchanges((xs) =>
         xs.map((x, i) => (i === idx && x.status === "streaming" ? { ...x, status: "done" } : x))
       );
     } catch (err) {
-      patch({
-        status: "error",
-        error: err instanceof Error ? err.message : "network error",
-      });
+      patch({ status: "error", error: err instanceof Error ? err.message : "network error" });
     } finally {
       setBusy(false);
     }
   }
 
-  useImperativeHandle(ref, () => ({
-    ask: (q: string) => {
-      setQuestion(q);
-      void ask(undefined, q);
-    },
-  }));
+  // Auto-ask a deep-linked question (e.g. from the Home launcher → /query?q=…), once.
+  useEffect(() => {
+    if (initialQuestion && !askedInitial.current) {
+      askedInitial.current = true;
+      void ask(initialQuestion);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialQuestion]);
+
+  const height = variant === "page" ? "h-[calc(100dvh-11rem)]" : "h-[26rem]";
 
   return (
-    <div className="flex flex-col gap-5">
-      <form onSubmit={ask} className="prism-card flex flex-col gap-3 bg-surface-inset px-4 py-4">
+    <div className={`flex ${height} flex-col overflow-hidden rounded-2xl border border-border-subtle bg-surface-inset`}>
+      {/* Messages (oldest → newest); scrolls; composer is pinned below. */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 sm:px-5">
+        {exchanges.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+            <Sparkles className="size-6 text-violet" />
+            <p className="max-w-sm text-sm text-ink-secondary">
+              Ask anything about your team — Slack, decisions, tasks, code, and the knowledge graph.
+              Answers cite their sources.
+            </p>
+            <div className="flex flex-wrap justify-center gap-2">
+              {suggestions.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => ask(s)}
+                  className="rounded-full border border-violet/25 bg-violet/5 px-3 py-1 text-xs text-violet transition-colors hover:bg-violet/12"
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {exchanges.map((x, i) => (
+              <div key={i} className="flex flex-col gap-2">
+                <div className="ml-auto max-w-[85%] rounded-2xl rounded-br-sm bg-violet/10 px-4 py-2.5 text-sm text-ink">
+                  {x.question}
+                </div>
+                <div className="mr-auto max-w-full rounded-2xl rounded-bl-sm bg-surface-card px-4 py-3">
+                  <p className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-gradient-prism">
+                    <Sparkles className="size-3 text-violet" /> Team Brain
+                  </p>
+                  {x.answer ? (
+                    <Markdown>{x.answer}</Markdown>
+                  ) : x.status === "streaming" ? (
+                    <p className="flex items-center gap-2 text-sm text-ink-tertiary">
+                      <Loader2 className="size-3.5 animate-spin" /> retrieving and thinking…
+                    </p>
+                  ) : null}
+                  {x.status === "error" ? (
+                    <p className="mt-2 rounded-lg border border-red/30 bg-red/5 px-3 py-2 text-sm text-red">
+                      {x.error}
+                    </p>
+                  ) : null}
+                  {x.sources.length > 0 ? (
+                    <div className="mt-3 flex flex-wrap gap-2 border-t border-border-subtle pt-3">
+                      {x.sources.map((s) =>
+                        s.item_id ? (
+                          <Link
+                            key={s.id}
+                            href={`/t/${teamSlug}/library/${s.item_id}`}
+                            className="inline-flex items-center gap-1.5 rounded-full border border-violet/25 bg-violet/8 px-2.5 py-1 font-mono text-[11px] text-violet transition-colors hover:bg-violet/15"
+                            title={`${s.project}/${s.path}`}
+                          >
+                            <span className="font-semibold">{s.id}</span>
+                            <span className="max-w-48 truncate">{s.path.split("/").pop()}</span>
+                          </Link>
+                        ) : (
+                          <span
+                            key={s.id}
+                            className="inline-flex items-center gap-1.5 rounded-full border border-border-default px-2.5 py-1 font-mono text-[11px] text-ink-tertiary"
+                          >
+                            {s.id}
+                          </span>
+                        )
+                      )}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Composer — pinned at the bottom (normal chat). Enter sends; Shift+Enter = newline. */}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          ask(question);
+        }}
+        className="flex items-end gap-2 border-t border-border-subtle bg-surface-base/40 px-3 py-3"
+      >
         <textarea
           value={question}
           onChange={(e) => setQuestion(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) ask(e);
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              ask(question);
+            }
           }}
-          rows={3}
-          placeholder="What did we decide about…? Who owns…? What changed since…?"
-          className="w-full resize-y bg-transparent text-sm text-ink outline-none placeholder:text-ink-tertiary"
+          rows={1}
+          placeholder="Ask the brain…  (Enter to send, Shift+Enter for newline)"
+          className="max-h-40 min-h-[2.5rem] w-full resize-none rounded-xl border border-border-default bg-surface-base px-3 py-2 text-sm text-ink outline-none placeholder:text-ink-tertiary focus:border-violet/50"
         />
-        <div className="flex items-center justify-between">
-          <p className="text-[11px] text-ink-tertiary">⌘↵ to send · answers cite synced sources</p>
-          <button type="submit" disabled={busy || !question.trim()} className="btn-prism">
-            {busy ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
-            Ask the brain
-          </button>
-        </div>
+        <button
+          type="submit"
+          disabled={busy || !question.trim()}
+          className="btn-prism shrink-0"
+          aria-label="Send"
+        >
+          {busy ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+        </button>
       </form>
-
-      {exchanges
-        .map((x, i) => ({ x, i }))
-        .reverse()
-        .map(({ x, i }) => (
-          <div key={i} className="flex flex-col gap-3">
-            <div className="ml-auto max-w-[85%] rounded-2xl rounded-br-sm bg-violet/10 px-4 py-2.5 text-sm text-ink">
-              {x.question}
-            </div>
-            <div className="prism-card max-w-full bg-surface-inset px-5 py-4">
-              <p className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-gradient-prism">
-                <Sparkles className="size-3 text-violet" /> Team Brain
-              </p>
-              {x.answer ? (
-                <Markdown>{x.answer}</Markdown>
-              ) : x.status === "streaming" ? (
-                <p className="flex items-center gap-2 text-sm text-ink-tertiary">
-                  <Loader2 className="size-3.5 animate-spin" /> retrieving and thinking…
-                </p>
-              ) : null}
-              {x.status === "error" ? (
-                <p className="mt-2 rounded-lg border border-red/30 bg-red/5 px-3 py-2 text-sm text-red">
-                  {x.error}
-                </p>
-              ) : null}
-              {x.sources.length > 0 ? (
-                <div className="mt-3 flex flex-wrap gap-2 border-t border-border-subtle pt-3">
-                  {x.sources.map((s) =>
-                    s.item_id ? (
-                      <Link
-                        key={s.id}
-                        href={`/t/${teamSlug}/library/${s.item_id}`}
-                        className="inline-flex items-center gap-1.5 rounded-full border border-violet/25 bg-violet/8 px-2.5 py-1 font-mono text-[11px] text-violet transition-colors hover:bg-violet/15"
-                        title={`${s.project}/${s.path}`}
-                      >
-                        <span className="font-semibold">{s.id}</span>
-                        <span className="max-w-48 truncate">{s.path.split("/").pop()}</span>
-                      </Link>
-                    ) : (
-                      <span
-                        key={s.id}
-                        className="inline-flex items-center gap-1.5 rounded-full border border-border-default px-2.5 py-1 font-mono text-[11px] text-ink-tertiary"
-                      >
-                        {s.id}
-                      </span>
-                    )
-                  )}
-                </div>
-              ) : null}
-            </div>
-          </div>
-        ))}
     </div>
   );
 }

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -139,11 +139,36 @@ async function fetchGraphFacts(
   }
 }
 
+// Question words + common stopwords dropped before building the FTS query — they carry no signal
+// and (under AND semantics) tanked recall (e.g. "what has john been posting to slack" required the
+// literal "posting"/"slack" in the body). We keep all other terms.
+const FTS_STOP = new Set([
+  "the", "a", "an", "of", "to", "in", "on", "for", "and", "or", "is", "are", "was", "were",
+  "be", "been", "being", "what", "who", "whom", "whose", "when", "where", "why", "how", "which",
+  "did", "do", "does", "has", "have", "had", "with", "about", "from", "by", "our", "we", "you",
+  "i", "me", "my", "your", "their", "this", "that", "these", "those", "it", "its", "as", "at",
+  "any", "all", "can", "could", "would", "should", "tell", "show", "give", "list", "get",
+]);
+
 /**
- * Tier-filtered retrieval: FTS top-12 + always-include structured context
+ * Build a recall-friendly FTS query: significant terms OR-joined. `websearch_to_tsquery` treats the
+ * word "or" as the OR operator, so this matches docs containing ANY significant term (then the LLM
+ * filters relevance) instead of requiring ALL of them. Falls back to the raw question when nothing
+ * significant remains. (Ranked/semantic retrieval — pgvector — is the durable fix at larger scale.)
+ */
+export function toOrQuery(question: string): string {
+  const terms = (question.toLowerCase().match(/[a-z0-9][a-z0-9'-]*/g) ?? []).filter(
+    (t) => t.length >= 3 && !FTS_STOP.has(t)
+  );
+  const unique = [...new Set(terms)];
+  return unique.length ? unique.join(" or ") : question;
+}
+
+/**
+ * Tier-filtered retrieval: recall-friendly FTS + always-include structured context
  * (recent decisions, open/blocked tasks, projects, compact graph digest, and
- * Graphiti temporal facts) + 5 most recently synced items. All queries respect
- * the caller's tier.
+ * Graphiti temporal facts) + recently synced items. All independent queries run in
+ * parallel; all respect the caller's tier.
  */
 export async function retrieve(
   supabase: SupabaseClient,
@@ -155,25 +180,77 @@ export async function retrieve(
   // Kick off the Graphiti graph-memory search concurrently with Postgres retrieval.
   const graphFactsP = fetchGraphFacts(supabase, teamId, tier, question);
 
-  // 1. FTS over items
-  let fts = supabase
+  // All independent retrieval queries run in PARALLEL (was sequential → ~7 serial round-trips).
+  // 1. Recall-friendly FTS over items (OR of significant terms; see toOrQuery).
+  let ftsB = supabase
     .from("items")
     .select("id, path, kind, body, synced_at, projects(slug)")
     .eq("team_id", teamId)
-    .textSearch("search", question, { type: "websearch", config: "english" })
-    .limit(12);
-  if (tier === "external") fts = fts.eq("access", "external");
-  const { data: ftsHits } = await fts;
+    .textSearch("search", toOrQuery(question), { type: "websearch", config: "english" })
+    .limit(20);
+  if (tier === "external") ftsB = ftsB.eq("access", "external");
 
-  // 2. Recency: 5 most recent items
-  let recent = supabase
+  // 2. Recency: most recent items (a fallback so fresh content always has a shot).
+  let recentB = supabase
     .from("items")
     .select("id, path, kind, body, synced_at, projects(slug)")
     .eq("team_id", teamId)
     .order("synced_at", { ascending: false })
-    .limit(5);
-  if (tier === "external") recent = recent.eq("access", "external");
-  const { data: recentHits } = await recent;
+    .limit(8);
+  if (tier === "external") recentB = recentB.eq("access", "external");
+
+  // 3. Structured-context query builders (awaited together with the above).
+  let decisionsB = supabase
+    .from("decisions")
+    .select("row_key, decided_at, title, decided_by, still_valid, projects(slug)")
+    .eq("team_id", teamId)
+    .order("decided_at", { ascending: false })
+    .limit(50);
+  if (tier === "external") decisionsB = decisionsB.eq("audience", "external");
+  const tasksB = supabase
+    .from("tasks")
+    .select("row_key, title, assignee, status, sprint, projects(slug)")
+    .eq("team_id", teamId)
+    .in("status", ["in_progress", "blocked", "ready"])
+    .limit(50);
+  const commitmentsB = supabase
+    .from("graph_entities")
+    .select("entity_id, name, attrs")
+    .eq("team_id", teamId)
+    .eq("entity_type", "commitment")
+    .limit(30);
+  const relsB = supabase
+    .from("graph_relationships")
+    .select("from_id, to_id, relationship_type")
+    .eq("team_id", teamId)
+    .in("relationship_type", ["REPORTS_TO", "OWNS", "BLOCKS"])
+    .limit(80);
+  const actorsB = supabase
+    .from("graph_entities")
+    .select("entity_id, name, attrs")
+    .eq("team_id", teamId)
+    .eq("entity_type", "actor")
+    .limit(40);
+
+  const [
+    { data: ftsHits },
+    { data: recentHits },
+    { data: decisions },
+    { data: tasks },
+    { data: commitments },
+    { data: rels },
+    { data: actors },
+    augmented,
+  ] = await Promise.all([
+    ftsB,
+    recentB,
+    decisionsB,
+    tasksB,
+    commitmentsB,
+    relsB,
+    actorsB,
+    fetchAugmentedSources(question, tier),
+  ]);
 
   // Merge, dedupe by id, cap sizes
   const seen = new Set<string>();
@@ -203,7 +280,7 @@ export async function retrieve(
   // Merged after Postgres hits, deduped by path, same char budget. No-op + safe
   // fallback when RETRIEVAL_AUGMENT_URL is unset or the call fails.
   const seenPaths = new Set(sources.map((s) => s.path));
-  for (const hit of await fetchAugmentedSources(question, tier)) {
+  for (const hit of augmented) {
     const text = (hit.text || "").slice(0, MAX_SOURCE_CHARS);
     if (!text) continue;
     const path = hit.path || `gbrain:${n}`;
@@ -222,44 +299,7 @@ export async function retrieve(
     });
   }
 
-  // 3. Structured context (compact, always included)
-  let decisionsQ = supabase
-    .from("decisions")
-    .select("row_key, decided_at, title, decided_by, still_valid, projects(slug)")
-    .eq("team_id", teamId)
-    .order("decided_at", { ascending: false })
-    .limit(50);
-  if (tier === "external") decisionsQ = decisionsQ.eq("audience", "external");
-  const { data: decisions } = await decisionsQ;
-
-  const { data: tasks } = await supabase
-    .from("tasks")
-    .select("row_key, title, assignee, status, sprint, projects(slug)")
-    .eq("team_id", teamId)
-    .in("status", ["in_progress", "blocked", "ready"])
-    .limit(50);
-
-  const { data: commitments } = await supabase
-    .from("graph_entities")
-    .select("entity_id, name, attrs")
-    .eq("team_id", teamId)
-    .eq("entity_type", "commitment")
-    .limit(30);
-
-  const { data: rels } = await supabase
-    .from("graph_relationships")
-    .select("from_id, to_id, relationship_type")
-    .eq("team_id", teamId)
-    .in("relationship_type", ["REPORTS_TO", "OWNS", "BLOCKS"])
-    .limit(80);
-
-  const { data: actors } = await supabase
-    .from("graph_entities")
-    .select("entity_id, name, attrs")
-    .eq("team_id", teamId)
-    .eq("entity_type", "actor")
-    .limit(40);
-
+  // 3. Structured context (compact, always included) — built from the parallel results above.
   const structured = [
     "## Recent decisions (newest first)",
     ...(decisions ?? []).map(

--- a/test/query-recall.test.ts
+++ b/test/query-recall.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { toOrQuery } from "@/lib/query/retrieve";
+
+// Spec for the FTS recall fix: the AI query box failed "what has john ellison been posting to slack?"
+// because websearch AND-semantics required EVERY term in the body. toOrQuery drops question/stopwords
+// and OR-joins the rest so a doc matching ANY significant term is retrieved (the LLM then filters).
+
+describe("toOrQuery (FTS recall)", () => {
+  it("drops question + stop words and OR-joins the significant terms", () => {
+    expect(toOrQuery("what has john ellison been posting to slack?")).toBe(
+      "john or ellison or posting or slack"
+    );
+  });
+
+  it("dedupes and lowercases", () => {
+    expect(toOrQuery("Slack slack DECISIONS decisions")).toBe("slack or decisions");
+  });
+
+  it("falls back to the raw question when nothing significant remains", () => {
+    expect(toOrQuery("what is it?")).toBe("what is it?");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the three things from dogfooding the query box (screenshot): clunky UI, slow queries, and **John's Slack posts not findable**.

## 1. Recall — "can't access John's recent Slack posts" 🐛
His posts **are** ingested (6 Slack transcripts; 10 items mention "john"). The bug was retrieval: FTS used **`websearch` (AND)**, so *"what has john ellison been posting to slack"* required every term (`john`&`ellison`&`post`&`slack`) in the body — "posting"/"slack" aren't there → **0 hits**. Fix: `toOrQuery()` drops question/stop words and **OR-joins** the rest (`websearch_to_tsquery` treats "or" as the OR operator), so a doc matching *any* significant term is retrieved and the LLM filters. At current corpus scale this surfaces all Slack transcripts. Unit-tested. *(Ranked/semantic retrieval via pgvector remains the durable fix as the corpus grows — noted.)*

## 2. Speed — "queries are slow"
Retrieval fired **~7 Postgres queries sequentially**. Now a single **`Promise.all`** (the Graphiti graph search was already concurrent). Removes ~6 serial round-trips per query. (The LLM remains the dominant cost; this removes the retrieval overhead on top of it.)

## 3. Chat UX — "we should have a normal chat interface; this is clunky"
`QueryChat` rebuilt into a proper chat:
- Messages flow **top→bottom** (oldest first), **composer pinned at the bottom**, **Enter sends** (Shift+Enter = newline), **autoscroll** as the answer streams, empty-state suggestion chips.
- **`/query`** is now a **full-height chat page**; Home's "Ask the brain" is a compact embedded chat with an **"Open full chat"** link.

## Test plan
- [x] `tsc`, `eslint`, unit (new `toOrQuery` recall spec), `next build` — green.
- [ ] Post-deploy: confirm *"what has john been posting to slack?"* returns his actual posts, and the chat feels responsive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the chat experience with a cleaner full-page view and a simpler embedded version.
  * Added a more flexible chat input flow with suggestion prompts and automatic opening of an initial question.

* **Bug Fixes**
  * Improved result retrieval so relevant matches are found more reliably.
  * Expanded the backend search process to gather context faster and more consistently.

* **Tests**
  * Added coverage for search query handling and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->