### PR TITLE
feat(query): per-person cross-tool activity digest in retrieval

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,7 +135,7 @@ sequenceDiagram
   participant LLM as Claude
   U->>Q: {question, project?}
   Q->>Q: auth · cost guard (per-member/day, per-team $/day in query_log)
-  Q->>RET: tier-filtered FTS top-12 + recent + structured digest (incl. per-contributor git activity, team tier)
+  Q->>RET: tier-filtered FTS top-12 + recent + structured digest (incl. per-contributor git activity + per-person cross-tool activity, team tier)
   RET-->>Q: {sources[], structured}
   Q->>CL: streamAnswer(ctx, question)
   CL->>LLM: cached system + numbered sources + question

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -21,6 +21,7 @@ export type RetrievedContext = {
 const MAX_SOURCE_CHARS = 8_000;
 const MAX_TOTAL_CHARS = 160_000; // ~40k tokens context cap
 const GIT_WINDOW_DAYS = 90; // recency window for the per-contributor git-activity digest
+const PEOPLE_WINDOW_DAYS = 90; // recency window for the per-person cross-tool activity digest
 
 // Optional external retrieval augmentation (e.g. a local GBrain adapter or a
 // cloud retrieval service). Vendor-neutral HTTP contract:
@@ -219,6 +220,71 @@ async function gitActivityDigest(supabase: SupabaseClient, teamId: string): Prom
 }
 
 /**
+ * Per-person cross-tool activity digest from attributed `items` — the payoff of the identity work:
+ * once Slack threads / Linear+Plane issues / docs carry the author's `member_id`, "what is each
+ * person doing" is answerable beyond git. Counts each person's recent items by source (Slack/PM/docs),
+ * EXCLUDING `git` (the git digest above covers code) and connector members (their `@connector.local`
+ * email). **team-tier only** — internal activity, never shown to an external viewer. Returns "" when
+ * there's nothing attributed.
+ */
+async function peopleActivityDigest(supabase: SupabaseClient, teamId: string): Promise<string> {
+  const since = new Date(Date.now() - PEOPLE_WINDOW_DAYS * 86_400_000).toISOString();
+  const { data: items } = await supabase
+    .from("items")
+    .select("member_id, kind, frontmatter, synced_at")
+    .eq("team_id", teamId)
+    .gte("synced_at", since)
+    .order("synced_at", { ascending: false })
+    .limit(5000);
+  if (!items?.length) return "";
+
+  const { data: members } = await supabase
+    .from("members")
+    .select("id, display_name, email")
+    .eq("team_id", teamId);
+  const memById = new Map(
+    (members ?? []).map((m) => {
+      const r = m as { id: string; display_name: string; email: string };
+      return [r.id, { name: r.display_name, email: r.email }];
+    })
+  );
+  // Connector members (slack-sync@connector.local, …) author the unattributed remainder — skip them.
+  const isConnector = (id: string) => (memById.get(id)?.email ?? "").endsWith("@connector.local");
+
+  type Agg = { name: string; email: string; bySource: Map<string, number>; last: string };
+  const byPerson = new Map<string, Agg>();
+  for (const it of items as {
+    member_id: string | null;
+    kind: string | null;
+    frontmatter: Record<string, unknown> | null;
+    synced_at: string | Date;
+  }[]) {
+    if (!it.member_id || isConnector(it.member_id)) continue;
+    const fm = it.frontmatter ?? {};
+    const source = typeof fm.source === "string" && fm.source ? fm.source : it.kind ?? "item";
+    if (source === "git") continue; // code activity has its own section
+    // synced_at comes back as a Date on the pg adapter; normalize to an ISO string.
+    const ts = typeof it.synced_at === "string" ? it.synced_at : new Date(it.synced_at).toISOString();
+    const m = memById.get(it.member_id);
+    const a = byPerson.get(it.member_id) ?? { name: m?.name ?? "unknown", email: m?.email ?? "", bySource: new Map(), last: "" };
+    a.bySource.set(source, (a.bySource.get(source) ?? 0) + 1);
+    if (ts > a.last) a.last = ts;
+    byPerson.set(it.member_id, a);
+  }
+  if (byPerson.size === 0) return "";
+
+  const total = (a: Agg) => [...a.bySource.values()].reduce((x, y) => x + y, 0);
+  const lines = [...byPerson.values()]
+    .sort((a, b) => total(b) - total(a))
+    .slice(0, 15)
+    .map((p) => {
+      const parts = [...p.bySource.entries()].sort((a, b) => b[1] - a[1]).map(([s, n]) => `${n} ${s}`);
+      return `- ${p.name}${p.email ? ` (${p.email})` : ""}: ${parts.join(", ")}; last active ${p.last.slice(0, 10)}`;
+    });
+  return ["", `## Activity by person (Slack/issues/docs, last ${PEOPLE_WINDOW_DAYS}d)`, ...lines].join("\n");
+}
+
+/**
  * Tier-filtered retrieval: recall-friendly FTS + always-include structured context
  * (recent decisions, open/blocked tasks, projects, compact graph digest, Graphiti temporal facts,
  * + a per-contributor git-activity digest on the team tier) + recently synced items. All independent
@@ -233,8 +299,9 @@ export async function retrieve(
 ): Promise<RetrievedContext> {
   // Kick off the Graphiti graph-memory search concurrently with Postgres retrieval.
   const graphFactsP = fetchGraphFacts(supabase, teamId, tier, question);
-  // Git-activity digest (team tier only — code/contributor activity is internal) runs in parallel too.
+  // Git-activity + per-person activity digests (team tier only — internal) run in parallel too.
   const gitDigestP = tier === "team" ? gitActivityDigest(supabase, teamId) : Promise.resolve("");
+  const peopleDigestP = tier === "team" ? peopleActivityDigest(supabase, teamId) : Promise.resolve("");
 
   // All independent retrieval queries run in PARALLEL (was sequential → ~7 serial round-trips).
   // 1. Recall-friendly FTS over items (OR of significant terms; see toOrQuery).
@@ -356,7 +423,7 @@ export async function retrieve(
   }
 
   // 3. Structured context (compact, always included) — built from the parallel results above.
-  const gitDigest = await gitDigestP;
+  const [gitDigest, peopleDigest] = await Promise.all([gitDigestP, peopleDigestP]);
   const structured = [
     "## Recent decisions (newest first)",
     ...(decisions ?? []).map(
@@ -384,6 +451,7 @@ export async function retrieve(
     "## Key relationships",
     ...(rels ?? []).map((r) => `- ${r.from_id} ${r.relationship_type} ${r.to_id}`),
     gitDigest,
+    peopleDigest,
   ].join("\n");
 
   // 3b. Blend in Graphiti temporal facts (graph memory over all ingestions), if any.

--- a/test/datamechanics/people-activity-retrieval.datamechanics.test.ts
+++ b/test/datamechanics/people-activity-retrieval.datamechanics.test.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { ingestItem } from "@/lib/ingest";
+import { retrieve } from "@/lib/query/retrieve";
+import { db, seedTeam, sha } from "./helpers";
+
+// Spec: the payoff of the attribution work — once items carry the author's member_id, "what is each
+// person doing" is answerable across Slack/PM/docs (not just git). The digest counts each person's
+// attributed items by source, excludes git (its own digest) and connector members, team-tier only.
+
+async function addMember(teamId: string, email: string, name: string): Promise<string> {
+  const { data } = await db()
+    .from("members")
+    .insert({ team_id: teamId, email, display_name: name, actor_handle: `h-${randomUUID().slice(0, 8)}`, role: "member", tier: "team", status: "active" })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+async function put(
+  teamId: string,
+  actorMemberId: string,
+  authorMemberId: string | null,
+  o: { project: string; path: string; kind: string; source: string; body: string }
+) {
+  const payload = {
+    project: o.project,
+    path: o.path,
+    kind: o.kind as "transcript" | "deliverable" | "artifact",
+    actor: "",
+    content_sha256: sha(o.body),
+    access: "team" as const,
+    frontmatter: { source: o.source },
+    body: o.body,
+  };
+  return ingestItem(db(), { teamId, memberId: actorMemberId, apiKeyId: randomUUID() }, payload, "team", { authorMemberId });
+}
+
+describe("people-activity digest in retrieval (real Postgres)", () => {
+  it("summarizes each person's attributed activity by source; excludes git + connector members", async () => {
+    const seed = await seedTeam();
+    const alex = await addMember(seed.teamId, "alex@corp.com", "Alex Rivera");
+    const connector = await addMember(seed.teamId, "slack-sync@connector.local", "Slack Sync");
+
+    // Alex's attributed activity across tools (ingested BY the connector, attributed TO Alex).
+    await put(seed.teamId, connector, alex, { project: "slack", path: "slack/eng/1.md", kind: "transcript", source: "slack", body: "a" });
+    await put(seed.teamId, connector, alex, { project: "slack", path: "slack/eng/2.md", kind: "transcript", source: "slack", body: "b" });
+    await put(seed.teamId, connector, alex, { project: "linear-eng", path: "linear/eng/ENG-1.md", kind: "deliverable", source: "linear", body: "c" });
+    // A git commit attributed to Alex — must NOT be counted here (git has its own digest).
+    await put(seed.teamId, connector, alex, { project: "commits", path: "commits/r/x.md", kind: "artifact", source: "git", body: "d" });
+    // An UNATTRIBUTED slack item → stays on the connector member; must be excluded.
+    await put(seed.teamId, connector, null, { project: "slack", path: "slack/eng/3.md", kind: "transcript", source: "slack", body: "e" });
+
+    const ctx = await retrieve(db(), seed.teamId, "team", "what is everyone doing?");
+    expect(ctx.structured).toContain("## Activity by person");
+    expect(ctx.structured).toContain("Alex Rivera (alex@corp.com)");
+    expect(ctx.structured).toContain("2 slack, 1 linear"); // git excluded (else it'd be "…, 1 git")
+    expect(ctx.structured).not.toContain("Slack Sync"); // connector member excluded
+  });
+
+  it("is hidden from an external-tier viewer", async () => {
+    const seed = await seedTeam();
+    const alex = await addMember(seed.teamId, "alex@corp.com", "Alex Rivera");
+    await put(seed.teamId, seed.memberId, alex, { project: "slack", path: "slack/eng/1.md", kind: "transcript", source: "slack", body: "a" });
+    const ext = await retrieve(db(), seed.teamId, "external", "what is everyone doing?");
+    expect(ext.structured).not.toContain("Activity by person");
+  });
+});


### PR DESCRIPTION
The **payoff** of the whole identity thread. Once Slack threads, Linear/Plane issues, and docs carry the author's `member_id` (the attribution work in #86/#88/#90), *"what is each person doing"* becomes answerable across **every** tool — previously only git had a per-person digest (#86).

## What it does
`retrieve.ts` adds a **per-person activity digest** to the always-included structured context, beside the git digest:
- Counts each person's recent attributed `items` **by source** (Slack / Linear / Plane / docs).
- **Excludes** `git` (the git digest already covers code) and **connector members** (`@connector.local`, the unattributed remainder).
- **team-tier only** (internal activity, hidden from external viewers); runs in parallel with the other retrieval queries.

So a query like *"what has Alex been working on?"* now gets, e.g., `Alex Rivera (alex@corp.com): 12 slack, 5 linear, 3 plane; last active 2026-06-25` in context — grounded in real attributed activity.

## Verification
unit **224** ✓ · data-mechanics **156** ✓ · tsc ✓ · lint ✓ · drift ✓ — new tests prove per-source counts, git exclusion, connector-member exclusion, and external-tier hiding. No schema change.

## Note
Unattributed content (ingested before a person was mapped) sits under the connector and is excluded; the **"Re-attribute content"** button (#92) pulls it onto the right person, after which it appears here.