### PR TITLE
ci: advisory PR→task nudge + PR-template clarification (AIO-136)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,10 @@
 
 ## Work item
 
-<!-- Link this PR to a Linear issue so aios-work-sync closes it on merge. -->
+<!-- Reference the brain task so aios-work-sync advances it to Done on merge (brain → Linear).
+     No task yet, and this work should be tracked? Create one FIRST in the Team Brain dashboard
+     (→ Tasks; it projects to Linear), then put its key here. Don't hand-edit the Linear issue —
+     the brain is the source of truth, Linear is a one-way projection. -->
 AIOS-Work: <!-- e.g. AIO-72 -->
 
 ## Checklist

--- a/.github/workflows/pr-task-link.yml
+++ b/.github/workflows/pr-task-link.yml
@@ -1,0 +1,33 @@
+name: PR task link (advisory)
+
+# Nudge, not a gate: warns when a PR has no brain task work-key, so untracked work is
+# visible at review time. The actual close happens on merge via aios-work-sync.yml
+# (→ POST /api/v1/work-events → tasks.status=done → pm-sync projects to Linear).
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  work-key:
+    name: PR references a brain task
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for an AIOS work-key
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+          const pr = ev.pull_request || {};
+          const text = [pr.title, pr.body || "", pr.head?.ref || ""].join("\n");
+          // Same matcher aios-work-sync uses (lib/pm-sync/work-keys): AIO-12 / W2.5.8 / etc.
+          const re = /\b(?:AIOS-Work:\s*)?([A-Z][A-Z0-9]+-\d+|[A-Z]\d+(?:\.\d+)*)\b/g;
+          const keys = [...new Set([...text.matchAll(re)].map((m) => m[1]))];
+          if (keys.length) {
+            console.log(`Found work key(s): ${keys.join(", ")} — merge will advance the matching brain task to Done.`);
+          } else {
+            console.log("::warning title=No brain task linked::This PR has no AIOS work-key (e.g. `AIOS-Work: W2.5.8`). Merge won't auto-close a task in Linear. If this work should be tracked, link or create a brain task first. (Advisory — not blocking.)");
+          }
+          NODE


### PR DESCRIPTION
Part of AIO-136. team-brain already has the PR template + aios-work-sync + secrets, so the only net-new is the **advisory nudge**: `pr-task-link.yml` warns (non-blocking) when a PR has no brain task work-key, making untracked work visible at review time. Also adds a 'create the brain task first if none exists' note to the PR template.

AIOS-Work: AIO-136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI advisory warnings and PR template documentation; no runtime, auth, or merge-gating behavior.
> 
> **Overview**
> Adds a **non-blocking** GitHub Actions workflow that runs on PR open/edit/sync and scans the title, body, and branch for brain work-keys using the same regex as `lib/pm-sync/work-keys` and merge-time `aios-work-sync`. When none are found, it emits a GitHub **warning** so reviewers see untracked work; when keys are present, it logs that merge will advance those tasks.
> 
> The **PR template** “Work item” section is expanded to state that the brain task is the source of truth (create it in Team Brain first if missing; Linear is a one-way projection), replacing the shorter Linear-only close-on-merge note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15833b351caf95a542e4bcd4438c252e048f4c0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an advisory check for pull requests that detects linked work items and warns when none are found.
  * Updated pull request guidance to point contributors to the new work-item reference flow before merge.

* **Bug Fixes**
  * Improved consistency in how pull requests are associated with tracked work so merge behavior is clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->