### PR TITLE
feat(context): raise FTS candidate cap so broad queries keep their evidence (Gap #2 recall facet)

### DIFF
--- a/docs/design/context-retrieval-limits.md
+++ b/docs/design/context-retrieval-limits.md
@@ -59,10 +59,19 @@ real test") the moment the gap is closed. So the count of `it.fails` in these fi
 
 ## Status
 
-Gaps **#1, #3, #4, #5, #6 are fixed** and #2's ranking facet is fixed — the multi-channel adversarial
-suite is green except one remaining `it.fails`: the **recall ceiling** (a query legitimately matching
-50+ items returns only ~28). That's the one gap keyword search can't close on its own; the durable fix
-is **dense/pgvector retrieval + a reranker + query-scoped caps** (the `EMBEDDINGS_URL` leg already
-exists but is off by default). Everything else — short-token recall, `ts_rank` ordering, IDF grounding,
-channel scoping, full-corpus task counts, decision keyword search — now holds as channels multiply. The
-tests make each fix *provable*: each closed gap's `it.fails` flipped to a green `it()`.
+**All six gaps are addressed** — the multi-channel adversarial data-mechanics suite is fully green
+(every `it.fails` flipped to a green `it()`):
+
+- #1 short-token recall, #2 `ts_rank` ordering, #3 IDF grounding, #4 channel scoping, #5 full-corpus
+  task counts, #6 decision keyword search — all fixed as above.
+- **#2 recall facet** — the FTS candidate cap was raised 20 → `FTS_CANDIDATE_LIMIT` (50). A realistic
+  broad query no longer loses half its evidence; `MAX_TOTAL_CHARS` is still the real output ceiling, so
+  large corpora truncate best-ranked-first rather than blowing the token budget.
+- **Dense grounding** — `denseSearch` now applies a distance floor (`DENSE_MAX_DISTANCE`), so far
+  nearest-neighbors don't false-ground (they were silently overriding the IDF signal once dense went live).
+
+**What remains (intentionally, for the large-collective-data future, not this scale):** the recall
+ceiling BEYOND the candidate cap (a query matching *hundreds* of items) and true relevance beyond
+lexical rank — both the job of **dense/pgvector + a reranker**, whose leg exists (`EMBEDDINGS_URL`,
+`RERANK_URL`) and is now grounded safely. Also open: conjunctive intent ("auth AND payments" as a
+precision narrow), tracked by a unit `it.fails` in `test/query-adversarial`.

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -21,6 +21,12 @@ export type { Source, RetrievedContext };
 
 const MAX_SOURCE_CHARS = 8_000;
 const MAX_TOTAL_CHARS = 160_000; // ~40k tokens context cap
+// How many ranked keyword candidates to pull before the char budget truncates. Was 20 — too small
+// once many channels make a broad query legitimately match dozens of items; the top-20 then dropped
+// relevant evidence. `MAX_TOTAL_CHARS` is the real output ceiling (it truncates large corpora), so a
+// larger candidate pool just lets more of a many-small-item corpus through, best-ranked first. Tune
+// via FTS_CANDIDATE_LIMIT. (The recall CEILING beyond this is the dense/rerank job, not keyword FTS.)
+const FTS_CANDIDATE_LIMIT = Number(process.env.FTS_CANDIDATE_LIMIT ?? 50);
 const GIT_WINDOW_DAYS = 90; // recency window for the per-contributor git-activity digest
 const PEOPLE_WINDOW_DAYS = 90; // recency window for the per-person cross-tool activity digest
 
@@ -405,7 +411,7 @@ async function nativeRetrieve(
   //    (fts-search) because the builder emits an unordered `@@` filter.
   const terms = significantTerms(q);
   const orQuery = terms.length ? terms.join(" or ") : q;
-  const ftsP = rankedFtsSearch(teamId, tier, orQuery, 20, channel);
+  const ftsP = rankedFtsSearch(teamId, tier, orQuery, FTS_CANDIDATE_LIMIT, channel);
   // Grounding specificity (Gap #3) — runs concurrently; combined with hadFtsHit below.
   const specificityP = analyzeTermSpecificity(teamId, tier, terms);
   // Structured-context scaling (Gaps #5/#6): a FULL-corpus task count (aggregates survive the 80-row

--- a/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
+++ b/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
@@ -114,12 +114,12 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
     expect(await paths("scheduled security review")).toContain("slack/incidents/target.md");
   });
 
-  it.fails("GAP: a broad-but-legitimate query matches more items than the caps allow, unranked", async () => {
-    // Across 6 channels, 50 genuinely on-topic items about the payments migration. The unique-source
-    // ceiling is ~28 (FTS 20 + recency 8), so retrieval returns a bounded, UNRANKED subset — and with
-    // no ts_rank there's no guarantee it's the most relevant ~28. "Summarize the payments migration"
-    // then silently sees roughly half the real evidence. Desired: full recall for a topic this focused
-    // (or at least a *ranked* best-N, so what's dropped is provably the least relevant).
+  it("STRENGTH: a broad query gets full recall up to the raised candidate cap (Gap #2 recall facet)", async () => {
+    // Across 6 channels, 50 genuinely on-topic items about the payments migration. The FTS candidate
+    // cap was 20 (+8 recency) → ~half were silently dropped. Raised to FTS_CANDIDATE_LIMIT (50), all
+    // 50 now come through (they're small, so the char budget doesn't bind), best-ranked first. The
+    // ceiling still exists far higher — a corpus with hundreds of matches needs dense/rerank — but a
+    // realistic multi-channel broad query no longer loses half its evidence.
     const posted: string[] = [];
     for (let i = 0; i < 50; i++) {
       await post(`slack/ch${i % 6}`, `payments-${i}`, `Payments migration note ${i}: Stripe webhook cutover step ${i} discussed.`);


### PR DESCRIPTION
Item #2 of the retrieval re-review — the cheap recall win.

## Gap
The keyword FTS candidate limit was **20** (+8 recency). Once many channels make a broad query legitimately match dozens of items, the top-20 silently dropped ~half the relevant evidence — "summarize the payments migration" saw a fraction of the corpus.

## Fix
Raise it to `FTS_CANDIDATE_LIMIT` (default **50**, env-tunable). `MAX_TOTAL_CHARS` (~40k tokens) is still the real output ceiling, so this can't blow the token budget — a larger pool just lets more of a many-small-item corpus through, **best-ranked (ts_rank) first**; large items still truncate at the char budget. Recall can only go up.

## Result
- Closes the **last remaining `it.fails`** in the multi-channel adversarial suite: 50 on-topic items across 6 channels are now all retrieved (was ~28).
- `retrieval-eval` recall benchmark unchanged (raising the cap can't lower recall).

The **true** ceiling (a query matching *hundreds* of items, or relevance beyond lexical rank) stays the dense/rerank job — documented as large-collective-data future work.

## Test plan
- [x] Full unit tier green (509 + 1 unrelated expected-fail = the conjunctive-intent gap)
- [x] Full data-mechanics green (343, **zero expected-fail** — adversarial suite fully green)
- [x] `tsc`, `eslint`, docs-drift clean

Next: item #3 (reranker readiness + Graphiti fix-or-retire decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)