### PR TITLE
chore: graceful provider-key fallback on unmigrated DB + gitignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .aios-demo-key
+
+# Tessera: local direnv config, not committed
+.envrc

--- a/lib/integrations/manage.ts
+++ b/lib/integrations/manage.ts
@@ -182,7 +182,15 @@ export async function getProviderKey(
     .eq("status", "enabled")
     .limit(1)
     .maybeSingle();
-  if (error) throw new Error(`load provider key failed: ${error.message}`);
+  if (error) {
+    // A not-yet-migrated DB may lack the `integrations` table entirely. Treat a
+    // missing table the same as "no key configured" so callers fall back to the
+    // process env (see the doc comment above) instead of 500-ing the query path.
+    if (/(relation|table).*does not exist|no such table/i.test(error.message)) {
+      return null;
+    }
+    throw new Error(`load provider key failed: ${error.message}`);
+  }
   const blob = (data as { secret_ciphertext: string | null } | null)?.secret_ciphertext;
   return blob ? decryptSecret(blob) : null;
 }


### PR DESCRIPTION
Two small local edits that were sitting uncommitted in the primary checkout, preserved here rather than lost.

- **`getProviderKey`**: on a fresh self-hosted instance whose schema hasn't been loaded yet, the `integrations` table doesn't exist and the read threw → 500 on the query path. This degrades a missing table to `null`, which the callers already treat as "no configured key" and fall back to the process-env key (the documented behavior). Only `"table/relation does not exist"` is swallowed; any other error still throws.
- **`.gitignore`**: ignore local `.envrc` (direnv config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error handling for unmigrated DBs plus a gitignore entry; no auth or data-model changes.
> 
> **Overview**
> **`getProviderKey`** no longer 500s when the database schema has not been applied yet. If Supabase reports that the `integrations` table/relation does not exist, the function returns `null` instead of throwing, matching the existing “no team key” path so query/LLM callers keep using process-env keys. Other load errors still throw.
> 
> **`.gitignore`** adds `.envrc` so local direnv config is not committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0b773471d59f04d17d5df9bb7dea6c926aa795. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->