### PR TITLE
fix(auth): fail closed on unknown visibility tiers (AIO-349)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -530,9 +530,12 @@ guard enforces it, it's named.
   places, all verified on real PG: the retrieval path (`retrieve.ts`), the API routes (they
   re-apply the filter), and the dashboard reads (`app/t/[team]/*`) — which now route every
   `items` read through the **`lib/auth/visibility` choke-point** (`visibleItems`/`canSeeAccess`).
+  That choke-point grants an unfiltered query only to the exact runtime tier `team`; malformed,
+  missing, or future tier strings fail closed to external-only rows rather than inheriting team
+  visibility.
   _Guard:_ `test/guards/dashboard-tier-filter.test.ts` fails the build if a dashboard page reads
-  `items` without the choke-point. _Verified:_ `access-isolation` + `dashboard-visibility`
-  data-mechanics tests.
+  `items` without the choke-point. _Verified:_ `lib/auth/visibility.test.ts` plus the
+  `access-isolation` + `dashboard-visibility` data-mechanics tests.
   🟡 **Not yet built — within-team privacy.** The tier model is binary (`team`/`external`); a
   `team` member sees _all_ `team` content. "Private to a subset of the team" (e.g. an ingested
   private Slack thread hidden from other team members) needs a finer-grained ACL (per-member or

--- a/lib/auth/visibility.test.ts
+++ b/lib/auth/visibility.test.ts
@@ -143,7 +143,7 @@ describe("scopeQueryLog", () => {
   });
 });
 
-describe("unknown/missing tier — inconsistent default across the choke-point (documented current behavior)", () => {
+describe("unknown/missing tier — fail-closed across the choke-point", () => {
   // `ViewerTier` is typed as the closed union "team" | "external", so a correctly-typed caller
   // can never construct anything else. But every one of these functions is a plain runtime
   // string check, and the real call sites feed them a DB-sourced or request-derived value cast
@@ -151,51 +151,63 @@ describe("unknown/missing tier — inconsistent default across the choke-point (
   // `auth.memberTier` off an API key row) — nothing stops a corrupt/legacy/typo'd tier value from
   // reaching these functions at the type boundary.
   //
-  // The six functions do NOT agree on a default for an unrecognized tier:
-  //   - visibleItems / visibleDecisions / visibleTasks / visibleByAccess check `tier !== "external"`
-  //     — an ALLOW-list of exactly one restricted value. Any other string ("admin", "", "TEAM", a
-  //     future tier nobody's added a branch for) falls through to the UNFILTERED branch: fail-OPEN.
-  //   - canSeeAccess checks `tier === "team"` — a DENY-by-default for team-tier content; an
-  //     unrecognized tier only sees rows explicitly marked `access === "external"`: fail-CLOSED.
-  // This suite documents the behavior as-is (not asserted as correct or incorrect) — see the PR
-  // description's "surprising" note on this asymmetry.
-  const unknownTiers = ["admin", "", "TEAM", "external ", "unknown"] as unknown as ViewerTier[];
-
-  it.each(unknownTiers)("visibleItems treats tier=%j as unrestricted (fail-open)", (tier) => {
-    const q = fakeQuery();
-    visibleItems(q, tier);
-    expect(q.calls).toEqual([]); // no filter applied — full visibility granted
-  });
-
-  it.each(unknownTiers)("visibleDecisions treats tier=%j as unrestricted (fail-open)", (tier) => {
-    const q = fakeQuery();
-    visibleDecisions(q, tier);
-    expect(q.calls).toEqual([]);
-  });
-
-  it.each(unknownTiers)("visibleTasks treats tier=%j as unrestricted (fail-open)", (tier) => {
-    const q = fakeQuery();
-    visibleTasks(q, tier);
-    expect(q.calls).toEqual([]);
-  });
-
-  it.each(unknownTiers)("visibleByAccess treats tier=%j as unrestricted (fail-open)", (tier) => {
-    const q = fakeQuery();
-    visibleByAccess(q, tier);
-    expect(q.calls).toEqual([]);
-  });
+  // Only the exact runtime value `team` is trusted with an unfiltered query. Corrupt, legacy,
+  // mistyped, or future tiers receive external-only visibility, matching canSeeAccess.
+  const unknownTiers = [
+    "admin",
+    "",
+    "TEAM",
+    "external ",
+    "unknown",
+  ] as unknown as ViewerTier[];
 
   it.each(unknownTiers)(
-    "canSeeAccess(tier=%j, 'team') denies team-tier content (fail-closed — inconsistent with the visibleX family above)",
+    "visibleItems filters tier=%j to external rows",
+    (tier) => {
+      const q = fakeQuery();
+      visibleItems(q, tier);
+      expect(q.calls).toEqual([{ column: "access", value: "external" }]);
+    },
+  );
+
+  it.each(unknownTiers)(
+    "visibleDecisions filters tier=%j to external rows",
+    (tier) => {
+      const q = fakeQuery();
+      visibleDecisions(q, tier);
+      expect(q.calls).toEqual([{ column: "audience", value: "external" }]);
+    },
+  );
+
+  it.each(unknownTiers)(
+    "visibleTasks filters tier=%j to external rows",
+    (tier) => {
+      const q = fakeQuery();
+      visibleTasks(q, tier);
+      expect(q.calls).toEqual([{ column: "audience", value: "external" }]);
+    },
+  );
+
+  it.each(unknownTiers)(
+    "visibleByAccess filters tier=%j to external rows",
+    (tier) => {
+      const q = fakeQuery();
+      visibleByAccess(q, tier);
+      expect(q.calls).toEqual([{ column: "access", value: "external" }]);
+    },
+  );
+
+  it.each(unknownTiers)(
+    "canSeeAccess(tier=%j, 'team') denies team-tier content",
     (tier) => {
       expect(canSeeAccess(tier, "team")).toBe(false);
-    }
+    },
   );
 
   it.each(unknownTiers)(
     "canSeeAccess(tier=%j, 'external') still grants external-access content regardless of tier (by design — external content is universally readable)",
     (tier) => {
       expect(canSeeAccess(tier, "external")).toBe(true);
-    }
+    },
   );
 });

--- a/lib/auth/visibility.ts
+++ b/lib/auth/visibility.ts
@@ -15,7 +15,7 @@ export type ViewerTier = "team" | "external";
  * recursive type doesn't trigger TS2589; the `.eq` shape is asserted by a localized cast.
  */
 export function visibleItems<Q>(query: Q, tier: ViewerTier): Q {
-  if (tier !== "external") return query;
+  if (tier === "team") return query;
   return (query as { eq(column: string, value: string): Q }).eq("access", "external");
 }
 
@@ -30,7 +30,7 @@ export function canSeeAccess(tier: ViewerTier, access: string): boolean {
  * rule as items on the postgres target (no RLS). Route dashboard decision reads through here.
  */
 export function visibleDecisions<Q>(query: Q, tier: ViewerTier): Q {
-  if (tier !== "external") return query;
+  if (tier === "team") return query;
   return (query as { eq(column: string, value: string): Q }).eq("audience", "external");
 }
 
@@ -41,7 +41,7 @@ export function visibleDecisions<Q>(query: Q, tier: ViewerTier): Q {
  * Route every tier-scoped task read (retrieval, the v1 pull API, dashboard boxes) through here.
  */
 export function visibleTasks<Q>(query: Q, tier: ViewerTier): Q {
-  if (tier !== "external") return query;
+  if (tier === "team") return query;
   return (query as { eq(column: string, value: string): Q }).eq("audience", "external");
 }
 
@@ -53,7 +53,7 @@ export function visibleTasks<Q>(query: Q, tier: ViewerTier): Q {
  * see team-sourced content. Route every tier-scoped Social read through here (no RLS backstop).
  */
 export function visibleByAccess<Q>(query: Q, tier: ViewerTier): Q {
-  if (tier !== "external") return query;
+  if (tier === "team") return query;
   return (query as { eq(column: string, value: string): Q }).eq("access", "external");
 }
 


### PR DESCRIPTION
Closes AIO-349.

Unknown, malformed, missing, and future runtime tier strings now receive external-only visibility at every list-scoping choke point. Only the exact `team` tier receives an unfiltered query.

Verification:
- `npm test` — 127 files passed, 1 skipped; 747 tests passed, 7 skipped
- `npm run build` — passed
- `npm run lint` — passed (one pre-existing warning)
- `npm run check:docs` — passed
- focused visibility suite — 44/44 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes tier-isolation logic on every dashboard/API read path that uses the visibility choke-point; there is no RLS backstop, so incorrect filtering would leak or hide content.
> 
> **Overview**
> **Tier list scoping now fails closed** when the runtime viewer tier is not exactly `team`. Previously, `visibleItems`, `visibleDecisions`, `visibleTasks`, and `visibleByAccess` used `tier !== "external"`, so corrupt, legacy, or mistyped tier strings (e.g. `admin`, `TEAM`, empty) skipped filters and could expose team-only rows—while `canSeeAccess` already denied non-`team` viewers for team content.
> 
> Each helper now grants an **unfiltered query only for `tier === "team"`**; every other value applies the same external-only `.eq` filter as a proper `external` viewer. Tests were updated from documenting the old asymmetry to asserting fail-closed behavior across all choke points; **ARCHITECTURE.md** records the invariant and points at `lib/auth/visibility.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fbfbedb3974059b7d97c33704e03036a078d0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access visibility to fail closed for missing, malformed, unknown, or future tier values.
  * Restricted unfiltered visibility to the exact `team` tier.
  * Ensured unexpected tiers only see content marked as external.

* **Tests**
  * Expanded coverage for invalid and unexpected access tiers.

* **Documentation**
  * Clarified tier-based visibility and verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->