### PR TITLE
perf(dashboard): collapse the team layout's two sequential auth queries into one

### DIFF
--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -6,6 +6,16 @@ import { activateInvitedMembership } from "@/lib/auth/pg-login";
 import { TeamNav, type NavEntry, type NavLeaf } from "@/components/team-nav";
 import { SignOutButton } from "@/components/account/sign-out-button";
 
+/** The caller's membership row + its embedded team, as returned by the single collapsed auth query. */
+type MembershipRow = {
+  id: string;
+  role: "admin" | "lead" | "member";
+  display_name: string;
+  tier: "team" | "external";
+  status: string;
+  teams: { id: string; slug: string; name: string } | null;
+};
+
 function NoTeamScreen({ slug }: { slug: string }) {
   return (
     <main className="flex flex-1 items-center justify-center bg-surface-raised px-6">
@@ -38,22 +48,18 @@ export default async function TeamLayout({
   const user = await getSessionUser();
   if (!user) return <NoTeamScreen slug={teamSlug} />;
 
-  // Membership is enforced below via the `me` lookup (app-code access control).
-  const { data: team } = await db
-    .from("teams")
-    .select("id, slug, name")
-    .eq("slug", teamSlug)
-    .maybeSingle();
-  if (!team) return <NoTeamScreen slug={teamSlug} />;
-
-  const { data: me } = await db
+  // One round-trip for auth: the caller's membership for THIS team + the team itself (embedded),
+  // instead of two sequential queries (team-by-slug, then member-by-team). This runs on every nav
+  // AND every router.refresh(), so collapsing it directly cuts the per-refresh latency. A user is
+  // normally in one team (self-hosted per org), so this returns a tiny row set we filter by slug.
+  const { data: memberships } = await db
     .from("members")
-    .select("id, role, display_name, tier, status")
-    .eq("team_id", team.id)
+    .select("id, role, display_name, tier, status, teams(id, slug, name)")
     .eq("auth_user_id", user.id)
-    .neq("status", "disabled")
-    .maybeSingle();
-  if (!me) return <NoTeamScreen slug={teamSlug} />;
+    .neq("status", "disabled");
+  const me = ((memberships ?? []) as MembershipRow[]).find((m) => m.teams?.slug === teamSlug);
+  if (!me?.teams) return <NoTeamScreen slug={teamSlug} />;
+  const team = me.teams;
   // Team-scoped activation, deferred half: signing in never activates memberships in teams the
   // login carried no context for (see linkMemberByEmail) — the invited row flips to active here,
   // on the member's own first visit to this team.


### PR DESCRIPTION
## The shared tax on every refresh

The team layout runs on **every navigation and every `router.refresh()`**, and it did **two sequential** round-trips to Railway Postgres on the critical path:

```
team = teams where slug = X          # round-trip 1
me   = members where team_id=team.id and auth_user_id=U   # round-trip 2 (depends on 1)
```

Because `router.refresh()` re-renders the layout, that fixed 2-hop cost was paid on **every button click across the whole app** — the shared component of the click-to-refresh lag diagnosed earlier.

## Fix — one embedded query

Collapse into a single query: the caller's membership filtered by `auth_user_id` (+ `status != disabled`), with the team **embedded** via the already-registered `members.team_id → teams` FK, then pick the row whose embedded team matches the slug.

```ts
const { data: memberships } = await db
  .from("members")
  .select("id, role, display_name, tier, status, teams(id, slug, name)")
  .eq("auth_user_id", user.id)
  .neq("status", "disabled");
const me = memberships.find((m) => m.teams?.slug === teamSlug);
if (!me?.teams) return <NoTeamScreen slug={teamSlug} />;
const team = me.teams;
```

**One round-trip instead of two, identical access decision.** (Self-hosted-per-org means a user is normally in one team, so the row set is tiny.)

## Access control — verified in a browser (this is an auth path)
- ✅ A **member** loads the dashboard — team name + admin-gated nav resolve from the embed.
- ✅ A **non-member** correctly gets the **"No team here for you"** screen (NoTeamScreen), not the dashboard.
- ✅ Admin-only surfaces still gate on `me.role`.

## Verified
- Unit (747) + tsc + lint + docs-drift green.
- Browser: member load, admin gating, and the non-member block all correct.

## Follow-up (not here)
The broader button audit: the cleanly-safe optimistic conversions (2 admin dropdowns + meeting push) shipped in #272. The remaining `router.refresh()` buttons are create/link/edit flows where the refresh legitimately re-fetches a server-rendered list — per-component refactors best done incrementally, not big-bang.

## Test plan
- [x] Unit + tsc + lint + docs-drift
- [x] Browser: member loads, non-member blocked, admin gating intact
- [ ] CI green → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)