### PR TITLE
feat(nav): lean primary nav; move Data under Admin

### DIFF
--- a/app/t/[team]/admin/data/page.tsx
+++ b/app/t/[team]/admin/data/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { DataBrowser } from "@/components/library/data-browser";
+
+export const metadata: Metadata = { title: "Data" };
+
+/**
+ * Admin → Data: the ingested-data channel browser. Moved here from the primary nav (2026-07-10) —
+ * it's a verification/debug view, so it's now admin-gated by the Admin layout. The heavy lifting
+ * lives in the shared `DataBrowser` server component; item detail stays at `/t/[team]/library/[id]`.
+ */
+export default async function AdminDataPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ team: string }>;
+  searchParams: Promise<{ channel?: string; limit?: string }>;
+}) {
+  const { team: teamSlug } = await params;
+  const { channel, limit } = await searchParams;
+  return (
+    <DataBrowser
+      teamSlug={teamSlug}
+      basePath={`/t/${teamSlug}/admin/data`}
+      channelParam={channel}
+      limitParam={limit}
+    />
+  );
+}

--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -70,27 +70,17 @@ export default async function TeamLayout({
     settingsChildren.push({ icon: "admin", label: "Admin", href: `${base}/admin` });
   }
 
-  // Grouped IA: ~6 primary entries. "Work" gathers the operational surfaces; Skills folds
-  // into Data (reached at /library/skills, not a top-level peer).
+  // Lean primary IA (2026-07-10, product call). Removed from the left nav — routes still resolve by
+  // direct URL, only the nav entry was cut: "Tasks" (/tasks), "Maturity" (/maturity), "Decisions"
+  // (/decisions, empty + unused). "Data" moved under Admin → Data (verification/debug view, now
+  // admin-gated). The "Work" group is dropped (nothing left in it; Projects stays commented out).
   const items: NavEntry[] = [
     { icon: "home", label: "Home", href: base, exact: true },
-    {
-      label: "Work",
-      children: [
-        { icon: "tasks", label: "Tasks", href: `${base}/tasks` },
-        // Projects hidden for now — the tab currently surfaces ingestion namespaces (slack, commits,
-        // github-*, …) rather than human work-projects. Unhide once it shows real projects.
-        // { icon: "projects", label: "Projects", href: `${base}/projects` },
-        { icon: "decisions", label: "Decisions", href: `${base}/decisions` },
-      ],
-    },
-    { icon: "library", label: "Data", href: `${base}/library` },
     { icon: "codebases", label: "Codebases", href: `${base}/codebases` },
-    { icon: "maturity", label: "Maturity", href: `${base}/maturity` },
+    { icon: "learning", label: "Learning", href: `${base}/learning` },
+    { icon: "query", label: "Query", href: `${base}/query` },
+    { label: "Settings", children: settingsChildren },
   ];
-  items.push({ icon: "learning", label: "Learning", href: `${base}/learning` });
-  items.push({ icon: "query", label: "Query", href: `${base}/query` });
-  items.push({ label: "Settings", children: settingsChildren });
 
   return (
     <div className="flex min-h-dvh flex-1 bg-surface-raised">

--- a/app/t/[team]/library/page.tsx
+++ b/app/t/[team]/library/page.tsx
@@ -1,173 +1,22 @@
-import type { Metadata } from "next";
-import Link from "next/link";
-import { Database } from "lucide-react";
-import { serverClient } from "@/lib/db/server";
-import { currentMember } from "@/lib/auth/guard";
-import { visibleItems } from "@/lib/auth/visibility";
-import { KindBadge } from "@/components/kind-badge";
-import { TierBadge } from "@/components/tier-badge";
-import { EmptyState } from "@/components/empty-state";
-import { timeAgo } from "@/components/format";
-import { ChannelRail } from "@/components/library/channel-rail";
-import { groupChannels, freshnessNow, previewLine, type ChannelRow } from "@/lib/library/channels";
+import { redirect } from "next/navigation";
 
-export const metadata: Metadata = { title: "Data" };
-
-// Occasional-use verification view: scan a bounded recent window for the channel list, and a single
-// channel's feed on demand. Both are generous for dogfooding; counts beyond the cap show as "N+".
-const CHANNEL_SCAN_CAP = 6000;
-const PAGE_SIZE = 50;
-const MAX_FEED = 500;
-
-type FeedItem = {
-  id: string;
-  path: string;
-  kind: string;
-  access: string;
-  actor: string;
-  synced_at: string;
-  body: string | null;
-};
-
-export default async function DataPage({
+/**
+ * The Data channel browser moved to Admin → Data (2026-07-10). This index route now redirects there,
+ * preserving any `?channel=`/`?limit=` deep link. Item detail (`/library/[id]`) and skills
+ * (`/library/skills`) stay put — they're linked from arc evidence, query citations, etc.
+ */
+export default async function LibraryIndexRedirect({
   params,
   searchParams,
 }: {
   params: Promise<{ team: string }>;
   searchParams: Promise<{ channel?: string; limit?: string }>;
 }) {
-  const { team: teamSlug } = await params;
-  const { channel: channelParam, limit: limitParam } = await searchParams;
-  const db = await serverClient();
-
-  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
-  if (!team) return null;
-
-  const me = await currentMember(team.id);
-  const tier = me?.tier ?? "external";
-
-  // 1) Channel list — group a bounded recent window of visible items by path prefix.
-  let chQuery = db
-    .from("items")
-    .select("path, synced_at")
-    .eq("team_id", team.id)
-    .order("synced_at", { ascending: false })
-    .limit(CHANNEL_SCAN_CAP);
-  chQuery = visibleItems(chQuery, tier); // external viewers never see team/admin content
-  const { data: chRows } = await chQuery;
-  const channels = groupChannels((chRows ?? []) as ChannelRow[]);
-
-  const selected =
-    channelParam && channels.some((c) => c.key === channelParam) ? channelParam : channels[0]?.key ?? null;
-  const limit = Math.min(MAX_FEED, Math.max(PAGE_SIZE, Number(limitParam) || PAGE_SIZE));
-
-  // 2) Selected channel feed — newest first, one extra row to detect "load more".
-  let items: FeedItem[] = [];
-  let hasMore = false;
-  if (selected) {
-    let feedQuery = db
-      .from("items")
-      .select("id, path, kind, access, actor, synced_at, body")
-      .eq("team_id", team.id)
-      .like("path", `${selected}/%`)
-      .order("synced_at", { ascending: false })
-      .limit(limit + 1);
-    feedQuery = visibleItems(feedQuery, tier);
-    const { data: feed } = await feedQuery;
-    // Exact prefix guard: LIKE treats `_` as a wildcard, so confirm the path segment boundary in JS.
-    const rows = ((feed ?? []) as FeedItem[]).filter((it) => it.path.startsWith(`${selected}/`));
-    hasMore = rows.length > limit;
-    items = rows.slice(0, limit);
-  }
-
-  const railChannels = channels.map((c) => ({
-    key: c.key,
-    source: c.source,
-    name: c.name,
-    count: c.count,
-    ago: timeAgo(c.lastSyncedAt),
-    fresh: freshnessNow(c.lastSyncedAt),
-  }));
-  const selectedChannel = channels.find((c) => c.key === selected) ?? null;
-  const totalItems = channels.reduce((sum, c) => sum + c.count, 0);
-  const cappedNote = (chRows ?? []).length >= CHANNEL_SCAN_CAP ? "+" : "";
-
-  return (
-    <div className="mx-auto flex max-w-6xl flex-col gap-5">
-      <div className="flex flex-wrap items-baseline justify-between gap-2">
-        <h1 className="text-2xl font-semibold text-ink">Data</h1>
-        <p className="text-xs text-ink-tertiary">
-          {channels.length} channel{channels.length === 1 ? "" : "s"} · {totalItems}
-          {cappedNote} items
-        </p>
-      </div>
-
-      {channels.length === 0 ? (
-        <EmptyState
-          icon={Database}
-          title="No data yet"
-          action="Connect a source in Admin → Integrations (Slack, Linear, GitHub, Plane) or run aios push from a repo. Ingested data shows up here, grouped by channel."
-        />
-      ) : (
-        <div className="grid grid-cols-1 gap-5 md:grid-cols-[220px_1fr]">
-          <aside className="md:sticky md:top-4 md:self-start">
-            <ChannelRail teamSlug={teamSlug} channels={railChannels} selectedKey={selected} />
-          </aside>
-
-          <section className="flex min-w-0 flex-col gap-3">
-            {selectedChannel && (
-              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 border-b border-border-subtle pb-2">
-                <h2 className="font-mono text-sm font-medium text-ink">{selectedChannel.key}</h2>
-                <span className="text-xs text-ink-tertiary">
-                  {selectedChannel.count}
-                  {cappedNote} items · last received {timeAgo(selectedChannel.lastSyncedAt)}
-                </span>
-              </div>
-            )}
-
-            {items.length === 0 ? (
-              <p className="px-1 py-6 text-sm text-ink-tertiary">No items in this channel.</p>
-            ) : (
-              <ol className="flex flex-col divide-y divide-border-subtle">
-                {items.map((it) => {
-                  const file = it.path.split("/").slice(2).join("/") || it.path;
-                  const preview = previewLine(it.body);
-                  return (
-                    <li key={it.id}>
-                      <Link
-                        href={`/t/${teamSlug}/library/${it.id}`}
-                        className="flex items-start gap-3 px-1 py-2.5 transition-colors hover:bg-surface-raised"
-                      >
-                        <span className="mt-0.5 flex shrink-0 items-center gap-1.5">
-                          <KindBadge kind={it.kind} />
-                          <TierBadge tier={it.access} />
-                        </span>
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate text-sm text-ink">{preview || file}</span>
-                          <span className="block truncate font-mono text-[11px] text-ink-tertiary">
-                            {file}
-                            {it.actor ? ` · @${it.actor}` : ""}
-                          </span>
-                        </span>
-                        <span className="mt-0.5 shrink-0 text-[11px] text-ink-tertiary">{timeAgo(it.synced_at)}</span>
-                      </Link>
-                    </li>
-                  );
-                })}
-              </ol>
-            )}
-
-            {hasMore && selected && (
-              <Link
-                href={`/t/${teamSlug}/library?channel=${encodeURIComponent(selected)}&limit=${limit + PAGE_SIZE}`}
-                className="self-center rounded-lg border border-border-default px-4 py-1.5 text-xs font-medium text-ink-secondary transition-colors hover:border-violet/30"
-              >
-                Load more
-              </Link>
-            )}
-          </section>
-        </div>
-      )}
-    </div>
-  );
+  const { team } = await params;
+  const { channel, limit } = await searchParams;
+  const qs = new URLSearchParams();
+  if (channel) qs.set("channel", channel);
+  if (limit) qs.set("limit", limit);
+  const query = qs.toString();
+  redirect(`/t/${team}/admin/data${query ? `?${query}` : ""}`);
 }

--- a/components/admin/admin-tabs.tsx
+++ b/components/admin/admin-tabs.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 
 const TABS = [
   { slug: "members", label: "Members" },
+  { slug: "data", label: "Data" },
   { slug: "usage", label: "Usage" },
   { slug: "keys", label: "API keys" },
   { slug: "integrations", label: "Integrations" },

--- a/components/library/channel-rail.tsx
+++ b/components/library/channel-rail.tsx
@@ -33,11 +33,13 @@ const DOT_TITLE: Record<Freshness, string> = {
  * hydration drift — this component only filters.
  */
 export function ChannelRail({
-  teamSlug,
+  basePath,
   channels,
   selectedKey,
 }: {
-  teamSlug: string;
+  /** Route the channel links resolve against (e.g. `/t/acme/admin/data`). Selecting a channel
+   *  appends `?channel=`, so the server re-renders the feed on that page. */
+  basePath: string;
   channels: RailChannel[];
   selectedKey: string | null;
 }) {
@@ -87,7 +89,7 @@ export function ChannelRail({
                 return (
                   <Link
                     key={c.key}
-                    href={`/t/${teamSlug}/library?channel=${encodeURIComponent(c.key)}`}
+                    href={`${basePath}?channel=${encodeURIComponent(c.key)}`}
                     aria-current={active ? "true" : undefined}
                     className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs transition-colors ${
                       active ? "bg-violet/10 text-violet" : "text-ink-secondary hover:bg-surface-raised"

--- a/components/library/data-browser.tsx
+++ b/components/library/data-browser.tsx
@@ -1,0 +1,179 @@
+import Link from "next/link";
+import { Database } from "lucide-react";
+import { serverClient } from "@/lib/db/server";
+import { currentMember } from "@/lib/auth/guard";
+import { visibleItems } from "@/lib/auth/visibility";
+import { KindBadge } from "@/components/kind-badge";
+import { TierBadge } from "@/components/tier-badge";
+import { EmptyState } from "@/components/empty-state";
+import { timeAgo } from "@/components/format";
+import { ChannelRail } from "@/components/library/channel-rail";
+import { groupChannels, freshnessNow, previewLine, type ChannelRow } from "@/lib/library/channels";
+
+// Occasional-use verification view: scan a bounded recent window for the channel list, and a single
+// channel's feed on demand. Both are generous for dogfooding; counts beyond the cap show as "N+".
+const CHANNEL_SCAN_CAP = 6000;
+const PAGE_SIZE = 50;
+const MAX_FEED = 500;
+
+type FeedItem = {
+  id: string;
+  path: string;
+  kind: string;
+  access: string;
+  actor: string;
+  synced_at: string;
+  body: string | null;
+};
+
+/**
+ * The ingested-data channel browser (formerly the `/library` "Data" page). Rendered under
+ * Admin → Data (`/t/[team]/admin/data`); `basePath` is where the channel rail + "load more" links
+ * resolve, so the same component can be mounted at a different route without hardcoding one. Item
+ * detail links still point at `/t/[team]/library/[id]` (that route stays). Tier-filtered via
+ * `visibleItems` (belt-and-suspenders — the Admin layout already gates to admin role).
+ */
+export async function DataBrowser({
+  teamSlug,
+  basePath,
+  channelParam,
+  limitParam,
+}: {
+  teamSlug: string;
+  basePath: string;
+  channelParam?: string;
+  limitParam?: string;
+}) {
+  const db = await serverClient();
+
+  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  if (!team) return null;
+
+  const me = await currentMember(team.id);
+  const tier = me?.tier ?? "external";
+
+  // 1) Channel list — group a bounded recent window of visible items by path prefix.
+  let chQuery = db
+    .from("items")
+    .select("path, synced_at")
+    .eq("team_id", team.id)
+    .order("synced_at", { ascending: false })
+    .limit(CHANNEL_SCAN_CAP);
+  chQuery = visibleItems(chQuery, tier); // external viewers never see team/admin content
+  const { data: chRows } = await chQuery;
+  const channels = groupChannels((chRows ?? []) as ChannelRow[]);
+
+  const selected =
+    channelParam && channels.some((c) => c.key === channelParam) ? channelParam : channels[0]?.key ?? null;
+  const limit = Math.min(MAX_FEED, Math.max(PAGE_SIZE, Number(limitParam) || PAGE_SIZE));
+
+  // 2) Selected channel feed — newest first, one extra row to detect "load more".
+  let items: FeedItem[] = [];
+  let hasMore = false;
+  if (selected) {
+    let feedQuery = db
+      .from("items")
+      .select("id, path, kind, access, actor, synced_at, body")
+      .eq("team_id", team.id)
+      .like("path", `${selected}/%`)
+      .order("synced_at", { ascending: false })
+      .limit(limit + 1);
+    feedQuery = visibleItems(feedQuery, tier);
+    const { data: feed } = await feedQuery;
+    // Exact prefix guard: LIKE treats `_` as a wildcard, so confirm the path segment boundary in JS.
+    const rows = ((feed ?? []) as FeedItem[]).filter((it) => it.path.startsWith(`${selected}/`));
+    hasMore = rows.length > limit;
+    items = rows.slice(0, limit);
+  }
+
+  const railChannels = channels.map((c) => ({
+    key: c.key,
+    source: c.source,
+    name: c.name,
+    count: c.count,
+    ago: timeAgo(c.lastSyncedAt),
+    fresh: freshnessNow(c.lastSyncedAt),
+  }));
+  const selectedChannel = channels.find((c) => c.key === selected) ?? null;
+  const totalItems = channels.reduce((sum, c) => sum + c.count, 0);
+  const cappedNote = (chRows ?? []).length >= CHANNEL_SCAN_CAP ? "+" : "";
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-lg font-semibold text-ink">Data</h2>
+        <p className="text-xs text-ink-tertiary">
+          {channels.length} channel{channels.length === 1 ? "" : "s"} · {totalItems}
+          {cappedNote} items
+        </p>
+      </div>
+
+      {channels.length === 0 ? (
+        <EmptyState
+          icon={Database}
+          title="No data yet"
+          action="Connect a source in Admin → Integrations (Slack, Linear, GitHub, Plane) or run aios push from a repo. Ingested data shows up here, grouped by channel."
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-[220px_1fr]">
+          <aside className="md:sticky md:top-4 md:self-start">
+            <ChannelRail basePath={basePath} channels={railChannels} selectedKey={selected} />
+          </aside>
+
+          <section className="flex min-w-0 flex-col gap-3">
+            {selectedChannel && (
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 border-b border-border-subtle pb-2">
+                <h3 className="font-mono text-sm font-medium text-ink">{selectedChannel.key}</h3>
+                <span className="text-xs text-ink-tertiary">
+                  {selectedChannel.count}
+                  {cappedNote} items · last received {timeAgo(selectedChannel.lastSyncedAt)}
+                </span>
+              </div>
+            )}
+
+            {items.length === 0 ? (
+              <p className="px-1 py-6 text-sm text-ink-tertiary">No items in this channel.</p>
+            ) : (
+              <ol className="flex flex-col divide-y divide-border-subtle">
+                {items.map((it) => {
+                  const file = it.path.split("/").slice(2).join("/") || it.path;
+                  const preview = previewLine(it.body);
+                  return (
+                    <li key={it.id}>
+                      <Link
+                        href={`/t/${teamSlug}/library/${it.id}`}
+                        className="flex items-start gap-3 px-1 py-2.5 transition-colors hover:bg-surface-raised"
+                      >
+                        <span className="mt-0.5 flex shrink-0 items-center gap-1.5">
+                          <KindBadge kind={it.kind} />
+                          <TierBadge tier={it.access} />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm text-ink">{preview || file}</span>
+                          <span className="block truncate font-mono text-[11px] text-ink-tertiary">
+                            {file}
+                            {it.actor ? ` · @${it.actor}` : ""}
+                          </span>
+                        </span>
+                        <span className="mt-0.5 shrink-0 text-[11px] text-ink-tertiary">{timeAgo(it.synced_at)}</span>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ol>
+            )}
+
+            {hasMore && selected && (
+              <Link
+                href={`${basePath}?channel=${encodeURIComponent(selected)}&limit=${limit + PAGE_SIZE}`}
+                className="self-center rounded-lg border border-border-default px-4 py-1.5 text-xs font-medium text-ink-secondary transition-colors hover:border-violet/30"
+              >
+                Load more
+              </Link>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,6 +8,58 @@ Format per item: **Status · Why deferred · When to revisit · How to do it**.
 
 ---
 
+## Active plan — navigation cleanup + Learning-page fixes (2026-07-10)
+
+Batch of product changes requested 2026-07-10. Sequenced as: (A) nav change → one commit/PR, then
+(B) two Learning-page fixes → one commit/PR. Items marked ✅ are done, ⏳ in progress, ⬜ not started.
+
+### A. Navigation cleanup (one PR)
+- ✅ **Remove "Tasks" from the left nav.** Route `/tasks` still resolves (direct URL); only the nav
+  entry was cut. `app/t/[team]/layout.tsx`.
+- ✅ **Remove "Maturity" from the left nav.** Route `/maturity` still resolves; nav entry cut.
+- ⏳ **Remove "Decisions" from the left nav + page.** Team confirmed it's empty and unused. Cut the
+  nav entry now. (Full backend teardown — table, ingest writer, `visibleDecisions` choke-point,
+  actions, tests — is a separate deferred item below; nav removal is the product-visible change.)
+- ⏳ **Move "Data" from the primary nav under Admin.** Data (`/library` index — the channel browser)
+  is a verification/debug view, not a daily surface. Move it to an **Admin → Data** tab
+  (`app/t/[team]/admin/data`), which makes it **admin-gated** (was all-tiers). `/library/[id]` item
+  detail and `/library/skills` stay put (linked from arc evidence, query citations — must not break);
+  `/library` index redirects to `/admin/data`. Parametrize `ChannelRail` base path.
+
+### B. Learning-page fixes (one PR)
+- ⬜ **Fix 1 — persist the arc cache + serve-stale-while-revalidate.** Today `getArcs` caches in
+  memory for 10 min, keyed by team+tier — lost on every deploy, not shared across instances, and the
+  first request after expiry blocks on the LLM. Add an `arc_cache` Postgres table
+  `(team_id, group_key, arcs jsonb, computed_at)`; `getArcs` reads it first (fresh → return; stale →
+  return stale immediately + fire-and-forget recompute with in-flight dedupe; cold → compute inline).
+  `recomputeArcs` writes back. **Chose SWR over a global timer-driven refresh** — a scheduler would
+  fire LLM calls for every team on a timer even when nobody's looking (cost multiplier + needs each
+  team's provider keys in the background); SWR only recomputes teams actually being viewed and still
+  gives warm reads. New table → `schema.sql` only (no migration; `create table if not exists`) + the
+  `<!-- drift:tables -->` block in `docs/ARCHITECTURE.md`.
+- ⬜ **Fix 2 — attribute *every* fact with its human, not just AI-agent-subject facts.** Today
+  `attributedFactTexts` prefixes a fact only when its `subject` is a recognized AI-agent name — so
+  arcs like "Context-Management System Enhancements" / "Deterministic Checklist Evaluator" (whose
+  facts have technical/component subjects) reach synthesis with no human, and render with no person's
+  name. The human IS resolvable (`items.member_id`) — surface it universally: prefix every fact that
+  has a resolvable human with `(Name)`, keeping the `(Name, via Agent)` form when the subject is an
+  agent. Mild redundancy when the subject already IS that human is an acceptable cost vs. unattributed
+  arcs. Pure change in `lib/graph/arc-attribution.ts` + tests.
+
+### Deferred out of this batch (not blocking A/B)
+- ⬜ **Full Decisions backend teardown.** Nav removal (above) hides it; full removal deletes the
+  `decisions` table, `lib/ingest` decision-row writer, `app/actions/decisions.ts`, `visibleDecisions`
+  choke-point, `components/decisions-table` + `decisions/*`, the `/decisions` route, the drift-guard
+  table block, and the decisions tests. Larger surgical change with schema/drift implications — do it
+  as its own PR once the nav removal has settled and nobody reports missing it.
+- ⬜ **Delete (vs. hide) the Tasks & Maturity routes.** Currently only unlinked from nav; routes still
+  resolve. Decide whether to delete the pages/loaders outright. Kept for now in case they're wanted
+  back.
+- ⬜ **Flatten the "Work" nav group.** After removing Tasks + Decisions, "Work" contains nothing (or
+  only future items). Either drop the group wrapper or repopulate it.
+
+---
+
 ## Cross-encoder reranker for retrieval (`RERANK_URL`)
 
 **Status:** Deferred (2026-07-02). Dense retrieval is live without it.


### PR DESCRIPTION
## Summary
Product call (2026-07-10) to declutter the left nav.

- **Removed from the left nav:** Tasks, Maturity, Decisions. Routes still resolve by direct URL — only the nav entry was cut. Decisions is empty + unused (full backend teardown tracked in `docs/TODO.md`, not done here).
- **Data moved under Admin → Data.** The ingested-data channel browser is a verification/debug view, not a daily surface, so it's now **admin-gated** (was all-tiers). Browser logic extracted into a shared `DataBrowser` server component. `/library` index → redirects to `/admin/data` (preserving `?channel`/`?limit`); `/library/[id]` detail and `/library/skills` stay put (linked from arc evidence, query citations).
- **"Work" nav group dropped** (empty after Tasks + Decisions removed).
- Records the full nav + Learning-page plan in `docs/TODO.md`.

Primary nav is now: Home / Codebases / Learning / Query / Settings.

## Test plan
- [x] `tsc`, `eslint`, docs-drift guard, full unit suite (509 passed) — all green
- [x] Browser-verified against a seeded local DB: nav shows only the 5 entries; Admin → Data loads with the Data tab active; `/library` 200-redirects to `/admin/data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)