### PR TITLE
AIO-220: CE shadow band beside AM on maturity dashboard

### DIFF
--- a/app/t/[team]/maturity/people/[handle]/page.tsx
+++ b/app/t/[team]/maturity/people/[handle]/page.tsx
@@ -14,6 +14,14 @@ function radarData(axes: AemAxes, team: AemAxes): RadarDatum[] {
   return AXIS_META.map((a) => ({ axis: a.label, you: axes[a.key], team: team[a.key] }));
 }
 
+function CeShadowBadge() {
+  return (
+    <span className="mt-1 inline-flex rounded-full bg-amber/10 px-2 py-0.5 text-[10px] font-medium text-amber-700">
+      shadow · uncalibrated
+    </span>
+  );
+}
+
 export default async function MemberMaturityPage({
   params,
 }: {
@@ -53,7 +61,7 @@ export default async function MemberMaturityPage({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
         <div className="card p-4">
           <div className="text-xs uppercase tracking-wide text-ink-subtle">Tasks</div>
           <div className="mt-1 text-xl tabular-nums text-ink">{latest.tasks}</div>
@@ -61,6 +69,13 @@ export default async function MemberMaturityPage({
         <div className="card p-4">
           <div className="text-xs uppercase tracking-wide text-ink-subtle">Sessions</div>
           <div className="mt-1 text-xl tabular-nums text-ink">{latest.sessions}</div>
+        </div>
+        <div className="card p-4">
+          <div className="text-xs uppercase tracking-wide text-ink-subtle">CE</div>
+          <div className="mt-1 text-xl tabular-nums text-ink">
+            {latest.ce_band == null ? "—" : `${latest.ce_band}/4`}
+          </div>
+          <CeShadowBadge />
         </div>
         <div className="card p-4">
           <div className="text-xs uppercase tracking-wide text-ink-subtle">Est. spend</div>
@@ -85,7 +100,9 @@ export default async function MemberMaturityPage({
           title="Axes vs. team average"
           hint="scored 0–4"
         />
-        <MaturityTimeline data={timeline.map((t) => ({ date: t.date, overall: t.overall }))} />
+        <MaturityTimeline
+          data={timeline.map((t) => ({ date: t.date, overall: t.overall, ce_band: t.ce_band }))}
+        />
       </div>
 
       <div className="card flex flex-col gap-2 p-5">

--- a/app/t/[team]/maturity/people/page.tsx
+++ b/app/t/[team]/maturity/people/page.tsx
@@ -25,6 +25,18 @@ function fmtTokens(n: number): string {
   return String(Math.round(n));
 }
 
+function CeShadowBadge() {
+  return (
+    <span className="ml-1.5 rounded-full bg-amber/10 px-2 py-0.5 text-[10px] font-medium text-amber-700">
+      shadow · uncalibrated
+    </span>
+  );
+}
+
+function fmtCeBand(band: number | null): string {
+  return band == null ? "—" : `${band}/4`;
+}
+
 function radarData(axes: AemAxes): RadarDatum[] {
   return AXIS_META.map((a) => ({ axis: a.label, you: axes[a.key] }));
 }
@@ -95,6 +107,7 @@ export default async function MaturityPage({ params }: { params: Promise<{ team:
                   <th className="px-4 py-3 font-medium">Member</th>
                   <th className="px-4 py-3 font-medium">Spine</th>
                   <th className="px-4 py-3 font-medium">Overall</th>
+                  <th className="px-4 py-3 font-medium">CE</th>
                   <th className="px-4 py-3 font-medium">Weakest axis</th>
                   <th className="px-4 py-3 text-right font-medium">Tasks</th>
                   <th className="px-4 py-3 text-right font-medium">Est. spend</th>
@@ -114,6 +127,10 @@ export default async function MaturityPage({ params }: { params: Promise<{ team:
                       <span className="rounded-full bg-surface-sunken px-2 py-0.5 font-mono text-xs text-ink">{m.spine}</span>
                     </td>
                     <td className="px-4 py-3 tabular-nums text-ink-secondary">{m.overall.toFixed(2)}</td>
+                    <td className="px-4 py-3 tabular-nums text-ink-secondary">
+                      {fmtCeBand(m.ce_band)}
+                      <CeShadowBadge />
+                    </td>
                     <td className="px-4 py-3 text-ink-secondary">
                       {AXIS_META.find((a) => a.key === m.weakest)?.label}
                     </td>

--- a/components/charts/maturity-timeline.tsx
+++ b/components/charts/maturity-timeline.tsx
@@ -12,19 +12,48 @@ import {
 import { AXIS_TICK, GRID_STROKE, PRISM, TOOLTIP_STYLE } from "./palette";
 import { ChartCard } from "./chart-card";
 
-export type TimelinePoint = { date: string; overall: number };
+export type TimelinePoint = { date: string; overall: number; ce_band?: number | null };
 
 /** Overall AEM score (0–4) over time — shows progression as the loop re-assesses. */
 export function MaturityTimeline({ data }: { data: TimelinePoint[] }) {
+  const hasCe = data.some((d) => d.ce_band != null);
   return (
-    <ChartCard title="Progression" hint="overall score over time" empty={data.length < 2}>
+    <ChartCard
+      title="Progression"
+      hint={
+        hasCe
+          ? "overall score and CE (shadow) over time — dashed CE line gaps when no reading"
+          : "overall score over time"
+      }
+      empty={data.length < 2}
+    >
       <ResponsiveContainer width="100%" height={220}>
         <LineChart data={data} margin={{ top: 4, right: 8, left: -24, bottom: 0 }}>
           <CartesianGrid vertical={false} stroke={GRID_STROKE} />
           <XAxis dataKey="date" tick={AXIS_TICK} tickLine={false} axisLine={false} minTickGap={28} />
           <YAxis tick={AXIS_TICK} tickLine={false} axisLine={false} width={32} domain={[0, 4]} />
           <Tooltip contentStyle={TOOLTIP_STYLE} />
-          <Line type="monotone" dataKey="overall" name="Overall" stroke={PRISM.violet} strokeWidth={1.75} dot={false} connectNulls />
+          <Line
+            type="monotone"
+            dataKey="overall"
+            name="Overall"
+            stroke={PRISM.violet}
+            strokeWidth={1.75}
+            dot={false}
+            connectNulls
+          />
+          {hasCe ? (
+            <Line
+              type="monotone"
+              dataKey="ce_band"
+              name="CE (shadow)"
+              stroke={PRISM.amber}
+              strokeWidth={1.5}
+              strokeDasharray="4 3"
+              dot={{ r: 2, fill: PRISM.amber, strokeWidth: 0 }}
+              connectNulls={false}
+            />
+          ) : null}
         </LineChart>
       </ResponsiveContainer>
     </ChartCard>

--- a/lib/metrics/individual-maturity.ts
+++ b/lib/metrics/individual-maturity.ts
@@ -133,6 +133,7 @@ type SnapshotRow = {
   canonical_autonomy: number;
   canonical_learning: number;
   canonical_cost_governance: number;
+  ce_band: number | null;
   tasks: number;
   sessions: number;
   total_cost_usd: number;
@@ -159,6 +160,7 @@ export type MemberMaturityCard = {
   date: string;
   spine: string;
   overall: number;
+  ce_band: number | null;
   axes: AemAxes;
   tasks: number;
   sessions: number;
@@ -200,7 +202,7 @@ export async function getTeamMaturity(
   const { data: snaps } = await supabase
     .from("agentic_maturity_snapshots")
     .select(
-      `member_id, snapshot_date, canonical_spine, canonical_overall, tasks, sessions,
+      `member_id, snapshot_date, canonical_spine, canonical_overall, ce_band, tasks, sessions,
        total_cost_usd, input_tokens, output_tokens, cache_read_tokens, ${AXIS_COLS.join(", ")}`
     )
     .eq("team_id", teamId)
@@ -235,6 +237,7 @@ export async function getTeamMaturity(
       date: dayStr(r.snapshot_date),
       spine: r.canonical_spine,
       overall: Number(r.canonical_overall),
+      ce_band: r.ce_band == null ? null : Number(r.ce_band),
       axes,
       tasks: Number(r.tasks),
       sessions: Number(r.sessions),
@@ -255,7 +258,10 @@ export async function getTeamMaturity(
   };
 }
 
-export type MemberTimelinePoint = { date: string } & AemAxes & { overall: number };
+export type MemberTimelinePoint = { date: string } & AemAxes & {
+  overall: number;
+  ce_band: number | null;
+};
 export type MemberMaturity = {
   handle: string;
   name: string;
@@ -290,7 +296,7 @@ export async function getMemberMaturity(
   const { data: snaps } = await supabase
     .from("agentic_maturity_snapshots")
     .select(
-      `member_id, snapshot_date, canonical_spine, canonical_overall, tasks, sessions,
+      `member_id, snapshot_date, canonical_spine, canonical_overall, ce_band, tasks, sessions,
        total_cost_usd, input_tokens, output_tokens, cache_read_tokens, ${AXIS_COLS.join(", ")}`
     )
     .eq("team_id", teamId)
@@ -304,6 +310,7 @@ export async function getMemberMaturity(
   const timeline: MemberTimelinePoint[] = rows.map((r) => ({
     date: dayStr(r.snapshot_date),
     overall: Number(r.canonical_overall),
+    ce_band: r.ce_band == null ? null : Number(r.ce_band),
     ...rowAxes(r),
   }));
   const last = rows[rows.length - 1];
@@ -312,6 +319,7 @@ export async function getMemberMaturity(
   const latest: MemberMaturityCard = {
     member_id: m.id, handle: m.actor_handle, name: m.display_name, avatar_url: m.avatar_url,
     date: dayStr(last.snapshot_date), spine: last.canonical_spine, overall: Number(last.canonical_overall),
+    ce_band: last.ce_band == null ? null : Number(last.ce_band),
     axes, tasks: Number(last.tasks), sessions: Number(last.sessions),
     total_cost_usd: Number(last.total_cost_usd ?? 0),
     total_tokens: Number(last.input_tokens ?? 0) + Number(last.output_tokens ?? 0) + Number(last.cache_read_tokens ?? 0),

--- a/test/datamechanics/maturity-read.datamechanics.test.ts
+++ b/test/datamechanics/maturity-read.datamechanics.test.ts
@@ -77,4 +77,30 @@ describe("agentic-maturity dashboard reads (real Postgres)", () => {
     const seed = await seedTeam();
     expect(await getMemberMaturity(db(), seed.teamId, "ghost", "team")).toBeNull();
   });
+
+  it("exposes ce_band on cards and timeline without affecting teamAxes or spineDistribution", async () => {
+    const seed = await seedTeam();
+    const alex = await createMember(db(), seed.teamId, {
+      email: "a@x.test",
+      displayName: "Alex",
+      actorHandle: "alex",
+      role: "member",
+    });
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-16", { ce_band: null }));
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-18", { ce_band: 3 }));
+
+    const team = await getTeamMaturity(db(), seed.teamId, "team");
+    const alexCard = team.members.find((m) => m.handle === "alex")!;
+    expect(alexCard.ce_band).toBe(3);
+    expect(team.teamAxes).toBeTruthy();
+    expect(Object.keys(team.spineDistribution).length).toBeGreaterThan(0);
+
+    const m = await getMemberMaturity(db(), seed.teamId, "alex", "team");
+    expect(m!.timeline.map((t) => t.ce_band)).toEqual([null, 3]);
+    expect(m!.latest.ce_band).toBe(3);
+
+    const ext = await getTeamMaturity(db(), seed.teamId, "external");
+    expect(ext.members).toEqual([]);
+    expect(await getMemberMaturity(db(), seed.teamId, "alex", "external")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Add `ce_band` to individual maturity reads (cards + timeline points)
- People table: new CE column with `shadow · uncalibrated` badge; em dash when null
- Deep-dive: CE stat card + dashed amber CE timeline line (`connectNulls={false}`)
- CE stays out of radar, spine distribution, and team axis rollups

## Test plan
- [x] `npm run lint && npm run typecheck`
- [x] `npm run db:test:up && npm run test:datamechanics:local`
- [x] Extended `maturity-read.datamechanics.test.ts` for ce_band exposure + external tier gate
- [ ] Manual: people table CE column; deep-dive chart shows dashed CE line with null gaps


Made with [Cursor](https://cursor.com)