### PR TITLE
fix(context): keep 2-char acronyms/versions in FTS query (Gap #1)

### DIFF
--- a/docs/design/context-retrieval-limits.md
+++ b/docs/design/context-retrieval-limits.md
@@ -29,10 +29,10 @@ real test") the moment the gap is closed. So the count of `it.fails` in these fi
 
 ## What we FAIL at (each is a live `it.fails` gap)
 
-1. **Short but load-bearing tokens are dropped.** `toOrQuery` discards every token < 3 chars, so
-   `CI`, `QA`, `PR`, `AI`, `S3`, `v2`, `k8`, `DB` never reach search — a query *about* them searches
-   on the leftover filler. Invisible with one channel; a routine "why didn't it find the CI thread?"
-   in an eng-heavy workspace.
+1. ~~**Short but load-bearing tokens are dropped.**~~ **FIXED** — `toOrQuery` now keeps a 2-char token
+   when it's an upper-cased acronym (`CI`, `QA`, `PR`, `DB`) or carries a digit (`S3`, `v2`, `k8`),
+   while still dropping lowercase common words (`us`, `up`, `so`). Proven end-to-end: a query whose
+   only shared terms are `CI`/`S3` now retrieves its doc.
 2. **No relevance ranking + hard caps → truncated, unranked recall at scale.** FTS is a bare
    `@@ websearch_to_tsquery` filter with **no `ts_rank ORDER BY`**, capped at 20 (+8 recency). A
    broad-but-legitimate query ("summarize the payments migration") that legitimately matches 50 items

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -151,15 +151,35 @@ const FTS_STOP = new Set([
 ]);
 
 /**
+ * Is this raw token (original case preserved) worth searching on?
+ *   • never a stopword
+ *   • ≥3 chars → yes
+ *   • exactly 2 chars → only if it's a version/product token with a digit (v2, s3, k8) OR an
+ *     acronym the user upper-cased (CI, QA, PR, DB) — NOT a lowercase common word (us, up, so, no).
+ *   • 1 char → no (single letters are noise)
+ * The 2-char rule is the fix for eng-heavy channels where CI/QA/PR/S3 are the load-bearing terms;
+ * dropping them (the old `length >= 3` filter) meant a query ABOUT them searched on filler words.
+ */
+function isSignificantTerm(original: string): boolean {
+  const t = original.toLowerCase();
+  if (FTS_STOP.has(t)) return false;
+  if (t.length >= 3) return true;
+  if (t.length === 2) return /\d/.test(t) || original === original.toUpperCase();
+  return false;
+}
+
+/**
  * Build a recall-friendly FTS query: significant terms OR-joined. `websearch_to_tsquery` treats the
  * word "or" as the OR operator, so this matches docs containing ANY significant term (then the LLM
  * filters relevance) instead of requiring ALL of them. Falls back to the raw question when nothing
  * significant remains. (Ranked/semantic retrieval — pgvector — is the durable fix at larger scale.)
  */
 export function toOrQuery(question: string): string {
-  const terms = (question.toLowerCase().match(/[a-z0-9][a-z0-9'-]*/g) ?? []).filter(
-    (t) => t.length >= 3 && !FTS_STOP.has(t)
-  );
+  // Match on the ORIGINAL (case preserved) so `isSignificantTerm` can tell an upper-cased acronym
+  // (CI) from a lowercase common word (us); lowercase only after the keep/drop decision.
+  const terms = (question.match(/[A-Za-z0-9][A-Za-z0-9'-]*/g) ?? [])
+    .filter(isSignificantTerm)
+    .map((t) => t.toLowerCase());
   const unique = [...new Set(terms)];
   return unique.length ? unique.join(" or ") : question;
 }
@@ -177,8 +197,8 @@ const MAX_EXPANSION_TERMS = 24;
 export function graphExpansionQuery(facts: GraphFact[]): string {
   const terms = new Set<string>();
   const add = (s: string | undefined | null) => {
-    for (const w of (s ?? "").toLowerCase().match(/[a-z0-9][a-z0-9'-]*/g) ?? []) {
-      if (w.length >= 3 && !FTS_STOP.has(w)) terms.add(w);
+    for (const w of (s ?? "").match(/[A-Za-z0-9][A-Za-z0-9'-]*/g) ?? []) {
+      if (isSignificantTerm(w)) terms.add(w.toLowerCase());
     }
   };
   for (const f of facts) {

--- a/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
+++ b/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
@@ -60,6 +60,17 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
     expect(await paths("SSRF image proxy vulnerability")).toContain("slack/security/ssrf.md");
   });
 
+  it("STRENGTH: a 2-char-acronym query now retrieves its doc end-to-end (Gap #1 fixed)", async () => {
+    // The only terms shared between question and doc are the acronyms CI + S3. Before the fix
+    // toOrQuery dropped every <3-char token, so the query searched on "happened" alone (absent from
+    // the doc) and never found it; the doc is buried under newer chatter so recency can't save it.
+    await post("slack/eng", "ci-outage", "The CI pipeline broke on the S3 upload step; reverted the change.");
+    for (let i = 0; i < 10; i++) {
+      await post("slack/random", `n${i}`, `Lunch and parking note ${i}; nothing technical.`);
+    }
+    expect(await paths("what happened with CI and S3?")).toContain("slack/eng/ci-outage.md");
+  });
+
   it("STRENGTH: tier isolation holds across every channel (external sees zero team content)", async () => {
     // The one invariant that MUST NOT degrade at scale: an external principal never sees team channels.
     for (const ch of ["slack/eng", "slack/payments", "slack/design", "slack/leadership", "slack/random"]) {

--- a/test/query-adversarial.test.ts
+++ b/test/query-adversarial.test.ts
@@ -12,31 +12,36 @@ import { toOrQuery } from "@/lib/query/retrieve";
  * tier isolation across channels) live in test/datamechanics/multichannel-adversarial.datamechanics.
  */
 
-describe("adversarial: short-token recall gap (worsens with eng-heavy channels)", () => {
-  // toOrQuery drops every token shorter than 3 chars. In an engineering Slack that means the most
-  // load-bearing search terms — CI, QA, PR, AI, UX, S3, k8, v2, DB — are silently discarded, so a
-  // query ABOUT them searches on the leftover filler words instead. This is invisible today (one
-  // low-volume channel) and becomes a routine "why didn't it find the CI outage thread?" at scale.
+describe("short-token recall (FIXED — was Gap #1; eng-heavy channels)", () => {
+  // toOrQuery used to drop every token < 3 chars, discarding the most load-bearing eng terms —
+  // CI, QA, PR, S3, v2, k8 — so a query ABOUT them searched on the leftover filler. Now a 2-char
+  // token is kept when it's an upper-cased acronym or carries a digit (version/product), while
+  // lowercase common words (us, up, so, no) are still dropped.
 
-  it("KNOWN GAP: a 2-char acronym is dropped from the FTS query", () => {
-    // "what is the status of CI" → only "status" survives; "ci" is gone.
-    // This documents (pins) the current lossy behavior so the fix below is legible.
-    expect(toOrQuery("what is the status of CI")).toBe("status");
+  it("keeps an upper-cased 2-char acronym alongside the other terms", () => {
+    expect(toOrQuery("what is the status of CI")).toBe("status or ci");
   });
 
-  it.fails("SHOULD keep short but meaningful acronyms (CI/QA/PR/AI/S3)", () => {
+  it("keeps short but meaningful acronyms (CI/PR/QA/S3)", () => {
     const terms = toOrQuery("did CI pass and is the PR ready for QA on S3?").split(" or ");
-    // desired: the acronyms are searchable terms, not discarded
     expect(terms).toContain("ci");
     expect(terms).toContain("pr");
     expect(terms).toContain("qa");
     expect(terms).toContain("s3");
   });
 
-  it.fails("SHOULD keep short version identifiers (v2, k8)", () => {
+  it("keeps short version identifiers (v2, k8)", () => {
     const terms = toOrQuery("is v2 deployed to k8?").split(" or ");
     expect(terms).toContain("v2");
     expect(terms).toContain("k8");
+  });
+
+  it("still drops lowercase 2-char common words (no acronym/version signal)", () => {
+    // "us"/"up"/"so" are noise, not acronyms — they must NOT become OR terms. (A real term keeps
+    // this off the raw-question fallback path.)
+    const terms = toOrQuery("so is the deployment up for us").split(" or ");
+    expect(terms).toContain("deployment");
+    for (const noise of ["us", "up", "so"]) expect(terms).not.toContain(noise);
   });
 });
 


### PR DESCRIPTION
First fix in the retrieval-gaps plan (from the adversarial suite in #180).

## Gap
`toOrQuery` dropped every token < 3 chars, so the load-bearing terms of an eng workspace — `CI`, `QA`, `PR`, `S3`, `v2`, `k8`, `DB` — never reached FTS. A query *about* them searched on the leftover filler and missed the doc.

## Fix
A 2-char token is kept when it's an **upper-cased acronym** (`CI`, `QA`, `PR`, `DB`) or **carries a digit** (`S3`, `v2`, `k8`); lowercase common words (`us`, `up`, `so`, `no`) are still dropped. The keep/drop decision is made on the original (case-preserved) token so an acronym is distinguishable from a common word. Applied to both `toOrQuery` and `graphExpansionQuery`.

## Proof
- The two short-token `it.fails` in `test/query-adversarial.test.ts` flip to green `it()`.
- New data-mechanics test: a query whose only shared terms are `CI` + `S3` now retrieves its doc through the **real** `retrieve()` (doc buried under newer chatter, so recency can't mask the win).
- `docs/design/context-retrieval-limits.md` updated — Gap #1 marked FIXED.

## Test plan
- [x] Unit tier green (431 + 1 expected-fail, down from +3)
- [x] Multichannel data-mechanics green (4 + 5 expected-fail)
- [x] `tsc`, `eslint`, docs-drift clean

Next in the plan: Gap #2 (`ts_rank` ordering — top-N becomes best-N) + Gap #3 (rank-based grounding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)