### PR TITLE
docs(pm): Plane is a supported provider, not retired (AIO-319, brain)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,7 +211,7 @@ flowchart LR
   EVT --> LINKS[("task_pm_links")]
   LINKS --> PMS["lib/pm-sync provider adapter"]
   PMS --> LINEAR["Linear completed workflow state (primary)"]
-  PMS --> PLANE["Plane completed state (legacy adapter)"]
+  PMS --> PLANE["Plane completed state (supported adapter)"]
   EVT --> UNRES["unresolved work_events for admin reconciliation"]
 ```
 
@@ -335,9 +335,11 @@ and their npm entries (`plane:backlog` / `linear:backlog` / `plane:views` / `pm:
 **deleted** (brain-api v1.2 Phase 3). The board is created/updated only via `lib/pm-sync`.
 
 **PM tool decision (resolved).** The Plane-vs-Linear bake-off (backlog epic W2.4) is settled —
-**Linear is the chosen PM tool**, and `teams.primary_pm_provider` is set to `linear`. The Plane
-adapter (`lib/pm-sync/plane.ts`) remains in code so the runtime projection path stays
-provider-neutral, but Plane is no longer used and the Plane seed/mirror scripts are gone.
+**Linear is AIOS's default PM tool**, and this team's `teams.primary_pm_provider` is set to
+`linear`. **Plane is not retired — it remains a fully supported provider:** the adapter
+(`lib/pm-sync/plane.ts`), the inbound ingestion runner (`runPlaneIngestion`), and the admin
+Primary-PM-tool selector all stay live for teams that prefer Plane. AIOS itself just runs Linear;
+only the internal Plane seed/mirror dev scripts were removed.
 
 ### Action layer (Organ 4) — policy-gated execution
 

--- a/docs/agent-handoffs.md
+++ b/docs/agent-handoffs.md
@@ -2,8 +2,8 @@
 
 > **Status:** Wave 1 (`F3`–`F5`, `W1.1`–`W1.4`) below has shipped and merged; the prompts are kept
 > as a worked template for how to structure a parallel-agent handoff. PM tracking has moved from
-> Plane to **Linear** (Plane is retired — see `docs/ARCHITECTURE.md` "PM tool decision (resolved)");
-> the tracking instructions below reflect that. Wave 2 (`W2.*`) was **superseded 2026-06-29** by the
+> Plane to **Linear** (Plane remains a supported provider, just not AIOS's default — see
+> `docs/ARCHITECTURE.md` "PM tool decision (resolved)"); the tracking instructions below reflect that. Wave 2 (`W2.*`) was **superseded 2026-06-29** by the
 > V1.0 Operator Loop roadmap — see the note under "Parallelization waves".
 
 Each prompt below is **self-contained**: copy one verbatim into a **fresh Claude Code session**.
@@ -29,8 +29,9 @@ projection path) — that's the workflow we're testing.
   `npm run test:datamechanics:local`, or (b) give an agent its own DB:
   `docker compose -f compose.test.yml -p <epic> up -d` on a different port. Data-mechanics tests seed
   random team ids, so they don't collide once the schema is loaded — only the reset step is destructive.
-- **Linear** is the canonical PM tool (Plane is retired). Track work via the brain-tasks CLI
-  (brain→Linear projection) — do not use the Plane MCP.
+- **Linear** is AIOS's default PM tool (Plane remains a supported provider, just not AIOS's
+  default). Track **AIOS's own** work via the brain-tasks CLI (brain→Linear projection) — do not use
+  the Plane MCP for AIOS-internal tracking.
 - Some `F3` scaffolding (encrypted-secret storage in `lib/integrations/manage.ts`) may already exist on
   `main` — **read main first and reconcile**, don't blindly recreate.
 


### PR DESCRIPTION
AIO-319 — team-brain side (paired with aios-workspace #215). **Decision (John): Plane stays a fully supported PM provider; AIOS itself just runs Linear.**

- `docs/ARCHITECTURE.md` "PM tool decision (resolved)": Linear is AIOS's default; **Plane is not retired** — the adapter (`lib/pm-sync/plane.ts`), `runPlaneIngestion`, and the admin Primary-PM-tool selector all stay live for teams that prefer Plane. Mermaid label `legacy adapter` → `supported adapter`.
- `docs/agent-handoffs.md`: separates **AIOS-internal** tracking (use Linear, not the Plane MCP) from the **product capability** (Plane supported). "Plane is retired" → "supported provider, just not AIOS's default."

**No code change** — the admin selector, adapter, and ingestion runner are intentionally live (the audit flagged the docs↔UI contradiction; this resolves it toward "Plane supported"). Confirmed the Plane scheduler tick stays per-integration gated.

Verified: `npm run check:docs` clean (prose edit, no enumerable-block change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only documentation updates with no runtime, API, or data-path changes.
> 
> **Overview**
> **Documentation-only** (AIO-319): aligns PM wording with product reality after an audit flagged docs contradicting the live admin Primary-PM selector and Plane adapter/ingestion paths.
> 
> **`docs/ARCHITECTURE.md`** reframes the resolved PM decision: **Linear stays AIOS’s default** (`teams.primary_pm_provider`), but **Plane is explicitly not retired** — `lib/pm-sync/plane.ts`, `runPlaneIngestion`, and the admin primary-PM selector remain for teams that choose Plane; only internal Plane seed/mirror dev scripts were removed. The PM-loop Mermaid node label changes from *legacy adapter* to **supported adapter**.
> 
> **`docs/agent-handoffs.md`** splits **AIOS-internal tracking** (use Linear / brain-tasks CLI, not Plane MCP) from **product capability** (Plane still supported). Replaces “Plane is retired” with “supported provider, just not AIOS’s default.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426b6a0214b07cd60eba7678d5a51ecded6b6aa4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->