### PR TITLE
feat(graph): probe Graphiti reachability (set-but-down leg reads as degraded)

### DIFF
--- a/components/admin/retrieval-health-card.tsx
+++ b/components/admin/retrieval-health-card.tsx
@@ -42,6 +42,15 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
     d.state === "off"
       ? undefined
       : `${d.coveragePct}% embedded (${d.embeddedItems}/${d.embeddableItems})${d.pendingItems ? `, ${d.pendingItems} pending` : ""}${d.lastEmbeddedAt ? `, last ${timeAgo(d.lastEmbeddedAt)}` : ""}`;
+  const graphDetail =
+    health.graph === "off"
+      ? "not configured"
+      : health.graph === "degraded"
+        ? "configured but unreachable"
+        : undefined;
+  // A configured-but-unreachable graph is a real failure (set GRAPHITI_URL but the service is down),
+  // distinct from simply "off" — flag it loudly (red), like a degraded semantic leg.
+  const graphDegraded = health.graph === "degraded";
   const worst = d.state === "degraded" || health.graph === "off";
 
   return (
@@ -57,9 +66,16 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
 
       <Leg name="Keyword" state="on" detail="always on (local Postgres FTS)" />
       <Leg name="Semantic" state={d.state} detail={denseDetail} />
-      <Leg name="Graph memory" state={health.graph} detail={health.graph === "off" ? "not configured" : undefined} />
+      <Leg name="Graph memory" state={health.graph} detail={graphDetail} />
       <Leg name="Reranker" state={health.rerank} detail={health.rerank === "off" ? "not configured" : undefined} />
 
+      {graphDegraded ? (
+        <p className="mt-2 rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
+          Graph memory is configured but not responding — <code>GRAPHITI_URL</code> is set, but its
+          <code> /healthcheck</code> failed (service down or unreachable). Keyword and semantic search
+          are unaffected; check the Graphiti service.
+        </p>
+      ) : null}
       {d.note ? (
         <p
           className={`mt-2 rounded-lg border px-3 py-2 text-xs ${

--- a/lib/graph/graphiti-client.test.ts
+++ b/lib/graph/graphiti-client.test.ts
@@ -58,6 +58,38 @@ describe("GraphitiClient", () => {
     expect(calls).toHaveLength(0);
   });
 
+  it("healthcheck GETs /healthcheck and returns true when the service answers", async () => {
+    const calls: Call[] = [];
+    const okFetch = (async (url: string) => {
+      calls.push({ url: String(url), body: undefined });
+      return { ok: true, status: 200, text: async () => "" } as Response;
+    }) as unknown as typeof fetch;
+    const c = new GraphitiClient({ baseUrl: "http://gx:8000", fetchImpl: okFetch });
+    expect(await c.healthcheck()).toBe(true);
+    expect(calls[0].url).toBe("http://gx:8000/healthcheck");
+  });
+
+  it("healthcheck returns false on a non-2xx (service up but unhealthy)", async () => {
+    const downFetch = (async () => ({ ok: false, status: 503, text: async () => "" }) as Response) as unknown as typeof fetch;
+    const c = new GraphitiClient({ baseUrl: "http://gx:8000", fetchImpl: downFetch });
+    expect(await c.healthcheck()).toBe(false);
+  });
+
+  it("healthcheck returns false (never throws) when the service is unreachable", async () => {
+    const throwFetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const c = new GraphitiClient({ baseUrl: "http://gx:8000", fetchImpl: throwFetch });
+    expect(await c.healthcheck()).toBe(false);
+  });
+
+  it("healthcheck returns false without a call when GRAPHITI_URL is unset/malformed", async () => {
+    const calls: Call[] = [];
+    const c = new GraphitiClient({ baseUrl: "http://", fetchImpl: stubFetch(calls) });
+    expect(await c.healthcheck()).toBe(false);
+    expect(calls).toHaveLength(0); // no doomed call to a malformed URL
+  });
+
   it("search POSTs group_ids + query and returns facts", async () => {
     const calls: Call[] = [];
     const facts = [{ fact: "Alex owns the payments service", valid_at: "2026-06-01T00:00:00Z" }];

--- a/lib/graph/graphiti-client.ts
+++ b/lib/graph/graphiti-client.ts
@@ -81,6 +81,27 @@ export class GraphitiClient {
     return graphitiConfigured(this.base);
   }
 
+  /**
+   * Liveness probe for the admin health card — `GET /healthcheck` with a SHORT timeout (independent of
+   * the 30s call timeout; a dashboard render must not hang on a dead service). Best-effort: returns
+   * false on any error (unconfigured, unreachable, timeout, non-2xx) so a set-but-down Graphiti reads
+   * as *degraded* on the dashboard instead of a false "on" — Graphiti's worker dies silently, so a
+   * configured URL alone is not evidence the leg actually works. Never throws.
+   */
+  async healthcheck(timeoutMs = 2500): Promise<boolean> {
+    if (!this.configured) return false;
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await this.fetch(`${this.base}/healthcheck`, { method: "GET", signal: ctrl.signal });
+      return res.ok;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(t);
+    }
+  }
+
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
     if (!this.configured) throw new Error("GRAPHITI_URL not set — Graphiti graph memory is not configured.");
     const ctrl = new AbortController();

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
-import { graphitiConfigured } from "@/lib/graph/graphiti-client";
+import { graphitiConfigured, GraphitiClient } from "@/lib/graph/graphiti-client";
 
 /**
  * Retrieval-stack health for the admin dashboard (Phase 1 of the retrieval-observability plan).
@@ -16,6 +16,10 @@ import { graphitiConfigured } from "@/lib/graph/graphiti-client";
 
 export type LegState = "on" | "off";
 export type DenseState = "off" | "healthy" | "building" | "degraded";
+// Graph is externally-dependent like dense, so it gets the same "configured-but-broken" middle state:
+// "degraded" = GRAPHITI_URL set but the service didn't answer /healthcheck (down/misconfigured). A
+// configured URL alone isn't proof the leg works — Graphiti's worker dies silently.
+export type GraphState = "off" | "on" | "degraded";
 
 export interface DenseHealth {
   state: DenseState;
@@ -31,7 +35,7 @@ export interface DenseHealth {
 export interface RetrievalHealth {
   keyword: LegState; // always "on"
   dense: DenseHealth;
-  graph: LegState;
+  graph: GraphState;
   rerank: LegState;
 }
 
@@ -44,6 +48,17 @@ const STALE_MS = 2 * 60 * 60 * 1000; // no embed activity in 2h + incomplete = s
  * actually calls Graphiti agree on whether the leg is on.
  */
 export const graphConfigured = graphitiConfigured;
+
+/**
+ * Derive the graph-leg state from its raw signals. Pure + unit-tested:
+ *   • not configured (no/malformed GRAPHITI_URL)         → "off"
+ *   • configured AND /healthcheck answered                → "on"
+ *   • configured BUT /healthcheck failed (down/unreachable) → "degraded"
+ */
+export function deriveGraphState(input: { configured: boolean; reachable: boolean }): GraphState {
+  if (!input.configured) return "off";
+  return input.reachable ? "on" : "degraded";
+}
 
 /**
  * Derive the dense-leg state from the raw signals. Pure + unit-tested — the fiddly bit is separating
@@ -69,11 +84,16 @@ export function deriveDenseState(input: {
 }
 
 export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealth> {
-  const graph: LegState = graphConfigured(process.env.GRAPHITI_URL) ? "on" : "off";
   const rerank: LegState = process.env.RERANK_URL ? "on" : "off";
   const configured = !!process.env.EMBEDDINGS_URL;
 
-  const dense = await denseHealth(teamId, configured);
+  // Graph + dense both hit the network — run them concurrently so the card render isn't serialized.
+  const graphConfiguredNow = graphConfigured(process.env.GRAPHITI_URL);
+  const [dense, graphReachable] = await Promise.all([
+    denseHealth(teamId, configured),
+    graphConfiguredNow ? new GraphitiClient().healthcheck() : Promise.resolve(false),
+  ]);
+  const graph = deriveGraphState({ configured: graphConfiguredNow, reachable: graphReachable });
   return { keyword: "on", dense, graph, rerank };
 }
 

--- a/test/retrieval-health.test.ts
+++ b/test/retrieval-health.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveDenseState, graphConfigured } from "@/lib/query/retrieval-health";
+import { deriveDenseState, deriveGraphState, graphConfigured } from "@/lib/query/retrieval-health";
 
 // Spec: the dense-leg state machine must separate off / building / degraded / healthy so the admin
 // card tells the truth — especially "degraded" (erroring or stalled, red) vs "building" (catching
@@ -52,5 +52,18 @@ describe("graphConfigured", () => {
   it("true for a real http(s) URL with a host", () => {
     expect(graphConfigured("http://graphiti.railway.internal:8000")).toBe(true);
     expect(graphConfigured("https://graph.example.com")).toBe(true);
+  });
+});
+
+describe("deriveGraphState", () => {
+  it("off when not configured (regardless of reachability)", () => {
+    expect(deriveGraphState({ configured: false, reachable: false })).toBe("off");
+    expect(deriveGraphState({ configured: false, reachable: true })).toBe("off");
+  });
+  it("on when configured AND /healthcheck answered", () => {
+    expect(deriveGraphState({ configured: true, reachable: true })).toBe("on");
+  });
+  it("degraded when configured BUT unreachable — the silent-failure case reviving must surface", () => {
+    expect(deriveGraphState({ configured: true, reachable: false })).toBe("degraded");
   });
 });


### PR DESCRIPTION
## What
Adds a **reachability probe** to the Graphiti graph-memory leg so the Admin → Integrations **Retrieval health** card distinguishes:
- **off** — `GRAPHITI_URL` not set / malformed
- **on** — configured AND `/healthcheck` answered
- **degraded** — configured BUT unreachable (service down / misconfigured)

This is the code-side half of "revive Graphiti" (item #5). The actual revival — standing up the `graphiti/` service and setting `GRAPHITI_URL` — is **infra I can't do from here** (can't deploy services / set Railway env; never `railway up`); this makes that revival **observable and safe** once you do it.

## Why
The health card previously reported the graph leg on/off purely on whether the URL was a valid http(s) URL. But Graphiti's async worker **dies silently on any non-cancelled exception** (per the integration notes) — so a *configured-but-broken* Graphiti would show a false **on**. That's exactly the silent-failure class the Phase-1 observability work exists to kill, and it's the failure most likely to bite right after a revival.

## How
- `GraphitiClient.healthcheck()` — best-effort `GET /healthcheck`, short (2.5s) timeout independent of the 30s call timeout so a dashboard render can't hang; returns `false` on any error, never throws.
- `retrieval-health`: graph leg is now `off | on | degraded` via a pure, unit-tested `deriveGraphState`; `getRetrievalHealth` probes reachability **concurrently** with the dense-coverage query.
- Card renders "configured but unreachable" + a red note when degraded, distinct from "off = not configured".

## Tests
- `deriveGraphState` — off (unconfigured), on (reachable), degraded (configured+unreachable).
- `healthcheck` — GETs `/healthcheck`, true on 2xx, false on non-2xx / thrown / unconfigured (no doomed call to a malformed URL).
- Full unit tier 578 passed · tsc/eslint/docs-drift clean.

## Deploy note
Config/logic only — **no schema change**. The runbook to actually stand up the service is in the PR discussion / handed to the owner separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)