### PR TITLE
fix(db): chat_messages search index in migration, not schema.sql

### DIFF
--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -874,7 +874,10 @@ create table if not exists chat_messages (
   search tsvector generated always as (to_tsvector('english', coalesce(content, ''))) stored
 );
 create index if not exists chat_messages_conversation_idx on chat_messages (conversation_id, created_at);
-create index if not exists chat_messages_search_idx on chat_messages using gin (search);
+-- NOTE: the `chat_messages_search_idx` GIN index lives in migration 20260707130000, NOT here — on a
+-- DB that already has chat_messages the create-table above is a no-op (so the `search` column isn't
+-- added here), and an index on a not-yet-existing column would fail. The migration adds the column
+-- then the index, covering both from-zero and existing prod.
 
 -- ── ingestion run log (observability for imports/scans) ───────────────────────
 -- One row per ingestion run: every scheduler tick, manual /sync, and codebase scan records its


### PR DESCRIPTION
Follow-up to #177. The `chat_messages.search` GIN index was placed in `schema.sql`'s create-table area. On a DB that **already has** `chat_messages` (prod), `create table if not exists` is a no-op, so the new `search` column isn't added by schema.sql — and the index on a non-existent column then fails (`column "search" does not exist`), aborting `pg:schema`. (From-zero worked, which is why local `db:test:up` didn't catch it — the exact CLAUDE.md §6 gotcha.)

Fix: the column-add **and** the index both live in migration `20260707130000` (runs after schema.sql, `if not exists`), covering from-zero and existing DBs. schema.sql keeps the column in the create-table body (from-zero) but drops the index line, with a comment explaining why.

- **Prod already reconciled** — I ran `pg:schema` (with the fix) against Railway; the `search` column + index are confirmed present. This PR just corrects the canonical `schema.sql`.
- Verified: from-zero `db:test:up` succeeds and the column is present; chat-search data-mechanics green.

No code change, no further prod action.