### PR TITLE
fix(deploy): converge integrations_type_check across replayed migrations

### DIFF
--- a/postgres/migrations/20260624120000_ai_provider_integration_types.sql
+++ b/postgres/migrations/20260624120000_ai_provider_integration_types.sql
@@ -2,6 +2,13 @@
 -- to integrations.type. The key itself goes in the encrypted secret_ciphertext column (same path
 -- as Slack/Plane); config stays empty for these types. Idempotent: drop + recreate the inline
 -- check (Postgres auto-names it integrations_type_check) with the widened value set.
+--
+-- REPLAY-SAFETY: pg:schema replays every migration on every deploy (no applied-tracking). This
+-- re-add must therefore allow the SAME complete set as schema.sql and every later migration —
+-- otherwise, replayed after a newer type ('openrouter'/'typefully') exists in prod, this narrower
+-- CHECK would reject a live row and abort the deploy (the 2026-07-13 incident). 'openrouter' and
+-- 'typefully' are intentionally listed here even though they were introduced by later migrations;
+-- test/guards/integrations-type-check-replay.test.ts fails the build if these ever drift apart.
 alter table integrations drop constraint if exists integrations_type_check;
 alter table integrations add constraint integrations_type_check
-  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google'));
+  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully'));

--- a/postgres/migrations/20260710140000_integrations_openrouter_type.sql
+++ b/postgres/migrations/20260710140000_integrations_openrouter_type.sql
@@ -1,6 +1,11 @@
 -- Allow 'openrouter' as an integration type (an OpenAI-compatible LLM gateway, per-team key + model).
 -- The `type` CHECK constraint on `integrations` predates it, so a from-zero schema.sql edit is a
 -- no-op on an existing prod DB — this migration widens the constraint in place. Idempotent.
+--
+-- REPLAY-SAFETY: pg:schema replays every migration on every deploy. This re-add must allow the SAME
+-- complete set as schema.sql and every later migration, so a replay after a newer type exists in
+-- prod can't reject a live row (the 2026-07-13 incident). 'typefully' (added by a later migration)
+-- is intentionally listed here; the replay-consistency guard fails the build if these drift apart.
 alter table integrations drop constraint if exists integrations_type_check;
 alter table integrations add constraint integrations_type_check
-  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter'));
+  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully'));

--- a/postgres/migrations/README.md
+++ b/postgres/migrations/README.md
@@ -13,6 +13,14 @@ Rules:
 - **Idempotent only.** Use `add column if not exists`, `create index if not exists`,
   guarded `do $$ … $$` blocks. Files are replayed on every rollout and in the
   migrate-from-zero test (`npm run db:test:up`), so a non-idempotent file will break CI.
+- **A re-added CHECK/constraint must allow the FULL current value set — not the set as of
+  the file's write date.** Because every file replays in order on every deploy, an *older*
+  `drop + re-add … check (x in (…))` that omits a value a *newer* migration added will, once
+  prod holds a row with that newer value, reject it and abort the release — even though each
+  file is individually idempotent (the 2026-07-13 `integrations_type_check` incident). So when
+  you widen an enumerated CHECK, update `schema.sql` **and every earlier migration that re-adds
+  the same constraint** to the identical complete list. Where a guard enforces this
+  (e.g. `test/guards/integrations-type-check-replay.test.ts`), it fails the build on drift.
 - **Name as `YYYYMMDDHHMMSS_short_description.sql`.**
 - **Mirror the change into `postgres/schema.sql`** so a from-zero load still produces the
   same shape — the file here is only what an *existing* DB needs to catch up.

--- a/test/guards/integrations-type-check-replay.test.ts
+++ b/test/guards/integrations-type-check-replay.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * `integrations_type_check` replay-consistency guard.
+ *
+ * Spec = the 2026-07-13 failed deploy. `npm run pg:schema` (the Railway preDeployCommand)
+ * REPLAYS every file in `postgres/migrations/` in lexical order on every deploy — there is no
+ * applied-tracking table (see `scripts/pg-load-schema.mjs`). Three migrations each
+ * `drop + re-add` the `integrations_type_check` CHECK, and each carried the *allowed set as of
+ * its own write date*:
+ *   - 20260624120000 → up to 'google'      (narrow)
+ *   - 20260710140000 → + 'openrouter'      (wider)
+ *   - 20260711160000 → + 'typefully'       (widest, == schema.sql)
+ * Once prod held an 'openrouter'/'typefully' integration row (allowed by the current, widest
+ * constraint), replaying the *earlier, narrower* migration re-imposed a CHECK that the existing
+ * row violated → "check constraint integrations_type_check is violated by some row" → the schema
+ * load aborted and the release was halted.
+ *
+ * Invariant that prevents recurrence: EVERY definition of `integrations_type_check` — the inline
+ * one in schema.sql and every re-add in a migration — must allow the identical, complete set of
+ * types. Then no intermediate replay state can ever be narrower than live data. Adding a new type
+ * means updating schema.sql AND every migration that re-adds the constraint, or this fails the
+ * build in review instead of on the next deploy.
+ */
+
+const PG_DIR = join(import.meta.dirname, "..", "..", "postgres");
+const MIG_DIR = join(PG_DIR, "migrations");
+
+/** Pull the quoted values out of a `check (type in ('a','b',...))` fragment. */
+function typeValues(fragment: string): string[] {
+  const m = fragment.match(/type\s+in\s*\(([^)]*)\)/i);
+  if (!m) return [];
+  return [...m[1].matchAll(/'([^']+)'/g)].map((x) => x[1]).sort();
+}
+
+/** The inline `integrations` column constraint in schema.sql (canonical from-zero shape). */
+function schemaSqlTypes(): string[] {
+  const sql = readFileSync(join(PG_DIR, "schema.sql"), "utf8");
+  const start = sql.indexOf("create table if not exists integrations (");
+  expect(start, "integrations table not found in schema.sql").toBeGreaterThan(-1);
+  const body = sql.slice(start, start + 1000);
+  return typeValues(body);
+}
+
+/** Every migration that re-adds `integrations_type_check`, mapped to its allowed set. */
+function migrationConstraints(): Array<{ file: string; types: string[] }> {
+  return readdirSync(MIG_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()
+    .map((f) => ({ file: f, sql: readFileSync(join(MIG_DIR, f), "utf8") }))
+    .filter(({ sql }) => /add constraint integrations_type_check/i.test(sql))
+    .map(({ file, sql }) => {
+      const idx = sql.indexOf("add constraint integrations_type_check");
+      return { file, types: typeValues(sql.slice(idx, idx + 400)) };
+    });
+}
+
+describe("integrations_type_check replay consistency", () => {
+  it("schema.sql defines a non-empty allowed set (extractor is non-vacuous)", () => {
+    const types = schemaSqlTypes();
+    expect(types.length).toBeGreaterThan(5);
+    expect(types).toContain("github");
+    expect(types).toContain("typefully");
+  });
+
+  it("every migration re-adds the constraint with the SAME complete set as schema.sql", () => {
+    const canonical = schemaSqlTypes();
+    const migrations = migrationConstraints();
+    expect(migrations.length, "no migration re-adds integrations_type_check").toBeGreaterThan(0);
+
+    const drift = migrations.filter(
+      (m) => JSON.stringify(m.types) !== JSON.stringify(canonical)
+    );
+    const detail = drift
+      .map((m) => `  ${m.file}: missing [${canonical.filter((t) => !m.types.includes(t)).join(", ")}]`)
+      .join("\n");
+    expect(
+      drift.map((m) => m.file),
+      `These migrations re-add integrations_type_check with a set that differs from schema.sql — ` +
+        `replaying them would reject rows the live constraint allows:\n${detail}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem — every deploy is failing at the `pg:schema` pre-deploy step

The #250 deploy (2026-07-13 16:36) **FAILED**; prod stayed on the prior build. The app image builds fine — the abort is in the Railway `preDeployCommand` (`npm run pg:schema`):

```
schema load failed: check constraint "integrations_type_check" of relation "integrations" is violated by some row
```

## Root cause — migration-replay ordering, not bad data

`pg:schema` **replays every file in `postgres/migrations/` in lexical order on every deploy** (no applied-tracking table; `scripts/pg-load-schema.mjs`). Three migrations each `drop + re-add` `integrations_type_check`, and the two older ones carried the allowed-type set *as of their write date*:

| migration | allowed set |
|---|---|
| `20260624120000_ai_provider_integration_types` | … up to `google` |
| `20260710140000_integrations_openrouter_type` | `+openrouter` |
| `20260711160000_publishing` | `+typefully` (== `schema.sql`) |

The 15:06 deploy succeeded, so afterward the live constraint allowed `typefully`/`openrouter`. Once a prod `integrations` row of that type existed, replaying the **older, narrower** Jun-24 migration re-imposed a CHECK the existing row violated → abort. Each file is individually idempotent; the bug is the **cross-migration ordering** relative to live data.

## Fix

- Both older migrations now re-add the constraint with the **identical complete set** as `schema.sql`, so no intermediate replay state is ever narrower than live data.
- **New guard** `test/guards/integrations-type-check-replay.test.ts` — asserts every `integrations_type_check` definition (schema.sql + all migrations) allows the same set; **fails the build on drift** so the next integration-type addition can't silently reintroduce this.
- `postgres/migrations/README.md` — documents the replay-safety rule for enumerated-CHECK widenings.

## Verified to the observable outcome

- Reproduced the **exact prod error** on an ephemeral Postgres holding a `typefully` row: old narrow constraint → `violated by some row`; converged constraint → full migration replay clean (exit 0).
- Guard red before fix (named both offending migrations), green after.
- Full unit suite **679 passed**, docs-drift ✓, lint ✓.

## Test plan
- [x] Unit suite + new guard
- [x] From-zero schema load (`db:test:up`)
- [x] Replay against a populated DB with a `typefully` row (incident repro)
- [ ] CI green → merge → confirm Railway build succeeds and `pg:schema` runs clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenAI, Anthropic, Google, and Typefully integration types.

- **Bug Fixes**
  - Improved consistency when applying database migrations, preventing integration types from being unintentionally rejected.

- **Tests**
  - Added automated checks to detect mismatches between supported integration types and migration constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->