### PR TITLE
fix(auth): close the insecure direct-by-email login side door

### DIFF
--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+// Spec: this route is now a DEV-ONLY convenience (direct-by-email, no ownership proof) —
+// the real sign-in path is POST /api/auth/request-magic-link. It must 404 in production
+// unless explicitly re-enabled via ALLOW_DEV_LOGIN=1, mirroring app/auth/dev-login exactly.
+// Both cases short-circuit before any DB call (gate closes first; an empty body fails zod
+// validation next), so this stays in the unit tier — no Postgres needed.
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/login — dev-only gate", () => {
+  it("404s in production when ALLOW_DEV_LOGIN is unset", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("ALLOW_DEV_LOGIN", "");
+
+    const res = await POST(postReq({ email: "someone@test.local" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("does not gate in development, regardless of ALLOW_DEV_LOGIN", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("ALLOW_DEV_LOGIN", "");
+
+    const res = await POST(postReq({})); // invalid body -> proves we got PAST the gate
+    expect(res.status).toBe(422);
+  });
+
+  it("does not gate in production when ALLOW_DEV_LOGIN=1", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("ALLOW_DEV_LOGIN", "1");
+
+    const res = await POST(postReq({})); // invalid body -> proves we got PAST the gate
+    expect(res.status).toBe(422);
+  });
+});

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -11,14 +11,18 @@ const schema = z.object({
 });
 
 /**
- * Direct (passwordless) sign-in. Invite-only: if the email is a recognized
- * non-disabled member we set the signed session cookie immediately; otherwise we
- * reject with 403. No email round-trip / magic link.
- *
- * SECURITY: trusts the submitted email with no ownership proof — fine only for this
- * invite-only, self-hosted instance with a known member list. See lib/auth/pg-login.loginByEmail.
+ * DEV-ONLY direct (passwordless) sign-in: no email round-trip, sets the session
+ * cookie immediately for any recognized member. This used to be the production
+ * sign-in path — it traded ownership proof for convenience, which the code has long
+ * flagged as acceptable only for a small self-hosted instance. It no longer is: the
+ * real sign-in path is POST /api/auth/request-magic-link (see components/login-form).
+ * Hard-disabled outside development, mirroring app/auth/dev-login/route.ts exactly.
  */
 export async function POST(req: NextRequest) {
+  if (process.env.NODE_ENV === "production" && process.env.ALLOW_DEV_LOGIN !== "1") {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
   let body: unknown;
   try {
     body = await req.json();

--- a/app/api/auth/request-magic-link/route.ts
+++ b/app/api/auth/request-magic-link/route.ts
@@ -1,0 +1,44 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { issueMagicToken } from "@/lib/auth/pg-login";
+import { sendMagicLink } from "@/lib/auth/mailer";
+
+export const runtime = "nodejs";
+
+const schema = z.object({
+  email: z.string().email().max(200),
+  next: z.string().optional(),
+});
+
+/**
+ * Request a magic sign-in link — the primary sign-in path (replaces the insecure
+ * direct-by-email login at /api/auth/login, now dev-only). Never sets a session
+ * cookie itself; only GET /auth/confirm does that, once the emailed link is
+ * actually clicked. Keeps the prior UX of an explicit 403 for an unrecognized
+ * email (invite-only, no password to brute-force — not a meaningful enumeration
+ * risk for this self-hosted, small known-member product).
+ */
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_payload" }, { status: 422 });
+  }
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: "invalid_email" }, { status: 422 });
+
+  const email = parsed.data.email.trim().toLowerCase();
+  const nextParam = parsed.data.next ?? "/";
+  const safeNext = nextParam.startsWith("/") && !nextParam.startsWith("//") ? nextParam : "/";
+
+  const raw = await issueMagicToken(email, safeNext);
+  if (!raw) {
+    // Not a recognized member — invite-only.
+    return NextResponse.json({ error: "not_recognized" }, { status: 403 });
+  }
+
+  const appUrl = (process.env.APP_URL ?? new URL(req.url).origin).replace(/\/$/, "");
+  await sendMagicLink(email, `${appUrl}/auth/confirm?token=${raw}`);
+  return NextResponse.json({ ok: true });
+}

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { Loader2, Send } from "lucide-react";
+import { Loader2, Send, Mail } from "lucide-react";
 
 export function LoginForm({ next }: { next?: string }) {
   const [email, setEmail] = useState("");
-  const [state, setState] = useState<"idle" | "sending" | "error">("idle");
+  const [state, setState] = useState<"idle" | "sending" | "sent" | "error">("idle");
   const [error, setError] = useState("");
 
   async function onSubmit(e: React.FormEvent) {
@@ -14,10 +14,10 @@ export function LoginForm({ next }: { next?: string }) {
     setState("sending");
     setError("");
 
-    // Direct (passwordless) sign-in — recognized members are logged in
-    // immediately; unknown emails are rejected (invite-only).
+    // Magic-link sign-in: request a one-time link, then wait for the click on
+    // /auth/confirm to actually set the session — no direct-by-email login anymore.
     try {
-      const res = await fetch("/api/auth/login", {
+      const res = await fetch("/api/auth/request-magic-link", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, next }),
@@ -27,13 +27,25 @@ export function LoginForm({ next }: { next?: string }) {
         setError("That email isn't recognized. Team Brain is invite-only — ask your admin to add you.");
         return;
       }
-      if (!res.ok) throw new Error(`sign-in failed (${res.status})`);
-      const data = (await res.json()) as { redirect?: string };
-      window.location.href = data.redirect || next || "/";
+      if (!res.ok) throw new Error(`request failed (${res.status})`);
+      setState("sent");
     } catch (err) {
       setState("error");
-      setError(err instanceof Error ? err.message : "could not sign in");
+      setError(err instanceof Error ? err.message : "could not send link");
     }
+  }
+
+  if (state === "sent") {
+    return (
+      <div className="flex flex-col items-center gap-2 py-6 text-center">
+        <Mail className="size-8 text-violet" strokeWidth={1.5} />
+        <p className="text-sm font-medium text-ink">Check your email</p>
+        <p className="text-sm text-ink-secondary">
+          We sent a sign-in link to <span className="text-ink">{email}</span>. It&apos;s single-use and
+          expires in 15 minutes.
+        </p>
+      </div>
+    );
   }
 
   return (
@@ -57,7 +69,7 @@ export function LoginForm({ next }: { next?: string }) {
         ) : (
           <Send className="size-4" />
         )}
-        Sign in
+        Send sign-in link
       </button>
       {state === "error" ? <p className="text-sm text-red">{error}</p> : null}
     </form>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,16 +96,17 @@ This server **implements brain-api v1.3** (the wire contract; source of truth:
 
 Two principals, one tier model:
 
-- **Humans** — invite-only. Sign-in is **direct passwordless**:
-  POST `/api/auth/login` with a recognized member email → signed session cookie (no email
-  round-trip; unknown emails 403). Trusts the email with no ownership proof — acceptable only
-  for this self-hosted, small known-member instance (`lib/auth/pg-login.loginByEmail`). The
-  session is a `jose`-signed httpOnly cookie (`lib/auth/pg-session`).
-  Invite links (`GET /auth/confirm`) instead use a single-use magic-link token
-  (`issueMagicToken`/`redeemMagicToken`). A member's **first** redemption (an invite being
-  activated) routes through `/auth/welcome` — name, team, and inviter (resolved from the
+- **Humans** — invite-only, **passwordless via magic link**. `POST /api/auth/request-magic-link`
+  issues + emails a single-use token (`issueMagicToken`/`sendMagicLink`; unknown emails still
+  get an explicit 403, matching the prior direct-login UX) and never sets a session cookie
+  itself. Clicking the emailed link hits `GET /auth/confirm`, which verifies + consumes the
+  token (`redeemMagicToken`) and is the ONLY place that sets the session cookie
+  (`jose`-signed httpOnly, `lib/auth/pg-session`). A member's **first** redemption (an invite
+  being activated) routes through `/auth/welcome` — name, team, and inviter (resolved from the
   append-only `audit_log`, no `invited_by` column needed) — before landing on the dashboard;
-  later logins redirect straight through as before.
+  later logins redirect straight through. `POST /api/auth/login` (direct-by-email, no
+  ownership proof, no email round-trip) is now **dev-only** — 404s in production unless
+  `ALLOW_DEV_LOGIN=1` — mirroring `/auth/dev-login`'s existing gate exactly.
 - **Machines** — per-member API key `aios_<key_id>_<secret>` (sha256 at rest, shown
   once). Sync writes use the **service role** — confined to `lib/ingest`
   and audited on every write.
@@ -494,7 +495,8 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `PATCH /api/dashboard/conversations/:id` — rename a thread (owner-only)
 - `DELETE /api/dashboard/conversations/:id` — soft-archive a thread (owner-only)
 - `GET /api/dashboard/team-work` — dashboard "Working On": per-person summary (narrative arcs) + open tasks + recent accomplishments; session-authed; tier-scoped
-- `POST /api/auth/login` — postgres-mode direct passwordless sign-in (invite-only; 403 if unknown)
+- `POST /api/auth/login` — **dev-only** (404 in production unless `ALLOW_DEV_LOGIN=1`): direct passwordless sign-in with no ownership proof, kept as a dev/test convenience
+- `POST /api/auth/request-magic-link` — the real sign-in path: issues + emails a single-use magic link (invite-only; 403 if unknown); never sets a session cookie itself
 <!-- /drift:routes -->
 
 ### Database tables

--- a/test/http/auth.http.test.ts
+++ b/test/http/auth.http.test.ts
@@ -1,33 +1,87 @@
 import { describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
-import { BASE_URL, issueKeyFor, keyHeaders, seedMemberEmail, seedTeam } from "./http-helpers";
+import { issueMagicToken } from "@/lib/auth/pg-login";
+import { BASE_URL, db, issueKeyFor, keyHeaders, seedMemberEmail, seedTeam } from "./http-helpers";
 
-// HTTP auth edges that the in-process tier can't reach: the login route sets a
-// real Set-Cookie session, and /api/v1/me round-trips Bearer + X-AIOS-Team headers.
+// HTTP auth edges that the in-process tier can't reach: cookie-setting routes need a
+// real Set-Cookie response, and /api/v1/me round-trips Bearer + X-AIOS-Team headers.
+//
+// POST /api/auth/login's dev-only gate is covered at the unit tier
+// (app/api/auth/login/route.test.ts) instead of here: this suite's shared spawned
+// server runs with ALLOW_DEV_LOGIN=1 (see vitest.http.config.ts) so OTHER HTTP test
+// files can keep using it as a convenience session-setup helper.
 
-describe("POST /api/auth/login (HTTP)", () => {
-  it("rejects an unknown email with 403", async () => {
-    const res = await fetch(`${BASE_URL}/api/auth/login`, {
+describe("POST /api/auth/request-magic-link (HTTP)", () => {
+  it("rejects an unknown email with 403 and never sets a cookie", async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/request-magic-link`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: `nobody-${randomUUID().slice(0, 8)}@nope.test` }),
     });
     expect(res.status).toBe(403);
     expect((await res.json()).error).toBe("not_recognized");
+    expect(res.headers.get("set-cookie")).toBeNull();
   });
 
-  it("signs in a known member with 200 + a session cookie", async () => {
+  it("accepts a known member's email with 200 but never sets a session cookie itself", async () => {
     const seed = await seedTeam();
     const email = await seedMemberEmail(seed);
 
-    const res = await fetch(`${BASE_URL}/api/auth/login`, {
+    const res = await fetch(`${BASE_URL}/api/auth/request-magic-link`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email }),
     });
     expect(res.status).toBe(200);
     expect((await res.json()).ok).toBe(true);
+    // The link still has to be clicked (GET /auth/confirm) before any session exists.
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+});
+
+describe("GET /auth/confirm (HTTP) — full magic-link round trip", () => {
+  it("redeems a token minted for a known member, sets the session cookie, and routes a first login through /auth/welcome", async () => {
+    const seed = await seedTeam();
+    const email = await seedMemberEmail(seed);
+    // seedMemberEmail creates the member pre-activated (status: "active"), so this is
+    // a repeat-login redemption — mint the token the same way the real request route
+    // does, bypassing the outbound email (which isn't observable over HTTP here).
+    const raw = await issueMagicToken(email, `/t/${seed.teamSlug}`);
+    expect(raw).not.toBeNull();
+
+    const res = await fetch(`${BASE_URL}/auth/confirm?token=${raw}`, { redirect: "manual" });
+    expect(res.status).toBe(307);
     expect(res.headers.get("set-cookie") ?? "").toContain("aios_session");
+    expect(res.headers.get("location")).toContain(`/t/${seed.teamSlug}`);
+  });
+
+  it("routes an actual first login (invited member) through /auth/welcome, not straight to the team", async () => {
+    const seed = await seedTeam();
+    const email = `first-login-${randomUUID()}@test.local`;
+    await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email,
+        display_name: "First Login",
+        actor_handle: `first-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "team",
+        status: "invited",
+      });
+
+    const raw = await issueMagicToken(email, `/t/${seed.teamSlug}`, 1440);
+    const res = await fetch(`${BASE_URL}/auth/confirm?token=${raw}`, { redirect: "manual" });
+    expect(res.status).toBe(307);
+    expect(res.headers.get("set-cookie") ?? "").toContain("aios_session");
+    expect(res.headers.get("location")).toContain("/auth/welcome");
+  });
+
+  it("rejects an invalid token", async () => {
+    const res = await fetch(`${BASE_URL}/auth/confirm?token=not-a-real-token`, { redirect: "manual" });
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/login?error=invalid_link");
+    expect(res.headers.get("set-cookie")).toBeNull();
   });
 });
 

--- a/vitest.http.config.ts
+++ b/vitest.http.config.ts
@@ -28,6 +28,11 @@ process.env.DATABASE_URL = databaseTestUrl;
 process.env.SECRETS_KEY ??= Buffer.alloc(32, 7).toString("base64");
 // The login route signs sessions with AUTH_SECRET (lib/auth/pg-session requires >=16 chars).
 process.env.AUTH_SECRET ??= "http-tier-test-secret-not-for-production";
+// Several other HTTP-tier test files use the direct-by-email POST /api/auth/login as a
+// convenience helper to establish a session for testing unrelated pages — not to test
+// login itself. That route (like /auth/dev-login) is now dev-only in production, so the
+// spawned `next start` server needs this same escape hatch for those helpers to keep working.
+process.env.ALLOW_DEV_LOGIN ??= "1";
 // Server port override (default 3010 — see test/http/server-url.ts, which derives
 // the URL both the server and clients use). We avoid process.env.BASE_URL: Vite
 // reserves that name and pins it to "/".


### PR DESCRIPTION
## Summary
Reopened against `main` — the original PR (#159) was based on the now-merged-and-deleted `feat/onboarding-welcome-screen` branch, and GitHub auto-closed it (with no way to retarget a closed PR) once that branch was deleted. Same commit, cherry-picked cleanly onto current `main`, diff verified clean.

- `POST /api/auth/login` logged in as any recognized member by email alone — zero ownership proof — and was the path every regular sign-in used **today**, not just invites (the code's own SECURITY NOTE comments already flagged this as a real, acknowledged gap).
- Replaces it as the primary sign-in mechanism with the magic-link pipeline the invite flow already exercises:
  - New `POST /api/auth/request-magic-link` issues + emails a single-use link and never sets a session cookie itself — only `GET /auth/confirm` does that, once the link is actually clicked. Keeps the existing explicit-403-on-unknown-email UX.
  - `components/login-form.tsx` now requests a link and shows a "check your email" state instead of logging in directly.
  - `POST /api/auth/login` is hard-gated to dev/test only (404 in production unless `ALLOW_DEV_LOGIN=1`), mirroring `app/auth/dev-login`'s existing gate exactly.
- Two unrelated HTTP test files (`pm-sync-divergence`, `tasks-page`) used the old route as a convenience session-setup helper — the HTTP harness now sets `ALLOW_DEV_LOGIN=1` for its shared spawned server so they keep working unchanged.

## Test plan
- [x] `npx vitest run app/api/auth/login/route.test.ts` — 3/3 (unit tier)
- [x] `npm run test:http:local` — 21/21 across the full HTTP suite
- [x] `tsc --noEmit` / `eslint` — clean
- [x] `node scripts/check-docs-drift.mjs` — routes/tables/sources in sync, verified against current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the production authentication path and session issuance; misconfiguration of ALLOW_DEV_LOGIN or email delivery could block sign-in or leave a dev bypass enabled in prod.
> 
> **Overview**
> **Production sign-in no longer trusts email alone.** The login UI now calls **`POST /api/auth/request-magic-link`**, which emails a single-use link and does **not** set a session; only **`GET /auth/confirm`** mints the cookie after the link is clicked. Unknown members still get **403**.
> 
> **`POST /api/auth/login`** (instant session for any recognized email) is **dev/test only**: **404** in production unless **`ALLOW_DEV_LOGIN=1`**, matching **`/auth/dev-login`**. Unit tests cover the gate; HTTP tests cover the magic-link request path and full confirm round-trip (including first-login → `/auth/welcome`).
> 
> The HTTP test server sets **`ALLOW_DEV_LOGIN=1`** so other suites can keep using direct login as a session helper. **`docs/ARCHITECTURE.md`** and the drift route list reflect the new primary path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e6d4c8091ba60e18cb85b9deefe0d1ec37fae47. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->