### PR TITLE
fix(onboarding): greet with the team's display name, not its URL slug

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -24,25 +24,37 @@ function SetupChecklist({ teamSlug }: { teamSlug: string }) {
   const steps = [
     <span key="1">
       Invite your team in{" "}
-      <Link href={`/t/${teamSlug}/admin/members`} className="text-violet underline underline-offset-2">
+      <Link
+        href={`/t/${teamSlug}/admin/members`}
+        className="text-violet underline underline-offset-2"
+      >
         Admin → Members
       </Link>
     </span>,
     <span key="2">
-      Each teammate generates their own API key from their profile page once signed in (or an
-      admin can issue one for them in{" "}
-      <Link href={`/t/${teamSlug}/admin/keys`} className="text-violet underline underline-offset-2">
+      Each teammate generates their own API key from their profile page once
+      signed in (or an admin can issue one for them in{" "}
+      <Link
+        href={`/t/${teamSlug}/admin/keys`}
+        className="text-violet underline underline-offset-2"
+      >
         Admin → Keys
       </Link>
       )
     </span>,
     <span key="3">
-      Run <code className="rounded bg-surface-overlay px-1 py-0.5 font-mono text-xs">aios push</code>{" "}
+      Run{" "}
+      <code className="rounded bg-surface-overlay px-1 py-0.5 font-mono text-xs">
+        aios push
+      </code>{" "}
       from your project repo
     </span>,
     <span key="4">
       Ask your first question in{" "}
-      <Link href={`/t/${teamSlug}/query`} className="text-violet underline underline-offset-2">
+      <Link
+        href={`/t/${teamSlug}/query`}
+        className="text-violet underline underline-offset-2"
+      >
         Query
       </Link>
     </span>,
@@ -53,14 +65,20 @@ function SetupChecklist({ teamSlug }: { teamSlug: string }) {
       <div className="rounded-2xl bg-surface-inset px-8 py-10">
         <div className="mb-4 flex items-center gap-3">
           <Rocket className="size-6 text-violet" strokeWidth={1.5} />
-          <h2 className="text-xl font-semibold text-ink">Get your team brain online</h2>
+          <h2 className="text-xl font-semibold text-ink">
+            Get your team brain online
+          </h2>
         </div>
         <p className="mb-6 text-sm text-ink-secondary">
-          Nothing has been synced yet. Four steps and your team&apos;s memory starts compounding:
+          Nothing has been synced yet. Four steps and your team&apos;s memory
+          starts compounding:
         </p>
         <ol className="mb-6 flex flex-col gap-3">
           {steps.map((step, i) => (
-            <li key={i} className="flex items-start gap-3 text-sm text-ink-secondary">
+            <li
+              key={i}
+              className="flex items-start gap-3 text-sm text-ink-secondary"
+            >
               <span className="bg-gradient-prism mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold text-white">
                 {i + 1}
               </span>
@@ -100,14 +118,19 @@ export default async function TeamHome({
     .eq("status", "active")
     .maybeSingle();
   const isAdmin = me?.role === "admin";
-  const tier = ((me?.tier as "team" | "external" | undefined) ?? "external");
+  const tier = (me?.tier as "team" | "external" | undefined) ?? "external";
   const memberId = (me?.id as string | undefined) ?? "";
-  const firstName = ((me?.display_name as string | undefined) ?? "").trim().split(/\s+/)[0] || "there";
+  const firstName =
+    ((me?.display_name as string | undefined) ?? "").trim().split(/\s+/)[0] ||
+    "there";
 
   // Tier-filtered count (no RLS backstop in postgres mode).
   const { count: itemCount } = await visibleItems(
-    db.from("items").select("id", { count: "exact", head: true }).eq("team_id", team.id),
-    tier
+    db
+      .from("items")
+      .select("id", { count: "exact", head: true })
+      .eq("team_id", team.id),
+    tier,
   );
 
   // Has this member EVER issued their own key (revoked or not) — the proxy for "has this
@@ -150,6 +173,7 @@ export default async function TeamHome({
           firstName={firstName}
           agentPrompt={buildAgentOnboardingPrompt({
             teamSlug,
+            teamName: team.name,
             brainUrl: (process.env.APP_URL ?? "").replace(/\/$/, ""),
           })}
           keys={(keyRows ?? []) as MyKeyRow[]}
@@ -167,7 +191,7 @@ export default async function TeamHome({
         .eq("team_id", team.id)
         .order("decided_at", { ascending: false })
         .limit(8),
-      tier
+      tier,
     ),
   ]);
 
@@ -193,7 +217,10 @@ export default async function TeamHome({
       <WorkingOn teamSlug={teamSlug} />
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <DecisionsCard teamSlug={teamSlug} decisions={(decisions ?? []) as DecisionRow[]} />
+        <DecisionsCard
+          teamSlug={teamSlug}
+          decisions={(decisions ?? []) as DecisionRow[]}
+        />
         <TaskFunnel data={pulse.funnel} />
       </div>
     </div>

--- a/lib/onboarding/agent-prompt.test.ts
+++ b/lib/onboarding/agent-prompt.test.ts
@@ -5,6 +5,7 @@ describe("buildAgentOnboardingPrompt", () => {
   it("substitutes the team slug and brain url into the scaffold command", () => {
     const prompt = buildAgentOnboardingPrompt({
       teamSlug: "acme",
+      teamName: "acme",
       brainUrl: "https://brain.acme.example.com",
     });
 
@@ -13,13 +14,35 @@ describe("buildAgentOnboardingPrompt", () => {
     expect(prompt).toContain("--team-id acme");
   });
 
+  it("greets with the team's proper-cased display name, not its lowercase URL slug", () => {
+    const prompt = buildAgentOnboardingPrompt({
+      teamSlug: "acme-corp",
+      teamName: "Acme Corp",
+      brainUrl: "https://x.test",
+    });
+
+    expect(prompt).toContain('"Acme Corp" team');
+    expect(prompt).not.toContain('"acme-corp" team');
+    expect(prompt).toContain("--team-id acme-corp");
+  });
+
   it("keeps the human-readable doc URL as a fallback for non-agent readers", () => {
-    const prompt = buildAgentOnboardingPrompt({ teamSlug: "acme", brainUrl: "https://x.test" });
-    expect(prompt).toContain("https://aiosbrain.dev/getting-started/onboarding-a-contributor/");
+    const prompt = buildAgentOnboardingPrompt({
+      teamSlug: "acme",
+      teamName: "acme",
+      brainUrl: "https://x.test",
+    });
+    expect(prompt).toContain(
+      "https://aiosbrain.dev/getting-started/onboarding-a-contributor/",
+    );
   });
 
   it("tells the agent to self-serve the API key from the dashboard, not an admin", () => {
-    const prompt = buildAgentOnboardingPrompt({ teamSlug: "acme", brainUrl: "https://x.test" });
+    const prompt = buildAgentOnboardingPrompt({
+      teamSlug: "acme",
+      teamName: "acme",
+      brainUrl: "https://x.test",
+    });
     expect(prompt).toMatch(/My API keys.*not from an admin/s);
   });
 });

--- a/lib/onboarding/agent-prompt.ts
+++ b/lib/onboarding/agent-prompt.ts
@@ -1,5 +1,7 @@
 export interface AgentPromptContext {
   teamSlug: string;
+  /** The team's real display name (proper casing) — for prose, never the URL slug. */
+  teamName: string;
   /** This deployment's own base URL (APP_URL) — the brain a scaffolded workspace should connect to. */
   brainUrl: string;
 }
@@ -14,9 +16,13 @@ export interface AgentPromptContext {
  * themselves. Pure string template — no I/O, easy to keep in sync by eye with the
  * source doc in the sibling aios-workspace repo.
  */
-export function buildAgentOnboardingPrompt({ teamSlug, brainUrl }: AgentPromptContext): string {
+export function buildAgentOnboardingPrompt({
+  teamSlug,
+  teamName,
+  brainUrl,
+}: AgentPromptContext): string {
   return [
-    `You are onboarding a new AIOS individual contributor for the "${teamSlug}" team.`,
+    `You are onboarding a new AIOS individual contributor for the "${teamName}" team.`,
     `Follow exactly: https://aiosbrain.dev/getting-started/onboarding-a-contributor/`,
     ``,
     `Rules:`,


### PR DESCRIPTION
## Summary
- `buildAgentOnboardingPrompt` (#164) only accepted `teamSlug` (lowercase, URL-safe) and interpolated it directly into the greeting prose — `You are onboarding a new AIOS individual contributor for the "acme-corp" team.` — instead of the proper-cased display name.
- Every sibling onboarding surface built in this same workstream (`lib/auth/mailer.ts`, `lib/auth/welcome-context.ts`, `app/auth/welcome/page.tsx`) correctly uses the team's real `name` column; this one dropped it in favor of the slug, even though `team.name` was already in scope two lines away in `app/t/[team]/page.tsx` (used for `<AskBrain teamName={team.name} />`).
- Added `teamName` to `AgentPromptContext`, used it in the greeting line, kept `teamSlug` for the machine-facing `--team-id` flag, and threaded `team.name` through from the call site.
- The original unit test masked this because it used `teamSlug: "acme"` where slug and name happened to coincide — added a new test case with a slug/name that actually differ.

## Test plan
- [x] `npx vitest run lib/onboarding/agent-prompt.test.ts` — 4/4
- [x] `npx tsc --noEmit` — clean
- [x] Full `npm test` — passing (one pre-existing, unrelated timezone-formatting test failure reproduces identically on unmodified `main`)
- [x] `npm run lint` — clean (pre-existing unrelated warning only)
- [x] `npm run check:docs` — congruent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only onboarding string change with no auth, data, or API behavior changes.
> 
> **Overview**
> The **copy-to-agent onboarding prompt** on new members’ home now greets with the team’s **display name** (`team.name`) instead of the URL **slug**, while scaffold flags still use `--team-id` with the slug.
> 
> `AgentPromptContext` gains **`teamName`**; `app/t/[team]/page.tsx` passes `team.name` into `buildAgentOnboardingPrompt` on the member-setup path. Tests were updated and a case was added where slug and name differ (e.g. `acme-corp` vs `Acme Corp`).
> 
> Most edits in `page.tsx` are **formatting** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44df311405a681825eced466eef85f72d7f586e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->