### PR TITLE
feat(ops): runtime service-identity guard so aios can't load its schema onto a foreign DB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,13 @@ bash scripts/e2e.sh    # system-level integration: seed → push → materialize
   a PreToolUse hook (`scripts/railway-deploy-guard.sh`) blocks them (incl. `cd other && railway up`). Before
   *any* Railway command, confirm `railway status` shows **Project: AIOS**; audit all worktrees with
   `bash scripts/railway-link-check.sh`.
+- **Runtime backstop (`scripts/service-guard.mjs`).** The hook above only fires inside the agent's shell; it
+  can't stop a human `railway up` or any other path that lands this code on a foreign service. So the schema
+  loaders (`pg-load-schema.mjs` = the `preDeployCommand`, and `pg-load-vector.mjs`) call `assertServiceIdentity`
+  **before** connecting: if `RAILWAY_SERVICE_NAME` is set and isn't an AIOS service (`aios` / `aios-*`, override
+  via `AIOS_RAILWAY_SERVICES`), the load aborts non-zero and Railway halts the release — so this repo can never
+  inject its schema into another project's DB again (the 2026-06-27 Kula incident). Mirrors Kula's
+  `src/lib/service-guard.ts`; guarded by `test/guards/service-guard.test.ts`.
 
 ---
 

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -120,6 +120,16 @@ CLI is **read-only** here. The destructive verbs are **blocked** by `.claude/set
 (deny-list + the `scripts/railway-deploy-guard.sh` PreToolUse hook, which also catches the
 `cd other && <deploy>` form). See CLAUDE.md §6.
 
+### Runtime backstop (defense in depth)
+The hook only fires inside the agent's shell. The **runtime** guard covers everything else (a human
+`railway up`, or any path that lands this code on a foreign service): the schema loaders
+(`pg-load-schema.mjs` = the `preDeployCommand`, `pg-load-vector.mjs`) call `assertServiceIdentity`
+(`scripts/service-guard.mjs`) **before** opening a DB connection. If `RAILWAY_SERVICE_NAME` is set and
+isn't an AIOS service (`aios` / `aios-*`; override `AIOS_RAILWAY_SERVICES`), the load aborts non-zero and
+Railway halts the release — so aios can never inject its schema into another project's DB (2026-06-27).
+This mirrors Kula's `src/lib/service-guard.ts`; both apps carrying it is what makes the protection
+symmetric. Guarded by `test/guards/service-guard.test.ts`.
+
 ### After creating a new worktree
 Conductor spawns worktrees that can inherit a wrong link. Audit + fix:
 

--- a/scripts/pg-load-schema.mjs
+++ b/scripts/pg-load-schema.mjs
@@ -13,8 +13,14 @@
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { Client } from "pg";
+import { assertServiceIdentity } from "./service-guard.mjs";
 
 async function main() {
+  // On Railway, refuse to run if this app landed on a non-AIOS service — the
+  // 2026-06-27 vector: this preDeployCommand ran against Kula's DATABASE_URL and
+  // injected our schema into Kula's prod DB. Abort BEFORE reading DATABASE_URL.
+  assertServiceIdentity("load the AIOS schema");
+
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error("DATABASE_URL is required");
 

--- a/scripts/pg-load-vector.mjs
+++ b/scripts/pg-load-vector.mjs
@@ -9,8 +9,13 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { Client } from "pg";
+import { assertServiceIdentity } from "./service-guard.mjs";
 
 async function main() {
+  // Same service-identity backstop as pg-load-schema.mjs — never load our schema
+  // onto a foreign (non-AIOS) Railway service's database.
+  assertServiceIdentity("load the AIOS pgvector schema");
+
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error("DATABASE_URL is required");
 

--- a/scripts/service-guard.mjs
+++ b/scripts/service-guard.mjs
@@ -1,0 +1,71 @@
+/**
+ * Service-identity guard — the runtime backstop against THIS (aios-team-brain) app
+ * being deployed onto another project's Railway service. It is the symmetric mirror
+ * of Kula's `src/lib/service-guard.ts`; the incident below is why both must exist.
+ *
+ * 2026-06-27 incident: an aios-team-brain Conductor worktree was `railway up`'d onto
+ * the **kula** Railway service. That deploy inherited the kula service's env (incl.
+ * DATABASE_URL) and its preDeployCommand — `npm run pg:schema` — ran THIS repo's
+ * schema.sql against Kula's PRODUCTION database, additively injecting ~33 foreign
+ * tables and taking Kula's WhatsApp webhook offline for ~24h.
+ *
+ * Railway injects `RAILWAY_SERVICE_NAME` into every deploy, reflecting the SERVICE the
+ * container runs on (not the app's own name). So if this code is ever running on a
+ * service that isn't one of AIOS's, we abort BEFORE opening a DB connection.
+ *
+ * Relationship to the other guard: `scripts/railway-deploy-guard.sh` is a PreToolUse
+ * hook that blocks `railway up`/`redeploy`/`down`/`delete` from the AGENT's shell.
+ * That only fires inside Claude Code with the hook active — it does nothing for a
+ * `railway up` typed by a human, or any other path that lands this code on a foreign
+ * service. THIS module is the runtime belt-and-suspenders: even if a foreign deploy
+ * happens, the schema load refuses to run against the wrong database.
+ *
+ * Only enforced when `RAILWAY_SERVICE_NAME` is present (i.e. on Railway). Local dev,
+ * tests, CI, and one-off scripts leave it unset and run unguarded.
+ */
+
+/**
+ * True when `name` is one of AIOS's own Railway services.
+ *
+ * Default policy accepts `aios` and any `aios-*` service (covers the production
+ * `aios-team-brain` service and any future `aios-web` / `aios-worker` split without
+ * extra config). Override with `AIOS_RAILWAY_SERVICES` (comma-separated, exact-match)
+ * if AIOS is renamed or its services don't share the `aios` prefix.
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
+export function isAiosService(name) {
+  const override = process.env.AIOS_RAILWAY_SERVICES;
+  if (override && override.trim()) {
+    return override
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .includes(name);
+  }
+  return name === "aios" || name.startsWith("aios-");
+}
+
+/**
+ * Throw if this process is running on a Railway service that isn't AIOS's.
+ * No-op when `RAILWAY_SERVICE_NAME` is unset (off-Railway).
+ *
+ * @param {string} context short verb phrase for the error, e.g. `'load the AIOS schema'`.
+ * @returns {void}
+ */
+export function assertServiceIdentity(context) {
+  const actual = process.env.RAILWAY_SERVICE_NAME;
+  if (!actual) return; // not on Railway — nothing to assert
+
+  if (!isAiosService(actual)) {
+    throw new Error(
+      `[service-guard] Refusing to ${context}: this is the aios-team-brain app but it is ` +
+        `running on Railway service '${actual}', which is not an AIOS service. ` +
+        `This almost always means the WRONG app was deployed onto this service ` +
+        `(the 2026-06-27 incident, when an aios worktree was railway-up'd onto Kula). ` +
+        `Aborting before touching the database. If AIOS was legitimately renamed or ` +
+        `split, set AIOS_RAILWAY_SERVICES (comma-separated) to the allowed service names.`
+    );
+  }
+}

--- a/test/guards/service-guard.test.ts
+++ b/test/guards/service-guard.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { assertServiceIdentity, isAiosService } from "../../scripts/service-guard.mjs";
+
+/**
+ * Service-identity guard — the runtime backstop that refuses to load this repo's schema
+ * when it is running on a NON-AIOS Railway service. Spec = the 2026-06-27 incident: an
+ * aios-team-brain worktree was `railway up`'d onto the **kula** service, whose
+ * preDeployCommand (`npm run pg:schema`) then injected our schema into Kula's prod DB.
+ *
+ * The guard mirrors Kula's `src/lib/service-guard.ts`. These assertions are derived from
+ * the intended contract, not the implementation:
+ *   - AIOS's own services (aios / aios-team-brain / aios-*) are accepted.
+ *   - Any other service (kula, kula-worker, …) is rejected.
+ *   - The check is a no-op off Railway (RAILWAY_SERVICE_NAME unset).
+ *   - An explicit AIOS_RAILWAY_SERVICES override wins.
+ * Plus a STRUCTURAL guard: both schema loaders must actually call assertServiceIdentity
+ * before opening a DB connection — otherwise the backstop isn't in the injection path.
+ */
+
+describe("isAiosService — allow-list policy", () => {
+  const saved = process.env.AIOS_RAILWAY_SERVICES;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.AIOS_RAILWAY_SERVICES;
+    else process.env.AIOS_RAILWAY_SERVICES = saved;
+  });
+
+  it("accepts AIOS's own services (prod + a future web/worker split)", () => {
+    delete process.env.AIOS_RAILWAY_SERVICES;
+    expect(isAiosService("aios-team-brain")).toBe(true); // the real prod service
+    expect(isAiosService("aios")).toBe(true);
+    expect(isAiosService("aios-web")).toBe(true);
+    expect(isAiosService("aios-worker")).toBe(true);
+  });
+
+  it("rejects a foreign service — Kula and anything else", () => {
+    delete process.env.AIOS_RAILWAY_SERVICES;
+    expect(isAiosService("kula")).toBe(false);
+    expect(isAiosService("kula-worker")).toBe(false);
+    expect(isAiosService("postgres")).toBe(false);
+    expect(isAiosService("some-other-app")).toBe(false);
+    // "aios" must be a real prefix, not a substring anywhere in the name.
+    expect(isAiosService("not-aios")).toBe(false);
+  });
+
+  it("honors an explicit AIOS_RAILWAY_SERVICES override (exact match only)", () => {
+    process.env.AIOS_RAILWAY_SERVICES = "brain-prod, brain-staging";
+    expect(isAiosService("brain-prod")).toBe(true);
+    expect(isAiosService("brain-staging")).toBe(true);
+    expect(isAiosService("aios-team-brain")).toBe(false); // override replaces the default policy
+  });
+});
+
+describe("assertServiceIdentity — abort on a foreign service", () => {
+  const savedService = process.env.RAILWAY_SERVICE_NAME;
+  const savedOverride = process.env.AIOS_RAILWAY_SERVICES;
+  beforeEach(() => {
+    delete process.env.AIOS_RAILWAY_SERVICES;
+  });
+  afterEach(() => {
+    if (savedService === undefined) delete process.env.RAILWAY_SERVICE_NAME;
+    else process.env.RAILWAY_SERVICE_NAME = savedService;
+    if (savedOverride === undefined) delete process.env.AIOS_RAILWAY_SERVICES;
+    else process.env.AIOS_RAILWAY_SERVICES = savedOverride;
+  });
+
+  it("is a no-op off Railway (RAILWAY_SERVICE_NAME unset) — local/CI run unguarded", () => {
+    delete process.env.RAILWAY_SERVICE_NAME;
+    expect(() => assertServiceIdentity("load the AIOS schema")).not.toThrow();
+  });
+
+  it("passes on AIOS's own service", () => {
+    process.env.RAILWAY_SERVICE_NAME = "aios-team-brain";
+    expect(() => assertServiceIdentity("load the AIOS schema")).not.toThrow();
+  });
+
+  it("THROWS on the kula service — this is the 2026-06-27 injection it must stop", () => {
+    process.env.RAILWAY_SERVICE_NAME = "kula";
+    expect(() => assertServiceIdentity("load the AIOS schema")).toThrow(/not an AIOS service/);
+  });
+});
+
+describe("the schema loaders wire the guard into the injection path", () => {
+  // "It should have been there" — made permanent. If a future edit removes the guard
+  // call (or moves it after the DB connection), this fails the build.
+  const scriptsDir = join(import.meta.dirname, "..", "..", "scripts");
+
+  for (const file of ["pg-load-schema.mjs", "pg-load-vector.mjs"]) {
+    it(`${file} calls assertServiceIdentity before constructing the pg Client`, () => {
+      const src = readFileSync(join(scriptsDir, file), "utf8");
+      expect(src).toMatch(/import\s*\{\s*assertServiceIdentity\s*\}\s*from\s*["']\.\/service-guard\.mjs["']/);
+      const guardAt = src.indexOf("assertServiceIdentity(");
+      const clientAt = src.indexOf("new Client(");
+      expect(guardAt).toBeGreaterThan(-1);
+      expect(clientAt).toBeGreaterThan(-1);
+      expect(guardAt).toBeLessThan(clientAt); // guard runs BEFORE any DB connection
+    });
+  }
+});


### PR DESCRIPTION
## Why

The runtime half of the fix for the **2026-06-27 incident**: an `aios-team-brain` worktree was `railway up`'d onto the **kula** Railway service, whose `preDeployCommand` (`npm run pg:schema`) then ran *this* repo's `schema.sql` against Kula's **production** DB — injecting ~33 foreign tables and taking Kula down for ~24h.

We already have `scripts/railway-deploy-guard.sh`, but that's a **PreToolUse hook** — it only fires inside the agent's shell. It can't stop a human `railway up`, or any other path that lands this code on a foreign service. This is the **runtime backstop** that makes the schema load itself refuse to run against a foreign DB (the symmetric mirror of Kula's `src/lib/service-guard.ts`; both apps carrying it is what makes the protection real).

## What

- **`scripts/service-guard.mjs`** — `assertServiceIdentity()` throws when `RAILWAY_SERVICE_NAME` is set and isn't an AIOS service (`aios` / `aios-*`; override via `AIOS_RAILWAY_SERVICES`). No-op off Railway (unset), so local/CI/tests run unguarded. Pure node (no tsx) so it runs in the pruned prod image.
- Wired into **both schema loaders, before the pg connection**: `pg-load-schema.mjs` (the Railway `preDeployCommand` — the exact injection vector) and `pg-load-vector.mjs`. On a foreign service the load aborts **non-zero**, so Railway halts the release before any DB write.
- Docs: `CLAUDE.md` §6 + `docs/OPS.md` §4.

## Verification

- ✅ On `RAILWAY_SERVICE_NAME=kula`, `node scripts/pg-load-schema.mjs` exits **1** with the guard error **before** connecting (`Aborting before touching the database`).
- ✅ On `aios-team-brain`, the guard passes and the loader proceeds to the DB (control).
- ✅ `test/guards/service-guard.test.ts` (8 tests): allow-list policy, foreign-service abort, `AIOS_RAILWAY_SERVICES` override, and a **structural** check that both loaders call the guard *before* `new Client`.
- ✅ `npm run typecheck`, `npm run check:docs`, `eslint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runtime safety check for Railway deployments to prevent database and schema loads from running against the wrong service.

* **Bug Fixes**
  * Schema and vector setup now stop early when the service identity doesn’t match the expected environment.
  * Improved service-name matching with a configurable allowlist override for valid deployment names.

* **Documentation**
  * Updated operations guidance to describe the new deployment backstop and when it triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->