### PR TITLE
feat(query): resolve relative dates in the asker's timezone; "today" = last 24h

### DIFF
--- a/app/api/dashboard/query/route.ts
+++ b/app/api/dashboard/query/route.ts
@@ -7,6 +7,7 @@ import { rateLimit } from "@/lib/api/rate-limit";
 import { errorResponse } from "@/lib/api/schemas";
 import { retrieve } from "@/lib/query/retrieve";
 import { streamAnswer } from "@/lib/query/claude";
+import { pickTimezone, DEFAULT_TIMEZONE } from "@/lib/query/timezone";
 import {
   ownsConversation,
   recentTurns,
@@ -72,6 +73,9 @@ const dashboardQuerySchema = z.object({
   // Persistent thread id. Omit to start a new conversation (the server creates one and returns its
   // id via a `conversation` SSE event); pass it back on later turns so history loads server-side.
   conversation_id: z.string().uuid().optional(),
+  // Browser-detected IANA timezone (Intl.DateTimeFormat().resolvedOptions().timeZone) so relative
+  // dates ("today") resolve in the ASKER's timezone. Optional/validated; falls back to profile/UTC.
+  tz: z.string().max(64).optional(),
 });
 
 /**
@@ -92,7 +96,7 @@ export async function POST(req: NextRequest) {
   }
   const parsed = dashboardQuerySchema.safeParse(json);
   if (!parsed.success) return errorResponse("invalid_payload", "question and team required", 422);
-  const { question, team: teamSlug, project, conversation_id } = parsed.data;
+  const { question, team: teamSlug, project, conversation_id, tz } = parsed.data;
 
   // Resolve team + membership under RLS — returns nothing unless the
   // signed-in user is an active member of that team.
@@ -114,6 +118,15 @@ export async function POST(req: NextRequest) {
 
   // Who the answer is FOR — anchors first-person resolution ("how about me?") to this person.
   const caller = { displayName: me.display_name, email: me.email, handle: me.actor_handle };
+
+  // Timezone for relative-date anchoring: browser tz (most accurate) → member profile → instance default.
+  const { data: prof } = await rls
+    .from("member_profiles")
+    .select("timezone")
+    .eq("team_id", team.id)
+    .eq("member_id", me.id)
+    .maybeSingle();
+  const timeZone = pickTimezone([tz, prof?.timezone, DEFAULT_TIMEZONE]);
 
   const memberTier = me.tier as "team" | "external";
   const supabase = adminClient();
@@ -188,7 +201,7 @@ export async function POST(req: NextRequest) {
 
       let answer = "";
       try {
-        for await (const chunk of streamAnswer(ctx, question, { anthropicKey, openaiKey }, priorTurns, caller)) {
+        for await (const chunk of streamAnswer(ctx, question, { anthropicKey, openaiKey }, priorTurns, caller, timeZone)) {
           if (chunk.type === "delta") {
             answer += chunk.text;
             send("delta", { text: chunk.text });

--- a/app/api/v1/query/route.ts
+++ b/app/api/v1/query/route.ts
@@ -5,6 +5,7 @@ import { rateLimit } from "@/lib/api/rate-limit";
 import { querySchema, errorResponse } from "@/lib/api/schemas";
 import { retrieve } from "@/lib/query/retrieve";
 import { streamAnswer } from "@/lib/query/claude";
+import { pickTimezone, DEFAULT_TIMEZONE } from "@/lib/query/timezone";
 import { getProviderKey } from "@/lib/integrations/manage";
 import {
   ownsConversation,
@@ -74,6 +75,15 @@ export async function POST(req: NextRequest) {
   // Who the answer is FOR — anchors first-person resolution ("what did I ship?") to this member.
   const caller = { displayName: auth.displayName, email: auth.email, handle: auth.actorHandle };
 
+  // Timezone for relative-date anchoring (no browser here): member profile → instance default.
+  const { data: prof } = await supabase
+    .from("member_profiles")
+    .select("timezone")
+    .eq("team_id", auth.teamId)
+    .eq("member_id", auth.memberId)
+    .maybeSingle();
+  const timeZone = pickTimezone([prof?.timezone, DEFAULT_TIMEZONE]);
+
   const started = Date.now();
   const ctx = await retrieve(supabase, auth.teamId, auth.memberTier, question, project);
 
@@ -93,7 +103,7 @@ export async function POST(req: NextRequest) {
 
       let answer = "";
       try {
-        for await (const chunk of streamAnswer(ctx, question, { anthropicKey, openaiKey }, priorTurns, caller)) {
+        for await (const chunk of streamAnswer(ctx, question, { anthropicKey, openaiKey }, priorTurns, caller, timeZone)) {
           if (chunk.type === "delta") {
             answer += chunk.text;
             send("delta", { text: chunk.text });

--- a/components/query-chat.tsx
+++ b/components/query-chat.tsx
@@ -97,6 +97,8 @@ export function QueryChat({
         body: JSON.stringify({
           question: text,
           team: teamSlug,
+          // Browser timezone so "today"/"this week" resolve in the user's local time, not server UTC.
+          tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
           ...(conversationId ? { conversation_id: conversationId } : {}),
         }),
       });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,12 +141,12 @@ sequenceDiagram
   participant RET as lib/query/retrieve
   participant CL as lib/query/claude
   participant LLM as Claude
-  U->>Q: {question, project?}
-  Q->>Q: auth · cost guard (per-member/day, per-team $/day in query_log)
+  U->>Q: {question, project?, tz?}  %% tz = browser IANA timezone (dashboard)
+  Q->>Q: auth · cost guard (per-member/day, per-team $/day in query_log) · resolve timezone (browser tz → member profile → BRAIN_DEFAULT_TIMEZONE → UTC)
   Q->>RET: tier-filtered FTS top-12 + recent + Graphiti semantic expansion + structured digest (git + per-person activity digests included only for activity questions — context shaping)
   RET-->>Q: {sources[], structured}
-  Q->>CL: streamAnswer(ctx, question, keys, history, caller)  %% caller = signed-in member (name/email/handle) so first-person "how about me?" resolves; ctx.grounded=false → abstain note (stay-quiet)
-  CL->>LLM: cached system + caller anchor + numbered sources + question
+  Q->>CL: streamAnswer(ctx, question, keys, history, caller, timeZone)  %% caller = signed-in member (name/email/handle) so first-person "how about me?" resolves; timeZone anchors relative dates ("today" = last 24h in the user's tz); ctx.grounded=false → abstain note (stay-quiet)
+  CL->>LLM: cached system + date/tz anchor + caller anchor + numbered sources + question
   LLM-->>U: SSE delta* then sources then done(usage)
 ```
 

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -32,19 +32,51 @@ Rules:
 - Answer EVERY part of a multi-part question. If it contains several asks (e.g. about two different people), address each one explicitly — never silently drop a part.
 - If a <conversation_so_far> block is present, use it to resolve references to earlier turns ("he", "she", "they", "that", "the same one"). It is prior context only — still answer ONLY from the sources and structured context below.
 - Decisions marked [SUPERSEDED] are no longer valid — say so if relevant.
-- Interpret relative dates ("today", "yesterday", "this week", "recently") against the Current date given at the top of the context. Dates in the structured context (e.g. a task's "updated" date) are UTC calendar dates — compare them to the Current date to answer "what happened today/this week".
+- Interpret relative dates in the USER'S timezone stated at the top of the context. "today" means the last 24 hours (the rolling window given, NOT the calendar day) — so an item timestamped within that window counts as "today" even if its calendar date reads as yesterday. "yesterday" = the 24h before that; "this week" = the last 7 days; "recently" ≈ the last two weeks. Dates in the structured context (e.g. a task's "updated" date, a commit's day) are calendar dates and may be in UTC or the commit's own timezone — reconcile them against the window rather than assuming the user's calendar day.
 - Never speculate about content above the caller's access tier; what you were given is what they may see.`;
 
-const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+/** Render an instant's Y-M-D, H:M, weekday and UTC-offset in a given IANA timezone. */
+function partsInZone(now: Date, timeZone: string): { date: string; time: string; weekday: string; offset: string } {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23", // 00–23 (avoids the "24:00" ICU quirk at midnight)
+    weekday: "long",
+    timeZoneName: "longOffset",
+  });
+  const p = Object.fromEntries(fmt.formatToParts(now).map((x) => [x.type, x.value]));
+  return {
+    date: `${p.year}-${p.month}-${p.day}`,
+    time: `${p.hour}:${p.minute}`,
+    weekday: p.weekday ?? "",
+    offset: (p.timeZoneName ?? "GMT+00:00").replace("GMT", "UTC"),
+  };
+}
 
 /**
- * A single line stating today's date, injected at the top of the query context so the model can
- * resolve "today / this week / recently". UTC to match the structured digest's date basis (all
- * digest dates are UTC ISO slices). Pure + injectable `now` for deterministic tests.
+ * The date/time anchor injected at the top of the query context. States NOW in the user's timezone
+ * and defines "today" as the trailing 24 hours (a rolling window with an explicit UTC cutoff the
+ * model can compare digest dates against) — so a GMT+8 user's 05:00-UTC commit reads as "today",
+ * not "yesterday". Pure + injectable (`now`, `timeZone`) for deterministic tests; invalid tz → UTC.
  */
-export function currentDateLine(now: Date = new Date()): string {
-  const iso = now.toISOString().slice(0, 10);
-  return `Current date: ${iso} (${WEEKDAYS[now.getUTCDay()]}, UTC).`;
+export function currentDateLine(now: Date = new Date(), timeZone: string = "UTC"): string {
+  let z = timeZone;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: z });
+  } catch {
+    z = "UTC";
+  }
+  const { date, time, weekday, offset } = partsInZone(now, z);
+  const since = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  return (
+    `Current date & time: ${date} ${time} (${weekday}) — user timezone ${z} (${offset}).\n` +
+    `"today" = the last 24 hours (rolling window since ${since}); "yesterday" = the 24h before that; ` +
+    `"this week" = the last 7 days. Resolve all relative dates in the user's timezone.`
+  );
 }
 
 /**
@@ -149,7 +181,8 @@ export async function* streamAnswer(
   question: string,
   keys: ProviderKeys = {},
   history: ChatTurn[] = [],
-  caller?: CallerIdentity
+  caller?: CallerIdentity,
+  timeZone: string = "UTC"
 ): AsyncGenerator<
   | { type: "delta"; text: string }
   | { type: "done"; usage: QueryUsage }
@@ -167,7 +200,7 @@ export async function* streamAnswer(
 
   // Local OpenAI-compatible backend (Ollama/Hermes) — fully on-machine, $0.
   if (LLM_BASE_URL) {
-    yield* streamLocal(note, who, convo, ctx.structured, sourcesBlock, question, keys.openaiKey);
+    yield* streamLocal(note, who, convo, ctx.structured, sourcesBlock, question, timeZone, keys.openaiKey);
     return;
   }
 
@@ -189,7 +222,7 @@ export async function* streamAnswer(
       {
         role: "user",
         content: [
-          { type: "text", text: currentDateLine() },
+          { type: "text", text: currentDateLine(new Date(), timeZone) },
           ...(who ? [{ type: "text" as const, text: who }] : []),
           ...(note ? [{ type: "text" as const, text: note }] : []),
           { type: "text", text: `<structured_context>\n${ctx.structured}\n</structured_context>` },
@@ -237,13 +270,14 @@ async function* streamLocal(
   structured: string,
   sourcesBlock: string,
   question: string,
+  timeZone: string,
   openaiKey?: string | null
 ): AsyncGenerator<
   | { type: "delta"; text: string }
   | { type: "done"; usage: QueryUsage }
 > {
   const userContent =
-    currentDateLine() +
+    currentDateLine(new Date(), timeZone) +
     "\n\n" +
     (who ? `${who}\n\n` : "") +
     note +

--- a/lib/query/timezone.ts
+++ b/lib/query/timezone.ts
@@ -1,0 +1,33 @@
+/**
+ * Timezone resolution for query date-anchoring. Relative dates ("today", "this week") must be
+ * interpreted in the ASKER's timezone, not the server's UTC — a commit made at 05:00 UTC is
+ * "this afternoon" for a GMT+8 user, so a UTC-only anchor mis-buckets their own recent work.
+ *
+ * Pure + dependency-free (Intl only) so it unit-tests without a DB or a clock.
+ */
+
+/** Instance-wide fallback when we have no better signal (browser tz / member profile). */
+export const DEFAULT_TIMEZONE = process.env.BRAIN_DEFAULT_TIMEZONE || "UTC";
+
+/** True when `tz` is a resolvable IANA timezone (e.g. "Asia/Singapore", "UTC"). */
+export function isValidTimeZone(tz: string): boolean {
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * First valid IANA timezone from the candidates, else "UTC". Callers pass their preference order,
+ * e.g. [browserTz, memberProfileTz, DEFAULT_TIMEZONE] — most-specific/most-accurate first.
+ */
+export function pickTimezone(candidates: Array<string | null | undefined>): string {
+  for (const c of candidates) {
+    const tz = c?.trim();
+    if (tz && isValidTimeZone(tz)) return tz;
+  }
+  return "UTC";
+}

--- a/test/query-current-date.test.ts
+++ b/test/query-current-date.test.ts
@@ -2,26 +2,45 @@ import { describe, expect, it } from "vitest";
 import { currentDateLine } from "@/lib/query/claude";
 
 /**
- * Spec: the query prompt must state today's date so the brain can resolve relative dates
- * ("today", "this week"). Derived from the product requirement (the brain should know when
- * "today" is), not the implementation. UTC, with the weekday, matching the digest date basis.
+ * Spec: the query prompt must anchor relative dates in the ASKER's timezone, and define "today" as
+ * a rolling 24h window (not the server's UTC calendar day). Derived from the product requirement —
+ * a GMT+8 user's 05:00-UTC commit is "today" for them, and a UTC-only anchor mis-bucketed it as
+ * yesterday. The window cutoff is an explicit UTC instant so the model can compare digest dates.
  */
 
 describe("currentDateLine", () => {
-  it("states the given date as a UTC calendar date with weekday", () => {
-    // 2026-06-26 is a Friday (UTC).
-    const line = currentDateLine(new Date("2026-06-26T09:30:00Z"));
-    expect(line).toBe("Current date: 2026-06-26 (Friday, UTC).");
+  it("states NOW in the given timezone with weekday and UTC offset", () => {
+    // 2026-07-01T05:05:00Z is 13:05 on 2026-07-01 in UTC+8 (a Wednesday).
+    const line = currentDateLine(new Date("2026-07-01T05:05:00Z"), "Asia/Singapore");
+    expect(line).toContain("2026-07-01 13:05");
+    expect(line).toContain("Wednesday");
+    expect(line).toContain("Asia/Singapore");
+    expect(line).toContain("UTC+08:00");
   });
 
-  it("uses the UTC day even when the local time would roll to the next date", () => {
-    // 23:30Z on the 26th is still the 26th in UTC regardless of the runner's timezone.
+  it("crosses the date line: an evening-UTC instant is already tomorrow in +8", () => {
+    // 2026-06-30T20:00:00Z is 2026-07-01 04:00 in UTC+8.
+    const line = currentDateLine(new Date("2026-06-30T20:00:00Z"), "Asia/Singapore");
+    expect(line).toContain("2026-07-01 04:00");
+  });
+
+  it('defines "today" as the trailing 24h with an explicit UTC cutoff', () => {
+    const now = new Date("2026-07-01T05:05:00Z");
+    const line = currentDateLine(now, "Asia/Singapore");
+    expect(line).toMatch(/last 24 hours/i);
+    // cutoff = now - 24h = 2026-06-30T05:05:00Z
+    expect(line).toContain("2026-06-30T05:05:00.000Z");
+  });
+
+  it("falls back to UTC for an unknown timezone", () => {
+    const line = currentDateLine(new Date("2026-06-26T09:30:00Z"), "Not/AZone");
+    expect(line).toContain("2026-06-26 09:30");
+    expect(line).toContain("UTC (UTC+00:00)");
+  });
+
+  it("defaults to UTC when no timezone is given", () => {
     const line = currentDateLine(new Date("2026-06-26T23:30:00Z"));
-    expect(line).toContain("2026-06-26");
-    expect(line).toContain("Friday");
-  });
-
-  it("defaults to now() and yields a well-formed line", () => {
-    expect(currentDateLine()).toMatch(/^Current date: \d{4}-\d{2}-\d{2} \([A-Z][a-z]+, UTC\)\.$/);
+    expect(line).toContain("2026-06-26 23:30");
+    expect(line).toContain("UTC");
   });
 });

--- a/test/query-timezone.test.ts
+++ b/test/query-timezone.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isValidTimeZone, pickTimezone } from "@/lib/query/timezone";
+
+// Spec: relative-date anchoring must use the asker's timezone, resolved from the most accurate
+// available signal (browser → member profile → instance default), and never crash on bad input.
+
+describe("isValidTimeZone", () => {
+  it("accepts IANA zones and UTC", () => {
+    expect(isValidTimeZone("Asia/Singapore")).toBe(true);
+    expect(isValidTimeZone("America/Los_Angeles")).toBe(true);
+    expect(isValidTimeZone("UTC")).toBe(true);
+  });
+  it("rejects garbage and empties", () => {
+    expect(isValidTimeZone("Not/AZone")).toBe(false);
+    expect(isValidTimeZone("")).toBe(false);
+    expect(isValidTimeZone("nonsense")).toBe(false);
+  });
+});
+
+describe("pickTimezone", () => {
+  it("returns the first valid candidate in preference order", () => {
+    expect(pickTimezone(["Asia/Singapore", "UTC"])).toBe("Asia/Singapore");
+    expect(pickTimezone([null, "  ", "bogus", "Europe/Paris"])).toBe("Europe/Paris");
+  });
+  it("trims candidates before validating", () => {
+    expect(pickTimezone(["  Asia/Tokyo  "])).toBe("Asia/Tokyo");
+  });
+  it("falls back to UTC when nothing is valid", () => {
+    expect(pickTimezone([null, undefined, "", "nope"])).toBe("UTC");
+    expect(pickTimezone([])).toBe("UTC");
+  });
+});


### PR DESCRIPTION
## Problem
Relative dates were anchored to **server UTC**. A GMT+8 user's commit made at 05:00 UTC (their early afternoon) was labeled "yesterday", and "what did I do today?" missed it. This is the same class of confusion behind "my commits from today didn't show up".

## Fix
The query pipeline now resolves **each asker's timezone** and defines **"today" as a rolling 24-hour window** (a timezone-independent instant range) with an explicit UTC cutoff the model can compare digest dates against.

- **`lib/query/timezone.ts`** (new) — `pickTimezone(candidates)` + `isValidTimeZone` (IANA via `Intl`). Instance default via `BRAIN_DEFAULT_TIMEZONE` (→ `UTC`).
- **`lib/query/claude.ts`** — `currentDateLine(now, tz)` renders NOW in the user's tz with weekday + UTC offset and states the rolling-24h window; `streamAnswer` takes `timeZone`; system prompt updated ("today" = last 24h; resolve relative dates in the user's tz).
- **Routes** — resolve tz in preference order: **browser tz** (dashboard body) → **member profile** (`member_profiles.timezone`) → `BRAIN_DEFAULT_TIMEZONE` → `UTC`.
- **`components/query-chat.tsx`** — sends `Intl.DateTimeFormat().resolvedOptions().timeZone` with each query (most accurate source; always present in-browser).

## Why a rolling window
"Last 24h" is the same instant range in every timezone, so it sidesteps calendar-boundary ambiguity entirely. Timezone still governs *display* ("Current date & time … Asia/Singapore (UTC+08:00)") and calendar terms ("this week" = last 7 days).

## Tests
- `test/query-current-date.test.ts` (rewritten) — tz rendering, date-line crossing (evening-UTC = next day in +8), explicit 24h cutoff, unknown-tz + no-tz fallback to UTC.
- `test/query-timezone.test.ts` (new) — `isValidTimeZone` / `pickTimezone` preference order + fallback.
- Full unit tier green (279), `tsc`/lint clean, docs-drift green; ARCHITECTURE query-flow diagram updated.

## Ops note
No member profiles set a timezone yet, so the **dashboard** uses the browser tz (works immediately). The **machine API** (CLI) has no browser — set `BRAIN_DEFAULT_TIMEZONE` on the instance, or populate `member_profiles.timezone`, to override UTC there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queries now respect the user’s timezone when interpreting relative dates like “today,” “yesterday,” and “this week.”
  * The chat request now sends the browser’s timezone automatically for more accurate answers.

* **Bug Fixes**
  * Improved timezone fallback handling so results use a valid timezone when the browser setting is unavailable or invalid.
  * Updated date-related responses to avoid server-time mismatches.

* **Documentation**
  * Updated architecture docs to reflect the new timezone-aware query flow.

* **Tests**
  * Added and updated tests for timezone validation, fallback behavior, and relative-date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->