### PR TITLE
fix(provisioning): recognize Linear's live duplicate-invite wording as skipped (AIO-328)

### DIFF
--- a/lib/provisioning/linear.ts
+++ b/lib/provisioning/linear.ts
@@ -59,7 +59,9 @@ export const linearAdapter: ProvisioningAdapter = {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       // An already-member / already-invited error is not a failure — the person is reachable.
-      if (/already/i.test(msg)) return { tool: "linear", status: "skipped", detail: msg };
+      // Linear's live wording for a duplicate pending invite is exactly "Existing invite."
+      // (observed in the 2026-07-10 prod E2E), which a plain /already/i heuristic misses.
+      if (/already|existing invite/i.test(msg)) return { tool: "linear", status: "skipped", detail: msg };
       return { tool: "linear", status: "failed", detail: msg };
     }
   },

--- a/test/provisioning-adapters.test.ts
+++ b/test/provisioning-adapters.test.ts
@@ -63,6 +63,18 @@ describe("linear provisioning adapter", () => {
     expect(res.detail).toMatch(/already/i);
   });
 
+  it('maps Linear\'s live duplicate-invite wording ("Existing invite.") to skipped', async () => {
+    // Exact message observed against the real Linear API in the 2026-07-10 prod E2E —
+    // it does NOT contain "already", which a plain /already/i heuristic requires.
+    const { fetchImpl } = linearFetch({ errors: [{ message: "Linear GraphQL failed: Existing invite." }] });
+    const db = fakeIntegrationsDb([{ type: "linear", secret: "lin_key", config: {} }]);
+
+    const res = await linearAdapter.invite(db, "team-1", member(), fetchImpl);
+
+    expect(res.status).toBe("skipped");
+    expect(res.detail).toMatch(/existing invite/i);
+  });
+
   it("maps any other GraphQL error to failed with the message", async () => {
     const { fetchImpl } = linearFetch({ errors: [{ message: "Rate limited" }] });
     const db = fakeIntegrationsDb([{ type: "linear", secret: "lin_key", config: {} }]);


### PR DESCRIPTION
## What

The prod E2E of the member-onboarding cascade caught this: Linear's real duplicate-pending-invite GraphQL error is exactly **"Existing invite."** — it doesn't contain "already", which the skip heuristic required. So an idempotent re-invite reported `✗ linear failed` (and left a red retry badge) over what is a perfectly healthy "they're already invited" state.

One-line widen to `/already|existing invite/i` + a spec test pinning the exact observed wording.

## Verified

- New unit test red against the old regex, green now; full unit suite 504 passed.
- Live repro: `aios member invite <existing-email> --tools linear` against prod returned `failed — Linear GraphQL failed: Existing invite.` before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-classification change in the Linear invite adapter with a regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes **false `failed` results** when re-inviting someone who already has a pending Linear org invite.
> 
> The Linear adapter’s catch block now treats duplicate-invite GraphQL errors as **`skipped`** (same as other “already invited” cases) by widening the message heuristic from `/already/i` to **`/already|existing invite/i`**. Production returns the exact text **"Existing invite."**, which previously did not match and surfaced as a failed linear step with a retry badge.
> 
> Adds a unit test that pins that live error wording; the rest of the test file diff is formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90379c3bbe0c48031afd3ace86627eaace7b547a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->