### PR TITLE
feat(brand): brand assets library — reference URLs/logos/examples for generation

### DIFF
--- a/app/t/[team]/admin/brand/actions.ts
+++ b/app/t/[team]/admin/brand/actions.ts
@@ -4,7 +4,8 @@ import { revalidatePath } from "next/cache";
 import { adminClient } from "@/lib/db/admin";
 import { requireTeamAdmin as requireAdmin } from "@/lib/auth/guard";
 import { saveBrandProfile } from "@/lib/brand/manage";
-import type { BrandProfileInput } from "@/lib/brand/schema";
+import { addBrandAsset, removeBrandAsset } from "@/lib/brand/assets";
+import type { BrandProfileInput, BrandAssetInput } from "@/lib/brand/schema";
 
 /** Save the team's brand profile (admins only). Validation lives in the single-writer lib. */
 export async function saveBrand(
@@ -17,6 +18,35 @@ export async function saveBrand(
     await saveBrandProfile(adminClient(), ctx.teamId, input, { memberId: ctx.memberId });
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not save brand profile" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/brand`);
+  return { ok: true };
+}
+
+/** Add a brand asset (admins only). */
+export async function addAsset(
+  teamSlug: string,
+  input: BrandAssetInput
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    await addBrandAsset(adminClient(), ctx.teamId, input, { memberId: ctx.memberId });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not add asset" };
+  }
+  revalidatePath(`/t/${teamSlug}/admin/brand`);
+  return { ok: true };
+}
+
+/** Remove a brand asset (admins only). */
+export async function removeAsset(teamSlug: string, id: string): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    await removeBrandAsset(adminClient(), ctx.teamId, id, { memberId: ctx.memberId });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not remove asset" };
   }
   revalidatePath(`/t/${teamSlug}/admin/brand`);
   return { ok: true };

--- a/app/t/[team]/admin/brand/page.tsx
+++ b/app/t/[team]/admin/brand/page.tsx
@@ -1,6 +1,8 @@
 import { serverClient } from "@/lib/db/server";
 import { getBrandProfile } from "@/lib/brand/manage";
+import { listBrandAssets } from "@/lib/brand/assets";
 import { BrandManager } from "@/components/admin/brand-manager";
+import { BrandAssetsPanel } from "@/components/admin/brand-assets-panel";
 import type { BrandProfileInput } from "@/lib/brand/schema";
 
 export default async function BrandAdminPage({ params }: { params: Promise<{ team: string }> }) {
@@ -10,7 +12,7 @@ export default async function BrandAdminPage({ params }: { params: Promise<{ tea
   const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
-  const record = await getBrandProfile(db, team.id);
+  const [record, assets] = await Promise.all([getBrandProfile(db, team.id), listBrandAssets(db, team.id)]);
   const profile: BrandProfileInput | null = record
     ? { voice: record.voice, knowledge: record.knowledge, governance: record.governance }
     : null;
@@ -23,6 +25,7 @@ export default async function BrandAdminPage({ params }: { params: Promise<{ tea
         before it can be approved or published. Everything here is optional — fill in what matters.
       </p>
       <BrandManager teamSlug={teamSlug} profile={profile} />
+      <BrandAssetsPanel teamSlug={teamSlug} assets={assets} />
     </div>
   );
 }

--- a/components/admin/brand-assets-panel.tsx
+++ b/components/admin/brand-assets-panel.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Link2, Image as ImageIcon, BookOpen, Plus, X } from "lucide-react";
+import { addAsset, removeAsset } from "@/app/t/[team]/admin/brand/actions";
+import type { BrandAssetRow } from "@/lib/brand/assets";
+
+type Kind = "url" | "asset" | "reference";
+
+const KIND_META: Record<Kind, { label: string; icon: typeof Link2; hint: string }> = {
+  url: { label: "URL", icon: Link2, hint: "a website or link to reference" },
+  asset: { label: "Asset", icon: ImageIcon, hint: "a logo/image asset link" },
+  reference: { label: "Reference", icon: BookOpen, hint: "an example to emulate (URL optional)" },
+};
+
+export function BrandAssetsPanel({ teamSlug, assets }: { teamSlug: string; assets: BrandAssetRow[] }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [kind, setKind] = useState<Kind>("url");
+  const [label, setLabel] = useState("");
+  const [url, setUrl] = useState("");
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  function submit() {
+    setError(null);
+    startTransition(async () => {
+      const res = await addAsset(teamSlug, { kind, label: label.trim(), url: url.trim(), notes: notes.trim() });
+      if (!res.ok) return setError(res.error ?? "could not add asset");
+      setLabel("");
+      setUrl("");
+      setNotes("");
+      router.refresh();
+    });
+  }
+
+  function remove(id: string) {
+    setError(null);
+    startTransition(async () => {
+      const res = await removeAsset(teamSlug, id);
+      if (!res.ok) return setError(res.error ?? "could not remove asset");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="prism-card flex flex-col gap-3 p-4">
+      <div>
+        <p className="text-sm font-medium text-ink">Brand assets</p>
+        <p className="text-xs text-ink-tertiary">
+          Reference material the Social Brain layers into generation — your site, logos, and examples
+          to emulate.
+        </p>
+      </div>
+
+      {assets.length > 0 ? (
+        <ul className="flex flex-col divide-y divide-border-subtle/60">
+          {assets.map((a) => {
+            const Icon = KIND_META[a.kind].icon;
+            return (
+              <li key={a.id} className="flex items-center gap-3 py-2 text-sm">
+                <Icon className="size-4 shrink-0 text-violet" />
+                <span className="font-medium text-ink">{a.label}</span>
+                {a.url ? (
+                  <a href={a.url} target="_blank" rel="noreferrer" className="truncate text-xs text-violet hover:underline">
+                    {a.url}
+                  </a>
+                ) : null}
+                {a.notes ? <span className="truncate text-xs text-ink-tertiary">— {a.notes}</span> : null}
+                <button
+                  type="button"
+                  onClick={() => remove(a.id)}
+                  disabled={pending}
+                  className="ml-auto text-ink-tertiary hover:text-red"
+                  aria-label="Remove asset"
+                >
+                  <X className="size-4" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="text-xs text-ink-tertiary">No assets yet.</p>
+      )}
+
+      <form
+        onSubmit={(e) => { e.preventDefault(); submit(); }}
+        className="flex flex-col gap-2 border-t border-border-subtle pt-3 sm:flex-row sm:items-end"
+      >
+        <label className="flex flex-col gap-1 text-xs text-ink-tertiary">
+          Kind
+          <select className="prism-input" value={kind} onChange={(e) => setKind(e.target.value as Kind)}>
+            {(Object.keys(KIND_META) as Kind[]).map((k) => (
+              <option key={k} value={k}>{KIND_META[k].label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-1 flex-col gap-1 text-xs text-ink-tertiary">
+          Label
+          <input className="prism-input" value={label} onChange={(e) => setLabel(e.target.value)} placeholder="e.g. Marketing site" />
+        </label>
+        <label className="flex flex-1 flex-col gap-1 text-xs text-ink-tertiary">
+          URL {kind === "reference" ? "(optional)" : ""}
+          <input className="prism-input" value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://…" />
+        </label>
+        <button type="submit" disabled={pending || !label.trim()} className="btn-prism justify-center">
+          <Plus className="size-4" /> Add
+        </button>
+      </form>
+      {error ? <p className="text-sm text-red">{error}</p> : null}
+    </div>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -461,7 +461,7 @@ erDiagram
 | `lib/work-events`                                                                     | Merged-work event ingestion; idempotently marks matching tasks done                                                                                       |
 | `lib/pm-sync`                                                                         | Provider-neutral Plane/Linear status sync, errors recorded on task links                                                                                  |
 | `lib/jobs` | Durable job/outbox (Social Brain M0): single-writer store + backoff + registry + in-process poller. The one primitive for async work that must survive redeploys/retries |
-| `lib/brand` | Brand Brain (Social Brain M1): per-team voice/knowledge/governance config — single-writer store + `.strict()` validation. Read by the content pipeline to generate in-voice + enforce governance |
+| `lib/brand` | Brand Brain: per-team voice/knowledge/governance config (`manage`) + reference **assets** library — URLs/logos/examples (`assets`, single-writer). `.strict()` validation. Read by the content pipeline to generate in-voice, layer in assets, and enforce governance |
 | `lib/social` | Social Brain content domain: opportunity → plan → variant single-writer store + lifecycle; the evidence→tier-leak invariant (`tier.ts`); **discovery** (`discover.ts` + `discover-score.ts`) — deterministic scan of recent decision/deliverable/artifact `items` → ranked opportunities (idempotent, per-item tier); and **planning** (`plan.ts`) — brand-aware, deterministic first-cut opportunity → plan + platform variants (idempotent, tier-inherited). Exposed via **Admin → Social**. Tier inherited from evidence, propagated down the chain (no RLS backstop) |
 | `lib/policy`                                                                          | Policy evaluation + approval queue (Organ 6)                                                                                                              |
 | `lib/api`                                                                             | auth, rate-limit, audit, zod schemas                                                                                                                      |
@@ -605,7 +605,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 `codebases` · `code_metrics` · `code_contributions` · `github_issues` · `member_emails` ·
 `member_identities` · `member_secrets` · `member_profiles` · `member_time_off` · `member_goals` · `member_provisioning` · `integrations` ·
 `agentic_maturity_snapshots` · `task_pm_links` · `work_events` · `usage_costs` · `subscriptions` · `graph_episodes` · `arc_cache` ·
-`conversations` · `chat_messages` · `ingest_runs` · `social_jobs` · `brand_profiles` · `social_opportunities` · `content_plans` · `content_variants` ·
+`conversations` · `chat_messages` · `ingest_runs` · `social_jobs` · `brand_profiles` · `brand_assets` · `social_opportunities` · `content_plans` · `content_variants` ·
 `meeting_notes` · `meeting_note_attendees`
 <!-- /drift:tables -->
 

--- a/lib/brand/assets.ts
+++ b/lib/brand/assets.ts
@@ -1,0 +1,93 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { audit } from "@/lib/api/audit";
+import { validateBrandAsset } from "./schema";
+import type { BrandAssetInput } from "./schema";
+
+/**
+ * SINGLE WRITER for the `brand_assets` table (CLAUDE.md §2) — the per-team reference library the
+ * Brand Brain layers into generation (website/URLs, logo/image links, examples to emulate).
+ * Validates each asset (kind/label/url shape, ./schema) and audits add/remove with label+kind only
+ * (URLs are non-secret but we keep meta minimal). Guarded by test/guards/single-writer-brand-assets.
+ * Reads are unrestricted at the lib level; the /admin area is admin-gated in app code.
+ */
+
+export interface BrandAssetRow {
+  id: string;
+  kind: "url" | "asset" | "reference";
+  label: string;
+  url: string | null;
+  notes: string;
+  created_at: string;
+}
+
+export interface BrandActor {
+  memberId?: string | null;
+}
+
+const COLS = "id, kind, label, url, notes, created_at";
+
+/** The team's brand assets, newest first. */
+export async function listBrandAssets(db: DbClient, teamId: string): Promise<BrandAssetRow[]> {
+  const { data, error } = await db
+    .from("brand_assets")
+    .select(COLS)
+    .eq("team_id", teamId)
+    .order("created_at", { ascending: false });
+  if (error) throw new Error(`brand assets read failed: ${error.message}`);
+  return (data ?? []) as BrandAssetRow[];
+}
+
+/** Add a brand asset (validated + audited). Returns the created row. */
+export async function addBrandAsset(
+  db: DbClient,
+  teamId: string,
+  input: BrandAssetInput,
+  actor: BrandActor = {}
+): Promise<BrandAssetRow> {
+  const clean = validateBrandAsset(input);
+  const { data, error } = await db
+    .from("brand_assets")
+    .insert({
+      team_id: teamId,
+      kind: clean.kind,
+      label: clean.label,
+      url: clean.url || null,
+      notes: clean.notes ?? "",
+      created_by: actor.memberId ?? null,
+    })
+    .select(COLS)
+    .single();
+  if (error || !data) throw new Error(`brand asset add failed: ${error?.message ?? "no row"}`);
+
+  await audit(db, {
+    team_id: teamId,
+    actor_kind: "member",
+    member_id: actor.memberId ?? null,
+    action: "brand.asset_added",
+    target_type: "brand_asset",
+    target_id: data.id,
+    meta: { kind: clean.kind, label: clean.label },
+  });
+  return data as BrandAssetRow;
+}
+
+/** Remove a brand asset (team-scoped + audited). */
+export async function removeBrandAsset(
+  db: DbClient,
+  teamId: string,
+  id: string,
+  actor: BrandActor = {}
+): Promise<void> {
+  const { error } = await db.from("brand_assets").delete().eq("team_id", teamId).eq("id", id);
+  if (error) throw new Error(`brand asset remove failed: ${error.message}`);
+  await audit(db, {
+    team_id: teamId,
+    actor_kind: "member",
+    member_id: actor.memberId ?? null,
+    action: "brand.asset_removed",
+    target_type: "brand_asset",
+    target_id: id,
+    meta: {},
+  });
+}

--- a/lib/brand/schema.ts
+++ b/lib/brand/schema.ts
@@ -65,6 +65,34 @@ export type BrandKnowledge = z.infer<typeof brandKnowledgeSchema>;
 export type BrandGovernance = z.infer<typeof brandGovernanceSchema>;
 export type BrandProfileInput = z.infer<typeof brandProfileSchema>;
 
+/** A brand asset: a reference URL, an image/logo asset link, or an example to emulate. */
+export const brandAssetSchema = z
+  .object({
+    kind: z.enum(["url", "asset", "reference"]),
+    label: z.string().trim().min(1).max(200),
+    url: z.union([z.string().trim().url().max(2000), z.literal("")]).optional(),
+    notes: z.string().max(2000).optional(),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if ((v.kind === "url" || v.kind === "asset") && !v.url) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "a URL is required for this kind", path: ["url"] });
+    }
+  });
+
+export type BrandAssetInput = z.infer<typeof brandAssetSchema>;
+
+/** Validate an untrusted brand asset; throws BrandProfileError with a readable reason. */
+export function validateBrandAsset(input: unknown): BrandAssetInput {
+  const parsed = brandAssetSchema.safeParse(input);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const path = first.path.join(".") || "(root)";
+    throw new BrandProfileError(`invalid brand asset: ${path} — ${first.message}`);
+  }
+  return parsed.data;
+}
+
 /** Overall cap on the serialized profile (defense against an oversized config blob). */
 export const MAX_BRAND_BYTES = 32 * 1024;
 

--- a/postgres/migrations/20260711120000_brand_assets.sql
+++ b/postgres/migrations/20260711120000_brand_assets.sql
@@ -1,0 +1,19 @@
+-- Brand assets (Social Brain): a per-team library of reference material the Brand Brain layers
+-- into generation — website/URLs, logo/image asset links, and reference examples to emulate. A
+-- one-to-many companion to `brand_profiles` (which holds the voice/knowledge/governance config).
+-- Non-secret (public URLs + notes); credentials never live here. Single writer: lib/brand/assets.ts.
+--
+-- Mirrors postgres/schema.sql (from-zero load). Idempotent: safe to replay. No RLS — the /admin
+-- area is admin-gated in app code.
+
+create table if not exists brand_assets (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  kind text not null check (kind in ('url', 'asset', 'reference')),
+  label text not null,
+  url text,                                  -- required for kind url/asset; optional for reference
+  notes text not null default '',
+  created_by uuid references members(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+create index if not exists brand_assets_team_idx on brand_assets (team_id, created_at desc);

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1051,6 +1051,20 @@ create table if not exists brand_profiles (
   updated_at timestamptz not null default now()
 );
 
+-- Brand assets: per-team reference library (website/URLs, logo/image links, reference examples)
+-- the Brand Brain layers into generation. Non-secret. Single writer: lib/brand/assets.ts.
+create table if not exists brand_assets (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  kind text not null check (kind in ('url', 'asset', 'reference')),
+  label text not null,
+  url text,
+  notes text not null default '',
+  created_by uuid references members(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+create index if not exists brand_assets_team_idx on brand_assets (team_id, created_at desc);
+
 -- ── Social Brain content domain (M2 foundation) ──────────────────────────────
 -- The durable data model + lifecycle for opportunity → plan → variant. Each row carries an
 -- `access` tier inherited from its source evidence, so tier isolation (CLAUDE.md §5) propagates

--- a/test/brand-schema.test.ts
+++ b/test/brand-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { validateBrandProfile, BrandProfileError, MAX_BRAND_BYTES } from "@/lib/brand/schema";
+import { validateBrandProfile, validateBrandAsset, BrandProfileError, MAX_BRAND_BYTES } from "@/lib/brand/schema";
 
 /**
  * Spec for Brand Brain validation: accept a well-formed profile, and reject the three ways a
@@ -35,5 +35,29 @@ describe("brand profile validation", () => {
   it("rejects an oversized profile", () => {
     const huge = { knowledge: { history: "x".repeat(MAX_BRAND_BYTES + 100) } };
     expect(() => validateBrandProfile(huge)).toThrow(/too large/);
+  });
+});
+
+describe("brand asset validation", () => {
+  it("accepts a url asset with a valid URL", () => {
+    const a = validateBrandAsset({ kind: "url", label: "Site", url: "https://example.com" });
+    expect(a.kind).toBe("url");
+    expect(a.url).toBe("https://example.com");
+  });
+
+  it("requires a URL for url/asset kinds", () => {
+    expect(() => validateBrandAsset({ kind: "url", label: "Site" })).toThrow(BrandProfileError);
+    expect(() => validateBrandAsset({ kind: "asset", label: "Logo", url: "" })).toThrow(BrandProfileError);
+  });
+
+  it("allows a reference with no URL", () => {
+    const a = validateBrandAsset({ kind: "reference", label: "Tone example", notes: "emulate this" });
+    expect(a.kind).toBe("reference");
+  });
+
+  it("rejects an empty label, a bad URL, and unknown keys", () => {
+    expect(() => validateBrandAsset({ kind: "url", label: "", url: "https://x.com" })).toThrow(BrandProfileError);
+    expect(() => validateBrandAsset({ kind: "url", label: "Site", url: "not-a-url" })).toThrow(BrandProfileError);
+    expect(() => validateBrandAsset({ kind: "url", label: "Site", url: "https://x.com", secret: "x" })).toThrow(BrandProfileError);
   });
 });

--- a/test/datamechanics/brand-assets.datamechanics.test.ts
+++ b/test/datamechanics/brand-assets.datamechanics.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { addBrandAsset, listBrandAssets, removeBrandAsset } from "@/lib/brand/assets";
+import { db, seedTeam } from "./helpers";
+
+/**
+ * Spec for the brand assets library on real Postgres. Derived from intent: a team maintains a
+ * reference library the Brand Brain uses; assets persist, list newest-first, are team-scoped, and
+ * removable — every mutation audited.
+ */
+describe("brand_assets (real Postgres)", () => {
+  it("adds, lists (newest first), and removes assets", async () => {
+    const { teamId, memberId } = await seedTeam();
+    const a = await addBrandAsset(db(), teamId, { kind: "url", label: "Site", url: "https://aios.dev" }, { memberId });
+    await addBrandAsset(db(), teamId, { kind: "reference", label: "Tone example", notes: "emulate" }, { memberId });
+
+    let assets = await listBrandAssets(db(), teamId);
+    expect(assets.length).toBe(2);
+    expect(assets[0].label).toBe("Tone example"); // newest first
+    expect(assets.find((x) => x.id === a.id)!.url).toBe("https://aios.dev");
+
+    await removeBrandAsset(db(), teamId, a.id, { memberId });
+    assets = await listBrandAssets(db(), teamId);
+    expect(assets.length).toBe(1);
+    expect(assets[0].kind).toBe("reference");
+  });
+
+  it("scopes assets to the team", async () => {
+    const a = await seedTeam();
+    const b = await seedTeam();
+    await addBrandAsset(db(), a.teamId, { kind: "url", label: "A site", url: "https://a.com" }, { memberId: a.memberId });
+    expect(await listBrandAssets(db(), b.teamId)).toEqual([]);
+  });
+
+  it("audits an add with kind + label", async () => {
+    const { teamId, memberId } = await seedTeam();
+    await addBrandAsset(db(), teamId, { kind: "url", label: "Blog", url: "https://blog.aios.dev" }, { memberId });
+    const { data } = await db()
+      .from("audit_log")
+      .select("action, meta")
+      .eq("team_id", teamId)
+      .eq("action", "brand.asset_added")
+      .maybeSingle();
+    expect(data).toBeTruthy();
+    expect(data.meta.kind).toBe("url");
+    expect(data.meta.label).toBe("Blog");
+  });
+});

--- a/test/datamechanics/setup.ts
+++ b/test/datamechanics/setup.ts
@@ -8,6 +8,7 @@ const DATA_TABLES = [
   "content_variants",
   "content_plans",
   "social_opportunities",
+  "brand_assets",
   "brand_profiles",
   "social_jobs",
   "integrations",

--- a/test/guards/single-writer-brand-assets.test.ts
+++ b/test/guards/single-writer-brand-assets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Single-writer guard for the `brand_assets` table (CLAUDE.md §2). Written ONLY by
+ * `lib/brand/assets.ts` (validates + audits). Fails the build if any other file writes it.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCAN_DIRS = ["app", "lib", "scripts"];
+const OWNERS = [join("lib", "brand", "assets.ts")];
+const WRITE_RE = /from\(\s*["']brand_assets["']\s*\)\s*\.\s*(insert|update|upsert|delete)\b/g;
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+function offenders(): string[] {
+  const hits: string[] = [];
+  for (const d of SCAN_DIRS) {
+    for (const file of walk(join(ROOT, d))) {
+      const rel = file.slice(ROOT.length + 1);
+      if (OWNERS.some((o) => rel === o)) continue;
+      if (rel.endsWith(".test.ts") || rel.includes("fake-supabase")) continue;
+      const src = readFileSync(file, "utf8");
+      for (const m of src.matchAll(WRITE_RE)) hits.push(`${rel}: .from("brand_assets").${m[1]}(`);
+    }
+  }
+  return hits.sort();
+}
+
+describe("single-writer: brand_assets table", () => {
+  it("only lib/brand/assets.ts writes the brand_assets table", () => {
+    const violations = offenders();
+    expect(violations, `brand_assets written outside lib/brand/assets.ts:\n${violations.join("\n")}`).toEqual([]);
+  });
+
+  it("the matcher discriminates (non-vacuity)", () => {
+    expect(WRITE_RE.test('db.from("brand_assets").insert(')).toBe(true);
+    WRITE_RE.lastIndex = 0;
+    expect(WRITE_RE.test('db.from("brand_assets").select(')).toBe(false);
+    WRITE_RE.lastIndex = 0;
+  });
+});


### PR DESCRIPTION
## What

A **brand assets module** for the Brand Brain — the reference-material library you asked for. A per-team collection of website/URLs, logo/image asset links, and reference examples to emulate, which the Social Brain layers into generation. Companion to `brand_profiles` (voice/knowledge/governance).

First of the generation-phase PRs (text generation consumes this next; image + cost guard follow).

## Changes
- **`brand_assets` table** (`kind` url|asset|reference, label, url, notes) — schema + additive migration `20260711120000_brand_assets.sql`. Non-secret.
- **`lib/brand/assets.ts`** — single-writer store: `listBrandAssets` / `addBrandAsset` / `removeBrandAsset`, validated + audited (keys-only meta).
- **`lib/brand/schema.ts`** — `validateBrandAsset`: `.strict()`, URL required for url/asset kinds, optional for reference.
- **Admin → Brand** — a "Brand assets" panel (add with kind/label/URL, remove) below the profile editor.
- Architecture map updated (drift:tables + module map).

## Tests
- `test/guards/single-writer-brand-assets.test.ts` — structural single-writer guard.
- `test/brand-schema.test.ts` — url-required / bad-url / unknown-key / reference-no-url.
- `test/datamechanics/brand-assets.datamechanics.test.ts` — **real-Postgres**: add/list newest-first/remove, team scoping, audit.

## Verification
`check:docs` ✓ (49 tables) · `typecheck` ✓ · `lint` ✓ (0 err) · unit **558 passed** ✓ · brand-assets data-mechanics ✓ · migrate-from-zero ✓ · `next build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin brand assets library for URLs, files, and references.
  * Admins can add, view, and remove assets with labels, notes, and optional URLs.
  * Added validation to ensure asset details are complete and correctly formatted.
  * Assets are displayed in newest-first order and scoped to the current team.

* **Documentation**
  * Updated architecture documentation to include the brand assets library and data storage.

* **Tests**
  * Added coverage for asset validation, team scoping, auditing, and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->