### PR TITLE
feat(meetings): detailed, skimmable bulleted summaries + regenerate

### DIFF
--- a/app/t/[team]/meetings/[id]/page.tsx
+++ b/app/t/[team]/meetings/[id]/page.tsx
@@ -60,6 +60,8 @@ export default async function MeetingNotePage({
       </div>
 
       <MeetingDetailTabs
+        teamSlug={teamSlug}
+        noteId={note.id}
         summary={note.summary}
         rawText={note.rawText}
         actionItems={

--- a/app/t/[team]/meetings/actions.ts
+++ b/app/t/[team]/meetings/actions.ts
@@ -11,6 +11,7 @@ import {
   createMeetingNote,
   canSeeMeetingNotes,
   getMeetingNote,
+  updateMeetingSummary,
   MEETING_NOTES_PROJECT_SLUG,
 } from "@/lib/meetings/notes";
 import { extractFromTranscript, type RosterPerson } from "@/lib/meetings/llm-extract";
@@ -200,6 +201,48 @@ export async function extractMeetingActionItemsAction(
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "extraction failed" };
   }
+}
+
+/**
+ * Re-run the LLM summary pass on an existing note and replace its summary — so older meetings with a
+ * prose paragraph can be refreshed to the new detailed bulleted format. Team-tier only; best-effort
+ * (a failed LLM call leaves the existing summary untouched).
+ */
+export async function regenerateMeetingSummaryAction(
+  teamSlug: string,
+  noteId: string
+): Promise<{ ok: boolean; error?: string }> {
+  const team = await resolveTeam(teamSlug);
+  if (!team) return { ok: false, error: "team not found" };
+
+  const me = await currentMember(team.id);
+  if (!me) return { ok: false, error: "not a member of this team" };
+  if (!canSeeMeetingNotes(me.tier)) return { ok: false, error: "team-tier membership required" };
+
+  const admin = adminClient();
+  const note = await getMeetingNote(admin, team.id, noteId, me.tier);
+  if (!note) return { ok: false, error: "meeting note not found" };
+
+  const [{ data: rosterRows }, openaiKey, anthropicKey] = await Promise.all([
+    admin.from("members").select("id, display_name").eq("team_id", team.id).eq("status", "active"),
+    getProviderKey(admin, team.id, "openai"),
+    getProviderKey(admin, team.id, "anthropic"),
+  ]);
+  const roster: RosterPerson[] = ((rosterRows ?? []) as { id: string; display_name: string }[]).map((m) => ({
+    id: m.id,
+    displayName: m.display_name,
+  }));
+
+  const ex = await extractFromTranscript(note.rawText, roster, { openaiKey, anthropicKey });
+  if (!ex.summary.trim()) return { ok: false, error: "could not regenerate summary (LLM unavailable)" };
+
+  try {
+    await updateMeetingSummary(admin, team.id, noteId, ex.summary);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "could not save summary" };
+  }
+  revalidatePath(`/t/${team.slug}/meetings/${noteId}`);
+  return { ok: true };
 }
 
 export interface PushTaskResult {

--- a/components/meetings/meeting-detail-tabs.tsx
+++ b/components/meetings/meeting-detail-tabs.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import { FileText, ScrollText } from "lucide-react";
+import { useState, useTransition, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { FileText, Loader2, RefreshCw, ScrollText } from "lucide-react";
+import { summaryBullets } from "@/lib/meetings/summary-format";
+import { regenerateMeetingSummaryAction } from "@/app/t/[team]/meetings/actions";
 
 type TabKey = "summary" | "transcript";
 
 interface MeetingDetailTabsProps {
+  teamSlug: string;
+  noteId: string;
   summary: string;
   rawText: string;
   /** The action-items section, rendered under the summary (it owns its own server actions). */
@@ -15,10 +20,24 @@ interface MeetingDetailTabsProps {
 /**
  * Right-pane tabs for a meeting: "Summary" (the LLM summary plus the action-items section beneath it)
  * and "Transcript" (the full raw text). Summary leads because it's the digest; the transcript is the
- * evidence you drop into on demand.
+ * evidence you drop into on demand. A bulleted summary renders as a list; a prose one (older notes)
+ * stays a paragraph, with a "Regenerate" control to refresh it to the detailed bulleted format.
  */
-export function MeetingDetailTabs({ summary, rawText, actionItems }: MeetingDetailTabsProps) {
+export function MeetingDetailTabs({ teamSlug, noteId, summary, rawText, actionItems }: MeetingDetailTabsProps) {
   const [tab, setTab] = useState<TabKey>("summary");
+  const router = useRouter();
+  const [regenerating, startRegen] = useTransition();
+  const [regenError, setRegenError] = useState<string | null>(null);
+  const bullets = summaryBullets(summary);
+
+  function regenerate() {
+    setRegenError(null);
+    startRegen(async () => {
+      const res = await regenerateMeetingSummaryAction(teamSlug, noteId);
+      if (!res.ok) return setRegenError(res.error ?? "could not regenerate");
+      router.refresh();
+    });
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -38,12 +57,31 @@ export function MeetingDetailTabs({ summary, rawText, actionItems }: MeetingDeta
       {tab === "summary" ? (
         <div className="flex flex-col gap-5">
           <div className="prism-card flex flex-col gap-2 px-5 py-4">
-            <h2 className="text-xs font-semibold uppercase tracking-wider text-ink-tertiary">Summary</h2>
-            {summary ? (
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-ink-tertiary">Summary</h2>
+              <button
+                type="button"
+                onClick={regenerate}
+                disabled={regenerating}
+                className="inline-flex items-center gap-1 text-xs text-ink-tertiary hover:text-ink disabled:opacity-50"
+                title="Re-summarize the transcript in the detailed bulleted format"
+              >
+                {regenerating ? <Loader2 className="size-3.5 animate-spin" /> : <RefreshCw className="size-3.5" />}
+                Regenerate
+              </button>
+            </div>
+            {bullets.length ? (
+              <ul className="flex list-disc flex-col gap-1.5 pl-5 text-sm text-ink-secondary">
+                {bullets.map((b, i) => (
+                  <li key={i}>{b}</li>
+                ))}
+              </ul>
+            ) : summary ? (
               <p className="whitespace-pre-wrap text-sm text-ink-secondary">{summary}</p>
             ) : (
               <p className="text-sm italic text-ink-tertiary">No summary available.</p>
             )}
+            {regenError ? <p className="text-xs text-rose-500">{regenError}</p> : null}
           </div>
           {actionItems}
         </div>

--- a/lib/meetings/llm-extract.ts
+++ b/lib/meetings/llm-extract.ts
@@ -33,12 +33,16 @@ const ANTHROPIC_MODEL = process.env.MEETINGS_ANTHROPIC_MODEL ?? "claude-sonnet-5
 const MAX_TRANSCRIPT_CHARS = 15_000;
 
 const SYSTEM_PROMPT =
-  "You are reading a meeting transcript or notes document. Write a concise 2-3 sentence summary " +
-  "(present tense, specific — what was discussed/decided, not generic filler), and list the full " +
-  "names of every person who appears to have attended or spoken, exactly as they're referred to in " +
-  "the text. Return ONLY a JSON object of the form " +
-  '{"summary":"...","attendees":["Full Name", ...]}. No prose, no markdown code fences — the raw ' +
-  "JSON object only. If you can't tell who attended, return an empty attendees array — never guess.";
+  "You are reading a meeting transcript or notes document. Produce two things:\n" +
+  "(1) A DETAILED but SKIMMABLE summary as a bulleted list — 4 to 8 bullets. Each bullet is ONE " +
+  "specific point: a topic discussed, a decision made, a problem or blocker raised, or a next step. " +
+  "Present tense, concrete, no filler or generic phrasing. Each bullet MUST start with '- ' and be " +
+  "on its own line.\n" +
+  "(2) The full names of every person who appears to have attended or spoken, exactly as they're " +
+  "referred to in the text.\n" +
+  'Return ONLY a JSON object of the form {"summary":"- ...\\n- ...","attendees":["Full Name", ...]}. ' +
+  "No prose outside the JSON, no markdown code fences. If you can't tell who attended, return an " +
+  "empty attendees array — never guess.";
 
 export function extractJsonObject(raw: string): string {
   const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);

--- a/lib/meetings/notes.ts
+++ b/lib/meetings/notes.ts
@@ -207,6 +207,21 @@ export async function createMeetingNoteFromItem(
   return { id: noteId, created: true };
 }
 
+/** Replace a note's summary (e.g. after a "regenerate summary" pass). Single writer for the column. */
+export async function updateMeetingSummary(
+  admin: DbClient,
+  teamId: string,
+  noteId: string,
+  summary: string
+): Promise<void> {
+  const { error } = await admin
+    .from("meeting_notes")
+    .update({ summary: summary.trim() })
+    .eq("team_id", teamId)
+    .eq("id", noteId);
+  if (error) throw new Error(`meeting summary update failed: ${error.message}`);
+}
+
 type MemberRow = {
   id: string;
   display_name: string;

--- a/lib/meetings/summary-format.ts
+++ b/lib/meetings/summary-format.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse a meeting summary into bullet points for skimmable rendering. Pure (no server-only) so the
+ * client detail view and tests share it. Summaries are now generated as a bulleted list
+ * (lib/meetings/llm-extract), but older notes hold a prose paragraph — this returns [] for those so
+ * the UI falls back to paragraph rendering instead of mangling a sentence into fake bullets.
+ */
+
+const BULLET_RE = /^\s*[-*•]\s+/;
+
+export function summaryBullets(summary: string): string[] {
+  const lines = summary.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const bullets = lines.filter((l) => BULLET_RE.test(l));
+  // Treat as a bulleted list only when it clearly IS one: ≥2 bullets and (almost) every line is a
+  // bullet. A lone leading "- " in an otherwise prose blob shouldn't trigger list rendering.
+  if (bullets.length >= 2 && bullets.length >= lines.length - 1) {
+    return bullets.map((l) => l.replace(BULLET_RE, "").trim()).filter(Boolean);
+  }
+  return [];
+}

--- a/test/meetings-summary-format.test.ts
+++ b/test/meetings-summary-format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { summaryBullets } from "@/lib/meetings/summary-format";
+
+/**
+ * Spec for the summary bullet parser: a bulleted summary renders as a list; a prose paragraph does
+ * not (falls back to `[]`). Derived from the display intent, not the implementation.
+ */
+describe("summaryBullets", () => {
+  it("parses a bulleted summary into stripped points", () => {
+    const s = "- Discussed the mission-control dashboard\n- Decided to leverage gbrain + Hermes\n- Next: configure personal setups";
+    expect(summaryBullets(s)).toEqual([
+      "Discussed the mission-control dashboard",
+      "Decided to leverage gbrain + Hermes",
+      "Next: configure personal setups",
+    ]);
+  });
+
+  it("accepts •/* markers", () => {
+    expect(summaryBullets("• one\n* two")).toEqual(["one", "two"]);
+  });
+
+  it("returns [] for a prose paragraph (renders as text, not fake bullets)", () => {
+    expect(summaryBullets("During the meeting, Chetan and a colleague discussed feedback and progress.")).toEqual([]);
+  });
+
+  it("returns [] for a single bullet (not clearly a list)", () => {
+    expect(summaryBullets("- just one point")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

The Meetings summary was a single dense 2-3 sentence paragraph (see the screenshot). Make it **detailed and skimmable** — a bulleted list.

## Changes
- **Prompt** (`lib/meetings/llm-extract`) now asks for a **4-8 bullet** summary — one specific point per bullet (topic discussed / decision / blocker / next step), each on its own line.
- **`lib/meetings/summary-format`** (pure) parses a summary into bullets; a bulleted summary renders as a `<ul>`, an older prose summary stays a paragraph (no fake-bullet mangling).
- **Detail view** renders the list + a **"Regenerate"** control (`regenerateMeetingSummaryAction` re-runs the LLM pass and replaces the summary via the `meeting_notes` single writer), so existing prose notes can be refreshed to the new format.

## Tests
- `test/meetings-summary-format.test.ts` — bullet parse, `•`/`*` markers, prose fallback, single-bullet guard.
- typecheck ✓ · lint ✓ (0 err) · unit ✓ · `next build` ✓. No schema change.

Part 1 of the Meetings improvements (next: auto-extract action items on GUI upload for prose commitments; then intelligent merge of duplicate uploads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)