### PR TITLE
fix(api): align BRAIN_API_VERSION with pinned contract v1.5

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ flowchart LR
 
 ## Auth & access tiers
 
-This server **implements brain-api v1.3** (the wire contract; source of truth:
+This server **implements brain-api v1.5** (the wire contract; source of truth:
 `aios-workspace/docs/brain-api.md`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`) and asserted against this sentence by
 `test/guards/contract-version.test.ts` — bump all three together on a contract change.

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -9,4 +9,4 @@
  * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
  */
-export const BRAIN_API_VERSION = "1.3";
+export const BRAIN_API_VERSION = "1.5";


### PR DESCRIPTION
Aligns BRAIN_API_VERSION (was "1.3") and the docs/ARCHITECTURE.md version claim with the pinned contract in aios-workspace/docs/brain-api.md, which is at v1.5 — found via a remediation-plan audit of brain-api version drift (W0.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version-constant alignment only; no runtime API or auth behavior changes in this diff.
> 
> **Overview**
> Fixes **brain-api version drift** (W0.4): the pinned contract in `aios-workspace/docs/brain-api.md` is v1.5, but the server still declared **v1.3**.
> 
> `BRAIN_API_VERSION` in `lib/api/version.ts` and the canonical “implements brain-api v…” sentence in `docs/ARCHITECTURE.md` are both updated to **v1.5**, keeping the constant, architecture doc, and external contract in sync. `test/guards/contract-version.test.ts` already asserts against the constant, so no test changes were required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e738d05d756cd6fa9f80210bd34142be00e9b61d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s supported Brain API version to a newer release.
  * Aligned the documented API contract version with the currently expected version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->