### PR TITLE
fix(context): rank keyword FTS by ts_rank so top-N is best-N (Gap #2)

### DIFF
--- a/docs/design/context-retrieval-limits.md
+++ b/docs/design/context-retrieval-limits.md
@@ -33,11 +33,12 @@ real test") the moment the gap is closed. So the count of `it.fails` in these fi
    when it's an upper-cased acronym (`CI`, `QA`, `PR`, `DB`) or carries a digit (`S3`, `v2`, `k8`),
    while still dropping lowercase common words (`us`, `up`, `so`). Proven end-to-end: a query whose
    only shared terms are `CI`/`S3` now retrieves its doc.
-2. **No relevance ranking + hard caps → truncated, unranked recall at scale.** FTS is a bare
-   `@@ websearch_to_tsquery` filter with **no `ts_rank ORDER BY`**, capped at 20 (+8 recency). A
-   broad-but-legitimate query ("summarize the payments migration") that legitimately matches 50 items
-   returns ~28, and there's **no guarantee they're the most relevant 28** (test: 22/50 dropped).
-   Single channel ≈ always under the cap; many channels routinely blow past it.
+2. **Hard caps → truncated recall at scale.** ~~No relevance ranking~~ **RANKING FIXED** — the FTS
+   query now orders by `ts_rank` (`lib/query/fts-search`), so the capped top-20 is the *most relevant*
+   20, not an arbitrary 20 (proven: a 5-term-match item beats 25 single-term items into the window
+   even when recency can't save it). **Still open:** the *recall ceiling* — a query legitimately
+   matching 50 items still returns only ~28 (test: 22/50 dropped). Ranking makes the kept set the
+   best set; closing the ceiling needs dense/pgvector retrieval + higher/query-scoped caps.
 3. **False grounding.** `grounded = ftsHits > 0`. An incidental stemmed term ("update" chatter across
    channels) flips `grounded` true for a topic the brain has **never ingested** (Helsinki datacenter
    migration) → the answer layer won't abstain → confabulation risk. More channels ⇒ more incidental

--- a/lib/query/fts-search.ts
+++ b/lib/query/fts-search.ts
@@ -1,0 +1,67 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+
+/**
+ * Ranked keyword (FTS) retrieval over `items.search`. The builder path emits a bare
+ * `search @@ websearch_to_tsquery(...)` filter with a plain `LIMIT` and NO ordering, so at scale the
+ * top-N is "any N matching rows" in physical order — a highly-relevant doc that matches five query
+ * terms has no priority over one that incidentally matches a single common word. This runs the same
+ * match but orders by `ts_rank` DESC, so the capped window is the *best* N, not an arbitrary N (Gap
+ * #2 from the multi-channel adversarial suite). Postgres-only, same raw-SQL precedent as dense-search.
+ *
+ * `rank` is returned so callers can reason about match strength. Tier is enforced in-DB on the live
+ * `items.access` (external callers never get team content) — the sole enforcement, no RLS backstop.
+ */
+
+export interface FtsHit {
+  id: string;
+  path: string;
+  kind: string;
+  body: string;
+  synced_at: string;
+  project: string;
+  rank: number;
+}
+
+export async function rankedFtsSearch(
+  teamId: string,
+  tier: "team" | "external",
+  orQuery: string,
+  limit = 20
+): Promise<FtsHit[]> {
+  if (!orQuery.trim()) return [];
+  const params: unknown[] = [orQuery, teamId];
+  let where = "i.team_id = $2 and i.search @@ websearch_to_tsquery('english', $1)";
+  if (tier === "external") where += " and i.access = 'external'";
+  params.push(limit);
+  const limitIdx = params.length;
+
+  const sql = `
+    select i.id, i.path, i.kind, i.body, i.synced_at, coalesce(p.slug, '') as project,
+           ts_rank(i.search, websearch_to_tsquery('english', $1)) as rank
+    from items i
+    left join projects p on p.id = i.project_id
+    where ${where}
+    order by rank desc, i.synced_at desc
+    limit $${limitIdx}`;
+
+  const res = await runSql<{
+    id: string;
+    path: string;
+    kind: string;
+    body: string | null;
+    synced_at: string | Date;
+    project: string;
+    rank: number | string;
+  }>(sql, params);
+
+  return res.rows.map((r) => ({
+    id: r.id,
+    path: r.path,
+    kind: r.kind,
+    body: r.body ?? "",
+    synced_at: r.synced_at instanceof Date ? r.synced_at.toISOString() : String(r.synced_at ?? ""),
+    project: r.project,
+    rank: typeof r.rank === "number" ? r.rank : Number(r.rank) || 0,
+  }));
+}

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -11,6 +11,7 @@ import {
 } from "./provider";
 import { externalProvider } from "./external-provider";
 import { denseSearch, fuseByRrf } from "./dense-search";
+import { rankedFtsSearch } from "./fts-search";
 
 // Types live in ./provider (the pluggable seam). Re-exported here so existing importers
 // (lib/query/claude, tests, …) keep importing them from "@/lib/query/retrieve" unchanged.
@@ -365,14 +366,10 @@ async function nativeRetrieve(
   const peopleDigestP = wantsActivity ? peopleActivityDigest(db, teamId) : Promise.resolve("");
 
   // All independent retrieval queries run in PARALLEL (was sequential → ~7 serial round-trips).
-  // 1. Recall-friendly FTS over items (OR of significant terms; see toOrQuery).
-  let ftsB = db
-    .from("items")
-    .select("id, path, kind, body, synced_at, projects(slug)")
-    .eq("team_id", teamId)
-    .textSearch("search", toOrQuery(question), { type: "websearch", config: "english" })
-    .limit(20);
-  if (tier === "external") ftsB = ftsB.eq("access", "external");
+  // 1. Recall-friendly, RANKED FTS over items (OR of significant terms; see toOrQuery). Ordered by
+  //    ts_rank so the capped top-20 is the most relevant 20, not an arbitrary 20 (Gap #2). Raw SQL
+  //    (fts-search) because the builder emits an unordered `@@` filter.
+  const ftsP = rankedFtsSearch(teamId, tier, toOrQuery(question), 20);
 
   // 2. Recency: most recent items (a fallback so fresh content always has a shot).
   let recentB = db
@@ -439,7 +436,7 @@ async function nativeRetrieve(
           .limit(40);
 
   const [
-    { data: ftsHits },
+    ftsHits,
     { data: recentHits },
     { data: decisions },
     { data: tasks },
@@ -448,7 +445,7 @@ async function nativeRetrieve(
     { data: actors },
     augmented,
   ] = await Promise.all([
-    ftsB,
+    ftsP,
     recentB,
     decisionsB,
     tasksB,
@@ -458,23 +455,30 @@ async function nativeRetrieve(
     fetchAugmentedSources(question, tier),
   ]);
 
-  // Merge, dedupe by id, cap sizes
+  // Merge, dedupe by id, cap sizes. Ranked FTS hits (already ordered by relevance) come first, then
+  // recency padding. Normalize the two row shapes (FTS carries `project` as a slug string; the
+  // recency builder embeds `projects(slug)`).
+  type MergeHit = { id: string; path: string; kind: string; body: string; synced_at: string; slug: string };
+  const iso = (v: string | Date): string => (v instanceof Date ? v.toISOString() : String(v ?? ""));
+  const rankedHits: MergeHit[] = ftsHits.map((h) => ({ id: h.id, path: h.path, kind: h.kind, body: h.body, synced_at: h.synced_at, slug: h.project }));
+  const recencyHits: MergeHit[] = ((recentHits ?? []) as { id: string; path: string; kind: string; body: string | null; synced_at: string | Date; projects: unknown }[]).map(
+    (h) => ({ id: h.id, path: h.path, kind: h.kind, body: h.body ?? "", synced_at: iso(h.synced_at), slug: (h.projects as { slug: string })?.slug ?? "" })
+  );
   const seen = new Set<string>();
   const sources: Source[] = [];
   let total = 0;
   let n = 1;
-  for (const hit of [...(ftsHits ?? []), ...(recentHits ?? [])]) {
+  for (const hit of [...rankedHits, ...recencyHits]) {
     if (seen.has(hit.id)) continue;
     seen.add(hit.id);
-    const slug = (hit.projects as unknown as { slug: string })?.slug ?? "";
-    if (projectSlug && slug !== projectSlug) continue;
+    if (projectSlug && hit.slug !== projectSlug) continue;
     const text = (hit.body || "").slice(0, MAX_SOURCE_CHARS);
     if (total + text.length > MAX_TOTAL_CHARS) break;
     total += text.length;
     sources.push({
       sid: `S${n++}`,
       item_id: hit.id,
-      project: slug,
+      project: hit.slug,
       path: hit.path,
       kind: hit.kind,
       synced_at: hit.synced_at,
@@ -508,7 +512,7 @@ async function nativeRetrieve(
   // Grounding signal (stay-quiet): did query-specific SEARCH match anything, or are the sources just
   // recency padding? FTS/semantic hits = real grounding; if both are empty the answer layer is told
   // retrieval found no strong match so it abstains instead of confabulating from recent items.
-  let grounded = (ftsHits?.length ?? 0) > 0;
+  let grounded = ftsHits.length > 0;
 
   // 2c. Semantic expansion via Graphiti (the graph search ran in parallel above). Use the facts'
   // entity/relationship terms to expand the FTS and surface items the literal keyword search missed.
@@ -516,24 +520,16 @@ async function nativeRetrieve(
   const graphFacts = await graphFactsP;
   const expansion = graphExpansionQuery(graphFacts);
   if (expansion) {
-    let semB = db
-      .from("items")
-      .select("id, path, kind, body, synced_at, projects(slug)")
-      .eq("team_id", teamId)
-      .textSearch("search", expansion, { type: "websearch", config: "english" })
-      .limit(10);
-    if (tier === "external") semB = semB.eq("access", "external");
-    const { data: semHits } = await semB;
-    if ((semHits?.length ?? 0) > 0) grounded = true;
-    for (const hit of (semHits ?? []) as { id: string; path: string; kind: string; body: string; synced_at: string; projects: unknown }[]) {
+    const semHits = await rankedFtsSearch(teamId, tier, expansion, 10);
+    if (semHits.length > 0) grounded = true;
+    for (const hit of semHits) {
       if (seen.has(hit.id)) continue;
       seen.add(hit.id);
-      const slug = (hit.projects as { slug: string })?.slug ?? "";
-      if (projectSlug && slug !== projectSlug) continue;
+      if (projectSlug && hit.project !== projectSlug) continue;
       const text = (hit.body || "").slice(0, MAX_SOURCE_CHARS);
       if (total + text.length > MAX_TOTAL_CHARS) break;
       total += text.length;
-      sources.push({ sid: `S${n++}`, item_id: hit.id, project: slug, path: hit.path, kind: hit.kind, synced_at: hit.synced_at, text });
+      sources.push({ sid: `S${n++}`, item_id: hit.id, project: hit.project, path: hit.path, kind: hit.kind, synced_at: hit.synced_at, text });
     }
   }
 
@@ -565,7 +561,7 @@ async function nativeRetrieve(
     }
     orderedSources = fuseByRrf(
       sources,
-      (ftsHits ?? []).map((h) => (h as { id: string }).id),
+      ftsHits.map((h) => h.id),
       denseHits.map((h) => h.item_id)
     );
   }

--- a/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
+++ b/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
@@ -71,6 +71,21 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
     expect(await paths("what happened with CI and S3?")).toContain("slack/eng/ci-outage.md");
   });
 
+  it("STRENGTH: ts_rank puts the most-specific item into the capped window (Gap #2 fixed)", async () => {
+    // 25 weak items across channels each match ONE query term ("migration"); one target matches five.
+    // The target is buried under 8 newer filler items so recency can't rescue it — its ONLY path in
+    // is ranked FTS. Before Gap #2, FTS was an unordered `@@` filter, so the target (26th of 26
+    // matches, capped at 20) could be dropped; now ts_rank orders it #1 so it's always retrieved.
+    for (let i = 0; i < 25; i++) {
+      await post(`slack/ch${i % 6}`, `weak-${i}`, `General migration reminder ${i}: nothing specific to report today.`);
+    }
+    await post("slack/payments", "target", "Payments migration: the Stripe webhook cutover and rollback plan were finalized.");
+    for (let i = 0; i < 8; i++) {
+      await post("slack/random", `newer-${i}`, `Fresh unrelated chatter ${i}: lunch and parking.`);
+    }
+    expect(await paths("payments migration Stripe webhook cutover rollback")).toContain("slack/payments/target.md");
+  });
+
   it("STRENGTH: tier isolation holds across every channel (external sees zero team content)", async () => {
     // The one invariant that MUST NOT degrade at scale: an external principal never sees team channels.
     for (const ch of ["slack/eng", "slack/payments", "slack/design", "slack/leadership", "slack/random"]) {


### PR DESCRIPTION
Second fix in the retrieval-gaps plan. **Highest-leverage** of the set — the multi-channel failure.

## Gap
The keyword FTS query was a bare `search @@ websearch_to_tsquery(...)` filter with a plain `LIMIT` and **no ordering**. At scale the capped top-20 was "any 20 matching rows" in physical order — a doc matching five query terms had no priority over one incidentally matching a single common word. Invisible at one channel; across many busy channels the answer grounds on an arbitrary slice of the evidence.

## Fix
`lib/query/fts-search` runs the same match **ordered by `ts_rank` DESC** (raw SQL — same Postgres-only precedent as `dense-search`) and returns the rank score. `retrieve()` uses it for both the primary and the graph-expansion FTS pass. The capped window is now the *most relevant* window.

Pure reordering → **can't reduce recall** (the `retrieval-eval` recall benchmark is unchanged) and **no abstain-regression risk** (no thresholds, no magic numbers).

## Scope (deliberately narrow)
- Fixes the **ranking** facet of Gap #2.
- The **recall-ceiling** facet (a query legitimately matching 50 items still returns ~28) is a separate, harder problem for dense/pgvector retrieval — its `it.fails` stays open.
- **Gap #3 (false grounding) is NOT bundled**: a naive rank/term-count threshold would wrongly reject *specific single-term* queries (SSRF, a ticket id) and regress real Q&A. It needs its own term-specificity design — next PR.

## Proof
- New data-mechanics test: a 5-term-match target beats 25 single-term items into the capped window **when buried under newer filler** (so only ranking, not recency, can retrieve it).
- `retrieval-eval` recall benchmark unchanged (no recall regression).
- `docs/design/context-retrieval-limits.md` — Gap #2 ranking marked FIXED, recall ceiling noted open.

## Test plan
- [x] Full unit tier green (437 + 1 expected-fail)
- [x] Full data-mechanics tier green (306 + 5 expected-fail)
- [x] `tsc`, `eslint`, docs-drift clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)