### PR TITLE
docs: fix stale placeholder org URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AIOS Team Brain
 
 Mission control for agentic teamwork. Contributor repos (built on
-[Agentic Team Ops](https://github.com/your-github-org/aios-workspace)) sync
+[Agentic Team Ops](https://github.com/aiosbrain/aios-workspace)) sync
 tier-tagged content here via the `aios` CLI; the dashboard surfaces tasks,
 projects, decisions, deliverables, transcripts, and a grounded natural-language
 query over the team's shared memory.


### PR DESCRIPTION
## Summary
README linked to `github.com/your-github-org/aios-workspace` — a literal copy-paste placeholder that never got the real org substituted in. Confirmed the real org via `aios-workspace`'s own git remote (`aiosbrain`).

Flagged during the onboarding audit ([artifact](https://claude.ai/code/artifact/50631a28-8699-4bf6-8430-385721c5e5a4)) as an OSS-readiness gap; fixing now as a trivial standalone doc fix.

## Test plan
- [x] `npm run check:docs` passes (docs-drift guard unaffected — this isn't a route/table/source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL fix with no runtime, API, or security impact.
> 
> **Overview**
> Updates the **Agentic Team Ops** link in `README.md` from `github.com/your-github-org/aios-workspace` to **`github.com/aiosbrain/aios-workspace`**, so onboarding docs point at the actual contributor repo instead of a copy-paste placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63d8c845140f6060e7f8dfb33ea31d8c2b62287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README link in the introduction to point to the correct workspace repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->