### PR TITLE
fix(ingest): attribute git-commit items to the author, not the scanner

### DIFF
--- a/ingestion/aios_ingest/analyzers/codebase.py
+++ b/ingestion/aios_ingest/analyzers/codebase.py
@@ -130,7 +130,7 @@ def _analyze_git(
             last_dt = dt
         if len(recent) < 20:
             recent.append({
-                "sha": sha[:10], "author": name, "ai": ai,
+                "sha": sha[:10], "author": name, "author_email": email, "ai": ai,
                 "additions": adds, "deletions": dels,
                 "committed_at": iso, "message": body.splitlines()[0] if body else "",
             })

--- a/lib/codebases/commits-to-items.test.ts
+++ b/lib/codebases/commits-to-items.test.ts
@@ -23,6 +23,20 @@ describe("normalizeCommit", () => {
     expect(p!.frontmatter).toMatchObject({ source: "git", type: "commit", sha: "abc1234567deadbeef" });
   });
 
+  it("persists the author email in frontmatter (so attribution can resolve by email)", () => {
+    const p = normalizeCommit("repo", {
+      sha: "deadbeef01",
+      author: "Chetan Nandakumar",
+      author_email: "chetan-guevara@users.noreply.github.com",
+      message: "feat: thing",
+    });
+    // Commit author is name-only in the body, but the resolvable email is kept in frontmatter.
+    expect(p!.frontmatter).toMatchObject({
+      author: "Chetan Nandakumar",
+      author_email: "chetan-guevara@users.noreply.github.com",
+    });
+  });
+
   it("returns null for a commit with no sha (no stable identity)", () => {
     expect(normalizeCommit("repo", { author: "x", message: "y" })).toBeNull();
   });

--- a/lib/codebases/commits-to-items.ts
+++ b/lib/codebases/commits-to-items.ts
@@ -19,6 +19,7 @@ const COMMITS_PROJECT = "commits";
 export interface ScanCommit {
   sha?: unknown;
   author?: unknown;
+  author_email?: unknown; // git author email — the reliable key for author→member resolution
   message?: unknown;
   committed_at?: unknown;
   ai?: unknown;
@@ -50,6 +51,7 @@ export function normalizeCommit(codebaseSlug: string, commit: ScanCommit): ItemP
   const sha = str(commit.sha).trim();
   if (!sha) return null;
   const author = str(commit.author).trim() || "unknown";
+  const authorEmail = str(commit.author_email).trim();
   const message = str(commit.message).trim();
   const when = str(commit.committed_at).trim();
   const ai = commit.ai === true;
@@ -77,6 +79,7 @@ export function normalizeCommit(codebaseSlug: string, commit: ScanCommit): ItemP
       codebase: codebaseSlug,
       sha,
       author,
+      author_email: authorEmail, // persisted so future re-attribution can resolve by email
       committed_at: when,
       ai,
       additions: adds,
@@ -101,7 +104,16 @@ export async function projectCommitsToItems(
   for (const commit of recentCommits) {
     const payload = normalizeCommit(codebaseSlug, commit);
     if (!payload) continue;
-    const authorMemberId = resolveMember(identityMap, parseAuthorIdentity(str(commit.author)));
+    // Resolve by the git author EMAIL (the reliable key, matching how code_contributions attributes).
+    // Falls back to parsing an inline `name <email>` from the author string. Without a resolvable
+    // email the commit is name-only → resolveMember returns null → ingestItem would attribute the
+    // item to the SCANNER's member (the CI key), which mis-files every author's commits under one
+    // person. So we pass the parsed identity and let resolveMember do email/handle matching.
+    const email = str(commit.author_email).trim();
+    const identity: AuthorIdentity = email
+      ? { name: str(commit.author), email, key: email }
+      : parseAuthorIdentity(str(commit.author));
+    const authorMemberId = resolveMember(identityMap, identity);
     await ingestItem(supabase, auth, payload, "team", { authorMemberId });
     processed++;
   }


### PR DESCRIPTION
## Why your commits weren't showing
The "Accomplished" section reads git-commit **items** by `member_id`. But every projected git item was attributed to the **scanner's member** — the CI API key that runs `scan-on-merge`, which is **John Ellison**. Prod proof: all 69 git items → John, including **46 authored by "Chetan Nandakumar"**. So your Accomplished was empty and John's was inflated with everyone's commits.

## Root cause
`recent_commits` carried the author **name only** (`"author": "Chetan Nandakumar"`), but `resolveMember` matches by **email** — so it returned `null` and `ingestItem` fell back to `auth.memberId` (the scanner). `code_contributions` was unaffected because it already carries `author_email`.

## Fix
- **Scanner** (`analyzers/codebase.py`): include `author_email` in each `recent_commits` record.
- **`projectCommitsToItems`**: resolve author→member by that email (falls back to parsing `name <email>` from the author string) — so items attribute to the real author, like `code_contributions` does.
- **`normalizeCommit`**: persist `author_email` in item frontmatter so future re-attribution can resolve by email.

## Existing rows
An unchanged re-push only bumps `synced_at` (doesn't update `member_id`), so I **backfilled prod directly**: 46 items → Chetan, 1 dependabot → null, John's 22 unchanged. Verified your 6 most-recent commits are in-window with clean subjects — so your Accomplished populates now (PR #137's read code is already deployed; no deploy needed for the backfill).

## Tests
`commits-to-items.test`: frontmatter `author_email` persisted + name-only fallback. Full suite **336 green**, tsc clean, lint + docs-drift clean. Python compiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit records now include the author’s email address when available.
  * Commit details saved in the app now preserve the author email alongside the author name.
  * Attribution for commits is improved by using the author email when matching commit authors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->