### PR TITLE
AIO-145: Linear⇄brain inbound apply (brain-side half)

### DIFF
--- a/app/t/[team]/admin/pm-sync/page.tsx
+++ b/app/t/[team]/admin/pm-sync/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { serverClient } from "@/lib/supabase/server";
-import { isDiverged } from "@/lib/pm-sync/reconcile";
+import { classifyInboundRow, loadInboundRows } from "@/lib/pm-sync/inbound";
 import { ProjectBoardButton } from "./project-board-button";
 import { ReconcileButton } from "./reconcile-button";
 
@@ -16,7 +16,7 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
     .maybeSingle();
   if (!team) return null;
 
-  const [{ data: unresolved }, { data: failedLinks }, { data: seenLinks }] = await Promise.all([
+  const [{ data: unresolved }, { data: failedLinks }, inboundRows] = await Promise.all([
     supabase
       .from("work_events")
       .select("row_key, repo, merged_sha, pr_url, pr_title, error, created_at")
@@ -31,27 +31,23 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
       .not("last_error", "is", null)
       .order("updated_at", { ascending: false })
       .limit(50),
-    // Inbound divergence (Phase 5): links the reconcile pass has recorded a provider_seen_status on.
-    // Divergence is computed in JS (the pg adapter can't compare two columns in a filter).
-    supabase
-      .from("task_pm_links")
-      .select("row_key, provider, provider_url, last_projected_status, provider_seen_status, updated_at")
-      .eq("team_id", team.id)
-      .not("provider_seen_status", "is", null)
-      .order("updated_at", { ascending: false })
-      .limit(200),
+    // Inbound divergence (brain-api v1.4): the enriched read the inbound engine itself uses —
+    // links + task rows + the exact brain-status baseline — so the page deterministically
+    // recomputes "conflict (both changed)" vs "pending apply" from persisted data alone.
+    loadInboundRows(supabase, team.id),
   ]);
 
-  const divergences = (
-    (seenLinks ?? []) as {
-      row_key: string;
-      provider: string;
-      provider_url: string | null;
-      last_projected_status: string | null;
-      provider_seen_status: string | null;
-      updated_at: string;
-    }[]
-  ).filter(isDiverged);
+  const divergences = inboundRows
+    .map((row) => ({ row, state: classifyInboundRow(row) }))
+    .filter((d) => d.state !== "in_sync")
+    .map(({ row, state }) => ({
+      row_key: row.link.row_key,
+      provider: row.link.provider,
+      provider_url: row.link.provider_url,
+      last_projected_status: row.link.last_projected_status,
+      provider_seen_status: row.link.provider_seen_status,
+      state,
+    }));
 
   return (
     <div className="flex flex-col gap-5">
@@ -72,9 +68,11 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
       <section className="prism-card p-4" data-section="inbound-divergence">
         <h2 className="text-lg font-semibold text-ink">Inbound divergence</h2>
         <p className="mt-1 text-sm text-ink-secondary">
-          Tasks whose state in the PM tool has drifted from what the brain last projected. The brain
-          is the source of truth — this is <span className="font-medium text-ink">surface-only</span>,
-          shown for a human to pull; it is never written back automatically.
+          Tasks whose state in the PM tool has drifted from what the brain last projected.
+          With inbound apply enabled, a <span className="font-medium text-ink">pending apply</span> row
+          is written to the brain on the next sync (the brain hadn&apos;t changed); a{" "}
+          <span className="font-medium text-ink">conflict</span> means both sides changed — it is
+          surfaced here for a human and never auto-merged.
         </p>
         <div className="mt-4">
           <ReconcileButton
@@ -90,6 +88,7 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
                 <th className="py-2 pr-4 font-medium">Provider</th>
                 <th className="py-2 pr-4 font-medium">Brain projected</th>
                 <th className="py-2 pr-4 font-medium">Seen in tool</th>
+                <th className="py-2 pr-4 font-medium">Resolution</th>
               </tr>
             </thead>
             <tbody>
@@ -101,10 +100,17 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
                   </td>
                   <td className="py-2 pr-4 text-ink-secondary">{d.last_projected_status}</td>
                   <td className="py-2 pr-4 font-medium text-amber-700">{d.provider_seen_status}</td>
+                  <td className="py-2 pr-4" data-resolution={d.state}>
+                    {d.state === "conflict" ? (
+                      <span className="font-medium text-red">conflict — both changed</span>
+                    ) : (
+                      <span className="text-ink-secondary">pending apply</span>
+                    )}
+                  </td>
                 </tr>
               ))}
               {divergences.length === 0 ? (
-                <tr><td colSpan={4} className="py-4 text-ink-tertiary">No divergence detected.</td></tr>
+                <tr><td colSpan={5} className="py-4 text-ink-tertiary">No divergence detected.</td></tr>
               ) : null}
             </tbody>
           </table>

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -332,6 +332,9 @@ const integrationConfigSchemas: Record<IntegrationType, z.ZodType> = {
       teamId: z.string().max(64).optional(),
       projectId: z.string().max(64).optional(),
       doneStateName: z.string().max(80).optional(),
+      // Per-team opt-in for the v1.4 inbound apply (Linear→brain status + adopt). Default off:
+      // enabling Linear-writes-brain is a deliberate, reversible, per-team act (brain-api v1.4).
+      inboundApply: z.boolean().optional(),
     })
     .strict(),
   plane: z

--- a/lib/db/pg/tx.ts
+++ b/lib/db/pg/tx.ts
@@ -1,0 +1,32 @@
+import "server-only";
+import type { PoolClient } from "pg";
+import { getPool } from "./pool";
+
+/**
+ * Run `fn` inside a single Postgres transaction on a dedicated pooled client.
+ * BEGIN → fn → COMMIT, with ROLLBACK on any throw. Used by the inbound PM-sync
+ * apply/adopt paths (brain-api v1.4), whose loop-prevention invariant requires
+ * `tasks.status` and the `task_pm_links` bookkeeping to move atomically.
+ *
+ * Postgres-backend only: the queries `fn` issues MUST run on the passed client
+ * (raw SQL), not through the supabase-compat adapter (whose queries would use
+ * other pooled connections outside this transaction).
+ */
+export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // the connection is being released anyway; the original error wins
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/lib/ingest/manual-sync.ts
+++ b/lib/ingest/manual-sync.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { runSlackIngestion, runPlaneIngestion, runLinearIngestion, runGithubIngestion } from "./run";
 import { adminClient } from "@/lib/supabase/admin";
 import { recordIngestRun } from "./runs";
+import { runLinearInbound, type InboundRunSummary } from "@/lib/pm-sync/inbound";
 
 /**
  * On-demand "scrape now" from the query box. `isSyncCommand` recognizes when a chat message is a
@@ -54,6 +55,19 @@ export async function runManualSync(teamId: string): Promise<ManualSyncResult> {
     safe(runGithubIngestion({ teamId })),
   ]);
 
+  // Inbound Linear→brain apply/adopt (brain-api v1.4): runs AFTER the Linear ingest leg above has
+  // resolved (never in parallel with it) so adopt sees freshly-imported mirror tasks. Per-team
+  // opt-in — a team without inboundApply gets a quiet no-op.
+  let inbound: InboundRunSummary | null = null;
+  if (linear?.integrations) {
+    try {
+      inbound = await runLinearInbound({ teamId });
+      if (inbound.skipped || !inbound.teams) inbound = null;
+    } catch {
+      inbound = null;
+    }
+  }
+
   // Record each configured source's run so a manual /sync failure is diagnosable in the runs log.
   const runsDb = adminClient();
   for (const [source, s] of [["slack", slack], ["plane", plane], ["linear", linear], ["github", github]] as const) {
@@ -67,6 +81,21 @@ export async function runManualSync(teamId: string): Promise<ManualSyncResult> {
       updated: s.updated,
       errors: s.errors,
       meta: { integrations: s.integrations },
+      startedAt,
+    });
+  }
+
+  if (inbound && (inbound.applied || inbound.adopted || inbound.conflicts || inbound.errors.length)) {
+    await recordIngestRun(runsDb, {
+      teamId,
+      source: "linear_inbound",
+      trigger: "manual",
+      ok: inbound.ok,
+      created: inbound.adopted,
+      updated: inbound.applied,
+      unchanged: inbound.noops,
+      errors: inbound.errors,
+      meta: { conflicts: inbound.conflicts, skipped: inbound.skippedReasons },
       startedAt,
     });
   }
@@ -88,6 +117,14 @@ export async function runManualSync(teamId: string): Promise<ManualSyncResult> {
   add("Plane", plane);
   add("Linear", linear);
   add("GitHub", github);
+
+  if (inbound && (inbound.applied || inbound.adopted || inbound.conflicts)) {
+    errors += inbound.errors.length;
+    const conflictNote = inbound.conflicts
+      ? ` — ${inbound.conflicts} conflict${inbound.conflicts > 1 ? "s" : ""} (see Admin → PM sync)`
+      : "";
+    lines.push(`- **Linear inbound**: ${inbound.applied} applied, ${inbound.adopted} adopted${conflictNote}`);
+  }
 
   let summary: string;
   if (!lines.length) {

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -3,6 +3,7 @@ import { runSlackIngestion, runPlaneIngestion, runLinearIngestion, runGithubInge
 import type { ImportSummary, IngestSummary } from "./run";
 import { adminClient } from "@/lib/supabase/admin";
 import { recordIngestRun } from "./runs";
+import { runLinearInbound } from "@/lib/pm-sync/inbound";
 
 /**
  * In-process poller — the single-service alternative to a separate cron worker.
@@ -27,6 +28,9 @@ export function startIngestScheduler(): void {
     await runImport(supabase, "slack", runSlackIngestion);
     await runImport(supabase, "plane", runPlaneIngestion);
     await runImport(supabase, "linear", runLinearIngestion);
+    // Inbound Linear→brain apply/adopt (brain-api v1.4) — sequenced AFTER the Linear ingest so
+    // adopt sees freshly-imported mirror tasks. Per-team opt-in; quiet no-op otherwise.
+    await runInbound(supabase);
     await runImport(supabase, "github", runGithubIngestion);
     // Incremental dense (semantic) indexing of newly-synced items. No-op unless dense retrieval is
     // configured (EMBEDDINGS_URL + pgvector schema); best-effort — never fails the tick.
@@ -38,6 +42,38 @@ export function startIngestScheduler(): void {
       console.error("[ingest] dense index tick failed:", err instanceof Error ? err.message : err);
     }
   };
+
+  // Inbound PM-sync step (brain-api v1.4): apply Linear board edits to brain tasks + adopt
+  // Linear-native issues, for opted-in teams. Records to ingest_runs like the importers; a
+  // quiet pass (nothing enabled / nothing changed / no conflicts) logs nothing.
+  async function runInbound(supabase: ReturnType<typeof adminClient>): Promise<void> {
+    const startedAt = Date.now();
+    try {
+      const s = await runLinearInbound();
+      if (s.skipped) return; // another run in-flight
+      const active = s.applied || s.adopted || s.conflicts || s.errors.length || s.skippedReasons.length;
+      if (!s.teams || !active) return;
+      console.info(
+        `[ingest] linear-inbound: applied ${s.applied}, adopted ${s.adopted}, conflicts ${s.conflicts} (${s.teams} teams)` +
+          (s.errors.length ? ` errors: ${s.errors.join("; ")}` : "")
+      );
+      await recordIngestRun(supabase, {
+        source: "linear_inbound",
+        trigger: "scheduler",
+        ok: s.ok,
+        created: s.adopted,
+        updated: s.applied,
+        unchanged: s.noops,
+        errors: s.errors,
+        meta: { teams: s.teams, conflicts: s.conflicts, skipped: s.skippedReasons },
+        startedAt,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[ingest] linear-inbound tick failed:`, msg);
+      await recordIngestRun(supabase, { source: "linear_inbound", trigger: "scheduler", ok: false, errors: [msg], startedAt });
+    }
+  }
 
   // Shared runner: run one source, log a line, and record the outcome to ingest_runs so a failure
   // (or a silent staleness) is diagnosable later instead of only living in container logs.

--- a/lib/ingest/sources/linear-normalize.ts
+++ b/lib/ingest/sources/linear-normalize.ts
@@ -68,6 +68,11 @@ function safeSegment(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
+/** The deterministic brain project slug a Linear team's issues mirror into (`linear-<teamKey>`). */
+export function linearMirrorProject(teamKey: string): string {
+  return `linear-${safeSegment(teamKey) || "team"}`;
+}
+
 // Linear state.type → brain status. Linear uses "canceled" (one l); both terminal states → done.
 const TYPE_TO_STATUS: Record<string, string> = {
   backlog: "backlog",
@@ -77,11 +82,29 @@ const TYPE_TO_STATUS: Record<string, string> = {
   canceled: "done",
 };
 
-/** A state NAMED like a brain status wins (e.g. a "Blocked" started state); else map by type. */
-function linearStatus(stateName: string | undefined, type: string | undefined): string {
+/**
+ * Strict variant for the inbound apply (brain-api v1.4): a state whose name doesn't match a brain
+ * status AND whose type isn't a known Linear group resolves to NULL — the contract treats an
+ * unresolvable state as a CONFLICT, never a silent default. `linearStatus` keeps the ingest
+ * behavior (defaults to backlog) by delegating here.
+ */
+export function linearStatusOrNull(stateName: string | undefined, type: string | undefined): string | null {
   const byName = normalizeTaskStatus(stateName ?? "");
   if (byName.raw_status === null && byName.status !== "backlog") return byName.status;
-  return TYPE_TO_STATUS[type ?? ""] ?? "backlog";
+  const byType = TYPE_TO_STATUS[type ?? ""];
+  if (byType) return byType;
+  // A state literally named "Backlog" (any/unknown type) still resolves by name.
+  return byName.raw_status === null ? byName.status : null;
+}
+
+/**
+ * A state NAMED like a brain status wins (e.g. a "Blocked" started state); else map by type.
+ * Exported (v1.4): the inbound apply reuses this exact mapper so inbound and ingest agree — it is
+ * keyed on Linear's 1-L `canceled`, never the 2-L `StateGroup` spelling (`provider.ts`), which
+ * would silently mis-map canceled states.
+ */
+export function linearStatus(stateName: string | undefined, type: string | undefined): string {
+  return linearStatusOrNull(stateName, type) ?? "backlog";
 }
 
 // Linear priority int → brain priority word.
@@ -89,7 +112,7 @@ const PRIORITY_BY_INT: Record<number, string> = { 0: "none", 1: "urgent", 2: "hi
 
 export function normalizeLinearTeam(input: NormalizeLinearInput): ItemPayload {
   const slugSeg = safeSegment(input.teamKey) || "team";
-  const project = `linear-${slugSeg}`;
+  const project = linearMirrorProject(input.teamKey);
 
   // Exclude every brain-owned issue (footer round-trippers + projection-linked), importing only
   // net-new Linear-side tasks. Stable sort so a re-import is byte-identical → a no-op at the sha writer.

--- a/lib/pm-sync/inbound.ts
+++ b/lib/pm-sync/inbound.ts
@@ -1,0 +1,636 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { isPostgresBackend } from "@/lib/db/backend";
+import { withTransaction } from "@/lib/db/pg/tx";
+import { fetchLinearTeam, type FetchedLinearTeam } from "@/lib/ingest/sources/linear";
+import {
+  linearMirrorProject,
+  linearStatusOrNull,
+  type LinearImportIssue,
+} from "@/lib/ingest/sources/linear-normalize";
+import { linearAdapter } from "@/lib/pm-sync/linear";
+import { linearGraphql, parseExt, stripFooter, withFooter } from "@/lib/pm-sync/linear-client";
+import {
+  PROJECTION_TASK_COLS,
+  resolvePrimaryProvider,
+  toProjectable,
+  type ProjectionTaskRow,
+  type ResolvedPrimary,
+} from "@/lib/pm-sync/project";
+import {
+  projectionFingerprint,
+  type SeenState,
+  type TaskStatusValue,
+} from "@/lib/pm-sync/provider";
+import { isDiverged } from "@/lib/pm-sync/reconcile";
+import { adminClient } from "@/lib/supabase/admin";
+
+/**
+ * Inbound Linear→brain apply + adopt (brain-api v1.4, AIO-145) — the write half that turns the
+ * Phase 5 surface-only divergence read (`reconcile.ts`) into a policy-driven sync.
+ *
+ * Field policy (v1.4, hardcoded default): `status = pm-wins-if-brain-unchanged`;
+ * `title/body/labels/priority` stay brain-wins and are NEVER written by the apply loop.
+ *
+ * "Brain unchanged" is TWO checks, both required (round-3 review, binding):
+ *   1. exact-status baseline — `task_pm_links.last_projected_brain_status === tasks.status`.
+ *      The projection fingerprint hashes the provider state GROUP, and in_progress/blocked both
+ *      hash to `started`, so the fingerprint alone would silently overwrite a same-group brain
+ *      edit. The baseline is written by outbound projection success, adopt, and inbound apply.
+ *   2. fingerprint equality — `projection_fingerprint === projectionFingerprint(task, parent)`.
+ *      Catches a pending title/body/labels/priority/parent edit; applying a status while another
+ *      field is pending would either swallow that edit (if we refreshed the fingerprint) or echo
+ *      it — so both-changed is a CONFLICT, surfaced, never auto-merged.
+ *
+ * Loop prevention (normative): an apply updates `tasks.status` and the link bookkeeping
+ * (`last_projected_status` + `last_projected_brain_status` + a recomputed `projection_fingerprint`)
+ * ATOMICALLY in one Postgres transaction, guarded on the expected pre-apply status (optimistic
+ * concurrency — a concurrent brain edit aborts into a conflict). The next reactive projection sees
+ * an equal fingerprint and makes ZERO provider writes: no echo loop.
+ *
+ * Adopt (Phase B): a Linear-native issue (no `aios-ext` footer, no link) was already imported by
+ * `runLinearIngestion` as a mirror task under the deterministic `linear-<teamKey>` project — adopt
+ * BACKFILLS the two-way link (never a fresh task insert), flips `origin` to 'ui' (so the next
+ * ingest diff-delete can't remove it), seeds `tasks.body` once from the Linear description (so a
+ * later outbound projection can't wipe the native description with an empty brain body), and
+ * appends the `aios-ext` footer to the EXISTING Linear description. Tier safety is structural
+ * (`access_tier` has no admin; the mirror import is fixed to `team`) and asserted here.
+ *
+ * Trigger: poll-only — the 30-min ingest scheduler tick + manual "sync now", both AFTER the Linear
+ * ingest leg. Gated per team by `config.inboundApply === true` on the Linear integration (default
+ * off). Webhooks are explicitly out of scope for v1 (brain-api v1.4).
+ */
+
+// Adoption NEVER creates or elevates beyond team tier (brain-api v1.4 tier-safety invariant).
+// `access_tier` is structurally admin-free ('team' | 'external'), but assert intent explicitly.
+const ADOPT_TIER = "team" as const;
+
+// ── Result shapes (signal-shaped, per the bidirectional-pm-sync spec) ───────────────────────────
+
+export interface InboundConflict {
+  kind: "pm_sync_conflict";
+  source: "linear";
+  tier: typeof ADOPT_TIER;
+  occurredAt: string;
+  /** Linear resource (node) id. */
+  ref: string;
+  payload: {
+    task_id: string | null;
+    row_key: string;
+    linear_state: string;
+    brain_state: string | null;
+    reason: string;
+  };
+}
+
+export interface InboundApplied {
+  kind: "pm_sync_applied";
+  source: "linear";
+  tier: typeof ADOPT_TIER;
+  occurredAt: string;
+  ref: string;
+  payload: { task_id: string; row_key: string; linear_state: string; brain_state: string; from: string };
+}
+
+export interface InboundResult {
+  provider: "linear" | null;
+  /** false when the team hasn't opted in (config.inboundApply) — everything else is empty. */
+  enabled: boolean;
+  applied: InboundApplied[];
+  conflicts: InboundConflict[];
+  noops: number;
+  /** row_keys adopted this pass (link backfilled onto an ingest-created mirror task). */
+  adopted: string[];
+  /** Fail-soft skip reasons (no destination, missing mirror task, footer backfill failure…). */
+  skipped: string[];
+  reason?: string;
+}
+
+function emptyResult(over: Partial<InboundResult> = {}): InboundResult {
+  return { provider: null, enabled: false, applied: [], conflicts: [], noops: 0, adopted: [], skipped: [], ...over };
+}
+
+// ── Enriched read (links + tasks + parent resolution) — shared by the engine and the admin page ──
+
+const INBOUND_LINK_COLS =
+  "id, team_id, project_id, task_id, row_key, provider, provider_resource_id, provider_external_source, provider_url, projection_fingerprint, last_projected_status, last_projected_brain_status, provider_seen_status";
+
+export interface InboundLink {
+  id: string;
+  team_id: string;
+  project_id: string;
+  task_id: string | null;
+  row_key: string;
+  provider: string;
+  provider_resource_id: string | null;
+  provider_external_source: string;
+  provider_url: string;
+  projection_fingerprint: string | null;
+  last_projected_status: string | null;
+  last_projected_brain_status: string | null;
+  provider_seen_status: string | null;
+}
+
+export interface InboundRow {
+  link: InboundLink;
+  task: ProjectionTaskRow | null;
+  /** The parent task's provider resource id, resolved exactly as outbound does (by parent_row_key). */
+  parentResourceId: string | null;
+  /** Fingerprint recomputed from the CURRENT persisted task row (null when the task is missing). */
+  currentFingerprint: string | null;
+  brainUnchanged: boolean;
+}
+
+export type InboundRowState = "in_sync" | "pending_apply" | "conflict";
+
+/**
+ * Pure, persisted-data-only classification — the admin PM-sync page uses this to deterministically
+ * distinguish "conflict (both changed)" from "pending apply (Linear moved, brain unchanged)"
+ * without a provider round-trip (round-3 review Major 3).
+ */
+export function classifyInboundRow(row: InboundRow): InboundRowState {
+  if (!isDiverged(row.link)) return "in_sync";
+  return row.brainUnchanged ? "pending_apply" : "conflict";
+}
+
+/**
+ * Load every Linear link for the team enriched with its task row, outbound-identical parent
+ * resolution, the recomputed fingerprint, and the two-check `brainUnchanged` verdict.
+ */
+export async function loadInboundRows(supabase: SupabaseClient, teamId: string): Promise<InboundRow[]> {
+  const { data: linkData } = await supabase
+    .from("task_pm_links")
+    .select(INBOUND_LINK_COLS)
+    .eq("team_id", teamId)
+    .eq("provider", "linear");
+  const links = (linkData ?? []) as InboundLink[];
+  if (!links.length) return [];
+
+  const taskIds = links.map((l) => l.task_id).filter((v): v is string => !!v);
+  const tasksById = new Map<string, ProjectionTaskRow>();
+  if (taskIds.length) {
+    const { data: taskData } = await supabase
+      .from("tasks")
+      .select(PROJECTION_TASK_COLS)
+      .eq("team_id", teamId)
+      .in("id", taskIds);
+    for (const t of (taskData ?? []) as ProjectionTaskRow[]) tasksById.set(t.id, t);
+  }
+
+  // parent_row_key → provider resource id, per project — the same lookup outbound resolves
+  // through its `resolved` map / parent link (Major 4: children must not false-conflict).
+  const resourceByProjectRowKey = new Map<string, string>();
+  for (const l of links) {
+    if (l.provider_resource_id) resourceByProjectRowKey.set(`${l.project_id}:${l.row_key}`, l.provider_resource_id);
+  }
+
+  return links.map((link) => {
+    const task = link.task_id ? (tasksById.get(link.task_id) ?? null) : null;
+    const parentKey = (task?.parent_row_key ?? "").trim();
+    const parentResourceId = parentKey
+      ? (resourceByProjectRowKey.get(`${link.project_id}:${parentKey}`) ?? null)
+      : null;
+    const currentFingerprint = task
+      ? projectionFingerprint(toProjectable(task, parentResourceId), parentResourceId)
+      : null;
+    const brainUnchanged =
+      !!task &&
+      link.last_projected_brain_status !== null &&
+      link.last_projected_brain_status === task.status &&
+      link.projection_fingerprint !== null &&
+      link.projection_fingerprint === currentFingerprint;
+    return { link, task, parentResourceId, currentFingerprint, brainUnchanged };
+  });
+}
+
+// ── Phase A: apply (pm-wins-if-brain-unchanged, status only) ────────────────────────────────────
+
+function conflictOf(link: InboundLink, seenName: string, brainState: string | null, reason: string): InboundConflict {
+  return {
+    kind: "pm_sync_conflict",
+    source: "linear",
+    tier: ADOPT_TIER,
+    occurredAt: new Date().toISOString(),
+    ref: link.provider_resource_id ?? link.row_key,
+    payload: { task_id: link.task_id, row_key: link.row_key, linear_state: seenName, brain_state: brainState, reason },
+  };
+}
+
+/**
+ * Atomic apply: `tasks.status` first (guarded on the expected pre-apply status — optimistic
+ * concurrency), then the link bookkeeping, in ONE transaction. Returns false when the guard
+ * trips (concurrent brain edit) — the caller surfaces a conflict instead.
+ */
+async function applyStatusTx(args: {
+  link: InboundLink;
+  task: ProjectionTaskRow;
+  newStatus: TaskStatusValue;
+  seenName: string;
+  parentResourceId: string | null;
+}): Promise<boolean> {
+  const { link, task, newStatus, seenName, parentResourceId } = args;
+  // Recompute the OUTBOUND fingerprint for the post-apply shape so the next projection
+  // short-circuits (no echo). Separate concept from the conflict baseline (review Major 2).
+  const postFingerprint = projectionFingerprint(
+    toProjectable({ ...task, status: newStatus }, parentResourceId),
+    parentResourceId
+  );
+  return withTransaction(async (client) => {
+    if (newStatus !== task.status) {
+      const res = await client.query(
+        `update tasks set status = $1, updated_at = now() where id = $2 and status = $3`,
+        [newStatus, task.id, task.status]
+      );
+      if ((res.rowCount ?? 0) === 0) return false; // concurrent brain edit → conflict, no write
+    } else {
+      // Status text is already equal (e.g. two Linear names mapping to the same brain status):
+      // verify the baseline still holds under lock, then only refresh the bookkeeping — never
+      // bump tasks.updated_at for a no-change apply (it would trigger a spurious writeback row).
+      const res = await client.query(`select status from tasks where id = $1 for update`, [task.id]);
+      if (res.rows[0]?.status !== task.status) return false;
+    }
+    await client.query(
+      `update task_pm_links
+          set projection_fingerprint = $1,
+              last_projected_status = $2,
+              last_projected_brain_status = $3,
+              provider_seen_status = $2,
+              last_error = null,
+              updated_at = now()
+        where id = $4`,
+      [postFingerprint, seenName, newStatus, link.id]
+    );
+    return true;
+  });
+}
+
+async function applyInbound(
+  supabase: SupabaseClient,
+  teamId: string,
+  seenByResource: Map<string, SeenState>,
+  result: InboundResult
+): Promise<void> {
+  const rows = await loadInboundRows(supabase, teamId);
+  for (const row of rows) {
+    const { link, task } = row;
+    if (!link.provider_resource_id) continue; // never projected/adopted — nothing to reconcile
+    const seen = seenByResource.get(link.provider_resource_id);
+    if (!seen) {
+      result.noops += 1; // provider has no state for this item (e.g. deleted) — leave as-is
+      continue;
+    }
+
+    // Persist the freshly-seen state name (write-if-changed — same semantics as reconcile.ts).
+    if (seen.name !== link.provider_seen_status) {
+      await supabase
+        .from("task_pm_links")
+        .update({ provider_seen_status: seen.name, updated_at: new Date().toISOString() })
+        .eq("id", link.id);
+      link.provider_seen_status = seen.name;
+    }
+
+    if (!isDiverged({ last_projected_status: link.last_projected_status, provider_seen_status: seen.name })) {
+      result.noops += 1;
+      continue;
+    }
+    if (!task) {
+      result.conflicts.push(conflictOf(link, seen.name, null, "no brain task row linked"));
+      continue;
+    }
+    if (!row.brainUnchanged) {
+      // Both changed since the last projection — surface, never auto-merge (v1.4 normative).
+      result.conflicts.push(conflictOf(link, seen.name, task.status, "brain changed since last projection"));
+      continue;
+    }
+
+    const newStatus = linearStatusOrNull(seen.name, seen.type) as TaskStatusValue | null;
+    if (!newStatus) {
+      // Renamed/deleted state with no resolvable group → conflict, not an apply (v1.4 normative).
+      const reason = `unresolvable Linear state "${seen.name}" (type "${seen.type}")`;
+      result.conflicts.push(conflictOf(link, seen.name, task.status, reason));
+      await supabase
+        .from("task_pm_links")
+        .update({ last_error: `inbound: ${reason}`.slice(0, 1000), updated_at: new Date().toISOString() })
+        .eq("id", link.id);
+      continue;
+    }
+
+    const applied = await applyStatusTx({
+      link,
+      task,
+      newStatus,
+      seenName: seen.name,
+      parentResourceId: row.parentResourceId,
+    });
+    if (!applied) {
+      result.conflicts.push(conflictOf(link, seen.name, task.status, "concurrent brain edit during apply"));
+      continue;
+    }
+    result.applied.push({
+      kind: "pm_sync_applied",
+      source: "linear",
+      tier: ADOPT_TIER,
+      occurredAt: new Date().toISOString(),
+      ref: link.provider_resource_id,
+      payload: {
+        task_id: task.id,
+        row_key: link.row_key,
+        linear_state: seen.name,
+        brain_state: newStatus,
+        from: task.status,
+      },
+    });
+  }
+}
+
+// ── Phase B: adopt (backfill the link onto the ingest-created mirror task) ──────────────────────
+
+/** Parent-before-child ordering over the candidate issues (by Linear identifier). */
+function topoIssues(issues: LinearImportIssue[]): LinearImportIssue[] {
+  const byKey = new Map(issues.map((it) => [it.identifier, it]));
+  const ordered: LinearImportIssue[] = [];
+  const placed = new Set<string>();
+  const visiting = new Set<string>();
+  const place = (it: LinearImportIssue) => {
+    if (placed.has(it.identifier) || visiting.has(it.identifier)) return;
+    visiting.add(it.identifier);
+    const parentKey = it.parent?.identifier;
+    if (parentKey && byKey.has(parentKey)) place(byKey.get(parentKey)!);
+    visiting.delete(it.identifier);
+    placed.add(it.identifier);
+    ordered.push(it);
+  };
+  for (const it of issues) place(it);
+  return ordered;
+}
+
+async function adoptInbound(
+  supabase: SupabaseClient,
+  teamId: string,
+  primary: ResolvedPrimary,
+  fetched: FetchedLinearTeam,
+  result: InboundResult,
+  fetchImpl: typeof fetch
+): Promise<void> {
+  // Tier-safety assertion (mirrors the /api/v1/items 422 boundary): adoption is team-tier, always.
+  if ((ADOPT_TIER as string) !== "team") throw new Error("inbound adopt must be team-tier");
+
+  const mirrorSlug = linearMirrorProject(fetched.teamKey);
+  const { data: proj } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("slug", mirrorSlug)
+    .maybeSingle();
+  if (!proj) {
+    result.skipped.push(`mirror project ${mirrorSlug} not found — run Linear ingest first`);
+    return;
+  }
+  const projectId = (proj as { id: string }).id;
+
+  // Links for dedupe (owned node ids) + outbound-identical parent resolution within the mirror.
+  const { data: linkData } = await supabase
+    .from("task_pm_links")
+    .select("project_id, row_key, provider_resource_id")
+    .eq("team_id", teamId)
+    .eq("provider", "linear");
+  const ownedIds = new Set<string>();
+  const resourceByRowKey = new Map<string, string>();
+  for (const l of (linkData ?? []) as { project_id: string; row_key: string; provider_resource_id: string | null }[]) {
+    if (!l.provider_resource_id) continue;
+    ownedIds.add(l.provider_resource_id);
+    if (l.project_id === projectId) resourceByRowKey.set(l.row_key, l.provider_resource_id);
+  }
+
+  // Candidates: genuinely Linear-authored (no aios-ext footer, no projection/adoption link yet).
+  const candidates = topoIssues(fetched.issues.filter((it) => !parseExt(it.description) && !ownedIds.has(it.id)));
+  const externalSource = (primary.integration.config?.externalSource as string | undefined) || "aios-backlog";
+
+  for (const it of candidates) {
+    const { data: taskData } = await supabase
+      .from("tasks")
+      .select(PROJECTION_TASK_COLS)
+      .eq("team_id", teamId)
+      .eq("project_id", projectId)
+      .eq("row_key", it.identifier)
+      .maybeSingle();
+    const task = taskData as ProjectionTaskRow | null;
+    if (!task) {
+      result.skipped.push(`${it.identifier}: no mirror task yet (Linear ingest pending)`);
+      continue;
+    }
+
+    // One-time ownership seed of the description (not the recurring apply loop, which never
+    // writes body): without it, the first outbound projection after a brain-side edit would
+    // overwrite the Linear-native description with the mirror task's empty body.
+    const body = (task.body ?? "").trim() ? task.body : stripFooter(it.description);
+    // Adopt takes the CURRENT Linear state as the task's status (the mirror row may be stale if
+    // the board moved after the last ingest tick) — content flows from Linear at adoption.
+    const status = (linearStatusOrNull(it.state?.name, it.state?.type) ?? task.status) as TaskStatusValue;
+    const stateName = it.state?.name ?? "";
+    const parentKey = (task.parent_row_key ?? "").trim();
+    const parentResourceId = parentKey ? (resourceByRowKey.get(parentKey) ?? null) : null;
+    // Seed the fingerprint for the post-adopt shape so the first outbound pass short-circuits
+    // (adopt-no-duplicate: projection must never create a second Linear issue).
+    const fingerprint = projectionFingerprint(
+      toProjectable({ ...task, status, body }, parentResourceId),
+      parentResourceId
+    );
+
+    const inserted = await withTransaction(async (client) => {
+      const res = await client.query(
+        `insert into task_pm_links
+           (team_id, project_id, task_id, row_key, provider, provider_resource_id,
+            provider_external_source, provider_external_id, provider_url,
+            last_projected_status, last_projected_brain_status, projection_fingerprint,
+            provider_seen_status, updated_at)
+         values ($1, $2, $3, $4, 'linear', $5, $6, $7, $8, $9, $10, $11, $9, now())
+         on conflict (team_id, project_id, row_key, provider) do nothing
+         returning id`,
+        [
+          teamId,
+          projectId,
+          task.id,
+          it.identifier,
+          it.id,
+          externalSource,
+          it.identifier,
+          it.url ?? "",
+          stateName,
+          status,
+          fingerprint,
+        ]
+      );
+      if ((res.rowCount ?? 0) === 0) return false; // raced adopt — the unique index guarantees no duplicate
+      // origin 'ui': once owned, ingest excludes this issue from the mirror push, and only
+      // origin='sync' rows are diff-deleted — the flip is what makes the adopted task durable.
+      await client.query(
+        `update tasks set origin = 'ui', status = $1, body = $2, updated_at = now() where id = $3`,
+        [status, body, task.id]
+      );
+      return true;
+    });
+    if (!inserted) continue;
+
+    resourceByRowKey.set(it.identifier, it.id);
+    result.adopted.push(it.identifier);
+
+    // Post-commit: append the durable aios-ext footer to the EXISTING Linear description so
+    // `isBrainOwned` excludes the issue on the next ingest tick. Best-effort — the link's
+    // provider_resource_id already excludes it (ownedResourceIds), so a failure self-heals.
+    try {
+      await linearGraphql(
+        fetchImpl,
+        primary.integration.secret ?? "",
+        `mutation AdoptFooter($id: String!, $description: String!) {
+          issueUpdate(id: $id, input: { description: $description }) { success issue { id } }
+        }`,
+        { id: it.id, description: withFooter(stripFooter(it.description), it.identifier, externalSource) }
+      );
+    } catch (err) {
+      result.skipped.push(
+        `${it.identifier}: adopted, but footer backfill failed (${err instanceof Error ? err.message : "error"})`
+      );
+    }
+  }
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Run the full inbound pass (apply + adopt) for one team. Fail-soft at every gate: no Linear
+ * primary / no opt-in / no teamId / supabase legacy backend all return an explanatory reason
+ * instead of throwing (matching the ingest runner's surfaced-reason pattern).
+ */
+export async function runInboundForTeam(
+  supabase: SupabaseClient,
+  teamId: string,
+  opts: { fetchImpl?: typeof fetch } = {}
+): Promise<InboundResult> {
+  const primary = await resolvePrimaryProvider(supabase, teamId);
+  if (primary.provider !== "linear") {
+    return emptyResult({ provider: null, reason: primary.provider === null ? (primary.reason ?? "no primary PM provider") : "inbound apply is Linear-only" });
+  }
+  if (primary.integration === null) {
+    return emptyResult({ provider: "linear", reason: primary.reason });
+  }
+  if (primary.integration.config?.inboundApply !== true) {
+    return emptyResult({
+      provider: "linear",
+      reason: "inbound apply is not enabled for this team (set inboundApply on the Linear integration)",
+    });
+  }
+  if (!isPostgresBackend()) {
+    // The v1.4 loop-prevention invariant requires a real transaction; the legacy supabase-js
+    // backend has no transactional write path, so inbound stays off there rather than running
+    // non-atomically against the contract.
+    return emptyResult({
+      provider: "linear",
+      enabled: true,
+      skipped: ["inbound apply requires the postgres backend (atomic loop-prevention)"],
+      reason: "inbound apply requires the postgres backend",
+    });
+  }
+  const teamIdConfig = primary.integration.config?.teamId as string | undefined;
+  if (!teamIdConfig) {
+    return emptyResult({
+      provider: "linear",
+      enabled: true,
+      skipped: ["Linear integration has no teamId configured — cannot reconcile or adopt"],
+      reason: "missing config.teamId",
+    });
+  }
+
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const result = emptyResult({ provider: "linear", enabled: true });
+
+  // Phase A — apply. One read-only provider listing ({name,type} per issue id).
+  const seenByResource = await linearAdapter.fetchSeenStates!({ integration: primary.integration, fetchImpl });
+  await applyInbound(supabase, teamId, seenByResource, result);
+
+  // Phase B — adopt. Reuses the ingest fetch (identifier/description/url, footer detection).
+  const fetched = await fetchLinearTeam({
+    apiKey: primary.integration.secret ?? "",
+    teamId: teamIdConfig,
+    fetchImpl,
+  });
+  await adoptInbound(supabase, teamId, primary, fetched, result, fetchImpl);
+
+  return result;
+}
+
+export interface InboundRunSummary {
+  ok: boolean;
+  teams: number;
+  applied: number;
+  adopted: number;
+  conflicts: number;
+  noops: number;
+  errors: string[];
+  skippedReasons: string[];
+  /** true when another inbound run was already in flight (single-flight, like the ingest runners). */
+  skipped?: boolean;
+}
+
+let inboundRunning = false;
+
+/**
+ * Run the inbound pass for every team with an enabled Linear integration (or one team). Called by
+ * the ingest scheduler tick and manual "sync now" AFTER the Linear ingest leg, so adopt sees
+ * freshly-imported mirror tasks. Single-flight, per-team fail-soft — mirrors runLinearIngestion.
+ */
+export async function runLinearInbound(
+  opts: { teamId?: string; fetchImpl?: typeof fetch } = {}
+): Promise<InboundRunSummary> {
+  const summary: InboundRunSummary = {
+    ok: true,
+    teams: 0,
+    applied: 0,
+    adopted: 0,
+    conflicts: 0,
+    noops: 0,
+    errors: [],
+    skippedReasons: [],
+  };
+  if (inboundRunning) return { ...summary, skipped: true };
+  inboundRunning = true;
+  try {
+    const supabase = adminClient();
+    let teamIds: string[];
+    if (opts.teamId) {
+      teamIds = [opts.teamId];
+    } else {
+      const { data } = await supabase
+        .from("integrations")
+        .select("team_id")
+        .eq("type", "linear")
+        .eq("status", "enabled");
+      teamIds = [...new Set(((data ?? []) as { team_id: string }[]).map((r) => r.team_id))];
+    }
+    for (const teamId of teamIds) {
+      try {
+        const r = await runInboundForTeam(supabase, teamId, { fetchImpl: opts.fetchImpl });
+        if (!r.enabled) continue; // not opted in / not Linear — quiet no-op
+        summary.teams += 1;
+        summary.applied += r.applied.length;
+        summary.adopted += r.adopted.length;
+        summary.conflicts += r.conflicts.length;
+        summary.noops += r.noops;
+        summary.skippedReasons.push(...r.skipped.map((s) => `team ${teamId}: ${s}`));
+        for (const c of r.conflicts) {
+          console.info(
+            `[pm-sync] inbound conflict ${c.payload.row_key}: linear "${c.payload.linear_state}" vs brain "${c.payload.brain_state}" (${c.payload.reason})`
+          );
+        }
+      } catch (err) {
+        summary.errors.push(`team ${teamId}: ${err instanceof Error ? err.message : "inbound failed"}`);
+      }
+    }
+    summary.ok = summary.errors.length === 0;
+    return summary;
+  } finally {
+    inboundRunning = false;
+  }
+}

--- a/lib/pm-sync/index.ts
+++ b/lib/pm-sync/index.ts
@@ -8,6 +8,8 @@ import type { PmProvider } from "@/lib/pm-sync/provider";
 export { projectTask, projectAllTasks } from "@/lib/pm-sync/project";
 export type { ProjectionReport, ProjectionTaskRow } from "@/lib/pm-sync/project";
 export { projectTaskByIdAfterWrite, projectChangedTasksAfterWrite } from "@/lib/pm-sync/after-write";
+export { runInboundForTeam, runLinearInbound, loadInboundRows, classifyInboundRow } from "@/lib/pm-sync/inbound";
+export type { InboundResult, InboundRunSummary, InboundRow, InboundRowState } from "@/lib/pm-sync/inbound";
 
 export interface TaskForPmSync {
   id: string;

--- a/lib/pm-sync/linear.ts
+++ b/lib/pm-sync/linear.ts
@@ -13,6 +13,7 @@ import {
   type PrepareInput,
   type ProviderSyncInput,
   type ProviderSyncResult,
+  type SeenState,
   type StateGroup,
   type UpsertWorkItemInput,
   type UpsertWorkItemResult,
@@ -250,15 +251,15 @@ export const linearAdapter: PmAdapter = {
     return buildBootstrap(ctx, teamId);
   },
 
-  // Phase 5 inbound reconcile: list every issue once and return resource id → current state NAME.
-  // Read-only (reuses the projection bootstrap queries; performs no mutations).
-  async fetchSeenStates({ integration, fetchImpl }: FetchSeenStatesInput): Promise<Map<string, string>> {
+  // Phase 5 inbound reconcile / v1.4 inbound apply: list every issue once and return resource id →
+  // current state { name, type }. Read-only (reuses the projection bootstrap queries; no mutations).
+  async fetchSeenStates({ integration, fetchImpl }: FetchSeenStatesInput): Promise<Map<string, SeenState>> {
     const ctx = linearCtx({ integration, fetchImpl });
     const teamId = requireString(ctx.teamIdConfig, "Linear teamId (config.teamId) for reconcile");
     const boot = await buildBootstrap(ctx, teamId);
-    const seen = new Map<string, string>();
+    const seen = new Map<string, SeenState>();
     for (const [id, issue] of boot.issuesById) {
-      if (issue.state?.name) seen.set(id, issue.state.name);
+      if (issue.state?.name) seen.set(id, { name: issue.state.name, type: issue.state.type ?? "" });
     }
     return seen;
   },

--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -116,7 +116,9 @@ export async function resolvePrimaryProvider(
   return { provider: null, reason: "multiple PM integrations enabled but teams.primary_pm_provider is unset" };
 }
 
-function toProjectable(row: ProjectionTaskRow, parentResourceId: string | null): ProjectableTask {
+// Exported so the inbound apply (lib/pm-sync/inbound.ts) recomputes fingerprints over the EXACT
+// same projectable shape the outbound engine hashes — the two must never drift.
+export function toProjectable(row: ProjectionTaskRow, parentResourceId: string | null): ProjectableTask {
   return {
     row_key: row.row_key,
     title: row.title,
@@ -133,7 +135,7 @@ function toProjectable(row: ProjectionTaskRow, parentResourceId: string | null):
 // Columns of task_pm_links the projection engine reads. The pg adapter (prod) rejects a bare
 // "*" column reference, so every select / insert-returning must name columns explicitly.
 const LINK_COLS =
-  "id, team_id, project_id, task_id, row_key, provider, provider_resource_id, provider_external_source, provider_external_id, provider_url, projection_fingerprint, last_projected_status, provider_seen_status";
+  "id, team_id, project_id, task_id, row_key, provider, provider_resource_id, provider_external_source, provider_external_id, provider_url, projection_fingerprint, last_projected_status, last_projected_brain_status, provider_seen_status";
 
 // The exact `tasks` columns that hydrate a ProjectionTaskRow. Named explicitly (the pg adapter
 // rejects "*") and shared by every loader so the projected shape can't drift between call sites.
@@ -176,7 +178,10 @@ async function persistSuccess(
   supabase: SupabaseClient,
   link: TaskPmLink,
   result: UpsertWorkItemResult,
-  fingerprint: string
+  fingerprint: string,
+  // Exact brain `tasks.status` this projection wrote from — the inbound conflict baseline
+  // (brain-api v1.4). The group-granular fingerprint can't distinguish in_progress vs blocked.
+  brainStatus: string
 ) {
   const now = new Date().toISOString();
   await supabase
@@ -188,6 +193,7 @@ async function persistSuccess(
       last_synced_status: result.syncedStatus ?? null,
       last_synced_at: now,
       last_projected_status: result.syncedStatus ?? null,
+      last_projected_brain_status: brainStatus,
       projection_fingerprint: fingerprint,
       last_error: null,
       updated_at: now,
@@ -288,7 +294,7 @@ export async function projectTask(
       bootstrap: opts.bootstrap,
       fetchImpl: opts.fetchImpl,
     });
-    await persistSuccess(supabase, link, result, fingerprint);
+    await persistSuccess(supabase, link, result, fingerprint, row.status);
     opts.resolved?.set(row.row_key, result.providerResourceId);
     return { row_key: row.row_key, provider, status: result.status, providerResourceId: result.providerResourceId };
   } catch (e) {

--- a/lib/pm-sync/provider.ts
+++ b/lib/pm-sync/provider.ts
@@ -27,6 +27,10 @@ export interface TaskPmLink {
   projection_fingerprint?: string | null;
   last_projected_status?: string | null;
   provider_seen_status?: string | null;
+  // Exact brain `tasks.status` at the last successful projection/adopt/inbound apply — the
+  // inbound conflict baseline (brain-api v1.4). The fingerprint hashes the provider state GROUP,
+  // so it cannot distinguish same-group statuses (in_progress vs blocked); this can.
+  last_projected_brain_status?: string | null;
 }
 
 export interface ProviderSyncResult {
@@ -98,6 +102,15 @@ export interface FetchSeenStatesInput {
   fetchImpl?: typeof fetch;
 }
 
+// A provider workflow state as currently seen on the board. `name` is the display name (what
+// reconcile persists to provider_seen_status); `type` is the provider's raw state group — for
+// Linear the 1-L `backlog|unstarted|started|completed|canceled` — which the inbound apply needs
+// to map a seen state to a brain status via the SAME mapper ingest uses (linearStatus).
+export interface SeenState {
+  name: string;
+  type: string;
+}
+
 export interface PmAdapter {
   provider: PmProvider;
   // Optional per-run prefetch: returns an opaque provider bootstrap (states/labels/items/modules)
@@ -105,10 +118,11 @@ export interface PmAdapter {
   prepare?(input: PrepareInput): Promise<unknown>;
   upsertWorkItem(input: UpsertWorkItemInput): Promise<UpsertWorkItemResult>;
   moveToDone(input: ProviderSyncInput): Promise<ProviderSyncResult>;
-  // Inbound reconciliation (brain-api v1.2 Phase 5): read the CURRENT provider workflow-state NAME
-  // for every projected item, keyed by provider resource id. Read-only — never mutates the provider.
-  // Optional: a provider without an implementation simply has no divergence detection.
-  fetchSeenStates?(input: FetchSeenStatesInput): Promise<Map<string, string>>;
+  // Inbound reconciliation (brain-api v1.2 Phase 5 / v1.4 inbound apply): read the CURRENT
+  // provider workflow state ({ name, type }) for every projected item, keyed by provider resource
+  // id. Read-only — never mutates the provider. Optional: a provider without an implementation
+  // simply has no divergence detection (and no inbound apply).
+  fetchSeenStates?(input: FetchSeenStatesInput): Promise<Map<string, SeenState>>;
 }
 
 // status → desired provider state. Both providers share five workflow groups; `blocked` has no

--- a/lib/pm-sync/reconcile.ts
+++ b/lib/pm-sync/reconcile.ts
@@ -100,22 +100,22 @@ export async function reconcileProviderState(
     const seen = seenByResource.get(link.provider_resource_id!) ?? null;
     if (seen === null) continue; // provider has no state for this item (e.g. deleted) — leave as-is
 
-    // Persist the seen state ONLY when it changed — keeps a re-run write-free (idempotent).
-    if (seen !== link.provider_seen_status) {
+    // Persist the seen state NAME ONLY when it changed — keeps a re-run write-free (idempotent).
+    if (seen.name !== link.provider_seen_status) {
       await supabase
         .from("task_pm_links")
-        .update({ provider_seen_status: seen, updated_at: new Date().toISOString() })
+        .update({ provider_seen_status: seen.name, updated_at: new Date().toISOString() })
         .eq("id", link.id);
       seenUpdated += 1;
     }
 
     // Surface divergence from the brain's last projection — using the freshly-seen value.
-    if (isDiverged({ last_projected_status: link.last_projected_status, provider_seen_status: seen })) {
+    if (isDiverged({ last_projected_status: link.last_projected_status, provider_seen_status: seen.name })) {
       divergences.push({
         row_key: link.row_key,
         provider: link.provider,
         last_projected_status: link.last_projected_status,
-        provider_seen_status: seen,
+        provider_seen_status: seen.name,
       });
     }
   }

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -406,6 +406,11 @@ create table if not exists task_pm_links (
   last_projected_status text,
   projection_fingerprint text,
   provider_seen_status text,
+  -- Inbound conflict baseline (brain-api v1.4): the EXACT brain `tasks.status` at the last
+  -- successful outbound projection / adoption / inbound apply. The provider-group fingerprint
+  -- alone cannot decide "brain unchanged" — in_progress and blocked both hash to group 'started',
+  -- so a same-group brain edit would be silently overwritten without this exact baseline.
+  last_projected_brain_status text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   unique (team_id, project_id, row_key, provider)
@@ -416,6 +421,7 @@ create index if not exists task_pm_links_team_provider_idx on task_pm_links (tea
 alter table task_pm_links add column if not exists last_projected_status text;
 alter table task_pm_links add column if not exists projection_fingerprint text;
 alter table task_pm_links add column if not exists provider_seen_status text;
+alter table task_pm_links add column if not exists last_projected_brain_status text;
 
 -- Observable work events from code repos. The initial event is "merged": after a PR
 -- lands on main, the matching task row moves to done and provider sync is attempted.

--- a/test/datamechanics/pm-sync-inbound.datamechanics.test.ts
+++ b/test/datamechanics/pm-sync-inbound.datamechanics.test.ts
@@ -1,0 +1,567 @@
+import { describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { runInboundForTeam } from "@/lib/pm-sync/inbound";
+import { projectAllTasks, toProjectable, type ProjectionTaskRow } from "@/lib/pm-sync/project";
+import { projectionFingerprint } from "@/lib/pm-sync/provider";
+import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
+import { runSql } from "@/lib/db/pg/pool";
+import { db, seedTeam, type Seed } from "./helpers";
+
+// Spec (brain-api v1.4 — Linear⇄brain inbound apply, AIO-145): the write half of Phase 5.
+//   • APPLY: a Linear status change lands on `tasks.status` ONLY when the brain is unchanged since
+//     its last projection — and "unchanged" is BOTH the exact brain-status baseline
+//     (`last_projected_brain_status === tasks.status`; the group-granular fingerprint cannot tell
+//     in_progress from blocked) AND fingerprint equality (a pending title/body edit blocks apply).
+//   • NO ECHO: an apply refreshes the outbound fingerprint atomically, so the next projection
+//     makes ZERO provider mutations.
+//   • CONFLICT: both-changed is surfaced, never auto-merged, and never writes `tasks.status`.
+//   • ADOPT: a Linear-native issue's ingest-created mirror task gets the two-way link backfilled
+//     (team tier, origin flipped to 'ui', footer appended) — never a duplicate.
+// Verified to the observable outcome on real Postgres with a mutation-counting Linear stub.
+
+// ── Linear stub: projection bootstrap + import queries + counted mutations ──────────────────────
+const STATES = [
+  { id: "ls-backlog", name: "Backlog", type: "backlog" },
+  { id: "ls-todo", name: "Todo", type: "unstarted" },
+  { id: "ls-started", name: "In Progress", type: "started" },
+  { id: "ls-blocked", name: "Blocked", type: "started" },
+  { id: "ls-done", name: "Done", type: "completed" },
+  { id: "ls-canceled", name: "Canceled", type: "canceled" },
+];
+
+interface MockIssue {
+  id: string;
+  identifier?: string;
+  title?: string;
+  description?: string | null;
+  url?: string;
+  priority?: number;
+  parent?: { id?: string; identifier?: string } | null;
+  state?: { id?: string; name?: string; type?: string } | null;
+  labels?: { nodes: { id?: string; name: string }[] } | null;
+  assignee?: null;
+  team?: { id: string } | null;
+}
+
+function linearMock(issues: MockIssue[]) {
+  const mutations: { name: string; variables: Record<string, unknown> }[] = [];
+  const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const { query, variables } = JSON.parse(String(init?.body));
+    if (query.includes("ProjectionBootstrap")) {
+      return Response.json({ data: { team: { states: { nodes: STATES }, labels: { nodes: [] } } } });
+    }
+    if (query.includes("ProjectionMembers")) {
+      return Response.json({
+        data: { team: { members: { pageInfo: { hasNextPage: false, endCursor: "" }, nodes: [] } } },
+      });
+    }
+    if (query.includes("ProjectionIssues")) {
+      return Response.json({
+        data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: issues } } },
+      });
+    }
+    if (query.includes("ImportIssues")) {
+      return Response.json({
+        data: {
+          team: {
+            key: "ENG",
+            members: { nodes: [] },
+            issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: issues },
+          },
+        },
+      });
+    }
+    if (/^\s*mutation/.test(query)) {
+      const name = query.match(/mutation (\w+)/)?.[1] ?? "op";
+      mutations.push({ name, variables });
+      if (name === "CreateIssue") {
+        return Response.json({
+          data: { issueCreate: { issue: { id: `li-created-${mutations.length}`, identifier: "T-NEW", url: "" } } },
+        });
+      }
+      if (name === "CreateLabel") {
+        return Response.json({ data: { issueLabelCreate: { issueLabel: { id: `lb-${mutations.length}` } } } });
+      }
+      return Response.json({ data: { issueUpdate: { success: true, issue: { id: "x" } } } });
+    }
+    return Response.json({ data: {} });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations };
+}
+
+// ── Seeds ────────────────────────────────────────────────────────────────────────────────────────
+
+async function seedLinearPrimary(seed: Seed, config: Record<string, unknown> = { teamId: "team-uuid", inboundApply: true }) {
+  await db().from("teams").update({ primary_pm_provider: "linear" }).eq("id", seed.teamId);
+  const auth = { teamId: seed.teamId, memberId: seed.memberId };
+  const { id } = await upsertIntegration(db(), auth, { type: "linear", name: "linear", config });
+  await setIntegrationSecret(db(), auth, id, "lin_api_x");
+  return id;
+}
+
+async function seedProject(teamId: string, slug = `p-${randomUUID().slice(0, 6)}`): Promise<string> {
+  const { data } = await db().from("projects").insert({ team_id: teamId, slug, name: "Proj" }).select("id").single();
+  return (data as { id: string }).id;
+}
+
+// The exact fingerprint the outbound engine would have stored for this task shape.
+function fp(over: Partial<ProjectionTaskRow> & { row_key: string; status: string }, parentResourceId: string | null = null): string {
+  const row: ProjectionTaskRow = {
+    id: "",
+    team_id: "",
+    project_id: "",
+    title: over.row_key,
+    sprint: "",
+    priority: "none",
+    labels: [],
+    body: "",
+    parent_row_key: null,
+    assignee: "",
+    ...over,
+    status: over.status as ProjectionTaskRow["status"],
+  };
+  return projectionFingerprint(toProjectable(row, parentResourceId), parentResourceId);
+}
+
+// A linked, previously-projected task with full v1.4 bookkeeping (baseline + fingerprint).
+async function seedLinkedTask(
+  seed: Seed,
+  projectId: string,
+  args: {
+    rowKey: string;
+    resourceId: string;
+    status: string; // current brain tasks.status
+    lastProjected: string; // Linear state NAME at last projection
+    baselineStatus?: string | null; // last_projected_brain_status (defaults to current status)
+    fingerprint?: string | null; // defaults to fingerprint of the CURRENT task shape
+    parentRowKey?: string | null;
+    parentResourceId?: string | null;
+    body?: string;
+    origin?: string;
+  }
+) {
+  const baseline = args.baselineStatus === undefined ? args.status : args.baselineStatus;
+  const { data: task } = await db()
+    .from("tasks")
+    .insert({
+      team_id: seed.teamId,
+      project_id: projectId,
+      row_key: args.rowKey,
+      title: args.rowKey,
+      status: args.status,
+      origin: args.origin ?? "ui",
+      body: args.body ?? "",
+      parent_row_key: args.parentRowKey ?? null,
+    })
+    .select("id")
+    .single();
+  const taskId = (task as { id: string }).id;
+  const fingerprint =
+    args.fingerprint === undefined
+      ? fp(
+          { row_key: args.rowKey, status: args.status, parent_row_key: args.parentRowKey ?? null, body: args.body ?? "" },
+          args.parentResourceId ?? null
+        )
+      : args.fingerprint;
+  await db().from("task_pm_links").insert({
+    team_id: seed.teamId,
+    project_id: projectId,
+    task_id: taskId,
+    row_key: args.rowKey,
+    provider: "linear",
+    provider_external_id: args.rowKey,
+    provider_external_source: "aios-backlog",
+    provider_resource_id: args.resourceId,
+    provider_url: `https://linear.app/${args.resourceId}`,
+    last_projected_status: args.lastProjected,
+    last_projected_brain_status: baseline,
+    projection_fingerprint: fingerprint,
+    provider_seen_status: null,
+  });
+  return taskId;
+}
+
+async function readLink(teamId: string, rowKey: string) {
+  const { data } = await db()
+    .from("task_pm_links")
+    .select(
+      "id, provider_resource_id, provider_seen_status, last_projected_status, last_projected_brain_status, projection_fingerprint, last_error, updated_at"
+    )
+    .eq("team_id", teamId)
+    .eq("row_key", rowKey)
+    .single();
+  return data as {
+    id: string;
+    provider_resource_id: string | null;
+    provider_seen_status: string | null;
+    last_projected_status: string | null;
+    last_projected_brain_status: string | null;
+    projection_fingerprint: string | null;
+    last_error: string | null;
+    updated_at: string;
+  };
+}
+
+async function readTask(taskId: string) {
+  const { data } = await db().from("tasks").select("status, body, origin, updated_at").eq("id", taskId).single();
+  return data as { status: string; body: string; origin: string; updated_at: string };
+}
+
+const issue = (id: string, stateId: string, over: Partial<MockIssue> = {}): MockIssue => ({
+  id,
+  state: STATES.filter((s) => s.id === stateId).map((s) => ({ id: s.id, name: s.name, type: s.type }))[0],
+  ...over,
+});
+
+describe("inbound apply — pm-wins-if-brain-unchanged (real Postgres)", () => {
+  it("applies a Linear move when the brain is unchanged, atomically refreshing baseline + fingerprint", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    // Brain last projected "Todo" (ready); someone moved the issue to Done. Brain untouched since.
+    const taskId = await seedLinkedTask(seed, project, {
+      rowKey: "P1",
+      resourceId: "li-1",
+      status: "ready",
+      lastProjected: "Todo",
+    });
+
+    const { fetchImpl, mutations } = linearMock([issue("li-1", "ls-done", { identifier: "P1" })]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+
+    expect(result.enabled).toBe(true);
+    expect(result.conflicts).toEqual([]);
+    expect(result.applied).toHaveLength(1);
+    expect(result.applied[0].payload).toMatchObject({ row_key: "P1", from: "ready", brain_state: "done" });
+
+    const task = await readTask(taskId);
+    expect(task.status).toBe("done");
+    expect(task.body).toBe(""); // body is NEVER written by the apply loop
+
+    const link = await readLink(seed.teamId, "P1");
+    expect(link.last_projected_status).toBe("Done");
+    expect(link.last_projected_brain_status).toBe("done");
+    expect(link.provider_seen_status).toBe("Done");
+    // Fingerprint recomputed for the post-apply shape — what the next projection will compute.
+    expect(link.projection_fingerprint).toBe(fp({ row_key: "P1", status: "done" }));
+    // Apply is inbound-only: zero provider mutations.
+    expect(mutations).toEqual([]);
+  });
+
+  it("no-echo: the projection pass after an apply makes ZERO provider mutations", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    await seedLinkedTask(seed, project, { rowKey: "P1", resourceId: "li-1", status: "ready", lastProjected: "Todo" });
+
+    const inbound = linearMock([issue("li-1", "ls-done", { identifier: "P1" })]);
+    await runInboundForTeam(db(), seed.teamId, { fetchImpl: inbound.fetchImpl });
+
+    const outbound = linearMock([issue("li-1", "ls-done", { identifier: "P1" })]);
+    const { reports } = await projectAllTasks(db(), seed.teamId, project, { fetchImpl: outbound.fetchImpl, throttleMs: 0 });
+    expect(reports.map((r) => r.status)).toEqual(["skipped"]);
+    expect(outbound.mutations).toEqual([]);
+  });
+
+  it("same-group Linear-only change (In Progress → Blocked) applies, then projects with zero mutations", async () => {
+    // Round-3 review verification #2: the exact baseline lets a same-GROUP provider change apply.
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    const taskId = await seedLinkedTask(seed, project, {
+      rowKey: "P2",
+      resourceId: "li-2",
+      status: "in_progress",
+      lastProjected: "In Progress",
+    });
+
+    const inbound = linearMock([issue("li-2", "ls-blocked", { identifier: "P2" })]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl: inbound.fetchImpl });
+    expect(result.conflicts).toEqual([]);
+    expect(result.applied).toHaveLength(1);
+    expect((await readTask(taskId)).status).toBe("blocked");
+    const link = await readLink(seed.teamId, "P2");
+    expect(link.last_projected_brain_status).toBe("blocked");
+    expect(link.last_projected_status).toBe("Blocked");
+
+    const outbound = linearMock([issue("li-2", "ls-blocked", { identifier: "P2" })]);
+    const { reports } = await projectAllTasks(db(), seed.teamId, project, { fetchImpl: outbound.fetchImpl, throttleMs: 0 });
+    expect(reports.map((r) => r.status)).toEqual(["skipped"]);
+    expect(outbound.mutations).toEqual([]);
+  });
+
+  it("concurrent same-group brain edit (in_progress → blocked) + Linear move = CONFLICT, no status write", async () => {
+    // Round-3 review verification #1: the fingerprint hashes the state GROUP, so in_progress and
+    // blocked hash identically — only the exact baseline catches this. Must NOT silently apply.
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    const taskId = await seedLinkedTask(seed, project, {
+      rowKey: "P3",
+      resourceId: "li-3",
+      status: "blocked", // brain moved in_progress → blocked after the last projection…
+      baselineStatus: "in_progress", // …which projected in_progress
+      fingerprint: fp({ row_key: "P3", status: "in_progress" }), // group-equal to blocked!
+      lastProjected: "In Progress",
+    });
+
+    const { fetchImpl } = linearMock([issue("li-3", "ls-done", { identifier: "P3" })]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+
+    expect(result.applied).toEqual([]);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].payload).toMatchObject({ row_key: "P3", linear_state: "Done", brain_state: "blocked" });
+    // No write: brain status intact, bookkeeping untouched (stays diverged/surfaced).
+    expect((await readTask(taskId)).status).toBe("blocked");
+    const link = await readLink(seed.teamId, "P3");
+    expect(link.last_projected_brain_status).toBe("in_progress");
+    expect(link.last_projected_status).toBe("In Progress");
+    expect(link.projection_fingerprint).toBe(fp({ row_key: "P3", status: "in_progress" }));
+  });
+
+  it("pending non-status brain edit (fingerprint mismatch) + Linear move = CONFLICT", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    // Title changed in the brain since last projection (fingerprint differs), status baseline equal.
+    const taskId = await seedLinkedTask(seed, project, {
+      rowKey: "P4",
+      resourceId: "li-4",
+      status: "ready",
+      fingerprint: fp({ row_key: "P4-old-title", status: "ready", title: "P4-old-title" }),
+      lastProjected: "Todo",
+    });
+
+    const { fetchImpl } = linearMock([issue("li-4", "ls-done", { identifier: "P4" })]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+    expect(result.applied).toEqual([]);
+    expect(result.conflicts).toHaveLength(1);
+    expect((await readTask(taskId)).status).toBe("ready");
+  });
+
+  it("is idempotent — a second inbound pass is a pure no-op (updated_at frozen)", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    await seedLinkedTask(seed, project, { rowKey: "P5", resourceId: "li-5", status: "ready", lastProjected: "Todo" });
+
+    const first = linearMock([issue("li-5", "ls-done", { identifier: "P5" })]);
+    const r1 = await runInboundForTeam(db(), seed.teamId, { fetchImpl: first.fetchImpl });
+    expect(r1.applied).toHaveLength(1);
+    const afterFirst = await readLink(seed.teamId, "P5");
+
+    const second = linearMock([issue("li-5", "ls-done", { identifier: "P5" })]);
+    const r2 = await runInboundForTeam(db(), seed.teamId, { fetchImpl: second.fetchImpl });
+    expect(r2.applied).toEqual([]);
+    expect(r2.conflicts).toEqual([]);
+    expect(r2.noops).toBeGreaterThan(0);
+    expect(second.mutations).toEqual([]);
+    expect(new Date((await readLink(seed.teamId, "P5")).updated_at).getTime()).toBe(
+      new Date(afterFirst.updated_at).getTime()
+    );
+  });
+
+  it("child task: apply fingerprints with the REAL parent resource id; next projection = zero mutations", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    await seedLinkedTask(seed, project, { rowKey: "E1", resourceId: "li-epic", status: "in_progress", lastProjected: "In Progress" });
+    const childId = await seedLinkedTask(seed, project, {
+      rowKey: "C1",
+      resourceId: "li-child",
+      status: "ready",
+      lastProjected: "Todo",
+      parentRowKey: "E1",
+      parentResourceId: "li-epic",
+    });
+
+    const inbound = linearMock([
+      issue("li-epic", "ls-started", { identifier: "E1" }),
+      issue("li-child", "ls-done", { identifier: "C1", parent: { id: "li-epic" } }),
+    ]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl: inbound.fetchImpl });
+    expect(result.conflicts).toEqual([]);
+    expect(result.applied).toHaveLength(1);
+    expect((await readTask(childId)).status).toBe("done");
+    expect((await readLink(seed.teamId, "C1")).projection_fingerprint).toBe(
+      fp({ row_key: "C1", status: "done", parent_row_key: "E1" }, "li-epic")
+    );
+
+    const outbound = linearMock([
+      issue("li-epic", "ls-started", { identifier: "E1" }),
+      issue("li-child", "ls-done", { identifier: "C1", parent: { id: "li-epic" } }),
+    ]);
+    const { reports } = await projectAllTasks(db(), seed.teamId, project, { fetchImpl: outbound.fetchImpl, throttleMs: 0 });
+    expect(reports.map((r) => r.status)).toEqual(["skipped", "skipped"]);
+    expect(outbound.mutations).toEqual([]);
+  });
+
+  it("maps a Canceled (1-L 'canceled' type) state to done — the 2-L StateGroup fork can't mis-map", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    const taskId = await seedLinkedTask(seed, project, { rowKey: "P6", resourceId: "li-6", status: "ready", lastProjected: "Todo" });
+
+    const { fetchImpl } = linearMock([issue("li-6", "ls-canceled", { identifier: "P6" })]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+    expect(result.conflicts).toEqual([]);
+    expect(result.applied).toHaveLength(1);
+    expect((await readTask(taskId)).status).toBe("done");
+  });
+
+  it("an unresolvable Linear state (renamed/unknown group) is a CONFLICT, never a silent default", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    const taskId = await seedLinkedTask(seed, project, { rowKey: "P7", resourceId: "li-7", status: "ready", lastProjected: "Todo" });
+
+    const { fetchImpl } = linearMock([
+      { id: "li-7", identifier: "P7", state: { id: "ls-x", name: "Weird", type: "mystery" } },
+    ]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+    expect(result.applied).toEqual([]);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].payload.reason).toMatch(/unresolvable/i);
+    expect((await readTask(taskId)).status).toBe("ready");
+    expect((await readLink(seed.teamId, "P7")).last_error).toMatch(/unresolvable/i);
+  });
+
+  it("outbound projection populates the exact brain-status baseline the inbound check depends on", async () => {
+    // Round-3 review verification #3 (outbound half; the adopt half is asserted below).
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    await db()
+      .from("tasks")
+      .insert({ team_id: seed.teamId, project_id: project, row_key: "N1", title: "N1", status: "in_progress", origin: "ui" });
+
+    const { fetchImpl } = linearMock([]);
+    const { reports } = await projectAllTasks(db(), seed.teamId, project, { fetchImpl, throttleMs: 0 });
+    expect(reports.map((r) => r.status)).toEqual(["synced"]);
+    expect((await readLink(seed.teamId, "N1")).last_projected_brain_status).toBe("in_progress");
+  });
+
+  it("does nothing without the per-team opt-in (config.inboundApply)", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed, { teamId: "team-uuid" }); // no inboundApply
+    const project = await seedProject(seed.teamId);
+    const taskId = await seedLinkedTask(seed, project, { rowKey: "P8", resourceId: "li-8", status: "ready", lastProjected: "Todo" });
+
+    const { fetchImpl } = linearMock([issue("li-8", "ls-done", { identifier: "P8" })]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toMatch(/not enabled/i);
+    expect(result.applied).toEqual([]);
+    expect((await readTask(taskId)).status).toBe("ready");
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0); // never touches the provider
+  });
+});
+
+describe("inbound adopt — Linear-native issues become owned team-tier tasks (real Postgres)", () => {
+  // Mimic what runLinearIngestion creates for a Linear-native issue: a mirror task, no link.
+  async function seedMirrorTask(seed: Seed, projectId: string, rowKey: string, status = "in_progress", parentRowKey: string | null = null) {
+    const { data } = await db()
+      .from("tasks")
+      .insert({
+        team_id: seed.teamId,
+        project_id: projectId,
+        row_key: rowKey,
+        title: `Native ${rowKey}`,
+        status,
+        origin: "sync",
+        parent_row_key: parentRowKey,
+      })
+      .select("id")
+      .single();
+    return (data as { id: string }).id;
+  }
+
+  it("adopts: backfills the link + footer, flips origin to 'ui', seeds body, and never duplicates", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const mirror = await seedProject(seed.teamId, "linear-eng");
+    const taskId = await seedMirrorTask(seed, mirror, "ENG-1");
+
+    const native = issue("li-n1", "ls-started", {
+      identifier: "ENG-1",
+      title: "Native ENG-1",
+      description: "A Linear-authored description",
+      url: "https://linear.app/li-n1",
+    });
+    const first = linearMock([native]);
+    const r1 = await runInboundForTeam(db(), seed.teamId, { fetchImpl: first.fetchImpl });
+    expect(r1.adopted).toEqual(["ENG-1"]);
+
+    const link = await readLink(seed.teamId, "ENG-1");
+    expect(link.provider_resource_id).toBe("li-n1");
+    expect(link.last_projected_status).toBe("In Progress");
+    expect(link.last_projected_brain_status).toBe("in_progress"); // review verification #3 (adopt half)
+    expect(link.projection_fingerprint).toBeTruthy();
+
+    const task = await readTask(taskId);
+    expect(task.origin).toBe("ui"); // survives the next ingest diff-delete
+    expect(task.body).toBe("A Linear-authored description"); // one-time ownership seed
+
+    // Footer appended to the EXISTING description (nothing wiped), exactly once.
+    const footers = first.mutations.filter((m) => m.name === "AdoptFooter");
+    expect(footers).toHaveLength(1);
+    expect(String(footers[0].variables.description)).toContain("A Linear-authored description");
+    expect(String(footers[0].variables.description)).toContain("aios-ext: ENG-1");
+
+    // Re-run: the link's resource id excludes the issue — no duplicate, no second footer write.
+    const second = linearMock([native]);
+    const r2 = await runInboundForTeam(db(), seed.teamId, { fetchImpl: second.fetchImpl });
+    expect(r2.adopted).toEqual([]);
+    const { data: links } = await db().from("task_pm_links").select("id").eq("team_id", seed.teamId).eq("row_key", "ENG-1");
+    expect(links).toHaveLength(1);
+    expect(second.mutations).toEqual([]);
+
+    // Adopt-no-duplicate: the first outbound pass fingerprint-short-circuits (zero mutations).
+    const outbound = linearMock([{ ...native, description: String(footers[0].variables.description) }]);
+    const { reports } = await projectAllTasks(db(), seed.teamId, mirror, { fetchImpl: outbound.fetchImpl, throttleMs: 0 });
+    expect(reports.map((r) => r.status)).toEqual(["skipped"]);
+    expect(outbound.mutations).toEqual([]);
+  });
+
+  it("adopts the CURRENT Linear state even when the mirror row is stale", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const mirror = await seedProject(seed.teamId, "linear-eng");
+    const taskId = await seedMirrorTask(seed, mirror, "ENG-2", "ready"); // ingest saw Todo…
+
+    const { fetchImpl } = linearMock([issue("li-n2", "ls-done", { identifier: "ENG-2", description: "" })]); // …board moved to Done
+    await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+    expect((await readTask(taskId)).status).toBe("done");
+    expect((await readLink(seed.teamId, "ENG-2")).last_projected_brain_status).toBe("done");
+  });
+
+  it("no destination: a missing mirror task fails soft (skip + surfaced reason, no insert)", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    await seedProject(seed.teamId, "linear-eng"); // project exists, but ingest hasn't created the task
+
+    const { fetchImpl } = linearMock([issue("li-n3", "ls-started", { identifier: "ENG-3", description: "" })]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+    expect(result.adopted).toEqual([]);
+    expect(result.skipped.some((s) => s.includes("ENG-3"))).toBe(true);
+    const { data: links } = await db().from("task_pm_links").select("id").eq("team_id", seed.teamId);
+    expect(links ?? []).toHaveLength(0);
+  });
+
+  it("no destination: an integration without teamId fails soft with a surfaced reason", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed, { inboundApply: true }); // no teamId
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl: linearMock([]).fetchImpl });
+    expect(result.reason).toMatch(/teamId/);
+    expect(result.adopted).toEqual([]);
+    expect(result.applied).toEqual([]);
+  });
+
+  it("tier safety is structural: access_tier has no admin value; adopt is team-tier by construction", async () => {
+    const { rows } = await runSql<{ v: string }>(
+      `select unnest(enum_range(null::access_tier))::text as v`,
+      []
+    );
+    expect(rows.map((r) => r.v).sort()).toEqual(["external", "team"]);
+  });
+});

--- a/test/datamechanics/setup.ts
+++ b/test/datamechanics/setup.ts
@@ -13,6 +13,7 @@ const DATA_TABLES = [
   "graph_relationships",
   "graph_entities",
   "decisions",
+  "task_pm_links",
   "tasks",
   "item_versions",
   "items",

--- a/test/integration-config.test.ts
+++ b/test/integration-config.test.ts
@@ -73,6 +73,18 @@ describe("validateIntegrationConfig()", () => {
     ).toEqual({ teamId: "team-uuid", projectId: "project-uuid", doneStateName: "Done" });
   });
 
+  it("accepts the Linear inboundApply opt-in (brain-api v1.4) but still no secret-like keys", () => {
+    expect(validateIntegrationConfig("linear", { teamId: "team-uuid", inboundApply: true })).toEqual({
+      teamId: "team-uuid",
+      inboundApply: true,
+    });
+    // Boundary regression for the DEFERRED webhook work: a webhook signing secret has no home in
+    // config — the secret-key scan must keep rejecting it (it belongs in an encrypted column).
+    expect(() => validateIntegrationConfig("linear", { webhookSecret: "whsec_x" })).toThrow(/secret-like key/i);
+    // …and any other webhook-ish key is rejected by the strict allowlist.
+    expect(() => validateIntegrationConfig("linear", { webhookUrl: "https://x" })).toThrow(IntegrationConfigError);
+  });
+
   it("treats LLM provider keys as secret-only (empty config; the key lives in secret_ciphertext)", () => {
     for (const type of ["openai", "anthropic", "google"] as const) {
       // No non-secret config — empty object is the only valid config.

--- a/test/pm-sync-inbound-status.test.ts
+++ b/test/pm-sync-inbound-status.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { linearMirrorProject, linearStatus, linearStatusOrNull } from "@/lib/ingest/sources/linear-normalize";
+
+// Spec (brain-api v1.4): inbound status mapping reuses the SINGLE ingest mapper — a state NAMED
+// like a brain status wins, else Linear's raw state.type (1-L "canceled") maps by group. The
+// strict variant returns null for an unresolvable state (the contract treats that as a CONFLICT,
+// never a silent default). Inbound must NEVER route through the 2-L `StateGroup` spelling.
+
+describe("linearStatusOrNull / linearStatus", () => {
+  it("maps by name override first (a 'Blocked' started state is blocked, not in_progress)", () => {
+    expect(linearStatusOrNull("Blocked", "started")).toBe("blocked");
+    expect(linearStatusOrNull("In Progress", "started")).toBe("in_progress");
+  });
+
+  it("maps Linear's 1-L 'canceled' type to done — the canceled/cancelled fork can't mis-map", () => {
+    expect(linearStatusOrNull("Canceled", "canceled")).toBe("done");
+    expect(linearStatusOrNull("Duplicate", "canceled")).toBe("done");
+    // The 2-L spelling is NOT a Linear state.type; only the name-override path could resolve it.
+    expect(linearStatusOrNull("Cancelled", "cancelled")).toBeNull();
+  });
+
+  it("maps the remaining groups by type", () => {
+    expect(linearStatusOrNull("Icebox", "backlog")).toBe("backlog");
+    expect(linearStatusOrNull("Todo", "unstarted")).toBe("ready");
+    expect(linearStatusOrNull("Doing", "started")).toBe("in_progress");
+    expect(linearStatusOrNull("Shipped", "completed")).toBe("done");
+  });
+
+  it("a state literally named Backlog resolves by name even with an unknown type", () => {
+    expect(linearStatusOrNull("Backlog", "mystery")).toBe("backlog");
+  });
+
+  it("returns null for an unresolvable state (unknown name AND unknown type) — conflict, not default", () => {
+    expect(linearStatusOrNull("Weird", "mystery")).toBeNull();
+    expect(linearStatusOrNull(undefined, undefined)).toBeNull();
+  });
+
+  it("linearStatus keeps the ingest default (backlog) for unresolvable states", () => {
+    expect(linearStatus("Weird", "mystery")).toBe("backlog");
+    expect(linearStatus("Blocked", "started")).toBe("blocked");
+  });
+});
+
+describe("linearMirrorProject", () => {
+  it("derives the deterministic mirror slug ingest and adopt share", () => {
+    expect(linearMirrorProject("ENG")).toBe("linear-eng");
+    expect(linearMirrorProject("Team Ops!")).toBe("linear-team-ops");
+    expect(linearMirrorProject("")).toBe("linear-team");
+  });
+});


### PR DESCRIPTION
## What

The brain-side half of **bidirectional task sync (Linear ⇄ brain), Phase 5** — implements the `brain-api.md` **v1.4** "Linear→brain inbound apply" contract (already merged in aios-workspace). Poll-only, per-team opt-in, tier-safe.

- **Apply** (`status = pm-wins-if-brain-unchanged`): a Linear board move lands on `tasks.status` only when the brain hasn't changed since its last projection. `title/body/labels/priority` stay brain-wins and are never written by the apply loop.
- **Conflict**: both-changed is surfaced (signal-shaped record + admin page), never auto-merged. Unresolvable Linear states (renamed/deleted, unknown group) are conflicts, never silent defaults.
- **Adopt**: a Linear-native issue's ingest-created `linear-<teamKey>` mirror task gets the two-way link backfilled (never a fresh insert): current Linear state applied, `origin` flipped to `ui` (survives ingest diff-delete), `aios-ext` footer appended to the *existing* description, fingerprint seeded so the first outbound pass short-circuits (adopt-no-duplicate). Team tier only — `access_tier` is structurally admin-free and asserted.
- **No echo**: an apply atomically refreshes `last_projected_status` + `last_projected_brain_status` + a recomputed outbound fingerprint with `tasks.status` in **one pg transaction**, guarded on the expected pre-apply status (optimistic concurrency). The next projection makes zero provider writes (tested).
- **Triggers**: the existing 30-min ingest scheduler tick + manual "sync now", both sequenced after the Linear ingest leg; recorded to `ingest_runs` as `linear_inbound`. Gated by `config.inboundApply === true` on the Linear integration (default **off**).

## The three round-3 [Major] resolutions (binding)

1. **Exact brain-status baseline** — new internal `task_pm_links.last_projected_brain_status` (idempotent `add column if not exists`), written by outbound projection success, adopt, and inbound apply. The provider-group fingerprint alone never decides "brain unchanged" (`in_progress` and `blocked` both hash to group `started`).
2. **No-echo fingerprint ≠ conflict baseline** — `brainUnchanged` = exact baseline equality **and** fingerprint equality (the fingerprint check additionally blocks an apply while a title/body/labels edit is pending outbound, so a stale fingerprint is never stamped over an unprojected edit). The outbound fingerprint is recomputed for the post-apply shape inside the same transaction — that alone carries the no-echo guarantee.
3. **Deterministic conflict surfacing** — the admin PM-sync page now classifies divergences from **persisted data only** via the same enriched read the engine uses (`loadInboundRows` + `classifyInboundRow`): "conflict — both changed" vs "pending apply". No provider round-trip, reproducible after any scheduler run. (Unresolvable-state conflicts additionally persist `last_error` on the link.)

All three "Verification to add" datamechanics tests are included: concurrent same-group edit → conflict with no status write; same-group Linear-only change applies + next projection makes zero provider mutations; adopt and outbound both populate the baseline before inbound uses it.

## Contract notes (v1.4 deltas worth a doc touch-up, not silent divergence)

- v1.4 says *"Brain unchanged" is fingerprint equality* and "this subsumes a status-group comparison". The round-3 review showed the group-granular fingerprint is unsound for same-group brain edits — implemented as fingerprint equality **AND** the exact-status baseline (strictly stronger; no wire change). Suggest a v1.4.x wording fix in `docs/brain-api.md` (that file is workspace-side and read-only for this PR).
- **Adopt seeds `tasks.body` once** from the Linear-native description. The v1.4 field-policy table says body is "never applied inbound", but without this one-time ownership seed the first outbound projection after any brain-side edit would overwrite the native Linear description with the mirror task's empty body (data loss). Scoped strictly to adoption — the recurring apply loop never touches body.
- v1.4's "gated by a per-team opt-in flag" is realized as `inboundApply: boolean` in the Linear integration's non-secret config allowlist (dashboard-editable, default off, secret-key scan untouched).
- On the legacy `DB_BACKEND=supabase` backend inbound stays off with a surfaced reason: the normative "single DB transaction" invariant has no transactional write path there, and running non-atomically would violate the contract.

## Verification

- `npx tsc --noEmit` — clean; `npm run lint` — clean (one pre-existing warning in an untouched test).
- `npm test` — **363 passed**, 7 skipped, 1 failed: `test/query-current-date.test.ts` "falls back to UTC" — **pre-existing, environment-dependent** (local ICU renders "UTC (UTC)" vs "UTC (UTC+00:00)"); fails identically on `main` on this machine, file untouched.
- `npm run db:test:up && npm run test:datamechanics` — **221 passed**, 3 skipped (55 files), including the new 15-test `pm-sync-inbound` suite and the existing `reconcile-divergence` + `reactive-projection` suites against the changed seen-state contract.

## Deferred (per plan + v1.4 "out of scope")

- Linear **webhook receiver** (needs its own contract section, encrypted `webhook_secret_ciphertext`, HMAC-over-raw-body verify, replay/idempotency). Poll covers every acceptance criterion; the config secret-key boundary regression is tested.
- Operator-loop **C1 collector** wiring for `pm_sync_conflict`/`pm_sync_applied` signals (workspace-side; conflicts surface via the admin page + `InboundResult` for now).
- Per-team **field-policy configurability** and inbound apply for non-status fields (`INBOUND_FIELD_POLICY` is the hardcoded v1.4 default with a clear extension point).
- Plane inbound (no `fetchSeenStates` on that adapter).
- Workspace-side spec/rubric files (`bidirectional-pm-sync.md` signal contract, `pm-sync-inbound.md` rubric) — they live in aios-workspace, which is read-only for this brain-side PR.

Linear: AIO-145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Writes `tasks.status` and PM link state with nuanced conflict rules and requires Postgres transactions; misclassification could overwrite brain edits or cause sync loops, though tests cover no-echo and conflict paths.
> 
> **Overview**
> Implements **brain-api v1.4** Linear inbound: when a team sets `inboundApply` on its Linear integration, poll runs (after Linear ingest) can **apply** PM workflow moves to `tasks.status` only if the brain is unchanged since last projection, and **adopt** Linear-native issues by backfilling `task_pm_links` onto existing mirror tasks.
> 
> **Apply policy** is status-only (`pm-wins-if-brain-unchanged`). “Brain unchanged” requires both `last_projected_brain_status === tasks.status` (new column) and projection fingerprint equality, so same-group edits (e.g. in_progress vs blocked) and pending title/body edits become **conflicts**, not silent overwrites. Applies run in a **Postgres transaction** (`withTransaction`) updating status and link bookkeeping together; legacy non-Postgres backends skip inbound.
> 
> **Adopt** links ingest mirror rows, flips `origin` to `ui`, seeds body once, appends `aios-ext` footer in Linear, and seeds fingerprints to avoid duplicate outbound issues.
> 
> The **Admin → PM sync** divergence table now uses the same enriched read as the engine (`loadInboundRows` / `classifyInboundRow`) to label rows **pending apply** vs **conflict — both changed**. Outbound projection and reconcile now persist the exact brain baseline and Linear `SeenState` `{ name, type }` for mapping via shared `linearStatusOrNull`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03cb60a4c148439ac507b51fa78fbcffb897e684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbound sync for Linear items, including apply/adopt handling and clearer “pending apply” vs “conflict” outcomes.
  * Added a new Resolution column in PM Sync views and updated sync summaries to include inbound activity.
  * Expanded Linear integration settings to support an inbound apply option.

* **Bug Fixes**
  * Improved status mapping and conflict detection for Linear syncs.
  * Made sync updates more reliable by using transaction-safe database writes and better error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->