### PR TITLE
feat: adopt @aios-alpha/design 0.3.0 (off-white + effects)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,11 +84,12 @@ h3 {
   background: var(--gradient-prism);
 }
 
-/* Frosted nav / sidebar layer */
+/* Frosted nav / sidebar layer — liquid-glass tokens (mode-aware, 0.3.0) */
 .frosted {
-  background: var(--color-surface-nav);
-  backdrop-filter: blur(20px) saturate(1.2);
-  -webkit-backdrop-filter: blur(20px) saturate(1.2);
+  background: var(--aios-glass-bg);
+  border-color: var(--aios-glass-border);
+  backdrop-filter: var(--aios-blur-glass-strong) saturate(1.2);
+  -webkit-backdrop-filter: var(--aios-blur-glass-strong) saturate(1.2);
 }
 
 /* Cards: flat at rest, violet-tinted glow on hover — never black shadows. */
@@ -96,6 +97,8 @@ h3 {
   background: var(--color-surface-card);
   border: 1px solid var(--color-border-subtle);
   border-radius: 0.75rem;
+  /* subtle mode-aware resting elevation (0.3.0 effects layer) */
+  box-shadow: var(--aios-shadow-glow-card);
   transition: all 0.3s ease;
 }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -28,7 +28,7 @@ export default async function LoginPage({
       <div className="relative w-full max-w-sm">
         <div className="bg-gradient-prism rounded-2xl p-[1px]">
           <div className="rounded-2xl bg-surface-inset px-8 py-10">
-            <p className="font-display text-sm font-semibold uppercase tracking-[0.15em] text-gradient-prism">
+            <p className="font-display text-sm uppercase tracking-[0.15em] text-gradient-prism">
               Team Brain
             </p>
             <h1 className="mt-2 text-2xl font-semibold text-ink">Sign in</h1>

--- a/app/t/[team]/codebases/[slug]/contributors/[author]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/contributors/[author]/page.tsx
@@ -72,7 +72,7 @@ export default async function ContributorPage({
               </span>
             )}
             <div>
-              <h1 className="font-display text-2xl font-semibold text-ink">{c.name}</h1>
+              <h1 className="font-display text-2xl text-ink">{c.name}</h1>
               <div className="mt-0.5 flex items-center gap-3 text-xs text-ink-tertiary">
                 {c.github_login ? (
                   <a

--- a/app/t/[team]/codebases/[slug]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/page.tsx
@@ -53,7 +53,7 @@ export default async function CodebaseDetailPage({
         </Link>
         <div className="mt-2 flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <h1 className="font-display text-2xl font-semibold text-ink">{cb.slug}</h1>
+            <h1 className="font-display text-2xl text-ink">{cb.slug}</h1>
             {cb.full_name ? (
               <a
                 href={`https://github.com/${cb.full_name}`}

--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -91,10 +91,10 @@ export default async function TeamLayout({
     <div className="flex min-h-dvh flex-1 bg-surface-raised">
       <aside className="frosted sticky top-0 flex h-dvh w-60 shrink-0 flex-col border-r border-border-subtle px-4 py-6">
         <div className="mb-8 px-3">
-          <p className="font-display text-[11px] font-semibold uppercase tracking-[0.18em] text-gradient-prism">
+          <p className="font-display text-[11px] uppercase tracking-[0.18em] text-gradient-prism">
             Team Brain
           </p>
-          <h2 className="mt-1 truncate font-display text-lg font-semibold text-ink" title={team.name}>
+          <h2 className="mt-1 truncate font-display text-lg text-ink" title={team.name}>
             {team.name}
           </h2>
         </div>

--- a/app/t/[team]/maturity/page.tsx
+++ b/app/t/[team]/maturity/page.tsx
@@ -73,7 +73,7 @@ export default async function MaturityPage({
               <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-ink-tertiary">
                 Repos at L3+ (agent-ready)
               </p>
-              <p className="mt-1 font-display text-4xl font-semibold text-gradient-prism">
+              <p className="mt-1 font-display text-4xl text-gradient-prism">
                 {m.pctAtL3Plus}%
               </p>
               <p className="mt-1 text-xs text-ink-secondary">

--- a/app/t/[team]/people/[handle]/page.tsx
+++ b/app/t/[team]/people/[handle]/page.tsx
@@ -116,7 +116,7 @@ export default async function PersonPage({
               </span>
             )}
             <div>
-              <h1 className="font-display text-2xl font-semibold text-ink">{p.name}</h1>
+              <h1 className="font-display text-2xl text-ink">{p.name}</h1>
               <div className="mt-0.5 flex items-center gap-3 text-xs text-ink-tertiary">
                 <span className="capitalize">{p.role}</span>
                 {p.github_login ? (

--- a/app/t/[team]/projects/page.tsx
+++ b/app/t/[team]/projects/page.tsx
@@ -57,7 +57,7 @@ export default async function ProjectsPage({ params }: { params: Promise<{ team:
               className="prism-card prism-card-hover flex flex-col gap-3 px-5 py-5"
             >
               <div>
-                <h2 className="font-display text-lg font-semibold text-ink">{p.name || p.slug}</h2>
+                <h2 className="font-display text-lg text-ink">{p.name || p.slug}</h2>
                 <p className="font-mono text-xs text-ink-tertiary">{p.slug}</p>
               </div>
               <div className="mt-auto flex items-center gap-4 text-xs text-ink-secondary">

--- a/components/codebases/codebase-card.tsx
+++ b/components/codebases/codebase-card.tsx
@@ -13,7 +13,7 @@ export function CodebaseCard({ teamSlug, cb }: { teamSlug: string; cb: CodebaseS
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <h2 className="truncate font-display text-lg font-semibold text-ink">{cb.slug}</h2>
+          <h2 className="truncate font-display text-lg text-ink">{cb.slug}</h2>
           <p className="truncate font-mono text-xs text-ink-tertiary">{cb.full_name || cb.slug}</p>
         </div>
         {cb.scanned ? (

--- a/components/dashboard/ask-brain.tsx
+++ b/components/dashboard/ask-brain.tsx
@@ -8,7 +8,7 @@ export function AskBrain({ teamSlug, teamName }: { teamSlug: string; teamName: s
   return (
     <section className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <h2 className="flex items-center gap-2 font-display text-lg font-semibold text-ink">
+        <h2 className="flex items-center gap-2 font-display text-lg text-ink">
           <Sparkles className="size-4 text-violet" /> Ask {teamName}&apos;s brain
         </h2>
         <Link

--- a/components/dashboard/kpi-stat.tsx
+++ b/components/dashboard/kpi-stat.tsx
@@ -18,7 +18,7 @@ export function KpiStat({ kpi }: { kpi: Kpi }) {
         {kpi.label}
       </p>
       <div className="flex items-end justify-between gap-2">
-        <span className="font-display text-2xl font-semibold leading-none text-ink">
+        <span className="font-display text-2xl leading-none text-ink">
           {kpi.value}
         </span>
         <span className={accent}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@aios-alpha/design": "^0.2.1",
-        "@aios-alpha/ui": "^0.2.1",
+        "@aios-alpha/design": "^0.3.0",
+        "@aios-alpha/ui": "^0.3.0",
         "@anthropic-ai/sdk": "^0.105.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -50,18 +50,18 @@
       }
     },
     "node_modules/@aios-alpha/design": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@aios-alpha/design/-/design-0.2.1.tgz",
-      "integrity": "sha512-BljGQdicgNqp9BNggoCFDolwSD+Q6r4KBAMDqEqfXxd2HLYP0rT2+ManlCoG+JK4RChCvg1bF1/GeGPgSQ5P2Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aios-alpha/design/-/design-0.3.0.tgz",
+      "integrity": "sha512-EfOL11d/5VUbpdjPxXOXbChC3mxUVX5qfO+J6faYNBLJPORps8YyQwfLraAg00SLqVi1voS7gtqPcYutXRkGKw==",
       "license": "MIT",
       "dependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "node_modules/@aios-alpha/ui": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@aios-alpha/ui/-/ui-0.2.1.tgz",
-      "integrity": "sha512-WdFGb+z+X8KAHkvxDDo2+uDay+XjOiaBJ3Kw6BKDdSu3gcUzX31yULfFQkTyDctw62lgCu80GX/5p5L3/267DA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aios-alpha/ui/-/ui-0.3.0.tgz",
+      "integrity": "sha512-0tiJvPJ8DAYCZJzodHuwaMzni3VyZBO7JNBuuuasW6IUc46B5QYSPoxKtgvihk1zfhxBglHDYUrZQOlGAHf9bg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "test:http:local": "npm run build && DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.http.config.ts"
   },
   "dependencies": {
-    "@aios-alpha/design": "^0.2.1",
-    "@aios-alpha/ui": "^0.2.1",
+    "@aios-alpha/design": "^0.3.0",
+    "@aios-alpha/ui": "^0.3.0",
     "@anthropic-ai/sdk": "^0.105.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
Bumps `@aios-alpha/design`/`@aios-alpha/ui` 0.2.1 → 0.3.0 (off-white + effects token update) across 14 files. Rebased onto current `main` to resolve conflicts in `components/dashboard/ask-brain.tsx` (main restructured this component after this branch diverged; kept main's structure, applied the design branch's only real change there — dropping `font-semibold` from the heading) and `components/dashboard/agents-placeholder.tsx` (already deleted on main; deletion kept). Supersedes #75, which has drifted from main and is unresolvable in place. Branch was verified ready by the 2026-07-09 launch audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and dependency-only changes (CSS tokens and heading classes); no auth, API, or data logic.
> 
> **Overview**
> Upgrades **`@aios-alpha/design`** and **`@aios-alpha/ui`** from **0.2.1 → 0.3.0** (off-white palette and effects tokens).
> 
> **`app/globals.css`** wires the new token layer: **`.frosted`** uses liquid-glass vars (`--aios-glass-bg`, `--aios-glass-border`, `--aios-blur-glass-strong`) instead of `--color-surface-nav` and fixed blur; **`.prism-card`** gets resting elevation via **`--aios-shadow-glow-card`**.
> 
> Across login, team layout/sidebar, maturity, people/codebases/projects pages, and dashboard/codebase components, **`font-semibold` is removed** from **`font-display`** headings and key stats so display type follows the 0.3.0 weight (regular display + global `h1–h3` at 400).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4516bf9e86cbb52b34c8a37be3080aa9f3502a35. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->