### PR TITLE
feat(meetings): backfill-merge existing duplicate meetings (admin action)

### DIFF
--- a/app/t/[team]/meetings/actions.ts
+++ b/app/t/[team]/meetings/actions.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { serverClient } from "@/lib/db/server";
 import { adminClient } from "@/lib/db/admin";
-import { currentMember } from "@/lib/auth/guard";
+import { currentMember, requireTeamAdmin } from "@/lib/auth/guard";
 import { resolveAnsweringKeys } from "@/lib/query/answering";
 import {
   createMeetingNote,
@@ -16,7 +16,7 @@ import {
 import { extractFromTranscript, type RosterPerson } from "@/lib/meetings/llm-extract";
 import { extractAndStoreActionItems } from "@/lib/meetings/action-items";
 import { MEETING_TODO_PROJECT_SLUG } from "@/lib/meetings/extract-todos";
-import { findDuplicateMeeting, mergeIntoMeetingNote } from "@/lib/meetings/merge";
+import { findDuplicateMeeting, mergeIntoMeetingNote, backfillMergeDuplicateMeetings } from "@/lib/meetings/merge";
 import { backfillMeetingNotesFromItems } from "@/lib/meetings/from-items";
 import {
   projectRows,
@@ -131,6 +131,27 @@ export async function uploadMeetingNoteAction(
 
   revalidatePath(`/t/${team.slug}/meetings`);
   return { ok: true, id: noteId };
+}
+
+/**
+ * One-time cleanup: merge already-created duplicate meetings (same date + overlapping transcripts)
+ * into one note each, crediting all submitters and hiding the folded-away copies. Admin-only (it's a
+ * bulk, content-mutating operation). Uses the same LLM merge as the live upload path.
+ */
+export async function mergeDuplicateMeetingsAction(
+  teamSlug: string
+): Promise<{ ok: boolean; merged?: number; clusters?: number; error?: string }> {
+  const ctx = await requireTeamAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  const admin = adminClient();
+  const keys = await resolveAnsweringKeys(admin, ctx.teamId);
+  try {
+    const s = await backfillMergeDuplicateMeetings(admin, ctx.teamId, { keys, actorMemberId: ctx.memberId });
+    revalidatePath(`/t/${teamSlug}/meetings`);
+    return { ok: true, merged: s.merged, clusters: s.clusters };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "merge failed" };
+  }
 }
 
 /**

--- a/app/t/[team]/meetings/layout.tsx
+++ b/app/t/[team]/meetings/layout.tsx
@@ -7,6 +7,7 @@ import { listMeetingNotesForTeam, type MeetingNoteSummary } from "@/lib/meetings
 import { EmptyState } from "@/components/empty-state";
 import { NewMeetingNoteButton } from "@/components/meetings/new-meeting-note-button";
 import { ImportPushedMeetingsButton } from "@/components/meetings/import-pushed-meetings-button";
+import { MergeDuplicatesButton } from "@/components/meetings/merge-duplicates-button";
 import { MeetingListPane } from "@/components/meetings/meeting-list-pane";
 
 /** When the meeting happened, if known, else when it was ingested — the sort key for the list. */
@@ -55,6 +56,7 @@ export default async function MeetingsLayout({
         </div>
         {canManage ? (
           <div className="flex items-center gap-2">
+            {me.role === "admin" ? <MergeDuplicatesButton teamSlug={teamSlug} /> : null}
             <ImportPushedMeetingsButton teamSlug={teamSlug} />
             <NewMeetingNoteButton teamSlug={teamSlug} />
           </div>

--- a/components/meetings/merge-duplicates-button.tsx
+++ b/components/meetings/merge-duplicates-button.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Combine, Loader2 } from "lucide-react";
+import { mergeDuplicateMeetingsAction } from "@/app/t/[team]/meetings/actions";
+
+/**
+ * Admin-only one-time cleanup: merge already-created duplicate meetings (same date + overlapping
+ * transcripts) into one note each. Confirms first — it mutates transcripts and hides the duplicates.
+ */
+export function MergeDuplicatesButton({ teamSlug }: { teamSlug: string }) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+  const [msg, setMsg] = useState<string | null>(null);
+
+  function run() {
+    if (!window.confirm("Merge same-day duplicate meetings into one each? Transcripts are combined and the duplicates are hidden.")) return;
+    setMsg(null);
+    start(async () => {
+      const res = await mergeDuplicateMeetingsAction(teamSlug);
+      if (!res.ok) return setMsg(res.error ?? "merge failed");
+      setMsg(res.merged ? `Merged ${res.merged} duplicate${res.merged === 1 ? "" : "s"}.` : "No duplicates found.");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {msg ? <span className="text-xs text-ink-tertiary">{msg}</span> : null}
+      <button
+        type="button"
+        onClick={run}
+        disabled={pending}
+        className="btn-ghost"
+        title="Merge same-day duplicate meetings into one"
+      >
+        {pending ? <Loader2 className="size-4 animate-spin" /> : <Combine className="size-4" />}
+        Merge duplicates
+      </button>
+    </div>
+  );
+}

--- a/lib/meetings/merge.ts
+++ b/lib/meetings/merge.ts
@@ -7,7 +7,7 @@ import { completeTextOrNull } from "@/lib/llm/complete";
 import { extractFromTranscript, type ProviderKeys, type RosterPerson } from "./llm-extract";
 import { extractAndStoreActionItems } from "./action-items";
 import { canLlmMerge, mergeTranscripts, transcriptOverlap } from "./merge-format";
-import { addMeetingNoteAttendees, addMeetingNoteSubmitters, updateMeetingSummary } from "./notes";
+import { addMeetingNoteAttendees, addMeetingNoteSubmitters, setMeetingNoteMergedInto, updateMeetingSummary } from "./notes";
 
 const MERGE_SYSTEM =
   "You are given two transcripts of the SAME meeting, captured by different note-takers. They " +
@@ -127,10 +127,13 @@ export async function findDuplicateMeeting(
 
 export interface MergeInput {
   newRawText: string;
-  newSubmitterId: string;
+  /** The incoming upload's submitter to credit (null for a CLI-imported note with no submitter). */
+  newSubmitterId: string | null;
   newAttendeeIds?: string[];
   roster: RosterPerson[];
   keys: ProviderKeys;
+  /** A valid member to attribute the re-ingest to when neither note has a submitter (e.g. backfill). */
+  authorFallbackMemberId?: string | null;
   /** Injectable merge (tests). Defaults to LLM merge with a deterministic union fallback. */
   mergeTranscript?: (existing: string, incoming: string) => Promise<string>;
 }
@@ -152,7 +155,8 @@ export async function mergeIntoMeetingNote(
     ? await input.mergeTranscript(match.existingRawText, input.newRawText)
     : (await mergeTranscriptsLLM(match.existingRawText, input.newRawText, input.keys).catch(() => null)) ??
       mergeTranscripts(match.existingRawText, input.newRawText);
-  const author = match.primarySubmitterId ?? input.newSubmitterId;
+  const author = match.primarySubmitterId ?? input.newSubmitterId ?? input.authorFallbackMemberId ?? null;
+  if (!author) throw new Error("mergeIntoMeetingNote: no member to attribute the merged transcript to");
 
   // Re-ingest the merged transcript into the SAME item (team+project+path upsert → new sha/body).
   await ingestItem(
@@ -208,4 +212,123 @@ export async function mergeIntoMeetingNote(
   });
 
   return match.noteId;
+}
+
+/** Build a fresh DuplicateMatch for a note by re-reading its (possibly just-merged) transcript. */
+async function loadMatchForNote(admin: DbClient, teamId: string, noteId: string): Promise<DuplicateMatch | null> {
+  const { data: n } = await admin
+    .from("meeting_notes")
+    .select("id, source_item_id, submitted_by, title")
+    .eq("team_id", teamId)
+    .eq("id", noteId)
+    .maybeSingle();
+  const note = n as { id: string; source_item_id: string; submitted_by: string | null; title: string } | null;
+  if (!note) return null;
+  const { data: item } = await admin
+    .from("items")
+    .select("id, path, access, body, projects(slug)")
+    .eq("id", note.source_item_id)
+    .maybeSingle();
+  const it = item as { path: string; access: "team" | "external"; body: string; projects?: { slug?: string } } | null;
+  if (!it?.body) return null;
+  return {
+    noteId: note.id,
+    sourceItemId: note.source_item_id,
+    itemPath: it.path,
+    itemProject: it.projects?.slug ?? "meeting-notes",
+    itemAccess: it.access,
+    title: note.title,
+    existingRawText: it.body,
+    primarySubmitterId: note.submitted_by,
+    overlap: 1,
+  };
+}
+
+export interface BackfillMergeSummary {
+  scanned: number;
+  clusters: number;
+  merged: number;
+}
+
+/**
+ * One-time cleanup: find already-created duplicate meeting notes (same date + overlapping
+ * transcripts) and merge each cluster into its EARLIEST note, crediting all submitters and hiding
+ * the folded-away copies (`merged_into`). Uses the same LLM merge as the live upload path. Bounded,
+ * best-effort per cluster. `actorMemberId` attributes the re-ingest when a note has no submitter.
+ */
+export async function backfillMergeDuplicateMeetings(
+  admin: DbClient,
+  teamId: string,
+  opts: { keys: ProviderKeys; actorMemberId: string; threshold?: number }
+): Promise<BackfillMergeSummary> {
+  const threshold = opts.threshold ?? DEFAULT_MERGE_THRESHOLD;
+  const summary: BackfillMergeSummary = { scanned: 0, clusters: 0, merged: 0 };
+
+  const { data: notes } = await admin
+    .from("meeting_notes")
+    .select("id, source_item_id, submitted_by, occurred_at, created_at")
+    .eq("team_id", teamId)
+    .is("merged_into", null);
+  type Row = { id: string; source_item_id: string; submitted_by: string | null; occurred_at: string | null; created_at: string };
+  const rows = ((notes ?? []) as Row[]).filter((r) => r.occurred_at);
+  summary.scanned = rows.length;
+  if (rows.length < 2) return summary;
+
+  const { data: items } = await admin
+    .from("items")
+    .select("id, body")
+    .in("id", rows.map((r) => r.source_item_id));
+  const bodyById = new Map(((items ?? []) as { id: string; body: string }[]).map((i) => [i.id, i.body ?? ""]));
+
+  const roster: RosterPerson[] = await admin
+    .from("members")
+    .select("id, display_name")
+    .eq("team_id", teamId)
+    .eq("status", "active")
+    .then(({ data }) => ((data ?? []) as { id: string; display_name: string }[]).map((m) => ({ id: m.id, displayName: m.display_name })));
+
+  // Group by date.
+  const byDate = new Map<string, Row[]>();
+  for (const r of rows) byDate.set(r.occurred_at!, [...(byDate.get(r.occurred_at!) ?? []), r]);
+
+  for (const group of byDate.values()) {
+    if (group.length < 2) continue;
+    group.sort((a, b) => (a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0));
+
+    // Greedy cluster by overlap against each cluster's (earliest) primary.
+    const clusters: Row[][] = [];
+    for (const note of group) {
+      const body = bodyById.get(note.source_item_id) ?? "";
+      if (!body.trim()) continue;
+      const target = clusters.find((cl) => transcriptOverlap(body, bodyById.get(cl[0].source_item_id) ?? "") >= threshold);
+      if (target) target.push(note);
+      else clusters.push([note]);
+    }
+
+    for (const cl of clusters) {
+      if (cl.length < 2) continue;
+      summary.clusters++;
+      const primary = cl[0];
+      for (const dup of cl.slice(1)) {
+        const match = await loadMatchForNote(admin, teamId, primary.id);
+        if (!match) continue;
+        const { data: att } = await admin.from("meeting_note_attendees").select("member_id").eq("meeting_note_id", dup.id);
+        try {
+          await mergeIntoMeetingNote(admin, teamId, match, {
+            newRawText: bodyById.get(dup.source_item_id) ?? "",
+            newSubmitterId: dup.submitted_by,
+            newAttendeeIds: ((att ?? []) as { member_id: string }[]).map((a) => a.member_id),
+            roster,
+            keys: opts.keys,
+            authorFallbackMemberId: opts.actorMemberId,
+          });
+          await setMeetingNoteMergedInto(admin, dup.id, primary.id);
+          summary.merged++;
+        } catch {
+          // one bad cluster member never fails the whole backfill
+        }
+      }
+    }
+  }
+  return summary;
 }

--- a/lib/meetings/notes.ts
+++ b/lib/meetings/notes.ts
@@ -229,6 +229,12 @@ export async function addMeetingNoteAttendees(admin: DbClient, noteId: string, m
   if (error) throw new Error(`meeting note attendees insert failed: ${error.message}`);
 }
 
+/** Point a duplicate note at the survivor it was merged into (hides it from the list). */
+export async function setMeetingNoteMergedInto(admin: DbClient, noteId: string, targetNoteId: string): Promise<void> {
+  const { error } = await admin.from("meeting_notes").update({ merged_into: targetNoteId }).eq("id", noteId);
+  if (error) throw new Error(`meeting note merged_into update failed: ${error.message}`);
+}
+
 /** Replace a note's summary (e.g. after a "regenerate summary" pass). Single writer for the column. */
 export async function updateMeetingSummary(
   admin: DbClient,
@@ -303,6 +309,7 @@ export async function listMeetingNotesForTeam(
     .from("meeting_notes")
     .select("id, source_item_id, submitted_by, title, summary, occurred_at, created_at")
     .eq("team_id", teamId)
+    .is("merged_into", null) // hide notes that were merged into another (deduped)
     .order("created_at", { ascending: false })
     .limit(200);
   const rows = (notes ?? []) as NoteRow[];

--- a/postgres/migrations/20260715130000_meeting_note_merged_into.sql
+++ b/postgres/migrations/20260715130000_meeting_note_merged_into.sql
@@ -1,0 +1,8 @@
+-- Soft-hide merged-away duplicate meeting notes (Meetings merge backfill). When two already-created
+-- notes turn out to be the same meeting, their content is merged into one and the other is pointed
+-- at the survivor via `merged_into`; readers hide notes with `merged_into` set. Keeping the row (vs
+-- deleting the item) means the CLI import path never resurfaces it. Sole writer: lib/meetings/notes.ts.
+-- Additive + idempotent; mirrored into schema.sql for from-zero.
+
+alter table meeting_notes add column if not exists merged_into uuid references meeting_notes(id) on delete set null;
+create index if not exists meeting_notes_merged_into_idx on meeting_notes (merged_into);

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -902,10 +902,14 @@ create table if not exists meeting_notes (
   title text not null,
   summary text not null default '',
   occurred_at date,
+  -- Set when this note was merged into another (same meeting, deduped); readers hide these.
+  merged_into uuid references meeting_notes(id) on delete set null,
   created_at timestamptz not null default now(),
   unique (source_item_id)
 );
 create index if not exists meeting_notes_team_idx on meeting_notes (team_id, created_at desc);
+alter table meeting_notes add column if not exists merged_into uuid references meeting_notes(id) on delete set null;
+create index if not exists meeting_notes_merged_into_idx on meeting_notes (merged_into);
 
 -- LLM-matched roster attendees (many-to-many; an unmatched name in the transcript is simply
 -- dropped, never blocks the note from saving).

--- a/test/datamechanics/meetings-backfill-merge.datamechanics.test.ts
+++ b/test/datamechanics/meetings-backfill-merge.datamechanics.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createMeetingNote, listMeetingNotesForTeam } from "@/lib/meetings/notes";
+import { backfillMergeDuplicateMeetings } from "@/lib/meetings/merge";
+import { db, seedTeam } from "./helpers";
+
+/**
+ * Spec for the one-time duplicate-merge backfill on real Postgres. Derived from intent: already-
+ * created same-date overlapping notes collapse into one (crediting all submitters, hiding the
+ * folded-away copies), while a same-date but unrelated meeting is left alone. Model unconfigured →
+ * the deterministic union runs.
+ */
+const DATE = "2026-07-03";
+const A =
+  "Chetan and John discussed the mission control dashboard. They agreed to leverage gbrain and Hermes. " +
+  "John will configure the personal setup for genetic projects and review the task management approach.";
+const B =
+  "They agreed to leverage gbrain and Hermes. John will configure the personal setup for genetic projects. " +
+  "John also confirmed the launch deadline is next Friday.";
+const UNRELATED = "Alice and Bob planned the Q3 marketing campaign budget and the launch timeline for the new mobile app store.";
+
+async function member(teamId: string, name: string): Promise<string> {
+  const { data } = await db()
+    .from("members")
+    .insert({ team_id: teamId, email: `${randomUUID()}@test.local`, display_name: name, actor_handle: `${name}-${randomUUID().slice(0, 6)}`, role: "member", tier: "team", status: "active" })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+describe("backfill: merge duplicate meetings (real Postgres)", () => {
+  it("collapses same-date overlapping notes into one, credits both, and leaves unrelated meetings alone", async () => {
+    const { teamId, memberId: chetan } = await seedTeam();
+    const john = await member(teamId, "John");
+
+    await createMeetingNote(db(), teamId, { title: "AIOS sync", rawText: A, submittedByMemberId: chetan, occurredAt: DATE });
+    await createMeetingNote(db(), teamId, { title: "AIOS sync", rawText: B, submittedByMemberId: john, occurredAt: DATE });
+    await createMeetingNote(db(), teamId, { title: "Standup", rawText: UNRELATED, submittedByMemberId: chetan, occurredAt: DATE });
+
+    // Three separate notes before the backfill.
+    expect((await listMeetingNotesForTeam(db(), teamId, "team")).length).toBe(3);
+
+    const summary = await backfillMergeDuplicateMeetings(db(), teamId, { keys: {}, actorMemberId: chetan });
+    expect(summary.clusters).toBe(1);
+    expect(summary.merged).toBe(1);
+
+    const visible = await listMeetingNotesForTeam(db(), teamId, "team");
+    expect(visible.length).toBe(2); // the merged AIOS note + the untouched standup
+
+    const aios = visible.find((n) => n.title === "AIOS sync")!;
+    expect(aios.submitters.map((s) => s.id).sort()).toEqual([chetan, john].sort());
+    expect(visible.some((n) => n.title === "Standup")).toBe(true);
+  });
+
+  it("is a no-op when there are no duplicates", async () => {
+    const { teamId, memberId } = await seedTeam();
+    await createMeetingNote(db(), teamId, { title: "Solo", rawText: A, submittedByMemberId: memberId, occurredAt: DATE });
+    const summary = await backfillMergeDuplicateMeetings(db(), teamId, { keys: {}, actorMemberId: memberId });
+    expect(summary.merged).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

A one-time **"Merge duplicates"** cleanup for the meetings that were already uploaded as separate notes (the live upload path only merges *new* duplicates). Collapses same-date overlapping notes into one, crediting everyone.

## Changes
- **`merged_into` column** (soft-hide): a folded-away duplicate points at the survivor; `listMeetingNotesForTeam` filters `merged_into IS NULL`. Keeping the row (vs deleting the item) means the CLI import never resurfaces it.
- **`backfillMergeDuplicateMeetings`**: groups non-merged notes by date, clusters by transcript overlap, merges each cluster into its **earliest** note via the same **LLM merge (with lossless fallback)** — crediting all submitters, unioning attendees, refreshing summary + action items — then hides the copies. Best-effort per cluster; **same-date-but-unrelated** meetings are left alone.
- **`mergeIntoMeetingNote`** now separates the ingest author from credited submitters (`authorFallbackMemberId`), so notes with **no submitter** (CLI-imported) still merge cleanly.
- **Admin-only "Merge duplicates" button** on the Meetings header (confirms first — it mutates transcripts + hides dupes).

## Tests
- `test/datamechanics/meetings-backfill-merge.datamechanics.test.ts` — **real-Postgres**: 3 notes (2 same-date overlapping + 1 unrelated) → after backfill, one merged AIOS note with **both** submitters + the untouched standup; no-op when there are no duplicates.

## Verification
`check:docs` ✓ · `typecheck` ✓ · `lint` ✓ (0 err) · unit **747 passed** ✓ · meetings data-mechanics **16** ✓ · migrate-from-zero ✓ · `next build` ✓.

Completes both asks: **LLM merge** (#271) + this **backfill**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)