### PR TITLE
feat(query): semantic retrieval via Graphiti query-expansion

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,7 +136,7 @@ sequenceDiagram
   participant LLM as Claude
   U->>Q: {question, project?}
   Q->>Q: auth · cost guard (per-member/day, per-team $/day in query_log)
-  Q->>RET: tier-filtered FTS top-12 + recent + structured digest (incl. per-contributor git activity + per-person cross-tool activity, team tier)
+  Q->>RET: tier-filtered FTS top-12 + recent + Graphiti semantic expansion + structured digest (incl. per-contributor git activity + per-person cross-tool activity, team tier)
   RET-->>Q: {sources[], structured}
   Q->>CL: streamAnswer(ctx, question)
   CL->>LLM: cached system + numbered sources + question
@@ -145,8 +145,12 @@ sequenceDiagram
 
 > **Retrieval recall is benchmarked.** `test/datamechanics/retrieval-eval.datamechanics.test.ts` is a
 > deterministic eval: a fixed corpus + question→expected-source cases scoring recall@sources through the
-> real `retrieve()`. It pins the current keyword-FTS floor (6/9; the 3 misses are paraphrase/"semantic"
-> gaps) so retrieval upgrades (semantic/hybrid) are *provable* and regressions fail CI.
+> real `retrieve()`. It pins the keyword-FTS floor (6/9; 3 paraphrase/"semantic" gaps) so retrieval
+> upgrades are *provable* and regressions fail CI. **Semantic expansion** (`graphExpansionQuery`): when
+> Graphiti is configured, its hybrid search returns the relevant entities/facts for a question; those
+> terms expand a second FTS pass to surface items a literal search missed. The live eval
+> (`retrieval-semantic.datamechanics.test.ts`, self-skips unless `GRAPHITI_URL` is set) proves it
+> closes all 3 gaps (6/9 → 9/9 on the gap set).
 
 ### Ingestion sidecar pipeline
 

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -166,6 +166,32 @@ export function toOrQuery(question: string): string {
   return unique.length ? unique.join(" or ") : question;
 }
 
+const MAX_EXPANSION_TERMS = 24;
+
+/**
+ * SEMANTIC EXPANSION via Graphiti. The graph's hybrid search returns the *facts* (entities +
+ * relationships) relevant to a question even when it's phrased with no surface-term overlap. We
+ * harvest the salient words from those facts (entity names + fact text) into extra FTS OR-terms, so
+ * a second keyword pass can reach the *source items* a literal search missed (paraphrase/synonym
+ * recall — Graphiti's `/search` returns facts, not item ids, so query-expansion is how we surface
+ * items). Pure + unit-tested; returns "" when there are no facts (→ keyword-only, no behavior change).
+ */
+export function graphExpansionQuery(facts: GraphFact[]): string {
+  const terms = new Set<string>();
+  const add = (s: string | undefined | null) => {
+    for (const w of (s ?? "").toLowerCase().match(/[a-z0-9][a-z0-9'-]*/g) ?? []) {
+      if (w.length >= 3 && !FTS_STOP.has(w)) terms.add(w);
+    }
+  };
+  for (const f of facts) {
+    add(f.source_node_name);
+    add(f.target_node_name);
+    add(f.fact);
+    if (terms.size >= MAX_EXPANSION_TERMS) break;
+  }
+  return [...terms].slice(0, MAX_EXPANSION_TERMS).join(" or ");
+}
+
 /**
  * Per-contributor git-activity digest from `code_contributions` (the scan aggregates). This is the
  * ONLY place the query pipeline surfaces git history — without it, "what is John doing in git" has
@@ -422,6 +448,32 @@ export async function retrieve(
     });
   }
 
+  // 2c. Semantic expansion via Graphiti (the graph search ran in parallel above). Use the facts'
+  // entity/relationship terms to expand the FTS and surface items the literal keyword search missed.
+  // No-op when Graphiti is unconfigured / returned nothing → pure keyword behavior, no regression.
+  const graphFacts = await graphFactsP;
+  const expansion = graphExpansionQuery(graphFacts);
+  if (expansion) {
+    let semB = supabase
+      .from("items")
+      .select("id, path, kind, body, synced_at, projects(slug)")
+      .eq("team_id", teamId)
+      .textSearch("search", expansion, { type: "websearch", config: "english" })
+      .limit(10);
+    if (tier === "external") semB = semB.eq("access", "external");
+    const { data: semHits } = await semB;
+    for (const hit of (semHits ?? []) as { id: string; path: string; kind: string; body: string; synced_at: string; projects: unknown }[]) {
+      if (seen.has(hit.id)) continue;
+      seen.add(hit.id);
+      const slug = (hit.projects as { slug: string })?.slug ?? "";
+      if (projectSlug && slug !== projectSlug) continue;
+      const text = (hit.body || "").slice(0, MAX_SOURCE_CHARS);
+      if (total + text.length > MAX_TOTAL_CHARS) break;
+      total += text.length;
+      sources.push({ sid: `S${n++}`, item_id: hit.id, project: slug, path: hit.path, kind: hit.kind, synced_at: hit.synced_at, text });
+    }
+  }
+
   // 3. Structured context (compact, always included) — built from the parallel results above.
   const [gitDigest, peopleDigest] = await Promise.all([gitDigestP, peopleDigestP]);
   const structured = [
@@ -454,8 +506,8 @@ export async function retrieve(
     peopleDigest,
   ].join("\n");
 
-  // 3b. Blend in Graphiti temporal facts (graph memory over all ingestions), if any.
-  const graphFacts = await graphFactsP;
+  // 3b. Blend in Graphiti temporal facts (graph memory over all ingestions), if any. (`graphFacts`
+  // was awaited above for the semantic expansion.)
   const structuredWithGraph = graphFacts.length
     ? structured +
       "\n\n" +

--- a/test/datamechanics/retrieval-semantic.datamechanics.test.ts
+++ b/test/datamechanics/retrieval-semantic.datamechanics.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { retrieve } from "@/lib/query/retrieve";
+import { projectItemsToGraph } from "@/lib/graph/project";
+import { GraphitiClient } from "@/lib/graph/graphiti-client";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+
+/**
+ * LIVE eval for semantic retrieval (Organ 3). Proves that Graphiti-backed query expansion closes the
+ * paraphrase gaps the keyword-FTS floor misses (the 3 gaps recorded in retrieval-eval). It needs a
+ * running Graphiti stack + an LLM key for extraction, so it SELF-SKIPS unless GRAPHITI_URL is set —
+ * CI (keyword-only) is unaffected; run it locally against `graphiti/docker-compose.yml`:
+ *   GRAPHITI_URL=http://localhost:8000 npm run test:datamechanics:local -- retrieval-semantic
+ */
+
+const live = process.env.GRAPHITI_URL ? describe : describe.skip;
+
+interface Doc { path: string; body: string; kind?: "deliverable" | "transcript" }
+
+// The 3 keyword-floor gap targets — paraphrase questions with no surface-term overlap.
+const TARGETS: Doc[] = [
+  { path: "deliverables/auth-redesign.md", body: "Authentication redesign: we migrated to passwordless magic links and removed the legacy password flow entirely." },
+  { path: "transcripts/customer-call.md", kind: "transcript", body: "Call with Acme Corp: they require single sign-on and audit logs before signing the enterprise contract." },
+  { path: "deliverables/perf-notes.md", body: "The dashboard felt sluggish; we added database indexes and cut p95 latency from 1200ms to 180ms." },
+];
+// Fillers (ingested after) dominate the recency window so only search can surface the targets.
+const FILLERS: Doc[] = [
+  { path: "deliverables/lunch.md", body: "Team lunch moves to Thursdays; vegetarian options added to the catering order." },
+  { path: "deliverables/wifi.md", body: "Office wifi password rotates monthly; grab it from the front desk." },
+  { path: "deliverables/holiday.md", body: "Office closed the last week of December for the winter break." },
+  { path: "deliverables/expenses.md", body: "Submit travel expense reports by the fifth of each month." },
+  { path: "deliverables/parking.md", body: "Visitor parking is in lot C; register the plate at reception." },
+  { path: "deliverables/allhands.md", body: "The monthly all-hands moves to the larger room downstairs." },
+  { path: "deliverables/desk.md", body: "Hot desks are bookable a week ahead through the room calendar." },
+  { path: "deliverables/printer.md", body: "The third-floor printer is back online; install the driver from the portal." },
+];
+const GAPS = [
+  { q: "how do users sign in now?", target: "deliverables/auth-redesign.md" },
+  { q: "what does the large prospect need before they commit?", target: "transcripts/customer-call.md" },
+  { q: "what made the app faster?", target: "deliverables/perf-notes.md" },
+];
+
+let seed: Seed;
+
+live("semantic retrieval via live Graphiti", () => {
+  beforeEach(async () => {
+    seed = await seedTeam();
+    for (const d of [...TARGETS, ...FILLERS]) {
+      await ingest(seed, { kind: d.kind ?? "deliverable", path: d.path, body: d.body, access: "team" });
+    }
+  });
+
+  it("closes the keyword-floor paraphrase gaps once items are in the graph", async () => {
+    // Project into Graphiti, then wait for async LLM extraction (serial; ~15s/episode).
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: seed.teamSlug, client: new GraphitiClient() });
+    await new Promise((r) => setTimeout(r, 180_000));
+
+    const missed: string[] = [];
+    for (const g of GAPS) {
+      const ctx = await retrieve(db(), seed.teamId, "team", g.q);
+      if (!ctx.sources.map((s) => s.path).includes(g.target)) missed.push(`${g.q} → ${g.target}`);
+    }
+    console.info(`[semantic-live] gaps closed: ${GAPS.length - missed.length}/${GAPS.length}` + (missed.length ? `; still missed: ${missed.join("; ")}` : ""));
+    expect(missed, "semantic expansion should retrieve these paraphrase targets").toEqual([]);
+  }, 300_000);
+});

--- a/test/query-recall.test.ts
+++ b/test/query-recall.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { toOrQuery } from "@/lib/query/retrieve";
+import { toOrQuery, graphExpansionQuery } from "@/lib/query/retrieve";
+import type { GraphFact } from "@/lib/graph/graphiti-client";
 
 // Spec for the FTS recall fix: the AI query box failed "what has john ellison been posting to slack?"
 // because websearch AND-semantics required EVERY term in the body. toOrQuery drops question/stopwords
@@ -18,5 +19,32 @@ describe("toOrQuery (FTS recall)", () => {
 
   it("falls back to the raw question when nothing significant remains", () => {
     expect(toOrQuery("what is it?")).toBe("what is it?");
+  });
+});
+
+// Spec: Graphiti facts → FTS expansion terms. A paraphrased question ("how do users sign in?") has
+// no overlap with the auth doc, but the graph's facts name the real entities ("magic links",
+// "passwordless authentication"); harvesting those lets a second FTS pass reach the source item.
+describe("graphExpansionQuery (semantic expansion)", () => {
+  const facts: GraphFact[] = [
+    { fact: "Authentication uses passwordless magic links", source_node_name: "Authentication", target_node_name: "Magic Links" },
+    { fact: "The legacy password flow was removed" },
+  ];
+
+  it("harvests entity names + fact terms into an OR query (lowercased, stopwords/short dropped)", () => {
+    const q = graphExpansionQuery(facts);
+    for (const t of ["authentication", "passwordless", "magic", "links", "legacy", "password", "flow"]) {
+      expect(q.split(" or ")).toContain(t);
+    }
+    expect(q.split(" or ")).not.toContain("the"); // stopword dropped (as a standalone term)
+  });
+
+  it("returns '' for no facts (→ keyword-only, no behavior change)", () => {
+    expect(graphExpansionQuery([])).toBe("");
+  });
+
+  it("caps the number of expansion terms", () => {
+    const many: GraphFact[] = Array.from({ length: 50 }, (_, i) => ({ fact: `alpha${i} beta${i} gamma${i} delta${i}` }));
+    expect(graphExpansionQuery(many).split(" or ").length).toBeLessThanOrEqual(24);
   });
 });


### PR DESCRIPTION
**Step 2 of context management — and it's measured against the eval harness (#97).** Closes the 3 paraphrase gaps the keyword-FTS floor can't reach, using the **already-live Graphiti** (no new vector store in the brain DB).

## How it works
Graphiti's `/search` returns the **facts** (entities + relationships) relevant to a question even when it's phrased with zero surface-term overlap — but facts aren't item ids, so they can't be mapped to sources directly. So `graphExpansionQuery` harvests the salient terms from those facts (entity names + fact text) into extra FTS OR-terms, and a **second keyword pass surfaces the source items** the literal search missed.

The graph search already runs in parallel with the main FTS, so this adds **one bounded query only when Graphiti returned facts**; unconfigured → pure keyword behavior, **zero regression**.

## Proven (eval-first)
- **CI eval (#97) unchanged at the 6/9 keyword floor** — Graphiti isn't in CI, so the deterministic floor is untouched (proves no regression).
- **Live eval** (`retrieval-semantic.datamechanics.test.ts`, **self-skips unless `GRAPHITI_URL` is set**): I ran it against a real `graphiti` + `neo4j` stack — projected the corpus into the graph, and **all 3 gaps** (`how-login`, `big-deal`, `speedup`) are now retrieved. **6/9 → 9/9 on the gap set.**
- unit **236** (+3 `graphExpansionQuery`) · data-mechanics **169 + 1 skipped** (the live test) · tsc · lint · drift ✓. No schema change.

## Net
Search now reaches the right document for a *paraphrased* question, not just a keyword match — and because Graphiti is live in prod, this is active there. The eval harness makes the improvement a measured fact, not a claim.