### PR TITLE
fix(dashboard): git commits as accomplishments; strip Linear keys from arcs

### DIFF
--- a/lib/dashboard/team-work-live.ts
+++ b/lib/dashboard/team-work-live.ts
@@ -3,7 +3,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { getArcs, type ProviderKeys } from "@/lib/graph/arcs";
 import { visibleGroupIds, type AccessTier } from "@/lib/graph/group";
 import type { RosterPerson } from "./people-match";
-import { assembleTeamWork, type TaskLite, type PersonWork } from "./team-work";
+import { assembleTeamWork, commitSubject, type TaskLite, type CommitLite, type PersonWork } from "./team-work";
 
 /**
  * Live wiring for the consolidated "Working On" box: roster (members) + tasks (one query) + arcs
@@ -45,13 +45,23 @@ export async function getTeamWork(
   if (roster.length === 0) return [];
 
   const doneSinceIso = new Date(Date.now() - DONE_WINDOW_DAYS * 86_400_000).toISOString();
-  const [{ data: taskRows }, arcs] = await Promise.all([
+  const [{ data: taskRows }, { data: commitRows }, arcs] = await Promise.all([
     supabase
       .from("tasks")
       .select("id, title, assignee, status, updated_at")
       .eq("team_id", teamId)
       .order("updated_at", { ascending: false })
       .limit(2000),
+    // Git commits are member_id-attributed (author→member at scan time) — the real "done" signal for
+    // code contributors, who often have no `done` task rows. frontmatter->>source='git' + member set.
+    supabase
+      .from("items")
+      .select("id, body, member_id, frontmatter, synced_at")
+      .eq("team_id", teamId)
+      .eq("frontmatter->>source", "git")
+      .not("member_id", "is", null)
+      .order("synced_at", { ascending: false })
+      .limit(600),
     getArcs(teamSlug, tier, visibleGroupIds(teamSlug, tier), keys).catch(() => []),
   ]);
 
@@ -70,6 +80,24 @@ export async function getTeamWork(
     updatedAt: typeof t.updated_at === "string" ? t.updated_at : new Date(t.updated_at).toISOString(),
   }));
 
-  const people = assembleTeamWork(roster, tasks, arcs, doneSinceIso);
+  const commits: CommitLite[] = ((commitRows ?? []) as {
+    id: string;
+    body: string | null;
+    member_id: string | null;
+    frontmatter: Record<string, unknown> | null;
+    synced_at: string | Date;
+  }[]).flatMap((r) => {
+    if (!r.member_id) return [];
+    const committedAt = r.frontmatter?.committed_at;
+    // Commit date drives the "accomplished" window; normalize to UTC ISO so it sorts vs task dates.
+    const at = committedAt
+      ? new Date(String(committedAt)).toISOString()
+      : typeof r.synced_at === "string"
+        ? r.synced_at
+        : new Date(r.synced_at).toISOString();
+    return [{ id: r.id, memberId: r.member_id, title: commitSubject(r.body ?? ""), at }];
+  });
+
+  const people = assembleTeamWork(roster, tasks, arcs, commits, doneSinceIso);
   return people.filter((p) => p.summary || p.threads.length || p.openTasks.length || p.accomplished.length);
 }

--- a/lib/dashboard/team-work.ts
+++ b/lib/dashboard/team-work.ts
@@ -29,6 +29,32 @@ export interface ArcLite {
   participants: string[];
 }
 
+/** A shipped git commit, already attributed to a roster member by member_id (clean identity). */
+export interface CommitLite {
+  id: string;
+  memberId: string;
+  title: string; // commit subject
+  at: string; // ISO (UTC) — normalized upstream so it sorts against task updatedAt
+}
+
+/**
+ * Pull the commit subject out of a projected git-item body (lib/codebases/commits-to-items). The
+ * body is `# Commit <sha> — <repo>\n\n**<author>** · <date>\n\n<message>\n\n\`<sha>\` · +a/-d`, so the
+ * subject is the first line that isn't the heading, the bold author line, or the backtick footer.
+ * Pure so it's unit-tested against the real format.
+ */
+export function commitSubject(body: string): string {
+  for (const raw of (body ?? "").split("\n")) {
+    const l = raw.trim();
+    if (!l) continue;
+    if (l.startsWith("# Commit")) continue; // heading
+    if (l.startsWith("**")) continue; // author · date line
+    if (l.startsWith("`")) continue; // `sha` · +a/-d footer
+    return l;
+  }
+  return "";
+}
+
 export interface PersonWork {
   memberId: string;
   name: string;
@@ -53,6 +79,7 @@ export function assembleTeamWork(
   roster: RosterPerson[],
   tasks: TaskLite[],
   arcs: ArcLite[],
+  commits: CommitLite[],
   doneSinceIso: string
 ): PersonWork[] {
   const assignedPerson = (assignee: string): RosterPerson | undefined =>
@@ -70,11 +97,26 @@ export function assembleTeamWork(
       .filter((t) => OPEN_STATUSES.has(t.status))
       .slice(0, MAX_OPEN)
       .map((t) => ({ id: t.id, title: t.title, status: t.status }));
-    const accomplished = mine
+
+    // Accomplished = completed tasks (assignee-matched) + shipped commits (member_id-attributed),
+    // newest first, de-duped by title, capped. Git is the real "done" signal for code contributors,
+    // who often have no `done` task rows at all.
+    const doneTasks = mine
       .filter((t) => t.status === "done" && t.updatedAt >= doneSinceIso)
-      .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
-      .slice(0, MAX_DONE)
       .map((t) => ({ id: t.id, title: t.title, at: t.updatedAt }));
+    const myCommits = commits
+      .filter((c) => c.memberId === person.memberId && c.at >= doneSinceIso && c.title)
+      .map((c) => ({ id: c.id, title: c.title, at: c.at }));
+    const seenTitles = new Set<string>();
+    const accomplished = [...doneTasks, ...myCommits]
+      .sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0))
+      .filter((e) => {
+        const key = e.title.trim().toLowerCase();
+        if (seenTitles.has(key)) return false;
+        seenTitles.add(key);
+        return true;
+      })
+      .slice(0, MAX_DONE);
 
     const personArcs = arcsForPerson(person);
     return {

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -52,6 +52,22 @@ function stableId(title: string): string {
 }
 
 /**
+ * Strip issue/task keys (Linear/Jira-style `AIO-138`, optionally bracketed) from arc text. The graph
+ * facts carry these keys, so the LLM tends to echo them into titles/summaries — but they're noise in
+ * a human-facing narrative. Removes the key and tidies the leftover brackets/spacing/punctuation.
+ * Pure + exported so it's unit-tested.
+ */
+export function stripTaskKeys(text: string): string {
+  return (text ?? "")
+    .replace(/[([]\s*[A-Z][A-Z0-9]+-\d+\s*[)\]]/g, "") // (AIO-138) / [AIO-138]
+    .replace(/\b[A-Z][A-Z0-9]+-\d+\b/g, "") // bare AIO-138
+    .replace(/\s+([.,;:)])/g, "$1") // space before punctuation
+    .replace(/\(\s*\)/g, "") // empty parens left behind
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+/**
  * Parse + normalize the LLM's JSON into safe arcs: caps at 5, coerces confidence, defaults missing
  * fields, assigns a stable id from the title, stamps `derived_at`. Returns [] on malformed input.
  * Pure + exported so the fragile parsing is unit-tested without an LLM.
@@ -63,11 +79,11 @@ export function parseArcsJson(raw: string | null, now = new Date().toISOString()
     if (!Array.isArray(obj.arcs)) return [];
     return obj.arcs.slice(0, 5).map((a) => ({
       id: stableId(a.title ?? ""),
-      title: (a.title ?? "Untitled").toString(),
+      title: stripTaskKeys((a.title ?? "Untitled").toString()) || "Untitled",
       confidence: (["high", "medium", "low"] as const).includes(a.confidence as "high")
         ? (a.confidence as NarrativeArc["confidence"])
         : "low",
-      summary: (a.summary ?? "").toString(),
+      summary: stripTaskKeys((a.summary ?? "").toString()),
       participants: Array.isArray(a.participants) ? a.participants.map(String) : [],
       supporting_sources: Array.isArray(a.supporting_sources) ? a.supporting_sources.map(String) : [],
       derived_at: now,

--- a/test/dashboard-team-work.test.ts
+++ b/test/dashboard-team-work.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assembleTeamWork, type TaskLite, type ArcLite } from "@/lib/dashboard/team-work";
+import { assembleTeamWork, commitSubject, type TaskLite, type ArcLite, type CommitLite } from "@/lib/dashboard/team-work";
 import type { RosterPerson } from "@/lib/dashboard/people-match";
 
 /**
@@ -30,20 +30,27 @@ const arcs: ArcLite[] = [
   { title: "Query quality", summary: "Improving retrieval and dates.", confidence: "medium", participants: ["Chetan Nandakumar"] },
 ];
 
+// Git commits are already attributed to a roster member by member_id (not by name).
+const commits: CommitLite[] = [
+  { id: "cm1", memberId: "c", title: "feat(query): timezone-aware dates", at: "2026-06-24T00:00:00.000Z" },
+  { id: "cm2", memberId: "c", title: "fix(dashboard): pulse date window", at: "2026-06-26T00:00:00.000Z" },
+  { id: "cm3", memberId: "c", title: "ancient commit", at: "2026-05-01T00:00:00.000Z" }, // before window
+];
+
 describe("assembleTeamWork", () => {
   it("dedupes noisy names onto one roster row and buckets that person's tasks", () => {
-    const people = assembleTeamWork(roster, tasks, arcs, DONE_SINCE);
+    const people = assembleTeamWork(roster, tasks, arcs, commits, DONE_SINCE);
     const john = people.find((p) => p.memberId === "j")!;
 
     expect(john.name).toBe("John Ellison"); // canonical roster name, not the graph's "John"
     // "John", "john-ellison", "John Ellison" all fold onto this one person.
     expect(john.openTasks.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
-    // Accomplished = done + within window; t3 (May) excluded, t4 (Jun 25) included.
+    // Accomplished = done task within window; t3 (May) excluded, t4 (Jun 25) included.
     expect(john.accomplished.map((t) => t.id)).toEqual(["t4"]);
   });
 
   it("pulls each person's summary + threads from the arcs they participate in", () => {
-    const people = assembleTeamWork(roster, tasks, arcs, DONE_SINCE);
+    const people = assembleTeamWork(roster, tasks, arcs, commits, DONE_SINCE);
     const john = people.find((p) => p.memberId === "j")!;
     const chetan = people.find((p) => p.memberId === "c")!;
 
@@ -54,9 +61,32 @@ describe("assembleTeamWork", () => {
     expect(chetan.openTasks.map((t) => t.id)).toEqual(["t5"]);
   });
 
+  it("surfaces git commits as accomplishments (the fix for a code contributor with no done tasks)", () => {
+    const people = assembleTeamWork(roster, tasks, arcs, commits, DONE_SINCE);
+    const chetan = people.find((p) => p.memberId === "c")!;
+    // Chetan has NO done tasks, but two in-window commits → newest first, ancient one excluded.
+    expect(chetan.accomplished.map((a) => a.id)).toEqual(["cm2", "cm1"]);
+    expect(chetan.accomplished.map((a) => a.title)).toContain("fix(dashboard): pulse date window");
+  });
+
   it("does not attribute another person's task (Priya) to anyone on the roster", () => {
-    const people = assembleTeamWork(roster, tasks, arcs, DONE_SINCE);
+    const people = assembleTeamWork(roster, tasks, arcs, commits, DONE_SINCE);
     const allTaskIds = people.flatMap((p) => [...p.openTasks, ...p.accomplished].map((t) => t.id));
     expect(allTaskIds).not.toContain("t6");
+  });
+});
+
+describe("commitSubject", () => {
+  it("extracts the commit subject from a projected git-item body", () => {
+    const body =
+      "# Commit c4e3bc5bd7 — aios-team-brain\n\n" +
+      "**Chetan Nandakumar** · 2026-06-29T21:28:52-07:00\n\n" +
+      "feat(chat): persistent chat history (cross-session, cross-interface) (#117)\n\n" +
+      "`c4e3bc5bd7` · +881/-16";
+    expect(commitSubject(body)).toBe("feat(chat): persistent chat history (cross-session, cross-interface) (#117)");
+  });
+  it("returns empty string for a body with no message", () => {
+    expect(commitSubject("# Commit abc — repo\n\n**Someone** · date\n\n`abc` · +1/-0")).toBe("");
+    expect(commitSubject("")).toBe("");
   });
 });

--- a/test/graph-arcs-parse.test.ts
+++ b/test/graph-arcs-parse.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { parseArcsJson } from "@/lib/graph/arcs";
+import { parseArcsJson, stripTaskKeys } from "@/lib/graph/arcs";
 
 /**
  * Spec for the arc JSON normalizer (the fragile bit — an LLM's JSON is untrusted). Derived from the
  * contract the panel needs: safe defaults, capped at 5, coerced confidence, stable ids, never throws.
  */
+
+describe("stripTaskKeys", () => {
+  it("removes Linear/Jira-style issue keys from narrative text", () => {
+    expect(stripTaskKeys("Shipping the learning layer (AIO-138) and events")).toBe(
+      "Shipping the learning layer and events"
+    );
+    expect(stripTaskKeys("AIO-111 covers auth; AIO-146 covers RLS.")).toBe("covers auth; covers RLS.");
+    expect(stripTaskKeys("Working on [AIO-9] the importer.")).toBe("Working on the importer.");
+  });
+  it("leaves ordinary text untouched", () => {
+    expect(stripTaskKeys("Improving retrieval and dates.")).toBe("Improving retrieval and dates.");
+    expect(stripTaskKeys("")).toBe("");
+  });
+});
+
+describe("parseArcsJson strips task keys from title + summary", () => {
+  it("does not echo issue keys into the human-facing arc", () => {
+    const raw = JSON.stringify({
+      arcs: [{ title: "Learning layer (AIO-138)", confidence: "high", summary: "Building AIO-138 and AIO-146.", participants: [] }],
+    });
+    const [arc] = parseArcsJson(raw, "2026-07-02T00:00:00.000Z");
+    expect(arc.title).toBe("Learning layer");
+    expect(arc.summary).toBe("Building and.");
+    expect(arc.summary).not.toMatch(/AIO-\d+/);
+  });
+});
 
 describe("parseArcsJson", () => {
   const NOW = "2026-07-02T00:00:00.000Z";


### PR DESCRIPTION
Two fixes to the new "Working On" box, both from what you saw on the live dashboard.

### 1. "Why isn't there anything accomplished for me?"
Because "Accomplished" only read `done` **tasks**, and you have **zero** — your 8 tasks are backlog/in-progress. Your real accomplishments are **git commits** (~49 in the last window). John shows accomplishments only because he has 112 done tasks.

**Fix:** "Accomplished" now merges **completed tasks** (assignee-matched) with **shipped git commits** (member_id-attributed — clean identity, no name-matching needed). Newest first, de-duped by title, capped. The commit subject is parsed from the projected git-item body via a pure, unit-tested `commitSubject()`.

Verified in prod data: you have git items like `feat(chat): persistent chat history (#117)` attributed to your member_id — these will now populate your Accomplished list.

### 2. "In the narrative arcs, don't include the Linear task numbers"
`stripTaskKeys()` removes Linear/Jira-style keys (`AIO-138`, `(AIO-146)`) from the arc **title + summary**, applied in `parseArcsJson` (the single normalization point) — so both the dashboard "Working On" summary and the Learning page read clean. Pure + unit-tested; also tidies leftover brackets/spacing.

### Tests / checks
- `assembleTeamWork` gains a `commits` arg + a git-accomplishments case (a contributor with no done tasks still shows commits).
- `commitSubject` and `stripTaskKeys` unit-tested (incl. the exact git-item body format and `parseArcsJson` no longer echoing keys).
- Full unit tier green, `tsc` clean, lint + docs-drift clean.

Code-only; deploys on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard updates now include recent Git commits alongside completed tasks, giving a fuller view of team accomplishments.
  * Commit subjects are now extracted and shown more cleanly in activity summaries.

* **Bug Fixes**
  * Removed task key noise from generated arc titles and summaries so human-facing text reads more naturally.
  * Improved how accomplishments are ordered and de-duplicated, with newer items shown first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->