### PR TITLE
feat(admin): retrieval-stack health card + loud dense-embedding failures (Phase 1a)

### DIFF
--- a/app/t/[team]/admin/integrations/page.tsx
+++ b/app/t/[team]/admin/integrations/page.tsx
@@ -8,6 +8,8 @@ import { GithubReposPanel } from "@/components/admin/github-repos-panel";
 import { getCodebaseFreshness } from "@/lib/metrics/codebases";
 import { listRecentIngestRuns } from "@/lib/ingest/runs";
 import { IngestRunsPanel } from "@/components/admin/ingest-runs-panel";
+import { getRetrievalHealth } from "@/lib/query/retrieval-health";
+import { RetrievalHealthCard } from "@/components/admin/retrieval-health-card";
 
 export const metadata: Metadata = { title: "Integrations" };
 
@@ -42,12 +44,13 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
     : { data: null };
 
   const db = adminClient();
-  const [integrations, ingestRuns, freshness] = await Promise.all([
+  const [integrations, ingestRuns, freshness, retrievalHealth] = await Promise.all([
     listIntegrations(db, team.id, { role: me?.role as string | undefined }) as Promise<IntegrationRow[]>,
     listRecentIngestRuns(db, team.id, 30),
     // Already-scanned repos (from codebase scans) → offered as one-click link suggestions. Read
     // through the tier-gated codebases choke point (CLAUDE.md §5), never the table directly.
     getCodebaseFreshness(db, team.id, (me?.tier as "team" | "external") ?? "external"),
+    getRetrievalHealth(team.id),
   ]);
   const githubIntegration = integrations.find((i) => i.type === "github") ?? null;
   const scannedRepos = Array.from(
@@ -64,6 +67,7 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
           integrations to run ingestion. Secrets are stored encrypted and never shown again.
         </p>
       </div>
+      <RetrievalHealthCard health={retrievalHealth} />
       <GithubReposPanel
         teamSlug={teamSlug}
         integration={githubIntegration}

--- a/components/admin/retrieval-health-card.tsx
+++ b/components/admin/retrieval-health-card.tsx
@@ -1,0 +1,82 @@
+import type { RetrievalHealth, DenseState, LegState } from "@/lib/query/retrieval-health";
+import { timeAgo } from "@/components/format";
+
+/**
+ * Admin → Integrations "Retrieval health" card. Surfaces the per-leg state of the context stack so a
+ * silently-degraded semantic index (the OpenAI-quota failure mode) is visible instead of invisible.
+ * Keyword FTS is always on; dense/graph/rerank are optional + externally dependent.
+ */
+
+const DOT: Record<DenseState | LegState, string> = {
+  healthy: "bg-emerald-500",
+  on: "bg-emerald-500",
+  building: "bg-amber-500",
+  degraded: "bg-red-500",
+  off: "bg-ink-tertiary/40",
+};
+
+const LABEL: Record<DenseState | LegState, string> = {
+  healthy: "healthy",
+  on: "on",
+  building: "building",
+  degraded: "degraded",
+  off: "off",
+};
+
+function Leg({ name, state, detail }: { name: string; state: DenseState | LegState; detail?: string }) {
+  return (
+    <div className="flex items-center gap-2.5 py-1.5">
+      <span className={`size-2 shrink-0 rounded-full ${DOT[state]}`} />
+      <span className="w-24 shrink-0 text-sm text-ink">{name}</span>
+      <span className={`text-xs font-medium ${state === "degraded" ? "text-red-600" : state === "building" ? "text-amber-600" : "text-ink-secondary"}`}>
+        {LABEL[state]}
+      </span>
+      {detail ? <span className="text-xs text-ink-tertiary">· {detail}</span> : null}
+    </div>
+  );
+}
+
+export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
+  const d = health.dense;
+  const denseDetail =
+    d.state === "off"
+      ? undefined
+      : `${d.coveragePct}% embedded (${d.embeddedItems}/${d.embeddableItems})${d.pendingItems ? `, ${d.pendingItems} pending` : ""}${d.lastEmbeddedAt ? `, last ${timeAgo(d.lastEmbeddedAt)}` : ""}`;
+  const worst = d.state === "degraded" || health.graph === "off";
+
+  return (
+    <div className="prism-card flex flex-col gap-1 p-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-ink">Retrieval health</h2>
+        <span className="text-xs text-ink-tertiary">how the brain answers questions</span>
+      </div>
+      <p className="mb-1 text-xs text-ink-secondary">
+        The context stack behind every query. Keyword search always works; the others are optional and
+        depend on external services, so a quiet failure is flagged here.
+      </p>
+
+      <Leg name="Keyword" state="on" detail="always on (local Postgres FTS)" />
+      <Leg name="Semantic" state={d.state} detail={denseDetail} />
+      <Leg name="Graph memory" state={health.graph} detail={health.graph === "off" ? "not configured" : undefined} />
+      <Leg name="Reranker" state={health.rerank} detail={health.rerank === "off" ? "not configured" : undefined} />
+
+      {d.note ? (
+        <p
+          className={`mt-2 rounded-lg border px-3 py-2 text-xs ${
+            d.state === "degraded"
+              ? "border-red-400/30 bg-red-400/10 text-red-600 dark:text-red-300"
+              : "border-border-subtle bg-white/[0.02] text-ink-tertiary"
+          }`}
+        >
+          {d.note}
+        </p>
+      ) : null}
+      {worst && !d.note ? (
+        <p className="mt-2 rounded-lg border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-300">
+          Some retrieval legs are off — answers rely on keyword search alone. That&apos;s fine at small
+          scale but weaker for paraphrased questions across a large corpus.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -33,13 +33,41 @@ export function startIngestScheduler(): void {
     await runInbound(db);
     await runImport(db, "github", runGithubIngestion);
     // Incremental dense (semantic) indexing of newly-synced items. No-op unless dense retrieval is
-    // configured (EMBEDDINGS_URL + pgvector schema); best-effort — never fails the tick.
-    try {
-      const { indexPendingItems } = await import("@/lib/query/dense-index");
-      const d = await indexPendingItems();
-      if (d.indexed) console.info(`[ingest] dense: embedded ${d.indexed} items (${d.chunks} chunks)`);
-    } catch (err) {
-      console.error("[ingest] dense index tick failed:", err instanceof Error ? err.message : err);
+    // configured (EMBEDDINGS_URL + pgvector schema); best-effort — never fails the tick. A batch where
+    // items were SCANNED but all FAILED (e.g. embeddings quota/outage) records an ERROR run so the
+    // degraded stack shows on Admin → Integrations instead of silently indexing nothing.
+    {
+      const startedAt = Date.now();
+      try {
+        const { indexPendingItems } = await import("@/lib/query/dense-index");
+        const d = await indexPendingItems();
+        if (d.indexed) console.info(`[ingest] dense: embedded ${d.indexed} items (${d.chunks} chunks)`);
+        if (d.failed > 0) {
+          console.error(`[ingest] dense: ${d.failed}/${d.scanned} items failed to embed — ${d.errorSample ?? "unknown error"}`);
+          await recordIngestRun(db, {
+            source: "dense",
+            trigger: "scheduler",
+            ok: false,
+            created: d.indexed,
+            errors: [`${d.failed} of ${d.scanned} items failed to embed: ${d.errorSample ?? "unknown error"}`],
+            meta: { indexed: d.indexed, failed: d.failed, chunks: d.chunks },
+            startedAt,
+          });
+        } else if (d.indexed > 0) {
+          await recordIngestRun(db, {
+            source: "dense",
+            trigger: "scheduler",
+            ok: true,
+            created: d.indexed,
+            meta: { indexed: d.indexed, chunks: d.chunks },
+            startedAt,
+          });
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error("[ingest] dense index tick failed:", msg);
+        await recordIngestRun(db, { source: "dense", trigger: "scheduler", ok: false, errors: [msg], startedAt });
+      }
     }
   };
 

--- a/lib/query/dense-index.ts
+++ b/lib/query/dense-index.ts
@@ -97,6 +97,8 @@ export interface BatchIndexResult {
   indexed: number;
   chunks: number;
   skipped: boolean; // true = dense retrieval off (whole batch was a no-op)
+  failed: number; // items that errored (e.g. embeddings quota/outage) — surfaced, not swallowed
+  errorSample?: string; // first error message, for the health/alert surface
 }
 
 /**
@@ -106,7 +108,7 @@ export interface BatchIndexResult {
  * transient embeddings error) is skipped so the rest of the batch still indexes.
  */
 export async function indexPendingItems(limit = 100, apiKey?: string | null): Promise<BatchIndexResult> {
-  if (!(await denseIndexAvailable())) return { scanned: 0, indexed: 0, chunks: 0, skipped: true };
+  if (!(await denseIndexAvailable())) return { scanned: 0, indexed: 0, chunks: 0, skipped: true, failed: 0 };
   const pending = await runSql<{
     id: string;
     team_id: string;
@@ -125,6 +127,8 @@ export async function indexPendingItems(limit = 100, apiKey?: string | null): Pr
   );
   let indexed = 0;
   let chunks = 0;
+  let failed = 0;
+  let errorSample: string | undefined;
   const keyByTeam = new Map<string, string | null>(); // resolve each team's embedding key once
   for (const it of pending.rows) {
     try {
@@ -143,9 +147,13 @@ export async function indexPendingItems(limit = 100, apiKey?: string | null): Pr
         indexed++;
         chunks += r.chunks;
       }
-    } catch {
-      // transient (e.g. embeddings) error on one item — skip, continue the batch
+    } catch (err) {
+      // An embeddings error (quota/outage/auth) on one item — skip it, continue the batch, but COUNT
+      // it and keep the first message so the caller can surface a degraded stack instead of the old
+      // silent "indexed: 0". A whole-batch failure (every item errored) is how a provider outage looks.
+      failed++;
+      if (!errorSample) errorSample = err instanceof Error ? err.message : String(err);
     }
   }
-  return { scanned: pending.rows.length, indexed, chunks, skipped: false };
+  return { scanned: pending.rows.length, indexed, chunks, skipped: false, failed, errorSample };
 }

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -1,0 +1,150 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+
+/**
+ * Retrieval-stack health for the admin dashboard (Phase 1 of the retrieval-observability plan).
+ *
+ * Keyword FTS is always on and local. The other legs are optional + externally-dependent and can
+ * silently drop out — dense (pgvector + an embeddings provider) especially, which we watched go dark
+ * under an OpenAI quota outage with zero signal. This computes a per-leg status + the dense embedding
+ * COVERAGE (embedded vs embeddable items) so "is semantic search actually working right now, and how
+ * much of the corpus does it cover?" is answerable on the dashboard instead of invisible.
+ *
+ * Best-effort: the whole thing degrades to sane defaults on error (never throws into a page render).
+ */
+
+export type LegState = "on" | "off";
+export type DenseState = "off" | "healthy" | "building" | "degraded";
+
+export interface DenseHealth {
+  state: DenseState;
+  embeddableItems: number;
+  embeddedItems: number;
+  pendingItems: number;
+  coveragePct: number; // 0–100
+  lastEmbeddedAt: string | null;
+  lastRunFailed: boolean;
+  note?: string;
+}
+
+export interface RetrievalHealth {
+  keyword: LegState; // always "on"
+  dense: DenseHealth;
+  graph: LegState;
+  rerank: LegState;
+}
+
+const COVERAGE_FLOOR = 0.9; // ≥90% embedded = healthy
+const STALE_MS = 2 * 60 * 60 * 1000; // no embed activity in 2h + incomplete = stalled, not "building"
+
+/** True when GRAPHITI_URL is a usable http(s) URL with a host (prod had a malformed "http://"). */
+export function graphConfigured(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const u = new URL(url);
+    return (u.protocol === "http:" || u.protocol === "https:") && u.hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derive the dense-leg state from the raw signals. Pure + unit-tested — the fiddly bit is separating
+ * "off" (not set up) from "building" (catching up, amber) from "degraded" (erroring or stalled, red)
+ * from "healthy" (green). `embeddable === 0` is healthy (nothing to embed).
+ */
+export function deriveDenseState(input: {
+  configured: boolean; // EMBEDDINGS_URL set
+  pgvectorLoaded: boolean; // item_chunks table present
+  embeddable: number;
+  embedded: number;
+  lastRunFailed: boolean;
+  lastEmbeddedAtMs: number | null;
+  nowMs: number;
+}): DenseState {
+  if (!input.configured || !input.pgvectorLoaded) return "off";
+  if (input.lastRunFailed) return "degraded"; // embedding is erroring right now (e.g. quota/outage)
+  if (input.embeddable === 0) return "healthy";
+  const coverage = input.embedded / input.embeddable;
+  if (coverage >= COVERAGE_FLOOR) return "healthy";
+  const stalled = input.lastEmbeddedAtMs === null || input.nowMs - input.lastEmbeddedAtMs > STALE_MS;
+  return stalled ? "degraded" : "building"; // incomplete + not progressing = degraded; else catching up
+}
+
+export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealth> {
+  const graph: LegState = graphConfigured(process.env.GRAPHITI_URL) ? "on" : "off";
+  const rerank: LegState = process.env.RERANK_URL ? "on" : "off";
+  const configured = !!process.env.EMBEDDINGS_URL;
+
+  const dense = await denseHealth(teamId, configured);
+  return { keyword: "on", dense, graph, rerank };
+}
+
+async function denseHealth(teamId: string, configured: boolean): Promise<DenseHealth> {
+  const empty: DenseHealth = {
+    state: "off",
+    embeddableItems: 0,
+    embeddedItems: 0,
+    pendingItems: 0,
+    coveragePct: 0,
+    lastEmbeddedAt: null,
+    lastRunFailed: false,
+  };
+  if (!configured) return { ...empty, note: "EMBEDDINGS_URL not set — semantic search is off; keyword search still works." };
+
+  try {
+    // Coverage: embeddable items (non-empty body) vs those with an up-to-date chunk. Throws if the
+    // optional pgvector schema (item_chunks) isn't loaded → treated as "off" below.
+    const cov = await runSql<{ embeddable: number | string; embedded: number | string; last: string | Date | null }>(
+      `with ch as (select item_id, min(content_sha256) as sha from item_chunks where team_id = $1 group by item_id)
+       select
+         count(*) filter (where i.body <> '') as embeddable,
+         count(*) filter (where i.body <> '' and ch.sha = i.content_sha256) as embedded,
+         (select max(created_at) from item_chunks where team_id = $1) as last
+       from items i
+       left join ch on ch.item_id = i.id
+       where i.team_id = $1`,
+      [teamId]
+    );
+    const embeddable = Number(cov.rows[0]?.embeddable ?? 0);
+    const embedded = Number(cov.rows[0]?.embedded ?? 0);
+    const lastRaw = cov.rows[0]?.last ?? null;
+    const lastEmbeddedAt = lastRaw instanceof Date ? lastRaw.toISOString() : (lastRaw as string | null);
+
+    // Most recent dense embedding run (per-team or instance-wide) — a failed one = degraded now.
+    const runRes = await runSql<{ ok: boolean }>(
+      `select ok from ingest_runs where source = 'dense' and (team_id = $1 or team_id is null)
+       order by finished_at desc limit 1`,
+      [teamId]
+    );
+    const lastRunFailed = runRes.rows.length > 0 && runRes.rows[0].ok === false;
+
+    const state = deriveDenseState({
+      configured: true,
+      pgvectorLoaded: true,
+      embeddable,
+      embedded,
+      lastRunFailed,
+      lastEmbeddedAtMs: lastEmbeddedAt ? Date.parse(lastEmbeddedAt) : null,
+      nowMs: Date.now(),
+    });
+    return {
+      state,
+      embeddableItems: embeddable,
+      embeddedItems: embedded,
+      pendingItems: Math.max(0, embeddable - embedded),
+      coveragePct: embeddable ? Math.round((embedded / embeddable) * 100) : 100,
+      lastEmbeddedAt,
+      lastRunFailed,
+      note:
+        state === "degraded"
+          ? "Semantic search is degraded — recent embeddings failed (check the embeddings provider/quota). Keyword search is unaffected."
+          : state === "building"
+            ? "Semantic index is catching up on the backlog."
+            : undefined,
+    };
+  } catch {
+    // item_chunks missing (pgvector schema not loaded) or a DB hiccup → semantic search is effectively off.
+    return { ...empty, note: "pgvector schema not loaded — semantic search is off; keyword search still works." };
+  }
+}

--- a/test/datamechanics/retrieval-health.datamechanics.test.ts
+++ b/test/datamechanics/retrieval-health.datamechanics.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getRetrievalHealth } from "@/lib/query/retrieval-health";
+import { seedTeam, type Seed } from "./helpers";
+
+// Spec: getRetrievalHealth must degrade GRACEFULLY against the real DB — the standard test Postgres
+// has no pgvector/item_chunks, which is exactly the "semantic search off" reality it must report
+// (not throw). Keyword is always on; graph/rerank reflect env.
+
+const ENV = { ...process.env };
+afterEach(() => {
+  process.env = { ...ENV };
+  vi.unstubAllEnvs();
+});
+
+describe("getRetrievalHealth (real Postgres, no pgvector)", () => {
+  it("reports keyword on and semantic off (pgvector schema not loaded) without throwing", async () => {
+    const seed: Seed = await seedTeam();
+    vi.stubEnv("EMBEDDINGS_URL", "https://api.openai.com/v1"); // configured, but item_chunks absent
+    const h = await getRetrievalHealth(seed.teamId);
+    expect(h.keyword).toBe("on");
+    expect(h.dense.state).toBe("off");
+    expect(h.dense.note).toMatch(/pgvector/i);
+  });
+
+  it("reports semantic off with the right reason when EMBEDDINGS_URL is unset", async () => {
+    const seed: Seed = await seedTeam();
+    vi.stubEnv("EMBEDDINGS_URL", "");
+    const h = await getRetrievalHealth(seed.teamId);
+    expect(h.dense.state).toBe("off");
+    expect(h.dense.note).toMatch(/EMBEDDINGS_URL/);
+  });
+
+  it("reflects graph + rerank config (malformed GRAPHITI_URL reads off)", async () => {
+    const seed: Seed = await seedTeam();
+    vi.stubEnv("GRAPHITI_URL", "http://"); // the malformed value prod actually had
+    vi.stubEnv("RERANK_URL", "");
+    const h = await getRetrievalHealth(seed.teamId);
+    expect(h.graph).toBe("off");
+    expect(h.rerank).toBe("off");
+
+    vi.stubEnv("RERANK_URL", "https://rerank.example.com");
+    expect((await getRetrievalHealth(seed.teamId)).rerank).toBe("on");
+  });
+});

--- a/test/query-dense-index.test.ts
+++ b/test/query-dense-index.test.ts
@@ -26,6 +26,6 @@ describe("dense indexing when unconfigured", () => {
 
   it("indexPendingItems() is a clean no-op (no DB access) when dense retrieval is off", async () => {
     const r = await indexPendingItems();
-    expect(r).toEqual({ scanned: 0, indexed: 0, chunks: 0, skipped: true });
+    expect(r).toEqual({ scanned: 0, indexed: 0, chunks: 0, skipped: true, failed: 0 });
   });
 });

--- a/test/retrieval-health.test.ts
+++ b/test/retrieval-health.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { deriveDenseState, graphConfigured } from "@/lib/query/retrieval-health";
+
+// Spec: the dense-leg state machine must separate off / building / degraded / healthy so the admin
+// card tells the truth — especially "degraded" (erroring or stalled, red) vs "building" (catching
+// up, amber). This is the logic that would have flagged the silent OpenAI-quota outage.
+
+const base = {
+  configured: true,
+  pgvectorLoaded: true,
+  embeddable: 100,
+  embedded: 100,
+  lastRunFailed: false,
+  lastEmbeddedAtMs: Date.parse("2026-07-09T12:00:00Z"),
+  nowMs: Date.parse("2026-07-09T12:10:00Z"),
+};
+
+describe("deriveDenseState", () => {
+  it("off when embeddings aren't configured or pgvector isn't loaded", () => {
+    expect(deriveDenseState({ ...base, configured: false })).toBe("off");
+    expect(deriveDenseState({ ...base, pgvectorLoaded: false })).toBe("off");
+  });
+
+  it("degraded when the most recent embedding run failed (the quota/outage case)", () => {
+    expect(deriveDenseState({ ...base, lastRunFailed: true })).toBe("degraded");
+  });
+
+  it("healthy at ≥90% coverage, or when there's nothing to embed", () => {
+    expect(deriveDenseState({ ...base, embeddable: 100, embedded: 95 })).toBe("healthy");
+    expect(deriveDenseState({ ...base, embeddable: 0, embedded: 0 })).toBe("healthy");
+  });
+
+  it("building when incomplete but recently progressing (amber, not red)", () => {
+    expect(deriveDenseState({ ...base, embeddable: 100, embedded: 40 })).toBe("building");
+  });
+
+  it("degraded when incomplete AND stalled (no recent embed activity)", () => {
+    expect(deriveDenseState({ ...base, embeddable: 100, embedded: 40, lastEmbeddedAtMs: null })).toBe("degraded");
+    const stale = Date.parse("2026-07-09T09:00:00Z"); // >2h before now
+    expect(deriveDenseState({ ...base, embeddable: 100, embedded: 40, lastEmbeddedAtMs: stale })).toBe("degraded");
+  });
+});
+
+describe("graphConfigured", () => {
+  it("false for the malformed 'http://' that prod actually had", () => {
+    expect(graphConfigured("http://")).toBe(false);
+  });
+  it("false for unset or garbage", () => {
+    expect(graphConfigured(undefined)).toBe(false);
+    expect(graphConfigured("not a url")).toBe(false);
+  });
+  it("true for a real http(s) URL with a host", () => {
+    expect(graphConfigured("http://graphiti.railway.internal:8000")).toBe(true);
+    expect(graphConfigured("https://graph.example.com")).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase 1 of retrieval observability — **the "flag issues on the dashboard" ask**. (Phase 1b = email alerts, next PR.)

## Why
Retrieval is hybrid (keyword FTS + dense vector), but the dense leg depends on pgvector + an external embeddings provider and can **silently drop out** — we watched it go dark under an OpenAI quota outage this session with **zero signal** (`indexPendingItems` swallowed every per-item error and reported `indexed:0`). Nobody could tell semantic search had stopped, or how much of the corpus it even covers. Neither could I, when you asked — the prod DB isn't reachable from outside Railway. This makes it visible **in the product**.

## What
- **Loud failures** — `indexPendingItems` now counts failed items + keeps the first error instead of swallowing them; the scheduler records a `dense` **error run** so it shows in the existing "Recent ingestion runs" panel.
- **Health check** (`lib/query/retrieval-health`) — per-leg state: keyword (always on), **dense** (`off`/`building`/`degraded`/`healthy` with embedding **coverage %** + last-embed time), graph, rerank. `deriveDenseState` is pure + unit-tested; `graphConfigured` correctly reads prod's malformed `"http://"` as **off**. Best-effort — degrades to `off` (never throws) when pgvector isn't loaded.
- **Dashboard card** (`RetrievalHealthCard` on Admin → Integrations) — red/amber/green per leg, coverage front-and-center, plain-language degradation note.

## What this immediately tells you
Once deployed, the card on your prod Admin → Integrations will show the **actual embedding coverage %** and whether dense is currently degraded — the exact question I couldn't answer remotely.

## Test plan
- [x] Unit: `deriveDenseState` 4-state machine + `graphConfigured` (incl. the `"http://"` case)
- [x] Data-mechanics: `getRetrievalHealth` degrades gracefully with no pgvector, right off-reason, reflects graph/rerank env
- [x] Full unit tier green (454 + 1 expected-fail); full data-mechanics green (315 + 1); tsc/lint/docs-drift clean
- [ ] Card not browser-verified (presentational, tested data path) — worth a glance post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin card showing retrieval health at a glance, including keyword, semantic, graph memory, and reranker status.
  * Added retrieval health checks that summarize coverage, freshness, and recent ingestion status for better visibility.

* **Bug Fixes**
  * Dense indexing now records partial and full failures more accurately in run history.
  * Retrieval health now degrades gracefully when required services or database features are unavailable, instead of failing outright.

* **Tests**
  * Added coverage for retrieval health state handling and URL validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->