### PR TITLE
Add RESOLVER.md skill/doc routing

### DIFF
--- a/.claude/resolver-fixtures.yaml
+++ b/.claude/resolver-fixtures.yaml
@@ -1,0 +1,26 @@
+# Routing fixtures for the aios-team-brain resolver.
+# Schema: ~/Projects/.tessera/resolver/fixtures-schema.yaml
+# Run: node ~/Projects/.tessera/resolver/bin/routing-eval.mjs <this-repo>
+fixtures:
+  - intent: "Add a new ingest source"
+    expected: "ARCHITECTURE.md"
+  - intent: "Deploy the latest changes"
+    expected: "merging to main"
+  - intent: "Run railway up to push this fix"
+    expected: "never up/redeploy/down/delete"
+  - intent: "Add a new dashboard page listing team items"
+    expected: "lib/auth/visibility"
+  - intent: "Change the push endpoint's payload"
+    expected: "brain-api.md"
+  - intent: "Add a status column to the tasks table"
+    expected: "postgres/migrations"
+  - intent: "Write a test for the dedup logic"
+    expected: "Spec-first"
+  - intent: "Sync the board to Plane"
+    expected: "Plane is retired"
+  - intent: "Clean up the diverged feature branch"
+    expected: "branch-reconciliation"
+  - intent: "Is the tier filter test actually running in CI?"
+    expected: "test-ci-wiring-audit"
+  - intent: "Why isn't this task showing up in Linear?"
+    expected: "lib/pm-sync"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 # AIOS Team Brain — operating manual
 
+**Skill/doc routing: see `RESOLVER.md`** — gates (architecture-map loop, Railway
+read-only, tier isolation, brain-api, migrations, spec-first tests, Linear-only)
+and skill routing.
+
 This file is read at the start of every session. It encodes the durable conventions for
 working in this repo. Follow it over generic habits.
 

--- a/RESOLVER.md
+++ b/RESOLVER.md
@@ -1,0 +1,49 @@
+---
+resolver: v1
+scope: aios-team-brain
+parent: ../RESOLVER.md
+skills_roots: [.claude/skills]
+fixtures: .claude/resolver-fixtures.yaml
+---
+
+# aios-team-brain — Resolver
+
+Canonical router for the Team Brain repo. `CLAUDE.md` is the entrypoint; this
+file decides which skill, rule, or doc to load. Gates always apply. Parent
+gates (AIOS hub, Tessera root) apply in addition.
+
+## Always-On Gates
+
+| Trigger | Load |
+|---|---|
+| BEFORE building any change | `docs/ARCHITECTURE.md` — consult the sources-of-truth table; reason from the source of truth, never a random call site |
+| AFTER building any change | Update `docs/ARCHITECTURE.md` **in the same PR**; enumerable surfaces are machine-guarded by `scripts/check-docs-drift.mjs` (CI + pre-push) |
+| Any task that will create commits | Worktree REQUIRED — never branch in the primary checkout (hub rule) |
+| Any Railway command | **Read-only CLI**: status/logs/variables/deployment-list ONLY; never up/redeploy/down/delete — deploys happen ONLY by merging to main. Confirm `railway status` shows Project: AIOS first (`scripts/railway-deploy-guard.sh` + `scripts/service-guard.mjs` enforce; the 2026-06-27 Kula incident) |
+| Any read path or dashboard surface touched | Tier isolation is an app-code invariant (no RLS): route through the `lib/auth/visibility.ts` choke point; guard test `test/guards/dashboard-tier-filter.test.ts` |
+| Any sync-protocol/API change | Pinned contract `../aios-workspace/docs/brain-api.md` — versioned bump there first |
+| Adding a column to an existing table | `postgres/migrations/` (alter) AND mirror into `postgres/schema.sql` (from-zero) — editing create-table alone is a prod no-op |
+| Writing any test | Spec-first, never characterization-first; pick the tier by failure mode (unit / data-mechanics / integration / eval — CLAUDE.md §4) |
+| Any PM/board work | `aios-linear` (global skill) — Linear only; **Plane is retired**: never register or use the `lib/pm-sync` Plane adapter (still present for historical rows; removal is a scoped migration, tracked in the resolver audit) |
+
+## Functional Areas
+
+| Trigger | Skill |
+|---|---|
+| Admin/ops tasks on the brain instance | `.claude/skills/admin/SKILL.md` |
+| Branches diverged / reconcile a fork | `.claude/skills/branch-reconciliation/SKILL.md` |
+| "Is this test actually wired into CI" | `.claude/skills/test-ci-wiring-audit/SKILL.md` |
+| PM projection questions (brain→Linear) | `lib/pm-sync/` — the brain's tasks table is canonical, projection is one-way; reconcile reads live status surface-only |
+
+## Agent Roles
+
+| Need | Agent |
+|---|---|
+| (never auto-selected) | `.claude/agents/code-reviewer.md` — plain diffs → built-in `code-review`; see the workspace resolver's review arbitration |
+
+## Disambiguation
+
+1. Most-specific scope wins; ties break project local > global > plugin > built-in.
+2. Persistence/access bugs → data-mechanics tier (real Postgres), never the FakeSupabase shape tier — a stubbed-model green is false confidence for a data-pipeline change.
+3. A claim is real only when a red test reproduces the observable outcome; audits and AI-suggested bugs are hypotheses to re-derive.
+4. Guards are built reactively — each must trace to a real bug or contract (CLAUDE.md §7); don't add ceremony guards.


### PR DESCRIPTION
## What

Team-brain phase (P3c) of the Tessera resolver rollout (thin harness, fat skills). Pairs with johnellison/aios#7 (hub) and aiosbrain/aios-workspace#254 (toolkit).

- **`RESOLVER.md`** — trigger→doc/skill routing table: the architecture-map build loop, worktree rule, **Railway read-only gate** (with the Kula-incident guard chain), tier-isolation choke point (`lib/auth/visibility.ts`), brain-api pinned contract, the add-a-column migrations rule, spec-first testing, and the **Linear-only/Plane-retired** gate.
- **CLAUDE.md** — one routing pointer added at top; all prose stays (it's the fat canonical home the gate rows point into).
- **11 routing fixtures**, 100% pass.

## Deliberately NOT in this PR

The retired Plane adapter is **not** deleted. Scouting showed it's much wider than `lib/pm-sync/plane.ts`: ingest sources (`lib/ingest/sources/plane*.ts`), API schemas, identity, integrations UI, and the `PmProvider` type — plus historical rows with `provider='plane'`. That's a scoped migration, not a cleanup; proposed separately in the estate audit report. The resolver's hard gate keeps agents out of it meanwhile.

## Verified

- `resolver-health.mjs`: 0 errors (1 expected cross-PR warning: `parent: ../RESOLVER.md` resolves when the hub PR merges)
- `routing-eval.mjs`: 11/11 fixtures
- `npm run check:docs`: docs congruent ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and agent-routing metadata only; no application, auth, or deploy logic is modified.
> 
> **Overview**
> Introduces **Tessera resolver v1** routing for this repo: a new **`RESOLVER.md`** that maps triggers to always-on gates (architecture-map loop, worktree-only commits, Railway read-only deploy policy, tier isolation via `lib/auth/visibility.ts`, `brain-api.md` contract, Postgres migration rules, spec-first testing, Linear-only PM) plus functional skills (admin, branch-reconciliation, test-ci-wiring-audit, `lib/pm-sync`).
> 
> **`CLAUDE.md`** gains a short top-of-file pointer to that router; existing operating-manual prose is unchanged.
> 
> Adds **`.claude/resolver-fixtures.yaml`** with 11 intent→expected routing eval cases for `routing-eval.mjs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b83a6ba00bcfc3191afaee456e5fb7cd335fb5a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->