### PR TITLE
ci: cancel superseded runs (concurrency)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [main]
 
+# Cancel superseded runs on the same ref so rapid pushes don't pile up parallel
+# Postgres/build jobs. Each job already caches npm via setup-node (cache: "npm").
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Required gate: docs inventories must match the code (see docs/ARCHITECTURE.md).
   # Make this a required status check on `main` so PRs can't merge while docs drift.


### PR DESCRIPTION
Add a `concurrency` group (cancel-in-progress) so rapid pushes to a PR don't leave stale Postgres/build jobs running in parallel. Caching is already present on every dep-installing job. No behavior change to the checks themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only scheduling change; check logic and gates are untouched, with the usual caveat that cancelled runs no longer report status for superseded commits until the latest run finishes.
> 
> **Overview**
> Adds a **workflow-level `concurrency` block** to the main CI workflow so only the latest run per ref is kept active.
> 
> The group is `ci-${{ github.workflow }}-${{ github.ref }}` with **`cancel-in-progress: true`**, so rapid PR pushes or `main` pushes stop older Postgres/build jobs instead of stacking parallel runs. Comments note that npm caching via `setup-node` is unchanged.
> 
> **No changes** to job definitions, steps, or pass/fail behavior of the checks themselves—only how overlapping runs are scheduled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb409953893325b8e0fdd2c19ccd2b4de6bfaee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI run handling so newer runs can replace outdated ones, reducing queued duplicates and speeding up feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->