### PR TITLE
feat(admin): create-team CLI command for no-SQL bootstrap (AIO-199)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -90,6 +90,21 @@ Production is Postgres on Railway. After a merge that changes `postgres/schema.s
 `npm run pg:schema` against the prod `DATABASE_URL` and confirm the platform started a new build
 (CI webhooks can be dropped — re-trigger if the latest deploy predates the merge).
 
+## Bootstrapping a fresh instance (first team + admin)
+
+AIOS is self-hosted per organization (see CLAUDE.md §5) — there's no public signup. The first
+team and its first admin are created once, with no hand-written SQL, by chaining two idempotent
+CLI commands (against the target `DATABASE_URL` — prod uses the Railway DB):
+
+```bash
+npm run admin -- create-team <slug> --name "<Display Name>"
+npm run admin -- create-member <you@org.com> --name "<Your Name>" --handle <you> --role admin --team <slug>
+```
+
+Both are safe to re-run: `create-team` returns the existing row for an already-used slug, and
+`create-member` takes `--upsert` if you need to re-run it. From here, follow "Giving a new
+contributor brain access" below to invite everyone else onto the same team.
+
 ## Giving a new contributor brain access (admins)
 
 People are invite-only; machines (the `aios` CLI / sidecar) use a per-member API key. To onboard

--- a/lib/admin/teams.ts
+++ b/lib/admin/teams.ts
@@ -5,6 +5,55 @@ import type { ActorContext } from "./members";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
 
+export interface TeamInput {
+  slug: string;
+  name: string;
+}
+
+/**
+ * Create a team — the no-SQL bootstrap primitive for a fresh instance. Pairs with
+ * `createMember({ role: "admin" })` to stand up the first team + admin without
+ * hand-written SQL (AIOS is self-hosted per organization; this is NOT a public
+ * signup path — see CLAUDE.md §5). Idempotent: an existing slug returns that row
+ * rather than erroring, so a bootstrap script can be re-run safely.
+ */
+export async function createTeam(
+  admin: SupabaseClient,
+  input: TeamInput,
+  opts: { actor?: ActorContext } = {}
+): Promise<{ id: string; slug: string; name: string }> {
+  const slug = input.slug.trim().toLowerCase();
+  if (!SLUG_RE.test(slug)) throw new Error(`invalid slug '${slug}' (need ^[a-z0-9][a-z0-9-]*$)`);
+  const name = input.name.trim();
+  if (!name) throw new Error("name is required");
+
+  const { data: existing } = await admin
+    .from("teams")
+    .select("id, slug, name")
+    .eq("slug", slug)
+    .maybeSingle();
+  if (existing) return existing as { id: string; slug: string; name: string };
+
+  const { data, error } = await admin
+    .from("teams")
+    .insert({ slug, name })
+    .select("id, slug, name")
+    .single();
+  if (error || !data) throw new Error(`create team failed: ${error?.message}`);
+  const team = data as { id: string; slug: string; name: string };
+
+  await audit(admin, {
+    team_id: team.id,
+    actor_kind: opts.actor?.kind ?? "system",
+    member_id: opts.actor?.memberId ?? null,
+    action: "team.created",
+    target_type: "team",
+    target_id: team.id,
+    meta: { slug, name },
+  });
+  return team;
+}
+
 /**
  * Rename a team's slug and/or display name. Idempotent (setting the slug/name it
  * already has is a no-op, not an error). The slug must be route-safe and unique.

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -96,7 +96,11 @@ async function main() {
   switch (cmd) {
     case "create-team": {
       const slug = positionals[0] || die("usage: create-team <slug> --name <display>");
-      const name = (flags.name as string) || die("usage: create-team <slug> --name <display>");
+      // `--name` with no following value parses as boolean `true` (parseArgs), which would
+      // otherwise pass truthiness here and crash later at `.trim()` instead of showing usage.
+      const name =
+        (typeof flags.name === "string" && flags.name) ||
+        die("usage: create-team <slug> --name <display>");
       const team = await createTeam(admin, { slug, name });
       console.log(`✓ team ${team.slug} (${team.id}) "${team.name}"`);
       break;

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -13,7 +13,7 @@ import { adminClient } from "@/lib/supabase/admin";
 import { createMember, deleteMember } from "@/lib/admin/members";
 import { issueApiKey, revokeApiKey } from "@/lib/admin/keys";
 import { issueLoginLink } from "@/lib/admin/login";
-import { renameTeam } from "@/lib/admin/teams";
+import { createTeam, renameTeam } from "@/lib/admin/teams";
 import { addAuthorAlias } from "@/lib/admin/aliases";
 import { linkGithub, listOrgMembers } from "@/lib/codebases/github";
 import { setMemberIdentity } from "@/lib/identity/member-identities";
@@ -53,6 +53,7 @@ async function resolveTeam(admin: ReturnType<typeof adminClient>, ref: string) {
 }
 
 const USAGE = `Team Brain admin CLI — commands:
+  create-team <slug> --name <display>   # bootstrap: create a team, no SQL. Idempotent.
   create-member <email> --name <n> --handle <h> [--role admin|lead|member] [--team <slug>] [--upsert]
   login-link <email> [--team <slug>] [--ttl-min <n>] [--base-url <url> | env BRAIN_URL]
   issue-key <member-email> [--name <n>] [--team <slug>]
@@ -93,6 +94,13 @@ async function main() {
   const teamSlug = (flags.team as string) || "demo";
 
   switch (cmd) {
+    case "create-team": {
+      const slug = positionals[0] || die("usage: create-team <slug> --name <display>");
+      const name = (flags.name as string) || die("usage: create-team <slug> --name <display>");
+      const team = await createTeam(admin, { slug, name });
+      console.log(`✓ team ${team.slug} (${team.id}) "${team.name}"`);
+      break;
+    }
     case "create-member": {
       const email = positionals[0] || die("usage: create-member <email> --name <n> --handle <h>");
       const team = await resolveTeam(admin, teamSlug);

--- a/test/datamechanics/team-creation.datamechanics.test.ts
+++ b/test/datamechanics/team-creation.datamechanics.test.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createTeam } from "@/lib/admin/teams";
+import { db } from "./helpers";
+
+// Spec: createTeam is the no-SQL bootstrap primitive for a fresh instance — an admin runs
+// this (via `npm run admin -- create-team`) instead of hand-writing SQL. Verified on real
+// Postgres: it must actually persist a row, enforce the same slug shape the schema check
+// constraint requires, be idempotent (safe to re-run a bootstrap script), and audit itself.
+
+describe("createTeam (real Postgres)", () => {
+  it("persists a new team row with the given slug and name", async () => {
+    const slug = `team-${randomUUID().slice(0, 8)}`;
+    const team = await createTeam(db(), { slug, name: "Acme Corp" });
+
+    expect(team.slug).toBe(slug);
+    expect(team.name).toBe("Acme Corp");
+    expect(team.id).toBeTruthy();
+
+    const { data: row } = await db().from("teams").select("id, slug, name").eq("id", team.id).single();
+    expect(row).toMatchObject({ id: team.id, slug, name: "Acme Corp" });
+  });
+
+  it("is idempotent — re-running with the same slug returns the existing row, not a duplicate", async () => {
+    const slug = `team-${randomUUID().slice(0, 8)}`;
+    const first = await createTeam(db(), { slug, name: "Original Name" });
+    const second = await createTeam(db(), { slug, name: "Ignored On Re-run" });
+
+    expect(second.id).toBe(first.id);
+    expect(second.name).toBe("Original Name"); // the existing row wins, not the re-run's input
+
+    const { data: rows } = await db().from("teams").select("id").eq("slug", slug);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("rejects a slug that violates the schema's check constraint", async () => {
+    await expect(createTeam(db(), { slug: "Not_A_Valid_Slug!", name: "X" })).rejects.toThrow(/invalid slug/);
+  });
+
+  it("rejects an empty name", async () => {
+    const slug = `team-${randomUUID().slice(0, 8)}`;
+    await expect(createTeam(db(), { slug, name: "   " })).rejects.toThrow(/name is required/);
+  });
+
+  it("writes an audit_log entry for the new team", async () => {
+    const slug = `team-${randomUUID().slice(0, 8)}`;
+    const team = await createTeam(db(), { slug, name: "Audited Co" });
+
+    const { data: entries } = await db()
+      .from("audit_log")
+      .select("action, target_type, target_id, team_id")
+      .eq("target_id", team.id)
+      .eq("action", "team.created");
+    expect(entries).toHaveLength(1);
+    expect(entries?.[0]).toMatchObject({
+      action: "team.created",
+      target_type: "team",
+      target_id: team.id,
+      team_id: team.id,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Every Team Brain instance/team was created only via raw SQL or `seed-demo.ts` — there was no `create-team` command paired with the existing `create-member`.
- Adds `createTeam()` to `lib/admin/teams.ts` (same audited-primitive pattern as `createMember`/`renameTeam`: slug validation, idempotent on an existing slug).
- Adds `npm run admin -- create-team <slug> --name <display>` to the CLI.
- Documents the two-command bootstrap (`create-team` → `create-member --role admin`) in `DEVELOPMENT.md`.

**Deliberately scoped down**: per `CLAUDE.md` §5, AIOS is self-hosted per organization — there's no public multi-tenant signup story, so this is NOT a "create your team" public wizard. It's the no-SQL fix for the actual pain: a fresh instance's first admin currently has to hand-write SQL just to get a team row to attach their own `create-member --role admin` to. A web "+ New team" UI for an org adding a *second* team to an already-running instance is a reasonable follow-up, but belongs behind existing admin auth and wasn't built here to keep this change scoped to the bootstrap gap.

Closes AIO-199. Full audit context: https://claude.ai/code/artifact/50631a28-8699-4bf6-8430-385721c5e5a4

## Test plan
- [x] New data-mechanics test (real Postgres via `npm run db:test:up`): persistence, idempotency (re-run returns the existing row, doesn't duplicate or overwrite), slug/name validation, and the `audit_log` entry — 5/5 passing
- [x] Manually ran `npm run admin -- create-team acme-corp --name "Acme Corp"` twice against the test DB — same team ID both times
- [x] `npm run check:docs` passes (no route/table/source drift — `teams` table is unchanged)
- [x] `npm run lint` clean (one pre-existing unrelated warning in another file)
- [x] `npm test` — no new failures (3 pre-existing failures on `main`: missing `neo4j-driver` dep in `lib/graph/neo4j.ts` and a timezone-formatting test, unrelated to this change)
- [ ] Note for reviewer: `npm run typecheck` currently fails on `lib/graph/neo4j.ts` (missing `neo4j-driver` — pre-existing on `main`, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-only CLI and library primitive with validation and audit; no public signup or schema changes.
> 
> **Overview**
> Adds a **no-SQL bootstrap path** for a fresh self-hosted instance: operators can create the first team without raw SQL or `seed-demo`, then chain `create-member --role admin` as documented in `DEVELOPMENT.md`.
> 
> **`createTeam()`** in `lib/admin/teams.ts` follows the same audited-admin pattern as other primitives: normalizes/validates slug (`^[a-z0-9][a-z0-9-]*$`), requires a display name, inserts into `teams`, and records `team.created` in `audit_log`. **Idempotent** on slug — an existing slug returns that row (re-runs do not duplicate or rename).
> 
> **`npm run admin -- create-team <slug> --name <display>`** wires the primitive into the CLI, including a guard so a bare `--name` flag fails with usage instead of crashing on `.trim()`.
> 
> **Data-mechanics coverage** on real Postgres checks persistence, idempotency, validation, and audit logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd2753a52fc4088da9a2296c3a9b2c569a14107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to create the first team in a self-hosted setup.
  * Documented how to bootstrap a fresh instance by creating the initial team and admin account.

* **Bug Fixes**
  * Team creation is now safe to re-run for the same team slug without creating duplicates.
  * Added validation so invalid slugs and blank team names are rejected with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->