### PR TITLE
fix(ingest): stop mis-attributing unresolved authors to the connector

### DIFF
--- a/lib/codebases/commits-to-items.ts
+++ b/lib/codebases/commits-to-items.ts
@@ -106,9 +106,9 @@ export async function projectCommitsToItems(
     if (!payload) continue;
     // Resolve by the git author EMAIL (the reliable key, matching how code_contributions attributes).
     // Falls back to parsing an inline `name <email>` from the author string. Without a resolvable
-    // email the commit is name-only → resolveMember returns null → ingestItem would attribute the
-    // item to the SCANNER's member (the CI key), which mis-files every author's commits under one
-    // person. So we pass the parsed identity and let resolveMember do email/handle matching.
+    // email the commit is name-only → resolveMember returns null → the item stays unattributed
+    // (member_id: null), rather than being mis-filed under the scanner's own identity. So we pass
+    // the parsed identity and let resolveMember do email/handle matching.
     const email = str(commit.author_email).trim();
     const identity: AuthorIdentity = email
       ? { name: str(commit.author), email, key: email }

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -45,8 +45,12 @@ export async function ingestItem(
   // INTERNAL-only attribution override (NOT on the wire ItemPayload, so external pushers can't
   // spoof authorship). When an internal caller already knows the content's author — e.g. the
   // codebase scanner attributing a commit to a resolved member — it passes that here; otherwise
-  // the item is attributed to the ingesting actor (`auth.memberId`), as before.
-  opts?: { authorMemberId?: string | null }
+  // (opts omitted entirely) the item is attributed to the ingesting actor (`auth.memberId`). A
+  // caller that HAS attempted resolution but come up empty must pass `authorMemberId: null`
+  // explicitly (not omit opts) — that's the only way to say "leave this unattributed" rather than
+  // "attribute to whoever's pushing," so a connector ingesting on behalf of an unresolved human
+  // never silently falls back to the connector's own member_id.
+  opts?: { authorMemberId: string | null }
 ): Promise<IngestResult> {
   // 1. project
   const { data: project, error: projErr } = await db
@@ -109,7 +113,7 @@ export async function ingestItem(
     body: payload.body,
     content_sha256: existing ? existing.content_sha256 : PENDING_SHA,
     actor: payload.actor ?? "",
-    member_id: opts?.authorMemberId ?? auth.memberId,
+    member_id: opts ? opts.authorMemberId : auth.memberId,
     synced_at: now,
     updated_at: now,
   };
@@ -131,7 +135,7 @@ export async function ingestItem(
     content_sha256: payload.content_sha256,
     frontmatter: payload.frontmatter ?? {},
     body: payload.body,
-    member_id: auth.memberId,
+    member_id: opts ? opts.authorMemberId : auth.memberId,
   });
   if (versionErr) throw new Error(`item version insert failed: ${versionErr.message}`);
 

--- a/lib/ingest/reattribute.ts
+++ b/lib/ingest/reattribute.ts
@@ -7,13 +7,17 @@ import { parseAuthorIdentity } from "@/lib/codebases/commits-to-items";
  * Re-attribute existing items to the CURRENT identity mappings. `ingestItem` only stamps
  * `items.member_id` on create/change, so when an admin adds or corrects an identity mapping (or an
  * email alias) AFTER content was ingested, those already-stored unchanged rows keep their old
- * attribution (often the connector member). This pass re-resolves each item's author from its
- * frontmatter against the freshly-built identity map and re-points `member_id`.
+ * attribution. This pass re-resolves each item's author from its frontmatter against the freshly-
+ * built identity map and re-points `member_id`.
  *
  * Lives in lib/ingest because it writes `items` (the single-writer guard). Conservative: it only
- * RE-POINTS to a positively-resolved member that differs from the current one — it never
- * un-attributes (a row that no longer resolves is left as-is), so it can't erase good attribution.
- * Idempotent: a second run with no mapping changes updates nothing.
+ * RE-POINTS to a positively-resolved member that differs from the current one — it never erases a
+ * previously-resolved HUMAN's attribution (a row that no longer resolves and isn't on a connector
+ * is left as-is). The one exception: a row still attributed to a connector service-account
+ * (`is_connector = true` — a pre-fix leftover from before ingestion correctly left unresolved
+ * authors unattributed) that STILL doesn't resolve is cleared to `null` rather than left on the
+ * connector, since that was never "good attribution" to begin with. Idempotent: a second run with
+ * no mapping changes updates nothing.
  */
 
 export interface ReattributeSummary {
@@ -47,6 +51,12 @@ export async function reattributeItems(
     .from("items")
     .select("id, member_id, frontmatter")
     .eq("team_id", teamId);
+  const { data: connectors } = await db
+    .from("members")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("is_connector", true);
+  const connectorIds = new Set((connectors ?? []).map((c) => (c as { id: string }).id));
 
   const rows = (items ?? []) as {
     id: string;
@@ -59,6 +69,13 @@ export async function reattributeItems(
     const resolved = resolveItemAuthor(idMap, it.frontmatter ?? {});
     if (resolved && resolved !== it.member_id) {
       const { error } = await db.from("items").update({ member_id: resolved }).eq("id", it.id);
+      if (error) throw new Error(`reattribute item ${it.id}: ${error.message}`);
+      updated++;
+    } else if (!resolved && it.member_id && connectorIds.has(it.member_id)) {
+      // Never "good attribution" — a pre-fix row still standing on a connector member with no
+      // real author resolvable. Clear it, same conservative bar (only touches a strictly-worse
+      // value), never applied to a previously-resolved human's attribution.
+      const { error } = await db.from("items").update({ member_id: null }).eq("id", it.id);
       if (error) throw new Error(`reattribute item ${it.id}: ${error.message}`);
       updated++;
     }

--- a/test/datamechanics/commit-items.datamechanics.test.ts
+++ b/test/datamechanics/commit-items.datamechanics.test.ts
@@ -46,9 +46,9 @@ describe("commits → searchable, attributed items (real Postgres)", () => {
     expect((resolved as { kind: string }).kind).toBe("artifact");
     expect((resolved as { frontmatter: Record<string, unknown> }).frontmatter.source).toBe("git");
 
-    // The unresolved commit falls back to the ingesting actor (member B).
+    // The unresolved commit stays unattributed — not falling back to the ingesting scanner.
     const { data: unresolved } = await db().from("items").select("member_id").eq("team_id", seed.teamId).eq("path", `commits/aios-team-brain/${"b".repeat(40)}.md`).single();
-    expect((unresolved as { member_id: string }).member_id).toBe(scannerId);
+    expect((unresolved as { member_id: string | null }).member_id).toBeNull();
 
     // Searchable: an NL query for the commit message surfaces it via FTS.
     const ctx = await retrieve(db(), seed.teamId, "team", "login redirect bug");

--- a/test/datamechanics/reattribute.datamechanics.test.ts
+++ b/test/datamechanics/reattribute.datamechanics.test.ts
@@ -1,36 +1,118 @@
 import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
+import { ingestItem } from "@/lib/ingest";
 import { reattributeItems } from "@/lib/ingest/reattribute";
 import { setMemberIdentity } from "@/lib/identity/member-identities";
 import { addAuthorAlias } from "@/lib/admin/aliases";
-import { db, ingest, seedTeam } from "./helpers";
+import { db, seedTeam, sha, type Seed } from "./helpers";
 
-// Spec: ingest only stamps items.member_id at create/change time, so content ingested BEFORE a
-// person's identity was mapped stays attributed to the connector. reattributeItems re-applies the
-// current mappings to existing rows. Verified on real Postgres.
+// Spec: ingest only stamps items.member_id on create/change, and (post attribution-fix) an
+// unresolved author is left unattributed (null), never falling back to the ingesting connector.
+// reattributeItems re-applies current identity mappings to already-ingested rows, turning a null
+// into a resolved member_id once mapping exists — and, for the narrow legacy case of a row still
+// standing on a connector service-account from before the fix, clears it to null instead of
+// leaving it there (a connector id was never "good attribution"). It still never erases a
+// previously-resolved HUMAN's attribution just because re-resolution comes up empty on a later
+// run. Verified on real Postgres.
 
-async function addMember(teamId: string): Promise<string> {
+async function addMember(
+  teamId: string,
+  opts: { connector?: boolean } = {},
+): Promise<string> {
   const { data } = await db()
     .from("members")
-    .insert({ team_id: teamId, email: `m-${randomUUID()}@test.local`, display_name: "Author", actor_handle: `h-${randomUUID().slice(0, 8)}`, role: "member", tier: "team", status: "active" })
+    .insert({
+      team_id: teamId,
+      email: `m-${randomUUID()}@test.local`,
+      display_name: opts.connector ? "Slack Sync" : "Author",
+      actor_handle: `h-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+      is_connector: Boolean(opts.connector),
+    })
     .select("id")
     .single();
   return (data as { id: string }).id;
 }
+
 async function memberOf(teamId: string, path: string): Promise<string | null> {
-  const { data } = await db().from("items").select("member_id").eq("team_id", teamId).eq("path", path).maybeSingle();
+  const { data } = await db()
+    .from("items")
+    .select("member_id")
+    .eq("team_id", teamId)
+    .eq("path", path)
+    .maybeSingle();
   return (data as { member_id: string | null } | null)?.member_id ?? null;
+}
+
+/** Ingest via a connector, author unresolved at ingest time (opts.authorMemberId: null explicitly). */
+async function putUnresolved(
+  seed: Seed,
+  connectorId: string,
+  path: string,
+  frontmatter: Record<string, unknown>,
+) {
+  return ingestItem(
+    db(),
+    { teamId: seed.teamId, memberId: connectorId, apiKeyId: randomUUID() },
+    {
+      project: "acme",
+      kind: "transcript",
+      actor: "",
+      content_sha256: sha(path),
+      access: "team",
+      path,
+      body: "hello",
+      frontmatter,
+    },
+    "team",
+    { authorMemberId: null },
+  );
+}
+
+/** Ingest attributed directly to a known (resolved) member — a "good attribution" baseline. */
+async function putResolved(
+  seed: Seed,
+  actorId: string,
+  authorId: string,
+  path: string,
+  frontmatter: Record<string, unknown>,
+) {
+  return ingestItem(
+    db(),
+    { teamId: seed.teamId, memberId: actorId, apiKeyId: randomUUID() },
+    {
+      project: "acme",
+      kind: "transcript",
+      actor: "",
+      content_sha256: sha(path),
+      access: "team",
+      path,
+      body: "hello",
+      frontmatter,
+    },
+    "team",
+    { authorMemberId: authorId },
+  );
 }
 
 describe("reattributeItems (real Postgres)", () => {
   it("re-points a Slack item to the author once their Slack id is mapped; idempotent after", async () => {
-    const seed = await seedTeam(); // member A = ingest actor
-    const author = await addMember(seed.teamId); // member B = real author
+    const seed = await seedTeam();
+    const connector = await addMember(seed.teamId, { connector: true });
+    const author = await addMember(seed.teamId);
 
-    await ingest(seed, { kind: "transcript", path: "slack/eng/1.md", body: "hello", access: "team", frontmatter: { source: "slack", author_id: "U1" } });
-    expect(await memberOf(seed.teamId, "slack/eng/1.md")).toBe(seed.memberId); // attributed to the connector
+    await putUnresolved(seed, connector, "slack/eng/1.md", {
+      source: "slack",
+      author_id: "U1",
+    });
+    expect(await memberOf(seed.teamId, "slack/eng/1.md")).toBeNull(); // unresolved at ingest time
 
-    await setMemberIdentity(db(), seed.teamId, author, { provider: "slack", externalId: "U1" });
+    await setMemberIdentity(db(), seed.teamId, author, {
+      provider: "slack",
+      externalId: "U1",
+    });
     const s = await reattributeItems(db(), seed.teamId);
     expect(s.updated).toBe(1);
     expect(await memberOf(seed.teamId, "slack/eng/1.md")).toBe(author); // now the real person
@@ -41,7 +123,10 @@ describe("reattributeItems (real Postgres)", () => {
   it("re-points a git commit item once an email alias is added", async () => {
     const seed = await seedTeam();
     const author = await addMember(seed.teamId);
-    await ingest(seed, { kind: "artifact", path: "commits/repo/abc.md", body: "fix", access: "team", frontmatter: { source: "git", author: "Bob <bob@personal.com>" } });
+    await putUnresolved(seed, seed.memberId, "commits/repo/abc.md", {
+      source: "git",
+      author: "Bob <bob@personal.com>",
+    });
 
     expect((await reattributeItems(db(), seed.teamId)).updated).toBe(0); // not yet resolvable
     await addAuthorAlias(db(), seed.teamId, author, "bob@personal.com");
@@ -49,11 +134,39 @@ describe("reattributeItems (real Postgres)", () => {
     expect(await memberOf(seed.teamId, "commits/repo/abc.md")).toBe(author);
   });
 
-  it("never un-attributes when the author no longer resolves", async () => {
+  it("never un-attributes a real human's existing attribution when the author no longer resolves", async () => {
     const seed = await seedTeam();
-    await ingest(seed, { kind: "transcript", path: "slack/eng/2.md", body: "x", access: "team", frontmatter: { source: "slack", author_id: "U-unknown" } });
+    const knownAuthor = await addMember(seed.teamId);
+    // Ingested already attributed to a real, non-connector member — "good attribution" — and the
+    // frontmatter's slack id was never mapped, so reattribute's resolution comes up empty.
+    await putResolved(seed, seed.memberId, knownAuthor, "slack/eng/2.md", {
+      source: "slack",
+      author_id: "U-unknown",
+    });
+
     const s = await reattributeItems(db(), seed.teamId);
     expect(s.updated).toBe(0);
-    expect(await memberOf(seed.teamId, "slack/eng/2.md")).toBe(seed.memberId); // left as-is
+    expect(await memberOf(seed.teamId, "slack/eng/2.md")).toBe(knownAuthor); // left as-is, never erased
+  });
+
+  it("clears a connector-attributed item to null when the author still doesn't resolve (legacy pre-fix data)", async () => {
+    const seed = await seedTeam();
+    const connector = await addMember(seed.teamId, { connector: true });
+    await putUnresolved(seed, connector, "slack/eng/3.md", {
+      source: "slack",
+      author_id: "U-unknown-2",
+    });
+    // Simulate a legacy row from before the attribution fix, where this would have landed on the
+    // connector instead of staying null.
+    await db()
+      .from("items")
+      .update({ member_id: connector })
+      .eq("team_id", seed.teamId)
+      .eq("path", "slack/eng/3.md");
+    expect(await memberOf(seed.teamId, "slack/eng/3.md")).toBe(connector);
+
+    const s = await reattributeItems(db(), seed.teamId);
+    expect(s.updated).toBe(1);
+    expect(await memberOf(seed.teamId, "slack/eng/3.md")).toBeNull(); // cleared, not left on the connector
   });
 });


### PR DESCRIPTION
## Summary
- `ingestItem`'s fallback (`opts?.authorMemberId ?? auth.memberId`) couldn't distinguish "no opts passed → attribute to the acting key owner" from "opts passed, author genuinely unresolved → should stay `null`" — so an unmapped human's content (Slack thread, Plane doc, Linear issue) silently landed on the connector service-account's `member_id` instead of staying unattributed. `item_versions` had the same bug, unconditionally (ignored `authorMemberId` entirely).
- Tightens `opts`'s type (`authorMemberId` no longer optional once `opts` is passed) so "opts present" is unambiguous, and fixes both the `items` and `item_versions` writes: `member_id: opts ? opts.authorMemberId : auth.memberId`.
- Updates the stale comment in `lib/codebases/commits-to-items.ts` that documented the old buggy "falls back to the scanner" behavior.
- Extends `reattributeItems` (`lib/ingest/reattribute.ts`) with one additive, narrow case: a row still standing on a connector (`is_connector = true`, from before this fix) that still doesn't resolve gets cleared to `null` via the existing "Re-attribute content" admin action. The existing conservative guarantee — never erase a previously-resolved *human's* attribution — is unchanged; this only cleans up the one case that was never good attribution to begin with (a fake connector id standing in for an unknown person). This is how prod rows already mis-attributed to `plane-sync`/`slack-sync`/etc. get cleaned up, with no new one-off script.

## Test plan
- [x] Flipped `test/datamechanics/commit-items.datamechanics.test.ts` (unresolved commit now asserts `null`, not the scanner's id).
- [x] Rewrote `test/datamechanics/reattribute.datamechanics.test.ts`: the shared `ingest()` test helper never passed `opts`, so it didn't actually exercise the buggy path — added local `putUnresolved`/`putResolved` helpers (matching the pattern already in `people-activity-retrieval.datamechanics.test.ts`) so the tests genuinely simulate a connector ingesting on behalf of an unresolved human. Covers: re-point once identity is mapped, idempotency, the original "never erase a resolved human's attribution" guarantee (unchanged), and the new "clear a connector-attributed legacy row" case.
- [x] Regression check: `test/datamechanics/people-activity-retrieval.datamechanics.test.ts` already exercised the real bug scenario directly and already asserted connector exclusion via its own `!it.member_id` check — confirmed it still passes unmodified.
- [x] `npx tsc --noEmit` — clean (verified every `ingestItem` call site is compatible with the tightened `opts` type).
- [x] `npm run lint` — clean (pre-existing unrelated warning only).
- [x] `npm run check:docs` — congruent.
- [x] Full `npm run test:datamechanics` — 275/275 passing (2 skipped).
- [x] Full `npm test` — passing (one pre-existing, unrelated timezone-formatting test failure reproduces identically on unmodified `main`).

Depends on PR #168 (merged) for `members.is_connector`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ingest attribution for all synced content and `item_versions`; behavior is intentional but affects how `items.member_id` is stored and how people/activity queries interpret authorship.
> 
> **Overview**
> Fixes connector sync incorrectly claiming authorship when identity resolution fails. **Unresolved authors now get `member_id: null`** instead of the ingesting API key’s member (e.g. `slack-sync`, commit scanner).
> 
> **`ingestItem`** distinguishes omitting `opts` (attribute to `auth.memberId`) from passing `{ authorMemberId: null }` (explicitly unattributed). Both **`items` and `item_versions`** use `member_id: opts ? opts.authorMemberId : auth.memberId` so version history matches item attribution.
> 
> **`reattributeItems`** adds a narrow cleanup path: rows still on a connector member (`is_connector`) that still don’t resolve are cleared to `null`; re-pointing when mappings appear and **not** stripping real humans’ attribution is unchanged.
> 
> Datamechanics tests cover unresolved commits, reattribute flows, and legacy connector-attributed rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0700849a0390fa050fdf44e1ba4ea3f55e26c98c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->