### PR TITLE
fix: rename stray supabase→db refs on the home page (main was broken)

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -113,7 +113,7 @@ export default async function TeamHome({
   // Has this member EVER issued their own key (revoked or not) — the proxy for "has this
   // person's workstation setup even started," independent of whether the TEAM has synced
   // anything yet (a member invited into an already-active team must still see this).
-  const { count: ownKeyCount } = await supabase
+  const { count: ownKeyCount } = await db
     .from("api_keys")
     .select("id", { count: "exact", head: true })
     .eq("team_id", team.id)
@@ -135,7 +135,7 @@ export default async function TeamHome({
   }
 
   if (homeState === "member-setup") {
-    const { data: keyRows } = await supabase
+    const { data: keyRows } = await db
       .from("api_keys")
       .select("id, key_id, name, created_at, last_used_at, revoked_at")
       .eq("team_id", team.id)


### PR DESCRIPTION
## Why
\`main\` is currently non-compiling (\`tsc\`: \`Cannot find name 'supabase'\`). Root cause: \`app/t/[team]/page.tsx\` had two leftover \`supabase\` identifier references that the supabase→db rename (#162) missed — they were added by a PR (#163/#164) that merged after #162's branch point, so the rename never touched them.

Caught this while rebasing an unrelated PR onto \`main\` and hitting a fresh \`tsc\` failure in a file that PR never touches.

## Test plan
- [x] \`tsc --noEmit\` clean (repo-wide)
- [x] \`eslint\` clean
- [x] Full unit tier 379 passed
- [x] docs-drift clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed member home/setup pages so API key status and key details load more reliably.
  * Improved consistency in how key-related information is fetched, helping the page show the correct setup state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->