### PR TITLE
fix(query): normalize bare GMT/UTC longOffset across ICU builds

### DIFF
--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -53,8 +53,20 @@ function partsInZone(now: Date, timeZone: string): { date: string; time: string;
     date: `${p.year}-${p.month}-${p.day}`,
     time: `${p.hour}:${p.minute}`,
     weekday: p.weekday ?? "",
-    offset: (p.timeZoneName ?? "GMT+00:00").replace("GMT", "UTC"),
+    offset: normalizeOffset(p.timeZoneName ?? "GMT+00:00"),
   };
+}
+
+/**
+ * Normalize an ICU `longOffset` string to a deterministic "UTC±HH:MM" form. Some ICU builds render
+ * UTC's longOffset as bare "GMT" instead of "GMT+00:00" (both are valid CLDR renderings) — left
+ * unhandled, that yields "UTC" instead of "UTC+00:00" after the GMT→UTC replace, which is
+ * inconsistent across Node/ICU builds even for the same input instant/timezone. Normalize the
+ * offsetless case explicitly so output doesn't depend on the local ICU data.
+ */
+function normalizeOffset(raw: string): string {
+  const withUtc = raw.replace("GMT", "UTC");
+  return withUtc === "UTC" ? "UTC+00:00" : withUtc;
 }
 
 /**

--- a/test/query-current-date.test.ts
+++ b/test/query-current-date.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { currentDateLine } from "@/lib/query/claude";
 
 /**
@@ -42,5 +42,33 @@ describe("currentDateLine", () => {
     const line = currentDateLine(new Date("2026-06-26T23:30:00Z"));
     expect(line).toContain("2026-06-26 23:30");
     expect(line).toContain("UTC");
+  });
+
+  describe("ICU longOffset edge cases", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("normalizes a bare 'GMT' longOffset (some ICU builds omit '+00:00' for UTC) to 'UTC+00:00'", () => {
+      // Some ICU builds render longOffset for UTC as bare "GMT" instead of "GMT+00:00" — both are
+      // valid CLDR renderings, but the code must produce identical output either way. Simulate that
+      // build by rewriting the timeZoneName part on top of whatever this environment's ICU returns.
+      const originalFormatToParts = Intl.DateTimeFormat.prototype.formatToParts;
+      vi.spyOn(Intl.DateTimeFormat.prototype, "formatToParts").mockImplementation(function (
+        this: Intl.DateTimeFormat,
+        ...args: Parameters<typeof originalFormatToParts>
+      ) {
+        const parts = originalFormatToParts.apply(this, args);
+        return parts.map((part) =>
+          part.type === "timeZoneName" && part.value.replace("GMT", "UTC") === "UTC+00:00"
+            ? { ...part, value: "GMT" }
+            : part
+        );
+      });
+
+      const line = currentDateLine(new Date("2026-06-26T09:30:00Z"), "UTC");
+      expect(line).toContain("2026-06-26 09:30");
+      expect(line).toContain("UTC (UTC+00:00)");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `currentDateLine` (`lib/query/claude.ts`) renders the user-timezone offset via `Intl.DateTimeFormat`'s `timeZoneName: "longOffset"` and a `GMT`→`UTC` string replace. Some ICU builds render UTC's longOffset as bare `"GMT"` instead of `"GMT+00:00"` (both are valid CLDR renderings) — on those builds the replace produced `"UTC"` instead of `"UTC+00:00"`, making `test/query-current-date.test.ts > currentDateLine > falls back to UTC for an unknown timezone` fail locally (Node 20/22) while passing in CI, which happens to run an ICU build that always includes the offset suffix.
- Found while local coverage generation was blocked on this environment-sensitive failure.
- Fixed by normalizing in the implementation: after the `GMT`→`UTC` replace, a bare `"UTC"` (no offset) is explicitly mapped to `"UTC+00:00"`, so output is deterministic regardless of the local ICU build.
- Added a regression test that stubs `Intl.DateTimeFormat.prototype.formatToParts` to force the bare-`"GMT"` timeZoneName path, independent of which ICU build the test runner happens to have.

## Test plan
- [x] `npx vitest run test/query-current-date.test.ts` — 6/6 pass, including new regression case
- [x] `npm test` — full suite passes (455 passed, 1 pre-existing expected-fail, 7 skipped, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small string normalization in query prompt date anchoring with no auth, data, or API surface changes.
> 
> **Overview**
> **`currentDateLine`** now routes ICU `longOffset` strings through **`normalizeOffset`**, so when some Node/ICU builds emit bare `"GMT"` for UTC (instead of `"GMT+00:00"`), the prompt still shows **`UTC+00:00`** rather than a bare **`UTC`** after the existing GMT→UTC replace.
> 
> A regression test stubs **`Intl.DateTimeFormat.prototype.formatToParts`** to force that bare-`GMT` path so the behavior is verified independent of the runner’s ICU data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e0bbdfda2670f8590a8b5802f9dc13de3050170. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->