### PR TITLE
fix(ci): correct scan-on-merge repo guard (aiosbrain, not AIOS-alpha)

### DIFF
--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -29,7 +29,7 @@ jobs:
   scan:
     name: codebase readiness scan → brain
     runs-on: ubuntu-latest
-    if: github.repository == 'AIOS-alpha/aios-team-brain'
+    if: github.repository == 'aiosbrain/aios-team-brain'
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Problem
`scan-on-merge` is the only automated path that refreshes **commit history** in the brain (`code_contributions` + commits→searchable git items, via `aios-ingest scan`). Its job guard was:

```yaml
if: github.repository == 'AIOS-alpha/aios-team-brain'
```

The real repo is **`aiosbrain/aios-team-brain`**, so the condition was never true and the job **skipped on every merge to main** (1s, `skipped`) since it was added — including #119, #118, #117, #108, #111.

## Impact
Commit history froze at the last **manual** `aios-ingest scan` (2026-06-26). The 30-min in-process scheduler (`lib/ingest/scheduler.ts`) pulls GitHub **issues + files only**, not commits — so "what are my recent commits?" never saw work after June 26.

Verified in prod: `code_contributions` max day = 2026-06-26; GitHub *issue* items fresh (today). Confirms the two paths and that only the commit path was dead.

## Fix
One line — correct the org in the guard so the scan runs on every merge to main again.

## Follow-up (not in this PR)
- Backfill today's commits with a one-off scan once merged.
- Persist import/sync errors somewhere queryable (currently console-only for scheduled runs) — tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated scan conditions so it runs only for the intended repository, preventing scans from triggering in the wrong project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->