### PR TITLE
feat(learning): ground narrative-arc synthesis in human attribution

### DIFF
--- a/docs/design/brain-learning-panel.md
+++ b/docs/design/brain-learning-panel.md
@@ -125,25 +125,44 @@ any search affordance. No new plumbing — both already read from the same `item
 3. **Layer 2** (events) — episodes + participants reconciled to `members`.
 4. **Layer 3** (arcs) — synthesis + cache; then inline edit + recompute + correction writeback.
 
-## Human attribution for AI-agent participants (added 2026-07-08)
+## Human attribution for AI-agent participants (added 2026-07-08, extended 2026-07-08)
 
-Layer 3's `participants` are LLM-synthesized from episode prose, so a recognized AI-agent/tool name
-(e.g. "Claude Code", "AIOS Team Brain", "Claude Agent SDK" — mentioned in a Slack message or PR body,
-not a real actor) could stand in a narrative arc as if it were the person who did the work, with no
-way to trace it to a human. Every ingested item already carries a real attribution
-(`items.member_id` → `members`, excluding connector service-accounts — see `lib/ingest/run.ts`'s
-`resolveConnectorAuth`/`is_connector`), so `getArcs`/`recomputeArcs` (`lib/graph/arcs.ts`) now:
+A recognized AI-agent/tool name (e.g. "Claude Code", "AIOS Team Brain", "Claude Agent SDK" —
+mentioned in a Slack message or PR body, not a real actor) could stand in a narrative arc as if it
+were the person who did the work, with no way to trace it to a human. Every ingested item already
+carries a real attribution (`items.member_id` → `members`, excluding connector service-accounts —
+see `lib/ingest/run.ts`'s `resolveConnectorAuth`/`is_connector`), so `getArcs`/`recomputeArcs`
+(`lib/graph/arcs.ts`) resolve it in **two places**, not one:
 
-1. Resolve, per arc, the distinct human (non-connector) display names behind that arc's OWN evidence
-   items (`resolveHumanActors`, joining `items` → `members` in Postgres, team-scoped).
-2. Rewrite `participants` (`attributeParticipants` in `lib/graph/arc-attribution.ts`, pure + unit
-   tested) so a recognized AI-agent name is tagged `"Claude Code (Chetan Nandakumar)"`, or
-   `"Claude Code (unattributed AI agent)"` when no human resolves — never silently dropped or guessed.
+1. **The synthesis PROMPT (input)** — before calling the LLM, every numbered fact `[F12] …` fed to
+   the arc-synthesis prompt is attributed: if a fact's `subject` is a recognized AI-agent name, its
+   text is prefixed `"(Chetan Nandakumar, via Claude Code) Claude Code refactored the auth module"`
+   (`attributedFactTexts` in `lib/graph/arc-attribution.ts`, pure). This grounds the LLM's summary
+   text in a human from the start, instead of only patching the arc's `participants` array after the
+   fact — a summary that used to read "Claude Code is refactoring auth" now has the human in its own
+   input to draw from.
+2. **The arc OUTPUT (`participants`)** — `attributeParticipants` still rewrites a recognized AI-agent
+   participant name to `"Claude Code (Chetan Nandakumar)"`, or `"Claude Code (unattributed AI agent)"`
+   when no human resolves, as a backstop in case the LLM still echoes a bare agent name into
+   `participants` despite the grounded prompt.
 
-This only covers Layer 3 (narrative arcs). Layer 2's `participants` (`recentEvents` in
-`lib/graph/learning.ts`) are still raw `MENTIONS` entity names from Graphiti's own extractor,
-unattributed — the same gap could recur there if a future change surfaces Layer 2 participants
-more prominently in the UI.
+Both steps resolve humans from the SAME batched Postgres query, `resolveHumanActorsByItem` — one
+`items → members` round trip for every item id touched by a `getArcs`/`recomputeArcs` call (not one
+query per fact and another per arc), returning an `item id → human` map that both `attributedFactTexts`
+(prompt) and the `participants` rewrite (output) read from in-memory. `resolveHumanActors` (a thin
+wrapper returning the deduped name list) is kept for callers that only need that shape.
+
+**Latency trade-off:** the fact-resolution step must complete BEFORE the LLM call now (the prompt
+depends on it), so `resolveEpisodeItems` + `resolveHumanActorsByItem` can no longer run in
+`Promise.all` alongside `callLLMRaw` the way they used to. This adds one sequential Postgres round
+trip to every `getArcs`/`recomputeArcs` call — accepted as the cost of a synthesis input that's
+grounded in a human instead of raw tool-name prose.
+
+**Still not covered:** Layer 2's `participants` (`recentEvents` in `lib/graph/learning.ts`) are still
+raw `MENTIONS` entity names from Graphiti's own extractor, unattributed — the same gap could recur
+there if a future change surfaces Layer 2 participants more prominently in the UI. Layer 1's
+`subject`/`object` fields have the same characteristic (raw extracted entity names) but are not
+currently displayed as if they were actors.
 
 ## Risks & mitigations
 - **Schema coupling** — we depend on Graphiti's internal Neo4j labels/props, which can change across

--- a/lib/graph/arc-attribution.ts
+++ b/lib/graph/arc-attribution.ts
@@ -43,6 +43,13 @@ export function isAiAgentName(name: string): boolean {
 /** Cap how many humans get named in one attribution tag — readability, not a data limit. */
 const MAX_ATTRIBUTED_HUMANS = 2;
 
+/** Format the "(human, via agent)" / "(unattributed AI agent: agent)" tag shared by fact- and
+ *  participant-level attribution. `humanNames` should already exclude connector service-accounts. */
+function attributionTag(agentName: string, humanNames: string[]): string {
+  const humans = [...new Set(humanNames.filter(Boolean))].slice(0, MAX_ATTRIBUTED_HUMANS);
+  return humans.length ? `(${humans.join(", ")}, via ${agentName})` : `(unattributed AI agent: ${agentName})`;
+}
+
 /**
  * Rewrite an arc's `participants` so any recognized AI-agent name is tagged with the human(s)
  * responsible for the underlying work. Non-agent names pass through unchanged. `humanNames` should
@@ -54,5 +61,51 @@ export function attributeParticipants(participants: string[], humanNames: string
   return participants.map((p) => {
     if (!isAiAgentName(p)) return p;
     return humans.length ? `${p} (${humans.join(", ")})` : `${p} (unattributed AI agent)`;
+  });
+}
+
+/** The minimal shape of a graph fact `attributeFactText`/`attributedFactTexts` need — structurally
+ *  compatible with `AtomicFact` (lib/graph/learning.ts) without importing it, so this module stays a
+ *  plain, dependency-free pure module. */
+export interface FactRef {
+  fact: string;
+  subject: string;
+  episodeUuids: string[];
+}
+
+/**
+ * Prefix a single fact's text with its human attribution, but ONLY when the fact's `subject` is a
+ * recognized AI-agent name — an ordinary human subject needs no prefix, the fact text already names
+ * them. This grounds the arc-synthesis LLM's INPUT in a real human (so a summary like "Claude Code is
+ * refactoring auth" becomes "Chetan Nandakumar (via Claude Code) is refactoring auth"), rather than
+ * only patching the arc's output `participants` after the fact (`attributeParticipants`, above).
+ */
+export function attributeFactText(fact: string, subject: string, humanNames: string[]): string {
+  if (!isAiAgentName(subject)) return fact;
+  return `${attributionTag(subject, humanNames)} ${fact}`;
+}
+
+/**
+ * Batch version of `attributeFactText` for the numbered facts fed to the synthesis prompt. For each
+ * fact, resolves its source item(s) via `episodeUuids` → `epToItem`, looks up each item's human via
+ * `humanByItem`, and attributes the fact text if its subject is a recognized AI agent. Pure — the two
+ * maps are pre-resolved by the caller (arcs.ts, which owns the DB/Neo4j round trips).
+ */
+export function attributedFactTexts(
+  facts: FactRef[],
+  epToItem: Map<string, { itemId?: string }>,
+  humanByItem: Map<string, string>
+): string[] {
+  return facts.map((f) => {
+    const humans = [
+      ...new Set(
+        f.episodeUuids
+          .map((u) => epToItem.get(u)?.itemId)
+          .filter((id): id is string => !!id)
+          .map((id) => humanByItem.get(id))
+          .filter((h): h is string => !!h)
+      ),
+    ];
+    return attributeFactText(f.fact, f.subject, humans);
   });
 }

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -5,7 +5,7 @@ import type { DbClient } from "@/lib/db/types";
 import { recentFacts, resolveEpisodeItems, type AtomicFact } from "./learning";
 import { GraphitiClient } from "./graphiti-client";
 import { episodeGroupId, type AccessTier } from "./group";
-import { attributeParticipants } from "./arc-attribution";
+import { attributeParticipants, attributedFactTexts } from "./arc-attribution";
 
 /**
  * Layer 3 — narrative arcs. Gathers the recent graph substrate (facts, last 7d, tier-scoped),
@@ -242,14 +242,15 @@ async function callAnthropic(userContent: string, apiKey?: string | null): Promi
 }
 
 /**
- * Build the user prompt from the recent facts substrate (+ any human corrections). Facts are NUMBERED
- * `[F1] … [F2] …` so the model can cite them in `supporting_facts` — we map those numbers back to the
- * real facts (and their source items) to build verifiable evidence.
+ * Build the user prompt from the recent facts' (already-attributed, see `attributedFactTexts`) text
+ * + any human corrections. Facts are NUMBERED `[F1] … [F2] …` so the model can cite them in
+ * `supporting_facts` — we map those numbers back to the real facts (and their source items) to build
+ * verifiable evidence.
  */
-function buildPrompt(facts: AtomicFact[], corrections: string[]): string {
+function buildPrompt(factTexts: string[], corrections: string[]): string {
   const lines = [
     "Recent facts from the team knowledge graph (most recent first), each numbered for citation:",
-    ...facts.map((f, i) => `[F${i + 1}] ${f.fact}`),
+    ...factTexts.map((t, i) => `[F${i + 1}] ${t}`),
   ];
   if (corrections.length) {
     lines.push("", "Human corrections to incorporate:", ...corrections.map((c) => `- ${c}`));
@@ -258,42 +259,69 @@ function buildPrompt(facts: AtomicFact[], corrections: string[]): string {
 }
 
 /**
- * Distinct human (non-connector) display names behind a set of brain item ids — the traceable
- * humans behind an arc's evidence, used to tag any AI-agent participant name (`arc-attribution.ts`)
- * instead of letting the tool stand in for a person. Best-effort: [] on any failure or when nothing
- * resolves (e.g. a connector-only item, or Postgres unreachable) — an unattributed AI agent is still
- * more honest than a thrown error.
+ * Item id → resolved human (non-connector) display name, for a batch of brain item ids in one query
+ * — the primitive both the synthesis PROMPT (`attributedFactTexts`, grounding the LLM's input) and
+ * the arc OUTPUT (`attributeParticipants`, tagging `participants`) build on, so a whole `getArcs` call
+ * costs one Postgres round trip regardless of how many facts/arcs reference those items. Best-effort:
+ * an empty map on failure or when an item has no resolvable (non-connector) human — an unattributed
+ * AI agent is still more honest than a thrown error.
  */
-export async function resolveHumanActors(db: DbClient, teamId: string, itemIds: string[]): Promise<string[]> {
+async function resolveHumanActorsByItem(
+  db: DbClient,
+  teamId: string,
+  itemIds: string[]
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
   const ids = [...new Set(itemIds.filter(Boolean))];
-  if (ids.length === 0) return [];
+  if (ids.length === 0) return out;
   try {
     const { data } = await db
       .from("items")
-      .select("members(display_name, is_connector)")
+      .select("id, members(display_name, is_connector)")
       .eq("team_id", teamId)
       .in("id", ids);
-    const rows = (data ?? []) as { members: { display_name: string | null; is_connector: boolean } | null }[];
-    const names = rows
-      .map((r) => r.members)
-      .filter((m): m is { display_name: string; is_connector: boolean } => !!m && !m.is_connector && !!m.display_name)
-      .map((m) => m.display_name);
-    return [...new Set(names)];
+    const rows = (data ?? []) as {
+      id: string;
+      members: { display_name: string | null; is_connector: boolean } | null;
+    }[];
+    for (const r of rows) {
+      const m = r.members;
+      if (m && !m.is_connector && m.display_name) out.set(r.id, m.display_name);
+    }
   } catch {
-    return [];
+    // best-effort — empty map on failure
   }
+  return out;
+}
+
+/** Distinct human (non-connector) display names behind a set of brain item ids. Thin wrapper over
+ *  `resolveHumanActorsByItem` for callers that only need the deduped name list, not the per-item map. */
+export async function resolveHumanActors(db: DbClient, teamId: string, itemIds: string[]): Promise<string[]> {
+  const byItem = await resolveHumanActorsByItem(db, teamId, itemIds);
+  return [...new Set(byItem.values())];
+}
+
+/** Distinct humans behind a set of item ids, looked up in an already-resolved `humanByItem` map
+ *  (no DB access) — shared by the per-arc `participants` rewrite below. */
+function humansForItems(itemIds: (string | undefined)[], humanByItem: Map<string, string>): string[] {
+  return [
+    ...new Set(
+      itemIds.filter((id): id is string => !!id).map((id) => humanByItem.get(id)).filter((h): h is string => !!h)
+    ),
+  ];
 }
 
 /** Rewrite each arc's `participants` to tag recognized AI-agent names with the human(s) behind that
- *  arc's own evidence items (never cross-arc — an arc's attribution must trace to ITS OWN work). */
-async function withHumanAttribution(db: DbClient, teamId: string, arcs: NarrativeArc[]): Promise<NarrativeArc[]> {
-  return Promise.all(
-    arcs.map(async (arc) => {
-      const itemIds = arc.evidence.map((e) => e.itemId).filter((id): id is string => !!id);
-      const humans = await resolveHumanActors(db, teamId, itemIds);
-      return { ...arc, participants: attributeParticipants(arc.participants, humans) };
-    })
-  );
+ *  arc's own evidence items (never cross-arc — an arc's attribution must trace to ITS OWN work).
+ *  Pure over an already-resolved `humanByItem` map — no DB access here. */
+function attributeArcs(arcs: NarrativeArc[], humanByItem: Map<string, string>): NarrativeArc[] {
+  return arcs.map((arc) => ({
+    ...arc,
+    participants: attributeParticipants(
+      arc.participants,
+      humansForItems(arc.evidence.map((e) => e.itemId), humanByItem)
+    ),
+  }));
 }
 
 // In-memory cache (single-instance app). Keyed by the tier-visible group set.
@@ -316,11 +344,15 @@ export async function getArcs(
   const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
   const facts = await recentFacts(groups, since, MAX_FACTS);
   if (facts.length === 0) return [];
-  const [raw, epToItem] = await Promise.all([
-    callLLMRaw(buildPrompt(facts, []), keys),
-    resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids)),
-  ]);
-  const arcs = await withHumanAttribution(db, teamId, parseArcsJson(raw, { facts, epToItem }));
+  // Sequential, not Promise.all-able: the PROMPT needs each fact's human attribution baked in
+  // (attributedFactTexts), so item/human resolution must finish before the LLM call starts — a real
+  // latency cost, traded for a synthesis input that's grounded in a human from the start rather than
+  // patched after the fact.
+  const epToItem = await resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids));
+  const allItemIds = [...new Set([...epToItem.values()].map((v) => v.itemId).filter((id): id is string => !!id))];
+  const humanByItem = await resolveHumanActorsByItem(db, teamId, allItemIds);
+  const raw = await callLLMRaw(buildPrompt(attributedFactTexts(facts, epToItem, humanByItem), []), keys);
+  const arcs = attributeArcs(parseArcsJson(raw, { facts, epToItem }), humanByItem);
   cache.set(key, { arcs, at: Date.now() });
   return arcs;
 }
@@ -342,11 +374,14 @@ export async function recomputeArcs(
   if (groups.length === 0) return [];
   const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
   const facts = await recentFacts(groups, since, MAX_FACTS);
-  const [raw, epToItem] = await Promise.all([
-    callLLMRaw(buildPrompt(facts, corrections.map((c) => c.corrected_text)), keys),
-    resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids)),
-  ]);
-  const arcs = await withHumanAttribution(db, teamId, parseArcsJson(raw, { facts, epToItem }));
+  const epToItem = await resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids));
+  const allItemIds = [...new Set([...epToItem.values()].map((v) => v.itemId).filter((id): id is string => !!id))];
+  const humanByItem = await resolveHumanActorsByItem(db, teamId, allItemIds);
+  const raw = await callLLMRaw(
+    buildPrompt(attributedFactTexts(facts, epToItem, humanByItem), corrections.map((c) => c.corrected_text)),
+    keys
+  );
+  const arcs = attributeArcs(parseArcsJson(raw, { facts, epToItem }), humanByItem);
   cache.set(groups.slice().sort().join(","), { arcs, at: Date.now() });
 
   // Persist corrections as first-class episodes (team-tier group; corrections are internal).

--- a/test/arc-attribution.test.ts
+++ b/test/arc-attribution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { attributeParticipants, isAiAgentName } from "@/lib/graph/arc-attribution";
+import { attributeParticipants, attributedFactTexts, attributeFactText, isAiAgentName } from "@/lib/graph/arc-attribution";
 
 /**
  * Spec: an AI agent/tool name in an arc's `participants` must never stand in for a human — it gets
@@ -58,6 +58,59 @@ describe("attributeParticipants", () => {
     expect(attributeParticipants(["Claude Code", "Chetan Nandakumar"], ["Chetan Nandakumar"])).toEqual([
       "Claude Code (Chetan Nandakumar)",
       "Chetan Nandakumar",
+    ]);
+  });
+});
+
+describe("attributeFactText", () => {
+  it("prefixes a fact whose subject is a recognized AI agent with its human, via the agent", () => {
+    expect(attributeFactText("Claude Code refactored the auth module", "Claude Code", ["Chetan Nandakumar"])).toBe(
+      "(Chetan Nandakumar, via Claude Code) Claude Code refactored the auth module"
+    );
+  });
+
+  it("marks the agent unattributed when no human resolves", () => {
+    expect(attributeFactText("AIOS Team Brain shipped the importer", "AIOS Team Brain", [])).toBe(
+      "(unattributed AI agent: AIOS Team Brain) AIOS Team Brain shipped the importer"
+    );
+  });
+
+  it("leaves a fact whose subject is an ordinary human untouched", () => {
+    expect(attributeFactText("Chetan shipped the Linear importer", "Chetan", ["Chetan Nandakumar"])).toBe(
+      "Chetan shipped the Linear importer"
+    );
+  });
+});
+
+describe("attributedFactTexts", () => {
+  const epToItem = new Map([
+    ["ep-1", { itemId: "item-aaa" }],
+    ["ep-2", { itemId: "item-bbb" }],
+  ]);
+  const humanByItem = new Map([["item-aaa", "Chetan Nandakumar"]]);
+
+  it("resolves each fact's human via its episodes and only tags AI-agent subjects", () => {
+    const facts = [
+      { fact: "Claude Code refactored the auth module", subject: "Claude Code", episodeUuids: ["ep-1"] },
+      { fact: "John reviewed the RLS change", subject: "John", episodeUuids: ["ep-1"] },
+    ];
+    expect(attributedFactTexts(facts, epToItem, humanByItem)).toEqual([
+      "(Chetan Nandakumar, via Claude Code) Claude Code refactored the auth module",
+      "John reviewed the RLS change",
+    ]);
+  });
+
+  it("tags an AI-agent subject unattributed when its item has no resolvable human", () => {
+    const facts = [{ fact: "Codex opened a PR", subject: "Codex", episodeUuids: ["ep-2"] }];
+    expect(attributedFactTexts(facts, epToItem, humanByItem)).toEqual([
+      "(unattributed AI agent: Codex) Codex opened a PR",
+    ]);
+  });
+
+  it("handles a fact with no resolvable episode/item at all", () => {
+    const facts = [{ fact: "Claude Code did something", subject: "Claude Code", episodeUuids: [] }];
+    expect(attributedFactTexts(facts, epToItem, humanByItem)).toEqual([
+      "(unattributed AI agent: Claude Code) Claude Code did something",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #179. That PR only tagged an arc's OUTPUT `participants` after synthesis. This grounds the LLM's INPUT too: every numbered fact fed to the arc-synthesis prompt is now attributed when its subject is a recognized AI agent — `[F12] Claude Code refactored the auth module` becomes `[F12] (Chetan Nandakumar, via Claude Code) Claude Code refactored the auth module` — so the synthesized summary text itself (not just the participants array) is grounded in the responsible human from the start.

- `attributedFactTexts`/`attributeFactText` (`lib/graph/arc-attribution.ts`, pure, unit tested) — prefixes a fact's text with `(human, via agent)` or `(unattributed AI agent: agent)` only when its `subject` is a recognized AI-agent name; ordinary human subjects pass through untouched.
- `resolveHumanActorsByItem` (`lib/graph/arcs.ts`) replaces the old per-arc `resolveHumanActors` DB call with ONE batched Postgres query per `getArcs`/`recomputeArcs` call, covering every item id touched by any fact or arc — shared by both the prompt-attribution step and the existing `participants` rewrite (`resolveHumanActors` kept as a thin wrapper for callers that only need the deduped name list).
- **Latency trade-off (documented in `docs/design/brain-learning-panel.md`):** fact/human resolution must now finish before the LLM call (the prompt depends on it), so it can no longer run in `Promise.all` alongside `callLLMRaw`. Accepted as the cost of a synthesis input grounded in a human instead of raw tool-name prose.

## Test plan
- [x] Unit: `test/arc-attribution.test.ts` extended — `attributeFactText`/`attributedFactTexts` (agent-subject prefixing, unattributed fallback, ordinary-human pass-through, no-episode fact)
- [x] Real-Postgres data-mechanics: existing `resolveHumanActors` coverage unchanged (same public behavior, refactored implementation)
- [x] Full suites green: 429 unit, 301 data-mechanics, tsc clean, eslint clean, docs-drift in sync