### PR TITLE
feat(gateway): durable approval administration and resume (AIO-407)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           node-version: "20"
           cache: "npm"
       - run: npm ci
+      - run: npm run test:gateway-approval-contracts
       - run: npm test
       # Coverage gate: thresholds in vitest.config.ts (lib/** scope). Fails the job
       # if coverage drops below the floor. Ratchet thresholds up as tests improve.
@@ -95,6 +96,7 @@ jobs:
       - run: npm ci
       # migrate-from-zero into the service DB (also the replay guard)
       - run: DATABASE_URL="$DATABASE_TEST_URL" npm run pg:schema
+      - run: npm run test:gateway-approval
       - run: npm run test:datamechanics
 
   http-tests:
@@ -128,6 +130,7 @@ jobs:
       # Production build first; global-setup spawns `next start` against .next.
       - run: npm run build
       - run: npm run test:http
+      - run: npm run test:http:gateway-approval
 
   ingestion-tests:
     name: Ingestion tests (pytest)

--- a/app/api/internal/executor-gateway/v1/admin/[teamSlug]/approvals/[approvalId]/decision/route.ts
+++ b/app/api/internal/executor-gateway/v1/admin/[teamSlug]/approvals/[approvalId]/decision/route.ts
@@ -1,0 +1,43 @@
+import { adminFailure, gatewayAdminContext } from "@/lib/gateway/admin-http";
+import { decideGatewayApproval } from "@/lib/gateway/admin-persistence";
+import {
+  exactObject,
+  gatewayDisabled,
+  gatewayError,
+  gatewayJson,
+  isResponse,
+  isUuid,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ teamSlug: string; approvalId: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const path = await params;
+  const ctx = await gatewayAdminContext(path.teamSlug);
+  if (isResponse(ctx)) return ctx;
+  if (!isUuid(path.approvalId)) return gatewayError("gateway_not_found", 404);
+  const body = await readGatewayJson(req);
+  if (isResponse(body)) return body;
+  if (
+    !exactObject(body, ["decision", "correlationId"]) ||
+    !["approve", "deny"].includes(String(body.decision)) ||
+    !isUuid(body.correlationId)
+  )
+    return gatewayError("gateway_invalid_request", 400);
+  try {
+    return gatewayJson(
+      await decideGatewayApproval(
+        ctx,
+        path.approvalId,
+        body.decision as "approve" | "deny",
+        body.correlationId,
+      ),
+    );
+  } catch (error) {
+    return adminFailure(error, body.correlationId);
+  }
+}

--- a/app/api/internal/executor-gateway/v1/admin/[teamSlug]/approvals/route.ts
+++ b/app/api/internal/executor-gateway/v1/admin/[teamSlug]/approvals/route.ts
@@ -1,0 +1,18 @@
+import { gatewayAdminContext, adminFailure } from "@/lib/gateway/admin-http";
+import { listGatewayApprovals } from "@/lib/gateway/admin-persistence";
+import { gatewayDisabled, gatewayJson, isResponse } from "@/lib/gateway/http";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ teamSlug: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const ctx = await gatewayAdminContext((await params).teamSlug);
+  if (isResponse(ctx)) return ctx;
+  try {
+    return gatewayJson({ approvals: await listGatewayApprovals(ctx) });
+  } catch (error) {
+    return adminFailure(error);
+  }
+}

--- a/app/api/internal/executor-gateway/v1/admin/[teamSlug]/policies/[policyId]/route.ts
+++ b/app/api/internal/executor-gateway/v1/admin/[teamSlug]/policies/[policyId]/route.ts
@@ -1,0 +1,67 @@
+import { adminFailure, gatewayAdminContext } from "@/lib/gateway/admin-http";
+import {
+  deleteGatewayAdminPolicy,
+  updateGatewayAdminPolicy,
+} from "@/lib/gateway/admin-persistence";
+import { parseGatewayPolicyInput } from "@/lib/gateway/admin-validation";
+import {
+  gatewayDisabled,
+  gatewayError,
+  gatewayJson,
+  isResponse,
+  isUuid,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ teamSlug: string; policyId: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const path = await params;
+  const ctx = await gatewayAdminContext(path.teamSlug);
+  if (isResponse(ctx)) return ctx;
+  if (!isUuid(path.policyId)) return gatewayError("gateway_not_found", 404);
+  const body = await readGatewayJson(req);
+  if (isResponse(body)) return body;
+  const input = parseGatewayPolicyInput(body);
+  if (!input) return gatewayError("gateway_invalid_request", 400);
+  try {
+    return gatewayJson(await updateGatewayAdminPolicy(ctx, path.policyId, input));
+  } catch (error) {
+    return adminFailure(error, input.correlationId);
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ teamSlug: string; policyId: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const path = await params;
+  const ctx = await gatewayAdminContext(path.teamSlug);
+  if (isResponse(ctx)) return ctx;
+  if (!isUuid(path.policyId)) return gatewayError("gateway_not_found", 404);
+  const body = await readGatewayJson(req);
+  if (
+    isResponse(body) ||
+    !body ||
+    typeof body !== "object" ||
+    Array.isArray(body) ||
+    Object.keys(body).length !== 1 ||
+    !Object.hasOwn(body, "correlationId") ||
+    !isUuid((body as Record<string, unknown>).correlationId)
+  )
+    return isResponse(body)
+      ? body
+      : gatewayError("gateway_invalid_request", 400);
+  const correlationId = (body as { correlationId: string }).correlationId;
+  try {
+    await deleteGatewayAdminPolicy(ctx, path.policyId, correlationId);
+    return gatewayJson({ deleted: true });
+  } catch (error) {
+    return adminFailure(error, correlationId);
+  }
+}

--- a/app/api/internal/executor-gateway/v1/admin/[teamSlug]/policies/route.ts
+++ b/app/api/internal/executor-gateway/v1/admin/[teamSlug]/policies/route.ts
@@ -1,0 +1,47 @@
+import { adminFailure, gatewayAdminContext } from "@/lib/gateway/admin-http";
+import {
+  createGatewayAdminPolicy,
+  listGatewayAdminPolicies,
+} from "@/lib/gateway/admin-persistence";
+import { parseGatewayPolicyInput } from "@/lib/gateway/admin-validation";
+import {
+  gatewayDisabled,
+  gatewayError,
+  gatewayJson,
+  isResponse,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ teamSlug: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const ctx = await gatewayAdminContext((await params).teamSlug);
+  if (isResponse(ctx)) return ctx;
+  try {
+    return gatewayJson({ policies: await listGatewayAdminPolicies(ctx) });
+  } catch (error) {
+    return adminFailure(error);
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ teamSlug: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const ctx = await gatewayAdminContext((await params).teamSlug);
+  if (isResponse(ctx)) return ctx;
+  const body = await readGatewayJson(req);
+  if (isResponse(body)) return body;
+  const input = parseGatewayPolicyInput(body);
+  if (!input) return gatewayError("gateway_invalid_request", 400);
+  try {
+    return gatewayJson(await createGatewayAdminPolicy(ctx, input), 201);
+  } catch (error) {
+    return adminFailure(error, input.correlationId);
+  }
+}

--- a/app/api/internal/executor-gateway/v1/admin/[teamSlug]/service-identities/[serviceIdentityId]/credentials/[credentialId]/revoke/route.ts
+++ b/app/api/internal/executor-gateway/v1/admin/[teamSlug]/service-identities/[serviceIdentityId]/credentials/[credentialId]/revoke/route.ts
@@ -1,0 +1,58 @@
+import { adminFailure, gatewayAdminContext } from "@/lib/gateway/admin-http";
+import { revokeGatewayCredential } from "@/lib/gateway/admin-persistence";
+import {
+  exactObject,
+  gatewayDisabled,
+  gatewayError,
+  gatewayJson,
+  isResponse,
+  isUuid,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+
+export async function POST(
+  req: Request,
+  {
+    params,
+  }: {
+    params: Promise<{
+      teamSlug: string;
+      serviceIdentityId: string;
+      credentialId: string;
+    }>;
+  },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const path = await params;
+  const ctx = await gatewayAdminContext(path.teamSlug);
+  if (isResponse(ctx)) return ctx;
+  if (
+    !isUuid(path.serviceIdentityId) ||
+    !/^[A-Za-z0-9_-]{22}$/.test(path.credentialId)
+  )
+    return gatewayError("gateway_not_found", 404);
+  const body = await readGatewayJson(req);
+  if (
+    isResponse(body) ||
+    !exactObject(body, ["correlationId"]) ||
+    !isUuid(body.correlationId)
+  )
+    return isResponse(body)
+      ? body
+      : gatewayError("gateway_invalid_request", 400);
+  try {
+    await revokeGatewayCredential(
+      ctx,
+      path.serviceIdentityId,
+      path.credentialId,
+      body.correlationId,
+    );
+    return gatewayJson({
+      credentialId: path.credentialId,
+      revoked: true,
+    });
+  } catch (error) {
+    return adminFailure(error, body.correlationId);
+  }
+}

--- a/app/api/internal/executor-gateway/v1/admin/[teamSlug]/service-identities/[serviceIdentityId]/credentials/route.ts
+++ b/app/api/internal/executor-gateway/v1/admin/[teamSlug]/service-identities/[serviceIdentityId]/credentials/route.ts
@@ -1,0 +1,78 @@
+import { adminFailure, gatewayAdminContext } from "@/lib/gateway/admin-http";
+import {
+  listGatewayCredentials,
+  rotateGatewayCredential,
+} from "@/lib/gateway/admin-persistence";
+import {
+  exactObject,
+  gatewayDisabled,
+  gatewayError,
+  gatewayJson,
+  isResponse,
+  isUuid,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ teamSlug: string; serviceIdentityId: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const path = await params;
+  const ctx = await gatewayAdminContext(path.teamSlug);
+  if (isResponse(ctx)) return ctx;
+  if (!isUuid(path.serviceIdentityId))
+    return gatewayError("gateway_not_found", 404);
+  try {
+    return gatewayJson({
+      credentials: await listGatewayCredentials(ctx, path.serviceIdentityId),
+    });
+  } catch (error) {
+    return adminFailure(error);
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ teamSlug: string; serviceIdentityId: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const path = await params;
+  const ctx = await gatewayAdminContext(path.teamSlug);
+  if (isResponse(ctx)) return ctx;
+  if (!isUuid(path.serviceIdentityId))
+    return gatewayError("gateway_not_found", 404);
+  const body = await readGatewayJson(req);
+  if (isResponse(body)) return body;
+  if (
+    !exactObject(
+      body,
+      ["credentialId", "secret", "replacesCredentialId", "correlationId"],
+      ["expiresAt"],
+    ) ||
+    typeof body.credentialId !== "string" ||
+    typeof body.secret !== "string" ||
+    typeof body.replacesCredentialId !== "string" ||
+    !isUuid(body.correlationId) ||
+    (body.expiresAt !== undefined &&
+      (typeof body.expiresAt !== "string" ||
+        !Number.isFinite(Date.parse(body.expiresAt))))
+  )
+    return gatewayError("gateway_invalid_request", 400);
+  try {
+    return gatewayJson(
+      await rotateGatewayCredential(ctx, path.serviceIdentityId, {
+        credentialId: body.credentialId,
+        secret: body.secret,
+        replacesCredentialId: body.replacesCredentialId,
+        correlationId: body.correlationId,
+        ...(body.expiresAt === undefined ? {} : { expiresAt: body.expiresAt }),
+      }),
+      201,
+    );
+  } catch (error) {
+    return adminFailure(error, body.correlationId);
+  }
+}

--- a/app/api/internal/executor-gateway/v1/executions/[executionId]/resume-claim/route.ts
+++ b/app/api/internal/executor-gateway/v1/executions/[executionId]/resume-claim/route.ts
@@ -1,0 +1,150 @@
+import { decryptSecretBytes } from "@/lib/secrets/crypto";
+import { canonicalize } from "@/lib/gateway/canonical";
+import { decryptGatewayRequestEnvelope } from "@/lib/gateway/envelope";
+import {
+  authenticateGatewayRequest,
+  enforceGatewayLimit,
+  exactObject,
+  gatewayDisabled,
+  gatewayError,
+  gatewayJson,
+  isResponse,
+  isUuid,
+  readGatewayJson,
+} from "@/lib/gateway/http";
+import {
+  GATEWAY_TOOLS,
+  gatewayRequestHash,
+  normalizeGatewayArgs,
+} from "@/lib/gateway/normalize";
+import {
+  failGatewayCredentialSealing,
+  GatewayPersistenceError,
+  resumeClaimGatewayExecution,
+} from "@/lib/gateway/persistence";
+import { sealCredential } from "@/lib/gateway/sealed-credential";
+import { GATEWAY_TOOLKIT } from "@/lib/gateway/types";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ executionId: string }> },
+) {
+  const disabled = gatewayDisabled();
+  if (disabled) return disabled;
+  const auth = await authenticateGatewayRequest(req);
+  if (isResponse(auth)) return auth;
+  let correlationId: string | null = null;
+  let executionId = "";
+  try {
+    executionId = (await params).executionId;
+    if (!isUuid(executionId))
+      return gatewayError("gateway_not_found", 404);
+    const limited = await enforceGatewayLimit(`gateway:${auth.id}:resume-claim`, 120);
+    if (limited) return limited;
+    const body = await readGatewayJson(req);
+    if (isResponse(body)) return body;
+    if (
+      !exactObject(body, [
+        "executorTenantId",
+        "executorSubjectId",
+        "toolkit",
+        "tool",
+        "requestHash",
+        "correlationId",
+        "idempotencyKey",
+      ]) ||
+      typeof body.executorTenantId !== "string" ||
+      !body.executorTenantId ||
+      typeof body.executorSubjectId !== "string" ||
+      !body.executorSubjectId ||
+      body.toolkit !== GATEWAY_TOOLKIT ||
+      typeof body.tool !== "string" ||
+      !GATEWAY_TOOLS.some((tool) => tool === body.tool) ||
+      typeof body.requestHash !== "string" ||
+      !/^[0-9a-f]{64}$/.test(body.requestHash) ||
+      !isUuid(body.correlationId) ||
+      typeof body.idempotencyKey !== "string" ||
+      !body.idempotencyKey
+    )
+      return gatewayError("gateway_invalid_request", 400);
+    correlationId = body.correlationId;
+    const result = await resumeClaimGatewayExecution({
+      service: auth,
+      executionId,
+      executorTenantId: body.executorTenantId,
+      executorSubjectId: body.executorSubjectId,
+      toolkit: body.toolkit,
+      tool: body.tool,
+      requestHash: body.requestHash,
+      correlationId,
+      idempotencyKey: body.idempotencyKey,
+      useWinningPayload: async (payload) => {
+        const normalized = decryptGatewayRequestEnvelope<Record<string, unknown>>(
+          payload.encryptedRequestEnvelope,
+          { executionId: payload.executionId, serviceIdentityId: auth.id },
+        );
+        const checked = normalizeGatewayArgs(payload.tool, normalized);
+        if (
+          canonicalize(checked) !== canonicalize(normalized as never) ||
+          gatewayRequestHash(checked) !== payload.requestHash
+        )
+          throw new Error("gateway_envelope_invalid");
+        const plaintext = decryptSecretBytes(payload.credentialCiphertext);
+        try {
+          const sealed = sealCredential({
+            pat: plaintext,
+            serviceSecret: auth.secretBytes,
+            credentialId: auth.credentialId,
+            credentialVersion: auth.credentialVersion,
+            serviceIdentityId: auth.id,
+            executionId: payload.executionId,
+          });
+          return {
+            status: "claimed" as const,
+            executionId: payload.executionId,
+            toolkit: payload.toolkit,
+            tool: payload.tool,
+            normalizedArgs: checked,
+            sealedCredential: sealed.sealedCredential,
+            credentialExpiresAt: payload.credentialExpiresAt,
+          };
+        } finally {
+          plaintext.fill(0);
+        }
+      },
+    });
+    return gatewayJson(
+      result.status === "claimed"
+        ? result.value
+        : {
+            status: "already_claimed",
+            executionId: result.executionId,
+            state: result.state,
+          },
+    );
+  } catch (error) {
+    if (error instanceof GatewayPersistenceError) {
+      const status =
+        error.code === "gateway_not_found"
+          ? 404
+          : error.code === "gateway_approval_expired"
+            ? 410
+            : error.code === "gateway_scope_not_found"
+              ? 422
+              : error.code === "gateway_idempotency_conflict"
+                ? 409
+                : 422;
+      return gatewayError(error.code, status, correlationId);
+    }
+    if (executionId && correlationId) {
+      await failGatewayCredentialSealing({
+        serviceIdentityId: auth.id,
+        executionId,
+        correlationId,
+      }).catch(() => undefined);
+    }
+    return gatewayError("gateway_credential_failure", 500, correlationId);
+  } finally {
+    auth.secretBytes.fill(0);
+  }
+}

--- a/app/t/[team]/admin/approvals/actions.ts
+++ b/app/t/[team]/admin/approvals/actions.ts
@@ -5,6 +5,13 @@ import { adminClient } from "@/lib/db/admin";
 import { requireTeamAdmin as requireAdmin } from "@/lib/auth/guard";
 import { resolveApproval } from "@/lib/actions";
 import { createE2BSandbox } from "@/lib/actions/sandbox/e2b";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  authorizeGatewayAdmin,
+  decideGatewayApproval,
+  GatewayAdminError,
+} from "@/lib/gateway/admin-persistence";
+import { isUuid } from "@/lib/gateway/http";
 
 /**
  * Decide a queued approval (admins only). Approve → `resolveApproval` resumes & runs the action's
@@ -33,5 +40,42 @@ export async function decideApproval(
     return { ok: true, message: `Approved${outcome.actionStatus ? ` — action ${outcome.actionStatus}` : ""}.` };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "could not decide" };
+  }
+}
+
+export async function decideManagedGatewayApproval(
+  teamSlug: string,
+  approvalId: string,
+  decision: "approve" | "deny",
+  correlationId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  if (process.env.AIOS_GATEWAY_INTERNAL_ENABLED !== "true")
+    return { ok: false, error: "approval not found" };
+  if (
+    !isUuid(approvalId) ||
+    !isUuid(correlationId) ||
+    (decision !== "approve" && decision !== "deny")
+  )
+    return { ok: false, error: "invalid request" };
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: "admins only" };
+  try {
+    const ctx = await authorizeGatewayAdmin(teamSlug, user.id);
+    await decideGatewayApproval(
+      ctx,
+      approvalId,
+      decision,
+      correlationId,
+    );
+    revalidatePath(`/t/${teamSlug}/admin/approvals`);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof GatewayAdminError
+          ? error.code
+          : "could not decide",
+    };
   }
 }

--- a/app/t/[team]/admin/approvals/page.tsx
+++ b/app/t/[team]/admin/approvals/page.tsx
@@ -1,5 +1,14 @@
 import { serverClient } from "@/lib/db/server";
 import { ApprovalsQueue, type ApprovalRow, type DecidedRow } from "@/components/admin/approvals-queue";
+import {
+  ManagedGatewayApprovals,
+  type ManagedGatewayApprovalRow,
+} from "@/components/admin/managed-gateway-approvals";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  authorizeGatewayAdmin,
+  listGatewayApprovals,
+} from "@/lib/gateway/admin-persistence";
 
 export default async function ApprovalsAdminPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
@@ -23,6 +32,19 @@ export default async function ApprovalsAdminPage({ params }: { params: Promise<{
     .order("decided_at", { ascending: false })
     .limit(10);
 
+  let managed: ManagedGatewayApprovalRow[] | null = null;
+  if (process.env.AIOS_GATEWAY_INTERNAL_ENABLED === "true") {
+    const user = await getSessionUser();
+    if (user) {
+      try {
+        const ctx = await authorizeGatewayAdmin(teamSlug, user.id);
+        managed = (await listGatewayApprovals(ctx)) as ManagedGatewayApprovalRow[];
+      } catch {
+        managed = null;
+      }
+    }
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <p className="text-sm text-ink-secondary">
@@ -34,6 +56,11 @@ export default async function ApprovalsAdminPage({ params }: { params: Promise<{
         pending={(pending ?? []) as ApprovalRow[]}
         recent={(recent ?? []) as DecidedRow[]}
       />
+      {managed ? (
+        <div className="mt-3 border-t border-border-subtle pt-6">
+          <ManagedGatewayApprovals teamSlug={teamSlug} approvals={managed} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/components/admin/managed-gateway-approvals.tsx
+++ b/components/admin/managed-gateway-approvals.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Check, ShieldCheck, X } from "lucide-react";
+import { decideManagedGatewayApproval } from "@/app/t/[team]/admin/approvals/actions";
+
+export type ManagedGatewayApprovalRow = {
+  approvalId: string;
+  executionId: string;
+  memberId: string;
+  memberName: string;
+  tool: string;
+  resource: string;
+  requestHashPrefix: string;
+  createdAt: string;
+  expiresAt: string;
+  status: string;
+};
+
+function age(createdAt: string): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - Date.parse(createdAt)) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ago`;
+}
+
+export function ManagedGatewayApprovals({
+  teamSlug,
+  approvals,
+}: {
+  teamSlug: string;
+  approvals: ManagedGatewayApprovalRow[];
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function decide(row: ManagedGatewayApprovalRow, decision: "approve" | "deny") {
+    const verb = decision === "approve" ? "Approve" : "Deny";
+    if (!window.confirm(`${verb} ${row.tool} for ${row.memberName}?`)) return;
+    setError(null);
+    setActiveId(row.approvalId);
+    startTransition(async () => {
+      const result = await decideManagedGatewayApproval(
+        teamSlug,
+        row.approvalId,
+        decision,
+        crypto.randomUUID(),
+      );
+      if (!result.ok) setError(result.error ?? "Could not decide approval.");
+      else router.refresh();
+      setActiveId(null);
+    });
+  }
+
+  return (
+    <section aria-labelledby="managed-gateway-heading" className="flex flex-col gap-3">
+      <div className="flex items-start gap-3">
+        <ShieldCheck className="mt-0.5 size-5 text-violet" aria-hidden="true" />
+        <div>
+          <h2 id="managed-gateway-heading" className="text-base font-semibold text-ink">
+            Managed gateway approvals
+          </h2>
+          <p className="text-sm text-ink-secondary">
+            Read-only GitHub requests paused for an administrator. The queue shows only
+            the member, allowlisted repository, request fingerprint prefix, and expiry.
+          </p>
+        </div>
+      </div>
+
+      {approvals.length === 0 ? (
+        <div className="prism-card px-4 py-5 text-sm text-ink-tertiary">
+          No managed gateway requests are waiting.
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {approvals.map((row) => {
+            const pending = isPending && activeId === row.approvalId;
+            return (
+              <article key={row.approvalId} className="prism-card flex flex-col gap-3 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-ink">{row.memberName}</p>
+                    <p className="mt-1 break-all font-mono text-xs text-ink-secondary">
+                      {row.tool} · {row.resource}
+                    </p>
+                  </div>
+                  <span className="rounded-full bg-amber/10 px-2 py-0.5 text-xs font-medium text-amber-700">
+                    Pending
+                  </span>
+                </div>
+                <dl className="grid gap-2 text-xs text-ink-tertiary sm:grid-cols-3">
+                  <div>
+                    <dt className="font-medium text-ink-secondary">Request</dt>
+                    <dd className="font-mono">{row.requestHashPrefix}…</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-ink-secondary">Age</dt>
+                    <dd
+                      suppressHydrationWarning
+                      title={new Date(row.createdAt).toLocaleString()}
+                    >
+                      {age(row.createdAt)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-ink-secondary">Expires</dt>
+                    <dd>{new Date(row.expiresAt).toLocaleString()}</dd>
+                  </div>
+                </dl>
+                <div className="flex flex-wrap justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => decide(row, "deny")}
+                    disabled={isPending}
+                    className="flex items-center gap-1 rounded-lg border border-red/40 bg-red/10 px-3 py-1.5 text-xs font-medium text-red outline-none transition-opacity focus-visible:ring-2 focus-visible:ring-red/40 disabled:opacity-50"
+                  >
+                    <X className="size-3.5" aria-hidden="true" />
+                    {pending ? "Working…" : "Deny"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => decide(row, "approve")}
+                    disabled={isPending}
+                    className="flex items-center gap-1 rounded-lg border border-emerald/40 bg-emerald/10 px-3 py-1.5 text-xs font-medium text-emerald-700 outline-none transition-opacity focus-visible:ring-2 focus-visible:ring-emerald/40 disabled:opacity-50"
+                  >
+                    <Check className="size-3.5" aria-hidden="true" />
+                    {pending ? "Working…" : "Approve"}
+                  </button>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+      {error ? (
+        <p role="alert" className="text-sm text-red">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ portable: plain SQL migrations, Postgres-backed rate limiting, no Vercel-only de
 > ingestion sources) are guarded against drift by `scripts/check-docs-drift.mjs` — see
 > [Docs drift guard](#docs-drift-guard).
 >
-> **Last verified against code: 2026-06-22.** If a flow here disagrees with the code, the
+> **Last verified against code: 2026-07-16.** If a flow here disagrees with the code, the
 > code wins — fix the doc (same PR).
 
 ## Sources of truth
@@ -58,17 +58,21 @@ Reason from this table, not from a random call site.
 
 | State | Store | Sole writer | Readers | Access/retention |
 |---|---|---|---|---|
-| Gateway service credentials and Executor subjects | `gateway_service_identities`, `executor_subject_bindings` | `lib/gateway/persistence.ts` | internal gateway routes | exact team + service + tenant + subject binding; hashed credentials; revoke rather than delete |
+| Gateway service identity, independently rotatable credentials, and Executor subjects | `gateway_service_identities`, `gateway_service_credentials`, `executor_subject_bindings` | `lib/gateway/persistence.ts`; admin mutations in `lib/gateway/admin-persistence.ts` | internal gateway and strict admin-session routes | stable identity remains the binding authority; authentication reads only active credential rows; legacy identity digests are immutable compatibility data; exact team + service + tenant + subject binding; revoke rather than delete |
 | Member GitHub connection, one-use lease, and limiter | `gateway_connections`, `gateway_resolution_leases`, `gateway_rate_limits` | `lib/gateway/persistence.ts` | internal resolver/authorization routes | exact team + member + subject; GitHub-only; opaque refs; lease hashes only; 30-second maximum TTL; single transactional consumption; fail-closed DB-time buckets |
-| Durable request, approval, and claim state | `gateway_executions`, `gateway_approvals` | `lib/gateway/persistence.ts` | later authorization/resume routes only | encrypted request envelope (64 KiB sealed maximum); retained identity/request fields; 15-minute maximum approval TTL; exclusive row-lock claim |
-| Strict gateway compliance audit | `gateway_audit_log` | `lib/gateway/persistence.ts` in the same transaction as authorization state | admin compliance surfaces in later slices | append-only trigger; fixed non-secret columns only; no JSON escape hatch; team deletion is restricted while retained records exist |
+| Durable request, approval, and claim state | `gateway_executions`, `gateway_approvals` | `lib/gateway/persistence.ts`; decisions in `lib/gateway/admin-persistence.ts` | resume route and managed Approvals admin section | encrypted request envelope plus immutable hash/principal/resource snapshots; 15-minute maximum approval TTL; database-time expiry; credential-scoped advisory lock remains held from committed winning claim through the one request-local decrypt/seal callback |
+| Strict gateway compliance audit | `gateway_audit_log` | `lib/gateway/persistence.ts` and `lib/gateway/admin-persistence.ts`, in the same transaction as state | managed admin routes and compliance review | append-only trigger; partial uniqueness for decision/claim/expiry/rotation/revocation/settlement; fixed non-secret columns only; no JSON escape hatch; team deletion is restricted while retained records exist |
 
-The gateway writer guard is `node scripts/check-gateway-writers.mjs`. The persistence owner uses a
+The gateway writer guard is `node scripts/check-gateway-writers.mjs`. Its only approved owners are
+`lib/gateway/persistence.ts` and the narrowly scoped `lib/gateway/admin-persistence.ts`. They use a
 dedicated pooled transaction for every lease/decision/approval/claim transition. A failed audit
 insert rolls back the state transition. Cross-team, cross-member, and cross-subject lookups return
 the same typed not-found/denied class before any credential lookup. Request envelopes use
 AES-256-GCM with execution/service identity as authenticated additional data; wrong keys, tampering,
 or binding changes produce the same typed fail-closed error and never fall back to plaintext.
+Credential rotation accepts client-generated material, stores only its digest, never returns the
+secret, and leaves both versions independently active until expiry or explicit revocation. Claim
+and revocation take the same credential-scoped PostgreSQL advisory lock.
 
 Operational rows are revoked, not deleted. `gateway_audit_log`, `gateway_executions`, and
 `gateway_approvals` are retained compliance history; UPDATE/DELETE triggers protect their immutable
@@ -620,6 +624,16 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `POST /api/internal/executor-gateway/v1/resolve-lease` — service-authenticated, version-pinned, one-use 30-second credential-resolution lease
 - `POST /api/internal/executor-gateway/v1/authorize-and-redeem` — exact-call policy decision and post-audit request-local PAT sealing
 - `POST /api/internal/executor-gateway/v1/record-outcome` — idempotent execution settlement with one immutable outcome audit
+- `POST /api/internal/executor-gateway/v1/executions/:executionId/resume-claim` — service-authenticated, idempotent approved-execution claim; only the committed winner receives normalized arguments and a credential sealed to the authenticating credential row
+- `GET /api/internal/executor-gateway/v1/admin/:teamSlug/approvals` — strict same-team admin-session managed gateway queue
+- `POST /api/internal/executor-gateway/v1/admin/:teamSlug/approvals/:approvalId/decision` — database-time approve/deny transition with strict audit
+- `GET /api/internal/executor-gateway/v1/admin/:teamSlug/policies` — list gateway-prefixed policy rules
+- `POST /api/internal/executor-gateway/v1/admin/:teamSlug/policies` — create a tagged-subject gateway policy
+- `PATCH /api/internal/executor-gateway/v1/admin/:teamSlug/policies/:policyId` — update a same-team gateway policy
+- `DELETE /api/internal/executor-gateway/v1/admin/:teamSlug/policies/:policyId` — delete a same-team gateway policy
+- `GET /api/internal/executor-gateway/v1/admin/:teamSlug/service-identities/:serviceIdentityId/credentials` — list non-secret credential metadata
+- `POST /api/internal/executor-gateway/v1/admin/:teamSlug/service-identities/:serviceIdentityId/credentials` — add a client-generated overlapping credential without returning its secret
+- `POST /api/internal/executor-gateway/v1/admin/:teamSlug/service-identities/:serviceIdentityId/credentials/:credentialId/revoke` — advisory-lock-linearized credential revocation
 - `POST /api/v1/items` — upsert synced content
 - `GET /api/v1/items` — tier-filtered, keyset-paginated pull
 - `GET /api/v1/items/:id` — single item fetch
@@ -671,7 +685,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 <!-- drift:tables -->
 
 `auth_users` · `auth_tokens` · `oauth_states` · `teams` · `members` · `api_keys` · `audit_log` ·
-`gateway_service_identities` · `executor_subject_bindings` · `gateway_connections` · `gateway_resolution_leases` ·
+`gateway_service_identities` · `gateway_service_credentials` · `executor_subject_bindings` · `gateway_connections` · `gateway_resolution_leases` ·
 `gateway_executions` · `gateway_approvals` · `gateway_audit_log` · `gateway_rate_limits` · `rate_limits` ·
 `projects` · `items` · `item_versions` · `tasks` · `decisions` · `graph_entities` ·
 `graph_relationships` · `query_log` · `policies` · `approval_requests` · `actions` ·

--- a/lib/gateway/admin-http.ts
+++ b/lib/gateway/admin-http.ts
@@ -1,0 +1,27 @@
+import "server-only";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  authorizeGatewayAdmin,
+  GatewayAdminError,
+  type GatewayAdminContext,
+} from "./admin-persistence";
+import { gatewayError } from "./http";
+
+export async function gatewayAdminContext(
+  teamSlug: string,
+): Promise<GatewayAdminContext | Response> {
+  const user = await getSessionUser();
+  if (!user) return gatewayError("gateway_unauthorized", 401);
+  try {
+    return await authorizeGatewayAdmin(teamSlug, user.id);
+  } catch (error) {
+    return error instanceof GatewayAdminError
+      ? gatewayError(error.code, error.status)
+      : gatewayError("gateway_internal", 500);
+  }
+}
+
+export const adminFailure = (error: unknown, correlationId: string | null = null) =>
+  error instanceof GatewayAdminError
+    ? gatewayError(error.code, error.status, correlationId)
+    : gatewayError("gateway_internal", 500, correlationId);

--- a/lib/gateway/admin-persistence.ts
+++ b/lib/gateway/admin-persistence.ts
@@ -1,0 +1,515 @@
+import "server-only";
+import { createHash, randomUUID } from "node:crypto";
+import { getPool } from "@/lib/db/pg/pool";
+import { withTransaction } from "@/lib/db/pg/tx";
+import { GATEWAY_TOOLS, normalizeGatewayArgs } from "./normalize";
+
+const sha256 = (value: Buffer) => createHash("sha256").update(value).digest("hex");
+
+export class GatewayAdminError extends Error {
+  constructor(
+    readonly code:
+      | "gateway_forbidden"
+      | "gateway_not_found"
+      | "gateway_scope_not_found"
+      | "gateway_approval_expired"
+      | "gateway_idempotency_conflict"
+      | "gateway_invalid_request",
+    readonly status: number,
+  ) {
+    super(code);
+    this.name = "GatewayAdminError";
+  }
+}
+
+export type GatewayAdminContext = {
+  teamId: string;
+  teamSlug: string;
+  memberId: string;
+};
+
+export async function authorizeGatewayAdmin(
+  teamSlug: string,
+  authUserId: string,
+): Promise<GatewayAdminContext> {
+  return withTransaction(async (client) => {
+    const team = await client.query<{ id: string }>(
+      `select id from teams where slug=$1`,
+      [teamSlug],
+    );
+    if (!team.rows[0]) throw new GatewayAdminError("gateway_not_found", 404);
+    const member = await client.query<{
+      id: string;
+      role: string;
+      tier: string;
+      status: string;
+    }>(
+      `select id,role::text,tier::text,status::text
+         from members where team_id=$1 and auth_user_id=$2`,
+      [team.rows[0].id, authUserId],
+    );
+    const row = member.rows[0];
+    if (!row) throw new GatewayAdminError("gateway_not_found", 404);
+    if (row.status !== "active" || row.tier !== "team")
+      throw new GatewayAdminError("gateway_scope_not_found", 422);
+    if (row.role !== "admin")
+      throw new GatewayAdminError("gateway_forbidden", 403);
+    return { teamId: team.rows[0].id, teamSlug, memberId: row.id };
+  });
+}
+
+async function expireGatewayApprovals(
+  client: import("pg").PoolClient,
+  ctx: GatewayAdminContext,
+  correlationId: string,
+) {
+  const expired = await client.query<{
+    id: string;
+    execution_id: string;
+    member_id: string;
+    service_identity_id: string;
+    subject_binding_id: string;
+    connection_id: string;
+  }>(
+    `with due as (
+       select a.id,a.execution_id,e.member_id,e.service_identity_id,
+              e.subject_binding_id,e.connection_id
+         from gateway_approvals a
+         join gateway_executions e on e.id=a.execution_id and e.team_id=a.team_id
+        where a.team_id=$1 and a.status in ('pending','approved') and a.expires_at<=now()
+        for update of a,e
+     ), approvals as (
+       update gateway_approvals a
+          set status='expired',decided_at=coalesce(a.decided_at,now()),
+              decision_correlation_id=coalesce(a.decision_correlation_id,$2),updated_at=now()
+         from due where a.id=due.id
+       returning due.*
+     )
+     update gateway_executions e set state='expired',updated_at=now()
+       from approvals a where e.id=a.execution_id
+     returning a.*`,
+    [ctx.teamId, correlationId],
+  );
+  for (const row of expired.rows) {
+    await client.query(
+      `insert into gateway_audit_log(
+         team_id,member_id,service_identity_id,subject_binding_id,connection_id,
+         execution_id,approval_id,event,correlation_id
+       ) values($1,$2,$3,$4,$5,$6,$7,'approval_expired',$8)
+       on conflict do nothing`,
+      [ctx.teamId,row.member_id,row.service_identity_id,row.subject_binding_id,
+       row.connection_id,row.execution_id,row.id,correlationId],
+    );
+  }
+}
+
+export async function listGatewayApprovals(ctx: GatewayAdminContext) {
+  return withTransaction(async (client) => {
+    await expireGatewayApprovals(client, ctx, randomUUID());
+    const result = await client.query(
+      `select a.id "approvalId",e.id "executionId",m.id "memberId",
+              coalesce(nullif(m.display_name,''),m.actor_handle) "memberName",
+              e.tool,e.policy_resource resource,left(e.request_hash,12) "requestHashPrefix",
+              e.created_at "createdAt",a.expires_at "expiresAt",a.status
+         from gateway_approvals a
+         join gateway_executions e on e.id=a.execution_id and e.team_id=a.team_id
+         join members m on m.id=e.member_id and m.team_id=e.team_id
+        where a.team_id=$1 and a.status='pending'
+        order by e.created_at asc`,
+      [ctx.teamId],
+    );
+    return result.rows;
+  });
+}
+
+export async function decideGatewayApproval(
+  ctx: GatewayAdminContext,
+  approvalId: string,
+  decision: "approve" | "deny",
+  correlationId: string,
+) {
+  const outcome = await withTransaction(async (client) => {
+    const found = await client.query<{
+      execution_id: string;
+      status: string;
+      expired: boolean;
+      member_id: string;
+      service_identity_id: string;
+      subject_binding_id: string;
+      connection_id: string;
+    }>(
+      `select a.execution_id,a.status,(a.expires_at<=now()) expired,
+              e.member_id,e.service_identity_id,e.subject_binding_id,e.connection_id
+         from gateway_approvals a
+         join gateway_executions e on e.id=a.execution_id and e.team_id=a.team_id
+        where a.id=$1 and a.team_id=$2 for update of a,e`,
+      [approvalId, ctx.teamId],
+    );
+    const row = found.rows[0];
+    if (!row) throw new GatewayAdminError("gateway_not_found", 404);
+    if (row.expired) {
+      await client.query(
+        `update gateway_approvals set status='expired',decided_at=coalesce(decided_at,now()),
+           decision_correlation_id=coalesce(decision_correlation_id,$1),updated_at=now()
+         where id=$2`,
+        [correlationId, approvalId],
+      );
+      await client.query(
+        `update gateway_executions set state='expired',updated_at=now() where id=$1`,
+        [row.execution_id],
+      );
+      await client.query(
+        `insert into gateway_audit_log(
+          team_id,member_id,service_identity_id,subject_binding_id,connection_id,
+          execution_id,approval_id,event,correlation_id
+        ) values($1,$2,$3,$4,$5,$6,$7,'approval_expired',$8)
+        on conflict do nothing`,
+        [ctx.teamId,row.member_id,row.service_identity_id,row.subject_binding_id,
+         row.connection_id,row.execution_id,approvalId,correlationId],
+      );
+      return { expired: true as const };
+    }
+    if (row.status !== "pending")
+      throw new GatewayAdminError("gateway_idempotency_conflict", 409);
+    const status = decision === "approve" ? "approved" : "denied";
+    const state = decision === "approve" ? "approved" : "cancelled";
+    await client.query(
+      `update gateway_approvals set status=$1,approver_member_id=$2,decided_at=now(),
+       decision_correlation_id=$3,updated_at=now() where id=$4`,
+      [status, ctx.memberId, correlationId, approvalId],
+    );
+    await client.query(
+      `update gateway_executions set state=$1,updated_at=now() where id=$2`,
+      [state, row.execution_id],
+    );
+    const inserted = await client.query<{ decided_at: string }>(
+      `insert into gateway_audit_log(
+         team_id,member_id,service_identity_id,subject_binding_id,connection_id,
+         execution_id,approval_id,event,correlation_id
+       ) values($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       returning created_at decided_at`,
+      [ctx.teamId,row.member_id,row.service_identity_id,row.subject_binding_id,
+       row.connection_id,row.execution_id,approvalId,
+       decision === "approve" ? "approval_approved" : "approval_denied",correlationId],
+    );
+    return {
+      expired: false as const,
+      approvalId,
+      executionId: row.execution_id,
+      status,
+      decidedAt: inserted.rows[0].decided_at,
+    };
+  });
+  if (outcome.expired)
+    throw new GatewayAdminError("gateway_approval_expired", 410);
+  return {
+    approvalId: outcome.approvalId,
+    executionId: outcome.executionId,
+    status: outcome.status,
+    decidedAt: outcome.decidedAt,
+  };
+}
+
+export type GatewayPolicyInput = {
+  subject:
+    | { type: "actor"; memberId: string }
+    | { type: "role"; role: "admin" | "lead" | "member" }
+    | { type: "tier"; tier: "team" | "external" }
+    | { type: "team" };
+  tool: string;
+  resource: string;
+  effect: "block" | "require_approval" | "allow";
+  priority: number;
+  enabled: boolean;
+  correlationId: string;
+};
+
+function validatePolicy(input: GatewayPolicyInput) {
+  if (
+    !Number.isInteger(input.priority) ||
+    input.priority < -2_147_483_648 ||
+    input.priority > 2_147_483_647 ||
+    (input.tool !== "*" && !GATEWAY_TOOLS.some((tool) => tool === input.tool)) ||
+    !["block", "require_approval", "allow"].includes(input.effect)
+  )
+    throw new GatewayAdminError("gateway_invalid_request", 400);
+  if (input.resource === "github.repository:*") return;
+  const resource = /^github\.repository:([^/]+)\/(.+)$/.exec(input.resource);
+  if (!resource) throw new GatewayAdminError("gateway_invalid_request", 400);
+  try {
+    const normalized = normalizeGatewayArgs("github.repository.get", {
+      owner: resource[1],
+      repo: resource[2],
+    });
+    if (
+      `github.repository:${normalized.owner}/${normalized.repo}` !== input.resource
+    )
+      throw new Error("not canonical");
+  } catch {
+    throw new GatewayAdminError("gateway_invalid_request", 400);
+  }
+}
+
+async function policyColumns(
+  client: import("pg").PoolClient,
+  ctx: GatewayAdminContext,
+  input: GatewayPolicyInput,
+) {
+  validatePolicy(input);
+  let actor: string | null = null;
+  if (input.subject.type === "actor") {
+    const member = await client.query<{ actor_handle: string }>(
+      `select actor_handle from members where id=$1 and team_id=$2`,
+      [input.subject.memberId, ctx.teamId],
+    );
+    if (!member.rows[0]) throw new GatewayAdminError("gateway_not_found", 404);
+    actor = member.rows[0].actor_handle;
+  }
+  return {
+    actor,
+    role: input.subject.type === "role" ? input.subject.role : null,
+    tier: input.subject.type === "tier" ? input.subject.tier : null,
+    action: `gateway.aios-github-readonly.${input.tool}`,
+    effect: input.effect === "block" ? "deny" : input.effect,
+  };
+}
+
+const gatewayPolicySelect = `select id,priority,subject_role::text "subjectRole",
+  subject_tier::text "subjectTier",subject_actor "subjectActor",
+  replace(action,'gateway.aios-github-readonly.','') tool,resource,
+  case when effect='deny' then 'block' else effect::text end effect,
+  enabled,created_at "createdAt",updated_at "updatedAt"
+  from policies`;
+
+export async function listGatewayAdminPolicies(ctx: GatewayAdminContext) {
+  return withTransaction(async (client) => (
+    await client.query(
+      `${gatewayPolicySelect} where team_id=$1
+        and action like 'gateway.aios-github-readonly.%' order by priority desc,id`,
+      [ctx.teamId],
+    )
+  ).rows);
+}
+
+export async function createGatewayAdminPolicy(
+  ctx: GatewayAdminContext,
+  input: GatewayPolicyInput,
+) {
+  return withTransaction(async (client) => {
+    const cols = await policyColumns(client, ctx, input);
+    const result = await client.query(
+      `insert into policies(team_id,priority,subject_role,subject_tier,subject_actor,
+        action,resource,effect,enabled,created_by)
+       values($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) returning id`,
+      [ctx.teamId,input.priority,cols.role,cols.tier,cols.actor,cols.action,
+      input.resource,cols.effect,input.enabled,ctx.memberId],
+    );
+    await client.query(
+      `insert into gateway_audit_log(
+         team_id,member_id,event,policy_rule_id,correlation_id
+       ) values($1,$2,'policy_created',$3,$4)`,
+      [ctx.teamId,ctx.memberId,result.rows[0].id,input.correlationId],
+    );
+    return (await client.query(
+      `${gatewayPolicySelect} where id=$1 and team_id=$2`,
+      [result.rows[0].id, ctx.teamId],
+    )).rows[0];
+  });
+}
+
+export async function updateGatewayAdminPolicy(
+  ctx: GatewayAdminContext,
+  policyId: string,
+  input: GatewayPolicyInput,
+) {
+  return withTransaction(async (client) => {
+    const cols = await policyColumns(client, ctx, input);
+    const changed = await client.query(
+      `update policies set priority=$1,subject_role=$2,subject_tier=$3,
+         subject_actor=$4,action=$5,resource=$6,effect=$7,enabled=$8,updated_at=now()
+       where id=$9 and team_id=$10 and action like 'gateway.aios-github-readonly.%'
+       returning id`,
+      [input.priority,cols.role,cols.tier,cols.actor,cols.action,input.resource,
+       cols.effect,input.enabled,policyId,ctx.teamId],
+    );
+    if (!changed.rows[0]) throw new GatewayAdminError("gateway_not_found", 404);
+    await client.query(
+      `insert into gateway_audit_log(
+         team_id,member_id,event,policy_rule_id,correlation_id
+       ) values($1,$2,'policy_updated',$3,$4)`,
+      [ctx.teamId,ctx.memberId,policyId,input.correlationId],
+    );
+    return (await client.query(
+      `${gatewayPolicySelect} where id=$1 and team_id=$2`,
+      [policyId, ctx.teamId],
+    )).rows[0];
+  });
+}
+
+export async function deleteGatewayAdminPolicy(
+  ctx: GatewayAdminContext,
+  policyId: string,
+  correlationId: string,
+) {
+  return withTransaction(async (client) => {
+    const deleted = await client.query(
+      `delete from policies where id=$1 and team_id=$2
+        and action like 'gateway.aios-github-readonly.%' returning id`,
+      [policyId, ctx.teamId],
+    );
+    if (!deleted.rows[0]) throw new GatewayAdminError("gateway_not_found", 404);
+    await client.query(
+      `insert into gateway_audit_log(
+         team_id,member_id,event,policy_rule_id,correlation_id
+       ) values($1,$2,'policy_deleted',$3,$4)`,
+      [ctx.teamId,ctx.memberId,policyId,correlationId],
+    );
+  });
+}
+
+export async function listGatewayCredentials(
+  ctx: GatewayAdminContext,
+  serviceIdentityId: string,
+) {
+  return withTransaction(async (client) => {
+    const identity = await client.query(
+      `select id from gateway_service_identities where id=$1 and team_id=$2`,
+      [serviceIdentityId, ctx.teamId],
+    );
+    if (!identity.rows[0]) throw new GatewayAdminError("gateway_not_found", 404);
+    return (await client.query(
+      `select credential_id "credentialId",version,created_at "createdAt",
+              expires_at "expiresAt",revoked_at "revokedAt",
+              replaces_credential_id "replacesCredentialId"
+         from gateway_service_credentials
+        where service_identity_id=$1 and team_id=$2 order by version desc`,
+      [serviceIdentityId, ctx.teamId],
+    )).rows;
+  });
+}
+
+function decodeCredential(credentialId: string, secret: string) {
+  if (!/^[A-Za-z0-9_-]{22}$/.test(credentialId) || !/^[A-Za-z0-9_-]{43}$/.test(secret))
+    throw new GatewayAdminError("gateway_invalid_request", 400);
+  const id = Buffer.from(credentialId, "base64url");
+  const bytes = Buffer.from(secret, "base64url");
+  try {
+    if (id.length !== 16 || id.toString("base64url") !== credentialId ||
+        bytes.length !== 32 || bytes.toString("base64url") !== secret)
+      throw new GatewayAdminError("gateway_invalid_request", 400);
+    return bytes;
+  } catch (error) {
+    bytes.fill(0);
+    throw error;
+  } finally {
+    id.fill(0);
+  }
+}
+
+export async function rotateGatewayCredential(
+  ctx: GatewayAdminContext,
+  serviceIdentityId: string,
+  input: {
+    credentialId: string;
+    secret: string;
+    replacesCredentialId: string;
+    correlationId: string;
+    expiresAt?: string;
+  },
+) {
+  const replacementBytes = Buffer.from(input.replacesCredentialId, "base64url");
+  if (
+    input.credentialId === input.replacesCredentialId ||
+    !/^[A-Za-z0-9_-]{22}$/.test(input.replacesCredentialId) ||
+    replacementBytes.length !== 16 ||
+    replacementBytes.toString("base64url") !== input.replacesCredentialId
+  ) {
+    replacementBytes.fill(0);
+    throw new GatewayAdminError("gateway_invalid_request", 400);
+  }
+  replacementBytes.fill(0);
+  const bytes = decodeCredential(input.credentialId, input.secret);
+  try {
+    return await withTransaction(async (client) => {
+      await client.query(
+        `select pg_advisory_xact_lock(hashtextextended($1,408))`,
+        [serviceIdentityId],
+      );
+      if (input.expiresAt) {
+        const expiry = await client.query<{ valid: boolean }>(
+          `select $1::timestamptz>now() valid`,
+          [input.expiresAt],
+        );
+        if (!expiry.rows[0].valid)
+          throw new GatewayAdminError("gateway_invalid_request", 400);
+      }
+      const prior = await client.query(
+        `select id from gateway_service_credentials
+          where service_identity_id=$1 and team_id=$2 and credential_id=$3 for update`,
+        [serviceIdentityId, ctx.teamId, input.replacesCredentialId],
+      );
+      if (!prior.rows[0]) throw new GatewayAdminError("gateway_not_found", 404);
+      const version = await client.query<{ next: number }>(
+        `select coalesce(max(version),0)::int+1 next
+           from gateway_service_credentials
+          where service_identity_id=$1 and team_id=$2`,
+        [serviceIdentityId, ctx.teamId],
+      );
+      const inserted = await client.query<{ id: string }>(
+        `insert into gateway_service_credentials(
+           team_id,service_identity_id,credential_id,version,secret_hash,
+           replaces_credential_id,expires_at,created_by_member_id
+         ) values($1,$2,$3,$4,$5,$6,$7,$8) returning id`,
+        [ctx.teamId,serviceIdentityId,input.credentialId,version.rows[0].next,
+         sha256(bytes),input.replacesCredentialId,input.expiresAt ?? null,ctx.memberId],
+      );
+      await client.query(
+        `insert into gateway_audit_log(team_id,service_identity_id,credential_row_id,
+          event,correlation_id) values($1,$2,$3,'credential_rotated',$4)`,
+        [ctx.teamId,serviceIdentityId,inserted.rows[0].id,input.correlationId],
+      );
+      return (await client.query(
+        `select credential_id "credentialId",version,created_at "createdAt",
+                expires_at "expiresAt",revoked_at "revokedAt",
+                replaces_credential_id "replacesCredentialId"
+           from gateway_service_credentials where id=$1`,
+        [inserted.rows[0].id],
+      )).rows[0];
+    });
+  } finally {
+    bytes.fill(0);
+  }
+}
+
+export async function revokeGatewayCredential(
+  ctx: GatewayAdminContext,
+  serviceIdentityId: string,
+  credentialId: string,
+  correlationId: string,
+) {
+  const client = await getPool().connect();
+  try {
+    await client.query(`select pg_advisory_lock(hashtextextended($1,407))`, [credentialId]);
+    await client.query("BEGIN");
+    const revoked = await client.query<{ id: string }>(
+      `update gateway_service_credentials set revoked_at=coalesce(revoked_at,now())
+        where credential_id=$1 and service_identity_id=$2 and team_id=$3
+        returning id`,
+      [credentialId, serviceIdentityId, ctx.teamId],
+    );
+    if (!revoked.rows[0]) throw new GatewayAdminError("gateway_not_found", 404);
+    await client.query(
+      `insert into gateway_audit_log(team_id,service_identity_id,credential_row_id,
+       event,correlation_id) values($1,$2,$3,'credential_revoked',$4)
+       on conflict do nothing`,
+      [ctx.teamId,serviceIdentityId,revoked.rows[0].id,correlationId],
+    );
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    await client.query(`select pg_advisory_unlock(hashtextextended($1,407))`, [credentialId]).catch(() => undefined);
+    client.release();
+  }
+}

--- a/lib/gateway/admin-validation.ts
+++ b/lib/gateway/admin-validation.ts
@@ -1,0 +1,62 @@
+import type { GatewayPolicyInput } from "./admin-persistence";
+import { exactObject, isUuid } from "./http";
+
+export function parseGatewayPolicyInput(value: unknown): GatewayPolicyInput | null {
+  if (
+    !exactObject(value, [
+      "subject",
+      "tool",
+      "resource",
+      "effect",
+      "priority",
+      "enabled",
+      "correlationId",
+    ]) ||
+    typeof value.tool !== "string" ||
+    typeof value.resource !== "string" ||
+    !["block", "require_approval", "allow"].includes(String(value.effect)) ||
+    !Number.isInteger(value.priority) ||
+    typeof value.enabled !== "boolean" ||
+    !isUuid(value.correlationId)
+  )
+    return null;
+  const subject = value.subject;
+  if (!subject || typeof subject !== "object" || Array.isArray(subject)) return null;
+  const record = subject as Record<string, unknown>;
+  let parsed: GatewayPolicyInput["subject"];
+  if (record.type === "team" && exactObject(record, ["type"])) {
+    parsed = { type: "team" };
+  } else if (
+    record.type === "actor" &&
+    exactObject(record, ["type", "memberId"]) &&
+    isUuid(record.memberId)
+  ) {
+    parsed = { type: "actor", memberId: record.memberId };
+  } else if (
+    record.type === "role" &&
+    exactObject(record, ["type", "role"]) &&
+    ["admin", "lead", "member"].includes(String(record.role))
+  ) {
+    parsed = {
+      type: "role",
+      role: record.role as "admin" | "lead" | "member",
+    };
+  } else if (
+    record.type === "tier" &&
+    exactObject(record, ["type", "tier"]) &&
+    ["team", "external"].includes(String(record.tier))
+  ) {
+    parsed = { type: "tier", tier: record.tier as "team" | "external" };
+  } else {
+    return null;
+  }
+  return {
+    subject: parsed,
+    tool: value.tool,
+    resource: value.resource,
+    effect: value.effect as GatewayPolicyInput["effect"],
+    priority: value.priority as number,
+    enabled: value.enabled,
+    correlationId: value.correlationId,
+  };
+}

--- a/lib/gateway/envelope.ts
+++ b/lib/gateway/envelope.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 import { GATEWAY_ENVELOPE_MAX_BYTES } from "./types";
+import { canonicalize } from "./canonical";
 
 const VERSION = 1;
 const IV_BYTES = 12;
@@ -25,55 +26,103 @@ function envelopeKey(raw = process.env.GATEWAY_REQUEST_ENVELOPE_KEY): Buffer {
   const key = /^[0-9a-fA-F]{64}$/.test(trimmed)
     ? Buffer.from(trimmed, "hex")
     : Buffer.from(trimmed, "base64");
-  if (key.length !== 32) throw new GatewayEnvelopeError("gateway_envelope_key_invalid");
+  if (key.length !== 32) {
+    key.fill(0);
+    throw new GatewayEnvelopeError("gateway_envelope_key_invalid");
+  }
   return key;
 }
 
-function aad(executionId: string, serviceIdentityId: string): Buffer {
+function legacyAad(executionId: string, serviceIdentityId: string): Buffer {
   return Buffer.from(`gateway-request-envelope:v1:${executionId}:${serviceIdentityId}`, "utf8");
+}
+
+function aad(executionId: string): Buffer {
+  return Buffer.from(`aios-gateway-request-envelope:v1\0${executionId}`, "utf8");
 }
 
 export function encryptGatewayRequestEnvelope(
   normalizedArgs: unknown,
   binding: { executionId: string; serviceIdentityId: string },
-  key: Buffer = envelopeKey()
+  key?: Buffer,
+  fixedNonce?: Buffer,
 ): Buffer {
-  const plaintext = Buffer.from(JSON.stringify(normalizedArgs), "utf8");
-  if (plaintext.length + OVERHEAD_BYTES > GATEWAY_ENVELOPE_MAX_BYTES) {
-    throw new GatewayEnvelopeError("gateway_envelope_too_large");
+  const plaintext = Buffer.from(canonicalize(normalizedArgs as never), "utf8");
+  const resolvedKey = key ?? envelopeKey();
+  try {
+    const iv = fixedNonce ?? randomBytes(IV_BYTES);
+    if (iv.length !== IV_BYTES)
+      throw new GatewayEnvelopeError("gateway_envelope_invalid");
+    const cipher = createCipheriv("aes-256-gcm", resolvedKey, iv);
+    cipher.setAAD(aad(binding.executionId));
+    const ciphertextAndTag = Buffer.concat([
+      cipher.update(plaintext),
+      cipher.final(),
+      cipher.getAuthTag(),
+    ]);
+    const wire = Buffer.from(
+      `v1.${iv.toString("base64url")}.${ciphertextAndTag.toString("base64url")}`,
+      "ascii",
+    );
+    if (wire.length > GATEWAY_ENVELOPE_MAX_BYTES)
+      throw new GatewayEnvelopeError("gateway_envelope_too_large");
+    return wire;
+  } finally {
+    plaintext.fill(0);
+    if (!key) resolvedKey.fill(0);
   }
-  const iv = randomBytes(IV_BYTES);
-  const cipher = createCipheriv("aes-256-gcm", key, iv);
-  cipher.setAAD(aad(binding.executionId, binding.serviceIdentityId));
-  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
-  return Buffer.concat([Buffer.from([VERSION]), iv, cipher.getAuthTag(), ciphertext]);
 }
 
 export function decryptGatewayRequestEnvelope<T = unknown>(
   envelope: Buffer,
   binding: { executionId: string; serviceIdentityId: string },
-  key: Buffer = envelopeKey()
+  key?: Buffer,
 ): T {
+  const resolvedKey = key ?? envelopeKey();
+  let plaintext: Buffer | null = null;
   try {
-    if (
-      envelope.length < OVERHEAD_BYTES ||
-      envelope.length > GATEWAY_ENVELOPE_MAX_BYTES ||
-      envelope[0] !== VERSION
-    ) {
+    if (envelope.length > GATEWAY_ENVELOPE_MAX_BYTES) {
       throw new Error("malformed");
     }
-    const iv = envelope.subarray(1, 1 + IV_BYTES);
-    const tag = envelope.subarray(1 + IV_BYTES, OVERHEAD_BYTES);
-    const ciphertext = envelope.subarray(OVERHEAD_BYTES);
-    const decipher = createDecipheriv("aes-256-gcm", key, iv);
-    decipher.setAAD(aad(binding.executionId, binding.serviceIdentityId));
+    let iv: Buffer;
+    let tag: Buffer;
+    let ciphertext: Buffer;
+    let authenticatedData: Buffer;
+    if (envelope[0] === VERSION) {
+      if (envelope.length < OVERHEAD_BYTES) throw new Error("malformed");
+      iv = envelope.subarray(1, 1 + IV_BYTES);
+      tag = envelope.subarray(1 + IV_BYTES, OVERHEAD_BYTES);
+      ciphertext = envelope.subarray(OVERHEAD_BYTES);
+      authenticatedData = legacyAad(binding.executionId, binding.serviceIdentityId);
+    } else {
+      const parts = envelope.toString("ascii").split(".");
+      if (parts.length !== 3 || parts[0] !== "v1" || !parts[1] || !parts[2])
+        throw new Error("malformed");
+      iv = Buffer.from(parts[1], "base64url");
+      const payload = Buffer.from(parts[2], "base64url");
+      if (
+        iv.length !== IV_BYTES ||
+        payload.length < TAG_BYTES ||
+        iv.toString("base64url") !== parts[1] ||
+        payload.toString("base64url") !== parts[2]
+      )
+        throw new Error("malformed");
+      tag = payload.subarray(-TAG_BYTES);
+      ciphertext = payload.subarray(0, -TAG_BYTES);
+      authenticatedData = aad(binding.executionId);
+    }
+    const decipher = createDecipheriv("aes-256-gcm", resolvedKey, iv);
+    decipher.setAAD(authenticatedData);
     decipher.setAuthTag(tag);
-    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
     return JSON.parse(plaintext.toString("utf8")) as T;
   } catch (error) {
     if (error instanceof GatewayEnvelopeError && error.code === "gateway_envelope_key_invalid") {
       throw error;
     }
     throw new GatewayEnvelopeError("gateway_envelope_invalid");
+  } finally {
+    plaintext?.fill(0);
+    if (!key) resolvedKey.fill(0);
   }
 }

--- a/lib/gateway/http.ts
+++ b/lib/gateway/http.ts
@@ -11,6 +11,7 @@ import {
 export const GATEWAY_MAX_RAW_BODY_BYTES = 65_536;
 const messages: Record<string, string> = {
   gateway_unauthorized: "Unauthorized",
+  gateway_forbidden: "Forbidden",
   gateway_version_mismatch: "Gateway version mismatch",
   gateway_invalid_request: "Invalid request",
   gateway_payload_too_large: "Request body too large",
@@ -18,6 +19,7 @@ const messages: Record<string, string> = {
   gateway_rate_limited: "Rate limit exceeded",
   gateway_not_found: "Not found",
   gateway_scope_not_found: "Gateway scope not found",
+  gateway_approval_expired: "Approval expired",
   gateway_lease_invalid: "Invalid lease",
   gateway_policy_stale: "Gateway policy changed",
   gateway_allow_already_committed: "Allow already committed",

--- a/lib/gateway/persistence.ts
+++ b/lib/gateway/persistence.ts
@@ -1,7 +1,9 @@
 import "server-only";
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import type { PoolClient } from "pg";
+import { getPool } from "@/lib/db/pg/pool";
 import { withTransaction } from "@/lib/db/pg/tx";
+import { canonicalize } from "./canonical";
 import {
   GATEWAY_APPROVAL_TTL_MINUTES,
   GATEWAY_LEASE_TTL_SECONDS,
@@ -36,19 +38,33 @@ export async function registerGatewayServiceIdentity(input: {
   }
   const credentialIdBytes = Buffer.from(input.credentialId, "base64url");
   const credentialBytes = Buffer.from(input.credential, "base64url");
-  if (credentialIdBytes.length !== 16 || credentialIdBytes.toString("base64url") !== input.credentialId || credentialBytes.length !== 32 || credentialBytes.toString("base64url") !== input.credential) {
-    throw new Error("gateway_service_credential_invalid");
+  try {
+    if (credentialIdBytes.length !== 16 || credentialIdBytes.toString("base64url") !== input.credentialId || credentialBytes.length !== 32 || credentialBytes.toString("base64url") !== input.credential) {
+      throw new Error("gateway_service_credential_invalid");
+    }
+    const id = randomUUID();
+    await withTransaction(async (client) => {
+      const digest = sha256(credentialBytes);
+      await client.query(
+        `insert into gateway_service_identities
+         (id, team_id, environment, credential_id, credential_hash, credential_version, expires_at)
+         values ($1,$2,$3,$4,$5,$6,$7)`,
+        [id, input.teamId, input.environment, input.credentialId, digest,
+         input.credentialVersion ?? 1, input.expiresAt ?? null],
+      );
+      await client.query(
+        `insert into gateway_service_credentials
+         (team_id,service_identity_id,credential_id,version,secret_hash,expires_at)
+         values ($1,$2,$3,$4,$5,$6)`,
+        [input.teamId, id, input.credentialId, input.credentialVersion ?? 1,
+         digest, input.expiresAt ?? null],
+      );
+    });
+    return { id };
+  } finally {
+    credentialIdBytes.fill(0);
+    credentialBytes.fill(0);
   }
-  const id = randomUUID();
-  await withTransaction(async (client) => {
-    await client.query(
-      `insert into gateway_service_identities
-       (id, team_id, environment, credential_id, credential_hash, credential_version, expires_at)
-       values ($1,$2,$3,$4,$5,$6,$7)`,
-      [id, input.teamId, input.environment, input.credentialId, sha256(credentialBytes), input.credentialVersion ?? 1, input.expiresAt ?? null]
-    );
-  });
-  return { id };
 }
 
 export type AuthenticatedGatewayService = {
@@ -57,6 +73,7 @@ export type AuthenticatedGatewayService = {
   environment: string;
   credentialId: string;
   credentialVersion: number;
+  credentialRowId: string;
   secretBytes: Buffer;
 };
 
@@ -81,8 +98,11 @@ export async function authenticateGatewayServiceCredential(
     credentialIdBytes.toString("base64url") !== match[1] ||
     secretBytes.length !== 32 ||
     secretBytes.toString("base64url") !== match[2]
-  )
+  ) {
+    credentialIdBytes.fill(0);
+    secretBytes.fill(0);
     throw new GatewayAuthenticationError();
+  }
   const candidate = createHash("sha256").update(secretBytes).digest();
   try {
     return await withTransaction(async (client) => {
@@ -90,40 +110,57 @@ export async function authenticateGatewayServiceCredential(
         id: string;
         team_id: string;
         environment: string;
+        credential_row_id: string;
         credential_id: string;
-        credential_hash: string;
-        credential_version: number;
+        secret_hash: string;
+        version: number;
       }>(
-        `select id, team_id, environment, credential_id, credential_hash, credential_version
-           from gateway_service_identities where credential_id=$1 and revoked_at is null
-            and activated_at <= now() and (expires_at is null or expires_at > now()) for update`,
+        `select s.id, s.team_id, s.environment, c.id credential_row_id,
+                c.credential_id, c.secret_hash, c.version
+           from gateway_service_credentials c
+           join gateway_service_identities s
+             on s.id=c.service_identity_id and s.team_id=c.team_id
+          where c.credential_id=$1 and c.revoked_at is null
+            and c.activated_at <= now() and (c.expires_at is null or c.expires_at > now())
+            and s.revoked_at is null and (s.expires_at is null or s.expires_at > now())
+          for update of c`,
         [match[1]],
       );
       const row = result.rows[0];
       const stored =
-        row && /^[0-9a-f]{64}$/.test(row.credential_hash)
-          ? Buffer.from(row.credential_hash, "hex")
+        row && /^[0-9a-f]{64}$/.test(row.secret_hash)
+          ? Buffer.from(row.secret_hash, "hex")
           : Buffer.alloc(32);
-      const matches =
-        stored.length === candidate.length &&
-        timingSafeEqual(stored, candidate);
-      if (!row || !matches) throw new GatewayAuthenticationError();
-      await client.query(
-        `update gateway_service_identities set last_authenticated_at=now() where id=$1`,
-        [row.id],
-      );
-      return {
-        id: row.id,
-        teamId: row.team_id,
-        environment: row.environment,
-        credentialId: row.credential_id,
-        credentialVersion: row.credential_version,
-        secretBytes,
-      };
+      try {
+        const matches =
+          stored.length === candidate.length &&
+          timingSafeEqual(stored, candidate);
+        if (!row || !matches) throw new GatewayAuthenticationError();
+        await client.query(
+          `update gateway_service_credentials set last_authenticated_at=now() where id=$1`,
+          [row.credential_row_id],
+        );
+        return {
+          id: row.id,
+          teamId: row.team_id,
+          environment: row.environment,
+          credentialId: row.credential_id,
+          credentialVersion: row.version,
+          credentialRowId: row.credential_row_id,
+          secretBytes,
+        };
+      } finally {
+        candidate.fill(0);
+        stored.fill(0);
+        credentialIdBytes.fill(0);
+      }
     });
   } catch (error) {
-    if (error instanceof GatewayAuthenticationError) secretBytes.fill(0);
+    secretBytes.fill(0);
     throw error;
+  } finally {
+    candidate.fill(0);
+    credentialIdBytes.fill(0);
   }
 }
 
@@ -241,8 +278,16 @@ export async function consumeLeaseAndCreateExecution(input: Scope & {
   policyRuleId?: string;
 }): Promise<AuthorizeDecision> {
   return withTransaction(async (client) => {
-    const leaseResult = await client.query<{ id: string; connection_id: string; subject_binding_id: string }>(
-      `select l.id, l.connection_id, l.subject_binding_id
+    const leaseResult = await client.query<{
+      id: string;
+      connection_id: string;
+      subject_binding_id: string;
+      actor_handle: string;
+      role: string;
+      tier: string;
+    }>(
+      `select l.id, l.connection_id, l.subject_binding_id,
+              m.actor_handle,m.role::text role,m.tier::text tier
          from gateway_resolution_leases l
          join executor_subject_bindings b on b.id=l.subject_binding_id and b.team_id=l.team_id
          join gateway_connections c on c.id=l.connection_id and c.team_id=l.team_id
@@ -268,13 +313,18 @@ export async function consumeLeaseAndCreateExecution(input: Scope & {
       `insert into gateway_executions
        (id, team_id, member_id, service_identity_id, subject_binding_id, connection_id, lease_id,
         correlation_id, idempotency_key, toolkit, tool, request_hash, encrypted_request_envelope,
+        actor_snapshot,role_snapshot,tier_snapshot,policy_resource,request_envelope_hash,
         decision, state, policy_version, policy_rule_id, claimed_at, claimed_by_correlation_id)
-       values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
-               case when $14::text='allow' then now() else null end,
-               case when $14::text='allow' then $8::uuid else null end)`,
+       values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,
+               $19,$20,$21,$22,
+               case when $19::text='allow' then now() else null end,
+               case when $19::text='allow' then $8::uuid else null end)`,
       [input.executionId, input.teamId, input.memberId, input.serviceIdentityId, lease.subject_binding_id,
        lease.connection_id, lease.id, input.correlationId, input.idempotencyKey, input.toolkit, input.tool,
-       input.requestHash, input.encryptedRequestEnvelope, input.decision, state,
+       input.requestHash, input.encryptedRequestEnvelope,
+       lease.actor_handle,lease.role,lease.tier,"github.repository:*",
+       sha256(input.encryptedRequestEnvelope),
+       input.decision, state,
        input.policyVersion ?? null, input.policyRuleId ?? null]
     );
     await client.query(`update gateway_resolution_leases set consumed_at=now() where id=$1`, [lease.id]);
@@ -417,6 +467,309 @@ export async function claimApprovedExecution(input: Scope & {
   });
 }
 
+export type ResumeClaimPayload = {
+  executionId: string;
+  toolkit: string;
+  tool: string;
+  requestHash: string;
+  encryptedRequestEnvelope: Buffer;
+  credentialCiphertext: string;
+  credentialExpiresAt: string | null;
+};
+
+export type ResumeClaimResult<T> =
+  | { status: "claimed"; value: T }
+  | {
+      status: "already_claimed";
+      executionId: string;
+      state: "claimed" | "succeeded" | "failed";
+    };
+
+/**
+ * Claim an approved execution and commit its audit record before exposing any
+ * ciphertext to the request-local callback. A session advisory lock remains held
+ * across that callback; credential revocation takes the same lock.
+ */
+export async function resumeClaimGatewayExecution<T>(input: {
+  service: AuthenticatedGatewayService;
+  executionId: string;
+  executorTenantId: string;
+  executorSubjectId: string;
+  toolkit: string;
+  tool: string;
+  requestHash: string;
+  correlationId: string;
+  idempotencyKey: string;
+  useWinningPayload: (payload: ResumeClaimPayload) => Promise<T> | T;
+}): Promise<ResumeClaimResult<T>> {
+  const client = await getPool().connect();
+  let inTransaction = false;
+  let locked = false;
+  let committedError: GatewayPersistenceError | null = null;
+  try {
+    await client.query(
+      `select pg_advisory_lock(hashtextextended($1, 407))`,
+      [input.service.credentialId],
+    );
+    locked = true;
+    await client.query("BEGIN");
+    inTransaction = true;
+    const result = await client.query<{
+      id: string;
+      team_id: string;
+      member_id: string;
+      service_identity_id: string;
+      subject_binding_id: string;
+      connection_id: string;
+      toolkit: string;
+      tool: string;
+      request_hash: string;
+      encrypted_request_envelope: Buffer;
+      request_envelope_hash: string;
+      actor_snapshot: string;
+      role_snapshot: "admin" | "lead" | "member";
+      tier_snapshot: "team" | "external";
+      policy_resource: string;
+      state: string;
+      resume_fingerprint: string | null;
+      claim_idempotency_key: string | null;
+      approval_id: string;
+      approval_status: string;
+      approval_expires_at: string;
+      approval_expired: boolean;
+      executor_tenant_id: string;
+      executor_subject_id: string;
+      member_actor: string;
+      member_role: "admin" | "lead" | "member";
+      member_tier: "team" | "external";
+      member_status: string;
+      binding_revoked_at: string | null;
+      binding_expires_at: string | null;
+      binding_active: boolean;
+      connection_enabled: boolean;
+      connection_revoked_at: string | null;
+      connection_provider: string;
+      connection_credential_expires_at: string | null;
+      connection_active: boolean;
+      credential_ciphertext: string;
+      credential_expires_at: string | null;
+      credential_active: boolean;
+      identity_active: boolean;
+    }>(
+      `select e.id,e.team_id,e.member_id,e.service_identity_id,e.subject_binding_id,
+              e.connection_id,e.toolkit,e.tool,e.request_hash,e.encrypted_request_envelope,
+              e.request_envelope_hash,e.actor_snapshot,e.role_snapshot,e.tier_snapshot,
+              e.policy_resource,e.state,e.resume_fingerprint,e.claim_idempotency_key,
+              a.id approval_id,a.status approval_status,a.expires_at approval_expires_at,
+              (a.expires_at<=now()) approval_expired,
+              b.executor_tenant_id,b.executor_subject_id,b.revoked_at binding_revoked_at,
+              b.expires_at binding_expires_at,
+              (b.revoked_at is null and (b.expires_at is null or b.expires_at>now())) binding_active,
+              m.actor_handle member_actor,
+              m.role::text member_role,m.tier::text member_tier,m.status::text member_status,
+              c.enabled connection_enabled,c.revoked_at connection_revoked_at,
+              c.provider connection_provider,c.credential_expires_at connection_credential_expires_at,
+              (c.enabled and c.revoked_at is null and
+                (c.credential_expires_at is null or c.credential_expires_at>now())) connection_active,
+              c.credential_ciphertext,c.credential_expires_at,
+              (gc.revoked_at is null and gc.activated_at<=now()
+                and (gc.expires_at is null or gc.expires_at>now())) credential_active,
+              (s.revoked_at is null and (s.expires_at is null or s.expires_at>now())) identity_active
+         from gateway_executions e
+         join gateway_approvals a on a.execution_id=e.id and a.team_id=e.team_id
+         join executor_subject_bindings b on b.id=e.subject_binding_id and b.team_id=e.team_id
+         join members m on m.id=e.member_id and m.team_id=e.team_id
+         join gateway_connections c on c.id=e.connection_id and c.team_id=e.team_id
+         join gateway_service_identities s on s.id=e.service_identity_id and s.team_id=e.team_id
+         join gateway_service_credentials gc
+           on gc.id=$5 and gc.service_identity_id=e.service_identity_id and gc.team_id=e.team_id
+        where e.id=$1 and e.service_identity_id=$2
+          and b.executor_tenant_id=$3 and b.executor_subject_id=$4
+        for update of e,a,gc`,
+      [
+        input.executionId,
+        input.service.id,
+        input.executorTenantId,
+        input.executorSubjectId,
+        input.service.credentialRowId,
+      ],
+    );
+    const row = result.rows[0];
+    if (!row) {
+      await client.query("ROLLBACK");
+      inTransaction = false;
+      throw new GatewayPersistenceError("gateway_not_found");
+    }
+    const fingerprint = sha256(
+      canonicalize({
+        credentialId: input.service.credentialId,
+        credentialVersion: input.service.credentialVersion,
+        executionId: input.executionId,
+        executorSubjectId: input.executorSubjectId,
+        executorTenantId: input.executorTenantId,
+        memberId: row.member_id,
+        requestHash: input.requestHash,
+        serviceIdentityId: input.service.id,
+        teamId: row.team_id,
+        tool: input.tool,
+        toolkit: input.toolkit,
+      }),
+    );
+    if (["claimed", "succeeded", "failed"].includes(row.state)) {
+      if (
+        row.resume_fingerprint !== fingerprint ||
+        row.claim_idempotency_key !== input.idempotencyKey
+      ) {
+        await client.query("ROLLBACK");
+        inTransaction = false;
+        throw new GatewayPersistenceError("gateway_idempotency_conflict");
+      }
+      await client.query("COMMIT");
+      inTransaction = false;
+      return {
+        status: "already_claimed",
+        executionId: row.id,
+        state: row.state as "claimed" | "succeeded" | "failed",
+      };
+    }
+    if (row.approval_expired) {
+      await client.query(
+        `update gateway_approvals set status='expired',decided_at=coalesce(decided_at,now()),
+           decision_correlation_id=coalesce(decision_correlation_id,$1),updated_at=now()
+         where id=$2 and status in ('pending','approved')`,
+        [input.correlationId, row.approval_id],
+      );
+      await client.query(
+        `update gateway_executions set state='expired',updated_at=now()
+          where id=$1 and state in ('approval_required','approved')`,
+        [row.id],
+      );
+      await client.query(
+        `insert into gateway_audit_log(
+           team_id,member_id,service_identity_id,subject_binding_id,connection_id,
+           execution_id,approval_id,event,correlation_id
+         ) values($1,$2,$3,$4,$5,$6,$7,'approval_expired',$8)
+         on conflict do nothing`,
+        [row.team_id,row.member_id,row.service_identity_id,row.subject_binding_id,
+         row.connection_id,row.id,row.approval_id,input.correlationId],
+      );
+      committedError = new GatewayPersistenceError("gateway_approval_expired");
+    } else {
+      const resource = /^github\.repository:([^/]+)\/(.+)$/.exec(row.policy_resource);
+      const currentPolicy = resource
+        ? evaluateGatewayPolicy(await loadGatewayPolicies(client, row.team_id), {
+            principal: {
+              actor: row.member_actor,
+              role: row.member_role,
+              tier: row.member_tier,
+            },
+            tool: input.tool,
+            owner: resource[1],
+            repo: resource[2],
+          })
+        : null;
+      const eligible =
+        row.state === "approved" &&
+        row.approval_status === "approved" &&
+        row.toolkit === input.toolkit &&
+        row.tool === input.tool &&
+        row.request_hash === input.requestHash &&
+        row.request_envelope_hash === sha256(row.encrypted_request_envelope) &&
+        row.actor_snapshot === row.member_actor &&
+        row.role_snapshot === row.member_role &&
+        row.tier_snapshot === row.member_tier &&
+        row.member_status === "active" &&
+        row.member_tier === "team" &&
+        row.binding_active &&
+        row.connection_active &&
+        row.connection_provider === "github" &&
+        row.credential_active &&
+        row.identity_active &&
+        currentPolicy !== null &&
+        currentPolicy.decision !== "block";
+      if (!eligible) {
+        await client.query(
+          `update gateway_approvals set status='cancelled',decided_at=coalesce(decided_at,now()),
+             decision_correlation_id=coalesce(decision_correlation_id,$1),updated_at=now()
+           where id=$2 and status in ('pending','approved')`,
+          [input.correlationId, row.approval_id],
+        );
+        await client.query(
+          `update gateway_executions set state='cancelled',updated_at=now()
+            where id=$1 and state in ('approval_required','approved')`,
+          [row.id],
+        );
+        await client.query(
+          `insert into gateway_audit_log(
+             team_id,member_id,service_identity_id,subject_binding_id,connection_id,
+             execution_id,approval_id,event,correlation_id
+           ) values($1,$2,$3,$4,$5,$6,$7,'approval_cancelled',$8)
+           on conflict do nothing`,
+          [row.team_id,row.member_id,row.service_identity_id,row.subject_binding_id,
+           row.connection_id,row.id,row.approval_id,input.correlationId],
+        );
+        committedError = new GatewayPersistenceError("gateway_scope_not_found");
+      } else {
+        await client.query(
+          `update gateway_executions
+              set state='claimed',claimed_at=now(),claimed_by_correlation_id=$1,
+                  resume_fingerprint=$2,claim_idempotency_key=$3,claimed_credential_id=$4,
+                  updated_at=now()
+            where id=$5 and state='approved'`,
+          [input.correlationId,fingerprint,input.idempotencyKey,
+           input.service.credentialRowId,row.id],
+        );
+        await client.query(
+          `insert into gateway_audit_log(
+             team_id,member_id,service_identity_id,credential_row_id,subject_binding_id,
+             connection_id,execution_id,approval_id,event,toolkit,tool,request_hash,
+             correlation_id,idempotency_key
+           ) values($1,$2,$3,$4,$5,$6,$7,$8,'execution_claimed',$9,$10,$11,$12,$13)`,
+          [row.team_id,row.member_id,row.service_identity_id,input.service.credentialRowId,
+           row.subject_binding_id,row.connection_id,row.id,row.approval_id,row.toolkit,
+           row.tool,row.request_hash,input.correlationId,input.idempotencyKey],
+        );
+      }
+    }
+    await client.query("COMMIT");
+    inTransaction = false;
+    if (committedError) throw committedError;
+    return {
+      status: "claimed",
+      value: await input.useWinningPayload({
+        executionId: row.id,
+        toolkit: row.toolkit,
+        tool: row.tool,
+        requestHash: row.request_hash,
+        encryptedRequestEnvelope: row.encrypted_request_envelope,
+        credentialCiphertext: row.credential_ciphertext,
+        credentialExpiresAt: row.credential_expires_at,
+      }),
+    };
+  } catch (error) {
+    if (inTransaction) {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        // original error wins
+      }
+    }
+    throw error;
+  } finally {
+    if (locked) {
+      try {
+        await client.query(
+          `select pg_advisory_unlock(hashtextextended($1, 407))`,
+          [input.service.credentialId],
+        );
+      } catch {
+        // releasing the client also releases session locks
+      }
+    }
+    client.release();
+  }
+}
+
 export async function findGatewayConnection(input: Scope & { connectionRef: string }) {
   return withTransaction((client) => activeConnection(client, input, input.connectionRef));
 }
@@ -518,6 +871,8 @@ export async function authorizeLeaseAndCreateExecution(input: {
   correlationId: string;
   idempotencyKey: string;
   requestEnvelope: Buffer;
+  /** Test/support seam for shorter database-enforced approvals; routes omit it. */
+  approvalTtlMilliseconds?: number;
 }): Promise<AuthorizeDecision> {
   return withTransaction(async (client) => {
     const incomingLease = await client.query<{
@@ -612,8 +967,18 @@ export async function authorizeLeaseAndCreateExecution(input: {
         : policy.decision === "block"
           ? "blocked"
           : "approval_required";
+    const policyResource = `github.repository:${input.normalizedArgs.owner}/${input.normalizedArgs.repo}`;
     await client.query(
-      `insert into gateway_executions(id,team_id,member_id,service_identity_id,subject_binding_id,connection_id,lease_id,correlation_id,idempotency_key,toolkit,tool,request_hash,encrypted_request_envelope,decision,state,policy_version,policy_rule_id,claimed_at,claimed_by_correlation_id) values($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,case when $14='allow' then now() end,case when $14='allow' then $8::uuid end)`,
+      `insert into gateway_executions(
+        id,team_id,member_id,service_identity_id,subject_binding_id,connection_id,lease_id,
+        correlation_id,idempotency_key,toolkit,tool,request_hash,encrypted_request_envelope,
+        actor_snapshot,role_snapshot,tier_snapshot,policy_resource,request_envelope_hash,
+        decision,state,policy_version,policy_rule_id,claimed_at,claimed_by_correlation_id
+       ) values(
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,
+        $19,$20,$21,$22,case when $19='allow' then now() end,
+        case when $19='allow' then $8::uuid end
+       )`,
       [
         executionId,
         row.team_id,
@@ -628,6 +993,11 @@ export async function authorizeLeaseAndCreateExecution(input: {
         input.tool,
         input.requestHash,
         input.requestEnvelope,
+        row.actor_handle,
+        row.role,
+        row.tier,
+        policyResource,
+        sha256(input.requestEnvelope),
         policy.decision,
         state,
         policy.policyVersion,
@@ -642,8 +1012,22 @@ export async function authorizeLeaseAndCreateExecution(input: {
     if (policy.decision === "require_approval") {
       const id = randomUUID();
       const made = await client.query<{ id: string; expires_at: string }>(
-        `insert into gateway_approvals(id,team_id,execution_id,expires_at) values($1,$2,$3,now()+interval '15 minutes') returning id,expires_at`,
-        [id, row.team_id, executionId],
+        `insert into gateway_approvals(id,team_id,execution_id,expires_at)
+         values($1,$2,$3,now()+($4::text || ' milliseconds')::interval)
+         returning id,expires_at`,
+        [
+          id,
+          row.team_id,
+          executionId,
+          Math.max(
+            1,
+            Math.min(
+              GATEWAY_APPROVAL_TTL_MINUTES * 60_000,
+              input.approvalTtlMilliseconds ??
+                GATEWAY_APPROVAL_TTL_MINUTES * 60_000,
+            ),
+          ),
+        ],
       );
       approval = made.rows[0];
     }

--- a/lib/gateway/types.ts
+++ b/lib/gateway/types.ts
@@ -119,7 +119,10 @@ export type GatewayPersistenceErrorCode =
   | "gateway_scope_not_found"
   | "gateway_lease_invalid"
   | "gateway_execution_not_claimable"
-  | "gateway_approval_not_pending";
+  | "gateway_approval_not_pending"
+  | "gateway_not_found"
+  | "gateway_approval_expired"
+  | "gateway_idempotency_conflict";
 
 export class GatewayPersistenceError extends Error {
   constructor(readonly code: GatewayPersistenceErrorCode) {

--- a/lib/policy/manage.ts
+++ b/lib/policy/manage.ts
@@ -46,10 +46,24 @@ export interface PolicyActor {
 
 function validate(input: PolicyInput): void {
   if (!input.action?.trim()) throw new Error("action is required (e.g. \"code.run\" or \"item.*\")");
+  if (input.action.trim().startsWith("gateway."))
+    throw new Error("gateway policies must be managed from Managed gateway administration");
   if (!EFFECTS.includes(input.effect)) throw new Error(`invalid effect "${input.effect}"`);
   if (input.subjectRole && !ROLES.includes(input.subjectRole)) throw new Error("invalid subject role");
   if (input.subjectTier && !TIERS.includes(input.subjectTier)) throw new Error("invalid subject tier");
   if (input.priority != null && !Number.isInteger(input.priority)) throw new Error("priority must be an integer");
+}
+
+async function assertNonGatewayPolicy(db: DbClient, teamId: string, id: string): Promise<void> {
+  const { data, error } = await db
+    .from("policies")
+    .select("action")
+    .eq("team_id", teamId)
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw new Error(`policy lookup failed: ${error.message}`);
+  if ((data as { action?: string } | null)?.action?.startsWith("gateway."))
+    throw new Error("gateway policies must be managed from Managed gateway administration");
 }
 
 /** The mutable rule fields (shared by create + update). */
@@ -75,7 +89,9 @@ export async function listAllPolicies(db: DbClient, teamId: string): Promise<Pol
     .order("priority", { ascending: false })
     .order("created_at", { ascending: true });
   if (error) throw new Error(`policy list failed: ${error.message}`);
-  return (data ?? []) as PolicyRecord[];
+  return ((data ?? []) as PolicyRecord[]).filter(
+    (policy) => !policy.action.startsWith("gateway."),
+  );
 }
 
 export async function createPolicy(
@@ -107,6 +123,7 @@ export async function updatePolicy(
   actor: PolicyActor = {}
 ): Promise<void> {
   validate(input);
+  await assertNonGatewayPolicy(db, teamId, id);
   const { error } = await db
     .from("policies")
     .update({ ...fields(input), updated_at: new Date().toISOString() })
@@ -127,6 +144,7 @@ export async function setPolicyEnabled(
   enabled: boolean,
   actor: PolicyActor = {}
 ): Promise<void> {
+  await assertNonGatewayPolicy(db, teamId, id);
   const { error } = await db
     .from("policies")
     .update({ enabled, updated_at: new Date().toISOString() })
@@ -145,6 +163,7 @@ export async function deletePolicy(
   id: string,
   actor: PolicyActor = {}
 ): Promise<void> {
+  await assertNonGatewayPolicy(db, teamId, id);
   const { error } = await db.from("policies").delete().eq("team_id", teamId).eq("id", id);
   if (error) throw new Error(`policy delete failed: ${error.message}`);
   await audit(db, {

--- a/lib/secrets/crypto.test.ts
+++ b/lib/secrets/crypto.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { randomBytes } from "node:crypto";
-import { encryptSecret, decryptSecret, generateSecretsKey } from "@/lib/secrets/crypto";
+import {
+  decryptSecret,
+  decryptSecretBytes,
+  encryptSecret,
+  generateSecretsKey,
+} from "@/lib/secrets/crypto";
 
 const KEY = randomBytes(32);
 
@@ -8,6 +13,14 @@ describe("connector secret crypto (AES-256-GCM)", () => {
   it("round-trips plaintext", () => {
     const token = "xoxb-1234567890-abcdefABCDEF";
     expect(decryptSecret(encryptSecret(token, KEY), KEY)).toBe(token);
+  });
+
+  it("can return caller-owned plaintext bytes without consuming a supplied key", () => {
+    const key = Buffer.from(KEY);
+    const plaintext = decryptSecretBytes(encryptSecret("gateway-pat", key), key);
+    expect(plaintext.toString("utf8")).toBe("gateway-pat");
+    expect(key).toEqual(KEY);
+    plaintext.fill(0);
   });
 
   it("produces a different ciphertext each time (random IV)", () => {

--- a/lib/secrets/crypto.ts
+++ b/lib/secrets/crypto.ts
@@ -20,7 +20,9 @@ export function secretsKey(): Buffer {
   }
   const key = decodeKey(raw);
   if (key.length !== KEY_LEN) {
-    throw new Error(`SECRETS_KEY must decode to ${KEY_LEN} bytes (got ${key.length}).`);
+    const length = key.length;
+    key.fill(0);
+    throw new Error(`SECRETS_KEY must decode to ${KEY_LEN} bytes (got ${length}).`);
   }
   return key;
 }
@@ -40,16 +42,32 @@ export function encryptSecret(plaintext: string, key: Buffer = secretsKey()): st
   return Buffer.concat([iv, tag, ct]).toString("base64");
 }
 
-/** Decrypt a base64(iv|tag|ciphertext) blob. Throws on a bad key or tampered data. */
-export function decryptSecret(blob: string, key: Buffer = secretsKey()): string {
+/** Decrypt into caller-owned bytes. A default environment key is always zeroed. */
+export function decryptSecretBytes(blob: string, key?: Buffer): Buffer {
+  const resolvedKey = key ?? secretsKey();
   const buf = Buffer.from(blob, "base64");
-  if (buf.length < IV_LEN + TAG_LEN) throw new Error("ciphertext too short / malformed");
-  const iv = buf.subarray(0, IV_LEN);
-  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
-  const ct = buf.subarray(IV_LEN + TAG_LEN);
-  const decipher = createDecipheriv("aes-256-gcm", key, iv);
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+  try {
+    if (buf.length < IV_LEN + TAG_LEN) throw new Error("ciphertext too short / malformed");
+    const iv = buf.subarray(0, IV_LEN);
+    const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+    const ct = buf.subarray(IV_LEN + TAG_LEN);
+    const decipher = createDecipheriv("aes-256-gcm", resolvedKey, iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ct), decipher.final()]);
+  } finally {
+    buf.fill(0);
+    if (!key) resolvedKey.fill(0);
+  }
+}
+
+/** Decrypt a base64(iv|tag|ciphertext) blob. Throws on a bad key or tampered data. */
+export function decryptSecret(blob: string, key?: Buffer): string {
+  const plaintext = decryptSecretBytes(blob, key);
+  try {
+    return plaintext.toString("utf8");
+  } finally {
+    plaintext.fill(0);
+  }
 }
 
 /** Generate a fresh base64 SECRETS_KEY (for provisioning a deployment). */

--- a/package.json
+++ b/package.json
@@ -31,8 +31,12 @@
     "test:datamechanics": "vitest run --config vitest.datamechanics.config.ts",
     "test:datamechanics:local": "DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.datamechanics.config.ts",
     "test:http": "vitest run --config vitest.http.config.ts",
+    "test:http:gateway-approval": "AIOS_GATEWAY_INTERNAL_ENABLED=true vitest run --config vitest.http.config.ts gateway-approval-enabled",
     "test:gateway-contracts": "vitest run test/gateway/gateway-contracts.test.ts",
+    "test:gateway-approval-contracts": "vitest run test/gateway/gateway-approval-contracts.test.ts",
     "test:gateway-api": "vitest run test/gateway test/guards/gateway-writers.test.ts",
+    "test:gateway-approval:unit": "vitest run test/gateway/gateway-approval-contracts.test.ts test/gateway/gateway-approval.test.ts test/guards/gateway-writers.test.ts",
+    "test:gateway-approval": "npm run test:gateway-approval:unit && vitest run --config vitest.datamechanics.config.ts gateway-approval",
     "test:http:local": "npm run build && DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.http.config.ts"
   },
   "dependencies": {

--- a/postgres/migrations/20260716120000_gateway_approval_admin.sql
+++ b/postgres/migrations/20260716120000_gateway_approval_admin.sql
@@ -1,0 +1,220 @@
+-- AIO-407: durable gateway approvals, resumable claims, and independently
+-- rotatable service credentials. This migration is additive and replay-safe.
+
+do $$
+declare legacy record;
+begin
+  for legacy in
+    select credential_id,credential_hash,credential_version
+      from gateway_service_identities
+  loop
+    begin
+      if legacy.credential_id !~ '^[A-Za-z0-9_-]{22}$'
+        or legacy.credential_hash !~ '^[0-9a-f]{64}$'
+        or legacy.credential_version <= 0
+        or octet_length(decode(translate(legacy.credential_id,'-_','+/') || '==','base64')) <> 16
+        or translate(rtrim(encode(
+             decode(translate(legacy.credential_id,'-_','+/') || '==','base64'),
+             'base64'
+           ),'='),'+/','-_') <> legacy.credential_id then
+        raise exception 'gateway_service_identity_legacy_preflight';
+      end if;
+    exception when others then
+      raise exception 'gateway_service_identity_legacy_preflight';
+    end;
+  end loop;
+end $$;
+
+create table if not exists gateway_service_credentials (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null,
+  service_identity_id uuid not null,
+  credential_id text not null unique check (credential_id ~ '^[A-Za-z0-9_-]{22}$'),
+  version integer not null check (version > 0),
+  secret_hash text not null check (secret_hash ~ '^[0-9a-f]{64}$'),
+  replaces_credential_id text,
+  activated_at timestamptz not null default now(),
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  last_authenticated_at timestamptz,
+  created_by_member_id uuid,
+  created_at timestamptz not null default now(),
+  unique (team_id, id),
+  unique (service_identity_id, version),
+  foreign key (team_id, service_identity_id)
+    references gateway_service_identities(team_id, id) on delete restrict,
+  foreign key (team_id, created_by_member_id)
+    references members(team_id, id) on delete restrict,
+  check (expires_at is null or expires_at > activated_at),
+  check (revoked_at is null or revoked_at >= activated_at)
+);
+create index if not exists gateway_service_credentials_identity_idx
+  on gateway_service_credentials (team_id, service_identity_id, created_at desc);
+
+insert into gateway_service_credentials
+  (team_id, service_identity_id, credential_id, version, secret_hash,
+   activated_at, expires_at, revoked_at, last_authenticated_at, created_at)
+select team_id, id, credential_id, credential_version, credential_hash,
+       activated_at, expires_at, revoked_at, last_authenticated_at, created_at
+  from gateway_service_identities
+on conflict (credential_id) do nothing;
+
+alter table gateway_executions add column if not exists actor_snapshot text;
+alter table gateway_executions add column if not exists role_snapshot text;
+alter table gateway_executions add column if not exists tier_snapshot text;
+alter table gateway_executions add column if not exists policy_resource text;
+alter table gateway_executions add column if not exists request_envelope_hash text;
+alter table gateway_executions add column if not exists resume_fingerprint text;
+alter table gateway_executions add column if not exists claim_idempotency_key text;
+alter table gateway_executions add column if not exists claimed_credential_id uuid;
+
+update gateway_executions e
+   set actor_snapshot = coalesce(e.actor_snapshot, m.actor_handle),
+       role_snapshot = coalesce(e.role_snapshot, m.role::text),
+       tier_snapshot = coalesce(e.tier_snapshot, m.tier::text),
+       policy_resource = coalesce(e.policy_resource, 'github.repository:*'),
+       request_envelope_hash = coalesce(
+         e.request_envelope_hash,
+         encode(sha256(e.encrypted_request_envelope), 'hex')
+       )
+  from members m
+ where m.id=e.member_id and m.team_id=e.team_id
+   and (e.actor_snapshot is null or e.role_snapshot is null or e.tier_snapshot is null
+     or e.policy_resource is null or e.request_envelope_hash is null);
+
+alter table gateway_executions alter column actor_snapshot set not null;
+alter table gateway_executions alter column role_snapshot set not null;
+alter table gateway_executions alter column tier_snapshot set not null;
+alter table gateway_executions alter column policy_resource set not null;
+alter table gateway_executions alter column request_envelope_hash set not null;
+alter table gateway_executions drop constraint if exists gateway_executions_role_snapshot_check;
+alter table gateway_executions add constraint gateway_executions_role_snapshot_check
+  check (role_snapshot in ('admin','lead','member'));
+alter table gateway_executions drop constraint if exists gateway_executions_tier_snapshot_check;
+alter table gateway_executions add constraint gateway_executions_tier_snapshot_check
+  check (tier_snapshot in ('team','external'));
+alter table gateway_executions drop constraint if exists gateway_executions_request_envelope_hash_check;
+alter table gateway_executions add constraint gateway_executions_request_envelope_hash_check
+  check (request_envelope_hash ~ '^[0-9a-f]{64}$');
+alter table gateway_executions drop constraint if exists gateway_executions_resume_fingerprint_check;
+alter table gateway_executions add constraint gateway_executions_resume_fingerprint_check
+  check (resume_fingerprint is null or resume_fingerprint ~ '^[0-9a-f]{64}$');
+alter table gateway_executions drop constraint if exists gateway_executions_claimed_credential_fk;
+alter table gateway_executions add constraint gateway_executions_claimed_credential_fk
+  foreign key (team_id, claimed_credential_id)
+  references gateway_service_credentials(team_id, id) on delete restrict;
+
+alter table gateway_approvals add column if not exists decision_correlation_id uuid;
+
+alter table gateway_audit_log add column if not exists credential_row_id uuid;
+alter table gateway_audit_log drop constraint if exists gateway_audit_log_credential_row_fk;
+alter table gateway_audit_log add constraint gateway_audit_log_credential_row_fk
+  foreign key (team_id, credential_row_id)
+  references gateway_service_credentials(team_id, id) on delete restrict;
+alter table gateway_audit_log drop constraint if exists gateway_audit_log_event_check;
+alter table gateway_audit_log add constraint gateway_audit_log_event_check check (event in
+  ('lease_issued', 'decision_blocked', 'decision_approval_required', 'decision_allowed',
+   'approval_approved', 'approval_denied', 'approval_expired', 'approval_cancelled',
+   'execution_claimed', 'outcome_recorded', 'connection_revoked',
+   'service_identity_revoked', 'credential_rotated', 'credential_revoked',
+   'policy_created', 'policy_updated', 'policy_deleted'));
+
+create unique index if not exists gateway_audit_log_decision_approval_unq
+  on gateway_audit_log (approval_id) where event in ('approval_approved','approval_denied');
+create unique index if not exists gateway_audit_log_claim_execution_unq
+  on gateway_audit_log (execution_id) where event='execution_claimed';
+create unique index if not exists gateway_audit_log_expiry_approval_unq
+  on gateway_audit_log (approval_id) where event='approval_expired';
+create unique index if not exists gateway_audit_log_cancel_approval_unq
+  on gateway_audit_log (approval_id) where event='approval_cancelled';
+create unique index if not exists gateway_audit_log_rotation_credential_unq
+  on gateway_audit_log (credential_row_id) where event='credential_rotated';
+create unique index if not exists gateway_audit_log_revocation_credential_unq
+  on gateway_audit_log (credential_row_id) where event='credential_revoked';
+
+create or replace function gateway_service_credential_protect()
+returns trigger language plpgsql as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'gateway service credentials must be revoked, not deleted';
+  end if;
+  if new.id is distinct from old.id
+    or new.team_id is distinct from old.team_id
+    or new.service_identity_id is distinct from old.service_identity_id
+    or new.credential_id is distinct from old.credential_id
+    or new.version is distinct from old.version
+    or new.secret_hash is distinct from old.secret_hash
+    or new.replaces_credential_id is distinct from old.replaces_credential_id
+    or new.activated_at is distinct from old.activated_at
+    or new.expires_at is distinct from old.expires_at
+    or new.created_by_member_id is distinct from old.created_by_member_id
+    or (old.revoked_at is not null and new.revoked_at is distinct from old.revoked_at)
+    or new.created_at is distinct from old.created_at then
+    raise exception 'gateway service credential identity fields are immutable';
+  end if;
+  return new;
+end $$;
+drop trigger if exists gateway_service_credentials_protect on gateway_service_credentials;
+create trigger gateway_service_credentials_protect
+  before update or delete on gateway_service_credentials
+  for each row execute function gateway_service_credential_protect();
+
+create or replace function gateway_approval_protect()
+returns trigger language plpgsql as $$
+begin
+  if tg_op = 'DELETE' then raise exception 'gateway_approvals are retained'; end if;
+  if new.team_id is distinct from old.team_id
+    or new.execution_id is distinct from old.execution_id
+    or new.expires_at is distinct from old.expires_at
+    or (old.approver_member_id is not null
+        and new.approver_member_id is distinct from old.approver_member_id)
+    or (old.decided_at is not null and new.decided_at is distinct from old.decided_at)
+    or (old.decision_correlation_id is not null
+        and new.decision_correlation_id is distinct from old.decision_correlation_id)
+    or new.created_at is distinct from old.created_at then
+    raise exception 'gateway approval identity/expiry fields are immutable';
+  end if;
+  if new.status is distinct from old.status
+    and not (
+      (old.status='pending' and new.status in ('approved','denied','expired','cancelled'))
+      or (old.status='approved' and new.status in ('expired','cancelled'))
+    ) then
+    raise exception 'gateway approval transition is invalid';
+  end if;
+  return new;
+end $$;
+drop trigger if exists gateway_approvals_protect on gateway_approvals;
+create trigger gateway_approvals_protect
+  before update or delete on gateway_approvals
+  for each row execute function gateway_approval_protect();
+
+create or replace function gateway_execution_protect()
+returns trigger language plpgsql as $$
+begin
+  if tg_op = 'DELETE' then raise exception 'gateway_executions are retained'; end if;
+  if new.team_id is distinct from old.team_id or new.member_id is distinct from old.member_id
+    or new.service_identity_id is distinct from old.service_identity_id
+    or new.subject_binding_id is distinct from old.subject_binding_id
+    or new.connection_id is distinct from old.connection_id or new.lease_id is distinct from old.lease_id
+    or new.correlation_id is distinct from old.correlation_id or new.idempotency_key is distinct from old.idempotency_key
+    or new.toolkit is distinct from old.toolkit or new.tool is distinct from old.tool
+    or new.request_hash is distinct from old.request_hash
+    or new.encrypted_request_envelope is distinct from old.encrypted_request_envelope
+    or new.decision is distinct from old.decision or new.policy_version is distinct from old.policy_version
+    or new.policy_rule_id is distinct from old.policy_rule_id or new.created_at is distinct from old.created_at
+    or new.actor_snapshot is distinct from old.actor_snapshot
+    or new.role_snapshot is distinct from old.role_snapshot
+    or new.tier_snapshot is distinct from old.tier_snapshot
+    or new.policy_resource is distinct from old.policy_resource
+    or new.request_envelope_hash is distinct from old.request_envelope_hash
+    or (old.resume_fingerprint is not null and new.resume_fingerprint is distinct from old.resume_fingerprint)
+    or (old.claim_idempotency_key is not null and new.claim_idempotency_key is distinct from old.claim_idempotency_key)
+    or (old.claimed_credential_id is not null and new.claimed_credential_id is distinct from old.claimed_credential_id) then
+    raise exception 'gateway execution identity/request fields are immutable';
+  end if;
+  return new;
+end $$;
+drop trigger if exists gateway_executions_protect on gateway_executions;
+create trigger gateway_executions_protect
+  before update or delete on gateway_executions
+  for each row execute function gateway_execution_protect();

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -358,6 +358,56 @@ create table if not exists gateway_service_identities (
 create index if not exists gateway_service_identities_team_env_idx
   on gateway_service_identities (team_id, environment);
 
+do $$
+declare legacy record;
+begin
+  for legacy in
+    select credential_id,credential_hash,credential_version
+      from gateway_service_identities
+  loop
+    begin
+      if legacy.credential_id !~ '^[A-Za-z0-9_-]{22}$'
+        or legacy.credential_hash !~ '^[0-9a-f]{64}$'
+        or legacy.credential_version <= 0
+        or octet_length(decode(translate(legacy.credential_id,'-_','+/') || '==','base64')) <> 16
+        or translate(rtrim(encode(
+             decode(translate(legacy.credential_id,'-_','+/') || '==','base64'),
+             'base64'
+           ),'='),'+/','-_') <> legacy.credential_id then
+        raise exception 'gateway_service_identity_legacy_preflight';
+      end if;
+    exception when others then
+      raise exception 'gateway_service_identity_legacy_preflight';
+    end;
+  end loop;
+end $$;
+
+create table if not exists gateway_service_credentials (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null,
+  service_identity_id uuid not null,
+  credential_id text not null unique check (credential_id ~ '^[A-Za-z0-9_-]{22}$'),
+  version integer not null check (version > 0),
+  secret_hash text not null check (secret_hash ~ '^[0-9a-f]{64}$'),
+  replaces_credential_id text,
+  activated_at timestamptz not null default now(),
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  last_authenticated_at timestamptz,
+  created_by_member_id uuid,
+  created_at timestamptz not null default now(),
+  unique (team_id, id),
+  unique (service_identity_id, version),
+  foreign key (team_id, service_identity_id)
+    references gateway_service_identities(team_id, id) on delete restrict,
+  foreign key (team_id, created_by_member_id)
+    references members(team_id, id) on delete restrict,
+  check (expires_at is null or expires_at > activated_at),
+  check (revoked_at is null or revoked_at >= activated_at)
+);
+create index if not exists gateway_service_credentials_identity_idx
+  on gateway_service_credentials (team_id, service_identity_id, created_at desc);
+
 create table if not exists executor_subject_bindings (
   id uuid primary key default gen_random_uuid(),
   team_id uuid not null,
@@ -458,6 +508,14 @@ create table if not exists gateway_executions (
   request_hash text not null check (request_hash ~ '^[0-9a-f]{64}$'),
   encrypted_request_envelope bytea not null
     check (octet_length(encrypted_request_envelope) between 1 and 65536),
+  actor_snapshot text not null,
+  role_snapshot text not null check (role_snapshot in ('admin', 'lead', 'member')),
+  tier_snapshot text not null check (tier_snapshot in ('team', 'external')),
+  policy_resource text not null,
+  request_envelope_hash text not null check (request_envelope_hash ~ '^[0-9a-f]{64}$'),
+  resume_fingerprint text check (resume_fingerprint is null or resume_fingerprint ~ '^[0-9a-f]{64}$'),
+  claim_idempotency_key text,
+  claimed_credential_id uuid,
   decision text not null check (decision in ('block', 'require_approval', 'allow')),
   state text not null check (state in
     ('blocked', 'approval_required', 'approved', 'claimed', 'succeeded', 'failed', 'cancelled', 'expired')),
@@ -489,6 +547,47 @@ create table if not exists gateway_executions (
 create index if not exists gateway_executions_scope_idx
   on gateway_executions (team_id, member_id, subject_binding_id, created_at desc);
 
+-- Additive replay path for deployments whose gateway_executions table predates AIO-407.
+alter table gateway_executions add column if not exists actor_snapshot text;
+alter table gateway_executions add column if not exists role_snapshot text;
+alter table gateway_executions add column if not exists tier_snapshot text;
+alter table gateway_executions add column if not exists policy_resource text;
+alter table gateway_executions add column if not exists request_envelope_hash text;
+alter table gateway_executions add column if not exists resume_fingerprint text;
+alter table gateway_executions add column if not exists claim_idempotency_key text;
+alter table gateway_executions add column if not exists claimed_credential_id uuid;
+update gateway_executions e
+   set actor_snapshot=coalesce(e.actor_snapshot,m.actor_handle),
+       role_snapshot=coalesce(e.role_snapshot,m.role::text),
+       tier_snapshot=coalesce(e.tier_snapshot,m.tier::text),
+       policy_resource=coalesce(e.policy_resource,'github.repository:*'),
+       request_envelope_hash=coalesce(e.request_envelope_hash,
+         encode(sha256(e.encrypted_request_envelope),'hex'))
+  from members m where m.id=e.member_id and m.team_id=e.team_id
+    and (e.actor_snapshot is null or e.role_snapshot is null or e.tier_snapshot is null
+      or e.policy_resource is null or e.request_envelope_hash is null);
+alter table gateway_executions alter column actor_snapshot set not null;
+alter table gateway_executions alter column role_snapshot set not null;
+alter table gateway_executions alter column tier_snapshot set not null;
+alter table gateway_executions alter column policy_resource set not null;
+alter table gateway_executions alter column request_envelope_hash set not null;
+alter table gateway_executions drop constraint if exists gateway_executions_role_snapshot_check;
+alter table gateway_executions add constraint gateway_executions_role_snapshot_check
+  check (role_snapshot in ('admin','lead','member'));
+alter table gateway_executions drop constraint if exists gateway_executions_tier_snapshot_check;
+alter table gateway_executions add constraint gateway_executions_tier_snapshot_check
+  check (tier_snapshot in ('team','external'));
+alter table gateway_executions drop constraint if exists gateway_executions_request_envelope_hash_check;
+alter table gateway_executions add constraint gateway_executions_request_envelope_hash_check
+  check (request_envelope_hash ~ '^[0-9a-f]{64}$');
+alter table gateway_executions drop constraint if exists gateway_executions_resume_fingerprint_check;
+alter table gateway_executions add constraint gateway_executions_resume_fingerprint_check
+  check (resume_fingerprint is null or resume_fingerprint ~ '^[0-9a-f]{64}$');
+alter table gateway_executions drop constraint if exists gateway_executions_claimed_credential_fk;
+alter table gateway_executions add constraint gateway_executions_claimed_credential_fk
+  foreign key (team_id,claimed_credential_id)
+  references gateway_service_credentials(team_id,id) on delete restrict;
+
 create table if not exists gateway_approvals (
   id uuid primary key default gen_random_uuid(),
   team_id uuid not null,
@@ -498,6 +597,7 @@ create table if not exists gateway_approvals (
   expires_at timestamptz not null,
   approver_member_id uuid,
   decided_at timestamptz,
+  decision_correlation_id uuid,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   unique (team_id, id),
@@ -507,6 +607,7 @@ create table if not exists gateway_approvals (
   check ((status = 'pending' and decided_at is null and approver_member_id is null)
       or (status <> 'pending' and decided_at is not null))
 );
+alter table gateway_approvals add column if not exists decision_correlation_id uuid;
 
 create table if not exists gateway_audit_log (
   id bigint generated always as identity primary key,
@@ -517,10 +618,13 @@ create table if not exists gateway_audit_log (
   connection_id uuid,
   execution_id uuid,
   approval_id uuid,
+  credential_row_id uuid,
   event text not null check (event in
     ('lease_issued', 'decision_blocked', 'decision_approval_required', 'decision_allowed',
-     'approval_approved', 'approval_denied', 'approval_expired', 'execution_claimed',
-     'outcome_recorded', 'connection_revoked', 'service_identity_revoked')),
+     'approval_approved', 'approval_denied', 'approval_expired', 'approval_cancelled',
+     'execution_claimed', 'outcome_recorded', 'connection_revoked',
+     'service_identity_revoked', 'credential_rotated', 'credential_revoked',
+     'policy_created', 'policy_updated', 'policy_deleted')),
   toolkit text,
   tool text,
   request_hash text check (request_hash is null or request_hash ~ '^[0-9a-f]{64}$'),
@@ -549,10 +653,34 @@ create table if not exists gateway_audit_log (
   foreign key (team_id, approval_id)
     references gateway_approvals(team_id, id) on delete restrict
 );
+alter table gateway_audit_log add column if not exists credential_row_id uuid;
+alter table gateway_audit_log drop constraint if exists gateway_audit_log_credential_row_fk;
+alter table gateway_audit_log add constraint gateway_audit_log_credential_row_fk
+  foreign key (team_id,credential_row_id)
+  references gateway_service_credentials(team_id,id) on delete restrict;
+alter table gateway_audit_log drop constraint if exists gateway_audit_log_event_check;
+alter table gateway_audit_log add constraint gateway_audit_log_event_check check (event in
+  ('lease_issued','decision_blocked','decision_approval_required','decision_allowed',
+   'approval_approved','approval_denied','approval_expired','approval_cancelled',
+   'execution_claimed','outcome_recorded','connection_revoked',
+   'service_identity_revoked','credential_rotated','credential_revoked',
+   'policy_created','policy_updated','policy_deleted'));
 create index if not exists gateway_audit_log_team_time_idx
   on gateway_audit_log (team_id, created_at desc);
 create unique index if not exists gateway_audit_log_outcome_execution_unq
   on gateway_audit_log (execution_id) where event='outcome_recorded';
+create unique index if not exists gateway_audit_log_decision_approval_unq
+  on gateway_audit_log (approval_id) where event in ('approval_approved','approval_denied');
+create unique index if not exists gateway_audit_log_claim_execution_unq
+  on gateway_audit_log (execution_id) where event='execution_claimed';
+create unique index if not exists gateway_audit_log_expiry_approval_unq
+  on gateway_audit_log (approval_id) where event='approval_expired';
+create unique index if not exists gateway_audit_log_cancel_approval_unq
+  on gateway_audit_log (approval_id) where event='approval_cancelled';
+create unique index if not exists gateway_audit_log_rotation_credential_unq
+  on gateway_audit_log (credential_row_id) where event='credential_rotated';
+create unique index if not exists gateway_audit_log_revocation_credential_unq
+  on gateway_audit_log (credential_row_id) where event='credential_revoked';
 
 create table if not exists gateway_rate_limits (
   bucket text not null,
@@ -589,6 +717,14 @@ begin
     or new.tool is distinct from old.tool
     or new.request_hash is distinct from old.request_hash
     or new.encrypted_request_envelope is distinct from old.encrypted_request_envelope
+    or new.actor_snapshot is distinct from old.actor_snapshot
+    or new.role_snapshot is distinct from old.role_snapshot
+    or new.tier_snapshot is distinct from old.tier_snapshot
+    or new.policy_resource is distinct from old.policy_resource
+    or new.request_envelope_hash is distinct from old.request_envelope_hash
+    or (old.resume_fingerprint is not null and new.resume_fingerprint is distinct from old.resume_fingerprint)
+    or (old.claim_idempotency_key is not null and new.claim_idempotency_key is distinct from old.claim_idempotency_key)
+    or (old.claimed_credential_id is not null and new.claimed_credential_id is distinct from old.claimed_credential_id)
     or new.decision is distinct from old.decision
     or new.policy_version is distinct from old.policy_version
     or new.policy_rule_id is distinct from old.policy_rule_id
@@ -611,8 +747,20 @@ begin
   if new.team_id is distinct from old.team_id
     or new.execution_id is distinct from old.execution_id
     or new.expires_at is distinct from old.expires_at
+    or (old.approver_member_id is not null
+        and new.approver_member_id is distinct from old.approver_member_id)
+    or (old.decided_at is not null and new.decided_at is distinct from old.decided_at)
+    or (old.decision_correlation_id is not null
+        and new.decision_correlation_id is distinct from old.decision_correlation_id)
     or new.created_at is distinct from old.created_at then
     raise exception 'gateway approval identity/expiry fields are immutable';
+  end if;
+  if new.status is distinct from old.status
+    and not (
+      (old.status='pending' and new.status in ('approved','denied','expired','cancelled'))
+      or (old.status='approved' and new.status in ('expired','cancelled'))
+    ) then
+    raise exception 'gateway approval transition is invalid';
   end if;
   return new;
 end $$;
@@ -636,6 +784,32 @@ end $$;
 drop trigger if exists gateway_service_identities_protect on gateway_service_identities;
 create trigger gateway_service_identities_protect before update or delete on gateway_service_identities
   for each row execute function gateway_service_identity_protect();
+
+create or replace function gateway_service_credential_protect()
+returns trigger language plpgsql as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'gateway service credentials must be revoked, not deleted';
+  end if;
+  if new.id is distinct from old.id
+    or new.team_id is distinct from old.team_id
+    or new.service_identity_id is distinct from old.service_identity_id
+    or new.credential_id is distinct from old.credential_id
+    or new.version is distinct from old.version
+    or new.secret_hash is distinct from old.secret_hash
+    or new.replaces_credential_id is distinct from old.replaces_credential_id
+    or new.activated_at is distinct from old.activated_at
+    or new.expires_at is distinct from old.expires_at
+    or new.created_by_member_id is distinct from old.created_by_member_id
+    or (old.revoked_at is not null and new.revoked_at is distinct from old.revoked_at)
+    or new.created_at is distinct from old.created_at then
+    raise exception 'gateway service credential identity fields are immutable';
+  end if;
+  return new;
+end $$;
+drop trigger if exists gateway_service_credentials_protect on gateway_service_credentials;
+create trigger gateway_service_credentials_protect before update or delete on gateway_service_credentials
+  for each row execute function gateway_service_credential_protect();
 
 create or replace function executor_subject_binding_protect()
 returns trigger language plpgsql as $$

--- a/scripts/check-gateway-writers.mjs
+++ b/scripts/check-gateway-writers.mjs
@@ -3,9 +3,13 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 const ROOT = process.cwd();
-const OWNER = join("lib", "gateway", "persistence.ts");
+const OWNERS = new Set([
+  join("lib", "gateway", "persistence.ts"),
+  join("lib", "gateway", "admin-persistence.ts"),
+]);
 const TABLES = [
   "gateway_service_identities",
+  "gateway_service_credentials",
   "executor_subject_bindings",
   "gateway_connections",
   "gateway_resolution_leases",
@@ -16,6 +20,7 @@ const TABLES = [
 ];
 const SECRET_FIELDS = [
   "credential_hash",
+  "secret_hash",
   "credential_ciphertext",
   "lease_hash",
   "encrypted_request_envelope",
@@ -35,7 +40,7 @@ const violations = [];
 for (const top of scanDirs) {
   for (const file of walk(join(ROOT, top))) {
     const rel = relative(ROOT, file);
-    if (rel === OWNER || rel === join("scripts", "check-gateway-writers.mjs")) continue;
+    if (OWNERS.has(rel) || rel === join("scripts", "check-gateway-writers.mjs")) continue;
     const source = readFileSync(file, "utf8");
     for (const table of TABLES) {
       const queryBuilder = new RegExp(`from\\(\\s*["']${table}["']\\s*\\)\\s*\\.\\s*(?:insert|update|upsert|delete)\\b`, "i");
@@ -54,4 +59,4 @@ if (violations.length) {
   console.error("Gateway writer boundary violated:\n" + violations.sort().join("\n"));
   process.exit(1);
 }
-console.log(`gateway writer guard: OK (${TABLES.length} tables, ${SECRET_FIELDS.length} secret fields)`);
+console.log(`gateway writer guard: OK (${OWNERS.size} owners, ${TABLES.length} tables, ${SECRET_FIELDS.length} secret fields)`);

--- a/test/datamechanics/gateway-approval.datamechanics.test.ts
+++ b/test/datamechanics/gateway-approval.datamechanics.test.ts
@@ -1,0 +1,571 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { getPool } from "@/lib/db/pg/pool";
+import {
+  authorizeGatewayAdmin,
+  createGatewayAdminPolicy,
+  deleteGatewayAdminPolicy,
+  decideGatewayApproval,
+  listGatewayCredentials,
+  listGatewayApprovals,
+  listGatewayAdminPolicies,
+  revokeGatewayCredential,
+  rotateGatewayCredential,
+  updateGatewayAdminPolicy,
+} from "@/lib/gateway/admin-persistence";
+import { encryptGatewayRequestEnvelope } from "@/lib/gateway/envelope";
+import {
+  authenticateGatewayServiceCredential,
+  authorizeLeaseAndCreateExecution,
+  failGatewayCredentialSealing,
+  issueResolutionLease,
+  resumeClaimGatewayExecution,
+} from "@/lib/gateway/persistence";
+import { gatewayScope, seedGateway, type GatewaySeed } from "./gateway-helpers";
+import { db } from "./helpers";
+import { createPolicy, listAllPolicies, updatePolicy } from "@/lib/policy/manage";
+
+const KEY = Buffer.alloc(32, 19);
+const REQUEST_HASH = "4b18a1b9c0f093f7e46b4410e245fd88f011e6d820b34ef9446296ff9386f310";
+
+async function approvedExecution(options: {
+  approve?: boolean;
+  approvalTtlMilliseconds?: number;
+} = {}) {
+  const seed = await seedGateway();
+  await getPool().query(
+    `update members set role='admin' where id=$1 and team_id=$2`,
+    [seed.memberId, seed.teamId],
+  );
+  await getPool().query(
+    `insert into policies(team_id,action,resource,effect,priority)
+     values($1,'gateway.aios-github-readonly.github.repository.get',
+       'github.repository:octo/project','require_approval',10)`,
+    [seed.teamId],
+  );
+  const lease = await issueResolutionLease({
+    ...gatewayScope(seed),
+    connectionRef: seed.connectionRef,
+    audience: "aios-github-readonly",
+    correlationId: randomUUID(),
+  });
+  const executionId = randomUUID();
+  const decision = await authorizeLeaseAndCreateExecution({
+    serviceIdentityId: seed.serviceIdentityId,
+    executionId,
+    lease: lease.lease,
+    audience: "aios-github-readonly",
+    toolkit: "aios-github-readonly",
+    tool: "github.repository.get",
+    normalizedArgs: { owner: "octo", repo: "project" },
+    requestHash: REQUEST_HASH,
+    correlationId: randomUUID(),
+    idempotencyKey: randomUUID(),
+    requestEnvelope: encryptGatewayRequestEnvelope(
+      { owner: "octo", repo: "project" },
+      { executionId, serviceIdentityId: seed.serviceIdentityId },
+      KEY,
+    ),
+    approvalTtlMilliseconds: options.approvalTtlMilliseconds,
+  });
+  if (decision.decision !== "require_approval")
+    throw new Error("expected approval");
+  const ctx = {
+    teamId: seed.teamId,
+    teamSlug: seed.teamSlug,
+    memberId: seed.memberId,
+  };
+  if (options.approve !== false) {
+    await decideGatewayApproval(
+      ctx,
+      decision.approvalId,
+      "approve",
+      randomUUID(),
+    );
+  }
+  const service = await authenticateGatewayServiceCredential(
+    `Bearer aios_gw_${seed.credentialId}_${seed.credentialSecret}`,
+  );
+  return { seed, ctx, service, executionId, approvalId: decision.approvalId };
+}
+
+const claimInput = (
+  seed: GatewaySeed,
+  executionId: string,
+  service: Awaited<ReturnType<typeof authenticateGatewayServiceCredential>>,
+  idempotencyKey: string,
+  onPayload: () => void,
+) => ({
+  service,
+  executionId,
+  executorTenantId: seed.executorTenantId,
+  executorSubjectId: seed.executorSubjectId,
+  toolkit: "aios-github-readonly",
+  tool: "github.repository.get",
+  requestHash: REQUEST_HASH,
+  correlationId: randomUUID(),
+  idempotencyKey,
+  useWinningPayload: async (payload: { encryptedRequestEnvelope: Buffer }) => {
+    onPayload();
+    expect(payload.encryptedRequestEnvelope.length).toBeGreaterThan(0);
+    return "credential-bearing-response";
+  },
+});
+
+describe("gateway durable approval and resume", () => {
+  it("enforces the admin/member/lead/external authorization matrix", async () => {
+    const seed = await seedGateway();
+    const authUserId = randomUUID();
+    await getPool().query(`insert into auth_users(id,email) values($1,$2)`, [
+      authUserId,
+      `${randomUUID()}@test.local`,
+    ]);
+    await getPool().query(
+      `update members set auth_user_id=$1,role='admin',tier='team',status='active'
+        where id=$2 and team_id=$3`,
+      [authUserId, seed.memberId, seed.teamId],
+    );
+    await expect(authorizeGatewayAdmin(seed.teamSlug, authUserId)).resolves.toMatchObject({
+      teamId: seed.teamId,
+      memberId: seed.memberId,
+    });
+    for (const role of ["member", "lead"] as const) {
+      await getPool().query(`update members set role=$1 where id=$2`, [role, seed.memberId]);
+      await expect(authorizeGatewayAdmin(seed.teamSlug, authUserId)).rejects.toMatchObject({
+        code: "gateway_forbidden",
+        status: 403,
+      });
+    }
+    await getPool().query(
+      `update members set role='admin',tier='external' where id=$1`,
+      [seed.memberId],
+    );
+    await expect(authorizeGatewayAdmin(seed.teamSlug, authUserId)).rejects.toMatchObject({
+      code: "gateway_scope_not_found",
+      status: 422,
+    });
+    await expect(authorizeGatewayAdmin("unknown-team", authUserId)).rejects.toMatchObject({
+      code: "gateway_not_found",
+      status: 404,
+    });
+    const foreign = await seedGateway();
+    await expect(authorizeGatewayAdmin(foreign.teamSlug, authUserId)).rejects.toMatchObject({
+      code: "gateway_not_found",
+      status: 404,
+    });
+  });
+
+  it("returns one credential-bearing winner and credential-free identical retries", async () => {
+    const { seed, service, executionId } = await approvedExecution();
+    const idempotencyKey = randomUUID();
+    let payloads = 0;
+    const attempts = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        resumeClaimGatewayExecution(
+          claimInput(seed, executionId, service, idempotencyKey, () => payloads++),
+        ),
+      ),
+    );
+    expect(payloads).toBe(1);
+    expect(attempts.filter((value) => value.status === "claimed")).toHaveLength(1);
+    expect(
+      attempts.filter((value) => value.status === "already_claimed"),
+    ).toHaveLength(7);
+    await expect(
+      resumeClaimGatewayExecution(
+        claimInput(seed, executionId, service, randomUUID(), () => payloads++),
+      ),
+    ).rejects.toMatchObject({ code: "gateway_idempotency_conflict" });
+    expect(payloads).toBe(1);
+    service.secretBytes.fill(0);
+  });
+
+  it("never re-exposes a post-commit payload and settles seal failure as credential", async () => {
+    const { seed, service, executionId } = await approvedExecution();
+    const idempotencyKey = randomUUID();
+    let payloads = 0;
+    await expect(
+      resumeClaimGatewayExecution({
+        ...claimInput(seed, executionId, service, idempotencyKey, () => payloads++),
+        useWinningPayload: async () => {
+          payloads++;
+          throw new Error("injected seal failure");
+        },
+      }),
+    ).rejects.toThrow("injected seal failure");
+    expect(payloads).toBe(1);
+    expect(
+      await getPool().query(`select state from gateway_executions where id=$1`, [
+        executionId,
+      ]),
+    ).toMatchObject({ rows: [{ state: "claimed" }] });
+    await failGatewayCredentialSealing({
+      serviceIdentityId: seed.serviceIdentityId,
+      executionId,
+      correlationId: randomUUID(),
+    });
+    const restartedService = await authenticateGatewayServiceCredential(
+      `Bearer aios_gw_${seed.credentialId}_${seed.credentialSecret}`,
+    );
+    const retry = await resumeClaimGatewayExecution(
+      claimInput(
+        seed,
+        executionId,
+        restartedService,
+        idempotencyKey,
+        () => payloads++,
+      ),
+    );
+    expect(retry).toEqual({
+      status: "already_claimed",
+      executionId,
+      state: "failed",
+    });
+    expect(payloads).toBe(1);
+    const settled = await getPool().query(
+      `select state,outcome_classification from gateway_executions where id=$1`,
+      [executionId],
+    );
+    expect(settled.rows[0]).toEqual({
+      state: "failed",
+      outcome_classification: "credential",
+    });
+    restartedService.secretBytes.fill(0);
+    service.secretBytes.fill(0);
+  });
+
+  it("rolls the resumable claim back when strict claim audit fails", async () => {
+    const { seed, service, executionId } = await approvedExecution();
+    const correlationId = randomUUID();
+    await getPool().query(`
+      create or replace function gateway_test_reject_resumable_claim()
+      returns trigger language plpgsql as $$
+      begin
+        if new.event='execution_claimed' and new.correlation_id='${correlationId}'::uuid
+          then raise exception 'resumable claim audit rejected'; end if;
+        return new;
+      end $$;
+      drop trigger if exists gateway_test_reject_resumable_claim on gateway_audit_log;
+      create trigger gateway_test_reject_resumable_claim before insert on gateway_audit_log
+      for each row execute function gateway_test_reject_resumable_claim()
+    `);
+    let payloads = 0;
+    try {
+      await expect(
+        resumeClaimGatewayExecution({
+          ...claimInput(seed, executionId, service, randomUUID(), () => payloads++),
+          correlationId,
+        }),
+      ).rejects.toThrow("resumable claim audit rejected");
+      expect(payloads).toBe(0);
+      const state = await getPool().query(
+        `select state,claimed_at from gateway_executions where id=$1`,
+        [executionId],
+      );
+      expect(state.rows[0]).toEqual({ state: "approved", claimed_at: null });
+    } finally {
+      service.secretBytes.fill(0);
+      await getPool().query(`
+        drop trigger if exists gateway_test_reject_resumable_claim on gateway_audit_log;
+        drop function if exists gateway_test_reject_resumable_claim()
+      `);
+    }
+  });
+
+  it("cancels an approved execution when the frozen principal changes", async () => {
+    const { seed, service, executionId, approvalId } = await approvedExecution();
+    await getPool().query(
+      `update members set role='lead' where id=$1 and team_id=$2`,
+      [seed.memberId, seed.teamId],
+    );
+    await expect(
+      resumeClaimGatewayExecution(
+        claimInput(seed, executionId, service, randomUUID(), () => undefined),
+      ),
+    ).rejects.toMatchObject({ code: "gateway_scope_not_found" });
+    const state = await getPool().query(
+      `select e.state,a.status from gateway_executions e
+       join gateway_approvals a on a.execution_id=e.id where e.id=$1 and a.id=$2`,
+      [executionId, approvalId],
+    );
+    expect(state.rows[0]).toEqual({ state: "cancelled", status: "cancelled" });
+    service.secretBytes.fill(0);
+  });
+
+  it("cancels without a credential when actor, tier, connection, or policy scope changes", async () => {
+    const changes: Array<{
+      name: string;
+      apply: (seed: GatewaySeed) => Promise<unknown>;
+    }> = [
+      {
+        name: "actor",
+        apply: (seed) => getPool().query(
+          `update members set actor_handle=$1 where id=$2 and team_id=$3`,
+          [`changed-${randomUUID()}`, seed.memberId, seed.teamId],
+        ),
+      },
+      {
+        name: "tier",
+        apply: (seed) => getPool().query(
+          `update members set tier='external' where id=$1 and team_id=$2`,
+          [seed.memberId, seed.teamId],
+        ),
+      },
+      {
+        name: "connection",
+        apply: (seed) => getPool().query(
+          `update gateway_connections set enabled=false,revoked_at=now(),updated_at=now()
+            where id=$1 and team_id=$2`,
+          [seed.connectionId, seed.teamId],
+        ),
+      },
+      {
+        name: "policy",
+        apply: (seed) => getPool().query(
+          `insert into policies(team_id,action,resource,effect,priority)
+           values($1,'gateway.aios-github-readonly.github.repository.get',
+             'github.repository:octo/project','deny',100)`,
+          [seed.teamId],
+        ),
+      },
+    ];
+    for (const change of changes) {
+      const { seed, service, executionId, approvalId } = await approvedExecution();
+      await change.apply(seed);
+      let payloads = 0;
+      await expect(
+        resumeClaimGatewayExecution(
+          claimInput(seed, executionId, service, randomUUID(), () => payloads++),
+        ),
+        change.name,
+      ).rejects.toMatchObject({ code: "gateway_scope_not_found" });
+      expect(payloads, change.name).toBe(0);
+      const state = await getPool().query(
+        `select e.state,a.status from gateway_executions e
+         join gateway_approvals a on a.execution_id=e.id where e.id=$1 and a.id=$2`,
+        [executionId, approvalId],
+      );
+      expect(state.rows[0], change.name).toEqual({
+        state: "cancelled",
+        status: "cancelled",
+      });
+      service.secretBytes.fill(0);
+    }
+  });
+
+  it("keeps rotated credentials overlapping until lock-linearized revocation", async () => {
+    const { seed, ctx, service, executionId } = await approvedExecution();
+    const credentialId = randomBytes(16).toString("base64url");
+    const secret = randomBytes(32).toString("base64url");
+    const rotated = await rotateGatewayCredential(ctx, seed.serviceIdentityId, {
+      credentialId,
+      secret,
+      replacesCredentialId: seed.credentialId,
+      correlationId: randomUUID(),
+    });
+    expect(rotated).not.toHaveProperty("secret");
+    expect(await listGatewayCredentials(ctx, seed.serviceIdentityId)).toHaveLength(2);
+    const oldAuth = await authenticateGatewayServiceCredential(
+      `Bearer aios_gw_${seed.credentialId}_${seed.credentialSecret}`,
+    );
+    const newAuth = await authenticateGatewayServiceCredential(
+      `Bearer aios_gw_${credentialId}_${secret}`,
+    );
+    expect(oldAuth.id).toBe(newAuth.id);
+    expect(oldAuth.credentialRowId).not.toBe(newAuth.credentialRowId);
+    await resumeClaimGatewayExecution(
+      claimInput(seed, executionId, newAuth, randomUUID(), () => undefined),
+    );
+    const claimed = await getPool().query(
+      `select claimed_credential_id from gateway_executions where id=$1`,
+      [executionId],
+    );
+    expect(claimed.rows[0].claimed_credential_id).toBe(newAuth.credentialRowId);
+    await revokeGatewayCredential(
+      ctx,
+      seed.serviceIdentityId,
+      credentialId,
+      randomUUID(),
+    );
+    await expect(
+      authenticateGatewayServiceCredential(
+        `Bearer aios_gw_${credentialId}_${secret}`,
+      ),
+    ).rejects.toMatchObject({ code: "gateway_unauthorized" });
+    const stillActive = await authenticateGatewayServiceCredential(
+      `Bearer aios_gw_${seed.credentialId}_${seed.credentialSecret}`,
+    );
+    oldAuth.secretBytes.fill(0);
+    newAuth.secretBytes.fill(0);
+    stillActive.secretBytes.fill(0);
+    service.secretBytes.fill(0);
+  });
+
+  it("keeps gateway policy CRUD transactional and isolated from generic policies", async () => {
+    const { ctx, service } = await approvedExecution();
+    const correlationId = randomUUID();
+    const created = await createGatewayAdminPolicy(ctx, {
+      subject: { type: "team" },
+      tool: "github.issues.list",
+      resource: "github.repository:*",
+      effect: "allow",
+      priority: 2,
+      enabled: true,
+      correlationId,
+    });
+    expect(created.effect).toBe("allow");
+    const updated = await updateGatewayAdminPolicy(ctx, created.id, {
+      subject: { type: "tier", tier: "team" },
+      tool: "github.issues.list",
+      resource: "github.repository:octo/project",
+      effect: "block",
+      priority: 4,
+      enabled: true,
+      correlationId: randomUUID(),
+    });
+    expect(updated).toMatchObject({ effect: "block", priority: 4 });
+    expect(await listGatewayAdminPolicies(ctx)).toContainEqual(
+      expect.objectContaining({ id: created.id }),
+    );
+    expect(await listAllPolicies(db(), ctx.teamId)).not.toContainEqual(
+      expect.objectContaining({ id: created.id }),
+    );
+    await expect(
+      createPolicy(db(), ctx.teamId, {
+        action: "gateway.aios-github-readonly.*",
+        effect: "allow",
+      }),
+    ).rejects.toThrow("Managed gateway administration");
+    await expect(
+      updatePolicy(db(), ctx.teamId, created.id, {
+        action: "item.read",
+        effect: "allow",
+      }),
+    ).rejects.toThrow("Managed gateway administration");
+    await deleteGatewayAdminPolicy(ctx, created.id, randomUUID());
+    expect(await listGatewayAdminPolicies(ctx)).not.toContainEqual(
+      expect.objectContaining({ id: created.id }),
+    );
+    const policyEvents = await getPool().query<{ event: string }>(
+      `select event from gateway_audit_log where policy_rule_id=$1 order by id`,
+      [created.id],
+    );
+    expect(policyEvents.rows.map(({ event }) => event)).toEqual([
+      "policy_created",
+      "policy_updated",
+      "policy_deleted",
+    ]);
+    service.secretBytes.fill(0);
+  });
+
+  it("rolls credential rotation back when its strict audit insert fails", async () => {
+    const { seed, ctx, service } = await approvedExecution();
+    await getPool().query(`
+      create or replace function gateway_test_reject_rotation()
+      returns trigger language plpgsql as $$
+      begin
+        if new.event='credential_rotated' then raise exception 'audit rejected'; end if;
+        return new;
+      end $$;
+      drop trigger if exists gateway_test_reject_rotation on gateway_audit_log;
+      create trigger gateway_test_reject_rotation before insert on gateway_audit_log
+      for each row execute function gateway_test_reject_rotation()
+    `);
+    try {
+      await expect(
+        rotateGatewayCredential(ctx, seed.serviceIdentityId, {
+          credentialId: randomBytes(16).toString("base64url"),
+          secret: randomBytes(32).toString("base64url"),
+          replacesCredentialId: seed.credentialId,
+          correlationId: randomUUID(),
+        }),
+      ).rejects.toThrow("audit rejected");
+      expect(await listGatewayCredentials(ctx, seed.serviceIdentityId)).toHaveLength(1);
+    } finally {
+      service.secretBytes.fill(0);
+      await getPool().query(`
+        drop trigger if exists gateway_test_reject_rotation on gateway_audit_log;
+        drop function if exists gateway_test_reject_rotation()
+      `);
+    }
+  });
+
+  it("serializes concurrent rotations into distinct credential versions", async () => {
+    const { seed, ctx, service } = await approvedExecution();
+    const rotated = await Promise.all(
+      Array.from({ length: 2 }, () =>
+        rotateGatewayCredential(ctx, seed.serviceIdentityId, {
+          credentialId: randomBytes(16).toString("base64url"),
+          secret: randomBytes(32).toString("base64url"),
+          replacesCredentialId: seed.credentialId,
+          correlationId: randomUUID(),
+        }),
+      ),
+    );
+    expect(rotated.map((value) => value.version).sort()).toEqual([2, 3]);
+    expect(await listGatewayCredentials(ctx, seed.serviceIdentityId)).toHaveLength(3);
+    service.secretBytes.fill(0);
+  });
+
+  it("allows exactly one concurrent admin decision and one decision audit", async () => {
+    const { ctx, approvalId, executionId, service } = await approvedExecution({
+      approve: false,
+    });
+    const attempts = await Promise.allSettled(
+      Array.from({ length: 8 }, () =>
+        decideGatewayApproval(ctx, approvalId, "approve", randomUUID()),
+      ),
+    );
+    expect(attempts.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    expect(attempts.filter(({ status }) => status === "rejected")).toHaveLength(7);
+    const decision = await getPool().query(
+      `select e.state,a.status,count(l.id)::int audit_count
+         from gateway_executions e
+         join gateway_approvals a on a.execution_id=e.id
+         left join gateway_audit_log l on l.approval_id=a.id
+           and l.event in ('approval_approved','approval_denied')
+        where e.id=$1 and a.id=$2 group by e.state,a.status`,
+      [executionId, approvalId],
+    );
+    expect(decision.rows[0]).toEqual({
+      state: "approved",
+      status: "approved",
+      audit_count: 1,
+    });
+    service.secretBytes.fill(0);
+  });
+
+  it("uses database time to expire decision races exactly once", async () => {
+    const { ctx, approvalId, executionId, service } = await approvedExecution({
+      approve: false,
+      approvalTtlMilliseconds: 100,
+    });
+    const queue = await listGatewayApprovals(ctx);
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toEqual(
+      expect.objectContaining({
+        approvalId,
+        executionId,
+        requestHashPrefix: REQUEST_HASH.slice(0, 12),
+      }),
+    );
+    expect(queue[0]).not.toHaveProperty("requestHash");
+    expect(queue[0]).not.toHaveProperty("encryptedRequestEnvelope");
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    const settled = await Promise.allSettled([
+      decideGatewayApproval(ctx, approvalId, "approve", randomUUID()),
+      decideGatewayApproval(ctx, approvalId, "deny", randomUUID()),
+    ]);
+    expect(settled.every((result) => result.status === "rejected")).toBe(true);
+    const row = await getPool().query(
+      `select e.state,a.status,
+        (select count(*)::int from gateway_audit_log
+          where approval_id=a.id and event='approval_expired') audits
+       from gateway_executions e join gateway_approvals a on a.execution_id=e.id
+       where e.id=$1`,
+      [executionId],
+    );
+    expect(row.rows[0]).toEqual({ state: "expired", status: "expired", audits: 1 });
+    service.secretBytes.fill(0);
+  });
+});

--- a/test/datamechanics/gateway-helpers.ts
+++ b/test/datamechanics/gateway-helpers.ts
@@ -13,17 +13,21 @@ export type GatewaySeed = Seed & {
   connectionRef: string;
   executorTenantId: string;
   executorSubjectId: string;
+  credentialId: string;
+  credentialSecret: string;
 };
 
 export async function seedGateway(): Promise<GatewaySeed> {
   const team = await seedTeam();
   const executorTenantId = `tenant-${randomUUID()}`;
   const executorSubjectId = `subject-${randomUUID()}`;
+  const credentialId = randomBytes(16).toString("base64url");
+  const credentialSecret = randomBytes(32).toString("base64url");
   const service = await registerGatewayServiceIdentity({
     teamId: team.teamId,
     environment: "test",
-    credentialId: randomBytes(16).toString("base64url"),
-    credential: randomBytes(32).toString("base64url"),
+    credentialId,
+    credential: credentialSecret,
   });
   const binding = await bindExecutorSubject({
     ...team,
@@ -45,6 +49,8 @@ export async function seedGateway(): Promise<GatewaySeed> {
     connectionRef: connection.connectionRef,
     executorTenantId,
     executorSubjectId,
+    credentialId,
+    credentialSecret,
   };
 }
 

--- a/test/datamechanics/gateway-retention-guards.datamechanics.test.ts
+++ b/test/datamechanics/gateway-retention-guards.datamechanics.test.ts
@@ -2,7 +2,11 @@ import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { getPool } from "@/lib/db/pg/pool";
 import { encryptGatewayRequestEnvelope } from "@/lib/gateway/envelope";
-import { consumeLeaseAndCreateExecution, issueResolutionLease } from "@/lib/gateway/persistence";
+import {
+  approveGatewayExecution,
+  consumeLeaseAndCreateExecution,
+  issueResolutionLease,
+} from "@/lib/gateway/persistence";
 import { gatewayScope, seedGateway } from "./gateway-helpers";
 
 const KEY = Buffer.alloc(32, 46);
@@ -20,6 +24,12 @@ describe("gateway-retention-guards", () => {
       toolkit: "aios-github-readonly", tool: "github.repository.get", requestHash: "e".repeat(64),
       correlationId: randomUUID(), idempotencyKey: randomUUID(), decision: "require_approval",
     });
+    await approveGatewayExecution({
+      ...scope,
+      executionId,
+      approverMemberId: seed.memberId,
+      correlationId: randomUUID(),
+    });
     const client = await getPool().connect();
     try {
       await expect(client.query(`update gateway_audit_log set event='outcome_recorded' where team_id=$1`, [seed.teamId]))
@@ -28,10 +38,16 @@ describe("gateway-retention-guards", () => {
         .rejects.toThrow("gateway_audit_log is append-only");
       await expect(client.query(`update gateway_executions set tool='github.issue.get' where id=$1`, [executionId]))
         .rejects.toThrow("identity/request fields are immutable");
+      await expect(client.query(`update gateway_executions set actor_snapshot='other' where id=$1`, [executionId]))
+        .rejects.toThrow("identity/request fields are immutable");
       await expect(client.query(`delete from gateway_executions where id=$1`, [executionId]))
         .rejects.toThrow("gateway_executions are retained");
       await expect(client.query(`delete from gateway_approvals where execution_id=$1`, [executionId]))
         .rejects.toThrow("gateway_approvals are retained");
+      await expect(client.query(`update gateway_approvals set decided_at=decided_at+interval '1 second' where execution_id=$1`, [executionId]))
+        .rejects.toThrow("identity/expiry fields are immutable");
+      await expect(client.query(`update gateway_approvals set status='denied' where execution_id=$1`, [executionId]))
+        .rejects.toThrow("transition is invalid");
       await expect(client.query(`delete from gateway_resolution_leases where team_id=$1`, [seed.teamId]))
         .rejects.toThrow("must be revoked, not deleted");
       await expect(client.query(`delete from gateway_connections where id=$1`, [seed.connectionId]))
@@ -40,6 +56,10 @@ describe("gateway-retention-guards", () => {
         .rejects.toThrow("must be revoked, not deleted");
       await expect(client.query(`delete from gateway_service_identities where id=$1`, [seed.serviceIdentityId]))
         .rejects.toThrow("must be revoked, not deleted");
+      await expect(client.query(`delete from gateway_service_credentials where service_identity_id=$1`, [seed.serviceIdentityId]))
+        .rejects.toThrow("must be revoked, not deleted");
+      await expect(client.query(`update gateway_service_credentials set secret_hash=$1 where service_identity_id=$2`, ["f".repeat(64), seed.serviceIdentityId]))
+        .rejects.toThrow("credential identity fields are immutable");
       await expect(client.query(`update gateway_connections set member_id=$1 where id=$2`, [randomUUID(), seed.connectionId]))
         .rejects.toThrow("identity fields are immutable");
       await expect(client.query(`delete from teams where id=$1`, [seed.teamId])).rejects.toThrow();

--- a/test/datamechanics/gateway-schema-replay.datamechanics.test.ts
+++ b/test/datamechanics/gateway-schema-replay.datamechanics.test.ts
@@ -9,9 +9,16 @@ const schemaSql = readFileSync(join(ROOT, "postgres", "schema.sql"), "utf8");
 const migrationSql = readFileSync(
   join(ROOT, "postgres", "migrations", "20260714090000_gateway_persistence.sql"), "utf8"
 );
+const approvalMigrationSql = readFileSync(
+  join(ROOT, "postgres", "migrations", "20260716120000_gateway_approval_admin.sql"), "utf8"
+);
+const transportMigrationSql = readFileSync(
+  join(ROOT, "postgres", "migrations", "20260714120000_gateway_v110.sql"), "utf8"
+);
 const gatewayTables = [
-  "gateway_service_identities", "executor_subject_bindings", "gateway_connections",
+  "gateway_service_identities", "gateway_service_credentials", "executor_subject_bindings", "gateway_connections",
   "gateway_resolution_leases", "gateway_executions", "gateway_approvals", "gateway_audit_log",
+  "gateway_rate_limits",
 ];
 
 async function isolatedSchema(run: (client: Client, schema: string) => Promise<void>) {
@@ -34,11 +41,35 @@ describe("gateway-schema-replay", () => {
       await client.query(schemaSql);
       await client.query(migrationSql);
       await client.query(migrationSql);
+      const team = randomUUID();
+      await client.query(
+        `insert into teams(id,slug,name) values($1,$2,'Replay Team')`,
+        [team, `replay-${team.slice(0, 8)}`],
+      );
+      await client.query(
+        `insert into gateway_service_identities(
+          team_id,environment,credential_id,credential_hash,credential_version
+        ) values($1,'legacy','ICEiIyQlJicoKSorLC0uLw',$2,7)`,
+        [team, "a".repeat(64)],
+      );
+      await client.query(transportMigrationSql);
+      await client.query(approvalMigrationSql);
+      await client.query(approvalMigrationSql);
       const result = await client.query<{ tablename: string }>(
         `select tablename from pg_tables where schemaname=$1 and tablename=any($2) order by tablename`,
         [schema, gatewayTables]
       );
       expect(result.rows.map((row) => row.tablename)).toEqual([...gatewayTables].sort());
+      const copied = await client.query(
+        `select credential_id,version,secret_hash
+           from gateway_service_credentials where team_id=$1`,
+        [team],
+      );
+      expect(copied.rows[0]).toEqual({
+        credential_id: "ICEiIyQlJicoKSorLC0uLw",
+        version: 7,
+        secret_hash: "a".repeat(64),
+      });
     });
   });
 
@@ -47,14 +78,46 @@ describe("gateway-schema-replay", () => {
       await client.query(`create table teams (id uuid primary key default gen_random_uuid())`);
       await client.query(`create table members (
         id uuid primary key default gen_random_uuid(), team_id uuid not null references teams(id),
+        actor_handle text not null default 'actor', role text not null default 'member',
         status text not null default 'active', tier text not null default 'team')`);
       await client.query(migrationSql);
       await client.query(migrationSql);
+      await client.query(transportMigrationSql);
+      await client.query(transportMigrationSql);
+      await client.query(approvalMigrationSql);
+      await client.query(approvalMigrationSql);
       const result = await client.query<{ tablename: string }>(
         `select tablename from pg_tables where schemaname=$1 and tablename=any($2) order by tablename`,
         [schema, gatewayTables]
       );
       expect(result.rows.map((row) => row.tablename)).toEqual([...gatewayTables].sort());
+    });
+  });
+
+  it("fails legacy credential grammar before copying any digest", async () => {
+    await isolatedSchema(async (client) => {
+      await client.query(`create table teams (id uuid primary key default gen_random_uuid())`);
+      await client.query(`create table members (
+        id uuid primary key default gen_random_uuid(), team_id uuid not null references teams(id),
+        actor_handle text not null default 'actor', role text not null default 'member',
+        status text not null default 'active', tier text not null default 'team')`);
+      await client.query(migrationSql);
+      const team = randomUUID();
+      await client.query(`insert into teams(id) values($1)`, [team]);
+      await client.query(
+        `insert into gateway_service_identities(
+          team_id,environment,credential_id,credential_hash,credential_version
+        ) values($1,'legacy','not-canonical','not-a-digest',1)`,
+        [team],
+      );
+      await expect(client.query(approvalMigrationSql)).rejects.toThrow(
+        "gateway_service_identity_legacy_preflight",
+      );
+      const copied = await client.query(
+        `select count(*)::int n from pg_tables
+          where schemaname=current_schema() and tablename='gateway_service_credentials'`,
+      );
+      expect(copied.rows[0].n).toBe(0);
     });
   });
 });

--- a/test/datamechanics/setup.ts
+++ b/test/datamechanics/setup.ts
@@ -6,6 +6,7 @@ import { Client } from "pg";
 // truncation can't deadlock against in-flight adapter queries.
 const DATA_TABLES = [
   "gateway_audit_log",
+  "gateway_service_credentials",
   "gateway_approvals",
   "gateway_executions",
   "gateway_resolution_leases",

--- a/test/fixtures/contract/gateway-approval-v1.10.json
+++ b/test/fixtures/contract/gateway-approval-v1.10.json
@@ -1,0 +1,610 @@
+{
+  "$schema": "aios-gateway-approval-contract/v1.10",
+  "version": "1.10",
+  "baseContract": {
+    "path": "gateway-v1.10.json",
+    "sha256": "4ddd6495fa505b76118080865d60255bfba94a9ccda249defe428babb3d0c205"
+  },
+  "versionBoundary": {
+    "documentRevision": "1.10",
+    "memberApi": "1.9",
+    "internalGateway": "1.10"
+  },
+  "transport": {
+    "featureFlag": {
+      "name": "AIOS_GATEWAY_INTERNAL_ENABLED",
+      "enabledValue": "true",
+      "default": false,
+      "disabledResponse": {
+        "status": 404,
+        "code": "gateway_not_found",
+        "beforeAuthenticationOrBodyParsing": true
+      }
+    },
+    "headers": {
+      "Cache-Control": "no-store"
+    },
+    "errorEnvelope": {
+      "required": ["error"],
+      "additionalProperties": false,
+      "errorRequired": ["code", "message", "request_id", "correlation_id"],
+      "errorAdditionalProperties": false
+    },
+    "errors": {
+      "gateway_invalid_request": { "status": 400, "message": "Invalid request" },
+      "gateway_unauthorized": { "status": 401, "message": "Unauthorized" },
+      "gateway_forbidden": { "status": 403, "message": "Forbidden" },
+      "gateway_not_found": { "status": 404, "message": "Not found" },
+      "gateway_idempotency_conflict": { "status": 409, "message": "Idempotency conflict" },
+      "gateway_approval_expired": { "status": 410, "message": "Approval expired" },
+      "gateway_payload_too_large": { "status": 413, "message": "Request body too large" },
+      "gateway_unsupported_content_encoding": { "status": 415, "message": "Unsupported content encoding" },
+      "gateway_scope_not_found": { "status": 422, "message": "Gateway scope not found" },
+      "gateway_credential_failure": { "status": 500, "message": "Credential unavailable" },
+      "gateway_internal": { "status": 500, "message": "Internal gateway error" }
+    },
+    "nonEnumerating404": [
+      "foreign_service",
+      "foreign_team",
+      "foreign_subject",
+      "unknown_approval",
+      "unknown_execution",
+      "unknown_policy",
+      "unknown_service_identity",
+      "unknown_credential"
+    ]
+  },
+  "resumeClaim": {
+    "method": "POST",
+    "path": "/api/internal/executor-gateway/v1/executions/{executionId}/resume-claim",
+    "authentication": "gateway-service-credential",
+    "request": {
+      "type": "object",
+      "required": [
+        "executorTenantId",
+        "executorSubjectId",
+        "toolkit",
+        "tool",
+        "requestHash",
+        "correlationId",
+        "idempotencyKey"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "executorTenantId": "non-empty-string",
+        "executorSubjectId": "non-empty-string",
+        "toolkit": { "const": "aios-github-readonly" },
+        "tool": "base-contract-tool",
+        "requestHash": "lowercase-hex-sha256",
+        "correlationId": "uuid",
+        "idempotencyKey": "non-empty-string"
+      }
+    },
+    "responses": {
+      "claimed": {
+        "status": 200,
+        "body": {
+          "required": [
+            "status",
+            "executionId",
+            "toolkit",
+            "tool",
+            "normalizedArgs",
+            "sealedCredential",
+            "credentialExpiresAt"
+          ],
+          "additionalProperties": false,
+          "constants": { "status": "claimed", "toolkit": "aios-github-readonly" }
+        },
+        "credentialBearing": true
+      },
+      "alreadyClaimed": {
+        "status": 200,
+        "body": {
+          "required": ["status", "executionId", "state"],
+          "additionalProperties": false,
+          "constants": { "status": "already_claimed" },
+          "state": ["claimed", "succeeded", "failed"],
+          "forbidden": ["normalizedArgs", "sealedCredential", "credentialExpiresAt"]
+        },
+        "credentialBearing": false
+      }
+    },
+    "failures": {
+      "differentKeyOrFingerprint": "gateway_idempotency_conflict",
+      "foreignServiceTeamOrSubject": "gateway_not_found",
+      "expiredApproval": "gateway_approval_expired",
+      "knownIneligibleScope": "gateway_scope_not_found",
+      "sealFailure": "gateway_credential_failure"
+    },
+    "revalidation": [
+      "authenticating-credential-active",
+      "stable-service-identity",
+      "exact-executor-tenant",
+      "exact-executor-subject",
+      "original-member-active",
+      "original-role",
+      "original-team-tier",
+      "connection-owned-by-member",
+      "connection-provider-github",
+      "toolkit",
+      "tool",
+      "policy-resource",
+      "request-hash",
+      "encrypted-envelope-hash",
+      "current-gateway-policy"
+    ],
+    "custody": {
+      "claimAndAudit": "single-transaction",
+      "credentialScopedAdvisoryLock": "held-on-same-session-through-post-commit-decrypt-and-seal",
+      "revocationUsesSameLock": true,
+      "winningRequestLocalClosureOnly": true,
+      "retryMayDecryptOrReseal": false,
+      "persistCredentialBearingResponse": false,
+      "zeroPlaintextAndKeyBuffers": true
+    }
+  },
+  "admin": {
+    "authentication": "brain-admin-session",
+    "authorizationMatrix": {
+      "activeSameTeamAdmin": 200,
+      "member": 403,
+      "lead": 403,
+      "externalOrIneligible": 422,
+      "unknownOrForeignResource": 404,
+      "unauthenticated": 401
+    },
+    "routes": {
+      "approvalQueue": {
+        "method": "GET",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/approvals",
+        "response": {
+          "required": ["approvals"],
+          "additionalProperties": false,
+          "properties": {
+            "approvals": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "approvalId",
+                  "executionId",
+                  "memberId",
+                  "memberName",
+                  "tool",
+                  "resource",
+                  "requestHashPrefix",
+                  "createdAt",
+                  "expiresAt",
+                  "status"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "approvalId": "uuid",
+                  "executionId": "uuid",
+                  "memberId": "uuid",
+                  "memberName": "non-empty-string",
+                  "tool": "base-contract-tool",
+                  "resource": "canonical-github-repository-resource",
+                  "requestHashPrefix": { "pattern": "^[0-9a-f]{12}$" },
+                  "createdAt": "rfc3339-date-time",
+                  "expiresAt": "rfc3339-date-time",
+                  "status": { "const": "pending" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "approvalDecision": {
+        "method": "POST",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/approvals/{approvalId}/decision",
+        "request": {
+          "type": "object",
+          "required": ["decision", "correlationId"],
+          "additionalProperties": false,
+          "properties": {
+            "decision": { "enum": ["approve", "deny"] },
+            "correlationId": "uuid"
+          }
+        },
+        "response": {
+          "type": "object",
+          "required": ["approvalId", "executionId", "status", "decidedAt"],
+          "additionalProperties": false,
+          "properties": {
+            "approvalId": "uuid",
+            "executionId": "uuid",
+            "status": { "enum": ["approved", "denied"] },
+            "decidedAt": "rfc3339-date-time"
+          }
+        }
+      },
+      "policyList": {
+        "method": "GET",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/policies",
+        "response": {
+          "type": "object",
+          "required": ["policies"],
+          "additionalProperties": false,
+          "properties": {
+            "policies": {
+              "type": "array",
+              "items": { "$ref": "#/admin/schemas/gateway-policy-metadata" }
+            }
+          }
+        }
+      },
+      "policyCreate": {
+        "method": "POST",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/policies",
+        "request": { "$ref": "#/admin/schemas/gateway-policy-mutation" },
+        "response": { "$ref": "#/admin/schemas/gateway-policy-metadata" },
+        "status": 201
+      },
+      "policyUpdate": {
+        "method": "PATCH",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/policies/{policyId}",
+        "request": { "$ref": "#/admin/schemas/gateway-policy-mutation" },
+        "response": { "$ref": "#/admin/schemas/gateway-policy-metadata" },
+        "status": 200
+      },
+      "policyDelete": {
+        "method": "DELETE",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/policies/{policyId}",
+        "request": {
+          "type": "object",
+          "required": ["correlationId"],
+          "additionalProperties": false,
+          "properties": { "correlationId": "uuid" }
+        },
+        "response": {
+          "type": "object",
+          "required": ["deleted"],
+          "additionalProperties": false,
+          "properties": { "deleted": { "const": true } }
+        },
+        "status": 200
+      },
+      "credentialList": {
+        "method": "GET",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/service-identities/{serviceIdentityId}/credentials",
+        "response": {
+          "type": "object",
+          "required": ["credentials"],
+          "additionalProperties": false,
+          "properties": {
+            "credentials": {
+              "type": "array",
+              "items": { "$ref": "#/admin/schemas/gateway-credential-metadata" }
+            }
+          }
+        }
+      },
+      "credentialRotate": {
+        "method": "POST",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/service-identities/{serviceIdentityId}/credentials",
+        "request": {
+          "type": "object",
+          "required": ["credentialId", "secret", "replacesCredentialId", "correlationId"],
+          "optional": ["expiresAt"],
+          "additionalProperties": false,
+          "properties": {
+            "credentialId": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]{22}$",
+              "encoding": "canonical-base64url-no-padding",
+              "decodedBytes": 16
+            },
+            "secret": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]{43}$",
+              "encoding": "canonical-base64url-no-padding",
+              "decodedBytes": 32,
+              "minimumEntropyBits": 256
+            },
+            "replacesCredentialId": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]{22}$",
+              "encoding": "canonical-base64url-no-padding",
+              "decodedBytes": 16
+            },
+            "correlationId": "uuid",
+            "expiresAt": "optional-rfc3339-future-date-time"
+          }
+        },
+        "response": { "$ref": "#/admin/schemas/gateway-credential-metadata" },
+        "status": 201
+      },
+      "credentialRevoke": {
+        "method": "POST",
+        "path": "/api/internal/executor-gateway/v1/admin/{teamSlug}/service-identities/{serviceIdentityId}/credentials/{credentialId}/revoke",
+        "request": {
+          "type": "object",
+          "required": ["correlationId"],
+          "additionalProperties": false,
+          "properties": { "correlationId": "uuid" }
+        },
+        "response": {
+          "type": "object",
+          "required": ["credentialId", "revoked"],
+          "additionalProperties": false,
+          "properties": {
+            "credentialId": { "pattern": "^[A-Za-z0-9_-]{22}$" },
+            "revoked": { "const": true }
+          }
+        },
+        "status": 200
+      }
+    },
+    "schemas": {
+      "gateway-subject-selector": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["type", "memberId"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "const": "actor" },
+              "memberId": "uuid"
+            }
+          },
+          {
+            "type": "object",
+            "required": ["type", "role"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "const": "role" },
+              "role": { "enum": ["admin", "lead", "member"] }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["type", "tier"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "const": "tier" },
+              "tier": { "enum": ["team", "external"] }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["type"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "team" } }
+          }
+        ]
+      },
+      "gateway-policy-mutation": {
+        "type": "object",
+        "required": ["subject", "tool", "resource", "effect", "priority", "enabled", "correlationId"],
+        "additionalProperties": false,
+        "properties": {
+          "subject": { "$ref": "#/admin/schemas/gateway-subject-selector" },
+          "tool": { "oneOf": ["base-contract-tool", { "const": "*" }] },
+          "resource": "canonical-github-repository-resource-or-wildcard",
+          "effect": { "enum": ["block", "require_approval", "allow"] },
+          "priority": { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 },
+          "enabled": { "type": "boolean" },
+          "correlationId": "uuid"
+        }
+      },
+      "gateway-policy-metadata": {
+        "type": "object",
+        "required": [
+          "id",
+          "priority",
+          "subjectRole",
+          "subjectTier",
+          "subjectActor",
+          "tool",
+          "resource",
+          "effect",
+          "enabled",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": "uuid",
+          "priority": "signed-int32",
+          "subjectRole": "nullable-admin-lead-member",
+          "subjectTier": "nullable-team-external",
+          "subjectActor": "nullable-non-empty-string",
+          "tool": { "oneOf": ["base-contract-tool", { "const": "*" }] },
+          "resource": "canonical-github-repository-resource-or-wildcard",
+          "effect": { "enum": ["block", "require_approval", "allow"] },
+          "enabled": { "type": "boolean" },
+          "createdAt": "rfc3339-date-time",
+          "updatedAt": "rfc3339-date-time"
+        }
+      },
+      "gateway-credential-metadata": {
+        "type": "object",
+        "required": ["credentialId", "version", "createdAt", "expiresAt", "revokedAt", "replacesCredentialId"],
+        "additionalProperties": false,
+        "properties": {
+          "credentialId": { "pattern": "^[A-Za-z0-9_-]{22}$" },
+          "version": { "type": "integer", "minimum": 1 },
+          "createdAt": "rfc3339-date-time",
+          "expiresAt": "nullable-rfc3339-date-time",
+          "revokedAt": "nullable-rfc3339-date-time",
+          "replacesCredentialId": "nullable-canonical-base64url-16-bytes"
+        },
+        "forbidden": ["secret", "secretHash", "credentialHash"]
+      }
+    },
+    "policy": {
+      "toolkit": "aios-github-readonly",
+      "effects": ["block", "require_approval", "allow"],
+      "storedEffectMapping": { "block": "deny", "require_approval": "require_approval", "allow": "allow" },
+      "subjectSelector": {
+        "taggedUnion": [
+          { "type": "actor", "required": ["memberId"] },
+          { "type": "role", "required": ["role"] },
+          { "type": "tier", "required": ["tier"], "tier": ["team", "external"] },
+          { "type": "team", "required": [] }
+        ],
+        "exactlyOne": true
+      },
+      "requestFields": ["subject", "tool", "resource", "effect", "priority", "enabled", "correlationId"]
+    },
+    "credentialMetadataFieldsExactly": [
+      "credentialId",
+      "version",
+      "createdAt",
+      "expiresAt",
+      "revokedAt",
+      "replacesCredentialId"
+    ],
+    "rotation": {
+      "clientGeneratedSecret": true,
+      "secretReturned": false,
+      "overlapUntilExplicitRevocationOrExpiry": true
+    }
+  },
+  "policyPrecedence": {
+    "dimensions": [
+      ["actor", "role", "tier", "team"],
+      ["exact-tool", "wildcard-tool"],
+      ["exact-repository", "wildcard-repository"],
+      ["highest-numeric-priority"],
+      ["block", "require_approval", "allow"],
+      ["no-match-blocks"]
+    ],
+    "vectors": [
+      { "name": "actor-beats-role", "candidates": ["role:block", "actor:allow"], "winner": "actor:allow" },
+      { "name": "role-beats-tier", "candidates": ["tier:block", "role:allow"], "winner": "role:allow" },
+      { "name": "tier-beats-team", "candidates": ["team:block", "tier:allow"], "winner": "tier:allow" },
+      { "name": "exact-tool-beats-wildcard", "candidates": ["wildcard-tool:block", "exact-tool:allow"], "winner": "exact-tool:allow" },
+      { "name": "exact-resource-beats-wildcard", "candidates": ["wildcard-repository:block", "exact-repository:allow"], "winner": "exact-repository:allow" },
+      { "name": "priority-descending", "candidates": ["priority:1:block", "priority:2:allow"], "winner": "priority:2:allow" },
+      { "name": "effect-block", "candidates": ["allow", "require_approval", "block"], "winner": "block" },
+      { "name": "effect-approval", "candidates": ["allow", "require_approval"], "winner": "require_approval" },
+      { "name": "default-deny", "candidates": [], "winner": "block" }
+    ]
+  },
+  "stateMachine": {
+    "initial": { "execution": "approval_required", "approval": "pending" },
+    "transitions": [
+      { "event": "approve", "execution": "approval_required->approved", "approval": "pending->approved" },
+      { "event": "deny", "execution": "approval_required->cancelled", "approval": "pending->denied" },
+      { "event": "database-time-expiry", "execution": "approval_required->expired", "approval": "pending->expired" },
+      { "event": "claim", "execution": "approved->claimed", "approval": "approved->approved" },
+      { "event": "revalidation-failure", "execution": "approved->cancelled", "approval": "approved->cancelled" },
+      { "event": "seal-failure", "execution": "claimed->failed", "approval": "approved->approved", "classification": "credential" },
+      { "event": "outcome-success", "execution": "claimed->succeeded", "approval": "approved->approved", "classification": "success" },
+      { "event": "outcome-credential", "execution": "claimed->failed", "approval": "approved->approved", "classification": "credential" },
+      { "event": "outcome-network", "execution": "claimed->failed", "approval": "approved->approved", "classification": "network" },
+      { "event": "outcome-upstream", "execution": "claimed->failed", "approval": "approved->approved", "classification": "upstream" },
+      { "event": "outcome-response-too-large", "execution": "claimed->failed", "approval": "approved->approved", "classification": "response_too_large" },
+      { "event": "outcome-internal", "execution": "claimed->failed", "approval": "approved->approved", "classification": "internal" }
+    ],
+    "databaseTimeOnly": ["expiry", "decision-timestamp", "claim-timestamp", "credential-expiry"],
+    "oneEventIndexes": ["decision", "claim", "rotation", "revocation", "expiry", "settlement"]
+  },
+  "persistence": {
+    "credentialTable": "gateway_service_credentials",
+    "identityTableRemainsBindingAuthority": "gateway_service_identities",
+    "legacyCredentialColumns": "immutable-compatibility-data-not-authentication-source",
+    "legacyPreflightError": "gateway_service_identity_legacy_preflight",
+    "initialCredentialSource": "copy-existing-digest-never-derive-plaintext",
+    "immutableExecutionSnapshots": [
+      "actor",
+      "role",
+      "tier",
+      "policy-resource",
+      "encrypted-request-envelope",
+      "encrypted-request-envelope-hash",
+      "resume-fingerprint",
+      "claim-idempotency-key"
+    ],
+    "gatewaySqlWriters": ["lib/gateway/persistence.ts", "lib/gateway/admin-persistence.ts"]
+  },
+  "vectors": {
+    "resumeFingerprint": {
+      "fields": [
+        "credentialId",
+        "credentialVersion",
+        "executionId",
+        "executorSubjectId",
+        "executorTenantId",
+        "memberId",
+        "requestHash",
+        "serviceIdentityId",
+        "teamId",
+        "tool",
+        "toolkit"
+      ],
+      "value": {
+        "credentialId": "ICEiIyQlJicoKSorLC0uLw",
+        "credentialVersion": 2,
+        "executionId": "22222222-2222-4222-8222-222222222222",
+        "executorSubjectId": "executor-user-42",
+        "executorTenantId": "executor-tenant-7",
+        "memberId": "44444444-4444-4444-8444-444444444444",
+        "requestHash": "4b18a1b9c0f093f7e46b4410e245fd88f011e6d820b34ef9446296ff9386f310",
+        "serviceIdentityId": "11111111-1111-4111-8111-111111111111",
+        "teamId": "33333333-3333-4333-8333-333333333333",
+        "tool": "github.repository.get",
+        "toolkit": "aios-github-readonly"
+      },
+      "jcs": "{\"credentialId\":\"ICEiIyQlJicoKSorLC0uLw\",\"credentialVersion\":2,\"executionId\":\"22222222-2222-4222-8222-222222222222\",\"executorSubjectId\":\"executor-user-42\",\"executorTenantId\":\"executor-tenant-7\",\"memberId\":\"44444444-4444-4444-8444-444444444444\",\"requestHash\":\"4b18a1b9c0f093f7e46b4410e245fd88f011e6d820b34ef9446296ff9386f310\",\"serviceIdentityId\":\"11111111-1111-4111-8111-111111111111\",\"teamId\":\"33333333-3333-4333-8333-333333333333\",\"tool\":\"github.repository.get\",\"toolkit\":\"aios-github-readonly\"}",
+      "sha256": "0f0369a66660d1030e4104cfd394e001a16d90e0df6511698c6642ea92f7ee45"
+    },
+    "requestEnvelope": {
+      "algorithm": "AES-256-GCM",
+      "keyHex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      "nonceHex": "0c0d0e0f1011121314151617",
+      "aadUtf8": "aios-gateway-request-envelope:v1\u000022222222-2222-4222-8222-222222222222",
+      "normalizedArgsJcs": "{\"owner\":\"octo\",\"repo\":\"project\"}",
+      "requestHash": "4b18a1b9c0f093f7e46b4410e245fd88f011e6d820b34ef9446296ff9386f310",
+      "ciphertextAndTagHex": "e3dc06af11138e710d0827b6e5e404cb7771889e995f0188ebd0958a81c3b4d851ece0082f5e388b03825d26c60672b289",
+      "wire": "v1.DA0ODxAREhMUFRYX.49wGrxETjnENCCe25eQEy3dxiJ6ZXwGI69CVioHDtNhR7OAIL144iwOCXSbGBnKyiQ",
+      "wireSha256": "4d29bfa49a3c514746d0b2feea8acabc1f5291085f8f67dad294a434bcde0b63",
+      "maxPlaintextBytes": 65536,
+      "immutableAfterCreation": true
+    },
+    "rotatedCredentialSeal": {
+      "credentialId": "ICEiIyQlJicoKSorLC0uLw",
+      "credentialVersion": 2,
+      "materialBase64url": "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+      "storedDigest": "72dbb7336c76780023f83da4c355f2eeea85733b13d3477697917790c1229084",
+      "derivedMaterialHex": "12307534b863faaa2da3fce2598dc951616305a733ed581f83df599551e84c6a",
+      "protectedHeaderJcs": "{\"eid\":\"22222222-2222-4222-8222-222222222222\",\"exp\":1784044815,\"iat\":1784044800,\"kid\":\"ICEiIyQlJicoKSorLC0uLw.v2\",\"provider\":\"github\",\"sid\":\"11111111-1111-4111-8111-111111111111\",\"v\":1}",
+      "nonceHex": "202122232425262728292a2b",
+      "plaintextUtf8": "fixture-pat-readonly",
+      "sealed": "v1.eyJlaWQiOiIyMjIyMjIyMi0yMjIyLTQyMjItODIyMi0yMjIyMjIyMjIyMjIiLCJleHAiOjE3ODQwNDQ4MTUsImlhdCI6MTc4NDA0NDgwMCwia2lkIjoiSUNFaUl5UWxKaWNvS1NvckxDMHVMdy52MiIsInByb3ZpZGVyIjoiZ2l0aHViIiwic2lkIjoiMTExMTExMTEtMTExMS00MTExLTgxMTEtMTExMTExMTExMTExIiwidiI6MX0.ICEiIyQlJicoKSor.txZya27eDKroyOMxsvBfPhlFUzBZ_nF4R5NHj_htG1KXgwQ8"
+    }
+  },
+  "security": {
+    "queueFieldsOnly": ["member", "tool", "allowlisted-repository-resource", "request-hash-prefix", "age", "database-expiry"],
+    "neverExpose": [
+      "pat",
+      "service-secret",
+      "credential-ciphertext",
+      "encrypted-request-envelope",
+      "request-envelope-plaintext",
+      "lease",
+      "full-request-hash",
+      "derived-key",
+      "credential-bearing-retry"
+    ],
+    "strictAuditRollback": true,
+    "recursiveCanaryScan": true
+  },
+  "discovery": {
+    "expected": {
+      "resumeRoutes": 1,
+      "adminRoutes": 9,
+      "errors": 11,
+      "nonEnumerating404Families": 8,
+      "authorizationRoles": 6,
+      "policyVectors": 9,
+      "stateTransitions": 12,
+      "outcomeClassifications": 6,
+      "cryptographicVectors": 3,
+      "securityNeverExpose": 9
+    }
+  }
+}

--- a/test/gateway/gateway-approval-contracts.test.ts
+++ b/test/gateway/gateway-approval-contracts.test.ts
@@ -1,0 +1,242 @@
+import { createCipheriv, createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { canonicalize } from "@/lib/gateway/canonical";
+import {
+  decryptGatewayRequestEnvelope,
+  encryptGatewayRequestEnvelope,
+} from "@/lib/gateway/envelope";
+import { sealCredential } from "@/lib/gateway/sealed-credential";
+
+const fixturePath = join(
+  import.meta.dirname,
+  "..",
+  "fixtures",
+  "contract",
+  "gateway-approval-v1.10.json",
+);
+const bytes = readFileSync(fixturePath);
+const fixture = JSON.parse(bytes.toString("utf8"));
+
+describe("gateway approval v1.10 vendored contract", () => {
+  it("is the reviewed Workspace fixture and pins the AIO-401 base", () => {
+    expect(createHash("sha256").update(bytes).digest("hex")).toBe(
+      "b1bed83fbdd4e6cfff2200a4cefa828a2d770c66f898e9e7d704511935cc5e62",
+    );
+    expect(fixture.baseContract.sha256).toBe(
+      "4ddd6495fa505b76118080865d60255bfba94a9ccda249defe428babb3d0c205",
+    );
+    expect(fixture.versionBoundary).toEqual({
+      documentRevision: "1.10",
+      memberApi: "1.9",
+      internalGateway: "1.10",
+    });
+  });
+
+  it("discovers every required route and failure family non-vacuously", () => {
+    const expected = fixture.discovery.expected;
+    expect(Number(expected.resumeRoutes)).toBeGreaterThan(0);
+    expect(Number(expected.adminRoutes)).toBeGreaterThan(0);
+    expect(Object.keys(fixture.admin.routes)).toHaveLength(expected.adminRoutes);
+    expect(fixture.resumeClaim.path).toContain("resume-claim");
+    expect(Object.keys(fixture.transport.errors)).toHaveLength(expected.errors);
+    expect(fixture.transport.nonEnumerating404).toHaveLength(
+      expected.nonEnumerating404Families,
+    );
+  });
+
+  it("matches every frozen non-vacuous discovery count", () => {
+    const actual = {
+      resumeRoutes: 1,
+      adminRoutes: Object.keys(fixture.admin.routes).length,
+      errors: Object.keys(fixture.transport.errors).length,
+      nonEnumerating404Families: fixture.transport.nonEnumerating404.length,
+      authorizationRoles: Object.keys(fixture.admin.authorizationMatrix).length,
+      policyVectors: fixture.policyPrecedence.vectors.length,
+      stateTransitions: fixture.stateMachine.transitions.length,
+      outcomeClassifications: fixture.stateMachine.transitions.filter(
+        (transition: { event: string }) => transition.event.startsWith("outcome-"),
+      ).length,
+      cryptographicVectors: Object.keys(fixture.vectors).length,
+      securityNeverExpose: fixture.security.neverExpose.length,
+    };
+    expect(actual).toEqual(fixture.discovery.expected);
+    expect(Object.values(actual).every((count) => count > 0)).toBe(true);
+  });
+
+  it("freezes the exact resume request and credential-free retry", () => {
+    expect(fixture.resumeClaim.request.required).toEqual([
+      "executorTenantId",
+      "executorSubjectId",
+      "toolkit",
+      "tool",
+      "requestHash",
+      "correlationId",
+      "idempotencyKey",
+    ]);
+    expect(fixture.resumeClaim.request.additionalProperties).toBe(false);
+    const retry = fixture.resumeClaim.responses.alreadyClaimed;
+    expect(retry.credentialBearing).toBe(false);
+    expect(retry.body.forbidden).toEqual([
+      "normalizedArgs",
+      "sealedCredential",
+      "credentialExpiresAt",
+    ]);
+  });
+
+  it("matches the resume fingerprint vector", () => {
+    const vector = fixture.vectors.resumeFingerprint;
+    expect(canonicalize(vector.value)).toBe(vector.jcs);
+    expect(createHash("sha256").update(vector.jcs).digest("hex")).toBe(
+      vector.sha256,
+    );
+  });
+
+  it("seals exactly to the rotated credential version vector", () => {
+    const vector = fixture.vectors.rotatedCredentialSeal;
+    const sealed = sealCredential({
+      pat: Buffer.from(vector.plaintextUtf8),
+      serviceSecret: Buffer.from(vector.materialBase64url, "base64url"),
+      credentialId: vector.credentialId,
+      credentialVersion: vector.credentialVersion,
+      serviceIdentityId: "11111111-1111-4111-8111-111111111111",
+      executionId: "22222222-2222-4222-8222-222222222222",
+      now: 1784044800,
+      nonce: Buffer.from(vector.nonceHex, "hex"),
+    });
+    expect(sealed.sealedCredential).toBe(vector.sealed);
+  });
+
+  it("encrypts, hashes, and decrypts the request-envelope vector", () => {
+    const vector = fixture.vectors.requestEnvelope;
+    const envelope = encryptGatewayRequestEnvelope(
+      JSON.parse(vector.normalizedArgsJcs),
+      {
+        executionId: "22222222-2222-4222-8222-222222222222",
+        serviceIdentityId: "11111111-1111-4111-8111-111111111111",
+      },
+      Buffer.from(vector.keyHex, "hex"),
+      Buffer.from(vector.nonceHex, "hex"),
+    );
+    expect(envelope.toString("ascii")).toBe(vector.wire);
+    expect(createHash("sha256").update(envelope).digest("hex")).toBe(
+      vector.wireSha256,
+    );
+    expect(
+      decryptGatewayRequestEnvelope(
+        envelope,
+        {
+          executionId: "22222222-2222-4222-8222-222222222222",
+          serviceIdentityId: "11111111-1111-4111-8111-111111111111",
+        },
+        Buffer.from(vector.keyHex, "hex"),
+      ),
+    ).toEqual({ owner: "octo", repo: "project" });
+  });
+
+  it("continues decrypting committed AIO-401 binary envelopes", () => {
+    const executionId = "22222222-2222-4222-8222-222222222222";
+    const serviceIdentityId = "11111111-1111-4111-8111-111111111111";
+    const key = Buffer.alloc(32, 7);
+    const nonce = Buffer.alloc(12, 8);
+    const cipher = createCipheriv("aes-256-gcm", key, nonce);
+    cipher.setAAD(
+      Buffer.from(
+        `gateway-request-envelope:v1:${executionId}:${serviceIdentityId}`,
+      ),
+    );
+    const ciphertext = Buffer.concat([
+      cipher.update(JSON.stringify({ owner: "octo", repo: "project" })),
+      cipher.final(),
+    ]);
+    const legacy = Buffer.concat([
+      Buffer.from([1]),
+      nonce,
+      cipher.getAuthTag(),
+      ciphertext,
+    ]);
+    expect(
+      decryptGatewayRequestEnvelope(
+        legacy,
+        { executionId, serviceIdentityId },
+        key,
+      ),
+    ).toEqual({ owner: "octo", repo: "project" });
+  });
+
+  it("requires authoritative credential rows and two approved writers", () => {
+    expect(fixture.persistence.credentialTable).toBe(
+      "gateway_service_credentials",
+    );
+    expect(fixture.persistence.legacyPreflightError).toBe(
+      "gateway_service_identity_legacy_preflight",
+    );
+    expect(fixture.persistence.gatewaySqlWriters).toEqual([
+      "lib/gateway/persistence.ts",
+      "lib/gateway/admin-persistence.ts",
+    ]);
+  });
+
+  it("exhaustively discovers precedence and state transitions", () => {
+    const expected = fixture.discovery.expected;
+    expect(fixture.policyPrecedence.vectors).toHaveLength(expected.policyVectors);
+    expect(fixture.stateMachine.transitions).toHaveLength(
+      expected.stateTransitions,
+    );
+    expect(fixture.stateMachine.oneEventIndexes).toEqual([
+      "decision",
+      "claim",
+      "rotation",
+      "revocation",
+      "expiry",
+      "settlement",
+    ]);
+  });
+
+  it("keeps the admin queue and credential metadata secret-free", () => {
+    const queue =
+      fixture.admin.routes.approvalQueue.response.properties.approvals.items
+        .required;
+    expect(queue).not.toContain("encryptedRequestEnvelope");
+    expect(queue).not.toContain("credentialCiphertext");
+    expect(queue).not.toContain("requestHash");
+    expect(fixture.admin.credentialMetadataFieldsExactly).not.toContain("secret");
+    expect(fixture.security.neverExpose).toHaveLength(
+      fixture.discovery.expected.securityNeverExpose,
+    );
+  });
+
+  it("vendors exhaustive strict admin schemas", () => {
+    const schemas = fixture.admin.schemas;
+    expect(Object.keys(schemas)).toEqual([
+      "gateway-subject-selector",
+      "gateway-policy-mutation",
+      "gateway-policy-metadata",
+      "gateway-credential-metadata",
+    ]);
+    for (const route of Object.values(fixture.admin.routes) as Array<{
+      method: string;
+      path: string;
+      response?: unknown;
+    }>) {
+      expect(route.response, `${route.method} ${route.path}`).toBeDefined();
+    }
+    const rotation = fixture.admin.routes.credentialRotate.request;
+    expect(rotation.additionalProperties).toBe(false);
+    expect(rotation.properties.secret).toMatchObject({
+      decodedBytes: 32,
+      minimumEntropyBits: 256,
+    });
+    const tier = schemas["gateway-subject-selector"].oneOf.find(
+      (candidate: { properties: { type: { const: string } } }) =>
+        candidate.properties.type.const === "tier",
+    );
+    expect(tier.properties.tier.enum).toEqual(["team", "external"]);
+    expect(schemas["gateway-policy-mutation"].properties.priority).toEqual({
+      type: "integer",
+      minimum: -2147483648,
+      maximum: 2147483647,
+    });
+  });
+});

--- a/test/gateway/gateway-approval.test.ts
+++ b/test/gateway/gateway-approval.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseGatewayPolicyInput } from "@/lib/gateway/admin-validation";
+import {
+  evaluateGatewayPolicy,
+  type GatewayPolicyRow,
+} from "@/lib/gateway/policy";
+
+let id = 0;
+const row = (over: Partial<GatewayPolicyRow> = {}): GatewayPolicyRow => ({
+  id: `00000000-0000-4000-8000-${String(++id).padStart(12, "0")}`,
+  subject_role: null,
+  subject_tier: null,
+  subject_actor: null,
+  action: "gateway.aios-github-readonly.*",
+  resource: "github.repository:*",
+  priority: 0,
+  effect: "allow",
+  updated_at: "2026-07-16T00:00:00.000Z",
+  ...over,
+});
+const principal = {
+  actor: "alex",
+  role: "member" as const,
+  tier: "team" as const,
+};
+const input = { principal, tool: "github.repository.get", owner: "octo", repo: "project" };
+
+describe("gateway approval policy administration", () => {
+  it("implements the exhaustive precedence dimensions", () => {
+    const cases: Array<[string, GatewayPolicyRow[], "allow" | "block" | "require_approval"]> = [
+      ["actor beats role", [
+        row({ subject_role: "member", effect: "deny" }),
+        row({ subject_actor: "alex", effect: "allow" }),
+      ], "allow"],
+      ["role beats tier", [
+        row({ subject_tier: "team", effect: "deny" }),
+        row({ subject_role: "member", effect: "allow" }),
+      ], "allow"],
+      ["tier beats team", [
+        row({ effect: "deny" }),
+        row({ subject_tier: "team", effect: "allow" }),
+      ], "allow"],
+      ["exact tool beats wildcard", [
+        row({ effect: "deny" }),
+        row({ action: "gateway.aios-github-readonly.github.repository.get", effect: "allow" }),
+      ], "allow"],
+      ["exact repository beats wildcard", [
+        row({ effect: "deny" }),
+        row({ resource: "github.repository:octo/project", effect: "allow" }),
+      ], "allow"],
+      ["numeric priority", [
+        row({ priority: 1, effect: "deny" }),
+        row({ priority: 2, effect: "allow" }),
+      ], "allow"],
+      ["block is most restrictive", [
+        row({ effect: "allow" }),
+        row({ effect: "require_approval" }),
+        row({ effect: "deny" }),
+      ], "block"],
+      ["approval beats allow", [
+        row({ effect: "allow" }),
+        row({ effect: "require_approval" }),
+      ], "require_approval"],
+      ["no match blocks", [], "block"],
+    ];
+    expect(cases).toHaveLength(9);
+    for (const [name, policies, expected] of cases)
+      expect(evaluateGatewayPolicy(policies, input).decision, name).toBe(expected);
+  });
+
+  it("accepts exactly one tagged subject selector", () => {
+    const valid = {
+      subject: { type: "team" },
+      tool: "github.repository.get",
+      resource: "github.repository:octo/project",
+      effect: "require_approval",
+      priority: 5,
+      enabled: true,
+      correlationId: "11111111-1111-4111-8111-111111111111",
+    };
+    expect(parseGatewayPolicyInput(valid)?.subject).toEqual({ type: "team" });
+    expect(
+      parseGatewayPolicyInput({
+        ...valid,
+        subject: { type: "role", role: "member", tier: "team" },
+      }),
+    ).toBeNull();
+  });
+
+  it("discovers all nine admin operations and the resume route", () => {
+    const root = join(process.cwd(), "app/api/internal/executor-gateway/v1");
+    const sources = [
+      ["admin/[teamSlug]/approvals/route.ts", ["GET"]],
+      ["admin/[teamSlug]/approvals/[approvalId]/decision/route.ts", ["POST"]],
+      ["admin/[teamSlug]/policies/route.ts", ["GET", "POST"]],
+      ["admin/[teamSlug]/policies/[policyId]/route.ts", ["PATCH", "DELETE"]],
+      [
+        "admin/[teamSlug]/service-identities/[serviceIdentityId]/credentials/route.ts",
+        ["GET", "POST"],
+      ],
+      [
+        "admin/[teamSlug]/service-identities/[serviceIdentityId]/credentials/[credentialId]/revoke/route.ts",
+        ["POST"],
+      ],
+    ] as const;
+    let operations = 0;
+    for (const [file, methods] of sources) {
+      const source = readFileSync(join(root, file), "utf8");
+      for (const method of methods) {
+        expect(source).toContain(`export async function ${method}`);
+        operations++;
+      }
+    }
+    expect(operations).toBe(9);
+    expect(
+      readFileSync(
+        join(root, "executions/[executionId]/resume-claim/route.ts"),
+        "utf8",
+      ),
+    ).toContain("export async function POST");
+  });
+
+  it("keeps the managed queue recursively free of secret-bearing fields", () => {
+    const sources = [
+      "components/admin/managed-gateway-approvals.tsx",
+      "app/t/[team]/admin/approvals/page.tsx",
+    ].map((file) => readFileSync(join(process.cwd(), file), "utf8").toLowerCase());
+    for (const source of sources) {
+      expect(source).not.toContain("credentialciphertext");
+      expect(source).not.toContain("encryptedrequestenvelope");
+      expect(source).not.toContain("sealedcredential");
+      expect(source).not.toContain("lease");
+      expect(source).not.toContain("requesthash:");
+    }
+    const component = sources[0];
+    expect(component).toContain('aria-labelledby="managed-gateway-heading"');
+    expect(component).toContain("window.confirm");
+    expect(component).toContain("focus-visible:ring-2");
+    expect(component).toContain('role="alert"');
+    expect(component).toContain("sm:grid-cols-3");
+  });
+});

--- a/test/guards/gateway-writers.test.ts
+++ b/test/guards/gateway-writers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
 
 describe("gateway approved writers", () => {
-  it("node scripts/check-gateway-writers.mjs accepts only the domain owner", () => {
+  it("accepts only the two reviewed gateway persistence owners", () => {
     const result = spawnSync(process.execPath, ["scripts/check-gateway-writers.mjs"], {
       cwd: process.cwd(), encoding: "utf8",
     });

--- a/test/http/gateway-approval-enabled.http.test.ts
+++ b/test/http/gateway-approval-enabled.http.test.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { BASE_URL } from "./http-helpers";
+
+describe.runIf(process.env.AIOS_GATEWAY_INTERNAL_ENABLED === "true")(
+  "gateway approval routes while enabled (HTTP)",
+  () => {
+    it("requires a gateway service credential for resume", async () => {
+      const response = await fetch(
+        `${BASE_URL}/api/internal/executor-gateway/v1/executions/${randomUUID()}/resume-claim`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer deliberately-invalid",
+            "Content-Type": "application/json",
+          },
+          body: "{malformed",
+        },
+      );
+      expect(response.status).toBe(401);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect((await response.json()).error.code).toBe("gateway_unauthorized");
+    });
+
+    it("requires an authenticated admin session before parsing admin requests", async () => {
+      const response = await fetch(
+        `${BASE_URL}/api/internal/executor-gateway/v1/admin/team/approvals/${randomUUID()}/decision`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{malformed",
+        },
+      );
+      expect(response.status).toBe(401);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect((await response.json()).error.code).toBe("gateway_unauthorized");
+    });
+  },
+);

--- a/test/http/gateway-approval.http.test.ts
+++ b/test/http/gateway-approval.http.test.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { BASE_URL } from "./http-helpers";
+
+describe.runIf(process.env.AIOS_GATEWAY_INTERNAL_ENABLED !== "true")(
+  "gateway approval routes while disabled (HTTP)",
+  () => {
+    it("keeps resume and every admin route non-enumerating before auth or parsing", async () => {
+      const executionId = randomUUID();
+      const approvalId = randomUUID();
+      const serviceId = randomUUID();
+      const policyId = randomUUID();
+      const credentialId = "ICEiIyQlJicoKSorLC0uLw";
+      const requests: Array<[string, string]> = [
+        ["POST", `/api/internal/executor-gateway/v1/executions/${executionId}/resume-claim`],
+        ["GET", "/api/internal/executor-gateway/v1/admin/team/approvals"],
+        ["POST", `/api/internal/executor-gateway/v1/admin/team/approvals/${approvalId}/decision`],
+        ["GET", "/api/internal/executor-gateway/v1/admin/team/policies"],
+        ["POST", "/api/internal/executor-gateway/v1/admin/team/policies"],
+        ["PATCH", `/api/internal/executor-gateway/v1/admin/team/policies/${policyId}`],
+        ["DELETE", `/api/internal/executor-gateway/v1/admin/team/policies/${policyId}`],
+        ["GET", `/api/internal/executor-gateway/v1/admin/team/service-identities/${serviceId}/credentials`],
+        ["POST", `/api/internal/executor-gateway/v1/admin/team/service-identities/${serviceId}/credentials`],
+        ["POST", `/api/internal/executor-gateway/v1/admin/team/service-identities/${serviceId}/credentials/${credentialId}/revoke`],
+      ];
+      expect(requests).toHaveLength(10);
+      for (const [method, path] of requests) {
+        const response = await fetch(`${BASE_URL}${path}`, {
+          method,
+          headers: {
+            Authorization: "Bearer deliberately-invalid",
+            "Content-Type": "application/json",
+          },
+          body: method === "GET" ? undefined : "{malformed",
+        });
+        expect(response.status, `${method} ${path}`).toBe(404);
+        expect(response.headers.get("cache-control")).toBe("no-store");
+        expect((await response.json()).error.code).toBe("gateway_not_found");
+      }
+    });
+  },
+);


### PR DESCRIPTION
## What & Why

Implements the Brain half of AIO-407 against the reviewed Workspace gateway approval contract. It adds durable approval decisions, service-authenticated resume claims, strict gateway policy and credential administration, an additive authoritative credential-row migration, and a separate managed-approvals admin UI section. Existing AIO-401 member/internal wire behavior is preserved.

Depends on Workspace contract PR https://github.com/aiosbrain/aios-workspace/pull/332 and must merge after it.

## Work item

AIOS-Work: AIO-407

## Baselines and contract hashes

- Fresh fetched Brain baseline: `1e795c246ecc031baf5d9013d89a5cb2aaa9a788`
- Brain head: `f772dcf3312c91ececfa149bf113b3ca2cfe149c`
- Workspace baseline: `e62fd8dfb3324232faef0f63526dac24efc81b8c`
- AIO-401 base fixture SHA-256: `4ddd6495fa505b76118080865d60255bfba94a9ccda249defe428babb3d0c205`
- Vendored AIO-407 fixture SHA-256: `b1bed83fbdd4e6cfff2200a4cefa828a2d770c66f898e9e7d704511935cc5e62` (byte-identical to Workspace)
- Reconciled Linear spec SHA-256: `b723b253faf5a36817c3cbb383ab179e3cf20fa733f5c011cff04172578ab534` (`SPEC_READY`, 100, zero findings)

## Security and data-flow invariants

- `gateway_service_credentials` is authoritative for authentication; stable service identities remain binding anchors. Legacy hashes are immutable compatibility data and are never converted back to plaintext.
- Claim locks and revalidates the authenticating credential row, exact Executor subject, principal snapshots, active same-team member/tier, GitHub connection, request envelope/hash, tool/resource, and current gateway policy in one transaction.
- A credential-scoped PostgreSQL advisory lock spans the committed winning claim and the only post-commit PAT decrypt/seal closure; revocation uses the same lock.
- Only the winning request can receive normalized arguments and a credential sealed to the exact authenticating credential version. Identical retries are credential-free; conflicting retries are typed 409s.
- PAT/key/plaintext buffers are zeroed. Ciphertext and winning material are not persisted in responses or surfaced in admin UI/audit payloads.
- Admin authorization is same-team active admin only, with typed 401/403/404/422 and non-enumerating foreign-resource behavior.
- Gateway SQL is restricted by the writer guard to `lib/gateway/persistence.ts` and `lib/gateway/admin-persistence.ts`; routes and UI contain no SQL.
- `AIOS_GATEWAY_INTERNAL_ENABLED` remains disabled by default; new routes/UI are absent/non-enumerating while disabled.

## Verification (Node 20, PostgreSQL 16)

- `npm test` — 129 files passed, 1 skipped; 764 tests passed, 7 skipped
- `npm run test:gateway-approval:unit` — 18/18 passed
- `npm run test:gateway-approval` — unit/writer/contract 18/18 plus real-Postgres 12/12 passed
- `npm run test:datamechanics` — 112 files passed, 2 skipped; 472 tests passed, 4 skipped
- `npm run test:http` with flag disabled — 31 passed, 2 skipped
- `npm run test:http:gateway-approval` with flag enabled — 2/2 passed
- schema load + complete migration replay twice — passed
- `npm run coverage` — passed (31.58% statements, 27.96% branches, 38.22% functions, 32.59% lines)
- typecheck, docs drift, error-boundary drift, writer guard, build, current-tree gitleaks, `git diff --check` — passed
- lint — passed with one inherited unrelated warning in `me-slack-token.datamechanics.test.ts`
- build — passed with the inherited optional `@e2b/code-interpreter` warning
- brain-api conformance — member API remains 1.9; internal gateway remains 1.10; shipped member routes documented

## Checklist

- [x] `node scripts/check-docs-drift.mjs` passes locally
- [x] Unit tests pass: `npm test`
- [x] Datamechanics tests pass with PostgreSQL 16
- [x] No member sync-protocol version change; member API remains 1.9
- [x] Current-tree secret scan is clean and admin responses exclude secret material
- [x] No deployment, Railway, production credential, flag enablement, or merge performed

## Scope and deferred work

This PR contains the migration/schema, resume/admin runtime, focused UI, contract conformance, writer guard, and unit/HTTP/real-Postgres coverage. Member-facing connect/validate/status/disconnect and repository discovery, GitHub writes, deployment, Railway changes, production credential provisioning, flag enablement, and merge are deferred.

Merge order: Workspace #332 first, then this Brain PR.

## Bot review summary

No blocking findings returned. Cursor Bugbot and CodeRabbit were both rate-limited; all GitHub CI checks completed successfully, including real-Postgres, HTTP, unit, static, docs, ingestion, and gitleaks jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, encrypted credentials/PAT sealing, advisory-locked claims, and compliance audit invariants—large surface area even with the feature flag defaulting off.
> 
> **Overview**
> Adds the **managed GitHub gateway** slice for durable approvals, post-approval execution resume, and admin-only policy/credential control—behind `AIOS_GATEWAY_INTERNAL_ENABLED` (off by default).
> 
> **Runtime & persistence:** New internal routes cover `resume-claim` (service auth, idempotent claim, decrypt/seal only for the winning caller), team-scoped admin APIs for approval decisions, gateway-tagged policies, and credential list/rotate/revoke. `lib/gateway/admin-persistence.ts` owns transactional approve/deny with DB-time expiry, policy CRUD with audit, and advisory-lock-linearized credential rotation/revocation. Service auth moves to **`gateway_service_credentials`** with overlapping active versions; executions store principal/policy/envelope snapshots for claim-time revalidation.
> 
> **Schema & crypto:** Migration `20260716120000_gateway_approval_admin.sql` adds credential rows (backfilled from legacy identity digests), execution snapshot columns, stricter approval/audit uniqueness, and immutability triggers. Request envelopes gain a canonical wire format with legacy decrypt support; secrets crypto adds `decryptSecretBytes` with explicit buffer zeroing.
> 
> **Product & guardrails:** Team admins get a **Managed gateway approvals** section on the existing approvals page (server action + queue UI). Generic `lib/policy/manage` blocks `gateway.*` policies and hides them from normal policy lists. CI runs new `test:gateway-approval*` scripts; docs drift lists updated routes/tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f772dcf3312c91ececfa149bf113b3ca2cfe149c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
