### PR TITLE
fix(dashboard): count recent items/queries (pg adapter returns Date, not string)

### DIFF
--- a/lib/metrics/pulse.ts
+++ b/lib/metrics/pulse.ts
@@ -83,6 +83,17 @@ function isoDay(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
+/**
+ * Normalize a timestamptz to an ISO string. CRITICAL: the postgres adapter (the deployed backend)
+ * returns timestamptz columns as **Date objects**, while supabase returns ISO strings. The window
+ * math below compares/ slices these as strings, and `Date >= isoString` coerces the string to NaN
+ * (→ always false), which silently bucketed every recent row as "prior" — the dashboard read 0 with
+ * ↓100% on postgres. Mirrors lib/query/retrieve.ts. Accepts string | Date so both backends work.
+ */
+function toIso(v: string | Date): string {
+  return typeof v === "string" ? v : new Date(v).toISOString();
+}
+
 /** One bucket per day, oldest → newest, ending today. */
 function buildBuckets(days: number, now: Date): Bucket[] {
   const out: Bucket[] = [];
@@ -170,9 +181,10 @@ export async function getPulseMetrics(
       .limit(2_000),
   ]);
 
-  const itemRows = (itemsRes.data ?? []) as { kind: string; synced_at: string }[];
-  const queryRows = (queryRes.data ?? []) as { cost_usd: number | string; created_at: string }[];
-  const taskRows = (tasksRes.data ?? []) as { status: string; updated_at: string }[];
+  // NB: the pg adapter returns timestamptz as Date; supabase as string. Normalize via toIso below.
+  const itemRows = (itemsRes.data ?? []) as { kind: string; synced_at: string | Date }[];
+  const queryRows = (queryRes.data ?? []) as { cost_usd: number | string; created_at: string | Date }[];
+  const taskRows = (tasksRes.data ?? []) as { status: string; updated_at: string | Date }[];
   const commitRows = (commitRes.data ?? []) as { attrs: Record<string, unknown> }[];
 
   const winStartIso = windowStart.toISOString();
@@ -192,9 +204,10 @@ export async function getPulseMetrics(
   let itemsCurrent = 0;
   let itemsPrior = 0;
   for (const row of itemRows) {
-    if (inWindow(row.synced_at)) {
+    const syncedIso = toIso(row.synced_at);
+    if (inWindow(syncedIso)) {
       itemsCurrent++;
-      const i = index.get(row.synced_at.slice(0, 10));
+      const i = index.get(syncedIso.slice(0, 10));
       if (i !== undefined) {
         itemSpark[i]++;
         const kind = (ITEM_KINDS as readonly string[]).includes(row.kind)
@@ -216,10 +229,11 @@ export async function getPulseMetrics(
   let spendPrior = 0;
   for (const row of queryRows) {
     const cost = Number(row.cost_usd) || 0;
-    if (inWindow(row.created_at)) {
+    const createdIso = toIso(row.created_at);
+    if (inWindow(createdIso)) {
       queriesCurrent++;
       spendCurrent += cost;
-      const i = index.get(row.created_at.slice(0, 10));
+      const i = index.get(createdIso.slice(0, 10));
       if (i !== undefined) {
         querySpark[i]++;
         usage[i].queries++;
@@ -240,8 +254,9 @@ export async function getPulseMetrics(
     statusCounts.set(row.status, (statusCounts.get(row.status) ?? 0) + 1);
     if (IN_FLIGHT.has(row.status)) inFlight++;
     if (row.status === "blocked") blocked++;
-    if (inWindow(row.updated_at)) {
-      const i = index.get(row.updated_at.slice(0, 10));
+    const updatedIso = toIso(row.updated_at);
+    if (inWindow(updatedIso)) {
+      const i = index.get(updatedIso.slice(0, 10));
       if (i !== undefined) taskSpark[i]++;
     }
   }

--- a/test/datamechanics/pulse-metrics.datamechanics.test.ts
+++ b/test/datamechanics/pulse-metrics.datamechanics.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getPulseMetrics } from "@/lib/metrics/pulse";
+import { db, seedTeam, ingest } from "./helpers";
+
+/**
+ * Spec for the dashboard "pulse" metrics on REAL Postgres. The deployed pg adapter returns
+ * timestamptz columns as Date objects (supabase returns strings); the window math compared them as
+ * strings (`Date >= isoString` → coerces to NaN → always false), so every recent row was bucketed
+ * as "prior" and the dashboard read 0 items / 0 queries with ↓100% — while the data was clearly
+ * present. This tier is the ONLY one that reproduces it (the fake/supabase paths return strings).
+ * Derived from the product contract (recent activity must count as current), not the implementation.
+ */
+
+async function seedQuery(teamId: string, memberId: string, cost: number): Promise<void> {
+  const { error } = await db().from("query_log").insert({
+    team_id: teamId,
+    member_id: memberId,
+    question: "what happened today?",
+    answer_preview: "…",
+    cost_usd: cost,
+  });
+  if (error) throw new Error(`seed query_log failed: ${error.message}`);
+}
+
+describe("getPulseMetrics (real Postgres date windowing)", () => {
+  it("counts freshly-synced items and recent queries as CURRENT (not prior)", async () => {
+    const seed = await seedTeam();
+    // Three items ingested now → synced_at = now(), squarely inside the 30d window.
+    await ingest(seed, { path: "a.md", body: "alpha", access: "team", kind: "deliverable" });
+    await ingest(seed, { path: "b.md", body: "bravo", access: "team", kind: "deliverable" });
+    await ingest(seed, { path: "c.md", body: "charlie", access: "team", kind: "transcript" });
+    await seedQuery(seed.teamId, seed.memberId, 0.42);
+    await seedQuery(seed.teamId, seed.memberId, 0.08);
+
+    const pulse = await getPulseMetrics(db(), seed.teamId, "30d", {
+      isAdmin: true,
+      memberId: seed.memberId,
+    });
+
+    const kpi = (key: string) => pulse.kpis.find((k) => k.key === key);
+
+    // Items KPI: the bug reported 0 here. Now it must reflect the 3 in-window items.
+    expect(Number(kpi("items")!.value)).toBe(3);
+    // Queries KPI: 2 recent queries, not 0.
+    expect(Number(kpi("queries")!.value)).toBe(2);
+    // Spend rolls up the recent queries' cost.
+    expect(kpi("spend")!.value).toBe("$0.50");
+
+    // Time-series charts must have data in the window (they showed "No data in this window").
+    const knowledgeTotal = pulse.knowledge.reduce(
+      (s, p) => s + p.deliverable + p.transcript + p.decision + p.task + p.artifact + p.skill,
+      0
+    );
+    expect(knowledgeTotal).toBe(3);
+    const usageTotal = pulse.usage.reduce((s, p) => s + p.queries, 0);
+    expect(usageTotal).toBe(2);
+
+    // Sanity: a −100% delta is the exact bug signature (current=0, prior>0); must NOT reproduce.
+    expect(kpi("items")!.delta).not.toBe(-100);
+  });
+});


### PR DESCRIPTION
## Symptom
The Home dashboard showed **Items synced: 0 ↓100%**, **Team queries: 0 ↓100%**, and both charts read **"No data in this window"** — while the chat answered grounded questions and Tasks/Decisions rendered fine. Prod DB actually held **212 items and 37 queries in the last 30 days** (max timestamps = today).

## Root cause (backend-specific)
The **postgres adapter** (the deployed backend) returns `timestamptz` columns as **Date objects**; supabase returns ISO **strings**. `lib/metrics/pulse.ts` compared them as strings:

```ts
const inWindow = (iso: string) => iso >= winStartIso;   // Date >= "2026-06-03T…Z"
```

`Date >= isoString` coerces the Date to a number (ms) and the **string to `NaN`**, so `ms >= NaN` is **always false**. Every recent row failed the window test → bucketed as *prior* → `current = 0`, `prior = all` → **−100%**. Tasks/Decisions render because they don't filter by date. This is the same pg-adapter Date gotcha already handled in `lib/query/retrieve.ts`.

## Fix
Normalize each `timestamptz` to an ISO string with `toIso()` (mirrors retrieve.ts) before the window compare and day-bucketing — applied to `synced_at`, `created_at`, `updated_at`. Works on both backends (`string | Date`).

## Test
`test/datamechanics/pulse-metrics.datamechanics.test.ts` — real Postgres is the **only** tier that reproduces this (fake/supabase return strings). Seeds in-window items + queries and asserts they count as CURRENT (items=3, queries=2, spend, chart totals).
- **Verified red before the fix** (`expected +0 to be 3`), green after.

No schema change. Unit tier 317 green, lint + docs-drift clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metrics bucketing so recent activity is counted in the correct time window, even when timestamps come from different sources.
  * Prevented misclassification of items, queries, spend, and task activity caused by timestamp format differences.

* **Tests**
  * Added coverage for real database timestamp behavior to verify windowed metrics, aggregates, and trend calculations remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->