### PR TITLE
feat(query): resolve first-person "how about me?" to the signed-in member

### DIFF
--- a/app/api/dashboard/query/route.ts
+++ b/app/api/dashboard/query/route.ts
@@ -105,12 +105,15 @@ export async function POST(req: NextRequest) {
 
   const { data: me } = await rls
     .from("members")
-    .select("id, tier")
+    .select("id, tier, display_name, email, actor_handle")
     .eq("team_id", team.id)
     .eq("auth_user_id", user.id)
     .eq("status", "active")
     .maybeSingle();
   if (!me) return errorResponse("forbidden", "not a member of this team", 403);
+
+  // Who the answer is FOR — anchors first-person resolution ("how about me?") to this person.
+  const caller = { displayName: me.display_name, email: me.email, handle: me.actor_handle };
 
   const memberTier = me.tier as "team" | "external";
   const supabase = adminClient();
@@ -185,7 +188,7 @@ export async function POST(req: NextRequest) {
 
       let answer = "";
       try {
-        for await (const chunk of streamAnswer(ctx, question, { anthropicKey, openaiKey }, priorTurns)) {
+        for await (const chunk of streamAnswer(ctx, question, { anthropicKey, openaiKey }, priorTurns, caller)) {
           if (chunk.type === "delta") {
             answer += chunk.text;
             send("delta", { text: chunk.text });

--- a/app/api/v1/query/route.ts
+++ b/app/api/v1/query/route.ts
@@ -71,6 +71,9 @@ export async function POST(req: NextRequest) {
   }
   if (conversationId) await appendMessage(supabase, owner, conversationId, "user", question);
 
+  // Who the answer is FOR — anchors first-person resolution ("what did I ship?") to this member.
+  const caller = { displayName: auth.displayName, email: auth.email, handle: auth.actorHandle };
+
   const started = Date.now();
   const ctx = await retrieve(supabase, auth.teamId, auth.memberTier, question, project);
 
@@ -90,7 +93,7 @@ export async function POST(req: NextRequest) {
 
       let answer = "";
       try {
-        for await (const chunk of streamAnswer(ctx, question, { anthropicKey, openaiKey }, priorTurns)) {
+        for await (const chunk of streamAnswer(ctx, question, { anthropicKey, openaiKey }, priorTurns, caller)) {
           if (chunk.type === "delta") {
             answer += chunk.text;
             send("delta", { text: chunk.text });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,8 +145,8 @@ sequenceDiagram
   Q->>Q: auth · cost guard (per-member/day, per-team $/day in query_log)
   Q->>RET: tier-filtered FTS top-12 + recent + Graphiti semantic expansion + structured digest (git + per-person activity digests included only for activity questions — context shaping)
   RET-->>Q: {sources[], structured}
-  Q->>CL: streamAnswer(ctx, question)  %% ctx.grounded=false (no FTS/semantic match) → abstain note (stay-quiet)
-  CL->>LLM: cached system + numbered sources + question
+  Q->>CL: streamAnswer(ctx, question, keys, history, caller)  %% caller = signed-in member (name/email/handle) so first-person "how about me?" resolves; ctx.grounded=false → abstain note (stay-quiet)
+  CL->>LLM: cached system + caller anchor + numbered sources + question
   LLM-->>U: SSE delta* then sources then done(usage)
 ```
 

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -10,6 +10,8 @@ export type ApiAuth = {
   memberRole: "admin" | "lead" | "member";
   apiKeyId: string;
   actorHandle: string;
+  displayName: string | null;
+  email: string | null;
 };
 
 /**
@@ -40,7 +42,7 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
 
   const { data: key } = await supabase
     .from("api_keys")
-    .select("id, team_id, member_id, key_hash, revoked_at, members(actor_handle, tier, status, role), teams(slug)")
+    .select("id, team_id, member_id, key_hash, revoked_at, members(actor_handle, tier, status, role, display_name, email), teams(slug)")
     .eq("key_id", keyId)
     .maybeSingle();
 
@@ -52,7 +54,7 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
     return fail("bad_secret");
   }
 
-  const member = key.members as unknown as { actor_handle: string; tier: "team" | "external"; status: string; role: "admin" | "lead" | "member" };
+  const member = key.members as unknown as { actor_handle: string; tier: "team" | "external"; status: string; role: "admin" | "lead" | "member"; display_name: string | null; email: string | null };
   if (member?.status !== "active") return fail("member_not_active");
 
   const team = key.teams as unknown as { slug: string };
@@ -75,5 +77,7 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
     memberRole: member.role,
     apiKeyId: key.id,
     actorHandle: member.actor_handle,
+    displayName: member.display_name,
+    email: member.email,
   };
 }

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -65,6 +65,39 @@ export interface ChatTurn {
   answer: string;
 }
 
+/**
+ * The signed-in member a query is being answered FOR. Anchors first-person resolution: without it,
+ * "how about me?" has no referent (the model only sees a by-name activity digest, with no way to
+ * know which row is the caller). Every field optional — we render whatever identity we have.
+ */
+export interface CallerIdentity {
+  displayName?: string | null;
+  email?: string | null;
+  handle?: string | null;
+}
+
+/**
+ * A one-line "who is asking" anchor injected into the query context so the model can resolve
+ * first-person references ("me", "my", "I", "mine") to a concrete person — and match that person
+ * against the by-name entries in the structured digests (git/people activity, tasks, decisions).
+ * Pure + bounded; returns "" when we have no usable identity (→ no behavior change).
+ */
+export function callerBlock(caller?: CallerIdentity): string {
+  if (!caller) return "";
+  const name = (caller.displayName ?? "").trim();
+  const email = (caller.email ?? "").trim();
+  const handle = (caller.handle ?? "").trim();
+  if (!name && !email && !handle) return "";
+  const who = [name || null, email ? `<${email}>` : null, handle ? `@${handle}` : null]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    `<caller>\nYou are answering for ${who}. Resolve first-person references ("me", "my", "I", "mine") ` +
+    `to this person, and match them against the named entries in the structured context (e.g. the activity ` +
+    `digests, task assignees, decision authors).\n</caller>`
+  );
+}
+
 // Windowed memory: the brain is RAG-grounded, not a freeform chatbot, so we carry only the last
 // few turns (each answer truncated) — enough to resolve "he/that", cheap on tokens, no overflow.
 const MAX_HISTORY_TURNS = 6;
@@ -115,7 +148,8 @@ export async function* streamAnswer(
   ctx: RetrievedContext,
   question: string,
   keys: ProviderKeys = {},
-  history: ChatTurn[] = []
+  history: ChatTurn[] = [],
+  caller?: CallerIdentity
 ): AsyncGenerator<
   | { type: "delta"; text: string }
   | { type: "done"; usage: QueryUsage }
@@ -129,10 +163,11 @@ export async function* streamAnswer(
 
   const note = groundingNote(ctx.grounded);
   const convo = conversationBlock(history);
+  const who = callerBlock(caller);
 
   // Local OpenAI-compatible backend (Ollama/Hermes) — fully on-machine, $0.
   if (LLM_BASE_URL) {
-    yield* streamLocal(note, convo, ctx.structured, sourcesBlock, question, keys.openaiKey);
+    yield* streamLocal(note, who, convo, ctx.structured, sourcesBlock, question, keys.openaiKey);
     return;
   }
 
@@ -155,6 +190,7 @@ export async function* streamAnswer(
         role: "user",
         content: [
           { type: "text", text: currentDateLine() },
+          ...(who ? [{ type: "text" as const, text: who }] : []),
           ...(note ? [{ type: "text" as const, text: note }] : []),
           { type: "text", text: `<structured_context>\n${ctx.structured}\n</structured_context>` },
           { type: "text", text: sourcesBlock || "<no document sources matched>" },
@@ -196,6 +232,7 @@ export async function* streamAnswer(
  */
 async function* streamLocal(
   note: string,
+  who: string,
   convo: string,
   structured: string,
   sourcesBlock: string,
@@ -208,6 +245,7 @@ async function* streamLocal(
   const userContent =
     currentDateLine() +
     "\n\n" +
+    (who ? `${who}\n\n` : "") +
     note +
     `<structured_context>\n${structured}\n</structured_context>\n\n` +
     `${sourcesBlock || "<no document sources matched>"}\n\n` +

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -199,7 +199,7 @@ export function graphExpansionQuery(facts: GraphFact[]): string {
 // the question is actually about who's doing what — biased INCLUSIVE (a false positive just restores
 // the old always-on behavior; a false negative would drop relevant context, so we'd rather over-include).
 const ACTIVITY_INTENT =
-  /\b(who|whose|doing|working|worked|activity|active|busy|contribut\w*|commit\w*|posting|posted|assigned|assignee|standup|workload|lately|recently)\b|\bup to\b|\bthis (week|sprint|month)\b/i;
+  /\b(who|whose|doing|working|worked|activity|active|busy|contribut\w*|commit\w*|posting|posted|assigned|assignee|standup|workload|lately|recently|my|mine|github|submission\w*|prs?|ship\w*|complet\w*|accomplish\w*|finish\w*|deliver\w*|merg\w*|yesterday|today)\b|\bi've\b|\babout me\b|\bme[?!.\s]*$|\bpull request\b|\bup to\b|\b(this|last) (week|sprint|month)\b/i;
 
 /** True when a query is about people/activity (→ include the git + people-activity digests). */
 export function wantsActivityContext(question: string): boolean {

--- a/test/query-caller.test.ts
+++ b/test/query-caller.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { callerBlock, type CallerIdentity } from "@/lib/query/claude";
+
+// Spec: the query pipeline must tell the model WHO is asking, so first-person questions
+// ("how about me?", "what did I ship?") resolve to a concrete person and match that person's
+// row in the by-name activity digests. Before this, both query routes resolved the caller for
+// auth/rate-limiting but never surfaced the identity to the LLM — so "me" had no referent and
+// the brain replied "the context does not include contributions tied to specific users".
+
+describe("callerBlock", () => {
+  it("returns empty string when there is no usable identity (→ no behavior change)", () => {
+    expect(callerBlock(undefined)).toBe("");
+    expect(callerBlock({})).toBe("");
+    expect(callerBlock({ displayName: "  ", email: "", handle: null })).toBe("");
+  });
+
+  it("anchors first-person resolution to the caller's name/email/handle", () => {
+    const caller: CallerIdentity = {
+      displayName: "Chetan Nandakumar",
+      email: "chetan@example.com",
+      handle: "chetan",
+    };
+    const block = callerBlock(caller);
+    expect(block.startsWith("<caller>")).toBe(true);
+    expect(block.trimEnd().endsWith("</caller>")).toBe(true);
+    expect(block).toContain("Chetan Nandakumar");
+    expect(block).toContain("<chetan@example.com>");
+    expect(block).toContain("@chetan");
+    // The instruction the model needs to bind "me"/"my"/"I" to this person.
+    expect(block).toMatch(/resolve first-person references/i);
+    expect(block).toMatch(/"me"/);
+  });
+
+  it("renders whatever partial identity is available", () => {
+    const nameOnly = callerBlock({ displayName: "Priya" });
+    expect(nameOnly).toContain("answering for Priya.");
+    expect(nameOnly).not.toContain("<>"); // no empty email markup
+    expect(nameOnly).not.toContain("@\n"); // no dangling handle marker
+
+    const emailOnly = callerBlock({ email: "priya@example.com" });
+    expect(emailOnly).toContain("answering for <priya@example.com>.");
+    expect(emailOnly).not.toContain("undefined");
+    expect(emailOnly).not.toContain("null");
+  });
+});

--- a/test/query-recall.test.ts
+++ b/test/query-recall.test.ts
@@ -57,6 +57,23 @@ describe("wantsActivityContext (context shaping)", () => {
       expect(wantsActivityContext(q), q).toBe(true);
     }
   });
+  // Spec (this branch): first-person "what have I done" questions must route to the activity digests
+  // too — otherwise "how about me?" has no git/people context to ground on. Bias stays inclusive.
+  it("true for first-person / completed-work questions", () => {
+    for (const q of [
+      "how about me?",
+      "what about me",
+      "what have I shipped this week?",
+      "what did I complete yesterday?",
+      "my github submissions",
+      "what are my open PRs?",
+      "what did I finish today",
+      "what have I merged lately",
+      "tell me about my recent work",
+    ]) {
+      expect(wantsActivityContext(q), q).toBe(true);
+    }
+  });
   it("false for non-activity questions", () => {
     for (const q of ["what did we decide about auth?", "show me the Q3 roadmap", "how does login work?", "what is the SSRF fix?"]) {
       expect(wantsActivityContext(q), q).toBe(false);


### PR DESCRIPTION
## Problem
The chat answered `"what did John complete?"` but failed `"how about me?"` — it replied that the structured context had *"no details about individual contributions tied to specific users."*

**Root cause:** both query routes resolved *who the caller is* for auth / rate-limiting, then **never surfaced that identity to the LLM**. So first-person references (`me`/`my`/`I`) had no referent — the model only saw a by-name activity digest with no way to know which row was the caller. It was not a data problem: GitHub commits are correctly attributed to the member in the DB.

## Fix
- **`lib/query/claude.ts`** — new pure `callerBlock()` renders a `<caller>` anchor ("You are answering for {name} <{email}> @{handle}. Resolve 'me'/'my'/'I' to this person…"); `streamAnswer` injects it in both the Anthropic and local-LLM paths.
- **`app/api/dashboard/query/route.ts`** + **`app/api/v1/query/route.ts`** — thread the caller (name/email/handle) from the resolved member / API key into `streamAnswer`.
- **`lib/api/auth.ts`** — `ApiAuth` now carries `displayName`/`email` for the machine-API caller.
- **`lib/query/retrieve.ts`** — broaden `ACTIVITY_INTENT` so first-person / completed-work questions (`my`, `me`, `github`, `prs`, `complet*`, `ship*`, `merg*`, …) route to the git + people-activity digests. Necessary other half: without it those digests aren't even included.
- **`docs/ARCHITECTURE.md`** — query-flow diagram reflects the caller anchor.

## Tests
- New `test/query-caller.test.ts` — spec for `callerBlock` (identity anchor, partial identity, empty → no-op).
- Extended activity-intent spec in `test/query-recall.test.ts` with first-person / completed-work cases (and a still-excluded control).
- Full unit tier **272/272 green**, `tsc` clean, lint clean, docs-drift green.

## Verification (prod, read-only)
Member `Chetan` identity mapping is healthy: GitHub mapped via `member_emails` (43 commits attributed, none orphaned); Slack/Linear/Plane mapped in `member_identities`. Post-fix, `"how about me?"` now names the caller and surfaces their real recent work instead of the blanket "no per-user data" reply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved query responses with caller context, so the assistant can better understand who is asking.
  * Expanded activity-related question detection to better handle first-person and recent-work queries.

* **Bug Fixes**
  * Better supports queries like “what have I done?” or “what did I finish yesterday?” by routing them to the right context.
  * Handles partial identity details more gracefully when building caller context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->