### PR TITLE
feat(social): opt-in image generation (OpenAI) + daily cost guard

### DIFF
--- a/app/api/dashboard/social/media/[id]/route.ts
+++ b/app/api/dashboard/social/media/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { adminClient } from "@/lib/db/admin";
+import { currentMember } from "@/lib/auth/guard";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/dashboard/social/media/:id — serve a generated image's bytes. Session-authed and
+ * admin-only (the Social surface is admin-gated); the image is served out-of-band so the admin
+ * page never inlines multi-MB base64. Team is resolved from the asset, then the caller must be an
+ * admin of that team.
+ */
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const { data: asset } = await adminClient()
+    .from("media_assets")
+    .select("team_id, data_base64")
+    .eq("id", id)
+    .maybeSingle();
+  if (!asset) return new NextResponse("not found", { status: 404 });
+
+  const member = await currentMember((asset as { team_id: string }).team_id);
+  if (!member || member.role !== "admin") return new NextResponse("forbidden", { status: 403 });
+
+  const bytes = Buffer.from((asset as { data_base64: string }).data_base64, "base64");
+  return new NextResponse(bytes, {
+    status: 200,
+    headers: { "Content-Type": "image/png", "Cache-Control": "private, max-age=3600" },
+  });
+}

--- a/app/t/[team]/admin/social/actions.ts
+++ b/app/t/[team]/admin/social/actions.ts
@@ -9,6 +9,7 @@ import { discoverOpportunities } from "@/lib/social/discover";
 import { discoverOpportunitiesFromArcs } from "@/lib/social/discover-arcs";
 import { planOpportunity } from "@/lib/social/plan";
 import { generatePlanDrafts } from "@/lib/social/generate";
+import { generateVariantImage, imageBudget } from "@/lib/media/generate-image";
 
 type DiscoverResult = { ok: boolean; created?: number; skipped?: number; scanned?: number; error?: string };
 
@@ -79,5 +80,23 @@ export async function generateDrafts(
     return { ok: true, generated: s.generated, blocked: s.blocked, failed: s.failed };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "generation failed" };
+  }
+}
+
+/** Generate an image for a variant (admins only). Opt-in + daily-capped. */
+export async function generateImage(
+  teamSlug: string,
+  variantId: string
+): Promise<{ ok: boolean; remaining?: number; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  try {
+    const db = adminClient();
+    await generateVariantImage(db, ctx.teamId, variantId, { actor: { memberId: ctx.memberId } });
+    const budget = await imageBudget(db, ctx.teamId);
+    revalidatePath(`/t/${teamSlug}/admin/social`);
+    return { ok: true, remaining: budget.remaining };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "image generation failed" };
   }
 }

--- a/app/t/[team]/admin/social/page.tsx
+++ b/app/t/[team]/admin/social/page.tsx
@@ -1,5 +1,7 @@
 import { serverClient } from "@/lib/db/server";
 import { listOpportunities } from "@/lib/social/store";
+import { listTeamMediaMeta } from "@/lib/media/store";
+import { imageBudget } from "@/lib/media/generate-image";
 import { SocialOpportunitiesPanel, type VariantView } from "@/components/admin/social-opportunities-panel";
 
 export default async function SocialAdminPage({ params }: { params: Promise<{ team: string }> }) {
@@ -27,6 +29,12 @@ export default async function SocialAdminPage({ params }: { params: Promise<{ te
     if (oppId) (byOpportunity[oppId] ??= []).push(v);
   }
 
+  // Generated images grouped by variant (ids only — bytes are served by the media route).
+  const media = await listTeamMediaMeta(db, team.id, 200);
+  const mediaByVariant: Record<string, string[]> = {};
+  for (const m of media) (mediaByVariant[m.variant_id] ??= []).push(m.id);
+  const budget = await imageBudget(db, team.id);
+
   return (
     <div className="flex flex-col gap-4">
       <p className="text-sm text-ink-secondary">
@@ -40,6 +48,9 @@ export default async function SocialAdminPage({ params }: { params: Promise<{ te
         teamSlug={teamSlug}
         opportunities={opportunities}
         variantsByOpportunity={byOpportunity}
+        mediaByVariant={mediaByVariant}
+        imagesRemaining={budget.remaining}
+        imageCap={budget.cap}
       />
     </div>
   );

--- a/components/admin/social-opportunities-panel.tsx
+++ b/components/admin/social-opportunities-panel.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Radar, PenLine, Sparkles, AlertTriangle, ShieldAlert } from "lucide-react";
-import { discoverNow, discoverFromArcsNow, planNow, generateDrafts } from "@/app/t/[team]/admin/social/actions";
+import { Radar, PenLine, Sparkles, AlertTriangle, ShieldAlert, ImagePlus } from "lucide-react";
+import { discoverNow, discoverFromArcsNow, planNow, generateDrafts, generateImage } from "@/app/t/[team]/admin/social/actions";
 import type { OpportunityRow } from "@/lib/social/types";
 
 const PCT = (n: number) => `${Math.round(n * 100)}%`;
@@ -24,10 +24,16 @@ export function SocialOpportunitiesPanel({
   teamSlug,
   opportunities,
   variantsByOpportunity,
+  mediaByVariant,
+  imagesRemaining,
+  imageCap,
 }: {
   teamSlug: string;
   opportunities: OpportunityRow[];
   variantsByOpportunity: Record<string, VariantView[]>;
+  mediaByVariant: Record<string, string[]>;
+  imagesRemaining: number;
+  imageCap: number;
 }) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -73,6 +79,7 @@ export function SocialOpportunitiesPanel({
         >
           <Sparkles className="size-4" /> {pending ? "Discovering…" : "Discover from arcs"}
         </button>
+        <span className="ml-auto text-xs text-ink-tertiary">images today: {imageCap - imagesRemaining}/{imageCap}</span>
         {msg ? <p className="text-sm text-emerald-700">{msg}</p> : null}
         {error ? <p className="text-sm text-red">{error}</p> : null}
       </div>
@@ -149,6 +156,28 @@ export function SocialOpportunitiesPanel({
                               <AlertTriangle className="size-3" /> review: {warnings.map((x) => `“${x.term}”`).join(", ")}
                             </p>
                           ) : null}
+                          {(mediaByVariant[v.id] ?? []).length > 0 ? (
+                            <div className="mt-1 flex flex-wrap gap-2">
+                              {(mediaByVariant[v.id] ?? []).map((mid) => (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img key={mid} src={`/api/dashboard/social/media/${mid}`} alt="generated graphic" className="size-24 rounded object-cover" />
+                              ))}
+                            </div>
+                          ) : null}
+                          <button
+                            type="button"
+                            onClick={() => act(
+                              () => generateImage(teamSlug, v.id),
+                              (r) => { const x = r as { remaining?: number }; return `Image generated (${x.remaining} left today).`; },
+                              v.id
+                            )}
+                            disabled={pending || imagesRemaining <= 0}
+                            title={imagesRemaining <= 0 ? "Daily image cap reached" : undefined}
+                            className="mt-1 text-xs font-medium text-violet hover:underline disabled:opacity-50"
+                          >
+                            <ImagePlus className="mr-1 inline size-3" />
+                            {busyId === v.id ? "Generating image…" : "Generate image"}
+                          </button>
                         </li>
                       );
                     })}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -463,6 +463,7 @@ erDiagram
 | `lib/jobs` | Durable job/outbox (Social Brain M0): single-writer store + backoff + registry + in-process poller. The one primitive for async work that must survive redeploys/retries |
 | `lib/brand` | Brand Brain: per-team voice/knowledge/governance config (`manage`) + reference **assets** library — URLs/logos/examples (`assets`, single-writer). `.strict()` validation. Read by the content pipeline to generate in-voice, layer in assets, and enforce governance |
 | `lib/social` | Social Brain content domain: opportunity → plan → variant single-writer store + lifecycle; the evidence→tier-leak invariant (`tier.ts`); **discovery** from two sources — `discover.ts` + `discover-score.ts` (deterministic scan of recent decision/deliverable/artifact `items` → ranked opportunities, per-item tier) and **`discover-arcs.ts`** (Layer-3 narrative arcs → opportunities, `access` = most-restrictive tier across the arc's evidence via `evidenceCeiling`, idempotent by `arc:<id>`); **planning** (`plan.ts`) — brand-aware, deterministic first-cut opportunity → plan + platform variants (idempotent, tier-inherited); and **generation** — `llm` (reuse the answer-backend), `generate` (in-brand, evidence-grounded drafts), and the `validate` governance gate (block prohibited/confidential, warn unverified) → variant `generated`/`rejected`. Exposed via **Admin → Social** (`discoverNow` / `discoverFromArcsNow` / `planNow` / `generateDrafts`). Tier inherited from evidence, propagated down the chain (no RLS backstop) |
+| `lib/media` | Social Brain media: OpenAI image adapter (`providers/openai-image`), the opt-in + daily-capped `generate-image` (tier inherited from the variant), and the single-writer `store` (`media_assets`). Bytes served out-of-band by `/api/dashboard/social/media/:id` |
 | `lib/policy`                                                                          | Policy evaluation + approval queue (Organ 6)                                                                                                              |
 | `lib/api`                                                                             | auth, rate-limit, audit, zod schemas                                                                                                                      |
 | `lib/okf`                                                                             | OKF link-graph helpers                                                                                                                                    |
@@ -593,6 +594,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/dashboard/team-work` — dashboard "Working On": per-person summary (narrative arcs) + open tasks + recent accomplishments; session-authed; tier-scoped
 - `POST /api/auth/login` — email+password sign-in, the DEFAULT path (invite-only; uniform 401 on any failure)
 - `POST /api/auth/request-magic-link` — OPTIONAL secondary sign-in: issues + emails a single-use magic link (invite-only; 403 if unknown); never sets a session cookie itself; the login form only offers it when `magicLinkAvailable()` (a domain + mail provider are configured)
+- `GET /api/dashboard/social/media/:id` — serve a generated image's bytes (session-authed, admin-only; team resolved from the asset)
 <!-- /drift:routes -->
 
 ### Database tables
@@ -605,7 +607,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 `codebases` · `code_metrics` · `code_contributions` · `github_issues` · `member_emails` ·
 `member_identities` · `member_secrets` · `member_profiles` · `member_time_off` · `member_goals` · `member_provisioning` · `integrations` ·
 `agentic_maturity_snapshots` · `task_pm_links` · `work_events` · `usage_costs` · `subscriptions` · `graph_episodes` · `arc_cache` ·
-`conversations` · `chat_messages` · `ingest_runs` · `social_jobs` · `brand_profiles` · `brand_assets` · `social_opportunities` · `content_plans` · `content_variants` ·
+`conversations` · `chat_messages` · `ingest_runs` · `social_jobs` · `brand_profiles` · `brand_assets` · `social_opportunities` · `content_plans` · `content_variants` · `media_assets` ·
 `meeting_notes` · `meeting_note_attendees`
 <!-- /drift:tables -->
 

--- a/lib/media/generate-image.ts
+++ b/lib/media/generate-image.ts
@@ -1,0 +1,98 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { getProviderKey } from "@/lib/integrations/manage";
+import { getOpportunity, getPlan, getVariant } from "@/lib/social/store";
+import { addMediaAsset, countTodayImages, type MediaAssetMeta } from "./store";
+import { generateOpenAiImage } from "./providers/openai-image";
+
+/**
+ * Image generation for a content variant — OPT-IN (never automatic) and cost-capped. Image models
+ * cost real money, so this enforces a hard per-team daily cap (Chetan: 10/day) BEFORE calling the
+ * provider, and records an estimated cost per asset. Tier is inherited from the variant. The
+ * provider call is injectable so the data-mechanics tier can stub the model.
+ */
+
+export const DAILY_IMAGE_CAP = Number(process.env.SOCIAL_IMAGE_DAILY_CAP ?? 10);
+// Rough per-image estimate for gpt-image-1.5 at 1024² (token-billed; refine against the live meter).
+const EST_COST_USD = 0.04;
+
+export class ImageBudgetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImageBudgetError";
+  }
+}
+
+export type ImageGenerator = (args: { prompt: string; apiKey: string }) => Promise<{ b64: string; model: string }>;
+
+/** The image prompt derived from the opportunity. No text in the image (platforms overlay their own). */
+export function buildImagePrompt(title: string): string {
+  return (
+    `Create a clean, modern, professional social-media graphic that illustrates: ${title}. ` +
+    `Uncluttered and on-brand. Do NOT include any text, words, or letters in the image.`
+  );
+}
+
+export interface GenerateImageOptions {
+  actor?: { memberId?: string | null };
+  generate?: ImageGenerator;
+  now?: Date;
+}
+
+export interface ImageBudget {
+  used: number;
+  cap: number;
+  remaining: number;
+}
+
+/** Today's image budget for a team. */
+export async function imageBudget(db: DbClient, teamId: string, now = new Date()): Promise<ImageBudget> {
+  const used = await countTodayImages(db, teamId, now);
+  return { used, cap: DAILY_IMAGE_CAP, remaining: Math.max(0, DAILY_IMAGE_CAP - used) };
+}
+
+/** Generate one image for a variant. Throws ImageBudgetError if the daily cap is reached. */
+export async function generateVariantImage(
+  db: DbClient,
+  teamId: string,
+  variantId: string,
+  opts: GenerateImageOptions = {}
+): Promise<MediaAssetMeta> {
+  const now = opts.now ?? new Date();
+  const variant = await getVariant(db, teamId, variantId);
+  if (!variant) throw new Error(`generateVariantImage: variant ${variantId} not found for team`);
+  const plan = await getPlan(db, teamId, variant.plan_id);
+  if (!plan) throw new Error(`generateVariantImage: plan ${variant.plan_id} not found`);
+  const opp = await getOpportunity(db, teamId, plan.opportunity_id);
+  if (!opp) throw new Error(`generateVariantImage: opportunity ${plan.opportunity_id} not found`);
+
+  // Cost guard — enforced BEFORE any spend.
+  const used = await countTodayImages(db, teamId, now);
+  if (used >= DAILY_IMAGE_CAP) {
+    throw new ImageBudgetError(`daily image cap reached (${used}/${DAILY_IMAGE_CAP}); try again tomorrow`);
+  }
+
+  const apiKey = await getProviderKey(db, teamId, "openai");
+  if (!apiKey && !opts.generate) {
+    throw new Error("no OpenAI key configured — add one in Admin → Integrations");
+  }
+  const generate = opts.generate ?? (async ({ prompt, apiKey: key }) => generateOpenAiImage({ prompt, apiKey: key }));
+
+  const prompt = buildImagePrompt(opp.title);
+  const { b64, model } = await generate({ prompt, apiKey: apiKey ?? "" });
+
+  return addMediaAsset(
+    db,
+    teamId,
+    {
+      variantId,
+      access: variant.access, // inherited — image is as restricted as its variant
+      provider: "openai",
+      model,
+      prompt,
+      dataBase64: b64,
+      costUsd: EST_COST_USD,
+    },
+    opts.actor ?? {}
+  );
+}

--- a/lib/media/providers/openai-image.ts
+++ b/lib/media/providers/openai-image.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+/**
+ * OpenAI image generation adapter (Social Brain). Provider-specific detail behind a neutral
+ * interface (mirrors the pm-sync adapter pattern). Returns base64 bytes — the gpt-image-* models
+ * respond with `b64_json`, not a URL (verified in the provider spike). The API key is the standard
+ * OpenAI key (same as the answering LLM), resolved by the caller via getProviderKey.
+ */
+
+export interface ImageGenParams {
+  prompt: string;
+  apiKey: string;
+  model?: string;
+  size?: string;
+}
+
+export interface ImageGenResult {
+  b64: string;
+  model: string;
+}
+
+export const DEFAULT_IMAGE_MODEL = "gpt-image-1.5";
+
+export async function generateOpenAiImage(params: ImageGenParams): Promise<ImageGenResult> {
+  const model = params.model ?? DEFAULT_IMAGE_MODEL;
+  const res = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${params.apiKey}` },
+    body: JSON.stringify({ model, prompt: params.prompt, size: params.size ?? "1024x1024", n: 1 }),
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) {
+    throw new Error(`openai image ${model}: ${res.status} ${await res.text().catch(() => "")}`);
+  }
+  const j = (await res.json()) as { data?: { b64_json?: string }[] };
+  const b64 = j.data?.[0]?.b64_json;
+  if (!b64) throw new Error("openai image: response had no b64_json");
+  return { b64, model };
+}

--- a/lib/media/store.ts
+++ b/lib/media/store.ts
@@ -1,0 +1,112 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { audit } from "@/lib/api/audit";
+import type { AccessTier } from "@/lib/social/types";
+
+/**
+ * SINGLE WRITER for the `media_assets` table (CLAUDE.md §2) — generated images for a content
+ * variant. Writes go through `addMediaAsset` (audited with provider/model/cost, never the bytes).
+ * The image bytes (`data_base64`) are read only by the media-serving route, never listed in bulk.
+ * Guarded by test/guards/single-writer-media-assets.
+ */
+
+export interface MediaAssetMeta {
+  id: string;
+  variant_id: string;
+  access: AccessTier;
+  provider: string;
+  model: string;
+  cost_usd: number;
+  created_at: string;
+}
+
+const META_COLS = "id, variant_id, access, provider, model, cost_usd, created_at";
+
+function normalize(row: Record<string, unknown>): MediaAssetMeta {
+  return { ...(row as unknown as MediaAssetMeta), cost_usd: Number(row.cost_usd ?? 0) };
+}
+
+export interface AddMediaInput {
+  variantId: string;
+  access: AccessTier;
+  provider: string;
+  model: string;
+  prompt: string;
+  dataBase64: string;
+  costUsd: number;
+}
+
+export async function addMediaAsset(
+  db: DbClient,
+  teamId: string,
+  input: AddMediaInput,
+  actor: { memberId?: string | null } = {}
+): Promise<MediaAssetMeta> {
+  const { data, error } = await db
+    .from("media_assets")
+    .insert({
+      team_id: teamId,
+      variant_id: input.variantId,
+      access: input.access,
+      kind: "image",
+      provider: input.provider,
+      model: input.model,
+      prompt: input.prompt,
+      data_base64: input.dataBase64,
+      cost_usd: input.costUsd,
+      created_by: actor.memberId ?? null,
+    })
+    .select(META_COLS)
+    .single();
+  if (error || !data) throw new Error(`addMediaAsset failed: ${error?.message ?? "no row"}`);
+
+  await audit(db, {
+    team_id: teamId,
+    actor_kind: "member",
+    member_id: actor.memberId ?? null,
+    action: "media.generated",
+    target_type: "media_asset",
+    target_id: data.id,
+    meta: { provider: input.provider, model: input.model, cost_usd: input.costUsd },
+  });
+  return normalize(data);
+}
+
+/** Metadata for a team's media, newest first (no bytes — for listing/rendering via the route). */
+export async function listTeamMediaMeta(db: DbClient, teamId: string, limit = 100): Promise<MediaAssetMeta[]> {
+  const { data } = await db
+    .from("media_assets")
+    .select(META_COLS)
+    .eq("team_id", teamId)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  return ((data ?? []) as Record<string, unknown>[]).map(normalize);
+}
+
+/** The image bytes for one asset (team-scoped). Used only by the media-serving route. */
+export async function getMediaBytes(
+  db: DbClient,
+  teamId: string,
+  id: string
+): Promise<{ access: AccessTier; data_base64: string } | null> {
+  const { data } = await db
+    .from("media_assets")
+    .select("access, data_base64")
+    .eq("team_id", teamId)
+    .eq("id", id)
+    .maybeSingle();
+  return (data as { access: AccessTier; data_base64: string }) ?? null;
+}
+
+/** Count images generated for a team on the UTC day of `now` — the cost-cap counter. */
+export async function countTodayImages(db: DbClient, teamId: string, now: Date): Promise<number> {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const end = new Date(start.getTime() + 24 * 3_600_000);
+  const { count } = await db
+    .from("media_assets")
+    .select("id", { count: "exact", head: true })
+    .eq("team_id", teamId)
+    .gte("created_at", start.toISOString())
+    .lt("created_at", end.toISOString());
+  return count ?? 0;
+}

--- a/postgres/migrations/20260711140000_media_assets.sql
+++ b/postgres/migrations/20260711140000_media_assets.sql
@@ -1,0 +1,23 @@
+-- Generated media (Social Brain): images produced for a content variant. Opt-in per variant and
+-- rate-capped (10/team/day, lib/media/generate-image) since image generation costs real money.
+-- The image bytes live inline as base64 for V1 (low volume behind the cap); object storage is a
+-- later swap. Single writer: lib/media/store.ts. Tier inherited from the variant (no RLS backstop).
+--
+-- Mirrors postgres/schema.sql (from-zero load). Idempotent: safe to replay.
+
+create table if not exists media_assets (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  variant_id uuid not null references content_variants(id) on delete cascade,
+  access access_tier not null,               -- inherited from the variant
+  kind text not null default 'image' check (kind in ('image')),
+  provider text not null,                    -- e.g. 'openai'
+  model text not null,                       -- e.g. 'gpt-image-1.5'
+  prompt text not null default '',
+  data_base64 text not null,                 -- the image bytes (base64); V1 inline storage
+  cost_usd numeric(10, 5) not null default 0,
+  created_by uuid references members(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+create index if not exists media_assets_variant_idx on media_assets (variant_id, created_at desc);
+create index if not exists media_assets_team_day_idx on media_assets (team_id, created_at);

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1127,3 +1127,22 @@ create table if not exists content_variants (
 alter table content_variants add column if not exists validation jsonb not null default '{}';
 create index if not exists content_variants_team_plan_idx on content_variants (team_id, plan_id);
 create index if not exists content_variants_team_status_idx on content_variants (team_id, status);
+
+-- Generated media (images) for a variant. Opt-in + rate-capped (lib/media/generate-image); bytes
+-- inline as base64 for V1. Single writer: lib/media/store.ts. Tier inherited from the variant.
+create table if not exists media_assets (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  variant_id uuid not null references content_variants(id) on delete cascade,
+  access access_tier not null,
+  kind text not null default 'image' check (kind in ('image')),
+  provider text not null,
+  model text not null,
+  prompt text not null default '',
+  data_base64 text not null,
+  cost_usd numeric(10, 5) not null default 0,
+  created_by uuid references members(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+create index if not exists media_assets_variant_idx on media_assets (variant_id, created_at desc);
+create index if not exists media_assets_team_day_idx on media_assets (team_id, created_at);

--- a/test/datamechanics/media-generate.datamechanics.test.ts
+++ b/test/datamechanics/media-generate.datamechanics.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { createOpportunity } from "@/lib/social/store";
+import { planOpportunity } from "@/lib/social/plan";
+import { generateVariantImage, imageBudget, ImageBudgetError, DAILY_IMAGE_CAP } from "@/lib/media/generate-image";
+import { db, seedTeam } from "./helpers";
+
+/**
+ * Spec for image generation + the cost guard on real Postgres, with the provider STUBBED (the
+ * data-mechanics tier stubs the model). Derived from intent: an image is stored for the variant at
+ * the variant's tier, and generation is hard-capped per team per day (Chetan: 10) — enforced
+ * before any provider call.
+ */
+const stubGen = async () => ({ b64: Buffer.from("fake-png-bytes").toString("base64"), model: "gpt-image-1.5" });
+
+async function plannedVariant(access: "team" | "external" = "team") {
+  const seed = await seedTeam();
+  const opp = await createOpportunity(db(), seed.teamId, { access, sourceType: "manual", title: "Shipped the queue" });
+  const { variants } = await planOpportunity(db(), seed.teamId, opp.id, { memberId: seed.memberId });
+  return { seed, variant: variants[0] };
+}
+
+describe("image generation + cost guard (real Postgres, stubbed provider)", () => {
+  it("stores an image at the variant's tier and decrements the budget", async () => {
+    const { seed, variant } = await plannedVariant("team");
+    const asset = await generateVariantImage(db(), seed.teamId, variant.id, { generate: stubGen, actor: { memberId: seed.memberId } });
+    expect(asset.access).toBe("team");
+    expect(asset.provider).toBe("openai");
+    expect(asset.model).toBe("gpt-image-1.5");
+    expect(asset.cost_usd).toBeGreaterThan(0);
+
+    const budget = await imageBudget(db(), seed.teamId);
+    expect(budget.used).toBe(1);
+    expect(budget.remaining).toBe(DAILY_IMAGE_CAP - 1);
+  });
+
+  it("inherits external tier from an external variant", async () => {
+    const { seed, variant } = await plannedVariant("external");
+    const asset = await generateVariantImage(db(), seed.teamId, variant.id, { generate: stubGen });
+    expect(asset.access).toBe("external");
+  });
+
+  it("enforces the daily cap — the (cap+1)th image is rejected before any spend", async () => {
+    const { seed, variant } = await plannedVariant("team");
+    let providerCalls = 0;
+    const counted = async () => { providerCalls++; return stubGen(); };
+
+    for (let i = 0; i < DAILY_IMAGE_CAP; i++) {
+      await generateVariantImage(db(), seed.teamId, variant.id, { generate: counted });
+    }
+    expect((await imageBudget(db(), seed.teamId)).remaining).toBe(0);
+
+    await expect(generateVariantImage(db(), seed.teamId, variant.id, { generate: counted })).rejects.toBeInstanceOf(ImageBudgetError);
+    // The provider was never called for the over-cap request.
+    expect(providerCalls).toBe(DAILY_IMAGE_CAP);
+  });
+});

--- a/test/datamechanics/setup.ts
+++ b/test/datamechanics/setup.ts
@@ -5,6 +5,7 @@ import { Client } from "pg";
 // before each test. One dedicated connection (separate from the app's pool) so
 // truncation can't deadlock against in-flight adapter queries.
 const DATA_TABLES = [
+  "media_assets",
   "content_variants",
   "content_plans",
   "social_opportunities",

--- a/test/guards/single-writer-media-assets.test.ts
+++ b/test/guards/single-writer-media-assets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Single-writer guard for the `media_assets` table (CLAUDE.md §2). Written ONLY by
+ * `lib/media/store.ts` (validated + audited). Fails the build if any other file writes it.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCAN_DIRS = ["app", "lib", "scripts"];
+const OWNERS = [join("lib", "media", "store.ts")];
+const WRITE_RE = /from\(\s*["']media_assets["']\s*\)\s*\.\s*(insert|update|upsert|delete)\b/g;
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+function offenders(): string[] {
+  const hits: string[] = [];
+  for (const d of SCAN_DIRS) {
+    for (const file of walk(join(ROOT, d))) {
+      const rel = file.slice(ROOT.length + 1);
+      if (OWNERS.some((o) => rel === o)) continue;
+      if (rel.endsWith(".test.ts") || rel.includes("fake-supabase")) continue;
+      const src = readFileSync(file, "utf8");
+      for (const m of src.matchAll(WRITE_RE)) hits.push(`${rel}: .from("media_assets").${m[1]}(`);
+    }
+  }
+  return hits.sort();
+}
+
+describe("single-writer: media_assets table", () => {
+  it("only lib/media/store.ts writes the media_assets table", () => {
+    const violations = offenders();
+    expect(violations, `media_assets written outside lib/media/store.ts:\n${violations.join("\n")}`).toEqual([]);
+  });
+
+  it("the matcher discriminates (non-vacuity)", () => {
+    expect(WRITE_RE.test('db.from("media_assets").insert(')).toBe(true);
+    WRITE_RE.lastIndex = 0;
+    expect(WRITE_RE.test('db.from("media_assets").select(')).toBe(false);
+    WRITE_RE.lastIndex = 0;
+  });
+});

--- a/test/media-image-prompt.test.ts
+++ b/test/media-image-prompt.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildImagePrompt, DAILY_IMAGE_CAP } from "@/lib/media/generate-image";
+
+/**
+ * Spec for the image prompt + the cap default. Derived from intent: the prompt names the topic and
+ * forbids embedded text (platforms overlay their own); the default daily cap is 10 (Chetan).
+ */
+describe("image generation basics", () => {
+  it("prompt includes the title and forbids text in the image", () => {
+    const p = buildImagePrompt("Shipped the durable job queue");
+    expect(p).toContain("Shipped the durable job queue");
+    expect(p.toLowerCase()).toContain("no");
+    expect(p.toLowerCase()).toMatch(/text|words|letters/);
+  });
+
+  it("defaults the daily image cap to 10", () => {
+    expect(DAILY_IMAGE_CAP).toBe(10);
+  });
+});


### PR DESCRIPTION
## What

The **final generation piece** (your Q3 + Q4): per-variant **image generation**, **opt-in** and **hard-capped at 10/team/day**, using the OpenAI image API and the live key seam.

Builds on text generation (#227).

## Changes
- **`lib/media/providers/openai-image.ts`** — OpenAI image adapter (`gpt-image-1.5`, returns base64 per the provider spike), behind a neutral interface (mirrors the pm-sync adapter pattern).
- **`lib/media/generate-image.ts`** — `generateVariantImage`: **opt-in** (never automatic), **tier inherited** from the variant, with a **hard per-team daily cap (10, `SOCIAL_IMAGE_DAILY_CAP`) enforced BEFORE any provider call** (no spend past the cap). Records an estimated cost per asset. Provider injectable → the data-mechanics tier stubs it.
- **`media_assets` table** (bytes inline as base64 for V1 — object storage is a later swap) + single-writer `lib/media/store.ts` (audited; `countTodayImages` = the cap counter).
- **`GET /api/dashboard/social/media/:id`** — serves image bytes **out-of-band** (session-authed, admin-only), so the admin page never inlines multi-MB base64.
- **Admin → Social** — per-variant **"Generate image"** (disabled at the cap), inline thumbnails, and a **"images today: n/10"** readout.

## Cost guard (your Q4 = 10)
The cap is checked *before* the provider call, so hitting it costs nothing. Override via `SOCIAL_IMAGE_DAILY_CAP`. Per-asset cost is recorded (rough gpt-image-1.5 estimate; refine against the live meter).

## Tests
- `test/guards/single-writer-media-assets.test.ts`; `test/media-image-prompt.test.ts` (prompt forbids in-image text; cap default 10).
- `test/datamechanics/media-generate.datamechanics.test.ts` — **real-Postgres, stubbed provider**: image stored at the variant's tier, external inheritance, and the **(cap+1)th request throws `ImageBudgetError` before the provider is called**.

## Verification
`check:docs` ✓ (42 routes / 50 tables) · `typecheck` ✓ · `lint` ✓ (0 err) · unit **575 passed** ✓ · media data-mechanics **3/3** ✓ · migrate-from-zero ✓ · `next build` ✓.

## Note
As with text, the live OpenAI image call is stubbed in CI. Worth one real "Generate image" click post-merge to confirm the key + render. **This completes the text + image V1 generation phase.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)