### PR TITLE
feat(onboarding): personalize the new-member invite email

### DIFF
--- a/app/t/[team]/admin/actions.ts
+++ b/app/t/[team]/admin/actions.ts
@@ -16,19 +16,19 @@ async function requireAdmin(teamSlug: string) {
   if (!user) return null;
   const { data: team } = await supabase
     .from("teams")
-    .select("id")
+    .select("id, name")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
   const { data: me } = await supabase
     .from("members")
-    .select("id, role")
+    .select("id, role, display_name")
     .eq("team_id", team.id)
     .eq("auth_user_id", user.id)
     .eq("status", "active")
     .maybeSingle();
   if (me?.role !== "admin") return null;
-  return { teamId: team.id, myMemberId: me.id };
+  return { teamId: team.id, teamName: team.name, myMemberId: me.id, myDisplayName: me.display_name };
 }
 
 export async function inviteMember(
@@ -65,7 +65,11 @@ export async function inviteMember(
       const raw = await issueMagicToken(email, `/t/${teamSlug}`, 1440); // 24h invite TTL
       if (raw) link = `${appUrl}/auth/confirm?token=${raw}`;
     }
-    await sendInviteEmail(email, link);
+    await sendInviteEmail(email, link, {
+      inviteeName: form.displayName,
+      teamName: ctx.teamName,
+      inviterName: ctx.myDisplayName,
+    });
   } catch (e) {
     console.error("[invite] email send failed:", e instanceof Error ? e.message : e);
   }

--- a/lib/auth/mailer.test.ts
+++ b/lib/auth/mailer.test.ts
@@ -17,22 +17,59 @@ function mockFetch(ok: boolean) {
   return fn;
 }
 
-function sentBody(fn: ReturnType<typeof vi.fn>): { to: string; subject: string; text: string } {
+function sentBody(
+  fn: ReturnType<typeof vi.fn>
+): { to: string; subject: string; text: string; html?: string } {
   return JSON.parse((fn.mock.calls[0][1] as RequestInit).body as string);
 }
+
+const inviteCtx = { inviteeName: "Alicia Keys", teamName: "Acme Co", inviterName: "Bob Admin" };
 
 describe("mailer delivery", () => {
   it("sends via the Resend HTTP API when RESEND_API_KEY is set", async () => {
     vi.stubEnv("RESEND_API_KEY", "re_test_key");
     const fetchFn = mockFetch(true);
 
-    await sendInviteEmail("new@member.test", "https://brain.test/auth/confirm?token=REDACTED");
+    await sendInviteEmail("new@member.test", "https://brain.test/auth/confirm?token=REDACTED", inviteCtx);
 
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(fetchFn.mock.calls[0][0]).toBe("https://api.resend.com/emails");
     const body = sentBody(fetchFn);
     expect(body.to).toBe("new@member.test");
-    expect(body.subject).toMatch(/added to the AIOS Team Brain/i);
+    expect(body.subject).toContain("Bob Admin");
+    expect(body.subject).toContain("Acme Co");
+  });
+
+  it("personalizes the body with the invitee's first name, team, and inviter, in both text and html", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
+    const fetchFn = mockFetch(true);
+
+    await sendInviteEmail("new@member.test", "https://brain.test/auth/confirm?token=REDACTED", inviteCtx);
+
+    const body = sentBody(fetchFn);
+    expect(body.text).toContain("Alicia");
+    expect(body.text).toContain("Bob Admin");
+    expect(body.text).toContain("Acme Co");
+    expect(body.html).toBeTruthy();
+    expect(body.html).toContain("Alicia");
+    expect(body.html).toContain("Bob Admin");
+    expect(body.html).toContain("Acme Co");
+    expect(body.html).toMatch(/<a href="https:\/\/brain\.test\/auth\/confirm\?token=REDACTED"/);
+  });
+
+  it("escapes HTML-unsafe characters in names before rendering the html body", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
+    const fetchFn = mockFetch(true);
+
+    await sendInviteEmail("new@member.test", "https://brain.test/auth/confirm?token=REDACTED", {
+      inviteeName: "<script>alert(1)</script>",
+      teamName: "Acme & Co <b>",
+      inviterName: "Bob \"Boss\" Admin",
+    });
+
+    const body = sentBody(fetchFn);
+    expect(body.html).not.toContain("<script>");
+    expect(body.html).not.toContain("Acme & Co <b>");
   });
 
   it("does not throw when Resend rejects the send", async () => {
@@ -46,14 +83,14 @@ describe("mailer delivery", () => {
     vi.stubEnv("SMTP_URL", "");
     const fetchFn = vi.fn();
     vi.stubGlobal("fetch", fetchFn);
-    await expect(sendInviteEmail("a@b.test", null)).resolves.toBeUndefined();
+    await expect(sendInviteEmail("a@b.test", null, inviteCtx)).resolves.toBeUndefined();
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
   it("an invite with no link is a non-secret nudge (no token in the body)", async () => {
     vi.stubEnv("RESEND_API_KEY", "re_test_key");
     const fetchFn = mockFetch(true);
-    await sendInviteEmail("a@b.test", null);
+    await sendInviteEmail("a@b.test", null, inviteCtx);
     const body = sentBody(fetchFn);
     expect(body.text).not.toMatch(/token=/);
     expect(body.text).toMatch(/sign in/i);

--- a/lib/auth/mailer.ts
+++ b/lib/auth/mailer.ts
@@ -25,14 +25,29 @@ function senderFrom(): string {
   return "AIOS Team Brain <onboarding@resend.dev>";
 }
 
-async function deliver(to: string, subject: string, text: string): Promise<boolean> {
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+async function deliver(to: string, subject: string, body: { text: string; html?: string }): Promise<boolean> {
   const resendKey = process.env.RESEND_API_KEY;
   if (resendKey) {
     try {
       const res = await fetch("https://api.resend.com/emails", {
         method: "POST",
         headers: { Authorization: `Bearer ${resendKey}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ from: senderFrom(), to, subject, text }),
+        body: JSON.stringify({
+          from: senderFrom(),
+          to,
+          subject,
+          text: body.text,
+          ...(body.html ? { html: body.html } : {}),
+        }),
       });
       if (res.ok) return true;
       console.error(`[mailer] Resend rejected ${to}: HTTP ${res.status}`);
@@ -46,7 +61,13 @@ async function deliver(to: string, subject: string, text: string): Promise<boole
     try {
       const nodemailer = await import("nodemailer");
       const transport = nodemailer.createTransport(smtpUrl);
-      await transport.sendMail({ to, from: senderFrom(), subject, text });
+      await transport.sendMail({
+        to,
+        from: senderFrom(),
+        subject,
+        text: body.text,
+        ...(body.html ? { html: body.html } : {}),
+      });
       return true;
     } catch (err) {
       console.error(`[mailer] SMTP send failed for ${to}:`, err instanceof Error ? err.message : err);
@@ -65,21 +86,48 @@ async function deliver(to: string, subject: string, text: string): Promise<boole
 
 /** Magic-link sign-in email (login flow). Never throws. */
 export async function sendMagicLink(email: string, link: string): Promise<void> {
-  await deliver(
-    email,
-    "Your AIOS Team Brain sign-in link",
-    `Click to sign in (valid 15 minutes):\n\n${link}\n\nIf you didn't request this, ignore this email.`
-  );
+  await deliver(email, "Your AIOS Team Brain sign-in link", {
+    text: `Click to sign in (valid 15 minutes):\n\n${link}\n\nIf you didn't request this, ignore this email.`,
+  });
+}
+
+export interface InviteEmailContext {
+  /** The invitee's display name, as entered by the inviter. First name is used in the greeting. */
+  inviteeName: string;
+  teamName: string;
+  inviterName: string;
 }
 
 /**
  * New-member invite email. With a `link` (a one-time sign-in URL) it's a direct
  * sign-in; without one (no APP_URL configured) it's a non-secret nudge to sign in.
- * Never throws.
+ * Never throws. Names are attacker-controlled input (display names), so the HTML
+ * body escapes them — this is the only place they're rendered as markup.
  */
-export async function sendInviteEmail(email: string, link: string | null): Promise<void> {
+export async function sendInviteEmail(email: string, link: string | null, ctx: InviteEmailContext): Promise<void> {
+  const firstName = ctx.inviteeName.trim().split(/\s+/)[0] || ctx.inviteeName;
+  const subject = `${ctx.inviterName} added you to ${ctx.teamName} on AIOS`;
+
   const text = link
-    ? `You've been added to the AIOS Team Brain.\n\nSign in with this one-time link (single-use, expires in 24 hours):\n\n${link}\n\nIf you weren't expecting this, you can ignore this email.`
-    : `You've been added to the AIOS Team Brain. Open the team brain and sign in with this email address to get started.`;
-  await deliver(email, "You've been added to the AIOS Team Brain", text);
+    ? `Hi ${firstName},\n\n${ctx.inviterName} added you to ${ctx.teamName}'s AIOS Team Brain.\n\nSign in with this one-time link (single-use, expires in 24 hours):\n\n${link}\n\nIf you weren't expecting this, you can ignore this email.`
+    : `Hi ${firstName},\n\n${ctx.inviterName} added you to ${ctx.teamName}'s AIOS Team Brain. Open the team brain and sign in with this email address to get started.`;
+
+  const safeFirstName = escapeHtml(firstName);
+  const safeInviter = escapeHtml(ctx.inviterName);
+  const safeTeam = escapeHtml(ctx.teamName);
+  const intro = `<p>Hi ${safeFirstName},</p><p><strong>${safeInviter}</strong> added you to <strong>${safeTeam}</strong>'s AIOS Team Brain.</p>`;
+  const html = link
+    ? `<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:480px;margin:0 auto;padding:24px;color:#1a1a1a;">
+        ${intro}
+        <p style="margin:24px 0;">
+          <a href="${link}" style="background:#111;color:#fff;padding:12px 20px;border-radius:6px;text-decoration:none;font-weight:600;display:inline-block;">Sign in to AIOS</a>
+        </p>
+        <p style="color:#666;font-size:13px;">This link is single-use and expires in 24 hours. If you weren't expecting this, you can ignore this email.</p>
+      </div>`
+    : `<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:480px;margin:0 auto;padding:24px;color:#1a1a1a;">
+        ${intro}
+        <p>Open the team brain and sign in with this email address to get started.</p>
+      </div>`;
+
+  await deliver(email, subject, { text, html });
 }


### PR DESCRIPTION
## Summary
- Phase A1 of the onboarding overhaul plan (invite email → welcome screen → dashboard → workspace CLI).
- `sendInviteEmail` now takes `{ inviteeName, teamName, inviterName }` and sends an HTML body alongside the existing plain text, so the email actually names who invited you and to which team instead of a generic "you've been added" + bare link.
- No schema change — team name and inviter identity are already available in-request via the inviting admin's session.
- Names are attacker-controlled (display names), so the HTML body escapes them.

## Test plan
- [x] `npx vitest run lib/auth/mailer.test.ts` — 7/7 passing, including new personalization + HTML-escaping assertions
- [x] `tsc --noEmit` — no new errors in touched files
- [x] `eslint` on touched files — clean
- [x] pre-push docs-drift guard — routes/tables/sources in sync (no drift, this phase doesn't touch any guarded surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to invite email copy and delivery shape; HTML escaping mitigates XSS from display names, with no auth or schema changes.
> 
> **Overview**
> **Invite emails** now name the inviter and team instead of a generic “you’ve been added” message. The admin `inviteMember` flow loads **team name** and the inviting admin’s **display name** from the existing session query and passes them with the invitee’s display name into `sendInviteEmail`.
> 
> `sendInviteEmail` takes a new **`InviteEmailContext`**, uses a personalized **subject** (`{inviter} added you to {team} on AIOS`), greets by **first name** in plain text, and sends a styled **HTML** variant (CTA when a magic link exists). Shared **`deliver`** now accepts `{ text, html? }` for Resend and SMTP; magic-link mail stays text-only.
> 
> Display names are treated as untrusted in HTML: **`escapeHtml`** is applied before names appear in the HTML body. Tests cover personalization and escaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbaf3072d639288c592466f232f51c83f16f5452. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invite emails now include personalized details such as the invitee’s name, team name, and inviter name.
  * Admin areas can now surface the team name and your display name for a more personalized experience.

* **Bug Fixes**
  * Improved invite email rendering so names and other displayed text are safely escaped in HTML emails.
  * Invite emails now support both plain text and richer HTML formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->