### PR TITLE
feat(metrics): context_health ingest + dashboard (brain-api v1.11)

### DIFF
--- a/app/t/[team]/maturity/people/[handle]/page.tsx
+++ b/app/t/[team]/maturity/people/[handle]/page.tsx
@@ -61,7 +61,7 @@ export default async function MemberMaturityPage({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-6">
         <div className="card p-4">
           <div className="text-xs uppercase tracking-wide text-ink-subtle">Tasks</div>
           <div className="mt-1 text-xl tabular-nums text-ink">{latest.tasks}</div>
@@ -76,6 +76,12 @@ export default async function MemberMaturityPage({
             {latest.ce_band == null ? "—" : `${latest.ce_band}/4`}
           </div>
           <CeShadowBadge />
+        </div>
+        <div className="card p-4">
+          <div className="text-xs uppercase tracking-wide text-ink-subtle">Context</div>
+          <div className="mt-1 text-xl tabular-nums text-ink">
+            {latest.context_health_score == null ? "—" : `${latest.context_health_score}/4`}
+          </div>
         </div>
         <div className="card p-4">
           <div className="text-xs uppercase tracking-wide text-ink-subtle">Est. spend</div>

--- a/app/t/[team]/maturity/people/[handle]/page.tsx
+++ b/app/t/[team]/maturity/people/[handle]/page.tsx
@@ -14,6 +14,11 @@ function radarData(axes: AemAxes, team: AemAxes): RadarDatum[] {
   return AXIS_META.map((a) => ({ axis: a.label, you: axes[a.key], team: team[a.key] }));
 }
 
+/** Shared 0–4 band renderer (CE band, context-health score). */
+function fmtBand(value: number | null): string {
+  return value == null ? "—" : `${value}/4`;
+}
+
 function CeShadowBadge() {
   return (
     <span className="mt-1 inline-flex rounded-full bg-amber/10 px-2 py-0.5 text-[10px] font-medium text-amber-700">
@@ -73,14 +78,14 @@ export default async function MemberMaturityPage({
         <div className="card p-4">
           <div className="text-xs uppercase tracking-wide text-ink-subtle">CE</div>
           <div className="mt-1 text-xl tabular-nums text-ink">
-            {latest.ce_band == null ? "—" : `${latest.ce_band}/4`}
+            {fmtBand(latest.ce_band)}
           </div>
           <CeShadowBadge />
         </div>
         <div className="card p-4">
           <div className="text-xs uppercase tracking-wide text-ink-subtle">Context</div>
           <div className="mt-1 text-xl tabular-nums text-ink">
-            {latest.context_health_score == null ? "—" : `${latest.context_health_score}/4`}
+            {fmtBand(latest.context_health_score)}
           </div>
         </div>
         <div className="card p-4">

--- a/app/t/[team]/maturity/people/page.tsx
+++ b/app/t/[team]/maturity/people/page.tsx
@@ -37,6 +37,10 @@ function fmtCeBand(band: number | null): string {
   return band == null ? "—" : `${band}/4`;
 }
 
+function fmtContextHealth(score: number | null): string {
+  return score == null ? "—" : `${score}/4`;
+}
+
 function radarData(axes: AemAxes): RadarDatum[] {
   return AXIS_META.map((a) => ({ axis: a.label, you: axes[a.key] }));
 }
@@ -108,6 +112,7 @@ export default async function MaturityPage({ params }: { params: Promise<{ team:
                   <th className="px-4 py-3 font-medium">Spine</th>
                   <th className="px-4 py-3 font-medium">Overall</th>
                   <th className="px-4 py-3 font-medium">CE</th>
+                  <th className="px-4 py-3 font-medium">Context</th>
                   <th className="px-4 py-3 font-medium">Weakest axis</th>
                   <th className="px-4 py-3 text-right font-medium">Tasks</th>
                   <th className="px-4 py-3 text-right font-medium">Est. spend</th>
@@ -130,6 +135,9 @@ export default async function MaturityPage({ params }: { params: Promise<{ team:
                     <td className="px-4 py-3 tabular-nums text-ink-secondary">
                       {fmtCeBand(m.ce_band)}
                       <CeShadowBadge />
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-ink-secondary">
+                      {fmtContextHealth(m.context_health_score)}
                     </td>
                     <td className="px-4 py-3 text-ink-secondary">
                       {AXIS_META.find((a) => a.key === m.weakest)?.label}

--- a/app/t/[team]/maturity/people/page.tsx
+++ b/app/t/[team]/maturity/people/page.tsx
@@ -33,12 +33,9 @@ function CeShadowBadge() {
   );
 }
 
-function fmtCeBand(band: number | null): string {
-  return band == null ? "—" : `${band}/4`;
-}
-
-function fmtContextHealth(score: number | null): string {
-  return score == null ? "—" : `${score}/4`;
+/** Shared 0–4 band renderer (CE band, context-health score, team average). */
+function fmtBand(value: number | null): string {
+  return value == null ? "—" : `${value}/4`;
 }
 
 function radarData(axes: AemAxes): RadarDatum[] {
@@ -56,16 +53,28 @@ export default async function MaturityPage({ params }: { params: Promise<{ team:
   if (!me) return null;
 
   // Read helper enforces the team-tier gate (external → empty board).
-  const { members, teamAxes, spineDistribution, asOf } = await getTeamMaturity(db, team.id, me.tier);
+  const { members, teamAxes, spineDistribution, asOf, averageContextHealth } = await getTeamMaturity(
+    db,
+    team.id,
+    me.tier
+  );
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-5">
-      <div>
-        <h1 className="text-2xl font-semibold text-ink">Individual Maturity</h1>
-        <p className="text-sm text-ink-secondary">
-          Per-person AEM placement from local agent sessions (Claude Code · Codex · Cursor).
-          {asOf ? ` Latest snapshot ${asOf}.` : ""}
-        </p>
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-ink">Individual Maturity</h1>
+          <p className="text-sm text-ink-secondary">
+            Per-person AEM placement from local agent sessions (Claude Code · Codex · Cursor).
+            {asOf ? ` Latest snapshot ${asOf}.` : ""}
+          </p>
+        </div>
+        {averageContextHealth != null && (
+          <div className="text-right">
+            <div className="text-xs uppercase tracking-wide text-ink-subtle">Team context health</div>
+            <div className="text-lg tabular-nums text-ink">{fmtBand(averageContextHealth)}</div>
+          </div>
+        )}
       </div>
 
       {members.length === 0 ? (
@@ -133,11 +142,11 @@ export default async function MaturityPage({ params }: { params: Promise<{ team:
                     </td>
                     <td className="px-4 py-3 tabular-nums text-ink-secondary">{m.overall.toFixed(2)}</td>
                     <td className="px-4 py-3 tabular-nums text-ink-secondary">
-                      {fmtCeBand(m.ce_band)}
+                      {fmtBand(m.ce_band)}
                       <CeShadowBadge />
                     </td>
                     <td className="px-4 py-3 tabular-nums text-ink-secondary">
-                      {fmtContextHealth(m.context_health_score)}
+                      {fmtBand(m.context_health_score)}
                     </td>
                     <td className="px-4 py-3 text-ink-secondary">
                       {AXIS_META.find((a) => a.key === m.weakest)?.label}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,9 +123,10 @@ flowchart LR
 
 ## Auth & access tiers
 
-This server **implements brain-api v1.9** (the wire contract; source of truth:
+This server **implements brain-api v1.11** (the wire contract; source of truth:
 `aios-workspace/docs/brain-api.md`; v1.8 added the subscriptions endpoint,
-`POST /api/v1/subscriptions`). That version is pinned in code as `BRAIN_API_VERSION`
+`POST /api/v1/subscriptions`; v1.11 added the optional `context_health` scan summary
+on `POST /api/v1/metrics`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`), asserted against this sentence by
 `test/guards/contract-version.test.ts`, and mirrored by the vendored
 `test/fixtures/contract/brain-contract.json` (regenerated in lockstep with the canonical

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -247,6 +247,20 @@ export const maturitySnapshotPayloadSchema = z.object({
   // Shadow Cognitive-Ergonomics band (v1.3). No `.default()`: omitted (older client) must
   // stay distinguishable from an explicit null. Provenance-only — never recomputed here.
   ce_band: z.number().int().min(0).max(4).nullable().optional(),
+  // Context-health scan summary (scalars only — never content/paths). No `.default()`:
+  // omitted (older client / no scan yet) must stay distinguishable from an explicit push.
+  // Provenance-only — never recomputed here, never feeds placement().
+  context_health: z
+    .object({
+      score: z.number().int().min(0).max(4),
+      mode: z.enum(["workspace", "repo"]),
+      drift_count: z.number().int().nonnegative(),
+      versions_behind: z.number().int().nonnegative().nullable().optional(),
+      coverage_pct: z.number().min(0).max(100).nullable().optional(),
+      broken_link_count: z.number().int().nonnegative(),
+      checked_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    })
+    .optional(),
 });
 export type MaturitySnapshotPayload = z.infer<
   typeof maturitySnapshotPayloadSchema

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -9,7 +9,7 @@
  * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
  */
-export const BRAIN_API_VERSION = "1.9";
+export const BRAIN_API_VERSION = "1.11";
 
 /** Server-only Executor gateway negotiation; independent of the member API surface. */
 export const GATEWAY_CONTRACT_VERSION = "1.10";

--- a/lib/metrics/individual-maturity-ingest.ts
+++ b/lib/metrics/individual-maturity-ingest.ts
@@ -66,6 +66,16 @@ export async function ingestMaturitySnapshot(
         // Omitted (older client) → key absent, column untouched on conflict (preserves a
         // previously stored band). Explicit null → column set to NULL, clearing it.
         ...(payload.ce_band !== undefined ? { ce_band: payload.ce_band } : {}),
+        // Omitted (older client / no scan yet) → keys absent, columns untouched on conflict
+        // (preserves a previously stored context-health summary). context_health has no
+        // explicit-null path in the wire contract (it's an object-or-absent field), so this
+        // is a simple presence check.
+        ...(payload.context_health !== undefined
+          ? {
+              context_health_score: payload.context_health.score,
+              context_health: JSON.stringify(payload.context_health), // jsonb (postgres-only cast)
+            }
+          : {}),
       },
       { onConflict: "team_id,member_id,snapshot_date,metric" }
     )
@@ -89,6 +99,9 @@ export async function ingestMaturitySnapshot(
       // Preserve the omitted-vs-explicit-null distinction in the audit trail too — collapsing
       // them (e.g. via `?? null`) would hide whether a re-push actually cleared a stored band.
       ce_band: payload.ce_band === undefined ? "unchanged" : payload.ce_band,
+      // Same distinction for context_health: "unchanged" when the field is absent from the
+      // push (preserves whatever was stored before), else the pushed score.
+      context_health: payload.context_health === undefined ? "unchanged" : payload.context_health.score,
     },
   });
 

--- a/lib/metrics/individual-maturity.ts
+++ b/lib/metrics/individual-maturity.ts
@@ -134,6 +134,7 @@ type SnapshotRow = {
   canonical_learning: number;
   canonical_cost_governance: number;
   ce_band: number | null;
+  context_health_score: number | null;
   tasks: number;
   sessions: number;
   total_cost_usd: number;
@@ -161,6 +162,7 @@ export type MemberMaturityCard = {
   spine: string;
   overall: number;
   ce_band: number | null;
+  context_health_score: number | null;
   axes: AemAxes;
   tasks: number;
   sessions: number;
@@ -174,6 +176,7 @@ export type TeamMaturity = {
   members: MemberMaturityCard[];
   teamAxes: AemAxes;
   spineDistribution: Record<string, number>;
+  averageContextHealth: number | null;
 };
 
 function weakestOf(axes: AemAxes): keyof AemAxes {
@@ -188,6 +191,13 @@ function averageAxes(rows: AemAxes[]): AemAxes {
   return sum;
 }
 
+/** Mean of latest-per-member non-null context-health scores; null if none have scanned. */
+function averageContextHealth(scores: (number | null)[]): number | null {
+  const present = scores.filter((s): s is number => s != null);
+  if (!present.length) return null;
+  return Math.round((present.reduce((a, b) => a + b, 0) / present.length) * 100) / 100;
+}
+
 /**
  * Team view: each member's LATEST snapshot, the team-average axes (radar), and the
  * Spine distribution. Team-tier only — an external viewer gets an empty board.
@@ -197,12 +207,13 @@ export async function getTeamMaturity(
   teamId: string,
   tier: ViewerTier
 ): Promise<TeamMaturity> {
-  if (!canSeeMaturity(tier)) return { asOf: null, members: [], teamAxes: averageAxes([]), spineDistribution: {} };
+  if (!canSeeMaturity(tier))
+    return { asOf: null, members: [], teamAxes: averageAxes([]), spineDistribution: {}, averageContextHealth: null };
 
   const { data: snaps } = await db
     .from("agentic_maturity_snapshots")
     .select(
-      `member_id, snapshot_date, canonical_spine, canonical_overall, ce_band, tasks, sessions,
+      `member_id, snapshot_date, canonical_spine, canonical_overall, ce_band, context_health_score, tasks, sessions,
        total_cost_usd, input_tokens, output_tokens, cache_read_tokens, ${AXIS_COLS.join(", ")}`
     )
     .eq("team_id", teamId)
@@ -238,6 +249,7 @@ export async function getTeamMaturity(
       spine: r.canonical_spine,
       overall: Number(r.canonical_overall),
       ce_band: r.ce_band == null ? null : Number(r.ce_band),
+      context_health_score: r.context_health_score == null ? null : Number(r.context_health_score),
       axes,
       tasks: Number(r.tasks),
       sessions: Number(r.sessions),
@@ -255,6 +267,7 @@ export async function getTeamMaturity(
     members: cards,
     teamAxes: averageAxes(cards.map((c) => c.axes)),
     spineDistribution,
+    averageContextHealth: averageContextHealth(cards.map((c) => c.context_health_score)),
   };
 }
 
@@ -296,7 +309,7 @@ export async function getMemberMaturity(
   const { data: snaps } = await db
     .from("agentic_maturity_snapshots")
     .select(
-      `member_id, snapshot_date, canonical_spine, canonical_overall, ce_band, tasks, sessions,
+      `member_id, snapshot_date, canonical_spine, canonical_overall, ce_band, context_health_score, tasks, sessions,
        total_cost_usd, input_tokens, output_tokens, cache_read_tokens, ${AXIS_COLS.join(", ")}`
     )
     .eq("team_id", teamId)
@@ -320,6 +333,7 @@ export async function getMemberMaturity(
     member_id: m.id, handle: m.actor_handle, name: m.display_name, avatar_url: m.avatar_url,
     date: dayStr(last.snapshot_date), spine: last.canonical_spine, overall: Number(last.canonical_overall),
     ce_band: last.ce_band == null ? null : Number(last.ce_band),
+    context_health_score: last.context_health_score == null ? null : Number(last.context_health_score),
     axes, tasks: Number(last.tasks), sessions: Number(last.sessions),
     total_cost_usd: Number(last.total_cost_usd ?? 0),
     total_tokens: Number(last.input_tokens ?? 0) + Number(last.output_tokens ?? 0) + Number(last.cache_read_tokens ?? 0),

--- a/postgres/migrations/20260716130000_maturity_context_health.sql
+++ b/postgres/migrations/20260716130000_maturity_context_health.sql
@@ -1,0 +1,12 @@
+-- brain-api v1.11: optional context-health scan summary on AEM individual snapshots.
+-- context_health_score mirrors ce_band's shape (nullable smallint, 0-4, no default — null
+-- means "no scan yet / older client", distinct from 0). context_health is the full scalar
+-- summary object (score, mode, drift_count, versions_behind, coverage_pct, broken_link_count,
+-- checked_at) — scalars only, never content/paths. Provenance-only: the brain persists it
+-- verbatim and never recomputes it (never feeds placement()). Also mirrored into
+-- postgres/schema.sql for from-zero replay.
+alter table agentic_maturity_snapshots
+  add column if not exists context_health_score smallint
+  check (context_health_score is null or context_health_score between 0 and 4);
+alter table agentic_maturity_snapshots
+  add column if not exists context_health jsonb;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1387,6 +1387,12 @@ create table if not exists agentic_maturity_snapshots (
   -- Client-derived, provenance-only: never recomputed here, never feeds placement().
   -- Shadow / uncalibrated — never a canonical scorer input.
   ce_band smallint check (ce_band is null or ce_band between 0 and 4),
+  -- context-health scan summary (v1.11, optional, nullable, no default). Scalars only
+  -- (score, mode, drift_count, versions_behind, coverage_pct, broken_link_count, checked_at) —
+  -- never content/paths. context_health_score mirrors ce_band's shape for team-rollup queries;
+  -- context_health carries the full summary object. Provenance-only — never recomputed here.
+  context_health_score smallint check (context_health_score is null or context_health_score between 0 and 4),
+  context_health jsonb,
   created_at timestamptz not null default now(),
   unique (team_id, member_id, snapshot_date, metric)
 );

--- a/test/datamechanics/maturity-ingest.datamechanics.test.ts
+++ b/test/datamechanics/maturity-ingest.datamechanics.test.ts
@@ -176,4 +176,82 @@ describe("agentic-maturity snapshot ingest (real Postgres)", () => {
       expect((await metaFor(seedNull.teamId)).ce_band).toBeNull();
     });
   });
+
+  describe("context_health (v1.11 scan summary)", () => {
+    function contextHealth(over: Record<string, unknown> = {}) {
+      return {
+        score: 3,
+        mode: "workspace",
+        drift_count: 2,
+        versions_behind: 1,
+        coverage_pct: 80,
+        broken_link_count: 0,
+        checked_at: "2026-06-18",
+        ...over,
+      };
+    }
+
+    it("persists both the score column and the full jsonb summary", async () => {
+      const seed = await seedTeam();
+      await ingest(seed, snapshot({ context_health: contextHealth() }));
+      const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+      expect(row!.context_health_score).toBe(3);
+      expect(row!.context_health).toMatchObject(contextHealth());
+    });
+
+    it("stays NULL when the field is omitted (older client / no scan yet)", async () => {
+      const seed = await seedTeam();
+      await ingest(seed, snapshot());
+      const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+      expect(row!.context_health_score).toBeNull();
+      expect(row!.context_health).toBeNull();
+    });
+
+    it("column-wise merge: push-with-summary then re-push-without leaves it intact", async () => {
+      const seed = await seedTeam();
+      await ingest(seed, snapshot({ context_health: contextHealth() }));
+      await ingest(seed, snapshot({ tasks: 999 })); // no context_health key at all
+      const row = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+      expect(row!.context_health_score).toBe(3);
+      expect(Number(row!.tasks)).toBe(999); // the re-push's other fields DID apply
+    });
+
+    it("canonical_* columns are identical with and without context_health", async () => {
+      const seed = await seedTeam();
+      const withSummary = await ingest(seed, snapshot({ context_health: contextHealth() }));
+      const rowWith = await rowFor(seed.teamId, seed.memberId, "2026-06-18");
+
+      const seed2 = await seedTeam();
+      const withoutSummary = await ingest(seed2, snapshot());
+      const rowWithout = await rowFor(seed2.teamId, seed2.memberId, "2026-06-18");
+
+      expect(withSummary.canonical).toEqual(withoutSummary.canonical);
+      expect(rowWith!.canonical_spine).toBe(rowWithout!.canonical_spine);
+      expect(Number(rowWith!.canonical_overall)).toBe(Number(rowWithout!.canonical_overall));
+    });
+
+    // Regression: the audit trail must not collapse "omitted" and "explicit push" into the
+    // same logged value — that would hide whether a re-push actually updated the summary.
+    it("audit meta distinguishes omitted (unchanged) from an explicit push", async () => {
+      async function metaFor(teamId: string) {
+        const { data } = await db()
+          .from("audit_log")
+          .select("meta")
+          .eq("team_id", teamId)
+          .eq("action", "maturity.snapshot")
+          .order("created_at", { ascending: false })
+          .limit(1)
+          .single();
+        return (data as { meta: Record<string, unknown> }).meta;
+      }
+
+      const seedOmitted = await seedTeam();
+      await ingest(seedOmitted, snapshot());
+      expect((await metaFor(seedOmitted.teamId)).context_health).toBe("unchanged");
+
+      const seedPushed = await seedTeam();
+      await ingest(seedPushed, snapshot({ context_health: contextHealth() }));
+      expect((await metaFor(seedPushed.teamId)).context_health).toBe(3);
+    });
+  });
 });

--- a/test/datamechanics/maturity-read.datamechanics.test.ts
+++ b/test/datamechanics/maturity-read.datamechanics.test.ts
@@ -103,4 +103,49 @@ describe("agentic-maturity dashboard reads (real Postgres)", () => {
     expect(ext.members).toEqual([]);
     expect(await getMemberMaturity(db(), seed.teamId, "alex", "external")).toBeNull();
   });
+
+  function contextHealth(score: number, over: Record<string, unknown> = {}) {
+    return {
+      score, mode: "workspace", drift_count: 0, versions_behind: 0,
+      coverage_pct: 100, broken_link_count: 0, checked_at: "2026-06-18", ...over,
+    };
+  }
+
+  it("exposes context_health_score on cards + averages it across the team (latest per member)", async () => {
+    const seed = await seedTeam();
+    const alex = await createMember(db(), seed.teamId, { email: "a@x.test", displayName: "Alex", actorHandle: "alex", role: "member" });
+    const sam = await createMember(db(), seed.teamId, { email: "s@x.test", displayName: "Sam", actorHandle: "sam", role: "member" });
+
+    // alex: earlier snapshot has no scan, the latest carries a score of 4 (latest wins).
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-16"));
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-18", { context_health: contextHealth(4) }));
+    await ingest(seed.teamId, sam.id, snap("sam", "2026-06-18", { context_health: contextHealth(2) }));
+
+    const team = await getTeamMaturity(db(), seed.teamId, "team");
+    expect(team.members.find((mm) => mm.handle === "alex")!.context_health_score).toBe(4);
+    expect(team.members.find((mm) => mm.handle === "sam")!.context_health_score).toBe(2);
+    // Mean of the latest-per-member non-null scores: (4 + 2) / 2.
+    expect(team.averageContextHealth).toBe(3);
+
+    const m = await getMemberMaturity(db(), seed.teamId, "alex", "team");
+    expect(m!.latest.context_health_score).toBe(4);
+  });
+
+  it("averageContextHealth is null until a member scans, and skips members with no scan", async () => {
+    const seed = await seedTeam();
+    const alex = await createMember(db(), seed.teamId, { email: "a@x.test", displayName: "Alex", actorHandle: "alex", role: "member" });
+    const sam = await createMember(db(), seed.teamId, { email: "s@x.test", displayName: "Sam", actorHandle: "sam", role: "member" });
+
+    // No scans yet → no scores to average.
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-18"));
+    await ingest(seed.teamId, sam.id, snap("sam", "2026-06-18"));
+    const before = await getTeamMaturity(db(), seed.teamId, "team");
+    expect(before.members.every((mm) => mm.context_health_score == null)).toBe(true);
+    expect(before.averageContextHealth).toBeNull();
+
+    // Only alex scans → the average reflects alex alone (unscanned sam is skipped, not counted as 0).
+    await ingest(seed.teamId, alex.id, snap("alex", "2026-06-18", { context_health: contextHealth(3) }));
+    const after = await getTeamMaturity(db(), seed.teamId, "team");
+    expect(after.averageContextHealth).toBe(3);
+  });
 });

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -1,7 +1,7 @@
 {
   "$schema": "aios-brain-contract/v1",
   "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: node scripts/gen-contract-fixture.mjs.",
-  "version": "1.9",
+  "version": "1.11",
   "tierAliases": {
     "shared": {
       "team": "team",
@@ -83,5 +83,10 @@
     "slack",
     "github"
   ],
-  "contentHash": "0f086134229ce955aceb6e1aa888b3ad1555e9071032eb5250d8a0e8fcd99c36"
+  "gatewayContract": {
+    "path": "gateway-v1.10.json",
+    "version": "1.10",
+    "sha256": "4ddd6495fa505b76118080865d60255bfba94a9ccda249defe428babb3d0c205"
+  },
+  "contentHash": "bf02d592e0a3bd3dd0d07adb17e1da2bcee44e3841f018f147dd8469eb574bbd"
 }

--- a/test/guards/contract-conformance.test.ts
+++ b/test/guards/contract-conformance.test.ts
@@ -35,10 +35,13 @@ const canonical = (v: Json): Json =>
 
 describe("brain-api tier + SSE conformance", () => {
   it("fixture contentHash is intact (no out-of-band edit)", () => {
-    // v1.7 added provisioningTools (the member-invite tool vocabulary) to the pinned content.
-    const { version, tierAliases, sse, provisioningTools } = fixture;
+    // v1.7 added provisioningTools (the member-invite tool vocabulary); v1.10 added
+    // gatewayContract (AIO-407) to the pinned content.
+    const { version, tierAliases, sse, provisioningTools, gatewayContract } = fixture;
     const recomputed = createHash("sha256")
-      .update(JSON.stringify(canonical({ version, tierAliases, sse, provisioningTools })))
+      .update(
+        JSON.stringify(canonical({ version, tierAliases, sse, provisioningTools, gatewayContract })),
+      )
       .digest("hex");
     expect(recomputed).toBe(fixture.contentHash);
   });

--- a/test/http/metrics.http.test.ts
+++ b/test/http/metrics.http.test.ts
@@ -90,4 +90,103 @@ describe("POST /api/v1/metrics (HTTP)", () => {
     });
     expect(res.status).toBe(201);
   });
+
+  it("201s with a context_health summary and the DB row shows both columns", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(
+        payload({
+          context_health: {
+            score: 3,
+            mode: "workspace",
+            drift_count: 2,
+            versions_behind: 1,
+            coverage_pct: 80,
+            broken_link_count: 0,
+            checked_at: "2026-07-04",
+          },
+        })
+      ),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+
+    const { data } = await db()
+      .from("agentic_maturity_snapshots")
+      .select("context_health_score, context_health")
+      .eq("team_id", seed.teamId)
+      .eq("member_id", seed.memberId)
+      .eq("snapshot_date", "2026-07-04")
+      .single();
+    const row = data as { context_health_score: number; context_health: Record<string, unknown> };
+    expect(row.context_health_score).toBe(3);
+    expect(row.context_health).toMatchObject({ score: 3, mode: "workspace", drift_count: 2 });
+  });
+
+  it("422s on an out-of-range context_health score", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(
+        payload({
+          context_health: {
+            score: 9,
+            mode: "workspace",
+            drift_count: 0,
+            versions_behind: null,
+            coverage_pct: null,
+            broken_link_count: 0,
+            checked_at: "2026-07-04",
+          },
+        })
+      ),
+    });
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("invalid_payload");
+  });
+
+  it("422s on an invalid context_health mode", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(
+        payload({
+          context_health: {
+            score: 2,
+            mode: "bogus",
+            drift_count: 0,
+            versions_behind: null,
+            coverage_pct: null,
+            broken_link_count: 0,
+            checked_at: "2026-07-04",
+          },
+        })
+      ),
+    });
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("invalid_payload");
+  });
+
+  it("201s when context_health is omitted", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(METRICS, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(payload()),
+    });
+    expect(res.status).toBe(201);
+  });
 });

--- a/test/maturity-context-health-schema.test.ts
+++ b/test/maturity-context-health-schema.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { maturitySnapshotPayloadSchema } from "@/lib/api/schemas";
+
+// Spec (brain-api v1.11): context_health is an optional scan-summary object (score, mode,
+// drift_count, versions_behind, coverage_pct, broken_link_count, checked_at) with NO default —
+// an omitted field must stay distinguishable (undefined) so an older client's re-push can't
+// accidentally clear a previously stored summary.
+
+function payload(over: Record<string, unknown> = {}) {
+  return {
+    date: "2026-07-16",
+    signals: {
+      delegation_ratio: 0.3, correction_loop_avg: 1.2, error_rate: 0.05,
+      cost_per_task: 0.4, tokens_per_task: 30_000, cache_hit_rate: 0.8,
+      tool_diversity: 8, verify_tool_rate: 0.3, subagent_usage: 0.5,
+    },
+    ...over,
+  };
+}
+
+function contextHealth(over: Record<string, unknown> = {}) {
+  return {
+    score: 3,
+    mode: "workspace",
+    drift_count: 2,
+    versions_behind: 1,
+    coverage_pct: 80,
+    broken_link_count: 0,
+    checked_at: "2026-07-16",
+    ...over,
+  };
+}
+
+describe("maturitySnapshotPayloadSchema — context_health (v1.11)", () => {
+  it("accepts a valid context_health object", () => {
+    const parsed = maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth() }));
+    expect(parsed.context_health).toEqual(contextHealth());
+  });
+
+  it("accepts the boundary values (score 0/4, coverage_pct 0/100, nullable fields null)", () => {
+    const low = maturitySnapshotPayloadSchema.parse(
+      payload({ context_health: contextHealth({ score: 0, coverage_pct: 0, versions_behind: null }) })
+    );
+    expect(low.context_health?.score).toBe(0);
+    expect(low.context_health?.coverage_pct).toBe(0);
+    expect(low.context_health?.versions_behind).toBeNull();
+
+    const high = maturitySnapshotPayloadSchema.parse(
+      payload({ context_health: contextHealth({ score: 4, coverage_pct: 100 }) })
+    );
+    expect(high.context_health?.score).toBe(4);
+    expect(high.context_health?.coverage_pct).toBe(100);
+  });
+
+  it("accepts mode 'repo' and a null coverage_pct", () => {
+    const parsed = maturitySnapshotPayloadSchema.parse(
+      payload({ context_health: contextHealth({ mode: "repo", coverage_pct: null }) })
+    );
+    expect(parsed.context_health?.mode).toBe("repo");
+    expect(parsed.context_health?.coverage_pct).toBeNull();
+  });
+
+  it("stays undefined when omitted (distinguishable from an explicit push)", () => {
+    expect(maturitySnapshotPayloadSchema.parse(payload()).context_health).toBeUndefined();
+  });
+
+  it("rejects an out-of-range score", () => {
+    expect(() =>
+      maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth({ score: 5 }) }))
+    ).toThrow();
+    expect(() =>
+      maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth({ score: -1 }) }))
+    ).toThrow();
+  });
+
+  it("rejects an out-of-range coverage_pct", () => {
+    expect(() =>
+      maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth({ coverage_pct: 101 }) }))
+    ).toThrow();
+    expect(() =>
+      maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth({ coverage_pct: -1 }) }))
+    ).toThrow();
+  });
+
+  it("rejects an invalid mode", () => {
+    expect(() =>
+      maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth({ mode: "bogus" }) }))
+    ).toThrow();
+  });
+
+  it("rejects negative counts and a malformed checked_at", () => {
+    expect(() =>
+      maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth({ drift_count: -1 }) }))
+    ).toThrow();
+    expect(() =>
+      maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth({ broken_link_count: -1 }) }))
+    ).toThrow();
+    expect(() =>
+      maturitySnapshotPayloadSchema.parse(payload({ context_health: contextHealth({ checked_at: "07/16/2026" }) }))
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Brain-side half of the new **Context Engineering Health** metric (workspace PR: aiosbrain/aios-workspace — `feat/context-health`). The workspace computes mechanical context-drift/staleness/coverage checks locally and pushes derived scalars only; this PR ingests and surfaces them.

- `context_health` optional object on `POST /api/v1/metrics` (score 0–4, mode, drift_count, versions_behind, coverage_pct, broken_link_count, checked_at) — ce_band additive precedent: `.optional()`, no `.default()`, omitted ≠ null; older clients unaffected.
- Migration adds `context_health_score smallint (0–4 check)` + `context_health jsonb` to `agentic_maturity_snapshots`; scalars only, never content/paths (privacy comment in schema).
- Conditional ingest write + audit meta; `averageContextHealth` (latest-per-member mean) in `getTeamMaturity`; "Context" column on the people page + tile on the member deep-dive. Tier gating unchanged (`canSeeMaturity`).
- **brain-api v1.11**: `BRAIN_API_VERSION` 1.9 → 1.11 + ARCHITECTURE.md sentence (guard-enforced pair); canonical v1.11 contract fixture re-vendored byte-identical from aios-workspace; conformance guard hash set aligned with the workspace generator (`gatewayContract` was added to the pinned content by AIO-407, brain guard had lagged).

Known v1 limitation (deliberate): snapshots keyed (team, member, date, metric) — a member pushing from two repos the same day overwrites; fine for a provenance-only shadow signal, revisit if per-project keying is wanted.

## Test plan
- [x] Guards 85/85 (contract-version, contract-conformance incl. new hash set, migrations-numbering)
- [x] Schema tests: accepts valid/omitted, rejects score 5 / coverage 101 / bad mode
- [x] Datamechanics 16/16 + HTTP tier 9/9 against real test Postgres (5434)
- [x] Full `vitest run`: 772 passed, 0 failed; `tsc --noEmit` clean; lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the metrics wire contract, snapshot upsert/audit merge behavior, and a DB migration on a core maturity table; changes are additive with backward-compatible omission semantics and do not alter canonical placement scoring.
> 
> **Overview**
> Adds **brain-api v1.11** support for an optional **`context_health`** scan summary on maturity metric pushes: scalar-only fields (score 0–4, mode, drift/staleness/coverage counts, `checked_at`) are validated, stored on `agentic_maturity_snapshots` (`context_health_score` + `context_health` jsonb), and treated as **provenance-only** (same omit-vs-push semantics as `ce_band`—omitted re-pushes do not clear prior data).
> 
> **`BRAIN_API_VERSION`** moves **1.9 → 1.11** with docs, vendored contract fixture, and conformance hash updates (including **`gatewayContract`** in pinned content). Team/member maturity reads surface **`context_health_score`**; the people table and member snapshot grid add a **Context** column/tile. Coverage is backed by schema, datamechanics, and HTTP tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a4f62746ba4defc465e1847f7a841321648a1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context health scores and scan details to individual maturity profiles.
  * Added a Context column to the team maturity table.
  * Added a team-wide context health average to the page header.
  * Added validation and storage for optional context health scan results.
* **Documentation**
  * Updated the brain API contract documentation to version 1.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->