### PR TITLE
feat(query): "stay quiet" — abstain on weak retrieval grounding

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,7 +138,7 @@ sequenceDiagram
   Q->>Q: auth · cost guard (per-member/day, per-team $/day in query_log)
   Q->>RET: tier-filtered FTS top-12 + recent + Graphiti semantic expansion + structured digest (incl. per-contributor git activity + per-person cross-tool activity, team tier)
   RET-->>Q: {sources[], structured}
-  Q->>CL: streamAnswer(ctx, question)
+  Q->>CL: streamAnswer(ctx, question)  %% ctx.grounded=false (no FTS/semantic match) → abstain note (stay-quiet)
   CL->>LLM: cached system + numbered sources + question
   LLM-->>U: SSE delta* then sources then done(usage)
 ```

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -32,6 +32,18 @@ Rules:
 - Decisions marked [SUPERSEDED] are no longer valid — say so if relevant.
 - Never speculate about content above the caller's access tier; what you were given is what they may see.`;
 
+/**
+ * "Stay quiet" (Organ 3): when retrieval found no query-specific match (`grounded === false`), the
+ * sources are just recent items as background, not a real hit. We surface that explicitly so the
+ * model abstains instead of confabulating a connection. Soft — it still lets a clearly-relevant
+ * structured digest answer; it just removes the false confidence of "documents were retrieved".
+ */
+export function groundingNote(grounded: boolean): string {
+  return grounded
+    ? ""
+    : "[Retrieval note] No documents specifically matched this question — the sources below are recent items included only as background. If neither they nor the structured context clearly contain the answer, say you don't have that information rather than guessing.\n\n";
+}
+
 export type QueryUsage = {
   input_tokens: number;
   output_tokens: number;
@@ -64,9 +76,11 @@ export async function* streamAnswer(
     )
     .join("\n\n");
 
+  const note = groundingNote(ctx.grounded);
+
   // Local OpenAI-compatible backend (Ollama/Hermes) — fully on-machine, $0.
   if (LLM_BASE_URL) {
-    yield* streamLocal(ctx.structured, sourcesBlock, question, keys.openaiKey);
+    yield* streamLocal(note, ctx.structured, sourcesBlock, question, keys.openaiKey);
     return;
   }
 
@@ -88,6 +102,7 @@ export async function* streamAnswer(
       {
         role: "user",
         content: [
+          ...(note ? [{ type: "text" as const, text: note }] : []),
           { type: "text", text: `<structured_context>\n${ctx.structured}\n</structured_context>` },
           { type: "text", text: sourcesBlock || "<no document sources matched>" },
           { type: "text", text: `Question: ${question}` },
@@ -126,6 +141,7 @@ export async function* streamAnswer(
  * clean even when LLM_MODEL points at a reasoning model.
  */
 async function* streamLocal(
+  note: string,
   structured: string,
   sourcesBlock: string,
   question: string,
@@ -135,6 +151,7 @@ async function* streamLocal(
   | { type: "done"; usage: QueryUsage }
 > {
   const userContent =
+    note +
     `<structured_context>\n${structured}\n</structured_context>\n\n` +
     `${sourcesBlock || "<no document sources matched>"}\n\n` +
     `Question: ${question}`;

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -16,6 +16,8 @@ export type Source = {
 export type RetrievedContext = {
   sources: Source[];
   structured: string; // decisions/tasks/graph digest (always included)
+  /** True when query-specific search (FTS/semantic) matched something; false = only recency padding. */
+  grounded: boolean;
 };
 
 const MAX_SOURCE_CHARS = 8_000;
@@ -448,6 +450,11 @@ export async function retrieve(
     });
   }
 
+  // Grounding signal (stay-quiet): did query-specific SEARCH match anything, or are the sources just
+  // recency padding? FTS/semantic hits = real grounding; if both are empty the answer layer is told
+  // retrieval found no strong match so it abstains instead of confabulating from recent items.
+  let grounded = (ftsHits?.length ?? 0) > 0;
+
   // 2c. Semantic expansion via Graphiti (the graph search ran in parallel above). Use the facts'
   // entity/relationship terms to expand the FTS and surface items the literal keyword search missed.
   // No-op when Graphiti is unconfigured / returned nothing → pure keyword behavior, no regression.
@@ -462,6 +469,7 @@ export async function retrieve(
       .limit(10);
     if (tier === "external") semB = semB.eq("access", "external");
     const { data: semHits } = await semB;
+    if ((semHits?.length ?? 0) > 0) grounded = true;
     for (const hit of (semHits ?? []) as { id: string; path: string; kind: string; body: string; synced_at: string; projects: unknown }[]) {
       if (seen.has(hit.id)) continue;
       seen.add(hit.id);
@@ -524,5 +532,5 @@ export async function retrieve(
   // RERANK_URL is unset; reorders so the most relevant source is cited first.
   const ranked = await rerankSources(question, sources);
 
-  return { sources: ranked, structured: structuredWithGraph };
+  return { sources: ranked, structured: structuredWithGraph, grounded };
 }

--- a/test/datamechanics/grounding.datamechanics.test.ts
+++ b/test/datamechanics/grounding.datamechanics.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { retrieve } from "@/lib/query/retrieve";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+
+// Spec (stay-quiet): retrieve() reports `grounded` — true when query-specific search (FTS/semantic)
+// matched, false when the only sources are recency padding. The answer layer uses this to abstain
+// instead of confabulating. Verified on real Postgres.
+
+let seed: Seed;
+
+describe("retrieve grounding signal (real Postgres)", () => {
+  beforeEach(async () => {
+    seed = await seedTeam();
+    await ingest(seed, { kind: "deliverable", path: "deliverables/auth.md", body: "Authentication redesign: passwordless magic links replace the password flow.", access: "team" });
+    // a few unrelated docs so recency always returns something (the padding the signal must see past)
+    for (let i = 0; i < 3; i++) {
+      await ingest(seed, { kind: "deliverable", path: `deliverables/misc-${i}.md`, body: `Office logistics note ${i}: parking, wifi, lunch schedule.`, access: "team" });
+    }
+  });
+
+  it("grounded=true when the question matches a document", async () => {
+    const ctx = await retrieve(db(), seed.teamId, "team", "passwordless authentication magic links");
+    expect(ctx.grounded).toBe(true);
+    expect(ctx.sources.some((s) => s.path === "deliverables/auth.md")).toBe(true);
+  });
+
+  it("grounded=false for an off-topic question (only recency padding, no real match)", async () => {
+    const ctx = await retrieve(db(), seed.teamId, "team", "quarterly gross margin forecast for the Tokyo subsidiary");
+    expect(ctx.grounded).toBe(false);
+    // recency still returns the recent items as background — that's exactly what the signal guards against
+    expect(ctx.sources.length).toBeGreaterThan(0);
+  });
+});

--- a/test/grounding-note.test.ts
+++ b/test/grounding-note.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { groundingNote } from "@/lib/query/claude";
+
+// Spec: when retrieval found no query-specific match, the answer layer is told so it abstains.
+describe("groundingNote (stay-quiet)", () => {
+  it("is empty when grounded (no behavior change)", () => {
+    expect(groundingNote(true)).toBe("");
+  });
+
+  it("tells the model to abstain when retrieval found no strong match", () => {
+    const n = groundingNote(false);
+    expect(n).toContain("No documents specifically matched");
+    expect(n).toContain("say you don't have that information");
+  });
+});


### PR DESCRIPTION
Context-management (Organ 3): when retrieval found **no query-specific match** — the sources are just the recency-padding "8 most recent items" — the model could confabulate a connection. This makes the weak-grounding signal explicit so the brain abstains.

## What it does
- `retrieve()` now reports **`grounded`** on `RetrievedContext` — true iff **FTS or semantic search** actually matched something (recency padding doesn't count).
- `claude.ts` injects a soft **abstain note** (`groundingNote`) into both the Anthropic and local prompt paths when `grounded === false`: *"No documents specifically matched this question … if neither they nor the structured context clearly contain the answer, say you don't have that information rather than guessing."*

It's **soft** by design: a clearly-relevant structured digest (decisions/tasks/people) can still answer — it just removes the false confidence of "documents were retrieved" that drives confident-but-wrong answers.

## Verification
- data-mechanics: a matching question → `grounded=true`; an off-topic question (*"quarterly gross margin for the Tokyo subsidiary"*) → `grounded=false`, even though recency still returns padding (which is exactly what the signal sees past).
- unit **238** (+`groundingNote`) · data-mechanics **171 + 1 skipped** · tsc · lint · drift ✓. Retrieval-recall eval unaffected. No schema change.