### PR TITLE
feat(query): context shaping — gate heavy activity digests by query intent

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,7 +136,7 @@ sequenceDiagram
   participant LLM as Claude
   U->>Q: {question, project?}
   Q->>Q: auth · cost guard (per-member/day, per-team $/day in query_log)
-  Q->>RET: tier-filtered FTS top-12 + recent + Graphiti semantic expansion + structured digest (incl. per-contributor git activity + per-person cross-tool activity, team tier)
+  Q->>RET: tier-filtered FTS top-12 + recent + Graphiti semantic expansion + structured digest (git + per-person activity digests included only for activity questions — context shaping)
   RET-->>Q: {sources[], structured}
   Q->>CL: streamAnswer(ctx, question)  %% ctx.grounded=false (no FTS/semantic match) → abstain note (stay-quiet)
   CL->>LLM: cached system + numbered sources + question

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -194,6 +194,18 @@ export function graphExpansionQuery(facts: GraphFact[]): string {
   return [...terms].slice(0, MAX_EXPANSION_TERMS).join(" or ");
 }
 
+// Activity-intent detector for context shaping. The git + per-person activity digests are the
+// heaviest always-on context blocks (two extra scans + tokens). We only compute/include them when
+// the question is actually about who's doing what — biased INCLUSIVE (a false positive just restores
+// the old always-on behavior; a false negative would drop relevant context, so we'd rather over-include).
+const ACTIVITY_INTENT =
+  /\b(who|whose|doing|working|worked|activity|active|busy|contribut\w*|commit\w*|posting|posted|assigned|assignee|standup|workload|lately|recently)\b|\bup to\b|\bthis (week|sprint|month)\b/i;
+
+/** True when a query is about people/activity (→ include the git + people-activity digests). */
+export function wantsActivityContext(question: string): boolean {
+  return ACTIVITY_INTENT.test(question);
+}
+
 /**
  * Per-contributor git-activity digest from `code_contributions` (the scan aggregates). This is the
  * ONLY place the query pipeline surfaces git history — without it, "what is John doing in git" has
@@ -328,8 +340,10 @@ export async function retrieve(
   // Kick off the Graphiti graph-memory search concurrently with Postgres retrieval.
   const graphFactsP = fetchGraphFacts(supabase, teamId, tier, question);
   // Git-activity + per-person activity digests (team tier only — internal) run in parallel too.
-  const gitDigestP = tier === "team" ? gitActivityDigest(supabase, teamId) : Promise.resolve("");
-  const peopleDigestP = tier === "team" ? peopleActivityDigest(supabase, teamId) : Promise.resolve("");
+  // Context shaping: the activity digests are heavy + only relevant to "who's doing what" questions.
+  const wantsActivity = tier === "team" && wantsActivityContext(question);
+  const gitDigestP = wantsActivity ? gitActivityDigest(supabase, teamId) : Promise.resolve("");
+  const peopleDigestP = wantsActivity ? peopleActivityDigest(supabase, teamId) : Promise.resolve("");
 
   // All independent retrieval queries run in PARALLEL (was sequential → ~7 serial round-trips).
   // 1. Recall-friendly FTS over items (OR of significant terms; see toOrQuery).

--- a/test/datamechanics/context-shaping.datamechanics.test.ts
+++ b/test/datamechanics/context-shaping.datamechanics.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { retrieve } from "@/lib/query/retrieve";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+
+// Spec: context shaping — the git + per-person activity digests appear ONLY for activity questions,
+// trimming the two heaviest always-on blocks (and their scans) when irrelevant. Verified on real PG.
+
+let seed: Seed;
+
+describe("context shaping — activity digests gated by query (real Postgres)", () => {
+  beforeEach(async () => {
+    seed = await seedTeam();
+    // people-digest source: an item attributed to the seed member (a non-connector member).
+    await ingest(seed, { kind: "transcript", path: "slack/eng/1.md", body: "discussion about the release", access: "team", frontmatter: { source: "slack" } });
+    // git-digest source: a codebase + a contribution row for the member.
+    const { data: cb } = await db().from("codebases").insert({ team_id: seed.teamId, slug: "aios" }).select("id").single();
+    await db().from("code_contributions").insert({ team_id: seed.teamId, codebase_id: (cb as { id: string }).id, author_key: "t@x", author_name: "Tester", author_email: "t@x", member_id: seed.memberId, day: new Date().toISOString().slice(0, 10), commits: 4, ai_commits: 0, additions: 10, deletions: 2 });
+  });
+
+  it("includes the activity digests for a 'who is doing what' question", async () => {
+    const ctx = await retrieve(db(), seed.teamId, "team", "what is everyone working on this week?");
+    expect(ctx.structured).toContain("Activity by person");
+    expect(ctx.structured).toContain("Git activity");
+  });
+
+  it("omits them for an unrelated question (token + scan savings)", async () => {
+    const ctx = await retrieve(db(), seed.teamId, "team", "what did we decide about the database schema?");
+    expect(ctx.structured).not.toContain("Activity by person");
+    expect(ctx.structured).not.toContain("Git activity");
+  });
+});

--- a/test/query-recall.test.ts
+++ b/test/query-recall.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toOrQuery, graphExpansionQuery } from "@/lib/query/retrieve";
+import { toOrQuery, graphExpansionQuery, wantsActivityContext } from "@/lib/query/retrieve";
 import type { GraphFact } from "@/lib/graph/graphiti-client";
 
 // Spec for the FTS recall fix: the AI query box failed "what has john ellison been posting to slack?"
@@ -46,5 +46,20 @@ describe("graphExpansionQuery (semantic expansion)", () => {
   it("caps the number of expansion terms", () => {
     const many: GraphFact[] = Array.from({ length: 50 }, (_, i) => ({ fact: `alpha${i} beta${i} gamma${i} delta${i}` }));
     expect(graphExpansionQuery(many).split(" or ").length).toBeLessThanOrEqual(24);
+  });
+});
+
+// Spec: context shaping — the heavy activity digests are only included for "who's doing what"
+// questions. Biased inclusive (false positives just restore old behavior).
+describe("wantsActivityContext (context shaping)", () => {
+  it("true for activity/person questions", () => {
+    for (const q of ["what is John working on?", "who has been posting to slack?", "what has Priya been up to?", "show recent commits", "team workload this sprint"]) {
+      expect(wantsActivityContext(q), q).toBe(true);
+    }
+  });
+  it("false for non-activity questions", () => {
+    for (const q of ["what did we decide about auth?", "show me the Q3 roadmap", "how does login work?", "what is the SSRF fix?"]) {
+      expect(wantsActivityContext(q), q).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
> **Stacked on #99** (stay-quiet). Base = `chetan-guevara/stay-quiet`; retarget to `main` once #99 merges.

Context-management (Organ 3), the "context overload" attack. The **git** and **per-person activity** digests are the two heaviest always-on blocks — two extra DB scans + a chunk of tokens on **every** team-tier query. Now they're computed/included **only when the question is about who's-doing-what** (`wantsActivityContext`).

## What it does
- `retrieve()` gates `gitActivityDigest` + `peopleActivityDigest` behind `wantsActivityContext(question)` — so an unrelated query neither runs those scans nor pays their tokens.
- The cheaper, broadly-useful blocks (decisions / tasks / graph / Graphiti facts) stay always-on. This is the **conservative** slice of context shaping — trim the heavy, keep the safe.
- **Biased inclusive:** a false positive just restores the old behavior; a false negative would drop relevant context, so the detector over-includes (matches `who/doing/working/activity/commit/posting/workload/"up to"/"this sprint"…`).

## Verification
- data-mechanics: *"what is everyone working on this week?"* → both digests present; *"what did we decide about the schema?"* → both omitted (token + scan savings).
- unit **240** (+`wantsActivityContext`) · data-mechanics **173 + 1 skipped** · tsc · lint · drift ✓. Retrieval-recall eval unchanged (digests are structured, not sources). No schema change.

## Net (with #99)
Together these two close the context-management foundation: **stay-quiet** (abstain when grounding is weak) + **shaping** (don't dump the heavy digests when irrelevant) — both measurable against the eval harness, both attacking the deck's #1 problem.