### PR TITLE
fix(context): scope retrieval to an explicitly named channel (Gap #4)

### DIFF
--- a/docs/design/context-retrieval-limits.md
+++ b/docs/design/context-retrieval-limits.md
@@ -46,9 +46,10 @@ real test") the moment the gap is closed. So the count of `it.fails` in these fi
    → NOT grounded. Temporal deictics ("latest/recent/today") are now stopwords so they don't poison the
    signal. Verified: the "Helsinki migration" chatter no longer grounds, while a specific single-term
    query ("SSRF") still does.
-4. **No channel scoping.** A user who scopes explicitly ("…in the #sales channel") gets bleed from
-   other channels — path prefixes aren't a query dimension, so an `#eng` "Atlas" contaminates a
-   sales-scoped "Atlas" question. Same-name-different-meaning collisions multiply with channels.
+4. ~~**No channel scoping.**~~ **FIXED** — `parseChannelScope` detects an explicit `#channel` /
+   "in the X channel" qualifier (conservative — "the sales pipeline" never scopes), strips it from the
+   search terms, and filters item retrieval to that channel's path segment. An `#eng` "Atlas" no
+   longer contaminates a sales-scoped "Atlas" question; an unscoped query still sees both.
 5. ~~**Aggregation/rollup truncates.**~~ **FIXED** — a full-corpus **task count-by-status** line
    (`lib/query/structured-extras`) is now in the structured context, so "how many open tasks?" is
    correct regardless of the 80-row detail cap.
@@ -56,12 +57,12 @@ real test") the moment the gap is closed. So the count of `it.fails` in these fi
    ranked), so an on-record decision surfaces past the recency-50 window ("which vendor did we pick in
    Q1?" reaches it).
 
-## The through-line
+## Status
 
-The system is tuned for **one low-volume channel**: fixed caps are never hit, unranked FTS is fine
-because there's little to rank, recency masks crowding, and `grounded` rarely false-positives. Every
-gap above is a **scaling cliff** that the current corpus hides. The durable fixes are already gestured
-at in the code comments — **semantic/dense ranking (pgvector) + a reranker** for (1)(2), a stronger
-grounding signal than "any FTS hit" for (3), **channel/source as a first-class retrieval filter** for
-(4), and **query-scoped (not global-capped) structured context** for (5)(6). The tests here make each
-fix *provable*: close the gap and its `it.fails` turns red.
+Gaps **#1, #3, #4, #5, #6 are fixed** and #2's ranking facet is fixed — the multi-channel adversarial
+suite is green except one remaining `it.fails`: the **recall ceiling** (a query legitimately matching
+50+ items returns only ~28). That's the one gap keyword search can't close on its own; the durable fix
+is **dense/pgvector retrieval + a reranker + query-scoped caps** (the `EMBEDDINGS_URL` leg already
+exists but is off by default). Everything else — short-token recall, `ts_rank` ordering, IDF grounding,
+channel scoping, full-corpus task counts, decision keyword search — now holds as channels multiply. The
+tests make each fix *provable*: each closed gap's `it.fails` flipped to a green `it()`.

--- a/lib/query/fts-search.ts
+++ b/lib/query/fts-search.ts
@@ -27,12 +27,18 @@ export async function rankedFtsSearch(
   teamId: string,
   tier: "team" | "external",
   orQuery: string,
-  limit = 20
+  limit = 20,
+  channel?: string | null
 ): Promise<FtsHit[]> {
   if (!orQuery.trim()) return [];
   const params: unknown[] = [orQuery, teamId];
   let where = "i.team_id = $2 and i.search @@ websearch_to_tsquery('english', $1)";
   if (tier === "external") where += " and i.access = 'external'";
+  if (channel) {
+    // Channel scope (Gap #4): the channel is a path's 2nd segment, `<source>/<name>/…`.
+    params.push(channel);
+    where += ` and split_part(i.path, '/', 2) = $${params.length}`;
+  }
   params.push(limit);
   const limitIdx = params.length;
 

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -195,6 +195,25 @@ export function toOrQuery(question: string): string {
   return unique.length ? unique.join(" or ") : question;
 }
 
+/**
+ * Detect an EXPLICIT channel scope in the question and strip it (Gap #4). Conservative on purpose —
+ * only `#channel` (Slack style) or "in/on/from [the] X channel" qualify, so "the sales pipeline"
+ * (no literal "channel") never wrongly scopes. Returns the lowercased channel name (matched against
+ * a path's 2nd segment `<source>/<name>/…` in retrieval) and the question with the scope phrase
+ * removed, so the channel word doesn't also leak in as a content search term. Pure + unit-tested.
+ */
+export function parseChannelScope(question: string): { channel: string | null; cleaned: string } {
+  const hash = question.match(/#([a-z0-9][a-z0-9_-]{1,40})\b/i);
+  if (hash) {
+    return { channel: hash[1].toLowerCase(), cleaned: question.replace(hash[0], " ").replace(/\s{2,}/g, " ").trim() };
+  }
+  const phrase = question.match(/\b(?:in|on|from|to)\s+(?:the\s+)?([a-z0-9][a-z0-9_-]{1,40})\s+channel\b/i);
+  if (phrase) {
+    return { channel: phrase[1].toLowerCase(), cleaned: question.replace(phrase[0], " ").replace(/\s{2,}/g, " ").trim() };
+  }
+  return { channel: null, cleaned: question };
+}
+
 const MAX_EXPANSION_TERMS = 24;
 
 /**
@@ -364,14 +383,19 @@ async function nativeRetrieve(
   question: string,
   projectSlug?: string | null
 ): Promise<RetrievedContext> {
+  // Channel scope (Gap #4): if the question names a channel ("#eng" / "in the sales channel"), scope
+  // item retrieval to it and strip the phrase so the channel word isn't also a content search term.
+  const { channel, cleaned } = parseChannelScope(question);
+  const q = channel ? cleaned : question;
+
   // Kick off the Graphiti graph-memory search concurrently with Postgres retrieval.
-  const graphFactsP = fetchGraphFacts(db, teamId, tier, question);
+  const graphFactsP = fetchGraphFacts(db, teamId, tier, q);
   // Optional dense (semantic) passage search — pgvector. Runs concurrently; resolves to [] unless
   // EMBEDDINGS_URL is set AND the pgvector schema is loaded (default installs stay pure-FTS).
-  const denseP = denseSearch(teamId, tier, question, projectSlug);
+  const denseP = denseSearch(teamId, tier, q, projectSlug);
   // Git-activity + per-person activity digests (team tier only — internal) run in parallel too.
   // Context shaping: the activity digests are heavy + only relevant to "who's doing what" questions.
-  const wantsActivity = tier === "team" && wantsActivityContext(question);
+  const wantsActivity = tier === "team" && wantsActivityContext(q);
   const gitDigestP = wantsActivity ? gitActivityDigest(db, teamId) : Promise.resolve("");
   const peopleDigestP = wantsActivity ? peopleActivityDigest(db, teamId) : Promise.resolve("");
 
@@ -379,9 +403,9 @@ async function nativeRetrieve(
   // 1. Recall-friendly, RANKED FTS over items (OR of significant terms; see toOrQuery). Ordered by
   //    ts_rank so the capped top-20 is the most relevant 20, not an arbitrary 20 (Gap #2). Raw SQL
   //    (fts-search) because the builder emits an unordered `@@` filter.
-  const terms = significantTerms(question);
-  const orQuery = terms.length ? terms.join(" or ") : question;
-  const ftsP = rankedFtsSearch(teamId, tier, orQuery, 20);
+  const terms = significantTerms(q);
+  const orQuery = terms.length ? terms.join(" or ") : q;
+  const ftsP = rankedFtsSearch(teamId, tier, orQuery, 20, channel);
   // Grounding specificity (Gap #3) — runs concurrently; combined with hadFtsHit below.
   const specificityP = analyzeTermSpecificity(teamId, tier, terms);
   // Structured-context scaling (Gaps #5/#6): a FULL-corpus task count (aggregates survive the 80-row
@@ -398,6 +422,9 @@ async function nativeRetrieve(
     .order("synced_at", { ascending: false })
     .limit(8);
   if (tier === "external") recentB = recentB.eq("access", "external");
+  // Channel scope (Gap #4) — keep the recency fallback inside the same channel. LIKE on the 2nd
+  // path segment; the FTS leg uses a precise split_part match, this soft filter is fine for padding.
+  if (channel) recentB = recentB.like("path", `%/${channel}/%`);
 
   // 3. Structured-context query builders (awaited together with the above).
   let decisionsB = db
@@ -543,7 +570,7 @@ async function nativeRetrieve(
   const graphFacts = await graphFactsP;
   const expansion = graphExpansionQuery(graphFacts);
   if (expansion) {
-    const semHits = await rankedFtsSearch(teamId, tier, expansion, 10);
+    const semHits = await rankedFtsSearch(teamId, tier, expansion, 10, channel);
     if (semHits.length > 0) grounded = true;
     for (const hit of semHits) {
       if (seen.has(hit.id)) continue;

--- a/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
+++ b/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
@@ -164,15 +164,21 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
     expect(ctx.grounded).toBe(true);
   });
 
-  it.fails("GAP: no channel scoping — a channel-qualified query still bleeds in other channels", async () => {
-    // "Atlas" means different things in different channels: a project in #eng, a vendor in #sales.
-    // The user scopes explicitly ("...in the sales channel"), but retrieval has no channel filter —
-    // path prefixes aren't a query dimension — so the #eng Atlas bleeds in. Desired: sales-only.
+  it("STRENGTH: a channel-qualified query scopes to that channel (Gap #4 fixed)", async () => {
+    // "Atlas" means different things per channel: a project in #eng, a vendor in #sales. Scoping
+    // explicitly ("...in the sales channel") now filters retrieval to that channel's path prefix, so
+    // the #eng Atlas no longer bleeds in — while an UNSCOPED "Atlas" query still sees both.
     await post("slack/eng", "atlas", "Project Atlas: refactoring the retrieval layer to add reranking.");
     await post("slack/sales", "atlas", "Atlas Corp (vendor) sent the renewal quote for the analytics contract.");
-    const got = await paths("what's the latest on Atlas in the sales channel?");
-    const engBleed = got.filter((p) => p.startsWith("slack/eng/"));
-    expect(engBleed, `eng-channel Atlas bled into a sales-scoped query: ${engBleed.join(", ")}`).toEqual([]);
+
+    const scoped = await paths("what's the latest on Atlas in the sales channel?");
+    expect(scoped).toContain("slack/sales/atlas.md");
+    expect(scoped.filter((p) => p.startsWith("slack/eng/")), "eng bled into a sales-scoped query").toEqual([]);
+
+    // Sanity: without a scope, both channels' Atlas are eligible (no over-filtering).
+    const unscoped = await paths("what's the latest on Atlas?");
+    expect(unscoped).toContain("slack/sales/atlas.md");
+    expect(unscoped).toContain("slack/eng/atlas.md");
   });
 
   it("STRENGTH: task aggregation is correct past the 80 cap (Gap #5 fixed — full-corpus count)", async () => {

--- a/test/query-adversarial.test.ts
+++ b/test/query-adversarial.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toOrQuery } from "@/lib/query/retrieve";
+import { toOrQuery, parseChannelScope } from "@/lib/query/retrieve";
 
 /**
  * ADVERSARIAL — query-transformation limits (pure, deterministic). These probe the FTS query builder
@@ -75,6 +75,27 @@ describe("adversarial: a channel name is treated as a content term, not a scope"
 
   it("documents: the channel name leaks in as a plain search term", () => {
     expect(toOrQuery("what was decided in the payments channel").split(" or ")).toContain("payments");
+  });
+});
+
+describe("channel scope parsing (Gap #4 — conservative)", () => {
+  it("extracts a '#channel' scope and strips it from the query", () => {
+    const { channel, cleaned } = parseChannelScope("what shipped in #eng lately?");
+    expect(channel).toBe("eng");
+    expect(cleaned).not.toContain("#eng");
+  });
+
+  it("extracts an 'in the X channel' scope and strips the phrase", () => {
+    const { channel, cleaned } = parseChannelScope("what's the latest on Atlas in the sales channel?");
+    expect(channel).toBe("sales");
+    expect(cleaned).not.toMatch(/sales channel/i); // channel word doesn't leak into search terms
+    expect(toOrQuery(cleaned).split(" or ")).toContain("atlas");
+    expect(toOrQuery(cleaned).split(" or ")).not.toContain("sales");
+  });
+
+  it("does NOT scope when 'channel' is absent (no false positives)", () => {
+    expect(parseChannelScope("what's the sales pipeline forecast?").channel).toBeNull();
+    expect(parseChannelScope("how do users sign in?").channel).toBeNull();
   });
 });
 


### PR DESCRIPTION
Final fix in the retrieval-gaps plan.

## Gap
"Atlas" means different things per channel — a project in #eng, a vendor in #sales. A user who scopes explicitly ("...in the sales channel") still got the #eng Atlas bleeding in, because path prefixes weren't a query dimension.

## Fix
`parseChannelScope` detects an explicit scope — `#channel` (Slack style) or "in/on/from [the] X channel" — and is deliberately **conservative**: it requires the literal `#` or the word "channel", so "the sales pipeline" never wrongly scopes. It strips the scope phrase (so the channel word doesn't leak in as a content search term) and returns the channel name. Retrieval then filters items to that channel (the 2nd path segment `<source>/<name>/…`): a precise `split_part` match on the ranked FTS + expansion legs, and a `LIKE` on the recency fallback.

**Unscoped queries are byte-for-byte unchanged** (`parseChannelScope` → `{channel:null}`), so no regression risk.

## Proof (real Postgres)
- "...in the sales channel" Atlas query → only the sales Atlas (**no eng bleed**) ✅
- unscoped "Atlas" query → still sees **both** channels (no over-filtering) ✅
- pure parser unit-tested: `#eng`, "in the X channel", and the no-false-positive case ✅

## The suite is now green save one gap
This closes the last **keyword-addressable** gap. The multi-channel adversarial suite is green except a single `it.fails`: the **recall ceiling** (a query legitimately matching 50+ items returns ~28). That one needs **dense/pgvector + a reranker** — deliberately left open.

## Test plan
- [x] Full unit tier green (446 + 1 expected-fail)
- [x] Full data-mechanics green (312 + 1 expected-fail)
- [x] `tsc`, `eslint`, docs-drift clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)