### PR TITLE
feat(member-secrets): per-member Slack user-token store + /me/slack-token

### DIFF
--- a/app/api/v1/me/slack-token/route.ts
+++ b/app/api/v1/me/slack-token/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { errorResponse } from "@/lib/api/schemas";
+import { setMemberSecret, getMemberSecret, deleteMemberSecret } from "@/lib/member-secrets/manage";
+import { setMemberIdentity } from "@/lib/identity/member-identities";
+
+export const runtime = "nodejs";
+
+const NO_STORE = { "Cache-Control": "no-store" };
+
+/**
+ * The owner's OWN Slack USER token (xoxp) for "act as me" — the personal counterpart to the
+ * team's read-only Slack ingestion. Owner-only BY CONSTRUCTION: the member id comes from the
+ * authenticated API key (`auth.memberId`), never a parameter — a key can only touch its own
+ * token. The token is stored encrypted (member_secrets) and returned only over this TLS endpoint,
+ * never logged.
+ *
+ *   GET    → { connected, token, slack_user_id, workspace }  (the agent fetches its own token)
+ *   POST   {token}  → validate (auth.test) + store + capture identity   (manual-paste path)
+ *   DELETE → disconnect
+ */
+async function slackAuthTest(token: string) {
+  const res = await fetch("https://slack.com/api/auth.test", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return (await res.json()) as { ok: boolean; error?: string; user_id?: string; user?: string; team_id?: string; team?: string };
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+  const supabase = adminClient();
+  if (!(await rateLimit(supabase, `${auth.apiKeyId}:me:slack-token`, 60))) {
+    return errorResponse("rate_limited", "60 reads/min per key", 429);
+  }
+  const rec = await getMemberSecret(supabase, auth.teamId, auth.memberId, "slack");
+  if (!rec) {
+    return Response.json({ connected: false, error: "not_connected" }, { status: 404, headers: NO_STORE });
+  }
+  return Response.json(
+    {
+      connected: true,
+      token: rec.secret,
+      slack_user_id: rec.meta.slack_user_id ?? null,
+      workspace: rec.meta.workspace ?? null,
+    },
+    { headers: NO_STORE }
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+  const supabase = adminClient();
+  if (!(await rateLimit(supabase, `${auth.apiKeyId}:me:slack-token:write`, 20))) {
+    return errorResponse("rate_limited", "20 writes/min per key", 429);
+  }
+
+  let body: { token?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("bad_request", "expected JSON body { token }", 400);
+  }
+  const token = (body.token ?? "").trim();
+  if (!token.startsWith("xoxp-")) {
+    return errorResponse("bad_request", "token must be a Slack USER token (xoxp-…)", 400);
+  }
+
+  const test = await slackAuthTest(token);
+  if (!test.ok || !test.user_id) {
+    return errorResponse("invalid_token", `Slack rejected the token (${test.error ?? "auth.test failed"})`, 422);
+  }
+
+  await setMemberSecret(supabase, { teamId: auth.teamId, memberId: auth.memberId }, "slack", token, {
+    slack_user_id: test.user_id,
+    workspace: test.team ?? null,
+    workspace_id: test.team_id ?? null,
+    acquired_via: "paste",
+  });
+
+  // Capture the member's Slack identity so `slack dm --member` + resolve work afterward.
+  const { data: m } = await supabase
+    .from("members")
+    .select("email")
+    .eq("team_id", auth.teamId)
+    .eq("id", auth.memberId)
+    .maybeSingle();
+  try {
+    await setMemberIdentity(
+      supabase,
+      auth.teamId,
+      auth.memberId,
+      { provider: "slack", externalId: test.user_id, handle: test.user ?? "", email: (m?.email as string) ?? "" },
+      { actor: { kind: "member", memberId: auth.memberId } }
+    );
+  } catch {
+    // identity capture is best-effort; the token is stored regardless.
+  }
+
+  return Response.json(
+    { ok: true, slack_user_id: test.user_id, workspace: test.team ?? null },
+    { headers: NO_STORE }
+  );
+}
+
+export async function DELETE(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+  const supabase = adminClient();
+  await deleteMemberSecret(supabase, { teamId: auth.teamId, memberId: auth.memberId }, "slack");
+  return Response.json({ ok: true, connected: false }, { headers: NO_STORE });
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -446,6 +446,9 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/me` — authenticated member identity + role (drives client UI gating)
 - `GET /api/v1/members` — team roster + cross-tool identities for external resolution (team-tier only; `?email`/`?handle`/`?provider` filters)
 - `GET /api/v1/identities/resolve` — resolve a provider external_id (or email/handle) to a member + canonical contacts incl. `slack_id` (team-tier only; 404 on miss)
+- `GET /api/v1/me/slack-token` — the caller's OWN Slack user token for "act as me" (owner-only: member from the API key, never a param; 404 if not connected; `no-store`)
+- `POST /api/v1/me/slack-token` — connect the caller's Slack via manual paste: validate (`auth.test`) + store encrypted (`member_secrets`) + capture identity
+- `DELETE /api/v1/me/slack-token` — disconnect the caller's Slack
 - `POST /api/v1/query` — SSE grounded query (`delta`/`sources`/`done`)
 - `GET /api/v1/okf-bundle` — OKF link graph (tier-filtered, link redaction)
 - `POST /api/v1/actions` — request a policy-gated action (Organ 4)
@@ -466,7 +469,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 `projects` · `items` · `item_versions` · `tasks` · `decisions` · `graph_entities` ·
 `graph_relationships` · `query_log` · `policies` · `approval_requests` · `actions` ·
 `codebases` · `code_metrics` · `code_contributions` · `github_issues` · `member_emails` ·
-`member_identities` · `member_profiles` · `member_time_off` · `member_goals` · `integrations` ·
+`member_identities` · `member_secrets` · `member_profiles` · `member_time_off` · `member_goals` · `integrations` ·
 `agentic_maturity_snapshots` · `task_pm_links` · `work_events` · `usage_costs` · `graph_episodes`
 <!-- /drift:tables -->
 

--- a/lib/member-secrets/manage.ts
+++ b/lib/member-secrets/manage.ts
@@ -1,0 +1,109 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { audit } from "@/lib/api/audit";
+import { encryptSecret, decryptSecret } from "@/lib/secrets/crypto";
+
+/**
+ * The single writer/reader for `member_secrets` — a member's own encrypted secret (e.g. their
+ * Slack USER token for "act as me"). Mirrors lib/integrations/manage.ts but PER-MEMBER:
+ *  - team `integrations.secret_ciphertext` = team-scoped bot/read tokens (the team connector);
+ *  - `member_secrets` = per-member write-capable tokens, owned by ONE member.
+ * The plaintext is encrypted at rest (AES-256-GCM, lib/secrets/crypto.ts), decrypted only here +
+ * the owner-authed endpoint, and NEVER logged (audit records keys/flags only).
+ */
+
+export interface MemberAuth {
+  teamId: string;
+  memberId: string;
+}
+
+export interface MemberSecret {
+  secret: string;
+  meta: Record<string, unknown>;
+  updatedAt: string;
+}
+
+/** Upsert a member's secret for a provider (encrypts at rest; audits keys/flags only). */
+export async function setMemberSecret(
+  supabase: SupabaseClient,
+  auth: MemberAuth,
+  provider: string,
+  secret: string,
+  meta: Record<string, unknown> = {}
+): Promise<void> {
+  const p = provider.trim().toLowerCase();
+  if (!p) throw new Error("provider is required");
+  if (!secret) throw new Error("secret is required");
+  const { error } = await supabase
+    .from("member_secrets")
+    .upsert(
+      {
+        team_id: auth.teamId,
+        member_id: auth.memberId,
+        provider: p,
+        secret_ciphertext: encryptSecret(secret),
+        meta,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "team_id,member_id,provider" }
+    );
+  if (error) throw new Error(`member secret upsert failed: ${error.message}`);
+  await audit(supabase, {
+    team_id: auth.teamId,
+    actor_kind: "member",
+    member_id: auth.memberId,
+    action: "member_secret.set",
+    target_type: "member_secret",
+    target_id: p,
+    meta: { provider: p, secretSet: true, ...(meta.acquired_via ? { acquired_via: meta.acquired_via } : {}) }, // never the value
+  });
+}
+
+/** Read + decrypt a member's secret, or null if not connected. Server-only. */
+export async function getMemberSecret(
+  supabase: SupabaseClient,
+  teamId: string,
+  memberId: string,
+  provider: string
+): Promise<MemberSecret | null> {
+  const p = provider.trim().toLowerCase();
+  const { data, error } = await supabase
+    .from("member_secrets")
+    .select("secret_ciphertext, meta, updated_at")
+    .eq("team_id", teamId)
+    .eq("member_id", memberId)
+    .eq("provider", p)
+    .maybeSingle();
+  if (error) throw new Error(`member secret read failed: ${error.message}`);
+  if (!data) return null;
+  return {
+    secret: decryptSecret(data.secret_ciphertext as string),
+    meta: (data.meta as Record<string, unknown>) ?? {},
+    updatedAt: data.updated_at as string,
+  };
+}
+
+/** Delete a member's secret for a provider (disconnect). Audited. */
+export async function deleteMemberSecret(
+  supabase: SupabaseClient,
+  auth: MemberAuth,
+  provider: string
+): Promise<void> {
+  const p = provider.trim().toLowerCase();
+  const { error } = await supabase
+    .from("member_secrets")
+    .delete()
+    .eq("team_id", auth.teamId)
+    .eq("member_id", auth.memberId)
+    .eq("provider", p);
+  if (error) throw new Error(`member secret delete failed: ${error.message}`);
+  await audit(supabase, {
+    team_id: auth.teamId,
+    actor_kind: "member",
+    member_id: auth.memberId,
+    action: "member_secret.deleted",
+    target_type: "member_secret",
+    target_id: p,
+    meta: { provider: p },
+  });
+}

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -138,6 +138,26 @@ create table if not exists member_identities (
 );
 create index if not exists member_identities_member_idx on member_identities (member_id);
 
+-- Per-member encrypted secrets (e.g. a member's own Slack USER token for "act as me").
+-- DISTINCT from team `integrations.secret_ciphertext` (team-scoped, bot/read): this is
+-- per-member + write-capable, written only by lib/member-secrets/manage.ts (audited
+-- single writer) and read only by the owner via GET /api/v1/me/<provider>-token.
+-- `secret_ciphertext` is the AES-256-GCM blob (lib/secrets/crypto.ts); `meta` holds
+-- NON-secret context (slack_user_id, workspace, scopes, acquired_via). The secret value
+-- is never stored or logged in plaintext.
+create table if not exists member_secrets (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  member_id uuid not null references members(id) on delete cascade,
+  provider text not null,                  -- 'slack'
+  secret_ciphertext text not null,         -- AES-256-GCM blob (base64), encryptSecret()
+  meta jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (team_id, member_id, provider)
+);
+create index if not exists member_secrets_member_idx on member_secrets (member_id);
+
 -- ─────────────────────────────────────────────────────────────────────────────
 -- Identity CONTEXT layer — per-member curated context on top of the lean roster.
 -- These are MANUAL fields (a self-service profile + admin edit), distinct from the

--- a/supabase/migrations/20260627120000_member_secrets.sql
+++ b/supabase/migrations/20260627120000_member_secrets.sql
@@ -1,0 +1,17 @@
+-- Per-member encrypted secrets (e.g. a member's own Slack USER token for "act as me").
+-- DISTINCT from team `integrations.secret_ciphertext` (team-scoped, bot/read): per-member +
+-- write-capable, written only by lib/member-secrets/manage.ts (audited single writer) and read
+-- only by the owner via GET /api/v1/me/<provider>-token. `secret_ciphertext` is the AES-256-GCM
+-- blob (lib/secrets/crypto.ts); `meta` holds NON-secret context (slack_user_id, workspace, scopes).
+create table if not exists member_secrets (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  member_id uuid not null references members(id) on delete cascade,
+  provider text not null,
+  secret_ciphertext text not null,
+  meta jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (team_id, member_id, provider)
+);
+create index if not exists member_secrets_member_idx on member_secrets (member_id);

--- a/test/datamechanics/me-slack-token.datamechanics.test.ts
+++ b/test/datamechanics/me-slack-token.datamechanics.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { GET as tokenGET, DELETE as tokenDELETE } from "@/app/api/v1/me/slack-token/route";
+import { issueApiKey } from "@/lib/admin/keys";
+import { setMemberSecret, getMemberSecret } from "@/lib/member-secrets/manage";
+import { db, seedTeam, type Seed } from "./helpers";
+
+// The personal Slack token endpoint is owner-only BY CONSTRUCTION (member id from the API key,
+// never a parameter). This pins that property + storage round-trip against real Postgres:
+//   - the owner's key returns the owner's token (decrypted), connected:true
+//   - a DIFFERENT member's key returns 404 not_connected (can never read someone else's token)
+//   - the stored ciphertext is opaque (plaintext absent)
+//   - DELETE disconnects
+const URL = "http://test/api/v1/me/slack-token";
+
+async function memberWithKey(seed: Seed, opts: { distinct?: boolean } = {}) {
+  let memberId = seed.memberId;
+  if (opts.distinct) {
+    const { data } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `m-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "Other",
+        actor_handle: `other-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "team",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    memberId = (data as { id: string }).id;
+  }
+  const { key } = await issueApiKey(db(), seed.teamId, memberId, "key");
+  return { key, memberId };
+}
+
+function get(route: (r: NextRequest) => Promise<Response>, key: string, teamSlug: string, method = "GET") {
+  const req = new Request(URL, {
+    method,
+    headers: { Authorization: `Bearer ${key}`, "X-AIOS-Team": teamSlug },
+  }) as unknown as NextRequest;
+  return route(req);
+}
+
+describe("GET/DELETE /api/v1/me/slack-token (owner-only, real Postgres)", () => {
+  it("owner reads their token; another member cannot", async () => {
+    const seed = await seedTeam();
+    const owner = await memberWithKey(seed);
+    const other = await memberWithKey(seed, { distinct: true });
+
+    const xoxp = `xoxp-${randomUUID()}`;
+    await setMemberSecret(db(), { teamId: seed.teamId, memberId: owner.memberId }, "slack", xoxp, {
+      slack_user_id: "U0OWNER",
+      workspace: "Acme",
+    });
+
+    // ciphertext is opaque (plaintext absent)
+    const { data: row } = await db()
+      .from("member_secrets")
+      .select("secret_ciphertext")
+      .eq("member_id", owner.memberId)
+      .single();
+    expect((row as { secret_ciphertext: string }).secret_ciphertext).not.toContain(xoxp);
+
+    const ok = await get(tokenGET, owner.key, seed.teamSlug);
+    expect(ok.status).toBe(200);
+    const body = (await ok.json()) as { connected: boolean; token: string; slack_user_id: string };
+    expect(body.connected).toBe(true);
+    expect(body.token).toBe(xoxp);
+    expect(body.slack_user_id).toBe("U0OWNER");
+
+    const denied = await get(tokenGET, other.key, seed.teamSlug);
+    expect(denied.status).toBe(404); // other member has no token → never sees the owner's
+  });
+
+  it("DELETE disconnects", async () => {
+    const seed = await seedTeam();
+    const owner = await memberWithKey(seed);
+    await setMemberSecret(db(), { teamId: seed.teamId, memberId: owner.memberId }, "slack", `xoxp-${randomUUID()}`, {});
+
+    const del = await get(tokenDELETE, owner.key, seed.teamSlug, "DELETE");
+    expect(del.status).toBe(200);
+    expect(await getMemberSecret(db(), seed.teamId, owner.memberId, "slack")).toBeNull();
+  });
+});


### PR DESCRIPTION
The **individual** counterpart to the team's read-only Slack ingestion: a member's OWN Slack **user token** (xoxp) for "act as me" — send/DM/read/react as themselves — stored encrypted per-member.

## What
- **`member_secrets`** table (`postgres/schema.sql` + supabase migration): per-member encrypted secrets, distinct from team `integrations.secret_ciphertext`.
- **`lib/member-secrets/manage.ts`**: audited single writer/reader, reuses `lib/secrets/crypto` (AES-256-GCM). Audits keys/flags only — never the value.
- **`/api/v1/me/slack-token`** (GET/POST/DELETE): **owner-only by construction** — the member id comes from the API key, never a parameter, so a key can only touch its own token. POST validates against Slack `auth.test`, stores, and captures the member's Slack identity (`setMemberIdentity`). GET hands the owner their own token (`no-store`).
- Datamechanics test: owner-isolation (A's key never sees B's token), ciphertext opaque, DELETE disconnects.

## Why
Powers the gateway-free `slack` CLI: a member runs `slack connect xoxp-…` once → their agent fetches the token from the brain and acts as them on any machine. One-click OAuth is a fast-follow (separate PR; needs the AIOS Slack app registered).

## Notes
- Reuses `lib/api/auth` (`auth.memberId`), `lib/identity/member-identities`, `lib/api/rate-limit`. No changes to the team Slack connector.
- Typecheck + eslint clean; docs route/table inventories updated. Datamechanics test runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Stores and returns high-privilege Slack user tokens over the API; correctness of encryption and strict owner-only access (API key → member) is security-critical.
> 
> **Overview**
> Adds **per-member encrypted storage** for Slack user tokens (`xoxp`) so agents can “act as me,” separate from team-level read-only Slack integration secrets.
> 
> A new **`member_secrets`** table and **`lib/member-secrets/manage.ts`** upsert/read/delete paths encrypt values with the existing AES-256-GCM stack, audit metadata only, and never log plaintext. **`GET` / `POST` / `DELETE /api/v1/me/slack-token`** are scoped to the authenticated API key’s member (no member id parameter): connect validates via Slack `auth.test`, stores the token, best-effort **`setMemberIdentity`**, and GET returns the decrypted token with `Cache-Control: no-store` plus rate limits. Docs drift inventories and a datamechanics test pin owner isolation, opaque ciphertext, and disconnect behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92254163d56ab6213ac2e672d8353b283077d722. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->