### PR TITLE
feat(onboarding): personalize the agent-onboarding CTA prompt

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -7,6 +7,7 @@ import { CopySnippet } from "@/components/copy-snippet";
 import { getPulseMetrics } from "@/lib/metrics/pulse";
 import { parseRange } from "@/lib/metrics/range";
 import { pickHomeState } from "@/lib/dashboard/home-state";
+import { buildAgentOnboardingPrompt } from "@/lib/onboarding/agent-prompt";
 import { AskBrain } from "@/components/dashboard/ask-brain";
 import { KpiBand } from "@/components/dashboard/kpi-band";
 import { RangeSelector } from "@/components/dashboard/range-selector";
@@ -18,11 +19,6 @@ import type { DecisionRow } from "@/components/dashboard/types";
 import { KnowledgeGrowth } from "@/components/charts/knowledge-growth";
 import { UsageChart } from "@/components/charts/usage-chart";
 import { TaskFunnel } from "@/components/charts/task-funnel";
-
-/** Placeholder until the personalized template lands (aios-workspace docs/getting-started/agent-onboarding.md). */
-function buildAgentPrompt(teamSlug: string): string {
-  return `You are onboarding a new AIOS individual contributor for the "${teamSlug}" team. Follow exactly: https://aiosbrain.dev/getting-started/onboarding-a-contributor/`;
-}
 
 function SetupChecklist({ teamSlug }: { teamSlug: string }) {
   const steps = [
@@ -152,7 +148,10 @@ export default async function TeamHome({
         <WorkstationSetup
           teamSlug={teamSlug}
           firstName={firstName}
-          agentPrompt={buildAgentPrompt(teamSlug)}
+          agentPrompt={buildAgentOnboardingPrompt({
+            teamSlug,
+            brainUrl: (process.env.APP_URL ?? "").replace(/\/$/, ""),
+          })}
           keys={(keyRows ?? []) as MyKeyRow[]}
         />
       </div>

--- a/lib/onboarding/agent-prompt.test.ts
+++ b/lib/onboarding/agent-prompt.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentOnboardingPrompt } from "./agent-prompt";
+
+describe("buildAgentOnboardingPrompt", () => {
+  it("substitutes the team slug and brain url into the scaffold command", () => {
+    const prompt = buildAgentOnboardingPrompt({
+      teamSlug: "acme",
+      brainUrl: "https://brain.acme.example.com",
+    });
+
+    expect(prompt).toContain('"acme" team');
+    expect(prompt).toContain("--brain-url https://brain.acme.example.com");
+    expect(prompt).toContain("--team-id acme");
+  });
+
+  it("keeps the human-readable doc URL as a fallback for non-agent readers", () => {
+    const prompt = buildAgentOnboardingPrompt({ teamSlug: "acme", brainUrl: "https://x.test" });
+    expect(prompt).toContain("https://aiosbrain.dev/getting-started/onboarding-a-contributor/");
+  });
+
+  it("tells the agent to self-serve the API key from the dashboard, not an admin", () => {
+    const prompt = buildAgentOnboardingPrompt({ teamSlug: "acme", brainUrl: "https://x.test" });
+    expect(prompt).toMatch(/My API keys.*not from an admin/s);
+  });
+});

--- a/lib/onboarding/agent-prompt.ts
+++ b/lib/onboarding/agent-prompt.ts
@@ -1,0 +1,34 @@
+export interface AgentPromptContext {
+  teamSlug: string;
+  /** This deployment's own base URL (APP_URL) — the brain a scaffolded workspace should connect to. */
+  brainUrl: string;
+}
+
+/**
+ * The one-click "hand this to your coding agent" prompt shown on a brand-new member's
+ * dashboard (components/dashboard/workstation-setup.tsx). Personalizes the AF1
+ * "Contributor scaffold prompt" (aios-workspace/docs/getting-started/agent-onboarding.md)
+ * with this team's actual brain_url/team_id so the agent can scaffold and connect
+ * without asking the human to look those values up — the doc URL stays as the
+ * canonical human-readable fallback for anyone who'd rather read and run commands
+ * themselves. Pure string template — no I/O, easy to keep in sync by eye with the
+ * source doc in the sibling aios-workspace repo.
+ */
+export function buildAgentOnboardingPrompt({ teamSlug, brainUrl }: AgentPromptContext): string {
+  return [
+    `You are onboarding a new AIOS individual contributor for the "${teamSlug}" team.`,
+    `Follow exactly: https://aiosbrain.dev/getting-started/onboarding-a-contributor/`,
+    ``,
+    `Rules:`,
+    `- Run every command in order. Do not skip validation/validate-all.sh.`,
+    `- Ask for the contributor's handle if not given, then scaffold with:`,
+    `    --slug {handle}-workspace --brain-url ${brainUrl} --team-id ${teamSlug} --output ~/Projects/{handle}-workspace`,
+    `  (unless told otherwise).`,
+    `- Stop and report a BLOCKER if a step requires human admin action, browser OAuth, or a secret you cannot obtain.`,
+    `- Never commit API keys. Put AIOS_API_KEY in .env only — generate it from this dashboard's`,
+    `  "My API keys" panel (your own profile page), not from an admin.`,
+    `- After setup, run: aios status (must connect), validation/validate-all.sh . (exit 0).`,
+    ``,
+    `Report: workspace path, aios status summary, validate-all exit code, and every BLOCKER step.`,
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
Reopened against `main` — the original PR (#161) was based on the now-merged-and-deleted `feat/onboarding-dashboard-cta` branch, and GitHub auto-closed it once that branch was deleted. Same commit, cherry-picked cleanly onto current `main`, diff verified clean.

- New `lib/onboarding/agent-prompt.ts`: substitutes this team's actual `brain_url`/`team_id` into the AF1 "Contributor scaffold prompt" template (aios-workspace's `docs/getting-started/agent-onboarding.md`), so an agent driving setup via the copy-paste prompt doesn't have to ask the human to look those values up.
- Also updates the prompt to tell the agent to self-serve the API key from the dashboard's "My API keys" panel (already merged in #158) instead of asking a team admin.
- The plain doc URL stays in the prompt as the fallback for anyone who'd rather read and run commands themselves.

## Test plan
- [x] `npx vitest run lib/onboarding/agent-prompt.test.ts` — 3/3
- [x] `tsc --noEmit` / `eslint` — clean
- [x] `node scripts/check-docs-drift.mjs` — in sync, verified against current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-template onboarding copy only; no auth, data, or API behavior changes beyond what text is shown in WorkstationSetup.
> 
> **Overview**
> Replaces the team home page’s minimal inline agent prompt with **`buildAgentOnboardingPrompt`** in `lib/onboarding/agent-prompt.ts`, wired from **`member-setup`** via **`APP_URL`** (trimmed) as **`--brain-url`** and the team slug as **`--team-id`**.
> 
> The copy-paste CTA now follows the AF1 contributor scaffold template: ordered commands, scaffold flags, blocker handling, post-setup validation, and a report checklist. It still links the public onboarding doc for humans and **directs agents to create API keys from “My API keys” on the dashboard**, not via an admin.
> 
> **Vitest** covers slug/URL substitution, the doc fallback, and the self-serve key wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023c2652eff704cae59806546d0663e5c7eae3e0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->