### PR TITLE
feat(chat): LLM titles, sidebar search, client integration spec

### DIFF
--- a/app/api/dashboard/query/route.ts
+++ b/app/api/dashboard/query/route.ts
@@ -14,6 +14,7 @@ import {
   createConversation,
   appendMessage,
 } from "@/lib/chat/store";
+import { generateAndSetTitle } from "@/lib/chat/title";
 import { getProviderKey } from "@/lib/integrations/manage";
 import { isSyncCommand, runManualSync } from "@/lib/ingest/manual-sync";
 import { audit } from "@/lib/api/audit";
@@ -175,9 +176,11 @@ export async function POST(req: NextRequest) {
   const owner = { teamId: team.id, memberId: me.id };
   let conversationId = conversation_id && (await ownsConversation(supabase, owner, conversation_id)) ? conversation_id : null;
   const priorTurns = conversationId ? await recentTurns(supabase, owner, conversationId) : [];
+  let createdNew = false;
   if (!conversationId) {
     const created = await createConversation(supabase, owner, question);
     conversationId = created?.id ?? null;
+    createdNew = true;
   }
   if (conversationId) await appendMessage(supabase, owner, conversationId, "user", question);
 
@@ -228,6 +231,10 @@ export async function POST(req: NextRequest) {
                 output_tokens: chunk.usage.output_tokens,
                 cost_usd: chunk.usage.cost_usd,
               });
+              // On a new thread, replace the derived title with a short LLM-written one (bounded).
+              if (createdNew) {
+                await generateAndSetTitle(supabase, owner, conversationId, question, answer, { anthropicKey, openaiKey });
+              }
             }
 
             await supabase.from("query_log").insert({

--- a/app/api/v1/query/route.ts
+++ b/app/api/v1/query/route.ts
@@ -13,6 +13,7 @@ import {
   createConversation,
   appendMessage,
 } from "@/lib/chat/store";
+import { generateAndSetTitle } from "@/lib/chat/title";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
@@ -66,9 +67,11 @@ export async function POST(req: NextRequest) {
   const owner = { teamId: auth.teamId, memberId: auth.memberId };
   let conversationId = conversation_id && (await ownsConversation(supabase, owner, conversation_id)) ? conversation_id : null;
   const priorTurns = conversationId ? await recentTurns(supabase, owner, conversationId) : [];
+  let createdNew = false;
   if (!conversationId) {
     const created = await createConversation(supabase, owner, question);
     conversationId = created?.id ?? null;
+    createdNew = true;
   }
   if (conversationId) await appendMessage(supabase, owner, conversationId, "user", question);
 
@@ -130,6 +133,9 @@ export async function POST(req: NextRequest) {
                 output_tokens: chunk.usage.output_tokens,
                 cost_usd: chunk.usage.cost_usd,
               });
+              if (createdNew) {
+                await generateAndSetTitle(supabase, owner, conversationId, question, answer, { anthropicKey, openaiKey });
+              }
             }
 
             await supabase.from("query_log").insert({

--- a/components/chat/chat-workspace.tsx
+++ b/components/chat/chat-workspace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { MessageSquarePlus, Loader2, Trash2, Pencil } from "lucide-react";
+import { MessageSquarePlus, Loader2, Trash2, Pencil, Search } from "lucide-react";
 import { QueryChat, type Exchange } from "@/components/query-chat";
 
 interface ConversationListItem {
@@ -39,6 +39,7 @@ function toExchanges(messages: StoredMessage[]): Exchange[] {
  */
 export function ChatWorkspace({ teamSlug, initialQuestion }: { teamSlug: string; initialQuestion?: string }) {
   const [conversations, setConversations] = useState<ConversationListItem[]>([]);
+  const [filter, setFilter] = useState("");
   const [activeId, setActiveId] = useState<string | null>(null);
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const newNonce = useRef(0);
@@ -97,6 +98,11 @@ export function ChatWorkspace({ teamSlug, initialQuestion }: { teamSlug: string;
     void loadList();
   }
 
+  // Client-side title search over the already-loaded list (instant; owner data is here). Content
+  // search (over message bodies) would be a server FTS endpoint — a later increment.
+  const q = filter.trim().toLowerCase();
+  const shown = q ? conversations.filter((c) => (c.title || "").toLowerCase().includes(q)) : conversations;
+
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-[230px_1fr]">
       <aside className="flex flex-col gap-2 md:max-h-[calc(100dvh-11rem)]">
@@ -107,11 +113,24 @@ export function ChatWorkspace({ teamSlug, initialQuestion }: { teamSlug: string;
         >
           <MessageSquarePlus className="size-4" /> New chat
         </button>
+        {conversations.length > 0 ? (
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-ink-tertiary" />
+            <input
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Search chats…"
+              className="w-full rounded-lg border border-border-default bg-surface py-1.5 pl-8 pr-2 text-xs text-ink placeholder:text-ink-tertiary focus:border-violet/40 focus:outline-none"
+            />
+          </div>
+        ) : null}
         <div className="flex flex-col gap-0.5 overflow-y-auto">
           {conversations.length === 0 ? (
             <p className="px-2 py-3 text-xs text-ink-tertiary">No saved chats yet.</p>
+          ) : shown.length === 0 ? (
+            <p className="px-2 py-3 text-xs text-ink-tertiary">No chats match &ldquo;{filter}&rdquo;.</p>
           ) : (
-            conversations.map((c) => {
+            shown.map((c) => {
               const active = c.id === activeId;
               return (
                 <div

--- a/docs/CHAT-CLIENTS.md
+++ b/docs/CHAT-CLIENTS.md
@@ -1,0 +1,83 @@
+# Chat clients — using `conversation_id` (CLI, Telegram/Hermes)
+
+The brain is the **system of record** for chat. Conversations persist server-side, keyed by
+`conversation_id` and **owned by a member** — so the CLI and the Telegram-via-Hermes agent can
+continue the *same* threads as the web dashboard (they show up in that member's sidebar too),
+as long as they use an API key tied to that member.
+
+The **server side is already built** (`/api/v1/query` accepts `conversation_id`, persists each
+turn, loads a windowed history, auto-titles new threads). What remains is the **client side**:
+capture, persist, and resend the `conversation_id`. This doc is the contract + integration plan.
+
+## The wire contract — `POST /api/v1/query`
+
+Auth: `Authorization: Bearer <api_key>` (the key's member owns any conversation it touches).
+
+Request body:
+```jsonc
+{
+  "question": "what did he finish last week?",
+  "conversation_id": "…uuid…",   // OPTIONAL — omit to start a new thread
+  "project": null                 // optional retrieval scope
+}
+```
+
+Response: **SSE stream** (`text/event-stream`) with these events:
+```
+event: conversation      data: { "id": "…uuid…" }        ← FIRST; the thread this turn belongs to
+event: delta             data: { "text": "…" }            ← answer chunks (repeat)
+event: sources           data: { "sources": [ … ] }       ← cited items
+event: done              data: { "input_tokens": …, "cost_usd": … }
+event: error             data: { "message": "…" }         ← on failure (instead of done)
+```
+
+Server behavior you rely on:
+- **Omit `conversation_id`** → the server creates a thread and returns its id in the `conversation`
+  event. **Capture it.**
+- **Send `conversation_id`** → the server loads the **windowed history** (last ~6 turns, truncated)
+  so pronouns/follow-ups resolve. No need to send history yourself.
+- Ownership is enforced: a key can only continue **its own member's** conversations; an unknown or
+  someone else's id is treated as "start new" (you'll get a fresh id back).
+- New threads get an **auto-generated title** shortly after the first answer (no client action).
+
+## Client responsibilities (the pattern)
+
+1. On a **new** chat, send no `conversation_id`.
+2. Read the **`conversation` event** and remember its `id`.
+3. On the **next turn of the same chat**, send that `id`.
+4. Persist the id keyed by whatever "chat" means for your surface (a CLI session, a Telegram chat).
+
+## CLI (`aios`)
+
+- Store the current thread id in a small state file, e.g. `~/.aios/chat.json`:
+  `{ "conversation_id": "…", "updated_at": "…" }` (optionally keyed by cwd/project).
+- `aios chat "<question>"` → send the stored `conversation_id`; update it from the `conversation`
+  event. `aios chat --new` → clear it first (start a fresh thread).
+- `aios chat --list` could hit `GET /api/dashboard/conversations` — but that's session-authed, not
+  API-key; for the CLI, a `GET /api/v1/conversations` (API-key) would be a small server add if you
+  want list/resume from the terminal. (Not built yet — flag if you want it.)
+
+## Telegram via Hermes (the box on Fly.io)
+
+Goal: a Telegram conversation is one continuous brain thread (and appears in the member's web
+sidebar). Map **Telegram chat → brain `conversation_id`** on the Hermes box:
+
+- Keep a persistent map `telegram_chat_id → conversation_id` (SQLite/KV on the box). If Telegram
+  **topics/threads** are used, key on `(chat_id, message_thread_id)`.
+- On an inbound Telegram message:
+  1. Look up the `conversation_id` for that chat (may be absent).
+  2. `POST /api/v1/query` with the question (+ the id if present), using the API key of **the member
+     this Telegram user maps to** (so threads land in the right person's history).
+  3. From the `conversation` event, **upsert** `telegram_chat_id → id` (covers the first message,
+     which had no id).
+  4. Stream the `delta`s back to Telegram (edit-in-place or send on `done`).
+- A "/new" command clears the mapping for that chat to start fresh.
+
+Auth mapping note: one API key = one member = one owner of threads. If multiple Telegram users
+share one Hermes key, their chats all land under that one member (fine for a single-user assistant;
+for multi-user, issue a key per member and pick it by Telegram user).
+
+## Not yet on the server (say the word)
+- `GET /api/v1/conversations[/:id]` (API-key list/resume for the CLI) — the dashboard has the
+  session-authed equivalents; the API-key versions are a small add.
+- Content search over message bodies (the dashboard sidebar currently searches titles client-side).

--- a/lib/chat/store.ts
+++ b/lib/chat/store.ts
@@ -195,6 +195,25 @@ export async function renameConversation(
   return Boolean((data as { id: string } | null)?.id);
 }
 
+/**
+ * Set a conversation's title without bumping `updated_at` (so an auto-generated title doesn't
+ * reorder the list). Owner-scoped. Used by the background title generator; a no-op if not owned.
+ */
+export async function setTitle(
+  supabase: SupabaseClient,
+  owner: Owner,
+  conversationId: string,
+  title: string
+): Promise<void> {
+  const { error } = await supabase
+    .from("conversations")
+    .update({ title: deriveTitle(title) })
+    .eq("id", conversationId)
+    .eq("team_id", owner.teamId)
+    .eq("member_id", owner.memberId);
+  if (error) throw new Error(`setTitle: ${error.message}`);
+}
+
 /** Soft-delete (archive) — hides it from the list; messages stay for any later restore/audit. */
 export async function archiveConversation(
   supabase: SupabaseClient,

--- a/lib/chat/title.ts
+++ b/lib/chat/title.ts
@@ -1,0 +1,93 @@
+import "server-only";
+import Anthropic from "@anthropic-ai/sdk";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ProviderKeys } from "@/lib/query/claude";
+import { setTitle } from "@/lib/chat/store";
+
+/**
+ * Background conversation-title generator. After a conversation's first exchange we replace the
+ * derived (first-question) title with a short LLM-written label — the ChatGPT-style sidebar polish.
+ * Best-effort: any failure (no key, timeout) leaves the derived title in place. Cheap model + tiny
+ * output; runs after the answer has already streamed, so it never adds user-visible latency.
+ */
+
+// Cheap, fast model for titles (not the answer model). Local OpenAI-compatible backend wins if set.
+const TITLE_MODEL = "claude-haiku-4-5-20251001";
+const LLM_BASE_URL = process.env.LLM_BASE_URL;
+const LLM_MODEL = process.env.LLM_MODEL ?? "llama3.1-8b-64k:latest";
+
+const TITLE_SYSTEM =
+  "You label a chat with a 3–5 word title in Title Case. Output ONLY the title — no quotes, no trailing punctuation, no preamble.";
+
+/** Sanitize a model's title output to a single clean line (strip quotes/`<think>`, collapse, cap). */
+export function cleanTitle(raw: string, max = 60): string {
+  const stripped = String(raw ?? "").replace(/<think>[\s\S]*?<\/think>/g, ""); // drop reasoning spans
+  // First non-empty line (models sometimes emit a blank/preamble line first).
+  let t = (stripped.split("\n").map((s) => s.trim()).find(Boolean) ?? "").replace(/\s+/g, " ").trim();
+  t = t.replace(/^["'`\s]+|["'`\s.]+$/g, "").trim(); // surrounding quotes + trailing period
+  if (t.length > max) t = t.slice(0, max).trimEnd();
+  return t;
+}
+
+/** Generate a short title from the first Q+A, or null on any failure (caller keeps the derived title). */
+export async function generateTitle(
+  question: string,
+  answer: string,
+  keys: ProviderKeys = {}
+): Promise<string | null> {
+  const prompt = `Question: ${question.trim()}\n\nAnswer: ${answer.trim().slice(0, 600)}\n\nTitle:`;
+  try {
+    if (LLM_BASE_URL) {
+      const res = await fetch(`${LLM_BASE_URL.replace(/\/$/, "")}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${keys.openaiKey ?? process.env.OPENAI_API_KEY ?? "local"}`,
+        },
+        body: JSON.stringify({
+          model: LLM_MODEL,
+          max_tokens: 24,
+          messages: [
+            { role: "system", content: TITLE_SYSTEM },
+            { role: "user", content: prompt },
+          ],
+        }),
+        signal: AbortSignal.timeout(6000), // never hold the response open on a slow title call
+      });
+      if (!res.ok) return null;
+      const j = (await res.json()) as { choices?: { message?: { content?: string } }[] };
+      return cleanTitle(j.choices?.[0]?.message?.content ?? "") || null;
+    }
+    const client = new Anthropic(keys.anthropicKey ? { apiKey: keys.anthropicKey } : undefined);
+    const msg = await client.messages.create(
+      {
+        model: TITLE_MODEL,
+        max_tokens: 24,
+        system: TITLE_SYSTEM,
+        messages: [{ role: "user", content: prompt }],
+      },
+      { timeout: 6000, maxRetries: 0 }
+    );
+    const text = msg.content.map((b) => (b.type === "text" ? b.text : "")).join("");
+    return cleanTitle(text) || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Generate + persist a title for a freshly-created conversation. Best-effort (never throws to the caller). */
+export async function generateAndSetTitle(
+  supabase: SupabaseClient,
+  owner: { teamId: string; memberId: string },
+  conversationId: string,
+  question: string,
+  answer: string,
+  keys: ProviderKeys = {}
+): Promise<void> {
+  try {
+    const title = await generateTitle(question, answer, keys);
+    if (title) await setTitle(supabase, owner, conversationId, title);
+  } catch {
+    // keep the derived title
+  }
+}

--- a/test/chat-title.test.ts
+++ b/test/chat-title.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { cleanTitle } from "@/lib/chat/title";
+
+// Spec: the LLM title output is sanitized to one clean line for the sidebar — strip quotes,
+// reasoning spans, and trailing punctuation; collapse whitespace; cap length.
+
+describe("cleanTitle", () => {
+  it("strips surrounding quotes and trailing punctuation", () => {
+    expect(cleanTitle('"Weekly Accomplishments Review."')).toBe("Weekly Accomplishments Review");
+    expect(cleanTitle("  'Railway Deploy Incident'  ")).toBe("Railway Deploy Incident");
+  });
+
+  it("keeps only the first line", () => {
+    expect(cleanTitle("Linear Importer Status\nignore this second line")).toBe("Linear Importer Status");
+  });
+
+  it("drops <think> reasoning spans from reasoning models", () => {
+    expect(cleanTitle("<think>hmm what to call this</think>Chat History Design")).toBe("Chat History Design");
+  });
+
+  it("collapses whitespace and caps length", () => {
+    expect(cleanTitle("A    B   C")).toBe("A B C");
+    const long = "word ".repeat(40);
+    expect(cleanTitle(long, 20).length).toBeLessThanOrEqual(20);
+  });
+
+  it("returns empty string for empty/garbage input (caller keeps the derived title)", () => {
+    expect(cleanTitle("")).toBe("");
+    expect(cleanTitle('   ""   ')).toBe("");
+  });
+});


### PR DESCRIPTION
The three follow-ups to persistent chat history.

## #1 — LLM-generated titles
After a **new** thread's first exchange, a cheap **background** call (`lib/chat/title.ts`, bounded to 6s, local LLM or Anthropic haiku) replaces the derived first-question title with a short label — the ChatGPT-style sidebar polish. **Best-effort**: any failure (no key / timeout) keeps the derived title, and it runs *after* the answer has streamed, so zero user-visible latency. `store.setTitle` updates the title **without** bumping `updated_at` (so it doesn't reorder the list). Wired into both the dashboard and machine-API query routes.

## #2 — Conversation search
The `/query` sidebar gets an **instant client-side title filter** (the owner's list is already loaded — no backend round-trip). Content/FTS search over message bodies is noted as a later increment.

## #3 — CLI / Hermes integration spec (`docs/CHAT-CLIENTS.md`)
The `conversation_id` contract for the clients: the SSE event shape, capture/persist/resend the id, and the **Telegram-chat → conversation mapping** to run on the Hermes box (so a Telegram thread is one continuous brain conversation that also appears in the member's web sidebar). The server side is already built (#117/#118); this is the drop-in guide for the CLI/Hermes worktrees.

## Tests / verification
- +5 `cleanTitle` unit specs (quote/`<think>`/whitespace/cap handling).
- Full: **349 unit**, chat-store data-mechanics green; tsc + eslint + docs-drift clean.
- **No schema change** (uses the existing `conversations` table).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat conversations now get automatic titles for new threads.
  * Added chat sidebar search to quickly filter saved conversations.

* **Bug Fixes**
  * Improved conversation continuity so new chats are clearly distinguished from existing threads.
  * Search results now show a helpful message when no conversations match.

* **Documentation**
  * Added guidance for chat clients on continuing conversations across sessions and surfaces.

* **Tests**
  * Added coverage for chat title cleaning and formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->