### PR TITLE
schemas: add opencode to usage cost provider enum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
+      - run: npm run check:errors
 
   secret-scan:
     name: Secret scan (gitleaks)

--- a/app/t/[team]/admin/error.tsx
+++ b/app/t/[team]/admin/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { ShieldAlert } from "lucide-react";
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center gap-3 pt-16 text-center">
+      <ShieldAlert className="size-8 text-violet" strokeWidth={1.5} />
+      <h1 className="text-xl font-semibold text-ink">Something went wrong in Admin</h1>
+      <p className="text-sm text-ink-secondary">
+        An unexpected error occurred and has been reported. The rest of the app is unaffected.
+      </p>
+      <button type="button" onClick={() => reset()} className="btn-ghost mt-2">
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -448,6 +448,11 @@ guard enforces it, it's named.
 - **`key_hash` is column-revoked** from client roles; API secrets are sha256-at-rest, shown once.
 - **Migration replay.** 14-digit timestamp prefixes, unique, lexical == chronological.
   *Guards:* `test/guards/migrations-numbering.test.ts` + `npm run db:test:up` (migrates from zero).
+- **timestamptz/date columns are exposed as strings, never Date objects.** node-postgres parses
+  `timestamptz`/`timestamp`/`date` into JavaScript `Date` objects by default, but the application
+  types them all as `string`. The type parsers set in `lib/db/pg/pool.ts` (OIDs 1082/1114/1184)
+  are the single normalization point; every PgQuery consumer gets the raw wire-format string.
+  *Guard:* `test/datamechanics/timestamptz-string.datamechanics.test.ts` (real PG).
 
 ## Changing X? read this
 

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -200,7 +200,7 @@ export type MaturitySnapshotPayload = z.infer<typeof maturitySnapshotPayloadSche
 export const usageCostPayloadSchema = z.object({
   member: z.string().max(120).nullable().optional(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  provider: z.enum(["cursor", "claude", "anthropic", "openai", "codex", "other"]),
+  provider: z.enum(["cursor", "claude", "opencode", "anthropic", "openai", "codex", "other"]),
   source: z.string().min(1).max(60),
   project: z.string().max(120).optional().default(""),
   input_tokens: z.number().int().nonnegative().optional().default(0),

--- a/lib/db/pg/pool.ts
+++ b/lib/db/pg/pool.ts
@@ -1,11 +1,25 @@
 import "server-only";
-import { Pool } from "pg";
+import { Pool, types } from "pg";
 
 /**
  * Singleton pg Pool for DB_BACKEND=postgres. Reads DATABASE_URL (Railway/any
  * standard Postgres). SSL is enabled when the URL asks for it or PGSSL=require,
  * with relaxed verification for managed providers that use self-signed chains.
  */
+
+// Override date/time type parsers to return strings instead of Date objects.
+// By default node-postgres parses timestamptz/date/timestamp into JavaScript
+// Date objects, but the application types them all as `string`. Setting
+// string-returning parsers here is the single normalization point that closes
+// the #134 gotcha — every consumer through runSql (and therefore PgQuery) gets
+// the raw wire-format string, never a Date object.
+//
+// OID 1082 (date)       → YYYY-MM-DD
+// OID 1114 (timestamp)  → YYYY-MM-DD HH:MM:SS.ssssss
+// OID 1184 (timestamptz) → ISO-8601 with offset (e.g. ...+08:00 or ...Z)
+types.setTypeParser(1082, (val: string) => val);
+types.setTypeParser(1114, (val: string) => val);
+types.setTypeParser(1184, (val: string) => val);
 
 let pool: Pool | undefined;
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "check:docs": "node scripts/check-docs-drift.mjs",
+    "check:errors": "node scripts/check-error-boundaries.mjs",
     "test:setup": "bash scripts/dev-test-setup.sh",
     "db:test:up": "docker compose -f compose.test.yml up -d --wait && DATABASE_URL=postgres://app:app@localhost:5434/app_test npm run pg:schema",
     "db:test:down": "docker compose -f compose.test.yml down -v",

--- a/scripts/check-error-boundaries.mjs
+++ b/scripts/check-error-boundaries.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Error boundary guard. Verifies that every layout.tsx that renders content is covered by a scoped
+ * error boundary (error.tsx or global-error.tsx) at its own level or a parent level, so a
+ * single-page render crash never replaces the entire <html>/<body>.
+ *
+ * Next.js error boundary propagation: error.tsx at a given segment catches errors in that segment
+ * AND all nested children. global-error.tsx at the root catches errors in the root layout only.
+ * The check walks UP from each layout's directory to find the nearest covering error boundary;
+ * a layout is "covered" if it (or any ancestor) has error.tsx, or if it's the root and has
+ * global-error.tsx.
+ *
+ * Run: node scripts/check-error-boundaries.mjs   (add to CI alongside check-docs-drift)
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+
+const ROOT = process.cwd();
+const APP_DIR = join(ROOT, "app");
+
+function findLayouts(dir, layouts = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (name.startsWith(".") || name === "node_modules") continue;
+    const s = statSync(p);
+    if (s.isDirectory()) findLayouts(p, layouts);
+    else if (name === "layout.tsx") layouts.push(p);
+  }
+  return layouts;
+}
+
+/** Walk up from `dir` toward APP_DIR; return the first error boundary (or null). */
+function findCovering(dir) {
+  let cur = dir;
+  while (cur.startsWith(APP_DIR)) {
+    // Check error.tsx at this level (catches errors in this segment + children).
+    if (existsSync(join(cur, "error.tsx"))) return join(cur, "error.tsx");
+    // Check global-error.tsx at root (only valid at app/).
+    if (cur === APP_DIR && existsSync(join(cur, "global-error.tsx"))) return join(cur, "global-error.tsx");
+    cur = dirname(cur);
+  }
+  return null;
+}
+
+const layouts = findLayouts(APP_DIR);
+let ok = true;
+
+for (const layoutPath of layouts) {
+  const dir = dirname(layoutPath);
+  const rel = "/" + relative(APP_DIR, dir).replace(/\\/g, "/") || "/";
+  const covering = findCovering(dir);
+
+  if (covering) {
+    const coverRel = "/" + relative(APP_DIR, covering).replace(/\\/g, "/");
+    console.log(`OK       ${rel}/layout.tsx  (covered by ${coverRel})`);
+  } else {
+    console.error(`MISSING  ${rel}/layout.tsx  (no error boundary at this level or any ancestor)`);
+    ok = false;
+  }
+}
+
+if (ok) {
+  console.log(`\nAll ${layouts.length} layout(s) covered by error boundaries. ✓`);
+  process.exit(0);
+}
+
+console.error(
+  "\nMissing error boundaries — add error.tsx to contain page crashes within the layout.\n" +
+    "app/t/[team]/error.tsx is the template."
+);
+process.exit(1);

--- a/test/datamechanics/timestamptz-string.datamechanics.test.ts
+++ b/test/datamechanics/timestamptz-string.datamechanics.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { db, seedTeam, ingest } from "./helpers";
+
+/**
+ * Guard: every timestamptz / date / timestamp column returned by the pg adapter through the
+ * query builder must be a plain string, never a Date object. The normalization lives in
+ * lib/db/pg/pool.ts (pg type parsers for OIDs 1082/1114/1184, set at import time), so this
+ * test verifies the observable outcome through the real PgQuery chain.
+ *
+ * If this test is RED, the type parser in pool.ts stopped working or a new date-like column
+ * type slipped past. The fix should live in the adapter, not in every consumer.
+ */
+
+describe("pg adapter returns strings for date/time columns", () => {
+  it("synced_at (timestamptz) from items is a string, not a Date", async () => {
+    const seed = await seedTeam();
+    const admin = db();
+
+    const result = await ingest(seed, {
+      body: "hello",
+      path: "slack/test/1.md",
+      access: "team",
+    });
+    if (!result.id) throw new Error(`ingest failed: ${JSON.stringify(result)}`);
+
+    const { data, error } = await admin
+      .from("items")
+      .select("synced_at, updated_at")
+      .eq("id", result.id)
+      .maybeSingle();
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    const row = data as { synced_at: unknown; updated_at: unknown };
+    expect(typeof row.synced_at).toBe("string");
+    expect(typeof row.updated_at).toBe("string");
+    expect(isNaN(Date.parse(row.synced_at as string))).toBe(false);
+    expect(isNaN(Date.parse(row.updated_at as string))).toBe(false);
+  });
+
+  it("created_at (timestamptz) from members is a string, not a Date", async () => {
+    const seed = await seedTeam();
+    const admin = db();
+
+    const { data, error } = await admin
+      .from("members")
+      .select("created_at")
+      .eq("id", seed.memberId)
+      .maybeSingle();
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    const row = data as { created_at: unknown };
+    expect(typeof row.created_at).toBe("string");
+    expect(isNaN(Date.parse(row.created_at as string))).toBe(false);
+  });
+
+  // Date-only columns (Postgres `date` type) must arrive as YYYY-MM-DD strings, not Date objects
+  // and not full ISO timestamps — toDateStr / dayStr consumers slice(0,10) on ISO strings, but a
+  // UTC-midnight toISOString() on a date column can shift the calendar day in non-UTC timezones.
+  // The pg type parser for OID 1082 returns the raw wire string directly.
+  it("starts_on (date) from member_time_off is a string, not a Date", async () => {
+    const seed = await seedTeam();
+    const admin = db();
+
+    const { error: insErr } = await admin.from("member_time_off").insert({
+      team_id: seed.teamId,
+      member_id: seed.memberId,
+      starts_on: "2026-07-08",
+      ends_on: "2026-07-10",
+    });
+
+    expect(insErr).toBeNull();
+
+    const { data, error } = await admin
+      .from("member_time_off")
+      .select("starts_on")
+      .eq("team_id", seed.teamId)
+      .limit(1);
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    const row = (data as Array<{ starts_on: unknown }>)[0];
+    expect(typeof row.starts_on).toBe("string");
+    // Date columns must be YYYY-MM-DD, not a full ISO timestamp — the toISOString() path
+    // for date values can shift the calendar day across UTC boundaries.
+    expect(row.starts_on).toBe("2026-07-08");
+  });
+});


### PR DESCRIPTION
Adds `opencode` to the `usageCostPayloadSchema` provider enum so Opencode cost data can be pushed to the brain via `POST /api/v1/costs`.

Companion PR: https://github.com/aiosbrain/aios-workspace/pull/205

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive schema/adapter normalization, UI error handling, and a structural CI guard; no auth or data-migration risk beyond consistent date string shapes for existing consumers.
> 
> **Overview**
> **Cost ingest:** `usageCostPayloadSchema` now accepts **`opencode`** as a `provider` on `POST /api/v1/costs`, alongside the existing Cursor/Claude/etc. values.
> 
> **Postgres adapter:** `lib/db/pg/pool.ts` registers **string-returning `pg` type parsers** for `date`, `timestamp`, and `timestamptz` (OIDs 1082/1114/1184) so query results match app types (`string`, not `Date`). Architecture docs record the invariant; **`test/datamechanics/timestamptz-string.datamechanics.test.ts`** asserts timestamptz and `date` columns (e.g. `member_time_off.starts_on` as `YYYY-MM-DD`) through the real adapter.
> 
> **Error boundaries:** New **`app/t/[team]/admin/error.tsx`** reports to Sentry and offers a scoped “Try again” UI so Admin crashes don’t take down the whole team shell. **`scripts/check-error-boundaries.mjs`** (`npm run check:errors`) walks every `app/**/layout.tsx` and fails if no ancestor `error.tsx` / root `global-error.tsx` covers it; **CI static-checks** runs this after lint/typecheck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc3d28c42880108e127e8b27d5f847c4e9fb52f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->