### PR TITLE
AIO-141: GET /api/v1/company-graph (brain-side half)

### DIFF
--- a/app/api/v1/company-graph/route.ts
+++ b/app/api/v1/company-graph/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { errorResponse } from "@/lib/api/schemas";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/v1/company-graph — the structured stakeholder map (brain-api v1.5, AIO-141).
+ *
+ * Projects the structured Company-Graph (`graph_entities` / `graph_relationships`) as a
+ * people + ownership view for the workspace stakeholder-map surface (`aios stakeholders`,
+ * MCP `brain_stakeholders`). Answers "who owns domain X" and "who reports to whom".
+ * This is the typed-rows counterpart to POST /api/v1/query (the NL Graphiti memory) —
+ * a different subsystem; no prose here.
+ *
+ * Team-tier only: the graph tables carry a `team_id` but no per-row tier column and there
+ * is no RLS backstop, so this handler is the SOLE tier gate (same posture as /projects,
+ * /metrics, /codebases). An external key gets 403 forbidden_tier.
+ *
+ * Empty-graph contract: an authenticated team-tier key on an unseeded team returns
+ * `200 { "people": [], "ownership": [] }` — never a 500.
+ *
+ * Attendance ("who attended meeting Y") is NOT served here — it is derived client-side
+ * from GET /items meeting markers (contract v1.5 §company-graph, point 4).
+ */
+
+/** The relationship types projected into `ownership[]` (contract v1.5, point 2). */
+const OWNERSHIP_EDGE_TYPES = ["OWNS", "TOUCHES", "PRODUCES"];
+
+/** Project an optional string attr; a missing/non-string attr is emitted as null. */
+function attrStr(attrs: Record<string, unknown> | null, key: string): string | null {
+  const v = attrs?.[key];
+  return typeof v === "string" ? v : null;
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+  if (auth.memberTier !== "team") {
+    return errorResponse("forbidden_tier", "the company graph is team-tier only", 403);
+  }
+
+  const supabase = adminClient();
+  if (!(await rateLimit(supabase, `${auth.apiKeyId}:company-graph:get`, 60))) {
+    return errorResponse("rate_limited", "60 reads/min per key", 429);
+  }
+
+  // One entity read serves both halves: `people[]` (entity_type=actor) and the
+  // server-side join that resolves ownership edge targets (typically workflows).
+  const [entitiesRes, edgesRes] = await Promise.all([
+    supabase
+      .from("graph_entities")
+      .select("entity_id, entity_type, name, attrs")
+      .eq("team_id", auth.teamId)
+      .order("entity_id"),
+    supabase
+      .from("graph_relationships")
+      .select("from_id, to_id, relationship_type")
+      .eq("team_id", auth.teamId)
+      .in("relationship_type", OWNERSHIP_EDGE_TYPES)
+      .order("from_id"),
+  ]);
+  if (entitiesRes.error) return errorResponse("internal", entitiesRes.error.message, 500);
+  if (edgesRes.error) return errorResponse("internal", edgesRes.error.message, 500);
+
+  type EntityRow = {
+    entity_id: string;
+    entity_type: string;
+    name: string;
+    attrs: Record<string, unknown> | null;
+  };
+  const entities = (entitiesRes.data ?? []) as EntityRow[];
+  const byId = new Map(entities.map((e) => [e.entity_id, e]));
+
+  // people[]: every actor entity; role/job_family/reports_to projected out of attrs
+  // (the seed stores the whole fixture object in attrs), missing attrs → null.
+  const people = entities
+    .filter((e) => e.entity_type === "actor")
+    .map((e) => ({
+      entity_id: e.entity_id,
+      name: e.name,
+      role: attrStr(e.attrs, "role"),
+      job_family: attrStr(e.attrs, "job_family"),
+      reports_to: attrStr(e.attrs, "reports_to"),
+    }));
+
+  // ownership[]: OWNS/TOUCHES/PRODUCES edges with to_id resolved against the entity
+  // read above — this join is what makes `--owns "<domain>"` substring queries
+  // matchable. An edge whose to_id doesn't resolve is skipped (contract point 2).
+  const ownership = (edgesRes.data ?? []).flatMap(
+    (r: { from_id: string; to_id: string; relationship_type: string }) => {
+      const target = byId.get(r.to_id);
+      if (!target) return [];
+      return [
+        {
+          person_id: r.from_id,
+          relationship: r.relationship_type,
+          target_id: r.to_id,
+          target_kind: target.entity_type,
+          target_name: target.name,
+          target_job_family: attrStr(target.attrs, "job_family"),
+        },
+      ];
+    }
+  );
+
+  return Response.json({ people, ownership });
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -459,6 +459,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/tasks` — dashboard task changes for `aios pull` writeback
 - `GET /api/v1/decisions` — dashboard decision changes for `aios pull` writeback (tier-scoped)
 - `GET /api/v1/projects` — team project list for `aios pull` brain-project registration (team-tier only)
+- `GET /api/v1/company-graph` — structured stakeholder map for `aios stakeholders` / MCP `brain_stakeholders` (brain-api v1.5): `people[]` (actor entities with attrs-projected `role`/`job_family`/`reports_to`) + `ownership[]` (server-resolved `OWNS`/`TOUCHES`/`PRODUCES` edges → target workflow name/kind/job_family); team-tier only, app-code gate (no RLS backstop); unseeded team → `200` empty arrays
 - `GET /api/v1/me` — authenticated member identity + role (drives client UI gating)
 - `GET /api/v1/members` — team roster + cross-tool identities for external resolution, incl. `github_login`/`avatar_url` for contributor-avatar consumers like `aios timeline` (team-tier only; `?email`/`?handle`/`?provider` filters)
 - `GET /api/v1/identities/resolve` — resolve a provider external_id (or email/handle) to a member + canonical contacts incl. `slack_id` (team-tier only; 404 on miss)

--- a/test/datamechanics/company-graph.datamechanics.test.ts
+++ b/test/datamechanics/company-graph.datamechanics.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { GET as companyGraphGET } from "@/app/api/v1/company-graph/route";
+import { issueApiKey } from "@/lib/admin/keys";
+import { db, seedTeam, type Seed } from "./helpers";
+
+// HTTP edge for GET /api/v1/company-graph (brain-api v1.5, AIO-141). The graph tables
+// have a team_id but no per-row tier column and no RLS backstop, so the route handler
+// is the SOLE gate. Verified against the real handler + real Postgres:
+//   - team key 200 { people, ownership }, external key 403 forbidden_tier, bad key 401
+//   - people[] projects role/job_family/reports_to out of attrs (missing → null)
+//   - ownership[] is the server-side join (OWNS/TOUCHES/PRODUCES only; dangling
+//     to_id skipped; target_name/kind/job_family resolved from the target entity)
+//   - unseeded team → 200 { people: [], ownership: [] } (never 500)
+//   - another team's graph rows never leak
+
+const URL = "http://test/api/v1/company-graph";
+
+async function issueKeyFor(seed: Seed, tier: "team" | "external") {
+  let memberId = seed.memberId;
+  if (tier === "external") {
+    const { data, error } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `ext-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "External",
+        actor_handle: `ext-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "external",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`external member seed failed: ${error?.message}`);
+    memberId = (data as { id: string }).id;
+  }
+  const { key } = await issueApiKey(db(), seed.teamId, memberId, `${tier} key`);
+  return key;
+}
+
+function get(key: string, teamSlug: string) {
+  const req = new Request(URL, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${key}`, "X-AIOS-Team": teamSlug },
+  }) as unknown as NextRequest;
+  return companyGraphGET(req);
+}
+
+/** Seed a Veridian-shaped mini graph: 2 actors, 1 workflow, OWNS/TOUCHES/REPORTS_TO edges. */
+async function seedGraph(seed: Seed) {
+  const { error: eErr } = await db()
+    .from("graph_entities")
+    .insert([
+      {
+        team_id: seed.teamId,
+        entity_id: "actor-001",
+        entity_type: "actor",
+        name: "Nadia Kovalchuk",
+        // The seed stores the whole fixture object in attrs.
+        attrs: { id: "actor-001", name: "Nadia Kovalchuk", role: "Head of Finance", job_family: "Finance", reports_to: "actor-002" },
+      },
+      {
+        team_id: seed.teamId,
+        entity_id: "actor-002",
+        entity_type: "actor",
+        name: "Sarah Chen",
+        // No role/job_family/reports_to attrs → projected as null.
+        attrs: { id: "actor-002", name: "Sarah Chen" },
+      },
+      {
+        team_id: seed.teamId,
+        entity_id: "wf-001",
+        entity_type: "workflow",
+        name: "Month-End Financial Close",
+        attrs: { id: "wf-001", name: "Month-End Financial Close", job_family: "Finance" },
+      },
+    ]);
+  if (eErr) throw new Error(`graph entity seed failed: ${eErr.message}`);
+
+  const { error: rErr } = await db()
+    .from("graph_relationships")
+    .insert([
+      // Projected: an ownership edge, resolved against the workflow entity.
+      { team_id: seed.teamId, from_id: "actor-001", to_id: "wf-001", relationship_type: "OWNS", attrs: {} },
+      { team_id: seed.teamId, from_id: "actor-002", to_id: "wf-001", relationship_type: "TOUCHES", attrs: {} },
+      // Skipped: org edge — not an ownership type (people carry reports_to via attrs).
+      { team_id: seed.teamId, from_id: "actor-001", to_id: "actor-002", relationship_type: "REPORTS_TO", attrs: {} },
+      // Skipped: ownership edge whose to_id doesn't resolve to an entity.
+      { team_id: seed.teamId, from_id: "actor-001", to_id: "wf-gone", relationship_type: "OWNS", attrs: {} },
+    ]);
+  if (rErr) throw new Error(`graph relationship seed failed: ${rErr.message}`);
+}
+
+describe("company-graph endpoint (real handler, real Postgres)", () => {
+  it("team key: 200 with attrs-projected people[] and the server-side ownership join", async () => {
+    const seed = await seedTeam();
+    await seedGraph(seed);
+    const key = await issueKeyFor(seed, "team");
+
+    const res = await get(key, seed.teamSlug);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      people: { entity_id: string; name: string; role: string | null; job_family: string | null; reports_to: string | null }[];
+      ownership: { person_id: string; relationship: string; target_id: string; target_kind: string; target_name: string; target_job_family: string | null }[];
+    };
+
+    // people[]: only actors, attrs projected, missing attrs emitted as null (not omitted).
+    expect(body.people.map((p) => p.entity_id).sort()).toEqual(["actor-001", "actor-002"]);
+    const nadia = body.people.find((p) => p.entity_id === "actor-001");
+    expect(nadia).toEqual({
+      entity_id: "actor-001",
+      name: "Nadia Kovalchuk",
+      role: "Head of Finance",
+      job_family: "Finance",
+      reports_to: "actor-002",
+    });
+    const sarah = body.people.find((p) => p.entity_id === "actor-002");
+    expect(sarah).toEqual({
+      entity_id: "actor-002",
+      name: "Sarah Chen",
+      role: null,
+      job_family: null,
+      reports_to: null,
+    });
+
+    // ownership[]: OWNS + TOUCHES resolved; REPORTS_TO and the dangling edge excluded.
+    expect(body.ownership).toHaveLength(2);
+    const owns = body.ownership.find((o) => o.relationship === "OWNS");
+    expect(owns).toEqual({
+      person_id: "actor-001",
+      relationship: "OWNS",
+      target_id: "wf-001",
+      target_kind: "workflow",
+      target_name: "Month-End Financial Close",
+      target_job_family: "Finance",
+    });
+    expect(body.ownership.find((o) => o.relationship === "TOUCHES")?.person_id).toBe("actor-002");
+  });
+
+  it("tier gate: external key 403 forbidden_tier; bad key 401", async () => {
+    const seed = await seedTeam();
+    await seedGraph(seed);
+
+    const ext = await issueKeyFor(seed, "external");
+    const forbidden = await get(ext, seed.teamSlug);
+    expect(forbidden.status).toBe(403);
+    const err = (await forbidden.json()) as { error: { code: string } };
+    expect(err.error.code).toBe("forbidden_tier");
+
+    const unauthorized = await get("aios_nope_notakey", seed.teamSlug);
+    expect(unauthorized.status).toBe(401);
+  });
+
+  it("unseeded team: 200 { people: [], ownership: [] }, never 500", async () => {
+    const seed = await seedTeam();
+    const key = await issueKeyFor(seed, "team");
+
+    const res = await get(key, seed.teamSlug);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ people: [], ownership: [] });
+  });
+
+  it("team isolation: another team's graph rows never leak", async () => {
+    const seeded = await seedTeam();
+    await seedGraph(seeded);
+    const other = await seedTeam();
+    const key = await issueKeyFor(other, "team");
+
+    const res = await get(key, other.teamSlug);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ people: [], ownership: [] });
+  });
+});


### PR DESCRIPTION
## What

Implements the brain-side half of **brain-api v1.5** (AIO-141 — Meetings / stakeholder-map surface): `GET /api/v1/company-graph`, a team-tier read that projects the structured Company-Graph (`graph_entities` / `graph_relationships`) as `people[]` + `ownership[]` for the workspace consumers (`aios stakeholders` CLI, MCP `brain_stakeholders`).

## Design notes

- **Route skeleton mirrors `GET /api/v1/members`**: `authenticateApiKey` → team-tier gate → per-key rate limit (60/min, bucket `:company-graph:get`) → team-scoped read. No new storage, no new extraction — reads the existing seeded graph tables (same read paths `lib/query/retrieve.ts` uses).
- **Tier safety**: the graph tables carry `team_id` but no per-row tier column and there is no RLS backstop, so the route handler is the **sole gate** (same posture as `/projects`, `/metrics`, `/codebases`). External key → `403 forbidden_tier`; invalid key → `401`.
- **`people[]`**: every `entity_type = "actor"` row; `role` / `job_family` / `reports_to` projected out of `attrs` (the seed stores the whole fixture object there); a missing attr is emitted as `null`, not omitted.
- **`ownership[]`**: server-side join — every `OWNS` / `TOUCHES` / `PRODUCES` edge for the team, `to_id` resolved against the team's entities to fill `target_name` / `target_kind` / `target_job_family`. Dangling edges (unresolvable `to_id`) are skipped; non-ownership edge types (e.g. `REPORTS_TO`, which people carry via `attrs.reports_to`) are excluded.
- **Empty-graph contract**: an authenticated team-tier key on an unseeded team gets `200 { "people": [], "ownership": [] }` — never a `500`.
- **Attendance is NOT served here** (contract v1.5 point 4): "who attended meeting Y" stays client-side via `GET /items` meeting markers.
- `docs/ARCHITECTURE.md` route inventory updated (the `check:docs` drift guard requires it).

## Contract notes

- Verified against the pinned contract (`aios-workspace/docs/brain-api.md` v1.5, from the consumer branch) **and** the actual consumers (`scripts/brain-mcp.mjs`, `test/stakeholders.cli.test.mjs`): both parse `{ people[], ownership[] }` snake_case, exactly as implemented.
- **Version-constant tracking note (pre-existing drift, not changed here):** `lib/api/version.ts` still declares `BRAIN_API_VERSION = "1.2"` even though v1.4 (Linear inbound apply, AIO-145) is already merged. I did **not** bump it to 1.5 in this PR because v1.3's `ce_band` persistence ("the brain persists it verbatim") is not yet implemented brain-side — bumping would over-claim. Suggest a small follow-up: land `ce_band` persistence, then bump the constant + `docs/ARCHITECTURE.md` claim to 1.5 in one PR.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (1 pre-existing warning in `me-slack-token.datamechanics.test.ts`, untouched)
- `npm run check:docs` — green (routes/tables/sources in sync)
- `npm test` — 363 passed / 1 failed: the failure is the **pre-existing** `test/query-current-date.test.ts` Intl/ICU environment difference (`UTC` vs `UTC+00:00` formatting), unrelated to this additive change
- `npm run test:datamechanics:local` (real Postgres on 5434) — **235 passed**, including the new `test/datamechanics/company-graph.datamechanics.test.ts` (4 tests: tier gate + 401, attrs projection + join semantics, empty graph, cross-team isolation)

Linear: AIO-141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New team-scoped read over graph tables with app-code-only tier enforcement (no RLS); behavior is covered by datamechanics tests but mis-gating would expose org structure.
> 
> **Overview**
> Adds **brain-api v1.5** `GET /api/v1/company-graph`, a team-tier read that projects `graph_entities` / `graph_relationships` into `{ people[], ownership[] }` for `aios stakeholders` and MCP `brain_stakeholders`.
> 
> The handler follows the same pattern as other team-only routes (`authenticateApiKey` → **team-tier gate** → 60/min rate limit → team-scoped queries). Because graph tables have no RLS/tier column, the route is the **only** access control; external keys get `403 forbidden_tier`. **`people[]`** lists `actor` entities with `role`, `job_family`, and `reports_to` pulled from `attrs` (missing → `null`). **`ownership[]`** includes `OWNS` / `TOUCHES` / `PRODUCES` edges with targets resolved server-side (`target_name`, `target_kind`, `target_job_family`); dangling `to_id` and non-ownership edges are dropped. Unseeded teams return **200** with empty arrays.
> 
> `docs/ARCHITECTURE.md` route inventory is updated. New Postgres datamechanics tests cover projection, tier gate, empty graph, and cross-team isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5042eb4b4fd86eda4846d684b0ce268044c66ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint that returns a structured company/stakeholder graph for team workspaces.
  * Response includes people details and ownership relationships, with empty results when no data is available.

* **Bug Fixes**
  * Improved handling of missing or partial profile data by returning nulls for unavailable fields.
  * Prevents invalid or unresolved relationships from appearing in the returned graph.
  * Enforces access restrictions and rate limits for the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->