### PR TITLE
feat(onboarding): personalize the agent-onboarding CTA prompt

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -7,6 +7,7 @@ import { CopySnippet } from "@/components/copy-snippet";
 import { getPulseMetrics } from "@/lib/metrics/pulse";
 import { parseRange } from "@/lib/metrics/range";
 import { pickHomeState } from "@/lib/dashboard/home-state";
+import { buildAgentOnboardingPrompt } from "@/lib/onboarding/agent-prompt";
 import { AskBrain } from "@/components/dashboard/ask-brain";
 import { KpiBand } from "@/components/dashboard/kpi-band";
 import { RangeSelector } from "@/components/dashboard/range-selector";
@@ -18,11 +19,6 @@ import type { DecisionRow } from "@/components/dashboard/types";
 import { KnowledgeGrowth } from "@/components/charts/knowledge-growth";
 import { UsageChart } from "@/components/charts/usage-chart";
 import { TaskFunnel } from "@/components/charts/task-funnel";
-
-/** Placeholder until the personalized template lands (aios-workspace docs/getting-started/agent-onboarding.md). */
-function buildAgentPrompt(teamSlug: string): string {
-  return `You are onboarding a new AIOS individual contributor for the "${teamSlug}" team. Follow exactly: https://aiosbrain.dev/getting-started/onboarding-a-contributor/`;
-}
 
 function SetupChecklist({ teamSlug }: { teamSlug: string }) {
   const steps = [
@@ -152,7 +148,10 @@ export default async function TeamHome({
         <WorkstationSetup
           teamSlug={teamSlug}
           firstName={firstName}
-          agentPrompt={buildAgentPrompt(teamSlug)}
+          agentPrompt={buildAgentOnboardingPrompt({
+            teamSlug,
+            brainUrl: (process.env.APP_URL ?? "").replace(/\/$/, ""),
+          })}
           keys={(keyRows ?? []) as MyKeyRow[]}
         />
       </div>

--- a/lib/onboarding/agent-prompt.test.ts
+++ b/lib/onboarding/agent-prompt.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentOnboardingPrompt } from "./agent-prompt";
+
+describe("buildAgentOnboardingPrompt", () => {
+  it("substitutes the team slug and brain url into the scaffold command", () => {
+    const prompt = buildAgentOnboardingPrompt({
+      teamSlug: "acme",
+      brainUrl: "https://brain.acme.example.com",
+    });
+
+    expect(prompt).toContain('"acme" team');
+    expect(prompt).toContain("--brain-url https://brain.acme.example.com");
+    expect(prompt).toContain("--team-id acme");
+  });
+
+  it("keeps the human-readable doc URL as a fallback for non-agent readers", () => {
+    const prompt = buildAgentOnboardingPrompt({ teamSlug: "acme", brainUrl: "https://x.test" });
+    expect(prompt).toContain("https://aiosbrain.dev/getting-started/onboarding-a-contributor/");
+  });
+
+  it("tells the agent to self-serve the API key from the dashboard, not an admin", () => {
+    const prompt = buildAgentOnboardingPrompt({ teamSlug: "acme", brainUrl: "https://x.test" });
+    expect(prompt).toMatch(/My API keys.*not from an admin/s);
+  });
+});

--- a/lib/onboarding/agent-prompt.ts
+++ b/lib/onboarding/agent-prompt.ts
@@ -1,0 +1,34 @@
+export interface AgentPromptContext {
+  teamSlug: string;
+  /** This deployment's own base URL (APP_URL) — the brain a scaffolded workspace should connect to. */
+  brainUrl: string;
+}
+
+/**
+ * The one-click "hand this to your coding agent" prompt shown on a brand-new member's
+ * dashboard (components/dashboard/workstation-setup.tsx). Personalizes the AF1
+ * "Contributor scaffold prompt" (aios-workspace/docs/getting-started/agent-onboarding.md)
+ * with this team's actual brain_url/team_id so the agent can scaffold and connect
+ * without asking the human to look those values up — the doc URL stays as the
+ * canonical human-readable fallback for anyone who'd rather read and run commands
+ * themselves. Pure string template — no I/O, easy to keep in sync by eye with the
+ * source doc in the sibling aios-workspace repo.
+ */
+export function buildAgentOnboardingPrompt({ teamSlug, brainUrl }: AgentPromptContext): string {
+  return [
+    `You are onboarding a new AIOS individual contributor for the "${teamSlug}" team.`,
+    `Follow exactly: https://aiosbrain.dev/getting-started/onboarding-a-contributor/`,
+    ``,
+    `Rules:`,
+    `- Run every command in order. Do not skip validation/validate-all.sh.`,
+    `- Ask for the contributor's handle if not given, then scaffold with:`,
+    `    --slug {handle}-workspace --brain-url ${brainUrl} --team-id ${teamSlug} --output ~/Projects/{handle}-workspace`,
+    `  (unless told otherwise).`,
+    `- Stop and report a BLOCKER if a step requires human admin action, browser OAuth, or a secret you cannot obtain.`,
+    `- Never commit API keys. Put AIOS_API_KEY in .env only — generate it from this dashboard's`,
+    `  "My API keys" panel (your own profile page), not from an admin.`,
+    `- After setup, run: aios status (must connect), validation/validate-all.sh . (exit 0).`,
+    ``,
+    `Report: workspace path, aios status summary, validate-all exit code, and every BLOCKER step.`,
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- Phase B6 of the onboarding overhaul plan — closes the loop between the two repos. **Stacked on #158** (base branch is `feat/onboarding-dashboard-cta`), since this replaces that PR's placeholder `buildAgentPrompt`. Review #158 first; this diff is just the B6 delta.
- New `lib/onboarding/agent-prompt.ts`: substitutes this team's actual `brain_url`/`team_id` into the AF1 "Contributor scaffold prompt" template (aios-workspace's `docs/getting-started/agent-onboarding.md`), so an agent driving setup via the copy-paste prompt doesn't have to ask the human to look those values up.
- Also updates the prompt to tell the agent to self-serve the API key from the dashboard's "My API keys" panel (already built in #158) instead of asking a team admin — matching the actual capability that exists today.
- The plain doc URL (`https://aiosbrain.dev/getting-started/onboarding-a-contributor/`) stays in the prompt as the fallback for anyone who'd rather read and run commands themselves.

## Test plan
- [x] `npx vitest run lib/onboarding/agent-prompt.test.ts` — 3/3: team/brain-url substitution, doc-URL fallback present, self-serve-key instruction present
- [x] `tsc --noEmit` / `eslint` — clean
- [x] `node scripts/check-docs-drift.mjs` + pre-push guard — routes/tables/sources in sync (no drift, this phase doesn't touch any guarded surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-template onboarding copy only; no auth, API, or persistence changes beyond passing existing env and team slug into the prompt.
> 
> **Overview**
> Replaces the team home **placeholder** agent prompt with a shared **`buildAgentOnboardingPrompt`** helper that injects the real **team slug** and deployment **`APP_URL`** (as `--brain-url` / `--team-id`) into the scaffold instructions.
> 
> The generated text is a fuller **AF1 contributor onboarding** template: ordered commands, validation expectations, blocker reporting, and guidance to create **`AIOS_API_KEY`** from the dashboard **My API keys** panel instead of asking an admin—while keeping the public doc URL for humans who prefer to read the guide.
> 
> **`WorkstationSetup`** on the member-setup home path now receives this personalized string; **three unit tests** lock in substitution, doc fallback, and self-serve key wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f9d4c8c603571013535162a8161c03fd028a964. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->