### PR TITLE
feat(governance): Admin Policies editor + Approvals queue UI

### DIFF
--- a/app/t/[team]/admin/approvals/actions.ts
+++ b/app/t/[team]/admin/approvals/actions.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverClient } from "@/lib/supabase/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { getSessionUser } from "@/lib/auth/session";
+import { resolveIntegrationsAdmin } from "@/lib/integrations/read";
+import { resolveApproval } from "@/lib/actions";
+import { createE2BSandbox } from "@/lib/actions/sandbox/e2b";
+
+async function requireAdmin(teamSlug: string) {
+  const supabase = await serverClient();
+  const user = await getSessionUser();
+  if (!user) return null;
+  return resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+}
+
+/**
+ * Decide a queued approval (admins only). Approve → `resolveApproval` resumes & runs the action's
+ * handler (with the same E2B sandbox the action route uses, so an approved `code.run` can execute —
+ * fails closed if E2B isn't configured); deny → marks it denied. Both audited inside resolveApproval.
+ */
+export async function decideApproval(
+  teamSlug: string,
+  approvalRequestId: string,
+  decision: "approved" | "denied",
+  note?: string
+): Promise<{ ok: boolean; error?: string; message?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  if (decision !== "approved" && decision !== "denied") return { ok: false, error: "invalid decision" };
+  try {
+    const outcome = await resolveApproval(
+      adminClient(),
+      { approvalRequestId, decision, deciderMemberId: ctx.memberId, note },
+      { sandbox: createE2BSandbox() }
+    );
+    revalidatePath(`/t/${teamSlug}/admin/approvals`);
+    if (outcome.status === "not_found") return { ok: false, error: "approval not found" };
+    if (outcome.status === "already_decided") return { ok: false, error: "already decided by someone else" };
+    if (outcome.status === "denied") return { ok: true, message: "Denied." };
+    return { ok: true, message: `Approved${outcome.actionStatus ? ` — action ${outcome.actionStatus}` : ""}.` };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not decide" };
+  }
+}

--- a/app/t/[team]/admin/approvals/page.tsx
+++ b/app/t/[team]/admin/approvals/page.tsx
@@ -1,0 +1,39 @@
+import { serverClient } from "@/lib/supabase/server";
+import { ApprovalsQueue, type ApprovalRow, type DecidedRow } from "@/components/admin/approvals-queue";
+
+export default async function ApprovalsAdminPage({ params }: { params: Promise<{ team: string }> }) {
+  const { team: teamSlug } = await params;
+  const supabase = await serverClient();
+
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  const { data: pending } = await supabase
+    .from("approval_requests")
+    .select("id, requested_by_actor, action, resource, context, created_at")
+    .eq("team_id", team.id)
+    .eq("status", "pending")
+    .order("created_at", { ascending: false });
+
+  const { data: recent } = await supabase
+    .from("approval_requests")
+    .select("id, requested_by_actor, action, resource, status, decided_at, decision_note")
+    .eq("team_id", team.id)
+    .in("status", ["approved", "denied", "expired"])
+    .order("decided_at", { ascending: false })
+    .limit(10);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-ink-secondary">
+        Agent actions that matched a <code>require_approval</code> policy and are waiting on a human.
+        Approving resumes and runs the action; denying stops it. Both are audited.
+      </p>
+      <ApprovalsQueue
+        teamSlug={teamSlug}
+        pending={(pending ?? []) as ApprovalRow[]}
+        recent={(recent ?? []) as DecidedRow[]}
+      />
+    </div>
+  );
+}

--- a/app/t/[team]/admin/policies/actions.ts
+++ b/app/t/[team]/admin/policies/actions.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverClient } from "@/lib/supabase/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { getSessionUser } from "@/lib/auth/session";
+import { resolveIntegrationsAdmin } from "@/lib/integrations/read";
+import { createPolicy, updatePolicy, setPolicyEnabled, deletePolicy, type PolicyInput } from "@/lib/policy/manage";
+
+/** Admin gate (same shared resolver the other admin actions use). */
+async function requireAdmin(teamSlug: string) {
+  const supabase = await serverClient();
+  const user = await getSessionUser();
+  if (!user) return null;
+  return resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+}
+
+export type PolicyForm = PolicyInput & { id?: string };
+
+/** Create (no id) or update (id) a policy rule (admins only). */
+export async function savePolicy(teamSlug: string, form: PolicyForm): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  const actor = { memberId: ctx.memberId };
+  try {
+    if (form.id) await updatePolicy(adminClient(), ctx.teamId, form.id, form, actor);
+    else await createPolicy(adminClient(), ctx.teamId, form, actor);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not save policy" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/policies`);
+  return { ok: true };
+}
+
+export async function togglePolicy(teamSlug: string, id: string, enabled: boolean): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    await setPolicyEnabled(adminClient(), ctx.teamId, id, enabled, { memberId: ctx.memberId });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not toggle" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/policies`);
+  return { ok: true };
+}
+
+export async function removePolicy(teamSlug: string, id: string): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    await deletePolicy(adminClient(), ctx.teamId, id, { memberId: ctx.memberId });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not delete" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/policies`);
+  return { ok: true };
+}

--- a/app/t/[team]/admin/policies/page.tsx
+++ b/app/t/[team]/admin/policies/page.tsx
@@ -1,0 +1,25 @@
+import { serverClient } from "@/lib/supabase/server";
+import { listAllPolicies } from "@/lib/policy/manage";
+import { PoliciesManager } from "@/components/admin/policies-manager";
+
+export default async function PoliciesAdminPage({ params }: { params: Promise<{ team: string }> }) {
+  const { team: teamSlug } = await params;
+  const supabase = await serverClient();
+
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  const policies = await listAllPolicies(supabase, team.id);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-ink-secondary">
+        Rules the brain evaluates before an agent acts (<code>POST /api/v1/actions</code> → <code>authorize()</code>).
+        <strong> Default-deny</strong>: with no matching <code>allow</code>, an action is denied. Highest{" "}
+        <code>priority</code> wins; ties break most-restrictive (deny &gt; require_approval &gt; allow). Subject fields
+        left blank match anyone; <code>action</code>/<code>resource</code> are <code>*</code>-globs.
+      </p>
+      <PoliciesManager teamSlug={teamSlug} policies={policies} />
+    </div>
+  );
+}

--- a/components/admin/admin-tabs.tsx
+++ b/components/admin/admin-tabs.tsx
@@ -9,6 +9,8 @@ const TABS = [
   { slug: "keys", label: "API keys" },
   { slug: "integrations", label: "Integrations" },
   { slug: "pm-sync", label: "PM sync" },
+  { slug: "policies", label: "Policies" },
+  { slug: "approvals", label: "Approvals" },
   { slug: "audit", label: "Audit log" },
 ];
 

--- a/components/admin/approvals-queue.tsx
+++ b/components/admin/approvals-queue.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Check, X, Clock } from "lucide-react";
+import { decideApproval } from "@/app/t/[team]/admin/approvals/actions";
+
+export interface ApprovalRow {
+  id: string;
+  requested_by_actor: string;
+  action: string;
+  resource: string;
+  context: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface DecidedRow {
+  id: string;
+  requested_by_actor: string;
+  action: string;
+  resource: string;
+  status: string;
+  decided_at: string | null;
+  decision_note: string;
+}
+
+export function ApprovalsQueue({ teamSlug, pending, recent }: { teamSlug: string; pending: ApprovalRow[]; recent: DecidedRow[] }) {
+  const router = useRouter();
+  const [pendingTx, startTransition] = useTransition();
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  function decide(id: string, decision: "approved" | "denied") {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const res = await decideApproval(teamSlug, id, decision, notes[id]);
+      if (!res.ok) return setError(res.error ?? "could not decide");
+      setNotice(res.message ?? "Done.");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <p className="flex items-center gap-2 text-sm font-medium text-ink"><Clock className="size-4 text-amber-600" /> Pending ({pending.length})</p>
+        {pending.length === 0 ? (
+          <p className="text-sm text-ink-tertiary">Nothing waiting for approval.</p>
+        ) : (
+          pending.map((a) => (
+            <div key={a.id} className="prism-card flex flex-col gap-2 p-4">
+              <div className="flex flex-wrap items-center gap-2 text-sm">
+                <span className="rounded-full bg-amber/10 px-2 py-0.5 font-mono text-xs text-amber-700">{a.action}</span>
+                <span className="font-mono text-xs text-ink-secondary">{a.resource}</span>
+                <span className="text-xs text-ink-tertiary">requested by <span className="font-mono">{a.requested_by_actor || "—"}</span> · {new Date(a.created_at).toLocaleString()}</span>
+              </div>
+              {a.context && Object.keys(a.context).length ? (
+                <pre className="max-h-32 overflow-auto rounded-lg bg-surface-overlay p-2 text-xs text-ink-secondary">{JSON.stringify(a.context, null, 2)}</pre>
+              ) : null}
+              <div className="flex flex-wrap items-center gap-2">
+                <input
+                  className="prism-input h-8 flex-1 px-2 py-0 text-xs"
+                  placeholder="note (optional)"
+                  value={notes[a.id] ?? ""}
+                  onChange={(e) => setNotes({ ...notes, [a.id]: e.target.value })}
+                />
+                <button onClick={() => decide(a.id, "approved")} disabled={pendingTx} className="flex items-center gap-1 rounded-lg border border-emerald/40 bg-emerald/10 px-3 py-1 text-xs font-medium text-emerald-700 disabled:opacity-50"><Check className="size-3.5" /> Approve</button>
+                <button onClick={() => decide(a.id, "denied")} disabled={pendingTx} className="flex items-center gap-1 rounded-lg border border-red/40 bg-red/10 px-3 py-1 text-xs font-medium text-red disabled:opacity-50"><X className="size-3.5" /> Deny</button>
+              </div>
+            </div>
+          ))
+        )}
+        {error ? <p className="text-sm text-red">{error}</p> : null}
+        {notice ? <p className="text-sm text-emerald-700">{notice}</p> : null}
+      </div>
+
+      {recent.length ? (
+        <div className="flex flex-col gap-2">
+          <p className="text-sm font-medium text-ink-secondary">Recently decided</p>
+          <div className="prism-card divide-y divide-border-subtle">
+            {recent.map((a) => (
+              <div key={a.id} className="flex flex-wrap items-center gap-2 px-4 py-2 text-xs">
+                <span className={`rounded-full px-2 py-0.5 ${a.status === "approved" ? "bg-emerald/10 text-emerald-700" : "bg-red/10 text-red"}`}>{a.status}</span>
+                <span className="font-mono text-ink">{a.action}</span>
+                <span className="font-mono text-ink-tertiary">{a.resource}</span>
+                <span className="text-ink-tertiary">{a.decided_at ? new Date(a.decided_at).toLocaleString() : ""}</span>
+                {a.decision_note ? <span className="text-ink-tertiary">— {a.decision_note}</span> : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/admin/policies-manager.tsx
+++ b/components/admin/policies-manager.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Shield, Plus, Trash2, Pencil } from "lucide-react";
+import { savePolicy, togglePolicy, removePolicy, type PolicyForm } from "@/app/t/[team]/admin/policies/actions";
+
+type Effect = "allow" | "deny" | "require_approval";
+
+export interface PolicyRow {
+  id: string;
+  priority: number;
+  description: string;
+  subject_role: string | null;
+  subject_tier: string | null;
+  subject_actor: string | null;
+  action: string;
+  resource: string;
+  effect: Effect;
+  enabled: boolean;
+}
+
+const EFFECT_STYLE: Record<Effect, string> = {
+  allow: "bg-emerald/10 text-emerald-700",
+  deny: "bg-red/10 text-red",
+  require_approval: "bg-amber/10 text-amber-700",
+};
+
+const EMPTY: PolicyForm = { action: "", resource: "*", effect: "allow", priority: 0, description: "", subjectRole: null, subjectTier: null, subjectActor: "", enabled: true };
+
+function subjectLabel(p: PolicyRow): string {
+  const parts = [p.subject_role, p.subject_tier, p.subject_actor].filter(Boolean);
+  return parts.length ? parts.join(" · ") : "anyone";
+}
+
+export function PoliciesManager({ teamSlug, policies }: { teamSlug: string; policies: PolicyRow[] }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<PolicyForm>(EMPTY);
+  const editing = !!form.id;
+
+  function run(fn: () => Promise<{ ok: boolean; error?: string }>, after?: () => void) {
+    setError(null);
+    startTransition(async () => {
+      const res = await fn();
+      if (!res.ok) return setError(res.error ?? "something went wrong");
+      after?.();
+      router.refresh();
+    });
+  }
+
+  function edit(p: PolicyRow) {
+    setForm({
+      id: p.id, description: p.description, priority: p.priority,
+      subjectRole: (p.subject_role as PolicyForm["subjectRole"]) ?? null,
+      subjectTier: (p.subject_tier as PolicyForm["subjectTier"]) ?? null,
+      subjectActor: p.subject_actor ?? "", action: p.action, resource: p.resource, effect: p.effect, enabled: p.enabled,
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form
+        onSubmit={(e) => { e.preventDefault(); run(() => savePolicy(teamSlug, form), () => setForm(EMPTY)); }}
+        className="prism-card flex flex-col gap-3 p-4"
+      >
+        <p className="flex items-center gap-2 text-sm font-medium text-ink">
+          {editing ? <Pencil className="size-4 text-violet" /> : <Plus className="size-4 text-violet" />}
+          {editing ? "Edit policy" : "Add a policy"}
+        </p>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <label className="flex flex-col gap-1 text-xs text-ink-tertiary">Subject role
+            <select className="prism-input" value={form.subjectRole ?? ""} onChange={(e) => setForm({ ...form, subjectRole: (e.target.value || null) as PolicyForm["subjectRole"] })}>
+              <option value="">any</option><option value="admin">admin</option><option value="lead">lead</option><option value="member">member</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-ink-tertiary">Subject tier
+            <select className="prism-input" value={form.subjectTier ?? ""} onChange={(e) => setForm({ ...form, subjectTier: (e.target.value || null) as PolicyForm["subjectTier"] })}>
+              <option value="">any</option><option value="team">team</option><option value="external">external</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-ink-tertiary">Subject actor
+            <input className="prism-input" placeholder="any (actor handle)" value={form.subjectActor ?? ""} onChange={(e) => setForm({ ...form, subjectActor: e.target.value })} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-ink-tertiary">Priority
+            <input type="number" className="prism-input" value={form.priority ?? 0} onChange={(e) => setForm({ ...form, priority: Number(e.target.value) })} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-ink-tertiary">Action (glob)
+            <input className="prism-input" placeholder="code.run" value={form.action} onChange={(e) => setForm({ ...form, action: e.target.value })} required />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-ink-tertiary">Resource (glob)
+            <input className="prism-input" placeholder="*" value={form.resource ?? "*"} onChange={(e) => setForm({ ...form, resource: e.target.value })} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-ink-tertiary">Effect
+            <select className="prism-input" value={form.effect} onChange={(e) => setForm({ ...form, effect: e.target.value as Effect })}>
+              <option value="allow">allow</option><option value="require_approval">require_approval</option><option value="deny">deny</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-ink-tertiary">Description
+            <input className="prism-input" placeholder="why" value={form.description ?? ""} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+          </label>
+        </div>
+        <div className="flex items-center gap-2">
+          <button type="submit" disabled={pending} className="btn-prism justify-center"><Shield className="size-4" /> {editing ? "Save changes" : "Add policy"}</button>
+          {editing ? <button type="button" onClick={() => setForm(EMPTY)} className="rounded-lg border border-border-default px-3 py-1.5 text-sm text-ink-secondary">Cancel</button> : null}
+          {error ? <p className="text-sm text-red">{error}</p> : null}
+        </div>
+      </form>
+
+      {policies.length === 0 ? (
+        <p className="text-sm text-ink-tertiary">No policies yet — with none, every agent action is denied by default. Add an <code>allow</code> rule to permit something.</p>
+      ) : (
+        <div className="prism-card overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border-subtle text-left text-xs uppercase tracking-wide text-ink-tertiary">
+                <th className="px-3 py-2">Pri</th><th className="px-3 py-2">Subject</th><th className="px-3 py-2">Action</th><th className="px-3 py-2">Resource</th><th className="px-3 py-2">Effect</th><th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {policies.map((p) => (
+                <tr key={p.id} className={`border-b border-border-subtle last:border-0 ${p.enabled ? "" : "opacity-50"}`}>
+                  <td className="px-3 py-2 font-mono text-xs text-ink-secondary">{p.priority}</td>
+                  <td className="px-3 py-2 text-ink-secondary">{subjectLabel(p)}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-ink">{p.action}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-ink-secondary">{p.resource}</td>
+                  <td className="px-3 py-2"><span className={`rounded-full px-2 py-0.5 text-xs ${EFFECT_STYLE[p.effect]}`}>{p.effect}</span></td>
+                  <td className="px-3 py-2">
+                    <div className="flex items-center justify-end gap-1.5">
+                      <button onClick={() => run(() => togglePolicy(teamSlug, p.id, !p.enabled))} disabled={pending} className={`rounded-lg border px-2 py-0.5 text-xs ${p.enabled ? "border-violet/40 bg-violet/10 text-violet" : "border-border-default text-ink-tertiary"}`}>{p.enabled ? "On" : "Off"}</button>
+                      <button onClick={() => edit(p)} className="rounded-lg border border-border-default p-1 text-ink-secondary hover:text-ink" aria-label="Edit"><Pencil className="size-3.5" /></button>
+                      <button onClick={() => { if (window.confirm("Delete this policy?")) run(() => removePolicy(teamSlug, p.id)); }} disabled={pending} className="rounded-lg border border-border-default p-1 text-ink-secondary hover:text-red" aria-label="Delete"><Trash2 className="size-3.5" /></button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,8 +25,8 @@ Reason from this table, not from a random call site.
 | Primary PM provider | `teams.primary_pm_provider` | Admin → Integrations (`setPrimaryPmProvider`, admin-gated + audited) | `lib/pm-sync` projection | the single PM tool the brain projects into; null = projection no-ops / sole-enabled fallback |
 | Work events | `work_events` | `POST /api/v1/work-events` → `lib/work-events` | Admin → PM sync health | team-tier only; unresolved events are preserved for reconciliation |
 | Decisions | `decisions` | `lib/ingest` (sync rows) + `app/actions/decisions.ts` (UI; `source_item_id` NULL) | dashboard, `/api/v1/decisions` | team-scoped; UI rows (`source_item_id` NULL) never diff-deleted; writeback tier-scoped by `audience` |
-| Policy rules | `policies` | admin (role-gated) | `lib/policy.authorize` | role-gated (admin/lead) |
-| Approvals | `approval_requests` | `lib/policy.fileApprovalRequest`, `lib/actions.resolveApproval` | dashboard | role-gated decide |
+| Policy rules | `policies` | **`lib/policy/manage` only** (validated + audited) via the **Admin → Policies** editor (`savePolicy`/`togglePolicy`/`removePolicy`, admin-gated) | `lib/policy.authorize` (enabled-only) + the editor (`listAllPolicies`, incl. disabled) | admin-gated (the whole `/admin` area is) |
+| Approvals | `approval_requests` | `lib/policy.fileApprovalRequest` (queue) + `lib/actions.resolveApproval` (decide) — decided from the **Admin → Approvals** queue (`decideApproval`, admin-gated; approve resumes the action with the E2B sandbox) | Admin → Approvals page | admin-gated decide; audited |
 | Actions | `actions` | **`lib/actions.runAction` only** (service role) | dashboard | team-scoped |
 | Audit | `audit_log` | `lib/api/audit` (append-only, trigger-backed) | admin | append-only; admin read |
 | Identity | `teams`, `members`, `api_keys` | admin UI / seed / `lib/admin/*` (CLI: create/disable/delete members, rename teams, issue/revoke keys) | `lib/auth`, guards | role-gated; `key_hash` column-revoked; member disable/delete + team rename are audited (`member.disabled`/`member.deleted`/`team.renamed`); delete refuses the last active admin |

--- a/lib/policy/manage.ts
+++ b/lib/policy/manage.ts
@@ -1,0 +1,154 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { audit } from "@/lib/api/audit";
+import type { PolicyEffect } from "./evaluate";
+
+/**
+ * The single write path for the `policies` table — what the admin Policies editor calls. Validates
+ * the rule shape and audits every change, so policy authoring is centralized + traceable (the
+ * pure evaluator in ./evaluate decides; this just stores the rules it reads). Reads via
+ * `listAllPolicies` (incl. disabled, for the editor); `lib/policy.loadPolicies` loads enabled-only
+ * for `authorize()`.
+ */
+
+const EFFECTS: PolicyEffect[] = ["allow", "deny", "require_approval"];
+const ROLES = ["admin", "lead", "member"];
+const TIERS = ["team", "external"];
+
+export interface PolicyInput {
+  description?: string;
+  priority?: number;
+  subjectRole?: "admin" | "lead" | "member" | null;
+  subjectTier?: "team" | "external" | null;
+  subjectActor?: string | null;
+  action: string;
+  resource?: string;
+  effect: PolicyEffect;
+  enabled?: boolean;
+}
+
+export interface PolicyRecord {
+  id: string;
+  priority: number;
+  description: string;
+  subject_role: string | null;
+  subject_tier: string | null;
+  subject_actor: string | null;
+  action: string;
+  resource: string;
+  effect: PolicyEffect;
+  enabled: boolean;
+}
+
+export interface PolicyActor {
+  memberId?: string | null;
+}
+
+function validate(input: PolicyInput): void {
+  if (!input.action?.trim()) throw new Error("action is required (e.g. \"code.run\" or \"item.*\")");
+  if (!EFFECTS.includes(input.effect)) throw new Error(`invalid effect "${input.effect}"`);
+  if (input.subjectRole && !ROLES.includes(input.subjectRole)) throw new Error("invalid subject role");
+  if (input.subjectTier && !TIERS.includes(input.subjectTier)) throw new Error("invalid subject tier");
+  if (input.priority != null && !Number.isInteger(input.priority)) throw new Error("priority must be an integer");
+}
+
+/** The mutable rule fields (shared by create + update). */
+function fields(input: PolicyInput) {
+  return {
+    priority: input.priority ?? 0,
+    description: (input.description ?? "").trim(),
+    subject_role: input.subjectRole ?? null,
+    subject_tier: input.subjectTier ?? null,
+    subject_actor: (input.subjectActor ?? "").trim() || null,
+    action: input.action.trim(),
+    resource: (input.resource ?? "*").trim() || "*",
+    effect: input.effect,
+    enabled: input.enabled ?? true,
+  };
+}
+
+export async function listAllPolicies(supabase: SupabaseClient, teamId: string): Promise<PolicyRecord[]> {
+  const { data, error } = await supabase
+    .from("policies")
+    .select("id, priority, description, subject_role, subject_tier, subject_actor, action, resource, effect, enabled")
+    .eq("team_id", teamId)
+    .order("priority", { ascending: false })
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(`policy list failed: ${error.message}`);
+  return (data ?? []) as PolicyRecord[];
+}
+
+export async function createPolicy(
+  supabase: SupabaseClient,
+  teamId: string,
+  input: PolicyInput,
+  actor: PolicyActor = {}
+): Promise<string> {
+  validate(input);
+  const { data, error } = await supabase
+    .from("policies")
+    .insert({ team_id: teamId, created_by: actor.memberId ?? null, ...fields(input) })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`policy create failed: ${error?.message}`);
+  await audit(supabase, {
+    team_id: teamId, actor_kind: "member", member_id: actor.memberId ?? null,
+    action: "policy.created", target_type: "policy", target_id: data.id,
+    meta: { action: input.action, effect: input.effect, resource: input.resource ?? "*" },
+  });
+  return data.id;
+}
+
+export async function updatePolicy(
+  supabase: SupabaseClient,
+  teamId: string,
+  id: string,
+  input: PolicyInput,
+  actor: PolicyActor = {}
+): Promise<void> {
+  validate(input);
+  const { error } = await supabase
+    .from("policies")
+    .update({ ...fields(input), updated_at: new Date().toISOString() })
+    .eq("team_id", teamId)
+    .eq("id", id);
+  if (error) throw new Error(`policy update failed: ${error.message}`);
+  await audit(supabase, {
+    team_id: teamId, actor_kind: "member", member_id: actor.memberId ?? null,
+    action: "policy.updated", target_type: "policy", target_id: id,
+    meta: { action: input.action, effect: input.effect },
+  });
+}
+
+export async function setPolicyEnabled(
+  supabase: SupabaseClient,
+  teamId: string,
+  id: string,
+  enabled: boolean,
+  actor: PolicyActor = {}
+): Promise<void> {
+  const { error } = await supabase
+    .from("policies")
+    .update({ enabled, updated_at: new Date().toISOString() })
+    .eq("team_id", teamId)
+    .eq("id", id);
+  if (error) throw new Error(`policy toggle failed: ${error.message}`);
+  await audit(supabase, {
+    team_id: teamId, actor_kind: "member", member_id: actor.memberId ?? null,
+    action: enabled ? "policy.enabled" : "policy.disabled", target_type: "policy", target_id: id, meta: {},
+  });
+}
+
+export async function deletePolicy(
+  supabase: SupabaseClient,
+  teamId: string,
+  id: string,
+  actor: PolicyActor = {}
+): Promise<void> {
+  const { error } = await supabase.from("policies").delete().eq("team_id", teamId).eq("id", id);
+  if (error) throw new Error(`policy delete failed: ${error.message}`);
+  await audit(supabase, {
+    team_id: teamId, actor_kind: "member", member_id: actor.memberId ?? null,
+    action: "policy.deleted", target_type: "policy", target_id: id, meta: {},
+  });
+}

--- a/test/datamechanics/policy-manage.datamechanics.test.ts
+++ b/test/datamechanics/policy-manage.datamechanics.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { authorize } from "@/lib/policy";
+import { createPolicy, setPolicyEnabled, deletePolicy, listAllPolicies } from "@/lib/policy/manage";
+import { db, seedTeam } from "./helpers";
+
+// Spec: a policy authored in the admin UI (via lib/policy/manage) actually GOVERNS the engine's
+// authorize() decision — the whole point of the Policies editor. Verified on real Postgres.
+
+const principal = { role: "member" as const, tier: "team" as const, actor: "alex" };
+const req = { principal, action: "code.run", resource: "*" };
+
+describe("policy manage → authorize (real Postgres)", () => {
+  it("a UI-created policy governs authorize(); priority + toggle + delete all reflect", async () => {
+    const seed = await seedTeam();
+
+    // Default-deny with no rules.
+    expect((await authorize(db(), seed.teamId, req)).effect).toBe("deny");
+
+    // Create an allow → now allowed.
+    const allowId = await createPolicy(db(), seed.teamId, { action: "code.run", effect: "allow", priority: 1 });
+    expect((await authorize(db(), seed.teamId, req)).effect).toBe("allow");
+
+    // A higher-priority require_approval wins.
+    await createPolicy(db(), seed.teamId, { action: "code.*", effect: "require_approval", priority: 5 });
+    expect((await authorize(db(), seed.teamId, req)).effect).toBe("require_approval");
+
+    // Disabling the allow: listAllPolicies still shows it (editor needs disabled), authorize ignores it.
+    await setPolicyEnabled(db(), seed.teamId, allowId, false);
+    expect((await listAllPolicies(db(), seed.teamId)).find((p) => p.id === allowId)?.enabled).toBe(false);
+
+    // Delete the require_approval rule → only the (disabled) allow remains → back to default deny.
+    const ra = (await listAllPolicies(db(), seed.teamId)).find((p) => p.effect === "require_approval")!;
+    await deletePolicy(db(), seed.teamId, ra.id);
+    expect((await authorize(db(), seed.teamId, req)).effect).toBe("deny");
+  });
+
+  it("validates effect + requires an action", async () => {
+    const seed = await seedTeam();
+    await expect(createPolicy(db(), seed.teamId, { action: "", effect: "allow" })).rejects.toThrow(/action is required/);
+    await expect(createPolicy(db(), seed.teamId, { action: "x", effect: "bogus" as never })).rejects.toThrow(/invalid effect/);
+  });
+});


### PR DESCRIPTION
Closes the loop on **Organs 4 & 6**: the policy engine + approval queue were fully built and tested, but had **no human surface** — policy rules could only be inserted via SQL, and a `require_approval` action would queue with **no way to decide it** (`resolveApproval` was unwired to any UI). This adds both surfaces.

## Admin → Policies
Author / edit / toggle / delete policy rules in the dashboard: subject (role / tier / actor), `action` + `resource` globs, effect (allow / require_approval / deny), priority. Writes go through **`lib/policy/manage`** — the validated, audited single write path; the pure evaluator in `lib/policy/evaluate` is unchanged.

## Admin → Approvals
The pending-approvals queue with **Approve / Deny** wired to `lib/actions.resolveApproval`: approve **resumes and runs** the queued action (with the same E2B sandbox the action route uses — `code.run` fails closed if E2B isn't configured), deny stops it. Both audited. Shows the request context + a "recently decided" list.

Two new admin tabs (Policies, Approvals). The whole `/admin` area is already admin-gated; actions defense-in-depth gate too.

## Verified end-to-end (real Postgres + live browser)
- **data-mechanics:** a policy authored via `manage` actually **governs `authorize()`** — create→allow, a higher-priority `require_approval` wins, disable/delete reflect; plus validation. *(This is the spec: a UI-created rule changes the engine's decision.)*
- **live:** seeded 3 policies + a pending `code.run` approval, rendered both pages, clicked **Approve** → the request flips to `approved` (decider recorded), the action **resumes** (fails closed without a sandbox, as designed), and `approval.approved` lands in the audit log. Screenshots captured.
- unit **233** · data-mechanics **167** · tsc · lint · drift ✓. **No schema change.**

## Note
Approving a `code.run` only *executes* if an E2B sandbox is configured (`E2B_API_KEY`); otherwise it resumes and fails closed — the safe default. `note.create`-style actions resume and run fully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin pages for managing policies and approval requests.
  * Added a richer approvals queue with pending items, recent decisions, and approve/deny actions.
  * Added policy management tools to create, edit, enable/disable, and remove rules.
  * Added admin navigation links for the new sections.

* **Bug Fixes**
  * Improved handling for missing teams, invalid inputs, and failed approval or policy actions with clear feedback.

* **Documentation**
  * Updated governance docs to match the new admin workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->