### PR TITLE
feat(chat): conversation search by message content (FTS)

### DIFF
--- a/app/api/dashboard/conversations/route.ts
+++ b/app/api/dashboard/conversations/route.ts
@@ -2,17 +2,23 @@ import { NextRequest, NextResponse } from "next/server";
 import { adminClient } from "@/lib/db/admin";
 import { errorResponse } from "@/lib/api/schemas";
 import { resolveChatOwner } from "@/lib/chat/session";
-import { listConversations } from "@/lib/chat/store";
+import { listConversations, searchConversations } from "@/lib/chat/store";
 
 export const runtime = "nodejs";
 
-/** GET /api/dashboard/conversations?team=<slug> — the signed-in member's own chat threads. */
+/**
+ * GET /api/dashboard/conversations?team=<slug>[&q=<text>] — the signed-in member's own chat threads.
+ * With `q`, returns threads matching by title OR message content (owner-scoped FTS).
+ */
 export async function GET(req: NextRequest) {
   const teamSlug = req.nextUrl.searchParams.get("team") ?? "";
   if (!teamSlug) return errorResponse("invalid_payload", "team required", 422);
   const owner = await resolveChatOwner(teamSlug);
   if (!owner) return errorResponse("forbidden", "not a member of this team", 403);
 
-  const conversations = await listConversations(adminClient(), owner);
+  const q = (req.nextUrl.searchParams.get("q") ?? "").trim();
+  const conversations = q
+    ? await searchConversations(adminClient(), owner, q)
+    : await listConversations(adminClient(), owner);
   return NextResponse.json({ conversations });
 }

--- a/components/chat/chat-workspace.tsx
+++ b/components/chat/chat-workspace.tsx
@@ -40,6 +40,7 @@ function toExchanges(messages: StoredMessage[]): Exchange[] {
 export function ChatWorkspace({ teamSlug, initialQuestion }: { teamSlug: string; initialQuestion?: string }) {
   const [conversations, setConversations] = useState<ConversationListItem[]>([]);
   const [filter, setFilter] = useState("");
+  const [searchResults, setSearchResults] = useState<ConversationListItem[] | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const newNonce = useRef(0);
@@ -61,6 +62,29 @@ export function ChatWorkspace({ teamSlug, initialQuestion }: { teamSlug: string;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadList();
   }, [loadList]);
+
+  // Debounced server search (title OR message content, owner-scoped FTS). Empty query → clear so the
+  // full list shows. All setState happens inside the async timeout callback (never synchronously).
+  useEffect(() => {
+    const q = filter.trim();
+    const t = setTimeout(async () => {
+      if (!q) {
+        setSearchResults(null);
+        return;
+      }
+      try {
+        const res = await fetch(
+          `/api/dashboard/conversations?team=${encodeURIComponent(teamSlug)}&q=${encodeURIComponent(q)}`
+        );
+        if (!res.ok) return;
+        const body = (await res.json()) as { conversations?: ConversationListItem[] };
+        setSearchResults(body.conversations ?? []);
+      } catch {
+        // keep the instant client-side title fallback
+      }
+    }, q ? 250 : 0);
+    return () => clearTimeout(t);
+  }, [filter, teamSlug]);
 
   async function openConversation(id: string) {
     setLoadingId(id);
@@ -98,10 +122,13 @@ export function ChatWorkspace({ teamSlug, initialQuestion }: { teamSlug: string;
     void loadList();
   }
 
-  // Client-side title search over the already-loaded list (instant; owner data is here). Content
-  // search (over message bodies) would be a server FTS endpoint — a later increment.
-  const q = filter.trim().toLowerCase();
-  const shown = q ? conversations.filter((c) => (c.title || "").toLowerCase().includes(q)) : conversations;
+  // Search matches by title OR message content (server FTS). While the debounced request is in
+  // flight we show an instant client-side title filter as a fallback, then swap in the server hits.
+  const ql = filter.trim().toLowerCase();
+  const clientFiltered = ql
+    ? conversations.filter((c) => (c.title || "").toLowerCase().includes(ql))
+    : conversations;
+  const shown = ql ? searchResults ?? clientFiltered : conversations;
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-[230px_1fr]">

--- a/docs/CHAT-CLIENTS.md
+++ b/docs/CHAT-CLIENTS.md
@@ -81,5 +81,5 @@ for multi-user, issue a key per member and pick it by Telegram user).
 ## Not yet on the server (say the word)
 - API-key **rename/delete** of a conversation (the session-authed dashboard has `PATCH`/`DELETE`;
   the API-key list/get are built, management verbs are a small add).
-- Content search over message bodies (the dashboard sidebar currently searches titles client-side;
-  a server FTS endpoint would cover message content).
+- API-key **search** — the dashboard supports it (`GET /api/dashboard/conversations?q=` matches title
+  OR message content via FTS); the API-key `GET /api/v1/conversations` doesn't take `q` yet.

--- a/lib/chat/store.ts
+++ b/lib/chat/store.ts
@@ -121,6 +121,45 @@ export async function listConversations(
   return (data ?? []) as Conversation[];
 }
 
+/**
+ * Search the member's conversations by title OR message content (owner-scoped). Content matches use
+ * FTS over `chat_messages` (`websearch_to_tsquery`); title matches are a case-insensitive substring
+ * over the member's own list. Most-recent-active first, capped. Empty query → the plain list.
+ */
+export async function searchConversations(
+  db: DbClient,
+  owner: Owner,
+  query: string,
+  limit = 50
+): Promise<Conversation[]> {
+  const q = query.trim();
+  if (!q) return listConversations(db, owner, limit);
+  // Content matches: message bodies via FTS → the conversations they belong to (owner-scoped).
+  const { data: hits } = await db
+    .from("chat_messages")
+    .select("conversation_id")
+    .eq("team_id", owner.teamId)
+    .eq("member_id", owner.memberId)
+    .textSearch("search", q, { type: "websearch", config: "english" })
+    .limit(1000);
+  const contentIds = new Set(
+    (hits ?? []).map((h) => (h as { conversation_id: string }).conversation_id)
+  );
+  // The member's non-archived conversations; keep those whose title matches OR whose content matched.
+  const { data } = await db
+    .from("conversations")
+    .select("id, title, created_at, updated_at")
+    .eq("team_id", owner.teamId)
+    .eq("member_id", owner.memberId)
+    .is("archived_at", null)
+    .order("updated_at", { ascending: false })
+    .limit(500);
+  const ql = q.toLowerCase();
+  return ((data ?? []) as Conversation[])
+    .filter((c) => (c.title || "").toLowerCase().includes(ql) || contentIds.has(c.id))
+    .slice(0, limit);
+}
+
 /** A conversation's full message thread — owner-checked; null if not owned/absent. */
 export async function getConversation(
   db: DbClient,

--- a/postgres/migrations/20260707130000_chat_messages_search.sql
+++ b/postgres/migrations/20260707130000_chat_messages_search.sql
@@ -1,0 +1,5 @@
+-- Full-text search over chat message bodies, so the /query sidebar search can match conversation
+-- CONTENT (not just titles). Generated tsvector column + GIN index, mirroring items.search.
+alter table chat_messages add column if not exists search tsvector
+  generated always as (to_tsvector('english', coalesce(content, ''))) stored;
+create index if not exists chat_messages_search_idx on chat_messages using gin (search);

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -869,9 +869,12 @@ create table if not exists chat_messages (
   input_tokens integer not null default 0,
   output_tokens integer not null default 0,
   cost_usd numeric(10, 5) not null default 0,
-  created_at timestamptz not null default now()
+  created_at timestamptz not null default now(),
+  -- FTS over message bodies so the sidebar search can match conversation CONTENT (mirrors items.search).
+  search tsvector generated always as (to_tsvector('english', coalesce(content, ''))) stored
 );
 create index if not exists chat_messages_conversation_idx on chat_messages (conversation_id, created_at);
+create index if not exists chat_messages_search_idx on chat_messages using gin (search);
 
 -- ── ingestion run log (observability for imports/scans) ───────────────────────
 -- One row per ingestion run: every scheduler tick, manual /sync, and codebase scan records its

--- a/test/datamechanics/chat-search.datamechanics.test.ts
+++ b/test/datamechanics/chat-search.datamechanics.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db, seedTeam } from "./helpers";
+import {
+  createConversation,
+  appendMessage,
+  searchConversations,
+  listConversations,
+} from "@/lib/chat/store";
+
+// Spec (conversation content search) verified to the observable outcome on real Postgres: search
+// matches by message CONTENT (FTS) or title, stays owner-scoped, and empty query returns the list.
+
+async function secondMember(teamId: string): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: teamId,
+      email: `${randomUUID()}@test.local`,
+      display_name: "Other",
+      actor_handle: `actor-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seed member: ${error?.message}`);
+  return (data as { id: string }).id;
+}
+
+describe("chat search (data-mechanics)", () => {
+  it("finds a conversation by a distinctive word in its message content (FTS)", async () => {
+    const seed = await seedTeam();
+    const owner = { teamId: seed.teamId, memberId: seed.memberId };
+    const target = await createConversation(db(), owner, "Deploy chat");
+    await appendMessage(db(), owner, target!.id, "user", "how do I fix the photosynthesis pipeline?");
+    await appendMessage(db(), owner, target!.id, "assistant", "adjust the chlorophyll settings");
+    const other = await createConversation(db(), owner, "Unrelated");
+    await appendMessage(db(), owner, other!.id, "user", "something about railway deploys");
+
+    const hits = await searchConversations(db(), owner, "photosynthesis");
+    expect(hits.map((c) => c.id)).toEqual([target!.id]);
+  });
+
+  it("also matches by title", async () => {
+    const seed = await seedTeam();
+    const owner = { teamId: seed.teamId, memberId: seed.memberId };
+    const c = await createConversation(db(), owner, "Kubernetes migration plan");
+    await appendMessage(db(), owner, c!.id, "user", "hi");
+    const hits = await searchConversations(db(), owner, "kubernetes");
+    expect(hits.map((x) => x.id)).toContain(c!.id);
+  });
+
+  it("is owner-scoped: another member's matching content never surfaces", async () => {
+    const seed = await seedTeam();
+    const owner = { teamId: seed.teamId, memberId: seed.memberId };
+    const otherId = await secondMember(seed.teamId);
+    const other = { teamId: seed.teamId, memberId: otherId };
+    const theirs = await createConversation(db(), other, "Theirs");
+    await appendMessage(db(), other, theirs!.id, "user", "the photosynthesis secret plan");
+
+    expect(await searchConversations(db(), owner, "photosynthesis")).toEqual([]);
+  });
+
+  it("empty query returns the full list", async () => {
+    const seed = await seedTeam();
+    const owner = { teamId: seed.teamId, memberId: seed.memberId };
+    await createConversation(db(), owner, "one");
+    await createConversation(db(), owner, "two");
+    const searched = await searchConversations(db(), owner, "   ");
+    const listed = await listConversations(db(), owner);
+    expect(searched.map((c) => c.id).sort()).toEqual(listed.map((c) => c.id).sort());
+  });
+});


### PR DESCRIPTION
Completes the "conversation search" ask: the `/query` sidebar search was **title-only** — now it also matches **message content**, so you can find a thread by something said inside it.

- **Schema:** `chat_messages.search` tsvector generated column + GIN index (mirrors `items.search`). New column on an existing table → migration `20260707130000` + `schema.sql` mirror. ⚠️ **`npm run pg:schema` against prod required after merge.**
- **`store.searchConversations(owner, q)`** — content matches via FTS (`websearch_to_tsquery`) over `chat_messages`, unioned with case-insensitive title matches, **owner-scoped**.
- **`GET /api/dashboard/conversations?q=`** → search; without `q` → plain list.
- **Sidebar:** the filter box now does a **debounced server search** (title OR content), with the instant client-side title filter as an in-flight fallback.

## Tests
- +4 chat-search data-mechanics: content match (FTS), title match, **owner isolation** (member B's matching content never surfaces to A), empty→list.
- Full: **415 unit, 296 data-mechanics**; tsc + eslint + docs-drift clean.

> Deploy note: schema-change PR → I'll run `pg:schema` against prod right after merge (the generated column is harmless to the old code, so no downtime window).