### PR TITLE
feat(context): explicit AND operator for conjunctive intent

### DIFF
--- a/docs/design/context-retrieval-limits.md
+++ b/docs/design/context-retrieval-limits.md
@@ -69,9 +69,14 @@ real test") the moment the gap is closed. So the count of `it.fails` in these fi
   large corpora truncate best-ranked-first rather than blowing the token budget.
 - **Dense grounding** — `denseSearch` now applies a distance floor (`DENSE_MAX_DISTANCE`), so far
   nearest-neighbors don't false-ground (they were silently overriding the IDF signal once dense went live).
+- **Conjunctive intent** — an explicit upper-cased `AND` (`buildFtsQuery` / `conjunctiveTerms`) is now an
+  opt-in precision operator: "auth AND payments" narrows to docs about BOTH topics instead of OR-matching
+  either. `websearch_to_tsquery` already reads space/"and" as AND, so the join word alone flips the
+  operator — no SQL change. Upper-case only, so ordinary lowercase "and" (a stopword) never guts recall.
+  Proven at the FTS leg on real Postgres (retrieve()'s recency net always pads recent docs, so the
+  narrowing is only cleanly observable on the ranked candidates the operator controls).
 
 **What remains (intentionally, for the large-collective-data future, not this scale):** the recall
 ceiling BEYOND the candidate cap (a query matching *hundreds* of items) and true relevance beyond
 lexical rank — both the job of **dense/pgvector + a reranker**, whose leg exists (`EMBEDDINGS_URL`,
-`RERANK_URL`) and is now grounded safely. Also open: conjunctive intent ("auth AND payments" as a
-precision narrow), tracked by a unit `it.fails` in `test/query-adversarial`.
+`RERANK_URL`) and is now grounded safely.

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -196,9 +196,41 @@ export function significantTerms(question: string): string[] {
   return [...new Set(terms)];
 }
 
+/**
+ * Conjunctive intent (Gap: OR-semantics can't require BOTH topics). An explicit upper-cased `AND`
+ * between topics is an opt-in precision operator (like a search engine's AND): narrow to docs that
+ * contain ALL the named topics, instead of the OR default's recall bias. Returns the de-duped term
+ * list when the operator is present with a real topic on each side, else null (→ OR path unchanged).
+ *
+ * Deliberately ONLY upper-cased `AND`, never lowercase "and": "and" is a ubiquitous stopword (it is
+ * in FTS_STOP), so treating every "and" as a hard conjunction would gut recall on ordinary questions
+ * ("what did john and mary decide"). Conservative, mirroring parseChannelScope (Gap #4) — no false
+ * positives. Multi-word sides collapse to a flat AND of every significant term (websearch_to_tsquery
+ * has no grouping), so "auth flow AND payments" requires auth+flow+payments; single-word sides (the
+ * common "auth AND payments") are exact. Pure + unit-tested.
+ */
+export function conjunctiveTerms(question: string): string[] | null {
+  if (!/\bAND\b/.test(question)) return null; // case-sensitive: only the upper-cased operator
+  const sides = question.split(/\bAND\b/).map(significantTerms);
+  if (sides.length < 2 || sides.some((s) => s.length === 0)) return null; // a real topic each side
+  const all = [...new Set(sides.flat())];
+  return all.length >= 2 ? all : null;
+}
+
+/**
+ * The FTS query the retrieval leg runs. `websearch_to_tsquery('english', …)` reads the literal word
+ * "or" as OR and space/"and" as AND, so the join word alone flips the operator — no SQL change. OR by
+ * default (recall bias; the LLM filters relevance); AND only when `conjunctiveTerms` fires (precision).
+ */
+export function buildFtsQuery(question: string): { query: string; terms: string[]; conjunctive: boolean } {
+  const conj = conjunctiveTerms(question);
+  if (conj) return { query: conj.join(" and "), terms: conj, conjunctive: true };
+  const terms = significantTerms(question);
+  return { query: terms.length ? terms.join(" or ") : question, terms, conjunctive: false };
+}
+
 export function toOrQuery(question: string): string {
-  const unique = significantTerms(question);
-  return unique.length ? unique.join(" or ") : question;
+  return buildFtsQuery(question).query;
 }
 
 /**
@@ -409,16 +441,17 @@ async function nativeRetrieve(
   // 1. Recall-friendly, RANKED FTS over items (OR of significant terms; see toOrQuery). Ordered by
   //    ts_rank so the capped top-20 is the most relevant 20, not an arbitrary 20 (Gap #2). Raw SQL
   //    (fts-search) because the builder emits an unordered `@@` filter.
-  const terms = significantTerms(q);
-  const orQuery = terms.length ? terms.join(" or ") : q;
-  const ftsP = rankedFtsSearch(teamId, tier, orQuery, FTS_CANDIDATE_LIMIT, channel);
+  // OR of significant terms by default; AND when the query carries an explicit `AND` operator
+  // (conjunctive intent — narrows to docs about ALL topics). Same string flows to every FTS leg.
+  const { query: ftsQuery, terms } = buildFtsQuery(q);
+  const ftsP = rankedFtsSearch(teamId, tier, ftsQuery, FTS_CANDIDATE_LIMIT, channel);
   // Grounding specificity (Gap #3) — runs concurrently; combined with hadFtsHit below.
   const specificityP = analyzeTermSpecificity(teamId, tier, terms);
   // Structured-context scaling (Gaps #5/#6): a FULL-corpus task count (aggregates survive the 80-row
   // cap) + a keyword search over ALL decisions (an old-but-relevant decision survives the 50-row
   // recency window). Both run concurrently; folded into the structured block below.
   const taskCountsP = taskStatusCounts(teamId, tier);
-  const matchedDecisionsP = terms.length ? matchingDecisions(teamId, tier, orQuery, 10) : Promise.resolve([]);
+  const matchedDecisionsP = terms.length ? matchingDecisions(teamId, tier, ftsQuery, 10) : Promise.resolve([]);
 
   // 2. Recency: most recent items (a fallback so fresh content always has a shot).
   let recentB = db

--- a/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
+++ b/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { retrieve } from "@/lib/query/retrieve";
+import { retrieve, buildFtsQuery } from "@/lib/query/retrieve";
+import { rankedFtsSearch } from "@/lib/query/fts-search";
 import { db, ingest, seedTeam, type Seed } from "./helpers";
 
 /**
@@ -225,5 +226,34 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
     }
     const ctx = await retrieve(db(), seed.teamId, "team", "which vendor did we pick for the data warehouse?");
     expect(ctx.structured).toContain("DEC-000");
+  });
+
+  it("STRENGTH: an explicit AND narrows the FTS candidate set to docs about BOTH topics", async () => {
+    // Conjunctive intent is an FTS-leg property: retrieve()'s recency net ALWAYS pads in recent docs
+    // regardless of the query operator, so the narrowing is only cleanly observable on the ranked FTS
+    // candidates — the leg the operator actually controls. We pass the raw question through the SAME
+    // builder retrieve() uses (buildFtsQuery), so this proves the operator end-to-end at the DB.
+    await post("slack/security", "auth-only", "The auth login flow token rotation and session cookie hardening were shipped.");
+    await post("slack/finance", "payments-only", "The payments billing invoices and the payout schedule were reconciled this week.");
+    await post("slack/platform", "both", "The auth token is now verified inside the payments checkout flow before charging.");
+
+    const fts = async (question: string) => {
+      const { query } = buildFtsQuery(question);
+      const hits = await rankedFtsSearch(seed.teamId, "team", query, 50);
+      return hits.map((h) => h.path);
+    };
+
+    // AND operator → only the both-topics doc matches; the single-topic docs are excluded.
+    const andHits = await fts("auth AND payments");
+    expect(andHits).toContain("slack/platform/both.md");
+    expect(andHits).not.toContain("slack/security/auth-only.md");
+    expect(andHits).not.toContain("slack/finance/payments-only.md");
+
+    // Contrast — the plain OR query DOES surface every single-topic doc (proves the AND exclusion is
+    // the operator narrowing, not the docs being unfindable).
+    const orHits = await fts("auth payments");
+    expect(orHits).toContain("slack/security/auth-only.md");
+    expect(orHits).toContain("slack/finance/payments-only.md");
+    expect(orHits).toContain("slack/platform/both.md");
   });
 });

--- a/test/query-adversarial.test.ts
+++ b/test/query-adversarial.test.ts
@@ -45,25 +45,43 @@ describe("short-token recall (FIXED — was Gap #1; eng-heavy channels)", () => 
   });
 });
 
-describe("adversarial: OR-semantics trades precision for recall (multi-topic queries)", () => {
-  // toOrQuery OR-joins every significant term. That's a deliberate recall win for single-topic
-  // paraphrase queries, but it means a multi-topic question can't be expressed as a conjunction:
-  // "the AUTH decision in the PAYMENTS project" becomes auth|decision|payments, which also matches a
-  // pure-payments doc that has nothing to do with auth. At one channel this is tolerable noise; across
-  // dozens of channels the top-N (capped, unranked — see the DB suite) fills with these weak matches.
+describe("conjunctive intent (FIXED — explicit AND operator; precision on multi-topic queries)", () => {
+  // toOrQuery OR-joins every significant term — a deliberate recall win for single-topic paraphrase
+  // queries. But without an AND path a 2-topic question ("auth AND payments") can't narrow to docs
+  // about BOTH; the OR match also surfaces a pure-payments doc that has nothing to do with auth. An
+  // explicit upper-cased `AND` is now an opt-in precision operator (like a search engine's AND):
+  // upper-case only, so ordinary lowercase "and" (a stopword) never wrongly narrows and guts recall.
 
-  it("documents: OR-joins topics (recall bias) — no way to require ALL terms", () => {
+  it("OR-joins topics by default (recall bias) — lowercase 'and' does NOT narrow", () => {
+    // No explicit operator: "the auth decision in the payments project" stays a broad OR.
     expect(toOrQuery("the auth decision in the payments project")).toBe(
       "auth or decision or payments or project"
     );
   });
 
-  it.fails("SHOULD support conjunctive intent so a 2-topic query can require both topics", () => {
-    // A precision-preserving transform would let "auth AND payments" narrow to docs about both.
-    // Today there is no AND path — this asserts the capability we lack.
+  it("supports conjunctive intent so a 2-topic query requires BOTH topics", () => {
+    // websearch_to_tsquery reads space/"and" as AND, so the AND-join narrows to docs about both.
     const q = toOrQuery("auth AND payments");
     expect(q).toMatch(/auth.*and.*payments/i);
     expect(q).not.toBe("auth or payments");
+    expect(q).toBe("auth and payments");
+  });
+
+  it("only the UPPER-CASED operator narrows — lowercase 'and' is an ordinary stopword", () => {
+    // "auth and payments" (lowercase) is a normal question → OR of the two content terms, not a
+    // conjunction. This is what keeps recall intact for everyday phrasing.
+    expect(toOrQuery("auth and payments")).toBe("auth or payments");
+  });
+
+  it("does NOT narrow when a side has no significant topic (avoids false conjunctions)", () => {
+    // "the AND payments" — the left side is all stopwords, so there's no real 2-topic conjunction;
+    // fall back to the OR default rather than emit a one-sided AND.
+    expect(toOrQuery("the AND payments")).toBe("payments");
+  });
+
+  it("collapses multi-word sides to a flat AND of every significant term", () => {
+    // No grouping in websearch_to_tsquery, so "auth flow AND payments" requires all three.
+    expect(toOrQuery("auth flow AND payments")).toBe("auth and flow and payments");
   });
 });
 


### PR DESCRIPTION
## What
Adds an opt-in **conjunctive intent** operator to keyword retrieval. An upper-cased `AND` between topics ("auth AND payments") narrows to docs containing **both** topics, instead of the OR default which recall-matches *either*. This is the last remaining live `it.fails` in the multi-channel adversarial suite (item #1 of the deferred backlog).

## Why
The OR-recall default is right for single-topic paraphrase queries, but at multi-channel scale a 2-topic question can't be expressed as a conjunction — the OR match fills the (capped, ranked) top-N with docs that only touch one topic. There was no AND path.

## How
`websearch_to_tsquery('english', …)` already reads the literal word `"or"` as OR and space/`"and"` as AND — so the **join word alone flips the operator**, no SQL change:
- `conjunctiveTerms()` detects an explicit **upper-cased** `AND` with a real topic on each side, returns the de-duped term list, else `null`.
- `buildFtsQuery()` is the single builder both `toOrQuery` (unit-tested) and `retrieve()` use; AND-joins when conjunctive, OR-joins otherwise.
- **Upper-case only** — lowercase "and" is a ubiquitous stopword, so treating every "and" as a hard conjunction would gut recall. Conservative, mirroring `parseChannelScope` (Gap #4). No false positives.

## Tests
- **Unit** (`test/query-adversarial`): the `it.fails` conjunctive gap flipped to a green `it()`, plus boundary cases — lowercase "and" stays OR, one-sided AND falls back to OR, multi-word sides collapse to a flat AND.
- **Data-mechanics** (real Postgres): AND narrows the ranked FTS candidates to the both-topics doc and excludes single-topic docs; the OR contrast surfaces all three (proving the exclusion is the operator, not unfindable docs). Tested at the FTS leg because `retrieve()`'s recency net always pads recent docs regardless of operator.
- Full unit tier 570 passed · multichannel data-mechanics 13 passed · tsc/eslint/docs-drift clean.

## Deploy note
Config/logic only — **no schema change**, no `pg:schema` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)