### PR TITLE
feat: brain-canonical task model — CLI, assignee projection, inbound-only-Linear-authored

### DIFF
--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -10,7 +10,9 @@ import { z } from "zod";
 export const taskRowSchema = z.object({
   row_key: z.string().min(1),
   title: z.string(),
-  assignee: z.string().optional().default(""),
+  // Optional without a default so ingest can distinguish "omitted" (preserve existing assignee)
+  // from an explicit empty string (clear assignee).
+  assignee: z.string().optional(),
   status: z.string().optional().default(""),
   sprint: z.string().optional().default(""),
   due: z.string().nullable().optional(),

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -238,12 +238,13 @@ async function materializeTasks(
   // rows' projected fields changed this push (bounded reactive projection — see projectable-diff).
   const snapshotByKey = new Map<string, ProjectableSnapshot>();
   if (incomingKeys.size) {
-    const { data: before } = await supabase
+    const { data: before, error: beforeErr } = await supabase
       .from("tasks")
       .select("row_key, title, status, sprint, priority, labels, parent_row_key, assignee")
       .eq("team_id", teamId)
       .eq("project_id", projectId)
       .not("row_key", "is", null);
+    if (beforeErr) throw new Error(`task snapshot: ${beforeErr.message}`);
     for (const t of before ?? []) {
       if (!t.row_key || !incomingKeys.has(t.row_key)) continue;
       snapshotByKey.set(t.row_key, {

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -240,7 +240,7 @@ async function materializeTasks(
   if (incomingKeys.size) {
     const { data: before } = await supabase
       .from("tasks")
-      .select("row_key, title, status, sprint, priority, labels, parent_row_key")
+      .select("row_key, title, status, sprint, priority, labels, parent_row_key, assignee")
       .eq("team_id", teamId)
       .eq("project_id", projectId)
       .not("row_key", "is", null);
@@ -253,6 +253,7 @@ async function materializeTasks(
         priority: t.priority || "none",
         labels: t.labels ?? [],
         parent_row_key: t.parent_row_key ?? null,
+        assignee: t.assignee ?? "",
       });
     }
   }
@@ -260,8 +261,8 @@ async function materializeTasks(
 
   for (const row of rows) {
     const { status, raw_status } = normalizeTaskStatus(row.status || "");
-    // Projected-field change detection (title/status/sprint/priority/labels/parent only). A new row
-    // (no snapshot) is always "changed"; assignee/due/body changes never trigger projection.
+    // Projected-field change detection (title/status/sprint/priority/labels/parent/assignee). A new
+    // row (no snapshot) is always "changed"; due_date/body changes never trigger projection.
     const snapshot = snapshotByKey.get(row.row_key) ?? null;
     if (projectableChanged(snapshot, effectiveProjectable(row, snapshot))) changed.add(row.row_key);
     // `body` is dashboard/DB-only and `parent`/`labels`/`priority` are optional v1.2 fields: each is

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -274,7 +274,6 @@ async function materializeTasks(
       source_item_id: itemId,
       row_key: row.row_key,
       title: row.title,
-      assignee: row.assignee ?? "",
       status,
       raw_status,
       sprint: row.sprint ?? "",
@@ -282,6 +281,8 @@ async function materializeTasks(
       origin: "sync",
       updated_at: syncedAt,
     };
+    if ("assignee" in row) upsertRow.assignee = (row.assignee ?? "").trim();
+    else if (!snapshot) upsertRow.assignee = "";
     if ("parent" in row) upsertRow.parent_row_key = parentOf(row) || null;
     if ("labels" in row) upsertRow.labels = row.labels ?? [];
     if ("priority" in row) upsertRow.priority = normalizeTaskPriority(row.priority);

--- a/lib/ingest/projectable-diff.ts
+++ b/lib/ingest/projectable-diff.ts
@@ -5,11 +5,12 @@ import { normalizeTaskStatus, normalizeTaskPriority } from "@/lib/api/schemas";
  * *projected* fields changed — so an unchanged backlog never re-projects on every push (bounded; no
  * board spam). The projected field set the engine writes to the PM tool is:
  *
- *   title · normalized status · sprint · priority · labels · parent_row_key
+ *   title · normalized status · sprint · priority · labels · parent_row_key · assignee
  *
- * Notably NOT: `assignee` / `due_date` (never projected) and `body` (dashboard/DB-only on the push
- * path — `tasks.body` is owned by the dashboard, not the markdown table). A push that only flips
- * `due_date` or whose body/content_sha256 changed but projected columns didn't ⇒ no projection.
+ * `assignee` joined this set once the projection engine started writing it to the PM tool (resolved
+ * to a provider user). Notably still NOT: `due_date` (never projected) and `body` (dashboard/DB-only
+ * on the push path — `tasks.body` is owned by the dashboard, not the markdown table). A push that
+ * only flips `due_date` or whose body/content_sha256 changed but projected columns didn't ⇒ no projection.
  */
 export interface ProjectableSnapshot {
   title: string;
@@ -18,6 +19,7 @@ export interface ProjectableSnapshot {
   priority: string; // normalized: none | low | medium | high | urgent
   labels: string[];
   parent_row_key: string | null;
+  assignee: string;
 }
 
 // The subset of a parsed task row this predicate reads. Presence of `parent`/`labels`/`priority`
@@ -29,6 +31,7 @@ export interface IncomingProjectableRow {
   parent?: string | null;
   labels?: string[];
   priority?: string | null;
+  assignee?: string | null;
 }
 
 function sameLabels(a: string[], b: string[]): boolean {
@@ -52,6 +55,7 @@ export function effectiveProjectable(
     labels: "labels" in row ? row.labels ?? [] : snapshot?.labels ?? [],
     parent_row_key:
       "parent" in row ? (row.parent ?? "").trim() || null : snapshot?.parent_row_key ?? null,
+    assignee: "assignee" in row ? (row.assignee ?? "") : snapshot?.assignee ?? "",
   };
 }
 
@@ -67,6 +71,7 @@ export function projectableChanged(
     snapshot.sprint === effective.sprint &&
     (snapshot.priority || "none") === effective.priority &&
     (snapshot.parent_row_key ?? null) === (effective.parent_row_key ?? null) &&
+    (snapshot.assignee ?? "") === effective.assignee &&
     sameLabels(snapshot.labels ?? [], effective.labels ?? [])
   );
 }

--- a/lib/ingest/projectable-diff.ts
+++ b/lib/ingest/projectable-diff.ts
@@ -55,7 +55,7 @@ export function effectiveProjectable(
     labels: "labels" in row ? row.labels ?? [] : snapshot?.labels ?? [],
     parent_row_key:
       "parent" in row ? (row.parent ?? "").trim() || null : snapshot?.parent_row_key ?? null,
-    assignee: "assignee" in row ? (row.assignee ?? "") : snapshot?.assignee ?? "",
+    assignee: "assignee" in row ? (row.assignee ?? "").trim() : snapshot?.assignee ?? "",
   };
 }
 

--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -397,6 +397,20 @@ export async function runLinearIngestion(opts: { teamId?: string } = {}): Promis
         summary.errors.push(`team ${teamId}: no connector member`);
         continue;
       }
+      // Linear node ids the brain already owns via a projection/adoption link — excluded from the
+      // inbound mirror so only net-new Linear-authored issues import (brain authors → Linear out;
+      // only Linear-side tasks flow back in). Footer round-trippers are filtered in normalize too.
+      const { data: ownedLinks } = await supabase
+        .from("task_pm_links")
+        .select("provider_resource_id")
+        .eq("team_id", teamId)
+        .eq("provider", "linear")
+        .not("provider_resource_id", "is", null);
+      const ownedResourceIds = new Set(
+        ((ownedLinks ?? []) as { provider_resource_id: string | null }[])
+          .map((l) => l.provider_resource_id)
+          .filter((v): v is string => !!v)
+      );
       for (const integ of integrations) {
         summary.integrations++;
         const apiKey = integ.secret;
@@ -416,15 +430,15 @@ export async function runLinearIngestion(opts: { teamId?: string } = {}): Promis
             summary.errors.push(`team ${teamId}: linear identity sync: ${err instanceof Error ? err.message : "failed"}`);
           }
           const idMap = await buildIdentityMap(supabase, teamId);
-          // Issues → tasks (one kind=task item).
-          const payload = normalizeLinearTeam(fetched);
+          // Issues → tasks (one kind=task item). Brain-owned issues are excluded (only Linear-authored import).
+          const payload = normalizeLinearTeam({ ...fetched, ownedResourceIds });
           summary.items += payload.rows?.length ?? 0;
           const res = await ingestItem(supabase, auth, payload, "team");
           if (res.status === "created") summary.created++;
           else if (res.status === "updated") summary.updated++;
           else summary.unchanged++;
           // Issue text → deliverable items (searchable), one per issue; attributed to assignee.
-          for (const doc of normalizeLinearDocs(fetched)) {
+          for (const doc of normalizeLinearDocs({ ...fetched, ownedResourceIds })) {
             const authorMemberId = resolveByProviderId(idMap, "linear", String(doc.frontmatter?.assignee_id ?? ""));
             const r = await ingestItem(supabase, auth, doc, "team", { authorMemberId });
             if (r.status === "created") summary.created++;

--- a/lib/ingest/sources/linear-normalize.ts
+++ b/lib/ingest/sources/linear-normalize.ts
@@ -10,9 +10,11 @@ import { parseExt } from "@/lib/pm-sync/linear-client";
  * Mirrors lib/ingest/sources/plane-normalize.ts — same invariants:
  *   • Dedicated brain project per Linear team (`linear-<teamKey>`). The task diff-delete is
  *     project-wide, so Linear imports never share a project with CLI/UI/Plane tasks.
- *   • One-directional (Linear → brain), de-dupe over exclude. Linear is also the pm-sync OUTBOUND
- *     provider; issues the brain itself projected carry the `aios-ext: <row_key>` footer, so they
- *     are skipped on import (the brain already owns that row_key) — keeps "brain wins".
+ *   • One-directional (Linear → brain): import ONLY issues the brain doesn't already own — i.e.
+ *     genuinely Linear-originated tasks (authored inside Linear). An issue is brain-owned if it
+ *     carries the `aios-ext: <row_key>` footer (a brain→Linear round-tripper) OR its node id is in
+ *     `ownedResourceIds` (a task_pm_links projection/adoption link). Brain-authored work stays out of
+ *     the inbound mirror, so the mirror holds only net-new Linear-side tasks — keeps "brain wins".
  *   • Org structure preserved: sub-issue parent → parent_row_key (resolved within the imported set;
  *     a skipped/absent parent is nulled), project → sprint, cycle → `cycle:<name>` label,
  *     labels/state/priority/assignee carried through. Team tier; deterministic output (sha no-op).
@@ -36,6 +38,15 @@ export interface LinearImportIssue {
 export interface NormalizeLinearInput {
   teamKey: string; // e.g. "ENG" — drives the brain project slug
   issues: LinearImportIssue[];
+  // Linear node ids the brain already owns via a task_pm_links projection/adoption link. Issues whose
+  // id is here are excluded from the inbound mirror (the brain authored & projected them outbound), so
+  // only genuinely Linear-originated tasks are imported. Omitted in pure tests → falls back to footer-only.
+  ownedResourceIds?: Set<string>;
+}
+
+/** Brain-owned = carries the aios-ext footer (round-tripper) OR has a projection/adoption link. */
+function isBrainOwned(it: LinearImportIssue, owned: Set<string> | undefined): boolean {
+  return !!parseExt(it.description) || (owned?.has(it.id) ?? false);
 }
 
 export interface LinearTaskRow {
@@ -80,10 +91,10 @@ export function normalizeLinearTeam(input: NormalizeLinearInput): ItemPayload {
   const slugSeg = safeSegment(input.teamKey) || "team";
   const project = `linear-${slugSeg}`;
 
-  // De-dupe brain-projected round-trippers (issues carrying the aios-ext footer). Stable sort so a
-  // re-import produces byte-identical output → a true no-op at the sha256 writer.
+  // Exclude every brain-owned issue (footer round-trippers + projection-linked), importing only
+  // net-new Linear-side tasks. Stable sort so a re-import is byte-identical → a no-op at the sha writer.
   const included = input.issues
-    .filter((it) => !parseExt(it.description))
+    .filter((it) => !isBrainOwned(it, input.ownedResourceIds))
     .sort((a, b) => a.identifier.localeCompare(b.identifier));
 
   const includedKeys = new Set(included.map((it) => it.identifier));
@@ -136,13 +147,13 @@ export function normalizeLinearTeam(input: NormalizeLinearInput): ItemPayload {
 /**
  * Searchable companion to the task import: ONE `kind="deliverable"` item per issue carrying the full
  * title + description text, so issue prose is full-text searchable in the brain (the `items.search`
- * column) — not just the terse task table. Round-trippers (aios-ext footer) are skipped, same as the
- * task import. Content pattern (keyed by path, idempotent by sha, not diff-deleted).
+ * column) — not just the terse task table. Brain-owned issues (footer round-trippers + projection
+ * links) are skipped, same as the task import. Content pattern (keyed by path, idempotent by sha).
  */
 export function normalizeLinearDocs(input: NormalizeLinearInput): ItemPayload[] {
   const slugSeg = safeSegment(input.teamKey) || "team";
   return input.issues
-    .filter((it) => !parseExt(it.description))
+    .filter((it) => !isBrainOwned(it, input.ownedResourceIds))
     .map((it) => {
       const title = it.title?.trim() || "(untitled)";
       const description = (it.description ?? "").trim();

--- a/lib/pm-sync/linear.ts
+++ b/lib/pm-sync/linear.ts
@@ -45,9 +45,30 @@ interface LinearBootstrap {
   issuesById: Map<string, LinearIssue>;
 }
 
+// Build the assignee resolver index from team members. A normalized name OR displayName shared by two
+// different users is AMBIGUOUS and dropped — we never guess an owner (resolveAssigneeId then returns
+// undefined = leave untouched). Email is unique, so it is always authoritative (added after the drop).
+function indexMembers(nodes: LinearUser[]): Map<string, string> {
+  const map = new Map<string, string>();
+  const ambiguous = new Set<string>();
+  const addName = (key: string, id: string) => {
+    if (!key) return;
+    const prev = map.get(key);
+    if (prev && prev !== id) ambiguous.add(key);
+    else map.set(key, id);
+  };
+  for (const u of nodes) {
+    if (u.name) addName(normalizeName(u.name), u.id);
+    if (u.displayName) addName(normalizeName(u.displayName), u.id);
+  }
+  for (const key of ambiguous) map.delete(key);
+  for (const u of nodes) if (u.email) map.set(u.email.trim().toLowerCase(), u.id);
+  return map;
+}
+
 // Resolve a brain `assignee` free-text value to a Linear user id. Returns undefined when the text is
-// empty OR matches no member — callers treat undefined as "leave the provider assignee untouched"
-// (the brain never force-unassigns; it only sets an owner it can positively resolve).
+// empty OR matches no (unambiguous) member — callers treat undefined as "leave the provider assignee
+// untouched" (the brain never force-unassigns; it only sets an owner it can positively resolve).
 function resolveAssigneeId(members: Map<string, string>, assignee: string): string | undefined {
   const key = normalizeName(assignee || "");
   if (!key) return undefined;
@@ -92,7 +113,6 @@ async function buildBootstrap(ctx: LinearCtx, teamId: string): Promise<LinearBoo
     team: {
       states: { nodes: LinearState[] };
       labels: { nodes: LinearLabel[] };
-      members: { nodes: LinearUser[] };
     } | null;
   }>(
     ctx.fetchImpl,
@@ -101,7 +121,6 @@ async function buildBootstrap(ctx: LinearCtx, teamId: string): Promise<LinearBoo
       team(id: $teamId) {
         states(first: 100) { nodes { id name type } }
         labels(first: 250) { nodes { id name } }
-        members(first: 250) { nodes { id name displayName email } }
       }
     }`,
     { teamId }
@@ -109,14 +128,27 @@ async function buildBootstrap(ctx: LinearCtx, teamId: string): Promise<LinearBoo
   const states = data.team?.states.nodes ?? [];
   const labels = new Map<string, string>((data.team?.labels.nodes ?? []).map((l) => [l.name, l.id]));
 
-  // Index each member under its normalized name + displayName, and its lowercased email, so a brain
-  // assignee written as a full name, a handle, or an email all resolve to the same user id.
-  const members = new Map<string, string>();
-  for (const u of data.team?.members?.nodes ?? []) {
-    if (u.name) members.set(normalizeName(u.name), u.id);
-    if (u.displayName) members.set(normalizeName(u.displayName), u.id);
-    if (u.email) members.set(u.email.trim().toLowerCase(), u.id);
+  // Page ALL team members (one page caps at 250 → silently un-resolvable assignees on a large team),
+  // then index by normalized name + displayName + lowercased email (see indexMembers).
+  type MembersPage = { team: { members: { pageInfo: { hasNextPage: boolean; endCursor: string }; nodes: LinearUser[] } } | null };
+  const memberNodes: LinearUser[] = [];
+  let mAfter: string | null = null;
+  for (let i = 0; i < 50; i++) {
+    const mp: MembersPage = await linearGraphql<MembersPage>(
+      ctx.fetchImpl,
+      ctx.apiKey,
+      `query ProjectionMembers($teamId: String!, $after: String) {
+        team(id: $teamId) { members(first: 250, after: $after) { pageInfo { hasNextPage endCursor } nodes { id name displayName email } } }
+      }`,
+      { teamId, after: mAfter }
+    );
+    const conn = mp.team?.members;
+    if (!conn) break;
+    memberNodes.push(...conn.nodes);
+    if (!conn.pageInfo.hasNextPage || !conn.pageInfo.endCursor) break;
+    mAfter = conn.pageInfo.endCursor;
   }
+  const members = indexMembers(memberNodes);
 
   const issuesByExt = new Map<string, LinearIssue>();
   const issuesById = new Map<string, LinearIssue>();

--- a/lib/pm-sync/linear.ts
+++ b/lib/pm-sync/linear.ts
@@ -21,6 +21,7 @@ import { linearGraphql, parseExt, withFooter, stripFooter } from "@/lib/pm-sync/
 
 type LinearState = { id: string; name: string; type: string };
 type LinearLabel = { id: string; name: string };
+type LinearUser = { id: string; name?: string; displayName?: string; email?: string };
 type LinearIssue = {
   id: string;
   identifier?: string;
@@ -31,6 +32,7 @@ type LinearIssue = {
   parent?: { id: string } | null;
   state?: { id: string; name?: string; type?: string } | null;
   labels?: { nodes: LinearLabel[] } | null;
+  assignee?: { id: string } | null;
   team?: { id: string } | null;
 };
 
@@ -38,8 +40,18 @@ interface LinearBootstrap {
   teamId: string;
   states: LinearState[];
   labels: Map<string, string>; // name → id
+  members: Map<string, string>; // normalized name / displayName / email → user id
   issuesByExt: Map<string, LinearIssue>; // row_key → issue
   issuesById: Map<string, LinearIssue>;
+}
+
+// Resolve a brain `assignee` free-text value to a Linear user id. Returns undefined when the text is
+// empty OR matches no member — callers treat undefined as "leave the provider assignee untouched"
+// (the brain never force-unassigns; it only sets an owner it can positively resolve).
+function resolveAssigneeId(members: Map<string, string>, assignee: string): string | undefined {
+  const key = normalizeName(assignee || "");
+  if (!key) return undefined;
+  return members.get(key) ?? members.get((assignee || "").trim().toLowerCase());
 }
 
 // Plane↔Linear share five groups; Linear state.type uses "canceled" (one l).
@@ -80,6 +92,7 @@ async function buildBootstrap(ctx: LinearCtx, teamId: string): Promise<LinearBoo
     team: {
       states: { nodes: LinearState[] };
       labels: { nodes: LinearLabel[] };
+      members: { nodes: LinearUser[] };
     } | null;
   }>(
     ctx.fetchImpl,
@@ -88,12 +101,22 @@ async function buildBootstrap(ctx: LinearCtx, teamId: string): Promise<LinearBoo
       team(id: $teamId) {
         states(first: 100) { nodes { id name type } }
         labels(first: 250) { nodes { id name } }
+        members(first: 250) { nodes { id name displayName email } }
       }
     }`,
     { teamId }
   );
   const states = data.team?.states.nodes ?? [];
   const labels = new Map<string, string>((data.team?.labels.nodes ?? []).map((l) => [l.name, l.id]));
+
+  // Index each member under its normalized name + displayName, and its lowercased email, so a brain
+  // assignee written as a full name, a handle, or an email all resolve to the same user id.
+  const members = new Map<string, string>();
+  for (const u of data.team?.members?.nodes ?? []) {
+    if (u.name) members.set(normalizeName(u.name), u.id);
+    if (u.displayName) members.set(normalizeName(u.displayName), u.id);
+    if (u.email) members.set(u.email.trim().toLowerCase(), u.id);
+  }
 
   const issuesByExt = new Map<string, LinearIssue>();
   const issuesById = new Map<string, LinearIssue>();
@@ -107,7 +130,7 @@ async function buildBootstrap(ctx: LinearCtx, teamId: string): Promise<LinearBoo
         team(id: $teamId) {
           issues(first: 250, after: $after) {
             pageInfo { hasNextPage endCursor }
-            nodes { id identifier url title description priority parent { id } state { id name type } labels { nodes { id name } } team { id } }
+            nodes { id identifier url title description priority parent { id } state { id name type } labels { nodes { id name } } assignee { id } team { id } }
           }
         }
       }`,
@@ -123,7 +146,7 @@ async function buildBootstrap(ctx: LinearCtx, teamId: string): Promise<LinearBoo
     if (!conn.pageInfo.hasNextPage) break;
     after = conn.pageInfo.endCursor;
   }
-  return { teamId, states, labels, issuesByExt, issuesById };
+  return { teamId, states, labels, members, issuesByExt, issuesById };
 }
 
 async function ensureLabelIds(ctx: LinearCtx, boot: LinearBootstrap, names: string[]): Promise<string[]> {
@@ -173,12 +196,15 @@ async function resolveStatesForTeam(ctx: LinearCtx, teamId: string): Promise<Lin
   return data.team?.states.nodes ?? [];
 }
 
-function linearIssueMatches(issue: LinearIssue, desired: { title: string; stateId: string; priority: number; labelIds: string[]; parent: string | null; body: string }): boolean {
+function linearIssueMatches(issue: LinearIssue, desired: { title: string; stateId: string; priority: number; labelIds: string[]; parent: string | null; body: string; assigneeId: string | undefined }): boolean {
   if ((issue.title ?? "") !== desired.title) return false;
   if ((issue.state?.id ?? "") !== desired.stateId) return false;
   if ((issue.priority ?? 0) !== desired.priority) return false;
   if ((issue.parent?.id ?? null) !== desired.parent) return false;
   if (!sameLabelSet((issue.labels?.nodes ?? []).map((l) => l.id), desired.labelIds)) return false;
+  // Only a positively-resolved owner participates in the diff: undefined = "leave as-is", so a brain
+  // task with no resolvable owner never reports a mismatch on assignee (and never blanks it).
+  if (desired.assigneeId !== undefined && (issue.assignee?.id ?? null) !== desired.assigneeId) return false;
   if (stripFooter(issue.description) !== desired.body.trim()) return false;
   return true;
 }
@@ -246,8 +272,9 @@ export const linearAdapter: PmAdapter = {
     const labelIds = await ensureLabelIds(ctx, boot, task.labels);
     const priority = priorityToLinearInt(task.priority);
     const parent = task.parentResourceId ?? null;
+    const assigneeId = resolveAssigneeId(boot.members, task.assignee);
     const description = withFooter(task.body, task.row_key, ctx.externalSource);
-    const desiredFields = { title: task.title, stateId: state.id, priority, labelIds, parent, body: task.body };
+    const desiredFields = { title: task.title, stateId: state.id, priority, labelIds, parent, body: task.body, assigneeId };
 
     // Adopt-or-create: resource id wins, else the footer marker carrying the row_key.
     const existing = (link?.provider_resource_id ? boot.issuesById.get(link.provider_resource_id) : undefined) || boot.issuesByExt.get(task.row_key);
@@ -263,9 +290,9 @@ export const linearAdapter: PmAdapter = {
           `mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
             issueUpdate(id: $id, input: $input) { success issue { id identifier url } }
           }`,
-          { id: issue.id, input: { title: task.title, description, stateId: state.id, priority, labelIds, parentId: parent } }
+          { id: issue.id, input: { title: task.title, description, stateId: state.id, priority, labelIds, parentId: parent, ...(assigneeId !== undefined ? { assigneeId } : {}) } }
         );
-        issue = { ...issue, ...data.issueUpdate.issue, state: { id: state.id }, priority, labels: { nodes: labelIds.map((id) => ({ id, name: "" })) }, parent: parent ? { id: parent } : null, title: task.title, description };
+        issue = { ...issue, ...data.issueUpdate.issue, state: { id: state.id }, priority, labels: { nodes: labelIds.map((id) => ({ id, name: "" })) }, parent: parent ? { id: parent } : null, assignee: assigneeId !== undefined ? { id: assigneeId } : issue.assignee, title: task.title, description };
         boot.issuesById.set(issue.id, issue);
         mutated = true;
       }
@@ -276,9 +303,9 @@ export const linearAdapter: PmAdapter = {
         `mutation CreateIssue($input: IssueCreateInput!) {
           issueCreate(input: $input) { success issue { id identifier url } }
         }`,
-        { input: { teamId, title: task.title, description, stateId: state.id, priority, labelIds, parentId: parent } }
+        { input: { teamId, title: task.title, description, stateId: state.id, priority, labelIds, parentId: parent, ...(assigneeId !== undefined ? { assigneeId } : {}) } }
       );
-      issue = { ...data.issueCreate.issue, description, title: task.title };
+      issue = { ...data.issueCreate.issue, description, title: task.title, assignee: assigneeId !== undefined ? { id: assigneeId } : null };
       boot.issuesById.set(issue.id, issue);
       boot.issuesByExt.set(task.row_key, issue);
       mutated = true;

--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -35,6 +35,7 @@ export interface ProjectionTaskRow {
   labels: string[];
   body: string;
   parent_row_key: string | null;
+  assignee: string;
 }
 
 export type ProjectionStatus =
@@ -124,6 +125,7 @@ function toProjectable(row: ProjectionTaskRow, parentResourceId: string | null):
     priority: row.priority || "none",
     labels: row.labels ?? [],
     sprint: row.sprint ?? "",
+    assignee: row.assignee ?? "",
     parentResourceId,
   };
 }
@@ -136,7 +138,7 @@ const LINK_COLS =
 // The exact `tasks` columns that hydrate a ProjectionTaskRow. Named explicitly (the pg adapter
 // rejects "*") and shared by every loader so the projected shape can't drift between call sites.
 export const PROJECTION_TASK_COLS =
-  "id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key";
+  "id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key, assignee";
 
 // Get-or-create the task_pm_links row for (team, project, row_key, provider).
 async function ensureLink(

--- a/lib/pm-sync/provider.ts
+++ b/lib/pm-sync/provider.ts
@@ -56,6 +56,10 @@ export interface ProjectableTask {
   priority: string; // normalized: none | low | medium | high | urgent
   labels: string[];
   sprint: string; // Wave name → Plane module membership ("" = none)
+  // Free-text owner (brain-canonical). Adapters resolve it to a provider user; "" means the brain
+  // asserts no owner — adapters MUST leave the provider assignee untouched (never force-unassign),
+  // so a brain task with no owner can't blank an assignee a human set in the PM tool.
+  assignee: string;
   parentResourceId?: string | null;
 }
 
@@ -159,6 +163,7 @@ export function projectionFingerprint(
     priority: task.priority || "none",
     parent: parentResourceId ?? "",
     sprint: task.sprint ?? "",
+    assignee: task.assignee ?? "",
     group: desiredStateForStatus(task.status).group,
   });
   return createHash("sha256").update(payload).digest("hex");

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:login": "set -a; . ./.env.local; set +a; npx tsx scripts/dev-login.ts",
     "pg:schema": "node scripts/pg-load-schema.mjs",
     "admin": "npx tsx --conditions react-server scripts/admin.ts",
+    "brain-tasks": "npx tsx --conditions react-server scripts/brain-tasks.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",

--- a/scripts/brain-tasks.ts
+++ b/scripts/brain-tasks.ts
@@ -1,0 +1,319 @@
+/**
+ * Team Brain TASK CLI — make the brain `tasks` table the canonical, easy path.
+ *
+ * The brain is the source of truth: every task is created/edited HERE and then
+ * PROJECTED one-way into the team's primary PM tool (Linear). Never hand-create
+ * a Linear issue and expect the brain to know about it — that produces stale
+ * context, which is the whole thing the brain exists to prevent. Author here,
+ * then `project`.
+ *
+ * Run:  npx tsx --conditions react-server scripts/brain-tasks.ts <command> [args] [--flags]
+ * Prod: railway run -s Postgres bash -lc \
+ *         'DATABASE_URL=$DATABASE_PUBLIC_URL npx tsx --conditions react-server scripts/brain-tasks.ts <cmd>'
+ *
+ * Commands:
+ *   add    --team <slug|id> --project <id> --title <t> [--row-key <k>] [--status <s>]
+ *          [--priority <p>] [--labels a,b,c] [--parent <row_key>] [--sprint <s>]
+ *          [--assignee <text>] [--body-file <path>] [--origin ui|sync]
+ *   set    <row_key> --project <id> [--team <slug|id>] [--title <t>] [--status <s>]
+ *          [--priority <p>] [--labels a,b,c] [--parent <row_key>] [--sprint <s>]
+ *          [--clear-sprint] [--body-file <path>]
+ *   list   --team <slug|id> [--project <id>] [--sprint <s>]
+ *   show   <row_key> --project <id> [--team <slug|id>]
+ *   project --team <slug|id> [--project <id>]   # projectAllTasks (all projects if --project omitted)
+ *
+ * status:   backlog | ready | in_progress | blocked | done   (default backlog)
+ * priority: none | low | medium | high | urgent              (default none)
+ */
+import { readFileSync } from "node:fs";
+import { adminClient } from "@/lib/supabase/admin";
+import { uiRowKey } from "@/lib/ids";
+import { normalizeTaskPriority } from "@/lib/api/schemas";
+import { projectAllTasks } from "@/lib/pm-sync";
+import { getEnabledIntegrationsWithSecrets } from "@/lib/integrations/manage";
+import { linearGraphql } from "@/lib/pm-sync/linear-client";
+
+type Flags = Record<string, string | boolean>;
+type Admin = ReturnType<typeof adminClient>;
+
+const STATUSES = ["backlog", "ready", "in_progress", "blocked", "done"];
+
+function parseArgs(argv: string[]): { cmd: string; positionals: string[]; flags: Flags } {
+  const [cmd = "help", ...rest] = argv;
+  const positionals: string[] = [];
+  const flags: Flags = {};
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = rest[i + 1];
+      if (next === undefined || next.startsWith("--")) flags[key] = true;
+      else {
+        flags[key] = next;
+        i++;
+      }
+    } else positionals.push(a);
+  }
+  return { cmd, positionals, flags };
+}
+
+function die(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+async function resolveTeam(admin: Admin, ref: string) {
+  const col = /^[0-9a-f]{8}-[0-9a-f-]{27}$/i.test(ref) ? "id" : "slug";
+  const { data } = await admin.from("teams").select("id, slug").eq(col, ref).maybeSingle();
+  if (!data) die(`no team '${ref}'`);
+  return data as { id: string; slug: string };
+}
+
+function parseLabels(v: string | boolean | undefined): string[] | undefined {
+  if (typeof v !== "string") return undefined;
+  return v
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function readBody(flags: Flags): string | undefined {
+  const f = flags["body-file"];
+  if (typeof f !== "string") return undefined;
+  return readFileSync(f, "utf8");
+}
+
+function checkStatus(s: string | undefined): string | undefined {
+  if (s === undefined) return undefined;
+  if (!STATUSES.includes(s)) die(`invalid status '${s}' (one of: ${STATUSES.join(", ")})`);
+  return s;
+}
+
+const USAGE = `Team Brain task CLI — brain is canonical, project one-way to Linear.
+  add     --team <slug|id> --project <id> --title <t> [--row-key <k>] [--status <s>]
+          [--priority <p>] [--labels a,b,c] [--parent <row_key>] [--sprint <s>]
+          [--assignee <text>] [--body-file <path>] [--origin ui|sync]
+  set     <row_key> --project <id> [--team <slug|id>] [--title <t>] [--status <s>]
+          [--priority <p>] [--labels a,b,c] [--parent <row_key>] [--sprint <s>]
+          [--clear-sprint] [--body-file <path>]
+  list    --team <slug|id> [--project <id>] [--sprint <s>]
+  show    <row_key> --project <id> [--team <slug|id>]
+  project --team <slug|id> [--project <id>]
+  resolve --team <slug|id> [--filter <substr>]      # Linear identifier → node UUID + url
+  adopt   <row_key> --project <id> --resource-id <linear-uuid> [--url <u>]  # bind to existing issue
+status: ${STATUSES.join(" | ")}   priority: none|low|medium|high|urgent
+Requires DATABASE_URL (postgres). Defaults --team aios.`;
+
+// Null the stored projection_fingerprint on a row's links so the next `project` re-writes the
+// provider even if only fields the engine already saw changed. Idempotent + cheap.
+async function bumpFingerprint(admin: Admin, teamId: string, projectId: string, rowKey: string) {
+  await admin
+    .from("task_pm_links")
+    .update({ projection_fingerprint: null })
+    .eq("team_id", teamId)
+    .eq("project_id", projectId)
+    .eq("row_key", rowKey);
+}
+
+async function main() {
+  const { cmd, positionals, flags } = parseArgs(process.argv.slice(2));
+  if (cmd === "help" || flags.help) return console.log(USAGE);
+  if (!process.env.DATABASE_URL) die("DATABASE_URL is required");
+
+  const admin = adminClient();
+  const teamSlug = (flags.team as string) || "aios";
+
+  switch (cmd) {
+    case "add": {
+      const title = (flags.title as string)?.trim() || die("--title required");
+      const projectId = (flags.project as string) || die("--project <id> required");
+      const team = await resolveTeam(admin, teamSlug);
+      const row = {
+        team_id: team.id,
+        project_id: projectId,
+        row_key: (flags["row-key"] as string) || uiRowKey(),
+        title,
+        assignee: (flags.assignee as string) || "",
+        sprint: (flags.sprint as string) || "",
+        status: checkStatus(flags.status as string) || "backlog",
+        priority: normalizeTaskPriority((flags.priority as string) || "none"),
+        labels: parseLabels(flags.labels) ?? [],
+        parent_row_key: (flags.parent as string) || null,
+        body: readBody(flags) ?? "",
+        origin: ((flags.origin as string) || "ui") as "ui" | "sync",
+      };
+      const { data, error } = await admin
+        .from("tasks")
+        .insert(row)
+        .select("id, row_key, title, status, priority, parent_row_key")
+        .single();
+      if (error) die(error.message);
+      const t = data as { id: string; row_key: string };
+      console.log(`✓ added task ${t.row_key} (${t.id}) — "${title}" [${row.status}/${row.priority}]`);
+      break;
+    }
+    case "set": {
+      const rowKey = positionals[0] || die("usage: set <row_key> --project <id>");
+      const projectId = (flags.project as string) || die("--project <id> required");
+      const team = await resolveTeam(admin, teamSlug);
+      const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+      if (flags.title !== undefined) update.title = flags.title;
+      if (flags.status !== undefined) update.status = checkStatus(flags.status as string);
+      if (flags.priority !== undefined) update.priority = normalizeTaskPriority(flags.priority as string);
+      if (flags.labels !== undefined) update.labels = parseLabels(flags.labels) ?? [];
+      if (flags.parent !== undefined) update.parent_row_key = (flags.parent as string) || null;
+      if (flags["clear-sprint"]) update.sprint = "";
+      else if (flags.sprint !== undefined) update.sprint = flags.sprint;
+      const body = readBody(flags);
+      if (body !== undefined) update.body = body;
+
+      const { data, error } = await admin
+        .from("tasks")
+        .update(update)
+        .eq("team_id", team.id)
+        .eq("project_id", projectId)
+        .eq("row_key", rowKey)
+        .select("id, row_key, title")
+        .maybeSingle();
+      if (error) die(error.message);
+      if (!data) die(`no task '${rowKey}' in project ${projectId}`);
+      await bumpFingerprint(admin, team.id, projectId, rowKey);
+      console.log(`✓ updated ${rowKey}: ${Object.keys(update).filter((k) => k !== "updated_at").join(", ")} (re-project to push)`);
+      break;
+    }
+    case "list": {
+      const team = await resolveTeam(admin, teamSlug);
+      let q = admin
+        .from("tasks")
+        .select("row_key, title, status, priority, sprint, parent_row_key")
+        .eq("team_id", team.id);
+      if (flags.project) q = q.eq("project_id", flags.project as string);
+      if (flags.sprint) q = q.eq("sprint", flags.sprint as string);
+      const { data } = await q.order("row_key");
+      console.table(data ?? []);
+      break;
+    }
+    case "show": {
+      const rowKey = positionals[0] || die("usage: show <row_key> --project <id>");
+      const projectId = (flags.project as string) || die("--project <id> required");
+      const team = await resolveTeam(admin, teamSlug);
+      const { data } = await admin
+        .from("tasks")
+        .select("id, row_key, title, status, priority, labels, sprint, parent_row_key, assignee, body")
+        .eq("team_id", team.id)
+        .eq("project_id", projectId)
+        .eq("row_key", rowKey)
+        .maybeSingle();
+      if (!data) die(`no task '${rowKey}' in project ${projectId}`);
+      console.log(JSON.stringify(data, null, 2));
+      break;
+    }
+    case "project": {
+      const team = await resolveTeam(admin, teamSlug);
+      let projectIds: string[];
+      if (flags.project) projectIds = [flags.project as string];
+      else {
+        const { data } = await admin.from("projects").select("id").eq("team_id", team.id);
+        projectIds = ((data ?? []) as { id: string }[]).map((p) => p.id);
+      }
+      for (const pid of projectIds) {
+        const { provider, reports, reason } = await projectAllTasks(admin, team.id, pid);
+        if (reason) {
+          console.log(`• project ${pid}: no projection (${reason})`);
+          continue;
+        }
+        const counts: Record<string, number> = {};
+        for (const r of reports) counts[r.status] = (counts[r.status] ?? 0) + 1;
+        const summary = Object.entries(counts).map(([k, v]) => `${k}=${v}`).join(" ") || "no rows";
+        console.log(`✓ project ${pid} → ${provider}: ${summary}`);
+        const notable = reports.filter((r) => !["synced", "skipped"].includes(r.status));
+        for (const r of notable) console.log(`    ${r.status.padEnd(18)} ${r.row_key}${r.error ? ` — ${r.error}` : ""}`);
+      }
+      break;
+    }
+    case "resolve": {
+      // Dump Linear identifier → node UUID + url for the team's Linear integration, so existing
+      // issues can be adopted (brain-canonical) without editing their descriptions. --filter greps
+      // identifiers (case-insensitive substring).
+      const team = await resolveTeam(admin, teamSlug);
+      const integrations = await getEnabledIntegrationsWithSecrets(admin, team.id);
+      const lin = integrations.find((i) => i.type === "linear" && i.secret);
+      if (!lin) die("no enabled Linear integration with a secret for this team");
+      const teamId = (lin.config as { teamId?: string } | null)?.teamId || die("Linear integration has no config.teamId");
+      const filter = typeof flags.filter === "string" ? (flags.filter as string).toLowerCase() : null;
+      const rows: { identifier: string; id: string; url: string }[] = [];
+      let after: string | null = null;
+      for (let i = 0; i < 100; i++) {
+        const page = await linearGraphql<{ team: { issues: { pageInfo: { hasNextPage: boolean; endCursor: string }; nodes: { id: string; identifier: string; url: string }[] } } | null }>(
+          fetch,
+          lin.secret as string,
+          `query ResolveIssues($teamId: String!, $after: String) {
+            team(id: $teamId) { issues(first: 250, after: $after) { pageInfo { hasNextPage endCursor } nodes { id identifier url } } }
+          }`,
+          { teamId, after }
+        );
+        const conn = page.team?.issues;
+        if (!conn) break;
+        for (const n of conn.nodes) if (!filter || n.identifier.toLowerCase().includes(filter)) rows.push(n);
+        if (!conn.pageInfo.hasNextPage) break;
+        after = conn.pageInfo.endCursor;
+      }
+      rows.sort((a, b) => a.identifier.localeCompare(b.identifier, undefined, { numeric: true }));
+      for (const r of rows) console.log(`${r.identifier}\t${r.id}\t${r.url}`);
+      console.error(`(${rows.length} issues)`);
+      break;
+    }
+    case "adopt": {
+      // Bind a brain task's row_key to an EXISTING Linear issue (by node UUID) so the next `project`
+      // updates it in place instead of creating a duplicate. Idempotent.
+      const rowKey = positionals[0] || die("usage: adopt <row_key> --project <id> --resource-id <linear-uuid>");
+      const projectId = (flags.project as string) || die("--project <id> required");
+      const resourceId = (flags["resource-id"] as string) || die("--resource-id <linear-uuid> required");
+      const team = await resolveTeam(admin, teamSlug);
+      const { data: task } = await admin
+        .from("tasks")
+        .select("id")
+        .eq("team_id", team.id)
+        .eq("project_id", projectId)
+        .eq("row_key", rowKey)
+        .maybeSingle();
+      const taskId = (task as { id: string } | null)?.id ?? null;
+      const { data: existing } = await admin
+        .from("task_pm_links")
+        .select("id")
+        .eq("team_id", team.id)
+        .eq("project_id", projectId)
+        .eq("row_key", rowKey)
+        .eq("provider", "linear")
+        .maybeSingle();
+      const patch = {
+        task_id: taskId,
+        provider_resource_id: resourceId,
+        provider_url: (flags.url as string) || "",
+        projection_fingerprint: null,
+        updated_at: new Date().toISOString(),
+      };
+      if (existing) {
+        await admin.from("task_pm_links").update(patch).eq("id", (existing as { id: string }).id);
+      } else {
+        await admin.from("task_pm_links").insert({
+          team_id: team.id,
+          project_id: projectId,
+          row_key: rowKey,
+          provider: "linear",
+          provider_external_id: rowKey,
+          provider_external_source: "aios-backlog",
+          ...patch,
+        });
+      }
+      console.log(`✓ adopted ${rowKey} → linear ${resourceId} (re-project to push brain state)`);
+      break;
+    }
+    default:
+      die(`unknown command '${cmd}'\n\n${USAGE}`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => die(e instanceof Error ? e.message : String(e)));

--- a/scripts/brain-tasks.ts
+++ b/scripts/brain-tasks.ts
@@ -35,6 +35,9 @@ import { linearGraphql } from "@/lib/pm-sync/linear-client";
 
 type Flags = Record<string, string | boolean>;
 type Admin = ReturnType<typeof adminClient>;
+type ResolvePage = {
+  team: { issues: { pageInfo: { hasNextPage: boolean; endCursor: string }; nodes: { id: string; identifier: string; url: string }[] } } | null;
+};
 
 const STATUSES = ["backlog", "ready", "in_progress", "blocked", "done"];
 
@@ -244,7 +247,7 @@ async function main() {
       const rows: { identifier: string; id: string; url: string }[] = [];
       let after: string | null = null;
       for (let i = 0; i < 100; i++) {
-        const page = await linearGraphql<{ team: { issues: { pageInfo: { hasNextPage: boolean; endCursor: string }; nodes: { id: string; identifier: string; url: string }[] } } | null }>(
+        const page: ResolvePage = await linearGraphql<ResolvePage>(
           fetch,
           lin.secret as string,
           `query ResolveIssues($teamId: String!, $after: String) {
@@ -277,7 +280,11 @@ async function main() {
         .eq("project_id", projectId)
         .eq("row_key", rowKey)
         .maybeSingle();
-      const taskId = (task as { id: string } | null)?.id ?? null;
+      // Require the brain task to exist: a link with a null task_id would still exclude this Linear
+      // issue from inbound import (by resource id), then the next mirror diff-delete drops its synced
+      // row — silently orphaning a genuinely Linear-authored task. Add the task first.
+      const taskId = (task as { id: string } | null)?.id;
+      if (!taskId) die(`no brain task '${rowKey}' in project ${projectId} — \`add\` it before \`adopt\``);
       const { data: existing } = await admin
         .from("task_pm_links")
         .select("id")
@@ -293,19 +300,18 @@ async function main() {
         projection_fingerprint: null,
         updated_at: new Date().toISOString(),
       };
-      if (existing) {
-        await admin.from("task_pm_links").update(patch).eq("id", (existing as { id: string }).id);
-      } else {
-        await admin.from("task_pm_links").insert({
-          team_id: team.id,
-          project_id: projectId,
-          row_key: rowKey,
-          provider: "linear",
-          provider_external_id: rowKey,
-          provider_external_source: "aios-backlog",
-          ...patch,
-        });
-      }
+      const { error: adoptErr } = existing
+        ? await admin.from("task_pm_links").update(patch).eq("id", (existing as { id: string }).id)
+        : await admin.from("task_pm_links").insert({
+            team_id: team.id,
+            project_id: projectId,
+            row_key: rowKey,
+            provider: "linear",
+            provider_external_id: rowKey,
+            provider_external_source: "aios-backlog",
+            ...patch,
+          });
+      if (adoptErr) die(adoptErr.message);
       console.log(`✓ adopted ${rowKey} → linear ${resourceId} (re-project to push brain state)`);
       break;
     }

--- a/test/datamechanics/reactive-projection.datamechanics.test.ts
+++ b/test/datamechanics/reactive-projection.datamechanics.test.ts
@@ -201,6 +201,23 @@ describe("materialize changed-rows detection (real Postgres)", () => {
     expect(res.changedTaskRowKeys).toEqual([]);
   });
 
+  it("preserves an existing assignee when a later push omits the assignee key", async () => {
+    const seed = await seedTeam();
+    let res = await pushTasks(seed, "v1", [{ row_key: "P0", title: "Owned", assignee: "Chetan" }]);
+    expect(res.changedTaskRowKeys).toEqual(["P0"]);
+
+    res = await pushTasks(seed, "v2", [{ row_key: "P0", title: "Owned" }]);
+    expect(res.changedTaskRowKeys).toEqual([]);
+
+    const { data } = await db()
+      .from("tasks")
+      .select("assignee")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "P0")
+      .single();
+    expect((data as { assignee: string }).assignee).toBe("Chetan");
+  });
+
   it("flags a child whose dangling parent is nulled by an epic diff-delete", async () => {
     const seed = await seedTeam();
     await pushTasks(seed, "v1", [

--- a/test/ingest-linear-normalize.test.ts
+++ b/test/ingest-linear-normalize.test.ts
@@ -60,6 +60,19 @@ describe("normalizeLinearTeam", () => {
     expect(keys).toEqual(["ENG-1"]);
   });
 
+  it("excludes brain-owned issues (projection link) even without a footer — only Linear-authored import", () => {
+    const issues = [
+      { id: "u1", identifier: "ENG-1", title: "Linear-authored", state: { type: "backlog" as const } },
+      { id: "u2", identifier: "ENG-2", title: "Brain-owned, no footer", state: { type: "backlog" as const } },
+    ];
+    const ownedResourceIds = new Set(["u2"]); // ENG-2 has a task_pm_links link but no aios-ext footer
+    const p = normalizeLinearTeam({ teamKey: "ENG", issues, ownedResourceIds });
+    expect((p.rows as Record<string, unknown>[]).map((r) => r.row_key)).toEqual(["ENG-1"]);
+    // docs path excludes it too
+    const docs = normalizeLinearDocs({ teamKey: "ENG", issues, ownedResourceIds });
+    expect(docs.map((d) => d.frontmatter.identifier)).toEqual(["ENG-1"]);
+  });
+
   it("maps priority ints and terminal/canceled states correctly", () => {
     const p = normalizeLinearTeam({
       ...base,

--- a/test/pm-sync-adapters.test.ts
+++ b/test/pm-sync-adapters.test.ts
@@ -162,7 +162,10 @@ function linearMock(opts: { issues?: unknown[]; states?: unknown[]; labels?: unk
   const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
     const { query, variables } = JSON.parse(String(init?.body));
     if (query.includes("ProjectionBootstrap")) {
-      return Response.json({ data: { team: { states: { nodes: states }, labels: { nodes: opts.labels ?? [] }, members: { nodes: opts.members ?? [] } } } });
+      return Response.json({ data: { team: { states: { nodes: states }, labels: { nodes: opts.labels ?? [] } } } });
+    }
+    if (query.includes("ProjectionMembers")) {
+      return Response.json({ data: { team: { members: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: opts.members ?? [] } } } });
     }
     if (query.includes("ProjectionIssues")) {
       return Response.json({ data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: opts.issues ?? [] } } } });
@@ -244,6 +247,38 @@ describe("Linear projection — upsertWorkItem", () => {
       const create = mutations.find((m) => m.name === "CreateIssue");
       expect((create?.variables as { input: { assigneeId?: string } }).input.assigneeId).toBe("LU-7");
     }
+  });
+
+  it("does not guess when a normalized name is shared by two users (ambiguous → unresolved)", async () => {
+    // Two distinct users both normalize to "alexkim"; the ambiguous name must NOT resolve, but each
+    // user's unique email still does.
+    const members = [
+      { id: "LU-1", name: "Alex Kim", email: "alex.kim@x.io" },
+      { id: "LU-2", displayName: "alex-kim", email: "akim@x.io" },
+    ];
+    const task = projectable({ row_key: "P5", title: "Ambiguous", assignee: "Alex Kim" });
+    const { fetchImpl, mutations } = linearMock({ issues: [], members });
+    await linearAdapter.upsertWorkItem({
+      task,
+      link: { ...link, provider: "linear", row_key: "P5", provider_external_id: "P5" },
+      integration: linearIntegration,
+      desiredFingerprint: projectionFingerprint(task, null),
+      fetchImpl,
+    });
+    const create = mutations.find((m) => m.name === "CreateIssue");
+    expect((create?.variables as { input: Record<string, unknown> }).input).not.toHaveProperty("assigneeId");
+
+    // …but the unique email resolves unambiguously to that user.
+    const task2 = projectable({ row_key: "P6", title: "ByEmail", assignee: "akim@x.io" });
+    const m2 = linearMock({ issues: [], members });
+    await linearAdapter.upsertWorkItem({
+      task: task2,
+      link: { ...link, provider: "linear", row_key: "P6", provider_external_id: "P6" },
+      integration: linearIntegration,
+      desiredFingerprint: projectionFingerprint(task2, null),
+      fetchImpl: m2.fetchImpl,
+    });
+    expect((m2.mutations.find((m) => m.name === "CreateIssue")?.variables as { input: { assigneeId?: string } }).input.assigneeId).toBe("LU-2");
   });
 
   it("never sends assigneeId when the brain owner is empty or unresolved (no force-unassign)", async () => {

--- a/test/pm-sync-adapters.test.ts
+++ b/test/pm-sync-adapters.test.ts
@@ -60,7 +60,7 @@ function planeMock(opts: { items?: unknown[]; labels?: { id: string; name: strin
 }
 
 function projectable(over: Partial<ProjectableTask> = {}): ProjectableTask {
-  return { row_key: "P0", title: "Epic title", body: "Do the thing", status: "ready", priority: "none", labels: [], sprint: "", parentResourceId: null, ...over };
+  return { row_key: "P0", title: "Epic title", body: "Do the thing", status: "ready", priority: "none", labels: [], sprint: "", assignee: "", parentResourceId: null, ...over };
 }
 
 describe("Plane projection — upsertWorkItem", () => {
@@ -152,7 +152,7 @@ const linearIntegration = {
   config: { teamId: "team-uuid" },
 } as IntegrationWithSecret;
 
-function linearMock(opts: { issues?: unknown[]; states?: unknown[]; labels?: unknown[] } = {}) {
+function linearMock(opts: { issues?: unknown[]; states?: unknown[]; labels?: unknown[]; members?: unknown[] } = {}) {
   const mutations: { name: string; variables: { [k: string]: unknown } }[] = [];
   const states = opts.states ?? [
     { id: "ls-todo", name: "Todo", type: "unstarted" },
@@ -162,7 +162,7 @@ function linearMock(opts: { issues?: unknown[]; states?: unknown[]; labels?: unk
   const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
     const { query, variables } = JSON.parse(String(init?.body));
     if (query.includes("ProjectionBootstrap")) {
-      return Response.json({ data: { team: { states: { nodes: states }, labels: { nodes: opts.labels ?? [] } } } });
+      return Response.json({ data: { team: { states: { nodes: states }, labels: { nodes: opts.labels ?? [] }, members: { nodes: opts.members ?? [] } } } });
     }
     if (query.includes("ProjectionIssues")) {
       return Response.json({ data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: opts.issues ?? [] } } } });
@@ -227,6 +227,40 @@ describe("Linear projection — upsertWorkItem", () => {
     expect(result.status).toBe("synced");
     const create = mutations.find((m) => m.name === "CreateIssue");
     expect((create?.variables as { input: { description: string } }).input.description).toContain("aios-ext: P3 · source: aios-backlog");
+  });
+
+  it("resolves a brain assignee (by name / handle / email) to a Linear user id on create", async () => {
+    const members = [{ id: "LU-7", name: "Chetan", displayName: "chetan", email: "chetan@x.io" }];
+    for (const who of ["Chetan", "chetan", "CHETAN@X.IO"]) {
+      const task = projectable({ row_key: "P3", title: "Owned", assignee: who });
+      const { fetchImpl, mutations } = linearMock({ issues: [], members });
+      await linearAdapter.upsertWorkItem({
+        task,
+        link: { ...link, provider: "linear", row_key: "P3", provider_external_id: "P3" },
+        integration: linearIntegration,
+        desiredFingerprint: projectionFingerprint(task, null),
+        fetchImpl,
+      });
+      const create = mutations.find((m) => m.name === "CreateIssue");
+      expect((create?.variables as { input: { assigneeId?: string } }).input.assigneeId).toBe("LU-7");
+    }
+  });
+
+  it("never sends assigneeId when the brain owner is empty or unresolved (no force-unassign)", async () => {
+    const members = [{ id: "LU-7", name: "Chetan" }];
+    for (const who of ["", "Nobody Known"]) {
+      const task = projectable({ row_key: "P4", title: "Unowned", assignee: who });
+      const { fetchImpl, mutations } = linearMock({ issues: [], members });
+      await linearAdapter.upsertWorkItem({
+        task,
+        link: { ...link, provider: "linear", row_key: "P4", provider_external_id: "P4" },
+        integration: linearIntegration,
+        desiredFingerprint: projectionFingerprint(task, null),
+        fetchImpl,
+      });
+      const create = mutations.find((m) => m.name === "CreateIssue");
+      expect((create?.variables as { input: Record<string, unknown> }).input).not.toHaveProperty("assigneeId");
+    }
   });
 
   it("moveToDone (back-compat) moves an issue to the completed state", async () => {

--- a/test/projectable-diff.test.ts
+++ b/test/projectable-diff.test.ts
@@ -4,6 +4,7 @@ import {
   projectableChanged,
   type ProjectableSnapshot,
 } from "@/lib/ingest/projectable-diff";
+import { taskRowSchema } from "@/lib/api/schemas";
 
 // Spec: the reactive push path re-projects ONLY rows whose projected fields changed. Projected set is
 // title · normalized status · sprint · priority · labels · parent_row_key · assignee — NOT due/body.
@@ -37,6 +38,14 @@ describe("projectable-diff (changed-rows predicate)", () => {
     // a present-but-empty assignee clears it (change); an absent assignee key preserves the snapshot
     expect(projectableChanged(s, effectiveProjectable({ title: "T", assignee: "" }, s))).toBe(true);
     expect(projectableChanged(s, effectiveProjectable({ title: "T" }, s))).toBe(false);
+  });
+
+  it("a parsed row that omitted assignee still preserves the snapshot", () => {
+    const s = snap({ title: "T", assignee: "Chetan" });
+    const parsed = taskRowSchema.parse({ row_key: "T-1", title: "T" });
+    expect("assignee" in parsed).toBe(false);
+    expect(projectableChanged(s, effectiveProjectable(parsed, s))).toBe(false);
+    expect(effectiveProjectable(parsed, s).assignee).toBe("Chetan");
   });
 
   it("a title change is changed", () => {

--- a/test/projectable-diff.test.ts
+++ b/test/projectable-diff.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/ingest/projectable-diff";
 
 // Spec: the reactive push path re-projects ONLY rows whose projected fields changed. Projected set is
-// title · normalized status · sprint · priority · labels · parent_row_key — NOT assignee/due/body.
+// title · normalized status · sprint · priority · labels · parent_row_key · assignee — NOT due/body.
 
 const snap = (over: Partial<ProjectableSnapshot> = {}): ProjectableSnapshot => ({
   title: "T",
@@ -15,6 +15,7 @@ const snap = (over: Partial<ProjectableSnapshot> = {}): ProjectableSnapshot => (
   priority: "none",
   labels: [],
   parent_row_key: null,
+  assignee: "",
   ...over,
 });
 
@@ -23,10 +24,19 @@ describe("projectable-diff (changed-rows predicate)", () => {
     expect(projectableChanged(null, effectiveProjectable({ title: "x" }, null))).toBe(true);
   });
 
-  it("identical projected values are unchanged (a due/assignee-only edit never trips this)", () => {
+  it("identical projected values are unchanged (a due-only edit never trips this)", () => {
     const s = snap({ title: "x", status: "ready" });
-    // Six-col push re-emits title/status with the same values; due_date/assignee aren't in the set.
+    // Re-emits title/status with the same values; due_date isn't in the projected set.
     expect(projectableChanged(s, effectiveProjectable({ title: "x", status: "ready" }, s))).toBe(false);
+  });
+
+  it("an assignee change IS a change (assignee is now projected); same assignee is not", () => {
+    const s = snap({ title: "T", assignee: "Chetan" });
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", assignee: "Chetan" }, s))).toBe(false);
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", assignee: "John" }, s))).toBe(true);
+    // a present-but-empty assignee clears it (change); an absent assignee key preserves the snapshot
+    expect(projectableChanged(s, effectiveProjectable({ title: "T", assignee: "" }, s))).toBe(true);
+    expect(projectableChanged(s, effectiveProjectable({ title: "T" }, s))).toBe(false);
   });
 
   it("a title change is changed", () => {


### PR DESCRIPTION
Makes the brain `tasks` table the canonical, low-friction path for task work and closes the loops that let Linear drift the brain stale. Three parts.

## 1. `brain-tasks` CLI (`scripts/brain-tasks.ts`)
There was no easy "add a task to the brain" command, so the path of least resistance was hand-creating Linear issues — which immediately drifts the brain. This makes brain-first the easy path, reusing the real write/projection primitives.
- `add` / `set` / `list` / `show` — author tasks in the brain.
- `project` — run the real `projectAllTasks` engine.
- `resolve` — Linear identifier → node UUID + url.
- `adopt` — bind a brain `row_key` to an **existing** Linear issue (by UUID) so projection updates it **in place** (no duplicate identifiers) — the clean way to backfill Linear-native issues.

## 2. Assignee joins the projection model
The brain had an `assignee` column that never reached Linear — ownership silently diverged.
- `provider.ts`: `assignee` on `ProjectableTask` + in `projectionFingerprint`.
- `project.ts`: `assignee` in `PROJECTION_TASK_COLS` + row mapping.
- `linear.ts`: bootstrap fetches team members; brain `assignee` (free text) resolves to a Linear user by **name / displayName / email**; set on create + update. **Empty/unresolved owner = left untouched (never force-unassign).**

## 3. Inbound Linear import: only Linear-authored issues
The inbound `linear-<team>` mirror imported every footer-less board issue, so issues the brain OWNS (projected/adopted) but never footered got re-mirrored — shadowing the canonical backlog. Now it excludes any issue the brain already owns: aios-ext footer **OR** a `task_pm_links` projection/adoption link (`provider_resource_id == issue node id`). Only genuinely Linear-authored tasks import. Supports the two-workflow split: terminal authors brain→Linear, Linear authors flow back in. Self-heals the existing mirror on the first scheduler tick post-deploy.

## Tests
All green. Added: assignee resolve (name/handle/email) + no-force-unassign; inbound exclusion of a brain-owned-by-link issue with no footer.

## Proven against prod
Used to seed the V1 operator-loop epic (AIO-122–130) brain-canonical (adopted in place, zero duplicate identifiers), backfill organs (AIO-94–99 → Chetan, assignee synced), revive 4 retired-Plane pillars (AIO-131–134), and reconcile the canonical backlog to 104/104 projected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a task management CLI for creating, updating, listing, viewing, projecting, resolving, and adopting tasks.
  * Task assignees are now synchronized to Linear when they can be unambiguously matched.

* **Bug Fixes**
  * Imports now exclude issues already owned by the product system, reducing duplicate or unintended task syncing.
  * Re-sync detection and projection fingerprinting now account for assignees.
  * If an assignee is ambiguous or unresolved, the existing Linear assignee is left unchanged.
  * Assignees are preserved when later updates omit the assignee field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->