### PR TITLE
feat(members): one-trigger onboarding — invite cascade in UI + POST /api/v1/members/invite (AIO-328)

### DIFF
--- a/app/api/v1/members/invite/route.ts
+++ b/app/api/v1/members/invite/route.ts
@@ -1,0 +1,208 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/db/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { audit } from "@/lib/api/audit";
+import { errorResponse, memberInviteRequestSchema } from "@/lib/api/schemas";
+import { createMember, rollbackMemberCreation, MemberExistsError } from "@/lib/admin/members";
+import { syncMemberActor } from "@/lib/graph/company-actors";
+import { magicLinkAvailable } from "@/lib/auth/mailer";
+import { randomPassword } from "@/lib/auth/password";
+import { issueMemberInvite } from "@/lib/admin/invite";
+
+export const runtime = "nodejs";
+
+/**
+ * POST /api/v1/members/invite — invite a member and provision them into the team's tools (brain-api
+ * v1.7). The API counterpart of the admin server-action invite trigger, sharing the same core
+ * (`issueMemberInvite`) and primitives (createMember, issueLoginLink, adminSetPassword, provisioning).
+ *
+ * Auth: a team-tier, admin-role API key (else 403 `forbidden_role`). 10/min per key.
+ *
+ * Idempotent on (team_id, email): an existing NON-disabled member re-issues sign-in access and
+ * re-runs provisioning (`created:false`); a disabled member is rejected 422 (re-enabling is an
+ * explicit admin act, not an invite side effect). Provisioning is best-effort and never changes the
+ * HTTP status. Magic-link vs manual is decided purely by `magicLinkAvailable()` — there is no
+ * admin-choice over the API in v1.7.
+ */
+export async function POST(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+
+  // Inviting a member is an admin, team-tier operation — an external-tier key or a non-admin role
+  // gets 403 forbidden_role (never leaks whether the member/email exists).
+  if (auth.memberTier !== "team" || auth.memberRole !== "admin") {
+    return errorResponse("forbidden_role", "inviting members requires a team-tier admin key", 403);
+  }
+
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:members-invite:post`, 10))) {
+    return errorResponse("rate_limited", "10 invites/min per key", 429);
+  }
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return errorResponse("invalid_payload", "body must be JSON", 422);
+  }
+
+  const parsed = memberInviteRequestSchema.safeParse(json);
+  if (!parsed.success) {
+    return errorResponse("invalid_payload", parsed.error.issues[0]?.message ?? "invalid", 422);
+  }
+  const body = parsed.data;
+  const email = body.email.trim().toLowerCase();
+
+  const { data: teamRow } = await db
+    .from("teams")
+    .select("slug, name")
+    .eq("id", auth.teamId)
+    .maybeSingle();
+  const team = teamRow as { slug: string; name: string } | null;
+  const teamName = team?.name ?? "your team";
+  const teamSlug = team?.slug ?? auth.teamId;
+
+  // Idempotent lookup by (team_id, email). Only create when absent; a disabled member is a hard 422.
+  const { data: existingRow } = await db
+    .from("members")
+    .select("id, status, role, tier, display_name")
+    .eq("team_id", auth.teamId)
+    .eq("email", email)
+    .maybeSingle();
+  const existing = existingRow as
+    | { id: string; status: string; role: "admin" | "lead" | "member"; tier: "team" | "external"; display_name: string }
+    | null;
+
+  if (existing?.status === "disabled") {
+    return errorResponse(
+      "invalid_payload",
+      "this member is disabled; re-enable them explicitly before re-inviting",
+      422
+    );
+  }
+
+  let memberId: string;
+  let memberStatus: string;
+  let created: boolean;
+  let member: {
+    id: string;
+    email: string;
+    displayName: string;
+    role: "admin" | "lead" | "member";
+    tier: "team" | "external";
+  };
+
+  if (existing) {
+    created = false;
+    memberId = existing.id;
+    memberStatus = existing.status;
+    // Re-invite uses the member's stored identity (role/tier/display_name), not the payload — the
+    // invite re-issues access, it isn't a role/profile edit.
+    member = {
+      id: existing.id,
+      email,
+      displayName: existing.display_name,
+      role: existing.role,
+      tier: existing.tier,
+    };
+  } else {
+    try {
+      const c = await createMember(
+        db,
+        auth.teamId,
+        {
+          email: body.email,
+          displayName: body.display_name,
+          actorHandle: body.actor_handle,
+          role: body.role,
+        },
+        { actor: { kind: "member", memberId: auth.memberId } }
+      );
+      memberId = c.id;
+      memberStatus = c.status;
+    } catch (e) {
+      // A unique-constraint hit (e.g. actor_handle already taken, or an email race) is client input.
+      if (e instanceof MemberExistsError) return errorResponse("invalid_payload", e.message, 422);
+      return errorResponse("internal", e instanceof Error ? e.message : "create failed", 500);
+    }
+    created = true;
+    member = {
+      id: memberId,
+      email,
+      displayName: body.display_name,
+      role: body.role,
+      tier: "team",
+    };
+  }
+
+  const manual = !magicLinkAvailable();
+  const issued = await issueMemberInvite(db, {
+    teamId: auth.teamId,
+    member,
+    teamName,
+    inviterName: auth.displayName ?? "Your admin",
+    nextPath: `/t/${teamSlug}`,
+    teamUrl: (process.env.APP_URL ?? new URL(req.url).origin).replace(/\/$/, ""),
+    tools: body.tools,
+    manual,
+    password: manual ? randomPassword() : undefined,
+    actor: { kind: "member", memberId: auth.memberId },
+  });
+
+  if (!issued.ok) {
+    // Sign-in issuance (not provisioning) failed. Roll back a member we just created so we don't
+    // orphan an 'invited' row with no way to sign in; an existing member is left untouched.
+    if (created && manual) {
+      await rollbackMemberCreation(db, auth.teamId, memberId, {
+        actor: { kind: "member", memberId: auth.memberId },
+      });
+    }
+    return errorResponse("internal", issued.error, 500);
+  }
+
+  // Best-effort company-graph sync (never fails the invite), mirroring the server-action path.
+  try {
+    await syncMemberActor(db, auth.teamId, memberId);
+  } catch (e) {
+    console.error("[company-graph] actor sync failed on api invite:", e instanceof Error ? e.message : e);
+  }
+
+  await audit(db, {
+    team_id: auth.teamId,
+    actor_kind: "member",
+    member_id: auth.memberId,
+    api_key_id: auth.apiKeyId,
+    action: "member.invited",
+    target_type: "member",
+    target_id: memberId,
+    meta: { email, created, mode: issued.mode }, // no credentials/links
+  });
+
+  const invite =
+    issued.mode === "magic-link"
+      ? {
+          mode: "magic-link" as const,
+          email_delivered: issued.emailDelivered,
+          ...(issued.loginUrl ? { login_url: issued.loginUrl } : {}),
+        }
+      : {
+          mode: "manual" as const,
+          password: issued.password,
+          invite_message: issued.inviteMessage,
+        };
+
+  return Response.json(
+    {
+      member: { id: memberId, email, status: memberStatus, created },
+      invite,
+      provisioning: issued.provisioning.map((r) => ({
+        tool: r.tool,
+        status: r.status,
+        detail: r.detail,
+        ...(r.inviteLink ? { invite_link: r.inviteLink } : {}),
+      })),
+    },
+    { status: 200 }
+  );
+}

--- a/app/t/[team]/admin/actions.ts
+++ b/app/t/[team]/admin/actions.ts
@@ -7,14 +7,11 @@ import { requireTeamAdmin as requireAdmin } from "@/lib/auth/guard";
 import { createMember, rollbackMemberCreation, MemberExistsError, isValidInviteEmail } from "@/lib/admin/members";
 import { syncMemberActor } from "@/lib/graph/company-actors";
 import { issueApiKey as issueApiKeyPrimitive, revokeApiKey as revokeApiKeyPrimitive } from "@/lib/admin/keys";
-import { issueLoginLink } from "@/lib/admin/login";
-import { adminSetPassword } from "@/lib/auth/pg-login";
 import { isPasswordStrongEnough, randomPassword, MIN_PASSWORD_LENGTH } from "@/lib/auth/password";
-import { sendInviteEmail, magicLinkAvailable, buildManualInviteMessage } from "@/lib/auth/mailer";
-
-// Generous window for an admin-issued invite (vs. the 15-minute TTL for a self-service login link)
-// — the invitee may not open their email right away.
-const INVITE_LINK_TTL_MINUTES = 7 * 24 * 60;
+import { magicLinkAvailable } from "@/lib/auth/mailer";
+import { issueMemberInvite } from "@/lib/admin/invite";
+import { getProvisioningAvailability } from "@/lib/provisioning/run";
+import type { ProvisioningResult, ProvisioningTool } from "@/lib/provisioning/types";
 
 /** `APP_URL` if set, else the request's own host — so there's always a URL to show, even on a
  * fresh self-host with no domain configured yet. */
@@ -36,6 +33,9 @@ export type InviteMemberResult =
        * has a working fallback instead of a dead end. Security-equivalent to the manual path's
        * password reveal: same admin, same screen, shown once. */
       loginUrl?: string;
+      /** Per-tool provisioning cascade outcomes (empty when tools = "none"). Best-effort — never
+       * affects whether the invite itself succeeded. */
+      provisioning: ProvisioningResult[];
     }
   | {
       ok: true;
@@ -44,6 +44,7 @@ export type InviteMemberResult =
       email: string;
       password: string;
       inviteMessage: string;
+      provisioning: ProvisioningResult[];
     }
   | { ok: false; error: string };
 
@@ -67,6 +68,8 @@ export async function inviteMember(
     /** When true, skip the magic-link invite even if mail delivery is configured. */
     manualInvite?: boolean;
     password?: string;
+    /** Which external tools to provision the new member into. Default "all". */
+    tools?: ProvisioningTool[] | "all" | "none";
   }
 ): Promise<InviteMemberResult> {
   const ctx = await requireAdmin(teamSlug);
@@ -107,22 +110,47 @@ export async function inviteMember(
     return { ok: false, error: e instanceof Error ? e.message : "create failed" };
   }
 
-  if (!useMagicLink) {
-    try {
-      await adminSetPassword(email, password);
-    } catch (e) {
-      // Compensating action, not a transaction: createMember writes through the DbClient adapter
-      // while adminSetPassword writes auth_users via raw runSql (lib/db/pg/pool) — different
-      // connections/paths, so there's no single SQL transaction to wrap them in. If the password
-      // write fails AFTER the member row already landed, leaving it in place would orphan an
-      // 'invited' member with no way to ever sign in (no password, and magic-link isn't in play
-      // on this branch). rollbackMemberCreation hard-deletes it and audits the rollback so it's
-      // traceable, then we surface the failure so the admin can retry.
+  const [{ data: team }, { data: inviter }] = await Promise.all([
+    db.from("teams").select("name").eq("id", ctx.teamId).maybeSingle(),
+    db.from("members").select("display_name").eq("id", ctx.memberId).maybeSingle(),
+  ]);
+  const teamName = (team as { name: string } | null)?.name ?? teamSlug;
+  const inviterName = (inviter as { display_name: string } | null)?.display_name ?? "Your admin";
+
+  // Grant sign-in access + run the provisioning cascade through the shared invite core (same code
+  // path the REST endpoint uses). Provisioning can never fail the invite; the only hard failure is
+  // the sign-in issuance itself (no link, or the password write erroring).
+  const issued = await issueMemberInvite(db, {
+    teamId: ctx.teamId,
+    member: {
+      id: newMemberId,
+      email,
+      displayName: form.displayName,
+      role: form.role,
+      tier: "team",
+    },
+    teamName,
+    inviterName,
+    nextPath: `/t/${teamSlug}`,
+    teamUrl: await resolveTeamUrl(),
+    tools: form.tools ?? "all",
+    manual: !useMagicLink,
+    password,
+    actor: { kind: "member", memberId: ctx.memberId },
+  });
+
+  if (!issued.ok) {
+    // Compensating action, not a transaction: createMember writes through the DbClient adapter while
+    // the password write hits auth_users via raw runSql (lib/db/pg/pool) — different connections, so
+    // there's no single SQL transaction. Only the manual (password) path can leave an orphaned
+    // 'invited' member with no way to sign in; roll it back. A magic-link issuance failure leaves the
+    // member in place (the admin can retry) — matching the parent branch's behavior.
+    if (!useMagicLink) {
       await rollbackMemberCreation(db, ctx.teamId, newMemberId, {
         actor: { kind: "member", memberId: ctx.memberId },
       });
-      return { ok: false, error: e instanceof Error ? e.message : "could not set initial password" };
     }
+    return { ok: false, error: issued.error };
   }
 
   // Best-effort — the company graph is a derived context surface, not the source of truth; a
@@ -133,59 +161,47 @@ export async function inviteMember(
     console.error("[company-graph] actor sync failed on invite:", e instanceof Error ? e.message : e);
   }
 
-  const [{ data: team }, { data: inviter }] = await Promise.all([
-    db.from("teams").select("name").eq("id", ctx.teamId).maybeSingle(),
-    db.from("members").select("display_name").eq("id", ctx.memberId).maybeSingle(),
-  ]);
-  const teamName = (team as { name: string } | null)?.name ?? teamSlug;
-  const inviterName = (inviter as { display_name: string } | null)?.display_name ?? "Your admin";
+  revalidatePath(`/t/${teamSlug}/admin/members`);
 
-  if (useMagicLink) {
-    const { url } = await issueLoginLink(db, ctx.teamId, email, {
-      nextPath: `/t/${teamSlug}`,
-      ttlMinutes: INVITE_LINK_TTL_MINUTES,
-      baseUrl: process.env.APP_URL,
-      actor: { kind: "member", memberId: ctx.memberId },
-    });
-    if (!url) return { ok: false, error: "could not issue a sign-in link" };
-
-    let emailDelivered = false;
-    try {
-      emailDelivered = await sendInviteEmail(email, {
-        inviteeName: form.displayName,
-        teamName,
-        inviterName,
-        loginUrl: url,
-      });
-    } catch (e) {
-      console.error("[invite] email send failed:", e instanceof Error ? e.message : e);
-    }
-
-    revalidatePath(`/t/${teamSlug}/admin/members`);
+  if (issued.mode === "magic-link") {
     return {
       ok: true,
       mode: "magic-link",
       email,
-      emailDelivered,
-      // Same admin, same screen, shown once — security-equivalent to the manual path's password
-      // reveal. Only surfaced when delivery failed; otherwise the admin has no legitimate need to
-      // see the credential (it went out over email).
-      ...(emailDelivered ? {} : { loginUrl: url }),
+      emailDelivered: issued.emailDelivered,
+      ...(issued.loginUrl ? { loginUrl: issued.loginUrl } : {}),
+      provisioning: issued.provisioning,
     };
   }
 
-  const manualReason = form.manualInvite ? "admin-choice" : "no-mail";
-  const inviteMessage = buildManualInviteMessage({
-    inviteeName: form.displayName,
-    teamName,
-    inviterName,
-    teamUrl: await resolveTeamUrl(),
+  return {
+    ok: true,
+    mode: "manual",
+    reason: form.manualInvite ? "admin-choice" : "no-mail",
     email,
-    password,
-  });
+    password: issued.password,
+    inviteMessage: issued.inviteMessage,
+    provisioning: issued.provisioning,
+  };
+}
 
-  revalidatePath(`/t/${teamSlug}/admin/members`);
-  return { ok: true, mode: "manual", reason: manualReason, email, password, inviteMessage };
+export type ProvisioningAvailability = Array<{
+  tool: ProvisioningTool;
+  configured: boolean;
+  reason?: string;
+}>;
+
+/**
+ * Per-tool provisioning availability for the invite UI (admins only) — which tools are wired up
+ * (checkbox enabled + checked) vs not (disabled + the reason shown). Admin-gated wrapper over the
+ * `getProvisioningAvailability` lib read; returns an empty list for a non-admin.
+ */
+export async function getProvisioningAvailabilityAction(
+  teamSlug: string
+): Promise<ProvisioningAvailability> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return [];
+  return getProvisioningAvailability(adminClient(), ctx.teamId);
 }
 
 export async function issueApiKey(

--- a/app/t/[team]/admin/members/actions.ts
+++ b/app/t/[team]/admin/members/actions.ts
@@ -12,6 +12,8 @@ import { isPasswordStrongEnough, randomPassword, MIN_PASSWORD_LENGTH } from "@/l
 import { audit } from "@/lib/api/audit";
 import { updateMemberRole, deleteMember, updateMemberManager, type UpdateManagerResult } from "@/lib/admin/members";
 import { syncMemberActor } from "@/lib/graph/company-actors";
+import { runProvisioning } from "@/lib/provisioning/run";
+import type { ProvisioningResult, ProvisioningTool } from "@/lib/provisioning/types";
 
 // Providers whose identity is a stable user id in member_identities (GitHub uses its own login flow).
 const PROVIDERS = new Set(["slack", "linear", "plane"]);
@@ -318,6 +320,47 @@ export async function removeMember(
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not remove member" };
   }
+}
+
+/**
+ * Re-run the provisioning cascade for ONE tool for a member (admins only) — the retry behind a
+ * `failed` badge on the members table. Looks up the member row on THIS team (so a raw memberId can't
+ * reach across teams), rebuilds the `ProvisioningMember` shape, and runs the single-writer
+ * `runProvisioning` for just that tool. `runProvisioning` never throws; it upserts the member's row
+ * for that tool in place, so the badge reflects the fresh outcome after `revalidatePath`.
+ */
+export async function retryProvisioning(
+  teamSlug: string,
+  memberId: string,
+  tool: ProvisioningTool
+): Promise<{ ok: boolean; error?: string; result?: ProvisioningResult }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+
+  const db = adminClient();
+  const { data: member } = await db
+    .from("members")
+    .select("id, email, display_name, role, tier")
+    .eq("id", memberId)
+    .eq("team_id", ctx.teamId)
+    .maybeSingle();
+  if (!member) return { ok: false, error: "member not found on this team" };
+
+  const m = member as {
+    id: string;
+    email: string;
+    display_name: string;
+    role: "admin" | "lead" | "member";
+    tier: "team" | "external";
+  };
+  const [result] = await runProvisioning(
+    db,
+    ctx.teamId,
+    { id: m.id, email: m.email, displayName: m.display_name, role: m.role, tier: m.tier },
+    [tool]
+  );
+  revalidatePath(`/t/${teamSlug}/admin/members`);
+  return { ok: true, result };
 }
 
 /** Remove an email alias from a member (admins only). */

--- a/app/t/[team]/admin/members/page.tsx
+++ b/app/t/[team]/admin/members/page.tsx
@@ -1,4 +1,5 @@
 import { serverClient } from "@/lib/db/server";
+import { adminClient } from "@/lib/db/admin";
 import { InviteMember } from "@/components/admin/invite-member";
 import { MemberIdentities, type ProviderLink } from "@/components/admin/member-identities";
 import { MemberRoleSelect } from "@/components/admin/member-role-select";
@@ -6,7 +7,10 @@ import { ReattributeButton } from "@/components/admin/reattribute-button";
 import { ResetPasswordButton } from "@/components/admin/reset-password-button";
 import { RemoveMemberButton } from "@/components/admin/remove-member-button";
 import { ManagerSelect } from "@/components/admin/manager-select";
+import { MemberProvisioningCell } from "@/components/admin/member-provisioning-cell";
 import { listMemberIdentities } from "@/lib/identity/list";
+import { getProvisioningAvailabilityAction } from "@/app/t/[team]/admin/actions";
+import { getMemberProvisioning } from "@/lib/provisioning/run";
 
 export default async function MembersAdminPage({
   params,
@@ -38,6 +42,19 @@ export default async function MembersAdminPage({
     .filter((m) => m.status !== "disabled")
     .map((m) => ({ id: m.id as string, displayName: m.display_name as string }));
 
+  // Per-tool provisioning availability (drives the invite checkboxes) + each member's current
+  // provisioning rows (drives the compact retry badges). Reads go through the admin service client
+  // and the single-writer's read helpers — the members subtree is already admin-gated by the layout.
+  const adminDb = adminClient();
+  const provisioningAvailability = await getProvisioningAvailabilityAction(teamSlug);
+  const provisioningByMember = new Map(
+    await Promise.all(
+      (members ?? []).map(
+        async (m) => [m.id, await getMemberProvisioning(adminDb, team.id, m.id as string)] as const
+      )
+    )
+  );
+
   // All linked identities (email aliases + slack/linear/plane provider ids) for the panel.
   const identities = await listMemberIdentities(db, team.id);
   const providerOf = (memberId: string, provider: string): ProviderLink | null => {
@@ -55,7 +72,7 @@ export default async function MembersAdminPage({
         </p>
         <div className="flex items-center gap-2">
           <ReattributeButton teamSlug={teamSlug} />
-          <InviteMember teamSlug={teamSlug} />
+          <InviteMember teamSlug={teamSlug} provisioningAvailability={provisioningAvailability} />
         </div>
       </div>
       <div className="prism-card overflow-x-auto">
@@ -70,6 +87,7 @@ export default async function MembersAdminPage({
               <th className="px-4 py-3">Status</th>
               <th className="px-4 py-3">Reports to</th>
               <th className="px-4 py-3">Password</th>
+              <th className="px-4 py-3">Tools</th>
               <th className="px-4 py-3">Identities</th>
               <th className="px-4 py-3">Remove</th>
             </tr>
@@ -99,6 +117,13 @@ export default async function MembersAdminPage({
                 </td>
                 <td className="px-4 py-3">
                   <ResetPasswordButton teamSlug={teamSlug} memberId={m.id} />
+                </td>
+                <td className="px-4 py-3">
+                  <MemberProvisioningCell
+                    teamSlug={teamSlug}
+                    memberId={m.id}
+                    rows={provisioningByMember.get(m.id) ?? []}
+                  />
                 </td>
                 <td className="px-4 py-3">
                   <MemberIdentities

--- a/components/admin/invite-member.tsx
+++ b/components/admin/invite-member.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { UserPlus, Copy, Check, Dices } from "lucide-react";
+import { useMemo, useState, useTransition } from "react";
+import { UserPlus, Copy, Check, Dices, CircleSlash, Link2, AlertCircle } from "lucide-react";
 import { inviteMember, type InviteMemberResult } from "@/app/t/[team]/admin/actions";
+import type { ProvisioningAvailability } from "@/app/t/[team]/admin/actions";
+import type { ProvisioningResult, ProvisioningTool } from "@/lib/provisioning/types";
 
 type Issued = Extract<InviteMemberResult, { ok: true }>;
+
+const TOOL_LABEL: Record<ProvisioningTool, string> = {
+  linear: "Linear",
+  slack: "Slack",
+  github: "GitHub",
+};
 
 function CopyButton({ text, label }: { text: string; label: string }) {
   const [copied, setCopied] = useState(false);
@@ -24,7 +32,47 @@ function CopyButton({ text, label }: { text: string; label: string }) {
   );
 }
 
-export function InviteMember({ teamSlug }: { teamSlug: string }) {
+function ProvisioningBadge({ status }: { status: ProvisioningResult["status"] }) {
+  if (status === "sent") return <Check className="size-4 shrink-0 text-emerald-600" />;
+  if (status === "link_provided") return <Link2 className="size-4 shrink-0 text-violet" />;
+  if (status === "failed") return <AlertCircle className="size-4 shrink-0 text-red-600" />;
+  return <CircleSlash className="size-4 shrink-0 text-ink-tertiary" />;
+}
+
+/** The per-tool provisioning outcomes, rendered under a success card. */
+function ProvisioningResults({ results }: { results: ProvisioningResult[] }) {
+  if (results.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2 border-t border-border-subtle pt-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-ink-tertiary">Team tools</p>
+      {results.map((r) => (
+        <div key={r.tool} className="flex flex-col gap-1">
+          <div className="flex items-center gap-2 text-sm text-ink">
+            <ProvisioningBadge status={r.status} />
+            <span className="font-medium">{TOOL_LABEL[r.tool]}</span>
+            <span className="text-ink-secondary">— {r.detail}</span>
+          </div>
+          {r.status === "link_provided" && r.inviteLink && (
+            <div className="flex flex-wrap items-center gap-2 pl-6">
+              <pre className="whitespace-pre-wrap break-all rounded-lg bg-surface-overlay px-3 py-2 font-mono text-xs text-ink">
+                {r.inviteLink}
+              </pre>
+              <CopyButton text={r.inviteLink} label="Copy join link" />
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function InviteMember({
+  teamSlug,
+  provisioningAvailability = [],
+}: {
+  teamSlug: string;
+  provisioningAvailability?: ProvisioningAvailability;
+}) {
   const [open, setOpen] = useState(false);
   const [manual, setManual] = useState(false);
   const [password, setPassword] = useState("");
@@ -32,11 +80,28 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
   const [issued, setIssued] = useState<Issued | null>(null);
   const [pending, startTransition] = useTransition();
 
+  // Only configured tools default to checked; an unconfigured tool renders disabled with its reason.
+  const configuredTools = useMemo(
+    () => provisioningAvailability.filter((a) => a.configured).map((a) => a.tool),
+    [provisioningAvailability]
+  );
+  const [selected, setSelected] = useState<Set<ProvisioningTool>>(() => new Set(configuredTools));
+
+  function toggle(tool: ProvisioningTool) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(tool)) next.delete(tool);
+      else next.add(tool);
+      return next;
+    });
+  }
+
   function reset() {
     setIssued(null);
     setOpen(false);
     setManual(false);
     setPassword("");
+    setSelected(new Set(configuredTools));
   }
 
   if (issued?.mode === "magic-link") {
@@ -61,6 +126,7 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
             </p>
           </>
         )}
+        <ProvisioningResults results={issued.provisioning} />
         <button
           onClick={reset}
           className="self-start rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white"
@@ -86,6 +152,7 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
           <CopyButton text={issued.inviteMessage} label="Copy message" />
           <CopyButton text={issued.password} label="Copy password only" />
         </div>
+        <ProvisioningResults results={issued.provisioning} />
         <button
           onClick={reset}
           className="self-start rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white"
@@ -121,6 +188,7 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
             role: (String(formData.get("role")) as "admin" | "lead" | "member") || "member",
             manualInvite: manual,
             password: manual ? password || undefined : undefined,
+            tools: selected.size === 0 ? "none" : Array.from(selected),
           });
           if (!res.ok) setError(res.error);
           else setIssued(res);
@@ -141,6 +209,35 @@ export function InviteMember({ teamSlug }: { teamSlug: string }) {
           <option value="admin">admin</option>
         </select>
       </div>
+
+      {provisioningAvailability.length > 0 && (
+        <div className="flex flex-col gap-2 rounded-lg border border-border-subtle p-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-ink-tertiary">
+            Provision into team tools
+          </p>
+          <div className="flex flex-wrap gap-4">
+            {provisioningAvailability.map((a) => (
+              <label
+                key={a.tool}
+                title={a.configured ? undefined : a.reason}
+                className={`flex items-center gap-2 text-sm ${a.configured ? "text-ink" : "cursor-not-allowed text-ink-tertiary"}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(a.tool)}
+                  disabled={!a.configured}
+                  onChange={() => toggle(a.tool)}
+                  className="size-4 accent-violet disabled:opacity-50"
+                />
+                {TOOL_LABEL[a.tool]}
+                {!a.configured && a.reason ? (
+                  <span className="text-xs text-ink-tertiary">({a.reason})</span>
+                ) : null}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
 
       <button
         type="button"

--- a/components/admin/member-provisioning-cell.tsx
+++ b/components/admin/member-provisioning-cell.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { retryProvisioning } from "@/app/t/[team]/admin/members/actions";
+import type { ProvisioningResult, ProvisioningTool } from "@/lib/provisioning/types";
+
+const TOOL_LABEL: Record<ProvisioningTool, string> = {
+  linear: "Linear",
+  slack: "Slack",
+  github: "GitHub",
+};
+
+/**
+ * Compact per-tool provisioning status for one member row. Deliberately quiet: only `failed` tools
+ * surface (a red badge + a retry that re-runs `runProvisioning` for that one tool) — the states an
+ * admin acts on. `sent`/`link_provided`/`skipped` are omitted to keep the dense members table clean.
+ */
+export function MemberProvisioningCell({
+  teamSlug,
+  memberId,
+  rows,
+}: {
+  teamSlug: string;
+  memberId: string;
+  rows: ProvisioningResult[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const failed = rows.filter((r) => r.status === "failed");
+  if (failed.length === 0) return <span className="text-xs text-ink-tertiary">—</span>;
+
+  function retry(tool: ProvisioningTool) {
+    setError(null);
+    startTransition(async () => {
+      const res = await retryProvisioning(teamSlug, memberId, tool);
+      if (!res.ok) {
+        setError(res.error ?? "retry failed");
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      {failed.map((r) => (
+        <button
+          key={r.tool}
+          type="button"
+          disabled={pending}
+          onClick={() => retry(r.tool)}
+          title={`${r.detail} — click to retry`}
+          className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-2 py-0.5 text-xs text-red-600 hover:bg-red-500/20 disabled:opacity-50"
+        >
+          <AlertCircle className="size-3" />
+          {TOOL_LABEL[r.tool]}
+          <RefreshCw className="size-3" />
+        </button>
+      ))}
+      {error ? <span className="text-[11px] text-red-600">{error}</span> : null}
+    </div>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ Reason from this table, not from a random call site.
 | Identity | `teams`, `members`, `api_keys` | admin UI / seed / `lib/admin/*` (CLI: create/disable/delete/change-role members, rename teams, issue/revoke keys) | `lib/auth`, guards | role-gated; `key_hash` column-revoked; member disable/delete/role-change + team rename are audited (`member.disabled`/`member.deleted`/`member.role_changed`/`team.renamed`); an existing member's role is editable and a member is removable (soft-disable) from **Admin → Members** (`updateMemberRole` → `setMemberRole`; `deleteMember` → `removeMember`); a permanent hard delete stays CLI-only (`scripts/admin.ts delete-member <email> --hard`); role-change and remove both refuse to touch the last active admin (no lockout) |
 | Identities (author→member) | `member_emails` (email/git aliases) + `member_identities` (provider user ids: slack/linear/plane/… ) (+ `members.github_login`/`avatar_url`) | `lib/admin/*` + GitHub sync (`lib/codebases/github`) for emails; **`lib/identity/member-identities` only** (`setMemberIdentity`/`removeMemberIdentity`) for provider ids — auto-mapped by email via the shared **`lib/identity/provider-sync.syncProviderIdentities`** (Slack/Linear/Plane connectors call it in `lib/ingest/run`); admins view + correct every link in the **Admin → Members "Identities" panel** (`lib/identity/list.listMemberIdentities` reader; `linkMemberIdentity`/`unlinkMemberIdentity`/`addMemberEmail`/`removeMemberEmail` actions) — the fix for "different email per platform"; the **"Re-attribute content"** button (`reattributeIdentitiesNow` → `lib/ingest/reattribute.reattributeItems`) re-applies current mappings to already-ingested items (which were attributed at ingest time) | **`lib/identity/resolve`** (the one resolver: `byEmail` + `byProviderId`) → `lib/codebases/ingest`, `lib/ingest` Slack/Linear/Plane per-author attribution (each issue's assignee, each thread's author), costs/maturity, dashboard | team-scoped one-to-one (`unique(team_id,email)` / `unique(team_id,provider,external_id)`); cross-member remap blocked unless forced. **Slack auto-map needs `users:read.email`** (Linear/Plane carry emails via their API); else map manually |
 | Identity context (per-member) | `member_profiles` (1:1: timezone, `working_hours`, `preferred_channels`, location, bio) + `member_time_off` (PTO/holiday ranges) + `member_goals` (OKRs/goals, `source`-tagged) | **`lib/identity/profile` only** (single-writer guarded; validates tz/working-hours/channel-allowlist/dates + audits) — manual self-service profile + admin edit; `member_goals.source` ≠ `manual` reserved for a future JIRA/Plane-initiative importer (idempotent on `(team,source,external_id)` via a partial unique index) | **`lib/identity/context.getMemberContext`** (folds profile + time-off + goals + projects DERIVED from `tasks.assignee`) → People page (`app/t/[team]/people/[handle]`) | team-tier only — `canSeeMemberContext` gate returns null for `external` (sole enforcement, no RLS backstop); guarded by `test/guards/member-context-tier-filter` |
-| Member provisioning | `member_provisioning` | **`lib/provisioning/run` only** (single writer; `runProvisioning`) — the tool-invite cascade upserts one row per (member, tool) | Admin → Members provisioning status (later UI PR) via `getMemberProvisioning` | team-tier (admin area); no per-row tier column, no RLS backstop; audited (`member.provisioned`, tool + status only — never emails/links). Adapters (`lib/provisioning/{linear,slack,github}`) read the team's enabled `integrations` config/secret to send/surface invites; Slack is link-only (no invite API), GitHub uses `POST /orgs/{org}/invitations`, Linear uses the `organizationInviteCreate` GraphQL mutation |
+| Member provisioning | `member_provisioning` | **`lib/provisioning/run` only** (single writer; `runProvisioning`) — the tool-invite cascade upserts one row per (member, tool). Driven by both invite triggers via the shared `lib/admin/invite` core (admin action `inviteMember` + `POST /api/v1/members/invite`) and by the members-table per-tool retry (`retryProvisioning`) | Admin → Members provisioning-status badges via `getMemberProvisioning`; the invite success card renders the just-run results | team-tier (admin area); no per-row tier column, no RLS backstop; audited (`member.provisioned`, tool + status only — never emails/links). Adapters (`lib/provisioning/{linear,slack,github}`) read the team's enabled `integrations` config/secret to send/surface invites; Slack is link-only (no invite API), GitHub uses `POST /orgs/{org}/invitations`, Linear uses the `organizationInviteCreate` GraphQL mutation |
 | Sessions (postgres) | `auth_users`, `auth_tokens` | `lib/auth/pg-*` | `getSessionUser` | signed httpOnly cookie |
 | Personal Slack token + OAuth state | `member_secrets` (per-member encrypted `xoxp` "act as me" token) + `oauth_states` (single-use OAuth nonces) | **`lib/member-secrets/manage` only** (`setMemberSecret`/`deleteMemberSecret`) for the token; **`lib/auth/slack-oauth-state` only** for nonces (mint at `GET /api/auth/slack/start`, atomically consume at `/callback`) | `getMemberSecret` → owner-only `GET /api/v1/me/slack-token` (paste path) + `GET /api/auth/slack/status` (connected/identity, never the token); nonces are consume-once, read nowhere else | token encrypted at rest (AES-256-GCM, `lib/secrets`), returned only over the owner-authed token endpoint, never logged. OAuth state = signed short-TTL JWT (HS256, `AUTH_SECRET`) bound to the single-use `oauth_states` nonce → CSRF + replay guard; **residual v1 risk:** first-use code-injection if an *unused* signed state leaks within its 10-min TTL (v2: PKCE/browser-binding) |
 | Rate limits | `rate_limits` | `rate_limit_hit` rpc | — | service-role only |
@@ -92,20 +92,33 @@ flowchart LR
 ## Auth & access tiers
 
 This server **implements brain-api v1.6** (the wire contract; source of truth:
-`aios-workspace/docs/brain-api.md`). That version is pinned in code as `BRAIN_API_VERSION`
+`aios-workspace/docs/brain-api.md`). The member-invite endpoint (`POST /api/v1/members/invite`)
+is built to the v1.7 invite contract; the formal `BRAIN_API_VERSION` bump to `1.7` is a separate
+coordinated step (it regenerates the shared `brain-contract` fixture in lockstep with
+`aios-workspace`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`) and asserted against this sentence by
 `test/guards/contract-version.test.ts` — bump all three together on a contract change.
 
 Two principals, one tier model:
 
 - **Humans** — invite-only, two sign-in mechanisms:
-  - **Admin invite (`inviteMember`, Admin → Members).** Creates the member row, then either:
+  - **Admin invite (`inviteMember`, Admin → Members) + REST (`POST /api/v1/members/invite`).** Both
+    triggers create/resolve the member row and then run the SAME shared core (`lib/admin/invite`
+    `issueMemberInvite`), which grants sign-in access one of two ways and then runs the best-effort
+    tool-provisioning cascade (`lib/provisioning/run` — see the Member-provisioning row above):
     - **Magic-link invite** (default when `magicLinkAvailable()` — `APP_URL` + mail provider):
       `issueLoginLink` mints a single-use 7-day token and `sendInviteEmail` delivers a one-click
-      link; no password is set upfront. The admin UI reports whether delivery was confirmed.
-    - **Manual invite** (when mail isn't configured, or the admin chooses a password): sets the
+      link; no password is set upfront. Provisioning runs BEFORE the email so a Slack join link /
+      Linear+GitHub "invite on its way" note rides along in a "Your team tools" section. The admin
+      UI reports whether delivery was confirmed.
+    - **Manual invite** (when mail isn't configured, or — UI only — the admin chooses a password;
+      the API has no admin-choice and picks manual purely on `!magicLinkAvailable()`): sets the
       initial password via `adminSetPassword` (shown once to the admin as a ready-to-paste message
       from `buildManualInviteMessage` — URL, email, password — for Slack/DM/etc; never emailed).
+    - A provisioning failure NEVER fails the invite; per-tool outcomes are returned to the caller
+      (the UI success card + the members-table retry badge; the API `provisioning[]` array). The
+      REST route is idempotent on (team_id, email) — an existing non-disabled member re-issues access
+      + re-provisions (`created:false`), a disabled member is a hard 422.
   - **Email+password sign-in (always available — audit M1/M2b).** Members sign in with the
     password an admin set (or one they chose on first login — see welcome screen below) and can
     change it anytime (`/t/:team/account`). `POST /api/auth/login` verifies against the scrypt hash
@@ -507,6 +520,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/company-graph` — structured stakeholder map for `aios stakeholders` / MCP `brain_stakeholders` (brain-api v1.5): `people[]` (actor entities with attrs-projected `role`/`job_family`/`reports_to`) + `ownership[]` (server-resolved `OWNS`/`TOUCHES`/`PRODUCES` edges → target workflow name/kind/job_family); team-tier only, app-code gate (no RLS backstop); unseeded team → `200` empty arrays
 - `GET /api/v1/me` — authenticated member identity + role (drives client UI gating)
 - `GET /api/v1/members` — team roster + cross-tool identities for external resolution, incl. `github_login`/`avatar_url` for contributor-avatar consumers like `aios timeline` (team-tier only; `?email`/`?handle`/`?provider` filters)
+- `POST /api/v1/members/invite` — invite a member + run the tool-provisioning cascade (brain-api v1.7): team-tier **admin** key only (else 403 `forbidden_role`), 10/min; idempotent on (team_id, email) — existing non-disabled member → `created:false` + re-issue access + re-provision, disabled member → 422; magic-link vs manual decided by `magicLinkAvailable()`; provisioning is best-effort and never changes status; shares the `lib/admin/invite` core with the admin UI action
 - `GET /api/v1/identities/resolve` — resolve a provider external_id (or email/handle) to a member + canonical contacts incl. `slack_id` (team-tier only; 404 on miss)
 - `GET /api/v1/me/slack-token` — the caller's OWN Slack user token for "act as me" (owner-only: member from the API key, never a param; 404 if not connected; `no-store`)
 - `POST /api/v1/me/slack-token` — connect the caller's Slack via manual paste: validate (`auth.test`) + store encrypted (`member_secrets`) + capture identity

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,6 +119,30 @@ Two principals, one tier model:
       (the UI success card + the members-table retry badge; the API `provisioning[]` array). The
       REST route is idempotent on (team_id, email) — an existing non-disabled member re-issues access
       + re-provisions (`created:false`), a disabled member is a hard 422.
+
+    **Adding a provisioning tool** (say, `notion`) — not every integration gets one: only services
+    where "invite this person" is meaningful (a per-key AI provider or a data connector like
+    granola doesn't qualify). The checklist, in order:
+
+    1. `lib/provisioning/types.ts` — add the tool to the `ProvisioningTool` union. From here the
+       compiler forces step 2–3 (`ADAPTERS` is `Record<ProvisioningTool, ProvisioningAdapter>`).
+    2. `lib/provisioning/<tool>.ts` — the adapter: `isConfigured` + `invite`, **non-throwing**;
+       map the service's "already a member/invited" to `skipped` and permission errors to a
+       `failed` with an actionable detail.
+    3. `lib/provisioning/run.ts` — register it in `ADAPTERS` + `ALL_TOOLS`. The invite-form
+       checkbox, results card, members-table retry badge, upserts, and audit all light up from the
+       registry with no further wiring.
+    4. `lib/api/schemas.ts` — TWO spots: `PROVISIONING_TOOLS` (the invite request-schema enum) and
+       the tool's integration-type config allowlist (its invite-config keys).
+    5. Settings — `lib/provisioning/settings.ts` + the Member-onboarding panel: its config fields.
+    6. ⚠️ **Check constraints need a migration**: `member_provisioning.tool` (and, for a brand-new
+       integration type, `integrations.type`) are check-constrained and the tables already exist in
+       prod — widen via `postgres/migrations/` AND mirror in `schema.sql` (see §schema rules).
+    7. **Cross-repo, guard-enforced**: regenerate `brain-contract.json`'s `provisioningTools` (+
+       contentHash) in `aios-workspace/docs/contract/`, re-vendor the copy here, add a revision
+       bullet to `docs/brain-api.md`, and extend the `aios member` CLI's `TOOLS` set. The
+       conformance guards (`test/guards/contract-conformance.test.ts` here; the mirror in
+       aios-workspace) fail whichever side is missing the tool, so none of this relies on memory.
   - **Email+password sign-in (always available — audit M1/M2b).** Members sign in with the
     password an admin set (or one they chose on first login — see welcome screen below) and can
     change it anytime (`/t/:team/account`). `POST /api/auth/login` verifies against the scrypt hash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,13 +91,13 @@ flowchart LR
 
 ## Auth & access tiers
 
-This server **implements brain-api v1.6** (the wire contract; source of truth:
-`aios-workspace/docs/brain-api.md`). The member-invite endpoint (`POST /api/v1/members/invite`)
-is built to the v1.7 invite contract; the formal `BRAIN_API_VERSION` bump to `1.7` is a separate
-coordinated step (it regenerates the shared `brain-contract` fixture in lockstep with
-`aios-workspace`). That version is pinned in code as `BRAIN_API_VERSION`
-(`lib/api/version.ts`) and asserted against this sentence by
-`test/guards/contract-version.test.ts` — bump all three together on a contract change.
+This server **implements brain-api v1.7** (the wire contract; source of truth:
+`aios-workspace/docs/brain-api.md`; v1.7 added the member-invite endpoint,
+`POST /api/v1/members/invite`). That version is pinned in code as `BRAIN_API_VERSION`
+(`lib/api/version.ts`), asserted against this sentence by
+`test/guards/contract-version.test.ts`, and mirrored by the vendored
+`test/fixtures/contract/brain-contract.json` (regenerated in lockstep with the canonical
+copy in `aios-workspace/docs/contract/`) — bump all of them together on a contract change.
 
 Two principals, one tier model:
 

--- a/lib/admin/invite.ts
+++ b/lib/admin/invite.ts
@@ -1,0 +1,153 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { issueLoginLink } from "@/lib/admin/login";
+import { adminSetPassword } from "@/lib/auth/pg-login";
+import { sendInviteEmail, buildManualInviteMessage } from "@/lib/auth/mailer";
+import { runProvisioning } from "@/lib/provisioning/run";
+import type { ProvisioningResult, ProvisioningTool } from "@/lib/provisioning/types";
+import type { ActorContext } from "./members";
+
+/**
+ * The shared invite CORE reused by the two invite triggers — the admin server action
+ * (`app/t/[team]/admin/actions.ts inviteMember`) and the REST endpoint
+ * (`POST /api/v1/members/invite`). Given a member row that ALREADY exists (both callers own their own
+ * create/idempotency + rollback policy — the divergent part), it grants sign-in access one of two
+ * ways, runs the best-effort provisioning cascade, and (magic-link mode) folds the cascade's Slack
+ * link / Linear+GitHub status into the invite email:
+ *
+ *  - **magic-link** (`manual === false`): issue a single-use sign-in link, provision, then email it.
+ *  - **manual** (`manual === true`): set the given password directly, provision, and return a
+ *    ready-to-paste invite message.
+ *
+ * Provisioning is best-effort and NEVER changes the outcome (it can't throw; a `failed` tool is just
+ * a result row). The only hard failures are the sign-in issuance itself (no link, or the password
+ * write erroring) — surfaced as `{ ok: false }` so the caller can roll back a just-created member.
+ */
+
+// Generous window for an admin-issued invite (vs. the 15-minute TTL for a self-service login link)
+// — the invitee may not open their email right away.
+export const INVITE_LINK_TTL_MINUTES = 7 * 24 * 60;
+
+export interface IssueInviteMember {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "admin" | "lead" | "member";
+  tier: "team" | "external";
+}
+
+export interface IssueInviteInput {
+  teamId: string;
+  member: IssueInviteMember;
+  teamName: string;
+  inviterName: string;
+  /** Where the sign-in link lands after confirm (magic-link mode). */
+  nextPath: string;
+  /** Base sign-in URL for the manual copy-paste message. */
+  teamUrl: string;
+  /** Which tools to provision. */
+  tools: ProvisioningTool[] | "all" | "none";
+  /** false → magic-link; true → set `password` directly. */
+  manual: boolean;
+  /** Required when `manual` is true (the caller has already strength-checked / generated it). */
+  password?: string;
+  actor: ActorContext;
+}
+
+export type IssueInviteResult =
+  | {
+      ok: true;
+      mode: "magic-link";
+      emailDelivered: boolean;
+      /** Set ONLY when delivery failed — the already-issued link, so the caller has a fallback. */
+      loginUrl?: string;
+      provisioning: ProvisioningResult[];
+    }
+  | {
+      ok: true;
+      mode: "manual";
+      password: string;
+      inviteMessage: string;
+      provisioning: ProvisioningResult[];
+    }
+  | { ok: false; error: string };
+
+/**
+ * Distil the provisioning results into the invite email's "Your team tools" section: the Slack
+ * standing join link (only when `link_provided`) and whether Linear/GitHub actually `sent` an
+ * invite. Anything skipped/failed is omitted — the email only mentions tools the invitee can act on.
+ */
+function emailInviteTools(
+  results: ProvisioningResult[]
+): { slackInviteLink?: string; linearInvited?: boolean; githubInvited?: boolean } | undefined {
+  const slack = results.find((r) => r.tool === "slack" && r.status === "link_provided");
+  const linear = results.find((r) => r.tool === "linear" && r.status === "sent");
+  const github = results.find((r) => r.tool === "github" && r.status === "sent");
+  const out: { slackInviteLink?: string; linearInvited?: boolean; githubInvited?: boolean } = {};
+  if (slack?.inviteLink) out.slackInviteLink = slack.inviteLink;
+  if (linear) out.linearInvited = true;
+  if (github) out.githubInvited = true;
+  return Object.keys(out).length ? out : undefined;
+}
+
+export async function issueMemberInvite(
+  db: DbClient,
+  input: IssueInviteInput
+): Promise<IssueInviteResult> {
+  const { teamId, member, teamName, inviterName, nextPath, teamUrl, tools, manual, password, actor } =
+    input;
+
+  if (!manual) {
+    const { url } = await issueLoginLink(db, teamId, member.email, {
+      nextPath,
+      ttlMinutes: INVITE_LINK_TTL_MINUTES,
+      baseUrl: process.env.APP_URL,
+      actor,
+    });
+    if (!url) return { ok: false, error: "could not issue a sign-in link" };
+
+    // Provision BEFORE the email so the Slack join link / Linear+GitHub status can ride along.
+    const provisioning = await runProvisioning(db, teamId, member, tools);
+
+    let emailDelivered = false;
+    try {
+      emailDelivered = await sendInviteEmail(member.email, {
+        inviteeName: member.displayName,
+        teamName,
+        inviterName,
+        loginUrl: url,
+        tools: emailInviteTools(provisioning),
+      });
+    } catch (e) {
+      console.error("[invite] email send failed:", e instanceof Error ? e.message : e);
+    }
+
+    return {
+      ok: true,
+      mode: "magic-link",
+      emailDelivered,
+      // Same admin, same screen, shown once — surfaced only when delivery failed.
+      ...(emailDelivered ? {} : { loginUrl: url }),
+      provisioning,
+    };
+  }
+
+  const pw = password ?? "";
+  try {
+    await adminSetPassword(member.email, pw);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not set initial password" };
+  }
+
+  const provisioning = await runProvisioning(db, teamId, member, tools);
+  const inviteMessage = buildManualInviteMessage({
+    inviteeName: member.displayName,
+    teamName,
+    inviterName,
+    teamUrl,
+    email: member.email,
+    password: pw,
+  });
+
+  return { ok: true, mode: "manual", password: pw, inviteMessage, provisioning };
+}

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -242,6 +242,28 @@ export const workEventPayloadSchema = z.object({
 });
 export type WorkEventPayload = z.infer<typeof workEventPayloadSchema>;
 
+// ── Member invite (brain-api v1.7: POST /api/v1/members/invite) ─────────────────
+// Wire is snake_case. `tools` selects the provisioning cascade: the literal "all"/"none", or an
+// explicit array of tool names — an unknown tool name fails the `z.enum` (→ 422 invalid_payload).
+// `.strict()` rejects unknown top-level keys. Email uses zod's `.email()`, identical to
+// `isValidInviteEmail` (`lib/admin/members`, which is `z.string().email()`), kept inline so this
+// shared schema module stays free of the server-only members lib.
+export const PROVISIONING_TOOLS = ["linear", "slack", "github"] as const;
+
+export const memberInviteRequestSchema = z
+  .object({
+    email: z.string().email(),
+    display_name: z.string().trim().min(1),
+    actor_handle: z.string().trim().min(1),
+    role: z.enum(["member", "lead", "admin"]).optional().default("member"),
+    tools: z
+      .union([z.literal("all"), z.literal("none"), z.array(z.enum(PROVISIONING_TOOLS))])
+      .optional()
+      .default("all"),
+  })
+  .strict();
+export type MemberInviteRequest = z.infer<typeof memberInviteRequestSchema>;
+
 /**
  * Normalize tier per contract. Outward labels client (consultant) and company
  * (employee) → external. Returns null for admin/private/unknown (never stored).

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -9,4 +9,4 @@
  * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
  */
-export const BRAIN_API_VERSION = "1.6";
+export const BRAIN_API_VERSION = "1.7";

--- a/lib/auth/mailer.ts
+++ b/lib/auth/mailer.ts
@@ -137,6 +137,18 @@ export interface InviteEmailContext {
    * function never sends a broken email if ever called without one.
    */
   loginUrl?: string;
+  /**
+   * Provisioning-cascade outcomes, distilled for the email's "Your team tools" section (only the
+   * bits the invitee acts on). `slackInviteLink` is a standing join link the member opens themselves
+   * (Slack has no invite API); `linearInvited`/`githubInvited` note that a separate invitation email
+   * is on its way from that provider. All are attacker-influenced admin config, so the HTML body
+   * escapes them. Omitted (or all-empty) → no tools section is rendered.
+   */
+  tools?: {
+    slackInviteLink?: string;
+    linearInvited?: boolean;
+    githubInvited?: boolean;
+  };
 }
 
 /**
@@ -153,7 +165,17 @@ export async function sendInviteEmail(email: string, ctx: InviteEmailContext): P
   const textAction = ctx.loginUrl
     ? `Get started: ${ctx.loginUrl}\n\nThis link is single-use and valid for 7 days.`
     : `Ask your admin for your sign-in password, then open the team brain and sign in with this email address.`;
-  const text = `Hi ${firstName},\n\n${explainer}\n\n${textAction}`;
+
+  const t = ctx.tools;
+  const hasTools = Boolean(t && (t.slackInviteLink || t.linearInvited || t.githubInvited));
+  const textToolLines: string[] = [];
+  if (hasTools) {
+    if (t!.slackInviteLink) textToolLines.push(`- Slack: join your team's workspace: ${t!.slackInviteLink}`);
+    if (t!.linearInvited) textToolLines.push(`- Linear: a separate invitation email is on its way from Linear.`);
+    if (t!.githubInvited) textToolLines.push(`- GitHub: a separate invitation email is on its way from GitHub.`);
+  }
+  const toolsText = hasTools ? `\n\nYour team tools:\n${textToolLines.join("\n")}` : "";
+  const text = `Hi ${firstName},\n\n${explainer}\n\n${textAction}${toolsText}`;
 
   const safeFirstName = escapeHtml(firstName);
   const safeExplainer = escapeHtml(explainer);
@@ -163,9 +185,25 @@ export async function sendInviteEmail(email: string, ctx: InviteEmailContext): P
        <p style="font-size:13px;color:#666;">Or paste this link into your browser:<br>${escapeHtml(ctx.loginUrl)}</p>
        <p style="font-size:13px;color:#666;">This link is single-use and valid for 7 days.</p>`
     : `<p>Ask your admin for your sign-in password, then open the team brain and sign in with this email address.</p>`;
+
+  let toolsHtml = "";
+  if (hasTools) {
+    const items: string[] = [];
+    if (t!.slackInviteLink) {
+      items.push(
+        `<li>Slack: <a href="${escapeHtml(t!.slackInviteLink)}">join your team's workspace</a></li>`
+      );
+    }
+    if (t!.linearInvited) items.push(`<li>Linear: a separate invitation email is on its way from Linear.</li>`);
+    if (t!.githubInvited) items.push(`<li>GitHub: a separate invitation email is on its way from GitHub.</li>`);
+    toolsHtml = `<p style="font-weight:600;margin:16px 0 4px;">Your team tools</p>
+       <ul style="padding-left:18px;font-size:14px;color:#1a1a1a;">${items.join("")}</ul>`;
+  }
+
   const html = `<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:480px;margin:0 auto;padding:24px;color:#1a1a1a;">
         ${intro}
         ${htmlAction}
+        ${toolsHtml}
       </div>`;
 
   return deliver(email, subject, { text, html });

--- a/test/datamechanics/member-invite.datamechanics.test.ts
+++ b/test/datamechanics/member-invite.datamechanics.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { upsertIntegration } from "@/lib/integrations/manage";
+import { issueMemberInvite } from "@/lib/admin/invite";
+import { getMemberProvisioning } from "@/lib/provisioning/run";
+import { db, seedTeam } from "./helpers";
+
+// Spec: the shared invite core (lib/admin/invite.issueMemberInvite) — used by BOTH the admin action
+// and POST /api/v1/members/invite — grants access and runs the provisioning cascade for an
+// already-existing member. Re-inviting the SAME member must UPSERT the provisioning rows (one per
+// tool), never duplicate them — the idempotency the REST re-invite (created:false) relies on.
+// Verified to the observable outcome on real Postgres, in manual mode (deterministic, no network:
+// Slack is link-mode, linear/github are unconfigured → skipped, so no adapter reaches fetch).
+
+describe("issueMemberInvite — idempotent re-invite (real Postgres)", () => {
+  it("re-runs provisioning in place (no duplicate rows) and sets a manual password + message", async () => {
+    const seed = await seedTeam();
+    const auth = { teamId: seed.teamId, memberId: seed.memberId };
+    const member = {
+      id: seed.memberId,
+      email: "invitee@test.local",
+      displayName: "Invitee",
+      role: "member" as const,
+      tier: "team" as const,
+    };
+
+    await upsertIntegration(db(), auth, {
+      type: "slack",
+      name: "slack",
+      config: { inviteLink: "https://join.slack.com/t/x/abc" },
+    });
+
+    const first = await issueMemberInvite(db(), {
+      teamId: seed.teamId,
+      member,
+      teamName: "Acme",
+      inviterName: "Grace Hopper",
+      nextPath: `/t/${seed.teamSlug}`,
+      teamUrl: "https://brain.acme.test",
+      tools: "all",
+      manual: true,
+      password: "example-invite-password",
+      actor: { kind: "member", memberId: seed.memberId },
+    });
+
+    // Fetch impl is default here (unused in these deterministic paths); assert the manual outcome.
+    expect(first.ok).toBe(true);
+    if (!first.ok || first.mode !== "manual") throw new Error("expected manual mode");
+    expect(first.password).toBe("example-invite-password");
+    expect(first.inviteMessage).toContain("Sign in at: https://brain.acme.test");
+    expect(first.provisioning.find((r) => r.tool === "slack")?.status).toBe("link_provided");
+
+    const afterFirst = await getMemberProvisioning(db(), seed.teamId, seed.memberId);
+    expect(afterFirst).toHaveLength(3); // one row per tool
+    expect(afterFirst.find((r) => r.tool === "slack")?.inviteLink).toBe("https://join.slack.com/t/x/abc");
+
+    // Re-invite the SAME member → the same three rows are upserted, never duplicated.
+    const second = await issueMemberInvite(db(), {
+      teamId: seed.teamId,
+      member,
+      teamName: "Acme",
+      inviterName: "Grace Hopper",
+      nextPath: `/t/${seed.teamSlug}`,
+      teamUrl: "https://brain.acme.test",
+      tools: "all",
+      manual: true,
+      password: "second-invite-password",
+      actor: { kind: "member", memberId: seed.memberId },
+    });
+    expect(second.ok).toBe(true);
+
+    const afterSecond = await getMemberProvisioning(db(), seed.teamId, seed.memberId);
+    expect(afterSecond).toHaveLength(3); // still exactly one row per tool — upserted, not duplicated
+  });
+
+  it("provisions nothing when tools = 'none' (empty cascade)", async () => {
+    const seed = await seedTeam();
+    const res = await issueMemberInvite(db(), {
+      teamId: seed.teamId,
+      member: {
+        id: seed.memberId,
+        email: "invitee@test.local",
+        displayName: "Invitee",
+        role: "member",
+        tier: "team",
+      },
+      teamName: "Acme",
+      inviterName: "Grace Hopper",
+      nextPath: `/t/${seed.teamSlug}`,
+      teamUrl: "https://brain.acme.test",
+      tools: "none",
+      manual: true,
+      password: "example-invite-password",
+      actor: { kind: "member", memberId: seed.memberId },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.provisioning).toHaveLength(0);
+    expect(await getMemberProvisioning(db(), seed.teamId, seed.memberId)).toHaveLength(0);
+  });
+});

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -78,5 +78,10 @@
       }
     ]
   },
-  "contentHash": "94bc343a4c57d39ad2fbbd00d0a2cebe57c3356fb67d81361fac99de91006726"
+  "provisioningTools": [
+    "linear",
+    "slack",
+    "github"
+  ],
+  "contentHash": "bbed14ced6a77e7a0fd5b44aa148082e138b59b1e617395bd3e99aea992be6e5"
 }

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -1,7 +1,7 @@
 {
   "$schema": "aios-brain-contract/v1",
   "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: scratchpad gen-contract-fixture.mjs.",
-  "version": "1.6",
+  "version": "1.7",
   "tierAliases": {
     "shared": {
       "team": "team",
@@ -78,5 +78,5 @@
       }
     ]
   },
-  "contentHash": "8d77062d02b3d7d42c327cdfa4276ff84a5e459b21bac892dc1d25ba166b054f"
+  "contentHash": "94bc343a4c57d39ad2fbbd00d0a2cebe57c3356fb67d81361fac99de91006726"
 }

--- a/test/guards/contract-conformance.test.ts
+++ b/test/guards/contract-conformance.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
-import { normalizeTier } from "@/lib/api/schemas";
+import { normalizeTier, PROVISIONING_TOOLS } from "@/lib/api/schemas";
 import { formatSseFrame } from "@/lib/api/sse";
 import { BRAIN_API_VERSION } from "@/lib/api/version";
+import { ALL_TOOLS } from "@/lib/provisioning/run";
 
 /**
  * Server-side conformance guard for the workspace<->brain seam (AIO-314). The mirror of
@@ -34,15 +35,27 @@ const canonical = (v: Json): Json =>
 
 describe("brain-api tier + SSE conformance", () => {
   it("fixture contentHash is intact (no out-of-band edit)", () => {
-    const { version, tierAliases, sse } = fixture;
+    // v1.7 added provisioningTools (the member-invite tool vocabulary) to the pinned content.
+    const { version, tierAliases, sse, provisioningTools } = fixture;
     const recomputed = createHash("sha256")
-      .update(JSON.stringify(canonical({ version, tierAliases, sse })))
+      .update(JSON.stringify(canonical({ version, tierAliases, sse, provisioningTools })))
       .digest("hex");
     expect(recomputed).toBe(fixture.contentHash);
   });
 
   it("fixture version tracks BRAIN_API_VERSION", () => {
     expect(fixture.version).toBe(BRAIN_API_VERSION);
+  });
+
+  it("provisioning tool vocabulary matches the fixture (adapters registry + invite request schema)", () => {
+    // The workspace runs the mirror assertion against its `aios member` CLI TOOLS set. A tool
+    // added to lib/provisioning without the fixture (or vice versa) fails this build; the fixture
+    // regeneration then forces the workspace CLI to follow. Also pins PROVISIONING_TOOLS (the
+    // source of the REST request schema's enum) so the wire vocabulary can't drift from the
+    // adapters that back it.
+    const contractTools = [...fixture.provisioningTools].sort();
+    expect([...ALL_TOOLS].sort()).toEqual(contractTools);
+    expect([...PROVISIONING_TOOLS].sort()).toEqual(contractTools);
   });
 
   it("server normalizeTier matches every shared alias row", () => {

--- a/test/http/members-invite.http.test.ts
+++ b/test/http/members-invite.http.test.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { issueApiKey } from "@/lib/admin/keys";
+import { BASE_URL, db, keyHeaders, seedTeam, type Seed } from "./http-helpers";
+
+// The money tests for POST /api/v1/members/invite (brain-api v1.7): auth/role gating, the tools
+// vocabulary 422, and the exact snake_case wire shape on create + idempotent re-invite. Runs over a
+// real socket against the prod runtime + real Postgres. Mail is unconfigured in this tier
+// (magicLinkAvailable() === false) → the invite always resolves to MANUAL mode, so we assert
+// password + invite_message (and login_url is absent, being a magic-link-only field).
+
+const INVITE = `${BASE_URL}/api/v1/members/invite`;
+
+/** Issue a key for a member of a given tier + role on the seeded team. */
+async function issueKeyForRole(
+  seed: Seed,
+  tier: "team" | "external",
+  role: "admin" | "lead" | "member"
+): Promise<{ key: string }> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      email: `${role}-${tier}-${randomUUID().slice(0, 8)}@test.local`,
+      display_name: `${role} ${tier}`,
+      actor_handle: `${role}-${tier}-${randomUUID().slice(0, 8)}`,
+      role,
+      tier,
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`member seed failed: ${error?.message}`);
+  const { key } = await issueApiKey(db(), seed.teamId, (data as { id: string }).id, `${role} ${tier} key`);
+  return { key };
+}
+
+function invitePayload(over: Record<string, unknown> = {}) {
+  const suffix = randomUUID().slice(0, 8);
+  return {
+    email: `invitee-${suffix}@test.local`,
+    display_name: "New Invitee",
+    actor_handle: `invitee-${suffix}`,
+    ...over,
+  };
+}
+
+describe("POST /api/v1/members/invite (HTTP)", () => {
+  it("rejects a missing/invalid API key with 401", async () => {
+    const res = await fetch(INVITE, {
+      method: "POST",
+      headers: { Authorization: "Bearer nope", "Content-Type": "application/json" },
+      body: JSON.stringify(invitePayload()),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a team member-role key with 403 forbidden_role", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyForRole(seed, "team", "member");
+    const res = await fetch(INVITE, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(invitePayload()),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("forbidden_role");
+  });
+
+  it("rejects an external-tier admin key with 403 forbidden_role", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyForRole(seed, "external", "admin");
+    const res = await fetch(INVITE, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(invitePayload()),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("forbidden_role");
+  });
+
+  it("422s invalid_payload on an unknown tool name", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyForRole(seed, "team", "admin");
+    const res = await fetch(INVITE, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(invitePayload({ tools: ["linear", "jira"] })),
+    });
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("invalid_payload");
+  });
+
+  it("200s on create with the exact manual-mode wire shape (created:true, no login_url)", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyForRole(seed, "team", "admin");
+    const payload = invitePayload();
+
+    const res = await fetch(INVITE, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(payload),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.member.email).toBe(payload.email);
+    expect(body.member.created).toBe(true);
+    expect(typeof body.member.id).toBe("string");
+
+    // Mail is unconfigured in this tier → manual mode: password + invite_message, no login_url.
+    expect(body.invite.mode).toBe("manual");
+    expect(typeof body.invite.password).toBe("string");
+    expect(body.invite.password.length).toBeGreaterThan(0);
+    expect(typeof body.invite.invite_message).toBe("string");
+    expect(body.invite.login_url).toBeUndefined();
+
+    // Provisioning: default "all", nothing configured → three snake_case skipped rows.
+    expect(Array.isArray(body.provisioning)).toBe(true);
+    expect(new Set(body.provisioning.map((r: { tool: string }) => r.tool))).toEqual(
+      new Set(["linear", "slack", "github"])
+    );
+    for (const r of body.provisioning) {
+      expect(typeof r.tool).toBe("string");
+      expect(typeof r.status).toBe("string");
+      expect(typeof r.detail).toBe("string");
+    }
+
+    // The member landed in the DB as 'invited' under this team.
+    const { data: member } = await db()
+      .from("members")
+      .select("status, team_id")
+      .eq("id", body.member.id)
+      .single();
+    expect((member as { status: string }).status).toBe("invited");
+  });
+
+  it("200s idempotently on re-invite of the same email (created:false)", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyForRole(seed, "team", "admin");
+    const payload = invitePayload();
+
+    const first = await fetch(INVITE, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(payload),
+    });
+    expect(first.status).toBe(200);
+    expect((await first.json()).member.created).toBe(true);
+
+    const second = await fetch(INVITE, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify({ ...payload, actor_handle: `${payload.actor_handle}-2` }),
+    });
+    expect(second.status).toBe(200);
+    const secondBody = await second.json();
+    expect(secondBody.member.created).toBe(false);
+    expect(secondBody.member.email).toBe(payload.email);
+  });
+});

--- a/test/mailer-invite.test.ts
+++ b/test/mailer-invite.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { buildManualInviteMessage } from "@/lib/auth/mailer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildManualInviteMessage, sendInviteEmail } from "@/lib/auth/mailer";
 
 // Spec: the manual (no-mail-provider) invite path must hand the admin everything needed to
 // share access another way — the team brain URL, the sign-in email, and the password — not just
@@ -21,5 +21,78 @@ describe("buildManualInviteMessage", () => {
     expect(msg).toContain("Sign in at: https://brain.acme.test");
     expect(msg).toContain("Email: ada@acme.test");
     expect(msg).toContain("Password: example-invite-password");
+  });
+});
+
+// Spec: the magic-link invite email renders a "Your team tools" section from the provisioning
+// cascade — a Slack join link (as an anchor), and a note that Linear/GitHub invites arrive
+// separately when those tools sent one. Everything interpolated is HTML-escaped (the Slack link is
+// admin-controlled config). We capture the payload by stubbing the Resend HTTP call.
+describe("sendInviteEmail — Your team tools", () => {
+  const base = {
+    inviteeName: "Ada Lovelace",
+    teamName: "Acme",
+    inviterName: "Grace Hopper",
+    loginUrl: "https://brain.acme.test/auth/confirm?token=abc",
+  };
+
+  let captured: { text: string; html: string } | null;
+
+  beforeEach(() => {
+    captured = null;
+    process.env.RESEND_API_KEY = "test-key";
+    process.env.RESEND_FROM = "AIOS <noreply@acme.test>";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        captured = { text: body.text ?? "", html: body.html ?? "" };
+        return new Response(JSON.stringify({ id: "x" }), { status: 200 });
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.RESEND_API_KEY;
+    delete process.env.RESEND_FROM;
+  });
+
+  it("renders the Slack join link (escaped) + Linear/GitHub notes when provided", async () => {
+    const delivered = await sendInviteEmail("ada@acme.test", {
+      ...base,
+      tools: {
+        slackInviteLink: "https://join.slack.com/t/x?a=1&b=2",
+        linearInvited: true,
+        githubInvited: true,
+      },
+    });
+    expect(delivered).toBe(true);
+    expect(captured).not.toBeNull();
+
+    // Text version: plain link + separate-invite notes.
+    expect(captured!.text).toContain("Your team tools:");
+    expect(captured!.text).toContain("https://join.slack.com/t/x?a=1&b=2");
+    expect(captured!.text).toContain("Linear");
+    expect(captured!.text).toContain("GitHub");
+
+    // HTML version: the ampersand in the link is escaped inside the anchor href.
+    expect(captured!.html).toContain("Your team tools");
+    expect(captured!.html).toContain('href="https://join.slack.com/t/x?a=1&amp;b=2"');
+    expect(captured!.html).not.toContain("?a=1&b=2"); // raw, unescaped ampersand must not appear
+  });
+
+  it("omits the tools section entirely when no tools are provided", async () => {
+    await sendInviteEmail("ada@acme.test", base);
+    expect(captured!.text).not.toContain("Your team tools");
+    expect(captured!.html).not.toContain("Your team tools");
+  });
+
+  it("shows only the tools that have an outcome (Slack link absent → no Slack line)", async () => {
+    await sendInviteEmail("ada@acme.test", { ...base, tools: { linearInvited: true } });
+    expect(captured!.text).toContain("Your team tools:");
+    expect(captured!.text).toContain("Linear");
+    expect(captured!.text).not.toContain("join.slack.com");
+    expect(captured!.html).not.toContain("<a href=\"https://join");
   });
 });

--- a/test/member-invite-schema.test.ts
+++ b/test/member-invite-schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { memberInviteRequestSchema } from "@/lib/api/schemas";
+
+// Spec: the POST /api/v1/members/invite request body (brain-api v1.7) is snake_case, strict, and
+// gates the provisioning `tools` vocabulary. These assert the contract's accept/reject boundary and
+// its defaults — a route that parses a body outside this shape must 422, not silently coerce.
+
+const valid = {
+  email: "ada@acme.test",
+  display_name: "Ada Lovelace",
+  actor_handle: "ada",
+};
+
+describe("memberInviteRequestSchema", () => {
+  it("accepts a minimal body and applies role + tools defaults", () => {
+    const parsed = memberInviteRequestSchema.parse(valid);
+    expect(parsed.role).toBe("member");
+    expect(parsed.tools).toBe("all");
+  });
+
+  it("accepts an explicit tool array, the 'all' literal, and the 'none' literal", () => {
+    expect(memberInviteRequestSchema.safeParse({ ...valid, tools: ["linear", "slack"] }).success).toBe(true);
+    expect(memberInviteRequestSchema.safeParse({ ...valid, tools: "all" }).success).toBe(true);
+    expect(memberInviteRequestSchema.safeParse({ ...valid, tools: "none" }).success).toBe(true);
+    expect(memberInviteRequestSchema.safeParse({ ...valid, tools: [] }).success).toBe(true);
+  });
+
+  it("rejects an unknown tool name in the array", () => {
+    expect(memberInviteRequestSchema.safeParse({ ...valid, tools: ["linear", "jira"] }).success).toBe(false);
+    expect(memberInviteRequestSchema.safeParse({ ...valid, tools: "everything" }).success).toBe(false);
+  });
+
+  it("rejects a malformed email", () => {
+    expect(memberInviteRequestSchema.safeParse({ ...valid, email: "not-an-email" }).success).toBe(false);
+    expect(memberInviteRequestSchema.safeParse({ ...valid, email: "" }).success).toBe(false);
+  });
+
+  it("requires a non-empty display_name and actor_handle", () => {
+    expect(memberInviteRequestSchema.safeParse({ ...valid, display_name: "" }).success).toBe(false);
+    expect(memberInviteRequestSchema.safeParse({ ...valid, actor_handle: "  " }).success).toBe(false);
+  });
+
+  it("accepts each allowed role and rejects an unknown role", () => {
+    for (const role of ["member", "lead", "admin"]) {
+      expect(memberInviteRequestSchema.safeParse({ ...valid, role }).success, role).toBe(true);
+    }
+    expect(memberInviteRequestSchema.safeParse({ ...valid, role: "owner" }).success).toBe(false);
+  });
+
+  it("is strict — rejects unknown top-level keys", () => {
+    expect(memberInviteRequestSchema.safeParse({ ...valid, password: "sneaky" }).success).toBe(false);
+    expect(memberInviteRequestSchema.safeParse({ ...valid, tier: "external" }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The final brain piece of one-trigger member onboarding (AIO-328). **Stacked on #204 (audit fixes) + #205 (provisioning core)** — both are merged into this branch; once they land, this PR's diff reduces to its own commits.

- **Shared core** `lib/admin/invite.ts` (`issueMemberInvite`): sign-in issuance (magic-link or manual password) + provisioning cascade + invite email, used by both triggers. Member lifecycle (create vs idempotent lookup, rollback) stays per-caller where it genuinely diverges.
- **Admin UI** (`/t/[team]/admin/members`): per-tool checkboxes on the invite form (disabled with reason when unconfigured), per-tool results under the success card (badge + detail + copyable Slack link), and a Tools column with red retry badges for failed provisioning.
- **`POST /api/v1/members/invite`** (brain-api v1.7, contract aios-workspace#218): team-tier **admin** key only (403 `forbidden_role`), 10/min, strict zod body, idempotent on (team_id, email) — existing member → `created:false` + re-issued access + re-provision; disabled member → 422. Provisioning is best-effort and never changes the HTTP status. snake_case wire.
- **Invite email**: "Your team tools" section — Slack join link, note that Linear/GitHub invites arrive from those services (all HTML-escaped).
- **`BRAIN_API_VERSION` → 1.7** + re-vendored `brain-contract.json` fixture, in lockstep with the canonical copy regenerated in aios-workspace#218 (conformance guards green on both sides).
- ARCHITECTURE.md: route drift block, member-provisioning flow prose, implements-claim bump.

## Tests

- **HTTP tier (6/6)**: 401 bad key · 403 member-role team key · 403 external-tier admin key · 422 unknown tool · 200 create (wire shape verified, manual mode, `login_url` absent) · 200 idempotent re-invite.
- Unit 502 passed (schema vocab/defaults, mailer rendering + escaping, all contract/drift guards at v1.7); data-mechanics 338 passed (idempotent re-invite upserts, provisioning rows); lint/typecheck/check:docs green.

## Merge order

aios-workspace#218 → #204 → #205 → **this** → aios-workspace#223 (CLI; already 404-tolerant). After merge: `npm run pg:schema` against prod (new `member_provisioning` table) + confirm Railway build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches invite/sign-in, membership activation, and a new admin API that can return passwords and invite messages; provisioning calls external services with integration secrets.
> 
> **Overview**
> Delivers **one-trigger member onboarding**: a new **`POST /api/v1/members/invite`** (brain-api **v1.7**, team-tier admin key, rate-limited, idempotent on email) and the admin **`inviteMember`** action both call shared **`issueMemberInvite`** for sign-in (magic-link or manual) and a **best-effort tool provisioning cascade** (`lib/provisioning/*` → **`member_provisioning`**).
> 
> **Admin UX** gains per-tool invite checkboxes, provisioning outcomes on the success card (including fallback **`loginUrl`** when email delivery fails), a **Tools** column with per-tool retry, and **Integrations → Member onboarding** settings for Linear/Slack/GitHub hints. Invite emails can include a **“Your team tools”** section.
> 
> **Membership/auth behavior** changes: **`invited` → `active`** is **team-scoped** (magic link activates only the target team; password login defers activation to first team layout visit via **`activateInvitedMembership`**). Failed manual invites can **`rollbackMemberCreation`**; duplicates surface **`MemberExistsError`**. **`/auth/dev-login`** is **404 in production** with no escape hatch; **`purgeExpiredAuthRows`** runs on token issue and daily from the ingest scheduler.
> 
> Contract/docs bump to **v1.7** with updated **`brain-contract.json`** / provisioning tool guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d11587f973cf1a0df65b37738a27f893f09776d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->