### PR TITLE
feat(onboarding): add a first-login welcome screen

### DIFF
--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -28,7 +28,10 @@ export async function GET(request: NextRequest) {
       const dest = result.nextPath.startsWith("/") && !result.nextPath.startsWith("//")
         ? result.nextPath
         : "/";
-      const res = NextResponse.redirect(new URL(dest, base));
+      // First login (an invite being activated): route through the welcome screen
+      // instead of dropping straight onto the dashboard. Later logins are unaffected.
+      const target = result.firstLogin ? `/auth/welcome?next=${encodeURIComponent(dest)}` : dest;
+      const res = NextResponse.redirect(new URL(target, base));
       res.cookies.set(SESSION_COOKIE, await signSession(result.user), sessionCookieOptions());
       return res;
     }

--- a/app/auth/welcome/page.tsx
+++ b/app/auth/welcome/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { getSessionUser } from "@/lib/auth/session";
+import { getWelcomeContext } from "@/lib/auth/welcome-context";
+
+export const metadata: Metadata = { title: "Welcome" };
+
+function safeNext(next: string | undefined): string {
+  return next && next.startsWith("/") && !next.startsWith("//") ? next : "/";
+}
+
+function teamSlugFromPath(path: string): string | null {
+  const m = /^\/t\/([^/?]+)/.exec(path);
+  return m ? m[1] : null;
+}
+
+/**
+ * Shown once, on a member's first login (see app/auth/confirm/route.ts), instead of
+ * dropping them straight onto the dashboard with no acknowledgement of who they are
+ * or who invited them.
+ */
+export default async function WelcomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const { next } = await searchParams;
+  const dest = safeNext(next);
+
+  const user = await getSessionUser();
+  if (!user) redirect("/login");
+
+  const teamSlug = teamSlugFromPath(dest);
+  const ctx = teamSlug ? await getWelcomeContext(teamSlug, user.email) : null;
+  const firstName = ctx?.inviteeName.trim().split(/\s+/)[0] || "there";
+
+  return (
+    <main className="relative flex flex-1 items-center justify-center bg-surface-raised px-6 py-24">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(60% 50% at 50% 0%, rgba(124,58,237,0.07), transparent 70%), radial-gradient(40% 40% at 80% 100%, rgba(45,212,191,0.06), transparent 70%)",
+        }}
+      />
+      <div className="relative w-full max-w-sm">
+        <div className="bg-gradient-prism rounded-2xl p-[1px]">
+          <div className="rounded-2xl bg-surface-inset px-8 py-10">
+            <p className="font-display text-sm font-semibold uppercase tracking-[0.15em] text-gradient-prism">
+              Team Brain
+            </p>
+            <h1 className="mt-2 text-2xl font-semibold text-ink">Welcome, {firstName}</h1>
+            <p className="mt-1 mb-6 text-sm text-ink-secondary">
+              {ctx
+                ? ctx.inviterName
+                  ? `${ctx.inviterName} added you to ${ctx.teamName}.`
+                  : `You're joining ${ctx.teamName}.`
+                : "You're all set."}
+            </p>
+            <a href={dest} className="btn-prism w-full justify-center">
+              Continue to your dashboard
+            </a>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,6 +101,11 @@ Two principals, one tier model:
   round-trip; unknown emails 403). Trusts the email with no ownership proof — acceptable only
   for this self-hosted, small known-member instance (`lib/auth/pg-login.loginByEmail`). The
   session is a `jose`-signed httpOnly cookie (`lib/auth/pg-session`).
+  Invite links (`GET /auth/confirm`) instead use a single-use magic-link token
+  (`issueMagicToken`/`redeemMagicToken`). A member's **first** redemption (an invite being
+  activated) routes through `/auth/welcome` — name, team, and inviter (resolved from the
+  append-only `audit_log`, no `invited_by` column needed) — before landing on the dashboard;
+  later logins redirect straight through as before.
 - **Machines** — per-member API key `aios_<key_id>_<secret>` (sha256 at rest, shown
   once). Sync writes use the **service role** — confined to `lib/ingest`
   and audited on every write.

--- a/lib/auth/pg-login.ts
+++ b/lib/auth/pg-login.ts
@@ -86,6 +86,14 @@ export async function issueMagicToken(
 export interface RedeemResult {
   user: SessionUser;
   nextPath: string;
+  /** True iff this redemption activated an 'invited' member — the caller should show
+   * the one-time welcome screen instead of dropping straight onto the dashboard. */
+  firstLogin: boolean;
+}
+
+function teamSlugFromNextPath(nextPath: string): string | null {
+  const m = /^\/t\/([^/?]+)/.exec(nextPath);
+  return m ? m[1] : null;
 }
 
 /** Verify + consume a magic token; links the member and returns the session user. */
@@ -99,7 +107,22 @@ export async function redeemMagicToken(raw: string): Promise<RedeemResult | null
   );
   const tok = rows[0];
   if (!tok) return null;
+
+  // Capture 'invited' status BEFORE linkMemberByEmail activates it below.
+  let firstLogin = false;
+  const teamSlug = teamSlugFromNextPath(tok.next_path);
+  if (teamSlug) {
+    const { rows: memberRows } = await runSql<{ status: string }>(
+      `select m.status
+         from members m
+         join teams t on t.id = m.team_id
+        where t.slug = $1 and m.email = $2 and m.status <> 'disabled'`,
+      [teamSlug, tok.email]
+    );
+    firstLogin = memberRows[0]?.status === "invited";
+  }
+
   const id = await ensureAuthUser(tok.email);
   await linkMemberByEmail(id, tok.email);
-  return { user: { id, email: tok.email }, nextPath: tok.next_path };
+  return { user: { id, email: tok.email }, nextPath: tok.next_path, firstLogin };
 }

--- a/lib/auth/welcome-context.ts
+++ b/lib/auth/welcome-context.ts
@@ -1,0 +1,44 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+
+export interface WelcomeContext {
+  teamName: string;
+  inviteeName: string;
+  /** null when the member was created outside the invite UI (no audited actor). */
+  inviterName: string | null;
+}
+
+/**
+ * Resolve the "Welcome, {name} — you're joining {team}, invited by {inviter}" copy for a
+ * member's first login. Inviter identity is derived from the append-only `audit_log`
+ * (the `member.created` event recorded when they were invited) rather than a dedicated
+ * `invited_by` column — no schema change needed, and it degrades gracefully to null for
+ * members created without an audited actor (e.g. via the CLI as `system`).
+ */
+export async function getWelcomeContext(teamSlug: string, email: string): Promise<WelcomeContext | null> {
+  const { rows } = await runSql<{ team_name: string; member_id: string; display_name: string }>(
+    `select t.name as team_name, m.id as member_id, m.display_name
+       from members m
+       join teams t on t.id = m.team_id
+      where t.slug = $1 and m.email = $2 and m.status <> 'disabled'`,
+    [teamSlug, email]
+  );
+  const row = rows[0];
+  if (!row) return null;
+
+  const { rows: inviterRows } = await runSql<{ display_name: string }>(
+    `select inviter.display_name
+       from audit_log a
+       join members inviter on inviter.id = a.member_id
+      where a.target_type = 'member' and a.target_id = $1 and a.action = 'member.created'
+      order by a.created_at desc
+      limit 1`,
+    [row.member_id]
+  );
+
+  return {
+    teamName: row.team_name,
+    inviteeName: row.display_name,
+    inviterName: inviterRows[0]?.display_name ?? null,
+  };
+}

--- a/test/datamechanics/welcome-context.datamechanics.test.ts
+++ b/test/datamechanics/welcome-context.datamechanics.test.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createMember } from "@/lib/admin/members";
+import { issueMagicToken, redeemMagicToken } from "@/lib/auth/pg-login";
+import { getWelcomeContext } from "@/lib/auth/welcome-context";
+import { db, seedTeam } from "./helpers";
+
+// Spec: a member's first magic-link redemption (activating an invite) reports
+// firstLogin=true; a later redemption for the same member reports false. The welcome
+// screen's inviter name is derived from the append-only audit_log — no invited_by
+// column needed — and degrades to null for members created with no audited actor.
+// Verified to the observable outcome against real Postgres.
+
+describe("first-login welcome flow (real Postgres)", () => {
+  it("reports firstLogin=true on an invited member's first redemption, false on the next", async () => {
+    const seed = await seedTeam();
+    const email = `invitee-${randomUUID()}@test.local`;
+    await createMember(
+      db(),
+      seed.teamId,
+      { email, displayName: "Nina Invitee", actorHandle: `nina-${randomUUID().slice(0, 8)}`, role: "member" },
+      { actor: { kind: "member", memberId: seed.memberId } }
+    );
+
+    const firstToken = await issueMagicToken(email, `/t/${seed.teamSlug}`, 1440);
+    const firstResult = await redeemMagicToken(firstToken!);
+    expect(firstResult).not.toBeNull();
+    expect(firstResult!.firstLogin).toBe(true);
+
+    const secondToken = await issueMagicToken(email, `/t/${seed.teamSlug}`, 1440);
+    const secondResult = await redeemMagicToken(secondToken!);
+    expect(secondResult).not.toBeNull();
+    expect(secondResult!.firstLogin).toBe(false);
+  });
+
+  it("resolves the inviting admin's display name from the audit log", async () => {
+    const seed = await seedTeam();
+    const email = `invitee-${randomUUID()}@test.local`;
+    await createMember(
+      db(),
+      seed.teamId,
+      { email, displayName: "Nina Invitee", actorHandle: `nina-${randomUUID().slice(0, 8)}`, role: "member" },
+      { actor: { kind: "member", memberId: seed.memberId } }
+    );
+
+    const ctx = await getWelcomeContext(seed.teamSlug, email);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.inviteeName).toBe("Nina Invitee");
+    expect(ctx!.inviterName).toBe("Tester"); // seedTeam()'s seeded actor's display_name
+    expect(ctx!.teamName).toBe("Test Team");
+  });
+
+  it("resolves inviterName=null for a member created with no audited actor", async () => {
+    const seed = await seedTeam();
+    const email = `system-created-${randomUUID()}@test.local`;
+    await createMember(db(), seed.teamId, {
+      email,
+      displayName: "System Made",
+      actorHandle: `sysmade-${randomUUID().slice(0, 8)}`,
+      role: "member",
+    }); // no actor passed -> audit_log.member_id is null for this member.created event
+
+    const ctx = await getWelcomeContext(seed.teamSlug, email);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.inviterName).toBeNull();
+  });
+
+  it("returns null for an email with no member in this team", async () => {
+    const seed = await seedTeam();
+    expect(await getWelcomeContext(seed.teamSlug, "nobody@nowhere.test")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Phase A2 of the onboarding overhaul plan (stacks conceptually on #156).
- A member's first magic-link redemption now redirects through `/auth/welcome` ("Welcome, {name} — you're joining {team}, invited by {inviter}") instead of dropping silently onto the team dashboard. Later logins are unaffected — the redirect only changes for the `firstLogin` case.
- Inviter identity is derived from the existing append-only `audit_log` (the `member.created` event recorded when they were invited) — no `invited_by` column added.
- No schema change.

## Test plan
- [x] `npm run test:datamechanics:local` — 7/7 passing (real Postgres), including 4 new tests: firstLogin true→false across two redemptions, inviter-name resolution from audit_log, graceful null for members created with no audited actor, null context for an unknown email
- [x] `tsc --noEmit` — no new errors in touched files
- [x] `eslint` on touched files — clean
- [x] pre-push docs-drift guard — routes/tables/sources in sync
- [x] `docs/ARCHITECTURE.md` updated with the new welcome-screen flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auth onboarding UX only—session cookie behavior unchanged and no new persistence; `firstLogin` is scoped to magic-link redemption, not direct passwordless login.
> 
> **Overview**
> **First-time invite activation** no longer lands users directly on the team dashboard. When `redeemMagicToken` reports `firstLogin` (member was still `invited` before activation), `GET /auth/confirm` redirects to **`/auth/welcome?next=…`** with the session cookie set; later magic-link logins keep the previous direct redirect.
> 
> The new **`/auth/welcome`** page requires a session, sanitizes `next`, and shows personalized copy (first name, team, optional inviter). **`getWelcomeContext`** loads team/member data and resolves the inviter from the latest **`audit_log` `member.created`** row—no schema change; inviter is omitted when there is no audited actor.
> 
> **`redeemMagicToken`** now returns **`firstLogin`**, computed from team slug in `next_path` and member status before **`linkMemberByEmail`** flips `invited` → `active`. Architecture docs and datamechanics tests cover the `firstLogin` true→false behavior and audit-log inviter resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c97cab655d7927e8f240338b4e042894e659a3f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->