### PR TITLE
feat(gateway): implement internal v1.10 APIs (AIO-401)

### DIFF
--- a/app/api/internal/executor-gateway/v1/authorize-and-redeem/route.ts
+++ b/app/api/internal/executor-gateway/v1/authorize-and-redeem/route.ts
@@ -1,0 +1,155 @@
+import { randomUUID } from "node:crypto";
+import { decryptSecret } from "@/lib/secrets/crypto";
+import { canonicalize } from "@/lib/gateway/canonical";
+import { encryptGatewayRequestEnvelope } from "@/lib/gateway/envelope";
+import {
+  authenticateGatewayRequest,
+  enforceGatewayLimit,
+  exactObject,
+  gatewayDisabled,
+  gatewayError,
+  gatewayJson,
+  isResponse,
+  isUuid,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+import {
+  gatewayRequestHash,
+  normalizeGatewayArgs,
+} from "@/lib/gateway/normalize";
+import {
+  authorizeLeaseAndCreateExecution,
+  failGatewayCredentialSealing,
+  GatewayConflictError,
+  GatewayPersistenceError,
+  getGatewayCredentialForClaimedExecution,
+  reboundMemberForLease,
+} from "@/lib/gateway/persistence";
+import { sealCredential } from "@/lib/gateway/sealed-credential";
+import { GATEWAY_TOOLKIT } from "@/lib/gateway/types";
+
+export async function POST(req: Request) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const auth = await authenticateGatewayRequest(req);
+  if (isResponse(auth)) return auth;
+  let correlationId: string | null = null;
+  try {
+    const limited = await enforceGatewayLimit(
+      `gateway:${auth.id}:authorize`,
+      120,
+    );
+    if (limited) return limited;
+    const body = await readGatewayJson(req);
+    if (isResponse(body)) return body;
+    if (
+      !exactObject(body, [
+        "lease",
+        "toolkit",
+        "tool",
+        "normalizedArgs",
+        "requestHash",
+        "correlationId",
+        "idempotencyKey",
+      ]) ||
+      typeof body.lease !== "string" ||
+      !body.lease ||
+      body.toolkit !== GATEWAY_TOOLKIT ||
+      typeof body.tool !== "string" ||
+      typeof body.requestHash !== "string" ||
+      !/^[0-9a-f]{64}$/.test(body.requestHash) ||
+      !isUuid(body.correlationId) ||
+      typeof body.idempotencyKey !== "string" ||
+      !body.idempotencyKey
+    )
+      return gatewayError("gateway_invalid_request", 400);
+    correlationId = body.correlationId;
+    const memberId = await reboundMemberForLease({
+      serviceIdentityId: auth.id,
+      lease: body.lease,
+      audience: GATEWAY_TOOLKIT,
+    });
+    const memberLimited = await enforceGatewayLimit(
+      `gateway:member:${memberId}:authorize`,
+      120,
+    );
+    if (memberLimited) return memberLimited;
+    let normalized;
+    try {
+      normalized = normalizeGatewayArgs(body.tool, body.normalizedArgs);
+    } catch {
+      return gatewayError("gateway_invalid_request", 400, correlationId);
+    }
+    if (
+      canonicalize(normalized) !== canonicalize(body.normalizedArgs as never) ||
+      gatewayRequestHash(normalized) !== body.requestHash
+    )
+      return gatewayError("gateway_invalid_request", 400, correlationId);
+    const executionId = randomUUID();
+    const envelope = encryptGatewayRequestEnvelope(normalized, {
+      executionId,
+      serviceIdentityId: auth.id,
+    });
+    const decision = await authorizeLeaseAndCreateExecution({
+      serviceIdentityId: auth.id,
+      executionId,
+      lease: body.lease,
+      audience: GATEWAY_TOOLKIT,
+      toolkit: GATEWAY_TOOLKIT,
+      tool: body.tool,
+      normalizedArgs: normalized as {
+        owner: string;
+        repo: string;
+        [key: string]: string | number;
+      },
+      requestHash: body.requestHash,
+      correlationId,
+      idempotencyKey: body.idempotencyKey,
+      requestEnvelope: envelope,
+    });
+    if (decision.decision === "block")
+      return gatewayJson({ ...decision, code: "policy_denied" }, 403);
+    if (decision.decision === "require_approval")
+      return gatewayJson(decision, 202);
+    try {
+      const stored = await getGatewayCredentialForClaimedExecution({
+        serviceIdentityId: auth.id,
+        executionId: decision.executionId,
+      });
+      const plaintext = Buffer.from(decryptSecret(stored.ciphertext), "utf8");
+      try {
+        const sealed = sealCredential({
+          pat: plaintext,
+          serviceSecret: auth.secretBytes,
+          credentialId: auth.credentialId,
+          credentialVersion: auth.credentialVersion,
+          serviceIdentityId: auth.id,
+          executionId: decision.executionId,
+        });
+        return gatewayJson({
+          decision: "allow",
+          executionId: decision.executionId,
+          sealedCredential: sealed.sealedCredential,
+          credentialExpiresAt: stored.credentialExpiresAt,
+        });
+      } finally {
+        plaintext.fill(0);
+      }
+    } catch {
+      await failGatewayCredentialSealing({
+        serviceIdentityId: auth.id,
+        executionId: decision.executionId,
+        correlationId,
+      });
+      return gatewayError("gateway_credential_failure", 500, correlationId);
+    }
+  } catch (error) {
+    if (error instanceof GatewayConflictError)
+      return gatewayError(error.code, 409, correlationId);
+    if (error instanceof GatewayPersistenceError)
+      return gatewayError(error.code, 409, correlationId);
+    return gatewayError("gateway_internal", 500, correlationId);
+  } finally {
+    auth.secretBytes.fill(0);
+  }
+}

--- a/app/api/internal/executor-gateway/v1/record-outcome/route.ts
+++ b/app/api/internal/executor-gateway/v1/record-outcome/route.ts
@@ -1,0 +1,81 @@
+import {
+  authenticateGatewayRequest,
+  enforceGatewayLimit,
+  exactObject,
+  gatewayDisabled,
+  gatewayError,
+  isResponse,
+  isUuid,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+import {
+  GatewayPersistenceError,
+  recordGatewayOutcome,
+} from "@/lib/gateway/persistence";
+
+const classifications = [
+  "success",
+  "blocked",
+  "approval_required",
+  "credential",
+  "network",
+  "upstream",
+  "response_too_large",
+  "internal",
+];
+export async function POST(req: Request) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const auth = await authenticateGatewayRequest(req);
+  if (isResponse(auth)) return auth;
+  let correlationId: string | null = null;
+  try {
+    const limited = await enforceGatewayLimit(
+      `gateway:${auth.id}:outcome`,
+      240,
+    );
+    if (limited) return limited;
+    const body = await readGatewayJson(req);
+    if (isResponse(body)) return body;
+    if (
+      !exactObject(
+        body,
+        ["executionId", "correlationId", "classification"],
+        ["upstreamStatusClass", "responseBytes"],
+      ) ||
+      !isUuid(body.executionId) ||
+      !isUuid(body.correlationId) ||
+      typeof body.classification !== "string" ||
+      !classifications.includes(body.classification) ||
+      (body.upstreamStatusClass !== undefined &&
+        !["2xx", "3xx", "4xx", "5xx"].includes(
+          body.upstreamStatusClass as string,
+        )) ||
+      (body.responseBytes !== undefined &&
+        (!Number.isSafeInteger(body.responseBytes) ||
+          Number(body.responseBytes) < 0))
+    )
+      return gatewayError("gateway_invalid_request", 400);
+    correlationId = body.correlationId;
+    await recordGatewayOutcome({
+      serviceIdentityId: auth.id,
+      executionId: body.executionId,
+      correlationId,
+      classification: body.classification,
+      upstreamStatusClass: body.upstreamStatusClass as string | undefined,
+      responseBytes: body.responseBytes as number | undefined,
+    });
+    return new Response(null, {
+      status: 204,
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (error) {
+    if (error instanceof GatewayPersistenceError)
+      return gatewayError(error.code, 409, correlationId);
+    if (error instanceof Error && error.message === "gateway_outcome_conflict")
+      return gatewayError("gateway_outcome_conflict", 409, correlationId);
+    return gatewayError("gateway_internal", 500, correlationId);
+  } finally {
+    auth.secretBytes.fill(0);
+  }
+}

--- a/app/api/internal/executor-gateway/v1/resolve-lease/route.ts
+++ b/app/api/internal/executor-gateway/v1/resolve-lease/route.ts
@@ -1,0 +1,63 @@
+import {
+  authenticateGatewayRequest,
+  enforceGatewayLimit,
+  exactObject,
+  gatewayDisabled,
+  gatewayError,
+  gatewayJson,
+  isResponse,
+  isUuid,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+import {
+  GatewayPersistenceError,
+  resolveAndIssueLease,
+} from "@/lib/gateway/persistence";
+
+export async function POST(req: Request) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const auth = await authenticateGatewayRequest(req);
+  if (isResponse(auth)) return auth;
+  try {
+    const limited = await enforceGatewayLimit(
+      `gateway:${auth.id}:resolve`,
+      120,
+    );
+    if (limited) return limited;
+    const body = await readGatewayJson(req);
+    if (isResponse(body)) return body;
+    if (
+      !exactObject(body, [
+        "executorTenantId",
+        "executorSubjectId",
+        "connectionRef",
+        "correlationId",
+      ]) ||
+      typeof body.executorTenantId !== "string" ||
+      !body.executorTenantId ||
+      typeof body.executorSubjectId !== "string" ||
+      !body.executorSubjectId ||
+      typeof body.connectionRef !== "string" ||
+      !body.connectionRef ||
+      !isUuid(body.correlationId)
+    )
+      return gatewayError("gateway_invalid_request", 400);
+    return gatewayJson(
+      await resolveAndIssueLease({
+        serviceIdentityId: auth.id,
+        executorTenantId: body.executorTenantId,
+        executorSubjectId: body.executorSubjectId,
+        connectionRef: body.connectionRef,
+        audience: "aios-github-readonly",
+        correlationId: body.correlationId,
+      }),
+    );
+  } catch (error) {
+    return error instanceof GatewayPersistenceError
+      ? gatewayError(error.code, 422)
+      : gatewayError("gateway_internal", 500);
+  } finally {
+    auth.secretBytes.fill(0);
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,8 +58,8 @@ Reason from this table, not from a random call site.
 
 | State | Store | Sole writer | Readers | Access/retention |
 |---|---|---|---|---|
-| Gateway service credentials and Executor subjects | `gateway_service_identities`, `executor_subject_bindings` | `lib/gateway/persistence.ts` | later internal gateway routes only | exact team + service + tenant + subject binding; hashed credentials; revoke rather than delete |
-| Member GitHub connection and one-use lease | `gateway_connections`, `gateway_resolution_leases` | `lib/gateway/persistence.ts` | later resolver/authorization routes only | exact team + member + subject; GitHub-only; opaque refs; lease hashes only; 30-second maximum TTL; single transactional consumption |
+| Gateway service credentials and Executor subjects | `gateway_service_identities`, `executor_subject_bindings` | `lib/gateway/persistence.ts` | internal gateway routes | exact team + service + tenant + subject binding; hashed credentials; revoke rather than delete |
+| Member GitHub connection, one-use lease, and limiter | `gateway_connections`, `gateway_resolution_leases`, `gateway_rate_limits` | `lib/gateway/persistence.ts` | internal resolver/authorization routes | exact team + member + subject; GitHub-only; opaque refs; lease hashes only; 30-second maximum TTL; single transactional consumption; fail-closed DB-time buckets |
 | Durable request, approval, and claim state | `gateway_executions`, `gateway_approvals` | `lib/gateway/persistence.ts` | later authorization/resume routes only | encrypted request envelope (64 KiB sealed maximum); retained identity/request fields; 15-minute maximum approval TTL; exclusive row-lock claim |
 | Strict gateway compliance audit | `gateway_audit_log` | `lib/gateway/persistence.ts` in the same transaction as authorization state | admin compliance surfaces in later slices | append-only trigger; fixed non-secret columns only; no JSON escape hatch; team deletion is restricted while retained records exist |
 
@@ -614,6 +614,9 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 
 <!-- drift:routes -->
 
+- `POST /api/internal/executor-gateway/v1/resolve-lease` — service-authenticated, version-pinned, one-use 30-second credential-resolution lease
+- `POST /api/internal/executor-gateway/v1/authorize-and-redeem` — exact-call policy decision and post-audit request-local PAT sealing
+- `POST /api/internal/executor-gateway/v1/record-outcome` — idempotent execution settlement with one immutable outcome audit
 - `POST /api/v1/items` — upsert synced content
 - `GET /api/v1/items` — tier-filtered, keyset-paginated pull
 - `GET /api/v1/items/:id` — single item fetch
@@ -666,7 +669,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 
 `auth_users` · `auth_tokens` · `oauth_states` · `teams` · `members` · `api_keys` · `audit_log` ·
 `gateway_service_identities` · `executor_subject_bindings` · `gateway_connections` · `gateway_resolution_leases` ·
-`gateway_executions` · `gateway_approvals` · `gateway_audit_log` · `rate_limits` ·
+`gateway_executions` · `gateway_approvals` · `gateway_audit_log` · `gateway_rate_limits` · `rate_limits` ·
 `projects` · `items` · `item_versions` · `tasks` · `decisions` · `graph_entities` ·
 `graph_relationships` · `query_log` · `policies` · `approval_requests` · `actions` ·
 `codebases` · `code_metrics` · `code_contributions` · `github_issues` · `member_emails` ·

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -10,3 +10,6 @@
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
  */
 export const BRAIN_API_VERSION = "1.9";
+
+/** Server-only Executor gateway negotiation; independent of the member API surface. */
+export const GATEWAY_CONTRACT_VERSION = "1.10";

--- a/lib/gateway/canonical.ts
+++ b/lib/gateway/canonical.ts
@@ -1,0 +1,45 @@
+import "server-only";
+import { createHash } from "node:crypto";
+
+export type CanonicalJson =
+  | null
+  | boolean
+  | number
+  | string
+  | CanonicalJson[]
+  | { [key: string]: CanonicalJson };
+
+function jsonString(value: string): string {
+  for (let i = 0; i < value.length; i++) {
+    const unit = value.charCodeAt(i);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(++i);
+      if (!(next >= 0xdc00 && next <= 0xdfff))
+        throw new TypeError("unpaired Unicode surrogate");
+    } else if (unit >= 0xdc00 && unit <= 0xdfff)
+      throw new TypeError("unpaired Unicode surrogate");
+  }
+  return JSON.stringify(value);
+}
+
+/** Small RFC 8785/JCS serializer for the JSON-only gateway domain. */
+export function canonicalize(value: CanonicalJson): string {
+  if (value === null || typeof value === "boolean")
+    return JSON.stringify(value);
+  if (typeof value === "string") return jsonString(value);
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("non-finite JSON number");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (Object.getPrototypeOf(value) !== Object.prototype)
+    throw new TypeError("non-plain JSON object");
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${jsonString(key)}:${canonicalize(value[key])}`)
+    .join(",")}}`;
+}
+
+export function canonicalSha256(value: CanonicalJson): string {
+  return createHash("sha256").update(canonicalize(value), "utf8").digest("hex");
+}

--- a/lib/gateway/http.ts
+++ b/lib/gateway/http.ts
@@ -1,0 +1,161 @@
+import "server-only";
+import { randomUUID } from "node:crypto";
+import { GATEWAY_CONTRACT_VERSION } from "@/lib/api/version";
+import {
+  authenticateGatewayServiceCredential,
+  GatewayAuthenticationError,
+  gatewayRateLimit,
+  type AuthenticatedGatewayService,
+} from "./persistence";
+
+export const GATEWAY_MAX_RAW_BODY_BYTES = 65_536;
+const messages: Record<string, string> = {
+  gateway_unauthorized: "Unauthorized",
+  gateway_version_mismatch: "Gateway version mismatch",
+  gateway_invalid_request: "Invalid request",
+  gateway_payload_too_large: "Request body too large",
+  gateway_unsupported_content_encoding: "Unsupported content encoding",
+  gateway_rate_limited: "Rate limit exceeded",
+  gateway_not_found: "Not found",
+  gateway_scope_not_found: "Gateway scope not found",
+  gateway_lease_invalid: "Invalid lease",
+  gateway_policy_stale: "Gateway policy changed",
+  gateway_allow_already_committed: "Allow already committed",
+  gateway_idempotency_conflict: "Idempotency conflict",
+  gateway_outcome_conflict: "Outcome conflict",
+  gateway_credential_failure: "Credential unavailable",
+  gateway_internal: "Internal gateway error",
+};
+const noStore = {
+  "Cache-Control": "no-store",
+  "Content-Type": "application/json",
+};
+
+export function gatewayError(
+  code: string,
+  status: number,
+  correlationId: string | null = null,
+  extraHeaders: HeadersInit = {},
+): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code,
+        message: messages[code] ?? messages.gateway_internal,
+        request_id: randomUUID(),
+        correlation_id: correlationId,
+      },
+    }),
+    { status, headers: { ...noStore, ...extraHeaders } },
+  );
+}
+export function gatewayJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: noStore });
+}
+export function gatewayDisabled(): Response | null {
+  return process.env.AIOS_GATEWAY_INTERNAL_ENABLED === "true"
+    ? null
+    : gatewayError("gateway_not_found", 404);
+}
+
+export async function authenticateGatewayRequest(
+  req: Request,
+): Promise<AuthenticatedGatewayService | Response> {
+  try {
+    const service = await authenticateGatewayServiceCredential(
+      req.headers.get("authorization"),
+    );
+    if (
+      req.headers.get("x-aios-executor-version") !== "1.5.33" ||
+      req.headers.get("x-aios-companion-version") !== "0.1.0" ||
+      req.headers.get("x-aios-contract-version") !== GATEWAY_CONTRACT_VERSION
+    ) {
+      service.secretBytes.fill(0);
+      return gatewayError("gateway_version_mismatch", 409);
+    }
+    return service;
+  } catch (error) {
+    return error instanceof GatewayAuthenticationError
+      ? gatewayError("gateway_unauthorized", 401)
+      : gatewayError("gateway_internal", 500);
+  }
+}
+
+export async function readGatewayJson(
+  req: Request,
+): Promise<unknown | Response> {
+  const encoding = req.headers.get("content-encoding");
+  if (encoding && encoding.toLowerCase() !== "identity")
+    return gatewayError("gateway_unsupported_content_encoding", 415);
+  const declared = req.headers.get("content-length");
+  if (
+    declared !== null &&
+    (!/^\d+$/.test(declared) || Number(declared) > GATEWAY_MAX_RAW_BODY_BYTES)
+  )
+    return gatewayError("gateway_payload_too_large", 413);
+  if (!req.body) return gatewayError("gateway_invalid_request", 400);
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > GATEWAY_MAX_RAW_BODY_BYTES) {
+          await reader.cancel();
+          return gatewayError("gateway_payload_too_large", 413);
+        }
+        chunks.push(value);
+      }
+    }
+  } catch {
+    return gatewayError("gateway_invalid_request", 400);
+  }
+  const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch {
+    return gatewayError("gateway_invalid_request", 400);
+  }
+}
+
+export async function enforceGatewayLimit(
+  bucket: string,
+  limit: number,
+): Promise<Response | null> {
+  try {
+    const hit = await gatewayRateLimit(bucket, limit);
+    return hit.allowed
+      ? null
+      : gatewayError("gateway_rate_limited", 429, null, {
+          "Retry-After": String(hit.retryAfter),
+        });
+  } catch {
+    return gatewayError("gateway_rate_limited", 429, null, {
+      "Retry-After": "60",
+    });
+  }
+}
+
+export const isResponse = (value: unknown): value is Response =>
+  value instanceof Response;
+export const isUuid = (value: unknown): value is string =>
+  typeof value === "string" &&
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+export const exactObject = (
+  value: unknown,
+  required: string[],
+  optional: string[] = [],
+): value is Record<string, unknown> =>
+  !!value &&
+  typeof value === "object" &&
+  !Array.isArray(value) &&
+  Object.getPrototypeOf(value) === Object.prototype &&
+  required.every((key) => Object.hasOwn(value, key)) &&
+  Object.keys(value).every(
+    (key) => required.includes(key) || optional.includes(key),
+  );

--- a/lib/gateway/normalize.ts
+++ b/lib/gateway/normalize.ts
@@ -1,0 +1,163 @@
+import "server-only";
+import { canonicalSha256, type CanonicalJson } from "./canonical";
+
+export const GATEWAY_TOOLS = [
+  "github.repository.get",
+  "github.contents.get",
+  "github.issues.list",
+  "github.issue.get",
+  "github.pull_requests.list",
+  "github.pull_request.get",
+  "github.pull_request.files.list",
+] as const;
+export type GatewayTool = (typeof GATEWAY_TOOLS)[number];
+export type NormalizedArgs = Record<string, string | number>;
+
+export class GatewayArgumentError extends Error {
+  readonly code = "gateway_invalid_arguments";
+  constructor() {
+    super("Invalid gateway arguments");
+  }
+}
+
+const ASCII_EDGE = /^[\t\n\v\f\r ]+|[\t\n\v\f\r ]+$/g;
+const CONTROL = /[\u0000-\u001f\u007f]/;
+const fail = (): never => {
+  throw new GatewayArgumentError();
+};
+const plain = (value: unknown): Record<string, unknown> => {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  )
+    return fail();
+  return value as Record<string, unknown>;
+};
+const exact = (obj: Record<string, unknown>, fields: readonly string[]) => {
+  if (Object.keys(obj).some((key) => !fields.includes(key))) fail();
+};
+const text = (value: unknown): string =>
+  typeof value === "string" ? value.replace(ASCII_EDGE, "") : fail();
+const owner = (value: unknown): string => {
+  const v = text(value);
+  if (
+    v.length < 1 ||
+    v.length > 39 ||
+    !/^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(v) ||
+    v.includes("--")
+  )
+    fail();
+  return v;
+};
+const repo = (value: unknown): string => {
+  const v = text(value);
+  const length = [...v].length;
+  if (
+    length < 1 ||
+    length > 100 ||
+    CONTROL.test(v) ||
+    /[\\/]/.test(v) ||
+    /^\.+$/.test(v)
+  )
+    fail();
+  return v;
+};
+const pathValue = (value: unknown): string => {
+  const v = text(value);
+  if (
+    Buffer.byteLength(v, "utf8") > 1024 ||
+    v.includes("\0") ||
+    v.includes("\\") ||
+    v.startsWith("/") ||
+    v.split("/").some((s) => s === "." || s === "..")
+  )
+    fail();
+  return v;
+};
+const refValue = (value: unknown): string => {
+  const v = text(value);
+  if (!v || Buffer.byteLength(v, "utf8") > 255 || CONTROL.test(v)) fail();
+  return v;
+};
+const integer = (
+  value: unknown,
+  min: number,
+  max = Number.MAX_SAFE_INTEGER,
+): number => {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < min ||
+    value > max
+  )
+    fail();
+  return value as number;
+};
+const listFields = ["owner", "repo", "state", "page", "perPage"] as const;
+const list = (obj: Record<string, unknown>) => ({
+  owner: owner(obj.owner),
+  repo: repo(obj.repo),
+  state:
+    obj.state === undefined
+      ? "open"
+      : ["open", "closed", "all"].includes(text(obj.state))
+        ? text(obj.state)
+        : fail(),
+  page: obj.page === undefined ? 1 : integer(obj.page, 1, 10_000),
+  perPage: obj.perPage === undefined ? 30 : integer(obj.perPage, 1, 100),
+});
+
+export function normalizeGatewayArgs(
+  tool: string,
+  input: unknown,
+): NormalizedArgs {
+  const obj = plain(input);
+  switch (tool as GatewayTool) {
+    case "github.repository.get":
+      exact(obj, ["owner", "repo"]);
+      return { owner: owner(obj.owner), repo: repo(obj.repo) };
+    case "github.contents.get":
+      exact(obj, ["owner", "repo", "path", "ref"]);
+      return {
+        owner: owner(obj.owner),
+        repo: repo(obj.repo),
+        path: pathValue(obj.path),
+        ref: refValue(obj.ref),
+      };
+    case "github.issues.list":
+    case "github.pull_requests.list":
+      exact(obj, listFields);
+      return list(obj);
+    case "github.issue.get":
+      exact(obj, ["owner", "repo", "issueNumber"]);
+      return {
+        owner: owner(obj.owner),
+        repo: repo(obj.repo),
+        issueNumber: integer(obj.issueNumber, 1),
+      };
+    case "github.pull_request.get":
+      exact(obj, ["owner", "repo", "pullNumber"]);
+      return {
+        owner: owner(obj.owner),
+        repo: repo(obj.repo),
+        pullNumber: integer(obj.pullNumber, 1),
+      };
+    case "github.pull_request.files.list":
+      exact(obj, ["owner", "repo", "pullNumber", "page", "perPage"]);
+      return {
+        owner: owner(obj.owner),
+        repo: repo(obj.repo),
+        pullNumber: integer(obj.pullNumber, 1),
+        page: obj.page === undefined ? 1 : integer(obj.page, 1, 10_000),
+        perPage: obj.perPage === undefined ? 30 : integer(obj.perPage, 1, 100),
+      };
+    default:
+      return fail();
+  }
+}
+
+export function gatewayRequestHash(args: NormalizedArgs): string {
+  return canonicalSha256(args as CanonicalJson);
+}

--- a/lib/gateway/persistence.ts
+++ b/lib/gateway/persistence.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import type { PoolClient } from "pg";
 import { withTransaction } from "@/lib/db/pg/tx";
 import {
@@ -9,8 +9,10 @@ import {
   type AuthorizeDecision,
   type GatewayDecision,
 } from "./types";
+import { evaluateGatewayPolicy, gatewayPolicyVersion, loadGatewayPolicies } from "./policy";
+export { GatewayPersistenceError } from "./types";
 
-const sha256 = (value: string) => createHash("sha256").update(value, "utf8").digest("hex");
+const sha256 = (value: string | Buffer) => createHash("sha256").update(value).digest("hex");
 const opaque = () => randomBytes(32).toString("base64url");
 
 type Scope = {
@@ -29,17 +31,102 @@ export async function registerGatewayServiceIdentity(input: {
   credentialVersion?: number;
   expiresAt?: string;
 }): Promise<{ id: string }> {
+  if (!/^[A-Za-z0-9_-]{22}$/.test(input.credentialId) || !/^[A-Za-z0-9_-]{43}$/.test(input.credential)) {
+    throw new Error("gateway_service_credential_invalid");
+  }
+  const credentialIdBytes = Buffer.from(input.credentialId, "base64url");
+  const credentialBytes = Buffer.from(input.credential, "base64url");
+  if (credentialIdBytes.length !== 16 || credentialIdBytes.toString("base64url") !== input.credentialId || credentialBytes.length !== 32 || credentialBytes.toString("base64url") !== input.credential) {
+    throw new Error("gateway_service_credential_invalid");
+  }
   const id = randomUUID();
   await withTransaction(async (client) => {
     await client.query(
       `insert into gateway_service_identities
        (id, team_id, environment, credential_id, credential_hash, credential_version, expires_at)
        values ($1,$2,$3,$4,$5,$6,$7)`,
-      [id, input.teamId, input.environment, input.credentialId, sha256(input.credential), input.credentialVersion ?? 1, input.expiresAt ?? null]
+      [id, input.teamId, input.environment, input.credentialId, sha256(credentialBytes), input.credentialVersion ?? 1, input.expiresAt ?? null]
     );
   });
   return { id };
 }
+
+export type AuthenticatedGatewayService = {
+  id: string;
+  teamId: string;
+  environment: string;
+  credentialId: string;
+  credentialVersion: number;
+  secretBytes: Buffer;
+};
+
+export class GatewayAuthenticationError extends Error {
+  readonly code = "gateway_unauthorized";
+  constructor() {
+    super("Unauthorized");
+  }
+}
+
+export async function authenticateGatewayServiceCredential(
+  authorization: string | null,
+): Promise<AuthenticatedGatewayService> {
+  const match = /^Bearer aios_gw_([A-Za-z0-9_-]{22})_([A-Za-z0-9_-]{43})$/.exec(
+    authorization ?? "",
+  );
+  if (!match) throw new GatewayAuthenticationError();
+  const credentialIdBytes = Buffer.from(match[1], "base64url");
+  const secretBytes = Buffer.from(match[2], "base64url");
+  if (
+    credentialIdBytes.length !== 16 ||
+    credentialIdBytes.toString("base64url") !== match[1] ||
+    secretBytes.length !== 32 ||
+    secretBytes.toString("base64url") !== match[2]
+  )
+    throw new GatewayAuthenticationError();
+  const candidate = createHash("sha256").update(secretBytes).digest();
+  try {
+    return await withTransaction(async (client) => {
+      const result = await client.query<{
+        id: string;
+        team_id: string;
+        environment: string;
+        credential_id: string;
+        credential_hash: string;
+        credential_version: number;
+      }>(
+        `select id, team_id, environment, credential_id, credential_hash, credential_version
+           from gateway_service_identities where credential_id=$1 and revoked_at is null
+            and activated_at <= now() and (expires_at is null or expires_at > now()) for update`,
+        [match[1]],
+      );
+      const row = result.rows[0];
+      const stored =
+        row && /^[0-9a-f]{64}$/.test(row.credential_hash)
+          ? Buffer.from(row.credential_hash, "hex")
+          : Buffer.alloc(32);
+      const matches =
+        stored.length === candidate.length &&
+        timingSafeEqual(stored, candidate);
+      if (!row || !matches) throw new GatewayAuthenticationError();
+      await client.query(
+        `update gateway_service_identities set last_authenticated_at=now() where id=$1`,
+        [row.id],
+      );
+      return {
+        id: row.id,
+        teamId: row.team_id,
+        environment: row.environment,
+        credentialId: row.credential_id,
+        credentialVersion: row.credential_version,
+        secretBytes,
+      };
+    });
+  } catch (error) {
+    if (error instanceof GatewayAuthenticationError) secretBytes.fill(0);
+    throw error;
+  }
+}
+
 
 export async function bindExecutorSubject(input: Scope): Promise<{ id: string }> {
   const id = randomUUID();
@@ -119,13 +206,14 @@ export async function issueResolutionLease(
   return withTransaction(async (client) => {
     const connection = await activeConnection(client, input, input.connectionRef);
     if (!connection) throw new GatewayPersistenceError("gateway_scope_not_found");
+    const policyVersion = gatewayPolicyVersion(await loadGatewayPolicies(client, input.teamId));
     const inserted = await client.query<{ expires_at: string }>(
       `insert into gateway_resolution_leases
-       (lease_hash, audience, team_id, member_id, service_identity_id, subject_binding_id, connection_id, expires_at)
-       values ($1,$2,$3,$4,$5,$6,$7,now()+($8::text || ' seconds')::interval)
+       (lease_hash, audience, team_id, member_id, service_identity_id, subject_binding_id, connection_id, policy_version, expires_at)
+       values ($1,$2,$3,$4,$5,$6,$7,$8,now()+($9::text || ' seconds')::interval)
        returning expires_at`,
       [sha256(lease), input.audience, input.teamId, input.memberId, input.serviceIdentityId,
-       connection.subject_binding_id, connection.connection_id, GATEWAY_LEASE_TTL_SECONDS]
+       connection.subject_binding_id, connection.connection_id, policyVersion, GATEWAY_LEASE_TTL_SECONDS]
     );
     await client.query(
       `insert into gateway_audit_log
@@ -331,4 +419,443 @@ export async function claimApprovedExecution(input: Scope & {
 
 export async function findGatewayConnection(input: Scope & { connectionRef: string }) {
   return withTransaction((client) => activeConnection(client, input, input.connectionRef));
+}
+
+/** Resolve all request authority from stored bindings; callers provide no team/member/tier authority. */
+export async function resolveAndIssueLease(input: {
+  serviceIdentityId: string;
+  executorTenantId: string;
+  executorSubjectId: string;
+  connectionRef: string;
+  audience: string;
+  correlationId: string;
+}): Promise<{ lease: string; expiresAt: string }> {
+  const leaseValue = opaque();
+  return withTransaction(async (client) => {
+    const scope = await client.query<{
+      team_id: string;
+      member_id: string;
+      subject_binding_id: string;
+      connection_id: string;
+    }>(
+      `select c.team_id, c.member_id, b.id subject_binding_id, c.id connection_id
+         from gateway_connections c
+         join executor_subject_bindings b on b.id=c.subject_binding_id and b.team_id=c.team_id and b.member_id=c.member_id
+         join gateway_service_identities s on s.id=b.service_identity_id and s.team_id=b.team_id
+         join members m on m.id=c.member_id and m.team_id=c.team_id
+        where s.id=$1 and b.executor_tenant_id=$2 and b.executor_subject_id=$3 and c.connection_ref=$4
+          and c.provider='github' and c.enabled and c.revoked_at is null and (c.credential_expires_at is null or c.credential_expires_at > now())
+          and b.revoked_at is null and (b.expires_at is null or b.expires_at > now())
+          and s.revoked_at is null and (s.expires_at is null or s.expires_at > now())
+          and m.status='active' and m.tier='team'`,
+      [
+        input.serviceIdentityId,
+        input.executorTenantId,
+        input.executorSubjectId,
+        input.connectionRef,
+      ],
+    );
+    const row = scope.rows[0];
+    if (!row) throw new GatewayPersistenceError("gateway_scope_not_found");
+    const policyVersion = gatewayPolicyVersion(
+      await loadGatewayPolicies(client, row.team_id),
+    );
+    const inserted = await client.query<{ expires_at: string }>(
+      `insert into gateway_resolution_leases
+       (lease_hash,audience,team_id,member_id,service_identity_id,subject_binding_id,connection_id,policy_version,expires_at)
+       values ($1,$2,$3,$4,$5,$6,$7,$8,now()+interval '30 seconds') returning expires_at`,
+      [
+        sha256(leaseValue),
+        input.audience,
+        row.team_id,
+        row.member_id,
+        input.serviceIdentityId,
+        row.subject_binding_id,
+        row.connection_id,
+        policyVersion,
+      ],
+    );
+    await client.query(
+      `insert into gateway_audit_log (team_id,member_id,service_identity_id,subject_binding_id,connection_id,event,correlation_id) values ($1,$2,$3,$4,$5,'lease_issued',$6)`,
+      [
+        row.team_id,
+        row.member_id,
+        input.serviceIdentityId,
+        row.subject_binding_id,
+        row.connection_id,
+        input.correlationId,
+      ],
+    );
+    return { lease: leaseValue, expiresAt: inserted.rows[0].expires_at };
+  });
+}
+
+export class GatewayConflictError extends Error {
+  constructor(
+    readonly code:
+      | "gateway_policy_stale"
+      | "gateway_allow_already_committed"
+      | "gateway_idempotency_conflict"
+      | "gateway_outcome_conflict",
+  ) {
+    super(code);
+  }
+}
+
+export async function authorizeLeaseAndCreateExecution(input: {
+  serviceIdentityId: string;
+  executionId: string;
+  lease: string;
+  audience: string;
+  toolkit: string;
+  tool: string;
+  normalizedArgs: {
+    owner: string;
+    repo: string;
+    [key: string]: string | number;
+  };
+  requestHash: string;
+  correlationId: string;
+  idempotencyKey: string;
+  requestEnvelope: Buffer;
+}): Promise<AuthorizeDecision> {
+  return withTransaction(async (client) => {
+    const incomingLease = await client.query<{
+      id: string;
+      subject_binding_id: string;
+      connection_id: string;
+      consumed_at: string | null;
+    }>(
+      `select id,subject_binding_id,connection_id,consumed_at from gateway_resolution_leases where lease_hash=$1 and service_identity_id=$2 and audience=$3`,
+      [sha256(input.lease), input.serviceIdentityId, input.audience],
+    );
+    const prior = await client.query<{
+      toolkit: string;
+      tool: string;
+      request_hash: string;
+      subject_binding_id: string;
+      connection_id: string;
+    }>(
+      `select toolkit,tool,request_hash,subject_binding_id,connection_id from gateway_executions where service_identity_id=$1 and idempotency_key=$2`,
+      [input.serviceIdentityId, input.idempotencyKey],
+    );
+    if (prior.rows[0]) {
+      const same =
+        prior.rows[0].toolkit === input.toolkit &&
+        prior.rows[0].tool === input.tool &&
+        prior.rows[0].request_hash === input.requestHash &&
+        incomingLease.rows[0]?.subject_binding_id ===
+          prior.rows[0].subject_binding_id &&
+        incomingLease.rows[0]?.connection_id === prior.rows[0].connection_id;
+      throw new GatewayConflictError(
+        same
+          ? "gateway_allow_already_committed"
+          : "gateway_idempotency_conflict",
+      );
+    }
+    if (incomingLease.rows[0]?.consumed_at) {
+      const committed = await client.query<{
+        toolkit: string;
+        tool: string;
+        request_hash: string;
+      }>(
+        `select toolkit,tool,request_hash from gateway_executions where lease_id=$1`,
+        [incomingLease.rows[0].id],
+      );
+      const same =
+        committed.rows[0]?.toolkit === input.toolkit &&
+        committed.rows[0]?.tool === input.tool &&
+        committed.rows[0]?.request_hash === input.requestHash;
+      throw new GatewayConflictError(
+        same
+          ? "gateway_allow_already_committed"
+          : "gateway_idempotency_conflict",
+      );
+    }
+    const leased = await client.query<{
+      id: string;
+      team_id: string;
+      member_id: string;
+      subject_binding_id: string;
+      connection_id: string;
+      policy_version: string;
+      actor_handle: string;
+      role: "admin" | "lead" | "member";
+      tier: "team" | "external";
+    }>(
+      `select l.id,l.team_id,l.member_id,l.subject_binding_id,l.connection_id,l.policy_version,m.actor_handle,m.role::text,m.tier::text
+       from gateway_resolution_leases l
+       join gateway_service_identities s on s.id=l.service_identity_id and s.team_id=l.team_id
+       join executor_subject_bindings b on b.id=l.subject_binding_id and b.team_id=l.team_id
+       join gateway_connections c on c.id=l.connection_id and c.team_id=l.team_id
+       join members m on m.id=l.member_id and m.team_id=l.team_id
+       where l.lease_hash=$1 and l.audience=$2 and l.service_identity_id=$3 and l.consumed_at is null and l.revoked_at is null and l.expires_at>now()
+       and s.revoked_at is null and (s.expires_at is null or s.expires_at>now()) and b.revoked_at is null and (b.expires_at is null or b.expires_at>now())
+       and c.enabled and c.revoked_at is null and (c.credential_expires_at is null or c.credential_expires_at>now()) and m.status='active' and m.tier='team' for update of l`,
+      [sha256(input.lease), input.audience, input.serviceIdentityId],
+    );
+    const row = leased.rows[0];
+    if (!row) throw new GatewayPersistenceError("gateway_lease_invalid");
+    const policies = await loadGatewayPolicies(client, row.team_id);
+    const policy = evaluateGatewayPolicy(policies, {
+      principal: { actor: row.actor_handle, role: row.role, tier: row.tier },
+      tool: input.tool,
+      owner: input.normalizedArgs.owner,
+      repo: input.normalizedArgs.repo,
+    });
+    if (policy.policyVersion !== row.policy_version)
+      throw new GatewayConflictError("gateway_policy_stale");
+    const executionId = input.executionId;
+    const state =
+      policy.decision === "allow"
+        ? "claimed"
+        : policy.decision === "block"
+          ? "blocked"
+          : "approval_required";
+    await client.query(
+      `insert into gateway_executions(id,team_id,member_id,service_identity_id,subject_binding_id,connection_id,lease_id,correlation_id,idempotency_key,toolkit,tool,request_hash,encrypted_request_envelope,decision,state,policy_version,policy_rule_id,claimed_at,claimed_by_correlation_id) values($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,case when $14='allow' then now() end,case when $14='allow' then $8::uuid end)`,
+      [
+        executionId,
+        row.team_id,
+        row.member_id,
+        input.serviceIdentityId,
+        row.subject_binding_id,
+        row.connection_id,
+        row.id,
+        input.correlationId,
+        input.idempotencyKey,
+        input.toolkit,
+        input.tool,
+        input.requestHash,
+        input.requestEnvelope,
+        policy.decision,
+        state,
+        policy.policyVersion,
+        policy.policyRuleId,
+      ],
+    );
+    await client.query(
+      `update gateway_resolution_leases set consumed_at=now() where id=$1`,
+      [row.id],
+    );
+    let approval: { id: string; expires_at: string } | undefined;
+    if (policy.decision === "require_approval") {
+      const id = randomUUID();
+      const made = await client.query<{ id: string; expires_at: string }>(
+        `insert into gateway_approvals(id,team_id,execution_id,expires_at) values($1,$2,$3,now()+interval '15 minutes') returning id,expires_at`,
+        [id, row.team_id, executionId],
+      );
+      approval = made.rows[0];
+    }
+    const event =
+      policy.decision === "allow"
+        ? "decision_allowed"
+        : policy.decision === "block"
+          ? "decision_blocked"
+          : "decision_approval_required";
+    await client.query(
+      `insert into gateway_audit_log(team_id,member_id,service_identity_id,subject_binding_id,connection_id,execution_id,approval_id,event,toolkit,tool,request_hash,policy_version,policy_rule_id,decision,correlation_id,idempotency_key) values($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+      [
+        row.team_id,
+        row.member_id,
+        input.serviceIdentityId,
+        row.subject_binding_id,
+        row.connection_id,
+        executionId,
+        approval?.id ?? null,
+        event,
+        input.toolkit,
+        input.tool,
+        input.requestHash,
+        policy.policyVersion,
+        policy.policyRuleId,
+        policy.decision,
+        input.correlationId,
+        input.idempotencyKey,
+      ],
+    );
+    if (policy.decision === "allow") return { decision: "allow", executionId };
+    if (policy.decision === "block") return { decision: "block", executionId };
+    return {
+      decision: "require_approval",
+      executionId,
+      approvalId: approval!.id,
+      expiresAt: approval!.expires_at,
+    };
+  });
+}
+
+export async function reboundMemberForLease(input: {
+  serviceIdentityId: string;
+  lease: string;
+  audience: string;
+}): Promise<string> {
+  return withTransaction(async (client) => {
+    const result = await client.query<{ member_id: string }>(
+      `select member_id from gateway_resolution_leases where lease_hash=$1 and service_identity_id=$2 and audience=$3 and consumed_at is null and revoked_at is null and expires_at>now()`,
+      [sha256(input.lease), input.serviceIdentityId, input.audience],
+    );
+    if (!result.rows[0])
+      throw new GatewayPersistenceError("gateway_lease_invalid");
+    return result.rows[0].member_id;
+  });
+}
+
+export async function gatewayRateLimit(
+  bucket: string,
+  limit: number,
+): Promise<{ allowed: boolean; retryAfter: number }> {
+  return withTransaction(async (client) => {
+    const result = await client.query<{ count: number; retry_after: number }>(
+      `with clock as (select date_trunc('minute', clock_timestamp()) window_start, clock_timestamp() now_at),
+       hit as (insert into gateway_rate_limits(bucket,window_start,count)
+         select $1,window_start,1 from clock on conflict(bucket,window_start) do update set count=gateway_rate_limits.count+1
+         returning count)
+       select hit.count, greatest(1,ceil(extract(epoch from ((select window_start from clock)+interval '1 minute'-(select now_at from clock)))))::int retry_after from hit`,
+      [bucket],
+    );
+    return {
+      allowed: result.rows[0].count <= limit,
+      retryAfter: result.rows[0].retry_after,
+    };
+  });
+}
+
+export async function getGatewayCredentialForClaimedExecution(input: {
+  serviceIdentityId: string;
+  executionId: string;
+}): Promise<{ ciphertext: string; credentialExpiresAt: string | null }> {
+  return withTransaction(async (client) => {
+    const result = await client.query<{
+      credential_ciphertext: string;
+      credential_expires_at: string | null;
+    }>(
+      `select c.credential_ciphertext,c.credential_expires_at from gateway_executions e
+       join gateway_connections c on c.id=e.connection_id and c.team_id=e.team_id
+       join gateway_service_identities s on s.id=e.service_identity_id and s.team_id=e.team_id
+       where e.id=$1 and e.service_identity_id=$2 and e.state='claimed' and e.decision='allow'
+         and c.enabled and c.revoked_at is null and (c.credential_expires_at is null or c.credential_expires_at>now())
+         and s.revoked_at is null and (s.expires_at is null or s.expires_at>now())`,
+      [input.executionId, input.serviceIdentityId],
+    );
+    const row = result.rows[0];
+    if (!row)
+      throw new GatewayPersistenceError("gateway_execution_not_claimable");
+    return {
+      ciphertext: row.credential_ciphertext,
+      credentialExpiresAt: row.credential_expires_at,
+    };
+  });
+}
+
+export async function failGatewayCredentialSealing(input: {
+  serviceIdentityId: string;
+  executionId: string;
+  correlationId: string;
+}): Promise<void> {
+  await withTransaction(async (client) => {
+    const result = await client.query<{
+      team_id: string;
+      member_id: string;
+      subject_binding_id: string;
+      connection_id: string;
+    }>(
+      `update gateway_executions set state='failed',outcome_classification='credential',updated_at=now() where id=$1 and service_identity_id=$2 and state='claimed' and outcome_classification is null returning team_id,member_id,subject_binding_id,connection_id`,
+      [input.executionId, input.serviceIdentityId],
+    );
+    const row = result.rows[0];
+    if (!row) return;
+    await client.query(
+      `insert into gateway_audit_log(team_id,member_id,service_identity_id,subject_binding_id,connection_id,execution_id,event,correlation_id,outcome_classification) values($1,$2,$3,$4,$5,$6,'outcome_recorded',$7,'credential') on conflict do nothing`,
+      [
+        row.team_id,
+        row.member_id,
+        input.serviceIdentityId,
+        row.subject_binding_id,
+        row.connection_id,
+        input.executionId,
+        input.correlationId,
+      ],
+    );
+  });
+}
+
+export async function recordGatewayOutcome(input: {
+  serviceIdentityId: string;
+  executionId: string;
+  correlationId: string;
+  classification: string;
+  upstreamStatusClass?: string;
+  responseBytes?: number;
+}): Promise<"recorded" | "replay"> {
+  return withTransaction(async (client) => {
+    const current = await client.query<{
+      team_id: string;
+      member_id: string;
+      subject_binding_id: string;
+      connection_id: string;
+      state: string;
+      outcome_classification: string | null;
+      upstream_status_class: string | null;
+      response_bytes: string | null;
+    }>(
+      `select team_id,member_id,subject_binding_id,connection_id,state,outcome_classification,upstream_status_class,response_bytes::text from gateway_executions where id=$1 and service_identity_id=$2 for update`,
+      [input.executionId, input.serviceIdentityId],
+    );
+    const row = current.rows[0];
+    if (!row)
+      throw new GatewayPersistenceError("gateway_execution_not_claimable");
+    const upstream = input.upstreamStatusClass ?? null;
+    const bytes = input.responseBytes ?? null;
+    if (row.outcome_classification !== null) {
+      if (
+        row.outcome_classification === input.classification &&
+        row.upstream_status_class === upstream &&
+        (row.response_bytes === null ? null : Number(row.response_bytes)) ===
+          bytes
+      )
+        return "replay";
+      throw new Error("gateway_outcome_conflict");
+    }
+    const next =
+      row.state === "claimed"
+        ? input.classification === "success"
+          ? "succeeded"
+          : [
+                "credential",
+                "network",
+                "upstream",
+                "response_too_large",
+                "internal",
+              ].includes(input.classification)
+            ? "failed"
+            : null
+        : row.state === "blocked" && input.classification === "blocked"
+          ? "blocked"
+          : row.state === "approval_required" &&
+              input.classification === "approval_required"
+            ? "approval_required"
+            : null;
+    if (!next) throw new Error("gateway_outcome_conflict");
+    await client.query(
+      `update gateway_executions set state=$1,outcome_classification=$2,upstream_status_class=$3,response_bytes=$4,updated_at=now() where id=$5 and outcome_classification is null`,
+      [next, input.classification, upstream, bytes, input.executionId],
+    );
+    await client.query(
+      `insert into gateway_audit_log(team_id,member_id,service_identity_id,subject_binding_id,connection_id,execution_id,event,correlation_id,outcome_classification,upstream_status_class,response_bytes) values($1,$2,$3,$4,$5,$6,'outcome_recorded',$7,$8,$9,$10)`,
+      [
+        row.team_id,
+        row.member_id,
+        input.serviceIdentityId,
+        row.subject_binding_id,
+        row.connection_id,
+        input.executionId,
+        input.correlationId,
+        input.classification,
+        upstream,
+        bytes,
+      ],
+    );
+    return "recorded";
+  });
 }

--- a/lib/gateway/policy.ts
+++ b/lib/gateway/policy.ts
@@ -1,0 +1,123 @@
+import "server-only";
+import type { PoolClient } from "pg";
+import { canonicalSha256, type CanonicalJson } from "./canonical";
+import type { GatewayDecision } from "./types";
+
+export type GatewayPolicyRow = {
+  id: string;
+  subject_role: "admin" | "lead" | "member" | null;
+  subject_tier: "team" | "external" | null;
+  subject_actor: string | null;
+  action: string;
+  resource: string;
+  priority: number;
+  effect: "allow" | "deny" | "require_approval";
+  updated_at: string;
+};
+export type GatewayPrincipal = {
+  actor: string;
+  role: "admin" | "lead" | "member";
+  tier: "team" | "external";
+};
+export type GatewayPolicyResult = {
+  decision: GatewayDecision;
+  policyVersion: string;
+  policyRuleId: string | null;
+};
+
+const effectRank = { allow: 1, require_approval: 2, deny: 3 } as const;
+const decision = (effect: GatewayPolicyRow["effect"]): GatewayDecision =>
+  effect === "deny" ? "block" : effect;
+export function gatewayPolicyVersion(rows: GatewayPolicyRow[]): string {
+  const active = [...rows].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+  );
+  return canonicalSha256(
+    active.map((r) => ({
+      id: r.id,
+      subject_role: r.subject_role,
+      subject_tier: r.subject_tier,
+      subject_actor: r.subject_actor,
+      action: r.action,
+      resource: r.resource,
+      priority: r.priority,
+      effect: r.effect,
+      updated_at: r.updated_at,
+    })) as CanonicalJson,
+  );
+}
+function subjectSpecificity(
+  row: GatewayPolicyRow,
+  p: GatewayPrincipal,
+): number {
+  const dimensions =
+    Number(row.subject_actor !== null) +
+    Number(row.subject_role !== null) +
+    Number(row.subject_tier !== null);
+  if (dimensions > 1) return -1;
+  if (row.subject_actor !== null) return row.subject_actor === p.actor ? 4 : -1;
+  if (row.subject_role !== null) return row.subject_role === p.role ? 3 : -1;
+  if (row.subject_tier !== null) return row.subject_tier === p.tier ? 2 : -1;
+  return 1;
+}
+
+export function evaluateGatewayPolicy(
+  rows: GatewayPolicyRow[],
+  input: {
+    principal: GatewayPrincipal;
+    tool: string;
+    owner: string;
+    repo: string;
+  },
+): GatewayPolicyResult {
+  const action = `gateway.aios-github-readonly.${input.tool}`;
+  const resource = `github.repository:${input.owner}/${input.repo}`;
+  const active = [...rows].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+  );
+  const policyVersion = gatewayPolicyVersion(active);
+  const candidates = active
+    .map((row) => ({
+      row,
+      subject: subjectSpecificity(row, input.principal),
+      tool:
+        row.action === action
+          ? 2
+          : row.action === "gateway.aios-github-readonly.*"
+            ? 1
+            : -1,
+      resource:
+        row.resource === resource
+          ? 2
+          : row.resource === "github.repository:*"
+            ? 1
+            : -1,
+    }))
+    .filter((x) => x.subject > 0 && x.tool > 0 && x.resource > 0);
+  candidates.sort(
+    (a, b) =>
+      b.subject - a.subject ||
+      b.tool - a.tool ||
+      b.resource - a.resource ||
+      b.row.priority - a.row.priority ||
+      effectRank[b.row.effect] - effectRank[a.row.effect] ||
+      (a.row.id < b.row.id ? -1 : a.row.id > b.row.id ? 1 : 0),
+  );
+  const winner = candidates[0]?.row;
+  return {
+    decision: winner ? decision(winner.effect) : "block",
+    policyVersion,
+    policyRuleId: winner?.id ?? null,
+  };
+}
+
+export async function loadGatewayPolicies(
+  client: PoolClient,
+  teamId: string,
+): Promise<GatewayPolicyRow[]> {
+  const result = await client.query<GatewayPolicyRow>(
+    `select id::text, subject_role::text, subject_tier::text, subject_actor, action, resource, priority, effect::text, updated_at::text from policies where team_id=$1 and enabled order by id`,
+    [teamId],
+  );
+  return result.rows;
+}

--- a/lib/gateway/sealed-credential.ts
+++ b/lib/gateway/sealed-credential.ts
@@ -1,0 +1,153 @@
+import "server-only";
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  hkdfSync,
+  randomBytes,
+} from "node:crypto";
+import { canonicalize } from "./canonical";
+
+const SALT = createHash("sha256")
+  .update("aios-gateway-sealed-credential:v1", "ascii")
+  .digest();
+export const SEALED_CREDENTIAL_MAX_LIFETIME_SECONDS = 15;
+type Header = {
+  v: 1;
+  kid: string;
+  sid: string;
+  eid: string;
+  provider: "github";
+  iat: number;
+  exp: number;
+};
+
+function key(secret: Buffer, credentialId: string, version: number): Buffer {
+  return Buffer.from(
+    hkdfSync(
+      "sha256",
+      secret,
+      SALT,
+      Buffer.from(`${credentialId}\0${version}`, "utf8"),
+      32,
+    ),
+  );
+}
+
+export function sealCredential(input: {
+  pat: Buffer;
+  serviceSecret: Buffer;
+  credentialId: string;
+  credentialVersion: number;
+  serviceIdentityId: string;
+  executionId: string;
+  now?: number;
+  nonce?: Buffer;
+}): { sealedCredential: string; expiresAt: number } {
+  const iat = input.now ?? Math.floor(Date.now() / 1000);
+  const exp = iat + SEALED_CREDENTIAL_MAX_LIFETIME_SECONDS;
+  const header: Header = {
+    v: 1,
+    kid: `${input.credentialId}.v${input.credentialVersion}`,
+    sid: input.serviceIdentityId,
+    eid: input.executionId,
+    provider: "github",
+    iat,
+    exp,
+  };
+  const protectedBytes = Buffer.from(canonicalize(header), "utf8");
+  const nonce = input.nonce ?? randomBytes(12);
+  if (nonce.length !== 12) throw new Error("gateway_seal_failed");
+  const derived = key(
+    input.serviceSecret,
+    input.credentialId,
+    input.credentialVersion,
+  );
+  try {
+    const cipher = createCipheriv("aes-256-gcm", derived, nonce);
+    cipher.setAAD(protectedBytes);
+    const payload = Buffer.concat([
+      cipher.update(input.pat),
+      cipher.final(),
+      cipher.getAuthTag(),
+    ]);
+    return {
+      sealedCredential: `v1.${protectedBytes.toString("base64url")}.${nonce.toString("base64url")}.${payload.toString("base64url")}`,
+      expiresAt: exp,
+    };
+  } finally {
+    derived.fill(0);
+  }
+}
+
+export function openSealedCredential(input: {
+  sealedCredential: string;
+  serviceSecret: Buffer;
+  credentialId: string;
+  credentialVersion: number;
+  serviceIdentityId: string;
+  executionId: string;
+  now?: number;
+}): Buffer {
+  const [wireVersion, encodedHeader, encodedNonce, encodedPayload, extra] =
+    input.sealedCredential.split(".");
+  if (
+    wireVersion !== "v1" ||
+    !encodedHeader ||
+    !encodedNonce ||
+    !encodedPayload ||
+    extra
+  )
+    throw new Error("gateway_sealed_credential_invalid");
+  const headerBytes = Buffer.from(encodedHeader, "base64url");
+  const nonce = Buffer.from(encodedNonce, "base64url");
+  const payload = Buffer.from(encodedPayload, "base64url");
+  let header: Header;
+  try {
+    header = JSON.parse(headerBytes.toString("utf8")) as Header;
+  } catch {
+    throw new Error("gateway_sealed_credential_invalid");
+  }
+  const expectedKeys = ["eid", "exp", "iat", "kid", "provider", "sid", "v"];
+  const now = input.now ?? Math.floor(Date.now() / 1000);
+  if (
+    headerBytes.toString("base64url") !== encodedHeader ||
+    nonce.toString("base64url") !== encodedNonce ||
+    payload.toString("base64url") !== encodedPayload ||
+    canonicalize(header) !== headerBytes.toString("utf8") ||
+    JSON.stringify(Object.keys(header).sort()) !==
+      JSON.stringify(expectedKeys) ||
+    header.v !== 1 ||
+    header.kid !== `${input.credentialId}.v${input.credentialVersion}` ||
+    header.sid !== input.serviceIdentityId ||
+    header.eid !== input.executionId ||
+    header.provider !== "github" ||
+    !Number.isInteger(header.iat) ||
+    !Number.isInteger(header.exp) ||
+    header.exp <= header.iat ||
+    header.exp - header.iat > SEALED_CREDENTIAL_MAX_LIFETIME_SECONDS ||
+    now < header.iat ||
+    now >= header.exp ||
+    nonce.length !== 12 ||
+    payload.length < 16
+  )
+    throw new Error("gateway_sealed_credential_invalid");
+  const derived = key(
+    input.serviceSecret,
+    input.credentialId,
+    input.credentialVersion,
+  );
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", derived, nonce);
+    decipher.setAAD(headerBytes);
+    decipher.setAuthTag(payload.subarray(-16));
+    return Buffer.concat([
+      decipher.update(payload.subarray(0, -16)),
+      decipher.final(),
+    ]);
+  } catch {
+    throw new Error("gateway_sealed_credential_invalid");
+  } finally {
+    derived.fill(0);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "test:datamechanics": "vitest run --config vitest.datamechanics.config.ts",
     "test:datamechanics:local": "DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.datamechanics.config.ts",
     "test:http": "vitest run --config vitest.http.config.ts",
+    "test:gateway-contracts": "vitest run test/gateway/gateway-contracts.test.ts",
+    "test:gateway-api": "vitest run test/gateway test/guards/gateway-writers.test.ts",
     "test:http:local": "npm run build && DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.http.config.ts"
   },
   "dependencies": {

--- a/postgres/migrations/20260714120000_gateway_v110.sql
+++ b/postgres/migrations/20260714120000_gateway_v110.sql
@@ -1,0 +1,27 @@
+-- AIO-401: contract-first internal gateway transport/auth/rate/outcome invariants.
+do $$ begin
+  if exists (select 1 from gateway_service_identities where credential_id !~ '^[A-Za-z0-9_-]{22}$' or credential_hash !~ '^[0-9a-f]{64}$') then
+    raise exception 'legacy gateway service identity rows require explicit credential rotation';
+  end if;
+end $$;
+
+alter table gateway_service_identities drop constraint if exists gateway_service_identities_credential_id_check;
+alter table gateway_service_identities drop constraint if exists gateway_service_identities_credential_hash_check;
+alter table gateway_service_identities add constraint gateway_service_identities_credential_id_check check (credential_id ~ '^[A-Za-z0-9_-]{22}$');
+alter table gateway_service_identities add constraint gateway_service_identities_credential_hash_check check (credential_hash ~ '^[0-9a-f]{64}$');
+
+alter table gateway_resolution_leases add column if not exists policy_version text;
+update gateway_resolution_leases set policy_version='4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945' where policy_version is null;
+alter table gateway_resolution_leases alter column policy_version set not null;
+alter table gateway_resolution_leases drop constraint if exists gateway_resolution_leases_policy_version_check;
+alter table gateway_resolution_leases add constraint gateway_resolution_leases_policy_version_check check (policy_version ~ '^[0-9a-f]{64}$');
+
+create unique index if not exists gateway_audit_log_outcome_execution_unq
+  on gateway_audit_log (execution_id) where event='outcome_recorded';
+
+create table if not exists gateway_rate_limits (
+  bucket text not null,
+  window_start timestamptz not null,
+  count integer not null check (count > 0),
+  primary key (bucket, window_start)
+);

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -342,8 +342,8 @@ create table if not exists gateway_service_identities (
   id uuid primary key default gen_random_uuid(),
   team_id uuid not null references teams(id) on delete restrict,
   environment text not null check (environment <> ''),
-  credential_id text not null unique check (credential_id <> ''),
-  credential_hash text not null check (credential_hash <> ''),
+  credential_id text not null unique check (credential_id ~ '^[A-Za-z0-9_-]{22}$'),
+  credential_hash text not null check (credential_hash ~ '^[0-9a-f]{64}$'),
   credential_version integer not null default 1 check (credential_version > 0),
   rotated_from_id uuid references gateway_service_identities(id) on delete restrict,
   activated_at timestamptz not null default now(),
@@ -422,6 +422,7 @@ create table if not exists gateway_resolution_leases (
   service_identity_id uuid not null,
   subject_binding_id uuid not null,
   connection_id uuid not null,
+  policy_version text not null check (policy_version ~ '^[0-9a-f]{64}$'),
   created_at timestamptz not null default now(),
   expires_at timestamptz not null,
   consumed_at timestamptz,
@@ -550,6 +551,15 @@ create table if not exists gateway_audit_log (
 );
 create index if not exists gateway_audit_log_team_time_idx
   on gateway_audit_log (team_id, created_at desc);
+create unique index if not exists gateway_audit_log_outcome_execution_unq
+  on gateway_audit_log (execution_id) where event='outcome_recorded';
+
+create table if not exists gateway_rate_limits (
+  bucket text not null,
+  window_start timestamptz not null,
+  count integer not null check (count > 0),
+  primary key (bucket, window_start)
+);
 
 create or replace function gateway_audit_protect()
 returns trigger language plpgsql as $$
@@ -668,7 +678,8 @@ begin
     or new.team_id is distinct from old.team_id or new.member_id is distinct from old.member_id
     or new.service_identity_id is distinct from old.service_identity_id
     or new.subject_binding_id is distinct from old.subject_binding_id
-    or new.connection_id is distinct from old.connection_id or new.created_at is distinct from old.created_at
+    or new.connection_id is distinct from old.connection_id or new.policy_version is distinct from old.policy_version
+    or new.created_at is distinct from old.created_at
     or new.expires_at is distinct from old.expires_at then
     raise exception 'gateway resolution lease identity fields are immutable';
   end if; return new;

--- a/scripts/check-gateway-writers.mjs
+++ b/scripts/check-gateway-writers.mjs
@@ -12,6 +12,7 @@ const TABLES = [
   "gateway_executions",
   "gateway_approvals",
   "gateway_audit_log",
+  "gateway_rate_limits",
 ];
 const SECRET_FIELDS = [
   "credential_hash",

--- a/test/datamechanics/gateway-helpers.ts
+++ b/test/datamechanics/gateway-helpers.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { seedTeam, type Seed } from "./helpers";
 import {
   bindExecutorSubject,
@@ -22,8 +22,8 @@ export async function seedGateway(): Promise<GatewaySeed> {
   const service = await registerGatewayServiceIdentity({
     teamId: team.teamId,
     environment: "test",
-    credentialId: `svc-${randomUUID()}`,
-    credential: `synthetic-service-credential-${randomUUID()}`,
+    credentialId: randomBytes(16).toString("base64url"),
+    credential: randomBytes(32).toString("base64url"),
   });
   const binding = await bindExecutorSubject({
     ...team,

--- a/test/datamechanics/gateway-tenant-isolation.datamechanics.test.ts
+++ b/test/datamechanics/gateway-tenant-isolation.datamechanics.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { encryptGatewayRequestEnvelope } from "@/lib/gateway/envelope";
 import { getPool } from "@/lib/db/pg/pool";
@@ -139,8 +139,8 @@ describe("gateway-tenant-isolation", () => {
   it("refuses to bind an external member or connect through a revoked service", async () => {
     const external = await seedTeam();
     const service = await registerGatewayServiceIdentity({
-      teamId: external.teamId, environment: "test", credentialId: `svc-${randomUUID()}`,
-      credential: `synthetic-${randomUUID()}`,
+      teamId: external.teamId, environment: "test", credentialId: randomBytes(16).toString("base64url"),
+      credential: randomBytes(32).toString("base64url"),
     });
     await getPool().query(`update members set tier='external' where id=$1`, [external.memberId]);
     await expect(bindExecutorSubject({
@@ -150,8 +150,8 @@ describe("gateway-tenant-isolation", () => {
 
     const active = await seedTeam();
     const activeService = await registerGatewayServiceIdentity({
-      teamId: active.teamId, environment: "test", credentialId: `svc-${randomUUID()}`,
-      credential: `synthetic-${randomUUID()}`,
+      teamId: active.teamId, environment: "test", credentialId: randomBytes(16).toString("base64url"),
+      credential: randomBytes(32).toString("base64url"),
     });
     const binding = await bindExecutorSubject({
       teamId: active.teamId, memberId: active.memberId, serviceIdentityId: activeService.id,

--- a/test/datamechanics/gateway-v110.datamechanics.test.ts
+++ b/test/datamechanics/gateway-v110.datamechanics.test.ts
@@ -1,0 +1,229 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { encryptGatewayRequestEnvelope } from "@/lib/gateway/envelope";
+import {
+  authenticateGatewayServiceCredential,
+  authorizeLeaseAndCreateExecution,
+  failGatewayCredentialSealing,
+  gatewayRateLimit,
+  issueResolutionLease,
+  consumeLeaseAndCreateExecution,
+  recordGatewayOutcome,
+  registerGatewayServiceIdentity,
+} from "@/lib/gateway/persistence";
+import { getPool } from "@/lib/db/pg/pool";
+import { gatewayScope, seedGateway } from "./gateway-helpers";
+import { seedTeam } from "./helpers";
+
+describe("gateway v1.10 data mechanics", () => {
+  it("authenticates strict service grammar, supports overlap, and closes on revocation", async () => {
+    const team = await seedTeam();
+    const make = async () => {
+      const credentialId = randomBytes(16).toString("base64url");
+      const secret = randomBytes(32).toString("base64url");
+      const row = await registerGatewayServiceIdentity({
+        teamId: team.teamId,
+        environment: "test",
+        credentialId,
+        credential: secret,
+      });
+      return { ...row, credentialId, secret };
+    };
+    const first = await make();
+    const second = await make();
+    for (const value of [first, second]) {
+      const auth = await authenticateGatewayServiceCredential(
+        `Bearer aios_gw_${value.credentialId}_${value.secret}`,
+      );
+      expect(auth.id).toBe(value.id);
+      auth.secretBytes.fill(0);
+    }
+    await expect(
+      authenticateGatewayServiceCredential(
+        `Bearer aios_gw_${first.credentialId}_${randomBytes(32).toString("base64url")}`,
+      ),
+    ).rejects.toMatchObject({
+      code: "gateway_unauthorized",
+      message: "Unauthorized",
+    });
+    await getPool().query(
+      `update gateway_service_identities set revoked_at=now() where id=$1`,
+      [first.id],
+    );
+    await expect(
+      authenticateGatewayServiceCredential(
+        `Bearer aios_gw_${first.credentialId}_${first.secret}`,
+      ),
+    ).rejects.toMatchObject({
+      code: "gateway_unauthorized",
+      message: "Unauthorized",
+    });
+    const remaining = await authenticateGatewayServiceCredential(
+      `Bearer aios_gw_${second.credentialId}_${second.secret}`,
+    );
+    expect(remaining.id).toBe(second.id);
+    remaining.secretBytes.fill(0);
+  });
+
+  it("uses an atomic persistent gateway-owned minute bucket", async () => {
+    const bucket = `test-${randomUUID()}`;
+    const hits = await Promise.all(
+      Array.from({ length: 121 }, () => gatewayRateLimit(bucket, 120)),
+    );
+    expect(hits.filter((hit) => hit.allowed)).toHaveLength(120);
+    expect(hits.filter((hit) => !hit.allowed)).toHaveLength(1);
+    expect(
+      hits.every((hit) => hit.retryAfter >= 1 && hit.retryAfter <= 60),
+    ).toBe(true);
+  });
+
+  it("keeps one PAT ciphertext source and no member_secrets duplicate", async () => {
+    const seed = await seedGateway();
+    const custody = await getPool().query(
+      `select (select count(*)::int from gateway_connections where id=$1 and credential_ciphertext is not null) connection_rows,(select count(*)::int from member_secrets where team_id=$2 and member_id=$3 and provider='github') duplicate_rows`,
+      [seed.connectionId, seed.teamId, seed.memberId],
+    );
+    expect(custody.rows[0]).toEqual({ connection_rows: 1, duplicate_rows: 0 });
+  });
+
+  it("settles once, replays identically, and rejects divergent outcomes", async () => {
+    const seed = await seedGateway();
+    const scope = gatewayScope(seed);
+    const correlationId = randomUUID();
+    const executionId = randomUUID();
+    const lease = await issueResolutionLease({
+      ...scope,
+      connectionRef: seed.connectionRef,
+      audience: "aios-github-readonly",
+      correlationId,
+    });
+    await consumeLeaseAndCreateExecution({
+      ...scope,
+      lease: lease.lease,
+      audience: "aios-github-readonly",
+      executionId,
+      encryptedRequestEnvelope: encryptGatewayRequestEnvelope(
+        { owner: "octo", repo: "project" },
+        { executionId, serviceIdentityId: seed.serviceIdentityId },
+        Buffer.alloc(32, 7),
+      ),
+      toolkit: "aios-github-readonly",
+      tool: "github.repository.get",
+      requestHash: "a".repeat(64),
+      correlationId,
+      idempotencyKey: randomUUID(),
+      decision: "allow",
+    });
+    const outcome = {
+      serviceIdentityId: seed.serviceIdentityId,
+      executionId,
+      correlationId: randomUUID(),
+      classification: "success",
+      upstreamStatusClass: "2xx",
+      responseBytes: 123,
+    };
+    await expect(recordGatewayOutcome(outcome)).resolves.toBe("recorded");
+    await expect(
+      recordGatewayOutcome({ ...outcome, correlationId: randomUUID() }),
+    ).resolves.toBe("replay");
+    await expect(
+      recordGatewayOutcome({
+        ...outcome,
+        correlationId: randomUUID(),
+        responseBytes: 124,
+      }),
+    ).rejects.toThrow("gateway_outcome_conflict");
+    const rows = await getPool().query(
+      `select state,(select count(*)::int from gateway_audit_log where execution_id=$1 and event='outcome_recorded') audits from gateway_executions where id=$1`,
+      [executionId],
+    );
+    expect(rows.rows[0]).toEqual({ state: "succeeded", audits: 1 });
+  });
+
+  it("commits allow once, never replays it, and settles a post-commit seal failure", async () => {
+    const seed = await seedGateway();
+    await getPool().query(
+      `insert into policies(team_id,action,resource,effect,priority) values($1,$2,$3,'allow',10)`,
+      [
+        seed.teamId,
+        "gateway.aios-github-readonly.github.repository.get",
+        "github.repository:octo/project",
+      ],
+    );
+    const lease = await issueResolutionLease({
+      ...gatewayScope(seed),
+      connectionRef: seed.connectionRef,
+      audience: "aios-github-readonly",
+      correlationId: randomUUID(),
+    });
+    const input = {
+      serviceIdentityId: seed.serviceIdentityId,
+      executionId: randomUUID(),
+      lease: lease.lease,
+      audience: "aios-github-readonly",
+      toolkit: "aios-github-readonly",
+      tool: "github.repository.get",
+      normalizedArgs: { owner: "octo", repo: "project" },
+      requestHash: "b".repeat(64),
+      correlationId: randomUUID(),
+      idempotencyKey: randomUUID(),
+      requestEnvelope: Buffer.from("sealed-request"),
+    };
+    const allowed = await authorizeLeaseAndCreateExecution(input);
+    expect(allowed.decision).toBe("allow");
+    await expect(authorizeLeaseAndCreateExecution(input)).rejects.toMatchObject(
+      { code: "gateway_allow_already_committed" },
+    );
+    await failGatewayCredentialSealing({
+      serviceIdentityId: seed.serviceIdentityId,
+      executionId: allowed.executionId,
+      correlationId: randomUUID(),
+    });
+    const settled = await getPool().query(
+      `select state,outcome_classification from gateway_executions where id=$1`,
+      [allowed.executionId],
+    );
+    expect(settled.rows[0]).toEqual({
+      state: "failed",
+      outcome_classification: "credential",
+    });
+  });
+
+  it("detects stale policy without consuming the lease or creating an execution", async () => {
+    const seed = await seedGateway();
+    const policy = await getPool().query<{ id: string }>(
+      `insert into policies(team_id,action,resource,effect) values($1,'gateway.aios-github-readonly.*','github.repository:*','allow') returning id`,
+      [seed.teamId],
+    );
+    const lease = await issueResolutionLease({
+      ...gatewayScope(seed),
+      connectionRef: seed.connectionRef,
+      audience: "aios-github-readonly",
+      correlationId: randomUUID(),
+    });
+    await getPool().query(
+      `update policies set priority=priority+1,updated_at=now()+interval '1 second' where id=$1`,
+      [policy.rows[0].id],
+    );
+    await expect(
+      authorizeLeaseAndCreateExecution({
+        serviceIdentityId: seed.serviceIdentityId,
+        executionId: randomUUID(),
+        lease: lease.lease,
+        audience: "aios-github-readonly",
+        toolkit: "aios-github-readonly",
+        tool: "github.repository.get",
+        normalizedArgs: { owner: "octo", repo: "project" },
+        requestHash: "c".repeat(64),
+        correlationId: randomUUID(),
+        idempotencyKey: randomUUID(),
+        requestEnvelope: Buffer.from("sealed-request"),
+      }),
+    ).rejects.toMatchObject({ code: "gateway_policy_stale" });
+    const result = await getPool().query(
+      `select consumed_at,(select count(*)::int from gateway_executions where lease_id=gateway_resolution_leases.id) executions from gateway_resolution_leases where lease_hash=$1`,
+      [createHash("sha256").update(lease.lease).digest("hex")],
+    );
+    expect(result.rows[0]).toEqual({ consumed_at: null, executions: 0 });
+  });
+});

--- a/test/fixtures/contract/gateway-v1.10.json
+++ b/test/fixtures/contract/gateway-v1.10.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "aios-gateway-contract/v1.10",
+  "version": "1.10",
+  "serviceAuthentication": {
+    "bearerPattern": "^aios_gw_([A-Za-z0-9_-]{22})_([A-Za-z0-9_-]{43})$",
+    "credentialId": { "sourceBytes": 16, "encodedLength": 22 },
+    "secret": { "sourceBytes": 32, "encodedLength": 43, "storedDigest": "sha256-secret-bytes-lowercase-hex" },
+    "constantTimeDigestComparison": true,
+    "uniformFailure": { "status": 401, "code": "gateway_unauthorized", "message": "Unauthorized" },
+    "requiredHeaders": {
+      "X-AIOS-Executor-Version": "1.5.33",
+      "X-AIOS-Companion-Version": "0.1.0",
+      "X-AIOS-Contract-Version": "1.10"
+    },
+    "ordering": ["service_authentication", "version_check", "subject_connection_lease_pat_lookup"],
+    "overlap": "multiple independently active credential rows are accepted",
+    "responseKeyBinding": "the credential row that authenticated the request",
+    "preflight": "legacy rows that predate this grammar require explicit rotation",
+    "vector": {
+      "credentialId": "AAECAwQFBgcICQoLDA0ODw",
+      "materialBase64url": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+      "bearer": "aios_gw_AAECAwQFBgcICQoLDA0ODw_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+      "storedDigest": "630dcd2966c4336691125448bbb25b4ff412a49c732db2c8abc1b8581bd710dd"
+    }
+  },
+  "transport": {
+    "featureFlag": { "name": "AIOS_GATEWAY_INTERNAL_ENABLED", "enabledValue": "true", "default": false },
+    "disabledResponse": { "status": 404, "beforeAuthenticationOrBodyParsing": true },
+    "rawRequestLimitBytes": 65536,
+    "acceptedContentEncodings": ["identity"],
+    "errors": {
+      "schema": { "error": { "code": "string", "message": "allowlisted-string", "request_id": "uuid", "correlation_id": "uuid-or-null" } },
+      "headers": { "Cache-Control": "no-store" },
+      "union": {
+        "gateway_not_found": { "status": 404, "message": "Not found" },
+        "gateway_unauthorized": { "status": 401, "message": "Unauthorized" },
+        "gateway_version_mismatch": { "status": 409, "message": "Gateway version mismatch" },
+        "gateway_invalid_request": { "status": 400, "message": "Invalid request" },
+        "gateway_payload_too_large": { "status": 413, "message": "Request body too large" },
+        "gateway_unsupported_content_encoding": { "status": 415, "message": "Unsupported content encoding" },
+        "gateway_rate_limited": { "status": 429, "message": "Rate limit exceeded" },
+        "gateway_scope_not_found": { "status": 422, "message": "Gateway scope not found" },
+        "gateway_lease_invalid": { "status": 409, "message": "Invalid lease" },
+        "gateway_policy_stale": { "status": 409, "message": "Gateway policy changed" },
+        "gateway_allow_already_committed": { "status": 409, "message": "Allow already committed" },
+        "gateway_idempotency_conflict": { "status": 409, "message": "Idempotency conflict" },
+        "gateway_outcome_conflict": { "status": 409, "message": "Outcome conflict" },
+        "gateway_credential_failure": { "status": 500, "message": "Credential unavailable" },
+        "gateway_internal": { "status": 500, "message": "Internal gateway error" }
+      }
+    }
+  },
+  "routes": {
+    "resolveLease": {
+      "method": "POST",
+      "path": "/api/internal/executor-gateway/v1/resolve-lease",
+      "request": { "required": ["executorTenantId", "executorSubjectId", "connectionRef", "correlationId"], "additionalProperties": false },
+      "responses": { "200": { "required": ["lease", "expiresAt"], "additionalProperties": false } },
+      "lease": { "ttlSeconds": 30, "oneUse": true, "stored": "sha256-lowercase-hex" },
+      "rateLimitPerMinute": 120
+    },
+    "authorizeAndRedeem": {
+      "method": "POST",
+      "path": "/api/internal/executor-gateway/v1/authorize-and-redeem",
+      "request": { "required": ["lease", "toolkit", "tool", "normalizedArgs", "requestHash", "correlationId", "idempotencyKey"], "additionalProperties": false },
+      "responses": {
+        "200": { "decision": "allow", "required": ["decision", "executionId", "sealedCredential", "credentialExpiresAt"], "additionalProperties": false },
+        "202": { "decision": "require_approval", "required": ["decision", "executionId", "approvalId", "expiresAt"], "additionalProperties": false },
+        "403": { "decision": "block", "required": ["decision", "code", "executionId"], "additionalProperties": false }
+      },
+      "rateLimitPerMinute": { "service": 120, "reboundMember": 120 }
+    },
+    "recordOutcome": {
+      "method": "POST",
+      "path": "/api/internal/executor-gateway/v1/record-outcome",
+      "request": {
+        "required": ["executionId", "correlationId", "classification"],
+        "optional": ["upstreamStatusClass", "responseBytes"],
+        "additionalProperties": false
+      },
+      "responses": { "204": { "body": null } },
+      "rateLimitPerMinute": 240
+    }
+  },
+  "tools": {
+    "toolkit": "aios-github-readonly",
+    "definitions": {
+      "github.repository.get": { "fields": ["owner", "repo"] },
+      "github.contents.get": { "fields": ["owner", "repo", "path", "ref"] },
+      "github.issues.list": { "fields": ["owner", "repo", "state", "page", "perPage"] },
+      "github.issue.get": { "fields": ["owner", "repo", "issueNumber"] },
+      "github.pull_requests.list": { "fields": ["owner", "repo", "state", "page", "perPage"] },
+      "github.pull_request.get": { "fields": ["owner", "repo", "pullNumber"] },
+      "github.pull_request.files.list": { "fields": ["owner", "repo", "pullNumber", "page", "perPage"] }
+    },
+    "normalization": {
+      "unknownFields": "reject",
+      "strings": "trim-surrounding-ascii-whitespace-preserve-case-and-unicode",
+      "owner": "1-39 GitHub-compatible characters",
+      "repo": "1-100 chars; no control, slash, backslash, or dot-only name",
+      "path": "0-1024 UTF-8 bytes; no NUL, backslash, absolute path, dot, or dot-dot segment",
+      "ref": "required 1-255 UTF-8 bytes; no control characters",
+      "state": { "values": ["open", "closed", "all"], "default": "open" },
+      "page": { "jsonType": "integer", "default": 1, "minimum": 1, "maximum": 10000 },
+      "perPage": { "jsonType": "integer", "default": 30, "minimum": 1, "maximum": 100 },
+      "issueNumber": { "jsonType": "integer", "minimum": 1 },
+      "pullNumber": { "jsonType": "integer", "minimum": 1 },
+      "requestHash": "lowercase-hex-sha256-of-rfc8785-jcs-normalizedArgs"
+    },
+    "hashVectors": [
+      { "name": "repository-unicode-and-trim", "tool": "github.repository.get", "input": { "repo": "répo", "owner": " Octo " }, "normalizedArgs": { "owner": "Octo", "repo": "répo" }, "jcs": "{\"owner\":\"Octo\",\"repo\":\"répo\"}", "requestHash": "bf79950c6e23ff708593ded687e37a7f857aec6862f0e21275414448c7f88707" },
+      { "name": "contents-key-order", "tool": "github.contents.get", "input": { "ref": "main", "path": "src/é.ts", "repo": "project", "owner": "octo" }, "normalizedArgs": { "owner": "octo", "repo": "project", "path": "src/é.ts", "ref": "main" }, "jcs": "{\"owner\":\"octo\",\"path\":\"src/é.ts\",\"ref\":\"main\",\"repo\":\"project\"}", "requestHash": "09d54b8999110c3bf47ce4eaf02c3a9c1ddf70a993676676725c9abbcf27b86c" },
+      { "name": "issues-defaults", "tool": "github.issues.list", "input": { "repo": "project", "owner": "octo" }, "normalizedArgs": { "owner": "octo", "repo": "project", "state": "open", "page": 1, "perPage": 30 }, "jcs": "{\"owner\":\"octo\",\"page\":1,\"perPage\":30,\"repo\":\"project\",\"state\":\"open\"}", "requestHash": "239fab5482414add3f00baeb0dcd80f09c2b848891d109063f14984559a60612" },
+      { "name": "issue-positive-integer", "tool": "github.issue.get", "input": { "issueNumber": 7, "repo": "project", "owner": "octo" }, "normalizedArgs": { "owner": "octo", "repo": "project", "issueNumber": 7 }, "jcs": "{\"issueNumber\":7,\"owner\":\"octo\",\"repo\":\"project\"}", "requestHash": "277ec26803bb97bf219f0c079f050c63ec2d3df315ea6c3c284a6f30ed5a3e1c" },
+      { "name": "pull-list-explicit", "tool": "github.pull_requests.list", "input": { "perPage": 100, "page": 2, "state": "all", "repo": "project", "owner": "octo" }, "normalizedArgs": { "owner": "octo", "repo": "project", "state": "all", "page": 2, "perPage": 100 }, "jcs": "{\"owner\":\"octo\",\"page\":2,\"perPage\":100,\"repo\":\"project\",\"state\":\"all\"}", "requestHash": "957465bb7bda70fc7b248f4ebf617e96bee7d4c6c4e14b532fc3ddda43c64d7c" },
+      { "name": "pull-positive-integer", "tool": "github.pull_request.get", "input": { "pullNumber": 12, "repo": "project", "owner": "octo" }, "normalizedArgs": { "owner": "octo", "repo": "project", "pullNumber": 12 }, "jcs": "{\"owner\":\"octo\",\"pullNumber\":12,\"repo\":\"project\"}", "requestHash": "b04de41b0c3bb076ac84cb4d6074628e70d50828018ed8beb040f5061d9d598d" },
+      { "name": "pull-files", "tool": "github.pull_request.files.list", "input": { "page": 1, "pullNumber": 12, "perPage": 30, "repo": "project", "owner": "octo" }, "normalizedArgs": { "owner": "octo", "repo": "project", "pullNumber": 12, "page": 1, "perPage": 30 }, "jcs": "{\"owner\":\"octo\",\"page\":1,\"perPage\":30,\"pullNumber\":12,\"repo\":\"project\"}", "requestHash": "0f1f6c5d72d2ce3fde55fe65bf7cfb4e4115a392f7d62360000e7a0257e825ac" }
+    ],
+    "negativeVectors": [
+      { "name": "unknown-field", "tool": "github.repository.get", "input": { "owner": "octo", "repo": "project", "extra": true }, "code": "gateway_invalid_arguments" },
+      { "name": "fractional-page", "tool": "github.issues.list", "input": { "owner": "octo", "repo": "project", "page": 1.5 }, "code": "gateway_invalid_arguments" },
+      { "name": "dot-path", "tool": "github.contents.get", "input": { "owner": "octo", "repo": "project", "path": "a/../b", "ref": "main" }, "code": "gateway_invalid_arguments" }
+    ]
+  },
+  "policy": {
+    "actionExactPrefix": "gateway.aios-github-readonly.",
+    "actionWildcard": "gateway.aios-github-readonly.*",
+    "resourceExactPrefix": "github.repository:",
+    "resourceWildcard": "github.repository:*",
+    "precedence": ["subject:actor>role>tier>team", "tool:exact>wildcard", "resource:exact>wildcard", "priority:highest", "effect:block>require_approval>allow", "no-match:block"],
+    "version": "sha256-rfc8785-jcs-active-rows-sorted-by-id"
+  },
+  "sealedCredential": {
+    "patSource": "gateway_connections.credential_ciphertext",
+    "kdf": { "algorithm": "HKDF-SHA-256", "saltInputAscii": "aios-gateway-sealed-credential:v1", "info": "credential-id + NUL + decimal-credential-version", "outputBytes": 32 },
+    "wire": "v1.<base64url(protected-header-jcs)>.<base64url(12-byte-nonce)>.<base64url(ciphertext||16-byte-tag)>",
+    "headerFieldsExactly": ["v", "kid", "sid", "eid", "provider", "iat", "exp"],
+    "maxLifetimeSeconds": 15,
+    "cipher": "AES-256-GCM",
+    "aad": "exact decoded protected-header bytes",
+    "plaintext": "raw PAT bytes only",
+    "vector": {
+      "materialBytesHex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      "credentialId": "AAECAwQFBgcICQoLDA0ODw",
+      "credentialVersion": 1,
+      "serviceIdentityId": "11111111-1111-4111-8111-111111111111",
+      "executionId": "22222222-2222-4222-8222-222222222222",
+      "iat": 1784044800,
+      "exp": 1784044815,
+      "nonceHex": "000102030405060708090a0b",
+      "plaintextUtf8": "fixture-pat-readonly",
+      "saltHex": "d7b627a066978955646732543aa8e77a8b505b54c9267f2959a1cdd29d970805",
+      "derivedMaterialHex": "052d45f1a582cd2fd07ed3d7a62ff28afd367c788b23b8d14c462234f83a8798",
+      "protectedHeaderJcs": "{\"eid\":\"22222222-2222-4222-8222-222222222222\",\"exp\":1784044815,\"iat\":1784044800,\"kid\":\"AAECAwQFBgcICQoLDA0ODw.v1\",\"provider\":\"github\",\"sid\":\"11111111-1111-4111-8111-111111111111\",\"v\":1}",
+      "sealed": "v1.eyJlaWQiOiIyMjIyMjIyMi0yMjIyLTQyMjItODIyMi0yMjIyMjIyMjIyMjIiLCJleHAiOjE3ODQwNDQ4MTUsImlhdCI6MTc4NDA0NDgwMCwia2lkIjoiQUFFQ0F3UUZCZ2NJQ1FvTERBME9Edy52MSIsInByb3ZpZGVyIjoiZ2l0aHViIiwic2lkIjoiMTExMTExMTEtMTExMS00MTExLTgxMTEtMTExMTExMTExMTExIiwidiI6MX0.AAECAwQFBgcICQoL.nrq3BDy_LZFYaY1w7F5jTB3q8_i_5nR6wN5D9f_-qvhzK4Rh"
+    }
+  },
+  "stateMachine": {
+    "preCommitFailure": "no execution; lease remains retryable",
+    "allowCommit": "consume lease + insert claimed execution + strict audit atomically",
+    "postCommitSealFailure": "settle failed/credential + audit; return no credential",
+    "lostAllowResponse": "same lease or idempotency key => 409 gateway_allow_already_committed; never reseal or decrypt again",
+    "idempotencyConflict": "409 gateway_idempotency_conflict",
+    "outcomes": {
+      "claimed": { "success": "succeeded", "credential": "failed", "network": "failed", "upstream": "failed", "response_too_large": "failed", "internal": "failed" },
+      "blocked": { "blocked": "blocked" },
+      "approval_required": { "approval_required": "approval_required" }
+    },
+    "outcomeReplayIdentity": ["authenticated-service-identity", "executionId", "classification", "upstreamStatusClass", "responseBytes"]
+  }
+}

--- a/test/gateway/gateway-contracts.test.ts
+++ b/test/gateway/gateway-contracts.test.ts
@@ -1,0 +1,124 @@
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { GATEWAY_CONTRACT_VERSION } from "@/lib/api/version";
+import { canonicalize } from "@/lib/gateway/canonical";
+import {
+  gatewayRequestHash,
+  normalizeGatewayArgs,
+} from "@/lib/gateway/normalize";
+import {
+  evaluateGatewayPolicy,
+  type GatewayPolicyRow,
+} from "@/lib/gateway/policy";
+import {
+  openSealedCredential,
+  sealCredential,
+} from "@/lib/gateway/sealed-credential";
+
+const path = join(
+  import.meta.dirname,
+  "..",
+  "fixtures",
+  "contract",
+  "gateway-v1.10.json",
+);
+const bytes = readFileSync(path);
+const fixture = JSON.parse(bytes.toString("utf8"));
+
+describe("gateway-v1.10 vendored contract", () => {
+  it("is the reviewed byte-for-byte fixture", () => {
+    expect(createHash("sha256").update(bytes).digest("hex")).toBe(
+      "4ddd6495fa505b76118080865d60255bfba94a9ccda249defe428babb3d0c205",
+    );
+    expect(fixture.version).toBe(GATEWAY_CONTRACT_VERSION);
+    expect(Object.keys(fixture.routes)).toHaveLength(3);
+    expect(Object.keys(fixture.tools.definitions)).toHaveLength(7);
+  });
+  it("normalizes and hashes every positive vector", () => {
+    for (const vector of fixture.tools.hashVectors) {
+      const normalized = normalizeGatewayArgs(vector.tool, vector.input);
+      expect(normalized, vector.name).toEqual(vector.normalizedArgs);
+      expect(canonicalize(normalized), vector.name).toBe(vector.jcs);
+      expect(gatewayRequestHash(normalized), vector.name).toBe(
+        vector.requestHash,
+      );
+    }
+  });
+  it("rejects every negative vector", () => {
+    for (const vector of fixture.tools.negativeVectors)
+      expect(
+        () => normalizeGatewayArgs(vector.tool, vector.input),
+        vector.name,
+      ).toThrow("Invalid gateway arguments");
+  });
+  it("independently seals and opens the fixed vector", () => {
+    const v = fixture.sealedCredential.vector;
+    const sealed = sealCredential({
+      pat: Buffer.from(v.plaintextUtf8),
+      serviceSecret: Buffer.from(v.materialBytesHex, "hex"),
+      credentialId: v.credentialId,
+      credentialVersion: v.credentialVersion,
+      serviceIdentityId: v.serviceIdentityId,
+      executionId: v.executionId,
+      now: v.iat,
+      nonce: Buffer.from(v.nonceHex, "hex"),
+    });
+    expect(sealed.sealedCredential).toBe(v.sealed);
+    expect(
+      openSealedCredential({
+        sealedCredential: sealed.sealedCredential,
+        serviceSecret: Buffer.from(v.materialBytesHex, "hex"),
+        credentialId: v.credentialId,
+        credentialVersion: v.credentialVersion,
+        serviceIdentityId: v.serviceIdentityId,
+        executionId: v.executionId,
+        now: v.iat,
+      }).toString(),
+    ).toBe(v.plaintextUtf8);
+  });
+});
+
+describe("gateway policy precedence", () => {
+  const row = (over: Partial<GatewayPolicyRow>): GatewayPolicyRow => ({
+    id: randomUUID(),
+    subject_role: null,
+    subject_tier: null,
+    subject_actor: null,
+    action: "gateway.aios-github-readonly.*",
+    resource: "github.repository:*",
+    priority: 0,
+    effect: "allow",
+    updated_at: "2026-07-14T00:00:00.000Z",
+    ...over,
+  });
+  const input = {
+    principal: {
+      actor: "alex",
+      role: "member" as const,
+      tier: "team" as const,
+    },
+    tool: "github.repository.get",
+    owner: "octo",
+    repo: "project",
+  };
+  it("orders subject, tool, resource, priority, then restrictive effect", () => {
+    const winner = row({
+      id: "00000000-0000-4000-8000-000000000001",
+      subject_actor: "alex",
+      action: "gateway.aios-github-readonly.github.repository.get",
+      resource: "github.repository:octo/project",
+      priority: 3,
+      effect: "require_approval",
+    });
+    const result = evaluateGatewayPolicy(
+      [row({ priority: 999, effect: "deny" }), winner],
+      input,
+    );
+    expect(result.decision).toBe("require_approval");
+    expect(result.policyRuleId).toBe(winner.id);
+  });
+  it("defaults to block", () =>
+    expect(evaluateGatewayPolicy([], input).decision).toBe("block"));
+});

--- a/test/gateway/gateway-http.test.ts
+++ b/test/gateway/gateway-http.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  exactObject,
+  gatewayDisabled,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+
+describe("gateway raw request boundary", () => {
+  it("accepts exactly 65,536 raw bytes", async () => {
+    const body = `"${"a".repeat(65_534)}"`;
+    const result = await readGatewayJson(
+      new Request("http://local", { method: "POST", body }),
+    );
+    expect(typeof result).toBe("string");
+  });
+  it("rejects byte 65,537 with no-store", async () => {
+    const body = `"${"a".repeat(65_535)}"`;
+    const result = await readGatewayJson(
+      new Request("http://local", { method: "POST", body }),
+    );
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(413);
+    expect((result as Response).headers.get("cache-control")).toBe("no-store");
+  });
+  it("rejects an oversized declared length before reading", async () => {
+    const req = {
+      headers: new Headers({ "content-length": "65537" }),
+      get body(): never {
+        throw new Error("body accessed");
+      },
+    } as Request;
+    expect(((await readGatewayJson(req)) as Response).status).toBe(413);
+  });
+  it("counts a lying smaller content-length and rejects overflow", async () => {
+    const req = new Request("http://local", {
+      method: "POST",
+      body: `"${"a".repeat(65_535)}"`,
+      headers: { "content-length": "2" },
+    });
+    expect(((await readGatewayJson(req)) as Response).status).toBe(413);
+  });
+  it("counts a chunked/missing-length stream and rejects overflow", async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(65_000));
+        controller.enqueue(new Uint8Array(537));
+        controller.close();
+      },
+    });
+    const req = new Request("http://local", {
+      method: "POST",
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+    expect(req.headers.has("content-length")).toBe(false);
+    expect(((await readGatewayJson(req)) as Response).status).toBe(413);
+  });
+  it("rejects content encoding before parsing", async () => {
+    const result = await readGatewayJson(
+      new Request("http://local", {
+        method: "POST",
+        body: "{}",
+        headers: { "content-encoding": "gzip" },
+      }),
+    );
+    expect((result as Response).status).toBe(415);
+  });
+  it("requires exact object fields", () => {
+    expect(exactObject({ a: 1 }, ["a"])).toBe(true);
+    expect(exactObject({ a: 1, b: 2 }, ["a"])).toBe(false);
+  });
+  it("is disabled unless the value is exactly true", () => {
+    const prior = process.env.AIOS_GATEWAY_INTERNAL_ENABLED;
+    delete process.env.AIOS_GATEWAY_INTERNAL_ENABLED;
+    expect(gatewayDisabled()?.status).toBe(404);
+    process.env.AIOS_GATEWAY_INTERNAL_ENABLED = "TRUE";
+    expect(gatewayDisabled()?.status).toBe(404);
+    process.env.AIOS_GATEWAY_INTERNAL_ENABLED = "true";
+    expect(gatewayDisabled()).toBeNull();
+    if (prior === undefined) delete process.env.AIOS_GATEWAY_INTERNAL_ENABLED;
+    else process.env.AIOS_GATEWAY_INTERNAL_ENABLED = prior;
+  });
+});


### PR DESCRIPTION
## Summary

Implements the reviewed AIO-401 server-only gateway boundary on top of merged AIO-405 persistence.

Contract dependency: https://github.com/aiosbrain/aios-workspace/pull/322

- adds `GATEWAY_CONTRACT_VERSION = "1.10"` while retaining public `BRAIN_API_VERSION = "1.9"`
- vendors the dedicated gateway fixture byte-for-byte with a SHA-256 conformance guard
- adds strict service authentication and exact Executor/companion/contract version negotiation
- adds fixed seven-tool normalization and an audited RFC 8785/JCS canonicalizer
- adds gateway-specific policy precedence/versioning without changing the generic evaluator
- adds service-key-bound HKDF-SHA-256 + AES-256-GCM PAT sealing
- adds feature-flagged resolve, authorize/redeem, and outcome routes
- enforces a 65,536-byte raw request limit before JSON parsing and rejects compressed bodies
- adds persistent DB-time service/member limiters that deny on storage uncertainty
- adds stale-policy, idempotency, lost-response, post-commit seal-failure, and CAS outcome handling
- preserves `gateway_connections.credential_ciphertext` as the sole PAT ciphertext
- extends the AIO-405 single-writer guard and schema/migration invariants

## Safety

- routes return a non-enumerating no-store 404 unless `AIOS_GATEWAY_INTERNAL_ENABLED` is exactly `true`
- no deployment configuration in this repository enables the flag
- service auth precedes version checks; version mismatch precedes subject/connection/lease/PAT lookup
- allow commits strict audit before PAT decrypt/seal
- committed allow responses are never reissued, resealed, or decrypted twice
- no Railway or deployment state was changed

## Verification

- `npm test` — 730 passed, 7 skipped
- `npm run test:gateway-api` — 16 passed
- real-Postgres gateway suites — 20 passed
- `npm run typecheck`
- `npm run build`
- `npm run check:docs`
- `node scripts/check-gateway-writers.mjs`
- migration/schema load and replay checks
- gitleaks — no leaks
- `git diff --check`

The production build succeeds with the existing optional `@e2b/code-interpreter` warning.

## Review focus

- authentication timing/uniform failure and legacy-row migration preflight
- transaction boundary around lease consumption, strict audit, and post-commit sealing
- policy-version recomputation and precedence
- PAT custody and request-local plaintext lifetime
- lost-response/idempotency and concurrent outcome settlement
- raw-body and persistent-limiter failure behavior

## Merge sequencing

Do not enable the feature flag. Merge after the Workspace contract PR is approved and merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, credential decryption/sealing, and transactional lease/execution semantics; mistakes could leak PATs or allow policy bypass, though the flag stays off by default.
> 
> **Overview**
> Adds the **Executor internal gateway v1.10** surface behind `AIOS_GATEWAY_INTERNAL_ENABLED === "true"` (otherwise a no-store 404), with `GATEWAY_CONTRACT_VERSION = "1.10"` separate from the public brain API.
> 
> Three **POST** routes under `/api/internal/executor-gateway/v1/`: **resolve-lease** (scope → 30s one-use lease), **authorize-and-redeem** (JCS-normalized tool args + policy → allow with sealed PAT / block / approval), and **record-outcome** (idempotent execution settlement). Shared HTTP layer enforces strict service bearer auth, pinned executor/companion/contract headers, 65 KiB raw body limits, DB-backed rate limits, and standardized error JSON.
> 
> New gateway modules cover **RFC 8785 canonicalization**, seven-tool **normalization** + request hashes, **policy evaluation** with version pinning on leases, **HKDF + AES-GCM PAT sealing** for request-local credentials, and large **persistence** extensions (lease authorize flow, conflicts, outcomes, credential seal failures). Schema/migration adds `policy_version` on leases, `gateway_rate_limits`, stricter credential formats, and audit uniqueness for outcomes; docs drift lists and contract fixture tests lock the wire behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33a7eefc635f1e7a6de5e83bf8b0a941f0060c22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->