### PR TITLE
refactor: rename supabase-named identifiers to db (open-source cleanup)

### DIFF
--- a/app/actions/decisions.ts
+++ b/app/actions/decisions.ts
@@ -39,9 +39,9 @@ export async function createDecisionAction(
     return { ok: false, error: "admins and leads only" };
   }
 
-  const supabase = await serverClient();
+  const db = await serverClient();
   for (let attempt = 0; attempt < 2; attempt++) {
-    const { data, error } = await supabase
+    const { data, error } = await db
       .from("decisions")
       .insert({
         team_id: input.teamId,
@@ -72,8 +72,8 @@ export async function setDecisionValidityAction(
   decisionId: string,
   stillValid: boolean
 ): Promise<{ ok: boolean; error?: string }> {
-  const supabase = await serverClient();
-  const { data: decision } = await supabase
+  const db = await serverClient();
+  const { data: decision } = await db
     .from("decisions")
     .select("team_id")
     .eq("id", decisionId)
@@ -85,7 +85,7 @@ export async function setDecisionValidityAction(
     return { ok: false, error: "admins and leads only" };
   }
 
-  const { error } = await supabase
+  const { error } = await db
     .from("decisions")
     .update({ still_valid: stillValid, updated_at: new Date().toISOString() })
     .eq("id", decisionId);

--- a/app/actions/projects.ts
+++ b/app/actions/projects.ts
@@ -27,8 +27,8 @@ export async function createProjectAction(input: {
   const me = await currentMember(input.teamId);
   if (!me) return { ok: false, error: "not a member of this team" };
 
-  const supabase = await serverClient();
-  const { data, error } = await supabase
+  const db = await serverClient();
+  const { data, error } = await db
     .from("projects")
     .insert({ team_id: input.teamId, slug, name })
     .select("id, slug, name")

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -11,9 +11,8 @@ import { projectTaskByIdAfterWrite } from "@/lib/pm-sync";
 import { TASK_STATUSES, type Task, type TaskStatus } from "@/components/kanban/types";
 
 /**
- * Backend-agnostic task mutations initiated from the Kanban board. In supabase
- * mode these also satisfy RLS; in postgres mode the currentMember() guard is
- * the access control. (Browser → server action so no PostgREST is needed.)
+ * Task mutations initiated from the Kanban board. There is no RLS on the postgres target, so the
+ * `currentMember()` guard is the access control. (Browser → server action so no PostgREST is needed.)
  *
  * Reactive projection (brain-api v1.2 Phase 2): each successful write schedules a single-row
  * projection into the team's primary PM tool via `after()` (runs after the response). It loads the
@@ -44,8 +43,8 @@ export async function moveTaskAction(
   status: TaskStatus
 ): Promise<{ ok: boolean; error?: string }> {
   if (!TASK_STATUSES.includes(status)) return { ok: false, error: "invalid status" };
-  const supabase = await serverClient();
-  const { data: task } = await supabase
+  const db = await serverClient();
+  const { data: task } = await db
     .from("tasks")
     .select("team_id")
     .eq("id", taskId)
@@ -54,7 +53,7 @@ export async function moveTaskAction(
   const me = await currentMember((task as { team_id: string }).team_id);
   if (!me) return { ok: false, error: "not a member of this team" };
 
-  const { error } = await supabase
+  const { error } = await db
     .from("tasks")
     .update({ status, updated_at: new Date().toISOString() })
     .eq("id", taskId);
@@ -71,12 +70,12 @@ export async function createTaskAction(
   const me = await currentMember(input.teamId);
   if (!me) return { ok: false, error: "not a member of this team" };
 
-  const supabase = await serverClient();
+  const db = await serverClient();
   // Mint a stable `ui-` row_key so the task is visible to `GET /api/v1/tasks`
   // writeback (which filters `row_key is not null`) and round-trips into tasks.md.
   // Retry once on the (team_id,project_id,row_key) unique constraint.
   for (let attempt = 0; attempt < 2; attempt++) {
-    const { data, error } = await supabase
+    const { data, error } = await db
       .from("tasks")
       .insert({
         team_id: input.teamId,
@@ -124,8 +123,8 @@ export async function updateTaskAction(
   input: UpdateTaskInput
 ): Promise<{ ok: boolean; error?: string }> {
   if (!input.taskId) return { ok: false, error: "taskId required" };
-  const supabase = await serverClient();
-  const { data: task } = await supabase
+  const db = await serverClient();
+  const { data: task } = await db
     .from("tasks")
     .select("team_id, project_id, row_key")
     .eq("id", input.taskId)
@@ -149,7 +148,7 @@ export async function updateTaskAction(
     const parent = (input.parentRowKey ?? "").trim();
     if (parent) {
       if (parent === row.row_key) return { ok: false, error: "a task cannot be its own parent" };
-      const { data: parentRow } = await supabase
+      const { data: parentRow } = await db
         .from("tasks")
         .select("id")
         .eq("team_id", row.team_id)
@@ -161,7 +160,7 @@ export async function updateTaskAction(
       // Cycle guard: walk ancestors up from the proposed parent over the project's current edges;
       // reaching this row's own key means the new edge would form a loop. Bounded by the edge count
       // so a pre-existing data cycle can't spin forever.
-      const { data: edgeRows } = await supabase
+      const { data: edgeRows } = await db
         .from("tasks")
         .select("row_key, parent_row_key")
         .eq("team_id", row.team_id)
@@ -181,7 +180,7 @@ export async function updateTaskAction(
     update.parent_row_key = parent || null;
   }
 
-  const { error } = await supabase.from("tasks").update(update).eq("id", input.taskId);
+  const { error } = await db.from("tasks").update(update).eq("id", input.taskId);
   if (error) return { ok: false, error: error.message };
   scheduleProjection(input.taskId);
   return { ok: true };

--- a/app/api/auth/slack/callback/route.ts
+++ b/app/api/auth/slack/callback/route.ts
@@ -65,14 +65,14 @@ async function slackAuthTest(token: string): Promise<AuthTest> {
 }
 
 export async function GET(req: NextRequest) {
-  const supabase = adminClient();
+  const db = adminClient();
   const params = new URL(req.url).searchParams;
   const code = params.get("code");
   const state = params.get("state");
   const errorParam = params.get("error");
 
   const clientIp = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
-  if (!(await rateLimit(supabase, `slack-oauth:callback:${clientIp}`, 30))) {
+  if (!(await rateLimit(db, `slack-oauth:callback:${clientIp}`, 30))) {
     return htmlPage(429, "Too many attempts", "Please wait a minute and try connecting Slack again.");
   }
 
@@ -84,7 +84,7 @@ export async function GET(req: NextRequest) {
   }
 
   // Verify + consume the single-use state FIRST (CSRF/replay guard). Invalid/expired/used → stop.
-  const bound = await consumeSlackOAuthState(supabase, state);
+  const bound = await consumeSlackOAuthState(db, state);
   if (!bound) return denied();
 
   // User declined consent (Slack sends ?error with no code): nonce already consumed, store nothing.
@@ -101,7 +101,7 @@ export async function GET(req: NextRequest) {
     return htmlPage(422, "Slack connection failed", "Slack did not return a valid user token. You can close this tab and try again.");
   }
 
-  await setMemberSecret(supabase, { teamId: bound.teamId, memberId: bound.memberId }, "slack", token, {
+  await setMemberSecret(db, { teamId: bound.teamId, memberId: bound.memberId }, "slack", token, {
     slack_user_id: test.user_id,
     workspace: test.team ?? null,
     workspace_id: test.team_id ?? null,
@@ -109,7 +109,7 @@ export async function GET(req: NextRequest) {
   });
 
   // Capture the member's Slack identity so resolve + `slack dm --member` work afterward (best-effort).
-  const { data: m } = await supabase
+  const { data: m } = await db
     .from("members")
     .select("email")
     .eq("team_id", bound.teamId)
@@ -117,7 +117,7 @@ export async function GET(req: NextRequest) {
     .maybeSingle();
   try {
     await setMemberIdentity(
-      supabase,
+      db,
       bound.teamId,
       bound.memberId,
       { provider: "slack", externalId: test.user_id, handle: test.user ?? "", email: (m?.email as string) ?? "" },

--- a/app/api/auth/slack/start/route.ts
+++ b/app/api/auth/slack/start/route.ts
@@ -23,8 +23,8 @@ export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:slack-oauth:start`, 30))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:slack-oauth:start`, 30))) {
     return errorResponse("rate_limited", "30 starts/min per key", 429);
   }
 
@@ -35,9 +35,9 @@ export async function GET(req: NextRequest) {
   }
 
   // Opportunistic hygiene: drop this member's expired nonces (no GC job needed for v1).
-  await supabase.from("oauth_states").delete().eq("member_id", auth.memberId).lt("expires_at", new Date().toISOString());
+  await db.from("oauth_states").delete().eq("member_id", auth.memberId).lt("expires_at", new Date().toISOString());
 
-  const state = await createSlackOAuthState(supabase, auth.teamId, auth.memberId);
+  const state = await createSlackOAuthState(db, auth.teamId, auth.memberId);
 
   const params = new URLSearchParams({
     client_id: clientId,

--- a/app/api/auth/slack/status/route.ts
+++ b/app/api/auth/slack/status/route.ts
@@ -19,12 +19,12 @@ export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:slack-oauth:status`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:slack-oauth:status`, 60))) {
     return errorResponse("rate_limited", "60 reads/min per key", 429);
   }
 
-  const rec = await getMemberSecret(supabase, auth.teamId, auth.memberId, "slack");
+  const rec = await getMemberSecret(db, auth.teamId, auth.memberId, "slack");
   return Response.json(
     {
       connected: !!rec,

--- a/app/api/dashboard/query/route.ts
+++ b/app/api/dashboard/query/route.ts
@@ -31,7 +31,7 @@ const SSE_HEADERS = {
  * connector for the team instead of asking the LLM. team-tier only + its own rate limit (enforced
  * by the caller); writes go through the single-writer ingestion underneath, and the run is audited.
  */
-function syncResponse(supabase: ReturnType<typeof adminClient>, teamId: string, memberId: string): Response {
+function syncResponse(db: ReturnType<typeof adminClient>, teamId: string, memberId: string): Response {
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     async start(controller) {
@@ -43,7 +43,7 @@ function syncResponse(supabase: ReturnType<typeof adminClient>, teamId: string, 
         send("delta", { text: r.summary });
         send("sources", { sources: [] });
         send("done", { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cost_usd: 0 });
-        await audit(supabase, {
+        await audit(db, {
           team_id: teamId,
           actor_kind: "member",
           member_id: memberId,
@@ -130,7 +130,7 @@ export async function POST(req: NextRequest) {
   const timeZone = pickTimezone([tz, prof?.timezone, DEFAULT_TIMEZONE]);
 
   const memberTier = me.tier as "team" | "external";
-  const supabase = adminClient();
+  const db = adminClient();
 
   // The query box doubles as a scrape trigger: "/sync" / "scrape now" / … pulls every enabled
   // connector instead of asking the LLM. team-tier only (external collaborators can't trigger a
@@ -139,20 +139,20 @@ export async function POST(req: NextRequest) {
     if (memberTier === "external") {
       return errorResponse("forbidden", "scraping is available to team members only", 403);
     }
-    if (!(await rateLimit(supabase, `${me.id}:sync`, 2))) {
+    if (!(await rateLimit(db, `${me.id}:sync`, 2))) {
       return errorResponse("rate_limited", "2 scrapes/min per member — try again shortly", 429);
     }
-    return syncResponse(supabase, team.id, me.id);
+    return syncResponse(db, team.id, me.id);
   }
 
-  if (!(await rateLimit(supabase, `${me.id}:query`, 10))) {
+  if (!(await rateLimit(db, `${me.id}:query`, 10))) {
     return errorResponse("rate_limited", "10 queries/min per member", 429);
   }
 
   // Daily guards: per-member count + per-team budget from query_log
   const dayStart = new Date();
   dayStart.setHours(0, 0, 0, 0);
-  const { count: todayCount } = await supabase
+  const { count: todayCount } = await db
     .from("query_log")
     .select("id", { count: "exact", head: true })
     .eq("member_id", me.id)
@@ -160,7 +160,7 @@ export async function POST(req: NextRequest) {
   if ((todayCount ?? 0) >= DAILY_QUERIES_PER_MEMBER) {
     return errorResponse("rate_limited", `${DAILY_QUERIES_PER_MEMBER} queries/day per member`, 429);
   }
-  const { data: spend } = await supabase
+  const { data: spend } = await db
     .from("query_log")
     .select("cost_usd")
     .eq("team_id", team.id)
@@ -174,23 +174,23 @@ export async function POST(req: NextRequest) {
   // Load the prior turns for the LLM memory window BEFORE persisting the current question, then
   // record the user message. The assistant message is persisted once the answer finishes streaming.
   const owner = { teamId: team.id, memberId: me.id };
-  let conversationId = conversation_id && (await ownsConversation(supabase, owner, conversation_id)) ? conversation_id : null;
-  const priorTurns = conversationId ? await recentTurns(supabase, owner, conversationId) : [];
+  let conversationId = conversation_id && (await ownsConversation(db, owner, conversation_id)) ? conversation_id : null;
+  const priorTurns = conversationId ? await recentTurns(db, owner, conversationId) : [];
   let createdNew = false;
   if (!conversationId) {
-    const created = await createConversation(supabase, owner, question);
+    const created = await createConversation(db, owner, question);
     conversationId = created?.id ?? null;
     createdNew = true;
   }
-  if (conversationId) await appendMessage(supabase, owner, conversationId, "user", question);
+  if (conversationId) await appendMessage(db, owner, conversationId, "user", question);
 
   const started = Date.now();
-  const ctx = await retrieve(supabase, team.id, memberTier, question, project);
+  const ctx = await retrieve(db, team.id, memberTier, question, project);
 
   // Per-team provider keys (encrypted in integrations); null → env fallback in streamAnswer.
   const [anthropicKey, openaiKey] = await Promise.all([
-    getProviderKey(supabase, team.id, "anthropic"),
-    getProviderKey(supabase, team.id, "openai"),
+    getProviderKey(db, team.id, "anthropic"),
+    getProviderKey(db, team.id, "openai"),
   ]);
 
   const encoder = new TextEncoder();
@@ -225,7 +225,7 @@ export async function POST(req: NextRequest) {
 
             // Persist the assistant turn into the thread (full answer + cited sources + cost).
             if (conversationId) {
-              await appendMessage(supabase, owner, conversationId, "assistant", answer, {
+              await appendMessage(db, owner, conversationId, "assistant", answer, {
                 cited_item_ids: sources.map((s) => s.item_id).filter((id): id is string => Boolean(id)),
                 input_tokens: chunk.usage.input_tokens,
                 output_tokens: chunk.usage.output_tokens,
@@ -233,11 +233,11 @@ export async function POST(req: NextRequest) {
               });
               // On a new thread, replace the derived title with a short LLM-written one (bounded).
               if (createdNew) {
-                await generateAndSetTitle(supabase, owner, conversationId, question, answer, { anthropicKey, openaiKey });
+                await generateAndSetTitle(db, owner, conversationId, question, answer, { anthropicKey, openaiKey });
               }
             }
 
-            await supabase.from("query_log").insert({
+            await db.from("query_log").insert({
               team_id: team.id,
               member_id: me.id,
               question,

--- a/app/api/v1/actions/route.ts
+++ b/app/api/v1/actions/route.ts
@@ -19,8 +19,8 @@ export async function POST(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:actions:post`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:actions:post`, 60))) {
     return errorResponse("rate_limited", "60 actions/min per key", 429);
   }
 
@@ -37,7 +37,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const outcome = await runAction(
-      supabase,
+      db,
       {
         teamId: auth.teamId,
         memberId: auth.memberId,

--- a/app/api/v1/codebases/route.ts
+++ b/app/api/v1/codebases/route.ts
@@ -22,8 +22,8 @@ export async function POST(req: NextRequest) {
     return errorResponse("forbidden_tier", "codebase metrics are team-tier only", 403);
   }
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:codebases:post`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:codebases:post`, 60))) {
     return errorResponse("rate_limited", "60 scans/min per key", 429);
   }
 
@@ -51,8 +51,8 @@ export async function POST(req: NextRequest) {
   const headSha = parsed.data.metrics?.head_sha;
 
   try {
-    const result = await ingestCodebaseScan(supabase, auth, parsed.data);
-    await recordIngestRun(supabase, {
+    const result = await ingestCodebaseScan(db, auth, parsed.data);
+    await recordIngestRun(db, {
       teamId: auth.teamId,
       source: "scan",
       trigger,
@@ -64,7 +64,7 @@ export async function POST(req: NextRequest) {
     return Response.json({ status: "ok", ...result }, { status: 201 });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "scan ingest failed";
-    await recordIngestRun(supabase, {
+    await recordIngestRun(db, {
       teamId: auth.teamId,
       source: "scan",
       trigger,

--- a/app/api/v1/company-graph/route.ts
+++ b/app/api/v1/company-graph/route.ts
@@ -42,20 +42,20 @@ export async function GET(req: NextRequest) {
     return errorResponse("forbidden_tier", "the company graph is team-tier only", 403);
   }
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:company-graph:get`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:company-graph:get`, 60))) {
     return errorResponse("rate_limited", "60 reads/min per key", 429);
   }
 
   // One entity read serves both halves: `people[]` (entity_type=actor) and the
   // server-side join that resolves ownership edge targets (typically workflows).
   const [entitiesRes, edgesRes] = await Promise.all([
-    supabase
+    db
       .from("graph_entities")
       .select("entity_id, entity_type, name, attrs")
       .eq("team_id", auth.teamId)
       .order("entity_id"),
-    supabase
+    db
       .from("graph_relationships")
       .select("from_id, to_id, relationship_type")
       .eq("team_id", auth.teamId)

--- a/app/api/v1/costs/route.ts
+++ b/app/api/v1/costs/route.ts
@@ -17,8 +17,8 @@ export async function POST(req: NextRequest) {
     return errorResponse("forbidden_tier", "usage costs are team-tier only", 403);
   }
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:costs:post`, 120))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:costs:post`, 120))) {
     return errorResponse("rate_limited", "120 cost pushes/min per key", 429);
   }
 
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const result = await ingestUsageCost(supabase, auth, parsed.data);
+    const result = await ingestUsageCost(db, auth, parsed.data);
     return Response.json({ status: "ok", ...result }, { status: 201 });
   } catch (e) {
     // An unknown member handle is a client input error (the caller sent a handle the team

--- a/app/api/v1/decisions/route.ts
+++ b/app/api/v1/decisions/route.ts
@@ -16,15 +16,15 @@ export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:decisions:get`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:decisions:get`, 60))) {
     return errorResponse("rate_limited", "60 pulls/min per key", 429);
   }
 
   const since = new URL(req.url).searchParams.get("since") || "1970-01-01T00:00:00Z";
 
   try {
-    const decisions = await getDecisionWriteback(supabase, auth.teamId, auth.memberTier, since);
+    const decisions = await getDecisionWriteback(db, auth.teamId, auth.memberTier, since);
     return Response.json({ decisions, next_cursor: null });
   } catch (e) {
     return errorResponse("internal", e instanceof Error ? e.message : "writeback failed", 500);

--- a/app/api/v1/graph-query/route.ts
+++ b/app/api/v1/graph-query/route.ts
@@ -25,8 +25,8 @@ export async function POST(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:graph-query`, 30))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:graph-query`, 30))) {
     return errorResponse("rate_limited", "30/min per key", 429);
   }
 
@@ -45,13 +45,13 @@ export async function POST(req: NextRequest) {
   }
 
   // Resolve the team slug, then scope to the tiers this caller may see.
-  const { data: team } = await supabase.from("teams").select("slug").eq("id", auth.teamId).maybeSingle();
+  const { data: team } = await db.from("teams").select("slug").eq("id", auth.teamId).maybeSingle();
   if (!team) return errorResponse("internal", "team not found", 500);
   const groupIds = visibleGroupIds((team as { slug: string }).slug, auth.memberTier);
 
   try {
     const facts = await client.search(parsed.data.query, groupIds, parsed.data.maxFacts ?? 20);
-    await audit(supabase, {
+    await audit(db, {
       team_id: auth.teamId,
       actor_kind: "api_key",
       member_id: auth.memberId,

--- a/app/api/v1/identities/resolve/route.ts
+++ b/app/api/v1/identities/resolve/route.ts
@@ -27,8 +27,8 @@ export async function GET(req: NextRequest) {
     return errorResponse("forbidden_tier", "identity resolution is team-tier only", 403);
   }
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:resolve:get`, 120))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:resolve:get`, 120))) {
     return errorResponse("rate_limited", "120 resolves/min per key", 429);
   }
 
@@ -49,14 +49,14 @@ export async function GET(req: NextRequest) {
     return errorResponse("bad_request", "external_id requires provider", 400);
   }
 
-  const map = await buildIdentityMap(supabase, auth.teamId);
+  const map = await buildIdentityMap(db, auth.teamId);
   let memberId: string | null = null;
   if (externalId && provider) memberId = resolveByProviderId(map, provider, externalId);
   if (!memberId && (email || handle)) memberId = resolveMember(map, { email: email ?? undefined, key: handle ?? undefined });
 
   if (!memberId) return errorResponse("not_found", "no member matches that identifier", 404);
 
-  const { data: m, error } = await supabase
+  const { data: m, error } = await db
     .from("members")
     .select("id, email, display_name, actor_handle, github_login, role, tier")
     .eq("team_id", auth.teamId)
@@ -65,7 +65,7 @@ export async function GET(req: NextRequest) {
   if (error) return errorResponse("internal", error.message, 500);
   if (!m) return errorResponse("not_found", "member resolved but not readable", 404);
 
-  const identities = (await listMemberIdentities(supabase, auth.teamId)).get(memberId);
+  const identities = (await listMemberIdentities(db, auth.teamId)).get(memberId);
   const provs = identities?.providers ?? [];
   const slack = provs.find((p) => p.provider === "slack");
 

--- a/app/api/v1/integrations/route.ts
+++ b/app/api/v1/integrations/route.ts
@@ -20,14 +20,14 @@ export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:integrations:get`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:integrations:get`, 60))) {
     return errorResponse("rate_limited", "60/min per key", 429);
   }
 
   try {
-    const integrations = await listEnabledIntegrationSelections(supabase, auth.teamId);
-    await audit(supabase, {
+    const integrations = await listEnabledIntegrationSelections(db, auth.teamId);
+    await audit(db, {
       team_id: auth.teamId,
       actor_kind: "api_key",
       member_id: auth.memberId,

--- a/app/api/v1/items/[id]/route.ts
+++ b/app/api/v1/items/[id]/route.ts
@@ -12,14 +12,14 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string 
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:items:get`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:items:get`, 60))) {
     return errorResponse("rate_limited", "60 pulls/min per key", 429);
   }
 
   const { id } = await ctx.params;
 
-  let q = supabase
+  let q = db
     .from("items")
     .select("id, path, kind, access, frontmatter, body, content_sha256, actor, updated_at, projects(slug)")
     .eq("team_id", auth.teamId)

--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -20,8 +20,8 @@ export async function POST(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:items:post`, 120))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:items:post`, 120))) {
     return errorResponse("rate_limited", "120 pushes/min per key", 429);
   }
 
@@ -60,7 +60,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const result = await ingestItem(supabase, auth, parsed.data, tier);
+    const result = await ingestItem(db, auth, parsed.data, tier);
 
     // Reactive auto-projection (brain-api v1.2 Phase 2): on a task push that actually changed
     // projected fields, schedule a bounded projection of ONLY the changed rows into the team's
@@ -99,8 +99,8 @@ export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:items:get`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:items:get`, 60))) {
     return errorResponse("rate_limited", "60 pulls/min per key", 429);
   }
 
@@ -112,7 +112,7 @@ export async function GET(req: NextRequest) {
   const pathPrefix = url.searchParams.get("path_prefix");
 
   // Tier filtering re-applied server-side: external-tier keys see only external.
-  let q = supabase
+  let q = db
     .from("items")
     .select("id, path, kind, access, frontmatter, body, content_sha256, actor, updated_at, projects(slug)")
     .eq("team_id", auth.teamId)

--- a/app/api/v1/me/slack-token/route.ts
+++ b/app/api/v1/me/slack-token/route.ts
@@ -32,11 +32,11 @@ async function slackAuthTest(token: string) {
 export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:me:slack-token`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:me:slack-token`, 60))) {
     return errorResponse("rate_limited", "60 reads/min per key", 429);
   }
-  const rec = await getMemberSecret(supabase, auth.teamId, auth.memberId, "slack");
+  const rec = await getMemberSecret(db, auth.teamId, auth.memberId, "slack");
   if (!rec) {
     return Response.json({ connected: false, error: "not_connected" }, { status: 404, headers: NO_STORE });
   }
@@ -54,8 +54,8 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:me:slack-token:write`, 20))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:me:slack-token:write`, 20))) {
     return errorResponse("rate_limited", "20 writes/min per key", 429);
   }
 
@@ -75,7 +75,7 @@ export async function POST(req: NextRequest) {
     return errorResponse("invalid_token", `Slack rejected the token (${test.error ?? "auth.test failed"})`, 422);
   }
 
-  await setMemberSecret(supabase, { teamId: auth.teamId, memberId: auth.memberId }, "slack", token, {
+  await setMemberSecret(db, { teamId: auth.teamId, memberId: auth.memberId }, "slack", token, {
     slack_user_id: test.user_id,
     workspace: test.team ?? null,
     workspace_id: test.team_id ?? null,
@@ -83,7 +83,7 @@ export async function POST(req: NextRequest) {
   });
 
   // Capture the member's Slack identity so `slack dm --member` + resolve work afterward.
-  const { data: m } = await supabase
+  const { data: m } = await db
     .from("members")
     .select("email")
     .eq("team_id", auth.teamId)
@@ -91,7 +91,7 @@ export async function POST(req: NextRequest) {
     .maybeSingle();
   try {
     await setMemberIdentity(
-      supabase,
+      db,
       auth.teamId,
       auth.memberId,
       { provider: "slack", externalId: test.user_id, handle: test.user ?? "", email: (m?.email as string) ?? "" },
@@ -110,7 +110,7 @@ export async function POST(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
-  const supabase = adminClient();
-  await deleteMemberSecret(supabase, { teamId: auth.teamId, memberId: auth.memberId }, "slack");
+  const db = adminClient();
+  await deleteMemberSecret(db, { teamId: auth.teamId, memberId: auth.memberId }, "slack");
   return Response.json({ ok: true, connected: false }, { headers: NO_STORE });
 }

--- a/app/api/v1/members/route.ts
+++ b/app/api/v1/members/route.ts
@@ -29,8 +29,8 @@ export async function GET(req: NextRequest) {
     return errorResponse("forbidden_tier", "the roster is team-tier only", 403);
   }
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:members:get`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:members:get`, 60))) {
     return errorResponse("rate_limited", "60 reads/min per key", 429);
   }
 
@@ -39,7 +39,7 @@ export async function GET(req: NextRequest) {
   const handle = url.searchParams.get("handle")?.toLowerCase() || null;
   const provider = url.searchParams.get("provider")?.toLowerCase() || null;
 
-  let q = supabase
+  let q = db
     .from("members")
     .select("id, email, display_name, actor_handle, github_login, avatar_url, role, tier, status")
     .eq("team_id", auth.teamId)
@@ -50,7 +50,7 @@ export async function GET(req: NextRequest) {
   const { data: rows, error } = await q.order("display_name");
   if (error) return errorResponse("internal", error.message, 500);
 
-  const identities = await listMemberIdentities(supabase, auth.teamId);
+  const identities = await listMemberIdentities(db, auth.teamId);
 
   const members = (rows ?? [])
     .map((m) => {

--- a/app/api/v1/metrics/route.ts
+++ b/app/api/v1/metrics/route.ts
@@ -22,8 +22,8 @@ export async function POST(req: NextRequest) {
     return errorResponse("forbidden_tier", "agentic-maturity metrics are team-tier only", 403);
   }
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:metrics:post`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:metrics:post`, 60))) {
     return errorResponse("rate_limited", "60 snapshots/min per key", 429);
   }
 
@@ -43,7 +43,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const result = await ingestMaturitySnapshot(supabase, auth, parsed.data);
+    const result = await ingestMaturitySnapshot(db, auth, parsed.data);
     return Response.json({ status: "ok", ...result }, { status: 201 });
   } catch (e) {
     // Unknown member handle = client input error → 422, not a 500 brain fault.

--- a/app/api/v1/okf-bundle/route.ts
+++ b/app/api/v1/okf-bundle/route.ts
@@ -28,11 +28,11 @@ export async function GET(req: NextRequest) {
   const cursor = url.searchParams.get("cursor");
   const requestedTier = url.searchParams.get("tier");
 
-  const supabase = adminClient();
+  const db = adminClient();
   // include_body returns full text → tighter limit, per contract.
   const ok = includeBody
-    ? await rateLimit(supabase, `${auth.apiKeyId}:okf-body`, 10)
-    : await rateLimit(supabase, `${auth.apiKeyId}:okf`, 30);
+    ? await rateLimit(db, `${auth.apiKeyId}:okf-body`, 10)
+    : await rateLimit(db, `${auth.apiKeyId}:okf`, 30);
   if (!ok) return errorResponse("rate_limited", includeBody ? "10/min with body" : "30/min", 429);
 
   // Effective tier can never exceed the caller's ceiling.
@@ -45,7 +45,7 @@ export async function GET(req: NextRequest) {
   // join, so we filter by project_id instead.)
   let projectId: string | null = null;
   if (project) {
-    const { data: p } = await supabase
+    const { data: p } = await db
       .from("projects")
       .select("id")
       .eq("team_id", auth.teamId)
@@ -63,7 +63,7 @@ export async function GET(req: NextRequest) {
   // 1. Path → access map for the whole team, to resolve + redact links.
   //    (Whole-team is intentional: keys are slug-scoped, and cross-project
   //    links are preserved as "broken" per contract point 3.)
-  const { data: allRows, error: mapErr } = await supabase
+  const { data: allRows, error: mapErr } = await db
     .from("items")
     .select("path, access, projects(slug)")
     .eq("team_id", auth.teamId);
@@ -75,7 +75,7 @@ export async function GET(req: NextRequest) {
   }
 
   // 2. The page of nodes the caller's tier may see.
-  let q = supabase
+  let q = db
     .from("items")
     .select("path, kind, access, frontmatter, body, content_sha256, updated_at, projects(slug)")
     .eq("team_id", auth.teamId)

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -18,12 +18,12 @@ export async function GET(req: NextRequest) {
     return errorResponse("forbidden_tier", "projects are team-tier only", 403);
   }
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:projects:get`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:projects:get`, 60))) {
     return errorResponse("rate_limited", "60 pulls/min per key", 429);
   }
 
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("projects")
     .select("slug, name, last_synced_at")
     .eq("team_id", auth.teamId)

--- a/app/api/v1/query/route.ts
+++ b/app/api/v1/query/route.ts
@@ -25,15 +25,15 @@ export async function POST(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.memberId}:query`, 10))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.memberId}:query`, 10))) {
     return errorResponse("rate_limited", "10 queries/min per member", 429);
   }
 
   // Daily guards: per-member count + per-team budget from query_log
   const dayStart = new Date();
   dayStart.setHours(0, 0, 0, 0);
-  const { count: todayCount } = await supabase
+  const { count: todayCount } = await db
     .from("query_log")
     .select("id", { count: "exact", head: true })
     .eq("member_id", auth.memberId)
@@ -41,7 +41,7 @@ export async function POST(req: NextRequest) {
   if ((todayCount ?? 0) >= DAILY_QUERIES_PER_MEMBER) {
     return errorResponse("rate_limited", `${DAILY_QUERIES_PER_MEMBER} queries/day per member`, 429);
   }
-  const { data: spend } = await supabase
+  const { data: spend } = await db
     .from("query_log")
     .select("cost_usd")
     .eq("team_id", auth.teamId)
@@ -65,21 +65,21 @@ export async function POST(req: NextRequest) {
   // Telegram-via-Hermes turn continues the member's existing conversation. Load prior turns BEFORE
   // recording the current question; the assistant turn is persisted once streaming completes.
   const owner = { teamId: auth.teamId, memberId: auth.memberId };
-  let conversationId = conversation_id && (await ownsConversation(supabase, owner, conversation_id)) ? conversation_id : null;
-  const priorTurns = conversationId ? await recentTurns(supabase, owner, conversationId) : [];
+  let conversationId = conversation_id && (await ownsConversation(db, owner, conversation_id)) ? conversation_id : null;
+  const priorTurns = conversationId ? await recentTurns(db, owner, conversationId) : [];
   let createdNew = false;
   if (!conversationId) {
-    const created = await createConversation(supabase, owner, question);
+    const created = await createConversation(db, owner, question);
     conversationId = created?.id ?? null;
     createdNew = true;
   }
-  if (conversationId) await appendMessage(supabase, owner, conversationId, "user", question);
+  if (conversationId) await appendMessage(db, owner, conversationId, "user", question);
 
   // Who the answer is FOR — anchors first-person resolution ("what did I ship?") to this member.
   const caller = { displayName: auth.displayName, email: auth.email, handle: auth.actorHandle };
 
   // Timezone for relative-date anchoring (no browser here): member profile → instance default.
-  const { data: prof } = await supabase
+  const { data: prof } = await db
     .from("member_profiles")
     .select("timezone")
     .eq("team_id", auth.teamId)
@@ -88,12 +88,12 @@ export async function POST(req: NextRequest) {
   const timeZone = pickTimezone([prof?.timezone, DEFAULT_TIMEZONE]);
 
   const started = Date.now();
-  const ctx = await retrieve(supabase, auth.teamId, auth.memberTier, question, project);
+  const ctx = await retrieve(db, auth.teamId, auth.memberTier, question, project);
 
   // Per-team provider keys (encrypted in integrations); null → env fallback in streamAnswer.
   const [anthropicKey, openaiKey] = await Promise.all([
-    getProviderKey(supabase, auth.teamId, "anthropic"),
-    getProviderKey(supabase, auth.teamId, "openai"),
+    getProviderKey(db, auth.teamId, "anthropic"),
+    getProviderKey(db, auth.teamId, "openai"),
   ]);
 
   const encoder = new TextEncoder();
@@ -127,18 +127,18 @@ export async function POST(req: NextRequest) {
             send("done", chunk.usage);
 
             if (conversationId) {
-              await appendMessage(supabase, owner, conversationId, "assistant", answer, {
+              await appendMessage(db, owner, conversationId, "assistant", answer, {
                 cited_item_ids: sources.map((s) => s.item_id).filter((id): id is string => Boolean(id)),
                 input_tokens: chunk.usage.input_tokens,
                 output_tokens: chunk.usage.output_tokens,
                 cost_usd: chunk.usage.cost_usd,
               });
               if (createdNew) {
-                await generateAndSetTitle(supabase, owner, conversationId, question, answer, { anthropicKey, openaiKey });
+                await generateAndSetTitle(db, owner, conversationId, question, answer, { anthropicKey, openaiKey });
               }
             }
 
-            await supabase.from("query_log").insert({
+            await db.from("query_log").insert({
               team_id: auth.teamId,
               member_id: auth.memberId,
               question,

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -15,15 +15,15 @@ export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
   if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:tasks:get`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:tasks:get`, 60))) {
     return errorResponse("rate_limited", "60 pulls/min per key", 429);
   }
 
   const url = new URL(req.url);
   const since = url.searchParams.get("since") || "1970-01-01T00:00:00Z";
 
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("tasks")
     .select(
       "row_key, title, assignee, status, sprint, due_date, parent_row_key, labels, priority, origin, updated_at, projects(slug), items:source_item_id(synced_at)"

--- a/app/api/v1/work-events/route.ts
+++ b/app/api/v1/work-events/route.ts
@@ -14,8 +14,8 @@ export async function POST(req: NextRequest) {
     return errorResponse("forbidden_tier", "work events are team-tier only", 403);
   }
 
-  const supabase = adminClient();
-  if (!(await rateLimit(supabase, `${auth.apiKeyId}:work-events:post`, 60))) {
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:work-events:post`, 60))) {
     return errorResponse("rate_limited", "60 work events/min per key", 429);
   }
 
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const result = await ingestWorkEvent(
-      supabase,
+      db,
       { teamId: auth.teamId, memberId: auth.memberId, apiKeyId: auth.apiKeyId },
       parsed.data
     );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,11 @@ import { serverClient } from "@/lib/db/server";
 import { getSessionUser } from "@/lib/auth/session";
 
 export default async function Home() {
-  const supabase = await serverClient();
+  const db = await serverClient();
   const user = await getSessionUser();
   if (!user) redirect("/login");
 
-  const { data: memberships } = await supabase
+  const { data: memberships } = await db
     .from("members")
     .select("team_id, created_at, teams(slug)")
     .eq("auth_user_id", user.id)

--- a/app/t/[team]/admin/actions.ts
+++ b/app/t/[team]/admin/actions.ts
@@ -11,16 +11,16 @@ import { sendInviteEmail } from "@/lib/auth/mailer";
 
 /** Verify the caller is an active admin of the team; returns ids or null. */
 async function requireAdmin(teamSlug: string) {
-  const supabase = await serverClient();
+  const db = await serverClient();
   const user = await getSessionUser();
   if (!user) return null;
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
-  const { data: me } = await supabase
+  const { data: me } = await db
     .from("members")
     .select("id, role")
     .eq("team_id", team.id)

--- a/app/t/[team]/admin/approvals/actions.ts
+++ b/app/t/[team]/admin/approvals/actions.ts
@@ -9,10 +9,10 @@ import { resolveApproval } from "@/lib/actions";
 import { createE2BSandbox } from "@/lib/actions/sandbox/e2b";
 
 async function requireAdmin(teamSlug: string) {
-  const supabase = await serverClient();
+  const db = await serverClient();
   const user = await getSessionUser();
   if (!user) return null;
-  return resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+  return resolveIntegrationsAdmin(db, teamSlug, user.id);
 }
 
 /**

--- a/app/t/[team]/admin/approvals/page.tsx
+++ b/app/t/[team]/admin/approvals/page.tsx
@@ -3,19 +3,19 @@ import { ApprovalsQueue, type ApprovalRow, type DecidedRow } from "@/components/
 
 export default async function ApprovalsAdminPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
-  const { data: pending } = await supabase
+  const { data: pending } = await db
     .from("approval_requests")
     .select("id, requested_by_actor, action, resource, context, created_at")
     .eq("team_id", team.id)
     .eq("status", "pending")
     .order("created_at", { ascending: false });
 
-  const { data: recent } = await supabase
+  const { data: recent } = await db
     .from("approval_requests")
     .select("id, requested_by_actor, action, resource, status, decided_at, decision_note")
     .eq("team_id", team.id)

--- a/app/t/[team]/admin/audit/page.tsx
+++ b/app/t/[team]/admin/audit/page.tsx
@@ -7,16 +7,16 @@ export default async function AuditAdminPage({
   params: Promise<{ team: string }>;
 }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
 
-  const { data: entries } = await supabase
+  const { data: entries } = await db
     .from("audit_log")
     .select("id, actor_kind, action, target_type, target_id, meta, ip, created_at")
     .eq("team_id", team.id)

--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -32,10 +32,10 @@ export type PrimaryPmProvider = "plane" | "linear" | null;
  * Returns null on any non-admin/unknown/wrong-team caller → every write action rejects.
  */
 async function requireAdmin(teamSlug: string) {
-  const supabase = await serverClient();
+  const db = await serverClient();
   const user = await getSessionUser();
   if (!user) return null;
-  const ctx = await resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+  const ctx = await resolveIntegrationsAdmin(db, teamSlug, user.id);
   if (!ctx) return null;
   return { teamId: ctx.teamId, myMemberId: ctx.memberId };
 }

--- a/app/t/[team]/admin/integrations/page.tsx
+++ b/app/t/[team]/admin/integrations/page.tsx
@@ -41,13 +41,13 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
         .maybeSingle()
     : { data: null };
 
-  const supabase = adminClient();
+  const db = adminClient();
   const [integrations, ingestRuns, freshness] = await Promise.all([
-    listIntegrations(supabase, team.id, { role: me?.role as string | undefined }) as Promise<IntegrationRow[]>,
-    listRecentIngestRuns(supabase, team.id, 30),
+    listIntegrations(db, team.id, { role: me?.role as string | undefined }) as Promise<IntegrationRow[]>,
+    listRecentIngestRuns(db, team.id, 30),
     // Already-scanned repos (from codebase scans) → offered as one-click link suggestions. Read
     // through the tier-gated codebases choke point (CLAUDE.md §5), never the table directly.
-    getCodebaseFreshness(supabase, team.id, (me?.tier as "team" | "external") ?? "external"),
+    getCodebaseFreshness(db, team.id, (me?.tier as "team" | "external") ?? "external"),
   ]);
   const githubIntegration = integrations.find((i) => i.type === "github") ?? null;
   const scannedRepos = Array.from(

--- a/app/t/[team]/admin/keys/page.tsx
+++ b/app/t/[team]/admin/keys/page.tsx
@@ -8,9 +8,9 @@ export default async function KeysAdminPage({
   params: Promise<{ team: string }>;
 }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
@@ -18,12 +18,12 @@ export default async function KeysAdminPage({
   if (!team) return null;
 
   const [{ data: keys }, { data: members }] = await Promise.all([
-    supabase
+    db
       .from("api_keys")
       .select("id, key_id, name, created_at, last_used_at, revoked_at, members(display_name, actor_handle)")
       .eq("team_id", team.id)
       .order("created_at", { ascending: false }),
-    supabase
+    db
       .from("members")
       .select("id, display_name, actor_handle")
       .eq("team_id", team.id)

--- a/app/t/[team]/admin/layout.tsx
+++ b/app/t/[team]/admin/layout.tsx
@@ -11,18 +11,18 @@ export default async function AdminLayout({
   params: Promise<{ team: string }>;
 }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
   const user = await getSessionUser();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
     .maybeSingle();
 
   const { data: me } = team
-    ? await supabase
+    ? await db
         .from("members")
         .select("role")
         .eq("team_id", team.id)

--- a/app/t/[team]/admin/members/actions.ts
+++ b/app/t/[team]/admin/members/actions.ts
@@ -19,10 +19,10 @@ const PROVIDERS = new Set(["slack", "linear", "plane"]);
  * is the shared team-admin resolver). Returns null for any non-admin/unknown/wrong-team caller.
  */
 async function requireAdmin(teamSlug: string) {
-  const supabase = await serverClient();
+  const db = await serverClient();
   const user = await getSessionUser();
   if (!user) return null;
-  return resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+  return resolveIntegrationsAdmin(db, teamSlug, user.id);
 }
 
 /**

--- a/app/t/[team]/admin/members/page.tsx
+++ b/app/t/[team]/admin/members/page.tsx
@@ -10,23 +10,23 @@ export default async function MembersAdminPage({
   params: Promise<{ team: string }>;
 }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
 
-  const { data: members } = await supabase
+  const { data: members } = await db
     .from("members")
     .select("id, display_name, email, actor_handle, role, tier, status, github_login, avatar_url, created_at")
     .eq("team_id", team.id)
     .order("created_at");
 
   // All linked identities (email aliases + slack/linear/plane provider ids) for the panel.
-  const identities = await listMemberIdentities(supabase, team.id);
+  const identities = await listMemberIdentities(db, team.id);
   const providerOf = (memberId: string, provider: string): ProviderLink | null => {
     const p = identities.get(memberId)?.providers.find((x) => x.provider === provider);
     return p ? { externalId: p.externalId, handle: p.handle } : null;

--- a/app/t/[team]/admin/pm-sync/actions.ts
+++ b/app/t/[team]/admin/pm-sync/actions.ts
@@ -11,10 +11,10 @@ import { projectAllTasks, type ProjectionReport } from "@/lib/pm-sync";
 import { reconcileProviderState, type DivergenceRow } from "@/lib/pm-sync/reconcile";
 
 async function requireAdmin(teamSlug: string) {
-  const supabase = await serverClient();
+  const db = await serverClient();
   const user = await getSessionUser();
   if (!user) return null;
-  const ctx = await resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+  const ctx = await resolveIntegrationsAdmin(db, teamSlug, user.id);
   if (!ctx) return null;
   return { teamId: ctx.teamId, myMemberId: ctx.memberId };
 }

--- a/app/t/[team]/admin/pm-sync/page.tsx
+++ b/app/t/[team]/admin/pm-sync/page.tsx
@@ -8,8 +8,8 @@ export const metadata: Metadata = { title: "PM sync" };
 
 export default async function PmSyncPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
-  const { data: team } = await supabase
+  const db = await serverClient();
+  const { data: team } = await db
     .from("teams")
     .select("id, primary_pm_provider")
     .eq("slug", teamSlug)
@@ -17,14 +17,14 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
   if (!team) return null;
 
   const [{ data: unresolved }, { data: failedLinks }, inboundRows] = await Promise.all([
-    supabase
+    db
       .from("work_events")
       .select("row_key, repo, merged_sha, pr_url, pr_title, error, created_at")
       .eq("team_id", team.id)
       .eq("status", "unresolved")
       .order("created_at", { ascending: false })
       .limit(50),
-    supabase
+    db
       .from("task_pm_links")
       .select("row_key, provider, provider_external_id, provider_url, last_error, updated_at")
       .eq("team_id", team.id)
@@ -34,7 +34,7 @@ export default async function PmSyncPage({ params }: { params: Promise<{ team: s
     // Inbound divergence (brain-api v1.4): the enriched read the inbound engine itself uses —
     // links + task rows + the exact brain-status baseline — so the page deterministically
     // recomputes "conflict (both changed)" vs "pending apply" from persisted data alone.
-    loadInboundRows(supabase, team.id),
+    loadInboundRows(db, team.id),
   ]);
 
   const divergences = inboundRows

--- a/app/t/[team]/admin/policies/actions.ts
+++ b/app/t/[team]/admin/policies/actions.ts
@@ -9,10 +9,10 @@ import { createPolicy, updatePolicy, setPolicyEnabled, deletePolicy, type Policy
 
 /** Admin gate (same shared resolver the other admin actions use). */
 async function requireAdmin(teamSlug: string) {
-  const supabase = await serverClient();
+  const db = await serverClient();
   const user = await getSessionUser();
   if (!user) return null;
-  return resolveIntegrationsAdmin(supabase, teamSlug, user.id);
+  return resolveIntegrationsAdmin(db, teamSlug, user.id);
 }
 
 export type PolicyForm = PolicyInput & { id?: string };

--- a/app/t/[team]/admin/policies/page.tsx
+++ b/app/t/[team]/admin/policies/page.tsx
@@ -4,12 +4,12 @@ import { PoliciesManager } from "@/components/admin/policies-manager";
 
 export default async function PoliciesAdminPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
-  const policies = await listAllPolicies(supabase, team.id);
+  const policies = await listAllPolicies(db, team.id);
 
   return (
     <div className="flex flex-col gap-4">

--- a/app/t/[team]/admin/usage/page.tsx
+++ b/app/t/[team]/admin/usage/page.tsx
@@ -21,15 +21,15 @@ export default async function UsageAdminPage({
   const { team: teamSlug } = await params;
   const { range: rangeParam } = await searchParams;
   const range = parseRange(rangeParam);
-  const supabase = await serverClient();
+  const db = await serverClient();
 
   const [{ data: team }, user] = await Promise.all([
-    supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle(),
+    db.from("teams").select("id").eq("slug", teamSlug).maybeSingle(),
     getSessionUser(),
   ]);
   if (!team) return null;
 
-  const { data: me } = await supabase
+  const { data: me } = await db
     .from("members")
     .select("id, role")
     .eq("team_id", team.id)
@@ -42,11 +42,11 @@ export default async function UsageAdminPage({
   const viewer = { isAdmin, memberId };
 
   const [costs, external, throughput] = await Promise.all([
-    getPerMemberCosts(supabase, team.id, range, viewer),
-    getExternalCosts(supabase, team.id, range, viewer),
-    getThroughputVsCost(supabase, team.id, range, viewer),
+    getPerMemberCosts(db, team.id, range, viewer),
+    getExternalCosts(db, team.id, range, viewer),
+    getThroughputVsCost(db, team.id, range, viewer),
   ]);
-  const combined = await getCombinedSpend(supabase, team.id, range, viewer, external);
+  const combined = await getCombinedSpend(db, team.id, range, viewer, external);
 
   return (
     <div className="flex flex-col gap-6">

--- a/app/t/[team]/codebases/[slug]/contributors/[author]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/contributors/[author]/page.tsx
@@ -39,14 +39,14 @@ export default async function ContributorPage({
   const ref = parseAuthor(author);
   if (!ref) notFound();
   const range = parseRange((await searchParams).range);
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
   const me = await currentMember(team.id);
   if (!me) return null;
 
-  const c = await getContributorDetail(supabase, team.id, slug, ref, range, me.tier);
+  const c = await getContributorDetail(db, team.id, slug, ref, range, me.tier);
   if (!c) notFound();
 
   const aiPct = c.totals.commits ? Math.round((100 * c.totals.ai_commits) / c.totals.commits) : 0;

--- a/app/t/[team]/codebases/[slug]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/page.tsx
@@ -26,15 +26,15 @@ export default async function CodebaseDetailPage({
 
   const { team: teamSlug, slug } = await params;
   const range = parseRange((await searchParams).range);
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
   if (!me) return null;
 
-  const cb = await getCodebaseDetail(supabase, team.id, slug, range, me.tier);
+  const cb = await getCodebaseDetail(db, team.id, slug, range, me.tier);
   if (!cb) notFound();
 
   const langs = Object.entries(cb.languages)

--- a/app/t/[team]/codebases/github/page.tsx
+++ b/app/t/[team]/codebases/github/page.tsx
@@ -49,8 +49,8 @@ function FreshnessBadge({ f }: { f: Freshness }) {
 export default async function CodebasesGithubPage({ params }: { params: Promise<{ team: string }> }) {
 
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const db = await serverClient();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
@@ -69,7 +69,7 @@ export default async function CodebasesGithubPage({ params }: { params: Promise<
   }
 
   // Read helper enforces the team-tier gate; live HEAD compare is best-effort and never blocks.
-  const freshness = await getCodebaseFreshness(supabase, team.id, me.tier);
+  const freshness = await getCodebaseFreshness(db, team.id, me.tier);
   const rows = await withLiveHead(freshness, process.env.GITHUB_TOKEN);
 
   return (

--- a/app/t/[team]/codebases/page.tsx
+++ b/app/t/[team]/codebases/page.tsx
@@ -22,16 +22,16 @@ export default async function CodebasesPage({
 
   const { team: teamSlug } = await params;
   const range = parseRange((await searchParams).range);
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
   if (!me) return null;
 
   // Read helper enforces the team-tier gate (external → empty).
-  const { codebases, kpis } = await getCodebaseSummaries(supabase, team.id, range, me.tier);
+  const { codebases, kpis } = await getCodebaseSummaries(db, team.id, range, me.tier);
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-5">

--- a/app/t/[team]/decisions/page.tsx
+++ b/app/t/[team]/decisions/page.tsx
@@ -11,9 +11,9 @@ export const metadata: Metadata = { title: "Decisions" };
 
 export default async function DecisionsPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
@@ -24,7 +24,7 @@ export default async function DecisionsPage({ params }: { params: Promise<{ team
 
   // The viewer's tier gates the decision read (audience filter) — fetch it before the
   // query so an external principal never receives team-audience rows (no RLS backstop).
-  const { data: me } = await supabase
+  const { data: me } = await db
     .from("members")
     .select("role, tier")
     .eq("team_id", team.id)
@@ -35,7 +35,7 @@ export default async function DecisionsPage({ params }: { params: Promise<{ team
 
   const [{ data: decisions }, { data: projects }] = await Promise.all([
     visibleDecisions(
-      supabase
+      db
         .from("decisions")
         .select(
           "id, row_key, decided_at, title, rationale, decided_by, impact, tier, audience, still_valid, projects(slug)"
@@ -44,7 +44,7 @@ export default async function DecisionsPage({ params }: { params: Promise<{ team
         .order("decided_at", { ascending: false }),
       tier
     ),
-    supabase
+    db
       .from("projects")
       .select("id, slug, name")
       .eq("team_id", team.id)

--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -31,20 +31,20 @@ export default async function TeamLayout({
   params: Promise<{ team: string }>;
 }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
   const user = await getSessionUser();
   if (!user) return <NoTeamScreen slug={teamSlug} />;
 
   // Membership is enforced below via the `me` lookup (app-code access control).
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id, slug, name")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return <NoTeamScreen slug={teamSlug} />;
 
-  const { data: me } = await supabase
+  const { data: me } = await db
     .from("members")
     .select("id, role, display_name, tier")
     .eq("team_id", team.id)

--- a/app/t/[team]/learning/page.tsx
+++ b/app/t/[team]/learning/page.tsx
@@ -14,8 +14,8 @@ export const metadata: Metadata = { title: "Learning" };
  */
 export default async function LearningPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const db = await serverClient();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
   const me = await currentMember(team.id);
   if (!me) return null;

--- a/app/t/[team]/library/[itemId]/page.tsx
+++ b/app/t/[team]/library/[itemId]/page.tsx
@@ -14,16 +14,16 @@ export default async function LibraryItemPage({
   params: Promise<{ team: string; itemId: string }>;
 }) {
   const { team: teamSlug, itemId } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
 
-  const { data: item } = await supabase
+  const { data: item } = await db
     .from("items")
     .select(
       "id, path, kind, access, body, content_sha256, actor, synced_at, updated_at, projects(slug), members(display_name), item_versions(count)"

--- a/app/t/[team]/library/page.tsx
+++ b/app/t/[team]/library/page.tsx
@@ -38,16 +38,16 @@ export default async function DataPage({
 }) {
   const { team: teamSlug } = await params;
   const { channel: channelParam, limit: limitParam } = await searchParams;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
   const tier = me?.tier ?? "external";
 
   // 1) Channel list — group a bounded recent window of visible items by path prefix.
-  let chQuery = supabase
+  let chQuery = db
     .from("items")
     .select("path, synced_at")
     .eq("team_id", team.id)
@@ -65,7 +65,7 @@ export default async function DataPage({
   let items: FeedItem[] = [];
   let hasMore = false;
   if (selected) {
-    let feedQuery = supabase
+    let feedQuery = db
       .from("items")
       .select("id, path, kind, access, actor, synced_at, body")
       .eq("team_id", team.id)

--- a/app/t/[team]/library/skills/page.tsx
+++ b/app/t/[team]/library/skills/page.tsx
@@ -65,14 +65,14 @@ function refCount(it: SkillItem): number {
 
 export default async function SkillsPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
   const { data: items } = await visibleItems(
-    supabase
+    db
       .from("items")
       .select("id, path, access, actor, synced_at, frontmatter, body, projects(slug)")
       .eq("team_id", team.id)

--- a/app/t/[team]/maturity/page.tsx
+++ b/app/t/[team]/maturity/page.tsx
@@ -30,16 +30,16 @@ export default async function MaturityPage({
 
   const { team: teamSlug } = await params;
   const range = parseRange((await searchParams).range);
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
   if (!me) return null;
 
   // Tier gate lives in getTeamMaturity → getCodebaseSummaries (team-only).
-  const m = await getTeamMaturity(supabase, team.id, range, me.tier);
+  const m = await getTeamMaturity(db, team.id, range, me.tier);
 
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-5">

--- a/app/t/[team]/maturity/people/[handle]/page.tsx
+++ b/app/t/[team]/maturity/people/[handle]/page.tsx
@@ -29,15 +29,15 @@ export default async function MemberMaturityPage({
 }) {
 
   const { team: teamSlug, handle } = await params;
-  const supabase = await serverClient();
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const db = await serverClient();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
   if (!me) return null;
 
   // Tier-gated read; external viewers and unknown handles → 404.
-  const data = await getMemberMaturity(supabase, team.id, handle, me.tier);
+  const data = await getMemberMaturity(db, team.id, handle, me.tier);
   if (!data) notFound();
 
   const { latest, timeline, teamAxes, prescription } = data;

--- a/app/t/[team]/maturity/people/page.tsx
+++ b/app/t/[team]/maturity/people/page.tsx
@@ -44,15 +44,15 @@ function radarData(axes: AemAxes): RadarDatum[] {
 export default async function MaturityPage({ params }: { params: Promise<{ team: string }> }) {
 
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
-  const { data: team } = await supabase.from("teams").select("id, name").eq("slug", teamSlug).maybeSingle();
+  const db = await serverClient();
+  const { data: team } = await db.from("teams").select("id, name").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
   if (!me) return null;
 
   // Read helper enforces the team-tier gate (external → empty board).
-  const { members, teamAxes, spineDistribution, asOf } = await getTeamMaturity(supabase, team.id, me.tier);
+  const { members, teamAxes, spineDistribution, asOf } = await getTeamMaturity(db, team.id, me.tier);
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-5">

--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -80,15 +80,15 @@ export default async function TeamHome({
   const { team: teamSlug } = await params;
   const { range: rangeParam } = await searchParams;
   const range = parseRange(rangeParam);
-  const supabase = await serverClient();
+  const db = await serverClient();
 
   const [{ data: team }, user] = await Promise.all([
-    supabase.from("teams").select("id, name").eq("slug", teamSlug).maybeSingle(),
+    db.from("teams").select("id, name").eq("slug", teamSlug).maybeSingle(),
     getSessionUser(),
   ]);
   if (!team) return null; // layout already rendered the no-team screen
 
-  const { data: me } = await supabase
+  const { data: me } = await db
     .from("members")
     .select("id, role, tier")
     .eq("team_id", team.id)
@@ -101,7 +101,7 @@ export default async function TeamHome({
 
   // Tier-filtered count (no RLS backstop in postgres mode).
   const { count: itemCount } = await visibleItems(
-    supabase.from("items").select("id", { count: "exact", head: true }).eq("team_id", team.id),
+    db.from("items").select("id", { count: "exact", head: true }).eq("team_id", team.id),
     tier
   );
 
@@ -115,9 +115,9 @@ export default async function TeamHome({
   }
 
   const [pulse, { data: decisions }] = await Promise.all([
-    getPulseMetrics(supabase, team.id, range, { isAdmin, memberId }),
+    getPulseMetrics(db, team.id, range, { isAdmin, memberId }),
     visibleDecisions(
-      supabase
+      db
         .from("decisions")
         .select("id, title, decided_at, tier, still_valid")
         .eq("team_id", team.id)

--- a/app/t/[team]/people/[handle]/actions.ts
+++ b/app/t/[team]/people/[handle]/actions.ts
@@ -30,8 +30,8 @@ interface Gate {
 }
 
 async function gate(teamSlug: string, targetMemberId: string): Promise<Gate | null> {
-  const supabase = await serverClient();
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const db = await serverClient();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
   const me = await currentMember((team as { id: string }).id);
   if (!me) return null;
@@ -142,8 +142,8 @@ export async function deleteMemberGoal(
  * closes); admins keep member-picker issuance for exceptional cases via /admin/keys.
  */
 async function selfGate(teamSlug: string): Promise<Gate | null> {
-  const supabase = await serverClient();
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const db = await serverClient();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
   const me = await currentMember((team as { id: string }).id);
   if (!me) return null;

--- a/app/t/[team]/people/[handle]/page.tsx
+++ b/app/t/[team]/people/[handle]/page.tsx
@@ -34,15 +34,15 @@ export default async function PersonPage({
 
   const { team: teamSlug, handle } = await params;
   const range = parseRange((await searchParams).range);
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
   const me = await currentMember(team.id);
   if (!me) return null;
 
   const decodedHandle = decodeURIComponent(handle);
-  const p = await getMemberProfile(supabase, team.id, decodedHandle, range, me.tier);
+  const p = await getMemberProfile(db, team.id, decodedHandle, range, me.tier);
 
   if (!p) {
     // getMemberProfile gates on canSeeCodebases(tier) — an external-tier member (a client/
@@ -50,7 +50,7 @@ export default async function PersonPage({
     // for their OWN handle. That's the correct tier gate for commit metrics, but it must not
     // also block them from managing their own API key — resolve "is this actually me" directly
     // against the members table, independent of the tier-gated profile query.
-    const { data: meRow } = await supabase
+    const { data: meRow } = await db
       .from("members")
       .select("actor_handle, github_login")
       .eq("id", me.id)
@@ -64,7 +64,7 @@ export default async function PersonPage({
 
     if (!isSelfByHandle) notFound();
 
-    const { data: keyRows } = await supabase
+    const { data: keyRows } = await db
       .from("api_keys")
       .select("id, key_id, name, created_at, last_used_at, revoked_at")
       .eq("team_id", team.id)
@@ -79,13 +79,13 @@ export default async function PersonPage({
     );
   }
 
-  const context = await getMemberContext(supabase, team.id, p.member_id, me.tier);
+  const context = await getMemberContext(db, team.id, p.member_id, me.tier);
   const canEdit = !!context && (me.id === p.member_id || me.role === "admin");
   const isSelf = me.id === p.member_id;
 
   let myKeys: MyKeyRow[] = [];
   if (isSelf) {
-    const { data } = await supabase
+    const { data } = await db
       .from("api_keys")
       .select("id, key_id, name, created_at, last_used_at, revoked_at")
       .eq("team_id", team.id)

--- a/app/t/[team]/projects/[project]/page.tsx
+++ b/app/t/[team]/projects/[project]/page.tsx
@@ -34,16 +34,16 @@ export default async function ProjectPage({
   params: Promise<{ team: string; project: string }>;
 }) {
   const { team: teamSlug, project: projectSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
 
-  const { data: project } = await supabase
+  const { data: project } = await db
     .from("projects")
     .select("id, slug, name, last_synced_at")
     .eq("team_id", team.id)
@@ -54,7 +54,7 @@ export default async function ProjectPage({
   const me = await currentMember(team.id);
   const [{ data: items }, { data: decisions }, { data: roster }] = await Promise.all([
     visibleItems(
-      supabase
+      db
         .from("items")
         .select("id, path, kind, access, actor, frontmatter, synced_at")
         .eq("team_id", team.id)
@@ -63,7 +63,7 @@ export default async function ProjectPage({
       me?.tier ?? "external"
     ),
     visibleDecisions(
-      supabase
+      db
         .from("decisions")
         .select("id, row_key, decided_at, title, decided_by, still_valid")
         .eq("team_id", team.id)
@@ -71,7 +71,7 @@ export default async function ProjectPage({
         .order("decided_at", { ascending: false }),
       me?.tier ?? "external"
     ),
-    supabase
+    db
       .from("members")
       .select("id, display_name, actor_handle, role")
       .eq("team_id", team.id)

--- a/app/t/[team]/projects/page.tsx
+++ b/app/t/[team]/projects/page.tsx
@@ -19,16 +19,16 @@ type ProjectCard = {
 
 export default async function ProjectsPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
 
-  const { data: projects } = await supabase
+  const { data: projects } = await db
     .from("projects")
     .select("id, slug, name, last_synced_at, items(count), tasks(count)")
     .eq("team_id", team.id)

--- a/app/t/[team]/query/page.tsx
+++ b/app/t/[team]/query/page.tsx
@@ -13,9 +13,9 @@ export default async function QueryPage({
 }) {
   const { team: teamSlug } = await params;
   const { q } = await searchParams;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id, name")
     .eq("slug", teamSlug)

--- a/app/t/[team]/tasks/page.tsx
+++ b/app/t/[team]/tasks/page.tsx
@@ -11,9 +11,9 @@ export const metadata: Metadata = { title: "Tasks" };
 
 export default async function TasksPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase
+  const { data: team } = await db
     .from("teams")
     .select("id")
     .eq("slug", teamSlug)
@@ -28,28 +28,28 @@ export default async function TasksPage({ params }: { params: Promise<{ team: st
   // works on both backends and keeps the per-task badge wiring intact.
   const [{ data: tasks }, { data: links }, { data: projects }, { data: members }, { data: me }] =
     await Promise.all([
-      supabase
+      db
         .from("tasks")
         .select("id, row_key, title, assignee, status, sprint, due_date, origin, project_id, updated_at, parent_row_key, labels, priority, body")
         .eq("team_id", team.id)
         .order("updated_at", { ascending: false })
         .limit(500),
-      supabase
+      db
         .from("task_pm_links")
         .select("task_id, provider, provider_url, last_synced_status, last_error")
         .eq("team_id", team.id),
-      supabase
+      db
         .from("projects")
         .select("id, slug, name")
         .eq("team_id", team.id)
         .order("slug"),
-      supabase
+      db
         .from("members")
         .select("id, display_name, actor_handle")
         .eq("team_id", team.id)
         .eq("status", "active")
         .order("display_name"),
-      supabase
+      db
         .from("members")
         .select("id")
         .eq("team_id", team.id)

--- a/app/t/[team]/team-tools/page.tsx
+++ b/app/t/[team]/team-tools/page.tsx
@@ -13,15 +13,15 @@ type Connector = { enabled?: boolean; name?: string; transport?: string; instanc
 
 export default async function TeamToolsPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const supabase = await serverClient();
+  const db = await serverClient();
 
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
   // Latest published blueprint for the team; tier-filtered in app code (no RLS in pg mode).
   const { data } = await visibleItems(
-    supabase
+    db
       .from("items")
       .select("body, actor, updated_at, frontmatter")
       .eq("team_id", team.id)

--- a/lib/actions/handlers.ts
+++ b/lib/actions/handlers.ts
@@ -29,7 +29,7 @@ const noteCreate: ActionHandler = {
     if (!access) return { ok: false, error: "invalid access tier" };
 
     const result = await ingestItem(
-      ctx.supabase,
+      ctx.db,
       { teamId: ctx.teamId, memberId: ctx.memberId ?? "", apiKeyId: ctx.apiKeyId ?? "" },
       {
         project,

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -41,7 +41,7 @@ export type RunActionOutcome = {
 type ExecOpts = { handlers?: ActionHandler[]; sandbox?: SandboxRunner };
 
 export async function runAction(
-  supabase: DbClient,
+  db: DbClient,
   input: RunActionInput,
   opts: ExecOpts = {}
 ): Promise<RunActionOutcome> {
@@ -50,7 +50,7 @@ export async function runAction(
   const apiKeyId = input.apiKeyId ?? null;
 
   // 1. record the request
-  const { data: row, error: insErr } = await supabase
+  const { data: row, error: insErr } = await db
     .from("actions")
     .insert({
       team_id: teamId,
@@ -65,17 +65,17 @@ export async function runAction(
     .single();
   if (insErr || !row) throw new Error(`action insert failed: ${insErr?.message}`);
   const actionId: string = row.id;
-  const auditAction = makeAuditAction(supabase, { teamId, memberId, apiKeyId, actionId });
+  const auditAction = makeAuditAction(db, { teamId, memberId, apiKeyId, actionId });
 
   // 2. authorize through the policy engine
-  const decision = await authorize(supabase, teamId, {
+  const decision = await authorize(db, teamId, {
     principal,
     action: request.type,
     resource: request.resource,
   });
 
   if (decision.effect === "deny") {
-    await supabase
+    await db
       .from("actions")
       .update({ status: "denied", decision: "deny", matched_policy_id: decision.matchedRuleId, updated_at: now() })
       .eq("id", actionId);
@@ -84,14 +84,14 @@ export async function runAction(
   }
 
   if (decision.effect === "require_approval") {
-    const approvalRequestId = await fileApprovalRequest(supabase, {
+    const approvalRequestId = await fileApprovalRequest(db, {
       teamId,
       request: { principal, action: request.type, resource: request.resource },
       decision,
       memberId,
       context: { params: request.params, action_id: actionId },
     });
-    await supabase
+    await db
       .from("actions")
       .update({
         status: "pending_approval",
@@ -106,15 +106,15 @@ export async function runAction(
   }
 
   // 3. allowed → execute
-  await supabase
+  await db
     .from("actions")
     .update({ status: "running", decision: "allow", matched_policy_id: decision.matchedRuleId, updated_at: now() })
     .eq("id", actionId);
 
   const exec = await executeHandler(
-    supabase,
+    db,
     actionId,
-    { supabase, teamId, memberId, apiKeyId, principal, sandbox: opts.sandbox ?? unconfiguredSandbox },
+    { db, teamId, memberId, apiKeyId, principal, sandbox: opts.sandbox ?? unconfiguredSandbox },
     request,
     opts.handlers,
     auditAction
@@ -145,13 +145,13 @@ export type ResolveApprovalOutcome = {
  * the service role to perform the resumed handler's writes.
  */
 export async function resolveApproval(
-  supabase: DbClient,
+  db: DbClient,
   input: ResolveApprovalInput,
   opts: ExecOpts = {}
 ): Promise<ResolveApprovalOutcome> {
   const { approvalRequestId, decision, deciderMemberId, note } = input;
 
-  const { data: appr } = await supabase
+  const { data: appr } = await db
     .from("approval_requests")
     .select("id, team_id, status")
     .eq("id", approvalRequestId)
@@ -159,14 +159,14 @@ export async function resolveApproval(
   if (!appr) return { approvalRequestId, status: "not_found" };
   if (appr.status !== "pending") return { approvalRequestId, status: "already_decided" };
 
-  const { data: action } = await supabase
+  const { data: action } = await db
     .from("actions")
     .select("id, action_type, resource, params, actor, member_id")
     .eq("approval_request_id", approvalRequestId)
     .maybeSingle();
 
   // Record the human decision on the approval request.
-  await supabase
+  await db
     .from("approval_requests")
     .update({
       status: decision,
@@ -176,7 +176,7 @@ export async function resolveApproval(
     })
     .eq("id", approvalRequestId);
 
-  const auditAction = makeAuditAction(supabase, {
+  const auditAction = makeAuditAction(db, {
     teamId: appr.team_id,
     memberId: deciderMemberId,
     apiKeyId: null,
@@ -186,7 +186,7 @@ export async function resolveApproval(
 
   if (decision === "denied") {
     if (action) {
-      await supabase.from("actions").update({ status: "denied", updated_at: now() }).eq("id", action.id);
+      await db.from("actions").update({ status: "denied", updated_at: now() }).eq("id", action.id);
     }
     return { approvalRequestId, status: "denied", actionId: action?.id ?? null, actionStatus: action ? "denied" : undefined };
   }
@@ -194,12 +194,12 @@ export async function resolveApproval(
   // approved → resume the action
   if (!action) return { approvalRequestId, status: "approved", actionId: null };
 
-  await supabase.from("actions").update({ status: "running", updated_at: now() }).eq("id", action.id);
+  await db.from("actions").update({ status: "running", updated_at: now() }).eq("id", action.id);
   const principal: Principal = { role: "member", tier: "team", actor: action.actor };
   const exec = await executeHandler(
-    supabase,
+    db,
     action.id,
-    { supabase, teamId: appr.team_id, memberId: action.member_id, apiKeyId: null, principal, sandbox: opts.sandbox ?? unconfiguredSandbox },
+    { db, teamId: appr.team_id, memberId: action.member_id, apiKeyId: null, principal, sandbox: opts.sandbox ?? unconfiguredSandbox },
     { type: action.action_type, resource: action.resource, params: action.params ?? {} },
     opts.handlers,
     auditAction
@@ -218,7 +218,7 @@ export async function resolveApproval(
 type ExecResult = { status: "succeeded" | "failed"; result?: Record<string, unknown>; error?: string };
 
 async function executeHandler(
-  supabase: DbClient,
+  db: DbClient,
   actionId: string,
   ctx: Parameters<ActionHandler["execute"]>[0],
   request: ActionRequest,
@@ -228,30 +228,30 @@ async function executeHandler(
   const handler = handlerRegistry(handlers).get(request.type);
   if (!handler) {
     const error = `no handler for action type '${request.type}'`;
-    await finish(supabase, actionId, "failed", { error });
+    await finish(db, actionId, "failed", { error });
     await auditAction("action.failed", { type: request.type, error });
     return { status: "failed", error };
   }
   try {
     const res = await handler.execute(ctx, request.params);
     const status = res.ok ? "succeeded" : "failed";
-    await finish(supabase, actionId, status, res.ok ? { output: res.output ?? {} } : { error: res.error ?? "failed" });
+    await finish(db, actionId, status, res.ok ? { output: res.output ?? {} } : { error: res.error ?? "failed" });
     await auditAction(`action.${status}`, { type: request.type });
     return { status, result: res.output, error: res.error };
   } catch (e) {
     const error = e instanceof Error ? e.message : "handler threw";
-    await finish(supabase, actionId, "failed", { error });
+    await finish(db, actionId, "failed", { error });
     await auditAction("action.failed", { type: request.type, error });
     return { status: "failed", error };
   }
 }
 
 function makeAuditAction(
-  supabase: DbClient,
+  db: DbClient,
   ids: { teamId: string; memberId: string | null; apiKeyId: string | null; actionId: string }
 ) {
   return (action: string, meta: Record<string, unknown>) =>
-    audit(supabase, {
+    audit(db, {
       team_id: ids.teamId,
       actor_kind: ids.apiKeyId ? "api_key" : "member",
       member_id: ids.memberId,
@@ -268,10 +268,10 @@ function now(): string {
 }
 
 async function finish(
-  supabase: DbClient,
+  db: DbClient,
   actionId: string,
   status: "succeeded" | "failed",
   result: Record<string, unknown>
 ): Promise<void> {
-  await supabase.from("actions").update({ status, result, updated_at: now() }).eq("id", actionId);
+  await db.from("actions").update({ status, result, updated_at: now() }).eq("id", actionId);
 }

--- a/lib/actions/types.ts
+++ b/lib/actions/types.ts
@@ -15,7 +15,7 @@ export interface ActionRequest {
 }
 
 export interface ActionContext {
-  supabase: DbClient; // service-role client
+  db: DbClient; // service-role client
   teamId: string;
   memberId: string | null;
   apiKeyId: string | null;

--- a/lib/api/audit.ts
+++ b/lib/api/audit.ts
@@ -14,9 +14,9 @@ export type AuditEntry = {
 };
 
 /** Append-only audit write via the service role. Best-effort: never throws. */
-export async function audit(supabase: DbClient, entry: AuditEntry) {
+export async function audit(db: DbClient, entry: AuditEntry) {
   try {
-    await supabase.from("audit_log").insert({
+    await db.from("audit_log").insert({
       team_id: entry.team_id,
       actor_kind: entry.actor_kind,
       member_id: entry.member_id ?? null,

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -23,11 +23,11 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
   const header = req.headers.get("authorization") || "";
   const teamHeader = req.headers.get("x-aios-team") || "";
   const m = header.match(/^Bearer\s+aios_([A-Za-z0-9]+)_([A-Za-z0-9_-]+)$/);
-  const supabase = adminClient();
+  const db = adminClient();
   const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || null;
 
   const fail = async (reason: string) => {
-    await audit(supabase, {
+    await audit(db, {
       team_id: null,
       actor_kind: "system",
       action: "auth.failed",
@@ -40,7 +40,7 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
   if (!m) return fail("malformed_bearer");
   const [, keyId, secret] = m;
 
-  const { data: key } = await supabase
+  const { data: key } = await db
     .from("api_keys")
     .select("id, team_id, member_id, key_hash, revoked_at, members(actor_handle, tier, status, role, display_name, email), teams(slug)")
     .eq("key_id", keyId)
@@ -64,7 +64,7 @@ export async function authenticateApiKey(req: Request): Promise<ApiAuth | null> 
   }
 
   // fire-and-forget last_used_at
-  void supabase
+  void db
     .from("api_keys")
     .update({ last_used_at: new Date().toISOString() })
     .eq("id", key.id)

--- a/lib/api/rate-limit.ts
+++ b/lib/api/rate-limit.ts
@@ -6,13 +6,13 @@ import type { DbClient } from "@/lib/db/types";
  * Window = 1 minute. Returns true if the call is allowed.
  */
 export async function rateLimit(
-  supabase: DbClient,
+  db: DbClient,
   bucket: string,
   limitPerMinute: number
 ): Promise<boolean> {
   const windowStart = new Date();
   windowStart.setSeconds(0, 0);
-  const { data, error } = await supabase.rpc("rate_limit_hit", {
+  const { data, error } = await db.rpc("rate_limit_hit", {
     p_bucket: bucket,
     p_window_start: windowStart.toISOString(),
   });

--- a/lib/auth/guard.ts
+++ b/lib/auth/guard.ts
@@ -10,16 +10,15 @@ export interface CurrentMember {
 }
 
 /**
- * Resolve the signed-in user's active membership in a team, or null. This is
- * the app-level access check that replaces RLS in postgres mode (and is a
- * defense-in-depth check in supabase mode). Use in server actions that mutate
- * team data initiated from the browser.
+ * Resolve the signed-in user's active membership in a team, or null. There is no RLS, so this
+ * app-code access check is the SOLE enforcement. Use in server actions that mutate team data
+ * initiated from the browser.
  */
 export async function currentMember(teamId: string): Promise<CurrentMember | null> {
   const user = await getSessionUser();
   if (!user) return null;
-  const supabase = await serverClient();
-  const { data } = await supabase
+  const db = await serverClient();
+  const { data } = await db
     .from("members")
     .select("id, role, tier")
     .eq("team_id", teamId)

--- a/lib/auth/slack-oauth-state.ts
+++ b/lib/auth/slack-oauth-state.ts
@@ -40,13 +40,13 @@ function secret(): Uint8Array {
  * Returns the signed `state` string for the Slack authorize URL.
  */
 export async function createSlackOAuthState(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   memberId: string
 ): Promise<string> {
   const nonce = randomUUID();
   const expiresAt = new Date(Date.now() + TTL_S * 1000).toISOString();
-  const { error } = await supabase
+  const { error } = await db
     .from("oauth_states")
     .insert({ nonce, team_id: teamId, member_id: memberId, provider: "slack", expires_at: expiresAt });
   if (error) throw new Error(`oauth state insert failed: ${error.message}`);
@@ -63,7 +63,7 @@ export async function createSlackOAuthState(
  * persisted row disagrees with the JWT claims. Single SQL UPDATE … RETURNING → no TOCTOU race.
  */
 export async function consumeSlackOAuthState(
-  supabase: DbClient,
+  db: DbClient,
   token: string | null | undefined
 ): Promise<{ teamId: string; memberId: string } | null> {
   if (!token) return null;
@@ -83,7 +83,7 @@ export async function consumeSlackOAuthState(
   }
 
   // Atomic single-use consume: succeeds only if the nonce is still unused and unexpired.
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("oauth_states")
     .update({ used_at: new Date().toISOString() })
     .eq("nonce", claims.nonce)

--- a/lib/auth/visibility.ts
+++ b/lib/auth/visibility.ts
@@ -1,10 +1,10 @@
 import "server-only";
 
 /**
- * Tier-visibility choke-point for dashboard reads (CLAUDE.md §5). In postgres mode there is
- * NO RLS, so this app-code filter is the SOLE enforcement that an `external`-tier viewer never
- * sees `team`/`admin` content; in supabase mode it's defense-in-depth alongside RLS. Route
- * every dashboard `items` read through here — the dashboard-tier-filter guard enforces it.
+ * Tier-visibility choke-point for dashboard reads (CLAUDE.md §5). There is NO RLS, so this
+ * app-code filter is the SOLE enforcement that an `external`-tier viewer never sees `team`/`admin`
+ * content. Route every dashboard `items` read through here — the dashboard-tier-filter guard
+ * enforces it.
  */
 
 export type ViewerTier = "team" | "external";

--- a/lib/chat/store.ts
+++ b/lib/chat/store.ts
@@ -45,11 +45,11 @@ export function deriveTitle(firstQuestion: string): string {
 type Owner = { teamId: string; memberId: string };
 
 export async function createConversation(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   title: string
 ): Promise<{ id: string } | null> {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("conversations")
     .insert({ team_id: owner.teamId, member_id: owner.memberId, title: deriveTitle(title) })
     .select("id")
@@ -60,11 +60,11 @@ export async function createConversation(
 
 /** True iff this member owns the conversation (the owner check every reader/writer runs first). */
 export async function ownsConversation(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   conversationId: string
 ): Promise<boolean> {
-  const { data } = await supabase
+  const { data } = await db
     .from("conversations")
     .select("id")
     .eq("id", conversationId)
@@ -76,14 +76,14 @@ export async function ownsConversation(
 }
 
 export async function appendMessage(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   conversationId: string,
   role: "user" | "assistant",
   content: string,
   usage: MessageUsage = {}
 ): Promise<void> {
-  const { error } = await supabase.from("chat_messages").insert({
+  const { error } = await db.from("chat_messages").insert({
     conversation_id: conversationId,
     team_id: owner.teamId,
     member_id: owner.memberId,
@@ -96,7 +96,7 @@ export async function appendMessage(
   });
   if (error) throw new Error(`appendMessage: ${error.message}`);
   // Bump the conversation so the list sorts most-recent-first.
-  await supabase
+  await db
     .from("conversations")
     .update({ updated_at: new Date().toISOString() })
     .eq("id", conversationId)
@@ -106,11 +106,11 @@ export async function appendMessage(
 
 /** The member's conversations, newest-active first, excluding archived. */
 export async function listConversations(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   limit = 100
 ): Promise<Conversation[]> {
-  const { data } = await supabase
+  const { data } = await db
     .from("conversations")
     .select("id, title, created_at, updated_at")
     .eq("team_id", owner.teamId)
@@ -123,11 +123,11 @@ export async function listConversations(
 
 /** A conversation's full message thread — owner-checked; null if not owned/absent. */
 export async function getConversation(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   conversationId: string
 ): Promise<{ id: string; title: string; messages: ChatMessage[] } | null> {
-  const { data: convo } = await supabase
+  const { data: convo } = await db
     .from("conversations")
     .select("id, title")
     .eq("id", conversationId)
@@ -137,7 +137,7 @@ export async function getConversation(
     .maybeSingle();
   const c = convo as { id: string; title: string } | null;
   if (!c) return null;
-  const { data: msgs } = await supabase
+  const { data: msgs } = await db
     .from("chat_messages")
     .select("id, role, content, cited_item_ids, created_at")
     .eq("conversation_id", conversationId)
@@ -150,13 +150,13 @@ export async function getConversation(
  * Owner-checked. Call this BEFORE persisting the current user message so it returns only prior turns.
  */
 export async function recentTurns(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   conversationId: string,
   maxTurns = 6
 ): Promise<ChatTurn[]> {
-  if (!(await ownsConversation(supabase, owner, conversationId))) return [];
-  const { data } = await supabase
+  if (!(await ownsConversation(db, owner, conversationId))) return [];
+  const { data } = await db
     .from("chat_messages")
     .select("role, content, created_at")
     .eq("conversation_id", conversationId)
@@ -177,12 +177,12 @@ export async function recentTurns(
 }
 
 export async function renameConversation(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   conversationId: string,
   title: string
 ): Promise<boolean> {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("conversations")
     .update({ title: deriveTitle(title), updated_at: new Date().toISOString() })
     .eq("id", conversationId)
@@ -200,12 +200,12 @@ export async function renameConversation(
  * reorder the list). Owner-scoped. Used by the background title generator; a no-op if not owned.
  */
 export async function setTitle(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   conversationId: string,
   title: string
 ): Promise<void> {
-  const { error } = await supabase
+  const { error } = await db
     .from("conversations")
     .update({ title: deriveTitle(title) })
     .eq("id", conversationId)
@@ -216,11 +216,11 @@ export async function setTitle(
 
 /** Soft-delete (archive) — hides it from the list; messages stay for any later restore/audit. */
 export async function archiveConversation(
-  supabase: DbClient,
+  db: DbClient,
   owner: Owner,
   conversationId: string
 ): Promise<boolean> {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("conversations")
     .update({ archived_at: new Date().toISOString() })
     .eq("id", conversationId)

--- a/lib/chat/title.ts
+++ b/lib/chat/title.ts
@@ -77,7 +77,7 @@ export async function generateTitle(
 
 /** Generate + persist a title for a freshly-created conversation. Best-effort (never throws to the caller). */
 export async function generateAndSetTitle(
-  supabase: DbClient,
+  db: DbClient,
   owner: { teamId: string; memberId: string },
   conversationId: string,
   question: string,
@@ -86,7 +86,7 @@ export async function generateAndSetTitle(
 ): Promise<void> {
   try {
     const title = await generateTitle(question, answer, keys);
-    if (title) await setTitle(supabase, owner, conversationId, title);
+    if (title) await setTitle(db, owner, conversationId, title);
   } catch {
     // keep the derived title
   }

--- a/lib/codebases/commits-to-items.ts
+++ b/lib/codebases/commits-to-items.ts
@@ -94,7 +94,7 @@ export function normalizeCommit(codebaseSlug: string, commit: ScanCommit): ItemP
  * Reuses the caller's already-built identity map. Returns the count of commits processed.
  */
 export async function projectCommitsToItems(
-  supabase: DbClient,
+  db: DbClient,
   auth: { teamId: string; memberId: string; apiKeyId: string },
   codebaseSlug: string,
   recentCommits: ScanCommit[],
@@ -114,7 +114,7 @@ export async function projectCommitsToItems(
       ? { name: str(commit.author), email, key: email }
       : parseAuthorIdentity(str(commit.author));
     const authorMemberId = resolveMember(identityMap, identity);
-    await ingestItem(supabase, auth, payload, "team", { authorMemberId });
+    await ingestItem(db, auth, payload, "team", { authorMemberId });
     processed++;
   }
   return processed;

--- a/lib/codebases/ingest.ts
+++ b/lib/codebases/ingest.ts
@@ -16,7 +16,7 @@ import { audit } from "@/lib/api/audit";
  *   • github_issues   — upsert (codebase_id, number)
  */
 export async function ingestCodebaseScan(
-  supabase: DbClient,
+  db: DbClient,
   auth: { teamId: string; memberId: string; apiKeyId: string },
   payload: CodebaseScanPayload
 ): Promise<{ codebase_id: string; metrics_id: string; contributions: number; issues: number }> {
@@ -24,7 +24,7 @@ export async function ingestCodebaseScan(
   const c = payload.codebase;
 
   // 1. upsert codebase identity + last_scan_at
-  const { data: codebase, error: cbErr } = await supabase
+  const { data: codebase, error: cbErr } = await db
     .from("codebases")
     .upsert(
       {
@@ -68,7 +68,7 @@ export async function ingestCodebaseScan(
   });
 
   // 3. upsert the metrics snapshot (time-series point, keyed by head_sha)
-  const { data: metrics, error: mErr } = await supabase
+  const { data: metrics, error: mErr } = await db
     .from("code_metrics")
     .upsert(
       {
@@ -113,14 +113,14 @@ export async function ingestCodebaseScan(
   let contribCount = 0;
   let commitItemCount = 0;
   if (payload.contributions.length || recentCommits.length) {
-    const identityMap = await buildIdentityMap(supabase, auth.teamId);
+    const identityMap = await buildIdentityMap(db, auth.teamId);
 
     for (const row of payload.contributions) {
       const mapped = resolveMember(identityMap, {
         email: row.author_email,
         key: row.author_key,
       });
-      const { error } = await supabase.from("code_contributions").upsert(
+      const { error } = await db.from("code_contributions").upsert(
         {
           team_id: auth.teamId,
           codebase_id: codebase.id,
@@ -142,13 +142,13 @@ export async function ingestCodebaseScan(
 
     // Project recent commits into searchable items (author message text + member attribution),
     // so NL queries can answer per-person git history — not just the aggregate counts above.
-    commitItemCount = await projectCommitsToItems(supabase, auth, c.slug, recentCommits, identityMap);
+    commitItemCount = await projectCommitsToItems(db, auth, c.slug, recentCommits, identityMap);
   }
 
   // 5. issues — upsert by number
   let issueCount = 0;
   for (const iss of payload.issues) {
-    const { error } = await supabase.from("github_issues").upsert(
+    const { error } = await db.from("github_issues").upsert(
       {
         team_id: auth.teamId,
         codebase_id: codebase.id,
@@ -171,7 +171,7 @@ export async function ingestCodebaseScan(
     issueCount++;
   }
 
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "api_key",
     member_id: auth.memberId,

--- a/lib/costs/ingest.ts
+++ b/lib/costs/ingest.ts
@@ -9,19 +9,19 @@ import { audit } from "@/lib/api/audit";
  * aggregates from `aios analyze --push` — Cursor dashboard USD + Claude session estimates.
  */
 export async function ingestUsageCost(
-  supabase: DbClient,
+  db: DbClient,
   auth: { teamId: string; memberId: string; apiKeyId: string },
   payload: UsageCostPayload
 ): Promise<{ cost_id: string; member_id: string }> {
   let memberId = auth.memberId;
   if (payload.member) {
-    const map = await buildIdentityMap(supabase, auth.teamId);
+    const map = await buildIdentityMap(db, auth.teamId);
     const resolved = resolveMember(map, { key: payload.member });
     if (!resolved) throw new IngestValidationError(`unknown member handle '${payload.member}'`);
     memberId = resolved;
   }
 
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("usage_costs")
     .upsert(
       {
@@ -45,7 +45,7 @@ export async function ingestUsageCost(
     .single();
   if (error || !data) throw new Error(`usage cost upsert failed: ${error?.message}`);
 
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "api_key",
     member_id: auth.memberId,

--- a/lib/dashboard/team-work-live.ts
+++ b/lib/dashboard/team-work-live.ts
@@ -28,13 +28,13 @@ function toRoster(
  * unavailable, so the box still shows tasks. Returns only people who have SOME signal.
  */
 export async function getTeamWork(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   teamSlug: string,
   tier: AccessTier,
   keys: ProviderKeys
 ): Promise<PersonWork[]> {
-  const { data: members } = await supabase
+  const { data: members } = await db
     .from("members")
     .select("id, display_name, actor_handle, email")
     .eq("team_id", teamId)
@@ -46,7 +46,7 @@ export async function getTeamWork(
 
   const doneSinceIso = new Date(Date.now() - DONE_WINDOW_DAYS * 86_400_000).toISOString();
   const [{ data: taskRows }, { data: commitRows }, arcs] = await Promise.all([
-    supabase
+    db
       .from("tasks")
       .select("id, title, assignee, status, updated_at")
       .eq("team_id", teamId)
@@ -54,7 +54,7 @@ export async function getTeamWork(
       .limit(2000),
     // Git commits are member_id-attributed (author→member at scan time) — the real "done" signal for
     // code contributors, who often have no `done` task rows. frontmatter->>source='git' + member set.
-    supabase
+    db
       .from("items")
       .select("id, body, member_id, frontmatter, synced_at")
       .eq("team_id", teamId)

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -87,7 +87,7 @@ function toEpisode(item: ItemRow): GraphEpisode {
  * an empty body are skipped (nothing to extract).
  */
 export async function projectItemsToGraph(
-  supabase: DbClient,
+  db: DbClient,
   args: {
     teamId: string;
     teamSlug: string;
@@ -101,7 +101,7 @@ export async function projectItemsToGraph(
   const limit = args.limit ?? 50;
   const kinds = args.kinds ?? PROJECTABLE_KINDS;
 
-  let q = supabase
+  let q = db
     .from("items")
     .select("id, kind, access, body, path, synced_at, frontmatter")
     .eq("team_id", args.teamId)
@@ -123,7 +123,7 @@ export async function projectItemsToGraph(
     }
     const contentSha = sha(episode.content);
 
-    const { data: existing } = await supabase
+    const { data: existing } = await db
       .from("graph_episodes")
       .select("content_sha256")
       .eq("team_id", args.teamId)
@@ -138,7 +138,7 @@ export async function projectItemsToGraph(
     const groupId = episodeGroupId(args.teamSlug, item.access);
     await client.addEpisodes(groupId, [episode]);
 
-    await supabase.from("graph_episodes").upsert(
+    await db.from("graph_episodes").upsert(
       {
         team_id: args.teamId,
         source_table: SOURCE_TABLE,
@@ -157,8 +157,8 @@ export async function projectItemsToGraph(
 
 /** Back-compat: project only Slack transcripts. Prefer `projectItemsToGraph` (all ingestions). */
 export async function projectSlackToGraph(
-  supabase: DbClient,
+  db: DbClient,
   args: { teamId: string; teamSlug: string; client?: GraphitiClient; since?: string; limit?: number }
 ): Promise<ProjectSummary> {
-  return projectItemsToGraph(supabase, { ...args, kinds: ["transcript"] });
+  return projectItemsToGraph(db, { ...args, kinds: ["transcript"] });
 }

--- a/lib/graph/run.test.ts
+++ b/lib/graph/run.test.ts
@@ -11,7 +11,7 @@ describe("runGraphProjection (configured gate)", () => {
     const from = vi.fn(() => {
       throw new Error("DB must not be touched when Graphiti is unconfigured");
     });
-    const res = await runGraphProjection({ client, supabase: { from } as never });
+    const res = await runGraphProjection({ client, db: { from } as never });
 
     expect(res.configured).toBe(false);
     expect(res.ok).toBe(true);

--- a/lib/graph/run.ts
+++ b/lib/graph/run.ts
@@ -29,10 +29,10 @@ export interface GraphProjectionSummary {
 const DEFAULT_LIMIT = Number(process.env.GRAPH_PROJECT_LIMIT ?? 500);
 
 async function resolveTeams(
-  supabase: DbClient,
+  db: DbClient,
   teamId?: string
 ): Promise<{ id: string; slug: string }[]> {
-  let q = supabase.from("teams").select("id, slug");
+  let q = db.from("teams").select("id, slug");
   if (teamId) q = q.eq("id", teamId);
   const { data, error } = await q;
   if (error) throw new Error(`graph projection: load teams failed: ${error.message}`);
@@ -42,7 +42,7 @@ async function resolveTeams(
 export async function runGraphProjection(opts?: {
   teamId?: string;
   client?: GraphitiClient;
-  supabase?: DbClient;
+  db?: DbClient;
   limit?: number;
 }): Promise<GraphProjectionSummary> {
   const client = opts?.client ?? new GraphitiClient();
@@ -57,14 +57,14 @@ export async function runGraphProjection(opts?: {
   };
   if (!client.configured) return summary; // nowhere to project — skip cleanly
 
-  const supabase = opts?.supabase ?? adminClient();
+  const db = opts?.db ?? adminClient();
   const limit = opts?.limit ?? DEFAULT_LIMIT;
-  const teams = await resolveTeams(supabase, opts?.teamId);
+  const teams = await resolveTeams(db, opts?.teamId);
   summary.teams = teams.length;
 
   for (const t of teams) {
     try {
-      const s = await projectItemsToGraph(supabase, {
+      const s = await projectItemsToGraph(db, {
         teamId: t.id,
         teamSlug: t.slug,
         client,

--- a/lib/identity/context.ts
+++ b/lib/identity/context.ts
@@ -102,7 +102,7 @@ function assigneeMatches(assignee: string, names: string[]): boolean {
  * resolves handle→member via getMemberProfile, so resolution isn't duplicated here).
  */
 export async function getMemberContext(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   memberId: string,
   tier: ViewerTier
@@ -110,7 +110,7 @@ export async function getMemberContext(
   if (!canSeeMemberContext(tier)) return null;
 
   // Member name/handle drive the derived-projects match against tasks.assignee (free text).
-  const { data: member } = await supabase
+  const { data: member } = await db
     .from("members")
     .select("display_name, actor_handle")
     .eq("team_id", teamId)
@@ -123,19 +123,19 @@ export async function getMemberContext(
     .map((n) => n.toLowerCase());
 
   const [profileRes, timeOffRes, goalsRes] = await Promise.all([
-    supabase
+    db
       .from("member_profiles")
       .select("timezone, working_hours, preferred_channels, location, bio")
       .eq("team_id", teamId)
       .eq("member_id", memberId)
       .maybeSingle(),
-    supabase
+    db
       .from("member_time_off")
       .select("id, starts_on, ends_on, kind, note")
       .eq("team_id", teamId)
       .eq("member_id", memberId)
       .order("starts_on", { ascending: true }),
-    supabase
+    db
       .from("member_goals")
       .select("id, kind, title, detail, status, target_date, source")
       .eq("team_id", teamId)
@@ -192,19 +192,19 @@ export async function getMemberContext(
     source: r.source,
   }));
 
-  const projects = await deriveProjects(supabase, teamId, names);
+  const projects = await deriveProjects(db, teamId, names);
 
   return { profile, timeOff, goals, projects };
 }
 
 /** Distinct projects this member is assigned tasks in, with open/total counts. */
 async function deriveProjects(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   names: string[]
 ): Promise<ProjectView[]> {
   if (!names.length) return [];
-  const { data: tasks } = await supabase
+  const { data: tasks } = await db
     .from("tasks")
     .select("project_id, assignee, status")
     .eq("team_id", teamId);
@@ -220,7 +220,7 @@ async function deriveProjects(
   }
   if (!byProject.size) return [];
 
-  const { data: projects } = await supabase
+  const { data: projects } = await db
     .from("projects")
     .select("id, slug, name")
     .eq("team_id", teamId)

--- a/lib/identity/list.ts
+++ b/lib/identity/list.ts
@@ -21,7 +21,7 @@ export interface MemberIdentityRecord {
 }
 
 export async function listMemberIdentities(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string
 ): Promise<Map<string, MemberIdentityRecord>> {
   const out = new Map<string, MemberIdentityRecord>();
@@ -34,7 +34,7 @@ export async function listMemberIdentities(
     return r;
   };
 
-  const { data: emails } = await supabase
+  const { data: emails } = await db
     .from("member_emails")
     .select("member_id, email")
     .eq("team_id", teamId);
@@ -42,7 +42,7 @@ export async function listMemberIdentities(
     if (e.email) rec(e.member_id).emails.push(e.email);
   }
 
-  const { data: identities } = await supabase
+  const { data: identities } = await db
     .from("member_identities")
     .select("member_id, provider, external_id, handle")
     .eq("team_id", teamId);

--- a/lib/identity/resolve.ts
+++ b/lib/identity/resolve.ts
@@ -32,10 +32,10 @@ export interface AuthorIdentity {
 
 /** Build lookup tables mapping author identity → member_id for the team. */
 export async function buildIdentityMap(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string
 ): Promise<IdentityMap> {
-  const { data } = await supabase
+  const { data } = await db
     .from("members")
     .select("id, email, actor_handle")
     .eq("team_id", teamId);
@@ -60,7 +60,7 @@ export async function buildIdentityMap(
   // Deliberately NOT added to emailDomains — alias domains like users.noreply.github.com are
   // shared, so widening the handle heuristic with them would re-introduce cross-author
   // misattribution (the bug PR #11 closed).
-  const { data: aliases } = await supabase
+  const { data: aliases } = await db
     .from("member_emails")
     .select("email, member_id")
     .eq("team_id", teamId);
@@ -71,7 +71,7 @@ export async function buildIdentityMap(
   // Cross-provider identities (Slack/Linear/… user ids). Keyed by (provider, external_id); any
   // email carried on the row is also folded into byEmail as a secondary exact match.
   const byProviderId = new Map<string, string>();
-  const { data: identities } = await supabase
+  const { data: identities } = await db
     .from("member_identities")
     .select("provider, external_id, email, member_id")
     .eq("team_id", teamId);
@@ -113,10 +113,10 @@ export function resolveMember(map: IdentityMap, identity: AuthorIdentity): strin
 
 /** Convenience: build the map once and resolve a batch of identities to member_ids. */
 export async function resolveMembers(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   identities: AuthorIdentity[]
 ): Promise<(string | null)[]> {
-  const map = await buildIdentityMap(supabase, teamId);
+  const map = await buildIdentityMap(db, teamId);
   return identities.map((id) => resolveMember(map, id));
 }

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -38,7 +38,7 @@ export interface IngestResult {
 }
 
 export async function ingestItem(
-  supabase: DbClient,
+  db: DbClient,
   auth: { teamId: string; memberId: string; apiKeyId: string },
   payload: ItemPayload,
   access: "team" | "external",
@@ -49,7 +49,7 @@ export async function ingestItem(
   opts?: { authorMemberId?: string | null }
 ): Promise<IngestResult> {
   // 1. project
-  const { data: project, error: projErr } = await supabase
+  const { data: project, error: projErr } = await db
     .from("projects")
     .upsert(
       { team_id: auth.teamId, slug: payload.project, last_synced_at: new Date().toISOString() },
@@ -60,7 +60,7 @@ export async function ingestItem(
   if (projErr || !project) throw new Error(`project upsert failed: ${projErr?.message}`);
 
   // 2. existing item?
-  const { data: existing } = await supabase
+  const { data: existing } = await db
     .from("items")
     .select("id, content_sha256")
     .eq("team_id", auth.teamId)
@@ -71,8 +71,8 @@ export async function ingestItem(
   const now = new Date().toISOString();
 
   if (existing && existing.content_sha256 === payload.content_sha256) {
-    await supabase.from("items").update({ synced_at: now }).eq("id", existing.id);
-    await audit(supabase, {
+    await db.from("items").update({ synced_at: now }).eq("id", existing.id);
+    await audit(db, {
       team_id: auth.teamId, actor_kind: "api_key",
       member_id: auth.memberId, api_key_id: auth.apiKeyId,
       action: "item.unchanged", target_type: "item", target_id: existing.id,
@@ -86,7 +86,7 @@ export async function ingestItem(
   let validatedTaskRows: TaskRow[] | undefined;
   if (payload.rows && payload.kind === "task") {
     validatedTaskRows = await parseAndValidateTaskRows(
-      supabase,
+      db,
       auth.teamId,
       project.id,
       payload.rows
@@ -111,16 +111,16 @@ export async function ingestItem(
 
   let itemId: string;
   if (existing) {
-    const { error } = await supabase.from("items").update(itemRecord).eq("id", existing.id);
+    const { error } = await db.from("items").update(itemRecord).eq("id", existing.id);
     if (error) throw new Error(`item update failed: ${error.message}`);
     itemId = existing.id;
   } else {
-    const { data, error } = await supabase.from("items").insert(itemRecord).select("id").single();
+    const { data, error } = await db.from("items").insert(itemRecord).select("id").single();
     if (error || !data) throw new Error(`item insert failed: ${error?.message}`);
     itemId = data.id;
   }
 
-  await supabase.from("item_versions").insert({
+  await db.from("item_versions").insert({
     item_id: itemId,
     content_sha256: payload.content_sha256,
     frontmatter: payload.frontmatter ?? {},
@@ -136,7 +136,7 @@ export async function ingestItem(
   if (payload.rows && (payload.kind === "task" || payload.kind === "decision")) {
     if (payload.kind === "task") {
       changedTaskRowKeys = await materializeTasks(
-        supabase,
+        db,
         auth.teamId,
         project.id,
         itemId,
@@ -144,11 +144,11 @@ export async function ingestItem(
         now
       );
     } else {
-      await materializeDecisions(supabase, auth.teamId, project.id, itemId, payload.rows, now);
+      await materializeDecisions(db, auth.teamId, project.id, itemId, payload.rows, now);
     }
   }
 
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId, actor_kind: "api_key",
     member_id: auth.memberId, api_key_id: auth.apiKeyId,
     action: existing ? "item.updated" : "item.created",
@@ -163,7 +163,7 @@ type TaskRow = NonNullable<ReturnType<typeof taskRowSchema.safeParse>["data"]>;
 
 /** Parse + parent-integrity checks only (no writes). Called before item upsert so 422 is clean. */
 async function parseAndValidateTaskRows(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   projectId: string,
   rawRows: unknown[]
@@ -183,7 +183,7 @@ async function parseAndValidateTaskRows(
   const parentMap = new Map<string, string>();
   const existingKeys = new Set<string>();
   {
-    const { data: existing } = await supabase
+    const { data: existing } = await db
       .from("tasks")
       .select("row_key, parent_row_key")
       .eq("team_id", teamId)
@@ -224,7 +224,7 @@ async function parseAndValidateTaskRows(
 }
 
 async function materializeTasks(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   projectId: string,
   itemId: string,
@@ -238,7 +238,7 @@ async function materializeTasks(
   // rows' projected fields changed this push (bounded reactive projection — see projectable-diff).
   const snapshotByKey = new Map<string, ProjectableSnapshot>();
   if (incomingKeys.size) {
-    const { data: before, error: beforeErr } = await supabase
+    const { data: before, error: beforeErr } = await db
       .from("tasks")
       .select("row_key, title, status, sprint, priority, labels, parent_row_key, assignee")
       .eq("team_id", teamId)
@@ -287,7 +287,7 @@ async function materializeTasks(
     if ("parent" in row) upsertRow.parent_row_key = parentOf(row) || null;
     if ("labels" in row) upsertRow.labels = row.labels ?? [];
     if ("priority" in row) upsertRow.priority = normalizeTaskPriority(row.priority);
-    const { data: task, error } = await supabase
+    const { data: task, error } = await db
       .from("tasks")
       .upsert(upsertRow, { onConflict: "team_id,project_id,row_key" })
       .select("id")
@@ -295,7 +295,7 @@ async function materializeTasks(
     if (error) throw new Error(`task row ${row.row_key}: ${error.message}`);
 
     if (row.pm_provider && row.pm_external_id) {
-      const { error: linkErr } = await supabase.from("task_pm_links").upsert(
+      const { error: linkErr } = await db.from("task_pm_links").upsert(
         {
           team_id: teamId,
           project_id: projectId,
@@ -313,7 +313,7 @@ async function materializeTasks(
   }
 
   // diff-delete: sync-originated rows absent from this push; UI rows survive.
-  const { data: current } = await supabase
+  const { data: current } = await db
     .from("tasks")
     .select("id, row_key, origin, parent_row_key")
     .eq("team_id", teamId)
@@ -322,7 +322,7 @@ async function materializeTasks(
   const survivors = new Set<string>();
   for (const t of current ?? []) {
     if (t.origin === "sync" && t.row_key && !incomingKeys.has(t.row_key)) {
-      await supabase.from("tasks").delete().eq("id", t.id);
+      await db.from("tasks").delete().eq("id", t.id);
     } else if (t.row_key) {
       survivors.add(t.row_key);
     }
@@ -333,7 +333,7 @@ async function materializeTasks(
   for (const t of current ?? []) {
     const parent = (t.parent_row_key ?? "").trim();
     if (parent && survivors.has(t.row_key!) && !survivors.has(parent)) {
-      await supabase.from("tasks").update({ parent_row_key: null }).eq("id", t.id);
+      await db.from("tasks").update({ parent_row_key: null }).eq("id", t.id);
       // Nulling a dangling parent IS a projected-field change (the child must un-nest on the board),
       // but it happens after the snapshot diff — so flag it here or reactive projection would miss it.
       if (t.row_key) changed.add(t.row_key);
@@ -346,7 +346,7 @@ async function materializeTasks(
 }
 
 async function materializeDecisions(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   projectId: string,
   itemId: string,
@@ -360,7 +360,7 @@ async function materializeDecisions(
 
   for (const row of rows) {
     const audience = normalizeTier(row.audience || "team") ?? "team";
-    const { error } = await supabase.from("decisions").upsert(
+    const { error } = await db.from("decisions").upsert(
       {
         team_id: teamId,
         project_id: projectId,

--- a/lib/ingest/reattribute.ts
+++ b/lib/ingest/reattribute.ts
@@ -39,11 +39,11 @@ function resolveItemAuthor(idMap: IdentityMap, fm: Record<string, unknown>): str
 }
 
 export async function reattributeItems(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string
 ): Promise<ReattributeSummary> {
-  const idMap = await buildIdentityMap(supabase, teamId);
-  const { data: items } = await supabase
+  const idMap = await buildIdentityMap(db, teamId);
+  const { data: items } = await db
     .from("items")
     .select("id, member_id, frontmatter")
     .eq("team_id", teamId);
@@ -58,7 +58,7 @@ export async function reattributeItems(
   for (const it of rows) {
     const resolved = resolveItemAuthor(idMap, it.frontmatter ?? {});
     if (resolved && resolved !== it.member_id) {
-      const { error } = await supabase.from("items").update({ member_id: resolved }).eq("id", it.id);
+      const { error } = await db.from("items").update({ member_id: resolved }).eq("id", it.id);
       if (error) throw new Error(`reattribute item ${it.id}: ${error.message}`);
       updated++;
     }

--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -49,8 +49,8 @@ function envSlackToken(): string | null {
 }
 
 /** Distinct teams that have at least one enabled Slack integration. */
-async function teamsWithSlack(supabase: DbClient): Promise<string[]> {
-  const { data } = await supabase
+async function teamsWithSlack(db: DbClient): Promise<string[]> {
+  const { data } = await db
     .from("integrations")
     .select("team_id")
     .eq("type", "slack")
@@ -67,11 +67,11 @@ interface ConnectorIdentity {
 
 /** Find (or auto-provision) the per-team connector member used as a given source's ingest actor. */
 async function resolveConnectorAuth(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   identity: ConnectorIdentity
 ): Promise<{ teamId: string; memberId: string; apiKeyId: string } | null> {
-  const { data: existing } = await supabase
+  const { data: existing } = await db
     .from("members")
     .select("id")
     .eq("team_id", teamId)
@@ -80,7 +80,7 @@ async function resolveConnectorAuth(
 
   let memberId = (existing as { id: string } | null)?.id;
   if (!memberId) {
-    const { data: created } = await supabase
+    const { data: created } = await db
       .from("members")
       .upsert(
         {
@@ -101,7 +101,7 @@ async function resolveConnectorAuth(
   if (!memberId) return null;
 
   // api_key_id is recorded in the audit row (no FK); reuse one if present.
-  const { data: key } = await supabase
+  const { data: key } = await db
     .from("api_keys")
     .select("id")
     .eq("team_id", teamId)
@@ -128,15 +128,15 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
   if (running) return { ...empty, skipped: true };
   running = true;
   try {
-    const supabase = adminClient();
-    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithSlack(supabase);
+    const db = adminClient();
+    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithSlack(db);
     const envToken = envSlackToken();
 
     const summary: IngestSummary = { ...empty };
     for (const teamId of teamIds) {
       let slackIntegrations;
       try {
-        slackIntegrations = (await getEnabledIntegrationsWithSecrets(supabase, teamId)).filter(
+        slackIntegrations = (await getEnabledIntegrationsWithSecrets(db, teamId)).filter(
           (i) => i.type === "slack"
         );
       } catch (err) {
@@ -145,7 +145,7 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
         continue;
       }
       if (slackIntegrations.length === 0) continue;
-      const auth = await resolveConnectorAuth(supabase, teamId, {
+      const auth = await resolveConnectorAuth(db, teamId, {
         handle: "slack-sync",
         email: "slack-sync@connector.local",
         displayName: "Slack Sync",
@@ -172,11 +172,11 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
         // Best-effort reconcile Slack users → members by email, then build the resolver map so
         // each thread's author is attributed to the real person (manual mappings included).
         try {
-          await syncSlackIdentities(supabase, teamId, detailed);
+          await syncSlackIdentities(db, teamId, detailed);
         } catch (err) {
           summary.errors.push(`team ${teamId}: slack identity sync: ${err instanceof Error ? err.message : "failed"}`);
         }
-        const idMap = await buildIdentityMap(supabase, teamId);
+        const idMap = await buildIdentityMap(db, teamId);
         const users = Object.fromEntries(detailed.map((u) => [u.id, u.displayName]));
         for (const channelId of channelIds) {
           summary.channels++;
@@ -191,7 +191,7 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
               });
               // Attribute the item to the thread author's mapped member (else the ingesting actor).
               const authorMemberId = resolveByProviderId(idMap, "slack", thread.root.user ?? "");
-              const res = await ingestItem(supabase, auth, payload, "team", { authorMemberId });
+              const res = await ingestItem(db, auth, payload, "team", { authorMemberId });
               if (res.status === "created") summary.created++;
               else if (res.status === "updated") summary.updated++;
               else summary.unchanged++;
@@ -227,8 +227,8 @@ export interface PlaneIngestSummary {
 }
 
 /** Distinct teams with at least one enabled Plane integration. */
-async function teamsWithPlane(supabase: DbClient): Promise<string[]> {
-  const { data } = await supabase
+async function teamsWithPlane(db: DbClient): Promise<string[]> {
+  const { data } = await db
     .from("integrations")
     .select("team_id")
     .eq("type", "plane")
@@ -258,14 +258,14 @@ export async function runPlaneIngestion(opts: { teamId?: string } = {}): Promise
   if (planeRunning) return { ...empty, skipped: true };
   planeRunning = true;
   try {
-    const supabase = adminClient();
-    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithPlane(supabase);
+    const db = adminClient();
+    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithPlane(db);
 
     const summary: PlaneIngestSummary = { ...empty };
     for (const teamId of teamIds) {
       let planeIntegrations;
       try {
-        planeIntegrations = (await getEnabledIntegrationsWithSecrets(supabase, teamId)).filter(
+        planeIntegrations = (await getEnabledIntegrationsWithSecrets(db, teamId)).filter(
           (i) => i.type === "plane"
         );
       } catch (err) {
@@ -273,7 +273,7 @@ export async function runPlaneIngestion(opts: { teamId?: string } = {}): Promise
         continue;
       }
       if (planeIntegrations.length === 0) continue;
-      const auth = await resolveConnectorAuth(supabase, teamId, {
+      const auth = await resolveConnectorAuth(db, teamId, {
         handle: "plane-sync",
         email: "plane-sync@connector.local",
         displayName: "Plane Sync",
@@ -311,22 +311,22 @@ export async function runPlaneIngestion(opts: { teamId?: string } = {}): Promise
           // Reconcile Plane members → people by email, then build the resolver map so each
           // work-item's assignee is attributed to the real person.
           try {
-            await syncProviderIdentities(supabase, teamId, "plane", fetched.memberDetails);
+            await syncProviderIdentities(db, teamId, "plane", fetched.memberDetails);
           } catch (err) {
             summary.errors.push(`team ${teamId}: plane identity sync: ${err instanceof Error ? err.message : "failed"}`);
           }
-          const idMap = await buildIdentityMap(supabase, teamId);
+          const idMap = await buildIdentityMap(db, teamId);
           // Work-items → tasks (one kind=task item).
           const payload = normalizePlaneProject({ ...fetched, aiosSources });
           summary.items += payload.rows?.length ?? 0;
-          const res = await ingestItem(supabase, auth, payload, "team");
+          const res = await ingestItem(db, auth, payload, "team");
           if (res.status === "created") summary.created++;
           else if (res.status === "updated") summary.updated++;
           else summary.unchanged++;
           // Work-item text → deliverable items (searchable), one per work-item; attributed to assignee.
           for (const doc of normalizePlaneDocs({ ...fetched, aiosSources })) {
             const authorMemberId = resolveByProviderId(idMap, "plane", String(doc.frontmatter?.assignee_id ?? ""));
-            const r = await ingestItem(supabase, auth, doc, "team", { authorMemberId });
+            const r = await ingestItem(db, auth, doc, "team", { authorMemberId });
             if (r.status === "created") summary.created++;
             else if (r.status === "updated") summary.updated++;
             else summary.unchanged++;
@@ -351,8 +351,8 @@ export async function runPlaneIngestion(opts: { teamId?: string } = {}): Promise
 export type ImportSummary = PlaneIngestSummary;
 
 /** Distinct teams with at least one enabled integration of a given type. */
-async function teamsWithType(supabase: DbClient, type: "linear" | "github"): Promise<string[]> {
-  const { data } = await supabase
+async function teamsWithType(db: DbClient, type: "linear" | "github"): Promise<string[]> {
+  const { data } = await db
     .from("integrations")
     .select("team_id")
     .eq("type", type)
@@ -376,19 +376,19 @@ export async function runLinearIngestion(opts: { teamId?: string } = {}): Promis
   if (linearRunning) return { ...emptyImportSummary(), skipped: true };
   linearRunning = true;
   try {
-    const supabase = adminClient();
-    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithType(supabase, "linear");
+    const db = adminClient();
+    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithType(db, "linear");
     const summary = emptyImportSummary();
     for (const teamId of teamIds) {
       let integrations;
       try {
-        integrations = (await getEnabledIntegrationsWithSecrets(supabase, teamId)).filter((i) => i.type === "linear");
+        integrations = (await getEnabledIntegrationsWithSecrets(db, teamId)).filter((i) => i.type === "linear");
       } catch (err) {
         summary.errors.push(`team ${teamId}: ${err instanceof Error ? err.message : "secret read failed"}`);
         continue;
       }
       if (integrations.length === 0) continue;
-      const auth = await resolveConnectorAuth(supabase, teamId, {
+      const auth = await resolveConnectorAuth(db, teamId, {
         handle: "linear-sync",
         email: "linear-sync@connector.local",
         displayName: "Linear Sync",
@@ -400,7 +400,7 @@ export async function runLinearIngestion(opts: { teamId?: string } = {}): Promis
       // Linear node ids the brain already owns via a projection/adoption link — excluded from the
       // inbound mirror so only net-new Linear-authored issues import (brain authors → Linear out;
       // only Linear-side tasks flow back in). Footer round-trippers are filtered in normalize too.
-      const { data: ownedLinks } = await supabase
+      const { data: ownedLinks } = await db
         .from("task_pm_links")
         .select("provider_resource_id")
         .eq("team_id", teamId)
@@ -425,22 +425,22 @@ export async function runLinearIngestion(opts: { teamId?: string } = {}): Promis
           // Reconcile Linear members → people by email, then build the resolver map so each
           // issue's assignee is attributed to the real person.
           try {
-            await syncProviderIdentities(supabase, teamId, "linear", fetched.members);
+            await syncProviderIdentities(db, teamId, "linear", fetched.members);
           } catch (err) {
             summary.errors.push(`team ${teamId}: linear identity sync: ${err instanceof Error ? err.message : "failed"}`);
           }
-          const idMap = await buildIdentityMap(supabase, teamId);
+          const idMap = await buildIdentityMap(db, teamId);
           // Issues → tasks (one kind=task item). Brain-owned issues are excluded (only Linear-authored import).
           const payload = normalizeLinearTeam({ ...fetched, ownedResourceIds });
           summary.items += payload.rows?.length ?? 0;
-          const res = await ingestItem(supabase, auth, payload, "team");
+          const res = await ingestItem(db, auth, payload, "team");
           if (res.status === "created") summary.created++;
           else if (res.status === "updated") summary.updated++;
           else summary.unchanged++;
           // Issue text → deliverable items (searchable), one per issue; attributed to assignee.
           for (const doc of normalizeLinearDocs({ ...fetched, ownedResourceIds })) {
             const authorMemberId = resolveByProviderId(idMap, "linear", String(doc.frontmatter?.assignee_id ?? ""));
-            const r = await ingestItem(supabase, auth, doc, "team", { authorMemberId });
+            const r = await ingestItem(db, auth, doc, "team", { authorMemberId });
             if (r.status === "created") summary.created++;
             else if (r.status === "updated") summary.updated++;
             else summary.unchanged++;
@@ -468,19 +468,19 @@ export async function runGithubIngestion(opts: { teamId?: string } = {}): Promis
   if (githubRunning) return { ...emptyImportSummary(), skipped: true };
   githubRunning = true;
   try {
-    const supabase = adminClient();
-    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithType(supabase, "github");
+    const db = adminClient();
+    const teamIds = opts.teamId ? [opts.teamId] : await teamsWithType(db, "github");
     const summary = emptyImportSummary();
     for (const teamId of teamIds) {
       let integrations;
       try {
-        integrations = (await getEnabledIntegrationsWithSecrets(supabase, teamId)).filter((i) => i.type === "github");
+        integrations = (await getEnabledIntegrationsWithSecrets(db, teamId)).filter((i) => i.type === "github");
       } catch (err) {
         summary.errors.push(`team ${teamId}: ${err instanceof Error ? err.message : "secret read failed"}`);
         continue;
       }
       if (integrations.length === 0) continue;
-      const auth = await resolveConnectorAuth(supabase, teamId, {
+      const auth = await resolveConnectorAuth(db, teamId, {
         handle: "github-sync",
         email: "github-sync@connector.local",
         displayName: "GitHub Sync",
@@ -506,7 +506,7 @@ export async function runGithubIngestion(opts: { teamId?: string } = {}): Promis
             const fetched = await fetchGithubRepoIssues({ owner, repo, token });
             const payload = normalizeGithubRepo(fetched);
             summary.items += payload.rows?.length ?? 0;
-            const res = await ingestItem(supabase, auth, payload, "team");
+            const res = await ingestItem(db, auth, payload, "team");
             if (res.status === "created") summary.created++;
             else if (res.status === "updated") summary.updated++;
             else summary.unchanged++;
@@ -519,7 +519,7 @@ export async function runGithubIngestion(opts: { teamId?: string } = {}): Promis
             const payloads = normalizeGithubFiles(fetched);
             summary.items += payloads.length;
             for (const payload of payloads) {
-              const res = await ingestItem(supabase, auth, payload, "team");
+              const res = await ingestItem(db, auth, payload, "team");
               if (res.status === "created") summary.created++;
               else if (res.status === "updated") summary.updated++;
               else summary.unchanged++;

--- a/lib/ingest/runs.ts
+++ b/lib/ingest/runs.ts
@@ -56,11 +56,11 @@ const MAX_ERROR_CHARS = 500;
  * Append one ingestion run. Never throws — a logging failure must not fail the ingestion it
  * describes. `ok` is derived to false whenever there are errors, even if the caller passed true.
  */
-export async function recordIngestRun(supabase: DbClient, run: IngestRunInput): Promise<void> {
+export async function recordIngestRun(db: DbClient, run: IngestRunInput): Promise<void> {
   try {
     const errors = (run.errors ?? []).slice(0, MAX_ERRORS).map((e) => String(e).slice(0, MAX_ERROR_CHARS));
     const finishedAt = run.finishedAt ?? Date.now();
-    await supabase.from("ingest_runs").insert({
+    await db.from("ingest_runs").insert({
       team_id: run.teamId ?? null,
       source: run.source,
       trigger: run.trigger,
@@ -86,7 +86,7 @@ export async function recordIngestRun(supabase: DbClient, run: IngestRunInput): 
  * aggregates (team_id null). Newest first. Read-only; the Admin page gates access (CLAUDE.md §5).
  */
 export async function listRecentIngestRuns(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   limit = 50
 ): Promise<IngestRunRow[]> {
@@ -95,8 +95,8 @@ export async function listRecentIngestRuns(
   // Two queries + JS merge: the postgres adapter has no `.or()`, and this is the team's own runs
   // PLUS instance-wide scheduler aggregates (team_id null). Newest first, capped at `limit`.
   const [own, aggregate] = await Promise.all([
-    supabase.from("ingest_runs").select(cols).eq("team_id", teamId).order("finished_at", { ascending: false }).limit(limit),
-    supabase.from("ingest_runs").select(cols).is("team_id", null).order("finished_at", { ascending: false }).limit(limit),
+    db.from("ingest_runs").select(cols).eq("team_id", teamId).order("finished_at", { ascending: false }).limit(limit),
+    db.from("ingest_runs").select(cols).is("team_id", null).order("finished_at", { ascending: false }).limit(limit),
   ]);
   return [...((own.data ?? []) as IngestRunRow[]), ...((aggregate.data ?? []) as IngestRunRow[])]
     .sort((a, b) => (a.finished_at < b.finished_at ? 1 : a.finished_at > b.finished_at ? -1 : 0))

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -24,14 +24,14 @@ export function startIngestScheduler(): void {
   const intervalMs = Math.max(1, minutes) * 60_000;
 
   const tick = async () => {
-    const supabase = adminClient();
-    await runImport(supabase, "slack", runSlackIngestion);
-    await runImport(supabase, "plane", runPlaneIngestion);
-    await runImport(supabase, "linear", runLinearIngestion);
+    const db = adminClient();
+    await runImport(db, "slack", runSlackIngestion);
+    await runImport(db, "plane", runPlaneIngestion);
+    await runImport(db, "linear", runLinearIngestion);
     // Inbound Linear→brain apply/adopt (brain-api v1.4) — sequenced AFTER the Linear ingest so
     // adopt sees freshly-imported mirror tasks. Per-team opt-in; quiet no-op otherwise.
-    await runInbound(supabase);
-    await runImport(supabase, "github", runGithubIngestion);
+    await runInbound(db);
+    await runImport(db, "github", runGithubIngestion);
     // Incremental dense (semantic) indexing of newly-synced items. No-op unless dense retrieval is
     // configured (EMBEDDINGS_URL + pgvector schema); best-effort — never fails the tick.
     try {
@@ -46,7 +46,7 @@ export function startIngestScheduler(): void {
   // Inbound PM-sync step (brain-api v1.4): apply Linear board edits to brain tasks + adopt
   // Linear-native issues, for opted-in teams. Records to ingest_runs like the importers; a
   // quiet pass (nothing enabled / nothing changed / no conflicts) logs nothing.
-  async function runInbound(supabase: ReturnType<typeof adminClient>): Promise<void> {
+  async function runInbound(db: ReturnType<typeof adminClient>): Promise<void> {
     const startedAt = Date.now();
     try {
       const s = await runLinearInbound();
@@ -57,7 +57,7 @@ export function startIngestScheduler(): void {
         `[ingest] linear-inbound: applied ${s.applied}, adopted ${s.adopted}, conflicts ${s.conflicts} (${s.teams} teams)` +
           (s.errors.length ? ` errors: ${s.errors.join("; ")}` : "")
       );
-      await recordIngestRun(supabase, {
+      await recordIngestRun(db, {
         source: "linear_inbound",
         trigger: "scheduler",
         ok: s.ok,
@@ -71,14 +71,14 @@ export function startIngestScheduler(): void {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[ingest] linear-inbound tick failed:`, msg);
-      await recordIngestRun(supabase, { source: "linear_inbound", trigger: "scheduler", ok: false, errors: [msg], startedAt });
+      await recordIngestRun(db, { source: "linear_inbound", trigger: "scheduler", ok: false, errors: [msg], startedAt });
     }
   }
 
   // Shared runner: run one source, log a line, and record the outcome to ingest_runs so a failure
   // (or a silent staleness) is diagnosable later instead of only living in container logs.
   async function runImport(
-    supabase: ReturnType<typeof adminClient>,
+    db: ReturnType<typeof adminClient>,
     label: string,
     run: () => Promise<ImportSummary | IngestSummary>
   ): Promise<void> {
@@ -101,7 +101,7 @@ export function startIngestScheduler(): void {
       // Skip logging unconfigured sources with nothing to report (avoids a no-op row every tick);
       // still record configured sources (proves the poller ran) and anything with errors.
       if (s.integrations === 0 && s.errors.length === 0) return;
-      await recordIngestRun(supabase, {
+      await recordIngestRun(db, {
         source: label,
         trigger: "scheduler",
         ok: s.ok,
@@ -115,7 +115,7 @@ export function startIngestScheduler(): void {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[ingest] ${label} tick failed:`, msg);
-      await recordIngestRun(supabase, { source: label, trigger: "scheduler", ok: false, errors: [msg], startedAt });
+      await recordIngestRun(db, { source: label, trigger: "scheduler", ok: false, errors: [msg], startedAt });
     }
   }
 

--- a/lib/integrations/github-link.ts
+++ b/lib/integrations/github-link.ts
@@ -18,8 +18,8 @@ interface GithubRow {
 }
 
 /** The team's canonical github integration (earliest-created if several), or null. */
-async function firstGithubRow(supabase: DbClient, teamId: string): Promise<GithubRow | null> {
-  const { data } = await supabase
+async function firstGithubRow(db: DbClient, teamId: string): Promise<GithubRow | null> {
+  const { data } = await db
     .from("integrations")
     .select("name, status, config")
     .eq("team_id", teamId)
@@ -41,12 +41,12 @@ function currentRepos(row: GithubRow | null): string[] {
 
 /** Upsert the canonical github row with a new repos list, preserving other config + status. */
 async function writeRepos(
-  supabase: DbClient,
+  db: DbClient,
   auth: IntegrationAuth,
   row: GithubRow | null,
   repos: string[]
 ): Promise<void> {
-  await upsertIntegration(supabase, auth, {
+  await upsertIntegration(db, auth, {
     type: "github",
     name: row?.name ?? "github", // conflict key is (team,type,name) — a stable name = one row
     config: { ...(row?.config ?? {}), repos },
@@ -59,13 +59,13 @@ async function writeRepos(
  * Returns the resulting repos list. Throws `RepoFormatError` on malformed input (surfaced to the UI).
  */
 export async function linkGithubRepo(
-  supabase: DbClient,
+  db: DbClient,
   auth: IntegrationAuth,
   repoInput: string
 ): Promise<string[]> {
-  const row = await firstGithubRow(supabase, auth.teamId);
+  const row = await firstGithubRow(db, auth.teamId);
   const repos = addRepo(currentRepos(row), repoInput); // validates + case-insensitive de-dup
-  await writeRepos(supabase, auth, row, repos);
+  await writeRepos(db, auth, row, repos);
   return repos;
 }
 
@@ -75,11 +75,11 @@ export async function linkGithubRepo(
  * upsert key.
  */
 export async function ensureGithubIntegration(
-  supabase: DbClient,
+  db: DbClient,
   auth: IntegrationAuth
 ): Promise<string> {
-  const row = await firstGithubRow(supabase, auth.teamId);
-  const { id } = await upsertIntegration(supabase, auth, {
+  const row = await firstGithubRow(db, auth.teamId);
+  const { id } = await upsertIntegration(db, auth, {
     type: "github",
     name: row?.name ?? "github",
     config: { ...(row?.config ?? {}), repos: currentRepos(row) }, // preserve repos, no-op if unchanged
@@ -94,10 +94,10 @@ export async function ensureGithubIntegration(
  * row regardless of enabled/disabled so an access check reflects the true stored token.
  */
 export async function githubReposAndToken(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string
 ): Promise<{ repos: string[]; token: string | null }> {
-  const { data } = await supabase
+  const { data } = await db
     .from("integrations")
     .select("config, secret_ciphertext")
     .eq("team_id", teamId)
@@ -113,13 +113,13 @@ export async function githubReposAndToken(
 
 /** Unlink a repo (case-insensitive). No-op if no github row / repo absent. Returns the repos list. */
 export async function unlinkGithubRepo(
-  supabase: DbClient,
+  db: DbClient,
   auth: IntegrationAuth,
   repoInput: string
 ): Promise<string[]> {
-  const row = await firstGithubRow(supabase, auth.teamId);
+  const row = await firstGithubRow(db, auth.teamId);
   if (!row) return [];
   const repos = removeRepo(currentRepos(row), repoInput);
-  await writeRepos(supabase, auth, row, repos);
+  await writeRepos(db, auth, row, repos);
   return repos;
 }

--- a/lib/integrations/manage.ts
+++ b/lib/integrations/manage.ts
@@ -23,13 +23,13 @@ export interface IntegrationAuth {
 }
 
 export async function upsertIntegration(
-  supabase: DbClient,
+  db: DbClient,
   auth: IntegrationAuth,
   input: IntegrationInput
 ): Promise<{ id: string; status: string }> {
   const config = validateIntegrationConfig(input.type, input.config); // throws IntegrationConfigError → 400
   const now = new Date().toISOString();
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("integrations")
     .upsert(
       {
@@ -47,7 +47,7 @@ export async function upsertIntegration(
     .single();
   if (error || !data) throw new Error(`integration upsert failed: ${error?.message}`);
 
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "member",
     member_id: auth.memberId,
@@ -60,18 +60,18 @@ export async function upsertIntegration(
 }
 
 export async function setIntegrationStatus(
-  supabase: DbClient,
+  db: DbClient,
   auth: IntegrationAuth,
   id: string,
   status: "enabled" | "disabled"
 ): Promise<void> {
-  const { error } = await supabase
+  const { error } = await db
     .from("integrations")
     .update({ status, updated_at: new Date().toISOString() })
     .eq("id", id)
     .eq("team_id", auth.teamId); // team-scope the write — no cross-team mutation
   if (error) throw new Error(`integration status update failed: ${error.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "member",
     member_id: auth.memberId,
@@ -83,17 +83,17 @@ export async function setIntegrationStatus(
 }
 
 export async function deleteIntegration(
-  supabase: DbClient,
+  db: DbClient,
   auth: IntegrationAuth,
   id: string
 ): Promise<void> {
-  const { error } = await supabase
+  const { error } = await db
     .from("integrations")
     .delete()
     .eq("id", id)
     .eq("team_id", auth.teamId);
   if (error) throw new Error(`integration delete failed: ${error.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "member",
     member_id: auth.memberId,
@@ -110,18 +110,18 @@ export async function deleteIntegration(
  * never the value).
  */
 export async function setIntegrationSecret(
-  supabase: DbClient,
+  db: DbClient,
   auth: IntegrationAuth,
   id: string,
   secret: string
 ): Promise<void> {
-  const { error } = await supabase
+  const { error } = await db
     .from("integrations")
     .update({ secret_ciphertext: encryptSecret(secret), updated_at: new Date().toISOString() })
     .eq("id", id)
     .eq("team_id", auth.teamId);
   if (error) throw new Error(`integration secret update failed: ${error.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "member",
     member_id: auth.memberId,
@@ -145,10 +145,10 @@ export interface IntegrationWithSecret {
  * from the connector-key-authenticated endpoint (GET /api/v1/integrations) — never a page.
  */
 export async function getEnabledIntegrationsWithSecrets(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string
 ): Promise<IntegrationWithSecret[]> {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("integrations")
     .select("id, type, name, config, secret_ciphertext")
     .eq("team_id", teamId)
@@ -170,11 +170,11 @@ export async function getEnabledIntegrationsWithSecrets(
  * Never reaches a browser; the key is decrypted only here, in-process.
  */
 export async function getProviderKey(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   type: ProviderIntegrationType
 ): Promise<string | null> {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("integrations")
     .select("secret_ciphertext")
     .eq("team_id", teamId)
@@ -206,10 +206,10 @@ export interface IntegrationSelection {
  * helpers are all admin-role-gated). Team-scoped: only the caller's `teamId` is returned.
  */
 export async function listEnabledIntegrationSelections(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string
 ): Promise<IntegrationSelection[]> {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("integrations")
     .select("id, type, name, config, status") // NOTE: no secret_ciphertext — by design
     .eq("team_id", teamId)

--- a/lib/integrations/read.ts
+++ b/lib/integrations/read.ts
@@ -31,13 +31,13 @@ export interface IntegrationMeta {
 }
 
 export async function listIntegrations(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   viewer: IntegrationsViewer
 ): Promise<IntegrationMeta[]> {
   // Admin-tier surface, no RLS on postgres → this app-code gate is the sole enforcement.
   if (!canManageIntegrations(viewer.role)) return [];
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("integrations")
     .select("id, type, name, config, status, secret_ciphertext, created_at")
     .eq("team_id", teamId)
@@ -64,13 +64,13 @@ export async function listIntegrations(
  * isolation.
  */
 export async function resolveIntegrationsAdmin(
-  supabase: DbClient,
+  db: DbClient,
   teamSlug: string,
   userId: string
 ): Promise<{ teamId: string; memberId: string } | null> {
-  const { data: team } = await supabase.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
-  const { data: me } = await supabase
+  const { data: me } = await db
     .from("members")
     .select("id, role")
     .eq("team_id", team.id)

--- a/lib/member-secrets/manage.ts
+++ b/lib/member-secrets/manage.ts
@@ -25,7 +25,7 @@ export interface MemberSecret {
 
 /** Upsert a member's secret for a provider (encrypts at rest; audits keys/flags only). */
 export async function setMemberSecret(
-  supabase: DbClient,
+  db: DbClient,
   auth: MemberAuth,
   provider: string,
   secret: string,
@@ -34,7 +34,7 @@ export async function setMemberSecret(
   const p = provider.trim().toLowerCase();
   if (!p) throw new Error("provider is required");
   if (!secret) throw new Error("secret is required");
-  const { error } = await supabase
+  const { error } = await db
     .from("member_secrets")
     .upsert(
       {
@@ -48,7 +48,7 @@ export async function setMemberSecret(
       { onConflict: "team_id,member_id,provider" }
     );
   if (error) throw new Error(`member secret upsert failed: ${error.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "member",
     member_id: auth.memberId,
@@ -61,13 +61,13 @@ export async function setMemberSecret(
 
 /** Read + decrypt a member's secret, or null if not connected. Server-only. */
 export async function getMemberSecret(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   memberId: string,
   provider: string
 ): Promise<MemberSecret | null> {
   const p = provider.trim().toLowerCase();
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("member_secrets")
     .select("secret_ciphertext, meta, updated_at")
     .eq("team_id", teamId)
@@ -85,19 +85,19 @@ export async function getMemberSecret(
 
 /** Delete a member's secret for a provider (disconnect). Audited. */
 export async function deleteMemberSecret(
-  supabase: DbClient,
+  db: DbClient,
   auth: MemberAuth,
   provider: string
 ): Promise<void> {
   const p = provider.trim().toLowerCase();
-  const { error } = await supabase
+  const { error } = await db
     .from("member_secrets")
     .delete()
     .eq("team_id", auth.teamId)
     .eq("member_id", auth.memberId)
     .eq("provider", p);
   if (error) throw new Error(`member secret delete failed: ${error.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "member",
     member_id: auth.memberId,

--- a/lib/metrics/codebases.ts
+++ b/lib/metrics/codebases.ts
@@ -47,7 +47,7 @@ type MetricRow = {
 };
 
 export async function getCodebaseSummaries(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   range: Range,
   tier: ViewerTier
@@ -57,12 +57,12 @@ export async function getCodebaseSummaries(
   const windowStart = new Date(Date.now() - rangeDays(range) * 86_400_000).toISOString();
 
   const [cbRes, mRes] = await Promise.all([
-    supabase
+    db
       .from("codebases")
       .select("id, slug, full_name, primary_language, stars, open_issues, last_scan_at")
       .eq("team_id", teamId)
       .order("last_scan_at", { ascending: false, nullsFirst: false }),
-    supabase
+    db
       .from("code_metrics")
       .select("codebase_id, scanned_at, agentic_score, health_score, test_coverage_pct, ai_commit_ratio, readiness_level, readiness_pct")
       .eq("team_id", teamId)
@@ -192,13 +192,13 @@ export interface CodebaseFreshness {
  * like the rest of codebase analytics (sole enforcement on postgres, no RLS).
  */
 export async function getCodebaseFreshness(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   tier: ViewerTier
 ): Promise<CodebaseFreshness[]> {
   if (!canSeeCodebases(tier)) return [];
 
-  const { data: cbData } = await supabase
+  const { data: cbData } = await db
     .from("codebases")
     .select("id, slug, full_name, default_branch, last_scan_at")
     .eq("team_id", teamId)
@@ -213,7 +213,7 @@ export async function getCodebaseFreshness(
   if (codebases.length === 0) return [];
 
   // Newest head_sha per codebase (rows arrive newest-first; first seen wins).
-  const { data: mData } = await supabase
+  const { data: mData } = await db
     .from("code_metrics")
     .select("codebase_id, head_sha, scanned_at")
     .eq("team_id", teamId)
@@ -317,7 +317,7 @@ export interface CodebaseDetail {
 }
 
 export async function getCodebaseDetail(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   slug: string,
   range: Range,
@@ -325,7 +325,7 @@ export async function getCodebaseDetail(
 ): Promise<CodebaseDetail | null> {
   if (!canSeeCodebases(tier)) return null;
 
-  const { data: cb } = await supabase
+  const { data: cb } = await db
     .from("codebases")
     .select(
       "id, slug, full_name, default_branch, description, homepage, primary_language, languages, stars, forks, open_issues, last_scan_at"
@@ -346,7 +346,7 @@ export async function getCodebaseDetail(
     "readiness_level, readiness_pct, readiness_pillars";
 
   const [metricsRes, contribRes, issuesRes, membersRes] = await Promise.all([
-    supabase
+    db
       .from("code_metrics")
       .select(METRIC_COLS)
       .eq("codebase_id", codebaseId)
@@ -354,19 +354,19 @@ export async function getCodebaseDetail(
       // DESC + limit keeps the newest points; reversed below for chronological trend.
       .order("scanned_at", { ascending: false })
       .limit(2000),
-    supabase
+    db
       .from("code_contributions")
       .select("author_key, author_name, member_id, day, commits, ai_commits, additions, deletions")
       .eq("codebase_id", codebaseId)
       .gte("day", windowStart.slice(0, 10))
       .limit(10_000),
-    supabase
+    db
       .from("github_issues")
       .select("number, title, state, is_pull_request, author_login, labels, url, opened_at")
       .eq("codebase_id", codebaseId)
       .order("updated_at", { ascending: false })
       .limit(200),
-    supabase.from("members").select("id, display_name, github_login, avatar_url").eq("team_id", teamId),
+    db.from("members").select("id, display_name, github_login, avatar_url").eq("team_id", teamId),
   ]);
 
   type MemberMeta = { display_name: string | null; github_login: string | null; avatar_url: string | null };
@@ -550,7 +550,7 @@ function dayStr(v: string | Date): string {
  * (the `lib/metrics/codebases` choke-point is the sole enforcement on postgres).
  */
 export async function getContributorDetail(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   slug: string,
   ref: ContributorRef,
@@ -559,7 +559,7 @@ export async function getContributorDetail(
 ): Promise<ContributorDetail | null> {
   if (!canSeeCodebases(tier)) return null;
 
-  const { data: cb } = await supabase
+  const { data: cb } = await db
     .from("codebases")
     .select("id, slug")
     .eq("team_id", teamId)
@@ -568,7 +568,7 @@ export async function getContributorDetail(
   if (!cb) return null;
 
   const windowStart = new Date(Date.now() - rangeDays(range) * 86_400_000).toISOString().slice(0, 10);
-  let q = supabase
+  let q = db
     .from("code_contributions")
     .select("author_key, author_name, member_id, day, commits, ai_commits, additions, deletions")
     .eq("codebase_id", (cb as { id: string }).id)
@@ -612,7 +612,7 @@ export async function getContributorDetail(
   let github_login: string | null = null;
   const member_id = "memberId" in ref ? ref.memberId : rows.find((r) => r.member_id)?.member_id ?? null;
   if (member_id) {
-    const { data: m } = await supabase
+    const { data: m } = await db
       .from("members")
       .select("display_name, avatar_url, github_login")
       .eq("id", member_id)
@@ -661,7 +661,7 @@ export interface MemberProfile {
  * the team's codebases. Looked up by `actor_handle` or `github_login`. Tier-gated team-only.
  */
 export async function getMemberProfile(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   handle: string,
   range: Range,
@@ -669,7 +669,7 @@ export async function getMemberProfile(
 ): Promise<MemberProfile | null> {
   if (!canSeeCodebases(tier)) return null;
 
-  const { data: members } = await supabase
+  const { data: members } = await db
     .from("members")
     .select("id, display_name, actor_handle, github_login, avatar_url, role, status")
     .eq("team_id", teamId);
@@ -692,7 +692,7 @@ export async function getMemberProfile(
   if (!member) return null;
 
   const windowStart = new Date(Date.now() - rangeDays(range) * 86_400_000).toISOString().slice(0, 10);
-  const { data: contribs } = await supabase
+  const { data: contribs } = await db
     .from("code_contributions")
     .select("day, commits, ai_commits, additions, deletions, codebases(slug)")
     .eq("team_id", teamId)

--- a/lib/metrics/external-costs.ts
+++ b/lib/metrics/external-costs.ts
@@ -65,7 +65,7 @@ function scopeUsageCosts<Q>(query: Q, viewer: QueryLogViewer): Q {
 }
 
 export async function getExternalCosts(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   range: Range,
   viewer: QueryLogViewer
@@ -76,7 +76,7 @@ export async function getExternalCosts(
 
   const [costRes, membersRes] = await Promise.all([
     scopeUsageCosts(
-      supabase
+      db
         .from("usage_costs")
         .select(
           "member_id, provider, source, project, input_tokens, output_tokens, cache_read_tokens, cost_usd, events, cost_date"
@@ -87,7 +87,7 @@ export async function getExternalCosts(
         .limit(50_000),
       viewer
     ),
-    supabase
+    db
       .from("members")
       .select("id, display_name, actor_handle, avatar_url")
       .eq("team_id", teamId),
@@ -168,7 +168,7 @@ export async function getExternalCosts(
 
 /** Combined brain + external spend for a member-facing total. */
 export async function getCombinedSpend(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   range: Range,
   viewer: QueryLogViewer,
@@ -177,7 +177,7 @@ export async function getCombinedSpend(
   const windowStart = new Date(Date.now() - rangeDays(range) * 86_400_000).toISOString();
 
   const brainRes = await scopeQueryLog(
-    supabase
+    db
       .from("query_log")
       .select("cost_usd")
       .eq("team_id", teamId)
@@ -187,7 +187,7 @@ export async function getCombinedSpend(
 
   const external =
     externalSummary ??
-    (await getExternalCosts(supabase, teamId, range, viewer));
+    (await getExternalCosts(db, teamId, range, viewer));
 
   const brain_usd = round(
     ((brainRes.data ?? []) as { cost_usd: number | string }[]).reduce(

--- a/lib/metrics/individual-maturity-ingest.ts
+++ b/lib/metrics/individual-maturity-ingest.ts
@@ -14,14 +14,14 @@ import { placement, type AemPlacement } from "@/lib/metrics/individual-maturity"
  * maturity.ts so the maturity-tier-filter guard only polices reads.
  */
 export async function ingestMaturitySnapshot(
-  supabase: DbClient,
+  db: DbClient,
   auth: { teamId: string; memberId: string; apiKeyId: string },
   payload: MaturitySnapshotPayload
 ): Promise<{ snapshot_id: string; member_id: string; canonical: AemPlacement }> {
   // Resolve the member: an explicit handle must map to a team member; else self.
   let memberId = auth.memberId;
   if (payload.member) {
-    const map = await buildIdentityMap(supabase, auth.teamId);
+    const map = await buildIdentityMap(db, auth.teamId);
     const resolved = resolveMember(map, { key: payload.member });
     if (!resolved) throw new IngestValidationError(`unknown member handle '${payload.member}'`);
     memberId = resolved;
@@ -30,7 +30,7 @@ export async function ingestMaturitySnapshot(
   const s = payload.signals;
   const canonical = placement(s);
 
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("agentic_maturity_snapshots")
     .upsert(
       {
@@ -73,7 +73,7 @@ export async function ingestMaturitySnapshot(
     .single();
   if (error || !data) throw new Error(`maturity snapshot upsert failed: ${error?.message}`);
 
-  await audit(supabase, {
+  await audit(db, {
     team_id: auth.teamId,
     actor_kind: "api_key",
     member_id: auth.memberId,

--- a/lib/metrics/individual-maturity.ts
+++ b/lib/metrics/individual-maturity.ts
@@ -193,13 +193,13 @@ function averageAxes(rows: AemAxes[]): AemAxes {
  * Spine distribution. Team-tier only — an external viewer gets an empty board.
  */
 export async function getTeamMaturity(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   tier: ViewerTier
 ): Promise<TeamMaturity> {
   if (!canSeeMaturity(tier)) return { asOf: null, members: [], teamAxes: averageAxes([]), spineDistribution: {} };
 
-  const { data: snaps } = await supabase
+  const { data: snaps } = await db
     .from("agentic_maturity_snapshots")
     .select(
       `member_id, snapshot_date, canonical_spine, canonical_overall, ce_band, tasks, sessions,
@@ -217,7 +217,7 @@ export async function getTeamMaturity(
   const memberIds = [...latest.keys()];
   const nameById = new Map<string, { handle: string; name: string; avatar: string | null }>();
   if (memberIds.length) {
-    const { data: members } = await supabase
+    const { data: members } = await db
       .from("members")
       .select("id, actor_handle, display_name, avatar_url")
       .in("id", memberIds);
@@ -277,14 +277,14 @@ export type MemberMaturity = {
  * (for the comparison radar) + the weakest-axis prescription. Team-tier only.
  */
 export async function getMemberMaturity(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   handle: string,
   tier: ViewerTier
 ): Promise<MemberMaturity | null> {
   if (!canSeeMaturity(tier)) return null;
 
-  const { data: member } = await supabase
+  const { data: member } = await db
     .from("members")
     .select("id, actor_handle, display_name, avatar_url")
     .eq("team_id", teamId)
@@ -293,7 +293,7 @@ export async function getMemberMaturity(
   if (!member) return null;
   const m = member as { id: string; actor_handle: string; display_name: string; avatar_url: string | null };
 
-  const { data: snaps } = await supabase
+  const { data: snaps } = await db
     .from("agentic_maturity_snapshots")
     .select(
       `member_id, snapshot_date, canonical_spine, canonical_overall, ce_band, tasks, sessions,
@@ -327,7 +327,7 @@ export async function getMemberMaturity(
   };
 
   // team average for the comparison overlay (reuse the team read, tier already checked)
-  const team = await getTeamMaturity(supabase, teamId, tier);
+  const team = await getTeamMaturity(db, teamId, tier);
 
   return {
     handle: m.actor_handle,

--- a/lib/metrics/maturity.ts
+++ b/lib/metrics/maturity.ts
@@ -37,7 +37,7 @@ function rank(level: string | null): number {
 }
 
 export async function getTeamMaturity(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   range: Range,
   tier: ViewerTier
@@ -51,7 +51,7 @@ export async function getTeamMaturity(
     repos: [],
   };
 
-  const { codebases } = await getCodebaseSummaries(supabase, teamId, range, tier);
+  const { codebases } = await getCodebaseSummaries(db, teamId, range, tier);
   if (!codebases.length) return empty;
 
   const distribution = { ...empty.distribution };

--- a/lib/metrics/members.ts
+++ b/lib/metrics/members.ts
@@ -65,7 +65,7 @@ const UNATTRIBUTED = "Unattributed";
  * through `scopeQueryLog`: admins get team-wide rows, everyone else only their own.
  */
 export async function getPerMemberCosts(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   range: Range,
   viewer: QueryLogViewer
@@ -74,7 +74,7 @@ export async function getPerMemberCosts(
 
   const [logRes, membersRes] = await Promise.all([
     scopeQueryLog(
-      supabase
+      db
         .from("query_log")
         .select("member_id, input_tokens, output_tokens, cache_read_tokens, cost_usd, created_at")
         .eq("team_id", teamId)
@@ -83,7 +83,7 @@ export async function getPerMemberCosts(
         .limit(50_000),
       viewer
     ),
-    supabase
+    db
       .from("members")
       .select("id, display_name, actor_handle, github_login, avatar_url")
       .eq("team_id", teamId),
@@ -170,7 +170,7 @@ export interface ThroughputCost {
  * authors have no member_id to attribute spend to).
  */
 export async function getThroughputVsCost(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   range: Range,
   viewer: QueryLogViewer
@@ -180,7 +180,7 @@ export async function getThroughputVsCost(
 
   // Contributions are restricted to the viewer's own member_id for non-admins (mirrors the
   // query_log scoping — a member must not see another member's throughput). Admins: team-wide.
-  let contribQuery = supabase
+  let contribQuery = db
     .from("code_contributions")
     .select("member_id, commits, ai_commits")
     .eq("team_id", teamId)
@@ -191,7 +191,7 @@ export async function getThroughputVsCost(
 
   const [contribRes, costs] = await Promise.all([
     contribQuery,
-    getPerMemberCosts(supabase, teamId, range, viewer),
+    getPerMemberCosts(db, teamId, range, viewer),
   ]);
 
   const contribRows = (contribRes.data ?? []) as {
@@ -230,7 +230,7 @@ export async function getThroughputVsCost(
   // (e.g. a member with commits but zero brain queries in the window).
   const missing = [...byMember.values()].filter((r) => r.member_name === "Member");
   if (missing.length) {
-    const { data: meta } = await supabase
+    const { data: meta } = await db
       .from("members")
       .select("id, display_name, actor_handle, avatar_url")
       .eq("team_id", teamId)

--- a/lib/metrics/pulse.ts
+++ b/lib/metrics/pulse.ts
@@ -85,10 +85,11 @@ function isoDay(d: Date): string {
 
 /**
  * Normalize a timestamptz to an ISO string. CRITICAL: the postgres adapter (the deployed backend)
- * returns timestamptz columns as **Date objects**, while supabase returns ISO strings. The window
- * math below compares/ slices these as strings, and `Date >= isoString` coerces the string to NaN
- * (→ always false), which silently bucketed every recent row as "prior" — the dashboard read 0 with
- * ↓100% on postgres. Mirrors lib/query/retrieve.ts. Accepts string | Date so both backends work.
+ * returns timestamptz columns as **Date objects**, whereas the legacy Supabase-js client returned
+ * ISO strings. The window math below compares/slices these as strings, and `Date >= isoString`
+ * coerces the string to NaN (→ always false), which silently bucketed every recent row as "prior" —
+ * the dashboard read 0 with ↓100% on postgres. Mirrors lib/query/retrieve.ts. Still accepts
+ * `string | Date` so a caller passing either shape normalizes correctly.
  */
 function toIso(v: string | Date): string {
   return typeof v === "string" ? v : new Date(v).toISOString();
@@ -133,7 +134,7 @@ const IN_FLIGHT = new Set(["ready", "in_progress", "blocked"]);
 // ── main ─────────────────────────────────────────────────────────────────────
 
 export async function getPulseMetrics(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   range: Range,
   viewer: { isAdmin: boolean; memberId: string }
@@ -150,7 +151,7 @@ export async function getPulseMetrics(
   // Fetch each source once over the combined [prior, now] window where a delta
   // is needed, then split current vs. prior in JS.
   const [itemsRes, queryRes, tasksRes] = await Promise.all([
-    supabase
+    db
       .from("items")
       .select("kind, synced_at")
       .eq("team_id", teamId)
@@ -158,7 +159,7 @@ export async function getPulseMetrics(
       .order("synced_at", { ascending: false })
       .limit(10_000),
     scopeQueryLog(
-      supabase
+      db
         .from("query_log")
         .select("cost_usd, created_at")
         .eq("team_id", teamId)
@@ -167,14 +168,14 @@ export async function getPulseMetrics(
         .limit(10_000),
       viewer
     ),
-    supabase
+    db
       .from("tasks")
       .select("status, updated_at")
       .eq("team_id", teamId)
       .limit(5_000),
   ]);
 
-  // NB: the pg adapter returns timestamptz as Date; supabase as string. Normalize via toIso below.
+  // NB: the pg adapter returns timestamptz as Date (legacy Supabase-js returned string). Normalize via toIso below.
   const itemRows = (itemsRes.data ?? []) as { kind: string; synced_at: string | Date }[];
   const queryRows = (queryRes.data ?? []) as { cost_usd: number | string; created_at: string | Date }[];
   const taskRows = (tasksRes.data ?? []) as { status: string; updated_at: string | Date }[];

--- a/lib/pm-sync/after-write.ts
+++ b/lib/pm-sync/after-write.ts
@@ -24,8 +24,8 @@ import {
 
 // Load a task by id with the canonical projection column set (shared with the engine). Missing row
 // (e.g. deleted between the write and the after() callback) → null.
-async function loadTaskById(supabase: DbClient, taskId: string): Promise<ProjectionTaskRow | null> {
-  const { data } = await supabase.from("tasks").select(PROJECTION_TASK_COLS).eq("id", taskId).maybeSingle();
+async function loadTaskById(db: DbClient, taskId: string): Promise<ProjectionTaskRow | null> {
+  const { data } = await db.from("tasks").select(PROJECTION_TASK_COLS).eq("id", taskId).maybeSingle();
   return (data as ProjectionTaskRow | null) ?? null;
 }
 
@@ -33,14 +33,14 @@ async function loadTaskById(supabase: DbClient, taskId: string): Promise<Project
 // moveTaskAction / updateTaskAction via after(). Always single-row — the UI bypasses the push-path
 // changed-rows guard (Decision 3) and the engine's fingerprint skip prevents a redundant write.
 export async function projectTaskByIdAfterWrite(
-  supabase: DbClient,
+  db: DbClient,
   taskId: string,
   opts: { fetchImpl?: typeof fetch } = {}
 ): Promise<ProjectionReport | null> {
   try {
-    const row = await loadTaskById(supabase, taskId);
+    const row = await loadTaskById(db, taskId);
     if (!row) return null;
-    return await projectTask(supabase, row, { fetchImpl: opts.fetchImpl });
+    return await projectTask(db, row, { fetchImpl: opts.fetchImpl });
   } catch {
     // Swallow — projection must never surface as a user-action failure.
     return null;
@@ -51,7 +51,7 @@ export async function projectTaskByIdAfterWrite(
 // semantics — prepare once, parent-before-child, shared resolved map, synced-only throttle — but
 // scoped to the rows whose projected fields changed this push.
 export async function projectChangedTasksAfterWrite(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   projectId: string,
   rowKeys: string[],
@@ -59,10 +59,10 @@ export async function projectChangedTasksAfterWrite(
 ): Promise<ProjectionReport[]> {
   if (!rowKeys.length) return [];
   try {
-    const primary = await resolvePrimaryProvider(supabase, teamId);
+    const primary = await resolvePrimaryProvider(db, teamId);
     if (primary.provider === null) return []; // no PM tool configured → nothing to project or surface
 
-    const { data } = await supabase
+    const { data } = await db
       .from("tasks")
       .select(PROJECTION_TASK_COLS)
       .eq("team_id", teamId)
@@ -76,11 +76,11 @@ export async function projectChangedTasksAfterWrite(
     // instead of failing silently. No bootstrap is reachable here, so don't take the batch path.
     if (primary.integration === null) {
       const reports: ProjectionReport[] = [];
-      for (const row of rows) reports.push(await projectTask(supabase, row, { primary, fetchImpl: opts.fetchImpl }));
+      for (const row of rows) reports.push(await projectTask(db, row, { primary, fetchImpl: opts.fetchImpl }));
       return reports;
     }
 
-    return await projectRows(supabase, primary, rows, { fetchImpl: opts.fetchImpl });
+    return await projectRows(db, primary, rows, { fetchImpl: opts.fetchImpl });
   } catch {
     return [];
   }

--- a/lib/pm-sync/inbound.ts
+++ b/lib/pm-sync/inbound.ts
@@ -158,8 +158,8 @@ export function classifyInboundRow(row: InboundRow): InboundRowState {
  * Load every Linear link for the team enriched with its task row, outbound-identical parent
  * resolution, the recomputed fingerprint, and the two-check `brainUnchanged` verdict.
  */
-export async function loadInboundRows(supabase: DbClient, teamId: string): Promise<InboundRow[]> {
-  const { data: linkData } = await supabase
+export async function loadInboundRows(db: DbClient, teamId: string): Promise<InboundRow[]> {
+  const { data: linkData } = await db
     .from("task_pm_links")
     .select(INBOUND_LINK_COLS)
     .eq("team_id", teamId)
@@ -170,7 +170,7 @@ export async function loadInboundRows(supabase: DbClient, teamId: string): Promi
   const taskIds = links.map((l) => l.task_id).filter((v): v is string => !!v);
   const tasksById = new Map<string, ProjectionTaskRow>();
   if (taskIds.length) {
-    const { data: taskData } = await supabase
+    const { data: taskData } = await db
       .from("tasks")
       .select(PROJECTION_TASK_COLS)
       .eq("team_id", teamId)
@@ -266,12 +266,12 @@ async function applyStatusTx(args: {
 }
 
 async function applyInbound(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   seenByResource: Map<string, SeenState>,
   result: InboundResult
 ): Promise<void> {
-  const rows = await loadInboundRows(supabase, teamId);
+  const rows = await loadInboundRows(db, teamId);
   for (const row of rows) {
     const { link, task } = row;
     if (!link.provider_resource_id) continue; // never projected/adopted — nothing to reconcile
@@ -283,7 +283,7 @@ async function applyInbound(
 
     // Persist the freshly-seen state name (write-if-changed — same semantics as reconcile.ts).
     if (seen.name !== link.provider_seen_status) {
-      await supabase
+      await db
         .from("task_pm_links")
         .update({ provider_seen_status: seen.name, updated_at: new Date().toISOString() })
         .eq("id", link.id);
@@ -309,7 +309,7 @@ async function applyInbound(
       // Renamed/deleted state with no resolvable group → conflict, not an apply (v1.4 normative).
       const reason = `unresolvable Linear state "${seen.name}" (type "${seen.type}")`;
       result.conflicts.push(conflictOf(link, seen.name, task.status, reason));
-      await supabase
+      await db
         .from("task_pm_links")
         .update({ last_error: `inbound: ${reason}`.slice(0, 1000), updated_at: new Date().toISOString() })
         .eq("id", link.id);
@@ -366,7 +366,7 @@ function topoIssues(issues: LinearImportIssue[]): LinearImportIssue[] {
 }
 
 async function adoptInbound(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   primary: ResolvedPrimary,
   fetched: FetchedLinearTeam,
@@ -377,7 +377,7 @@ async function adoptInbound(
   if ((ADOPT_TIER as string) !== "team") throw new Error("inbound adopt must be team-tier");
 
   const mirrorSlug = linearMirrorProject(fetched.teamKey);
-  const { data: proj } = await supabase
+  const { data: proj } = await db
     .from("projects")
     .select("id")
     .eq("team_id", teamId)
@@ -390,7 +390,7 @@ async function adoptInbound(
   const projectId = (proj as { id: string }).id;
 
   // Links for dedupe (owned node ids) + outbound-identical parent resolution within the mirror.
-  const { data: linkData } = await supabase
+  const { data: linkData } = await db
     .from("task_pm_links")
     .select("project_id, row_key, provider_resource_id")
     .eq("team_id", teamId)
@@ -408,7 +408,7 @@ async function adoptInbound(
   const externalSource = (primary.integration.config?.externalSource as string | undefined) || "aios-backlog";
 
   for (const it of candidates) {
-    const { data: taskData } = await supabase
+    const { data: taskData } = await db
       .from("tasks")
       .select(PROJECTION_TASK_COLS)
       .eq("team_id", teamId)
@@ -500,15 +500,15 @@ async function adoptInbound(
 
 /**
  * Run the full inbound pass (apply + adopt) for one team. Fail-soft at every gate: no Linear
- * primary / no opt-in / no teamId / supabase legacy backend all return an explanatory reason
- * instead of throwing (matching the ingest runner's surfaced-reason pattern).
+ * primary / no opt-in / no teamId all return an explanatory reason instead of throwing (matching
+ * the ingest runner's surfaced-reason pattern).
  */
 export async function runInboundForTeam(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   opts: { fetchImpl?: typeof fetch } = {}
 ): Promise<InboundResult> {
-  const primary = await resolvePrimaryProvider(supabase, teamId);
+  const primary = await resolvePrimaryProvider(db, teamId);
   if (primary.provider !== "linear") {
     return emptyResult({ provider: null, reason: primary.provider === null ? (primary.reason ?? "no primary PM provider") : "inbound apply is Linear-only" });
   }
@@ -536,7 +536,7 @@ export async function runInboundForTeam(
 
   // Phase A — apply. One read-only provider listing ({name,type} per issue id).
   const seenByResource = await linearAdapter.fetchSeenStates!({ integration: primary.integration, fetchImpl });
-  await applyInbound(supabase, teamId, seenByResource, result);
+  await applyInbound(db, teamId, seenByResource, result);
 
   // Phase B — adopt. Reuses the ingest fetch (identifier/description/url, footer detection).
   const fetched = await fetchLinearTeam({
@@ -544,7 +544,7 @@ export async function runInboundForTeam(
     teamId: teamIdConfig,
     fetchImpl,
   });
-  await adoptInbound(supabase, teamId, primary, fetched, result, fetchImpl);
+  await adoptInbound(db, teamId, primary, fetched, result, fetchImpl);
 
   return result;
 }
@@ -585,12 +585,12 @@ export async function runLinearInbound(
   if (inboundRunning) return { ...summary, skipped: true };
   inboundRunning = true;
   try {
-    const supabase = adminClient();
+    const db = adminClient();
     let teamIds: string[];
     if (opts.teamId) {
       teamIds = [opts.teamId];
     } else {
-      const { data } = await supabase
+      const { data } = await db
         .from("integrations")
         .select("team_id")
         .eq("type", "linear")
@@ -599,7 +599,7 @@ export async function runLinearInbound(
     }
     for (const teamId of teamIds) {
       try {
-        const r = await runInboundForTeam(supabase, teamId, { fetchImpl: opts.fetchImpl });
+        const r = await runInboundForTeam(db, teamId, { fetchImpl: opts.fetchImpl });
         if (!r.enabled) continue; // not opted in / not Linear — quiet no-op
         summary.teams += 1;
         summary.applied += r.applied.length;

--- a/lib/pm-sync/index.ts
+++ b/lib/pm-sync/index.ts
@@ -48,19 +48,19 @@ function mapStatus(status: ProjectionReport["status"]): TaskPmSyncReport["status
 // Back-compat wrapper retained for the work-events report shape. Loads the full task row and
 // delegates to the projection engine in statusOnly mode (reconcile workflow state only).
 export async function syncTaskPmLinks(
-  supabase: DbClient,
+  db: DbClient,
   task: TaskForPmSync,
   opts: { fetchImpl?: typeof fetch } = {}
 ): Promise<TaskPmSyncReport[]> {
   if (!task.row_key) return [{ row_key: "", provider: null, status: "no_link" }];
 
-  const { data } = await supabase
+  const { data } = await db
     .from("tasks")
     .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key")
     .eq("id", task.id)
     .maybeSingle();
   if (!data) return [{ row_key: task.row_key, provider: null, status: "no_link" }];
 
-  const report = await projectTask(supabase, data as ProjectionTaskRow, { statusOnly: true, fetchImpl: opts.fetchImpl });
+  const report = await projectTask(db, data as ProjectionTaskRow, { statusOnly: true, fetchImpl: opts.fetchImpl });
   return [{ row_key: report.row_key, provider: report.provider, status: mapStatus(report.status), error: report.error }];
 }

--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -91,11 +91,11 @@ function chooseIntegration(integrations: IntegrationWithSecret[], provider: PmPr
 // Resolve the team's projection target: its configured primary_pm_provider, or — if unset — the
 // sole enabled PM integration. Ambiguous/none → null (caller no-ops with a clear report).
 export async function resolvePrimaryProvider(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string
 ): Promise<PrimaryResolution> {
-  const integrations = await getEnabledIntegrationsWithSecrets(supabase, teamId);
-  const { data: team } = await supabase.from("teams").select("primary_pm_provider").eq("id", teamId).maybeSingle();
+  const integrations = await getEnabledIntegrationsWithSecrets(db, teamId);
+  const { data: team } = await db.from("teams").select("primary_pm_provider").eq("id", teamId).maybeSingle();
   const configured = (team?.primary_pm_provider as PmProvider | null) ?? null;
 
   if (configured) {
@@ -144,12 +144,12 @@ export const PROJECTION_TASK_COLS =
 
 // Get-or-create the task_pm_links row for (team, project, row_key, provider).
 async function ensureLink(
-  supabase: DbClient,
+  db: DbClient,
   row: ProjectionTaskRow,
   provider: PmProvider,
   defaultSource: string
 ): Promise<TaskPmLink> {
-  const { data: existing } = await supabase
+  const { data: existing } = await db
     .from("task_pm_links")
     .select(LINK_COLS)
     .eq("team_id", row.team_id)
@@ -169,13 +169,13 @@ async function ensureLink(
     provider_external_source: defaultSource,
     provider_url: "",
   };
-  const { data, error } = await supabase.from("task_pm_links").insert(insert).select(LINK_COLS).single();
+  const { data, error } = await db.from("task_pm_links").insert(insert).select(LINK_COLS).single();
   if (error) throw new Error(`create task PM link failed: ${error.message}`);
   return data as TaskPmLink;
 }
 
 async function persistSuccess(
-  supabase: DbClient,
+  db: DbClient,
   link: TaskPmLink,
   result: UpsertWorkItemResult,
   fingerprint: string,
@@ -184,7 +184,7 @@ async function persistSuccess(
   brainStatus: string
 ) {
   const now = new Date().toISOString();
-  await supabase
+  await db
     .from("task_pm_links")
     .update({
       provider_resource_id: result.providerResourceId,
@@ -201,20 +201,20 @@ async function persistSuccess(
     .eq("id", link.id);
 }
 
-async function persistError(supabase: DbClient, link: TaskPmLink, message: string) {
-  await supabase
+async function persistError(db: DbClient, link: TaskPmLink, message: string) {
+  await db
     .from("task_pm_links")
     .update({ last_error: message.slice(0, 1000), updated_at: new Date().toISOString() })
     .eq("id", link.id);
 }
 
 async function loadTaskByRowKey(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   projectId: string,
   rowKey: string
 ): Promise<ProjectionTaskRow | null> {
-  const { data } = await supabase
+  const { data } = await db
     .from("tasks")
     .select(PROJECTION_TASK_COLS)
     .eq("team_id", teamId)
@@ -227,21 +227,21 @@ async function loadTaskByRowKey(
 // Project one task into the team's primary PM tool. Resolves the parent first (so the provider
 // sub-issue link exists), upserts the work item, and persists the link bookkeeping. Brain-wins.
 export async function projectTask(
-  supabase: DbClient,
+  db: DbClient,
   row: ProjectionTaskRow,
   opts: ProjectTaskOptions = {}
 ): Promise<ProjectionReport> {
   if (!row.row_key) return { row_key: "", provider: null, status: "no_row_key" };
 
-  const primary: PrimaryResolution = opts.primary ?? (await resolvePrimaryProvider(supabase, row.team_id));
+  const primary: PrimaryResolution = opts.primary ?? (await resolvePrimaryProvider(db, row.team_id));
   if (primary.provider === null) {
     return { row_key: row.row_key, provider: null, status: "no_primary_provider", error: primary.reason };
   }
   if (primary.integration === null) {
     // Provider is known but its integration is missing — create/find the link and record the
     // error on it so the pm-sync failure surface shows it, then report missing_integration.
-    const link = await ensureLink(supabase, row, primary.provider, "aios-backlog");
-    await persistError(supabase, link, primary.reason);
+    const link = await ensureLink(db, row, primary.provider, "aios-backlog");
+    await persistError(db, link, primary.reason);
     return { row_key: row.row_key, provider: primary.provider, status: "missing_integration", error: primary.reason };
   }
   const { provider, integration } = primary;
@@ -261,11 +261,11 @@ export async function projectTask(
         return { row_key: row.row_key, provider, status: "cycle", error: `parent cycle at ${row.row_key}` };
       }
       visiting.add(row.row_key);
-      const parentRow = await loadTaskByRowKey(supabase, row.team_id, row.project_id, row.parent_row_key);
+      const parentRow = await loadTaskByRowKey(db, row.team_id, row.project_id, row.parent_row_key);
       if (!parentRow) {
         return { row_key: row.row_key, provider, status: "missing_parent", error: `parent ${row.parent_row_key} not found` };
       }
-      const parentReport = await projectTask(supabase, parentRow, { ...opts, visiting });
+      const parentReport = await projectTask(db, parentRow, { ...opts, visiting });
       if (parentReport.status === "failed" || parentReport.status === "cycle" || parentReport.status === "missing_parent") {
         return { row_key: row.row_key, provider, status: parentReport.status, error: `parent ${row.parent_row_key}: ${parentReport.error ?? parentReport.status}` };
       }
@@ -273,7 +273,7 @@ export async function projectTask(
     }
   }
 
-  const link = await ensureLink(supabase, row, provider, defaultSource);
+  const link = await ensureLink(db, row, provider, defaultSource);
   const task = toProjectable(row, parentResourceId);
   const fingerprint = projectionFingerprint(task, parentResourceId);
 
@@ -294,12 +294,12 @@ export async function projectTask(
       bootstrap: opts.bootstrap,
       fetchImpl: opts.fetchImpl,
     });
-    await persistSuccess(supabase, link, result, fingerprint, row.status);
+    await persistSuccess(db, link, result, fingerprint, row.status);
     opts.resolved?.set(row.row_key, result.providerResourceId);
     return { row_key: row.row_key, provider, status: result.status, providerResourceId: result.providerResourceId };
   } catch (e) {
     const message = e instanceof Error ? e.message : "projection failed";
-    await persistError(supabase, link, message);
+    await persistError(db, link, message);
     return { row_key: row.row_key, provider, status: "failed", error: message };
   }
 }
@@ -337,7 +337,7 @@ export interface ProjectAllOptions {
 // rows that actually wrote. Both `projectAllTasks` (whole board) and the reactive changed-rows path
 // reuse this so the prepare/order/throttle semantics can't drift apart.
 export async function projectRows(
-  supabase: DbClient,
+  db: DbClient,
   primary: ResolvedPrimary,
   rows: ProjectionTaskRow[],
   opts: ProjectAllOptions = {}
@@ -357,7 +357,7 @@ export async function projectRows(
   const reports: ProjectionReport[] = [];
 
   for (const row of topoOrder(rows)) {
-    const report = await projectTask(supabase, row, {
+    const report = await projectTask(db, row, {
       primary,
       bootstrap,
       resolved,
@@ -374,17 +374,17 @@ export async function projectRows(
 // retired plane:backlog / linear:backlog seed scripts. ~80 rows × 1 provider ≈ ~90s with the
 // throttle. Continues on per-row failure and returns a per-row report.
 export async function projectAllTasks(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   projectId: string,
   opts: ProjectAllOptions = {}
 ): Promise<{ provider: PmProvider | null; reports: ProjectionReport[]; reason?: string }> {
-  const primary = await resolvePrimaryProvider(supabase, teamId);
+  const primary = await resolvePrimaryProvider(db, teamId);
   if (primary.provider === null || primary.integration === null) {
     return { provider: primary.provider, reports: [], reason: primary.reason };
   }
 
-  const { data: taskRows } = await supabase
+  const { data: taskRows } = await db
     .from("tasks")
     .select(PROJECTION_TASK_COLS)
     .eq("team_id", teamId)
@@ -393,6 +393,6 @@ export async function projectAllTasks(
   const rows = ((taskRows ?? []) as ProjectionTaskRow[]).filter((r) => r.row_key);
   if (!rows.length) return { provider: primary.provider, reports: [] };
 
-  const reports = await projectRows(supabase, primary, rows, opts);
+  const reports = await projectRows(db, primary, rows, opts);
   return { provider: primary.provider, reports };
 }

--- a/lib/pm-sync/reconcile.ts
+++ b/lib/pm-sync/reconcile.ts
@@ -69,11 +69,11 @@ export function isDiverged(link: {
 }
 
 export async function reconcileProviderState(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   opts: { fetchImpl?: typeof fetch } = {}
 ): Promise<ReconcileResult> {
-  const primary = await resolvePrimaryProvider(supabase, teamId);
+  const primary = await resolvePrimaryProvider(db, teamId);
   if (primary.provider === null || primary.integration === null) {
     return { provider: primary.provider, seenUpdated: 0, divergences: [], reason: primary.reason };
   }
@@ -82,7 +82,7 @@ export async function reconcileProviderState(
     return { provider: primary.provider, seenUpdated: 0, divergences: [], reason: `${primary.provider} has no inbound reconcile support` };
   }
 
-  const { data } = await supabase
+  const { data } = await db
     .from("task_pm_links")
     .select(LINK_COLS)
     .eq("team_id", teamId)
@@ -102,7 +102,7 @@ export async function reconcileProviderState(
 
     // Persist the seen state NAME ONLY when it changed — keeps a re-run write-free (idempotent).
     if (seen.name !== link.provider_seen_status) {
-      await supabase
+      await db
         .from("task_pm_links")
         .update({ provider_seen_status: seen.name, updated_at: new Date().toISOString() })
         .eq("id", link.id);

--- a/lib/policy/index.ts
+++ b/lib/policy/index.ts
@@ -44,10 +44,10 @@ function mapRow(r: PolicyRow): PolicyRule {
 }
 
 export async function loadPolicies(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string
 ): Promise<PolicyRule[]> {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("policies")
     .select(
       "id, priority, subject_role, subject_tier, subject_actor, action, resource, effect, enabled"
@@ -60,11 +60,11 @@ export async function loadPolicies(
 }
 
 export async function authorize(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   request: PolicyRequest
 ): Promise<PolicyDecision> {
-  const rules = await loadPolicies(supabase, teamId);
+  const rules = await loadPolicies(db, teamId);
   return evaluatePolicy(rules, request);
 }
 
@@ -72,7 +72,7 @@ export async function authorize(
  * Record a pending approval for a `require_approval` decision. Returns the request id.
  */
 export async function fileApprovalRequest(
-  supabase: DbClient,
+  db: DbClient,
   args: {
     teamId: string;
     request: PolicyRequest;
@@ -81,7 +81,7 @@ export async function fileApprovalRequest(
     context?: Record<string, unknown>;
   }
 ): Promise<string> {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("approval_requests")
     .insert({
       team_id: args.teamId,

--- a/lib/policy/manage.ts
+++ b/lib/policy/manage.ts
@@ -67,8 +67,8 @@ function fields(input: PolicyInput) {
   };
 }
 
-export async function listAllPolicies(supabase: DbClient, teamId: string): Promise<PolicyRecord[]> {
-  const { data, error } = await supabase
+export async function listAllPolicies(db: DbClient, teamId: string): Promise<PolicyRecord[]> {
+  const { data, error } = await db
     .from("policies")
     .select("id, priority, description, subject_role, subject_tier, subject_actor, action, resource, effect, enabled")
     .eq("team_id", teamId)
@@ -79,19 +79,19 @@ export async function listAllPolicies(supabase: DbClient, teamId: string): Promi
 }
 
 export async function createPolicy(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   input: PolicyInput,
   actor: PolicyActor = {}
 ): Promise<string> {
   validate(input);
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("policies")
     .insert({ team_id: teamId, created_by: actor.memberId ?? null, ...fields(input) })
     .select("id")
     .single();
   if (error || !data) throw new Error(`policy create failed: ${error?.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: teamId, actor_kind: "member", member_id: actor.memberId ?? null,
     action: "policy.created", target_type: "policy", target_id: data.id,
     meta: { action: input.action, effect: input.effect, resource: input.resource ?? "*" },
@@ -100,20 +100,20 @@ export async function createPolicy(
 }
 
 export async function updatePolicy(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   id: string,
   input: PolicyInput,
   actor: PolicyActor = {}
 ): Promise<void> {
   validate(input);
-  const { error } = await supabase
+  const { error } = await db
     .from("policies")
     .update({ ...fields(input), updated_at: new Date().toISOString() })
     .eq("team_id", teamId)
     .eq("id", id);
   if (error) throw new Error(`policy update failed: ${error.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: teamId, actor_kind: "member", member_id: actor.memberId ?? null,
     action: "policy.updated", target_type: "policy", target_id: id,
     meta: { action: input.action, effect: input.effect },
@@ -121,33 +121,33 @@ export async function updatePolicy(
 }
 
 export async function setPolicyEnabled(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   id: string,
   enabled: boolean,
   actor: PolicyActor = {}
 ): Promise<void> {
-  const { error } = await supabase
+  const { error } = await db
     .from("policies")
     .update({ enabled, updated_at: new Date().toISOString() })
     .eq("team_id", teamId)
     .eq("id", id);
   if (error) throw new Error(`policy toggle failed: ${error.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: teamId, actor_kind: "member", member_id: actor.memberId ?? null,
     action: enabled ? "policy.enabled" : "policy.disabled", target_type: "policy", target_id: id, meta: {},
   });
 }
 
 export async function deletePolicy(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   id: string,
   actor: PolicyActor = {}
 ): Promise<void> {
-  const { error } = await supabase.from("policies").delete().eq("team_id", teamId).eq("id", id);
+  const { error } = await db.from("policies").delete().eq("team_id", teamId).eq("id", id);
   if (error) throw new Error(`policy delete failed: ${error.message}`);
-  await audit(supabase, {
+  await audit(db, {
     team_id: teamId, actor_kind: "member", member_id: actor.memberId ?? null,
     action: "policy.deleted", target_type: "policy", target_id: id, meta: {},
   });

--- a/lib/query/provider.ts
+++ b/lib/query/provider.ts
@@ -34,7 +34,7 @@ export type RetrievedContext = {
 };
 
 export interface RetrievalRequest {
-  supabase: DbClient;
+  db: DbClient;
   teamId: string;
   tier: "team" | "external";
   question: string;

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -120,7 +120,7 @@ const GRAPH_FACTS_LIMIT = Number(process.env.GRAPH_QUERY_FACTS ?? 12);
 const GRAPH_QUERY_TIMEOUT_MS = Number(process.env.GRAPH_QUERY_TIMEOUT_MS ?? 4000);
 
 async function fetchGraphFacts(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   tier: "team" | "external",
   question: string
@@ -128,7 +128,7 @@ async function fetchGraphFacts(
   const client = new GraphitiClient({ timeoutMs: GRAPH_QUERY_TIMEOUT_MS });
   if (!client.configured) return [];
   try {
-    const { data: team } = await supabase.from("teams").select("slug").eq("id", teamId).maybeSingle();
+    const { data: team } = await db.from("teams").select("slug").eq("id", teamId).maybeSingle();
     const slug = (team as { slug: string } | null)?.slug;
     if (!slug) return [];
     const groupIds = visibleGroupIds(slug, tier);
@@ -209,9 +209,9 @@ export function wantsActivityContext(question: string): boolean {
  * member display name in here. **team-tier only** — code/contributor activity is internal, never
  * shown to an external viewer (CLAUDE.md §5). Returns "" when there's no recent activity.
  */
-async function gitActivityDigest(supabase: DbClient, teamId: string): Promise<string> {
+async function gitActivityDigest(db: DbClient, teamId: string): Promise<string> {
   const since = new Date(Date.now() - GIT_WINDOW_DAYS * 86_400_000).toISOString().slice(0, 10);
-  const { data: contribs } = await supabase
+  const { data: contribs } = await db
     .from("code_contributions")
     .select("codebase_id, member_id, author_name, author_email, commits, ai_commits, additions, deletions, day")
     .eq("team_id", teamId)
@@ -220,9 +220,9 @@ async function gitActivityDigest(supabase: DbClient, teamId: string): Promise<st
     .limit(2000);
   if (!contribs?.length) return "";
 
-  const { data: members } = await supabase.from("members").select("id, display_name").eq("team_id", teamId);
+  const { data: members } = await db.from("members").select("id, display_name").eq("team_id", teamId);
   const nameById = new Map((members ?? []).map((m) => [(m as { id: string }).id, (m as { display_name: string }).display_name]));
-  const { data: cbs } = await supabase.from("codebases").select("id, slug").eq("team_id", teamId);
+  const { data: cbs } = await db.from("codebases").select("id, slug").eq("team_id", teamId);
   const slugById = new Map((cbs ?? []).map((c) => [(c as { id: string }).id, (c as { slug: string }).slug]));
 
   type Agg = { name: string; email: string; commits: number; ai: number; adds: number; dels: number; repos: Set<string>; lastDay: string };
@@ -262,9 +262,9 @@ async function gitActivityDigest(supabase: DbClient, teamId: string): Promise<st
  * email). **team-tier only** — internal activity, never shown to an external viewer. Returns "" when
  * there's nothing attributed.
  */
-async function peopleActivityDigest(supabase: DbClient, teamId: string): Promise<string> {
+async function peopleActivityDigest(db: DbClient, teamId: string): Promise<string> {
   const since = new Date(Date.now() - PEOPLE_WINDOW_DAYS * 86_400_000).toISOString();
-  const { data: items } = await supabase
+  const { data: items } = await db
     .from("items")
     .select("member_id, kind, frontmatter, synced_at")
     .eq("team_id", teamId)
@@ -273,7 +273,7 @@ async function peopleActivityDigest(supabase: DbClient, teamId: string): Promise
     .limit(5000);
   if (!items?.length) return "";
 
-  const { data: members } = await supabase
+  const { data: members } = await db
     .from("members")
     .select("id, display_name, email")
     .eq("team_id", teamId);
@@ -326,26 +326,26 @@ async function peopleActivityDigest(supabase: DbClient, teamId: string): Promise
  * queries run in parallel; all respect the caller's tier.
  */
 async function nativeRetrieve(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   tier: "team" | "external",
   question: string,
   projectSlug?: string | null
 ): Promise<RetrievedContext> {
   // Kick off the Graphiti graph-memory search concurrently with Postgres retrieval.
-  const graphFactsP = fetchGraphFacts(supabase, teamId, tier, question);
+  const graphFactsP = fetchGraphFacts(db, teamId, tier, question);
   // Optional dense (semantic) passage search — pgvector. Runs concurrently; resolves to [] unless
   // EMBEDDINGS_URL is set AND the pgvector schema is loaded (default installs stay pure-FTS).
   const denseP = denseSearch(teamId, tier, question, projectSlug);
   // Git-activity + per-person activity digests (team tier only — internal) run in parallel too.
   // Context shaping: the activity digests are heavy + only relevant to "who's doing what" questions.
   const wantsActivity = tier === "team" && wantsActivityContext(question);
-  const gitDigestP = wantsActivity ? gitActivityDigest(supabase, teamId) : Promise.resolve("");
-  const peopleDigestP = wantsActivity ? peopleActivityDigest(supabase, teamId) : Promise.resolve("");
+  const gitDigestP = wantsActivity ? gitActivityDigest(db, teamId) : Promise.resolve("");
+  const peopleDigestP = wantsActivity ? peopleActivityDigest(db, teamId) : Promise.resolve("");
 
   // All independent retrieval queries run in PARALLEL (was sequential → ~7 serial round-trips).
   // 1. Recall-friendly FTS over items (OR of significant terms; see toOrQuery).
-  let ftsB = supabase
+  let ftsB = db
     .from("items")
     .select("id, path, kind, body, synced_at, projects(slug)")
     .eq("team_id", teamId)
@@ -354,7 +354,7 @@ async function nativeRetrieve(
   if (tier === "external") ftsB = ftsB.eq("access", "external");
 
   // 2. Recency: most recent items (a fallback so fresh content always has a shot).
-  let recentB = supabase
+  let recentB = db
     .from("items")
     .select("id, path, kind, body, synced_at, projects(slug)")
     .eq("team_id", teamId)
@@ -363,7 +363,7 @@ async function nativeRetrieve(
   if (tier === "external") recentB = recentB.eq("access", "external");
 
   // 3. Structured-context query builders (awaited together with the above).
-  let decisionsB = supabase
+  let decisionsB = db
     .from("decisions")
     .select("row_key, decided_at, title, decided_by, still_valid, projects(slug)")
     .eq("team_id", teamId)
@@ -374,25 +374,25 @@ async function nativeRetrieve(
   // can ground on finished tasks. `tasks.updated_at` is bumped on every sync upsert (incl. a
   // status→done transition), so recency ordering surfaces today's completions. (Was active-only:
   // `in_progress/blocked/ready`, which structurally hid every completion from the brain.)
-  const tasksB = supabase
+  const tasksB = db
     .from("tasks")
     .select("row_key, title, assignee, status, sprint, updated_at, projects(slug)")
     .eq("team_id", teamId)
     .order("updated_at", { ascending: false })
     .limit(80);
-  const commitmentsB = supabase
+  const commitmentsB = db
     .from("graph_entities")
     .select("entity_id, name, attrs")
     .eq("team_id", teamId)
     .eq("entity_type", "commitment")
     .limit(30);
-  const relsB = supabase
+  const relsB = db
     .from("graph_relationships")
     .select("from_id, to_id, relationship_type")
     .eq("team_id", teamId)
     .in("relationship_type", ["REPORTS_TO", "OWNS", "BLOCKS"])
     .limit(80);
-  const actorsB = supabase
+  const actorsB = db
     .from("graph_entities")
     .select("entity_id, name, attrs")
     .eq("team_id", teamId)
@@ -477,7 +477,7 @@ async function nativeRetrieve(
   const graphFacts = await graphFactsP;
   const expansion = graphExpansionQuery(graphFacts);
   if (expansion) {
-    let semB = supabase
+    let semB = db
       .from("items")
       .select("id, path, kind, body, synced_at, projects(slug)")
       .eq("team_id", teamId)
@@ -592,7 +592,7 @@ async function nativeRetrieve(
  */
 export const nativeProvider: RetrievalProvider = {
   name: "native",
-  retrieve: (r) => nativeRetrieve(r.supabase, r.teamId, r.tier, r.question, r.projectSlug),
+  retrieve: (r) => nativeRetrieve(r.db, r.teamId, r.tier, r.question, r.projectSlug),
 };
 
 /**
@@ -601,12 +601,12 @@ export const nativeProvider: RetrievalProvider = {
  * swapping the whole context layer for gbrain/another is `CONTEXT_PROVIDER=external` + an adapter.
  */
 export async function retrieve(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   tier: "team" | "external",
   question: string,
   projectSlug?: string | null
 ): Promise<RetrievedContext> {
   const provider = selectedProviderName() === "external" ? externalProvider : nativeProvider;
-  return provider.retrieve({ supabase, teamId, tier, question, projectSlug: projectSlug ?? null });
+  return provider.retrieve({ db, teamId, tier, question, projectSlug: projectSlug ?? null });
 }

--- a/lib/sync/decisions.ts
+++ b/lib/sync/decisions.ts
@@ -31,12 +31,12 @@ export interface DecisionWritebackGroup {
  * `external` viewer receives only `audience='external'` decisions.
  */
 export async function getDecisionWriteback(
-  supabase: DbClient,
+  db: DbClient,
   teamId: string,
   tier: ViewerTier,
   since: string
 ): Promise<DecisionWritebackGroup[]> {
-  let query = supabase
+  let query = db
     .from("decisions")
     .select(
       "row_key, decided_at, title, rationale, decided_by, impact, tier, audience, updated_at, source_item_id, projects(slug), items:source_item_id(synced_at)"

--- a/lib/work-events/ingest.ts
+++ b/lib/work-events/ingest.ts
@@ -33,13 +33,13 @@ function eventKeys(payload: WorkEventPayload): string[] {
 }
 
 export async function ingestWorkEvent(
-  supabase: DbClient,
+  db: DbClient,
   auth: WorkEventAuth,
   payload: WorkEventPayload,
   opts: { syncPm?: boolean; fetchImpl?: typeof fetch } = {}
 ): Promise<WorkEventIngestResult> {
   const now = new Date().toISOString();
-  const { data: project } = await supabase
+  const { data: project } = await db
     .from("projects")
     .select("id")
     .eq("team_id", auth.teamId)
@@ -53,7 +53,7 @@ export async function ingestWorkEvent(
 
   for (const rowKey of eventKeys(payload)) {
     const { data: task } = projectId
-      ? await supabase
+      ? await db
           .from("tasks")
           .select("id, team_id, project_id, row_key")
           .eq("team_id", auth.teamId)
@@ -65,7 +65,7 @@ export async function ingestWorkEvent(
     const found = task as { id: string; team_id: string; project_id: string; row_key: string } | null;
     const status = found ? "applied" : "unresolved";
 
-    const { data: event, error: eventErr } = await supabase
+    const { data: event, error: eventErr } = await db
       .from("work_events")
       .upsert(
         {
@@ -92,7 +92,7 @@ export async function ingestWorkEvent(
 
     if (!found) {
       unresolved.push({ row_key: rowKey });
-      await audit(supabase, {
+      await audit(db, {
         team_id: auth.teamId,
         actor_kind: "api_key",
         member_id: auth.memberId,
@@ -105,7 +105,7 @@ export async function ingestWorkEvent(
       continue;
     }
 
-    const { error: taskErr } = await supabase
+    const { error: taskErr } = await db
       .from("tasks")
       .update({ status: "done", updated_at: now })
       .eq("id", found.id)
@@ -113,7 +113,7 @@ export async function ingestWorkEvent(
     if (taskErr) throw new Error(`task completion update failed: ${taskErr.message}`);
     applied.push({ row_key: rowKey, task_id: found.id });
 
-    await audit(supabase, {
+    await audit(db, {
       team_id: auth.teamId,
       actor_kind: "api_key",
       member_id: auth.memberId,
@@ -127,13 +127,13 @@ export async function ingestWorkEvent(
     if (opts.syncPm !== false) {
       // Full projection (not done-only): load the now-done task row and project it through the
       // upsert path so a task with no pre-existing link/item still gets created + linked.
-      const { data: fullRow } = await supabase
+      const { data: fullRow } = await db
         .from("tasks")
         .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key")
         .eq("id", found.id)
         .maybeSingle();
       if (fullRow) {
-        const report = await projectTask(supabase, fullRow as ProjectionTaskRow, { fetchImpl: opts.fetchImpl });
+        const report = await projectTask(db, fullRow as ProjectionTaskRow, { fetchImpl: opts.fetchImpl });
         pm_sync.push(projectionToSyncReport(report));
       }
     }

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -19,7 +19,7 @@ if (!process.env.DATABASE_URL) {
   console.error("set DATABASE_URL (try: npx dotenvx run -f .env.local -- …, or export it)");
   process.exit(1);
 }
-const supabase = pgClient() as unknown as DbClient;
+const db = pgClient() as unknown as DbClient;
 
 const FIXTURES = path.resolve(__dirname, "..", "fixtures");
 const PROJECT_SLUG = "northwind-aios";
@@ -101,7 +101,7 @@ function* walk(dir: string, base: string): Generator<string> {
 
 async function main() {
   // 1. demo team
-  const { data: team, error: teamErr } = await supabase
+  const { data: team, error: teamErr } = await db
     .from("teams")
     .upsert({ slug: "demo", name: "Northwind Robotics — AI Transformation" }, { onConflict: "slug" })
     .select("id")
@@ -119,7 +119,7 @@ async function main() {
   ];
   const members: Record<string, string> = {};
   for (const m of memberDefs) {
-    const { data } = await supabase
+    const { data } = await db
       .from("members")
       .upsert(
         { team_id: team.id, ...m, status: "active", auth_user_id: null },
@@ -134,7 +134,7 @@ async function main() {
   const keyId = randomBytes(6).toString("hex");
   const secret = randomBytes(32).toString("base64url");
   const fullKey = `aios_${keyId}_${secret}`;
-  await supabase.from("api_keys").insert({
+  await db.from("api_keys").insert({
     team_id: team.id,
     member_id: members["alex"],
     key_id: keyId,
@@ -157,7 +157,7 @@ async function main() {
       : kind === "decision" ? parseDecisionRows(body)
       : undefined;
     await ingestItem(
-      supabase,
+      db,
       auth,
       {
         project: PROJECT_SLUG,
@@ -190,7 +190,7 @@ async function main() {
     const json = load(file);
     const items = Array.isArray(json) ? json : json[arrayKey] ?? Object.values(json)[0];
     for (const e of items as Record<string, unknown>[]) {
-      await supabase.from("graph_entities").upsert(
+      await db.from("graph_entities").upsert(
         {
           team_id: team.id,
           entity_id: String(e.id),
@@ -207,7 +207,7 @@ async function main() {
   const rels = Array.isArray(relJson) ? relJson : relJson.relationships ?? Object.values(relJson)[0];
   let relCount = 0;
   for (const r of rels as Record<string, unknown>[]) {
-    const { error } = await supabase.from("graph_relationships").upsert(
+    const { error } = await db.from("graph_relationships").upsert(
       {
         team_id: team.id,
         from_id: String(r.from_id),
@@ -221,11 +221,11 @@ async function main() {
   }
 
   // 6. verify materialization (the regression assertions)
-  const { count: taskCount } = await supabase
+  const { count: taskCount } = await db
     .from("tasks").select("id", { count: "exact", head: true }).eq("team_id", team.id);
-  const { count: decisionCount } = await supabase
+  const { count: decisionCount } = await db
     .from("decisions").select("id", { count: "exact", head: true }).eq("team_id", team.id);
-  const { count: itemCount } = await supabase
+  const { count: itemCount } = await db
     .from("items").select("id", { count: "exact", head: true }).eq("team_id", team.id);
 
   console.log(`team: demo (${team.id})`);

--- a/test/datamechanics/graph-project.datamechanics.test.ts
+++ b/test/datamechanics/graph-project.datamechanics.test.ts
@@ -125,13 +125,13 @@ describe("runGraphProjection runner (real Postgres, mocked Graphiti)", () => {
     await ingest(seed, { kind: "transcript", path: "slack/client/2.md", body: "beta thread", access: "external" });
 
     const fake = new FakeGraphiti();
-    const first = await runGraphProjection({ teamId: seed.teamId, client: client(fake), supabase: db() });
+    const first = await runGraphProjection({ teamId: seed.teamId, client: client(fake), db: db() });
     expect(first.configured).toBe(true);
     expect(first.teams).toBe(1);
     expect(first.projected).toBe(2);
     expect(fake.pushes.map((p) => p.groupId).sort()).toEqual([`${slug}_external`, `${slug}_team`]);
 
-    const second = await runGraphProjection({ teamId: seed.teamId, client: client(new FakeGraphiti()), supabase: db() });
+    const second = await runGraphProjection({ teamId: seed.teamId, client: client(new FakeGraphiti()), db: db() });
     expect(second.projected).toBe(0);
     expect(second.skipped).toBe(2); // idempotent across the runner too
   });

--- a/test/datamechanics/pulse-metrics.datamechanics.test.ts
+++ b/test/datamechanics/pulse-metrics.datamechanics.test.ts
@@ -4,10 +4,11 @@ import { db, seedTeam, ingest } from "./helpers";
 
 /**
  * Spec for the dashboard "pulse" metrics on REAL Postgres. The deployed pg adapter returns
- * timestamptz columns as Date objects (supabase returns strings); the window math compared them as
- * strings (`Date >= isoString` → coerces to NaN → always false), so every recent row was bucketed
- * as "prior" and the dashboard read 0 items / 0 queries with ↓100% — while the data was clearly
- * present. This tier is the ONLY one that reproduces it (the fake/supabase paths return strings).
+ * timestamptz columns as Date objects (the legacy Supabase-js client returned strings); the window
+ * math compared them as strings (`Date >= isoString` → coerces to NaN → always false), so every
+ * recent row was bucketed as "prior" and the dashboard read 0 items / 0 queries with ↓100% — while
+ * the data was clearly present. This tier is the ONLY one that reproduces it (the FakeSupabase test
+ * double, matching the old client's shape, returns strings same as it always did).
  * Derived from the product contract (recent activity must count as current), not the implementation.
  */
 

--- a/test/guards/codebases-tier-filter.test.ts
+++ b/test/guards/codebases-tier-filter.test.ts
@@ -65,7 +65,7 @@ describe("codebase tier isolation", () => {
   });
 
   it("the matcher discriminates (non-vacuity)", () => {
-    expect(TABLES.test('supabase.from("code_metrics").select("x")')).toBe(true);
-    expect(TABLES.test('supabase.from("items").select("x")')).toBe(false);
+    expect(TABLES.test('db.from("code_metrics").select("x")')).toBe(true);
+    expect(TABLES.test('db.from("items").select("x")')).toBe(false);
   });
 });

--- a/test/guards/dashboard-tier-filter.test.ts
+++ b/test/guards/dashboard-tier-filter.test.ts
@@ -65,8 +65,8 @@ describe("dashboard tier isolation", () => {
   });
 
   it("the matchers discriminate (non-vacuity)", () => {
-    expect(READS_ITEMS.test('supabase.from("items").select("id")')).toBe(true);
-    expect(READS_DECISIONS.test('supabase.from("decisions").select("id")')).toBe(true);
+    expect(READS_ITEMS.test('db.from("items").select("id")')).toBe(true);
+    expect(READS_DECISIONS.test('db.from("decisions").select("id")')).toBe(true);
     expect(CHOKE.test("query = visibleItems(query, me.tier)")).toBe(true);
     expect(DECISION_CHOKE.test("visibleDecisions(q, tier)")).toBe(true);
     expect(CHOKE.test('q.eq("team_id", t)')).toBe(false);

--- a/test/guards/integrations-tier-filter.test.ts
+++ b/test/guards/integrations-tier-filter.test.ts
@@ -70,7 +70,7 @@ describe("integrations tier/role isolation", () => {
   });
 
   it("the matcher discriminates (non-vacuity)", () => {
-    expect(TABLE.test('supabase.from("integrations").select("x")')).toBe(true);
-    expect(TABLE.test('supabase.from("items").select("x")')).toBe(false);
+    expect(TABLE.test('db.from("integrations").select("x")')).toBe(true);
+    expect(TABLE.test('db.from("items").select("x")')).toBe(false);
   });
 });

--- a/test/guards/maturity-tier-filter.test.ts
+++ b/test/guards/maturity-tier-filter.test.ts
@@ -62,7 +62,7 @@ describe("agentic-maturity tier isolation", () => {
   });
 
   it("the matcher discriminates (non-vacuity)", () => {
-    expect(TABLE.test('supabase.from("agentic_maturity_snapshots").select("x")')).toBe(true);
-    expect(TABLE.test('supabase.from("items").select("x")')).toBe(false);
+    expect(TABLE.test('db.from("agentic_maturity_snapshots").select("x")')).toBe(true);
+    expect(TABLE.test('db.from("items").select("x")')).toBe(false);
   });
 });

--- a/test/guards/member-context-tier-filter.test.ts
+++ b/test/guards/member-context-tier-filter.test.ts
@@ -59,7 +59,7 @@ describe("identity-context tier isolation", () => {
   });
 
   it("the matcher discriminates (non-vacuity)", () => {
-    expect(TABLES.test('supabase.from("member_goals").select("x")')).toBe(true);
-    expect(TABLES.test('supabase.from("members").select("x")')).toBe(false);
+    expect(TABLES.test('db.from("member_goals").select("x")')).toBe(true);
+    expect(TABLES.test('db.from("members").select("x")')).toBe(false);
   });
 });

--- a/test/guards/query-log-visibility.test.ts
+++ b/test/guards/query-log-visibility.test.ts
@@ -56,7 +56,7 @@ describe("query_log row-level visibility", () => {
   });
 
   it("the matchers discriminate (non-vacuity)", () => {
-    expect(READS_QUERY_LOG.test('supabase.from("query_log").select("cost_usd")')).toBe(true);
+    expect(READS_QUERY_LOG.test('db.from("query_log").select("cost_usd")')).toBe(true);
     expect(SCOPE.test("scopeQueryLog(q, { isAdmin, memberId })")).toBe(true);
     expect(SCOPE.test('q.eq("team_id", t)')).toBe(false);
   });

--- a/test/guards/single-writer-chat.test.ts
+++ b/test/guards/single-writer-chat.test.ts
@@ -57,9 +57,9 @@ describe("single-writer: conversations / chat_messages", () => {
 
   it("the matcher discriminates (non-vacuity)", () => {
     const W = () => new RegExp(WRITE_RE.source, "g");
-    expect(W().test('await supabase.from("conversations").insert(rec)')).toBe(true);
-    expect(W().test('supabase.from("chat_messages")\n  .update(x)')).toBe(true);
-    expect(W().test('supabase.from("conversations").select("id").eq("team_id", t)')).toBe(false);
-    expect(W().test('supabase.from("tasks").upsert(row)')).toBe(false);
+    expect(W().test('await db.from("conversations").insert(rec)')).toBe(true);
+    expect(W().test('db.from("chat_messages")\n  .update(x)')).toBe(true);
+    expect(W().test('db.from("conversations").select("id").eq("team_id", t)')).toBe(false);
+    expect(W().test('db.from("tasks").upsert(row)')).toBe(false);
   });
 });

--- a/test/guards/single-writer-codebases.test.ts
+++ b/test/guards/single-writer-codebases.test.ts
@@ -63,9 +63,9 @@ describe("single-writer: codebase analytics tables", () => {
   });
 
   it("the matcher discriminates (non-vacuity)", () => {
-    expect(WRITE_RE.test('supabase.from("code_metrics").upsert(')).toBe(true);
+    expect(WRITE_RE.test('db.from("code_metrics").upsert(')).toBe(true);
     WRITE_RE.lastIndex = 0;
-    expect(WRITE_RE.test('supabase.from("code_metrics").select(')).toBe(false);
+    expect(WRITE_RE.test('db.from("code_metrics").select(')).toBe(false);
     WRITE_RE.lastIndex = 0;
   });
 });

--- a/test/guards/single-writer-graph-episodes.test.ts
+++ b/test/guards/single-writer-graph-episodes.test.ts
@@ -50,7 +50,7 @@ describe("single-writer: graph_episodes", () => {
 
   it("the matcher discriminates (non-vacuity)", () => {
     const W = () => new RegExp(WRITE_RE.source, "g");
-    expect(W().test('supabase.from("graph_episodes").upsert(x)')).toBe(true);
-    expect(W().test('supabase.from("graph_episodes").select("id")')).toBe(false);
+    expect(W().test('db.from("graph_episodes").upsert(x)')).toBe(true);
+    expect(W().test('db.from("graph_episodes").select("id")')).toBe(false);
   });
 });

--- a/test/guards/single-writer-integrations.test.ts
+++ b/test/guards/single-writer-integrations.test.ts
@@ -54,9 +54,9 @@ describe("single-writer: integrations table", () => {
   });
 
   it("the matcher discriminates (non-vacuity)", () => {
-    expect(WRITE_RE.test('supabase.from("integrations").upsert(')).toBe(true);
+    expect(WRITE_RE.test('db.from("integrations").upsert(')).toBe(true);
     WRITE_RE.lastIndex = 0;
-    expect(WRITE_RE.test('supabase.from("integrations").select(')).toBe(false);
+    expect(WRITE_RE.test('db.from("integrations").select(')).toBe(false);
     WRITE_RE.lastIndex = 0;
   });
 });

--- a/test/guards/single-writer-item-chunks.test.ts
+++ b/test/guards/single-writer-item-chunks.test.ts
@@ -62,7 +62,7 @@ describe("single-writer: item_chunks table", () => {
     RAW_RE.lastIndex = 0;
     expect(RAW_RE.test("select content from item_chunks where team_id = $1")).toBe(false);
     RAW_RE.lastIndex = 0;
-    expect(BUILDER_RE.test('supabase.from("item_chunks").insert(')).toBe(true);
+    expect(BUILDER_RE.test('db.from("item_chunks").insert(')).toBe(true);
     BUILDER_RE.lastIndex = 0;
   });
 });

--- a/test/guards/single-writer-items.test.ts
+++ b/test/guards/single-writer-items.test.ts
@@ -58,11 +58,11 @@ describe("single-writer: items / item_versions", () => {
 
   it("the matcher discriminates (non-vacuity)", () => {
     const W = () => new RegExp(WRITE_RE.source, "g");
-    expect(W().test('await supabase.from("items").insert(rec)')).toBe(true);
-    expect(W().test('await supabase.from("item_versions")\n  .update(x)')).toBe(true);
+    expect(W().test('await db.from("items").insert(rec)')).toBe(true);
+    expect(W().test('await db.from("item_versions")\n  .update(x)')).toBe(true);
     // reads must NOT trip it
-    expect(W().test('supabase.from("items").select("id").eq("team_id", t)')).toBe(false);
+    expect(W().test('db.from("items").select("id").eq("team_id", t)')).toBe(false);
     // a different table must NOT trip it
-    expect(W().test('supabase.from("tasks").upsert(row)')).toBe(false);
+    expect(W().test('db.from("tasks").upsert(row)')).toBe(false);
   });
 });

--- a/test/guards/single-writer-member-secrets.test.ts
+++ b/test/guards/single-writer-member-secrets.test.ts
@@ -53,9 +53,9 @@ describe("single-writer: member_secrets table", () => {
   });
 
   it("the matcher discriminates (non-vacuity)", () => {
-    expect(WRITE_RE.test('supabase.from("member_secrets").upsert(')).toBe(true);
+    expect(WRITE_RE.test('db.from("member_secrets").upsert(')).toBe(true);
     WRITE_RE.lastIndex = 0;
-    expect(WRITE_RE.test('supabase.from("member_secrets").select(')).toBe(false);
+    expect(WRITE_RE.test('db.from("member_secrets").select(')).toBe(false);
     WRITE_RE.lastIndex = 0;
   });
 });

--- a/test/guards/single-writer-profile.test.ts
+++ b/test/guards/single-writer-profile.test.ts
@@ -58,9 +58,9 @@ describe("single-writer: identity context tables", () => {
   });
 
   it("the matcher discriminates writes from reads (non-vacuity)", () => {
-    expect(writeRe("member_goals").test('supabase.from("member_goals").insert(')).toBe(true);
+    expect(writeRe("member_goals").test('db.from("member_goals").insert(')).toBe(true);
     expect(writeRe("member_profiles").test('admin.from("member_profiles").upsert(')).toBe(true);
     expect(writeRe("member_time_off").test('admin.from("member_time_off").delete(')).toBe(true);
-    expect(writeRe("member_goals").test('supabase.from("member_goals").select(')).toBe(false);
+    expect(writeRe("member_goals").test('db.from("member_goals").select(')).toBe(false);
   });
 });

--- a/test/query-provider.test.ts
+++ b/test/query-provider.test.ts
@@ -37,8 +37,8 @@ describe("selectedProviderName", () => {
 describe("externalProvider", () => {
   it("returns an empty, ungrounded context when RETRIEVAL_AUGMENT_URL is unset (never throws)", async () => {
     const ctx = await externalProvider.retrieve({
-      // supabase is unused on the no-URL path
-      supabase: null as never,
+      // db is unused on the no-URL path
+      db: null as never,
       teamId: "t1",
       tier: "team",
       question: "anything",


### PR DESCRIPTION
Mechanical cleanup flagged in the 2026-07-05 audit (code-quality dimension): Postgres has been the only backend for a while now — `adminClient()`/`serverClient()` both just return `pgClient()`, there's no `DB_BACKEND` branching, no `@supabase/supabase-js` dependency, no `SUPABASE_*` env vars anywhere — but the generic DB-client parameter/variable was still universally named `supabase` throughout (605 occurrences / ~130 files), which reads as misleading residue on an open-source project.

## What changed
Identifier-only rename: `supabase` → `db` wherever it's a bare lowercase word-boundary match (parameter names, local variables, object properties). Verified safe first — **no quoted `"supabase"` string literal exists anywhere**, so nothing branches on it at runtime; this is purely naming.

**Explicitly protected, left untouched:**
- `lib/ingest/fake-supabase.ts` (filename + its `FakeSupabase` export) — a deliberately-named legacy test double, documented by name in `CLAUDE.md` §4. Not residue, a real artifact.
- Prose referencing `supabase-js` / the `supabase-compat adapter` — these accurately describe the real npm package / API shape the query builder mimics.

**Manually fixed (not mechanical):** a handful of comments used "supabase" as a *mode name* rather than the variable name (e.g. "in supabase mode... in postgres mode", describing a dual-backend era that no longer exists). The blind rename left these reading as nonsensical "db mode". I diffed every changed comment line by hand and rewrote these to either state the current reality plainly (no RLS, postgres is the only mode) or restore the accurate historical reference to Supabase-js where the comment explains a workaround still present in the code today (e.g. `lib/metrics/pulse.ts`'s `toIso` still accepts `string | Date` because of it).

## Verification
**unit 368 · data-mechanics 243 · http 18 · tsc · lint · docs-drift** — all match the pre-rename baseline exactly (pure rename, zero behavior change). No schema change.