### PR TITLE
feat(skills): add branch-reconciliation + test-ci-wiring-audit skills

### DIFF
--- a/.claude/skills/branch-reconciliation/SKILL.md
+++ b/.claude/skills/branch-reconciliation/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: branch-reconciliation
+description: >
+  Classify every unmerged remote branch as (a) truly unmerged with live content,
+  (b) already shipped under a different hash — a squash-merge duplicate, safe to
+  delete, with evidence attached — or (c) genuinely stale/abandoned. Use when asked
+  "are these branches actually stale", "check unmerged branches", "clean up feature
+  branches", or /branch-reconcile. Classification only — never deletes or merges.
+---
+
+# Branch reconciliation
+
+## Why this exists
+
+A 2026-07-09 audit of this repo found ~31 of the 54 non-dependabot "unmerged"
+branches were byte-identical duplicates of already-merged work (e.g.
+`chetan/fix-gap*` = PRs #182-188, `chat-*` = PRs #117/118/145/177). The repo-wide
+`supabase`→`db` rename made merged work *look* unmerged when diffed naively
+against `main` — `git branch --no-merged` and a plain `git diff` both false-positive
+heavily on squash merges. Don't trust either signal alone; this skill encodes the
+cheap-to-expensive verification ladder that catches it.
+
+## Steps
+
+Run the cheap passes on every branch before spending a real read on any of them.
+
+1. **Enumerate.**
+   ```bash
+   git fetch --prune
+   git branch -r --no-merged origin/main
+   ```
+
+2. **Cheap pass — patch-equivalence.** For each candidate branch:
+   ```bash
+   git cherry origin/main origin/<branch>
+   ```
+   Every commit prefixed `-` is patch-equivalent to something already on `main`.
+   If **all** commits come back `-`, bucket as **(b) squash-duplicate** — record
+   the matching `main` commit(s) as evidence and stop there.
+
+3. **For branches with `+` commits, check squash-merge equivalence.** `git cherry`
+   only catches patch-identical commits — it misses squash merges, which rewrite
+   the diff into a single new commit. For each `+` commit / remaining branch:
+   ```bash
+   git diff origin/main...origin/<branch> --name-only
+   # then per changed file, compare current main content directly:
+   git diff origin/main:<file> origin/<branch>:<file>
+   gh pr list --state merged --search "<branch-name OR topic>"
+   git log origin/main --grep="<commit subject>"
+   ```
+   If the file-level diffs are empty (or trivially whitespace/rename) against
+   current `main`, and a merged PR or matching commit subject is found, bucket as
+   **(b)** with the PR number / commit SHA as evidence. This step is what catches
+   what step 2 misses — squash merges hide equivalence from `git cherry` entirely.
+
+4. **Real read — only for survivors.** Branches that fail both the cherry check
+   and the content-compare are the only ones worth actually opening. Read the
+   diff for content, assess shippability, and flag merge risk against current
+   `main` (conflicts, staleness, whether the feature is still wanted). Bucket as
+   **(a) truly unmerged** if it has live, shippable content, or **(c) stale /
+   abandoned** if it's dead work, a spike, or superseded by other since-merged
+   work.
+
+5. **Report.** Output **one table**, nothing else:
+
+   | branch | class | evidence (PR#/commit) | recommended action |
+   |---|---|---|---|
+   | `chetan/fix-gap-x` | (b) squash-duplicate | PR #184 | delete-with-evidence |
+   | `chat-widget-v2` | (a) truly unmerged | — | needs-owner-decision |
+   | `spike/old-idea` | (c) stale | last commit 2025-11 | delete-with-evidence |
+
+   Recommended action is one of: `merge`, `delete-with-evidence`,
+   `needs-owner-decision`. **This skill classifies only — it never deletes or
+   merges a branch.** Hand the table to a human (or a separate, explicitly
+   authorized cleanup step) to act on.
+
+## Model tiering
+
+- Steps 1-3 (fetch, `git cherry`, diff/grep/gh checks) are cheap, mechanical,
+  high-volume — run them on a **haiku-tier** model.
+- Step 4 (the real read of survivors) needs judgment about shippability and risk
+  — run it on a **sonnet-tier** model, and only on the branches that survive the
+  cheap passes.

--- a/.claude/skills/test-ci-wiring-audit/SKILL.md
+++ b/.claude/skills/test-ci-wiring-audit/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: test-ci-wiring-audit
+description: >
+  Find test files on disk that run in neither `npm test` nor CI (orphaned tests —
+  false confidence) plus stale coverage reports that cite deleted files. Use when
+  asked "is this test actually running", "check test wiring", "orphaned tests",
+  "is the coverage report fresh", or /test-wiring-check. Static parsing only —
+  flags issues and suggests fixes, never edits wiring itself.
+---
+
+# Test/CI wiring audit
+
+## Why this exists
+
+A 2026-07-09 audit of this repo found `coverage/coverage-summary.json` was 12
+days stale and cited `lib/auth/supabase-auth.ts` — a file deleted in the
+supabase-removal refactor — as a top-15 worst-covered file, while CI was
+actually green across 143 test files. A stale coverage report can point at
+dead file paths and misrepresent real coverage; a test file that exists on
+disk can silently run in neither `npm test` nor CI and give false confidence.
+Both failure modes are purely static/mechanical to detect — no code execution
+needed.
+
+## Steps
+
+1. **Enumerate test files on disk.**
+   ```bash
+   git ls-files '*.test.ts' '*.test.tsx' '*.test.mjs'
+   # plus ingestion-side pytest files, e.g.:
+   git ls-files 'ingestion/**/test_*.py' 'ingestion/**/*_test.py'
+   ```
+   Exclude `node_modules/` and `.next/` (should already be excluded by
+   `git ls-files`, but double-check if falling back to `find`/`glob`).
+
+2. **Parse what's actually wired.**
+   - `package.json`: read the `scripts.test` chain (and any script it calls
+     transitively — `pretest`, `test:unit`, `test:integration`, etc.) and expand
+     every glob/pattern it passes to the test runner.
+   - `.github/workflows/*.yml`: read every `test`-labeled step/job, including
+     matrix jobs, and any Python-side step (`pytest`, `python -m pytest`, tox).
+   - Build the set of file *patterns* actually invoked by each surface (npm
+     script vs. CI workflow) — don't assume they're identical.
+
+3. **Classify every test file found in step 1** against the two wired sets from
+   step 2:
+   - **both** — covered by `npm test` and CI. Fine.
+   - **one-only** — runs locally but not in CI, or vice versa. **Flag.**
+   - **neither** — matches no invoked pattern in either surface. **ORPHANED.**
+
+4. **Coverage staleness check.**
+   ```bash
+   stat -f %m coverage/coverage-summary.json   # or ls -l / date -r, mtime
+   git log -1 --format=%ci origin/main
+   ```
+   If the coverage report's mtime predates the latest `main` commit by a
+   meaningful margin (days, not minutes), flag it as stale. Independently, for
+   every file the report names as a top-offender / worst-covered file, verify
+   it still exists on disk (`git ls-files --error-unmatch <path>` or a plain
+   existence check). Any named file that no longer exists is hard evidence the
+   report is stale and must be regenerated before being trusted.
+
+5. **Report.** Output two things only:
+   - An **orphaned/one-only test table**: file path → status (`one-only:
+     local-only` / `one-only: CI-only` / `orphaned`) → suggested exact wiring
+     fix (e.g. "add `test/foo.test.ts` to the `test:integration` glob in
+     `package.json`" or "add a step to `.github/workflows/ci.yml`").
+   - A **coverage verdict**: fresh/stale, with the stale reasons (mtime gap,
+     and/or list of named files that no longer exist).
+
+   This skill only flags and suggests — it does not edit `package.json`,
+   workflow YAML, or the coverage report itself.
+
+## Model tiering
+
+Entirely **haiku-tier**: static file enumeration, glob/pattern parsing, mtime
+comparison, and existence checks. No code execution, no judgment calls about
+test quality or shippability.


### PR DESCRIPTION
## Summary
- Add `.claude/skills/branch-reconciliation/SKILL.md` — classifies unmerged remote branches as truly-unmerged, squash-merge duplicates already shipped under a different hash, or genuinely stale. Encodes a cheap-to-expensive verification ladder (`git cherry` → per-file content-compare → real read) so squash merges don't false-positive as unmerged work. Classification only, never deletes/merges.
- Add `.claude/skills/test-ci-wiring-audit/SKILL.md` — finds test files on disk wired into neither `npm test` nor CI (orphaned), and flags stale coverage reports that cite files no longer on disk. Static parsing only, flags/suggests but doesn't edit wiring.

Both originate from a 2026-07-09 pre-demo launch audit of this repo, which found:
- ~31 of 54 non-dependabot "unmerged" branches were byte-identical duplicates of already-merged work — the repo-wide supabase→db rename made merged work look unmerged under a naive diff.
- `coverage/coverage-summary.json` was 12 days stale and cited a file deleted in the supabase-removal refactor as a top-15 worst-covered file, while CI was actually green across 143 test files.

## Test plan
- [x] Diff scoped to exactly the two new skill directories (verified via `git diff --cached --stat`)
- [x] Frontmatter/voice matches the existing `.claude/skills/admin/SKILL.md` convention
- [ ] Dry-run each skill against this repo's actual branch/CI state (follow-up, not required to merge doc-only skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill definitions with no runtime, CI, or application code changes.
> 
> **Overview**
> Adds two **Claude Code skills** (doc-only under `.claude/skills/`) that encode audit playbooks from a 2026-07-09 repo review.
> 
> **`branch-reconciliation`** walks remote branches that look unmerged through a cheap-to-expensive ladder (`git cherry`, per-file compares against `main`, merged-PR/`git log` evidence), then classifies each as truly unmerged, squash-duplicate already on `main`, or stale. Output is a single action table; the skill **never** deletes or merges branches.
> 
> **`test-ci-wiring-audit`** statically lists test files on disk, compares them to patterns invoked by `npm test` and CI workflows, flags orphaned or local/CI-only mismatches, and checks whether `coverage/coverage-summary.json` is stale (mtime vs `main`, paths in the report that no longer exist). It **suggests** wiring fixes only—no edits to `package.json` or workflows.
> 
> Both skills include frontmatter and model-tiering notes aligned with existing skills like `admin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f36a8edbc69119ce9792d20db0d411031f3454d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new workflow guides for reviewing branch status and test/CI wiring.
  * The branch review guide helps classify branches as active, duplicate, or stale using a step-by-step verification process.
  * The test/CI guide helps identify missing or orphaned test coverage and check whether coverage reports are up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->