### PR TITLE
fix(codebases): make AI-assisted-commit detection model-agnostic

### DIFF
--- a/ingestion/aios_ingest/analyzers/codebase.py
+++ b/ingestion/aios_ingest/analyzers/codebase.py
@@ -3,8 +3,9 @@
 Produces the payload for POST /api/v1/codebases. With ONE deliberate exception
 (``readiness`` — see below) it computes no scores; the brain derives ``agentic_score`` /
 ``health_score`` from these raw inputs (one scoring implementation, unit-tested in TS). The
-key AI-transformation signal is the ``Co-Authored-By: Claude`` commit trailer — treated
-as a heuristic for AI-*assisted* commits, not exact AI-authored lines.
+key AI-transformation signal is a ``Co-Authored-By: <tool>`` commit trailer (Claude, Codex,
+Cursor, OpenCode, GitHub Copilot, Devin — see ``_AI_TRAILER`` below) or a generated-with
+banner — treated as a heuristic for AI-*assisted* commits, not exact AI-authored lines.
 
 **The readiness exception:** AEM agent-readiness is scored HERE (``analyzers/readiness.py``)
 against the vendored rubric, because its checks are filesystem questions only the scanner can
@@ -33,7 +34,15 @@ log = logging.getLogger(__name__)
 # unit/record separators that won't appear in commit metadata
 _RS = "\x1e"
 _FS = "\x1f"
-_AI_TRAILER = re.compile(r"co-authored-by:\s*claude", re.IGNORECASE)
+# Commit-message markers left by AI coding agents (case-insensitive). Mirrors
+# lib/codebases/github-api-scan.ts's AI_MARKERS — keep both in sync; the shared
+# fixture at test/fixtures/ai-trailer-cases.json pins every case both sides must pass.
+_AI_TRAILER = re.compile(
+    r"co-authored-by:\s*(claude|codex|cursor|opencode|github copilot|devin)\b"
+    r"|generated with \[claude code\]"
+    r"|🤖 generated with",
+    re.IGNORECASE,
+)
 _CODE_EXT = {
     ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".rb", ".php",
     ".c", ".h", ".cpp", ".cs", ".sql", ".sh", ".mjs", ".cjs", ".svelte", ".vue",

--- a/ingestion/tests/test_codebase_analyzer.py
+++ b/ingestion/tests/test_codebase_analyzer.py
@@ -3,9 +3,11 @@ idempotency, and graceful behavior without a GitHub token."""
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 from aios_ingest.analyzers.codebase import (
     _detect_scaffolding,
@@ -134,6 +136,31 @@ def test_live_scan_carries_scored_readiness(tmp_path):
     assert isinstance(m["readiness_pct"], float)
     assert m["readiness_pillars"]["docs"]["passed"] == 1
     assert m["readiness_rubric_version"] == "1.1.0"
+
+
+def test_ai_commit_detection_is_model_agnostic(tmp_path):
+    """_AI_TRAILER must recognize every AI coding tool's trailer, not just Claude's.
+
+    Shared with test/github-api-scan.test.ts's isAiAssisted suite — both detectors must
+    agree on every case in the fixture, so they can't silently diverge again the way the
+    Python-only "claude" regex and the TS AI_MARKERS list already had."""
+    fixture_path = Path(__file__).resolve().parents[2] / "test" / "fixtures" / "ai-trailer-cases.json"
+    cases = json.loads(fixture_path.read_text())
+
+    repo = _init(tmp_path)
+    (repo / "seed.txt").write_text("x")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "seed")
+
+    expected_ai_commits = 0
+    for i, case in enumerate(cases):
+        (repo / f"f{i}.txt").write_text(str(i))
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", case["message"])
+        expected_ai_commits += 1 if case["expected"] else 0
+
+    m = analyze_repo(str(repo), slug="x")["metrics"]
+    assert m["ai_commits_window"] == expected_ai_commits
 
 
 def test_history_points_carry_null_readiness(tmp_path):

--- a/lib/codebases/github-api-scan.ts
+++ b/lib/codebases/github-api-scan.ts
@@ -62,12 +62,16 @@ export interface ApiContribution {
 
 // ── pure helpers (unit-tested) ────────────────────────────────────────────────
 
-// Commit-message markers left by AI coding agents (case-insensitive). Mirrors the trailers
-// this repo's own tooling emits; extend as new agents appear.
+// Commit-message markers left by AI coding agents (case-insensitive). Mirrors
+// ingestion/aios_ingest/analyzers/codebase.py's _AI_TRAILER — keep both in sync; the
+// shared fixture at test/fixtures/ai-trailer-cases.json pins every case both sides must
+// pass. Extend as new agents appear.
 const AI_MARKERS = [
   "co-authored-by: claude",
   "generated with [claude code]",
+  "co-authored-by: codex",
   "co-authored-by: cursor",
+  "co-authored-by: opencode",
   "co-authored-by: github copilot",
   "co-authored-by: devin",
   "🤖 generated with",

--- a/test/fixtures/ai-trailer-cases.json
+++ b/test/fixtures/ai-trailer-cases.json
@@ -1,0 +1,12 @@
+[
+  {"message": "fix: thing\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>", "expected": true},
+  {"message": "feat: x\n\n🤖 Generated with [Claude Code]", "expected": true},
+  {"message": "fix: thing\n\nCo-authored-by: Codex <noreply@openai.com>", "expected": true},
+  {"message": "fix: thing\n\nCo-authored-by: Cursor <cursoragent@cursor.com>", "expected": true},
+  {"message": "fix: thing\n\nCo-authored-by: OpenCode <noreply@opencode.ai>", "expected": true},
+  {"message": "chore\n\nco-authored-by: github copilot", "expected": true},
+  {"message": "fix\n\nCo-Authored-By: Devin <devin@cognition.ai>", "expected": true},
+  {"message": "fix: correct off-by-one in pager", "expected": false},
+  {"message": "Co-authored-by: Jane Dev <jane@acme.com>", "expected": false},
+  {"message": "docs: mention codex in the README", "expected": false}
+]

--- a/test/github-api-scan.test.ts
+++ b/test/github-api-scan.test.ts
@@ -6,19 +6,16 @@ import {
   aggregateContributions,
   type ApiCommit,
 } from "@/lib/codebases/github-api-scan";
+import aiTrailerCases from "@/test/fixtures/ai-trailer-cases.json";
 
 // Spec: the GitHub-API sync must derive per-(author, day) contributions and AI-assist counts
 // from a commit list WITHOUT a checkout, tolerating the messy shapes GitHub returns.
 
 describe("isAiAssisted", () => {
-  it("detects known agent trailers (case-insensitive)", () => {
-    expect(isAiAssisted("fix: thing\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>")).toBe(true);
-    expect(isAiAssisted("feat: x\n\n🤖 Generated with [Claude Code]")).toBe(true);
-    expect(isAiAssisted("chore\n\nco-authored-by: github copilot")).toBe(true);
-  });
-  it("is false for ordinary human commits", () => {
-    expect(isAiAssisted("fix: correct off-by-one in pager")).toBe(false);
-    expect(isAiAssisted("Co-authored-by: Jane Dev <jane@acme.com>")).toBe(false);
+  // Shared with ingestion/tests/test_codebase_analyzer.py's _AI_TRAILER test — both
+  // detectors must agree on every case in the fixture, so they can't silently diverge.
+  it.each(aiTrailerCases)("$message -> $expected", ({ message, expected }) => {
+    expect(isAiAssisted(message)).toBe(expected);
   });
 });
 


### PR DESCRIPTION
## Summary
- Two independent AI-commit detectors existed in this repo, each covering a different, incomplete subset of tools, and disagreeing with each other:
  - **Python** (`ingestion/aios_ingest/analyzers/codebase.py`, feeds `ai_commits_window` → `agentic_score`) matched only `claude`.
  - **TypeScript** (`lib/codebases/github-api-scan.ts`'s `AI_MARKERS`, feeds a separate `code_contributions`-only path) matched claude/cursor/copilot/devin/a generic banner, but not codex or opencode.
- Traced from `aios-workspace` showing only 242/330 commits as "AI-assisted" despite being entirely agent-authored. Pulled every distinct `Co-authored-by:` trailer that repo's own git history (11k+ matches) actually contains — confirms Claude, Cursor, and OpenCode trailers are all genuinely in use there. Codex's default trailer (`Co-authored-by: Codex <noreply@openai.com>`, shipped in [openai/codex#11617](https://github.com/openai/codex/pull/11617)) doesn't appear in that repo's history yet, but it's a real, documented, default-on convention worth recognizing.
- Widens both detectors to the same canonical set (claude/codex/cursor/opencode/github copilot/devin + existing generic banner styles).
- Adds a shared JSON fixture (`test/fixtures/ai-trailer-cases.json`) that both languages' test suites assert against, so the two detectors can't silently diverge again the way they already had. Includes a deliberate negative case — "codex" mentioned in commit *prose*, not as a trailer — as a regression guard against overly broad substring matching (this repo's real history has exactly that pattern).

**Expectation-setting:** this does not retroactively recover attribution for commits that never carried any trailer at all (e.g. squash-merged PRs from earlier sessions with no `Co-Authored-By` line at all) — only for commits that already carry a Cursor/OpenCode/Codex trailer this heuristic was simply blind to.

## Test plan
- [x] `python3 -m pytest ingestion/tests/ -q` — 89/89 pass (new `test_ai_commit_detection_is_model_agnostic` included)
- [x] `npx vitest run` — 713/720 pass, 7 pre-existing skips, 0 failures
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint lib/codebases/github-api-scan.ts test/github-api-scan.test.ts` — clean
- [ ] After merge: re-run/wait for `aios-workspace`'s next scan-on-merge and confirm `ai_commits_window` ticks up for any Cursor/OpenCode-trailer commits previously missed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Heuristic-only changes to commit-message classification with shared fixture tests; no auth, persistence schema, or API contract changes.
> 
> **Overview**
> **Aligns two AI-commit heuristics** that previously disagreed: the Python git scanner (`_AI_TRAILER` → `ai_commits_window` / agentic scoring) and the TypeScript GitHub API path (`AI_MARKERS` → `code_contributions`).
> 
> Both now recognize the same tool set—**Claude, Codex, Cursor, OpenCode, GitHub Copilot, Devin**, plus existing **generated-with** banners—instead of Python matching only Claude and TypeScript missing Codex/OpenCode.
> 
> Adds **`test/fixtures/ai-trailer-cases.json`** and wires **Python** (`test_ai_commit_detection_is_model_agnostic`) and **Vitest** (`isAiAssisted` via `it.each`) to the same cases, including negatives (human co-authors, “codex” in prose only) so the detectors cannot drift again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8cf65040b13accd2fa97faa966424494871b1ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->