### PR TITLE
fix(graph): treat a malformed GRAPHITI_URL as off (no doomed calls) — review item #3

### DIFF
--- a/lib/graph/graphiti-client.test.ts
+++ b/lib/graph/graphiti-client.test.ts
@@ -21,6 +21,15 @@ describe("GraphitiClient", () => {
     await expect(c.search("q", ["g"])).rejects.toThrow(/not set/);
   });
 
+  it("is NOT configured for a malformed URL — no doomed calls (prod had 'http://')", async () => {
+    // The old `base.length > 0` treated "http://" as configured → every query fired a doomed call.
+    for (const bad of ["http://", "https://", "not a url", "://x"]) {
+      expect(new GraphitiClient({ baseUrl: bad }).configured, bad).toBe(false);
+    }
+    expect(new GraphitiClient({ baseUrl: "http://gx:8000" }).configured).toBe(true);
+    expect(new GraphitiClient({ baseUrl: "http://gx:8000/" }).configured).toBe(true); // trailing slash ok
+  });
+
   it("addEpisodes POSTs mapped episodes to /messages", async () => {
     const calls: Call[] = [];
     const c = new GraphitiClient({ baseUrl: "http://gx:8000", fetchImpl: stubFetch(calls) });

--- a/lib/graph/graphiti-client.ts
+++ b/lib/graph/graphiti-client.ts
@@ -13,6 +13,23 @@ import "server-only";
  * `fetchImpl`/`baseUrl` are injectable so the client is unit-testable without a live Graphiti.
  */
 
+/**
+ * Is `url` a USABLE Graphiti endpoint? A valid http(s) URL with a host. This is stricter than
+ * "non-empty" on purpose: prod once carried a malformed `GRAPHITI_URL = "http://"`, which the old
+ * `base.length > 0` check treated as configured → every query + scheduler tick fired a doomed HTTP
+ * call and swallowed the error. Shared with the Admin retrieval-health card so the runtime and the
+ * dashboard agree on whether the graph leg is on. Pure — unit-tested.
+ */
+export function graphitiConfigured(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const u = new URL(url);
+    return (u.protocol === "http:" || u.protocol === "https:") && u.hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 export interface GraphEpisode {
   /** The episode text Graphiti extracts entities/relationships from. */
   content: string;
@@ -61,7 +78,7 @@ export class GraphitiClient {
   }
 
   get configured(): boolean {
-    return this.base.length > 0;
+    return graphitiConfigured(this.base);
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
+import { graphitiConfigured } from "@/lib/graph/graphiti-client";
 
 /**
  * Retrieval-stack health for the admin dashboard (Phase 1 of the retrieval-observability plan).
@@ -37,16 +38,12 @@ export interface RetrievalHealth {
 const COVERAGE_FLOOR = 0.9; // ≥90% embedded = healthy
 const STALE_MS = 2 * 60 * 60 * 1000; // no embed activity in 2h + incomplete = stalled, not "building"
 
-/** True when GRAPHITI_URL is a usable http(s) URL with a host (prod had a malformed "http://"). */
-export function graphConfigured(url: string | undefined): boolean {
-  if (!url) return false;
-  try {
-    const u = new URL(url);
-    return (u.protocol === "http:" || u.protocol === "https:") && u.hostname.length > 0;
-  } catch {
-    return false;
-  }
-}
+/**
+ * True when GRAPHITI_URL is a usable http(s) URL with a host (prod had a malformed "http://").
+ * Single source of truth with the runtime GraphitiClient, so the health card and the code that
+ * actually calls Graphiti agree on whether the leg is on.
+ */
+export const graphConfigured = graphitiConfigured;
 
 /**
  * Derive the dense-leg state from the raw signals. Pure + unit-tested — the fiddly bit is separating


### PR DESCRIPTION
Item #3 of the retrieval re-review — the actionable, non-destructive slice.

## Gap
`GraphitiClient.configured` was `base.length > 0`, so the malformed prod value `GRAPHITI_URL = "http://"` read as **configured** → every query's `fetchGraphFacts` and every scheduler tick fired a doomed HTTP call to `"http://"` and swallowed the error. The Admin retrieval-health card (via a stricter check) already said **off**, so runtime and dashboard disagreed.

## Fix
One shared validator `graphitiConfigured(url)` — a valid http(s) URL with a host — is now the source of truth for **both** `GraphitiClient.configured` and the health card's `graphConfigured`. A malformed/empty URL cleanly disables the leg: no per-query wasted calls, no error-log noise, runtime matches the card. A real URL is unaffected (trailing slash tolerated).

## Why this, and not more, for #3
Review item #3 was "reranker + Graphiti fix-or-retire + provider de-risk." Honestly scoped:
- **Graphiti** — this PR makes the OFF state *clean* without ripping out the subsystem; a real `GRAPHITI_URL` still turns graph memory on. That's the safe, non-destructive fix. Full retirement would be a large destructive change I won't make unilaterally.
- **Reranker** — code exists and is correct on review, but it's **off** (`RERANK_URL` unset), won't be used at your data scale, and needs an external rerank service. Turning it on is an infra decision, not code.
- **Provider de-risk** — you already deferred this to the self-hoster.

So #1 and #2 were real code fixes; #3's remaining pieces are **decisions/infra**, surfaced below, not silently skipped.

## Test plan
- [x] `GraphitiClient.configured` rejects `http://` / `https://` / `not a url` / `://x`, accepts a real URL (± trailing slash)
- [x] Existing `graphConfigured` tests pass via the shared validator
- [x] Full unit tier green (519 + 1 unrelated expected-fail); full data-mechanics green (347); tsc/lint/docs-drift clean

## Open decisions (yours, not code)
1. **Graphiti**: fix the prod `GRAPHITI_URL` to a real endpoint to revive graph memory, or leave it off. It's now cleanly off and shown as such on the health card.
2. **Reranker**: enable (`RERANK_URL` → a rerank service) when your candidate pools get large enough to need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)