### PR TITLE
fix(auth): invite-flow audit fixes — team-scoped activation + 7 hardening fixes (AIO-328)

### DIFF
--- a/app/auth/dev-login/route.ts
+++ b/app/auth/dev-login/route.ts
@@ -12,7 +12,7 @@ export const runtime = "nodejs";
  * isn't single-use-fragile. Hard-disabled outside development.
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NODE_ENV === "production" && process.env.ALLOW_DEV_LOGIN !== "1") {
+  if (process.env.NODE_ENV === "production") {
     return new NextResponse("dev-login is disabled", { status: 404 });
   }
 

--- a/app/t/[team]/admin/actions.ts
+++ b/app/t/[team]/admin/actions.ts
@@ -4,7 +4,7 @@ import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { adminClient } from "@/lib/db/admin";
 import { requireTeamAdmin as requireAdmin } from "@/lib/auth/guard";
-import { createMember } from "@/lib/admin/members";
+import { createMember, rollbackMemberCreation, MemberExistsError, isValidInviteEmail } from "@/lib/admin/members";
 import { syncMemberActor } from "@/lib/graph/company-actors";
 import { issueApiKey as issueApiKeyPrimitive, revokeApiKey as revokeApiKeyPrimitive } from "@/lib/admin/keys";
 import { issueLoginLink } from "@/lib/admin/login";
@@ -27,7 +27,16 @@ async function resolveTeamUrl(): Promise<string> {
 }
 
 export type InviteMemberResult =
-  | { ok: true; mode: "magic-link"; email: string; emailDelivered: boolean }
+  | {
+      ok: true;
+      mode: "magic-link";
+      email: string;
+      emailDelivered: boolean;
+      /** Set ONLY when `emailDelivered` is false — the already-issued sign-in link, so the admin
+       * has a working fallback instead of a dead end. Security-equivalent to the manual path's
+       * password reveal: same admin, same screen, shown once. */
+      loginUrl?: string;
+    }
   | {
       ok: true;
       mode: "manual";
@@ -74,6 +83,10 @@ export async function inviteMember(
   }
 
   const email = form.email.trim().toLowerCase();
+  if (!isValidInviteEmail(email)) {
+    return { ok: false, error: "invalid email address" };
+  }
+
   const db = adminClient();
   let newMemberId: string;
   try {
@@ -89,9 +102,27 @@ export async function inviteMember(
       { actor: { kind: "member", memberId: ctx.memberId } }
     );
     newMemberId = created.id;
-    if (!useMagicLink) await adminSetPassword(email, password);
   } catch (e) {
+    if (e instanceof MemberExistsError) return { ok: false, error: e.message };
     return { ok: false, error: e instanceof Error ? e.message : "create failed" };
+  }
+
+  if (!useMagicLink) {
+    try {
+      await adminSetPassword(email, password);
+    } catch (e) {
+      // Compensating action, not a transaction: createMember writes through the DbClient adapter
+      // while adminSetPassword writes auth_users via raw runSql (lib/db/pg/pool) — different
+      // connections/paths, so there's no single SQL transaction to wrap them in. If the password
+      // write fails AFTER the member row already landed, leaving it in place would orphan an
+      // 'invited' member with no way to ever sign in (no password, and magic-link isn't in play
+      // on this branch). rollbackMemberCreation hard-deletes it and audits the rollback so it's
+      // traceable, then we surface the failure so the admin can retry.
+      await rollbackMemberCreation(db, ctx.teamId, newMemberId, {
+        actor: { kind: "member", memberId: ctx.memberId },
+      });
+      return { ok: false, error: e instanceof Error ? e.message : "could not set initial password" };
+    }
   }
 
   // Best-effort — the company graph is a derived context surface, not the source of truth; a
@@ -131,7 +162,16 @@ export async function inviteMember(
     }
 
     revalidatePath(`/t/${teamSlug}/admin/members`);
-    return { ok: true, mode: "magic-link", email, emailDelivered };
+    return {
+      ok: true,
+      mode: "magic-link",
+      email,
+      emailDelivered,
+      // Same admin, same screen, shown once — security-equivalent to the manual path's password
+      // reveal. Only surfaced when delivery failed; otherwise the admin has no legitimate need to
+      // see the credential (it went out over email).
+      ...(emailDelivered ? {} : { loginUrl: url }),
+    };
   }
 
   const manualReason = form.manualInvite ? "admin-choice" : "no-mail";

--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { CircleAlert } from "lucide-react";
 import { serverClient } from "@/lib/db/server";
 import { getSessionUser } from "@/lib/auth/session";
+import { activateInvitedMembership } from "@/lib/auth/pg-login";
 import { TeamNav, type NavEntry, type NavLeaf } from "@/components/team-nav";
 import { SignOutButton } from "@/components/account/sign-out-button";
 
@@ -47,12 +48,16 @@ export default async function TeamLayout({
 
   const { data: me } = await db
     .from("members")
-    .select("id, role, display_name, tier")
+    .select("id, role, display_name, tier, status")
     .eq("team_id", team.id)
     .eq("auth_user_id", user.id)
-    .eq("status", "active")
+    .neq("status", "disabled")
     .maybeSingle();
   if (!me) return <NoTeamScreen slug={teamSlug} />;
+  // Team-scoped activation, deferred half: signing in never activates memberships in teams the
+  // login carried no context for (see linkMemberByEmail) — the invited row flips to active here,
+  // on the member's own first visit to this team.
+  if (me.status === "invited") await activateInvitedMembership(team.id, user.id);
 
   const base = `/t/${team.slug}`;
 

--- a/components/admin/invite-member.tsx
+++ b/components/admin/invite-member.tsx
@@ -45,8 +45,22 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
         <p className="text-sm font-medium text-ink">
           {issued.emailDelivered
             ? `Invite email sent to ${issued.email} with a one-time sign-in link (valid 7 days).`
-            : `Member created for ${issued.email}, but we couldn't confirm the invite email was delivered. Check your mail provider settings, or ask them to request a sign-in link at the login page.`}
+            : `Member created for ${issued.email}, but we couldn't confirm the invite email was delivered.`}
         </p>
+        {!issued.emailDelivered && issued.loginUrl && (
+          <>
+            <pre className="whitespace-pre-wrap break-all rounded-lg bg-surface-overlay px-3 py-2 font-mono text-xs text-ink">
+              {issued.loginUrl}
+            </pre>
+            <div className="flex gap-2">
+              <CopyButton text={issued.loginUrl} label="Copy sign-in link" />
+            </div>
+            <p className="text-xs text-ink-tertiary">
+              Email delivery failed — share this sign-in link directly, or re-invite with a manual
+              password.
+            </p>
+          </>
+        )}
         <button
           onClick={reset}
           className="self-start rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,6 +134,16 @@ Two principals, one tier model:
 - **Tiers** — `team` (sees all) vs `external` (sees only external). `admin`/`private`
   are rejected with **422** at the API and never reach the database.
 
+**Accepted behavior — the magic-link enumeration oracle.** `POST /api/auth/request-magic-link`'s
+explicit 403 `not_recognized` for an unknown email is a deliberate, disclosed design choice, not an
+oversight: this is an invite-only, self-hosted surface with a small known-member set, so confirming
+"does this email have an account" carries little practical risk, and the alternative (a fake-success
+response for a typo'd email) would silently break the sign-in UX with no way to recover. `POST
+/api/auth/login` — the default, always-available sign-in path — deliberately does NOT make the same
+tradeoff: its failure response stays a uniform 401 `invalid_credentials` regardless of cause, because
+password login is reachable unconditionally while the magic-link route is only ever offered by the
+login form when an admin has opted into mail delivery (`magicLinkAvailable()`).
+
 ## Key flows
 
 ### Sync ingest — `POST /api/v1/items`

--- a/lib/admin/members.ts
+++ b/lib/admin/members.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { z } from "zod";
 import type { DbClient } from "@/lib/db/types";
 import { audit } from "@/lib/api/audit";
 
@@ -19,6 +20,32 @@ export interface MemberInput {
 export interface ActorContext {
   kind?: "member" | "system";
   memberId?: string | null;
+}
+
+/** Thrown by `createMember` when the team already has a member with this email or actor
+ * handle (the `members_team_id_email_key` / `members_team_id_actor_handle_key` unique
+ * constraints) — a friendly, dedicated error instead of leaking the raw pg constraint-violation
+ * text to callers (the admin UI, the CLI). */
+export class MemberExistsError extends Error {
+  constructor() {
+    super("a member with this email or handle already exists");
+    this.name = "MemberExistsError";
+  }
+}
+
+/** Pure detector, extracted so the constraint-name matching is unit-testable without a DB: does
+ * this pg error message indicate the `members` table's team+email or team+actor_handle unique
+ * constraint was violated? */
+export function isMemberUniqueConstraintViolation(pgErrorMessage: string): boolean {
+  return /members_team_id_email_key|members_team_id_actor_handle_key/.test(pgErrorMessage);
+}
+
+/** Pure validator, extracted so it's unit-testable without a session/DB: is this a well-formed
+ * email address? `inviteMember` (`app/t/[team]/admin/actions.ts`) runs this on the
+ * trimmed/lowercased email BEFORE calling `createMember`, so a malformed address never reaches
+ * the DB or mints a member row. */
+export function isValidInviteEmail(email: string): boolean {
+  return z.string().email().safeParse(email).success;
 }
 
 export async function createMember(
@@ -44,7 +71,12 @@ export async function createMember(
     : admin.from("members").insert({ ...row, status: "invited" });
 
   const { data, error } = await builder.select("id, status").single();
-  if (error || !data) throw new Error(`create member failed: ${error?.message}`);
+  if (error || !data) {
+    if (error && isMemberUniqueConstraintViolation(error.message)) {
+      throw new MemberExistsError();
+    }
+    throw new Error(`create member failed: ${error?.message}`);
+  }
 
   await audit(admin, {
     team_id: teamId,
@@ -56,6 +88,36 @@ export async function createMember(
     meta: { email, role: input.role, upsert: Boolean(opts.upsert) },
   });
   return { id: data.id, status: data.status };
+}
+
+/**
+ * Compensating action for a failed invite: hard-deletes a just-created member row and audits the
+ * rollback (`member.deleted`, `meta.reason = "invite-rollback"`) — distinct from `deleteMember`'s
+ * own hard-delete path (which is an intentional admin removal, has a different audit meta shape,
+ * and enforces the last-admin guard, which doesn't apply here: this member was never active).
+ *
+ * Exists because `inviteMember` (`app/t/[team]/admin/actions.ts`) can't wrap `createMember` and
+ * `adminSetPassword` in one SQL transaction — `createMember` writes through the `DbClient` adapter
+ * while `adminSetPassword` writes `auth_users` via raw `runSql` (`lib/db/pg/pool`), different
+ * connections/paths. If the password write fails after the member row already landed, this is the
+ * explicit, auditable undo instead of leaving an orphaned 'invited' member with no way to sign in.
+ */
+export async function rollbackMemberCreation(
+  admin: DbClient,
+  teamId: string,
+  memberId: string,
+  opts: { actor?: ActorContext } = {}
+): Promise<void> {
+  await admin.from("members").delete().eq("id", memberId);
+  await audit(admin, {
+    team_id: teamId,
+    actor_kind: opts.actor?.kind ?? "system",
+    member_id: opts.actor?.memberId ?? null,
+    action: "member.deleted",
+    target_type: "member",
+    target_id: memberId,
+    meta: { reason: "invite-rollback" },
+  });
 }
 
 export interface UpdateRoleResult {

--- a/lib/auth/cleanup.ts
+++ b/lib/auth/cleanup.ts
@@ -1,0 +1,34 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+
+/**
+ * Housekeeping for the two single-use/expiring auth tables. Both `auth_tokens` (magic-link /
+ * invite tokens) and `oauth_states` (Slack-connect nonces) are write-once, ephemeral rows —
+ * nothing ever reads a used or expired one again — so they're pure accumulation without this.
+ * Deletes rows that are done being useful:
+ *   - already consumed (`used_at is not null`), or
+ *   - expired for at least 7 days (`expires_at < now() - interval '7 days'` — a short grace
+ *     window past expiry in case an ops investigation needs a recently-expired row).
+ *
+ * Raw `runSql` (not the `DbClient` adapter) to match `lib/auth/pg-login.ts`, which this module is
+ * the housekeeping counterpart to — no `DbClient` is threaded through either. Best-effort by
+ * contract at the call sites (scheduler tick, `issueMagicToken`); this function itself still lets
+ * a real DB error propagate so a caller that awaits it directly (e.g. a test) sees the failure.
+ */
+
+export interface PurgeResult {
+  authTokens: number;
+  oauthStates: number;
+}
+
+export async function purgeExpiredAuthRows(): Promise<PurgeResult> {
+  const tokens = await runSql(
+    `delete from auth_tokens where used_at is not null or expires_at < now() - interval '7 days'`,
+    []
+  );
+  const states = await runSql(
+    `delete from oauth_states where expires_at < now() - interval '7 days' or used_at is not null`,
+    []
+  );
+  return { authTokens: tokens.rowCount, oauthStates: states.rowCount };
+}

--- a/lib/auth/pg-login.ts
+++ b/lib/auth/pg-login.ts
@@ -25,12 +25,44 @@ export async function ensureAuthUser(email: string): Promise<string> {
   return rows[0].id;
 }
 
-/** First login: claim invited member row(s) for this email and activate them. */
-export async function linkMemberByEmail(authUserId: string, email: string): Promise<void> {
+/**
+ * First login: link this email's member rows to the auth user (identity only — every team's
+ * row, since the credential is per-email), and activate the invited row **only for `teamId`**
+ * when the login carries team context (a magic link minted for `/t/<team>`). Activation is
+ * team-scoped on purpose: with one email on multiple teams, signing in to team A must never
+ * flip team B's `invited` row to `active` — B activates on the member's first visit instead
+ * (`activateInvitedMembership`, called from `app/t/[team]/layout.tsx`).
+ */
+export async function linkMemberByEmail(
+  authUserId: string,
+  email: string,
+  teamId?: string | null
+): Promise<void> {
   await runSql(
-    `update members set auth_user_id = $1, status = 'active'
+    `update members set auth_user_id = $1
      where email = $2 and auth_user_id is null and status <> 'disabled'`,
     [authUserId, email]
+  );
+  if (teamId) {
+    await runSql(
+      `update members set status = 'active'
+       where team_id = $1 and email = $2 and status = 'invited'`,
+      [teamId, email]
+    );
+  }
+}
+
+/**
+ * The deferred half of team-scoped activation: flip the caller's own `invited` membership in
+ * one team to `active` on their first authorized visit (the team layout calls this after
+ * resolving the session user's row). `authUserId` comes from the caller's session, so this can
+ * only ever activate the caller's own membership.
+ */
+export async function activateInvitedMembership(teamId: string, authUserId: string): Promise<void> {
+  await runSql(
+    `update members set status = 'active'
+     where team_id = $1 and auth_user_id = $2 and status = 'invited'`,
+    [teamId, authUserId]
   );
 }
 
@@ -63,20 +95,16 @@ export async function loginWithPassword(
   if (!hash) return null; // no password set yet — ask an admin, don't fall back to passwordless
   if (!(await verifyPasswordHash(password, hash))) return null;
 
-  // Capture 'invited' status BEFORE the update below activates it (same pattern as redeemMagicToken).
+  // Capture 'invited' status BEFORE linking (same pattern as redeemMagicToken).
   const { rows: before } = await runSql<{ status: string }>(
     `select status from members where email = $1 and status <> 'disabled' limit 1`,
     [email]
   );
   const firstLogin = before[0]?.status === "invited";
   const id = await ensureAuthUser(email);
-  await runSql(
-    `update members
-        set auth_user_id = $1,
-            status = case when status = 'invited' then 'active' else status end
-      where email = $2 and status <> 'disabled'`,
-    [id, email]
-  );
+  // Identity linking only — a password login carries no team context, so activation is
+  // deferred to the first team visit (see linkMemberByEmail's docblock).
+  await linkMemberByEmail(id, email);
   return { user: { id, email }, firstLogin };
 }
 
@@ -185,21 +213,24 @@ export async function redeemMagicToken(raw: string): Promise<RedeemResult | null
   const tok = rows[0];
   if (!tok) return null;
 
-  // Capture 'invited' status BEFORE linkMemberByEmail activates it below.
+  // Capture 'invited' status BEFORE linkMemberByEmail activates it below, and resolve the
+  // token's team so activation stays scoped to the team the link was minted for.
   let firstLogin = false;
+  let teamId: string | null = null;
   const teamSlug = teamSlugFromNextPath(tok.next_path);
   if (teamSlug) {
-    const { rows: memberRows } = await runSql<{ status: string }>(
-      `select m.status
+    const { rows: memberRows } = await runSql<{ status: string; team_id: string }>(
+      `select m.status, m.team_id
          from members m
          join teams t on t.id = m.team_id
         where t.slug = $1 and m.email = $2 and m.status <> 'disabled'`,
       [teamSlug, tok.email]
     );
     firstLogin = memberRows[0]?.status === "invited";
+    teamId = memberRows[0]?.team_id ?? null;
   }
 
   const id = await ensureAuthUser(tok.email);
-  await linkMemberByEmail(id, tok.email);
+  await linkMemberByEmail(id, tok.email, teamId);
   return { user: { id, email: tok.email }, nextPath: tok.next_path, firstLogin };
 }

--- a/lib/auth/pg-login.ts
+++ b/lib/auth/pg-login.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { createHash, randomBytes } from "node:crypto";
 import { runSql } from "@/lib/db/pg/pool";
 import { hashPassword, verifyPasswordHash } from "./password";
+import { purgeExpiredAuthRows } from "./cleanup";
 import type { SessionUser } from "./pg-session";
 
 /**
@@ -150,6 +151,12 @@ export async function issueMagicToken(
      values ($1, $2, $3, $4)`,
     [hash, email, nextPath, expires]
   );
+  // Opportunistic housekeeping — every token issuance is a natural, low-cost moment to sweep
+  // expired/used auth_tokens + oauth_states rows (two small indexed deletes). Fire-and-forget:
+  // must never block or fail token issuance, so errors are swallowed here, not propagated.
+  void purgeExpiredAuthRows().catch((err) => {
+    console.error("[auth] opportunistic cleanup failed:", err instanceof Error ? err.message : err);
+  });
   return raw;
 }
 

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -32,6 +32,7 @@ export function startIngestScheduler(): void {
     // adopt sees freshly-imported mirror tasks. Per-team opt-in; quiet no-op otherwise.
     await runInbound(db);
     await runImport(db, "github", runGithubIngestion);
+    await runAuthCleanup(db);
     // Incremental dense (semantic) indexing of newly-synced items. No-op unless dense retrieval is
     // configured (EMBEDDINGS_URL + pgvector schema); best-effort — never fails the tick. A batch where
     // items were SCANNED but all FAILED (e.g. embeddings quota/outage) records an ERROR run so the
@@ -151,6 +152,49 @@ export function startIngestScheduler(): void {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[ingest] ${label} tick failed:`, msg);
       await recordIngestRun(db, { source: label, trigger: "scheduler", ok: false, errors: [msg], startedAt });
+    }
+  }
+
+  // Housekeeping: purge expired/used auth_tokens + oauth_states rows (lib/auth/cleanup). A
+  // scheduler tick runs far more often than this needs to, so it's throttled to once/day —
+  // checked via the last recorded 'auth_cleanup' ingest_runs row, the same "read the last
+  // recorded run" pattern the dense-index leg uses for its own edge detection
+  // (lib/query/retrieval-alert.lastDenseRunFailed). A quiet pass (nothing to purge, or throttled)
+  // logs and records nothing.
+  const AUTH_CLEANUP_INTERVAL_MS = 24 * 60 * 60_000;
+  async function runAuthCleanup(db: ReturnType<typeof adminClient>): Promise<void> {
+    const startedAt = Date.now();
+    try {
+      const { data: last } = await db
+        .from("ingest_runs")
+        .select("started_at")
+        .eq("source", "auth_cleanup")
+        .order("started_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      const lastStartedAt = (last as { started_at: string } | null)?.started_at;
+      if (lastStartedAt && Date.now() - new Date(lastStartedAt).getTime() < AUTH_CLEANUP_INTERVAL_MS) {
+        return; // already ran within the last day
+      }
+      const { purgeExpiredAuthRows } = await import("@/lib/auth/cleanup");
+      const result = await purgeExpiredAuthRows();
+      if (result.authTokens || result.oauthStates) {
+        console.info(
+          `[ingest] auth-cleanup: purged ${result.authTokens} auth_tokens, ${result.oauthStates} oauth_states`
+        );
+      }
+      await recordIngestRun(db, {
+        source: "auth_cleanup",
+        trigger: "scheduler",
+        ok: true,
+        updated: result.authTokens + result.oauthStates,
+        meta: { authTokens: result.authTokens, oauthStates: result.oauthStates },
+        startedAt,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error("[ingest] auth-cleanup tick failed:", msg);
+      await recordIngestRun(db, { source: "auth_cleanup", trigger: "scheduler", ok: false, errors: [msg], startedAt });
     }
   }
 

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -159,8 +159,9 @@ export function startIngestScheduler(): void {
   // scheduler tick runs far more often than this needs to, so it's throttled to once/day —
   // checked via the last recorded 'auth_cleanup' ingest_runs row, the same "read the last
   // recorded run" pattern the dense-index leg uses for its own edge detection
-  // (lib/query/retrieval-alert.lastDenseRunFailed). A quiet pass (nothing to purge, or throttled)
-  // logs and records nothing.
+  // (lib/query/retrieval-alert.lastDenseRunFailed). A throttled pass records nothing; a completed
+  // sweep always records a run (that row IS the throttle bookkeeping) and logs only when it
+  // actually purged something.
   const AUTH_CLEANUP_INTERVAL_MS = 24 * 60 * 60_000;
   async function runAuthCleanup(db: ReturnType<typeof adminClient>): Promise<void> {
     const startedAt = Date.now();

--- a/test/datamechanics/auth-cleanup.datamechanics.test.ts
+++ b/test/datamechanics/auth-cleanup.datamechanics.test.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { purgeExpiredAuthRows } from "@/lib/auth/cleanup";
+import { db, seedTeam } from "./helpers";
+
+// Spec: purgeExpiredAuthRows must delete auth_tokens/oauth_states rows that are done being
+// useful — already consumed (used_at set) or expired for 7+ days — and must NOT touch a fresh,
+// unused, unexpired row (the "leave a live sign-in link alone" case). Verified to the observable
+// outcome: what actually survives in real Postgres after the purge.
+
+function iso(msFromNow: number): string {
+  return new Date(Date.now() + msFromNow).toISOString();
+}
+
+const DAY_MS = 24 * 60 * 60_000;
+
+describe("purgeExpiredAuthRows (real Postgres)", () => {
+  it("deletes used and 7+ day expired auth_tokens; leaves a fresh, unused, unexpired token", async () => {
+    await seedTeam();
+
+    // Survivor: fresh, unused, still valid (a live magic-link the user hasn't clicked yet).
+    await db().from("auth_tokens").insert({
+      token_hash: `fresh-${randomUUID()}`,
+      email: "fresh@test.local",
+      expires_at: iso(15 * 60_000), // 15 min from now
+      used_at: null,
+    });
+    // Purged: consumed, even though not yet expired.
+    await db().from("auth_tokens").insert({
+      token_hash: `used-${randomUUID()}`,
+      email: "used@test.local",
+      expires_at: iso(15 * 60_000),
+      used_at: new Date().toISOString(),
+    });
+    // Survivor: expired less than 7 days ago (grace window for ops investigation).
+    await db().from("auth_tokens").insert({
+      token_hash: `recently-expired-${randomUUID()}`,
+      email: "recent@test.local",
+      expires_at: iso(-1 * 60_000), // 1 min ago
+      used_at: null,
+    });
+    // Purged: expired well past the 7-day grace window.
+    await db().from("auth_tokens").insert({
+      token_hash: `stale-${randomUUID()}`,
+      email: "stale@test.local",
+      expires_at: iso(-8 * DAY_MS),
+      used_at: null,
+    });
+
+    const result = await purgeExpiredAuthRows();
+    expect(result.authTokens).toBe(2);
+
+    const { data: remaining } = await db().from("auth_tokens").select("token_hash");
+    const survivorHashes = (remaining ?? []).map((r) => (r as { token_hash: string }).token_hash);
+    expect(survivorHashes.some((h) => h.startsWith("fresh-"))).toBe(true);
+    expect(survivorHashes.some((h) => h.startsWith("recently-expired-"))).toBe(true);
+    expect(survivorHashes.some((h) => h.startsWith("used-"))).toBe(false);
+    expect(survivorHashes.some((h) => h.startsWith("stale-"))).toBe(false);
+  });
+
+  it("deletes used and 7+ day expired oauth_states; leaves a fresh, unused, unexpired nonce", async () => {
+    const seed = await seedTeam();
+
+    await db().from("oauth_states").insert({
+      team_id: seed.teamId,
+      member_id: seed.memberId,
+      provider: "slack",
+      expires_at: iso(5 * 60_000),
+      used_at: null,
+    });
+    const { data: used } = await db()
+      .from("oauth_states")
+      .insert({
+        team_id: seed.teamId,
+        member_id: seed.memberId,
+        provider: "slack",
+        expires_at: iso(5 * 60_000),
+        used_at: new Date().toISOString(),
+      })
+      .select("nonce")
+      .single();
+    const { data: stale } = await db()
+      .from("oauth_states")
+      .insert({
+        team_id: seed.teamId,
+        member_id: seed.memberId,
+        provider: "slack",
+        expires_at: iso(-8 * DAY_MS),
+        used_at: null,
+      })
+      .select("nonce")
+      .single();
+
+    const result = await purgeExpiredAuthRows();
+    expect(result.oauthStates).toBe(2);
+
+    const { data: remaining } = await db().from("oauth_states").select("nonce, used_at");
+    const remainingNonces = new Set((remaining ?? []).map((r) => (r as { nonce: string }).nonce));
+    expect(remainingNonces.size).toBe(1); // only the fresh one survives
+    expect(remainingNonces.has((used as { nonce: string }).nonce)).toBe(false);
+    expect(remainingNonces.has((stale as { nonce: string }).nonce)).toBe(false);
+  });
+});

--- a/test/datamechanics/integrations-auth.datamechanics.test.ts
+++ b/test/datamechanics/integrations-auth.datamechanics.test.ts
@@ -40,8 +40,9 @@ async function seedMemberWithAuth(
     })
     .select("id")
     .single();
-  const userId = await ensureAuthUser(email); // activates + links auth_user_id
-  await linkMemberByEmail(userId, email);
+  const userId = await ensureAuthUser(email);
+  // Team-scoped activation: pass the team so the invited row is linked AND activated here.
+  await linkMemberByEmail(userId, email, teamId);
   return { memberId: m!.id as string, userId };
 }
 

--- a/test/datamechanics/invite-rollback.datamechanics.test.ts
+++ b/test/datamechanics/invite-rollback.datamechanics.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { createMember, rollbackMemberCreation, MemberExistsError } from "@/lib/admin/members";
+import { db, seedTeam } from "./helpers";
+
+// Spec: inviteMember's manual-password branch calls createMember then adminSetPassword; the two
+// can't share a SQL transaction (different write paths — see rollbackMemberCreation's docblock).
+// If adminSetPassword fails after createMember succeeded, the caller must compensate with
+// rollbackMemberCreation so no orphaned 'invited' member (with no password, unable to ever sign
+// in) is left behind. This exercises exactly that compensating action against real Postgres —
+// the same primitive inviteMember calls on an adminSetPassword failure — and asserts the
+// observable outcome: the member row is gone and the rollback is audited.
+describe("rollbackMemberCreation (real Postgres) — invite compensating delete", () => {
+  it("leaves no orphaned member row after a simulated adminSetPassword failure", async () => {
+    const seed = await seedTeam();
+    const created = await createMember(db(), seed.teamId, {
+      email: "orphan-risk@test.local",
+      displayName: "Orphan Risk",
+      actorHandle: "orphanrisk",
+      role: "member",
+    });
+    expect(created.status).toBe("invited");
+
+    // Simulate: adminSetPassword threw after createMember succeeded — the caller (inviteMember)
+    // reacts by rolling back instead of leaving the member row in place.
+    await rollbackMemberCreation(db(), seed.teamId, created.id, {
+      actor: { kind: "member", memberId: seed.memberId },
+    });
+
+    const { data: after } = await db().from("members").select("id").eq("id", created.id).maybeSingle();
+    expect(after).toBeNull(); // no orphan left behind
+
+    const { data: audits } = await db()
+      .from("audit_log")
+      .select("action, target_id, meta")
+      .eq("team_id", seed.teamId)
+      .eq("target_id", created.id)
+      .eq("action", "member.deleted");
+    const rollbackAudit = (audits ?? [])[0] as { action: string; meta: { reason?: string } } | undefined;
+    expect(rollbackAudit).toBeTruthy();
+    expect(rollbackAudit!.meta.reason).toBe("invite-rollback");
+  });
+
+  it("a rolled-back email can be re-invited afterward (no lingering unique-constraint conflict)", async () => {
+    const seed = await seedTeam();
+    const created = await createMember(db(), seed.teamId, {
+      email: "retry-me@test.local",
+      displayName: "Retry Me",
+      actorHandle: "retryme",
+      role: "member",
+    });
+    await rollbackMemberCreation(db(), seed.teamId, created.id);
+
+    const retried = await createMember(db(), seed.teamId, {
+      email: "retry-me@test.local",
+      displayName: "Retry Me",
+      actorHandle: "retryme",
+      role: "member",
+    });
+    expect(retried.status).toBe("invited");
+    expect(retried.id).not.toBe(created.id);
+  });
+});
+
+// Spec (fix E): createMember must turn a raw pg unique-constraint violation into a dedicated,
+// friendly MemberExistsError — not the raw "create member failed: duplicate key..." pg text —
+// for both the team+email and team+actor_handle constraints.
+describe("createMember duplicate detection (real Postgres)", () => {
+  it("throws MemberExistsError on a duplicate email within the same team", async () => {
+    const seed = await seedTeam();
+    await createMember(db(), seed.teamId, {
+      email: "dupe@test.local",
+      displayName: "First",
+      actorHandle: "first-handle",
+      role: "member",
+    });
+
+    await expect(
+      createMember(db(), seed.teamId, {
+        email: "dupe@test.local",
+        displayName: "Second",
+        actorHandle: "second-handle",
+        role: "member",
+      })
+    ).rejects.toBeInstanceOf(MemberExistsError);
+  });
+
+  it("throws MemberExistsError on a duplicate actor handle within the same team", async () => {
+    const seed = await seedTeam();
+    await createMember(db(), seed.teamId, {
+      email: "handle-a@test.local",
+      displayName: "First",
+      actorHandle: "shared-handle",
+      role: "member",
+    });
+
+    await expect(
+      createMember(db(), seed.teamId, {
+        email: "handle-b@test.local",
+        displayName: "Second",
+        actorHandle: "shared-handle",
+        role: "member",
+      })
+    ).rejects.toBeInstanceOf(MemberExistsError);
+  });
+
+  it("the same email is fine on a DIFFERENT team (team-scoped uniqueness)", async () => {
+    const seedA = await seedTeam();
+    const seedB = await seedTeam();
+    await createMember(db(), seedA.teamId, {
+      email: "cross-team@test.local",
+      displayName: "A",
+      actorHandle: "cross-a",
+      role: "member",
+    });
+
+    const onB = await createMember(db(), seedB.teamId, {
+      email: "cross-team@test.local",
+      displayName: "B",
+      actorHandle: "cross-b",
+      role: "member",
+    });
+    expect(onB.status).toBe("invited");
+  });
+});

--- a/test/datamechanics/login.datamechanics.test.ts
+++ b/test/datamechanics/login.datamechanics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { adminSetPassword, loginWithPassword } from "@/lib/auth/pg-login";
+import { activateInvitedMembership, adminSetPassword, loginWithPassword } from "@/lib/auth/pg-login";
 import { db, seedTeam } from "./helpers";
 
 // Spec (audit M1/M2b): email+password login is invite-only AND requires a password an admin has
@@ -45,7 +45,7 @@ describe("loginWithPassword (real Postgres, invite-only, password-gated)", () =>
     expect(await loginWithPassword(email, "not-the-real-password")).toBeNull();
   });
 
-  it("signs in with the correct password, force-links the auth user, activates invited, and reports firstLogin", async () => {
+  it("signs in with the correct password, links the auth user, and reports firstLogin — activation is deferred to the first team visit", async () => {
     const seed = await seedTeam();
     const email = "invitee@test.local";
     await db().from("members").insert({
@@ -57,20 +57,28 @@ describe("loginWithPassword (real Postgres, invite-only, password-gated)", () =>
     const result = await loginWithPassword(email, "the-real-password-123");
     expect(result).not.toBeNull();
     expect(result!.user.email).toBe(email);
-    // Was 'invited' before this login — this is the activation, so the caller should route
-    // through the one-time welcome screen (audit-adjacent: matches redeemMagicToken's behavior).
+    // Was 'invited' before this login — the caller routes through the one-time welcome screen.
     expect(result!.firstLogin).toBe(true);
 
-    // Outcome in the DB: activated + linked to the same auth user the session carries.
+    // Outcome in the DB: linked to the session's auth user, but STILL invited — a password
+    // login carries no team context, so team-scoped activation happens on the member's first
+    // visit to the team (activateInvitedMembership via the team layout), never at sign-in.
     const { data } = await db()
       .from("members")
       .select("auth_user_id, status")
       .eq("email", email)
       .maybeSingle();
-    expect(data!.status).toBe("active");
+    expect(data!.status).toBe("invited");
     expect(data!.auth_user_id).toBe(result!.user.id);
 
-    // A second login is NOT a first login — the member is already active.
+    // First team visit activates; a login after that is no longer a first login.
+    await activateInvitedMembership(seed.teamId, result!.user.id);
+    const { data: after } = await db()
+      .from("members")
+      .select("status")
+      .eq("email", email)
+      .maybeSingle();
+    expect(after!.status).toBe("active");
     const second = await loginWithPassword(email, "the-real-password-123");
     expect(second!.firstLogin).toBe(false);
   });

--- a/test/datamechanics/team-scoped-activation.datamechanics.test.ts
+++ b/test/datamechanics/team-scoped-activation.datamechanics.test.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  activateInvitedMembership,
+  adminSetPassword,
+  issueMagicToken,
+  loginWithPassword,
+  redeemMagicToken,
+} from "@/lib/auth/pg-login";
+import { db, seedTeam, type Seed } from "./helpers";
+
+// Spec (audit fix #1): activation is TEAM-SCOPED. One email can be a member of several teams in
+// the same DB; signing in with team context (a magic link minted for /t/<team>) must activate
+// ONLY that team's invited row, and a context-free password login must activate none — the other
+// teams' rows flip to active on the member's own first visit (activateInvitedMembership, called
+// by the team layout). Identity linking (auth_user_id) is per-email and applies to every row.
+
+async function inviteTo(seed: Seed, email: string): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      email,
+      display_name: "Two Teams",
+      actor_handle: `dual-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "invited",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`invite seed failed: ${error?.message}`);
+  return data.id;
+}
+
+async function memberState(id: string): Promise<{ status: string; auth_user_id: string | null }> {
+  const { data } = await db()
+    .from("members")
+    .select("status, auth_user_id")
+    .eq("id", id)
+    .maybeSingle();
+  return data as { status: string; auth_user_id: string | null };
+}
+
+describe("team-scoped activation (real Postgres)", () => {
+  it("redeeming a magic link for team A activates A only — team B stays invited (but linked)", async () => {
+    const teamA = await seedTeam();
+    const teamB = await seedTeam();
+    const email = `dual-${randomUUID().slice(0, 8)}@test.local`;
+    const idA = await inviteTo(teamA, email);
+    const idB = await inviteTo(teamB, email);
+
+    const raw = await issueMagicToken(email, `/t/${teamA.teamSlug}`);
+    expect(raw).toBeTruthy();
+    const redeemed = await redeemMagicToken(raw!);
+    expect(redeemed).toBeTruthy();
+    expect(redeemed!.firstLogin).toBe(true);
+
+    const a = await memberState(idA);
+    const b = await memberState(idB);
+    expect(a.status).toBe("active");
+    expect(a.auth_user_id).toBe(redeemed!.user.id);
+    expect(b.status).toBe("invited"); // the isolation invariant under test
+    expect(b.auth_user_id).toBe(redeemed!.user.id); // identity linking is per-email
+  });
+
+  it("a password login (no team context) links identity but activates nothing", async () => {
+    const teamA = await seedTeam();
+    const teamB = await seedTeam();
+    const email = `pw-${randomUUID().slice(0, 8)}@test.local`;
+    const idA = await inviteTo(teamA, email);
+    const idB = await inviteTo(teamB, email);
+
+    await adminSetPassword(email, "a-strong-enough-password");
+    const login = await loginWithPassword(email, "a-strong-enough-password");
+    expect(login).toBeTruthy();
+    expect(login!.firstLogin).toBe(true);
+
+    for (const id of [idA, idB]) {
+      const row = await memberState(id);
+      expect(row.status).toBe("invited");
+      expect(row.auth_user_id).toBe(login!.user.id);
+    }
+
+    // First visit to team B activates B only (the layout's deferred half).
+    await activateInvitedMembership(teamB.teamId, login!.user.id);
+    expect((await memberState(idB)).status).toBe("active");
+    expect((await memberState(idA)).status).toBe("invited");
+  });
+
+  it("activateInvitedMembership only touches the caller's own membership", async () => {
+    const team = await seedTeam();
+    const emailMine = `mine-${randomUUID().slice(0, 8)}@test.local`;
+    const emailOther = `other-${randomUUID().slice(0, 8)}@test.local`;
+    const idMine = await inviteTo(team, emailMine);
+    const idOther = await inviteTo(team, emailOther);
+
+    await adminSetPassword(emailMine, "a-strong-enough-password");
+    const login = await loginWithPassword(emailMine, "a-strong-enough-password");
+    await activateInvitedMembership(team.teamId, login!.user.id);
+
+    expect((await memberState(idMine)).status).toBe("active");
+    expect((await memberState(idOther)).status).toBe("invited");
+  });
+});

--- a/test/dev-login-route.test.ts
+++ b/test/dev-login-route.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+// Spec: dev-login is a bypass-auth footgun — mint a session for ANY email with no credential
+// check. It must be unconditionally unreachable in production; the guard is checked FIRST, before
+// any DB/session work, so this is testable purely (no DB mocking needed — the 404 return happens
+// before ensureAuthUser/linkMemberByEmail/signSession are ever called).
+const { GET } = await import("@/app/auth/dev-login/route");
+
+function request(url: string): NextRequest {
+  return new Request(url) as unknown as NextRequest;
+}
+
+describe("GET /auth/dev-login — hard prod guard", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 404 unconditionally in production, with no escape hatch", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    // Previously ALLOW_DEV_LOGIN=1 re-enabled this in prod — must no longer have any effect.
+    vi.stubEnv("ALLOW_DEV_LOGIN", "1");
+
+    const res = await GET(request("http://test.local/auth/dev-login?email=alex@demo.aios.local"));
+    expect(res.status).toBe(404);
+  });
+
+  it("stays reachable outside production", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+
+    // Non-production: the route proceeds past the guard into ensureAuthUser/DB work, which throws
+    // in this unit context (no DATABASE_URL) — proving the guard did NOT short-circuit here. The
+    // guard's job is only to block production; DB behavior is out of scope for this unit test.
+    await expect(
+      GET(request("http://test.local/auth/dev-login?email=alex@demo.aios.local"))
+    ).rejects.toThrow();
+  });
+});

--- a/test/invite-member-guards.test.ts
+++ b/test/invite-member-guards.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { isValidInviteEmail, isMemberUniqueConstraintViolation, MemberExistsError } from "@/lib/admin/members";
+
+// Spec: inviteMember (app/t/[team]/admin/actions.ts) must reject a malformed email BEFORE ever
+// calling createMember — no malformed address should reach the DB or mint a member row. The
+// validator is a thin zod .email() wrapper; the assertion is about the boundary it draws (what's
+// accepted vs rejected), not about re-testing zod itself.
+describe("isValidInviteEmail", () => {
+  it("accepts well-formed addresses", () => {
+    expect(isValidInviteEmail("ada@acme.test")).toBe(true);
+    expect(isValidInviteEmail("first.last+tag@sub.example.co")).toBe(true);
+  });
+
+  it("rejects malformed addresses", () => {
+    expect(isValidInviteEmail("")).toBe(false);
+    expect(isValidInviteEmail("not-an-email")).toBe(false);
+    expect(isValidInviteEmail("missing-domain@")).toBe(false);
+    expect(isValidInviteEmail("@missing-local.test")).toBe(false);
+    expect(isValidInviteEmail("spaces in@email.test")).toBe(false);
+  });
+});
+
+// Spec: createMember must turn a raw pg unique-constraint violation on `members` (team+email or
+// team+actor_handle) into a friendly, dedicated MemberExistsError — never leak the raw
+// "duplicate key value violates unique constraint ..." pg text to the admin UI or CLI.
+describe("isMemberUniqueConstraintViolation", () => {
+  it("recognizes the team+email unique-constraint violation", () => {
+    const msg =
+      'duplicate key value violates unique constraint "members_team_id_email_key"';
+    expect(isMemberUniqueConstraintViolation(msg)).toBe(true);
+  });
+
+  it("recognizes the team+actor_handle unique-constraint violation", () => {
+    const msg =
+      'duplicate key value violates unique constraint "members_team_id_actor_handle_key"';
+    expect(isMemberUniqueConstraintViolation(msg)).toBe(true);
+  });
+
+  it("does not match unrelated pg errors", () => {
+    expect(isMemberUniqueConstraintViolation("connection terminated unexpectedly")).toBe(false);
+    expect(isMemberUniqueConstraintViolation('violates foreign key constraint "members_team_id_fkey"')).toBe(
+      false
+    );
+  });
+});
+
+describe("MemberExistsError", () => {
+  it("carries the friendly message, not the raw pg text", () => {
+    const err = new MemberExistsError();
+    expect(err.message).toBe("a member with this email or handle already exists");
+    expect(err.name).toBe("MemberExistsError");
+    expect(err).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## What

Fixes all 8 findings from the 2026-07-10 members/onboarding audit (precursor to the member-provisioning cascade PRs):

1. **Team-scoped activation** — signing in used to flip `invited` → `active` on EVERY team sharing the email (`linkMemberByEmail`/`loginWithPassword` had no `team_id` filter). Now: a magic link activates only the team it was minted for; a password login links identity only; other teams activate on the member's own first visit (`activateInvitedMembership` in the team layout).
2. **dev-login hard prod guard** — unconditional 404 in production; `ALLOW_DEV_LOGIN` escape hatch (an any-member account-takeover primitive) deleted.
3. **Auth-row cleanup** — `purgeExpiredAuthRows()` sweeps used/expired `auth_tokens` + `oauth_states` (daily scheduler leg + opportunistic on token issuance). They were pure accumulation before.
4. **Server-side email validation** on invite (zod `.email()`).
5. **Invite rollback** — a failed `adminSetPassword` after `createMember` no longer strands an orphaned invited member; compensating audited hard-delete (no shared SQL txn possible across the DbClient/runSql write paths — documented).
6. **Friendly duplicate error** — `MemberExistsError` instead of raw pg constraint text.
7. **Delivery-failure fallback** — when the invite email doesn't deliver, the admin gets the already-issued sign-in link (copy button) instead of a dead end.
8. **Docs** — the intentional `request-magic-link` enumeration oracle documented as accepted behavior in ARCHITECTURE.md.

## Tests

- Unit: 477 passed (new: dev-login prod guard, email validation, duplicate detector).
- Data-mechanics (real PG, fresh `db:test:up`): **334 passed** — new spec-first coverage: two-team activation isolation on magic-link redeem, link-without-activate on password login, self-only activation, purge survivors/casualties, rollback leaves no orphan + is retry-safe.
- `lint` / `typecheck` / `check:docs` green.

## Behavior notes

- `firstLogin` (welcome-screen routing) semantics unchanged for magic-link; for password login it now means "has an invited row" until first team visit.
- Multi-team deployments: an invited membership no longer silently activates from another team's sign-in — status now means the member actually showed up.

Part of the member-onboarding cascade series: contract aios-workspace#218, CLI aios-workspace#223, provisioning core + triggers follow in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core auth (membership activation, dev-login prod guard, invite rollback) and multi-team behavior; mistakes could block sign-in or leave inconsistent member state.
> 
> **Overview**
> Hardens member onboarding and auth after an invite/onboarding audit: **team-scoped activation**, safer invites, and housekeeping.
> 
> **Activation** no longer flips every team’s `invited` row when one email signs in. `linkMemberByEmail` links `auth_user_id` across teams but only sets `active` when login has team context (magic link’s `/t/<slug>`). Password login links identity only; `activateInvitedMembership` runs on first visit in `app/t/[team]/layout.tsx`, which also allows `invited` (not only `active`) memberships through the gate.
> 
> **Security / ops:** `/auth/dev-login` returns 404 in production with no `ALLOW_DEV_LOGIN` bypass. New `purgeExpiredAuthRows` drops stale `auth_tokens` and `oauth_states` (daily ingest scheduler leg + fire-and-forget on token issue).
> 
> **Invite flow:** Server-side `isValidInviteEmail`, `MemberExistsError` for duplicate email/handle, and `rollbackMemberCreation` if `adminSetPassword` fails after `createMember`. Magic-link invites expose `loginUrl` to the admin when email delivery fails (copy UI). **Docs:** `ARCHITECTURE.md` documents the accepted magic-link email enumeration behavior vs uniform password-login failures.
> 
> **Tests** cover prod dev-login guard, purge rules, rollback, team isolation, and deferred password activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b37974e682534e883a500f5a2950305765a0a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->