### PR TITLE
chore(worktree): hydrate .envrc/.env.local/.env.keys into new git worktrees

### DIFF
--- a/scripts/link-worktree-env.sh
+++ b/scripts/link-worktree-env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Hydrate a freshly created git worktree with the local, gitignored dev config that
+# `git worktree add` can't bring along. `.envrc`, `.env.local`, and `.env.keys` all match
+# `.gitignore`'s `.env*` pattern, so a new worktree checkout starts with none of them:
+#   - `.env.local` (dotenvx-encrypted: DATABASE_URL, AUTH_SECRET, RESEND_API_KEY, APP_URL, ...)
+#     is decrypted at request time by Next's own `@next/env` loader using the sibling
+#     `.env.keys` — both files just need to physically exist in cwd for `npm run dev` /
+#     `next build` to pick them up. Neither direnv nor the shell is involved in this part.
+#   - `.envrc` is the separate, lower-privilege Tessera root cascade (shared keys like
+#     ANTHROPIC_API_KEY) — this DOES need direnv active to reach the shell/process env.
+# Symlinks both sets (plus node_modules) from the PRIMARY checkout — resolved via
+# `git rev-parse --git-common-dir`, so this needs no arguments and works from any worktree —
+# into the current directory, then runs `direnv allow` for the second piece. Idempotent: safe
+# to re-run.
+#
+# Run from INSIDE the new worktree, right after `git worktree add`:
+#   cd ../aios-team-brain-<task>
+#   ../aios-team-brain/scripts/link-worktree-env.sh
+
+set -euo pipefail
+
+common_dir="$(git rev-parse --git-common-dir)"
+main_worktree="$(cd "$(dirname "$common_dir")" && pwd)"
+here="$(pwd)"
+
+if [[ "$main_worktree" == "$here" ]]; then
+  echo "Already in the primary checkout ($here) — nothing to hydrate."
+  exit 0
+fi
+
+for name in node_modules .envrc .env.local .env.keys .env; do
+  src="$main_worktree/$name"
+  [[ -e "$src" ]] || continue
+
+  if [[ -e "$here/$name" && ! -L "$here/$name" ]]; then
+    echo "skip $name — a real file already exists here (not overwriting)"
+    continue
+  fi
+
+  ln -sfn "$src" "$here/$name"
+  echo "linked $name -> $src"
+done
+
+if command -v direnv >/dev/null 2>&1; then
+  direnv allow "$here" || echo "direnv allow failed — run it manually if the cascade doesn't auto-load"
+else
+  echo "direnv not installed — secrets are linked but won't auto-load into the shell"
+fi

--- a/scripts/link-worktree-env.sh
+++ b/scripts/link-worktree-env.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 #
 # Hydrate a freshly created git worktree with the local, gitignored dev config that
-# `git worktree add` can't bring along. `.envrc`, `.env.local`, and `.env.keys` all match
-# `.gitignore`'s `.env*` pattern, so a new worktree checkout starts with none of them:
+# `git worktree add` can't bring along. `.envrc`, `.env.local`, `.env.keys`, and `.env` all
+# match `.gitignore`'s `.env*` pattern, so a new worktree checkout starts with none of them:
 #   - `.env.local` (dotenvx-encrypted: DATABASE_URL, AUTH_SECRET, RESEND_API_KEY, APP_URL, ...)
 #     is decrypted at request time by Next's own `@next/env` loader using the sibling
 #     `.env.keys` — both files just need to physically exist in cwd for `npm run dev` /
 #     `next build` to pick them up. Neither direnv nor the shell is involved in this part.
 #   - `.envrc` is the separate, lower-privilege Tessera root cascade (shared keys like
 #     ANTHROPIC_API_KEY) — this DOES need direnv active to reach the shell/process env.
-# Symlinks both sets (plus node_modules) from the PRIMARY checkout — resolved via
+#   - `.env` is a plain (unencrypted) env file, also gitignored.
+# Symlinks all four (plus node_modules) from the PRIMARY checkout — resolved via
 # `git rev-parse --git-common-dir`, so this needs no arguments and works from any worktree —
-# into the current directory, then runs `direnv allow` for the second piece. Idempotent: safe
-# to re-run.
+# into the current directory, then runs `direnv allow` for the cascade piece.
+# Idempotent: safe to re-run; will not overwrite existing real files or working symlinks.
 #
 # Run from INSIDE the new worktree, right after `git worktree add`:
 #   cd ../aios-team-brain-<task>
@@ -33,8 +34,12 @@ for name in node_modules .envrc .env.local .env.keys .env; do
   src="$main_worktree/$name"
   [[ -e "$src" ]] || continue
 
-  if [[ -e "$here/$name" && ! -L "$here/$name" ]]; then
-    echo "skip $name — a real file already exists here (not overwriting)"
+  if [[ -e "$here/$name" ]]; then
+    if [[ -L "$here/$name" ]]; then
+      echo "skip $name — already linked"
+    else
+      echo "skip $name — a real file/directory already exists here (not overwriting)"
+    fi
     continue
   fi
 


### PR DESCRIPTION
## Summary

While working on #169 in a fresh worktree, `npm run dev`/manual browser testing wasn't safely possible: `git worktree add` only checks out git-tracked content, and `.envrc`, `.env.local` (dotenvx-encrypted `DATABASE_URL`/`AUTH_SECRET`/`RESEND_API_KEY`/`APP_URL`), and `.env.keys` all match `.gitignore`'s `.env*` pattern — so every new worktree starts with none of them.

Two independent things were missing:
- `.env.local` + `.env.keys` need to physically exist in cwd for Next's own `@next/env` loader to decrypt them (dotenvx) when running `next dev`/`build` — no direnv involved in this part.
- `.envrc` needs to exist for direnv to activate the separate, lower-privilege Tessera root cascade (shared keys like `ANTHROPIC_API_KEY`).

`scripts/link-worktree-env.sh` symlinks all three (plus `node_modules`, replacing the manual step in the documented worktree recipe) from the primary checkout — found via `git rev-parse --git-common-dir`, so it takes no arguments and works from any worktree — then runs `direnv allow`. No-ops safely if run from the primary checkout itself. Idempotent.

Verified manually: ran it in the worktree used for #169, confirmed `@next/env`'s `loadEnvConfig` successfully decrypts `.env.local` afterward (checked key presence only, never printed values), and confirmed the primary-checkout no-op guard.

## Test plan
- [x] Ran the script in a live worktree — symlinks created correctly, `direnv allow` succeeds
- [x] Confirmed `@next/env`'s loader decrypts `.env.local` via the symlinked `.env.keys` afterward
- [x] Confirmed running it from the primary checkout is a safe no-op
- [x] `shellcheck` clean
- [ ] Follow-up (separate repo): update `aios/CLAUDE.md`'s worktree recipe to call this script instead of the manual `node_modules` symlink line — not included here since the `aios/` monorepo root currently has an unrelated in-progress uncommitted edit I didn't want to commit around

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only shell helper; no application runtime, auth, or deploy paths change, and it refuses to overwrite existing real files in the worktree.
> 
> **Overview**
> Adds **`scripts/link-worktree-env.sh`** so a new **`git worktree`** checkout can reuse the primary tree’s gitignored local dev setup without copying secrets.
> 
> The script resolves the primary checkout via **`git rev-parse --git-common-dir`**, then symlinks **`node_modules`**, **`.envrc`**, **`.env.local`**, **`.env.keys`**, and **`.env`** when they exist on the primary side. It **no-ops** in the primary checkout, **won’t replace** an existing real file in the worktree, and is safe to re-run. If **`direnv`** is installed it runs **`direnv allow`** so the **`.envrc`** cascade can load.
> 
> This replaces the manual **`node_modules`** symlink step in the documented worktree recipe and covers the missing **`.env*`** files that **`git worktree add`** cannot bring along.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5087462cef0cc62a9d5e32c02e02f04d194f6c97. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helper script to quickly link common environment and dependency files into a new worktree.
  * Supports automatically loading the environment when available, while safely avoiding overwriting existing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->