### PR TITLE
feat(learning): trace AI-agent narrative-arc participants back to a human

### DIFF
--- a/app/api/brain/arcs/recompute/route.ts
+++ b/app/api/brain/arcs/recompute/route.ts
@@ -50,10 +50,15 @@ export async function POST(req: NextRequest) {
     getProviderKey(admin, team.id, "openai"),
     getProviderKey(admin, team.id, "anthropic"),
   ]);
-  const arcs = await recomputeArcs(teamSlug, tier, visibleGroupIds(teamSlug, tier), corrections, {
-    openaiKey,
-    anthropicKey,
-  });
+  const arcs = await recomputeArcs(
+    admin,
+    team.id,
+    teamSlug,
+    tier,
+    visibleGroupIds(teamSlug, tier),
+    corrections,
+    { openaiKey, anthropicKey }
+  );
 
   return Response.json({ arcs, as_of: new Date().toISOString() });
 }

--- a/app/api/brain/arcs/route.ts
+++ b/app/api/brain/arcs/route.ts
@@ -45,7 +45,10 @@ export async function POST(req: NextRequest) {
     getProviderKey(admin, team.id, "openai"),
     getProviderKey(admin, team.id, "anthropic"),
   ]);
-  const arcs = await getArcs(teamSlug, tier, visibleGroupIds(teamSlug, tier), { openaiKey, anthropicKey });
+  const arcs = await getArcs(admin, team.id, teamSlug, tier, visibleGroupIds(teamSlug, tier), {
+    openaiKey,
+    anthropicKey,
+  });
 
   return Response.json({ arcs, as_of: new Date().toISOString() });
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -509,7 +509,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `POST /api/v1/graph-query` — NL query over Graphiti graph memory; tier-scoped group_ids; citable facts
 - `GET /api/brain/facts` — Brain-Learning panel Layer 1: recent Graphiti facts (last 24h) read directly from Neo4j; session-authed; tier-scoped via `visibleGroupIds` (sole enforcement, no RLS backstop)
 - `GET /api/brain/events` — Brain-Learning Layer 2: recent events (source episodes) with participants + extracted facts; session-authed; tier-scoped via `visibleGroupIds`
-- `POST /api/brain/arcs` — Brain-Learning Layer 3: LLM-synthesized narrative arcs from the last 7d of the graph (cached 10 min); session-authed; tier-scoped
+- `POST /api/brain/arcs` — Brain-Learning Layer 3: LLM-synthesized narrative arcs from the last 7d of the graph (cached 10 min); session-authed; tier-scoped. A recognized AI-agent/tool name in `participants` (e.g. "Claude Code", "AIOS Team Brain" — extracted from episode prose, not a real actor) is rewritten to name the human(s) behind that arc's evidence items (`lib/graph/arc-attribution.ts` + `resolveHumanActors` in `lib/graph/arcs.ts`, joining `items.member_id` → `members`, excluding connector service-accounts), or tagged "(unattributed AI agent)" when no human resolves
 - `POST /api/brain/arcs/recompute` — re-derive arcs with human corrections + write each correction back to Graphiti as a `correction:<arc_id>` episode (team-tier only)
 - `POST /api/dashboard/query` — same query pipeline, session-authenticated; persists the thread (`conversation_id`)
 - `GET /api/dashboard/conversations` — the signed-in member's own chat threads (owner-scoped)

--- a/docs/design/brain-learning-panel.md
+++ b/docs/design/brain-learning-panel.md
@@ -125,6 +125,26 @@ any search affordance. No new plumbing — both already read from the same `item
 3. **Layer 2** (events) — episodes + participants reconciled to `members`.
 4. **Layer 3** (arcs) — synthesis + cache; then inline edit + recompute + correction writeback.
 
+## Human attribution for AI-agent participants (added 2026-07-08)
+
+Layer 3's `participants` are LLM-synthesized from episode prose, so a recognized AI-agent/tool name
+(e.g. "Claude Code", "AIOS Team Brain", "Claude Agent SDK" — mentioned in a Slack message or PR body,
+not a real actor) could stand in a narrative arc as if it were the person who did the work, with no
+way to trace it to a human. Every ingested item already carries a real attribution
+(`items.member_id` → `members`, excluding connector service-accounts — see `lib/ingest/run.ts`'s
+`resolveConnectorAuth`/`is_connector`), so `getArcs`/`recomputeArcs` (`lib/graph/arcs.ts`) now:
+
+1. Resolve, per arc, the distinct human (non-connector) display names behind that arc's OWN evidence
+   items (`resolveHumanActors`, joining `items` → `members` in Postgres, team-scoped).
+2. Rewrite `participants` (`attributeParticipants` in `lib/graph/arc-attribution.ts`, pure + unit
+   tested) so a recognized AI-agent name is tagged `"Claude Code (Chetan Nandakumar)"`, or
+   `"Claude Code (unattributed AI agent)"` when no human resolves — never silently dropped or guessed.
+
+This only covers Layer 3 (narrative arcs). Layer 2's `participants` (`recentEvents` in
+`lib/graph/learning.ts`) are still raw `MENTIONS` entity names from Graphiti's own extractor,
+unattributed — the same gap could recur there if a future change surfaces Layer 2 participants
+more prominently in the UI.
+
 ## Risks & mitigations
 - **Schema coupling** — we depend on Graphiti's internal Neo4j labels/props, which can change across
   Graphiti versions. *Mitigate:* pin the `zepai/graphiti` image tag; isolate ALL Cypher in

--- a/lib/dashboard/team-work-live.ts
+++ b/lib/dashboard/team-work-live.ts
@@ -72,7 +72,7 @@ export async function getTeamWork(
         .limit(600),
       tier
     ),
-    getArcs(teamSlug, tier, visibleGroupIds(teamSlug, tier), keys).catch(() => []),
+    getArcs(db, teamId, teamSlug, tier, visibleGroupIds(teamSlug, tier), keys).catch(() => []),
   ]);
 
   const tasks: TaskLite[] = ((taskRows ?? []) as {

--- a/lib/graph/arc-attribution.ts
+++ b/lib/graph/arc-attribution.ts
@@ -1,0 +1,58 @@
+/**
+ * Layer 3 human attribution. An AI agent/tool name (e.g. "Claude Code", "AIOS Team Brain") is not a
+ * traceable actor by itself — it shows up in `participants` only because the arc-synthesis LLM read
+ * it out of episode prose (a Slack message, a PR body). Every ingested item is already attributed to
+ * a human via `items.member_id` (excluding connector service-accounts, `members.is_connector`), so
+ * this rewrites a recognized AI-agent participant to name the human actually responsible for that
+ * work, instead of letting the tool stand in for one.
+ */
+
+/**
+ * Product/tool names that turn up in Slack/PR text but are never themselves a traceable human.
+ * Exact match (trimmed, case-insensitive) — deliberately a fixed list rather than a substring/regex
+ * match, so a person actually named e.g. "Claude" or "Cursor" is never misattributed.
+ */
+const KNOWN_AI_AGENT_NAMES = new Set([
+  "claude",
+  "claude code",
+  "claude agent sdk",
+  "claude sdk",
+  "aios team brain",
+  "team brain",
+  "chatgpt",
+  "gpt-4",
+  "gpt-4o",
+  "gpt-5",
+  "openai",
+  "anthropic",
+  "github copilot",
+  "copilot",
+  "codex",
+  "cursor",
+  "the ai",
+  "ai agent",
+  "ai assistant",
+  "the assistant",
+  "the bot",
+]);
+
+export function isAiAgentName(name: string): boolean {
+  return KNOWN_AI_AGENT_NAMES.has(name.trim().toLowerCase());
+}
+
+/** Cap how many humans get named in one attribution tag — readability, not a data limit. */
+const MAX_ATTRIBUTED_HUMANS = 2;
+
+/**
+ * Rewrite an arc's `participants` so any recognized AI-agent name is tagged with the human(s)
+ * responsible for the underlying work. Non-agent names pass through unchanged. `humanNames` should
+ * already exclude connector service-accounts — pass [] when none resolve, which tags the agent as
+ * unattributed rather than silently dropping or guessing at a human.
+ */
+export function attributeParticipants(participants: string[], humanNames: string[]): string[] {
+  const humans = [...new Set(humanNames.filter(Boolean))].slice(0, MAX_ATTRIBUTED_HUMANS);
+  return participants.map((p) => {
+    if (!isAiAgentName(p)) return p;
+    return humans.length ? `${p} (${humans.join(", ")})` : `${p} (unattributed AI agent)`;
+  });
+}

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -1,9 +1,11 @@
 import "server-only";
 import { createHash } from "node:crypto";
 import Anthropic from "@anthropic-ai/sdk";
+import type { DbClient } from "@/lib/db/types";
 import { recentFacts, resolveEpisodeItems, type AtomicFact } from "./learning";
 import { GraphitiClient } from "./graphiti-client";
 import { episodeGroupId, type AccessTier } from "./group";
+import { attributeParticipants } from "./arc-attribution";
 
 /**
  * Layer 3 — narrative arcs. Gathers the recent graph substrate (facts, last 7d, tier-scoped),
@@ -255,11 +257,57 @@ function buildPrompt(facts: AtomicFact[], corrections: string[]): string {
   return lines.join("\n");
 }
 
+/**
+ * Distinct human (non-connector) display names behind a set of brain item ids — the traceable
+ * humans behind an arc's evidence, used to tag any AI-agent participant name (`arc-attribution.ts`)
+ * instead of letting the tool stand in for a person. Best-effort: [] on any failure or when nothing
+ * resolves (e.g. a connector-only item, or Postgres unreachable) — an unattributed AI agent is still
+ * more honest than a thrown error.
+ */
+export async function resolveHumanActors(db: DbClient, teamId: string, itemIds: string[]): Promise<string[]> {
+  const ids = [...new Set(itemIds.filter(Boolean))];
+  if (ids.length === 0) return [];
+  try {
+    const { data } = await db
+      .from("items")
+      .select("members(display_name, is_connector)")
+      .eq("team_id", teamId)
+      .in("id", ids);
+    const rows = (data ?? []) as { members: { display_name: string | null; is_connector: boolean } | null }[];
+    const names = rows
+      .map((r) => r.members)
+      .filter((m): m is { display_name: string; is_connector: boolean } => !!m && !m.is_connector && !!m.display_name)
+      .map((m) => m.display_name);
+    return [...new Set(names)];
+  } catch {
+    return [];
+  }
+}
+
+/** Rewrite each arc's `participants` to tag recognized AI-agent names with the human(s) behind that
+ *  arc's own evidence items (never cross-arc — an arc's attribution must trace to ITS OWN work). */
+async function withHumanAttribution(db: DbClient, teamId: string, arcs: NarrativeArc[]): Promise<NarrativeArc[]> {
+  return Promise.all(
+    arcs.map(async (arc) => {
+      const itemIds = arc.evidence.map((e) => e.itemId).filter((id): id is string => !!id);
+      const humans = await resolveHumanActors(db, teamId, itemIds);
+      return { ...arc, participants: attributeParticipants(arc.participants, humans) };
+    })
+  );
+}
+
 // In-memory cache (single-instance app). Keyed by the tier-visible group set.
 const cache = new Map<string, { arcs: NarrativeArc[]; at: number }>();
 
 /** Synthesize (or return cached) arcs for a team+tier. Empty when the graph/LLM is unavailable. */
-export async function getArcs(teamSlug: string, tier: AccessTier, groups: string[], keys: ProviderKeys): Promise<NarrativeArc[]> {
+export async function getArcs(
+  db: DbClient,
+  teamId: string,
+  teamSlug: string,
+  tier: AccessTier,
+  groups: string[],
+  keys: ProviderKeys
+): Promise<NarrativeArc[]> {
   if (groups.length === 0) return [];
   const key = groups.slice().sort().join(",");
   const hit = cache.get(key);
@@ -272,7 +320,7 @@ export async function getArcs(teamSlug: string, tier: AccessTier, groups: string
     callLLMRaw(buildPrompt(facts, []), keys),
     resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids)),
   ]);
-  const arcs = parseArcsJson(raw, { facts, epToItem });
+  const arcs = await withHumanAttribution(db, teamId, parseArcsJson(raw, { facts, epToItem }));
   cache.set(key, { arcs, at: Date.now() });
   return arcs;
 }
@@ -283,6 +331,8 @@ export async function getArcs(teamSlug: string, tier: AccessTier, groups: string
  * informs future synthesis. Writeback is best-effort — a Graphiti hiccup doesn't fail the recompute.
  */
 export async function recomputeArcs(
+  db: DbClient,
+  teamId: string,
   teamSlug: string,
   tier: AccessTier,
   groups: string[],
@@ -296,7 +346,7 @@ export async function recomputeArcs(
     callLLMRaw(buildPrompt(facts, corrections.map((c) => c.corrected_text)), keys),
     resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids)),
   ]);
-  const arcs = parseArcsJson(raw, { facts, epToItem });
+  const arcs = await withHumanAttribution(db, teamId, parseArcsJson(raw, { facts, epToItem }));
   cache.set(groups.slice().sort().join(","), { arcs, at: Date.now() });
 
   // Persist corrections as first-class episodes (team-tier group; corrections are internal).

--- a/test/arc-attribution.test.ts
+++ b/test/arc-attribution.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { attributeParticipants, isAiAgentName } from "@/lib/graph/arc-attribution";
+
+/**
+ * Spec: an AI agent/tool name in an arc's `participants` must never stand in for a human — it gets
+ * tagged with the human(s) actually behind the work, or explicitly marked unattributed. Derived from
+ * the product requirement: "any AI agent should be traceable to a human."
+ */
+
+describe("isAiAgentName", () => {
+  it("recognizes known AI agent/tool/product names, case-insensitively and trimmed", () => {
+    expect(isAiAgentName("Claude Code")).toBe(true);
+    expect(isAiAgentName("  claude code  ")).toBe(true);
+    expect(isAiAgentName("AIOS Team Brain")).toBe(true);
+    expect(isAiAgentName("Claude Agent SDK")).toBe(true);
+    expect(isAiAgentName("GitHub Copilot")).toBe(true);
+    expect(isAiAgentName("ChatGPT")).toBe(true);
+  });
+
+  it("does not misfire on a human's real name via substring matching", () => {
+    // "Claude" alone IS in the known-agent list (the common self-reference), but a name that merely
+    // CONTAINS an agent name must not match — exact-match only, never substring.
+    expect(isAiAgentName("Claudia Rivera")).toBe(false);
+    expect(isAiAgentName("Cursor Jones")).toBe(false);
+    expect(isAiAgentName("Sarah Chen")).toBe(false);
+  });
+});
+
+describe("attributeParticipants", () => {
+  it("tags a recognized AI agent with the resolved human(s)", () => {
+    expect(attributeParticipants(["Claude Code"], ["Chetan Nandakumar"])).toEqual([
+      "Claude Code (Chetan Nandakumar)",
+    ]);
+  });
+
+  it("leaves ordinary human participants untouched", () => {
+    expect(attributeParticipants(["Chetan Nandakumar", "John Smith"], [])).toEqual([
+      "Chetan Nandakumar",
+      "John Smith",
+    ]);
+  });
+
+  it("marks an AI agent unattributed when no human resolves, rather than dropping or guessing", () => {
+    expect(attributeParticipants(["AIOS Team Brain"], [])).toEqual(["AIOS Team Brain (unattributed AI agent)"]);
+  });
+
+  it("joins up to 2 distinct humans and caps beyond that", () => {
+    expect(attributeParticipants(["Claude Code"], ["Alice", "Bob", "Carol"])).toEqual([
+      "Claude Code (Alice, Bob)",
+    ]);
+  });
+
+  it("dedupes repeated human names", () => {
+    expect(attributeParticipants(["Claude Code"], ["Alice", "Alice"])).toEqual(["Claude Code (Alice)"]);
+  });
+
+  it("handles a mix of agent and human participants in one arc", () => {
+    expect(attributeParticipants(["Claude Code", "Chetan Nandakumar"], ["Chetan Nandakumar"])).toEqual([
+      "Claude Code (Chetan Nandakumar)",
+      "Chetan Nandakumar",
+    ]);
+  });
+});

--- a/test/datamechanics/arc-attribution.datamechanics.test.ts
+++ b/test/datamechanics/arc-attribution.datamechanics.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db, seedTeam, ingest, sha } from "./helpers";
+import { ingestItem } from "@/lib/ingest";
+import { resolveHumanActors } from "@/lib/graph/arcs";
+
+// Spec (narrative-arc human attribution, real Postgres): the join that turns a brain item's
+// `member_id` into a traceable human name for the arc-attribution layer — must resolve real humans,
+// exclude connector service-accounts (never a real person), and stay team-scoped.
+
+async function connectorMember(teamId: string, displayName: string): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: teamId,
+      email: `${randomUUID()}@connector.local`,
+      display_name: displayName,
+      actor_handle: `connector-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+      is_connector: true,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seed connector member: ${error?.message}`);
+  return (data as { id: string }).id;
+}
+
+describe("resolveHumanActors (data-mechanics)", () => {
+  it("resolves the human display name behind an item's member_id", async () => {
+    const seed = await seedTeam();
+    const res = await ingest(seed, { path: "slack/eng/1.md", body: "shipped the importer", access: "team" });
+
+    const humans = await resolveHumanActors(db(), seed.teamId, [res.id]);
+    expect(humans).toEqual(["Tester"]);
+  });
+
+  it("excludes a connector service-account — a connector is never a traceable human", async () => {
+    const seed = await seedTeam();
+    const connectorId = await connectorMember(seed.teamId, "Slack Sync");
+    const body = "connector-authored content";
+    const item = await ingestItem(
+      db(),
+      { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: randomUUID() },
+      {
+        project: "acme",
+        kind: "deliverable",
+        actor: "slack-sync",
+        frontmatter: {},
+        body,
+        content_sha256: sha(body),
+        path: "slack/eng/2.md",
+        access: "team",
+      },
+      "team",
+      { authorMemberId: connectorId }
+    );
+
+    const humans = await resolveHumanActors(db(), seed.teamId, [item.id]);
+    expect(humans).toEqual([]);
+  });
+
+  it("is team-scoped — an item id from another team never resolves", async () => {
+    const seedA = await seedTeam();
+    const seedB = await seedTeam();
+    const res = await ingest(seedA, { path: "slack/eng/3.md", body: "team A work", access: "team" });
+
+    expect(await resolveHumanActors(db(), seedB.teamId, [res.id])).toEqual([]);
+  });
+
+  it("dedupes across multiple items attributed to the same human", async () => {
+    const seed = await seedTeam();
+    const a = await ingest(seed, { path: "slack/eng/4.md", body: "part one", access: "team" });
+    const b = await ingest(seed, { path: "slack/eng/5.md", body: "part two", access: "team" });
+
+    expect(await resolveHumanActors(db(), seed.teamId, [a.id, b.id])).toEqual(["Tester"]);
+  });
+
+  it("returns [] for an empty item id list", async () => {
+    const seed = await seedTeam();
+    expect(await resolveHumanActors(db(), seed.teamId, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Narrative arc `participants` are LLM-synthesized from episode prose, so a recognized AI-agent/tool name (Claude Code, AIOS Team Brain, Claude Agent SDK, ...) could stand in an arc as if it were the person who did the work, with no way to trace it to a human.
- `getArcs`/`recomputeArcs` (`lib/graph/arcs.ts`) now resolve, per arc, the distinct human (non-connector) display names behind that arc's own evidence items (`resolveHumanActors`, joining `items.member_id` → `members`, team-scoped) and rewrite `participants` (`lib/graph/arc-attribution.ts`) so an agent name is tagged `"Claude Code (Chetan Nandakumar)"`, or `"Claude Code (unattributed AI agent)"` when no human resolves.
- Docs updated per the architecture-map build loop (`docs/ARCHITECTURE.md`, `docs/design/brain-learning-panel.md` — the design doc had flagged this reconciliation as an unbuilt step).

## Test plan
- [x] Unit: `test/arc-attribution.test.ts` (pure attribution logic — agent recognition, human tagging, dedup, cap-at-2, unattributed fallback)
- [x] Real-Postgres data-mechanics: `test/datamechanics/arc-attribution.datamechanics.test.ts` (resolves real human, excludes connector service-accounts, team-scoped, dedupes across items, empty list)
- [x] Full suites green: 423 unit, 301 data-mechanics, tsc clean, eslint clean, docs-drift in sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arc participant names now better reflect the human contributors behind AI-generated activity.
  * When a human can’t be determined, participants are now clearly labeled as an unattributed AI agent.

* **Bug Fixes**
  * Improved consistency in arc display by resolving participant names from underlying evidence instead of relying on AI/tool names.
  * Preserved existing arc results and caching behavior while refining attribution output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->