### PR TITLE
feat(learning): verifiable, clickable evidence for narrative arcs

### DIFF
--- a/components/learning/arcs-panel.tsx
+++ b/components/learning/arcs-panel.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Loader2, Sparkles, RefreshCw } from "lucide-react";
+import Link from "next/link";
+import { Loader2, Sparkles, RefreshCw, ChevronRight, ExternalLink } from "lucide-react";
+
+interface ArcEvidence {
+  fact: string;
+  at?: string;
+  itemId?: string;
+  source?: string;
+}
 
 interface Arc {
   id: string;
@@ -10,6 +18,7 @@ interface Arc {
   summary: string;
   participants: string[];
   supporting_sources: string[];
+  evidence: ArcEvidence[];
   derived_at: string;
 }
 
@@ -165,10 +174,31 @@ export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
               </div>
             ) : null}
 
-            {arc.supporting_sources.length ? (
-              <p className="text-[11px] text-ink-tertiary">
-                sources: {arc.supporting_sources.join(" · ")}
-              </p>
+            {arc.evidence.length ? (
+              <details className="group/ev mt-0.5">
+                <summary className="flex w-fit cursor-pointer list-none items-center gap-1 text-xs font-medium text-ink-secondary transition-colors hover:text-ink">
+                  <ChevronRight className="size-3.5 transition-transform group-open/ev:rotate-90" />
+                  Evidence ({arc.evidence.length})
+                </summary>
+                <ul className="mt-2 flex flex-col gap-2 border-l border-border-subtle pl-3">
+                  {arc.evidence.map((e, i) => (
+                    <li key={i} className="flex flex-col gap-0.5">
+                      <span className="text-sm leading-snug text-ink-secondary">{e.fact}</span>
+                      {e.itemId ? (
+                        <Link
+                          href={`/t/${teamSlug}/library/${e.itemId}`}
+                          className="inline-flex w-fit items-center gap-1 text-[11px] text-violet hover:underline"
+                        >
+                          view source{e.source ? ` · ${e.source}` : ""}
+                          <ExternalLink className="size-3" />
+                        </Link>
+                      ) : e.source ? (
+                        <span className="text-[11px] text-ink-tertiary">{e.source}</span>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </details>
             ) : null}
           </div>
         );

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { createHash } from "node:crypto";
 import Anthropic from "@anthropic-ai/sdk";
-import { recentFacts } from "./learning";
+import { recentFacts, resolveEpisodeItems, type AtomicFact } from "./learning";
 import { GraphitiClient } from "./graphiti-client";
 import { episodeGroupId, type AccessTier } from "./group";
 
@@ -14,13 +14,23 @@ import { episodeGroupId, type AccessTier } from "./group";
  * LLM provider mirrors the Q&A path: OpenAI-compatible (`LLM_BASE_URL`) when set, else Anthropic.
  */
 
+/** One piece of verifiable evidence behind an arc: the real graph fact + a link to its source item. */
+export interface ArcEvidence {
+  fact: string; // the actual fact text extracted from the graph (not an LLM paraphrase)
+  at?: string; // ISO timestamp of the fact
+  itemId?: string; // brain item id (from the source episode `items:<id>`) → /library/<id> link
+  source?: string; // slack / github / linear … when resolvable
+}
+
 export interface NarrativeArc {
   id: string;
   title: string;
   confidence: "high" | "medium" | "low";
   summary: string;
   participants: string[];
+  /** Legacy free-text refs (kept for back-compat); `evidence` is the linkable, verifiable version. */
   supporting_sources: string[];
+  evidence: ArcEvidence[];
   derived_at: string;
 }
 
@@ -43,10 +53,11 @@ const CACHE_TTL_MS = 10 * 60_000;
 
 const SYSTEM_PROMPT =
   "You are analyzing a team knowledge graph. Identify 3-5 active narrative arcs — ongoing storylines " +
-  "about what this team is working through. Return ONLY a JSON object of the form " +
+  "about what this team is working through. Each fact below is numbered [F1], [F2], … — for every arc, " +
+  "cite the 2-5 fact numbers that support it in `supporting_facts`. Return ONLY a JSON object of the form " +
   '{"arcs":[{"title":"short","confidence":"high|medium|low","summary":"2-3 sentences, present tense, ' +
-  'specific","participants":["names"],"supporting_sources":["short source refs"]}]}. No prose, no ' +
-  "markdown code fences — the raw JSON object only.";
+  'specific","participants":["names"],"supporting_facts":[1,2,3]}]}. Use only fact numbers that appear ' +
+  "below. No prose, no markdown code fences — the raw JSON object only.";
 
 function stableId(title: string): string {
   return "arc-" + createHash("sha256").update(title.trim().toLowerCase()).digest("hex").slice(0, 10);
@@ -68,27 +79,81 @@ export function stripTaskKeys(text: string): string {
     .trim();
 }
 
+/** Options for `parseArcsJson`: the numbered facts + episode→item map used to resolve cited evidence. */
+export interface ParseArcsOptions {
+  facts?: AtomicFact[];
+  epToItem?: Map<string, { itemId?: string; source?: string }>;
+  now?: string;
+}
+
+/**
+ * Map an arc's cited `supporting_facts` (1-based indices into the numbered facts) back to the REAL
+ * facts, resolving each one's source item via its episodes. Out-of-range / duplicate indices are
+ * dropped; capped at 8. Pure — this is what makes each arc's evidence verifiable + linkable.
+ */
+function buildEvidence(
+  indices: unknown,
+  facts: AtomicFact[],
+  epToItem: Map<string, { itemId?: string; source?: string }>
+): ArcEvidence[] {
+  if (!Array.isArray(indices)) return [];
+  const out: ArcEvidence[] = [];
+  const seen = new Set<string>();
+  for (const rawIdx of indices) {
+    const i = typeof rawIdx === "number" ? rawIdx : parseInt(String(rawIdx), 10);
+    if (!Number.isInteger(i) || i < 1 || i > facts.length) continue;
+    const f = facts[i - 1];
+    if (seen.has(f.id)) continue;
+    seen.add(f.id);
+    let itemId: string | undefined;
+    let source: string | undefined;
+    for (const uuid of f.episodeUuids) {
+      const hit = epToItem.get(uuid);
+      if (hit?.source && !source) source = hit.source;
+      if (hit?.itemId) {
+        itemId = hit.itemId;
+        source = hit.source ?? source;
+        break;
+      }
+    }
+    out.push({ fact: f.fact, at: f.at, itemId, source });
+    if (out.length >= 8) break;
+  }
+  return out;
+}
+
 /**
  * Parse + normalize the LLM's JSON into safe arcs: caps at 5, coerces confidence, defaults missing
- * fields, assigns a stable id from the title, stamps `derived_at`. Returns [] on malformed input.
- * Pure + exported so the fragile parsing is unit-tested without an LLM.
+ * fields, assigns a stable id from the title, stamps `derived_at`, and resolves cited `supporting_facts`
+ * indices → verifiable `evidence` (falls back to any free-text `supporting_sources` as unlinked
+ * evidence). Returns [] on malformed input. Pure + exported so the fragile parsing is unit-tested.
  */
-export function parseArcsJson(raw: string | null, now = new Date().toISOString()): NarrativeArc[] {
+export function parseArcsJson(raw: string | null, opts: ParseArcsOptions = {}): NarrativeArc[] {
+  const { facts = [], epToItem = new Map(), now = new Date().toISOString() } = opts;
   if (!raw) return [];
   try {
-    const obj = JSON.parse(extractJsonObject(raw)) as { arcs?: Partial<NarrativeArc>[] };
+    const obj = JSON.parse(extractJsonObject(raw)) as {
+      arcs?: (Partial<NarrativeArc> & { supporting_facts?: unknown })[];
+    };
     if (!Array.isArray(obj.arcs)) return [];
-    return obj.arcs.slice(0, 5).map((a) => ({
-      id: stableId(a.title ?? ""),
-      title: stripTaskKeys((a.title ?? "Untitled").toString()) || "Untitled",
-      confidence: (["high", "medium", "low"] as const).includes(a.confidence as "high")
-        ? (a.confidence as NarrativeArc["confidence"])
-        : "low",
-      summary: stripTaskKeys((a.summary ?? "").toString()),
-      participants: Array.isArray(a.participants) ? a.participants.map(String) : [],
-      supporting_sources: Array.isArray(a.supporting_sources) ? a.supporting_sources.map(String) : [],
-      derived_at: now,
-    }));
+    return obj.arcs.slice(0, 5).map((a) => {
+      const supporting_sources = Array.isArray(a.supporting_sources) ? a.supporting_sources.map(String) : [];
+      const cited = buildEvidence(a.supporting_facts, facts, epToItem);
+      // Fall back to free-text sources (unlinked) if the model didn't cite fact numbers.
+      const evidence = cited.length ? cited : supporting_sources.map((s) => ({ fact: s }));
+      return {
+        id: stableId(a.title ?? ""),
+        title: stripTaskKeys((a.title ?? "Untitled").toString()) || "Untitled",
+        confidence: (["high", "medium", "low"] as const).includes(a.confidence as "high")
+          ? (a.confidence as NarrativeArc["confidence"])
+          : "low",
+        summary: stripTaskKeys((a.summary ?? "").toString()),
+        participants: Array.isArray(a.participants) ? a.participants.map(String) : [],
+        supporting_sources,
+        evidence,
+        derived_at: now,
+      };
+    });
   } catch (err) {
     // The prompt asks for "ONLY JSON", but Claude/GPT often ignore that and wrap the object in a
     // markdown fence or a leading sentence anyway — extractJsonObject handles the common cases, so
@@ -117,19 +182,17 @@ function extractJsonObject(raw: string): string {
   return start !== -1 && end !== -1 && end > start ? body.slice(start, end + 1) : body;
 }
 
-/** Ask the configured LLM for arcs as JSON; returns [] on any transport/parse failure (best-effort —
- *  an LLM outage or a stale model id must degrade to "no arcs" instead of failing the whole request). */
-async function callLLM(userContent: string, keys: ProviderKeys): Promise<NarrativeArc[]> {
-  let raw: string | null;
+/** Ask the configured LLM for the raw arcs JSON; null on any transport failure (best-effort — an LLM
+ *  outage or a stale model id must degrade to "no arcs" instead of failing the whole request). */
+async function callLLMRaw(userContent: string, keys: ProviderKeys): Promise<string | null> {
   try {
-    raw = LLM_BASE_URL
+    return LLM_BASE_URL
       ? await callOpenAICompatible(userContent, keys.openaiKey)
       : await callAnthropic(userContent, keys.anthropicKey);
   } catch (err) {
     console.error("[arcs] LLM call failed:", err instanceof Error ? err.message : err);
-    return [];
+    return null;
   }
-  return parseArcsJson(raw);
 }
 
 async function callOpenAICompatible(userContent: string, apiKey?: string | null): Promise<string | null> {
@@ -176,9 +239,16 @@ async function callAnthropic(userContent: string, apiKey?: string | null): Promi
   return block && block.type === "text" ? block.text : null;
 }
 
-/** Build the user prompt from the recent facts substrate (+ any human corrections to incorporate). */
-function buildPrompt(facts: string[], corrections: string[]): string {
-  const lines = ["Recent facts from the team knowledge graph (most recent first):", ...facts.map((f) => `- ${f}`)];
+/**
+ * Build the user prompt from the recent facts substrate (+ any human corrections). Facts are NUMBERED
+ * `[F1] … [F2] …` so the model can cite them in `supporting_facts` — we map those numbers back to the
+ * real facts (and their source items) to build verifiable evidence.
+ */
+function buildPrompt(facts: AtomicFact[], corrections: string[]): string {
+  const lines = [
+    "Recent facts from the team knowledge graph (most recent first), each numbered for citation:",
+    ...facts.map((f, i) => `[F${i + 1}] ${f.fact}`),
+  ];
   if (corrections.length) {
     lines.push("", "Human corrections to incorporate:", ...corrections.map((c) => `- ${c}`));
   }
@@ -198,7 +268,11 @@ export async function getArcs(teamSlug: string, tier: AccessTier, groups: string
   const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
   const facts = await recentFacts(groups, since, MAX_FACTS);
   if (facts.length === 0) return [];
-  const arcs = await callLLM(buildPrompt(facts.map((f) => f.fact), []), keys);
+  const [raw, epToItem] = await Promise.all([
+    callLLMRaw(buildPrompt(facts, []), keys),
+    resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids)),
+  ]);
+  const arcs = parseArcsJson(raw, { facts, epToItem });
   cache.set(key, { arcs, at: Date.now() });
   return arcs;
 }
@@ -218,10 +292,11 @@ export async function recomputeArcs(
   if (groups.length === 0) return [];
   const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
   const facts = await recentFacts(groups, since, MAX_FACTS);
-  const arcs = await callLLM(
-    buildPrompt(facts.map((f) => f.fact), corrections.map((c) => c.corrected_text)),
-    keys
-  );
+  const [raw, epToItem] = await Promise.all([
+    callLLMRaw(buildPrompt(facts, corrections.map((c) => c.corrected_text)), keys),
+    resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids)),
+  ]);
+  const arcs = parseArcsJson(raw, { facts, epToItem });
   cache.set(groups.slice().sort().join(","), { arcs, at: Date.now() });
 
   // Persist corrections as first-class episodes (team-tier group; corrections are internal).

--- a/lib/graph/learning.ts
+++ b/lib/graph/learning.ts
@@ -82,6 +82,38 @@ export async function recentFacts(
   }
 }
 
+/**
+ * Resolve a set of episode UUIDs → their source item id + source, tier-scoped. Episodes are named
+ * `items:<id>`, so this lets a fact (which carries `episodeUuids`) link back to the brain item that
+ * produced it — the provenance behind a narrative arc's evidence. Best-effort empty map on failure.
+ */
+export async function resolveEpisodeItems(
+  groups: string[],
+  uuids: string[]
+): Promise<Map<string, { itemId?: string; source?: string }>> {
+  const out = new Map<string, { itemId?: string; source?: string }>();
+  const unique = [...new Set(uuids.filter(Boolean))].slice(0, 500);
+  if (!neo4jConfigured() || groups.length === 0 || unique.length === 0) return out;
+  try {
+    const rows = await runRead<{ uuid: string; name: string | null; source: string | null }>(
+      `MATCH (ep:Episodic)
+       WHERE ep.group_id IN $groups AND ep.uuid IN $uuids
+       RETURN ep.uuid AS uuid, ep.name AS name, ep.source AS source`,
+      { groups, uuids: unique }
+    );
+    for (const r of rows) {
+      const name = r.name ?? "";
+      out.set(r.uuid, {
+        itemId: name.startsWith("items:") ? name.slice("items:".length) : undefined,
+        source: r.source ? r.source.toLowerCase() : undefined,
+      });
+    }
+    return out;
+  } catch {
+    return out; // degrade — evidence just won't carry links
+  }
+}
+
 /** Layer 2 — an event (a source episode) with its participants + the facts extracted from it. */
 export interface GraphEvent {
   id: string; // episode uuid

--- a/test/graph-arcs-parse.test.ts
+++ b/test/graph-arcs-parse.test.ts
@@ -25,7 +25,7 @@ describe("parseArcsJson strips task keys from title + summary", () => {
     const raw = JSON.stringify({
       arcs: [{ title: "Learning layer (AIO-138)", confidence: "high", summary: "Building AIO-138 and AIO-146.", participants: [] }],
     });
-    const [arc] = parseArcsJson(raw, "2026-07-02T00:00:00.000Z");
+    const [arc] = parseArcsJson(raw, { now: "2026-07-02T00:00:00.000Z" });
     expect(arc.title).toBe("Learning layer");
     expect(arc.summary).toBe("Building and.");
     expect(arc.summary).not.toMatch(/AIO-\d+/);
@@ -41,7 +41,7 @@ describe("parseArcsJson", () => {
         { title: "Auth rewrite", confidence: "high", summary: "Migrating to SSO.", participants: ["Alice"], supporting_sources: ["Slack"] },
       ],
     });
-    const [arc] = parseArcsJson(raw, NOW);
+    const [arc] = parseArcsJson(raw, { now: NOW });
     expect(arc).toMatchObject({
       title: "Auth rewrite",
       confidence: "high",
@@ -52,11 +52,11 @@ describe("parseArcsJson", () => {
     });
     expect(arc.id).toMatch(/^arc-[0-9a-f]{10}$/);
     // stable: same title → same id
-    expect(parseArcsJson(raw, NOW)[0].id).toBe(arc.id);
+    expect(parseArcsJson(raw, { now: NOW })[0].id).toBe(arc.id);
   });
 
   it("coerces a bad confidence to 'low' and defaults missing fields", () => {
-    const [arc] = parseArcsJson(JSON.stringify({ arcs: [{ title: "X", confidence: "vibes" }] }), NOW);
+    const [arc] = parseArcsJson(JSON.stringify({ arcs: [{ title: "X", confidence: "vibes" }] }), { now: NOW });
     expect(arc.confidence).toBe("low");
     expect(arc.summary).toBe("");
     expect(arc.participants).toEqual([]);
@@ -65,7 +65,7 @@ describe("parseArcsJson", () => {
 
   it("caps at 5 arcs", () => {
     const arcs = Array.from({ length: 9 }, (_, i) => ({ title: `A${i}`, confidence: "low" }));
-    expect(parseArcsJson(JSON.stringify({ arcs }), NOW)).toHaveLength(5);
+    expect(parseArcsJson(JSON.stringify({ arcs }), { now: NOW })).toHaveLength(5);
   });
 
   it("returns [] for null, malformed JSON, or a missing arcs array (never throws)", () => {
@@ -79,25 +79,69 @@ describe("parseArcsJson", () => {
   // diagnostics — exactly the failure mode reported on the Learning page.
   it("unwraps a JSON object wrapped in a ```json code fence", () => {
     const body = JSON.stringify({ arcs: [{ title: "Auth rewrite", confidence: "high" }] });
-    const [arc] = parseArcsJson("```json\n" + body + "\n```", NOW);
+    const [arc] = parseArcsJson("```json\n" + body + "\n```", { now: NOW });
     expect(arc.title).toBe("Auth rewrite");
   });
 
   it("unwraps a JSON object wrapped in a bare ``` code fence", () => {
     const body = JSON.stringify({ arcs: [{ title: "Auth rewrite", confidence: "high" }] });
-    const [arc] = parseArcsJson("```\n" + body + "\n```", NOW);
+    const [arc] = parseArcsJson("```\n" + body + "\n```", { now: NOW });
     expect(arc.title).toBe("Auth rewrite");
   });
 
   it("unwraps a JSON object padded with a leading/trailing sentence", () => {
     const body = JSON.stringify({ arcs: [{ title: "Auth rewrite", confidence: "high" }] });
-    const [arc] = parseArcsJson(`Here is the analysis:\n${body}\nLet me know if you need more.`, NOW);
+    const [arc] = parseArcsJson(`Here is the analysis:\n${body}\nLet me know if you need more.`, { now: NOW });
     expect(arc.title).toBe("Auth rewrite");
   });
 
   it("leaves a clean, unwrapped response untouched", () => {
     const raw = JSON.stringify({ arcs: [{ title: "Auth rewrite", confidence: "high" }] });
-    const [arc] = parseArcsJson(raw, NOW);
+    const [arc] = parseArcsJson(raw, { now: NOW });
     expect(arc.title).toBe("Auth rewrite");
+  });
+});
+
+describe("parseArcsJson evidence (verifiable, linkable)", () => {
+  const NOW = "2026-07-02T00:00:00.000Z";
+  const fact = (id: string, text: string, episodeUuids: string[] = []) => ({
+    id,
+    fact: text,
+    at: NOW,
+    subjectType: "person",
+    subject: "a",
+    object: "b",
+    episodeUuids,
+  });
+  const facts = [
+    fact("f1", "Chetan shipped the Linear importer", ["ep-1"]),
+    fact("f2", "John reviewed the RLS change", ["ep-2"]),
+    fact("f3", "Retrieval got date-awareness", []),
+  ];
+  const epToItem = new Map([
+    ["ep-1", { itemId: "item-aaa", source: "slack" }],
+    ["ep-2", { itemId: "item-bbb", source: "github" }],
+  ]);
+
+  it("maps cited fact numbers to real facts + resolves each one's source item", () => {
+    const raw = JSON.stringify({ arcs: [{ title: "Importers", confidence: "high", supporting_facts: [1, 3] }] });
+    const [arc] = parseArcsJson(raw, { facts, epToItem, now: NOW });
+    expect(arc.evidence).toEqual([
+      { fact: "Chetan shipped the Linear importer", at: NOW, itemId: "item-aaa", source: "slack" },
+      { fact: "Retrieval got date-awareness", at: NOW, itemId: undefined, source: undefined },
+    ]);
+  });
+
+  it("drops out-of-range and duplicate fact indices", () => {
+    const raw = JSON.stringify({ arcs: [{ title: "T", confidence: "low", supporting_facts: [2, 2, 99, 0, -1] }] });
+    const [arc] = parseArcsJson(raw, { facts, epToItem, now: NOW });
+    expect(arc.evidence.map((e) => e.fact)).toEqual(["John reviewed the RLS change"]);
+    expect(arc.evidence[0].itemId).toBe("item-bbb");
+  });
+
+  it("falls back to free-text supporting_sources (unlinked) when no fact numbers are cited", () => {
+    const raw = JSON.stringify({ arcs: [{ title: "T", confidence: "low", supporting_sources: ["Slack #eng", "a PR"] }] });
+    const [arc] = parseArcsJson(raw, { facts, epToItem, now: NOW });
+    expect(arc.evidence).toEqual([{ fact: "Slack #eng" }, { fact: "a PR" }]);
   });
 });


### PR DESCRIPTION
**Problem (from the screenshot/report):** on the learnings page, an arc's evidence was a tiny `sources: …` line of **LLM-invented short strings** — too small to read and impossible to verify (they didn't link to anything real).

**Fix:** make the evidence real and clickable, so you can click through to verify each cited fact.

- **Cite real facts by number.** Facts are now numbered `[F1] [F2] …` in the prompt; the model returns `supporting_facts: [1,3]` per arc (same idea as the `[S#]` citations in the Q&A path). `parseArcsJson` maps those indices back to the **actual `AtomicFact`s** and resolves each fact's **source item** via its episodes (episode name `items:<id>` → `lib/graph/learning.resolveEpisodeItems`, tier-scoped). `NarrativeArc` gains `evidence[]` = `{ fact, at, itemId?, source? }`. Falls back to the old free-text `supporting_sources` (unlinked) if the model doesn't cite numbers.
- **New UX.** The cramped one-liner becomes an expandable **"Evidence (N)"** dropdown: each supporting fact is shown at readable size with a **"view source ↗"** link to the library item — click through and verify.

## Notes
- Evidence links appear when the fact traces to an ingested item (the common case); a fact with no `items:<id>` episode shows the (still real) fact text without a link.
- Graphiti/Neo4j-gated like the rest of the panel — best-effort, degrades to no-arcs when unavailable.

## Tests
- +3 evidence-mapping unit specs (index→fact resolution, out-of-range/duplicate dropping, free-text fallback); existing parse tests migrated to the new `opts` signature.
- Full: **415 unit**; tsc + eslint + docs-drift clean. **No schema change.**

Verified at the unit/type/lint level; not browser-rendered here (Graphiti/DB env not in this worktree).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arc evidence is now shown as structured, expandable items with counts, individual facts, and source links when available.
  * Evidence can now be tied to specific cited facts for easier verification and navigation.

* **Bug Fixes**
  * Improved handling of arc evidence when citations are missing, invalid, or duplicated.
  * Added safer fallback display for evidence entries without direct links.

* **Tests**
  * Updated and expanded arc parsing coverage for evidence mapping and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->