### PR TITLE
fix(data): Data page 500 (Date-vs-string) + add a team-scoped error boundary

### DIFF
--- a/app/t/[team]/error.tsx
+++ b/app/t/[team]/error.tsx
@@ -1,0 +1,39 @@
+"use client"; // Error boundaries must be Client Components.
+
+/**
+ * Team-scoped error boundary. Without this, an unhandled render error on any single page
+ * (e.g. the July 2026 Data-page crash) falls through to app/global-error.tsx, which replaces
+ * the ENTIRE <html>/<body> — including the sidebar nav — leaving the user with no way to
+ * navigate away from the broken page. This boundary sits inside app/t/[team]/layout.tsx's
+ * {children} slot, so the layout (nav, header) keeps rendering normally around it and only
+ * the broken page's content area is replaced.
+ */
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { CircleAlert } from "lucide-react";
+
+export default function TeamError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center gap-3 pt-16 text-center">
+      <CircleAlert className="size-8 text-violet" strokeWidth={1.5} />
+      <h1 className="text-xl font-semibold text-ink">Something went wrong on this page</h1>
+      <p className="text-sm text-ink-secondary">
+        An unexpected error occurred and has been reported. The rest of the app is unaffected —
+        use the sidebar to go elsewhere, or retry this page.
+      </p>
+      <button type="button" onClick={() => reset()} className="btn-ghost mt-2">
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/lib/library/channels.ts
+++ b/lib/library/channels.ts
@@ -10,7 +10,9 @@
 
 export interface ChannelRow {
   path: string;
-  synced_at: string;
+  // The pg adapter returns timestamptz as a Date, not an ISO string (the #134 gotcha) — accept
+  // both so the caller can pass rows straight through. Normalized to an ISO string internally.
+  synced_at: string | Date;
 }
 
 export interface Channel {
@@ -29,21 +31,27 @@ export function parseChannel(path: string): { key: string; source: string; name:
   return { key: only, source: only, name: only };
 }
 
+/** Normalize a timestamptz value (Date from the pg adapter, or an ISO string) to an ISO string. */
+function isoOf(v: string | Date): string {
+  return typeof v === "string" ? v : v.toISOString();
+}
+
 /** Group rows into channels with item counts + most-recent arrival, sorted by recency (newest first). */
 export function groupChannels(rows: ChannelRow[]): Channel[] {
   const byKey = new Map<string, Channel>();
   for (const row of rows) {
     const { key, source, name } = parseChannel(row.path);
+    const syncedAt = isoOf(row.synced_at);
     const existing = byKey.get(key);
     if (!existing) {
-      byKey.set(key, { key, source, name, count: 1, lastSyncedAt: row.synced_at });
+      byKey.set(key, { key, source, name, count: 1, lastSyncedAt: syncedAt });
     } else {
       existing.count += 1;
-      // ISO-8601 strings compare lexicographically in timestamp order.
-      if (row.synced_at > existing.lastSyncedAt) existing.lastSyncedAt = row.synced_at;
+      // Compare by epoch ms — mixed "Z"/offset ISO forms don't sort lexicographically.
+      if (Date.parse(syncedAt) > Date.parse(existing.lastSyncedAt)) existing.lastSyncedAt = syncedAt;
     }
   }
-  return [...byKey.values()].sort((a, b) => b.lastSyncedAt.localeCompare(a.lastSyncedAt));
+  return [...byKey.values()].sort((a, b) => Date.parse(b.lastSyncedAt) - Date.parse(a.lastSyncedAt));
 }
 
 export type Freshness = "fresh" | "recent" | "stale";

--- a/test/library-channels.test.ts
+++ b/test/library-channels.test.ts
@@ -30,6 +30,20 @@ describe("groupChannels", () => {
     expect(eng.count).toBe(3);
     expect(eng.lastSyncedAt).toBe("2026-06-25T10:00:00Z"); // max, not first-seen
   });
+
+  // Regression for the prod crash "b.lastSyncedAt.localeCompare is not a function": the pg adapter
+  // returns `synced_at` as a Date, not an ISO string (the #134 gotcha) — the whole Data page 500'd
+  // whenever ≥2 channels existed. groupChannels must accept both and normalize.
+  it("accepts Date-typed synced_at (the pg adapter's real shape) without crashing", () => {
+    const channels = groupChannels([
+      { path: "slack/eng/3.md", synced_at: new Date("2026-06-25T10:00:00Z") },
+      { path: "slack/eng/1.md", synced_at: new Date("2026-06-25T09:00:00Z") },
+      { path: "linear/aio/A-1.md", synced_at: new Date("2026-06-25T11:00:00Z") },
+    ]);
+    expect(channels.map((c) => c.key)).toEqual(["linear/aio", "slack/eng"]);
+    const eng = channels.find((c) => c.key === "slack/eng")!;
+    expect(eng.lastSyncedAt).toBe("2026-06-25T10:00:00.000Z"); // normalized to ISO string for the UI
+  });
 });
 
 describe("freshness", () => {


### PR DESCRIPTION
## Why
The Data page ("What the brain is learning" → Data / library view) 500'd for any team with 2+ distinct channels. Confirmed via live server logs:

```
⨯ TypeError: b.lastSyncedAt.localeCompare is not a function
    at Array.sort
```

**Root cause:** `groupChannels()` in `lib/library/channels.ts` compared/sorted `synced_at` with string methods (`>`, `.localeCompare`), but the pg adapter returns `timestamptz` columns as JS `Date` objects, not ISO strings — the same gotcha already hit once in `lib/metrics/codebases.ts`. Reproduced locally with a failing test before fixing.

## The "Decisions and Data links are broken" report
Investigated separately and confirmed **Decisions has no bug** — verified in a real browser (production build, seeded data): it renders all 20 decision rows correctly, both loaded directly and via in-app navigation.

What was actually happening: this app has exactly **one** error boundary in the whole route tree (`app/global-error.tsx`), which replaces the entire `<html>/<body>` — including the sidebar nav — on any unhandled render error, anywhere. So when the Data page crashed, the nav vanished with it. From the user's side, every link looked broken, even though only one page actually had a bug.

## Fixes
1. **`lib/library/channels.ts`**: accept `string | Date` on `synced_at`, normalize once via `isoOf()`, compare by epoch ms instead of string ops.
2. **`app/t/[team]/error.tsx`** (new): a team-scoped error boundary. It sits inside the team layout's `{children}` slot, so a future crash on any single page is contained to that page's content area — the sidebar stays rendered and clickable instead of the whole app going blank.

## Verification
- New regression test reproduces the exact prod `TypeError` with `Date`-typed input (RED → GREEN).
- **The error boundary was verified end-to-end in a real browser**, not just read as "should work per Next.js docs": built production (`next build && next start`) against seeded data, forced a deliberate crash on the Data page, confirmed via the `browse` skill (headless Chromium) that:
  - Without the boundary: nav disappears, blank page (matches the reported screenshot).
  - With the boundary: nav stays fully intact, and clicking "Decisions" from the crashed Data page navigates cleanly and renders all 20 real rows.
- Full unit tier 412 passed, `tsc`, `eslint`, docs-drift clean.

## Test plan
- [x] `test/library-channels.test.ts` — Date-typed `synced_at` regression case
- [x] Manual: production build + real browser, crash-and-recover verified both without and with the boundary
- [ ] Live verify: reload the Data page after this deploys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a team-scoped error page with a clear fallback message and a retry button, helping keep the rest of the team layout usable when one page fails.
* **Bug Fixes**
  * Improved channel sync date handling so the latest synced channels are ordered correctly, even when date values arrive in different formats.
  * Prevented crashes caused by mixed date types during channel grouping and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->