### PR TITLE
fix(ingest): flag connector service-accounts, exclude from human-facing member surfaces

### DIFF
--- a/app/api/v1/members/route.ts
+++ b/app/api/v1/members/route.ts
@@ -43,6 +43,7 @@ export async function GET(req: NextRequest) {
     .from("members")
     .select("id, email, display_name, actor_handle, github_login, avatar_url, role, tier, status")
     .eq("team_id", auth.teamId)
+    .eq("is_connector", false)
     .neq("status", "disabled");
   if (email) q = q.eq("email", email);
   if (handle) q = q.eq("actor_handle", handle);

--- a/app/t/[team]/admin/members/page.tsx
+++ b/app/t/[team]/admin/members/page.tsx
@@ -26,6 +26,7 @@ export default async function MembersAdminPage({
     .from("members")
     .select("id, display_name, email, actor_handle, role, tier, status, github_login, avatar_url, created_at")
     .eq("team_id", team.id)
+    .eq("is_connector", false)
     .order("created_at");
 
   // All linked identities (email aliases + slack/linear/plane provider ids) for the panel.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,7 +242,8 @@ shown for a human to pull, never silently applied. Two-way write-back remains ou
 projection engine: `lib/ingest/sources/plane.ts` + `plane-normalize.ts` pull a Plane project's
 work-items **into** the brain as tasks, run in-process by `lib/ingest/run.ts: runPlaneIngestion`
 (scheduler tick + the admin **"Sync now"** button on a Plane integration; actor = the auto-provisioned
-`plane-sync` connector member). It shares the low-level HTTP client with the outbound adapter via
+`plane-sync` connector member, `members.is_connector = true` — excluded from Admin → Members and
+`/api/v1/members` so it never renders as a human). It shares the low-level HTTP client with the outbound adapter via
 `lib/pm-sync/plane-client.ts`. Two invariants keep it from fighting the projection engine:
 > • **Dedicated brain project per Plane project** (`plane-<identifier>`). `materializeTasks`'
 > diff-delete is **project-wide**, so a Plane import must never share a project with CLI/UI tasks

--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -93,6 +93,7 @@ async function resolveConnectorAuth(
           role: "member",
           tier: "team",
           status: "active",
+          is_connector: true,
         },
         { onConflict: "team_id,actor_handle" }
       )

--- a/postgres/migrations/20260706130000_members_is_connector.sql
+++ b/postgres/migrations/20260706130000_members_is_connector.sql
@@ -1,0 +1,12 @@
+-- Distinguish the auto-provisioned per-source ingest actor (lib/ingest/run.ts's
+-- resolveConnectorAuth: "slack-sync", "plane-sync", "linear-sync", "github-sync") from a real
+-- human team member. These rows exist purely so ingestion has a member_id to attribute its own
+-- writes/audit rows to — they were rendering in Admin -> Members and /api/v1/members
+-- indistinguishable from a person.
+alter table members add column if not exists is_connector boolean not null default false;
+
+-- Backfill the connector rows already auto-provisioned before this column existed.
+update members
+   set is_connector = true
+ where actor_handle in ('slack-sync', 'plane-sync', 'linear-sync', 'github-sync')
+   and is_connector = false;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -115,6 +115,10 @@ create table if not exists members (
   role member_role not null default 'member',
   tier access_tier not null default 'team',
   status member_status not null default 'invited',
+  -- true for the auto-provisioned per-source ingest actor (lib/ingest/run.ts's
+  -- resolveConnectorAuth), never for a real human — excluded from Admin -> Members and
+  -- /api/v1/members so a connector never renders indistinguishable from a person.
+  is_connector boolean not null default false,
   created_at timestamptz not null default now(),
   unique (team_id, email),
   unique (team_id, actor_handle)

--- a/test/datamechanics/members-resolve.datamechanics.test.ts
+++ b/test/datamechanics/members-resolve.datamechanics.test.ts
@@ -102,6 +102,32 @@ describe("members + identity-resolve endpoints (real handlers, real Postgres)", 
     expect(fresh?.avatar_url).toBeNull();
   });
 
+  it("members: excludes connector service-accounts (e.g. the auto-provisioned plane-sync actor)", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const { data: connector, error } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: "plane-sync@connector.local",
+        display_name: "Plane Sync",
+        actor_handle: "plane-sync",
+        role: "member",
+        tier: "team",
+        status: "active",
+        is_connector: true,
+      })
+      .select("id")
+      .single();
+    expect(error).toBeNull();
+    const connectorId = (connector as { id: string }).id;
+
+    const ok = await get(membersGET, MEMBERS_URL, team, seed.teamSlug);
+    const body = (await ok.json()) as { members: { id: string }[] };
+    expect(body.members.some((m) => m.id === connectorId)).toBe(false);
+    expect(body.members.some((m) => m.id === seed.memberId)).toBe(true);
+  });
+
   it("resolve: slack external_id → member; provider filter; 404 on miss", async () => {
     const seed = await seedTeam();
     const team = await issueKeyFor(seed, "team");


### PR DESCRIPTION
## Summary
- `resolveConnectorAuth` (`lib/ingest/run.ts`) auto-provisions a real `members` row per ingestion source (`Slack Sync`, `Plane Sync`, `Linear Sync`, `GitHub Sync`) so ingestion has a `member_id` to attribute its own writes/audit rows to. Nothing marked these as non-human, so they rendered in **Admin → Members** and `/api/v1/members` indistinguishable from a real teammate — confirmed 3 such rows in prod for the `aios` team.
- Adds `members.is_connector boolean not null default false` (migration + `schema.sql` mirror), sets it `true` at connector-provisioning time, and backfills the known prod rows by `actor_handle` (`slack-sync`/`plane-sync`/`linear-sync`/`github-sync`).
- Filters `is_connector = false` into the Admin → Members page query and the `/api/v1/members` roster endpoint (the two surfaces where a human reads this table expecting people).
- Updated `docs/ARCHITECTURE.md`'s Plane-import note to mention the flag.

## Scope note
This is the **short-term fix** for the surfaces where connector rows were visibly wrong (the immediate bug report). Scoping the deeper issue turned up a real correctness bug independent of this PR: identity resolution silently falls back to the connector's own `member_id` when an ingested item's actual human author can't be identity-mapped (`items.member_id`/`item_versions.member_id`), so unmapped human content gets mis-attributed to "Plane Sync" etc. rather than staying `null`. That's a separate, more careful fix to the ingestion attribution path (likely: stop creating a fake member at all, use `member_id: null` + the existing non-FK `items.actor` text column instead) and is being scoped separately — not included here to keep this PR small and reviewable.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (pre-existing unrelated warning only)
- [x] `npm run check:docs` — congruent
- [x] Migration applies cleanly via `npm run pg:schema` (migrate-from-zero replay)
- [x] New data-mechanics test: a connector row (`is_connector: true`) is excluded from `/api/v1/members`, a real member still appears
- [x] Full `npm run test:datamechanics` — 272/272 (2 skipped)
- [x] Full `npm test` — passing (one pre-existing, unrelated timezone-formatting test failure reproduces identically on unmodified `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema migration with backfill plus read-path filters on two roster surfaces; ingest attribution still uses connector `member_id` unchanged.
> 
> **Overview**
> Auto-provisioned ingest actors (`slack-sync`, `plane-sync`, etc.) were stored as normal `members` rows and showed up in **Admin → Members** and **`GET /api/v1/members`** like real teammates.
> 
> This PR adds **`members.is_connector`** (migration + `schema.sql`), sets it **`true`** when `resolveConnectorAuth` creates a connector, **backfills** known `actor_handle` values, and applies **`is_connector = false`** on the admin members query and the roster API. Architecture docs note that connector rows stay out of human roster surfaces.
> 
> A data-mechanics test asserts connector rows are omitted from `/api/v1/members` while real members still appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e79a4b039a99ced8e7c374f1f8f667503dd2fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->