### PR TITLE
ci: strip HTML comments before matching work keys (AIO-136)

### DIFF
--- a/.github/workflows/aios-work-sync.yml
+++ b/.github/workflows/aios-work-sync.yml
@@ -33,7 +33,12 @@ jobs:
 
           const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
           const pr = event.pull_request;
-          const text = [pr.title, pr.body || "", pr.head?.ref || ""].join("\n");
+          // Strip HTML comments first so PR-template placeholders (e.g. `<!-- e.g. AIO-72 -->`) aren't matched.
+          const text = [
+            pr.title || "",
+            (pr.body || "").replace(/<!--[\s\S]*?-->/g, " "),
+            pr.head?.ref || "",
+          ].join("\n");
           const re = /\b(?:AIOS-Work:\s*)?([A-Z][A-Z0-9]+-\d+|[A-Z]\d+(?:\.\d+)*)\b/g;
           const workKeys = [...new Set([...text.matchAll(re)].map((m) => m[1]))];
 

--- a/.github/workflows/pr-task-link.yml
+++ b/.github/workflows/pr-task-link.yml
@@ -21,7 +21,12 @@ jobs:
           const fs = require("node:fs");
           const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
           const pr = ev.pull_request || {};
-          const text = [pr.title, pr.body || "", pr.head?.ref || ""].join("\n");
+          // Strip HTML comments first so PR-template placeholders (e.g. `<!-- e.g. AIO-72 -->`) aren't matched.
+          const text = [
+            pr.title || "",
+            (pr.body || "").replace(/<!--[\s\S]*?-->/g, " "),
+            pr.head?.ref || "",
+          ].join("\n");
           // Same matcher aios-work-sync uses (lib/pm-sync/work-keys): AIO-12 / W2.5.8 / etc.
           const re = /\b(?:AIOS-Work:\s*)?([A-Z][A-Z0-9]+-\d+|[A-Z]\d+(?:\.\d+)*)\b/g;
           const keys = [...new Set([...text.matchAll(re)].map((m) => m[1]))];


### PR DESCRIPTION
Follow-up to the Bugbot/CodeRabbit finding on the workspace PR. Both `pr-task-link.yml` and `aios-work-sync.yml` matched on raw `pr.body`, so the PR-template placeholder `<!-- e.g. AIO-72 -->` counted as a real key. Strip HTML comments before matching.

AIOS-Work: AIO-136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CI-only change to work-key parsing; reduces incorrect task linking with no auth or runtime impact.
> 
> **Overview**
> Fixes false-positive AIOS work-key detection when PR bodies still contain the template placeholder `<!-- e.g. AIO-72 -->` inside HTML comments.
> 
> **`pr-task-link.yml`** and **`aios-work-sync.yml`** now remove HTML comments from `pr.body` with `replace(/<!--[\s\S]*?-->/g, " ")` before joining title, body, and branch for the existing work-key regex. Real keys outside comments (e.g. `AIOS-Work: AIO-136`) still match; advisory warnings and merge-time brain sync no longer treat example keys in the template as linked work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9c8a78f28fcabcabe31af4b6d9126321143469. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->