### PR TITLE
chore(nav): hide Projects from the sidebar for now

### DIFF
--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -73,7 +73,9 @@ export default async function TeamLayout({
       label: "Work",
       children: [
         { icon: "tasks", label: "Tasks", href: `${base}/tasks` },
-        { icon: "projects", label: "Projects", href: `${base}/projects` },
+        // Projects hidden for now — the tab currently surfaces ingestion namespaces (slack, commits,
+        // github-*, …) rather than human work-projects. Unhide once it shows real projects.
+        // { icon: "projects", label: "Projects", href: `${base}/projects` },
         { icon: "decisions", label: "Decisions", href: `${base}/decisions` },
       ],
     },


### PR DESCRIPTION
Hides the **Projects** link in the left sidebar. As discussed, the tab currently lists the `projects` table — which is populated with **ingestion namespaces** (`slack`, `commits`, `github-*`, `linear-*`, `plane-*`) that `ingestItem` auto-creates, i.e. connector plumbing rather than human work-projects.

- Commented out the nav entry (one-line unhide later, per "we can unhide it later").
- The `/t/[team]/projects` route is untouched — still reachable by URL; only the sidebar link is removed.

No schema/route/data change; nothing else references the nav entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Work navigation so the top-level Projects link is no longer shown.
  * The navigation now highlights ingestion namespaces in that area, while other entries like Decisions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->