### PR TITLE
chore(contract): implement brain-api v1.8 (catch pin up to shipped subscriptions)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,9 +97,9 @@ flowchart LR
 
 ## Auth & access tiers
 
-This server **implements brain-api v1.7** (the wire contract; source of truth:
-`aios-workspace/docs/brain-api.md`; v1.7 added the member-invite endpoint,
-`POST /api/v1/members/invite`). That version is pinned in code as `BRAIN_API_VERSION`
+This server **implements brain-api v1.8** (the wire contract; source of truth:
+`aios-workspace/docs/brain-api.md`; v1.8 added the subscriptions endpoint,
+`POST /api/v1/subscriptions`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`), asserted against this sentence by
 `test/guards/contract-version.test.ts`, and mirrored by the vendored
 `test/fixtures/contract/brain-contract.json` (regenerated in lockstep with the canonical

--- a/docs/ENGINEERING-CONSTITUTION.md
+++ b/docs/ENGINEERING-CONSTITUTION.md
@@ -13,7 +13,7 @@ governed by the sync contract and the tier model — there is no side channel.
 
 ## 2. The sync contract is law
 
-`aios-workspace/docs/brain-api.md` (currently v1.7, major `/api/v1`) is the single
+`aios-workspace/docs/brain-api.md` (currently v1.8, major `/api/v1`) is the single
 pinned contract. Any protocol change is a versioned change in that file first, with
 matching changes on both sides. Clients must ignore unknown item kinds
 (forward-compat); the brain must never silently change response shapes.
@@ -51,7 +51,7 @@ and update it in the same commit as any principle change.
 <!-- agent-digest:start -->
 - The brain is the ONE shared hub: workspaces push to it; it never reaches into a
   workspace; no side channels around the sync contract.
-- `brain-api.md` (v1.7, `/api/v1`) is law: protocol changes are versioned there
+- `brain-api.md` (v1.8, `/api/v1`) is law: protocol changes are versioned there
   FIRST with matching changes on both sides; never silently change a response
   shape; ignore-unknown-kinds stays intact.
 - Tier enforcement is a hard boundary: `admin`-tier content → 422 at the API

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -9,4 +9,4 @@
  * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
  */
-export const BRAIN_API_VERSION = "1.7";
+export const BRAIN_API_VERSION = "1.8";

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -1,7 +1,7 @@
 {
   "$schema": "aios-brain-contract/v1",
-  "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: scratchpad gen-contract-fixture.mjs.",
-  "version": "1.7",
+  "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: node scripts/gen-contract-fixture.mjs.",
+  "version": "1.8",
   "tierAliases": {
     "shared": {
       "team": "team",
@@ -83,5 +83,5 @@
     "slack",
     "github"
   ],
-  "contentHash": "bbed14ced6a77e7a0fd5b44aa148082e138b59b1e617395bd3e99aea992be6e5"
+  "contentHash": "65cf8bbe18270f8c720c99e1790992746f99b611d2d38e5569cb1929e8ee8ded"
 }


### PR DESCRIPTION
Matches the workspace contract PR **aiosbrain/aios-workspace#259**. The subscriptions endpoint (`POST /api/v1/subscriptions`) shipped as **v1.8** and is fully live here (route, `subscriptionPayloadSchema`, `lib/subscriptions/ingest`, the `subscriptions` table, `subscriptions.datamechanics.test.ts`, the ARCHITECTURE row), but the version **pin** still said 1.7. This moves it in lockstep.

## What's here

- **`lib/api/version.ts`**: `BRAIN_API_VERSION` `1.7` → `1.8` (the single server-side pin, guarded by `test/guards/contract-version.test.ts`).
- **`test/fixtures/contract/brain-contract.json`**: re-vendored **byte-for-byte** from the workspace canonical — `contentHash 65cf8bbe…`, identical to the workspace copy, so `/docs-sync` (Audit 1b) stays in sync.
- **`docs/ARCHITECTURE.md`**: the guarded "implements brain-api **v1.8**" sentence + its illustrative endpoint updated to subscriptions. (The historical "member-invite added in v1.7" note in the endpoint list stays accurate.)
- **`docs/ENGINEERING-CONSTITUTION.md`**: "currently **v1.8**" prose.

## Verification

- `vitest run test/guards/contract-conformance.test.ts test/guards/contract-version.test.ts` → **9/9 green** (version tracks `BRAIN_API_VERSION`, contentHash intact, ARCHITECTURE sentence matches).
- `node scripts/check-docs-drift.mjs` → green.
- Fixture `contentHash` is byte-identical to `aios-workspace/docs/contract/brain-contract.json`.

No runtime code branches on the version — this is a pin-alignment change to already-shipped code. Merge after / alongside aios-workspace#259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version-constant alignment only; no runtime behavior changes in the diff.
> 
> **Overview**
> Aligns the **brain-api contract version pin** with workspace **v1.8**, where `POST /api/v1/subscriptions` is the illustrative new endpoint. **`BRAIN_API_VERSION`** moves **1.7 → 1.8** in `lib/api/version.ts`; **`docs/ARCHITECTURE.md`** and **`docs/ENGINEERING-CONSTITUTION.md`** (including the agent digest) now state v1.8 and cite subscriptions instead of member-invite as the version example.
> 
> Re-vendors **`test/fixtures/contract/brain-contract.json`** to **1.8** with an updated **`contentHash`** and a corrected fixture-regeneration note (`node scripts/gen-contract-fixture.mjs`). No new routes or ingest logic in this diff—subscriptions were already implemented; this keeps guards (`contract-version`, `contract-conformance`) and `/docs-sync` in lockstep with **aios-workspace#259**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a79986c5196179efda633440694841baad58525. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->