### PR TITLE
perf(ui): make mutation buttons feel instant (optimistic state, drop redundant router.refresh)

### DIFF
--- a/components/admin/manager-select.tsx
+++ b/components/admin/manager-select.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { setMemberManager } from "@/app/t/[team]/admin/members/actions";
 
 /**
@@ -21,7 +20,6 @@ export function ManagerSelect({
   managerMemberId: string | null;
   candidates: { id: string; displayName: string }[];
 }) {
-  const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [value, setValue] = useState<string>(managerMemberId ?? "");
   const [error, setError] = useState<string | null>(null);
@@ -29,16 +27,16 @@ export function ManagerSelect({
   function change(next: string) {
     if (next === value) return;
     const prev = value;
-    setValue(next);
+    setValue(next); // optimistic: reflect the new manager instantly
     setError(null);
     startTransition(async () => {
       const res = await setMemberManager(teamSlug, memberId, next || null);
+      // No router.refresh(): this select is the only surface showing the assignment on the page
+      // (the company-graph is rebuilt server-side on read, not from a page re-render).
       if (!res.ok) {
-        setValue(prev);
+        setValue(prev); // revert on server rejection (self / cross-team / disabled / connector)
         setError(res.error ?? "could not set manager");
-        return;
       }
-      router.refresh();
     });
   }
 

--- a/components/admin/member-role-select.tsx
+++ b/components/admin/member-role-select.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { setMemberRole } from "@/app/t/[team]/admin/members/actions";
 
 type Role = "admin" | "lead" | "member";
@@ -26,7 +25,6 @@ export function MemberRoleSelect({
   memberId: string;
   role: Role;
 }) {
-  const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [value, setValue] = useState<Role>(role);
   const [error, setError] = useState<string | null>(null);
@@ -34,16 +32,16 @@ export function MemberRoleSelect({
   function change(next: Role) {
     if (next === value) return;
     const prev = value;
-    setValue(next);
+    setValue(next); // optimistic: reflect the new role instantly
     setError(null);
     startTransition(async () => {
       const res = await setMemberRole(teamSlug, memberId, next);
+      // No router.refresh(): the select is the only surface showing role, and it's already updated.
+      // Skipping the full-route re-render (2nd round-trip + layout re-query) is what removes the lag.
       if (!res.ok) {
-        setValue(prev);
+        setValue(prev); // revert on server rejection (e.g. demoting the last admin)
         setError(res.error ?? "could not change role");
-        return;
       }
-      router.refresh();
     });
   }
 

--- a/components/meetings/meeting-action-items.tsx
+++ b/components/meetings/meeting-action-items.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { CheckSquare, ExternalLink, ListChecks, Loader2, Sparkles, Square } from "lucide-react";
 
@@ -44,9 +44,17 @@ export function MeetingActionItems({ teamSlug, noteId, todos, provider }: Meetin
   const [pushing, startPush] = useTransition();
   const [msg, setMsg] = useState<string | null>(null);
   const [results, setResults] = useState<Map<string, PushTaskResult>>(new Map());
+  const [pushedProvider, setPushedProvider] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(todos.filter((t) => !t.pushed).map((t) => t.taskId)));
 
-  const pushable = useMemo(() => todos.filter((t) => !t.pushed), [todos]);
-  const [selected, setSelected] = useState<Set<string>>(() => new Set(pushable.map((t) => t.taskId)));
+  // A task counts as pushed if the server already recorded it OR we pushed it this session — so the
+  // UI reflects a push immediately, WITHOUT a router.refresh() (which would re-render the whole route).
+  function pushedInfo(t: ActionItemView): { provider: string; url: string } | null {
+    if (t.pushed) return t.pushed;
+    const r = results.get(t.taskId);
+    return r && r.url && r.status !== "failed" ? { provider: pushedProvider ?? provider ?? "", url: r.url } : null;
+  }
+  const pushable = todos.filter((t) => !pushedInfo(t));
 
   function toggle(taskId: string) {
     setSelected((prev) => {
@@ -78,14 +86,17 @@ export function MeetingActionItems({ teamSlug, noteId, todos, provider }: Meetin
     startPush(async () => {
       const res = await pushMeetingTasksAction(teamSlug, noteId, ids);
       if (!res.ok) return setMsg(res.error ?? "push failed");
-      const byId = new Map((res.results ?? []).map((r) => [r.taskId, r]));
-      setResults(byId);
-      const synced = (res.results ?? []).filter((r) => r.status === "synced" || r.status === "skipped").length;
-      const failed = (res.results ?? []).filter((r) => r.status === "failed").length;
+      const list = res.results ?? [];
+      // Merge the returned results into local state — the render marks these pushed from here, so no
+      // router.refresh() (2nd round-trip + full-route re-render) is needed to show the new status.
+      setResults((prev) => new Map([...prev, ...list.map((r) => [r.taskId, r] as const)]));
+      setPushedProvider(res.provider ?? provider ?? null);
+      const doneIds = new Set(list.filter((r) => r.status === "synced" || r.status === "skipped").map((r) => r.taskId));
+      setSelected((prev) => new Set([...prev].filter((id) => !doneIds.has(id)))); // drop pushed from selection
+      const failed = list.filter((r) => r.status === "failed").length;
       setMsg(
-        `Sent ${synced} to ${providerLabel(res.provider ?? provider)}${failed ? ` · ${failed} failed` : ""}.`
+        `Sent ${doneIds.size} to ${providerLabel(res.provider ?? provider)}${failed ? ` · ${failed} failed` : ""}.`
       );
-      router.refresh();
     });
   }
 
@@ -120,10 +131,11 @@ export function MeetingActionItems({ teamSlug, noteId, todos, provider }: Meetin
           <ul className="flex flex-col gap-1.5">
             {todos.map((t) => {
               const result = results.get(t.taskId);
+              const pushed = pushedInfo(t);
               const isSelected = selected.has(t.taskId);
               return (
                 <li key={t.taskId} className="flex items-start gap-2 text-sm">
-                  {t.pushed ? (
+                  {pushed ? (
                     <CheckSquare className="mt-0.5 size-4 shrink-0 text-emerald-500" />
                   ) : (
                     <button
@@ -145,28 +157,18 @@ export function MeetingActionItems({ teamSlug, noteId, todos, provider }: Meetin
                     <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-ink-tertiary">
                       {t.assignee ? <span>{t.assignee}</span> : null}
                       {t.due ? <span>· due {t.due}</span> : null}
-                      {t.pushed ? (
+                      {pushed ? (
                         <a
-                          href={t.pushed.url}
+                          href={pushed.url}
                           target="_blank"
                           rel="noreferrer"
                           className="inline-flex items-center gap-0.5 text-violet hover:underline"
                         >
-                          in {providerLabel(t.pushed.provider)}
+                          in {providerLabel(pushed.provider)}
                           <ExternalLink className="size-3" />
                         </a>
                       ) : result?.status === "failed" ? (
                         <span className="text-rose-500">{result.error ?? "push failed"}</span>
-                      ) : result?.url ? (
-                        <a
-                          href={result.url}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex items-center gap-0.5 text-violet hover:underline"
-                        >
-                          pushed
-                          <ExternalLink className="size-3" />
-                        </a>
                       ) : null}
                     </div>
                   </div>


### PR DESCRIPTION
## Why buttons felt laggy

Every mutation button used the App Router **`server action → router.refresh()`** pattern — **two sequential server round-trips** with no optimistic UI:

1. the mutation (round-trip #1), then
2. `router.refresh()` (round-trip #2) which re-renders the **entire route on the server** — the team layout's 2 sequential Railway auth queries **plus** the page's own data — before anything on screen changes.

So the control just spins for the full `action + full-route re-render`, against a remote (Railway) Postgres. That's the click-to-refresh delay.

## Fix (the 3 noisiest buttons)

Let local state be authoritative and drop the redundant second round-trip:

- **`member-role-select` / `manager-select`** (Admin → Members) — these already updated their value optimistically *before* the await, then called `router.refresh()` anyway. The select is the only surface on the page reflecting the change, so the refresh was pure tax. Removed it; the revert-on-error path is unchanged.
- **`meeting-action-items`** — push now marks tasks pushed from the action's returned results (urls + status) in local state and drops them from the selection, instead of `router.refresh()`. The "pushed" badge/link render instantly from local state.

## Measured before/after (local, seeded)

A role change now fires **exactly one request** — `POST …/members → 200` (~350ms) — with **no `?_rsc=` refetch**, and the value updates instantly. Before, the same POST was followed by a full-route **RSC refetch** (layout re-query + the whole members page re-render) as a second serial round-trip. Verified the change persists in Postgres, reverts on server rejection, and throws no console errors.

## Scope / follow-ups
- This PR does the **3 highest-frequency buttons**. ~21 other `router.refresh()` buttons remain — a follow-up can convert the ones that are already optimistic (safe) and keep refresh only where derived server UI genuinely needs it.
- **Shared win (bigger, separate):** collapse the team layout's 2 sequential auth queries into 1 (helps *every* refresh that stays). Deferred — the DB adapter's embedded-filter support needs checking first.

## Test plan
- [x] Unit (744) + tsc + lint green
- [x] Browser: role change = 1 request, no RSC refetch, persists, reverts on error, no console errors
- [ ] CI green → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manager and role changes now update immediately without requiring a page refresh.
  * Failed manager or role updates restore the previous selection and display an error.
  * Meeting action items now immediately reflect successful or skipped sync results.
  * Pushed meeting items display the correct provider and external link, while synced items are removed from the current selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->