### PR TITLE
feat(social): promote Social Brain to a first-class dashboard surface

### DIFF
--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -81,8 +81,12 @@ export default async function TeamLayout({
     { icon: "meetings", label: "Meetings", href: `${base}/meetings` },
     { icon: "learning", label: "Learning", href: `${base}/learning` },
     { icon: "query", label: "Query", href: `${base}/query` },
-    { label: "Settings", children: settingsChildren },
   ];
+  // Social Brain — an operator surface (discovers, generates, spends, publishes), so admin-only.
+  if (me.role === "admin") {
+    items.push({ icon: "social", label: "Social", href: `${base}/social` });
+  }
+  items.push({ label: "Settings", children: settingsChildren });
 
   return (
     <div className="flex min-h-dvh flex-1 bg-surface-raised">

--- a/app/t/[team]/social/actions.ts
+++ b/app/t/[team]/social/actions.ts
@@ -24,7 +24,7 @@ export async function discoverNow(teamSlug: string): Promise<DiscoverResult> {
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     const s = await discoverOpportunities(adminClient(), ctx.teamId, { actor: { memberId: ctx.memberId } });
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true, created: s.created, skipped: s.skipped, scanned: s.scanned };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "discovery failed" };
@@ -49,7 +49,7 @@ export async function discoverFromArcsNow(teamSlug: string): Promise<DiscoverRes
     const s = await discoverOpportunitiesFromArcs(db, ctx.teamId, teamSlug, "team", groups, { openaiKey, anthropicKey }, {
       actor: { memberId: ctx.memberId },
     });
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true, created: s.created, skipped: s.skipped, scanned: s.scanned };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "arc discovery failed" };
@@ -65,7 +65,7 @@ export async function planNow(
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     const r = await planOpportunity(adminClient(), ctx.teamId, opportunityId, { memberId: ctx.memberId });
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true, variants: r.variants.length, created: r.created };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "planning failed" };
@@ -81,7 +81,7 @@ export async function generateDrafts(
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     const s = await generatePlanDrafts(adminClient(), ctx.teamId, opportunityId);
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true, generated: s.generated, blocked: s.blocked, failed: s.failed };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "generation failed" };
@@ -97,7 +97,7 @@ export async function setAutonomyLevel(
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     await setAutonomy(adminClient(), ctx.teamId, level, { memberId: ctx.memberId });
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not set autonomy" };
@@ -113,7 +113,7 @@ export async function submitApproval(
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     const r = await submitForApproval(adminClient(), ctx.teamId, variantId, { memberId: ctx.memberId });
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true, outcome: r.outcome };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not submit" };
@@ -131,7 +131,7 @@ export async function decideContentApproval(
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     await decideApproval(adminClient(), ctx.teamId, approvalId, decision, note, { memberId: ctx.memberId });
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not decide" };
@@ -147,7 +147,7 @@ export async function connectTypefully(
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     await saveTypefully(adminClient(), { teamId: ctx.teamId, memberId: ctx.memberId }, input);
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not save Typefully key" };
@@ -160,7 +160,7 @@ export async function setDryRun(teamSlug: string, dryRun: boolean): Promise<{ ok
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     await setPublishDryRun(adminClient(), ctx.teamId, dryRun, { memberId: ctx.memberId });
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not set dry-run" };
@@ -179,7 +179,7 @@ export async function scheduleVariantAction(
     const when = at && at.trim() ? new Date(at) : undefined;
     if (when && Number.isNaN(when.getTime())) return { ok: false, error: "invalid schedule time" };
     const pub = await scheduleVariant(adminClient(), ctx.teamId, variantId, { at: when, actor: { memberId: ctx.memberId } });
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true, dryRun: pub.dry_run };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not schedule" };
@@ -197,7 +197,7 @@ export async function generateImage(
     const db = adminClient();
     await generateVariantImage(db, ctx.teamId, variantId, { actor: { memberId: ctx.memberId } });
     const budget = await imageBudget(db, ctx.teamId);
-    revalidatePath(`/t/${teamSlug}/admin/social`);
+    revalidatePath(`/t/${teamSlug}/social`);
     return { ok: true, remaining: budget.remaining };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "image generation failed" };

--- a/app/t/[team]/social/page.tsx
+++ b/app/t/[team]/social/page.tsx
@@ -1,4 +1,7 @@
+import Link from "next/link";
+import { CircleAlert } from "lucide-react";
 import { serverClient } from "@/lib/db/server";
+import { currentMember } from "@/lib/auth/guard";
 import { listOpportunities } from "@/lib/social/store";
 import { listTeamMediaMeta } from "@/lib/media/store";
 import { imageBudget } from "@/lib/media/generate-image";
@@ -8,17 +11,39 @@ import { listPublications } from "@/lib/social/publications";
 import { typefullyStatus } from "@/lib/integrations/typefully";
 import { SocialOpportunitiesPanel, type VariantView, type PendingApprovalView, type PublicationView } from "@/components/admin/social-opportunities-panel";
 
-export default async function SocialAdminPage({ params }: { params: Promise<{ team: string }> }) {
+function Kpi({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="prism-card flex flex-col gap-0.5 px-4 py-3">
+      <span className="text-2xl font-semibold text-ink">{value}</span>
+      <span className="text-xs text-ink-tertiary">{label}</span>
+    </div>
+  );
+}
+
+export default async function SocialPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
   const db = await serverClient();
 
   const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
-  // Admin view — the whole /admin area is admin-gated, so it sees all tiers (team).
+  // Operator surface — spends money + posts publicly, so admin-only (matches the nav gate).
+  const me = await currentMember(team.id);
+  if (!me || me.role !== "admin") {
+    return (
+      <div className="prism-card flex max-w-lg flex-col items-start gap-2 p-6">
+        <CircleAlert className="size-6 text-violet" strokeWidth={1.5} />
+        <h1 className="text-lg font-semibold text-ink">Social Brain is admin-only</h1>
+        <p className="text-sm text-ink-secondary">
+          Discovering, generating, and publishing content is restricted to team admins. Ask an admin
+          if you need access.
+        </p>
+      </div>
+    );
+  }
+
   const opportunities = await listOpportunities(db, team.id, "team", 100);
 
-  // Variants grouped by opportunity (plan is the join). Reads only; admin-gated area.
   const { data: plans } = await db.from("content_plans").select("id, opportunity_id").eq("team_id", team.id);
   const planToOpp = new Map((plans ?? []).map((p: { id: string; opportunity_id: string }) => [p.id, p.opportunity_id]));
   const { data: variants } = await db
@@ -28,18 +53,17 @@ export default async function SocialAdminPage({ params }: { params: Promise<{ te
     .order("created_at", { ascending: true });
 
   const byOpportunity: Record<string, VariantView[]> = {};
-  for (const v of (variants ?? []) as (VariantView & { plan_id: string })[]) {
+  const allVariants = (variants ?? []) as (VariantView & { plan_id: string })[];
+  for (const v of allVariants) {
     const oppId = planToOpp.get(v.plan_id);
     if (oppId) (byOpportunity[oppId] ??= []).push(v);
   }
 
-  // Generated images grouped by variant (ids only — bytes are served by the media route).
   const media = await listTeamMediaMeta(db, team.id, 200);
   const mediaByVariant: Record<string, string[]> = {};
   for (const m of media) (mediaByVariant[m.variant_id] ??= []).push(m.id);
   const budget = await imageBudget(db, team.id);
 
-  // Approval workflow (M4): autonomy + the pending queue, with per-variant context for display.
   const autonomy = await getAutonomy(db, team.id);
   const pendingRows = await listPendingApprovals(db, team.id);
   const variantCtx: Record<string, { platform: string; body: string; oppTitle: string }> = {};
@@ -56,7 +80,6 @@ export default async function SocialAdminPage({ params }: { params: Promise<{ te
     oppTitle: variantCtx[a.variant_id]?.oppTitle ?? "",
   }));
 
-  // Publishing (M5): Typefully connection, dry-run flag, and the publication ledger per variant.
   const [tf, publishDryRun, pubs] = await Promise.all([
     typefullyStatus(db, team.id),
     getPublishDryRun(db, team.id),
@@ -67,15 +90,32 @@ export default async function SocialAdminPage({ params }: { params: Promise<{ te
     (publicationsByVariant[p.variant_id] ??= []).push({ status: p.status, url: p.external_url, dryRun: p.dry_run });
   }
 
+  const publishedCount = pubs.filter((p) => p.status === "published").length;
+
   return (
-    <div className="flex flex-col gap-4">
-      <p className="text-sm text-ink-secondary">
-        The <strong>Social Brain</strong> turns your team’s knowledge into content. <em>Discover</em>
-        ranks recent decisions, deliverables, and commits; <em>Plan</em> shapes brand-aware variants;
-        <em>Generate</em> drafts each in your voice, grounded only in the source evidence and checked
-        against your governance rules. Each opportunity inherits the tier of its source, so
-        internal-only knowledge can never surface in a public post.
-      </p>
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-display text-2xl text-ink">Social Brain</h1>
+          <p className="mt-1 max-w-2xl text-sm text-ink-secondary">
+            Turn your team’s knowledge into content: <em>Discover</em> → <em>Plan</em> →{" "}
+            <em>Generate</em> → <em>Approve</em> → <em>Publish</em>. Every draft is grounded only in
+            its source evidence and checked against your brand governance, and each opportunity
+            inherits its source’s tier — internal knowledge never surfaces in a public post.
+          </p>
+        </div>
+        <Link href={`/t/${teamSlug}/admin/brand`} className="btn-ghost shrink-0">
+          Brand settings
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Kpi label="Opportunities" value={opportunities.length} />
+        <Kpi label="Drafts" value={allVariants.filter((v) => v.status === "generated" || v.body).length} />
+        <Kpi label="Pending approvals" value={pendingApprovals.length} />
+        <Kpi label="Published" value={publishedCount} />
+      </div>
+
       <SocialOpportunitiesPanel
         teamSlug={teamSlug}
         opportunities={opportunities}

--- a/components/admin/admin-tabs.tsx
+++ b/components/admin/admin-tabs.tsx
@@ -12,7 +12,6 @@ const TABS = [
   { slug: "pm-sync", label: "PM sync" },
   { slug: "policies", label: "Policies" },
   { slug: "brand", label: "Brand" },
-  { slug: "social", label: "Social" },
   { slug: "approvals", label: "Approvals" },
   { slug: "audit", label: "Audit log" },
 ];

--- a/components/admin/social-opportunities-panel.tsx
+++ b/components/admin/social-opportunities-panel.tsx
@@ -15,7 +15,7 @@ import {
   connectTypefully,
   setDryRun,
   scheduleVariantAction,
-} from "@/app/t/[team]/admin/social/actions";
+} from "@/app/t/[team]/social/actions";
 import { AUTONOMY_LEVELS, type AutonomyLevel } from "@/lib/social/autonomy";
 import type { OpportunityRow } from "@/lib/social/types";
 

--- a/components/team-nav.tsx
+++ b/components/team-nav.tsx
@@ -13,6 +13,7 @@ import {
   GitBranch,
   Home,
   ListTodo,
+  Megaphone,
   NotebookText,
   Shield,
   Sparkles,
@@ -33,6 +34,7 @@ const ICONS = {
   teamtools: Wrench,
   query: Sparkles,
   learning: Brain,
+  social: Megaphone,
   admin: Shield,
   account: UserCircle,
 } as const;


### PR DESCRIPTION
## What

You asked whether the Social Brain is on the dashboard — it wasn't (only under **Admin → Social**). This promotes it to a **top-level dashboard surface**.

## Changes
- **New route `app/t/[team]/social`** — a proper hub with a header + **KPI strip** (opportunities / drafts / pending approvals / published) above the full pipeline panel (Discover → Plan → Generate → Approve → Publish). **Admin-gated at the page** (it's an operator surface: it spends on generation and posts publicly).
- **Top-level "Social" nav entry** (admin-only, Megaphone icon) in the team layout.
- Moved the server actions to `app/t/[team]/social/actions.ts` (revalidate targets the new route); **removed the redundant Admin → Social tab + page**. Brand config stays under Admin (it's configuration) and is linked from the Social header.

## Note on visibility
Kept it **admin-only** (like the Admin entry) because operating it costs money + publishes. If you'd rather members get a **read-only** view, that's an easy follow-up (hide the action controls for non-admins).

## Verification
`check:docs` ✓ · `typecheck` ✓ · `lint` ✓ (0 err) · unit **601 passed** ✓ · `next build` ✓ (`/t/[team]/social`). No schema/API change — routing + UI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)