### PR TITLE
Harden: release readiness, CI gates, import boundaries, contract pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,34 @@ jobs:
           node-version: "20"
       - run: node scripts/check-docs-drift.mjs
 
+  static-checks:
+    name: Static checks (lint + typecheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # Working-tree scan (no git history): a backstop against newly committed secrets.
+      # Allowlist for example/fixture files lives in .gitleaks.toml. Pinned binary so we
+      # don't depend on the licensed gitleaks-action.
+      - name: Run gitleaks
+        env:
+          GITLEAKS_VERSION: "8.18.4"
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks detect --no-git --source . --config .gitleaks.toml --redact --no-banner --exit-code 1
+
   brain-tests:
     name: Brain unit tests (vitest)
     runs-on: ubuntu-latest
@@ -65,9 +93,9 @@ jobs:
   http-tests:
     name: Integration tests (HTTP)
     runs-on: ubuntu-latest
-    # Advisory until 5 consecutive green runs on main, then drop this line and add
-    # http-tests to branch protection (see docs/CI-ARCHITECTURE.md).
-    continue-on-error: true
+    # Now a blocking gate: the job was green on >5 consecutive `main` runs (the documented
+    # promotion bar — see docs/CI-ARCHITECTURE.md). To finish the promotion, add the
+    # "Integration tests (HTTP)" check to branch protection on `main` (repo Settings → Branches).
     services:
       postgres:
         image: postgres:16

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,17 +1,32 @@
 # gitleaks config for aios-team-brain.
-# Extends the built-in ruleset; only adds an allowlist for files that legitimately
-# contain key-shaped *placeholder* material (example env files, test fixtures).
-# CI scans the working tree (`detect --no-git`) as a backstop against newly committed secrets.
+# Extends the built-in ruleset. CI scans the working tree (`detect --no-git`) as a backstop
+# against newly committed secrets.
+#
+# Allowlisting philosophy: do NOT blanket-allow whole source dirs (that would let a real key
+# committed under test/ slip past the scan). Instead we (a) skip build output / dependency
+# trees that aren't our source, and (b) suppress only *obvious placeholder* values by regex,
+# so a real high-entropy secret in a test/fixture is still caught.
 
 [extend]
 useDefault = true
 
 [allowlist]
-description = "Placeholder/example secrets in example env files and test fixtures"
+description = "Build output + deps (not our source), example env files, and obvious placeholders"
+# Path skips: generated/vendored trees. node_modules etc. are absent in the CI secret-scan job
+# (no npm ci there), but listing them keeps a local `gitleaks detect --no-git` run honest too.
 paths = [
+  '''(^|/)node_modules/''',
+  '''(^|/)\.next/''',
+  '''(^|/)dist/''',
+  '''(^|/)build/''',
+  '''(^|/)coverage/''',
   '''\.env\.example$''',
-  '''.*\.test\.(ts|tsx|mjs|cjs|js|jsx)$''',
-  '''(^|/)test/''',
-  '''(^|/)__fixtures__/''',
-  '''(^|/)fixtures/''',
+]
+# Value skips: match the *secret* itself. Only obvious non-secret placeholders — an ascending
+# digit run, a repeated hex stub, or words like example/placeholder/dummy/changeme. A real
+# random secret will not contain these, so test-file fixtures pass while real keys still fail.
+regexes = [
+  '''1234567890''',
+  '''abcdefABCDEF''',
+  '''(?i)(example|placeholder|dummy|changeme|redacted|your[-_]?(api[-_]?)?(key|token|secret))''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# gitleaks config for aios-team-brain.
+# Extends the built-in ruleset; only adds an allowlist for files that legitimately
+# contain key-shaped *placeholder* material (example env files, test fixtures).
+# CI scans the working tree (`detect --no-git`) as a backstop against newly committed secrets.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Placeholder/example secrets in example env files and test fixtures"
+paths = [
+  '''\.env\.example$''',
+  '''.*\.test\.(ts|tsx|mjs|cjs|js|jsx)$''',
+  '''(^|/)test/''',
+  '''(^|/)__fixtures__/''',
+  '''(^|/)fixtures/''',
+]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Pravos LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,190 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 AIOS contributors
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or Derivative
-          Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2026 Pravos LLC
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues **privately**. Do not open a public GitHub issue for a
+suspected vulnerability.
+
+- Email **john@john-ellison.com** with a description, reproduction steps, and impact.
+- We aim to acknowledge within 3 business days and to agree on a disclosure timeline with you.
+- Please give us a reasonable window to ship a fix before any public disclosure.
+
+## Supported versions
+
+AIOS Team Brain is pre-1.0 and ships from `main`. Security fixes land on `main`; there is no
+back-port branch yet. Run the latest `main` (or the latest tagged release once one exists).
+
+## Security model (what the brain guarantees)
+
+- **Authentication.** Machine clients authenticate with a per-member API key
+  `aios_<key_id>_<secret>` — the secret is **sha256-at-rest** and shown once; comparison is
+  timing-safe (`lib/api/auth.ts`). Human sessions use a signed, httpOnly cookie.
+- **Tier isolation.** Synced content is tagged `team` / `external`; `admin`/`private` content is
+  rejected with **422** at the API boundary and never reaches the database. On the default
+  **postgres** backend there is **no RLS** — tier isolation is enforced entirely in app code and
+  covered by data-mechanics tests (`test/datamechanics/access-isolation.*`). See
+  `docs/ARCHITECTURE.md` §5.
+- **Single write path.** All synced content is written only through `lib/ingest`
+  (build-failing guard: `test/guards/single-writer-items.test.ts`).
+- **Secrets at rest.** Integration connector secrets are encrypted (AES-256-GCM, `lib/secrets`)
+  and decrypted only in-process for the runner — they never leave over HTTP.
+- **Audit.** Auth attempts and privileged actions append to an append-only `audit_log`.
+- **Rate limiting.** Per-key fixed-window limits (`lib/api/rate-limit.ts`), Postgres-backed.
+
+## Secrets hygiene
+
+- Never commit real secrets. `.env`, `.env.local`, and `.env.keys` are git-ignored; only
+  `.env.example` is tracked. CI runs **gitleaks** on every PR as a backstop.
+- Rotate API keys with the admin CLI (`npm run admin` → issue/revoke); revocation is by
+  `key_hash`.
+
+## Self-hosting deployment notes
+
+- **Postgres TLS.** `lib/db/pg/pool.ts` connects with `ssl: { rejectUnauthorized: false }` when
+  TLS is requested (`PGSSL=require` / `sslmode=require`). This is acceptable for managed providers
+  that present provider-managed certificates (e.g. Railway). If you self-host Postgres elsewhere,
+  prefer a pinned CA bundle / `sslmode=verify-full` so the connection is authenticated, not just
+  encrypted.
+- **Keep the database private.** The app enforces tier isolation in code; do not expose the
+  Postgres port publicly, and run the brain behind your own auth/network boundary.
+- **Sentry / external error reporting** is opt-in and inert unless a DSN is configured; review
+  what you forward before enabling it in a sensitive deployment.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,8 @@
 Please report security issues **privately**. Do not open a public GitHub issue for a
 suspected vulnerability.
 
-- Email **john@john-ellison.com** with a description, reproduction steps, and impact.
+- Use **GitHub's private vulnerability reporting**: the repository's **Security** tab →
+  **Report a vulnerability**. Include a description, reproduction steps, and impact.
 - We aim to acknowledge within 3 business days and to agree on a disclosure timeline with you.
 - Please give us a reasonable window to ship a fix before any public disclosure.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,11 @@ flowchart LR
 
 ## Auth & access tiers
 
+This server **implements brain-api v1.2** (the wire contract; source of truth:
+`aios-workspace/docs/brain-api.md`). That version is pinned in code as `BRAIN_API_VERSION`
+(`lib/api/version.ts`) and asserted against this sentence by
+`test/guards/contract-version.test.ts` — bump all three together on a contract change.
+
 Two principals, one tier model:
 
 - **Humans** — invite-only. In the **postgres** target, sign-in is **direct passwordless**:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -422,6 +422,13 @@ guard enforces it, it's named.
   no RLS backstop in postgres mode.
 - **Add a migration** → 14-digit timestamp prefix; run `npm run db:test:up` to prove replay.
 - **Change access control** → treat it as dual-backend; add/extend a data-mechanics parity test.
+- **Change the brain-api wire contract** → the contract is pinned in
+  `aios-workspace/docs/brain-api.md`; bump `BRAIN_API_VERSION` (`lib/api/version.ts`) and this
+  doc's `v<version>` references together (guard: `test/guards/contract-version.test.ts`).
+- **Cross the module boundary** → `lib/` is the backend domain layer (never imports `app/`), and
+  `app/` reaches the DB only through the backend factory (`lib/supabase/server|admin`), never
+  `lib/db/pg` internals. Both directions are enforced by `import/no-restricted-paths` in
+  `eslint.config.mjs`.
 
 ## Keeping this doc honest
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,30 @@ const eslintConfig = defineConfig([
         "warn",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
       ],
+      // Layering ratchet (both zones hold today — preventive, no current violations).
+      // See docs/ARCHITECTURE.md "Module map". The `import` plugin is provided by eslint-config-next.
+      "import/no-restricted-paths": [
+        "error",
+        {
+          zones: [
+            {
+              // The backend domain layer must not depend on the app/UI layer: app/ → lib/, never the reverse.
+              target: "./lib",
+              from: "./app",
+              message:
+                "lib/ is the backend domain layer and must not import from app/ (dependency flows app -> lib, never the reverse).",
+            },
+            {
+              // Don't reach past the backend factory into the pg client. Go through
+              // lib/supabase/{server,admin} (which select pg vs supabase) or a lib/ domain service.
+              target: "./app",
+              from: "./lib/db/pg",
+              message:
+                "Do not import lib/db/pg internals from app/. Use the backend factory (lib/supabase/server|admin) or a lib/ domain service so the db backend stays swappable.",
+            },
+          ],
+        },
+      ],
     },
   },
 ]);

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -1,0 +1,12 @@
+/**
+ * The brain-api contract version this server implements.
+ *
+ * Source of truth for the wire contract is `aios-workspace/docs/brain-api.md` (the pinned
+ * sync contract shared by the workspace CLI/MCP and this server). This constant is the
+ * single server-side declaration of which contract version the implementation targets —
+ * keep it in lockstep with that document and with `docs/ARCHITECTURE.md`.
+ *
+ * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
+ * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
+ */
+export const BRAIN_API_VERSION = "1.2";

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "prepare": "git config core.hooksPath .githooks || true",
     "dev:seed": "set -a; . ./.env.local; set +a; npx tsx --conditions react-server scripts/seed-demo.ts",
     "dev:login": "set -a; . ./.env.local; set +a; npx tsx scripts/dev-login.ts",
@@ -61,5 +62,8 @@
     "tsx": "^4.22.4",
     "typescript": "^5",
     "vitest": "^4.1.8"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "aios-team-brain",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/test/guards/contract-version.test.ts
+++ b/test/guards/contract-version.test.ts
@@ -14,23 +14,32 @@ import { BRAIN_API_VERSION } from "@/lib/api/version";
 
 const ARCH_DOC = join(import.meta.dirname, "..", "..", "docs", "ARCHITECTURE.md");
 
+// The architecture doc carries one canonical claim of the implemented version:
+//   "...implements brain-api v1.2..."
+// We assert that exact, version-anchored sentence (not just any `v1.2` substring, which the
+// doc mentions in many feature contexts). `\b` keeps v1.2 from matching v1.20.
+function implementsClaim(version: string): RegExp {
+  return new RegExp(String.raw`implements\s+\*{0,2}brain-api\s+v${version.replace(".", "\\.")}\b`, "i");
+}
+
 describe("brain-api contract version", () => {
   it("BRAIN_API_VERSION has a major.minor shape", () => {
     expect(BRAIN_API_VERSION).toMatch(/^\d+\.\d+$/);
   });
 
-  it("the architecture doc references the same version (`v<version>`)", () => {
+  it("the architecture doc's canonical claim matches the implemented version", () => {
     const doc = readFileSync(ARCH_DOC, "utf8");
     expect(
-      doc.includes(`v${BRAIN_API_VERSION}`),
-      `docs/ARCHITECTURE.md does not mention "v${BRAIN_API_VERSION}". ` +
-        `Bump BRAIN_API_VERSION and the architecture doc together when the contract changes.`
+      implementsClaim(BRAIN_API_VERSION).test(doc),
+      `docs/ARCHITECTURE.md must state "implements brain-api v${BRAIN_API_VERSION}". ` +
+        `Bump BRAIN_API_VERSION and that sentence together when the contract changes.`
     ).toBe(true);
   });
 
-  it("the doc-agreement check is non-vacuous", () => {
+  it("the claim is version-specific (non-vacuous)", () => {
     const doc = readFileSync(ARCH_DOC, "utf8");
-    // A version that is not the implemented one must NOT be claimed as implemented.
-    expect(doc.includes("v9.9")).toBe(false);
+    // The same anchored claim for a *different* version must NOT be present — proving the
+    // matcher is pinned to the actual version, not matching any text.
+    expect(implementsClaim("9.9").test(doc)).toBe(false);
   });
 });

--- a/test/guards/contract-version.test.ts
+++ b/test/guards/contract-version.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { BRAIN_API_VERSION } from "@/lib/api/version";
+
+/**
+ * Contract-version pin. The brain-api wire contract (source of truth:
+ * `aios-workspace/docs/brain-api.md`) is implemented here; `BRAIN_API_VERSION` is the single
+ * server-side declaration of which version is targeted. The workspace doc lives in a sibling
+ * repo we can't read from here, so the in-repo anchor is `docs/ARCHITECTURE.md`, which states
+ * the contract version in prose. This guard fails the build if the constant and the doc drift
+ * apart — forcing a contract bump to touch both in the same PR.
+ */
+
+const ARCH_DOC = join(import.meta.dirname, "..", "..", "docs", "ARCHITECTURE.md");
+
+describe("brain-api contract version", () => {
+  it("BRAIN_API_VERSION has a major.minor shape", () => {
+    expect(BRAIN_API_VERSION).toMatch(/^\d+\.\d+$/);
+  });
+
+  it("the architecture doc references the same version (`v<version>`)", () => {
+    const doc = readFileSync(ARCH_DOC, "utf8");
+    expect(
+      doc.includes(`v${BRAIN_API_VERSION}`),
+      `docs/ARCHITECTURE.md does not mention "v${BRAIN_API_VERSION}". ` +
+        `Bump BRAIN_API_VERSION and the architecture doc together when the contract changes.`
+    ).toBe(true);
+  });
+
+  it("the doc-agreement check is non-vacuous", () => {
+    const doc = readFileSync(ARCH_DOC, "utf8");
+    // A version that is not the implemented one must NOT be claimed as implemented.
+    expect(doc.includes("v9.9")).toBe(false);
+  });
+});


### PR DESCRIPTION
Architecture/safety/release hardening for OSS readiness. **No app behavior change** — additive docs, CI gates, a lint ratchet, and a contract-version guard. Three commits.

## Commit 1 — release & CI hardening
- **LICENSE** + **SECURITY.md** (was missing). *(License corrected to MIT in commit 3 — see below.)*
- **CI `static-checks` job** — `npm run lint` + new `typecheck` (`tsc --noEmit`). CI previously ran neither.
- **CI `secret-scan` job** — pinned gitleaks working-tree scan with a `.gitleaks.toml` allowlist for example/fixture files.
- **Promote HTTP integration tests** off `continue-on-error` — green on >5 consecutive `main` runs.
- `package.json`: `engines.node >=20` + `typecheck` script.

## Commit 2 — boundaries + contract pin
- **`import/no-restricted-paths`** (eslint), two zones mapping to real, currently-holding invariants: `lib/` must not import `app/`; `app/` must not import `lib/db/pg` internals. Proven non-vacuous. *(Originally-planned `app/t→ingest` / `ingest→pm-sync` zones dropped — those imports are legitimate.)*
- **`BRAIN_API_VERSION`** (`lib/api/version.ts`) + guard `test/guards/contract-version.test.ts` tying it to `docs/ARCHITECTURE.md`.

## Commit 3 — license fix
- Switch LICENSE from Apache-2.0 to **MIT** + `package.json` `license: MIT`, matching the documented fleet decision (PRD v0.3.1 / Decision log #1; website + design already ship MIT). The Apache text first copied from aios-workspace is itself stale vs that decision.

## Test evidence
`npm run lint` ✓ · `npm run typecheck` ✓ · `npm test` ✓ (47 files / 248 tests; +3 new) · `npm run check:docs` ✓ · gitleaks ✓ no leaks.

## Follow-up (repo admin)
Add **Integration tests (HTTP)**, **Static checks**, **Secret scan** to branch protection on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CI checks for linting, type checking, and secret scanning.
  * Introduced a published security policy and project license.
  * Documented the current API contract version in the architecture guide.

* **Bug Fixes**
  * Made HTTP integration tests a blocking CI check.
  * Tightened dependency boundaries so app and server code follow clearer layering rules.

* **Documentation**
  * Expanded architecture guidance for future contract and module-boundary changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->