### PR TITLE
chore(rubric): refresh vendored agent-readiness.json to v1.1.0

### DIFF
--- a/ingestion/aios_ingest/rubric/agent-readiness.json
+++ b/ingestion/aios_ingest/rubric/agent-readiness.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./agent-readiness.schema.json",
   "id": "aios.agent-readiness",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "title": "Codebase Agent-Readiness Rubric",
   "description": "Machine-readable scoring rubric for how ready a repository is for agents to work in it effectively and verifiably. Consumed by the aios-workspace validator (OGR10) and the aios-team-brain codebase scan. Each check is a binary, automatable signal (file existence + lightweight config parse). A repo's level is the highest level for which >= advanceThreshold of that level's cumulative checks pass. The Spine level is CAPPED at L3 when the Verification pillar scores 0 passing checks (the core AEM rule: no real agentic maturity without verification).",
   "advanceThreshold": 0.8,
@@ -136,7 +136,7 @@
       "level": "L4",
       "title": "Logging / monitoring present",
       "rationale": "Agent actions and runtime behavior are inspectable.",
-      "signal": { "anyFileExists": ["**/logger.*", "**/logging.*"], "orDependency": ["pino", "winston", "structlog", "loguru", "opentelemetry", "@opentelemetry/api", "sentry-sdk", "@sentry/node"] }
+      "signal": { "anyFileExists": ["**/logger.*", "**/logging.*", "**/telemetry/**", "**/*telemetry*.{ts,tsx,js,mjs,py,go,rb}"], "orDependency": ["pino", "winston", "structlog", "loguru", "opentelemetry", "@opentelemetry/api", "sentry-sdk", "@sentry/node"] }
     },
     {
       "id": "eval_harness",
@@ -144,7 +144,7 @@
       "level": "L4",
       "title": "Eval suite or LLM-as-judge harness",
       "rationale": "Verification becomes a first-class, measured artifact (EDD).",
-      "signal": { "anyPathMatches": ["**/evals/**", "**/eval/**", "**/*.eval.*", "**/promptfoo*.{yml,yaml,json}", "**/braintrust*", "**/.promptfoo*"], "orDependency": ["promptfoo", "braintrust", "deepeval", "ragas"] }
+      "signal": { "anyPathMatches": ["**/evals/**", "**/eval/**", "**/*.eval.*", "**/*-eval.*", "**/*-eval-*", "**/promptfoo*.{yml,yaml,json}", "**/braintrust*", "**/.promptfoo*"], "orDependency": ["promptfoo", "braintrust", "deepeval", "ragas"] }
     },
     {
       "id": "compounding_instructions",

--- a/ingestion/tests/test_codebase_analyzer.py
+++ b/ingestion/tests/test_codebase_analyzer.py
@@ -133,7 +133,7 @@ def test_live_scan_carries_scored_readiness(tmp_path):
     assert m["readiness_level"] == "L1"             # README + manifest
     assert isinstance(m["readiness_pct"], float)
     assert m["readiness_pillars"]["docs"]["passed"] == 1
-    assert m["readiness_rubric_version"] == "1.0.0"
+    assert m["readiness_rubric_version"] == "1.1.0"
 
 
 def test_history_points_carry_null_readiness(tmp_path):

--- a/ingestion/tests/test_readiness_scorer.py
+++ b/ingestion/tests/test_readiness_scorer.py
@@ -164,7 +164,7 @@ def test_pillars_shape_matches_brain_contract(tmp_path):
     for p in pillars.values():
         assert 0 <= p["passed"] <= p["total"]    # brain's passed<=total refine
     assert r["readiness_level"] in {"L0", "L1", "L2", "L3", "L4", "L5"}
-    assert r["readiness_rubric_version"] == "1.0.0"
+    assert r["readiness_rubric_version"] == "1.1.0"
 
 
 # ── failure + safety paths ───────────────────────────────────────────────────────────────
@@ -243,5 +243,5 @@ def test_vendored_rubric_loads_as_package_data():
 
     res = resources.files("aios_ingest.rubric") / "agent-readiness.json"
     data = json.loads(res.read_text(encoding="utf-8"))
-    assert data["version"] == "1.0.0"
+    assert data["version"] == "1.1.0"
     assert len(data["checks"]) == 18


### PR DESCRIPTION
## Summary
- Syncs the vendored rubric from the canonical source (aios PR #10, https://github.com/johnellison/aios/pull/10) via `ingestion/scripts/refresh-rubric.sh` — widens `observability` and `eval_harness` signals to recognize bespoke telemetry modules (`**/telemetry/**`, extension-restricted `**/*telemetry*.{ts,tsx,js,mjs,py,go,rb}`) and hyphen-named eval harnesses (`**/*-eval.*`, `**/*-eval-*`), version bump 1.0.0 → 1.1.0.
- Updates the two tests that hardcoded the prior version string (`test_readiness_scorer.py`).

**Depends on:** aios PR #10 landing first (or at least existing) — this vendored copy is byte-identical to that PR's edited canonical file.

## Verification
Ran `score_readiness()` locally against `aios-workspace` (which has a real telemetry module and a `spec-eval` harness that scored 0/1 on both pillars before this change):
```
evals: {'passed': 1, 'total': 1}
observability: {'passed': 1, 'total': 1}
```
`pytest ingestion/tests/test_rubric_valid.py ingestion/tests/test_readiness_scorer.py`: 19/20 pass. The one remaining failure, `test_vendored_matches_canonical`, is expected and self-resolving — its `_CANONICAL` path resolves to the *primary* `aios` checkout (not this worktree, and not aios PR #10's worktree), so it won't pass until PR #10 merges upstream and the primary checkout picks it up via a normal pull.

## Test plan
- [x] `score_readiness()` scores `aios-workspace` evals/observability as 1/1
- [x] `pytest ingestion/tests/test_rubric_valid.py ingestion/tests/test_readiness_scorer.py` — 19/20 pass (1 expected-until-merge failure, explained above)
- [ ] Re-run `test_vendored_matches_canonical` after aios PR #10 merges — should go green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive rubric pattern changes and a version bump only affect readiness scoring heuristics, not auth, data, or runtime behavior.
> 
> **Overview**
> Bumps the vendored **`agent-readiness.json`** rubric from **1.0.0 → 1.1.0** and aligns tests that assert `readiness_rubric_version`.
> 
> Scoring signals are widened so more real layouts count without changing thresholds or check count: **observability** now matches `**/telemetry/**` and extension-scoped `**/*telemetry*.{ts,tsx,js,mjs,py,go,rb}`; **eval_harness** adds `**/*-eval.*` and `**/*-eval-*` for hyphen-named eval suites (e.g. `spec-eval`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af0871a75dd118f9a5aee939f35d9c2503fe336. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->