### PR TITLE
feat(meetings): intelligently merge duplicate uploads (same meeting, both submitters)

### DIFF
--- a/app/t/[team]/meetings/[id]/page.tsx
+++ b/app/t/[team]/meetings/[id]/page.tsx
@@ -37,10 +37,12 @@ export default async function MeetingNotePage({
         <h2 className="font-display text-2xl text-ink">{note.title}</h2>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-tertiary">
           {note.occurredAt ? <span>{note.occurredAt}</span> : null}
-          {note.submittedBy ? (
+          {note.submitters.length ? (
             <span className="flex items-center gap-1.5">
-              <MemberAvatar person={note.submittedBy} size={16} />
-              Submitted by {note.submittedBy.displayName}
+              {note.submitters.map((s) => (
+                <MemberAvatar key={s.id} person={s} size={16} />
+              ))}
+              Submitted by {note.submitters.map((s) => s.displayName).join(" and ")}
             </span>
           ) : null}
         </div>

--- a/app/t/[team]/meetings/actions.ts
+++ b/app/t/[team]/meetings/actions.ts
@@ -16,6 +16,7 @@ import {
 import { extractFromTranscript, type RosterPerson } from "@/lib/meetings/llm-extract";
 import { extractAndStoreActionItems } from "@/lib/meetings/action-items";
 import { MEETING_TODO_PROJECT_SLUG } from "@/lib/meetings/extract-todos";
+import { findDuplicateMeeting, mergeIntoMeetingNote } from "@/lib/meetings/merge";
 import { backfillMeetingNotesFromItems } from "@/lib/meetings/from-items";
 import {
   projectRows,
@@ -50,7 +51,7 @@ async function resolveTeam(teamSlug: string): Promise<{ id: string; slug: string
  */
 export async function uploadMeetingNoteAction(
   input: z.input<typeof uploadSchema>
-): Promise<{ ok: boolean; error?: string; id?: string }> {
+): Promise<{ ok: boolean; error?: string; id?: string; merged?: boolean }> {
   const parsed = uploadSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: parsed.error.issues[0]?.message ?? "invalid upload" };
 
@@ -73,6 +74,26 @@ export async function uploadMeetingNoteAction(
   }));
 
   const extraction = await extractFromTranscript(parsed.data.rawText, roster, { openaiKey, anthropicKey });
+
+  // Duplicate detection: if this is the same meeting someone already uploaded (same date + enough
+  // content overlap), merge the transcripts into that note and credit both submitters instead of
+  // creating a second copy.
+  const dup = await findDuplicateMeeting(admin, team.id, parsed.data.occurredAt ?? null, parsed.data.rawText);
+  if (dup) {
+    try {
+      const mergedNoteId = await mergeIntoMeetingNote(admin, team.id, dup, {
+        newRawText: parsed.data.rawText,
+        newSubmitterId: me.id,
+        newAttendeeIds: extraction.attendeeMemberIds,
+        roster,
+        keys: { openaiKey, anthropicKey },
+      });
+      revalidatePath(`/t/${team.slug}/meetings`);
+      return { ok: true, id: mergedNoteId, merged: true };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "could not merge into the existing meeting" };
+    }
+  }
 
   let noteId: string;
   try {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -676,7 +676,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 `member_identities` · `member_secrets` · `member_profiles` · `member_time_off` · `member_goals` · `member_provisioning` · `integrations` ·
 `agentic_maturity_snapshots` · `task_pm_links` · `work_events` · `usage_costs` · `subscriptions` · `graph_episodes` · `arc_cache` ·
 `conversations` · `chat_messages` · `ingest_runs` · `social_jobs` · `brand_profiles` · `brand_assets` · `social_opportunities` · `content_plans` · `content_variants` · `media_assets` · `social_settings` · `content_approvals` · `social_publications` · `publication_analytics` ·
-`meeting_notes` · `meeting_note_attendees`
+`meeting_notes` · `meeting_note_attendees` · `meeting_note_submitters`
 
 <!-- /drift:tables -->
 

--- a/lib/meetings/merge-format.ts
+++ b/lib/meetings/merge-format.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure transcript similarity + merge for duplicate-meeting detection (Meetings merge). No
+ * server-only, so tests + the orchestration share it. Two people uploading the same meeting produce
+ * overlapping-but-not-identical transcripts (one may have missed parts), so:
+ *  - similarity uses the OVERLAP COEFFICIENT (|A∩B| / min(|A|,|B|)) on word shingles — high even
+ *    when one transcript is a partial subset of the other (Jaccard would under-score that case);
+ *  - merge is a deterministic UNION: the longer transcript as the base, plus the other's lines that
+ *    aren't already present, so no content is lost and near-duplicates aren't doubled.
+ */
+
+const SHINGLE_SIZE = 5;
+
+function normalizeWords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+/** Word n-gram shingles (order-sensitive), for content-overlap comparison. */
+export function transcriptShingles(text: string, size = SHINGLE_SIZE): Set<string> {
+  const words = normalizeWords(text);
+  const out = new Set<string>();
+  if (words.length < size) {
+    if (words.length) out.add(words.join(" ")); // short text: one shingle so it can still match itself
+    return out;
+  }
+  for (let i = 0; i + size <= words.length; i++) out.add(words.slice(i, i + size).join(" "));
+  return out;
+}
+
+/** Overlap coefficient in [0,1]: how much of the SMALLER transcript's content appears in the other. */
+export function transcriptOverlap(a: string, b: string): number {
+  const sa = transcriptShingles(a);
+  const sb = transcriptShingles(b);
+  if (sa.size === 0 || sb.size === 0) return 0;
+  const [small, large] = sa.size <= sb.size ? [sa, sb] : [sb, sa];
+  let inter = 0;
+  for (const s of small) if (large.has(s)) inter++;
+  return inter / small.size;
+}
+
+const normLine = (l: string): string => l.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+/**
+ * Deterministically merge two transcripts of the same meeting. The longer is the base; lines from
+ * the other whose normalized form isn't already present are appended under a labeled section, so a
+ * partial second transcript contributes only what it uniquely captured.
+ */
+export function mergeTranscripts(a: string, b: string): string {
+  const [base, other] = a.length >= b.length ? [a, b] : [b, a];
+  const present = new Set(base.split(/\r?\n/).map(normLine).filter(Boolean));
+  const extra = other
+    .split(/\r?\n/)
+    .map((l) => l.trimEnd())
+    .filter((l) => {
+      const n = normLine(l);
+      return n && !present.has(n);
+    });
+  if (extra.length === 0) return base;
+  return `${base.trimEnd()}\n\n--- additional from a second transcript ---\n${extra.join("\n")}`;
+}

--- a/lib/meetings/merge.ts
+++ b/lib/meetings/merge.ts
@@ -1,0 +1,167 @@
+import "server-only";
+import { createHash, randomUUID } from "node:crypto";
+import type { DbClient } from "@/lib/db/types";
+import { ingestItem } from "@/lib/ingest";
+import { audit } from "@/lib/api/audit";
+import { extractFromTranscript, type ProviderKeys, type RosterPerson } from "./llm-extract";
+import { extractAndStoreActionItems } from "./action-items";
+import { mergeTranscripts, transcriptOverlap } from "./merge-format";
+import { addMeetingNoteAttendees, addMeetingNoteSubmitters, updateMeetingSummary } from "./notes";
+
+/**
+ * Duplicate-meeting detection + merge (Meetings merge). When someone uploads a meeting that already
+ * exists (same date + enough content overlap — one transcriber may have missed parts), we merge the
+ * transcripts into the EXISTING note instead of creating a second one, credit both people as
+ * submitters, union the attendees, and re-summarize + re-extract action items on the merged text.
+ * Best-effort on the LLM steps (they degrade to empty); the transcript merge + submitter credit are
+ * the guaranteed outcomes.
+ */
+
+/** Default: at least half of the smaller transcript's content must appear in the other. */
+export const DEFAULT_MERGE_THRESHOLD = 0.5;
+
+const sha256 = (s: string): string => createHash("sha256").update(s).digest("hex");
+
+export interface DuplicateMatch {
+  noteId: string;
+  sourceItemId: string;
+  itemPath: string;
+  itemProject: string;
+  itemAccess: "team" | "external";
+  title: string;
+  existingRawText: string;
+  primarySubmitterId: string | null;
+  overlap: number;
+}
+
+/**
+ * Find an existing same-date meeting note whose transcript overlaps `rawText` enough to be the same
+ * meeting. Returns the best match ≥ threshold, or null (also null when `occurredAt` is unknown —
+ * without a date we don't auto-merge). Reads only.
+ */
+export async function findDuplicateMeeting(
+  admin: DbClient,
+  teamId: string,
+  occurredAt: string | null,
+  rawText: string,
+  threshold = DEFAULT_MERGE_THRESHOLD
+): Promise<DuplicateMatch | null> {
+  if (!occurredAt) return null;
+
+  const { data: notes } = await admin
+    .from("meeting_notes")
+    .select("id, source_item_id, submitted_by, title")
+    .eq("team_id", teamId)
+    .eq("occurred_at", occurredAt);
+  const noteRows = (notes ?? []) as { id: string; source_item_id: string; submitted_by: string | null; title: string }[];
+  if (!noteRows.length) return null;
+
+  const { data: items } = await admin
+    .from("items")
+    .select("id, path, access, body, projects(slug)")
+    .in("id", noteRows.map((n) => n.source_item_id));
+  const itemById = new Map(
+    ((items ?? []) as { id: string; path: string; access: "team" | "external"; body: string; projects?: { slug?: string } }[]).map(
+      (i) => [i.id, i]
+    )
+  );
+
+  let best: DuplicateMatch | null = null;
+  for (const n of noteRows) {
+    const item = itemById.get(n.source_item_id);
+    if (!item?.body) continue;
+    const overlap = transcriptOverlap(rawText, item.body);
+    if (overlap >= threshold && (!best || overlap > best.overlap)) {
+      best = {
+        noteId: n.id,
+        sourceItemId: n.source_item_id,
+        itemPath: item.path,
+        itemProject: item.projects?.slug ?? "meeting-notes",
+        itemAccess: item.access,
+        title: n.title,
+        existingRawText: item.body,
+        primarySubmitterId: n.submitted_by,
+        overlap,
+      };
+    }
+  }
+  return best;
+}
+
+export interface MergeInput {
+  newRawText: string;
+  newSubmitterId: string;
+  newAttendeeIds?: string[];
+  roster: RosterPerson[];
+  keys: ProviderKeys;
+}
+
+/**
+ * Merge a new upload into an existing note: union the transcripts (re-ingested into the existing
+ * item), credit both submitters, union attendees, and refresh the summary + action items. Returns
+ * the surviving note id.
+ */
+export async function mergeIntoMeetingNote(
+  admin: DbClient,
+  teamId: string,
+  match: DuplicateMatch,
+  input: MergeInput
+): Promise<string> {
+  const merged = mergeTranscripts(match.existingRawText, input.newRawText);
+  const author = match.primarySubmitterId ?? input.newSubmitterId;
+
+  // Re-ingest the merged transcript into the SAME item (team+project+path upsert → new sha/body).
+  await ingestItem(
+    admin,
+    { teamId, memberId: author, apiKeyId: randomUUID() },
+    {
+      project: match.itemProject,
+      path: match.itemPath,
+      kind: "transcript",
+      content_sha256: sha256(merged),
+      actor: "meeting-notes-merge",
+      access: match.itemAccess,
+      frontmatter: { title: match.title },
+      body: merged,
+    },
+    match.itemAccess,
+    { authorMemberId: author }
+  );
+
+  // Credit both submitters + union attendees from the new upload.
+  await addMeetingNoteSubmitters(admin, match.noteId, [match.primarySubmitterId, input.newSubmitterId].filter((x): x is string => !!x));
+  if (input.newAttendeeIds?.length) await addMeetingNoteAttendees(admin, match.noteId, input.newAttendeeIds);
+
+  // Refresh summary + attendees + action items on the merged text — best-effort (never fail merge).
+  try {
+    const ex = await extractFromTranscript(merged, input.roster, input.keys);
+    if (ex.summary.trim()) await updateMeetingSummary(admin, teamId, match.noteId, ex.summary);
+    if (ex.attendeeMemberIds.length) await addMeetingNoteAttendees(admin, match.noteId, ex.attendeeMemberIds);
+  } catch {
+    // summary refresh is a bonus
+  }
+  try {
+    await extractAndStoreActionItems(
+      admin,
+      teamId,
+      { id: match.sourceItemId, path: match.itemPath, access: match.itemAccess },
+      merged,
+      input.roster,
+      input.keys
+    );
+  } catch {
+    // action-item refresh is a bonus
+  }
+
+  await audit(admin, {
+    team_id: teamId,
+    actor_kind: "member",
+    member_id: input.newSubmitterId,
+    action: "meeting_note.merged",
+    target_type: "meeting_note",
+    target_id: match.noteId,
+    meta: { overlap: Math.round(match.overlap * 100) / 100, merged_from_item: match.sourceItemId },
+  });
+
+  return match.noteId;
+}

--- a/lib/meetings/notes.ts
+++ b/lib/meetings/notes.ts
@@ -50,6 +50,8 @@ export interface MeetingNoteSummary {
   occurredAt: string | null;
   createdAt: string;
   submittedBy: PersonRef | null;
+  /** All submitters (≥1 after a merge). Includes `submittedBy`; use this to render credit. */
+  submitters: PersonRef[];
   attendees: PersonRef[];
 }
 
@@ -207,6 +209,26 @@ export async function createMeetingNoteFromItem(
   return { id: noteId, created: true };
 }
 
+/** Add submitters to a note (idempotent) — used by the merge path to credit both uploaders. */
+export async function addMeetingNoteSubmitters(admin: DbClient, noteId: string, memberIds: string[]): Promise<void> {
+  const ids = [...new Set(memberIds.filter(Boolean))];
+  if (!ids.length) return;
+  const { error } = await admin
+    .from("meeting_note_submitters")
+    .upsert(ids.map((member_id) => ({ meeting_note_id: noteId, member_id })), { onConflict: "meeting_note_id,member_id" });
+  if (error) throw new Error(`meeting note submitters insert failed: ${error.message}`);
+}
+
+/** Add attendees to a note (idempotent) — used by the merge path to union both transcripts' rosters. */
+export async function addMeetingNoteAttendees(admin: DbClient, noteId: string, memberIds: string[]): Promise<void> {
+  const ids = [...new Set(memberIds.filter(Boolean))];
+  if (!ids.length) return;
+  const { error } = await admin
+    .from("meeting_note_attendees")
+    .upsert(ids.map((member_id) => ({ meeting_note_id: noteId, member_id })), { onConflict: "meeting_note_id,member_id" });
+  if (error) throw new Error(`meeting note attendees insert failed: ${error.message}`);
+}
+
 /** Replace a note's summary (e.g. after a "regenerate summary" pass). Single writer for the column. */
 export async function updateMeetingSummary(
   admin: DbClient,
@@ -286,37 +308,42 @@ export async function listMeetingNotesForTeam(
   const rows = (notes ?? []) as NoteRow[];
   if (!rows.length) return [];
 
-  const { data: attendeeRows } = await db
-    .from("meeting_note_attendees")
-    .select("meeting_note_id, member_id")
-    .in(
-      "meeting_note_id",
-      rows.map((r) => r.id)
-    );
-  const attendeesByNote = new Map<string, string[]>();
-  for (const a of (attendeeRows ?? []) as { meeting_note_id: string; member_id: string }[]) {
-    const arr = attendeesByNote.get(a.meeting_note_id) ?? [];
-    arr.push(a.member_id);
-    attendeesByNote.set(a.meeting_note_id, arr);
-  }
+  const noteIds = rows.map((r) => r.id);
+  const [{ data: attendeeRows }, { data: submitterRows }] = await Promise.all([
+    db.from("meeting_note_attendees").select("meeting_note_id, member_id").in("meeting_note_id", noteIds),
+    db.from("meeting_note_submitters").select("meeting_note_id, member_id").in("meeting_note_id", noteIds),
+  ]);
+  const groupByNote = (arr: { meeting_note_id: string; member_id: string }[]) => {
+    const m = new Map<string, string[]>();
+    for (const a of arr) m.set(a.meeting_note_id, [...(m.get(a.meeting_note_id) ?? []), a.member_id]);
+    return m;
+  };
+  const attendeesByNote = groupByNote((attendeeRows ?? []) as { meeting_note_id: string; member_id: string }[]);
+  const submittersByNote = groupByNote((submitterRows ?? []) as { meeting_note_id: string; member_id: string }[]);
 
   const allMemberIds = [
     ...new Set([
       ...rows.flatMap((r) => (r.submitted_by ? [r.submitted_by] : [])),
       ...[...attendeesByNote.values()].flat(),
+      ...[...submittersByNote.values()].flat(),
     ]),
   ];
   const people = await loadPeople(db, teamId, allMemberIds);
 
-  return rows.map((r) => ({
-    id: r.id,
-    title: r.title,
-    summary: r.summary,
-    occurredAt: r.occurred_at,
-    createdAt: r.created_at,
-    submittedBy: r.submitted_by ? (people.get(r.submitted_by) ?? null) : null,
-    attendees: (attendeesByNote.get(r.id) ?? []).map((id) => people.get(id)).filter((p): p is PersonRef => !!p),
-  }));
+  return rows.map((r) => {
+    // Submitters = the primary submitted_by plus any recorded via a merge, deduped, submitter first.
+    const submitterIds = [...new Set([...(r.submitted_by ? [r.submitted_by] : []), ...(submittersByNote.get(r.id) ?? [])])];
+    return {
+      id: r.id,
+      title: r.title,
+      summary: r.summary,
+      occurredAt: r.occurred_at,
+      createdAt: r.created_at,
+      submittedBy: r.submitted_by ? (people.get(r.submitted_by) ?? null) : null,
+      submitters: submitterIds.map((id) => people.get(id)).filter((p): p is PersonRef => !!p),
+      attendees: (attendeesByNote.get(r.id) ?? []).map((id) => people.get(id)).filter((p): p is PersonRef => !!p),
+    };
+  });
 }
 
 /** Team-tier only (see canSeeMeetingNotes) — returns null for an external caller or a miss. */
@@ -337,12 +364,19 @@ export async function getMeetingNote(
   const row = note as NoteRow | null;
   if (!row) return null;
 
-  const [{ data: item }, { data: attendeeRows }] = await Promise.all([
+  const [{ data: item }, { data: attendeeRows }, { data: submitterRows }] = await Promise.all([
     db.from("items").select("body").eq("id", row.source_item_id).maybeSingle(),
     db.from("meeting_note_attendees").select("member_id").eq("meeting_note_id", row.id),
+    db.from("meeting_note_submitters").select("member_id").eq("meeting_note_id", row.id),
   ]);
   const attendeeIds = ((attendeeRows ?? []) as { member_id: string }[]).map((a) => a.member_id);
-  const people = await loadPeople(db, teamId, row.submitted_by ? [...attendeeIds, row.submitted_by] : attendeeIds);
+  const submitterIds = [
+    ...new Set([
+      ...(row.submitted_by ? [row.submitted_by] : []),
+      ...((submitterRows ?? []) as { member_id: string }[]).map((s) => s.member_id),
+    ]),
+  ];
+  const people = await loadPeople(db, teamId, [...new Set([...attendeeIds, ...submitterIds])]);
 
   // Extracted todos: tasks materialized from this note's item (lib/meetings/extract-todos), in the
   // shared "Extracted from Meetings" project — so the UI can link straight to where each landed.
@@ -399,6 +433,7 @@ export async function getMeetingNote(
     occurredAt: row.occurred_at,
     createdAt: row.created_at,
     submittedBy: row.submitted_by ? (people.get(row.submitted_by) ?? null) : null,
+    submitters: submitterIds.map((id) => people.get(id)).filter((p): p is PersonRef => !!p),
     attendees: attendeeIds.map((mid) => people.get(mid)).filter((p): p is PersonRef => !!p),
     rawText: (item as { body: string } | null)?.body ?? "",
     extractedTodos,

--- a/postgres/migrations/20260715120000_meeting_note_submitters.sql
+++ b/postgres/migrations/20260715120000_meeting_note_submitters.sql
@@ -1,0 +1,12 @@
+-- Multiple submitters per meeting note (Meetings merge). When two people upload the same meeting
+-- (same date + overlapping content), the transcripts are merged into ONE note and both people are
+-- credited as submitters. `meeting_notes.submitted_by` stays the original/primary; this join table
+-- holds the full set. Sole writer: lib/meetings/notes.ts. Additive + idempotent; mirrored into
+-- schema.sql for from-zero.
+
+create table if not exists meeting_note_submitters (
+  meeting_note_id uuid not null references meeting_notes(id) on delete cascade,
+  member_id uuid not null references members(id) on delete cascade,
+  primary key (meeting_note_id, member_id)
+);
+create index if not exists meeting_note_submitters_member_idx on meeting_note_submitters (member_id);

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -916,6 +916,15 @@ create table if not exists meeting_note_attendees (
 );
 create index if not exists meeting_note_attendees_member_idx on meeting_note_attendees (member_id);
 
+-- Multiple submitters per note (Meetings merge): when two people upload the same meeting, both are
+-- credited. `meeting_notes.submitted_by` stays the primary; this holds the full set. Writer: notes.ts.
+create table if not exists meeting_note_submitters (
+  meeting_note_id uuid not null references meeting_notes(id) on delete cascade,
+  member_id uuid not null references members(id) on delete cascade,
+  primary key (meeting_note_id, member_id)
+);
+create index if not exists meeting_note_submitters_member_idx on meeting_note_submitters (member_id);
+
 create table if not exists graph_entities (
   id uuid primary key default gen_random_uuid(),
   team_id uuid not null references teams(id) on delete cascade,

--- a/test/datamechanics/meetings-merge.datamechanics.test.ts
+++ b/test/datamechanics/meetings-merge.datamechanics.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createMeetingNote, getMeetingNote } from "@/lib/meetings/notes";
+import { findDuplicateMeeting, mergeIntoMeetingNote } from "@/lib/meetings/merge";
+import { db, seedTeam } from "./helpers";
+
+/**
+ * Spec for duplicate-meeting merge on real Postgres. Derived from the scenario: two people upload
+ * the same meeting (same date, overlapping transcripts). The second upload must merge into the
+ * first note — not create a second — crediting both submitters and unioning unique content. A
+ * different-date or unrelated transcript must NOT match.
+ */
+const DATE = "2026-07-03";
+const A =
+  "Chetan and John discussed the mission control dashboard. They agreed to leverage gbrain and Hermes. " +
+  "John will configure the personal setup for genetic projects and review the task management approach.";
+// Same meeting, partially transcribed by a second person, plus one line they uniquely captured.
+const B =
+  "They agreed to leverage gbrain and Hermes. John will configure the personal setup for genetic projects. " +
+  "John also confirmed the launch deadline is next Friday.";
+const UNRELATED =
+  "Alice and Bob planned the Q3 marketing campaign budget and the launch timeline for the new mobile app store.";
+
+async function secondMember(teamId: string): Promise<string> {
+  const { data } = await db()
+    .from("members")
+    .insert({
+      team_id: teamId,
+      email: `${randomUUID()}@test.local`,
+      display_name: "John",
+      actor_handle: `john-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+    })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+describe("duplicate meeting merge (real Postgres)", () => {
+  it("merges a second upload into the same note, crediting both submitters and unioning content", async () => {
+    const { teamId, memberId: chetan } = await seedTeam();
+    const john = await secondMember(teamId);
+
+    const noteId = await createMeetingNote(db(), teamId, {
+      title: "AIOS sync",
+      rawText: A,
+      submittedByMemberId: chetan,
+      occurredAt: DATE,
+    });
+
+    const match = await findDuplicateMeeting(db(), teamId, DATE, B);
+    expect(match).toBeTruthy();
+    expect(match!.noteId).toBe(noteId);
+    expect(match!.overlap).toBeGreaterThan(0.5);
+
+    const mergedId = await mergeIntoMeetingNote(db(), teamId, match!, {
+      newRawText: B,
+      newSubmitterId: john,
+      roster: [],
+      keys: {},
+    });
+    expect(mergedId).toBe(noteId);
+
+    // Still exactly one note for the team.
+    const { count } = await db().from("meeting_notes").select("id", { count: "exact", head: true }).eq("team_id", teamId);
+    expect(count).toBe(1);
+
+    const note = await getMeetingNote(db(), teamId, noteId, "team");
+    expect(note!.submitters.map((s) => s.id).sort()).toEqual([chetan, john].sort());
+    // Merged transcript keeps the base and adds the second person's unique line.
+    expect(note!.rawText).toContain("mission control dashboard");
+    expect(note!.rawText).toContain("launch deadline is next Friday");
+  });
+
+  it("does not match an unrelated transcript or a different date", async () => {
+    const { teamId, memberId } = await seedTeam();
+    await createMeetingNote(db(), teamId, { title: "AIOS sync", rawText: A, submittedByMemberId: memberId, occurredAt: DATE });
+
+    expect(await findDuplicateMeeting(db(), teamId, DATE, UNRELATED)).toBeNull(); // low overlap
+    expect(await findDuplicateMeeting(db(), teamId, "2026-07-04", B)).toBeNull(); // different date
+  });
+});

--- a/test/guards/single-writer-meeting-notes.test.ts
+++ b/test/guards/single-writer-meeting-notes.test.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 const ROOT = join(import.meta.dirname, "..", "..");
 const SCAN_DIRS = ["app", "lib", "scripts"];
 const OWNER = join("lib", "meetings", "notes.ts");
-const TABLES = ["meeting_notes", "meeting_note_attendees"] as const;
+const TABLES = ["meeting_notes", "meeting_note_attendees", "meeting_note_submitters"] as const;
 const writeRe = (table: string) =>
   new RegExp(`from\\(\\s*["']${table}["']\\s*\\)\\s*\\.\\s*(insert|update|upsert|delete)\\b`, "g");
 

--- a/test/meetings-merge-format.test.ts
+++ b/test/meetings-merge-format.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { transcriptOverlap, mergeTranscripts } from "@/lib/meetings/merge-format";
+
+/**
+ * Spec for duplicate-meeting detection + merge. Derived from the scenario: two people upload the
+ * same meeting; one may have transcribed less. Overlap must stay HIGH when one is a partial subset,
+ * LOW for unrelated meetings; merge must union unique content without doubling near-duplicates.
+ */
+const A =
+  "Chetan and John discussed the mission control dashboard. They agreed to leverage gbrain and Hermes. " +
+  "John will configure the personal setup for genetic projects. They reviewed the task management approach.";
+const APartial = "They agreed to leverage gbrain and Hermes. John will configure the personal setup for genetic projects.";
+const Different = "Alice and Bob planned the Q3 marketing campaign budget and the launch timeline for the new mobile app.";
+
+describe("transcriptOverlap", () => {
+  it("scores a partial subset high (one person transcribed less)", () => {
+    expect(transcriptOverlap(A, APartial)).toBeGreaterThan(0.8);
+  });
+  it("scores an unrelated meeting low", () => {
+    expect(transcriptOverlap(A, Different)).toBeLessThan(0.2);
+  });
+  it("returns 0 when either side is empty", () => {
+    expect(transcriptOverlap(A, "")).toBe(0);
+  });
+});
+
+describe("mergeTranscripts", () => {
+  it("keeps the longer base and appends the other's unique lines", () => {
+    const merged = mergeTranscripts("line one\nline two\nline three", "line two\nline four");
+    expect(merged).toContain("line one");
+    expect(merged).toContain("line three");
+    expect(merged).toContain("line four"); // unique to the second
+    expect(merged.match(/line two/g)?.length).toBe(1); // not doubled
+  });
+  it("returns the base unchanged when the other adds nothing new", () => {
+    const base = "a\nb\nc";
+    expect(mergeTranscripts(base, "b\nc")).toBe(base);
+  });
+});


### PR DESCRIPTION
## What

When two people upload the **same meeting**, merge the transcripts into one note (crediting both) instead of leaving duplicates — the last of the three Meetings asks.

## How
- **Detect** (`findDuplicateMeeting`): an existing note with the **same date** whose transcript **overlaps enough**. Similarity is the **overlap coefficient** on word 5-gram shingles (`lib/meetings/merge-format`), so it stays high even when one person transcribed only part of the meeting (Jaccard would under-score that); unrelated meetings score low.
- **Merge** (`mergeIntoMeetingNote`): re-ingests a **deterministic union** of the two transcripts into the existing item (longer as base + the other's unique lines), then **re-summarizes + re-extracts action items** on the merged text, unions attendees, and credits **both** uploaders.
- **Both submitters**: new `meeting_note_submitters` join table (single-writer `notes.ts`, added to the guard); readers return `submitters[]`; the detail view shows **"Submitted by X and Y"**.
- `uploadMeetingNoteAction` runs the dup check before creating a note — a match merges and returns the existing note id.

## Design note
The merge is **deterministic** (union + dedupe) for V1 — predictable and testable; an LLM re-write could slot in later behind the same seam. Only auto-merges when a **date** is present (no date ⇒ never merge).

## Tests
- `test/meetings-merge-format.test.ts` — overlap high for a partial subset, low for unrelated; union dedupes near-duplicates.
- `test/datamechanics/meetings-merge.datamechanics.test.ts` — **real-Postgres**: two same-date overlapping uploads → **one** note with **both** submitters + merged transcript; no false match on a different date or unrelated content.

## Verification
`check:docs` ✓ (63 tables) · `typecheck` ✓ · `lint` ✓ (0 err) · unit **739 passed** ✓ · meetings data-mechanics **13** ✓ · migrate-from-zero ✓ · `next build` ✓.

Completes the Meetings improvements: skimmable bulleted summaries (#267) · auto-extract action items for all uploads + Send to Linear (#269) · duplicate merge (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Duplicate meeting uploads are now detected and merged instead of creating separate notes.
  * Merged notes preserve transcript content, attendees, and credit for all submitters.
  * Meeting notes now display multiple submitters and their avatars.
* **Bug Fixes**
  * Prevented duplicate transcript content during meeting merges.
* **Documentation**
  * Updated architecture documentation to reflect expanded meeting note support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->