### PR TITLE
fix(context): IDF-based grounding so incidental common words don't ground (Gap #3)

### DIFF
--- a/docs/design/context-retrieval-limits.md
+++ b/docs/design/context-retrieval-limits.md
@@ -39,10 +39,13 @@ real test") the moment the gap is closed. So the count of `it.fails` in these fi
    even when recency can't save it). **Still open:** the *recall ceiling* — a query legitimately
    matching 50 items still returns only ~28 (test: 22/50 dropped). Ranking makes the kept set the
    best set; closing the ceiling needs dense/pgvector retrieval + higher/query-scoped caps.
-3. **False grounding.** `grounded = ftsHits > 0`. An incidental stemmed term ("update" chatter across
-   channels) flips `grounded` true for a topic the brain has **never ingested** (Helsinki datacenter
-   migration) → the answer layer won't abstain → confabulation risk. More channels ⇒ more incidental
-   term overlap ⇒ the stay-quiet safety erodes.
+3. ~~**False grounding.**~~ **FIXED** — grounding now keys on term **specificity (document frequency)**,
+   not "any FTS hit" (`lib/query/grounding`). A *specific* (rare, ≤15%-of-corpus) term that actually
+   matches → grounded; if every query term is corpus-common → fall back to any-hit (no over-abstain on
+   "what's the latest update?"); otherwise (specific terms that match nothing + incidental common words)
+   → NOT grounded. Temporal deictics ("latest/recent/today") are now stopwords so they don't poison the
+   signal. Verified: the "Helsinki migration" chatter no longer grounds, while a specific single-term
+   query ("SSRF") still does.
 4. **No channel scoping.** A user who scopes explicitly ("…in the #sales channel") gets bleed from
    other channels — path prefixes aren't a query dimension, so an `#eng` "Atlas" contaminates a
    sales-scoped "Atlas" question. Same-name-different-meaning collisions multiply with channels.

--- a/lib/query/grounding.ts
+++ b/lib/query/grounding.ts
@@ -1,0 +1,63 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+
+/**
+ * Term-specificity analysis for the grounding signal (Gap #3). The old signal was
+ * `grounded = any FTS hit exists`; under OR-semantics one incidental common word ("update" chatter
+ * across channels) flipped it true for a topic never ingested → the abstain safety stopped firing.
+ *
+ * The fix keys on term RARITY (document frequency), not term count or ts_rank — because a specific
+ * single-term query ("SSRF", "AIO-146", a person's name) is strongly grounded but scores low on both.
+ * A term is "specific" when it appears in ≤ `GROUNDING_COMMON_FRAC` of the corpus (default 15%).
+ *
+ * Returns two flags the caller combines with "did FTS hit anything" (`hadFtsHit`):
+ *   • specificMatching — a specific term that ACTUALLY matches ≥1 item exists → real evidence → grounded.
+ *   • allCommon        — every query term is corpus-common → fall back to hadFtsHit (no regression,
+ *                        no over-abstain on legit common-word queries like "latest update").
+ * Neither → the false-grounding signature (specific terms that match nothing + incidental common
+ * words) → NOT grounded. Best-effort: on any error returns {false, true} so grounding degrades to
+ * the old any-hit behavior rather than throwing. Tier-scoped on the live `items.access`.
+ */
+
+const COMMON_FRAC = Number(process.env.GROUNDING_COMMON_FRAC ?? 0.15);
+
+export interface TermSpecificity {
+  specificMatching: boolean;
+  allCommon: boolean;
+}
+
+export async function analyzeTermSpecificity(
+  teamId: string,
+  tier: "team" | "external",
+  terms: string[]
+): Promise<TermSpecificity> {
+  if (terms.length === 0) return { specificMatching: false, allCommon: true };
+  try {
+    const access = tier === "external" ? "and access = 'external'" : "";
+    // One row per term: corpus total + that term's document frequency, both tier-scoped.
+    const sql = `
+      select t.term,
+        (select count(*) from items where team_id = $1 ${access}) as total,
+        (select count(*) from items where team_id = $1 ${access}
+           and search @@ websearch_to_tsquery('english', t.term)) as df
+      from unnest($2::text[]) as t(term)`;
+    const res = await runSql<{ term: string; total: number | string; df: number | string }>(sql, [teamId, terms]);
+    if (res.rows.length === 0) return { specificMatching: false, allCommon: true };
+
+    const total = Number(res.rows[0].total) || 0;
+    // A term in ≤ COMMON_FRAC of the corpus is "specific". ceil so a tiny corpus still discriminates
+    // (N=12, 15% → threshold 2: "SSRF" in 1 doc is specific, "update" in all 12 is common).
+    const threshold = Math.max(1, Math.ceil(COMMON_FRAC * total));
+
+    let specificMatching = false;
+    let allCommon = true;
+    for (const r of res.rows) {
+      const df = Number(r.df) || 0;
+      if (df >= 1 && df <= threshold) specificMatching = true; // specific AND actually matches
+      if (df <= threshold) allCommon = false; // a specific term (matching or not) means "not all common"
+    }
+    return { specificMatching, allCommon };
+  } catch {
+    return { specificMatching: false, allCommon: true }; // degrade to old any-hit behavior
+  }
+}

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -12,6 +12,7 @@ import {
 import { externalProvider } from "./external-provider";
 import { denseSearch, fuseByRrf } from "./dense-search";
 import { rankedFtsSearch } from "./fts-search";
+import { analyzeTermSpecificity } from "./grounding";
 
 // Types live in ./provider (the pluggable seam). Re-exported here so existing importers
 // (lib/query/claude, tests, …) keep importing them from "@/lib/query/retrieve" unchanged.
@@ -149,6 +150,10 @@ const FTS_STOP = new Set([
   "did", "do", "does", "has", "have", "had", "with", "about", "from", "by", "our", "we", "you",
   "i", "me", "my", "your", "their", "this", "that", "these", "those", "it", "its", "as", "at",
   "any", "all", "can", "could", "would", "should", "tell", "show", "give", "list", "get",
+  // Temporal/recency deictics: query INTENT, not content — they never match usefully as keywords
+  // and (df≈0) would otherwise poison the grounding signal (Gap #3). Recency is handled by the
+  // recency fallback + activity digests, not by matching the literal word.
+  "latest", "recent", "recently", "lately", "today", "yesterday", "tomorrow", "currently", "now", "soon", "upcoming",
 ]);
 
 /**
@@ -175,13 +180,17 @@ function isSignificantTerm(original: string): boolean {
  * filters relevance) instead of requiring ALL of them. Falls back to the raw question when nothing
  * significant remains. (Ranked/semantic retrieval — pgvector — is the durable fix at larger scale.)
  */
-export function toOrQuery(question: string): string {
+export function significantTerms(question: string): string[] {
   // Match on the ORIGINAL (case preserved) so `isSignificantTerm` can tell an upper-cased acronym
-  // (CI) from a lowercase common word (us); lowercase only after the keep/drop decision.
+  // (CI) from a lowercase common word (us); lowercase only after the keep/drop decision. De-duped.
   const terms = (question.match(/[A-Za-z0-9][A-Za-z0-9'-]*/g) ?? [])
     .filter(isSignificantTerm)
     .map((t) => t.toLowerCase());
-  const unique = [...new Set(terms)];
+  return [...new Set(terms)];
+}
+
+export function toOrQuery(question: string): string {
+  const unique = significantTerms(question);
   return unique.length ? unique.join(" or ") : question;
 }
 
@@ -369,7 +378,10 @@ async function nativeRetrieve(
   // 1. Recall-friendly, RANKED FTS over items (OR of significant terms; see toOrQuery). Ordered by
   //    ts_rank so the capped top-20 is the most relevant 20, not an arbitrary 20 (Gap #2). Raw SQL
   //    (fts-search) because the builder emits an unordered `@@` filter.
-  const ftsP = rankedFtsSearch(teamId, tier, toOrQuery(question), 20);
+  const terms = significantTerms(question);
+  const ftsP = rankedFtsSearch(teamId, tier, terms.length ? terms.join(" or ") : question, 20);
+  // Grounding specificity (Gap #3) — runs concurrently; combined with hadFtsHit below.
+  const specificityP = analyzeTermSpecificity(teamId, tier, terms);
 
   // 2. Recency: most recent items (a fallback so fresh content always has a shot).
   let recentB = db
@@ -509,10 +521,14 @@ async function nativeRetrieve(
     });
   }
 
-  // Grounding signal (stay-quiet): did query-specific SEARCH match anything, or are the sources just
-  // recency padding? FTS/semantic hits = real grounding; if both are empty the answer layer is told
-  // retrieval found no strong match so it abstains instead of confabulating from recent items.
-  let grounded = ftsHits.length > 0;
+  // Grounding signal (stay-quiet): is there query-SPECIFIC evidence, or are the sources just recency
+  // padding / an incidental common-word match? (Gap #3.) A specific (rare) term that actually matches
+  // → grounded. If every query term is corpus-common, fall back to "any FTS hit" (don't over-abstain
+  // on legit common-word queries). Otherwise — specific terms that match nothing + incidental common
+  // words — NOT grounded, so the answer layer abstains instead of confabulating.
+  const hadFtsHit = ftsHits.length > 0;
+  const spec = await specificityP;
+  let grounded = spec.specificMatching ? true : spec.allCommon ? hadFtsHit : false;
 
   // 2c. Semantic expansion via Graphiti (the graph search ran in parallel above). Use the facts'
   // entity/relationship terms to expand the FTS and surface items the literal keyword search missed.

--- a/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
+++ b/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
@@ -130,16 +130,38 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
     expect(missing, `${missing.length}/50 on-topic items were dropped by the caps`).toEqual([]);
   });
 
-  it.fails("GAP: false grounding — an incidental shared term flips `grounded` true for an absent topic", async () => {
-    // Many channels post routine "update" messages. A question about something the brain has NEVER
-    // ingested (Helsinki datacenter migration) shares the stemmed term "updat" with that chatter, so
-    // FTS matches → grounded=true → the answer layer won't abstain → confabulation risk. Desired:
-    // grounded=false, because nothing about the actual topic exists.
+  it("STRENGTH: false grounding fixed — an incidental common term does NOT ground an absent topic (Gap #3)", async () => {
+    // Many channels post routine "update" messages. A question about something NEVER ingested
+    // (Helsinki datacenter migration) shares the stemmed term "updat" with that chatter. The old
+    // signal (any FTS hit) flipped grounded=true → confabulation risk. The IDF signal sees that
+    // "update" is corpus-common while helsinki/datacenter/migration match nothing → grounded=false.
     for (let i = 0; i < 12; i++) {
       await post(`slack/ch${i % 6}`, `daily-${i}`, `Daily update ${i}: posted a quick update to the channel, all normal.`);
     }
     const ctx = await retrieve(db(), seed.teamId, "team", "any updates on the Helsinki datacenter migration?");
     expect(ctx.grounded).toBe(false);
+  });
+
+  it("STRENGTH: a SPECIFIC single-term query stays grounded amid common-word noise (Gap #3 no regression)", async () => {
+    // The danger of any naive grounding fix: rejecting a specific single-term query. "SSRF" is one
+    // term but rare (df=1) → must stay grounded even though the corpus is mostly common "update" chatter.
+    for (let i = 0; i < 12; i++) {
+      await post(`slack/ch${i % 6}`, `daily-${i}`, `Daily update ${i}: routine status, nothing notable.`);
+    }
+    await post("slack/security", "ssrf", "The SSRF vulnerability in the image proxy was patched.");
+    const ctx = await retrieve(db(), seed.teamId, "team", "was the SSRF issue fixed?");
+    expect(ctx.grounded).toBe(true);
+    expect(ctx.sources.some((s) => s.path === "slack/security/ssrf.md")).toBe(true);
+  });
+
+  it("STRENGTH: an all-common-term query still grounds on real matches (no over-abstain)", async () => {
+    // If every query term is corpus-common, the IDF signal falls back to "any FTS hit" so a legit
+    // "what's the latest update?" isn't wrongly forced to abstain.
+    for (let i = 0; i < 6; i++) {
+      await post(`slack/ch${i}`, `update-${i}`, `Weekly update ${i}: the team shipped features and fixed bugs.`);
+    }
+    const ctx = await retrieve(db(), seed.teamId, "team", "what are the latest updates?");
+    expect(ctx.grounded).toBe(true);
   });
 
   it.fails("GAP: no channel scoping — a channel-qualified query still bleeds in other channels", async () => {

--- a/test/query-adversarial.test.ts
+++ b/test/query-adversarial.test.ts
@@ -88,4 +88,10 @@ describe("strength: recall-friendly normalization we get RIGHT", () => {
   it("falls back to the raw question when nothing significant survives", () => {
     expect(toOrQuery("who is it?")).toBe("who is it?");
   });
+
+  it("drops temporal deictics so they don't become search/grounding noise (Gap #3 support)", () => {
+    // "latest"/"today"/"recent" are query intent, not content — recency is handled elsewhere.
+    expect(toOrQuery("what are the latest updates today?")).toBe("updates");
+    expect(toOrQuery("any recent deployment news").split(" or ")).not.toContain("recent");
+  });
 });


### PR DESCRIPTION
Third fix in the retrieval-gaps plan. Closes the **confabulation safety gap**.

## What grounding is
`grounded` is retrieval's honest "is there real evidence to answer this, or would the model be inventing it?" signal. `grounded=false` tells the answer layer to **abstain** ("I don't know") instead of confabulating from the recency padding we always include. It's the safety valve that separates a trustworthy memory from a plausible liar.

## Gap
Old signal: `grounded = any FTS hit exists`. FTS is OR-semantics, so **one incidental common word** ("update" chatter across channels) flipped `grounded` true for a topic never ingested (Helsinki datacenter migration) → the abstain safety silently stops firing. Worsens as more channels add incidental word-overlap.

## Why the obvious fixes are wrong
Requiring ≥2 matched terms, or a high `ts_rank`, **wrongly rejects specific single-term queries** — "SSRF", a ticket id "AIO-146", a person's name. Those are strongly grounded but low on both count and rank. The real signal is term **rarity (document frequency)**, not count or rank.

## Fix — `lib/query/grounding.analyzeTermSpecificity`
Per query term, compute tier-scoped `df` and classify:
- a **specific** (≤15%-of-corpus) term that **actually matches** → grounded (real evidence)
- **every** term corpus-common → fall back to any-hit (no over-abstain on "what's the latest update?")
- otherwise (specific terms matching nothing + incidental common words) → **NOT grounded** — the false-grounding signature

Best-effort (degrades to old behavior on error), runs concurrently (no added latency). Temporal deictics (`latest/recent/today/…`) become stopwords so they don't poison the signal.

## Proof (real Postgres)
- "Helsinki migration" chatter → **grounded=false** (was true) ✅ flips the adversarial `it.fails` → green
- specific single-term "SSRF" query → **grounded=true** (no regression) ✅
- all-common "latest updates" query → **grounded=true** (no over-abstain) ✅
- existing `grounding` + `retrieval-eval` + `context-shaping` suites unchanged ✅

## Test plan
- [x] Full unit tier green (442 + 1 expected-fail)
- [x] Full data-mechanics green (309 + 4 expected-fail, down from 5)
- [x] `tsc`, `eslint`, docs-drift clean

Next in the plan: #5/#6 (task/decision cap scaling), then #4 (channel scoping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved answer grounding so common words and recency phrases like “latest” or “today” no longer cause false grounding.
  * Queries with broad, corpus-common terms now behave more reliably, while specific terms still ground correctly.
  * Reduced over-abstaining when a query contains only common terms by falling back to real matches.
  
* **Tests**
  * Added coverage for grounding behavior across common-term, rare-term, and temporal-query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->