### PR TITLE
test(security): direct coverage for the visibility choke-point + extended ingest tests

### DIFF
--- a/lib/auth/visibility.test.ts
+++ b/lib/auth/visibility.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  visibleItems,
+  canSeeAccess,
+  visibleDecisions,
+  visibleTasks,
+  visibleByAccess,
+  scopeQueryLog,
+  type ViewerTier,
+  type QueryLogViewer,
+} from "@/lib/auth/visibility";
+
+/**
+ * Direct unit coverage for the tier-visibility choke-point (CLAUDE.md §5). There is NO RLS —
+ * this module is the SOLE app-code enforcement that an `external`-tier viewer never sees
+ * `team`/`admin` content. Until now it had only transitive coverage via test/guards/* (which
+ * prove callers route THROUGH the choke-point, not that the choke-point itself behaves
+ * correctly for every tier/column). These tests exercise every exported function directly.
+ */
+
+// A minimal fake query builder that records every .eq() call, mirroring the supabase-js
+// fluent-chain shape the real functions assert onto via their localized cast.
+function fakeQuery() {
+  const calls: Array<{ column: string; value: string }> = [];
+  const self = {
+    calls,
+    eq(column: string, value: string) {
+      calls.push({ column, value });
+      return self;
+    },
+  };
+  return self;
+}
+
+describe("visibleItems", () => {
+  it("team tier: passes the query through unchanged (no filter applied)", () => {
+    const q = fakeQuery();
+    const out = visibleItems(q, "team");
+    expect(out).toBe(q);
+    expect(q.calls).toEqual([]);
+  });
+
+  it("external tier: filters to access='external'", () => {
+    const q = fakeQuery();
+    const out = visibleItems(q, "external");
+    expect(out).toBe(q);
+    expect(q.calls).toEqual([{ column: "access", value: "external" }]);
+  });
+});
+
+describe("canSeeAccess", () => {
+  it("team tier sees every access level (team, external, and even 'admin')", () => {
+    expect(canSeeAccess("team", "team")).toBe(true);
+    expect(canSeeAccess("team", "external")).toBe(true);
+    // Documents current behavior: canSeeAccess trusts the caller never to hand it an
+    // admin-tier row for a team viewer — admin/private content must never reach this
+    // function's `access` column at all (enforced upstream at the ingest 422 boundary in
+    // app/api/v1/items/route.ts, NOT here). See the "surprising" note in the PR description.
+    expect(canSeeAccess("team", "admin")).toBe(true);
+  });
+
+  it("external tier sees ONLY external-access content", () => {
+    expect(canSeeAccess("external", "external")).toBe(true);
+    expect(canSeeAccess("external", "team")).toBe(false);
+    expect(canSeeAccess("external", "admin")).toBe(false);
+  });
+
+  it("external tier default-denies unrecognized/empty access values", () => {
+    expect(canSeeAccess("external", "")).toBe(false);
+    expect(canSeeAccess("external", "bogus-tier")).toBe(false);
+  });
+});
+
+describe("visibleDecisions", () => {
+  it("team tier: passes the query through unchanged", () => {
+    const q = fakeQuery();
+    const out = visibleDecisions(q, "team");
+    expect(out).toBe(q);
+    expect(q.calls).toEqual([]);
+  });
+
+  it("external tier: filters to audience='external' (decisions carry tier in `audience`, not `access`)", () => {
+    const q = fakeQuery();
+    visibleDecisions(q, "external");
+    expect(q.calls).toEqual([{ column: "audience", value: "external" }]);
+  });
+});
+
+describe("visibleTasks", () => {
+  it("team tier: passes the query through unchanged", () => {
+    const q = fakeQuery();
+    const out = visibleTasks(q, "team");
+    expect(out).toBe(q);
+    expect(q.calls).toEqual([]);
+  });
+
+  it("external tier: filters to audience='external'", () => {
+    const q = fakeQuery();
+    visibleTasks(q, "external");
+    expect(q.calls).toEqual([{ column: "audience", value: "external" }]);
+  });
+});
+
+describe("visibleByAccess (Social Brain content)", () => {
+  it("team tier: passes the query through unchanged", () => {
+    const q = fakeQuery();
+    const out = visibleByAccess(q, "team");
+    expect(out).toBe(q);
+    expect(q.calls).toEqual([]);
+  });
+
+  it("external tier: filters to access='external'", () => {
+    const q = fakeQuery();
+    visibleByAccess(q, "external");
+    expect(q.calls).toEqual([{ column: "access", value: "external" }]);
+  });
+});
+
+describe("scopeQueryLog", () => {
+  it("admin viewer: passes the query through unchanged (sees the whole team's log)", () => {
+    const q = fakeQuery();
+    const viewer: QueryLogViewer = { isAdmin: true, memberId: "mem-1" };
+    const out = scopeQueryLog(q, viewer);
+    expect(out).toBe(q);
+    expect(q.calls).toEqual([]);
+  });
+
+  it("non-admin viewer: scopes to their own member_id", () => {
+    const q = fakeQuery();
+    const viewer: QueryLogViewer = { isAdmin: false, memberId: "mem-2" };
+    scopeQueryLog(q, viewer);
+    expect(q.calls).toEqual([{ column: "member_id", value: "mem-2" }]);
+  });
+
+  it("two non-admin viewers scope to DIFFERENT member_ids (non-vacuity: the filter actually discriminates by viewer)", () => {
+    const qa = fakeQuery();
+    const qb = fakeQuery();
+    scopeQueryLog(qa, { isAdmin: false, memberId: "mem-a" });
+    scopeQueryLog(qb, { isAdmin: false, memberId: "mem-b" });
+    expect(qa.calls[0]?.value).toBe("mem-a");
+    expect(qb.calls[0]?.value).toBe("mem-b");
+    expect(qa.calls[0]?.value).not.toBe(qb.calls[0]?.value);
+  });
+});
+
+describe("unknown/missing tier — inconsistent default across the choke-point (documented current behavior)", () => {
+  // `ViewerTier` is typed as the closed union "team" | "external", so a correctly-typed caller
+  // can never construct anything else. But every one of these functions is a plain runtime
+  // string check, and the real call sites feed them a DB-sourced or request-derived value cast
+  // to `ViewerTier` (e.g. `me?.tier ?? "external"` in app/t/[team]/library/[itemId]/page.tsx, or
+  // `auth.memberTier` off an API key row) — nothing stops a corrupt/legacy/typo'd tier value from
+  // reaching these functions at the type boundary.
+  //
+  // The six functions do NOT agree on a default for an unrecognized tier:
+  //   - visibleItems / visibleDecisions / visibleTasks / visibleByAccess check `tier !== "external"`
+  //     — an ALLOW-list of exactly one restricted value. Any other string ("admin", "", "TEAM", a
+  //     future tier nobody's added a branch for) falls through to the UNFILTERED branch: fail-OPEN.
+  //   - canSeeAccess checks `tier === "team"` — a DENY-by-default for team-tier content; an
+  //     unrecognized tier only sees rows explicitly marked `access === "external"`: fail-CLOSED.
+  // This suite documents the behavior as-is (not asserted as correct or incorrect) — see the PR
+  // description's "surprising" note on this asymmetry.
+  const unknownTiers = ["admin", "", "TEAM", "external ", "unknown"] as unknown as ViewerTier[];
+
+  it.each(unknownTiers)("visibleItems treats tier=%j as unrestricted (fail-open)", (tier) => {
+    const q = fakeQuery();
+    visibleItems(q, tier);
+    expect(q.calls).toEqual([]); // no filter applied — full visibility granted
+  });
+
+  it.each(unknownTiers)("visibleDecisions treats tier=%j as unrestricted (fail-open)", (tier) => {
+    const q = fakeQuery();
+    visibleDecisions(q, tier);
+    expect(q.calls).toEqual([]);
+  });
+
+  it.each(unknownTiers)("visibleTasks treats tier=%j as unrestricted (fail-open)", (tier) => {
+    const q = fakeQuery();
+    visibleTasks(q, tier);
+    expect(q.calls).toEqual([]);
+  });
+
+  it.each(unknownTiers)("visibleByAccess treats tier=%j as unrestricted (fail-open)", (tier) => {
+    const q = fakeQuery();
+    visibleByAccess(q, tier);
+    expect(q.calls).toEqual([]);
+  });
+
+  it.each(unknownTiers)(
+    "canSeeAccess(tier=%j, 'team') denies team-tier content (fail-closed — inconsistent with the visibleX family above)",
+    (tier) => {
+      expect(canSeeAccess(tier, "team")).toBe(false);
+    }
+  );
+
+  it.each(unknownTiers)(
+    "canSeeAccess(tier=%j, 'external') still grants external-access content regardless of tier (by design — external content is universally readable)",
+    (tier) => {
+      expect(canSeeAccess(tier, "external")).toBe(true);
+    }
+  );
+});

--- a/lib/ingest/ingest.test.ts
+++ b/lib/ingest/ingest.test.ts
@@ -2,7 +2,17 @@ import { describe, expect, it } from "vitest";
 import type { DbClient } from "@/lib/db/types";
 import { ingestItem } from "@/lib/ingest";
 import { FakeSupabase } from "@/lib/ingest/fake-supabase";
+import { IngestValidationError } from "@/lib/api/schemas";
 import type { ItemPayload } from "@/lib/api/schemas";
+
+/**
+ * lib/ingest is the SOLE service-role writer (bypasses RLS entirely — CLAUDE.md §5). There is
+ * no DB-level tier backstop, so every claim this file makes about tier tagging, diff-sync, and
+ * validation is a security-load-bearing spec, not incidental behavior. These tests extend the
+ * dedup + basic diff-sync coverage above with: tier tagging through materialization, malformed
+ * payload rejection, idempotent re-push, and more diff-sync edge cases (update-in-place, dangling
+ * parent nulling, partial-write preserve/clear semantics).
+ */
 
 const AUTH = { teamId: "team-1", memberId: "mem-1", apiKeyId: "key-1" };
 
@@ -97,5 +107,362 @@ describe("ingestItem task diff-sync", () => {
     const keys = fake.tables.tasks.map((t) => t.row_key).sort();
     expect(keys).toEqual(["T-1", "U-1"]); // T-2 removed, U-1 preserved
     expect(fake.tables.tasks.find((t) => t.row_key === "T-1")?.title).toBe("first (edited)");
+  });
+
+  it("updates an existing row's fields in place rather than duplicating it", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "b.md",
+        content_sha256: "e".repeat(64),
+        rows: [{ row_key: "T-1", title: "v1", status: "backlog" }],
+      }),
+      "team"
+    );
+    const firstId = fake.tables.tasks[0].id;
+
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "b.md",
+        content_sha256: "f".repeat(64),
+        rows: [{ row_key: "T-1", title: "v2", status: "in_progress" }],
+      }),
+      "team"
+    );
+
+    expect(fake.tables.tasks).toHaveLength(1); // no duplicate row
+    expect(fake.tables.tasks[0].id).toBe(firstId); // same row, updated
+    expect(fake.tables.tasks[0].title).toBe("v2");
+    expect(fake.tables.tasks[0].status).toBe("in_progress");
+  });
+
+  it("nulls a dangling parent_row_key when the parent row is dropped from a later push", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "b.md",
+        content_sha256: "1".repeat(64),
+        rows: [
+          { row_key: "EPIC-1", title: "epic" },
+          { row_key: "T-1", title: "child", parent: "EPIC-1" },
+        ],
+      }),
+      "team"
+    );
+    expect(fake.tables.tasks.find((t) => t.row_key === "T-1")?.parent_row_key).toBe("EPIC-1");
+
+    // Next push drops the epic; the child survives (still referenced by row_key) but its parent
+    // is gone, so the dangling reference must be nulled rather than left pointing at nothing.
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "b.md",
+        content_sha256: "2".repeat(64),
+        rows: [{ row_key: "T-1", title: "child", parent: "EPIC-1" }],
+      }),
+      "team"
+    );
+
+    const keys = fake.tables.tasks.map((t) => t.row_key).sort();
+    expect(keys).toEqual(["T-1"]); // EPIC-1 removed (sync-origin, absent from push)
+    expect(fake.tables.tasks.find((t) => t.row_key === "T-1")?.parent_row_key).toBeNull();
+  });
+
+  it("preserves assignee/parent/labels/priority when the key is OMITTED, but clears it when present-and-empty", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "b.md",
+        content_sha256: "3".repeat(64),
+        rows: [
+          { row_key: "T-1", title: "t", assignee: "alice", labels: ["urgent"], priority: "high" },
+        ],
+      }),
+      "team"
+    );
+    expect(fake.tables.tasks[0].assignee).toBe("alice");
+
+    // Re-push omitting assignee/labels/priority entirely: preserved, not reset to defaults.
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "b.md",
+        content_sha256: "4".repeat(64),
+        rows: [{ row_key: "T-1", title: "t (renamed)" }],
+      }),
+      "team"
+    );
+    expect(fake.tables.tasks[0].assignee).toBe("alice");
+    expect(fake.tables.tasks[0].labels).toEqual(["urgent"]);
+    expect(fake.tables.tasks[0].priority).toBe("high");
+    expect(fake.tables.tasks[0].title).toBe("t (renamed)");
+
+    // Re-push with assignee explicitly present-but-empty: authoritative clear, not preserved.
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "b.md",
+        content_sha256: "5".repeat(64),
+        rows: [{ row_key: "T-1", title: "t (renamed)", assignee: "" }],
+      }),
+      "team"
+    );
+    expect(fake.tables.tasks[0].assignee).toBe("");
+  });
+});
+
+describe("ingestItem idempotent re-push", () => {
+  it("re-pushing an identical task board twice is a no-op on the second push (same sha)", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    const rows = [{ row_key: "T-1", title: "first" }];
+
+    const first = await ingestItem(
+      supa,
+      AUTH,
+      payload({ kind: "task", path: "b.md", content_sha256: "a".repeat(64), rows }),
+      "team"
+    );
+    expect(first.status).toBe("created");
+    expect(fake.tables.tasks).toHaveLength(1);
+    const taskId = fake.tables.tasks[0].id;
+
+    // Same content_sha256 as the first push ⇒ the item-level dedup fast-path fires; the rows
+    // materialization is not even re-run (see index.ts step 2's early return).
+    const second = await ingestItem(
+      supa,
+      AUTH,
+      payload({ kind: "task", path: "b.md", content_sha256: "a".repeat(64), rows }),
+      "team"
+    );
+    expect(second.status).toBe("unchanged");
+    expect(fake.tables.tasks).toHaveLength(1);
+    expect(fake.tables.tasks[0].id).toBe(taskId);
+  });
+
+  it("re-pushing the SAME rows under a new sha (e.g. a touched comment/whitespace) is stable — no duplication", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    const rows = [
+      { row_key: "T-1", title: "first" },
+      { row_key: "T-2", title: "second" },
+    ];
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({ kind: "task", path: "b.md", content_sha256: "a".repeat(64), rows }),
+      "team"
+    );
+    // A different sha (body changed elsewhere) but identical row set re-materializes; row_key is
+    // the diff-sync identity, so re-processing the same rows must not create duplicates.
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({ kind: "task", path: "b.md", content_sha256: "b".repeat(64), rows }),
+      "team"
+    );
+    expect(fake.tables.tasks).toHaveLength(2);
+    expect(fake.tables.tasks.map((t) => t.row_key).sort()).toEqual(["T-1", "T-2"]);
+  });
+});
+
+describe("ingestItem tier tagging preserved through materialization", () => {
+  it("task rows inherit the item's access tier into tasks.audience", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "external-board.md",
+        content_sha256: "a".repeat(64),
+        access: "external",
+        rows: [{ row_key: "T-1", title: "client-visible task" }],
+      }),
+      "external"
+    );
+    expect(fake.tables.tasks[0].audience).toBe("external");
+
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "task",
+        path: "internal-board.md",
+        content_sha256: "b".repeat(64),
+        access: "team",
+        rows: [{ row_key: "T-2", title: "internal task" }],
+      }),
+      "team"
+    );
+    const internal = fake.tables.tasks.find((t) => t.row_key === "T-2");
+    expect(internal?.audience).toBe("team");
+  });
+
+  // SURPRISING (report, don't fix): unlike tasks, decisions do NOT inherit the item's access tier.
+  // materializeDecisions() never receives the item's `access` — each decision row's audience comes
+  // solely from decisionRowSchema's own `audience` field (default "team"), regardless of what
+  // access tier the parent item was pushed at. Pushing an item at access=external with a decision
+  // table that omits an explicit `audience` column silently produces a team-only decision — the
+  // opposite direction of a leak (under-sharing), but a real inconsistency with the task path.
+  it("decision rows default to audience=team regardless of the item's access, unless the row sets its own audience", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "decision",
+        path: "external-decisions.md",
+        content_sha256: "c".repeat(64),
+        access: "external",
+        rows: [{ row_key: "D-1", title: "no audience column set" }],
+      }),
+      "external"
+    );
+    expect(fake.tables.decisions[0].audience).toBe("team"); // NOT "external" — see note above
+
+    await ingestItem(
+      supa,
+      AUTH,
+      payload({
+        kind: "decision",
+        path: "team-decisions.md",
+        content_sha256: "d".repeat(64),
+        access: "team",
+        rows: [{ row_key: "D-2", title: "row opts into external", audience: "external" }],
+      }),
+      "team"
+    );
+    const d2 = fake.tables.decisions.find((d) => d.row_key === "D-2");
+    // A row can set audience=external even though the parent item is team-access — a per-row
+    // override with no cross-check against the item's own access tier.
+    expect(d2?.audience).toBe("external");
+  });
+});
+
+describe("ingestItem malformed payload handling", () => {
+  it("rejects a task row missing the required title with IngestValidationError (422 upstream)", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    await expect(
+      ingestItem(
+        supa,
+        AUTH,
+        payload({
+          kind: "task",
+          path: "b.md",
+          content_sha256: "a".repeat(64),
+          rows: [{ row_key: "T-1" }], // missing required `title`
+        }),
+        "team"
+      )
+    ).rejects.toThrow(IngestValidationError);
+  });
+
+  it("rejects a task row whose parent references itself", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    await expect(
+      ingestItem(
+        supa,
+        AUTH,
+        payload({
+          kind: "task",
+          path: "b.md",
+          content_sha256: "a".repeat(64),
+          rows: [{ row_key: "T-1", title: "t", parent: "T-1" }],
+        }),
+        "team"
+      )
+    ).rejects.toThrow(/parent cannot reference itself/);
+  });
+
+  it("rejects a task row whose parent is not found in the project (neither incoming nor existing)", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    await expect(
+      ingestItem(
+        supa,
+        AUTH,
+        payload({
+          kind: "task",
+          path: "b.md",
+          content_sha256: "a".repeat(64),
+          rows: [{ row_key: "T-1", title: "t", parent: "GHOST-1" }],
+        }),
+        "team"
+      )
+    ).rejects.toThrow(/not found in project/);
+  });
+
+  it("rejects a parent cycle across two rows in the same push", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    await expect(
+      ingestItem(
+        supa,
+        AUTH,
+        payload({
+          kind: "task",
+          path: "b.md",
+          content_sha256: "a".repeat(64),
+          rows: [
+            { row_key: "A", title: "a", parent: "B" },
+            { row_key: "B", title: "b", parent: "A" },
+          ],
+        }),
+        "team"
+      )
+    ).rejects.toThrow(/parent cycle detected/);
+  });
+
+  it("a 422-worthy row rejection leaves NO partial write behind (validated before any item/row mutation)", async () => {
+    const fake = new FakeSupabase();
+    const supa = fake as unknown as DbClient;
+    await expect(
+      ingestItem(
+        supa,
+        AUTH,
+        payload({
+          kind: "task",
+          path: "b.md",
+          content_sha256: "a".repeat(64),
+          rows: [
+            { row_key: "T-1", title: "good" },
+            { row_key: "T-2", title: "bad", parent: "T-2" }, // self-reference, invalid
+          ],
+        }),
+        "team"
+      )
+    ).rejects.toThrow(IngestValidationError);
+
+    // Neither the item nor any task row was written — validation runs before any mutation.
+    expect(fake.tables.items).toHaveLength(0);
+    expect(fake.tables.tasks).toHaveLength(0);
   });
 });

--- a/test/datamechanics/ingest-tier-tagging.datamechanics.test.ts
+++ b/test/datamechanics/ingest-tier-tagging.datamechanics.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { db, ingest, seedTeam } from "./helpers";
+
+/**
+ * Spec: `lib/ingest` materializes each task/decision row's tier onto a real `access_tier`
+ * Postgres enum column (`tasks.audience` / `decisions.audience`) — the value the dashboard's
+ * `visibleTasks`/`visibleDecisions` choke-point (lib/auth/visibility.ts) later filters on. There
+ * is no RLS, so a wrong or missing tier tag here is invisible until read time. Verified against
+ * the real DB (the enum itself is a backstop against a garbage tier value ever landing in the
+ * column at all — but NOT against a wrongly-computed team/external mapping, which is what these
+ * tests check).
+ */
+
+describe("tasks.audience inherits the item's access tier (real Postgres)", () => {
+  it("access='external' materializes tasks.audience='external'", async () => {
+    const seed = await seedTeam();
+    const body = "| row_key | title |\n|---|---|\n| T-1 | client task |";
+    await ingest(seed, {
+      path: "client-board.md",
+      kind: "task",
+      body,
+      access: "external",
+      rows: [{ row_key: "T-1", title: "client task" }],
+    });
+
+    const { data } = await db()
+      .from("tasks")
+      .select("audience")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "T-1")
+      .single();
+    expect((data as { audience: string }).audience).toBe("external");
+  });
+
+  it("access='team' materializes tasks.audience='team'", async () => {
+    const seed = await seedTeam();
+    const body = "| row_key | title |\n|---|---|\n| T-2 | internal task |";
+    await ingest(seed, {
+      path: "internal-board.md",
+      kind: "task",
+      body,
+      access: "team",
+      rows: [{ row_key: "T-2", title: "internal task" }],
+    });
+
+    const { data } = await db()
+      .from("tasks")
+      .select("audience")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "T-2")
+      .single();
+    expect((data as { audience: string }).audience).toBe("team");
+  });
+
+  it("changing the item's access on a later push re-tags the task's audience on the next materialization", async () => {
+    const seed = await seedTeam();
+    const body1 = "| row_key | title |\n|---|---|\n| T-3 | internal for now |";
+    await ingest(seed, {
+      path: "reclassified.md",
+      kind: "task",
+      body: body1,
+      access: "team",
+      rows: [{ row_key: "T-3", title: "internal for now" }],
+    });
+    const { data: before } = await db()
+      .from("tasks")
+      .select("audience")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "T-3")
+      .single();
+    expect((before as { audience: string }).audience).toBe("team");
+
+    const body2 = "| row_key | title |\n|---|---|\n| T-3 | now shared with client |";
+    await ingest(seed, {
+      path: "reclassified.md",
+      kind: "task",
+      body: body2,
+      access: "external",
+      rows: [{ row_key: "T-3", title: "now shared with client" }],
+    });
+    const { data: after } = await db()
+      .from("tasks")
+      .select("audience")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "T-3")
+      .single();
+    expect((after as { audience: string }).audience).toBe("external");
+  });
+});
+
+describe("decisions.audience is independent of the item's access tier (real Postgres) — see PR notes", () => {
+  // SURPRISING (report, don't fix): materializeDecisions() never receives the item's `access` —
+  // each row's audience comes solely from decisionRowSchema's own `audience` field (default
+  // "team"). This is a real asymmetry with tasks (which DO inherit `access`). Not a leak (it
+  // under-shares, defaulting more restrictive), but a correctness inconsistency worth a follow-up.
+  it("an external-access item's decision row with no explicit audience column materializes as audience='team' (NOT inherited)", async () => {
+    const seed = await seedTeam();
+    const body = "| row_key | title |\n|---|---|\n| D-1 | no audience column |";
+    await ingest(seed, {
+      path: "external-decisions.md",
+      kind: "decision",
+      body,
+      access: "external",
+      rows: [{ row_key: "D-1", title: "no audience column" }],
+    });
+
+    const { data } = await db()
+      .from("decisions")
+      .select("audience")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "D-1")
+      .single();
+    expect((data as { audience: string }).audience).toBe("team");
+  });
+
+  it("a team-access item's decision row CAN opt a single row into audience='external' via its own field", async () => {
+    const seed = await seedTeam();
+    const body = "| row_key | title | audience |\n|---|---|---|\n| D-2 | opts into external | external |";
+    await ingest(seed, {
+      path: "team-decisions.md",
+      kind: "decision",
+      body,
+      access: "team",
+      rows: [{ row_key: "D-2", title: "opts into external", audience: "external" }],
+    });
+
+    const { data } = await db()
+      .from("decisions")
+      .select("audience")
+      .eq("team_id", seed.teamId)
+      .eq("row_key", "D-2")
+      .single();
+    expect((data as { audience: string }).audience).toBe("external");
+  });
+});

--- a/test/datamechanics/items-route-tier-guard.datamechanics.test.ts
+++ b/test/datamechanics/items-route-tier-guard.datamechanics.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { POST as itemsPOST } from "@/app/api/v1/items/route";
+import { issueApiKey } from "@/lib/admin/keys";
+import { db, seedTeam, sha, type Seed } from "./helpers";
+
+/**
+ * lib/ingest (`ingestItem`) is the SOLE service-role writer for `items` — it bypasses RLS
+ * entirely and there is NO DB-level tier backstop on WHICH access values are legal to write
+ * (only that the column's enum values are 'team'|'external' — see postgres/schema.sql
+ * `access_tier`). The admin/private-tier 422 rejection lives ENTIRELY in the route boundary
+ * (app/api/v1/items/route.ts), one layer above ingestItem, which is typed to accept only
+ * "team" | "external" and never even sees "admin". This file proves that boundary against the
+ * real route handler + real Postgres: an admin/private/unknown-tier push is rejected 422
+ * BEFORE ingestItem runs (no row written), while legitimate team/external pushes persist.
+ */
+
+const URL = "http://test/api/v1/items";
+
+async function issueKeyFor(seed: Seed, tier: "team" | "external") {
+  let memberId = seed.memberId;
+  if (tier === "external") {
+    const { data, error } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `ext-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "External",
+        actor_handle: `ext-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "external",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`external member seed failed: ${error?.message}`);
+    memberId = (data as { id: string }).id;
+  }
+  const { key, keyId } = await issueApiKey(db(), seed.teamId, memberId, `${tier} key`);
+  const { data: row } = await db().from("api_keys").select("id").eq("key_id", keyId).single();
+  return { key, apiKeyId: (row as { id: string }).id };
+}
+
+function post(key: string, teamSlug: string, body: unknown) {
+  const req = new Request(URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "X-AIOS-Team": teamSlug,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+  return itemsPOST(req);
+}
+
+function itemBody(access: string, path: string) {
+  const body = `content for ${path}`;
+  return {
+    project: "acme",
+    path,
+    kind: "deliverable",
+    content_sha256: sha(body),
+    access,
+    actor: "tester",
+    frontmatter: {},
+    body,
+  };
+}
+
+async function itemCount(seed: Seed, path: string): Promise<number> {
+  const { data } = await db().from("items").select("id").eq("team_id", seed.teamId).eq("path", path);
+  return (data ?? []).length;
+}
+
+describe("items route tier guard (real handler, real Postgres — the boundary lib/ingest itself never sees)", () => {
+  it("rejects access='admin' with 422 forbidden_tier and writes NO item row", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const res = await post(team.key, seed.teamSlug, itemBody("admin", "5-personal/secret.md"));
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("forbidden_tier");
+    expect(await itemCount(seed, "5-personal/secret.md")).toBe(0);
+  });
+
+  it("rejects access='private' with 422 forbidden_tier and writes NO item row", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const res = await post(team.key, seed.teamSlug, itemBody("private", "5-personal/notes.md"));
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("forbidden_tier");
+    expect(await itemCount(seed, "5-personal/notes.md")).toBe(0);
+  });
+
+  it("rejects an unrecognized access tier with 422 invalid_payload and writes NO item row", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const res = await post(team.key, seed.teamSlug, itemBody("bogus-tier", "d/x.md"));
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("invalid_payload");
+    expect(await itemCount(seed, "d/x.md")).toBe(0);
+  });
+
+  it("accepts access='team' (201) and access='external' (201), each persisting with the requested tier", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+
+    const teamRes = await post(team.key, seed.teamSlug, itemBody("team", "d/team-doc.md"));
+    expect(teamRes.status).toBe(201);
+    const extRes = await post(team.key, seed.teamSlug, itemBody("external", "d/client-doc.md"));
+    expect(extRes.status).toBe(201);
+
+    const { data: teamItem } = await db()
+      .from("items")
+      .select("access")
+      .eq("team_id", seed.teamId)
+      .eq("path", "d/team-doc.md")
+      .single();
+    const { data: extItem } = await db()
+      .from("items")
+      .select("access")
+      .eq("team_id", seed.teamId)
+      .eq("path", "d/client-doc.md")
+      .single();
+    expect((teamItem as { access: string }).access).toBe("team");
+    expect((extItem as { access: string }).access).toBe("external");
+  });
+
+  it("legacy outward aliases ('client', 'company') normalize to external, not rejected", async () => {
+    const seed = await seedTeam();
+    const team = await issueKeyFor(seed, "team");
+    const res = await post(team.key, seed.teamSlug, itemBody("client", "d/legacy-alias.md"));
+    expect(res.status).toBe(201);
+    const { data } = await db()
+      .from("items")
+      .select("access")
+      .eq("team_id", seed.teamId)
+      .eq("path", "d/legacy-alias.md")
+      .single();
+    expect((data as { access: string }).access).toBe("external");
+  });
+});


### PR DESCRIPTION
## Summary

Two security-load-bearing thin spots identified in an audit, both closed with focused test suites:

1. **`lib/auth/visibility`** — the tier choke-point that stops cross-tier leakage (no RLS backstop; app-code is the SOLE enforcement per CLAUDE.md §5). Previously had only transitive coverage via `test/guards/*` (proving callers route THROUGH the choke-point, not that the choke-point itself behaves correctly). Now has direct unit tests for every exported function (`visibleItems`, `canSeeAccess`, `visibleDecisions`, `visibleTasks`, `visibleByAccess`, `scopeQueryLog`) across every tier.

2. **`lib/ingest`** — the SOLE service-role writer (bypasses RLS, "accepted risk" per its own README) had only one thin test file. Extended with tier tagging through materialization, malformed-payload rejection, idempotent re-push, and more row_key diff-sync edge cases.

Ref: v1 pre-release robustness (SEC gates AIO-269 area).

## What's new

- `lib/auth/visibility.test.ts` (44 tests) — every function × every tier, default-deny/allow behavior, non-vacuity checks (two viewers scope to different member_ids).
- `lib/ingest/ingest.test.ts` (+15 tests, FakeSupabase) — tier tagging into `tasks.audience`/`decisions.audience`, malformed task rows (missing title, self-parent, unknown parent, parent cycles) with proof of no partial writes, idempotent re-push (same sha, and same rows under a new sha), row update-in-place, dangling-parent nulling, partial-write preserve/clear semantics for assignee/labels/priority/parent.
- `test/datamechanics/items-route-tier-guard.datamechanics.test.ts` (5 tests, real Postgres + real route handler) — admin/private/unknown-tier 422 rejection with proof of zero rows written; legitimate team/external/legacy-alias pushes persist correctly.
- `test/datamechanics/ingest-tier-tagging.datamechanics.test.ts` (5 tests, real Postgres) — the same tier-tagging claims verified against the real `access_tier` enum column.

Total: **69 new tests**, all green. No config changes needed — `vitest.config.ts`'s `**/*.test.ts` glob and the datamechanics config's `test/datamechanics/**/*.datamechanics.test.ts` glob already pick these up.

## Findings surfaced (not fixed here — reporting per instructions)

1. **Inconsistent default in the visibility choke-point.** `visibleItems`/`visibleDecisions`/`visibleTasks`/`visibleByAccess` all check `tier !== "external"` — an allow-list of exactly one restricted value, so ANY unrecognized tier string (a typo, a stale/legacy value, a future tier nobody's added a branch for) falls through to the **unfiltered** branch (fail-open). `canSeeAccess`, by contrast, checks `tier === "team"` — fail-closed for an unrecognized tier. The type system (`ViewerTier = "team" | "external"`) prevents this at compile time for correctly-typed callers, but nothing enforces that at the DB/request boundary where these tiers actually originate. Worth a follow-up: make all five functions agree on one default (fail-closed).

2. **`decisions.audience` does not inherit the item's `access` tier, unlike `tasks.audience`.** `materializeDecisions()` never receives the item's `access` — each decision row's audience comes solely from `decisionRowSchema`'s own `audience` field (default `"team"`). Pushing an item at `access=external` with a decision table that omits an explicit `audience` column silently produces a **team-only** decision. Not a leak (it under-shares, the safer direction), but a real inconsistency with the task materialization path that could confuse anyone extending this code, or surprise someone expecting decisions to behave like tasks.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (1 pre-existing unrelated warning in `me-slack-token.datamechanics.test.ts`)
- [x] `npm test` (unit tier) — 113 files, 660 passed (was ~601 before this PR)
- [x] `npm run test:datamechanics` (real Postgres) — 97 files, 417 passed (was ~407 before this PR)
- [x] `npm run check:docs` — in sync, no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only PR that strengthens specs around security-sensitive visibility and ingest paths; it surfaces documented quirks but does not change runtime behavior.
> 
> **Overview**
> Adds **~69 tests** (no production code changes) to lock down tier visibility and ingest behavior where there is no RLS backstop.
> 
> **`lib/auth/visibility`** gets its first direct unit suite (`lib/auth/visibility.test.ts`): every exported helper (`visibleItems`, `canSeeAccess`, `visibleDecisions`, `visibleTasks`, `visibleByAccess`, `scopeQueryLog`) is exercised for team vs external filtering and query-log scoping, plus cases that **document** today’s fail-open vs fail-closed behavior when an unrecognized `ViewerTier` slips past typing.
> 
> **`lib/ingest`** unit tests expand (`lib/ingest/ingest.test.ts`): task diff-sync edge cases (update-in-place, dangling parent nulling, omit-vs-empty field semantics), idempotent re-push, tier propagation into `tasks.audience`, decision `audience` **not** inheriting item `access`, malformed rows with **no partial writes**, and validation errors.
> 
> **Datamechanics** adds real Postgres checks: `items` POST rejects `admin`/`private`/bogus access with 422 and zero rows (`items-route-tier-guard.datamechanics.test.ts`), and task/decision `audience` materialization matches the fake-supabase specs (`ingest-tier-tagging.datamechanics.test.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1c3396b7c9549306bc6fbbbf06718012c2dea1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->