### PR TITLE
fix(db): liveness timeouts so a wedged connection can't take down the site

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -548,6 +548,17 @@ guard enforces it, it's named.
   types them all as `string`. The type parsers set in `lib/db/pg/pool.ts` (OIDs 1082/1114/1184)
   are the single normalization point; every PgQuery consumer gets the raw wire-format string.
   _Guard:_ `test/datamechanics/timestamptz-string.datamechanics.test.ts` (real PG).
+- **DB connections have liveness timeouts — a wedged one can't hold locks forever** (2026-07-13
+  outage). A pooled backend got stuck holding `tasks` ACCESS SHARE with a transaction open; with no
+  server/pool timeout it held that lock indefinitely, the next deploy's schema `ALTER` queued behind
+  it, and every query then queued behind the ALTER → full outage. The pool
+  (`lib/db/pg/pool.buildPoolConfig`) now sets `idle_in_transaction_session_timeout` (reaps a
+  leaked/zombie open transaction — the healthy `withTransaction` never idles, so only a stuck one is
+  killed), `statement_timeout`, `connectionTimeoutMillis` (fail-fast checkout when the pool is
+  exhausted — blast-radius containment), and TCP `keepAlive`; all env-overridable, `0` disables. The
+  schema loader (`scripts/pg-load-schema.mjs`, the Railway `preDeployCommand`) sets `lock_timeout`
+  so a migration fails fast instead of wedging the lock queue behind a stuck reader.
+  _Guards:_ `test/pg-pool-config.test.ts` + `test/pg-load-schema.test.ts`.
 
 ## Changing X? read this
 

--- a/lib/db/pg/pool.ts
+++ b/lib/db/pg/pool.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { Pool, types } from "pg";
+import { Pool, types, type PoolConfig } from "pg";
 
 /**
  * Singleton pg Pool for DB_BACKEND=postgres. Reads DATABASE_URL (Railway/any
@@ -23,10 +23,31 @@ types.setTypeParser(1184, (val: string) => val);
 
 let pool: Pool | undefined;
 
-export function getPool(): Pool {
-  if (pool) return pool;
+/** Parse an int from env, falling back to `fallback` when unset/blank/NaN. `0` is honored (disables). */
+function intFromEnv(raw: string | undefined, fallback: number): number {
+  if (raw == null || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
 
-  const connectionString = process.env.DATABASE_URL;
+/**
+ * Build the pg Pool config from env, with **liveness timeouts** that a single wedged connection
+ * would otherwise defeat (the 2026-07-13 outage): a pooled backend got stuck holding `tasks`
+ * ACCESS SHARE with an implicit transaction open, and — with no server- or pool-side timeout — held
+ * that lock indefinitely, so the next deploy's schema `ALTER` queued behind it and every query
+ * queued behind the ALTER. These bound that class:
+ *   • `idle_in_transaction_session_timeout` — Postgres kills a backend that opens a transaction and
+ *     then goes idle (a leaked/zombie txn), releasing its locks. A HEALTHY `withTransaction` never
+ *     idles (BEGIN→queries→COMMIT with no external awaits), so only a stuck one is reaped.
+ *   • `statement_timeout` — caps any single runaway statement so it can't hold locks forever.
+ *   • `connectionTimeoutMillis` — a checkout fails fast instead of hanging when the pool is
+ *     exhausted, so a lock pile-up degrades to fast errors that recover, not a total hang.
+ *   • `keepAlive` — TCP keepalive so a dead peer's socket is reaped instead of lingering.
+ * All are env-overridable; `0` disables (Postgres/pg semantics). The schema loader sets its OWN
+ * `lock_timeout` (scripts/pg-load-schema.mjs) so a migration can't be the one that wedges the queue.
+ */
+export function buildPoolConfig(env: NodeJS.ProcessEnv = process.env): PoolConfig {
+  const connectionString = env.DATABASE_URL;
   if (!connectionString) {
     throw new Error(
       "DB_BACKEND=postgres requires DATABASE_URL to be set (the Postgres connection string)."
@@ -35,15 +56,27 @@ export function getPool(): Pool {
 
   const wantsSsl =
     /\bsslmode=require\b/.test(connectionString) ||
-    process.env.PGSSL === "require" ||
-    process.env.PGSSLMODE === "require";
+    env.PGSSL === "require" ||
+    env.PGSSLMODE === "require";
 
-  pool = new Pool({
+  return {
     connectionString,
     ssl: wantsSsl ? { rejectUnauthorized: false } : undefined,
-    max: Number(process.env.PG_POOL_MAX ?? 10),
+    max: intFromEnv(env.PG_POOL_MAX, 10),
     idleTimeoutMillis: 30_000,
-  });
+    // App queries are all short; a leaked/zombie transaction is the failure mode we cap.
+    statement_timeout: intFromEnv(env.PG_STATEMENT_TIMEOUT_MS, 30_000),
+    idle_in_transaction_session_timeout: intFromEnv(env.PG_IDLE_TX_TIMEOUT_MS, 60_000),
+    connectionTimeoutMillis: intFromEnv(env.PG_CONNECT_TIMEOUT_MS, 10_000),
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000,
+  };
+}
+
+export function getPool(): Pool {
+  if (pool) return pool;
+
+  pool = new Pool(buildPoolConfig());
 
   pool.on("error", (err) => {
     // A pooled idle client errored (e.g. server restart). Log; pg will recycle.

--- a/scripts/pg-load-schema.mjs
+++ b/scripts/pg-load-schema.mjs
@@ -53,6 +53,15 @@ export async function loadSchema({
   });
   await client.connect();
   try {
+    // Bound how long any DDL below will WAIT for a table lock (not how long it runs once acquired —
+    // a legit long CREATE INDEX is unaffected). This runs on every deploy (Railway preDeployCommand),
+    // so without it a single stuck reader holding ACCESS SHARE makes an `ALTER` wait forever at the
+    // head of the lock queue, and every ordinary query then queues behind that ALTER — the mechanism
+    // behind the 2026-07-13 outage. With a bounded lock_timeout the migration fails fast, the release
+    // aborts (schema ahead of app is never shipped), Railway retries, and live traffic keeps flowing.
+    const lockTimeoutMs = Number(env.PG_MIGRATION_LOCK_TIMEOUT_MS ?? 15_000);
+    await client.query(`SET lock_timeout = ${Math.max(0, Math.trunc(lockTimeoutMs))}`);
+
     await client.query(sql);
     logger.log("✓ postgres/schema.sql loaded");
 

--- a/test/pg-load-schema.test.ts
+++ b/test/pg-load-schema.test.ts
@@ -95,6 +95,7 @@ describe("pg-load-schema", () => {
 
     expect(clients).toHaveLength(1);
     expect(clients[0].queries).toEqual([
+      "SET lock_timeout = 15000",
       "create table base();",
       "alter table base add column first text;",
       "alter table base add column second text;",
@@ -151,8 +152,9 @@ describe("pg-load-schema", () => {
       loadSchema({
         cwd: root,
         databaseUrl: "postgres://app:app@localhost:5432/app",
+        // Index 0 is `SET lock_timeout`, 1 is schema.sql; fail on the first migration (index 2).
         createClient: (config) => {
-          const client = new FakeClient(config, 1);
+          const client = new FakeClient(config, 2);
           clients.push(client);
           return client;
         },
@@ -161,7 +163,7 @@ describe("pg-load-schema", () => {
     ).rejects.toThrow("query failed");
 
     expect(clients).toHaveLength(1);
-    expect(clients[0].queries).toEqual(["create table base();"]);
+    expect(clients[0].queries).toEqual(["SET lock_timeout = 15000", "create table base();"]);
     expect(clients[0].ended).toBe(true);
   });
 });

--- a/test/pg-pool-config.test.ts
+++ b/test/pg-pool-config.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { buildPoolConfig } from "@/lib/db/pg/pool";
+
+/**
+ * Spec for the pg Pool liveness timeouts (2026-07-13 outage). A pooled backend got wedged holding a
+ * `tasks` lock with a transaction open, and — because the pool set NO idle/statement/connect timeout
+ * — held it indefinitely, cascading into a full outage when the next deploy's schema ALTER queued
+ * behind it. These assert the timeouts exist (so the class can't recur silently) and stay operator-
+ * tunable. Derived from what the pool MUST guarantee, not from reading the impl.
+ */
+
+const URL = "postgres://app:app@localhost:5432/app";
+
+describe("buildPoolConfig — liveness timeouts", () => {
+  it("sets every reaping timeout so a wedged connection can't hold locks forever", () => {
+    const cfg = buildPoolConfig({ DATABASE_URL: URL } as NodeJS.ProcessEnv);
+    // The direct fix for the outage: Postgres reaps a leaked/zombie open transaction.
+    expect(cfg.idle_in_transaction_session_timeout).toBeGreaterThan(0);
+    // A runaway single statement can't hold locks forever either.
+    expect(cfg.statement_timeout).toBeGreaterThan(0);
+    // Checkout fails fast instead of hanging when the pool is exhausted (blast-radius containment).
+    expect(cfg.connectionTimeoutMillis).toBeGreaterThan(0);
+    // A dead TCP peer's socket gets reaped rather than lingering.
+    expect(cfg.keepAlive).toBe(true);
+    expect(cfg.connectionString).toBe(URL);
+  });
+
+  it("honors env overrides, including 0 to disable a timeout", () => {
+    const cfg = buildPoolConfig({
+      DATABASE_URL: URL,
+      PG_STATEMENT_TIMEOUT_MS: "5000",
+      PG_IDLE_TX_TIMEOUT_MS: "0", // operator opt-out
+      PG_CONNECT_TIMEOUT_MS: "2500",
+      PG_POOL_MAX: "20",
+    } as NodeJS.ProcessEnv);
+    expect(cfg.statement_timeout).toBe(5000);
+    expect(cfg.idle_in_transaction_session_timeout).toBe(0);
+    expect(cfg.connectionTimeoutMillis).toBe(2500);
+    expect(cfg.max).toBe(20);
+  });
+
+  it("falls back to safe defaults on blank/NaN env values", () => {
+    const cfg = buildPoolConfig({
+      DATABASE_URL: URL,
+      PG_STATEMENT_TIMEOUT_MS: "",
+      PG_IDLE_TX_TIMEOUT_MS: "not-a-number",
+    } as NodeJS.ProcessEnv);
+    expect(cfg.statement_timeout).toBe(30_000);
+    expect(cfg.idle_in_transaction_session_timeout).toBe(60_000);
+  });
+
+  it("enables SSL only when the URL or env asks for it", () => {
+    expect(buildPoolConfig({ DATABASE_URL: `${URL}?sslmode=require` } as NodeJS.ProcessEnv).ssl).toEqual({
+      rejectUnauthorized: false,
+    });
+    expect(buildPoolConfig({ DATABASE_URL: URL, PGSSL: "require" } as NodeJS.ProcessEnv).ssl).toEqual({
+      rejectUnauthorized: false,
+    });
+    expect(buildPoolConfig({ DATABASE_URL: URL } as NodeJS.ProcessEnv).ssl).toBeUndefined();
+  });
+
+  it("refuses to build a config without DATABASE_URL", () => {
+    expect(() => buildPoolConfig({} as NodeJS.ProcessEnv)).toThrow(/DATABASE_URL/);
+  });
+});


### PR DESCRIPTION
## Incident (2026-07-13)

The site hung — nearly every read/write stalled. Root cause, verified against `pg_stat_activity`:

1. A pooled app connection got **wedged** — `active`/`ClientRead` with an implicit transaction open for ~1h, last statement the autocommit `SELECT … FROM tasks WHERE id IN (…)` from `loadInboundRows`. It belonged to an app instance torn down mid-query during two overlapping deploys; its socket was never cleanly closed, so Postgres kept the backend alive **holding `tasks` ACCESS SHARE**.
2. **Nothing could reap it** — the pool set no `idle_in_transaction_session_timeout`, no `statement_timeout`, no `keepAlive`.
3. The next deploy's `pg:schema` (`preDeployCommand`, every deploy) ran DDL needing ACCESS EXCLUSIVE on `tasks`. With **no `lock_timeout`** it queued *forever* behind the zombie's ACCESS SHARE — and a waiting exclusive lock blocks all later shared-lock requests, so every ordinary `SELECT` on `tasks` queued behind the ALTER. Whole site down.

Fixed live by `pg_terminate_backend` on the wedged pid (site recovered in seconds). This PR prevents the class.

## What this is NOT
Not an "await-an-external-call-inside-a-transaction" leak — `withTransaction` is the only transaction primitive, used in exactly two spots, both pure-DB with the Linear call placed *after* commit. The failure was a wedged/zombie connection that no timeout could reap.

## Fixes (defense in depth — either alone averts the outage)
- **`lib/db/pg/pool.ts`** — extract `buildPoolConfig(env)` and add `idle_in_transaction_session_timeout` (reaps a leaked/zombie open txn; a healthy `withTransaction` never idles, so only a stuck one is killed), `statement_timeout`, `connectionTimeoutMillis` (fail-fast checkout when the pool is exhausted — blast-radius containment), and TCP `keepAlive`. All env-overridable; `0` disables.
- **`scripts/pg-load-schema.mjs`** — `SET lock_timeout` before the DDL so a migration fails fast instead of wedging the lock queue behind a stuck reader.

## Test plan
- [x] `test/pg-pool-config.test.ts` — asserts the timeouts are present + env-tunable (incl. `0` disables, NaN → default)
- [x] `test/pg-load-schema.test.ts` — extended to assert `SET lock_timeout` is issued first
- [x] `tsc` clean · `lint` clean (pre-existing warning only) · `check:docs` clean
- [x] unit 545 pass
- [x] **data-mechanics 370 pass against real Postgres** with the new pool config active (timeouts don't break real connections); schema loader applies every migration with the `lock_timeout` SET
- Note: one pre-existing flaky data-mechanics test (`chat-store` newest-active ordering, timestamp-collision) is unrelated — passes 3/3 in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)