### PR TITLE
feat(admin): wire Linear inboundApply toggle into the integrations form (AIO-323)

### DIFF
--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -21,53 +21,21 @@ import { saveProvisioningSettings as saveProvisioningSettings_ } from "@/lib/pro
 import { validateGithubToken, checkRepoAccess, type RepoAccess } from "@/lib/integrations/github-validate";
 import { RepoFormatError } from "@/lib/integrations/github-repos";
 import { IntegrationConfigError, type IntegrationType } from "@/lib/api/schemas";
+import { buildConfig, toList } from "@/lib/integrations/build-config";
 import { audit } from "@/lib/api/audit";
 
 export type PrimaryPmProvider = "plane" | "linear" | null;
 
-function toList(raw: string): string[] {
-  return raw.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);
-}
-
-function toKeyValues(raw: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const part of toList(raw)) {
-    const m = part.match(/^([A-Za-z][A-Za-z0-9_-]*)\s*=\s*(.+)$/);
-    if (m) out[m[1]] = m[2].trim();
-  }
-  return out;
-}
-
-/** Map a single "selection" field to the per-type NON-SECRET config shape (validated downstream). */
-function buildConfig(type: IntegrationType, selection: string): Record<string, unknown> {
-  const list = toList(selection);
-  const kv = toKeyValues(selection);
-  switch (type) {
-    case "slack": return { channelIds: list };
-    case "github": return { repos: list };
-    case "granola": return { matchKeywords: list };
-    case "wise": return list[0] ? { profileId: list[0] } : {};
-    case "linear":
-      return Object.keys(kv).length
-        ? { teamId: kv.teamId, projectId: kv.projectId, doneStateName: kv.doneStateName }
-        : list[0] ? { projectId: list[0] } : {};
-    case "plane":
-      return Object.keys(kv).length
-        ? {
-            baseUrl: kv.baseUrl,
-            workspaceSlug: kv.workspaceSlug,
-            projectId: kv.projectId,
-            doneStateName: kv.doneStateName,
-            externalSource: kv.externalSource,
-          }
-        : list[0] ? { projectId: list[0] } : {};
-    default: return {};
-  }
-}
-
 export async function saveIntegration(
   teamSlug: string,
-  form: { type: IntegrationType; name: string; selection: string; secret: string }
+  form: {
+    type: IntegrationType;
+    name: string;
+    selection: string;
+    secret: string;
+    /** Linear only: per-team inbound-apply opt-in (Linear→brain). Default off. */
+    inboundApply?: boolean;
+  }
 ): Promise<{ ok: boolean; error?: string }> {
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
@@ -78,7 +46,7 @@ export async function saveIntegration(
     const { id } = await upsertIntegration(adminClient(), auth, {
       type: form.type,
       name,
-      config: buildConfig(form.type, form.selection),
+      config: buildConfig(form.type, form.selection, { inboundApply: form.inboundApply }),
       status: "enabled",
     });
     if (form.secret) await setIntegrationSecret(adminClient(), auth, id, form.secret);

--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -72,6 +72,7 @@ function summarizeConfig(type: IntegrationType, config: Record<string, unknown>)
       config.teamId ? `team ${config.teamId}` : null,
       config.projectId ? `project ${config.projectId}` : null,
       config.doneStateName ? `done ${config.doneStateName}` : null,
+      config.inboundApply === true ? "inbound ✓" : null,
     ].filter(Boolean).join(" · ") || "—";
   }
   if (type === "plane") {
@@ -126,11 +127,18 @@ export function IntegrationsManager({
       }
     });
   }
-  const [form, setForm] = useState<{ type: IntegrationType; name: string; selection: string; secret: string }>({
+  const [form, setForm] = useState<{
+    type: IntegrationType;
+    name: string;
+    selection: string;
+    secret: string;
+    inboundApply: boolean;
+  }>({
     type: "slack",
     name: "",
     selection: "",
     secret: "",
+    inboundApply: false,
   });
 
   function projectToGraph() {
@@ -287,7 +295,8 @@ export function IntegrationsManager({
           e.preventDefault();
           run(async () => {
             const res = await saveIntegration(teamSlug, form);
-            if (res.ok) setForm({ type: form.type, name: "", selection: "", secret: "" });
+            if (res.ok)
+              setForm({ type: form.type, name: "", selection: "", secret: "", inboundApply: false });
             return res;
           });
         }}
@@ -320,6 +329,21 @@ export function IntegrationsManager({
           value={form.selection}
           onChange={(e) => setForm({ ...form, selection: e.target.value })}
         />
+        {form.type === "linear" ? (
+          <label className="flex items-start gap-2 text-xs text-ink-secondary">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={form.inboundApply}
+              onChange={(e) => setForm({ ...form, inboundApply: e.target.checked })}
+            />
+            <span>
+              Apply inbound Linear changes back to the brain (two-way sync). Off by default — the
+              brain stays the source of truth; enabling lets a status change made directly in Linear
+              flow back. Reversible; re-save with this unchecked to turn it off.
+            </span>
+          </label>
+        ) : null}
         <input
           className="prism-input"
           type="password"

--- a/lib/integrations/build-config.ts
+++ b/lib/integrations/build-config.ts
@@ -1,0 +1,71 @@
+import type { IntegrationType } from "@/lib/api/schemas";
+
+// Map the admin form's single free-text "selection" field to the per-type NON-SECRET config shape
+// stored in `integrations.config` (validated downstream by `validateIntegrationConfig`). Extracted
+// from the admin server action so the parsing is unit-testable (a server-action module is
+// "use server" and can only export async actions).
+
+/** Split a free-text field on commas/newlines into trimmed, non-empty tokens. */
+export function toList(raw: string): string[] {
+  return raw
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function toKeyValues(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const part of toList(raw)) {
+    const m = part.match(/^([A-Za-z][A-Za-z0-9_-]*)\s*=\s*(.+)$/);
+    if (m) out[m[1]] = m[2].trim();
+  }
+  return out;
+}
+
+/** Non-selection options threaded from dedicated form controls (not the free-text field). */
+export interface BuildConfigOptions {
+  /** Linear only: per-team opt-in to inbound apply (Linear→brain). Off unless explicitly true —
+   *  the field is omitted when false so the gate (`config.inboundApply === true`) stays default-off. */
+  inboundApply?: boolean;
+}
+
+export function buildConfig(
+  type: IntegrationType,
+  selection: string,
+  opts: BuildConfigOptions = {}
+): Record<string, unknown> {
+  const list = toList(selection);
+  const kv = toKeyValues(selection);
+  switch (type) {
+    case "slack":
+      return { channelIds: list };
+    case "github":
+      return { repos: list };
+    case "granola":
+      return { matchKeywords: list };
+    case "wise":
+      return list[0] ? { profileId: list[0] } : {};
+    case "linear": {
+      const base = Object.keys(kv).length
+        ? { teamId: kv.teamId, projectId: kv.projectId, doneStateName: kv.doneStateName }
+        : list[0]
+          ? { projectId: list[0] }
+          : {};
+      return opts.inboundApply ? { ...base, inboundApply: true } : base;
+    }
+    case "plane":
+      return Object.keys(kv).length
+        ? {
+            baseUrl: kv.baseUrl,
+            workspaceSlug: kv.workspaceSlug,
+            projectId: kv.projectId,
+            doneStateName: kv.doneStateName,
+            externalSource: kv.externalSource,
+          }
+        : list[0]
+          ? { projectId: list[0] }
+          : {};
+    default:
+      return {};
+  }
+}

--- a/test/build-integration-config.test.ts
+++ b/test/build-integration-config.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildConfig } from "@/lib/integrations/build-config";
+import { validateIntegrationConfig } from "@/lib/api/schemas";
+
+// Spec for the admin form's selection → config mapping. The contract that matters for AIO-323:
+// the Linear `inboundApply` opt-in must be threadable from the UI (it previously required prod SQL),
+// stay OFF unless explicitly enabled, and produce config the downstream validator accepts.
+
+describe("buildConfig()", () => {
+  it("maps a Linear kv selection to the PM mapping hints", () => {
+    expect(buildConfig("linear", "teamId=T, projectId=P, doneStateName=Done")).toEqual({
+      teamId: "T",
+      projectId: "P",
+      doneStateName: "Done",
+    });
+  });
+
+  it("adds inboundApply:true ONLY when the toggle is set", () => {
+    expect(buildConfig("linear", "teamId=T", { inboundApply: true })).toEqual({
+      teamId: "T",
+      inboundApply: true,
+    });
+    // Default-off: omitted or false must NOT write the flag (gate checks `=== true`).
+    expect(buildConfig("linear", "teamId=T")).toEqual({ teamId: "T" });
+    expect(buildConfig("linear", "teamId=T", { inboundApply: false })).toEqual({ teamId: "T" });
+  });
+
+  it("carries inboundApply even for the bare-projectId Linear form", () => {
+    expect(buildConfig("linear", "project-uuid", { inboundApply: true })).toEqual({
+      projectId: "project-uuid",
+      inboundApply: true,
+    });
+  });
+
+  it("ignores inboundApply for non-Linear types", () => {
+    expect(buildConfig("slack", "C1, C2", { inboundApply: true })).toEqual({
+      channelIds: ["C1", "C2"],
+    });
+    expect(buildConfig("plane", "workspaceSlug=w", { inboundApply: true })).not.toHaveProperty(
+      "inboundApply"
+    );
+  });
+
+  it("produces config the downstream validator accepts (round-trip)", () => {
+    const cfg = buildConfig("linear", "teamId=team-uuid", { inboundApply: true });
+    expect(validateIntegrationConfig("linear", cfg)).toEqual({
+      teamId: "team-uuid",
+      inboundApply: true,
+    });
+  });
+});


### PR DESCRIPTION
## What & why

The per-integration `inboundApply` flag (Linear→brain inbound apply, gated at `lib/pm-sync/inbound.ts:519`, default off) had **no admin-UI control** — the integration form's `buildConfig` never wired it, so enabling it required **production SQL**. Found in the 2026-07-09 demo preflight (AIO-323).

## Change

- **Extract** `buildConfig` (+ `toList`) from the `"use server"` action into `lib/integrations/build-config.ts` so the selection→config mapping is unit-testable (a server-action module can only export async actions), and add an `inboundApply` option.
  - Linear only; **omitted unless explicitly `true`**, so the gate's `=== true` check stays default-off and **re-saving unchecked turns it back off** (reversible).
- **`integrations-manager.tsx`**: a Linear-only checkbox in the add/save form, threaded through `saveIntegration`. The Linear row summary now shows `inbound ✓` when enabled (visible confirmation).
- **Unit test** (`test/build-integration-config.test.ts`): `buildConfig` sets `inboundApply` only when toggled, ignores it for non-Linear types, and round-trips through `validateIntegrationConfig`.

## Notes / scope

- No route/table/source change — **docs-drift guard congruent**; `docs/ARCHITECTURE.md` needs no update. The `linear` config schema already permitted `inboundApply` (brain-api v1.4); only the UI wiring was missing.
- The gate (`inbound.ts:519`) and inbound persistence are unchanged and already covered by `test/datamechanics/pm-sync-inbound.datamechanics.test.ts`; this PR only makes the flag reachable from the UI.
- The add/save form doesn't pre-load an existing integration's config (pre-existing behavior for all fields), so flipping inbound on an existing Linear integration means re-saving it with the box checked — but it's now a **UI action, not SQL**.

## Verification (local)
- `npx tsc --noEmit` clean
- unit tier: full `npm test` green (509 passed, 1 expected-fail, skips); new + existing integration-config specs pass
- `npm run lint` — 0 errors (1 pre-existing warning in an untouched datamechanics test)
- `npm run check:docs` — routes/tables/sources all in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling the toggle turns on per-team Linear→brain inbound apply (behavior already implemented behind `config.inboundApply === true`); risk is operational—admins can now flip two-way sync without SQL, but defaults remain off and inbound logic is unchanged.
> 
> **Overview**
> **Linear integrations can now opt into inbound apply (Linear→brain two-way sync) from the admin UI**, instead of editing `integrations.config` in SQL.
> 
> `buildConfig` / `toList` move out of the `"use server"` actions module into **`lib/integrations/build-config.ts`** so the selection→config mapping is unit-testable. **`saveIntegration`** accepts optional **`inboundApply`** and passes it into **`buildConfig`**, which sets **`inboundApply: true`** on Linear config **only when the checkbox is checked** (omitted when off so existing **`=== true`** gating stays default-off and re-saving unchecked clears the flag).
> 
> **`integrations-manager`** adds a Linear-only checkbox on the add/save form, resets it after a successful save, and shows **`inbound ✓`** in the Linear row summary when enabled. **`test/build-integration-config.test.ts`** locks the default-off behavior, non-Linear ignore, and validator round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871bdd260bd0dc2047c2fc918b03ab87ed745a6a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->