### PR TITLE
chore(ops): guard against deploying this repo to the wrong Railway project

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "$comment": "Committed, team-shared guardrails for the aios-team-brain repo. The Railway rules below prevent a `railway up` from deploying this repo's code to the wrong Railway project (an aios worktree once drifted to the Kula link and a deploy took Kula down). Deploys happen only via merge to main → Railway GitHub auto-deploy. See CLAUDE.md §6 and scripts/railway-deploy-guard.sh.",
+  "permissions": {
+    "deny": [
+      "Bash(railway up)",
+      "Bash(railway up:*)",
+      "Bash(railway redeploy)",
+      "Bash(railway redeploy:*)",
+      "Bash(railway down)",
+      "Bash(railway down:*)",
+      "Bash(railway delete)",
+      "Bash(railway delete:*)",
+      "Bash(railway service delete:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/railway-deploy-guard.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,9 +129,20 @@ bash scripts/e2e.sh    # system-level integration: seed → push → materialize
   `pg:schema` after `schema.sql`, in filename order) **and** mirror it into `schema.sql` for
   from-zero. See `postgres/migrations/README.md`. (A brand-new table needs no migration —
   `create table if not exists` in `schema.sql` covers it.)
-- **Deploy:** Postgres on Railway (self-host portable). After a merge, run `npm run pg:schema` against
-  prod for any schema change, and **confirm the platform started a new build** (CI webhooks can be
-  silently dropped); re-trigger if the latest deploy predates the merge.
+- **Deploy:** Postgres on Railway (self-host portable). **Deploys happen ONLY by merging to `main`** —
+  Railway's GitHub integration auto-builds AIOS → `aios-team-brain`. After a merge, run `npm run pg:schema`
+  against prod for any schema change, and **confirm the platform started a new build** (`railway deployment
+  list`; CI webhooks can be silently dropped) — re-trigger via the Railway dashboard if the latest deploy
+  predates the merge.
+- **⛔ NEVER run `railway up` / `railway redeploy` / `railway down` / `railway delete`.** The Railway CLI is
+  **read-only** here (`status`, `logs`, `variables`, `deployment list`). `railway up` deploys the current
+  worktree's code to whatever project that directory is *linked* to (`~/.railway/config.json`, keyed by
+  absolute path) — and a Conductor worktree that drifted to the wrong link (an aios worktree linked to the
+  **Kula** project) once shipped this repo's code into Kula and took it down. The GitHub-merge path is bound
+  to the right project and cannot do that. This is **guarded**: `.claude/settings.json` denies those verbs +
+  a PreToolUse hook (`scripts/railway-deploy-guard.sh`) blocks them (incl. `cd other && railway up`). Before
+  *any* Railway command, confirm `railway status` shows **Project: AIOS**; audit all worktrees with
+  `bash scripts/railway-link-check.sh`.
 
 ---
 

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -103,3 +103,44 @@ the org (John is the **AIOS-alpha** org owner).
 3. Grant it access to the public AIOS repos. BugBot then comments on PRs with potential bugs.
 
 No env vars or secrets in this repo are required.
+
+---
+
+## 4. Railway deploy safety — links + project token — W1.4.5
+
+**Incident:** the Railway CLI links each directory to a project in `~/.railway/config.json`
+(keyed by absolute path). `railway up`/`redeploy` deploys the **current directory's code to that
+linked project**. A Conductor worktree for *this* repo had drifted to the **Kula** project's link,
+so a deploy from it shipped aios-team-brain into Kula and took Kula down.
+
+### The rule (enforced)
+Production deploys happen **only by merging to `main`** → Railway's GitHub integration auto-builds
+**AIOS → `aios-team-brain`** (bound in the dashboard; cannot target another project). The Railway
+CLI is **read-only** here. The destructive verbs are **blocked** by `.claude/settings.json`
+(deny-list + the `scripts/railway-deploy-guard.sh` PreToolUse hook, which also catches the
+`cd other && <deploy>` form). See CLAUDE.md §6.
+
+### After creating a new worktree
+Conductor spawns worktrees that can inherit a wrong link. Audit + fix:
+
+```bash
+bash scripts/railway-link-check.sh   # flags any aios dir not linked to AIOS
+# fix a flagged dir:
+( cd <path> && railway link --project AIOS --environment production --service aios-team-brain )
+```
+
+### Strongest guard — a project-scoped token (recommended) — HUMAN STEP
+A **project token** scopes the CLI to a single project + environment, so even a stray deploy from a
+mislinked directory physically cannot reach another project (e.g. Kula).
+
+1. Railway dashboard → **AIOS** project → **Settings → Tokens** → create a **Project token** for
+   the **production** environment (name it e.g. `aios-cli`).
+2. Put it in each aios worktree's environment (do **not** commit it):
+   ```bash
+   echo 'export RAILWAY_TOKEN=<the-project-token>' >> ~/.aios-railway.env   # or the worktree .env.local (gitignored)
+   ```
+   With `RAILWAY_TOKEN` set, the CLI ignores `~/.railway/config.json` and acts only on the AIOS
+   project — link drift becomes harmless.
+3. Verify: `railway status` shows **Project: AIOS** regardless of the directory's link.
+
+> Tokens are secrets — never commit them; rotate from the dashboard if exposed.

--- a/scripts/railway-deploy-guard.sh
+++ b/scripts/railway-deploy-guard.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# PreToolUse(Bash) guard — refuses Railway CLI deploy/destroy commands from this repo.
+#
+# WHY THIS EXISTS: `railway up` / `railway redeploy` deploy the CURRENT directory's code to
+# whatever Railway project the directory is *linked* to (link lives in ~/.railway/config.json,
+# keyed by absolute path). A Conductor worktree that drifted to the wrong link — an
+# aios-team-brain worktree linked to the **Kula** project — meant a `railway up` shipped this
+# repo's code into Kula's production service and took it down.
+#
+# THE RULE: the Railway CLI is READ-ONLY here (status, logs, variables, `deployment list`).
+# Production deploys happen ONLY by merging to `main` → Railway's GitHub integration auto-deploys
+# AIOS → aios-team-brain. That path is bound in the Railway dashboard and CANNOT target another
+# project, so it is impossible to deploy aios code to Kula that way.
+#
+# Reads the PreToolUse JSON on stdin; exits 2 (block) if the command invokes a write verb.
+
+set -euo pipefail
+
+input="$(cat)"
+
+# Pull out the proposed shell command (robust JSON parse); fall back to the raw payload.
+cmd="$(printf '%s' "$input" | python3 -c 'import sys,json
+try: sys.stdout.write(json.load(sys.stdin).get("tool_input",{}).get("command",""))
+except Exception: pass' 2>/dev/null || true)"
+[ -z "${cmd:-}" ] && cmd="$input"
+
+# Block only an actual `railway <verb>` INVOCATION — `railway` at a command boundary (start of a
+# line/command, or after whitespace/`;`/`|`/`&`/`(`, e.g. `cd other && railway up`). A mention in
+# docs/strings/commit messages (e.g. a backtick-quoted `railway up`) is not at a boundary, so
+# writing about these commands is never blocked.
+if printf '%s' "$cmd" | grep -Eq '(^|[[:space:];|&(])railway[[:space:]]+(up|redeploy|down|delete)([[:space:]]|;|\||&|\)|$)'; then
+  cat >&2 <<'MSG'
+⛔ BLOCKED: `railway up` / `redeploy` / `down` / `delete` is forbidden in the aios-team-brain repo.
+
+Deploy production ONLY by merging to `main` — Railway auto-deploys AIOS → aios-team-brain via the
+GitHub integration (it is bound to that project and cannot hit another one).
+
+The Railway CLI here is READ-ONLY: `railway status`, `railway logs`, `railway variables`,
+`railway deployment list`.
+
+History: a `railway up` from a worktree mislinked to the **Kula** project deployed this repo's
+code into Kula and took it down. That is exactly what this guard prevents.
+MSG
+  exit 2
+fi
+
+exit 0

--- a/scripts/railway-link-check.sh
+++ b/scripts/railway-link-check.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Audit the Railway CLI link map (~/.railway/config.json): flag any aios-team-brain directory
+# linked to a project OTHER than "AIOS". Conductor spawns worktrees that can drift to the wrong
+# link; a mislinked aios worktree is the exact condition that let a deploy hit the Kula project.
+#
+# Read-only. Exits non-zero if any aios directory is mislinked. Run it any time, e.g. after
+# creating a new worktree:  bash scripts/railway-link-check.sh
+
+set -euo pipefail
+
+CONFIG="${HOME}/.railway/config.json"
+if [[ ! -f "$CONFIG" ]]; then
+  echo "No Railway link map at $CONFIG (CLI never linked) — nothing to check."
+  exit 0
+fi
+
+python3 - "$CONFIG" <<'PY'
+import json, sys
+
+cfg = json.load(open(sys.argv[1]))
+bad = []
+total_aios = 0
+for path, p in cfg.get("projects", {}).items():
+    is_aios = "aios-team-brain" in path or path.rstrip("/").endswith("/aios")
+    if not is_aios:
+        continue
+    total_aios += 1
+    if p.get("name") != "AIOS":
+        bad.append((path, p.get("name")))
+
+if bad:
+    print("❌ aios-team-brain directories linked to the WRONG Railway project:")
+    for path, name in bad:
+        print(f"   {path}  ->  {name}")
+    print()
+    print("Fix each:  ( cd <path> && railway link --project AIOS --environment production --service aios-team-brain )")
+    sys.exit(1)
+
+print(f"✅ all {total_aios} aios-team-brain worktree link(s) point at the AIOS project.")
+PY


### PR DESCRIPTION
## Why
A Conductor worktree for this repo had drifted to the **Kula** project's Railway CLI link. The Railway CLI deploys *the current directory's code to whatever project that directory is linked to* (`~/.railway/config.json`, keyed by absolute path), so a deploy from that worktree shipped aios-team-brain into **Kula** and took Kula down. The GitHub-merge deploy path was never the culprit — it's bound in the Railway dashboard to AIOS → `aios-team-brain` and cannot target another project.

## Prevention (committed → protects every worktree + teammates)
- **`.claude/settings.json`** — `permissions.deny` for the destructive Railway verbs + a **PreToolUse hook** (`scripts/railway-deploy-guard.sh`) that blocks an actual `railway` deploy/destroy *invocation*, including the `cd other && <deploy>` bypass. Read-only Railway use (`status`, `logs`, `variables`, `deployment list`) and merely *mentioning* the commands in docs/commit messages are allowed (boundary-anchored match — verified).
- **`scripts/railway-link-check.sh`** — audits the link map and flags any aios directory not linked to AIOS. Run it after creating a worktree.
- **CLAUDE.md §6 + docs/OPS.md §4** — the rule (CLI read-only; deploy only via merge → GitHub auto-deploy; verify `railway status` = AIOS first) and the **project-token** gold-standard setup (scopes the CLI to AIOS so link drift can't reach another project).

## Already done out-of-band
- Relinked the drifted `cairo` worktree → AIOS; the link audit is now green for all 4 aios worktrees.

## Guard test matrix (in `scripts/railway-deploy-guard.sh`)
| Command | Result |
|---|---|
| `railway up --detach` | ⛔ blocked |
| `cd x && railway up` | ⛔ blocked |
| `railway status` / `railway deployment list` | ✅ allowed |
| doc/commit text mentioning a backtick-quoted command | ✅ allowed |

No app code or schema change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards to prevent accidental Railway deployments from the wrong project or worktree.
  * Introduced a link-checking command to verify Railway project mappings for local worktrees.

* **Documentation**
  * Expanded deployment guidance with clear rules for production releases, post-merge steps, and verification checks.
  * Added operational notes for auditing and correcting Railway link settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->