### PR TITLE
feat(admin): email admins when semantic search degrades/recovers (Phase 1b)

### DIFF
--- a/lib/auth/mailer.ts
+++ b/lib/auth/mailer.ts
@@ -84,6 +84,20 @@ async function deliver(to: string, subject: string, body: { text: string; html?:
   return false;
 }
 
+/**
+ * Ops/admin alert email (e.g. "semantic search degraded"). Plain-text, best-effort — never throws,
+ * returns whether a provider actually delivered it (false when none is configured). Not a secret, so
+ * it's fine that no provider = a logged drop.
+ */
+export async function sendOpsAlert(to: string, subject: string, text: string): Promise<boolean> {
+  return deliver(to, subject, { text });
+}
+
+/** Whether an email provider is configured at all (so callers can skip work when nothing can send). */
+export function mailerConfigured(): boolean {
+  return Boolean(process.env.RESEND_API_KEY || process.env.SMTP_URL);
+}
+
 /** Magic-link sign-in email (login flow). Never throws. */
 export async function sendMagicLink(email: string, link: string): Promise<void> {
   await deliver(email, "Your AIOS Team Brain sign-in link", {

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -38,6 +38,10 @@ export function startIngestScheduler(): void {
     // degraded stack shows on Admin → Integrations instead of silently indexing nothing.
     {
       const startedAt = Date.now();
+      const { lastDenseRunFailed, alertDenseDegraded, alertDenseRecovered } = await import("@/lib/query/retrieval-alert");
+      // Capture the leg's state BEFORE this tick so we can email admins only on the EDGE (ok→degraded
+      // or degraded→ok), not once per tick during a sustained outage.
+      const priorFailed = await lastDenseRunFailed(db).catch(() => false);
       try {
         const { indexPendingItems } = await import("@/lib/query/dense-index");
         const d = await indexPendingItems();
@@ -53,6 +57,7 @@ export function startIngestScheduler(): void {
             meta: { indexed: d.indexed, failed: d.failed, chunks: d.chunks },
             startedAt,
           });
+          await alertDenseDegraded(db, priorFailed, { failed: d.failed, scanned: d.scanned, errorSample: d.errorSample });
         } else if (d.indexed > 0) {
           await recordIngestRun(db, {
             source: "dense",
@@ -62,11 +67,13 @@ export function startIngestScheduler(): void {
             meta: { indexed: d.indexed, chunks: d.chunks },
             startedAt,
           });
+          await alertDenseRecovered(db, priorFailed, d.indexed);
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error("[ingest] dense index tick failed:", msg);
         await recordIngestRun(db, { source: "dense", trigger: "scheduler", ok: false, errors: [msg], startedAt });
+        await alertDenseDegraded(db, priorFailed, { failed: 0, scanned: 0, errorSample: msg });
       }
     }
   };

--- a/lib/query/retrieval-alert.ts
+++ b/lib/query/retrieval-alert.ts
@@ -1,0 +1,77 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { sendOpsAlert, mailerConfigured } from "@/lib/auth/mailer";
+
+/**
+ * Email admins when the dense (semantic) retrieval leg TRANSITIONS to/from degraded — Phase 1b of the
+ * retrieval-observability plan. Debounced by design: it only fires on the edge (last dense run's
+ * outcome flipped), so a sustained embeddings outage sends ONE alert, not one per scheduler tick.
+ *
+ * Dense indexing is instance-wide (a shared embeddings provider), so the alert goes to every active
+ * admin. Best-effort throughout — a mail failure must never affect the ingest tick.
+ */
+
+/** Was the most recent recorded dense run a failure? (false when there are none.) */
+export async function lastDenseRunFailed(db: DbClient): Promise<boolean> {
+  const { data } = await db
+    .from("ingest_runs")
+    .select("ok")
+    .eq("source", "dense")
+    .order("finished_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return !!data && (data as { ok: boolean }).ok === false;
+}
+
+async function activeAdminEmails(db: DbClient): Promise<string[]> {
+  const { data } = await db
+    .from("members")
+    .select("email")
+    .eq("role", "admin")
+    .eq("status", "active");
+  const emails = (data ?? [])
+    .map((m) => (m as { email: string | null }).email)
+    .filter((e): e is string => !!e && e.includes("@"));
+  return [...new Set(emails.map((e) => e.toLowerCase()))];
+}
+
+/**
+ * Notify admins that semantic search just broke. `priorFailed` is the leg's state BEFORE this tick,
+ * captured by the caller so we can detect the edge. No-op unless this is a fresh transition into
+ * failure and a mail provider is configured.
+ */
+export async function alertDenseDegraded(
+  db: DbClient,
+  priorFailed: boolean,
+  detail: { failed: number; scanned: number; errorSample?: string }
+): Promise<void> {
+  if (priorFailed || !mailerConfigured()) return; // debounce: only on the ok→degraded edge
+  try {
+    const admins = await activeAdminEmails(db);
+    if (admins.length === 0) return;
+    const where = process.env.APP_URL ? `${process.env.APP_URL.replace(/\/$/, "")} → Admin → Integrations` : "Admin → Integrations";
+    const text =
+      `Semantic (vector) search has stopped working: ${detail.failed} of ${detail.scanned} items failed to embed ` +
+      `this cycle.\n\nLikely cause: the embeddings provider is down or out of quota (check billing/keys). ` +
+      `Keyword search is unaffected, so the brain still answers — but paraphrased questions and large-corpus ` +
+      `recall are weaker until this recovers.\n\n` +
+      (detail.errorSample ? `Provider error: ${detail.errorSample}\n\n` : "") +
+      `See the Retrieval health card at ${where}. You'll get one more email when it recovers.`;
+    for (const to of admins) await sendOpsAlert(to, "⚠️ AIOS Team Brain — semantic search degraded", text);
+  } catch {
+    // best-effort — a mail failure must not affect the ingest tick
+  }
+}
+
+/** Notify admins that semantic search recovered — the symmetric edge (degraded→ok). */
+export async function alertDenseRecovered(db: DbClient, priorFailed: boolean, indexed: number): Promise<void> {
+  if (!priorFailed || !mailerConfigured()) return; // only on the degraded→ok edge
+  try {
+    const admins = await activeAdminEmails(db);
+    if (admins.length === 0) return;
+    const text = `Semantic (vector) search is working again — the embeddings backlog is indexing (${indexed} items this cycle). No action needed.`;
+    for (const to of admins) await sendOpsAlert(to, "✅ AIOS Team Brain — semantic search recovered", text);
+  } catch {
+    // best-effort
+  }
+}

--- a/test/datamechanics/retrieval-alert.datamechanics.test.ts
+++ b/test/datamechanics/retrieval-alert.datamechanics.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { lastDenseRunFailed } from "@/lib/query/retrieval-alert";
+import { recordIngestRun } from "@/lib/ingest/runs";
+import { db } from "./helpers";
+
+// Spec: lastDenseRunFailed reflects the MOST RECENT dense run's outcome — the edge-detection that
+// makes the degraded-email debounced (fire once on ok→degraded, not every tick). Verified on real
+// Postgres via the real recordIngestRun writer.
+
+const t = (iso: string) => Date.parse(iso);
+
+describe("lastDenseRunFailed (dense-leg edge detection)", () => {
+  it("false when there are no dense runs", async () => {
+    expect(await lastDenseRunFailed(db())).toBe(false);
+  });
+
+  it("tracks the newest dense run's ok flag as it flips", async () => {
+    await recordIngestRun(db(), { source: "dense", trigger: "scheduler", ok: true, startedAt: t("2026-07-09T10:00:00Z"), finishedAt: t("2026-07-09T10:00:01Z") });
+    expect(await lastDenseRunFailed(db())).toBe(false);
+
+    await recordIngestRun(db(), { source: "dense", trigger: "scheduler", ok: false, errors: ["quota"], startedAt: t("2026-07-09T10:30:00Z"), finishedAt: t("2026-07-09T10:30:01Z") });
+    expect(await lastDenseRunFailed(db())).toBe(true); // degraded now
+
+    await recordIngestRun(db(), { source: "dense", trigger: "scheduler", ok: true, startedAt: t("2026-07-09T11:00:00Z"), finishedAt: t("2026-07-09T11:00:01Z") });
+    expect(await lastDenseRunFailed(db())).toBe(false); // recovered
+  });
+
+  it("ignores other sources — a failed Slack run doesn't read as a dense failure", async () => {
+    await recordIngestRun(db(), { source: "dense", trigger: "scheduler", ok: true, startedAt: t("2026-07-09T10:00:00Z"), finishedAt: t("2026-07-09T10:00:01Z") });
+    await recordIngestRun(db(), { source: "slack", trigger: "scheduler", ok: false, errors: ["boom"], startedAt: t("2026-07-09T12:00:00Z"), finishedAt: t("2026-07-09T12:00:01Z") });
+    expect(await lastDenseRunFailed(db())).toBe(false); // the dense leg is still healthy
+  });
+});


### PR DESCRIPTION
Completes Phase 1 — the "**email the admin if possible**" half of your ask.

## What
The dense scheduler tick now captures the leg's prior state and, on the **edge** (ok→degraded or degraded→ok), emails every active admin. Debounced by design: a sustained embeddings outage sends **one** alert, not one per tick.

- `lib/auth/mailer.sendOpsAlert` — generic admin alert via the existing Resend/SMTP delivery (+ `mailerConfigured` gate).
- `lib/query/retrieval-alert` — `lastDenseRunFailed` (edge detection off `ingest_runs`) + `alertDenseDegraded`/`alertDenseRecovered` (resolve active-admin emails, send; no-op unless it's a fresh transition **and** a provider is configured). Best-effort — a mail failure never affects the ingest tick.
- `lib/ingest/scheduler` — capture `priorFailed` before the batch, fire the matching alert after recording the run.

The degraded email names the likely cause (provider down/quota), reassures that keyword search still answers, and points at the Retrieval health card (from #189).

## Test plan
- [x] Data-mechanics: `lastDenseRunFailed` tracks the newest dense run's outcome as it flips, ignores other sources (the debounce brain), false when none
- [x] Full unit tier green (454 + 1 expected-fail); full data-mechanics green (318 + 1); tsc/lint/docs-drift clean
- [ ] Live: needs `RESEND_API_KEY`/`SMTP_URL` set to actually deliver (no-op + logged drop otherwise) — verify once a provider is configured

## Phase 1 is now complete
Dashboard flag (#189) + email alerts (this). Phase 2 (provider de-risk) intentionally left to the self-hoster; Phase 3 (query-scoped caps, reranker, Graphiti) remains as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)