### PR TITLE
fix(context): full-corpus task counts + decision keyword search (Gaps #5, #6)

### DIFF
--- a/docs/design/context-retrieval-limits.md
+++ b/docs/design/context-retrieval-limits.md
@@ -49,12 +49,12 @@ real test") the moment the gap is closed. So the count of `it.fails` in these fi
 4. **No channel scoping.** A user who scopes explicitly ("…in the #sales channel") gets bleed from
    other channels — path prefixes aren't a query dimension, so an `#eng` "Atlas" contaminates a
    sales-scoped "Atlas" question. Same-name-different-meaning collisions multiply with channels.
-5. **Aggregation/rollup truncates.** The task digest caps at 80 (most-recently-updated), so "how many
-   open tasks?" undercounts once a multi-channel org passes 80 live tasks — the oldest-updated ones
-   are simply invisible to the answer.
-6. **Temporal fall-off.** The decisions digest caps at 50 (newest-first) with no date-range awareness.
-   "Which vendor did we pick in Q1?" loses grounding once ~50 newer decisions exist, even though the
-   decision is on record.
+5. ~~**Aggregation/rollup truncates.**~~ **FIXED** — a full-corpus **task count-by-status** line
+   (`lib/query/structured-extras`) is now in the structured context, so "how many open tasks?" is
+   correct regardless of the 80-row detail cap.
+6. ~~**Temporal fall-off.**~~ **FIXED** — ALL decisions are now **keyword-searched** (title+rationale,
+   ranked), so an on-record decision surfaces past the recency-50 window ("which vendor did we pick in
+   Q1?" reaches it).
 
 ## The through-line
 

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -13,6 +13,7 @@ import { externalProvider } from "./external-provider";
 import { denseSearch, fuseByRrf } from "./dense-search";
 import { rankedFtsSearch } from "./fts-search";
 import { analyzeTermSpecificity } from "./grounding";
+import { taskStatusCounts, matchingDecisions } from "./structured-extras";
 
 // Types live in ./provider (the pluggable seam). Re-exported here so existing importers
 // (lib/query/claude, tests, …) keep importing them from "@/lib/query/retrieve" unchanged.
@@ -379,9 +380,15 @@ async function nativeRetrieve(
   //    ts_rank so the capped top-20 is the most relevant 20, not an arbitrary 20 (Gap #2). Raw SQL
   //    (fts-search) because the builder emits an unordered `@@` filter.
   const terms = significantTerms(question);
-  const ftsP = rankedFtsSearch(teamId, tier, terms.length ? terms.join(" or ") : question, 20);
+  const orQuery = terms.length ? terms.join(" or ") : question;
+  const ftsP = rankedFtsSearch(teamId, tier, orQuery, 20);
   // Grounding specificity (Gap #3) — runs concurrently; combined with hadFtsHit below.
   const specificityP = analyzeTermSpecificity(teamId, tier, terms);
+  // Structured-context scaling (Gaps #5/#6): a FULL-corpus task count (aggregates survive the 80-row
+  // cap) + a keyword search over ALL decisions (an old-but-relevant decision survives the 50-row
+  // recency window). Both run concurrently; folded into the structured block below.
+  const taskCountsP = taskStatusCounts(teamId, tier);
+  const matchedDecisionsP = terms.length ? matchingDecisions(teamId, tier, orQuery, 10) : Promise.resolve([]);
 
   // 2. Recency: most recent items (a fallback so fresh content always has a shot).
   let recentB = db
@@ -583,13 +590,34 @@ async function nativeRetrieve(
   }
 
   // 3. Structured context (compact, always included) — built from the parallel results above.
-  const [gitDigest, peopleDigest] = await Promise.all([gitDigestP, peopleDigestP]);
+  const [gitDigest, peopleDigest, taskCounts, matchedDecisions] = await Promise.all([
+    gitDigestP,
+    peopleDigestP,
+    taskCountsP,
+    matchedDecisionsP,
+  ]);
+
+  // Decisions: the recency-50 window PLUS any keyword-matched decision that scrolled past it (Gap #6),
+  // deduped by row_key. Recency rows first (fresh context), then the older matches under their own note.
+  type DecisionLine = { row_key: string; decided_at: string | null; title: string; decided_by: string; still_valid: boolean; slug: string };
+  const recencyDecisions: DecisionLine[] = (decisions ?? []).map((d) => ({
+    row_key: d.row_key as string,
+    decided_at: (d.decided_at as string | null) ?? null,
+    title: d.title as string,
+    decided_by: d.decided_by as string,
+    still_valid: d.still_valid as boolean,
+    slug: (d.projects as unknown as { slug: string })?.slug ?? "",
+  }));
+  const recencyKeys = new Set(recencyDecisions.map((d) => d.row_key));
+  const olderMatches = matchedDecisions.filter((d) => !recencyKeys.has(d.row_key));
+  const fmtDecision = (d: DecisionLine) =>
+    `- #${d.row_key} (${d.decided_at ?? "?"}, ${d.slug}) ${d.title} — by ${d.decided_by}${d.still_valid ? "" : " [SUPERSEDED]"}`;
+
   const structured = [
+    `## Task counts (all ${taskCounts.total} tasks: ${taskCounts.open} open, ${taskCounts.byStatus.done ?? 0} done)`,
     "## Recent decisions (newest first)",
-    ...(decisions ?? []).map(
-      (d) =>
-        `- #${d.row_key} (${d.decided_at ?? "?"}, ${(d.projects as unknown as { slug: string })?.slug}) ${d.title} — by ${d.decided_by}${d.still_valid ? "" : " [SUPERSEDED]"}`
-    ),
+    ...recencyDecisions.map(fmtDecision),
+    ...(olderMatches.length ? ["", "## Older decisions matching this query", ...olderMatches.map(fmtDecision)] : []),
     "",
     "## Tasks (all statuses, most recently updated first)",
     ...(tasks ?? []).map((t) => {

--- a/lib/query/structured-extras.ts
+++ b/lib/query/structured-extras.ts
@@ -1,0 +1,97 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+
+/**
+ * Structured-context helpers that fix the "digests are recency-capped" scaling gaps (Gaps #5, #6).
+ *
+ * The task digest lists at most 80 rows and the decisions digest at most 50 (newest first), so in a
+ * busy multi-channel org an aggregate question ("how many open tasks?") undercounts and an older
+ * decision ("which vendor did we pick in Q1?") is simply absent. These two queries add (a) a
+ * FULL-corpus task count by status and (b) a keyword search over ALL decisions, so counts are
+ * complete and a relevant old decision surfaces regardless of the recency window. Both tier-scoped
+ * via `audience`; best-effort (empty on error). Postgres-only, same raw-SQL precedent as dense-search.
+ */
+
+export interface TaskCounts {
+  total: number;
+  open: number; // anything not `done`
+  byStatus: Record<string, number>;
+}
+
+/** Count ALL tasks by status (uncapped), tier-scoped. Powers a correct "how many open tasks" answer. */
+export async function taskStatusCounts(teamId: string, tier: "team" | "external"): Promise<TaskCounts> {
+  try {
+    const access = tier === "external" ? "and audience = 'external'" : "";
+    const sql = `select status, count(*)::int as n from tasks where team_id = $1 ${access} group by status`;
+    const res = await runSql<{ status: string; n: number }>(sql, [teamId]);
+    const byStatus: Record<string, number> = {};
+    let total = 0;
+    let open = 0;
+    for (const r of res.rows) {
+      byStatus[r.status] = r.n;
+      total += r.n;
+      if (r.status !== "done") open += r.n;
+    }
+    return { total, open, byStatus };
+  } catch {
+    return { total: 0, open: 0, byStatus: {} };
+  }
+}
+
+export interface DecisionMatch {
+  row_key: string;
+  decided_at: string | null;
+  title: string;
+  decided_by: string;
+  still_valid: boolean;
+  slug: string;
+}
+
+/**
+ * Keyword-search ALL decisions (title + rationale) for the query terms, tier-scoped, ranked. This is
+ * the only path to a decision that has scrolled past the recency-50 window — without it, "which
+ * vendor did we pick back in Q1?" has no grounding once ~50 newer decisions exist. Decisions have no
+ * FTS column, so we compute the tsvector inline (small table; a generated column + GIN is the
+ * durable optimization if this ever gets hot).
+ */
+export async function matchingDecisions(
+  teamId: string,
+  tier: "team" | "external",
+  orQuery: string,
+  limit = 10
+): Promise<DecisionMatch[]> {
+  if (!orQuery.trim()) return [];
+  try {
+    const access = tier === "external" ? "and d.audience = 'external'" : "";
+    const params: unknown[] = [orQuery, teamId, limit];
+    const sql = `
+      select d.row_key, d.decided_at, d.title, d.decided_by, d.still_valid, coalesce(p.slug, '') as slug,
+             ts_rank(to_tsvector('english', coalesce(d.title,'') || ' ' || coalesce(d.rationale,'')),
+                     websearch_to_tsquery('english', $1)) as rank
+      from decisions d
+      left join projects p on p.id = d.project_id
+      where d.team_id = $2 ${access}
+        and to_tsvector('english', coalesce(d.title,'') || ' ' || coalesce(d.rationale,''))
+            @@ websearch_to_tsquery('english', $1)
+      order by rank desc, d.decided_at desc
+      limit $3`;
+    const res = await runSql<{
+      row_key: string;
+      decided_at: string | Date | null;
+      title: string;
+      decided_by: string;
+      still_valid: boolean;
+      slug: string;
+    }>(sql, params);
+    return res.rows.map((r) => ({
+      row_key: r.row_key,
+      decided_at: r.decided_at instanceof Date ? r.decided_at.toISOString().slice(0, 10) : (r.decided_at as string | null),
+      title: r.title,
+      decided_by: r.decided_by,
+      still_valid: r.still_valid,
+      slug: r.slug,
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
+++ b/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
@@ -175,10 +175,9 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
     expect(engBleed, `eng-channel Atlas bled into a sales-scoped query: ${engBleed.join(", ")}`).toEqual([]);
   });
 
-  it.fails("GAP: task aggregation truncates — 'how many open tasks' undercounts past the 80 cap", async () => {
-    // A multi-channel org easily has >80 live tasks. The structured-context task digest caps at 80
-    // (most-recently-updated), so any count/rollup question is answered from a truncated board — the
-    // oldest-updated open tasks are simply invisible. Desired: the digest can represent all of them.
+  it("STRENGTH: task aggregation is correct past the 80 cap (Gap #5 fixed — full-corpus count)", async () => {
+    // A multi-channel org easily has >80 live tasks. The 80-row task DETAIL digest still caps, but a
+    // full-corpus count-by-status line now answers "how many open tasks?" correctly regardless.
     const projectId = await makeProject("ops");
     const base = Date.parse("2026-01-01T00:00:00Z");
     for (let i = 0; i < 90; i++) {
@@ -190,20 +189,18 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
         status: "in_progress",
         origin: "sync",
         audience: "team",
-        // task 0 is the oldest-updated → first to fall off the 80 cap.
         updated_at: new Date(base + i * 60_000).toISOString(),
       });
       if (error) throw new Error(`task insert failed: ${error.message}`);
     }
     const ctx = await retrieve(db(), seed.teamId, "team", "how many open tasks are there across the team?");
-    // Desired: the oldest-updated task is still represented so a count is complete.
-    expect(ctx.structured).toContain("TASK-000");
+    // The count reflects all 90, not the 80 the detail list can show.
+    expect(ctx.structured).toContain("90 open");
   });
 
-  it.fails("GAP: decisions fall off — an older decision is unanswerable once volume passes the 50 cap", async () => {
-    // The decisions digest caps at 50 (newest first), with no date-range awareness. In a busy org
-    // that's a few weeks of decisions; "what did we decide about vendor X back in Q1" then has NO
-    // grounding, even though the decision is on record. Desired: the older decision is retrievable.
+  it("STRENGTH: an older decision surfaces by keyword past the 50-cap (Gap #6 fixed — decision FTS)", async () => {
+    // The recency-50 decisions window still caps, but ALL decisions are now keyword-searched, so
+    // "which vendor did we pick in Q1?" reaches the old on-record decision regardless of recency.
     const projectId = await makeProject("gov");
     const base = Date.parse("2026-01-01T00:00:00Z");
     for (let i = 0; i < 60; i++) {


### PR DESCRIPTION
Structured-context scaling — the pair of digest-cap gaps.

## Gaps
- **#5** — the task digest lists ≤80 rows, so "how many open tasks?" undercounts once an org passes 80 live tasks; the oldest-updated open tasks are invisible.
- **#6** — the decisions digest is recency-only (newest 50, no keyword search), so "which vendor did we pick in Q1?" has **no grounding** once ~50 newer decisions exist, even though it's on record.

## Fixes (`lib/query/structured-extras`)
- **#5** — a full-corpus **count-by-status** line (uncapped) in the structured context. Aggregate/rollup answers are correct regardless of the 80-row *detail* cap.
- **#6** — **keyword-search ALL decisions** (title+rationale, `ts_rank`-ordered, tier-scoped); older matches fold into the structured context under their own note, deduped against the recency window. Decisions have no FTS column, so the tsvector is computed inline (small table).

Both run **concurrently** with existing retrieval (no added latency) and are best-effort (empty on error).

## Proof (real Postgres)
- 90 open tasks → structured reads **"90 open"** (not the 80 the list shows) ✅
- a vendor decision buried under 59 newer ones **surfaces by keyword** ✅
- existing task-digest + retrieval suites unchanged ✅

## Test plan
- [x] Full unit tier green (443 + 1 expected-fail)
- [x] Full data-mechanics green (311 + 2 expected-fail, down from 4)
- [x] `tsc`, `eslint`, docs-drift clean

**Remaining:** Gap #4 (channel scoping) next; and the recall-ceiling facet of #2 (dense/pgvector) stays open by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)