### PR TITLE
fix(onboarding): magic-link invite email + full manual-share fallback

### DIFF
--- a/app/auth/welcome/actions.ts
+++ b/app/auth/welcome/actions.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { getSessionUser } from "@/lib/auth/session";
+import { setPasswordIfUnset } from "@/lib/auth/pg-login";
+import { isPasswordStrongEnough, MIN_PASSWORD_LENGTH } from "@/lib/auth/password";
+
+/**
+ * Optional first-time password set, offered on the welcome screen to a member who signed in via
+ * magic link and has no password yet. Not a reset (no current-password check) — `setPasswordIfUnset`
+ * only writes when none exists, so this can't touch an account that already has one.
+ */
+export async function setInitialPassword(newPassword: string): Promise<{ ok: boolean; error?: string }> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: "not signed in" };
+  if (!isPasswordStrongEnough(newPassword)) {
+    return { ok: false, error: `password must be at least ${MIN_PASSWORD_LENGTH} characters` };
+  }
+
+  const set = await setPasswordIfUnset(user.id, newPassword);
+  if (!set) return { ok: false, error: "a password is already set for this account" };
+  return { ok: true };
+}

--- a/app/auth/welcome/page.tsx
+++ b/app/auth/welcome/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getSessionUser } from "@/lib/auth/session";
 import { getWelcomeContext } from "@/lib/auth/welcome-context";
+import { hasPasswordSet } from "@/lib/auth/pg-login";
+import { SetPasswordForm } from "./set-password-form";
 
 export const metadata: Metadata = { title: "Welcome" };
 
@@ -31,7 +33,10 @@ export default async function WelcomePage({
   if (!user) redirect("/login");
 
   const teamSlug = teamSlugFromPath(dest);
-  const ctx = teamSlug ? await getWelcomeContext(teamSlug, user.email) : null;
+  const [ctx, needsPassword] = await Promise.all([
+    teamSlug ? getWelcomeContext(teamSlug, user.email) : Promise.resolve(null),
+    hasPasswordSet(user.id).then((has) => !has),
+  ]);
   const firstName = ctx?.inviteeName.trim().split(/\s+/)[0] || "there";
 
   return (
@@ -61,6 +66,7 @@ export default async function WelcomePage({
             <a href={dest} className="btn-prism w-full justify-center">
               Continue to your dashboard
             </a>
+            {needsPassword && <SetPasswordForm />}
           </div>
         </div>
       </div>

--- a/app/auth/welcome/set-password-form.tsx
+++ b/app/auth/welcome/set-password-form.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { setInitialPassword } from "./actions";
+
+/**
+ * Optional password set for a member who just signed in via magic link. Skippable — they can
+ * always request a fresh magic link at /login if they never set one.
+ */
+export function SetPasswordForm() {
+  const [expanded, setExpanded] = useState(false);
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  if (done) {
+    return (
+      <p className="mt-4 text-center text-sm text-ink-secondary">
+        Password set. You can now sign in with your email + password too.
+      </p>
+    );
+  }
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="mt-4 w-full text-center text-xs text-ink-tertiary underline"
+      >
+        Set a password (optional — you can keep using emailed sign-in links instead)
+      </button>
+    );
+  }
+
+  return (
+    <form
+      className="mt-4 flex flex-col gap-2"
+      action={(formData) => {
+        setError(null);
+        startTransition(async () => {
+          const res = await setInitialPassword(String(formData.get("password") ?? ""));
+          if (!res.ok) setError(res.error ?? "failed");
+          else setDone(true);
+        });
+      }}
+    >
+      <input
+        name="password"
+        type="password"
+        required
+        placeholder="new password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="rounded-lg border border-border-default bg-surface-base px-3 py-2 text-sm text-ink outline-none focus:border-violet"
+      />
+      {error && <p className="text-xs text-red-600">{error}</p>}
+      <button
+        type="submit"
+        disabled={pending}
+        className="rounded-lg border border-border-default px-3 py-2 text-sm text-ink-secondary hover:text-ink disabled:opacity-50"
+      >
+        {pending ? "Setting…" : "Set password"}
+      </button>
+    </form>
+  );
+}

--- a/app/t/[team]/admin/actions.ts
+++ b/app/t/[team]/admin/actions.ts
@@ -26,8 +26,15 @@ async function resolveTeamUrl(): Promise<string> {
 }
 
 export type InviteMemberResult =
-  | { ok: true; mode: "magic-link"; email: string }
-  | { ok: true; mode: "manual"; email: string; password: string; inviteMessage: string }
+  | { ok: true; mode: "magic-link"; email: string; emailDelivered: boolean }
+  | {
+      ok: true;
+      mode: "manual";
+      reason: "no-mail" | "admin-choice";
+      email: string;
+      password: string;
+      inviteMessage: string;
+    }
   | { ok: false; error: string };
 
 /**
@@ -47,13 +54,15 @@ export async function inviteMember(
     displayName: string;
     actorHandle: string;
     role: "admin" | "lead" | "member";
+    /** When true, skip the magic-link invite even if mail delivery is configured. */
+    manualInvite?: boolean;
     password?: string;
   }
 ): Promise<InviteMemberResult> {
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
 
-  const useMagicLink = magicLinkAvailable() && !form.password?.trim();
+  const useMagicLink = magicLinkAvailable() && !form.manualInvite;
 
   let password = "";
   if (!useMagicLink) {
@@ -98,17 +107,23 @@ export async function inviteMember(
     });
     if (!url) return { ok: false, error: "could not issue a sign-in link" };
 
-    // Best-effort — never blocks the invite (the member row + link both already exist).
+    let emailDelivered = false;
     try {
-      await sendInviteEmail(email, { inviteeName: form.displayName, teamName, inviterName, loginUrl: url });
+      emailDelivered = await sendInviteEmail(email, {
+        inviteeName: form.displayName,
+        teamName,
+        inviterName,
+        loginUrl: url,
+      });
     } catch (e) {
       console.error("[invite] email send failed:", e instanceof Error ? e.message : e);
     }
 
     revalidatePath(`/t/${teamSlug}/admin/members`);
-    return { ok: true, mode: "magic-link", email };
+    return { ok: true, mode: "magic-link", email, emailDelivered };
   }
 
+  const manualReason = form.manualInvite ? "admin-choice" : "no-mail";
   const inviteMessage = buildManualInviteMessage({
     inviteeName: form.displayName,
     teamName,
@@ -119,7 +134,7 @@ export async function inviteMember(
   });
 
   revalidatePath(`/t/${teamSlug}/admin/members`);
-  return { ok: true, mode: "manual", email, password, inviteMessage };
+  return { ok: true, mode: "manual", reason: manualReason, email, password, inviteMessage };
 }
 
 export async function issueApiKey(

--- a/app/t/[team]/admin/actions.ts
+++ b/app/t/[team]/admin/actions.ts
@@ -1,20 +1,44 @@
 "use server";
 
+import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { adminClient } from "@/lib/db/admin";
 import { requireTeamAdmin as requireAdmin } from "@/lib/auth/guard";
 import { createMember } from "@/lib/admin/members";
 import { issueApiKey as issueApiKeyPrimitive, revokeApiKey as revokeApiKeyPrimitive } from "@/lib/admin/keys";
+import { issueLoginLink } from "@/lib/admin/login";
 import { adminSetPassword } from "@/lib/auth/pg-login";
 import { isPasswordStrongEnough, randomPassword, MIN_PASSWORD_LENGTH } from "@/lib/auth/password";
-import { sendInviteEmail } from "@/lib/auth/mailer";
+import { sendInviteEmail, magicLinkAvailable, buildManualInviteMessage } from "@/lib/auth/mailer";
+
+// Generous window for an admin-issued invite (vs. the 15-minute TTL for a self-service login link)
+// — the invitee may not open their email right away.
+const INVITE_LINK_TTL_MINUTES = 7 * 24 * 60;
+
+/** `APP_URL` if set, else the request's own host — so there's always a URL to show, even on a
+ * fresh self-host with no domain configured yet. */
+async function resolveTeamUrl(): Promise<string> {
+  if (process.env.APP_URL) return process.env.APP_URL.replace(/\/$/, "");
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host");
+  const proto = h.get("x-forwarded-proto") ?? "https";
+  return host ? `${proto}://${host}` : "";
+}
+
+export type InviteMemberResult =
+  | { ok: true; mode: "magic-link"; email: string }
+  | { ok: true; mode: "manual"; email: string; password: string; inviteMessage: string }
+  | { ok: false; error: string };
 
 /**
- * Create a member AND set their initial sign-in password (audit M1/M2b — replaces magic-link
- * invites). `form.password` is optional: an admin can type one, or leave it blank to get a strong
- * generated one — either way it's returned ONCE for the admin to hand to the person out-of-band
- * (same "shown once" pattern as API key issuance below), never emailed. The invite email is a
- * personalized courtesy notification (name/team/inviter) — it never carries the password.
+ * Create a member and get them working sign-in access, one of two ways depending on this
+ * deployment:
+ *  - **Magic-link** (default when `magicLinkAvailable()` — mail delivery is configured): email a
+ *    one-click, single-use sign-in link, valid 7 days. No password is set.
+ *  - **Manual** (mail delivery isn't configured, or the admin explicitly typed `form.password`):
+ *    set a password directly and return a complete, ready-to-paste invite (team brain URL,
+ *    sign-in email, password) for the admin to share out-of-band (Slack, DM, etc) — this is the
+ *    expected default path for a fresh self-hosted deployment with no mail provider set up.
  */
 export async function inviteMember(
   teamSlug: string,
@@ -25,19 +49,25 @@ export async function inviteMember(
     role: "admin" | "lead" | "member";
     password?: string;
   }
-): Promise<{ ok: boolean; password?: string; error?: string }> {
+): Promise<InviteMemberResult> {
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
 
-  const password = form.password?.trim() || randomPassword();
-  if (!isPasswordStrongEnough(password)) {
-    return { ok: false, error: `password must be at least ${MIN_PASSWORD_LENGTH} characters` };
+  const useMagicLink = magicLinkAvailable() && !form.password?.trim();
+
+  let password = "";
+  if (!useMagicLink) {
+    password = form.password?.trim() || randomPassword();
+    if (!isPasswordStrongEnough(password)) {
+      return { ok: false, error: `password must be at least ${MIN_PASSWORD_LENGTH} characters` };
+    }
   }
 
   const email = form.email.trim().toLowerCase();
+  const db = adminClient();
   try {
     await createMember(
-      adminClient(),
+      db,
       ctx.teamId,
       {
         email: form.email,
@@ -47,29 +77,49 @@ export async function inviteMember(
       },
       { actor: { kind: "member", memberId: ctx.memberId } }
     );
-    await adminSetPassword(email, password);
+    if (!useMagicLink) await adminSetPassword(email, password);
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "create failed" };
   }
 
-  // Best-effort courtesy notification — never blocks the invite, and never carries the password.
-  try {
-    const db = adminClient();
-    const [{ data: team }, { data: inviter }] = await Promise.all([
-      db.from("teams").select("name").eq("id", ctx.teamId).maybeSingle(),
-      db.from("members").select("display_name").eq("id", ctx.memberId).maybeSingle(),
-    ]);
-    await sendInviteEmail(email, {
-      inviteeName: form.displayName,
-      teamName: (team as { name: string } | null)?.name ?? teamSlug,
-      inviterName: (inviter as { display_name: string } | null)?.display_name ?? "Your admin",
+  const [{ data: team }, { data: inviter }] = await Promise.all([
+    db.from("teams").select("name").eq("id", ctx.teamId).maybeSingle(),
+    db.from("members").select("display_name").eq("id", ctx.memberId).maybeSingle(),
+  ]);
+  const teamName = (team as { name: string } | null)?.name ?? teamSlug;
+  const inviterName = (inviter as { display_name: string } | null)?.display_name ?? "Your admin";
+
+  if (useMagicLink) {
+    const { url } = await issueLoginLink(db, ctx.teamId, email, {
+      nextPath: `/t/${teamSlug}`,
+      ttlMinutes: INVITE_LINK_TTL_MINUTES,
+      baseUrl: process.env.APP_URL,
+      actor: { kind: "member", memberId: ctx.memberId },
     });
-  } catch (e) {
-    console.error("[invite] email send failed:", e instanceof Error ? e.message : e);
+    if (!url) return { ok: false, error: "could not issue a sign-in link" };
+
+    // Best-effort — never blocks the invite (the member row + link both already exist).
+    try {
+      await sendInviteEmail(email, { inviteeName: form.displayName, teamName, inviterName, loginUrl: url });
+    } catch (e) {
+      console.error("[invite] email send failed:", e instanceof Error ? e.message : e);
+    }
+
+    revalidatePath(`/t/${teamSlug}/admin/members`);
+    return { ok: true, mode: "magic-link", email };
   }
 
+  const inviteMessage = buildManualInviteMessage({
+    inviteeName: form.displayName,
+    teamName,
+    inviterName,
+    teamUrl: await resolveTeamUrl(),
+    email,
+    password,
+  });
+
   revalidatePath(`/t/${teamSlug}/admin/members`);
-  return { ok: true, password };
+  return { ok: true, mode: "manual", email, password, inviteMessage };
 }
 
 export async function issueApiKey(

--- a/components/admin/invite-member.tsx
+++ b/components/admin/invite-member.tsx
@@ -43,7 +43,9 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
     return (
       <div className="prism-card flex flex-col gap-3 border border-violet/40 p-4">
         <p className="text-sm font-medium text-ink">
-          Invite email sent to {issued.email} with a one-time sign-in link (valid 7 days).
+          {issued.emailDelivered
+            ? `Invite email sent to ${issued.email} with a one-time sign-in link (valid 7 days).`
+            : `Member created for ${issued.email}, but we couldn't confirm the invite email was delivered. Check your mail provider settings, or ask them to request a sign-in link at the login page.`}
         </p>
         <button
           onClick={reset}
@@ -56,13 +58,13 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
   }
 
   if (issued?.mode === "manual") {
+    const intro =
+      issued.reason === "admin-choice"
+        ? `Share this message with ${issued.email} directly (Slack, DM, etc). It's shown exactly once; only the password's hash is stored.`
+        : `Email delivery isn't configured for this deployment — share this message with ${issued.email} directly (Slack, DM, etc). It's shown exactly once; only the password's hash is stored.`;
     return (
       <div className="prism-card flex flex-col gap-3 border border-violet/40 p-4">
-        <p className="text-sm font-medium text-ink">
-          Email delivery isn&apos;t configured for this deployment — share this message with{" "}
-          {issued.email} directly (Slack, DM, etc). It&apos;s shown exactly once; only the
-          password&apos;s hash is stored.
-        </p>
+        <p className="text-sm font-medium text-ink">{intro}</p>
         <pre className="whitespace-pre-wrap rounded-lg bg-surface-overlay px-3 py-2 font-mono text-xs text-ink">
           {issued.inviteMessage}
         </pre>
@@ -103,6 +105,7 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
             displayName: String(formData.get("displayName") ?? ""),
             actorHandle: String(formData.get("actorHandle") ?? ""),
             role: (String(formData.get("role")) as "admin" | "lead" | "member") || "member",
+            manualInvite: manual,
             password: manual ? password || undefined : undefined,
           });
           if (!res.ok) setError(res.error);

--- a/components/admin/invite-member.tsx
+++ b/components/admin/invite-member.tsx
@@ -2,44 +2,79 @@
 
 import { useState, useTransition } from "react";
 import { UserPlus, Copy, Check, Dices } from "lucide-react";
-import { inviteMember } from "@/app/t/[team]/admin/actions";
+import { inviteMember, type InviteMemberResult } from "@/app/t/[team]/admin/actions";
+
+type Issued = Extract<InviteMemberResult, { ok: true }>;
+
+function CopyButton({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+      className="inline-flex items-center gap-2 rounded-lg border border-border-default px-3 py-2 text-sm text-ink-secondary hover:text-ink"
+    >
+      {copied ? <Check className="size-4 text-violet" /> : <Copy className="size-4" />}
+      {copied ? "Copied" : label}
+    </button>
+  );
+}
 
 export function InviteMember({ teamSlug }: { teamSlug: string }) {
   const [open, setOpen] = useState(false);
+  const [manual, setManual] = useState(false);
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [issued, setIssued] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [issued, setIssued] = useState<Issued | null>(null);
   const [pending, startTransition] = useTransition();
 
-  if (issued) {
+  function reset() {
+    setIssued(null);
+    setOpen(false);
+    setManual(false);
+    setPassword("");
+  }
+
+  if (issued?.mode === "magic-link") {
     return (
       <div className="prism-card flex flex-col gap-3 border border-violet/40 p-4">
         <p className="text-sm font-medium text-ink">
-          Member created — copy their password now and share it out-of-band. It is shown exactly
-          once; only its hash is stored.
+          Invite email sent to {issued.email} with a one-time sign-in link (valid 7 days).
         </p>
-        <div className="flex items-center gap-2">
-          <code className="flex-1 overflow-x-auto rounded-lg bg-surface-overlay px-3 py-2 font-mono text-xs text-ink">
-            {issued}
-          </code>
-          <button
-            onClick={async () => {
-              await navigator.clipboard.writeText(issued);
-              setCopied(true);
-              setTimeout(() => setCopied(false), 1500);
-            }}
-            className="rounded-lg border border-border-default p-2 text-ink-secondary hover:text-ink"
-            aria-label="Copy password"
-          >
-            {copied ? <Check className="size-4 text-violet" /> : <Copy className="size-4" />}
-          </button>
-        </div>
         <button
-          onClick={() => { setIssued(null); setOpen(false); setPassword(""); }}
+          onClick={reset}
           className="self-start rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white"
         >
-          Done — I copied it
+          Done
+        </button>
+      </div>
+    );
+  }
+
+  if (issued?.mode === "manual") {
+    return (
+      <div className="prism-card flex flex-col gap-3 border border-violet/40 p-4">
+        <p className="text-sm font-medium text-ink">
+          Email delivery isn&apos;t configured for this deployment — share this message with{" "}
+          {issued.email} directly (Slack, DM, etc). It&apos;s shown exactly once; only the
+          password&apos;s hash is stored.
+        </p>
+        <pre className="whitespace-pre-wrap rounded-lg bg-surface-overlay px-3 py-2 font-mono text-xs text-ink">
+          {issued.inviteMessage}
+        </pre>
+        <div className="flex gap-2">
+          <CopyButton text={issued.inviteMessage} label="Copy message" />
+          <CopyButton text={issued.password} label="Copy password only" />
+        </div>
+        <button
+          onClick={reset}
+          className="self-start rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white"
+        >
+          Done — I shared it
         </button>
       </div>
     );
@@ -68,10 +103,10 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
             displayName: String(formData.get("displayName") ?? ""),
             actorHandle: String(formData.get("actorHandle") ?? ""),
             role: (String(formData.get("role")) as "admin" | "lead" | "member") || "member",
-            password: password || undefined,
+            password: manual ? password || undefined : undefined,
           });
-          if (!res.ok) setError(res.error ?? "failed");
-          else setIssued(res.password ?? null);
+          if (!res.ok) setError(res.error);
+          else setIssued(res);
         });
       }}
     >
@@ -88,7 +123,18 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
           <option value="lead">lead</option>
           <option value="admin">admin</option>
         </select>
-        <div className="col-span-2 flex items-center gap-2">
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setManual((m) => !m)}
+        className="self-start text-xs text-ink-tertiary underline"
+      >
+        {manual ? "Use a magic sign-in link instead" : "Set a password manually instead"}
+      </button>
+
+      {manual && (
+        <div className="flex items-center gap-2">
           <input
             name="password"
             type="text"
@@ -107,7 +153,8 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
             <Dices className="size-4" />
           </button>
         </div>
-      </div>
+      )}
+
       {error && <p className="text-sm text-red-600">{error}</p>}
       <div className="flex gap-2">
         <button type="submit" disabled={pending}
@@ -120,8 +167,9 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
         </button>
       </div>
       <p className="text-xs text-ink-tertiary">
-        Invite-only: the member signs in with this email + password. Share the password with them
-        out-of-band (Slack, in person) — it&apos;s never emailed.
+        {manual
+          ? "The member signs in with this email + password. Share the password with them out-of-band (Slack, in person) — it's never emailed."
+          : "The member gets a one-click sign-in link by email. If this deployment has no mail provider configured, you'll get a ready-to-share invite instead."}
       </p>
     </form>
   );

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,14 +97,21 @@ This server **implements brain-api v1.3** (the wire contract; source of truth:
 Two principals, one tier model:
 
 - **Humans** — invite-only, two sign-in mechanisms:
-  - **Email+password (the DEFAULT, always available — audit M1/M2b).** An admin creates the
-    member and sets/resets their password (shown once, out-of-band — never emailed); the member
-    signs in with it and can change it anytime (`/t/:team/account`). `POST /api/auth/login`
-    verifies against the scrypt hash in `auth_users.password_hash` (`lib/auth/password`,
-    `lib/auth/pg-login.loginWithPassword`) → signed session cookie; the failure response is the
-    SAME (401 `invalid_credentials`) whether the email is unknown, has no password set, or the
-    password is wrong, so login can't be used to enumerate members. Needs no email infrastructure.
-  - **Magic link (OPTIONAL secondary path, needs a domain).** `POST /api/auth/request-magic-link`
+  - **Admin invite (`inviteMember`, Admin → Members).** Creates the member row, then either:
+    - **Magic-link invite** (default when `magicLinkAvailable()` — `APP_URL` + mail provider):
+      `issueLoginLink` mints a single-use 7-day token and `sendInviteEmail` delivers a one-click
+      link; no password is set upfront. The admin UI reports whether delivery was confirmed.
+    - **Manual invite** (when mail isn't configured, or the admin chooses a password): sets the
+      initial password via `adminSetPassword` (shown once to the admin as a ready-to-paste message
+      from `buildManualInviteMessage` — URL, email, password — for Slack/DM/etc; never emailed).
+  - **Email+password sign-in (always available — audit M1/M2b).** Members sign in with the
+    password an admin set (or one they chose on first login — see welcome screen below) and can
+    change it anytime (`/t/:team/account`). `POST /api/auth/login` verifies against the scrypt hash
+    in `auth_users.password_hash` (`lib/auth/password`, `lib/auth/pg-login.loginWithPassword`) →
+    signed session cookie; the failure response is the SAME (401 `invalid_credentials`) whether the
+    email is unknown, has no password set, or the password is wrong, so login can't be used to
+    enumerate members. Needs no email infrastructure.
+  - **Magic link sign-in (OPTIONAL secondary path, needs a domain).** `POST /api/auth/request-magic-link`
     issues + emails a single-use token (`issueMagicToken`/`sendMagicLink`; unknown emails get an
     explicit 403) and never sets a session cookie itself; only `GET /auth/confirm`
     (`redeemMagicToken`) does that, once the link is clicked. The login form only offers this
@@ -116,7 +123,8 @@ Two principals, one tier model:
     login-link`).
   - Either mechanism's **first** successful login (an invite's first activation) routes through
     `/auth/welcome` — name, team, and inviter (resolved from the append-only `audit_log`, no
-    `invited_by` column needed) — before landing on the dashboard; later logins go straight
+    `invited_by` column needed) — before landing on the dashboard; magic-link-only accounts can
+    optionally set a first password there (`setPasswordIfUnset`, skippable). Later logins go straight
     through (`loginWithPassword`'s and `redeemMagicToken`'s `firstLogin`). The session is a
     `jose`-signed httpOnly cookie (`lib/auth/pg-session`) either way.
 - **Machines** — per-member API key `aios_<key_id>_<secret>` (sha256 at rest, shown

--- a/lib/auth/mailer.test.ts
+++ b/lib/auth/mailer.test.ts
@@ -30,8 +30,9 @@ describe("mailer delivery", () => {
     vi.stubEnv("RESEND_API_KEY", "re_test_key");
     const fetchFn = mockFetch(true);
 
-    await sendInviteEmail("new@member.test", inviteCtx);
+    const delivered = await sendInviteEmail("new@member.test", inviteCtx);
 
+    expect(delivered).toBe(true);
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(fetchFn.mock.calls[0][0]).toBe("https://api.resend.com/emails");
     const body = sentBody(fetchFn);
@@ -82,7 +83,7 @@ describe("mailer delivery", () => {
     vi.stubEnv("SMTP_URL", "");
     const fetchFn = vi.fn();
     vi.stubGlobal("fetch", fetchFn);
-    await expect(sendInviteEmail("a@b.test", inviteCtx)).resolves.toBeUndefined();
+    await expect(sendInviteEmail("a@b.test", inviteCtx)).resolves.toBe(false);
     expect(fetchFn).not.toHaveBeenCalled();
   });
 

--- a/lib/auth/mailer.ts
+++ b/lib/auth/mailer.ts
@@ -102,36 +102,78 @@ export function magicLinkAvailable(): boolean {
   return Boolean(process.env.APP_URL) && Boolean(process.env.RESEND_API_KEY || process.env.SMTP_URL);
 }
 
+/** Shared across the emailed invite and the manual copy-paste invite, so tone/wording match. */
+function inviteExplainer(ctx: { teamName: string; inviterName: string }): string {
+  return (
+    `${ctx.inviterName} added you to ${ctx.teamName}'s AIOS Team Brain — your team's shared hub ` +
+    `for tasks, decisions, and knowledge synced from everyone's AIOS workspace.`
+  );
+}
+
 export interface InviteEmailContext {
   /** The invitee's display name, as entered by the inviter. First name is used in the greeting. */
   inviteeName: string;
   teamName: string;
   inviterName: string;
+  /**
+   * Ready-to-click sign-in link (single-use, 7-day magic-link token). Present whenever
+   * `magicLinkAvailable()` is true — the invite flow only calls `sendInviteEmail` in that case, since
+   * without a link there's nothing useful to email (the manual copy-paste path handles that case
+   * instead). Kept optional here, with the old "ask your admin" copy as a defensive fallback, so this
+   * function never sends a broken email if ever called without one.
+   */
+  loginUrl?: string;
 }
 
 /**
- * New-member invite courtesy email, personalized (name/team/inviter). Sign-in is email+password
- * (the admin shares the password out-of-band, the same "shown once" pattern as an API key) — this
- * email NEVER carries a secret, it's just a heads-up that an account exists. Never throws. Names
- * are attacker-controlled input (display names), so the HTML body escapes them — this is the only
- * place they're rendered as markup.
+ * New-member invite email, personalized (name/team/inviter) and carrying a one-click magic
+ * sign-in link when one is available. Never throws. Names are attacker-controlled input (display
+ * names), so the HTML body escapes them — this is the only place they're rendered as markup.
  */
 export async function sendInviteEmail(email: string, ctx: InviteEmailContext): Promise<void> {
   const firstName = ctx.inviteeName.trim().split(/\s+/)[0] || ctx.inviteeName;
   const subject = `${ctx.inviterName} added you to ${ctx.teamName} on AIOS`;
+  const explainer = inviteExplainer(ctx);
 
-  const text =
-    `Hi ${firstName},\n\n${ctx.inviterName} added you to ${ctx.teamName}'s AIOS Team Brain.\n\n` +
-    `Ask your admin for your sign-in password, then open the team brain and sign in with this email address.`;
+  const textAction = ctx.loginUrl
+    ? `Get started: ${ctx.loginUrl}\n\nThis link is single-use and valid for 7 days.`
+    : `Ask your admin for your sign-in password, then open the team brain and sign in with this email address.`;
+  const text = `Hi ${firstName},\n\n${explainer}\n\n${textAction}`;
 
   const safeFirstName = escapeHtml(firstName);
-  const safeInviter = escapeHtml(ctx.inviterName);
-  const safeTeam = escapeHtml(ctx.teamName);
-  const intro = `<p>Hi ${safeFirstName},</p><p><strong>${safeInviter}</strong> added you to <strong>${safeTeam}</strong>'s AIOS Team Brain.</p>`;
+  const safeExplainer = escapeHtml(explainer);
+  const intro = `<p>Hi ${safeFirstName},</p><p>${safeExplainer}</p>`;
+  const htmlAction = ctx.loginUrl
+    ? `<p><a href="${escapeHtml(ctx.loginUrl)}" style="display:inline-block;background:#7c3aed;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Get started</a></p>
+       <p style="font-size:13px;color:#666;">Or paste this link into your browser:<br>${escapeHtml(ctx.loginUrl)}</p>
+       <p style="font-size:13px;color:#666;">This link is single-use and valid for 7 days.</p>`
+    : `<p>Ask your admin for your sign-in password, then open the team brain and sign in with this email address.</p>`;
   const html = `<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:480px;margin:0 auto;padding:24px;color:#1a1a1a;">
         ${intro}
-        <p>Ask your admin for your sign-in password, then open the team brain and sign in with this email address.</p>
+        ${htmlAction}
       </div>`;
 
   await deliver(email, subject, { text, html });
+}
+
+export interface ManualInviteContext {
+  inviteeName: string;
+  teamName: string;
+  inviterName: string;
+  teamUrl: string;
+  email: string;
+  password: string;
+}
+
+/**
+ * Plain-text, ready-to-paste invite for admins on a deployment with no mail provider configured
+ * (`!magicLinkAvailable()`) — everything the admin needs to hand a new member sign-in access via
+ * Slack/DM/whatever channel they use: the team brain URL, the sign-in email, and the password.
+ */
+export function buildManualInviteMessage(ctx: ManualInviteContext): string {
+  const firstName = ctx.inviteeName.trim().split(/\s+/)[0] || ctx.inviteeName;
+  return (
+    `Hi ${firstName},\n\n${inviteExplainer(ctx)}\n\n` +
+    `Sign in at: ${ctx.teamUrl}\nEmail: ${ctx.email}\nPassword: ${ctx.password}`
+  );
 }

--- a/lib/auth/mailer.ts
+++ b/lib/auth/mailer.ts
@@ -130,7 +130,8 @@ export interface InviteEmailContext {
  * sign-in link when one is available. Never throws. Names are attacker-controlled input (display
  * names), so the HTML body escapes them — this is the only place they're rendered as markup.
  */
-export async function sendInviteEmail(email: string, ctx: InviteEmailContext): Promise<void> {
+/** Returns whether a configured mail provider accepted the message. Never throws. */
+export async function sendInviteEmail(email: string, ctx: InviteEmailContext): Promise<boolean> {
   const firstName = ctx.inviteeName.trim().split(/\s+/)[0] || ctx.inviteeName;
   const subject = `${ctx.inviterName} added you to ${ctx.teamName} on AIOS`;
   const explainer = inviteExplainer(ctx);
@@ -153,7 +154,7 @@ export async function sendInviteEmail(email: string, ctx: InviteEmailContext): P
         ${htmlAction}
       </div>`;
 
-  await deliver(email, subject, { text, html });
+  return deliver(email, subject, { text, html });
 }
 
 export interface ManualInviteContext {

--- a/lib/auth/pg-login.ts
+++ b/lib/auth/pg-login.ts
@@ -89,6 +89,30 @@ export async function adminSetPassword(email: string, password: string): Promise
   );
 }
 
+/** Whether this auth_users row already has a password (vs. a magic-link-only account). */
+export async function hasPasswordSet(authUserId: string): Promise<boolean> {
+  const { rows } = await runSql<{ password_hash: string | null }>(
+    `select password_hash from auth_users where id = $1`,
+    [authUserId]
+  );
+  return Boolean(rows[0]?.password_hash);
+}
+
+/**
+ * First-time password set for a magic-link-only account — deliberately NOT a reset: only writes
+ * when `password_hash` is currently null, so this can't be used to silently overwrite an existing
+ * password (that's `changePassword`, which requires the current one). Returns false if a password
+ * was already set.
+ */
+export async function setPasswordIfUnset(authUserId: string, password: string): Promise<boolean> {
+  const hash = await hashPassword(password);
+  const { rows } = await runSql<{ id: string }>(
+    `update auth_users set password_hash = $1 where id = $2 and password_hash is null returning id`,
+    [hash, authUserId]
+  );
+  return rows.length > 0;
+}
+
 /**
  * Self-service password change. Verifies `currentPassword` against the signed-in user's stored
  * hash before writing the new one — `authUserId` comes from the caller's own session (`sub`), so

--- a/test/datamechanics/set-password-if-unset.datamechanics.test.ts
+++ b/test/datamechanics/set-password-if-unset.datamechanics.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { adminSetPassword, ensureAuthUser, hasPasswordSet, loginWithPassword, setPasswordIfUnset } from "@/lib/auth/pg-login";
+import { db, seedTeam } from "./helpers";
+
+/**
+ * Spec: a magic-link-only account (no password yet) can set one exactly once — this is a
+ * first-time SET, not a reset, so once a password exists, a second call must be a no-op rather
+ * than silently overwriting it (that's `changePassword`'s job, and it requires the current
+ * password). Verified to the observable outcome on real Postgres: password_hash state and whether
+ * login with the attempted password actually works.
+ */
+
+describe("setPasswordIfUnset / hasPasswordSet (real Postgres)", () => {
+  it("sets a password for an account with none yet, and hasPasswordSet reflects it", async () => {
+    const seed = await seedTeam();
+    const email = "magiconly@test.local";
+    await db().from("members").insert({
+      team_id: seed.teamId, email, display_name: "Magic Only",
+      actor_handle: "magiconly", role: "member", tier: "team", status: "invited",
+    });
+    const authUserId = await ensureAuthUser(email);
+    expect(await hasPasswordSet(authUserId)).toBe(false);
+
+    const set = await setPasswordIfUnset(authUserId, "first-time-password");
+    expect(set).toBe(true);
+    expect(await hasPasswordSet(authUserId)).toBe(true);
+    expect(await loginWithPassword(email, "first-time-password")).not.toBeNull();
+  });
+
+  it("is a no-op once a password already exists — does not overwrite it", async () => {
+    const seed = await seedTeam();
+    const email = "already-has-one@test.local";
+    await db().from("members").insert({
+      team_id: seed.teamId, email, display_name: "Already Has One",
+      actor_handle: "alreadyhasone", role: "member", tier: "team", status: "active",
+    });
+    await adminSetPassword(email, "original-password");
+    const authUserId = await ensureAuthUser(email);
+
+    const set = await setPasswordIfUnset(authUserId, "attempted-overwrite");
+    expect(set).toBe(false);
+
+    // The original password still works; the attempted one does not.
+    expect(await loginWithPassword(email, "original-password")).not.toBeNull();
+    expect(await loginWithPassword(email, "attempted-overwrite")).toBeNull();
+  });
+});

--- a/test/mailer-invite.test.ts
+++ b/test/mailer-invite.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildManualInviteMessage } from "@/lib/auth/mailer";
+
+// Spec: the manual (no-mail-provider) invite path must hand the admin everything needed to
+// share access another way — the team brain URL, the sign-in email, and the password — not just
+// a bare password. This is the one artifact the admin UI copies verbatim into Slack/DM/etc.
+
+describe("buildManualInviteMessage", () => {
+  it("includes the greeting, explainer, url, email, and password", () => {
+    const msg = buildManualInviteMessage({
+      inviteeName: "Ada Lovelace",
+      teamName: "Acme",
+      inviterName: "Grace Hopper",
+      teamUrl: "https://brain.acme.test",
+      email: "ada@acme.test",
+      password: "s3cret-generated-pw",
+    });
+
+    expect(msg).toContain("Hi Ada,");
+    expect(msg).toContain("Grace Hopper added you to Acme's AIOS Team Brain");
+    expect(msg).toContain("Sign in at: https://brain.acme.test");
+    expect(msg).toContain("Email: ada@acme.test");
+    expect(msg).toContain("Password: s3cret-generated-pw");
+  });
+});

--- a/test/mailer-invite.test.ts
+++ b/test/mailer-invite.test.ts
@@ -13,13 +13,13 @@ describe("buildManualInviteMessage", () => {
       inviterName: "Grace Hopper",
       teamUrl: "https://brain.acme.test",
       email: "ada@acme.test",
-      password: "s3cret-generated-pw",
+      password: "example-invite-password",
     });
 
     expect(msg).toContain("Hi Ada,");
     expect(msg).toContain("Grace Hopper added you to Acme's AIOS Team Brain");
     expect(msg).toContain("Sign in at: https://brain.acme.test");
     expect(msg).toContain("Email: ada@acme.test");
-    expect(msg).toContain("Password: s3cret-generated-pw");
+    expect(msg).toContain("Password: example-invite-password");
   });
 });


### PR DESCRIPTION
## Summary

The invite email told new members to "ask your admin for your password" — no link, no explanation of what Team Brain is. This wires the existing (but previously invite-unused) magic-link auth machinery back into the invite flow, and covers **both** deployment shapes:

- **Mail delivery configured** (`magicLinkAvailable()`): `inviteMember()` skips setting a password entirely and emails a one-click, single-use, 7-day sign-in link (`issueLoginLink` → updated `sendInviteEmail`). Clicking it authenticates immediately via the existing `/auth/confirm` → `redeemMagicToken` path, routes through the existing first-login `/auth/welcome` screen, which now optionally offers to set a password (skippable — `setPasswordIfUnset`, a first-time-only set, not a reset).
- **No mail provider configured** (the expected default for a fresh self-host): skips the now-pointless email attempt and instead returns a complete, ready-to-copy invite (team brain URL + sign-in email + password) that the admin UI renders with a "Copy message" button, for pasting into Slack/DM/wherever.

The admin "Invite member" form defaults to the magic-link path and drops the password field, with a "set a password manually instead" toggle to force the manual path even when mail is configured.

## Changes
- `lib/auth/mailer.ts` — shared invite explainer copy; `sendInviteEmail` now sends a real magic-link email when a `loginUrl` is passed; new `buildManualInviteMessage` for the copy-paste fallback.
- `app/t/[team]/admin/actions.ts` — `inviteMember()` branches on `magicLinkAvailable()`.
- `components/admin/invite-member.tsx` — branches its confirmation UI on `mode: "magic-link" | "manual"`.
- `lib/auth/pg-login.ts` — new `hasPasswordSet` / `setPasswordIfUnset` primitives.
- `app/auth/welcome/{page,actions}.tsx`, `set-password-form.tsx` — optional first-login password step.

No schema changes — `auth_tokens`, nullable `auth_users.password_hash`, and `members.status` already support this.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (1 pre-existing unrelated warning)
- [x] `npm test` — 401 passed (1 pre-existing unrelated failure on `main` too — timezone formatting test, untouched by this PR)
- [x] `npm run test:datamechanics:local` — 273 passed, including new coverage for `hasPasswordSet`/`setPasswordIfUnset` against real Postgres
- [x] `npm run check:docs` — in sync
- [ ] Manual browser click-through of both invite paths — not performed in this session (no safe local `.env` available in the worktree to run the dev server against); recommend a manual smoke test before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches invite and password-setting auth paths (`inviteMember`, `setPasswordIfUnset`, invite email content) but uses existing token/login machinery and guards first-time password writes; main risk is misconfigured mail or admins misunderstanding magic-link vs manual outcomes.
> 
> **Overview**
> **Admin invites** no longer always create a password and send a “ask your admin for your password” email. When `magicLinkAvailable()` is true (and the admin doesn’t force manual), `inviteMember` mints a **7-day single-use sign-in link** via `issueLoginLink`, emails it through an updated **`sendInviteEmail`** (shared explainer + `loginUrl`), and returns **`mode: "magic-link"`** with a delivery flag. When mail isn’t configured—or the admin toggles **manual invite**—the flow sets an initial password and returns **`mode: "manual"`** with **`buildManualInviteMessage`** (team URL, email, password) for out-of-band sharing.
> 
> The **Invite member** UI matches those branches: magic-link success vs copy-message / copy-password, plus a toggle between magic link and manual password.
> 
> **First login after magic link:** `/auth/welcome` checks **`hasPasswordSet`** and shows a skippable **`SetPasswordForm`** backed by **`setInitialPassword`** → **`setPasswordIfUnset`** (first-time only, no overwrite). **`docs/ARCHITECTURE.md`** documents the split invite paths and optional welcome password.
> 
> Tests cover **`setPasswordIfUnset`/`hasPasswordSet`** on real Postgres, **`buildManualInviteMessage`**, and **`sendInviteEmail`** returning a boolean when no provider is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106435cab107039f0dd9faef66ef68bf319451e5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional first-time password setup during the welcome flow for users who signed in with a magic link.
  * Invite flows now support two modes: a magic-link invite or a manual invite with a shared password.
  * Added one-click copying for invite details in the admin invite experience.

* **Bug Fixes**
  * Improved password handling so existing passwords are never overwritten.
  * Updated invite emails and manual invite messages for clearer, consistent wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->