### PR TITLE
fix(context): distance floor on dense search so far neighbors don't false-ground

### DIFF
--- a/lib/auth/mailer.ts
+++ b/lib/auth/mailer.ts
@@ -84,6 +84,20 @@ async function deliver(to: string, subject: string, body: { text: string; html?:
   return false;
 }
 
+/**
+ * Ops/admin alert email (e.g. "semantic search degraded"). Plain-text, best-effort — never throws,
+ * returns whether a provider actually delivered it (false when none is configured). Not a secret, so
+ * it's fine that no provider = a logged drop.
+ */
+export async function sendOpsAlert(to: string, subject: string, text: string): Promise<boolean> {
+  return deliver(to, subject, { text });
+}
+
+/** Whether an email provider is configured at all (so callers can skip work when nothing can send). */
+export function mailerConfigured(): boolean {
+  return Boolean(process.env.RESEND_API_KEY || process.env.SMTP_URL);
+}
+
 /** Magic-link sign-in email (login flow). Never throws. */
 export async function sendMagicLink(email: string, link: string): Promise<void> {
   await deliver(email, "Your AIOS Team Brain sign-in link", {

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -38,6 +38,10 @@ export function startIngestScheduler(): void {
     // degraded stack shows on Admin → Integrations instead of silently indexing nothing.
     {
       const startedAt = Date.now();
+      const { lastDenseRunFailed, alertDenseDegraded, alertDenseRecovered } = await import("@/lib/query/retrieval-alert");
+      // Capture the leg's state BEFORE this tick so we can email admins only on the EDGE (ok→degraded
+      // or degraded→ok), not once per tick during a sustained outage.
+      const priorFailed = await lastDenseRunFailed(db).catch(() => false);
       try {
         const { indexPendingItems } = await import("@/lib/query/dense-index");
         const d = await indexPendingItems();
@@ -53,6 +57,7 @@ export function startIngestScheduler(): void {
             meta: { indexed: d.indexed, failed: d.failed, chunks: d.chunks },
             startedAt,
           });
+          await alertDenseDegraded(db, priorFailed, { failed: d.failed, scanned: d.scanned, errorSample: d.errorSample });
         } else if (d.indexed > 0) {
           await recordIngestRun(db, {
             source: "dense",
@@ -62,11 +67,13 @@ export function startIngestScheduler(): void {
             meta: { indexed: d.indexed, chunks: d.chunks },
             startedAt,
           });
+          await alertDenseRecovered(db, priorFailed, d.indexed);
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error("[ingest] dense index tick failed:", msg);
         await recordIngestRun(db, { source: "dense", trigger: "scheduler", ok: false, errors: [msg], startedAt });
+        await alertDenseDegraded(db, priorFailed, { failed: 0, scanned: 0, errorSample: msg });
       }
     }
   };

--- a/lib/query/dense-search.ts
+++ b/lib/query/dense-search.ts
@@ -20,7 +20,16 @@ export interface DenseHit {
   kind: string;
   synced_at: string;
   project: string;
+  dist: number; // cosine distance to the query (0 = identical … 2 = opposite); lower = more relevant
 }
+
+// Relevance floor for the vector search: nearest-neighbor ALWAYS returns its N closest chunks no
+// matter how far away, so an absent topic still yields "matches". Without a ceiling those far hits
+// (a) become junk context and (b) flip retrieve()'s grounding signal true — defeating the IDF
+// grounding safety. Only hits within this cosine distance are returned, so a dense hit is a REAL
+// semantic match. 0.6 (~similarity 0.4) keeps genuine paraphrase matches while rejecting the
+// unrelated tail; tune per embedding model via DENSE_MAX_DISTANCE.
+const DENSE_MAX_DISTANCE = Number(process.env.DENSE_MAX_DISTANCE ?? 0.6);
 
 export async function denseSearch(
   teamId: string,
@@ -45,11 +54,13 @@ export async function denseSearch(
       params.push(projectSlug);
       where += ` and p.slug = $${params.length}`;
     }
+    params.push(DENSE_MAX_DISTANCE);
+    const distIdx = params.length;
     params.push(limit);
     const limitIdx = params.length;
 
     const sql = `
-      select item_id, content, path, kind, synced_at, project from (
+      select item_id, content, path, kind, synced_at, project, dist from (
         select distinct on (c.item_id)
           c.item_id, c.content, i.path, i.kind, i.synced_at, coalesce(p.slug, '') as project,
           (c.embedding <=> $1::vector) as dist
@@ -59,6 +70,7 @@ export async function denseSearch(
         where ${where}
         order by c.item_id, (c.embedding <=> $1::vector)
       ) best
+      where dist <= $${distIdx}
       order by dist asc
       limit $${limitIdx}`;
 
@@ -69,6 +81,7 @@ export async function denseSearch(
       kind: string;
       synced_at: string | Date;
       project: string;
+      dist: number | string;
     }>(sql, params);
 
     return res.rows.map((r) => ({
@@ -79,6 +92,7 @@ export async function denseSearch(
       synced_at:
         r.synced_at instanceof Date ? r.synced_at.toISOString() : String(r.synced_at ?? ""),
       project: r.project,
+      dist: typeof r.dist === "number" ? r.dist : Number(r.dist) || 0,
     }));
   } catch {
     return []; // degrade to keyword FTS + Graphiti

--- a/lib/query/retrieval-alert.ts
+++ b/lib/query/retrieval-alert.ts
@@ -1,0 +1,77 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { sendOpsAlert, mailerConfigured } from "@/lib/auth/mailer";
+
+/**
+ * Email admins when the dense (semantic) retrieval leg TRANSITIONS to/from degraded — Phase 1b of the
+ * retrieval-observability plan. Debounced by design: it only fires on the edge (last dense run's
+ * outcome flipped), so a sustained embeddings outage sends ONE alert, not one per scheduler tick.
+ *
+ * Dense indexing is instance-wide (a shared embeddings provider), so the alert goes to every active
+ * admin. Best-effort throughout — a mail failure must never affect the ingest tick.
+ */
+
+/** Was the most recent recorded dense run a failure? (false when there are none.) */
+export async function lastDenseRunFailed(db: DbClient): Promise<boolean> {
+  const { data } = await db
+    .from("ingest_runs")
+    .select("ok")
+    .eq("source", "dense")
+    .order("finished_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return !!data && (data as { ok: boolean }).ok === false;
+}
+
+async function activeAdminEmails(db: DbClient): Promise<string[]> {
+  const { data } = await db
+    .from("members")
+    .select("email")
+    .eq("role", "admin")
+    .eq("status", "active");
+  const emails = (data ?? [])
+    .map((m) => (m as { email: string | null }).email)
+    .filter((e): e is string => !!e && e.includes("@"));
+  return [...new Set(emails.map((e) => e.toLowerCase()))];
+}
+
+/**
+ * Notify admins that semantic search just broke. `priorFailed` is the leg's state BEFORE this tick,
+ * captured by the caller so we can detect the edge. No-op unless this is a fresh transition into
+ * failure and a mail provider is configured.
+ */
+export async function alertDenseDegraded(
+  db: DbClient,
+  priorFailed: boolean,
+  detail: { failed: number; scanned: number; errorSample?: string }
+): Promise<void> {
+  if (priorFailed || !mailerConfigured()) return; // debounce: only on the ok→degraded edge
+  try {
+    const admins = await activeAdminEmails(db);
+    if (admins.length === 0) return;
+    const where = process.env.APP_URL ? `${process.env.APP_URL.replace(/\/$/, "")} → Admin → Integrations` : "Admin → Integrations";
+    const text =
+      `Semantic (vector) search has stopped working: ${detail.failed} of ${detail.scanned} items failed to embed ` +
+      `this cycle.\n\nLikely cause: the embeddings provider is down or out of quota (check billing/keys). ` +
+      `Keyword search is unaffected, so the brain still answers — but paraphrased questions and large-corpus ` +
+      `recall are weaker until this recovers.\n\n` +
+      (detail.errorSample ? `Provider error: ${detail.errorSample}\n\n` : "") +
+      `See the Retrieval health card at ${where}. You'll get one more email when it recovers.`;
+    for (const to of admins) await sendOpsAlert(to, "⚠️ AIOS Team Brain — semantic search degraded", text);
+  } catch {
+    // best-effort — a mail failure must not affect the ingest tick
+  }
+}
+
+/** Notify admins that semantic search recovered — the symmetric edge (degraded→ok). */
+export async function alertDenseRecovered(db: DbClient, priorFailed: boolean, indexed: number): Promise<void> {
+  if (!priorFailed || !mailerConfigured()) return; // only on the degraded→ok edge
+  try {
+    const admins = await activeAdminEmails(db);
+    if (admins.length === 0) return;
+    const text = `Semantic (vector) search is working again — the embeddings backlog is indexing (${indexed} items this cycle). No action needed.`;
+    for (const to of admins) await sendOpsAlert(to, "✅ AIOS Team Brain — semantic search recovered", text);
+  } catch {
+    // best-effort
+  }
+}

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -590,6 +590,9 @@ async function nativeRetrieve(
   let orderedSources = sources;
   const denseHits = await denseP;
   if (denseHits.length) {
+    // A dense hit here is a REAL semantic match — denseSearch applies a distance floor, so far
+    // nearest-neighbors (which every query has) are already excluded. That's what makes this a valid
+    // grounding signal rather than "any vector exists" (which would defeat the IDF grounding above).
     grounded = true;
     for (const h of denseHits) {
       if (seen.has(h.item_id)) continue;

--- a/test/datamechanics/dense-retrieval.datamechanics.test.ts
+++ b/test/datamechanics/dense-retrieval.datamechanics.test.ts
@@ -81,6 +81,23 @@ live("dense retrieval (real pgvector + stub embeddings)", () => {
     expect(ctx.grounded).toBe(true);
   });
 
+  it("does NOT ground on a far nearest-neighbor for an absent topic (distance floor)", async () => {
+    const seed = await seedTeam();
+    await ingest(seed, { path: "deliverables/auth.md", body: "We shipped auth: a passwordless login flow.", access: "team" });
+    await ingest(seed, { path: "deliverables/lunch.md", body: "Catering options for the team lunch.", access: "team" });
+    await ingest(seed, { path: "deliverables/parking.md", body: "Visitor parking is in lot C.", access: "team" });
+    expect((await indexPendingItems()).skipped).toBe(false);
+
+    // "latency" is a concept NONE of the docs embed, and its terms don't keyword-match either, so the
+    // nearest chunk is orthogonal (cosine dist ~1). WITHOUT the floor, dense would still return it and
+    // flip grounded=true (false grounding — the bug). With the floor it's excluded → grounded stays
+    // false, so the answer layer abstains instead of confabulating from an irrelevant nearest-neighbor.
+    const ctx = await retrieve(db(), seed.teamId, "team", "what is causing the high latency?");
+    expect(ctx.grounded).toBe(false);
+    // Recency padding still returns background items — exactly what grounded=false guards against.
+    expect(ctx.sources.length).toBeGreaterThan(0);
+  });
+
   it("does not leak team chunks to an external-tier caller", async () => {
     const seed = await seedTeam();
     await ingest(seed, {

--- a/test/datamechanics/retrieval-alert.datamechanics.test.ts
+++ b/test/datamechanics/retrieval-alert.datamechanics.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { lastDenseRunFailed } from "@/lib/query/retrieval-alert";
+import { recordIngestRun } from "@/lib/ingest/runs";
+import { db } from "./helpers";
+
+// Spec: lastDenseRunFailed reflects the MOST RECENT dense run's outcome — the edge-detection that
+// makes the degraded-email debounced (fire once on ok→degraded, not every tick). Verified on real
+// Postgres via the real recordIngestRun writer.
+
+const t = (iso: string) => Date.parse(iso);
+
+describe("lastDenseRunFailed (dense-leg edge detection)", () => {
+  it("false when there are no dense runs", async () => {
+    expect(await lastDenseRunFailed(db())).toBe(false);
+  });
+
+  it("tracks the newest dense run's ok flag as it flips", async () => {
+    await recordIngestRun(db(), { source: "dense", trigger: "scheduler", ok: true, startedAt: t("2026-07-09T10:00:00Z"), finishedAt: t("2026-07-09T10:00:01Z") });
+    expect(await lastDenseRunFailed(db())).toBe(false);
+
+    await recordIngestRun(db(), { source: "dense", trigger: "scheduler", ok: false, errors: ["quota"], startedAt: t("2026-07-09T10:30:00Z"), finishedAt: t("2026-07-09T10:30:01Z") });
+    expect(await lastDenseRunFailed(db())).toBe(true); // degraded now
+
+    await recordIngestRun(db(), { source: "dense", trigger: "scheduler", ok: true, startedAt: t("2026-07-09T11:00:00Z"), finishedAt: t("2026-07-09T11:00:01Z") });
+    expect(await lastDenseRunFailed(db())).toBe(false); // recovered
+  });
+
+  it("ignores other sources — a failed Slack run doesn't read as a dense failure", async () => {
+    await recordIngestRun(db(), { source: "dense", trigger: "scheduler", ok: true, startedAt: t("2026-07-09T10:00:00Z"), finishedAt: t("2026-07-09T10:00:01Z") });
+    await recordIngestRun(db(), { source: "slack", trigger: "scheduler", ok: false, errors: ["boom"], startedAt: t("2026-07-09T12:00:00Z"), finishedAt: t("2026-07-09T12:00:01Z") });
+    expect(await lastDenseRunFailed(db())).toBe(false); // the dense leg is still healthy
+  });
+});


### PR DESCRIPTION
Item #1 of the retrieval re-review — **promoted from Phase 2 to "do now" because it's an active correctness bug in prod.**

## Bug
Grounding (the abstain-or-answer safety) keys on IDF term-specificity for the keyword path (#186). But `retrieve()` also did `if (denseHits.length) grounded = true`, and `denseSearch` had **no minimum-similarity floor**. Vector nearest-neighbor *always* returns its N closest chunks no matter how far away — so for a topic never ingested, dense still returned "matches" and flipped `grounded=true`, silently overriding the IDF grounding. With dense **live in prod** (`EMBEDDINGS_URL` set, embeddings generating), the confabulation-abstain valve was being bypassed on real queries.

## Fix
Put the relevance floor in the retrieval primitive where it belongs: `denseSearch` now filters to hits within `DENSE_MAX_DISTANCE` (cosine distance, default `0.6` ≈ similarity 0.4, tunable per embedding model). A returned dense hit is therefore a **real** semantic match, which makes `retrieve()`'s grounding line correct automatically — no far neighbors to ground on. `DenseHit` exposes `dist` for observability/tuning.

Genuine paraphrase matches (dist≈0) are untouched, so dense keeps its semantic-recall value; only the far tail is dropped.

## Verified end-to-end (real pgvector + stub embeddings)
- Existing semantic-match case still grounds (dist≈0 < floor) — **no recall regression**
- **New** case: an absent-topic query whose nearest chunk is orthogonal (dist≈1) no longer grounds → `grounded=false` → the answer layer abstains (was the bug)

## Test plan
- [x] `test:datamechanics:vector` 3/3 (incl. the new floor/grounding proof)
- [x] Full unit tier green (454 + 1 expected-fail); standard data-mechanics green (318 + 1)
- [x] `tsc`, `eslint`, docs-drift clean

Next: item #2 (raise the FTS candidate cap + measure against the adversarial suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable email alerts for semantic search indexing failures and recovery.
  * Alerts are sent to active administrators when retrieval health changes.

* **Bug Fixes**
  * Dense search now excludes results beyond a configurable similarity-distance threshold.
  * Improved grounding behavior for irrelevant dense-search matches.

* **Tests**
  * Added coverage for dense-search abstention and retrieval health status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->