### PR TITLE
feat(auth): self-serve API key generation, closing the invite/key gap (AIO-200)

### DIFF
--- a/app/t/[team]/admin/keys/page.tsx
+++ b/app/t/[team]/admin/keys/page.tsx
@@ -34,8 +34,9 @@ export default async function KeysAdminPage({
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <p className="text-sm text-ink-secondary">
-          Per-member sync keys for the <code>aios</code> CLI. Secrets are hashed at rest and shown
-          exactly once at issue time.
+          Per-member sync keys for the <code>aios</code> CLI. Members can generate their own from
+          their profile page — use this to issue one on their behalf instead, or revoke any key.
+          Secrets are hashed at rest and shown exactly once at issue time.
         </p>
         <IssueKey teamSlug={teamSlug} members={members ?? []} />
       </div>
@@ -80,7 +81,8 @@ export default async function KeysAdminPage({
             {(keys ?? []).length === 0 && (
               <tr>
                 <td colSpan={6} className="px-4 py-8 text-center text-sm text-ink-tertiary">
-                  No keys yet — issue one so a member can run <code>aios push</code>.
+                  No keys yet — members can generate their own from their profile page, or issue
+                  one here for them.
                 </td>
               </tr>
             )}

--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -25,10 +25,12 @@ function SetupChecklist({ teamSlug }: { teamSlug: string }) {
       </Link>
     </span>,
     <span key="2">
-      Issue an API key in{" "}
+      Each teammate generates their own API key from their profile page once signed in (or an
+      admin can issue one for them in{" "}
       <Link href={`/t/${teamSlug}/admin/keys`} className="text-violet underline underline-offset-2">
         Admin → Keys
       </Link>
+      )
     </span>,
     <span key="3">
       Run <code className="rounded bg-surface-overlay px-1 py-0.5 font-mono text-xs">aios push</code>{" "}

--- a/app/t/[team]/people/[handle]/actions.ts
+++ b/app/t/[team]/people/[handle]/actions.ts
@@ -15,6 +15,7 @@ import {
   type TimeOffInput,
   type GoalInput,
 } from "@/lib/identity/profile";
+import { issueApiKey, revokeOwnApiKey } from "@/lib/admin/keys";
 
 /**
  * Server actions for the per-member identity context editor. The security boundary is
@@ -128,6 +129,52 @@ export async function deleteMemberGoal(
       actor: { kind: "member", memberId: ctx.actorMemberId },
     });
     revalidatePath(`/t/${teamSlug}/people/${memberId}`);
+    return { ok: true };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+/**
+ * Self-only gate for API keys — deliberately stricter than `gate()`: a member may issue or
+ * revoke ONLY their own key here, never a teammate's, even as an admin. An admin generating a
+ * secret on someone else's behalf has no safe way to hand it over (that's the whole gap this
+ * closes); admins keep member-picker issuance for exceptional cases via /admin/keys.
+ */
+async function selfGate(teamSlug: string): Promise<Gate | null> {
+  const supabase = await serverClient();
+  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+  const me = await currentMember((team as { id: string }).id);
+  if (!me) return null;
+  return { teamId: (team as { id: string }).id, actorMemberId: me.id };
+}
+
+type KeyResult = { ok: boolean; error?: string; key?: string };
+
+export async function issueMyApiKey(teamSlug: string, name: string): Promise<KeyResult> {
+  const ctx = await selfGate(teamSlug);
+  if (!ctx) return { ok: false, error: "not signed in" };
+  try {
+    const { key } = await issueApiKey(adminClient(), ctx.teamId, ctx.actorMemberId, name, {
+      actor: { kind: "member", memberId: ctx.actorMemberId },
+    });
+    revalidatePath(`/t/${teamSlug}/people/${ctx.actorMemberId}`);
+    return { ok: true, key };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function revokeMyApiKey(teamSlug: string, apiKeyId: string): Promise<KeyResult> {
+  const ctx = await selfGate(teamSlug);
+  if (!ctx) return { ok: false, error: "not signed in" };
+  try {
+    const { revoked } = await revokeOwnApiKey(adminClient(), ctx.teamId, ctx.actorMemberId, apiKeyId, {
+      actor: { kind: "member", memberId: ctx.actorMemberId },
+    });
+    if (!revoked) return { ok: false, error: "not allowed" };
+    revalidatePath(`/t/${teamSlug}/people/${ctx.actorMemberId}`);
     return { ok: true };
   } catch (e) {
     return fail(e);

--- a/app/t/[team]/people/[handle]/page.tsx
+++ b/app/t/[team]/people/[handle]/page.tsx
@@ -43,8 +43,43 @@ export default async function PersonPage({
   const me = await currentMember(team.id);
   if (!me) return null;
 
-  const p = await getMemberProfile(supabase, team.id, decodeURIComponent(handle), range, me.tier);
-  if (!p) notFound();
+  const decodedHandle = decodeURIComponent(handle);
+  const p = await getMemberProfile(supabase, team.id, decodedHandle, range, me.tier);
+
+  if (!p) {
+    // getMemberProfile gates on canSeeCodebases(tier) — an external-tier member (a client/
+    // consultant collaborator) can't see codebase contribution stats, so it returns null even
+    // for their OWN handle. That's the correct tier gate for commit metrics, but it must not
+    // also block them from managing their own API key — resolve "is this actually me" directly
+    // against the members table, independent of the tier-gated profile query.
+    const { data: meRow } = await supabase
+      .from("members")
+      .select("actor_handle, github_login")
+      .eq("id", me.id)
+      .maybeSingle();
+    const m = meRow as { actor_handle: string | null; github_login: string | null } | null;
+    const lc = decodedHandle.toLowerCase();
+    const isSelfByHandle =
+      me.id === decodedHandle ||
+      m?.actor_handle?.toLowerCase() === lc ||
+      m?.github_login?.toLowerCase() === lc;
+
+    if (!isSelfByHandle) notFound();
+
+    const { data: keyRows } = await supabase
+      .from("api_keys")
+      .select("id, key_id, name, created_at, last_used_at, revoked_at")
+      .eq("team_id", team.id)
+      .eq("member_id", me.id)
+      .order("created_at", { ascending: false });
+
+    return (
+      <div className="mx-auto flex max-w-2xl flex-col gap-5">
+        <h1 className="font-display text-2xl font-semibold text-ink">Your account</h1>
+        <MyApiKeys teamSlug={teamSlug} keys={(keyRows ?? []) as MyKeyRow[]} />
+      </div>
+    );
+  }
 
   const context = await getMemberContext(supabase, team.id, p.member_id, me.tier);
   const canEdit = !!context && (me.id === p.member_id || me.role === "admin");

--- a/app/t/[team]/people/[handle]/page.tsx
+++ b/app/t/[team]/people/[handle]/page.tsx
@@ -12,6 +12,7 @@ import { RangeSelector } from "@/components/dashboard/range-selector";
 import { CommitHeatmap } from "@/components/codebases/commit-heatmap";
 import { MemberContextPanel } from "@/components/people/member-context";
 import { ContextEditor } from "@/components/people/context-editor";
+import { MyApiKeys, type MyKeyRow } from "@/components/people/my-api-keys";
 
 export const metadata: Metadata = { title: "Profile" };
 
@@ -47,6 +48,18 @@ export default async function PersonPage({
 
   const context = await getMemberContext(supabase, team.id, p.member_id, me.tier);
   const canEdit = !!context && (me.id === p.member_id || me.role === "admin");
+  const isSelf = me.id === p.member_id;
+
+  let myKeys: MyKeyRow[] = [];
+  if (isSelf) {
+    const { data } = await supabase
+      .from("api_keys")
+      .select("id, key_id, name, created_at, last_used_at, revoked_at")
+      .eq("team_id", team.id)
+      .eq("member_id", me.id)
+      .order("created_at", { ascending: false });
+    myKeys = (data ?? []) as MyKeyRow[];
+  }
 
   const aiPct = p.totals.commits ? Math.round((100 * p.totals.ai_commits) / p.totals.commits) : 0;
 
@@ -101,6 +114,7 @@ export default async function PersonPage({
       {canEdit && context ? (
         <ContextEditor teamSlug={teamSlug} memberId={p.member_id} context={context} />
       ) : null}
+      {isSelf ? <MyApiKeys teamSlug={teamSlug} keys={myKeys} /> : null}
 
       <section className="prism-card flex flex-col gap-3 p-5">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-ink-tertiary">

--- a/components/people/my-api-keys.tsx
+++ b/components/people/my-api-keys.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { KeyRound, Copy, Check } from "lucide-react";
+import { issueMyApiKey, revokeMyApiKey } from "@/app/t/[team]/people/[handle]/actions";
+import { timeAgo } from "@/components/format";
+
+export interface MyKeyRow {
+  id: string;
+  key_id: string;
+  name: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+/**
+ * Self-serve API key management, shown only on your own profile (never a teammate's — see
+ * the self-only gate in actions.ts). Closes the invite/key gap: instead of an admin
+ * generating a secret and relaying it over Slack/1Password, you generate your own here once
+ * you've signed in via your invite email.
+ */
+export function MyApiKeys({ teamSlug, keys }: { teamSlug: string; keys: MyKeyRow[] }) {
+  return (
+    <section className="prism-card flex flex-col gap-3 p-5">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
+          My API keys
+        </h2>
+        <IssueMyKey teamSlug={teamSlug} />
+      </div>
+      <p className="text-xs text-ink-tertiary">
+        Used by the <code>aios</code> CLI to sync this workspace. Secrets are hashed at rest and
+        shown exactly once at issue time.
+      </p>
+      {keys.length ? (
+        <div className="overflow-x-auto rounded-lg border border-border-subtle">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border-subtle text-left text-xs uppercase tracking-wide text-ink-tertiary">
+                <th className="px-4 py-2">Key</th>
+                <th className="px-4 py-2">Name</th>
+                <th className="px-4 py-2">Last used</th>
+                <th className="px-4 py-2">Status</th>
+                <th className="px-4 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr key={k.id} className="border-b border-border-subtle last:border-0">
+                  <td className="px-4 py-2 font-mono text-xs text-ink-secondary">aios_{k.key_id}_…</td>
+                  <td className="px-4 py-2 text-ink">{k.name}</td>
+                  <td className="px-4 py-2 text-ink-tertiary">
+                    {k.last_used_at ? timeAgo(k.last_used_at) : "never"}
+                  </td>
+                  <td className="px-4 py-2">
+                    {k.revoked_at ? (
+                      <span className="text-xs text-red-600">revoked</span>
+                    ) : (
+                      <span className="text-xs text-emerald-600">active</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    {!k.revoked_at && <RevokeMyKeyButton teamSlug={teamSlug} apiKeyId={k.id} />}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="rounded-lg border border-dashed border-border-subtle px-4 py-6 text-center text-sm text-ink-tertiary">
+          No keys yet — generate one to run <code>aios push</code> from your workspace.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function IssueMyKey({ teamSlug }: { teamSlug: string }) {
+  const [open, setOpen] = useState(false);
+  const [issued, setIssued] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  if (issued) {
+    return (
+      <div className="prism-card flex flex-col gap-3 border border-violet/40 p-4">
+        <p className="text-sm font-medium text-ink">
+          Key issued — copy it now. It is shown exactly once; only its hash is stored.
+        </p>
+        <div className="flex items-center gap-2">
+          <code className="flex-1 overflow-x-auto rounded-lg bg-surface-overlay px-3 py-2 font-mono text-xs text-ink">
+            {issued}
+          </code>
+          <button
+            onClick={async () => {
+              await navigator.clipboard.writeText(issued);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            }}
+            className="rounded-lg border border-border-default p-2 text-ink-secondary hover:text-ink"
+            aria-label="Copy key"
+          >
+            {copied ? <Check className="size-4 text-violet" /> : <Copy className="size-4" />}
+          </button>
+        </div>
+        <button
+          onClick={() => {
+            setIssued(null);
+            setOpen(false);
+          }}
+          className="self-start rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white"
+        >
+          Done — I copied it
+        </button>
+      </div>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+      >
+        <KeyRound className="size-4" strokeWidth={1.75} />
+        Generate key
+      </button>
+    );
+  }
+
+  return (
+    <form
+      className="flex items-center gap-2"
+      action={(formData) => {
+        setError(null);
+        startTransition(async () => {
+          const res = await issueMyApiKey(teamSlug, String(formData.get("name") ?? ""));
+          if (!res.ok || !res.key) setError(res.error ?? "failed");
+          else setIssued(res.key);
+        });
+      }}
+    >
+      <input
+        name="name"
+        placeholder="key name (e.g. my-laptop)"
+        required
+        className="rounded-lg border border-border-default bg-surface-base px-3 py-2 text-sm text-ink outline-none focus:border-violet"
+      />
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <button
+        type="submit"
+        disabled={pending}
+        className="rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {pending ? "Issuing…" : "Generate"}
+      </button>
+      <button
+        type="button"
+        onClick={() => setOpen(false)}
+        className="rounded-lg border border-border-default px-4 py-2 text-sm text-ink-secondary"
+      >
+        Cancel
+      </button>
+    </form>
+  );
+}
+
+function RevokeMyKeyButton({ teamSlug, apiKeyId }: { teamSlug: string; apiKeyId: string }) {
+  const [pending, startTransition] = useTransition();
+  return (
+    <button
+      disabled={pending}
+      onClick={() =>
+        startTransition(async () => {
+          await revokeMyApiKey(teamSlug, apiKeyId);
+        })
+      }
+      className="rounded-lg border border-border-default px-3 py-1 text-xs text-ink-secondary hover:border-red-300 hover:text-red-600 disabled:opacity-50"
+    >
+      {pending ? "…" : "Revoke"}
+    </button>
+  );
+}

--- a/lib/admin/keys.ts
+++ b/lib/admin/keys.ts
@@ -61,3 +61,30 @@ export async function revokeApiKey(
     target_id: apiKeyId,
   });
 }
+
+/**
+ * Self-serve variant of revokeApiKey: a member may revoke ONLY their own key. Unlike
+ * revokeApiKey (which trusts the caller's authz check and only scopes by team), this
+ * primitive re-derives ownership from the DB itself, so the ownership check can never be
+ * skipped by a caller that forgets to gate it — same "single writer, one legal path"
+ * shape as createTeam/createMember. Returns false (no-op, not an error) if the key is
+ * absent or owned by someone else, so a caller can distinguish "not yours" from a DB error.
+ */
+export async function revokeOwnApiKey(
+  admin: SupabaseClient,
+  teamId: string,
+  memberId: string,
+  apiKeyId: string,
+  opts: { actor?: ActorContext } = {}
+): Promise<{ revoked: boolean }> {
+  const { data: row } = await admin
+    .from("api_keys")
+    .select("member_id")
+    .eq("id", apiKeyId)
+    .eq("team_id", teamId)
+    .maybeSingle();
+  if (!row || (row as { member_id: string }).member_id !== memberId) return { revoked: false };
+
+  await revokeApiKey(admin, teamId, apiKeyId, opts);
+  return { revoked: true };
+}

--- a/lib/admin/keys.ts
+++ b/lib/admin/keys.ts
@@ -67,8 +67,9 @@ export async function revokeApiKey(
  * revokeApiKey (which trusts the caller's authz check and only scopes by team), this
  * primitive re-derives ownership from the DB itself, so the ownership check can never be
  * skipped by a caller that forgets to gate it — same "single writer, one legal path"
- * shape as createTeam/createMember. Returns false (no-op, not an error) if the key is
- * absent or owned by someone else, so a caller can distinguish "not yours" from a DB error.
+ * shape as createTeam/createMember. Returns `{ revoked: false }` (no-op, not an error) if
+ * the key is absent, already revoked, or owned by someone else; throws on a genuine DB
+ * failure so a caller never mistakes "the lookup broke" for "not allowed."
  */
 export async function revokeOwnApiKey(
   admin: SupabaseClient,
@@ -77,13 +78,15 @@ export async function revokeOwnApiKey(
   apiKeyId: string,
   opts: { actor?: ActorContext } = {}
 ): Promise<{ revoked: boolean }> {
-  const { data: row } = await admin
+  const { data: row, error } = await admin
     .from("api_keys")
-    .select("member_id")
+    .select("member_id, revoked_at")
     .eq("id", apiKeyId)
     .eq("team_id", teamId)
     .maybeSingle();
-  if (!row || (row as { member_id: string }).member_id !== memberId) return { revoked: false };
+  if (error) throw new Error(`revoke key lookup failed: ${error.message}`);
+  const r = row as { member_id: string; revoked_at: string | null } | null;
+  if (!r || r.member_id !== memberId || r.revoked_at) return { revoked: false };
 
   await revokeApiKey(admin, teamId, apiKeyId, opts);
   return { revoked: true };

--- a/test/datamechanics/self-serve-api-keys.datamechanics.test.ts
+++ b/test/datamechanics/self-serve-api-keys.datamechanics.test.ts
@@ -57,11 +57,28 @@ describe("revokeOwnApiKey (real Postgres)", () => {
     expect(revoked).toBe(false);
   });
 
-  it("no-ops (does not throw) on an already-revoked or nonexistent key id", async () => {
+  it("no-ops (does not throw) on a nonexistent key id", async () => {
     const seed = await seedTeam();
     await expect(
       revokeOwnApiKey(db(), seed.teamId, seed.memberId, randomUUID())
     ).resolves.toEqual({ revoked: false });
+  });
+
+  it("no-ops on an already-revoked key it owns — does not re-revoke or duplicate the audit entry", async () => {
+    const seed = await seedTeam();
+    const { keyId: apiKeyRowId } = await issueOwnRow(seed.teamId, seed.memberId);
+    const first = await revokeOwnApiKey(db(), seed.teamId, seed.memberId, apiKeyRowId);
+    expect(first).toEqual({ revoked: true });
+
+    const second = await revokeOwnApiKey(db(), seed.teamId, seed.memberId, apiKeyRowId);
+    expect(second).toEqual({ revoked: false }); // already revoked — not re-revoked
+
+    const { data: entries } = await db()
+      .from("audit_log")
+      .select("id")
+      .eq("target_id", apiKeyRowId)
+      .eq("action", "api_key.revoked");
+    expect(entries).toHaveLength(1); // exactly one revoke event, not two
   });
 });
 

--- a/test/datamechanics/self-serve-api-keys.datamechanics.test.ts
+++ b/test/datamechanics/self-serve-api-keys.datamechanics.test.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { issueApiKey, revokeOwnApiKey } from "@/lib/admin/keys";
+import { db, seedTeam } from "./helpers";
+
+// Spec: self-serve key management closes the invite/key gap by letting a member issue their
+// own key instead of an admin generating a secret and relaying it out-of-band. The security
+// invariant is revokeOwnApiKey — a member must NEVER be able to revoke a teammate's key, even
+// by guessing/enumerating another key's row id. Verified on real Postgres.
+
+describe("revokeOwnApiKey (real Postgres)", () => {
+  it("revokes a key the member actually owns", async () => {
+    const seed = await seedTeam();
+    const { keyId: apiKeyRowId } = await issueOwnRow(seed.teamId, seed.memberId);
+
+    const { revoked } = await revokeOwnApiKey(db(), seed.teamId, seed.memberId, apiKeyRowId);
+    expect(revoked).toBe(true);
+
+    const { data: row } = await db().from("api_keys").select("revoked_at").eq("id", apiKeyRowId).single();
+    expect((row as { revoked_at: string | null }).revoked_at).not.toBeNull();
+  });
+
+  it("refuses to revoke a teammate's key — the core trust boundary", async () => {
+    const seed = await seedTeam();
+    // A second member on the SAME team, with their own key.
+    const { data: other } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `${randomUUID()}@test.local`,
+        display_name: "Other",
+        actor_handle: `actor-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "team",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    const otherMemberId = (other as { id: string }).id;
+    const { keyId: otherKeyRowId } = await issueOwnRow(seed.teamId, otherMemberId);
+
+    // seed.memberId (NOT the owner) tries to revoke it.
+    const { revoked } = await revokeOwnApiKey(db(), seed.teamId, seed.memberId, otherKeyRowId);
+    expect(revoked).toBe(false);
+
+    const { data: row } = await db().from("api_keys").select("revoked_at").eq("id", otherKeyRowId).single();
+    expect((row as { revoked_at: string | null }).revoked_at).toBeNull(); // untouched
+  });
+
+  it("refuses a key id from a different team entirely", async () => {
+    const seedA = await seedTeam();
+    const seedB = await seedTeam();
+    const { keyId: keyInTeamA } = await issueOwnRow(seedA.teamId, seedA.memberId);
+
+    // A member of team B tries to revoke a key that belongs to team A.
+    const { revoked } = await revokeOwnApiKey(db(), seedB.teamId, seedB.memberId, keyInTeamA);
+    expect(revoked).toBe(false);
+  });
+
+  it("no-ops (does not throw) on an already-revoked or nonexistent key id", async () => {
+    const seed = await seedTeam();
+    await expect(
+      revokeOwnApiKey(db(), seed.teamId, seed.memberId, randomUUID())
+    ).resolves.toEqual({ revoked: false });
+  });
+});
+
+/** Issue a key for a member and resolve the api_keys row id (not the key_id column). */
+async function issueOwnRow(teamId: string, memberId: string): Promise<{ keyId: string }> {
+  await issueApiKey(db(), teamId, memberId, "test key");
+  const { data } = await db()
+    .from("api_keys")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("member_id", memberId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+  return { keyId: (data as { id: string }).id };
+}


### PR DESCRIPTION
## Summary
`issueApiKey` already worked, but had no notification path — the admin saw the secret once in their own browser with no safe way to relay it except manual copy/paste over Slack or 1Password. Rather than build email delivery for a raw secret (arguably worse than the gap itself), **members now generate their own key** once they're signed in via their invite email.

- `lib/admin/keys.ts`: new `revokeOwnApiKey()` primitive — re-derives ownership from the DB itself rather than trusting the caller's authz check, so a member can never revoke a teammate's key even if a caller forgot to gate it (same "single writer, one legal path" shape as `createTeam`/`createMember` from AIO-199).
- `app/t/[team]/people/[handle]/actions.ts`: `issueMyApiKey`/`revokeMyApiKey`, gated by a **self-only** check — deliberately stricter than the existing admin-or-self `gate()`, since an admin generating a secret for someone else still has no safe way to hand it over.
- `components/people/my-api-keys.tsx`: a "My API keys" panel shown only on your own profile page (never a teammate's) — generate, copy-once, revoke.
- Updated the team home setup checklist and `/admin/keys` page copy to point at self-serve first, admin issuance as the fallback for exceptional cases.

**Also confirmed, not fixed**: `lib/auth/mailer.ts`'s `sendMagicLink` is genuinely dead code, not a wiring bug — the postgres backend's login (`app/api/auth/login/route.ts`) is an explicitly documented passwordless direct sign-in with no magic-link round-trip at all. Left as-is, out of scope for this PR.

Closes AIO-200. Full audit context: https://claude.ai/code/artifact/50631a28-8699-4bf6-8430-385721c5e5a4

## Test plan
- [x] New data-mechanics test (real Postgres): a member cannot revoke a teammate's key (same team), cannot revoke a key from a different team, and a stale/nonexistent key id no-ops rather than throwing — 4/4 passing
- [x] `npm run check:docs` passes (no route/table/source drift)
- [x] `npm run lint` clean (one pre-existing unrelated warning)
- [x] `npm test` — no new failures (same 3 pre-existing failures as `main`: missing `neo4j-driver` dep, a timezone-formatting test)
- [ ] Note for reviewer: `npm run typecheck` fails on `lib/graph/neo4j.ts` (missing `neo4j-driver`, pre-existing on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches API key issuance/revocation and new authorization paths; mitigated by self-only gating, DB-backed ownership on revoke, and targeted Postgres tests.
> 
> **Overview**
> Members can **generate and revoke their own** `aios` CLI sync keys from their profile page, so secrets are not relayed through admins after invite sign-in.
> 
> New **self-only** server actions (`issueMyApiKey` / `revokeMyApiKey`) always bind issuance and revocation to the signed-in member—**even admins** cannot use this path for someone else. Admin **Admin → Keys** remains for exceptional on-behalf issuance and team-wide revoke. **`revokeOwnApiKey`** in `lib/admin/keys` re-checks key ownership in the database before revoking, so callers cannot skip authorization by mistake.
> 
> The profile route adds a **My API keys** panel for the viewer’s own page only, plus a **tier bypass**: when `getMemberProfile` returns null for external-tier users on their own handle, the page still resolves “is me” and shows key management without commit stats. Setup checklist and admin keys copy now describe self-serve first.
> 
> Real Postgres tests cover cross-member, cross-team, missing, and double-revoke cases for `revokeOwnApiKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb8247f250e83cbdf7a6800c3bfba5d805c9d00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->