### PR TITLE
AIO-219: brain-api v1.3 — ce_band shadow band ingest + metrics HTTP test

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,7 +89,7 @@ flowchart LR
 
 ## Auth & access tiers
 
-This server **implements brain-api v1.2** (the wire contract; source of truth:
+This server **implements brain-api v1.3** (the wire contract; source of truth:
 `aios-workspace/docs/brain-api.md`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`) and asserted against this sentence by
 `test/guards/contract-version.test.ts` — bump all three together on a contract change.

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -191,6 +191,9 @@ export const maturitySnapshotPayloadSchema = z.object({
     .default({ spine: "L1", axes: {} }),
   sessions: z.number().int().nonnegative().optional().default(0),
   tasks: z.number().int().nonnegative().optional().default(0),
+  // Shadow Cognitive-Ergonomics band (v1.3). No `.default()`: omitted (older client) must
+  // stay distinguishable from an explicit null. Provenance-only — never recomputed here.
+  ce_band: z.number().int().min(0).max(4).nullable().optional(),
 });
 export type MaturitySnapshotPayload = z.infer<typeof maturitySnapshotPayloadSchema>;
 

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -9,4 +9,4 @@
  * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
  */
-export const BRAIN_API_VERSION = "1.2";
+export const BRAIN_API_VERSION = "1.3";

--- a/lib/metrics/individual-maturity-ingest.ts
+++ b/lib/metrics/individual-maturity-ingest.ts
@@ -63,6 +63,9 @@ export async function ingestMaturitySnapshot(
         canonical_learning: canonical.axes.learning,
         canonical_cost_governance: canonical.axes.cost_governance,
         canonical_overall: canonical.overall,
+        // Omitted (older client) → key absent, column untouched on conflict (preserves a
+        // previously stored band). Explicit null → column set to NULL, clearing it.
+        ...(payload.ce_band !== undefined ? { ce_band: payload.ce_band } : {}),
       },
       { onConflict: "team_id,member_id,snapshot_date,metric" }
     )
@@ -78,7 +81,13 @@ export async function ingestMaturitySnapshot(
     action: "maturity.snapshot",
     target_type: "member",
     target_id: memberId,
-    meta: { date: payload.date, spine: canonical.spine, overall: canonical.overall, tasks: payload.tasks },
+    meta: {
+      date: payload.date,
+      spine: canonical.spine,
+      overall: canonical.overall,
+      tasks: payload.tasks,
+      ce_band: payload.ce_band ?? null,
+    },
   });
 
   return { snapshot_id: data.id, member_id: memberId, canonical };

--- a/lib/metrics/individual-maturity-ingest.ts
+++ b/lib/metrics/individual-maturity-ingest.ts
@@ -86,7 +86,9 @@ export async function ingestMaturitySnapshot(
       spine: canonical.spine,
       overall: canonical.overall,
       tasks: payload.tasks,
-      ce_band: payload.ce_band ?? null,
+      // Preserve the omitted-vs-explicit-null distinction in the audit trail too — collapsing
+      // them (e.g. via `?? null`) would hide whether a re-push actually cleared a stored band.
+      ce_band: payload.ce_band === undefined ? "unchanged" : payload.ce_band,
     },
   });
 

--- a/postgres/migrations/20260704120000_maturity_ce_shadow.sql
+++ b/postgres/migrations/20260704120000_maturity_ce_shadow.sql
@@ -1,0 +1,7 @@
+-- brain-api v1.3: optional shadow Cognitive-Ergonomics band on AEM individual snapshots.
+-- Nullable, NO default — null means "insufficient baseline / older client", distinct from 0.
+-- Provenance-only: the brain persists it verbatim and never recomputes it (never feeds
+-- placement()). Also mirrored into postgres/schema.sql for from-zero replay.
+alter table agentic_maturity_snapshots
+  add column if not exists ce_band smallint
+  check (ce_band is null or ce_band between 0 and 4);

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -744,6 +744,10 @@ create table if not exists agentic_maturity_snapshots (
   canonical_learning numeric(4,2) not null default 0,
   canonical_cost_governance numeric(4,2) not null default 0,
   canonical_overall numeric(4,2) not null default 0,
+  -- shadow Cognitive-Ergonomics band (v1.3, optional, 0-4, nullable, no default).
+  -- Client-derived, provenance-only: never recomputed here, never feeds placement().
+  -- Shadow / uncalibrated — never a canonical scorer input.
+  ce_band smallint check (ce_band is null or ce_band between 0 and 4),
   created_at timestamptz not null default now(),
   unique (team_id, member_id, snapshot_date, metric)
 );

--- a/test/datamechanics/maturity-ingest.datamechanics.test.ts
+++ b/test/datamechanics/maturity-ingest.datamechanics.test.ts
@@ -93,4 +93,59 @@ describe("agentic-maturity snapshot ingest (real Postgres)", () => {
 
     await expect(ingest(seed, snapshot({ member: "ghost" }))).rejects.toThrow(/unknown member/i);
   });
+
+  describe("ce_band (v1.3 shadow band)", () => {
+    it("persists an explicit band; canonical_* is unaffected by its presence", async () => {
+      const seed = await seedTeam();
+      const withBand = await ingest(seed, snapshot({ ce_band: 3 }));
+      const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+      expect(row!.ce_band).toBe(3);
+      expect(withBand.canonical.spine).toMatch(/^L[1-5]$/);
+    });
+
+    it("persists an explicit null", async () => {
+      const seed = await seedTeam();
+      await ingest(seed, snapshot({ ce_band: null }));
+      const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+      expect(row!.ce_band).toBeNull();
+    });
+
+    it("stays NULL when the field is omitted (older client)", async () => {
+      const seed = await seedTeam();
+      await ingest(seed, snapshot());
+      const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+      expect(row!.ce_band).toBeNull();
+    });
+
+    it("column-wise merge: push-with-band then re-push-without leaves the band intact", async () => {
+      const seed = await seedTeam();
+      await ingest(seed, snapshot({ ce_band: 3 }));
+      await ingest(seed, snapshot({ tasks: 999 })); // no ce_band key at all
+      const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+      expect(row!.ce_band).toBe(3);
+      expect(Number(row!.tasks)).toBe(999); // the re-push's other fields DID apply
+    });
+
+    it("re-push with explicit null clears a previously stored band", async () => {
+      const seed = await seedTeam();
+      await ingest(seed, snapshot({ ce_band: 3 }));
+      await ingest(seed, snapshot({ ce_band: null }));
+      const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+      expect(row!.ce_band).toBeNull();
+    });
+
+    it("canonical_* columns are identical with and without ce_band", async () => {
+      const seed = await seedTeam();
+      const withBand = await ingest(seed, snapshot({ ce_band: 3 }));
+      const rowWith = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+
+      const seed2 = await seedTeam();
+      const withoutBand = await ingest(seed2, snapshot());
+      const rowWithout = await rowFor(seed2.teamId, seed2.memberId, "2026-06-18");
+
+      expect(withBand.canonical).toEqual(withoutBand.canonical);
+      expect(rowWith!.canonical_spine).toBe(rowWithout!.canonical_spine);
+      expect(Number(rowWith!.canonical_overall)).toBe(Number(rowWithout!.canonical_overall));
+    });
+  });
 });

--- a/test/datamechanics/maturity-ingest.datamechanics.test.ts
+++ b/test/datamechanics/maturity-ingest.datamechanics.test.ts
@@ -147,5 +147,33 @@ describe("agentic-maturity snapshot ingest (real Postgres)", () => {
       expect(rowWith!.canonical_spine).toBe(rowWithout!.canonical_spine);
       expect(Number(rowWith!.canonical_overall)).toBe(Number(rowWithout!.canonical_overall));
     });
+
+    // Regression: the audit trail must not collapse "omitted" and "explicit null" into the
+    // same logged value — that would hide whether a re-push actually cleared a stored band.
+    it("audit meta distinguishes omitted (unchanged) from an explicit band or null", async () => {
+      async function metaFor(teamId: string) {
+        const { data } = await db()
+          .from("audit_log")
+          .select("meta")
+          .eq("team_id", teamId)
+          .eq("action", "maturity.snapshot")
+          .order("created_at", { ascending: false })
+          .limit(1)
+          .single();
+        return (data as { meta: Record<string, unknown> }).meta;
+      }
+
+      const seedOmitted = await seedTeam();
+      await ingest(seedOmitted, snapshot());
+      expect((await metaFor(seedOmitted.teamId)).ce_band).toBe("unchanged");
+
+      const seedBand = await seedTeam();
+      await ingest(seedBand, snapshot({ ce_band: 3 }));
+      expect((await metaFor(seedBand.teamId)).ce_band).toBe(3);
+
+      const seedNull = await seedTeam();
+      await ingest(seedNull, snapshot({ ce_band: null }));
+      expect((await metaFor(seedNull.teamId)).ce_band).toBeNull();
+    });
   });
 });

--- a/test/http/metrics.http.test.ts
+++ b/test/http/metrics.http.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { BASE_URL, db, issueKeyFor, keyHeaders, seedTeam } from "./http-helpers";
+
+// HTTP edge of POST /api/v1/metrics (agentic-maturity snapshot ingest), closing a coverage
+// gap noted in AIO-219: this route previously had no HTTP-level test. Covers auth/tier
+// gating and the v1.3 ce_band field's 422 bound.
+
+const METRICS = `${BASE_URL}/api/v1/metrics`;
+
+function payload(over: Record<string, unknown> = {}) {
+  return {
+    date: "2026-07-04",
+    signals: {
+      delegation_ratio: 0.3, correction_loop_avg: 1.2, error_rate: 0.05,
+      cost_per_task: 0.4, tokens_per_task: 30_000, cache_hit_rate: 0.8,
+      tool_diversity: 8, verify_tool_rate: 0.3, subagent_usage: 0.5,
+    },
+    sessions: 40, tasks: 130,
+    ...over,
+  };
+}
+
+describe("POST /api/v1/metrics (HTTP)", () => {
+  it("rejects a missing/invalid API key with 401", async () => {
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: { Authorization: "Bearer nope", "Content-Type": "application/json" },
+      body: JSON.stringify(payload()),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects an external-tier key with 403 (agentic-maturity is team-tier only)", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "external");
+
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(payload()),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("forbidden_tier");
+  });
+
+  it("201s with a ce_band and the DB row shows the persisted band", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(payload({ ce_band: 3 })),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+
+    const { data } = await db()
+      .from("agentic_maturity_snapshots")
+      .select("ce_band")
+      .eq("team_id", seed.teamId)
+      .eq("member_id", seed.memberId)
+      .eq("snapshot_date", "2026-07-04")
+      .single();
+    expect((data as { ce_band: number }).ce_band).toBe(3);
+  });
+
+  it("422s on an out-of-range ce_band", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(payload({ ce_band: 7 })),
+    });
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("invalid_payload");
+  });
+
+  it("201s when ce_band is omitted (older client)", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(payload()),
+    });
+    expect(res.status).toBe(201);
+  });
+});

--- a/test/maturity-ce-band-schema.test.ts
+++ b/test/maturity-ce-band-schema.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { maturitySnapshotPayloadSchema } from "@/lib/api/schemas";
+
+// Spec (brain-api v1.3): ce_band is a shadow, provenance-only 0-4 integer with NO default —
+// an omitted field must stay distinguishable (undefined) from an explicit null, so an older
+// client's re-push can't accidentally clear a previously stored band.
+
+function payload(over: Record<string, unknown> = {}) {
+  return {
+    date: "2026-07-04",
+    signals: {
+      delegation_ratio: 0.3, correction_loop_avg: 1.2, error_rate: 0.05,
+      cost_per_task: 0.4, tokens_per_task: 30_000, cache_hit_rate: 0.8,
+      tool_diversity: 8, verify_tool_rate: 0.3, subagent_usage: 0.5,
+    },
+    ...over,
+  };
+}
+
+describe("maturitySnapshotPayloadSchema — ce_band (v1.3)", () => {
+  it("accepts the boundary values 0 and 4", () => {
+    expect(maturitySnapshotPayloadSchema.parse(payload({ ce_band: 0 })).ce_band).toBe(0);
+    expect(maturitySnapshotPayloadSchema.parse(payload({ ce_band: 4 })).ce_band).toBe(4);
+  });
+
+  it("accepts explicit null", () => {
+    expect(maturitySnapshotPayloadSchema.parse(payload({ ce_band: null })).ce_band).toBeNull();
+  });
+
+  it("stays undefined when omitted (distinguishable from explicit null)", () => {
+    expect(maturitySnapshotPayloadSchema.parse(payload()).ce_band).toBeUndefined();
+  });
+
+  it("rejects out-of-range and non-integer values", () => {
+    expect(() => maturitySnapshotPayloadSchema.parse(payload({ ce_band: 5 }))).toThrow();
+    expect(() => maturitySnapshotPayloadSchema.parse(payload({ ce_band: -1 }))).toThrow();
+    expect(() => maturitySnapshotPayloadSchema.parse(payload({ ce_band: 2.5 }))).toThrow();
+    expect(() => maturitySnapshotPayloadSchema.parse(payload({ ce_band: "3" }))).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- brain-api v1.3: `POST /api/v1/metrics` accepts an optional `ce_band` (0-4, nullable) — the Cognitive Ergonomics shadow band computed client-side alongside `provisional`. Persisted verbatim, provenance-only; never feeds the canonical `placement()` recompute.
- Column-wise upsert (omitted key ≠ explicit null): an older client's re-push preserves a previously stored band; an explicit `null` clears it.
- Closes a coverage gap: `POST /api/v1/metrics` had no HTTP-level test — added `test/http/metrics.http.test.ts` mirroring the `work-events` pattern (401/403/201/422/201-omitted).
- Version pins bumped together: `lib/api/version.ts` → `1.3`, `docs/ARCHITECTURE.md` contract sentence → v1.3 (guarded by `test/guards/contract-version.test.ts`).

**Deviation from the issue spec:** the spec calls for mirroring the migration into `supabase/migrations/`, but that directory was removed in #143 (Postgres-only backend). The migrations-numbering guard only checks `postgres/migrations/`, so the migration lands there only — confirmed by a clean `npm run db:test:up` replay-from-zero.

## Test plan
- [x] `npm run lint && npm run typecheck && npm test` — exit 0 (one pre-existing unrelated failure on `main` too: `test/query-current-date.test.ts` UTC fallback; a flaky `chat-store` ordering test also reproduces on `main` untouched)
- [x] `npm run db:test:up` — migration applies cleanly from-zero
- [x] `npm run test:datamechanics:local` — extended `maturity-ingest` suite: band persists, explicit null persists, omitted stays NULL, column-wise merge proof, re-push-null clears, canonical_* identical with/without band
- [x] `npm run test:http:local` — new `metrics.http.test.ts`: 401/403/201-with-band/422-out-of-range/201-omitted, all passing
- [x] Guard tests green: `migrations-numbering` + `contract-version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive contract and nullable column with backward-compatible omit semantics; canonical maturity scoring path unchanged. Risk is mainly client/schema drift if v1.3 clients send invalid bands (422).
> 
> **Overview**
> Bumps the implemented wire contract to **brain-api v1.3** (`BRAIN_API_VERSION` and `docs/ARCHITECTURE.md`).
> 
> **`POST /api/v1/metrics`** now accepts an optional **`ce_band`** (0–4 integer or explicit `null`) on AEM individual maturity snapshots. The value is **shadow / provenance-only**: stored verbatim on `agentic_maturity_snapshots.ce_band`, does not affect canonical `placement()` scoring. Schema validation deliberately has **no default** so **omitted** (older clients) stays distinct from **explicit null**.
> 
> Ingest uses a **column-wise upsert**: if `ce_band` is omitted on conflict, the column is left unchanged; explicit `null` clears a stored band. Audit `meta.ce_band` logs `"unchanged"` when omitted vs the actual value/null when sent.
> 
> Adds migration + `schema.sql` for nullable `ce_band` with a 0–4 check. Tests cover Zod bounds, datamechanics merge/clear behavior, and new HTTP coverage for the metrics route (401/403/201/422).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0107972932f6fb9c29368fd87fc58e81781928da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `ce_band` value in maturity snapshot submissions and storage.
  * Updated the API contract to version 1.3.

* **Bug Fixes**
  * Preserved existing `ce_band` values when later updates omit the field.
  * Accepted both explicit `null` and omitted values for older clients.

* **Tests**
  * Expanded coverage for request validation, persistence, and edge cases around `ce_band` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->