### PR TITLE
feat(api): expose avatar_url on GET /api/v1/members (AIO-206)

### DIFF
--- a/app/api/v1/members/route.ts
+++ b/app/api/v1/members/route.ts
@@ -12,6 +12,10 @@ export const runtime = "nodejs";
  * so an external tool (e.g. a Hermes comms agent or the `slack` CLI) can resolve "how do
  * I reach teammate X" from the single source of truth instead of a local list.
  *
+ * Also carries `github_login`/`avatar_url` (populated by the admin GitHub sync) so
+ * tools that render contributors — e.g. `aios timeline` — can resolve avatars from
+ * the brain before falling back to GitHub's public avatar CDN.
+ *
  * Team-tier only (the roster is team metadata; an external key gets 403). Optional filters:
  *   ?email=<addr>     exact roster email
  *   ?handle=<handle>  exact actor_handle
@@ -37,7 +41,7 @@ export async function GET(req: NextRequest) {
 
   let q = supabase
     .from("members")
-    .select("id, email, display_name, actor_handle, github_login, role, tier, status")
+    .select("id, email, display_name, actor_handle, github_login, avatar_url, role, tier, status")
     .eq("team_id", auth.teamId)
     .neq("status", "disabled");
   if (email) q = q.eq("email", email);
@@ -59,6 +63,7 @@ export async function GET(req: NextRequest) {
         display_name: m.display_name as string,
         actor_handle: m.actor_handle as string,
         github_login: (m.github_login as string | null) ?? null,
+        avatar_url: (m.avatar_url as string | null) ?? null,
         role: m.role as string,
         tier: m.tier as string,
         identities: provs,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -460,7 +460,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/decisions` — dashboard decision changes for `aios pull` writeback (tier-scoped)
 - `GET /api/v1/projects` — team project list for `aios pull` brain-project registration (team-tier only)
 - `GET /api/v1/me` — authenticated member identity + role (drives client UI gating)
-- `GET /api/v1/members` — team roster + cross-tool identities for external resolution (team-tier only; `?email`/`?handle`/`?provider` filters)
+- `GET /api/v1/members` — team roster + cross-tool identities for external resolution, incl. `github_login`/`avatar_url` for contributor-avatar consumers like `aios timeline` (team-tier only; `?email`/`?handle`/`?provider` filters)
 - `GET /api/v1/identities/resolve` — resolve a provider external_id (or email/handle) to a member + canonical contacts incl. `slack_id` (team-tier only; 404 on miss)
 - `GET /api/v1/me/slack-token` — the caller's OWN Slack user token for "act as me" (owner-only: member from the API key, never a param; 404 if not connected; `no-store`)
 - `POST /api/v1/me/slack-token` — connect the caller's Slack via manual paste: validate (`auth.test`) + store encrypted (`member_secrets`) + capture identity

--- a/test/datamechanics/members-resolve.datamechanics.test.ts
+++ b/test/datamechanics/members-resolve.datamechanics.test.ts
@@ -63,6 +63,45 @@ describe("members + identity-resolve endpoints (real handlers, real Postgres)", 
     expect(forbidden.status).toBe(403);
   });
 
+  it("members: carries avatar_url when the GitHub sync has populated it, null otherwise", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const { error } = await db()
+      .from("members")
+      .update({ github_login: "octocat", avatar_url: "https://avatars.githubusercontent.com/u/583231" })
+      .eq("id", seed.memberId)
+      .eq("team_id", seed.teamId);
+    expect(error).toBeNull();
+    const { data: unsynced, error: insertError } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `unsynced-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "Unsynced",
+        actor_handle: `unsynced-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "team",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    expect(insertError).toBeNull();
+    const unsyncedId = (unsynced as { id: string }).id;
+
+    const ok = await get(membersGET, MEMBERS_URL, team, seed.teamSlug);
+    expect(ok.status).toBe(200);
+    const body = (await ok.json()) as {
+      members: { id: string; github_login: string | null; avatar_url: string | null }[];
+    };
+    const synced = body.members.find((m) => m.id === seed.memberId);
+    expect(synced?.github_login).toBe("octocat");
+    expect(synced?.avatar_url).toBe("https://avatars.githubusercontent.com/u/583231");
+
+    const fresh = body.members.find((m) => m.id === unsyncedId);
+    expect(fresh?.github_login).toBeNull();
+    expect(fresh?.avatar_url).toBeNull();
+  });
+
   it("resolve: slack external_id → member; provider filter; 404 on miss", async () => {
     const seed = await seedTeam();
     const team = await issueKeyFor(seed, "team");


### PR DESCRIPTION
## What

Adds `avatar_url` to the `GET /api/v1/members` response, next to the existing `github_login` field. Both columns are populated exclusively by the admin GitHub sync (`lib/codebases/github.ts`); this just projects the stored value through the team-tier roster read.

## Why

Part of the Timeline epic (AIO-203): `aios timeline` renders contributor avatars and resolves a PR/commit author login → brain `avatar_url` first, falling back to GitHub's public avatar CDN for authors not yet synced as brain members.

## Notes

- No new route, no migration (both columns already exist in prod via additive `alter table`).
- Auth/tier gating unchanged: team-tier only, external keys still 403.
- Data-mechanics test added: synced member carries `github_login`/`avatar_url`, unsynced member returns nulls. Verified on real Postgres (3/3 pass).
- `docs/ARCHITECTURE.md` route inventory line updated in the same PR per the map build loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON field on an existing team-tier read; no schema, auth, or write-path changes.
> 
> **Overview**
> **Extends the team roster API** so each member includes **`avatar_url`** alongside the existing **`github_login`**, both read from `members` (filled by admin GitHub sync / `linkGithub`).
> 
> Consumers like **`aios timeline`** can resolve contributor avatars from the brain before falling back to GitHub’s public CDN. **Auth, tier gating, and filters are unchanged** (team-tier only).
> 
> Docs (`ARCHITECTURE.md` route line + route comment) and a **data-mechanics test** assert synced members return URL + login and unsynced members return nulls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72718be2506c9442d4b8347967aae9abf8505772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Member list responses now include avatar data when available, alongside existing GitHub login details.
* **Bug Fixes**
  * Members without synced GitHub information now correctly return null avatar fields instead of missing or inconsistent values.
* **Documentation**
  * Updated API documentation to reflect the expanded member response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->