### PR TITLE
feat(identity): member-lookup + identity-resolve API + link-identity CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ scaffolded spoke → idempotent re-push → materialization check → admin-tier
 - `POST /api/v1/items` — upsert synced content (Bearer key + `X-AIOS-Team`)
 - `GET  /api/v1/items?since=` — tier-filtered pull, keyset-paginated
 - `GET  /api/v1/tasks?since=` — dashboard task changes for `aios pull` writeback
+- `GET  /api/v1/members` — team roster + cross-tool identities (team-tier); filters `?email=` `?handle=` `?provider=`
+- `GET  /api/v1/identities/resolve?provider=slack&external_id=U…` — resolve an external id (or `?email=`/`?handle=`) to a member + their canonical contacts (team-tier; 404 on miss)
 - `POST /api/v1/query` — SSE: `delta` / `sources` / `done`
 - `POST /api/dashboard/query` — same pipeline, session-authenticated
 

--- a/app/api/v1/identities/resolve/route.ts
+++ b/app/api/v1/identities/resolve/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { errorResponse } from "@/lib/api/schemas";
+import { buildIdentityMap, resolveByProviderId, resolveMember } from "@/lib/identity/resolve";
+import { listMemberIdentities } from "@/lib/identity/list";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/v1/identities/resolve — resolve an external identifier to a team member and
+ * return their canonical contact set (incl. every provider identity, so a caller can map
+ * e.g. email → Slack `U…`). The congruent way for the `slack` CLI / Hermes to answer
+ * "what is teammate X's Slack id" without keeping a parallel list.
+ *
+ * Team-tier only. Resolution inputs (one required):
+ *   ?provider=<p>&external_id=<id>   provider user id (e.g. provider=slack&external_id=U…)
+ *   ?email=<addr>                    roster email or alias
+ *   ?handle=<handle>                 actor_handle
+ * Returns 404 when nothing resolves.
+ */
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+  if (auth.memberTier !== "team") {
+    return errorResponse("forbidden_tier", "identity resolution is team-tier only", 403);
+  }
+
+  const supabase = adminClient();
+  if (!(await rateLimit(supabase, `${auth.apiKeyId}:resolve:get`, 120))) {
+    return errorResponse("rate_limited", "120 resolves/min per key", 429);
+  }
+
+  const url = new URL(req.url);
+  const provider = url.searchParams.get("provider")?.toLowerCase() || null;
+  const externalId = url.searchParams.get("external_id") || null;
+  const email = url.searchParams.get("email")?.toLowerCase() || null;
+  const handle = url.searchParams.get("handle") || null;
+
+  if (!externalId && !email && !handle) {
+    return errorResponse(
+      "bad_request",
+      "supply one of: provider+external_id, email, or handle",
+      400
+    );
+  }
+  if (externalId && !provider) {
+    return errorResponse("bad_request", "external_id requires provider", 400);
+  }
+
+  const map = await buildIdentityMap(supabase, auth.teamId);
+  let memberId: string | null = null;
+  if (externalId && provider) memberId = resolveByProviderId(map, provider, externalId);
+  if (!memberId && (email || handle)) memberId = resolveMember(map, { email: email ?? undefined, key: handle ?? undefined });
+
+  if (!memberId) return errorResponse("not_found", "no member matches that identifier", 404);
+
+  const { data: m, error } = await supabase
+    .from("members")
+    .select("id, email, display_name, actor_handle, github_login, role, tier")
+    .eq("team_id", auth.teamId)
+    .eq("id", memberId)
+    .maybeSingle();
+  if (error) return errorResponse("internal", error.message, 500);
+  if (!m) return errorResponse("not_found", "member resolved but not readable", 404);
+
+  const identities = (await listMemberIdentities(supabase, auth.teamId)).get(memberId);
+  const provs = identities?.providers ?? [];
+  const slack = provs.find((p) => p.provider === "slack");
+
+  return Response.json({
+    member: {
+      id: m.id as string,
+      email: m.email as string,
+      display_name: m.display_name as string,
+      actor_handle: m.actor_handle as string,
+      github_login: (m.github_login as string | null) ?? null,
+      role: m.role as string,
+      tier: m.tier as string,
+    },
+    identities: provs,
+    email_aliases: identities?.emails ?? [],
+    // convenience: the Slack user id, when linked (used by the `slack` CLI resolver).
+    slack_id: slack?.externalId ?? null,
+  });
+}

--- a/app/api/v1/members/route.ts
+++ b/app/api/v1/members/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { errorResponse } from "@/lib/api/schemas";
+import { listMemberIdentities } from "@/lib/identity/list";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/v1/members — the team roster with contact handles + cross-tool identities,
+ * so an external tool (e.g. a Hermes comms agent or the `slack` CLI) can resolve "how do
+ * I reach teammate X" from the single source of truth instead of a local list.
+ *
+ * Team-tier only (the roster is team metadata; an external key gets 403). Optional filters:
+ *   ?email=<addr>     exact roster email
+ *   ?handle=<handle>  exact actor_handle
+ *   ?provider=<p>     only return members that have an identity for that provider (e.g. slack),
+ *                     and narrow each member's `identities` to that provider.
+ */
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+  if (auth.memberTier !== "team") {
+    return errorResponse("forbidden_tier", "the roster is team-tier only", 403);
+  }
+
+  const supabase = adminClient();
+  if (!(await rateLimit(supabase, `${auth.apiKeyId}:members:get`, 60))) {
+    return errorResponse("rate_limited", "60 reads/min per key", 429);
+  }
+
+  const url = new URL(req.url);
+  const email = url.searchParams.get("email")?.toLowerCase() || null;
+  const handle = url.searchParams.get("handle")?.toLowerCase() || null;
+  const provider = url.searchParams.get("provider")?.toLowerCase() || null;
+
+  let q = supabase
+    .from("members")
+    .select("id, email, display_name, actor_handle, github_login, role, tier, status")
+    .eq("team_id", auth.teamId)
+    .neq("status", "disabled");
+  if (email) q = q.eq("email", email);
+  if (handle) q = q.eq("actor_handle", handle);
+
+  const { data: rows, error } = await q.order("display_name");
+  if (error) return errorResponse("internal", error.message, 500);
+
+  const identities = await listMemberIdentities(supabase, auth.teamId);
+
+  const members = (rows ?? [])
+    .map((m) => {
+      const rec = identities.get(m.id as string);
+      let provs = rec?.providers ?? [];
+      if (provider) provs = provs.filter((p) => p.provider === provider);
+      return {
+        id: m.id as string,
+        email: m.email as string,
+        display_name: m.display_name as string,
+        actor_handle: m.actor_handle as string,
+        github_login: (m.github_login as string | null) ?? null,
+        role: m.role as string,
+        tier: m.tier as string,
+        identities: provs,
+        email_aliases: rec?.emails ?? [],
+      };
+    })
+    .filter((m) => !provider || m.identities.length > 0);
+
+  return Response.json({ members });
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -444,6 +444,8 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/decisions` — dashboard decision changes for `aios pull` writeback (tier-scoped)
 - `GET /api/v1/projects` — team project list for `aios pull` brain-project registration (team-tier only)
 - `GET /api/v1/me` — authenticated member identity + role (drives client UI gating)
+- `GET /api/v1/members` — team roster + cross-tool identities for external resolution (team-tier only; `?email`/`?handle`/`?provider` filters)
+- `GET /api/v1/identities/resolve` — resolve a provider external_id (or email/handle) to a member + canonical contacts incl. `slack_id` (team-tier only; 404 on miss)
 - `POST /api/v1/query` — SSE grounded query (`delta`/`sources`/`done`)
 - `GET /api/v1/okf-bundle` — OKF link graph (tier-filtered, link redaction)
 - `POST /api/v1/actions` — request a policy-gated action (Organ 4)

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -16,6 +16,7 @@ import { issueLoginLink } from "@/lib/admin/login";
 import { renameTeam } from "@/lib/admin/teams";
 import { addAuthorAlias } from "@/lib/admin/aliases";
 import { linkGithub, listOrgMembers } from "@/lib/codebases/github";
+import { setMemberIdentity } from "@/lib/identity/member-identities";
 
 type Flags = Record<string, string | boolean>;
 
@@ -62,6 +63,8 @@ const USAGE = `Team Brain admin CLI — commands:
   rename-team <new-slug> [--name <display>] [--team <id|slug>]
   add-author-alias <member-email> <git-identity> [--team <id|slug>] [--force]
   link-github <member-email> <github-login> [--team <id|slug>] [--force]   # needs GITHUB_TOKEN env
+  link-identity <member-email> <provider> <external-id> [--handle <h>] [--email <e>] [--team <id|slug>] [--force]
+                                         # link a provider user id (e.g. slack U…) to a member
   sync-github --org <org> [--team <id|slug>]                               # list candidates (needs GITHUB_TOKEN)
   pg:schema                              # load postgres/schema.sql (idempotent)
 Defaults: --team demo (accepts a team UUID too). Requires DATABASE_URL (postgres). GitHub token via GITHUB_TOKEN env only.`;
@@ -199,6 +202,30 @@ async function main() {
       console.log(
         `✓ linked ${email} → @${r.login} (avatar set); ${r.aliases.length} aliases, backfilled ${r.backfilled}`
       );
+      break;
+    }
+    case "link-identity": {
+      const email = positionals[0] || die("usage: link-identity <member-email> <provider> <external-id>");
+      const provider = positionals[1] || die("usage: link-identity <member-email> <provider> <external-id>");
+      const externalId = positionals[2] || die("usage: link-identity <member-email> <provider> <external-id>");
+      const team = await resolveTeam(admin, teamSlug);
+      const memberId = (await memberIdByEmail(admin, team.id, email)) || die(`no member ${email}`);
+      const r = await setMemberIdentity(
+        admin,
+        team.id,
+        memberId,
+        {
+          provider,
+          externalId,
+          handle: (flags.handle as string) || undefined,
+          email: (flags.email as string) || undefined,
+        },
+        { force: Boolean(flags.force), actor: { kind: "system" } }
+      );
+      if (r.conflict) {
+        die(`${provider}:${externalId} is already linked to a different member${r.note ? ` (${r.note})` : ""}; pass --force to reassign`);
+      }
+      console.log(`✓ ${provider}:${externalId} → ${email} (${r.created ? "created" : r.updated ? "updated" : "unchanged"})`);
       break;
     }
     case "sync-github": {

--- a/test/datamechanics/members-resolve.datamechanics.test.ts
+++ b/test/datamechanics/members-resolve.datamechanics.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { GET as membersGET } from "@/app/api/v1/members/route";
+import { GET as resolveGET } from "@/app/api/v1/identities/resolve/route";
+import { issueApiKey } from "@/lib/admin/keys";
+import { setMemberIdentity } from "@/lib/identity/member-identities";
+import { db, seedTeam, type Seed } from "./helpers";
+
+// HTTP edge for the two team-identity read endpoints. Both are team-tier only and
+// have no RLS backstop, so the route handler is the sole gate. Verified against the
+// real handlers + real Postgres:
+//   - team key 200, external key 403 forbidden_tier
+//   - /members?provider=slack narrows to members with a slack identity
+//   - /identities/resolve maps a slack external_id → the right member (and 404 on miss)
+
+const MEMBERS_URL = "http://test/api/v1/members";
+const RESOLVE_URL = "http://test/api/v1/identities/resolve";
+
+async function issueKeyFor(seed: Seed, tier: "team" | "external") {
+  let memberId = seed.memberId;
+  if (tier === "external") {
+    const { data, error } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `ext-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "External",
+        actor_handle: `ext-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "external",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`external member seed failed: ${error?.message}`);
+    memberId = (data as { id: string }).id;
+  }
+  const { key } = await issueApiKey(db(), seed.teamId, memberId, `${tier} key`);
+  return key;
+}
+
+function get(route: (r: NextRequest) => Promise<Response>, url: string, key: string, teamSlug: string) {
+  const req = new Request(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${key}`, "X-AIOS-Team": teamSlug },
+  }) as unknown as NextRequest;
+  return route(req);
+}
+
+describe("members + identity-resolve endpoints (real handlers, real Postgres)", () => {
+  it("members: team key 200, external key 403", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const ext = await issueKeyFor(seed, "external");
+
+    const ok = await get(membersGET, MEMBERS_URL, team, seed.teamSlug);
+    expect(ok.status).toBe(200);
+    const body = (await ok.json()) as { members: { id: string }[] };
+    expect(body.members.length).toBeGreaterThanOrEqual(1);
+
+    const forbidden = await get(membersGET, MEMBERS_URL, ext, seed.teamSlug);
+    expect(forbidden.status).toBe(403);
+  });
+
+  it("resolve: slack external_id → member; provider filter; 404 on miss", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const slackId = `U${randomUUID().slice(0, 8).toUpperCase()}`;
+    await setMemberIdentity(db(), seed.teamId, seed.memberId, {
+      provider: "slack",
+      externalId: slackId,
+      handle: "tester",
+    });
+
+    const hit = await get(resolveGET, `${RESOLVE_URL}?provider=slack&external_id=${slackId}`, team, seed.teamSlug);
+    expect(hit.status).toBe(200);
+    const body = (await hit.json()) as { member: { id: string }; slack_id: string };
+    expect(body.member.id).toBe(seed.memberId);
+    expect(body.slack_id).toBe(slackId);
+
+    const filtered = await get(membersGET, `${MEMBERS_URL}?provider=slack`, team, seed.teamSlug);
+    const fbody = (await filtered.json()) as { members: { id: string }[] };
+    expect(fbody.members.some((m) => m.id === seed.memberId)).toBe(true);
+
+    const miss = await get(resolveGET, `${RESOLVE_URL}?provider=slack&external_id=UNOPE0000`, team, seed.teamSlug);
+    expect(miss.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Exposes the existing identity system to external tools (Hermes comms agents, the `slack` CLI) so they resolve teammates from the single source of truth (`members` + `member_identities`) instead of a parallel list.

## What
- **`GET /api/v1/members`** — team roster + cross-tool identities (team-tier; `?email`/`?handle`/`?provider` filters)
- **`GET /api/v1/identities/resolve`** — map a provider `external_id` (or `email`/`handle`) → member + canonical contacts, with a convenience `slack_id` (team-tier; 404 on miss)
- **`admin link-identity <email> <provider> <external-id>`** — CLI wrapper over `setMemberIdentity` to link e.g. a Slack `U…` to a member
- Datamechanics route test (team 200 / external 403 / resolve hit+miss); README + ARCHITECTURE route inventory updated

## Why
The `slack` CLI and Hermes agents need to answer "what is teammate X's Slack id / how do I reach them" congruently — through the brain, not a markdown copy. Reuses `lib/identity/{resolve,list,member-identities}` and `lib/api/{auth,rate-limit,schemas}`; no schema changes.

## Notes
- Both endpoints are team-tier-only (no RLS backstop — the handler is the sole gate, matching `/api/v1/projects`).
- Typecheck + eslint clean. Datamechanics tests run in CI (need the test Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New read APIs expose full team roster and linked provider ids to any team-tier API key; access is handler-gated only (no RLS), so tier enforcement and key hygiene matter.
> 
> **Overview**
> Exposes the existing identity stack to **team-tier API keys** so tools like the `slack` CLI and Hermes can resolve teammates from the brain instead of maintaining parallel contact lists.
> 
> **`GET /api/v1/members`** returns the active roster with cross-provider identities and optional `?email` / `?handle` / `?provider` filters (provider narrows both the member set and each row’s `identities`). **`GET /api/v1/identities/resolve`** maps `provider`+`external_id`, email, or handle to a member plus canonical contacts, including a convenience `slack_id`; misses return **404**. Both routes use the same auth/rate-limit pattern as other team-only reads (e.g. projects) and **403** external-tier keys—there is no RLS backstop on these reads.
> 
> **`admin link-identity`** wraps `setMemberIdentity` for linking provider user ids (e.g. Slack `U…`) from the CLI, with `--force` for conflicts.
> 
> Adds datamechanics coverage (team 200 / external 403, resolve hit+miss, Slack provider filter) and updates README + ARCHITECTURE route inventories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10193b2cd5075729e8dbf4b43ac7cec77106ccd3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a team roster API endpoint with optional filtering by email, handle, or provider.
  * Added an identity resolution API endpoint to look up members by provider ID, email, or handle.
  * Added an admin command to link a member to an external identity, with optional handle/email details.

* **Bug Fixes**
  * API responses now consistently handle unauthorized, forbidden, rate-limited, missing, and not-found cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->