### PR TITLE
feat(retrieval): dedicated EMBEDDINGS_API_KEY to decouple embeddings from the answer LLM

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -47,11 +47,18 @@ export EMBEDDINGS_URL=https://api.openai.com/v1   # the embeddings endpoint (app
 npm run embed:backfill      # embed existing items (idempotent); new items index each ingest cycle
 ```
 
-**The embeddings key** is resolved the SAME way as the answering LLM's: the team's OpenAI key from
-**Admin → Integrations → AI model settings** (encrypted `integrations` store, via `getProviderKey`),
-falling back to the `OPENAI_API_KEY` env var when unset. So if you've already set the key in the
-dashboard for the LLM, dense retrieval reuses it — no extra env var needed. `EMBEDDINGS_URL` can be
-the same value as `LLM_BASE_URL` when both point at OpenAI.
+**The embeddings key** resolves in precedence order: `EMBEDDINGS_API_KEY` env → the team's OpenAI key
+from **Admin → Integrations → AI model settings** (encrypted `integrations` store, via `getProviderKey`)
+→ the `OPENAI_API_KEY` env. So by default, if you've already set the key in the dashboard for the LLM,
+dense retrieval reuses it — no extra env var needed, and `EMBEDDINGS_URL` can equal `LLM_BASE_URL` when
+both point at OpenAI.
+
+> **Decoupling (optional, recommended at scale).** Embeddings sharing the answer LLM's key means one
+> account's quota exhaustion silently takes down BOTH answering and semantic search at once. Set
+> **`EMBEDDINGS_API_KEY`** to a **separate account** to isolate them — semantic search then survives an
+> answer-LLM outage and vice-versa. It wins over the shared store key, so it's a one-env-var opt-in with
+> no dashboard change. Failures are already surfaced loudly on **Admin → Integrations → Retrieval health**
+> (coverage %, degraded state) + the admin email alert, so a degraded leg is visible either way.
 
 With `EMBEDDINGS_URL` unset **or** the pgvector schema not loaded, dense retrieval is a complete
 no-op — the brain behaves exactly as before. Dense hits are tier-filtered on live `items.access`

--- a/lib/query/embedding-key.ts
+++ b/lib/query/embedding-key.ts
@@ -3,12 +3,17 @@ import { adminClient } from "@/lib/db/admin";
 import { getProviderKey } from "@/lib/integrations/manage";
 
 /**
- * Resolve a team's OpenAI embeddings key from **AI model settings** (the encrypted integrations
- * store) — the same source the answering LLM uses (`getProviderKey`). Returns null when unset, in
- * which case `embed()` falls back to the process env (`OPENAI_API_KEY`), preserving env-only setups.
+ * Resolve a team's embeddings key. Precedence:
+ *   1. `EMBEDDINGS_API_KEY` env — a DEDICATED key that decouples semantic search from the answer
+ *      LLM's quota. Point it at a SEPARATE account so exhausting one provider (the OpenAI-quota
+ *      incident) can't silently zero out the other. Explicit opt-in → wins over the shared store key.
+ *   2. The team's OpenAI key from **AI model settings** (encrypted integrations store, via
+ *      `getProviderKey`) — today's default: embeddings reuse whatever the LLM uses.
+ *   3. null → `embed()` falls back to the process env (`OPENAI_API_KEY`), preserving env-only setups.
  * Best-effort: never throws (a decrypt/DB hiccup → null → env fallback, not a failed index/query).
  */
 export async function resolveEmbeddingKey(teamId: string): Promise<string | null> {
+  if (process.env.EMBEDDINGS_API_KEY) return process.env.EMBEDDINGS_API_KEY;
   try {
     return await getProviderKey(adminClient(), teamId, "openai");
   } catch {

--- a/lib/query/embeddings.ts
+++ b/lib/query/embeddings.ts
@@ -5,9 +5,11 @@ import "server-only";
  * `LLM_BASE_URL` / `RERANK_URL` convention (any provider that speaks the OpenAI wire shape: OpenAI,
  * Ollama, ZeroEntropy, a local server, …). Dense retrieval is OFF until `EMBEDDINGS_URL` is set.
  *
- *   EMBEDDINGS_URL   base URL, e.g. https://api.openai.com/v1  or  http://localhost:11434/v1
- *   EMBEDDINGS_MODEL default text-embedding-3-small
- *   EMBEDDINGS_DIM   default 1536 — MUST match the vector(N) column in postgres/optional/pgvector.sql
+ *   EMBEDDINGS_URL     base URL, e.g. https://api.openai.com/v1  or  http://localhost:11434/v1
+ *   EMBEDDINGS_MODEL   default text-embedding-3-small
+ *   EMBEDDINGS_DIM     default 1536 — MUST match the vector(N) column in postgres/optional/pgvector.sql
+ *   EMBEDDINGS_API_KEY optional — a DEDICATED embeddings key so semantic search survives the answer
+ *                      LLM's quota (and vice-versa). See resolveEmbeddingKey; unset → shared key.
  */
 
 const EMBEDDINGS_URL = process.env.EMBEDDINGS_URL;
@@ -17,6 +19,20 @@ const EMBEDDINGS_TIMEOUT_MS = Number(process.env.EMBEDDINGS_TIMEOUT_MS ?? 20_000
 /** True when an embeddings endpoint is configured (dense retrieval opt-in). */
 export function embeddingsConfigured(): boolean {
   return !!EMBEDDINGS_URL;
+}
+
+/**
+ * Resolve the bearer key for the embeddings call, in precedence order:
+ *   1. `apiKey` — the key the caller resolved (per-team store key via resolveEmbeddingKey, which
+ *      already prefers a dedicated embeddings key), or
+ *   2. `EMBEDDINGS_API_KEY` — a DEDICATED embeddings account at the env layer, so exhausting the
+ *      answer LLM's `OPENAI_API_KEY` quota can't silently kill semantic search too (the decouple), or
+ *   3. `OPENAI_API_KEY` — the shared env key (today's default; embeddings reuse the LLM's key), or
+ *   4. `"local"` — a placeholder for keyless self-hosted servers (Ollama/llama.cpp ignore it).
+ * Pure — no I/O — so the precedence is unit-testable without a live endpoint.
+ */
+export function embeddingAuthKey(apiKey?: string | null): string {
+  return apiKey ?? process.env.EMBEDDINGS_API_KEY ?? process.env.OPENAI_API_KEY ?? "local";
 }
 
 /**
@@ -35,7 +51,7 @@ export async function embed(texts: string[], apiKey?: string | null): Promise<nu
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey ?? process.env.OPENAI_API_KEY ?? "local"}`,
+        Authorization: `Bearer ${embeddingAuthKey(apiKey)}`,
       },
       body: JSON.stringify({ model: EMBEDDINGS_MODEL, input: texts }),
       signal: ctrl.signal,

--- a/test/embeddings-key.test.ts
+++ b/test/embeddings-key.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { embeddingAuthKey } from "@/lib/query/embeddings";
+
+/**
+ * The embeddings key precedence is the "provider de-risk" contract: a DEDICATED `EMBEDDINGS_API_KEY`
+ * lets semantic search run on a SEPARATE account from the answer LLM, so exhausting one provider's
+ * quota can't silently kill the other. These pin that precedence (pure — no live endpoint needed).
+ * `embeddingAuthKey` reads env at call time, so mutating process.env here is honest.
+ */
+describe("embeddingAuthKey precedence (provider de-risk)", () => {
+  const saved = { emb: process.env.EMBEDDINGS_API_KEY, oai: process.env.OPENAI_API_KEY };
+
+  beforeEach(() => {
+    delete process.env.EMBEDDINGS_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+  afterEach(() => {
+    // Restore exactly (a deleted var must stay deleted, not become the string "undefined").
+    if (saved.emb === undefined) delete process.env.EMBEDDINGS_API_KEY;
+    else process.env.EMBEDDINGS_API_KEY = saved.emb;
+    if (saved.oai === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = saved.oai;
+  });
+
+  it("caller-resolved key wins over every env (it already encodes the right choice)", () => {
+    process.env.EMBEDDINGS_API_KEY = "env-embed";
+    process.env.OPENAI_API_KEY = "env-openai";
+    expect(embeddingAuthKey("per-team-key")).toBe("per-team-key");
+  });
+
+  it("dedicated EMBEDDINGS_API_KEY decouples from the shared OPENAI_API_KEY when no caller key", () => {
+    process.env.EMBEDDINGS_API_KEY = "dedicated-embed";
+    process.env.OPENAI_API_KEY = "shared-openai";
+    expect(embeddingAuthKey(null)).toBe("dedicated-embed");
+    expect(embeddingAuthKey(undefined)).toBe("dedicated-embed");
+  });
+
+  it("falls back to the shared OPENAI_API_KEY (today's default) when no dedicated key", () => {
+    process.env.OPENAI_API_KEY = "shared-openai";
+    expect(embeddingAuthKey(null)).toBe("shared-openai");
+  });
+
+  it("falls back to 'local' for keyless self-hosted servers (Ollama/llama.cpp)", () => {
+    expect(embeddingAuthKey(null)).toBe("local");
+  });
+});


### PR DESCRIPTION
## What
Adds an optional **`EMBEDDINGS_API_KEY`** so semantic search can run on a **separate provider account** from the answering LLM. This is item #6 (provider de-risk) from the retrieval roadmap — kept deliberately simple (one env var, no schema/admin-UI change), per the "keep it simple / general info for self-hosters" steer.

## Why
Today embeddings resolve the **same** `"openai"` provider key the answering LLM uses (integrations store, falling back to `OPENAI_API_KEY`). So one account's quota exhaustion **silently takes down both** answering *and* semantic search at once — exactly the OpenAI-quota incident. Phase 1 (#189/#190) already made that failure *loud* (Retrieval-health card + admin email); this adds the missing lever to make the two **independent**.

## How
Precedence, backward-compatible (unset → today's behavior):
1. `EMBEDDINGS_API_KEY` env — a dedicated account, **wins** over the shared store key, so the store-based prod path decouples too.
2. team's `"openai"` key from Admin → Integrations (current default).
3. `OPENAI_API_KEY` env.
4. `"local"` for keyless self-hosted servers.

- `resolveEmbeddingKey` short-circuits to `EMBEDDINGS_API_KEY` first.
- Pure `embeddingAuthKey()` helper in `embeddings.ts` encodes the env-layer chain; `embed()` uses it.

## Tests
- Unit (`test/embeddings-key.test.ts`): pins the full precedence — caller key wins, dedicated key decouples from the shared key, shared-key fallback, keyless `"local"` fallback.
- Full unit tier 575 passed · tsc/eslint/docs-drift clean.

## Deploy note
Config/logic only — **no schema change**, no `pg:schema` step. Purely additive: existing deployments behave identically until someone sets `EMBEDDINGS_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)