### PR TITLE
chore: OSS front-door hygiene (version, CoC, issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Something in the Team Brain isn't working as documented
+title: "[bug] "
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- A clear, concise description of the bug. -->
+
+## Expected behavior
+
+<!-- What you expected to happen instead. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- `aios-team-brain` version/commit:
+- Deployment: self-hosted / Railway / other
+- Node version:
+- Postgres version:
+- LLM provider (Anthropic / local via `LLM_BASE_URL`):
+
+## Relevant logs / output
+
+```
+paste here
+```
+
+## Additional context
+
+<!-- Tier involved (admin/team/external), API route, or anything else that helps triage. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question / start a discussion
+    url: https://github.com/aiosbrain/aios-team-brain/discussions
+    about: Open-ended questions, ideas, and general discussion — not a specific bug or feature.
+  - name: AIOS Workspace (the contributor repo)
+    url: https://github.com/aiosbrain/aios-workspace
+    about: If your issue is about the individual workspace toolkit or the aios CLI rather than the Brain itself, file it there.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea for the Team Brain
+title: "[feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What are you trying to do that the Brain doesn't support today? -->
+
+## Proposed solution
+
+<!-- What would you like to happen? Point at the relevant surface if you know
+it — e.g. `lib/ingest`, `lib/query`, a dashboard page, the API contract in
+`aios-workspace/docs/brain-api.md`. -->
+
+## Alternatives considered
+
+<!-- Any other approaches you thought about. -->
+
+## Additional context
+
+<!-- Note if this touches the tier model (admin/team/external) or the sync
+contract — those are hard invariants and changes there need extra care. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,22 @@
+---
+name: Question
+about: Ask a question about using or running the Team Brain
+title: "[question] "
+labels: question
+assignees: ''
+---
+
+Before filing: check [DEVELOPMENT.md](../../DEVELOPMENT.md), [CONTRIBUTING.md](../../CONTRIBUTING.md),
+and [docs/](../../docs) — a lot of the "how do I" answers live there.
+
+For open-ended discussion (not a specific bug/feature), consider using
+[GitHub Discussions](../../discussions) instead — issues here are best for
+concrete, actionable questions.
+
+## Your question
+
+<!-- Ask away. -->
+
+## What you've already tried / read
+
+<!-- Docs consulted, commands run, etc. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening,
+offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, and will communicate reasons
+for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public
+spaces. Examples of representing our community include using an official
+e-mail address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**john@john-ellison.com**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public
+or private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-team-brain",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps `package.json` version to `0.7.0`, aligning with the already-shipped `v0.7.0` git tag (the real v1.0 bump comes later).
- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1, contact: john@john-ellison.com).
- Adds `.github/ISSUE_TEMPLATE/` (bug report, feature request, question) + `config.yml` routing open-ended questions to Discussions and cross-linking `aios-workspace`.

Part of the OSS front-door hygiene pass across both public AIOS repos (repo description + a GitHub release were handled directly via `gh`, no PR needed for those).

## Test plan
- [x] `npm run lint` — 0 errors (1 pre-existing unrelated warning)
- [x] `npm run typecheck` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and GitHub metadata only; no application, API, or runtime behavior changes.
> 
> **Overview**
> Prepares the public repo for open-source contributors by aligning the declared package version with the shipped **`v0.7.0`** tag and adding standard GitHub community files.
> 
> **`package.json`** version moves from **`0.1.0`** to **`0.7.0`**. New **`CODE_OF_CONDUCT.md`** (Contributor Covenant 2.1) documents enforcement contact. **`.github/ISSUE_TEMPLATE/`** adds bug, feature, and question forms plus **`config.yml`** contact links to Discussions and **`aios-workspace`** for off-repo issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c665470791377adc192bb7c63001c53a9ae4cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->