### PR TITLE
chore(api): bump BRAIN_API_VERSION to 1.6

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ flowchart LR
 
 ## Auth & access tiers
 
-This server **implements brain-api v1.5** (the wire contract; source of truth:
+This server **implements brain-api v1.6** (the wire contract; source of truth:
 `aios-workspace/docs/brain-api.md`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`) and asserted against this sentence by
 `test/guards/contract-version.test.ts` — bump all three together on a contract change.

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -9,4 +9,4 @@
  * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
  */
-export const BRAIN_API_VERSION = "1.5";
+export const BRAIN_API_VERSION = "1.6";


### PR DESCRIPTION
## Summary

Bumps `BRAIN_API_VERSION` (`lib/api/version.ts`) and `docs/ARCHITECTURE.md`'s canonical
"implements brain-api v1.6" claim, matching the sibling `aios-workspace` PR that documents
brain-api contract v1.6.

**No wire-shape change on this side.** v1.6 is a documentation-only bump: the 2026-07-09
audit found several server surfaces that were already shipped and API-key-authenticated but
missing from the pinned contract doc (`aios-workspace/docs/brain-api.md`) — `GET /me`, `POST
/actions`, `POST /graph-query`, `GET /members`, `GET /conversations` + `GET
/conversations/<id>`, `GET /identities/resolve`, `GET`/`POST`/`DELETE /me/slack-token`, and the
`blueprint` item kind. All of that code is unchanged here; only the version pin + architecture
doc reference move.

Companion PR (contract doc): aiosbrain/aios-workspace#210

## Test plan

- [x] `npx vitest run test/guards/contract-version.test.ts` — 3/3 pass (constant shape,
      architecture-doc claim matches `1.6`, claim is version-specific/non-vacuous)
- [x] `npx vitest run test/api test/guards test/datamechanics/me-slack-token.datamechanics.test.ts`
      — 19 files / 56 tests pass
- [x] `git push` pre-push docs-drift hook: routes/tables/sources all in sync — "Docs are
      congruent with the code."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version-constant only; no auth, data paths, or API handlers changed.
> 
> **Overview**
> Aligns the server’s declared brain-api contract from **v1.5** to **v1.6** by updating `BRAIN_API_VERSION` in `lib/api/version.ts` and the canonical “implements brain-api v…” sentence in `docs/ARCHITECTURE.md`, keeping the constant and architecture doc in lockstep for `test/guards/contract-version.test.ts`.
> 
> **No runtime or wire behavior changes in this repo.** v1.6 is a documentation-only contract bump (companion `aios-workspace` doc); existing API surfaces stay as-is—only the version pin and doc reference move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a986290079c89464bd63851a7820d94aabf6f0aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->