### PR TITLE
test(contract): server tier/SSE conformance guard + formatSseFrame (AIO-314, brain)

### DIFF
--- a/app/api/dashboard/query/route.ts
+++ b/app/api/dashboard/query/route.ts
@@ -5,6 +5,7 @@ import { adminClient } from "@/lib/db/admin";
 import { getSessionUser } from "@/lib/auth/session";
 import { rateLimit } from "@/lib/api/rate-limit";
 import { errorResponse } from "@/lib/api/schemas";
+import { formatSseFrame } from "@/lib/api/sse";
 import { retrieve } from "@/lib/query/retrieve";
 import { streamAnswer } from "@/lib/query/claude";
 import { pickTimezone, DEFAULT_TIMEZONE } from "@/lib/query/timezone";
@@ -36,7 +37,7 @@ function syncResponse(db: ReturnType<typeof adminClient>, teamId: string, member
   const stream = new ReadableStream({
     async start(controller) {
       const send = (event: string, data: unknown) =>
-        controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        controller.enqueue(encoder.encode(formatSseFrame(event, data)));
       try {
         send("delta", { text: "🔄 Scraping connectors (Slack · Plane · Linear · GitHub)…\n\n" });
         const r = await runManualSync(teamId);
@@ -197,7 +198,7 @@ export async function POST(req: NextRequest) {
   const stream = new ReadableStream({
     async start(controller) {
       const send = (event: string, data: unknown) =>
-        controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        controller.enqueue(encoder.encode(formatSseFrame(event, data)));
 
       // Tell the client which thread this turn belongs to (a new conversation returns its fresh id).
       if (conversationId) send("conversation", { id: conversationId });

--- a/app/api/v1/query/route.ts
+++ b/app/api/v1/query/route.ts
@@ -3,6 +3,7 @@ import { adminClient } from "@/lib/db/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/api/rate-limit";
 import { querySchema, errorResponse } from "@/lib/api/schemas";
+import { formatSseFrame } from "@/lib/api/sse";
 import { retrieve } from "@/lib/query/retrieve";
 import { streamAnswer } from "@/lib/query/claude";
 import { pickTimezone, DEFAULT_TIMEZONE } from "@/lib/query/timezone";
@@ -100,7 +101,7 @@ export async function POST(req: NextRequest) {
   const stream = new ReadableStream({
     async start(controller) {
       const send = (event: string, data: unknown) =>
-        controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        controller.enqueue(encoder.encode(formatSseFrame(event, data)));
 
       if (conversationId) send("conversation", { id: conversationId });
 

--- a/lib/api/sse.ts
+++ b/lib/api/sse.ts
@@ -1,0 +1,12 @@
+/**
+ * SSE frame formatter for the streaming query endpoints.
+ *
+ * This is the single source of the Server-Sent-Events wire format that the workspace client
+ * (`aios-workspace/scripts/brain-client.mjs`, `parseSseBlock`) parses. The format is pinned by the
+ * shared conformance fixture `docs/contract/brain-contract.json` (vendored here under
+ * `test/fixtures/contract/`) and guarded on both sides (AIO-314). Change the frame shape here and the
+ * conformance guards on both repos go red — that's the point.
+ */
+export function formatSseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "aios-brain-contract/v1",
+  "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: scratchpad gen-contract-fixture.mjs.",
+  "version": "1.6",
+  "tierAliases": {
+    "shared": {
+      "team": "team",
+      "external": "external",
+      "client": "external",
+      "company": "external"
+    },
+    "divergent": {
+      "private": {
+        "client": "admin",
+        "server": null
+      },
+      "admin": {
+        "client": "admin",
+        "server": null
+      },
+      "unknown-tier": {
+        "client": "unknown-tier",
+        "server": null
+      }
+    }
+  },
+  "sse": {
+    "frames": [
+      {
+        "name": "delta",
+        "event": "delta",
+        "data": {
+          "text": "Here is the answer."
+        },
+        "raw": "event: delta\ndata: {\"text\":\"Here is the answer.\"}\n\n"
+      },
+      {
+        "name": "sources",
+        "event": "sources",
+        "data": {
+          "sources": [
+            {
+              "id": "S1",
+              "item_id": "item_abc",
+              "project": "acme",
+              "path": "2-work/notes.md",
+              "kind": "note"
+            }
+          ]
+        },
+        "raw": "event: sources\ndata: {\"sources\":[{\"id\":\"S1\",\"item_id\":\"item_abc\",\"project\":\"acme\",\"path\":\"2-work/notes.md\",\"kind\":\"note\"}]}\n\n"
+      },
+      {
+        "name": "done",
+        "event": "done",
+        "data": {
+          "input_tokens": 1200,
+          "output_tokens": 340,
+          "cost_usd": 0.0123
+        },
+        "raw": "event: done\ndata: {\"input_tokens\":1200,\"output_tokens\":340,\"cost_usd\":0.0123}\n\n"
+      },
+      {
+        "name": "conversation",
+        "event": "conversation",
+        "data": {
+          "id": "conv_123"
+        },
+        "raw": "event: conversation\ndata: {\"id\":\"conv_123\"}\n\n"
+      },
+      {
+        "name": "forward-compat",
+        "event": "reasoning",
+        "data": {
+          "note": "an event kind the client does not know; per brain-api it MUST be ignored, not crash"
+        },
+        "raw": "event: reasoning\ndata: {\"note\":\"an event kind the client does not know; per brain-api it MUST be ignored, not crash\"}\n\n"
+      }
+    ]
+  },
+  "contentHash": "8d77062d02b3d7d42c327cdfa4276ff84a5e459b21bac892dc1d25ba166b054f"
+}

--- a/test/guards/contract-conformance.test.ts
+++ b/test/guards/contract-conformance.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { normalizeTier } from "@/lib/api/schemas";
+import { formatSseFrame } from "@/lib/api/sse";
+import { BRAIN_API_VERSION } from "@/lib/api/version";
+
+/**
+ * Server-side conformance guard for the workspace<->brain seam (AIO-314). The mirror of
+ * aios-workspace/test/contract-conformance.test.mjs, run against a vendored copy of the shared
+ * fixture (test/fixtures/contract/brain-contract.json, canonical home: aios-workspace/docs/contract).
+ *
+ * Asserts this repo's `normalizeTier` matches the shared tier rows + the SERVER column of the
+ * deliberately-divergent rows (admin/private/unknown → null), that `formatSseFrame` reproduces every
+ * contract SSE frame byte-for-byte, and that the fixture's version tracks BRAIN_API_VERSION and its
+ * contentHash is intact. Cross-repo drift (this copy vs the canonical) is caught by the root
+ * /docs-sync contentHash compare.
+ */
+
+const FIXTURE = join(import.meta.dirname, "..", "fixtures", "contract", "brain-contract.json");
+const fixture = JSON.parse(readFileSync(FIXTURE, "utf8"));
+
+// Same canonicalization the workspace test + generator use (recursive key sort → stable JSON).
+type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
+const canonical = (v: Json): Json =>
+  Array.isArray(v)
+    ? v.map(canonical)
+    : v && typeof v === "object"
+      ? Object.keys(v)
+          .sort()
+          .reduce<Record<string, Json>>((o, k) => ((o[k] = canonical(v[k])), o), {})
+      : v;
+
+describe("brain-api tier + SSE conformance", () => {
+  it("fixture contentHash is intact (no out-of-band edit)", () => {
+    const { version, tierAliases, sse } = fixture;
+    const recomputed = createHash("sha256")
+      .update(JSON.stringify(canonical({ version, tierAliases, sse })))
+      .digest("hex");
+    expect(recomputed).toBe(fixture.contentHash);
+  });
+
+  it("fixture version tracks BRAIN_API_VERSION", () => {
+    expect(fixture.version).toBe(BRAIN_API_VERSION);
+  });
+
+  it("server normalizeTier matches every shared alias row", () => {
+    for (const [input, expected] of Object.entries(fixture.tierAliases.shared)) {
+      expect(normalizeTier(input), `shared: ${input}`).toBe(expected);
+    }
+  });
+
+  it("server normalizeTier matches the server column of every divergent row (admin/private/unknown → null)", () => {
+    for (const [input, cols] of Object.entries(fixture.tierAliases.divergent)) {
+      expect(normalizeTier(input), `divergent(server): ${input}`).toBe((cols as { server: unknown }).server);
+    }
+  });
+
+  it("formatSseFrame reproduces every contract frame byte-for-byte", () => {
+    for (const frame of fixture.sse.frames) {
+      expect(formatSseFrame(frame.event, frame.data), `frame: ${frame.name}`).toBe(frame.raw);
+    }
+  });
+});


### PR DESCRIPTION
AIO-314 — team-brain side (paired with aios-workspace PR #214). **No published package** (per John's decision) — a shared fixture + a drift guard in each repo.

## What
- **`lib/api/sse.ts`** — `formatSseFrame(event, data)` extracted from the three inline SSE emitter closures in `app/api/v1/query/route.ts` and `app/api/dashboard/query/route.ts`. Byte-identical behavior; now the single source of the wire format the workspace client (`brain-client.mjs`) parses.
- **`test/fixtures/contract/brain-contract.json`** — vendored copy of the canonical fixture (home: `aios-workspace/docs/contract/`). Byte-identical; `contentHash` pinned.
- **`test/guards/contract-conformance.test.ts`** (unit tier — "all drift/contract guards" per §4) — asserts `normalizeTier` matches the shared rows + the **server** column of the divergent rows (`admin`/`private`/unknown → `null`), `formatSseFrame` reproduces every contract frame byte-for-byte, `version == BRAIN_API_VERSION`, `contentHash` intact.

Cross-repo drift (this vendored copy vs the canonical) is caught by the root `/docs-sync` hash check (added separately).

## Verification
- `npm run lint` + `npm run typecheck` clean.
- Unit suite **469 pass** (85 files); `npm run check:docs` clean (no new enumerable route/table/source — `sse.ts` is a lib helper).
- Conformance guard **5/5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor to a shared SSE helper with conformance tests; wire format is unchanged and guarded byte-for-byte.
> 
> **Overview**
> Introduces **`formatSseFrame`** in `lib/api/sse.ts` as the single place that shapes streaming query SSE (`event:` + JSON `data:` + blank line). **`/api/dashboard/query`** and **`/api/v1/query`** now call it instead of duplicating the same string template in their stream `send` helpers—behavior stays byte-identical.
> 
> Adds a **vendored** `test/fixtures/contract/brain-contract.json` (paired with aios-workspace) and **`test/guards/contract-conformance.test.ts`**, which locks **`normalizeTier`** to shared/divergent tier rows, checks fixture **`version`** vs **`BRAIN_API_VERSION`**, **`contentHash`** integrity, and that **`formatSseFrame`** matches every contract SSE frame exactly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8cf86cf51a14e07a93710dfaf8f969ae343145. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->