### PR TITLE
test: land cursor coverage branches (query route, tier scoping, metrics, schema loader)

### DIFF
--- a/scripts/pg-load-schema.mjs
+++ b/scripts/pg-load-schema.mjs
@@ -12,48 +12,66 @@
  */
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Client } from "pg";
 import { assertServiceIdentity } from "./service-guard.mjs";
 
-async function main() {
+export function shouldUseSsl(databaseUrl, env = process.env) {
+  return (
+    /\bsslmode=require\b/.test(databaseUrl) ||
+    env.PGSSL === "require" ||
+    env.PGSSLMODE === "require"
+  );
+}
+
+export async function loadSchema({
+  cwd = process.cwd(),
+  databaseUrl = process.env.DATABASE_URL,
+  env = process.env,
+  createClient,
+  readFile = readFileSync,
+  exists = existsSync,
+  readDir = readdirSync,
+  logger = console,
+} = {}) {
   // On Railway, refuse to run if this app landed on a non-AIOS service — the
   // 2026-06-27 vector: this preDeployCommand ran against Kula's DATABASE_URL and
-  // injected our schema into Kula's prod DB. Abort BEFORE reading DATABASE_URL.
+  // injected our schema into Kula's prod DB. Abort BEFORE reading DATABASE_URL or
+  // opening any database connection.
   assertServiceIdentity("load the AIOS schema");
 
-  const url = process.env.DATABASE_URL;
-  if (!url) throw new Error("DATABASE_URL is required");
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
 
-  const pgDir = path.join(process.cwd(), "postgres");
-  const sql = readFileSync(path.join(pgDir, "schema.sql"), "utf8");
-  const useSsl =
-    /\bsslmode=require\b/.test(url) ||
-    process.env.PGSSL === "require" ||
-    process.env.PGSSLMODE === "require";
+  const pgDir = path.join(cwd, "postgres");
+  const sql = readFile(path.join(pgDir, "schema.sql"), "utf8");
+  const useSsl = shouldUseSsl(databaseUrl, env);
 
-  const client = new Client({
-    connectionString: url,
+  const makeClient = createClient ?? ((config) => new Client(config));
+  const client = makeClient({
+    connectionString: databaseUrl,
     ssl: useSsl ? { rejectUnauthorized: false } : undefined,
   });
   await client.connect();
   try {
     await client.query(sql);
-    console.log("✓ postgres/schema.sql loaded");
+    logger.log("✓ postgres/schema.sql loaded");
 
     const migDir = path.join(pgDir, "migrations");
-    const files = existsSync(migDir)
-      ? readdirSync(migDir).filter((f) => f.endsWith(".sql")).sort()
+    const files = exists(migDir)
+      ? readDir(migDir).filter((f) => f.endsWith(".sql")).sort()
       : [];
     for (const f of files) {
-      await client.query(readFileSync(path.join(migDir, f), "utf8"));
-      console.log(`✓ postgres/migrations/${f} applied`);
+      await client.query(readFile(path.join(migDir, f), "utf8"));
+      logger.log(`✓ postgres/migrations/${f} applied`);
     }
   } finally {
     await client.end();
   }
 }
 
-main().catch((err) => {
-  console.error("schema load failed:", err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  loadSchema().catch((err) => {
+    console.error("schema load failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/test/codebase-readiness-schema.test.ts
+++ b/test/codebase-readiness-schema.test.ts
@@ -76,3 +76,30 @@ describe("codebaseScanPayloadSchema — readiness validation", () => {
     expect(r.success).toBe(true);
   });
 });
+
+describe("codebaseScanPayloadSchema — coverage validation", () => {
+  it("accepts line/function/branch coverage dimensions independently", () => {
+    const parsed = codebaseScanPayloadSchema.parse(
+      payload({
+        test_coverage_pct: 88.5,
+        test_coverage_functions_pct: null,
+        test_coverage_branches_pct: 42.25,
+      })
+    );
+
+    expect(parsed.metrics.test_coverage_pct).toBe(88.5);
+    expect(parsed.metrics.test_coverage_functions_pct).toBeNull();
+    expect(parsed.metrics.test_coverage_branches_pct).toBe(42.25);
+  });
+
+  it("rejects coverage percentages outside 0..100 for every dimension", () => {
+    for (const field of [
+      "test_coverage_pct",
+      "test_coverage_functions_pct",
+      "test_coverage_branches_pct",
+    ]) {
+      expect(codebaseScanPayloadSchema.safeParse(payload({ [field]: -0.01 })).success, field).toBe(false);
+      expect(codebaseScanPayloadSchema.safeParse(payload({ [field]: 100.01 })).success, field).toBe(false);
+    }
+  });
+});

--- a/test/dashboard-query-sync-route.test.ts
+++ b/test/dashboard-query-sync-route.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  memberTier: "team" as "team" | "external",
+  rateAllowed: true,
+  adminFrom: vi.fn(),
+  rateLimit: vi.fn(),
+  runManualSync: vi.fn(),
+  retrieve: vi.fn(),
+  streamAnswer: vi.fn(),
+  getProviderKey: vi.fn(),
+  audit: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: async () => ({ id: "auth-user-1" }),
+}));
+
+vi.mock("@/lib/db/server", () => ({
+  serverClient: async () => ({
+    from: (table: string) => {
+      const chain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        maybeSingle: vi.fn(async () => {
+          if (table === "teams") return { data: { id: "team-1" } };
+          if (table === "members") return { data: { id: "member-1", tier: h.memberTier } };
+          return { data: null };
+        }),
+      };
+      return chain;
+    },
+  }),
+}));
+
+vi.mock("@/lib/db/admin", () => ({
+  adminClient: () => ({ from: h.adminFrom }),
+}));
+
+vi.mock("@/lib/api/rate-limit", () => ({
+  rateLimit: h.rateLimit,
+}));
+
+vi.mock("@/lib/ingest/manual-sync", () => ({
+  isSyncCommand: (question: string) => question.trim() === "/sync",
+  runManualSync: h.runManualSync,
+}));
+
+vi.mock("@/lib/query/retrieve", () => ({
+  retrieve: h.retrieve,
+}));
+
+vi.mock("@/lib/query/claude", () => ({
+  streamAnswer: h.streamAnswer,
+}));
+
+vi.mock("@/lib/integrations/manage", () => ({
+  getProviderKey: h.getProviderKey,
+}));
+
+vi.mock("@/lib/api/audit", () => ({
+  audit: h.audit,
+}));
+
+const { POST } = await import("@/app/api/dashboard/query/route");
+
+function request(question: string): Parameters<typeof POST>[0] {
+  return new Request("http://test.local/api/dashboard/query", {
+    method: "POST",
+    body: JSON.stringify({ team: "acme", question }),
+  }) as Parameters<typeof POST>[0];
+}
+
+/**
+ * Spec for the query-box scrape route: a sync command is privileged ingestion, not a normal LLM
+ * question. External users must not be able to trigger it, and successful syncs must not consume the
+ * daily query budget or enter retrieval/LLM code paths.
+ */
+describe("POST /api/dashboard/query sync command", () => {
+  beforeEach(() => {
+    h.memberTier = "team";
+    h.rateAllowed = true;
+    h.adminFrom.mockReset();
+    h.rateLimit.mockReset().mockImplementation(async () => h.rateAllowed);
+    h.runManualSync.mockReset().mockResolvedValue({
+      summary: "**Scrape complete**\n\n- **Slack**: +1 new, ~2 updated",
+      created: 1,
+      updated: 2,
+      errors: 0,
+    });
+    h.retrieve.mockReset();
+    h.streamAnswer.mockReset();
+    h.getProviderKey.mockReset();
+    h.audit.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("denies external members before ingestion starts", async () => {
+    h.memberTier = "external";
+
+    const res = await POST(request("/sync"));
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("forbidden");
+    expect(h.rateLimit).not.toHaveBeenCalled();
+    expect(h.runManualSync).not.toHaveBeenCalled();
+    expect(h.retrieve).not.toHaveBeenCalled();
+    expect(h.streamAnswer).not.toHaveBeenCalled();
+  });
+
+  it("applies the sync-specific rate limit before ingestion starts", async () => {
+    h.rateAllowed = false;
+
+    const res = await POST(request("/sync"));
+
+    expect(res.status).toBe(429);
+    expect((await res.json()).error.code).toBe("rate_limited");
+    expect(h.rateLimit).toHaveBeenCalledWith(expect.anything(), "member-1:sync", 2);
+    expect(h.runManualSync).not.toHaveBeenCalled();
+    expect(h.retrieve).not.toHaveBeenCalled();
+    expect(h.streamAnswer).not.toHaveBeenCalled();
+  });
+
+  it("streams the manual sync result without entering the LLM query budget path", async () => {
+    const res = await POST(request("/sync"));
+    const text = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    expect(text).toContain("event: delta");
+    expect(text).toContain("Scrape complete");
+    expect(text).toContain("event: sources");
+    expect(text).toContain("event: done");
+    expect(h.rateLimit).toHaveBeenCalledWith(expect.anything(), "member-1:sync", 2);
+    expect(h.runManualSync).toHaveBeenCalledWith("team-1");
+    expect(h.audit).toHaveBeenCalledWith(expect.anything(), {
+      team_id: "team-1",
+      actor_kind: "member",
+      member_id: "member-1",
+      action: "ingest.manual_sync",
+      meta: { created: 1, updated: 2, errors: 0 },
+    });
+    expect(h.retrieve).not.toHaveBeenCalled();
+    expect(h.streamAnswer).not.toHaveBeenCalled();
+    expect(h.getProviderKey).not.toHaveBeenCalled();
+    expect(h.adminFrom).not.toHaveBeenCalled();
+  });
+});

--- a/test/datamechanics/graph-tier.datamechanics.test.ts
+++ b/test/datamechanics/graph-tier.datamechanics.test.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { issueApiKey } from "@/lib/admin/keys";
+import { retrieve } from "@/lib/query/retrieve";
+import { db, seedTeam, type Seed } from "./helpers";
+
+const GRAPH_URL = "http://graphiti.test";
+const ROUTE_URL = "http://test/api/v1/graph-query";
+
+type GraphitiSearchBody = {
+  query: string;
+  group_ids: string[];
+  max_facts: number;
+};
+
+/** Issue a key for the seeded team member (tier=team) or a fresh external member. */
+async function issueKeyFor(seed: Seed, tier: "team" | "external") {
+  let memberId = seed.memberId;
+  if (tier === "external") {
+    const { data, error } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `ext-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "External",
+        actor_handle: `ext-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "external",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`external member seed failed: ${error?.message}`);
+    memberId = (data as { id: string }).id;
+  }
+  const { key } = await issueApiKey(db(), seed.teamId, memberId, `${tier} graph key`);
+  return key;
+}
+
+function post(key: string, teamSlug: string, body: unknown) {
+  const req = new Request(ROUTE_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "X-AIOS-Team": teamSlug,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+  return req;
+}
+
+function stubGraphiti(facts = [{ fact: "Alex owns payments", valid_at: "2026-06-25T00:00:00Z" }]) {
+  const requests: GraphitiSearchBody[] = [];
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === `${GRAPH_URL}/search`) {
+      requests.push(JSON.parse(String(init?.body)) as GraphitiSearchBody);
+      return new Response(JSON.stringify({ facts }), { status: 200 });
+    }
+    return new Response(JSON.stringify({ results: [] }), { status: 200 });
+  });
+  vi.stubGlobal("fetch", fetchImpl);
+  vi.stubEnv("GRAPHITI_URL", GRAPH_URL);
+  return { requests, fetchImpl };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("Graphiti tier scoping (real routes/retrieval, stubbed Graphiti)", () => {
+  it("POST /api/v1/graph-query sends only external group_ids for an external key", async () => {
+    const { POST } = await import("@/app/api/v1/graph-query/route");
+    const seed = await seedTeam();
+    const extKey = await issueKeyFor(seed, "external");
+    const { requests } = stubGraphiti();
+
+    const res = await POST(post(extKey, seed.teamSlug, { query: "who owns payments?", maxFacts: 5 }));
+
+    expect(res.status).toBe(200);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toEqual({
+      query: "who owns payments?",
+      group_ids: [`${seed.teamSlug}_external`],
+      max_facts: 5,
+    });
+  });
+
+  it("POST /api/v1/graph-query sends both tier groups for a team key", async () => {
+    const { POST } = await import("@/app/api/v1/graph-query/route");
+    const seed = await seedTeam();
+    const teamKey = await issueKeyFor(seed, "team");
+    const { requests } = stubGraphiti();
+
+    const res = await POST(post(teamKey, seed.teamSlug, { query: "who owns payments?" }));
+
+    expect(res.status).toBe(200);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.group_ids.sort()).toEqual([`${seed.teamSlug}_external`, `${seed.teamSlug}_team`]);
+    expect(requests[0]?.max_facts).toBe(20);
+  });
+
+  it("retrieve() blends graph facts but scopes an external viewer to the external group only", async () => {
+    const seed = await seedTeam();
+    const { requests } = stubGraphiti();
+
+    const ctx = await retrieve(db(), seed.teamId, "external", "who owns payments?");
+
+    expect(ctx.structured).toContain("## Graph memory");
+    expect(ctx.structured).toContain("Alex owns payments");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.group_ids).toEqual([`${seed.teamSlug}_external`]);
+  });
+});

--- a/test/pg-load-schema.test.ts
+++ b/test/pg-load-schema.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type ClientConfig = {
+  connectionString: string;
+  ssl?: { rejectUnauthorized: boolean };
+};
+
+type LoadSchema = (options?: {
+  cwd?: string;
+  databaseUrl?: string;
+  env?: Record<string, string | undefined>;
+  createClient?: (config: ClientConfig) => FakeClient;
+  logger?: { log: (message: string) => void };
+}) => Promise<void>;
+
+class FakeClient {
+  connected = false;
+  ended = false;
+  queries: string[] = [];
+
+  constructor(
+    readonly config: ClientConfig,
+    private readonly failOnQueryIndex: number | null = null
+  ) {}
+
+  async connect() {
+    this.connected = true;
+  }
+
+  async query(sql: string) {
+    if (this.failOnQueryIndex === this.queries.length) {
+      throw new Error("query failed");
+    }
+    this.queries.push(sql);
+  }
+
+  async end() {
+    this.ended = true;
+  }
+}
+
+const tmpRoots: string[] = [];
+
+async function importLoader() {
+  return (await import("../scripts/pg-load-schema.mjs")) as {
+    loadSchema: LoadSchema;
+    shouldUseSsl: (databaseUrl: string, env?: Record<string, string | undefined>) => boolean;
+  };
+}
+
+function makeWorkspace(migrations: Record<string, string> = {}) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "pg-load-schema-"));
+  tmpRoots.push(root);
+  const pgDir = path.join(root, "postgres");
+  const migDir = path.join(pgDir, "migrations");
+  mkdirSync(migDir, { recursive: true });
+  writeFileSync(path.join(pgDir, "schema.sql"), "create table base();");
+  for (const [file, sql] of Object.entries(migrations)) {
+    writeFileSync(path.join(migDir, file), sql);
+  }
+  return root;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (tmpRoots.length > 0) {
+    rmSync(tmpRoots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("pg-load-schema", () => {
+  it("runs schema.sql before SQL migrations in lexical order", async () => {
+    const { loadSchema } = await importLoader();
+    const root = makeWorkspace({
+      "002_second.sql": "alter table base add column second text;",
+      "notes.txt": "not sql",
+      "001_first.sql": "alter table base add column first text;",
+    });
+    const clients: FakeClient[] = [];
+    const log = vi.fn();
+
+    await loadSchema({
+      cwd: root,
+      databaseUrl: "postgres://app:app@localhost:5432/app",
+      createClient: (config) => {
+        const client = new FakeClient(config);
+        clients.push(client);
+        return client;
+      },
+      logger: { log },
+    });
+
+    expect(clients).toHaveLength(1);
+    expect(clients[0].queries).toEqual([
+      "create table base();",
+      "alter table base add column first text;",
+      "alter table base add column second text;",
+    ]);
+    expect(clients[0].ended).toBe(true);
+    expect(log.mock.calls.map(([message]) => message.replace(/^.\s/, ""))).toEqual([
+      "postgres/schema.sql loaded",
+      "postgres/migrations/001_first.sql applied",
+      "postgres/migrations/002_second.sql applied",
+    ]);
+  });
+
+  it("uses SSL only when the database URL or environment explicitly requires it", async () => {
+    const { loadSchema, shouldUseSsl } = await importLoader();
+    expect(shouldUseSsl("postgres://db/app?sslmode=require", {})).toBe(true);
+    expect(shouldUseSsl("postgres://db/app", { PGSSL: "require" })).toBe(true);
+    expect(shouldUseSsl("postgres://db/app", { PGSSLMODE: "require" })).toBe(true);
+    expect(shouldUseSsl("postgres://db/app?sslmode=disable", {})).toBe(false);
+
+    const root = makeWorkspace();
+    const configs: ClientConfig[] = [];
+    await loadSchema({
+      cwd: root,
+      databaseUrl: "postgres://db/app?sslmode=require",
+      env: {},
+      createClient: (config) => {
+        configs.push(config);
+        return new FakeClient(config);
+      },
+      logger: { log: vi.fn() },
+    });
+
+    expect(configs).toEqual([
+      {
+        connectionString: "postgres://db/app?sslmode=require",
+        ssl: { rejectUnauthorized: false },
+      },
+    ]);
+  });
+
+  it("refuses to run without DATABASE_URL before touching the filesystem", async () => {
+    const { loadSchema } = await importLoader();
+    await expect(loadSchema({ databaseUrl: "" })).rejects.toThrow("DATABASE_URL is required");
+  });
+
+  it("closes the database connection when a migration query fails", async () => {
+    const { loadSchema } = await importLoader();
+    const root = makeWorkspace({
+      "001_first.sql": "alter table base add column first text;",
+    });
+    const clients: FakeClient[] = [];
+
+    await expect(
+      loadSchema({
+        cwd: root,
+        databaseUrl: "postgres://app:app@localhost:5432/app",
+        createClient: (config) => {
+          const client = new FakeClient(config, 1);
+          clients.push(client);
+          return client;
+        },
+        logger: { log: vi.fn() },
+      })
+    ).rejects.toThrow("query failed");
+
+    expect(clients).toHaveLength(1);
+    expect(clients[0].queries).toEqual(["create table base();"]);
+    expect(clients[0].ended).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the four audit-verified `cursor/missing-test-coverage-*` branches (genuine
test gap-fills, sitting on a stale Jun-26 base) rebased onto current `main`.
Supersedes `cursor/missing-test-coverage-6754`, `-105c`, `-606e`, `-84d3` — those
branches can be closed.

## Per-branch disposition

| Branch | Test(s) | Disposition |
|---|---|---|
| `cursor/missing-test-coverage-6754` (priority) | `test/dashboard-query-sync-route.test.ts` — the query-box `/sync` command on `app/api/dashboard/query/route.ts` (the live demo query box) | **Adapted.** `vi.mock` targets updated from `@/lib/supabase/{server,admin}` to `@/lib/db/{server,admin}` — main renamed the Supabase adapter to a Postgres one since this branch was cut. No assertion weakened; still asserts external members get 403 pre-ingestion, the sync rate limit gates before `runManualSync`, and a successful sync streams without touching `retrieve`/`streamAnswer`/the daily query budget. |
| `cursor/missing-test-coverage-105c` | `test/datamechanics/graph-tier.datamechanics.test.ts` — Graphiti tier scoping (`group_id` isolation) across `/api/v1/graph-query` and `retrieve()` | **Landed unmodified.** Signatures (`retrieve()`, `issueApiKey()`, `visibleGroupIds()`, `GraphitiClient.search()`) hadn't changed; all 3 cases pass as-is against real test Postgres. |
| `cursor/missing-test-coverage-606e` | `test/codebase-readiness-schema.test.ts` — codebase scan payload coverage-dimension validation | **Deduplicated.** The readiness-block half of this branch's test already exists on `main` verbatim (landed in a later PR) — kept main's version and added only the new `coverage validation` describe block (`test_coverage_{pct,functions_pct,branches_pct}` bounds-checking), which wasn't on main. |
| `cursor/missing-test-coverage-84d3` | `test/pg-load-schema.test.ts` + refactor of `scripts/pg-load-schema.mjs` | **Adapted.** The branch's tests require `scripts/pg-load-schema.mjs`'s `main()` to become an injectable `loadSchema()`/`shouldUseSsl()`. Main had since added an `assertServiceIdentity()` guard (the 2026-06-27 Kula cross-deploy incident backstop) inside `main()`. Re-applied the branch's refactor on top of that guard, keeping the guard call as the first statement in `loadSchema()`. Also had to move the default `new Client(...)` construction out of the parameter list into the function body so it stays *textually* after the guard call — `test/guards/service-guard.test.ts` enforces that ordering via a structural source-position check, and the naive default-parameter placement broke it (caught by the full suite, not weakened to pass). Includes the branch's follow-up `chore: keep schema loader test ascii` commit.

## Verification

- `npm test` — 462 passed, 1 pre-existing unrelated failure (`test/query-current-date.test.ts`, present on unmodified `main`, untouched by this PR).
- `npm run test:datamechanics:local` (fresh `db:test:up`) — 324 passed, 0 failed.
- `npm run typecheck` — clean.
- `npm run lint` — clean (0 errors; 1 pre-existing warning in an untouched file).
- `node scripts/pg-load-schema.mjs` against the test DB — confirmed the refactored CLI entrypoint still applies schema + migrations correctly and is idempotent.

## Test plan

- [x] CI green
- [ ] Not merging — leaving for review per instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production deploy hook logic is refactored for testability but behavior is preserved and covered by new unit tests; remaining risk is limited to subtle ordering/guard wiring in the schema loader.
> 
> **Overview**
> Adds **test coverage** across four areas that were previously under-specified, plus a small **refactor** of the Railway pre-deploy schema script so it can be unit-tested without hitting a real database.
> 
> **`scripts/pg-load-schema.mjs`** now exports **`loadSchema()`** and **`shouldUseSsl()`** with injectable filesystem, client factory, and logger. CLI behavior is unchanged (direct execution still calls `loadSchema()`). **`assertServiceIdentity()`** remains the first step inside `loadSchema()` so the cross-service deploy guard still runs before any connection; `new Client` was moved into the function body to satisfy the structural guard test.
> 
> New tests lock in: **`POST /api/dashboard/query`** **`/sync`** (403 for external members, sync rate limit before ingestion, SSE result without LLM/retrieve paths); **Graphiti tier `group_ids`** on **`/api/v1/graph-query`** and **`retrieve()`**; **`codebaseScanPayloadSchema`** bounds for line/function/branch coverage fields; and **migration order**, SSL selection, missing **`DATABASE_URL`**, and connection cleanup on migration failure for the schema loader.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5c06966d0c7d18e6c85ed38b6704f84ae1398f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->