### PR TITLE
feat(onboarding): one-CTA dashboard for brand-new members

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -6,15 +6,23 @@ import { getSessionUser } from "@/lib/auth/session";
 import { CopySnippet } from "@/components/copy-snippet";
 import { getPulseMetrics } from "@/lib/metrics/pulse";
 import { parseRange } from "@/lib/metrics/range";
+import { pickHomeState } from "@/lib/dashboard/home-state";
 import { AskBrain } from "@/components/dashboard/ask-brain";
 import { KpiBand } from "@/components/dashboard/kpi-band";
 import { RangeSelector } from "@/components/dashboard/range-selector";
 import { DecisionsCard } from "@/components/dashboard/decisions-card";
 import { WorkingOn } from "@/components/dashboard/working-on";
+import { WorkstationSetup } from "@/components/dashboard/workstation-setup";
+import type { MyKeyRow } from "@/components/people/my-api-keys";
 import type { DecisionRow } from "@/components/dashboard/types";
 import { KnowledgeGrowth } from "@/components/charts/knowledge-growth";
 import { UsageChart } from "@/components/charts/usage-chart";
 import { TaskFunnel } from "@/components/charts/task-funnel";
+
+/** Placeholder until the personalized template lands (aios-workspace docs/getting-started/agent-onboarding.md). */
+function buildAgentPrompt(teamSlug: string): string {
+  return `You are onboarding a new AIOS individual contributor for the "${teamSlug}" team. Follow exactly: https://aiosbrain.dev/getting-started/onboarding-a-contributor/`;
+}
 
 function SetupChecklist({ teamSlug }: { teamSlug: string }) {
   const steps = [
@@ -90,7 +98,7 @@ export default async function TeamHome({
 
   const { data: me } = await supabase
     .from("members")
-    .select("id, role, tier")
+    .select("id, role, tier, display_name")
     .eq("team_id", team.id)
     .eq("auth_user_id", user?.id ?? "")
     .eq("status", "active")
@@ -98,6 +106,7 @@ export default async function TeamHome({
   const isAdmin = me?.role === "admin";
   const tier = ((me?.tier as "team" | "external" | undefined) ?? "external");
   const memberId = (me?.id as string | undefined) ?? "";
+  const firstName = ((me?.display_name as string | undefined) ?? "").trim().split(/\s+/)[0] || "there";
 
   // Tier-filtered count (no RLS backstop in postgres mode).
   const { count: itemCount } = await visibleItems(
@@ -105,11 +114,47 @@ export default async function TeamHome({
     tier
   );
 
-  if (!itemCount) {
+  // Has this member EVER issued their own key (revoked or not) — the proxy for "has this
+  // person's workstation setup even started," independent of whether the TEAM has synced
+  // anything yet (a member invited into an already-active team must still see this).
+  const { count: ownKeyCount } = await supabase
+    .from("api_keys")
+    .select("id", { count: "exact", head: true })
+    .eq("team_id", team.id)
+    .eq("member_id", memberId);
+
+  const homeState = pickHomeState({
+    isAdmin,
+    itemCount: itemCount ?? 0,
+    hasOwnKey: (ownKeyCount ?? 0) > 0,
+  });
+
+  if (homeState === "admin-bootstrap") {
     return (
       <div className="mx-auto max-w-3xl pt-8">
         <h1 className="mb-6 text-2xl font-semibold text-ink">Home</h1>
         <SetupChecklist teamSlug={teamSlug} />
+      </div>
+    );
+  }
+
+  if (homeState === "member-setup") {
+    const { data: keyRows } = await supabase
+      .from("api_keys")
+      .select("id, key_id, name, created_at, last_used_at, revoked_at")
+      .eq("team_id", team.id)
+      .eq("member_id", memberId)
+      .order("created_at", { ascending: false });
+
+    return (
+      <div className="mx-auto max-w-3xl pt-8">
+        <h1 className="mb-6 text-2xl font-semibold text-ink">Home</h1>
+        <WorkstationSetup
+          teamSlug={teamSlug}
+          firstName={firstName}
+          agentPrompt={buildAgentPrompt(teamSlug)}
+          keys={(keyRows ?? []) as MyKeyRow[]}
+        />
       </div>
     );
   }

--- a/components/admin/invite-member.tsx
+++ b/components/admin/invite-member.tsx
@@ -13,7 +13,7 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
     return (
       <button
         onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-2 rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+        className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
       >
         <UserPlus className="size-4" strokeWidth={1.75} />
         Invite member

--- a/components/admin/issue-key.tsx
+++ b/components/admin/issue-key.tsx
@@ -49,7 +49,7 @@ export function IssueKey({ teamSlug, members }: { teamSlug: string; members: Mem
     return (
       <button
         onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-2 rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+        className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
       >
         <KeyRound className="size-4" strokeWidth={1.75} />
         Issue key

--- a/components/dashboard/workstation-setup.tsx
+++ b/components/dashboard/workstation-setup.tsx
@@ -1,0 +1,40 @@
+import { Rocket } from "lucide-react";
+import { CopySnippet } from "@/components/copy-snippet";
+import { MyApiKeys, type MyKeyRow } from "@/components/people/my-api-keys";
+
+/**
+ * First-screen for a brand-new member (see lib/dashboard/home-state.pickHomeState):
+ * one CTA — a copy-paste prompt for whatever coding agent they use — plus inline
+ * self-serve key generation, collapsed into a single screen instead of sending them
+ * to hunt for their profile page first.
+ */
+export function WorkstationSetup({
+  teamSlug,
+  firstName,
+  agentPrompt,
+  keys,
+}: {
+  teamSlug: string;
+  firstName: string;
+  agentPrompt: string;
+  keys: MyKeyRow[];
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="bg-gradient-prism rounded-2xl p-[1px]">
+        <div className="rounded-2xl bg-surface-inset px-8 py-10">
+          <div className="mb-4 flex items-center gap-3">
+            <Rocket className="size-6 text-violet" strokeWidth={1.5} />
+            <h2 className="text-xl font-semibold text-ink">Set up your AIOS workstation, {firstName}</h2>
+          </div>
+          <p className="mb-6 text-sm text-ink-secondary">
+            One step: paste this into Claude Code, Claude Desktop, Cursor, Codex, or Opencode — it
+            scaffolds your personal workspace and connects it to this team&apos;s brain.
+          </p>
+          <CopySnippet label="agent prompt" text={agentPrompt} />
+        </div>
+      </div>
+      <MyApiKeys teamSlug={teamSlug} keys={keys} />
+    </div>
+  );
+}

--- a/components/people/my-api-keys.tsx
+++ b/components/people/my-api-keys.tsx
@@ -123,7 +123,7 @@ function IssueMyKey({ teamSlug }: { teamSlug: string }) {
     return (
       <button
         onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-2 rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+        className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
       >
         <KeyRound className="size-4" strokeWidth={1.75} />
         Generate key

--- a/lib/dashboard/home-state.test.ts
+++ b/lib/dashboard/home-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { pickHomeState } from "./home-state";
+
+describe("pickHomeState", () => {
+  it("admin-bootstrap: admin on a team with nothing synced yet, regardless of their own key", () => {
+    expect(pickHomeState({ isAdmin: true, itemCount: 0, hasOwnKey: false })).toBe("admin-bootstrap");
+    expect(pickHomeState({ isAdmin: true, itemCount: 0, hasOwnKey: true })).toBe("admin-bootstrap");
+  });
+
+  it("member-setup: a non-admin who has never issued their own key, even on an already-active team", () => {
+    expect(pickHomeState({ isAdmin: false, itemCount: 0, hasOwnKey: false })).toBe("member-setup");
+    expect(pickHomeState({ isAdmin: false, itemCount: 42, hasOwnKey: false })).toBe("member-setup");
+  });
+
+  it("dashboard: everyone else", () => {
+    expect(pickHomeState({ isAdmin: false, itemCount: 42, hasOwnKey: true })).toBe("dashboard");
+    expect(pickHomeState({ isAdmin: false, itemCount: 0, hasOwnKey: true })).toBe("dashboard");
+    expect(pickHomeState({ isAdmin: true, itemCount: 42, hasOwnKey: false })).toBe("dashboard");
+    expect(pickHomeState({ isAdmin: true, itemCount: 42, hasOwnKey: true })).toBe("dashboard");
+  });
+});

--- a/lib/dashboard/home-state.ts
+++ b/lib/dashboard/home-state.ts
@@ -1,0 +1,23 @@
+export type HomeState = "admin-bootstrap" | "member-setup" | "dashboard";
+
+/**
+ * Which first-screen a team member sees. Pure so the truth table is unit-testable
+ * without a DB — the page wiring (app/t/[team]/page.tsx) supplies the inputs.
+ *
+ * "member-setup" is deliberately independent of `itemCount`: a member invited into an
+ * already-active team never had a zero-item team to trigger the old team-scoped
+ * checklist, so they'd otherwise land on the generic dashboard with no nudge at all.
+ */
+export function pickHomeState({
+  isAdmin,
+  itemCount,
+  hasOwnKey,
+}: {
+  isAdmin: boolean;
+  itemCount: number;
+  hasOwnKey: boolean;
+}): HomeState {
+  if (isAdmin && itemCount === 0) return "admin-bootstrap";
+  if (!isAdmin && !hasOwnKey) return "member-setup";
+  return "dashboard";
+}

--- a/test/datamechanics/home-state.datamechanics.test.ts
+++ b/test/datamechanics/home-state.datamechanics.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { pickHomeState } from "@/lib/dashboard/home-state";
+import { db, ingest, seedTeam } from "./helpers";
+
+// Spec: a non-admin member invited into an ALREADY-ACTIVE team (itemCount > 0) with zero
+// api_keys ever issued must land on "member-setup" — the root-cause bug this phase fixes
+// (the old team-scoped-only checklist never fired for this exact scenario, since it only
+// showed when the whole TEAM had zero synced items). Once that member issues a key, the
+// same team+member flips to "dashboard". Verified against real Postgres so the query shape
+// (api_keys existence per member, independent of revoked_at) is exercised, not just the
+// pure decision function in isolation.
+
+describe("dashboard home-state on an active team with a brand-new member (real Postgres)", () => {
+  it("member-setup fires for a member with no key, even though the team already has synced items", async () => {
+    const seed = await seedTeam();
+    await ingest(seed, { path: "docs/plan.md", body: "already active", access: "team" });
+
+    const { count: itemCount } = await db()
+      .from("items")
+      .select("id", { count: "exact", head: true })
+      .eq("team_id", seed.teamId);
+    expect(itemCount ?? 0).toBeGreaterThan(0); // non-vacuity: team really is active
+
+    const { count: ownKeyCount } = await db()
+      .from("api_keys")
+      .select("id", { count: "exact", head: true })
+      .eq("team_id", seed.teamId)
+      .eq("member_id", seed.memberId);
+    expect(ownKeyCount ?? 0).toBe(0);
+
+    expect(
+      pickHomeState({ isAdmin: false, itemCount: itemCount ?? 0, hasOwnKey: (ownKeyCount ?? 0) > 0 })
+    ).toBe("member-setup");
+  });
+
+  it("flips to dashboard once that same member issues a key", async () => {
+    const seed = await seedTeam();
+    await ingest(seed, { path: "docs/plan.md", body: "already active", access: "team" });
+    await db()
+      .from("api_keys")
+      .insert({
+        team_id: seed.teamId,
+        member_id: seed.memberId,
+        key_id: `k-${seed.memberId.slice(0, 8)}`,
+        key_hash: "irrelevant-hash-for-this-test",
+        name: "laptop",
+      });
+
+    const { count: itemCount } = await db()
+      .from("items")
+      .select("id", { count: "exact", head: true })
+      .eq("team_id", seed.teamId);
+    const { count: ownKeyCount } = await db()
+      .from("api_keys")
+      .select("id", { count: "exact", head: true })
+      .eq("team_id", seed.teamId)
+      .eq("member_id", seed.memberId);
+    expect(ownKeyCount ?? 0).toBe(1);
+
+    expect(
+      pickHomeState({ isAdmin: false, itemCount: itemCount ?? 0, hasOwnKey: (ownKeyCount ?? 0) > 0 })
+    ).toBe("dashboard");
+  });
+});


### PR DESCRIPTION
## Summary
- Phase A3+A4 of the onboarding overhaul plan (stacks conceptually on #156, #157).
- Root-cause fix: the old "nothing synced yet" checklist was **team**-scoped, so a member invited into an already-active team never saw any nudge at all — exactly the "it just dumps you on the dashboard with no next step" complaint.
- New pure `pickHomeState()` (unit-tested truth table) picks between three states using a member-scoped signal (has this person ever issued their own API key) alongside the existing team-scoped one:
  - admin, team has nothing synced yet → existing admin bootstrap checklist
  - non-admin with no key of their own → new one-CTA `WorkstationSetup` screen
  - everyone else → the normal dashboard
- **Important finding**: self-serve API key issuance already exists and is already data-mechanics-tested (`issueMyApiKey`/`MyApiKeys`) — this PR surfaces it from the dashboard (collapsing "go find your profile page" into the one CTA), it doesn't build new issuance capability.
- Also fixes the "potato-shaped" `Issue key` / `Invite member` / `Generate key` buttons — they were unguarded flex items next to long description text with no `shrink-0`/`whitespace-nowrap`, so under width pressure the button (not the paragraph) would shrink and its label would wrap to two lines.
- The `WorkstationSetup` CTA currently ships a placeholder agent prompt string; a follow-up phase (B6) replaces it with a real personalized template once the aios-workspace side of this plan lands.

## Test plan
- [x] `npx vitest run lib/dashboard/home-state.test.ts` — 3/3, the full three-way truth table
- [x] `npm run test:datamechanics:local` (new `home-state.datamechanics.test.ts`) — 2/2, seeded against real Postgres: an already-active team's brand-new member lands on member-setup, flips to dashboard once they issue a key
- [x] `tsc --noEmit` — no new errors in touched files
- [x] `eslint` on touched files — clean
- [x] pre-push docs-drift guard — routes/tables/sources in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding and dashboard routing only; reuses existing self-serve key issuance with no new auth or data-model changes.
> 
> **Overview**
> Fixes onboarding for **non-admins invited into teams that already have synced content**: home no longer keys only off team `itemCount === 0`, so those members were dropped on the full dashboard with no next step.
> 
> **`pickHomeState()`** chooses three first screens: admins on empty teams still get the existing bootstrap checklist; non-admins who have **never** issued their own API key (any row in `api_keys`, revoked or not) get a new **`WorkstationSetup`** view with a copy-paste agent prompt (placeholder URL for now) and inline **`MyApiKeys`**; everyone else gets the normal dashboard. The team home page loads `display_name` for greeting and runs the per-member key count query to drive that logic.
> 
> Minor UI: **Invite member**, **Issue key**, and **Generate key** buttons get `shrink-0` / `whitespace-nowrap` so labels don’t wrap under flex pressure.
> 
> Coverage: unit truth table for `pickHomeState` plus datamechanics tests against Postgres for the active-team / no-key scenario and flip after key issuance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a06d62d273b4918b9778a5bbb1225b654b77519. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->