### PR TITLE
feat(meetings): GUI upload auto-extracts action items (LLM-first) + Send to Linear

### DIFF
--- a/app/t/[team]/meetings/actions.ts
+++ b/app/t/[team]/meetings/actions.ts
@@ -12,14 +12,10 @@ import {
   canSeeMeetingNotes,
   getMeetingNote,
   updateMeetingSummary,
-  MEETING_NOTES_PROJECT_SLUG,
 } from "@/lib/meetings/notes";
 import { extractFromTranscript, type RosterPerson } from "@/lib/meetings/llm-extract";
 import { extractAndStoreActionItems } from "@/lib/meetings/action-items";
-import {
-  extractMeetingTodosForTeam,
-  MEETING_TODO_PROJECT_SLUG,
-} from "@/lib/meetings/extract-todos";
+import { MEETING_TODO_PROJECT_SLUG } from "@/lib/meetings/extract-todos";
 import { backfillMeetingNotesFromItems } from "@/lib/meetings/from-items";
 import {
   projectRows,
@@ -48,8 +44,9 @@ async function resolveTeam(teamSlug: string): Promise<{ id: string; slug: string
 /**
  * Upload a meeting transcript: resolves the submitter + team roster, runs the LLM
  * summary/attendee pass (best-effort — never blocks the upload, see lib/meetings/llm-extract),
- * writes the note via the single writer, then auto-extracts todo items scoped to just this note's
- * transcript. Team-tier only, matching lib/meetings/notes.canSeeMeetingNotes.
+ * writes the note via the single writer, then auto-extracts action items with the SAME LLM-first
+ * extractor the CLI/import path uses (`extractAndStoreActionItems`) — so prose commitments ("Alex
+ * will send the deck Friday") are caught, not just checkbox-style todos. Team-tier only.
  */
 export async function uploadMeetingNoteAction(
   input: z.input<typeof uploadSchema>
@@ -92,12 +89,24 @@ export async function uploadMeetingNoteAction(
   }
 
   try {
-    await extractMeetingTodosForTeam(admin, team.id, {
-      sourceProject: MEETING_NOTES_PROJECT_SLUG,
-      pathPrefix: `meetings/${noteId}`,
-    });
+    // Resolve the just-ingested transcript item so we can materialize its action items (LLM-first,
+    // same as the CLI import path). Best-effort — the note itself already saved.
+    const { data: nr } = await admin
+      .from("meeting_notes")
+      .select("source_item_id")
+      .eq("team_id", team.id)
+      .eq("id", noteId)
+      .maybeSingle();
+    const sourceItemId = (nr as { source_item_id: string } | null)?.source_item_id;
+    if (sourceItemId) {
+      const { data: item } = await admin.from("items").select("id, path, access").eq("id", sourceItemId).maybeSingle();
+      const itemRow = item as { id: string; path: string; access: "team" | "external" } | null;
+      if (itemRow) {
+        await extractAndStoreActionItems(admin, team.id, itemRow, parsed.data.rawText, roster, { openaiKey, anthropicKey });
+      }
+    }
   } catch {
-    // Todo extraction is best-effort — the note itself already saved successfully.
+    // Action-item extraction is best-effort — the note itself already saved successfully.
   }
 
   revalidatePath(`/t/${team.slug}/meetings`);

--- a/components/meetings/meeting-action-items.tsx
+++ b/components/meetings/meeting-action-items.tsx
@@ -83,7 +83,7 @@ export function MeetingActionItems({ teamSlug, noteId, todos, provider }: Meetin
       const synced = (res.results ?? []).filter((r) => r.status === "synced" || r.status === "skipped").length;
       const failed = (res.results ?? []).filter((r) => r.status === "failed").length;
       setMsg(
-        `Pushed ${synced} to ${providerLabel(res.provider ?? provider)}${failed ? ` · ${failed} failed` : ""}.`
+        `Sent ${synced} to ${providerLabel(res.provider ?? provider)}${failed ? ` · ${failed} failed` : ""}.`
       );
       router.refresh();
     });
@@ -190,7 +190,7 @@ export function MeetingActionItems({ teamSlug, noteId, todos, provider }: Meetin
                   title={!provider ? "Configure a PM integration in Admin → Integrations" : undefined}
                 >
                   {pushing ? <Loader2 className="size-4 animate-spin" /> : <ExternalLink className="size-4" />}
-                  Push to {label}
+                  Send to {label}
                 </button>
               </div>
             </div>

--- a/test/datamechanics/meetings-gui-extract.datamechanics.test.ts
+++ b/test/datamechanics/meetings-gui-extract.datamechanics.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { createMeetingNote } from "@/lib/meetings/notes";
+import { extractAndStoreActionItems } from "@/lib/meetings/action-items";
+import { MEETING_TODO_PROJECT_SLUG } from "@/lib/meetings/extract-todos";
+import type { ExtractedTodo } from "@/lib/meetings/extract-todos";
+import { db, seedTeam } from "./helpers";
+
+/**
+ * Spec for the GUI-upload path materializing action items via the LLM-first extractor (the same one
+ * the CLI/import path uses) — so a PROSE transcript ("Alex will send the deck Friday") yields tasks,
+ * not just checkbox-style todos. Model stubbed (data-mechanics tier). Mirrors what
+ * uploadMeetingNoteAction now does after createMeetingNote.
+ */
+describe("meeting GUI upload → action items (real Postgres, stubbed extractor)", () => {
+  it("extracts a prose commitment into a task in the meetings project", async () => {
+    const { teamId, memberId } = await seedTeam();
+    const rawText = "Chetan and Alex synced. Alex will send the deck by Friday and Chetan will wire up the dashboard.";
+    const noteId = await createMeetingNote(db(), teamId, {
+      title: "Sync",
+      rawText,
+      submittedByMemberId: memberId,
+    });
+
+    const { data: nr } = await db().from("meeting_notes").select("source_item_id").eq("id", noteId).maybeSingle();
+    const { data: item } = await db()
+      .from("items")
+      .select("id, path, access")
+      .eq("id", (nr as { source_item_id: string }).source_item_id)
+      .maybeSingle();
+
+    // Stub the LLM extractor with a prose-derived commitment the markdown scanner would miss.
+    const stub = async (): Promise<ExtractedTodo[]> => [
+      { title: "Send the deck", assignee: "Alex", due: "2026-07-17", line: 1, sourceText: "Alex will send the deck by Friday" },
+    ];
+    const n = await extractAndStoreActionItems(db(), teamId, item as { id: string; path: string; access: "team" | "external" }, rawText, [], {}, stub);
+    expect(n).toBe(1);
+
+    const { data: tasks } = await db()
+      .from("tasks")
+      .select("title, source_item_id, projects(slug)")
+      .eq("team_id", teamId)
+      .eq("source_item_id", (item as { id: string }).id);
+    const meetingTasks = ((tasks ?? []) as { title: string; projects?: { slug?: string } }[]).filter(
+      (t) => t.projects?.slug === MEETING_TODO_PROJECT_SLUG
+    );
+    expect(meetingTasks.length).toBe(1);
+    expect(meetingTasks[0].title).toBe("Send the deck");
+  });
+});


### PR DESCRIPTION
## What

Action items are now **auto-extracted for all notes** — the fix for the screenshot's "No action items yet" on a prose transcript.

**Root cause:** the GUI upload only ran the *markdown scanner* (`extractMeetingTodosForTeam`), which finds checkbox/"action item:"-style todos but misses **prose commitments** ("Alex will send the deck Friday"). The CLI/import path already used the LLM-first extractor. This routes the GUI upload through the **same** `extractAndStoreActionItems` (LLM-first, markdown fallback), so both paths behave identically.

## Changes
- `uploadMeetingNoteAction` resolves the just-ingested transcript item and calls `extractAndStoreActionItems` instead of the markdown-only extractor.
- Renamed the push control **"Push to …" → "Send to …"** — the clear send-to-Linear button.

## Tests
- `test/datamechanics/meetings-gui-extract.datamechanics.test.ts` — a prose commitment materializes as a task in the meetings project (model stubbed).
- typecheck ✓ · lint ✓ (0 err) · meetings data-mechanics **11 passed** ✓ · `next build` ✓.

Part 2 of the Meetings improvements (next: intelligent merge of duplicate uploads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)