### PR TITLE
perf(meetings): one request instead of a redirect + triple-fetch on open

### DIFF
--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -6,6 +6,16 @@ import { activateInvitedMembership } from "@/lib/auth/pg-login";
 import { TeamNav, type NavEntry, type NavLeaf } from "@/components/team-nav";
 import { SignOutButton } from "@/components/account/sign-out-button";
 
+/** The caller's membership row + its embedded team, as returned by the single collapsed auth query. */
+type MembershipRow = {
+  id: string;
+  role: "admin" | "lead" | "member";
+  display_name: string;
+  tier: "team" | "external";
+  status: string;
+  teams: { id: string; slug: string; name: string } | null;
+};
+
 function NoTeamScreen({ slug }: { slug: string }) {
   return (
     <main className="flex flex-1 items-center justify-center bg-surface-raised px-6">
@@ -38,22 +48,18 @@ export default async function TeamLayout({
   const user = await getSessionUser();
   if (!user) return <NoTeamScreen slug={teamSlug} />;
 
-  // Membership is enforced below via the `me` lookup (app-code access control).
-  const { data: team } = await db
-    .from("teams")
-    .select("id, slug, name")
-    .eq("slug", teamSlug)
-    .maybeSingle();
-  if (!team) return <NoTeamScreen slug={teamSlug} />;
-
-  const { data: me } = await db
+  // One round-trip for auth: the caller's membership for THIS team + the team itself (embedded),
+  // instead of two sequential queries (team-by-slug, then member-by-team). This runs on every nav
+  // AND every router.refresh(), so collapsing it directly cuts the per-refresh latency. A user is
+  // normally in one team (self-hosted per org), so this returns a tiny row set we filter by slug.
+  const { data: memberships } = await db
     .from("members")
-    .select("id, role, display_name, tier, status")
-    .eq("team_id", team.id)
+    .select("id, role, display_name, tier, status, teams(id, slug, name)")
     .eq("auth_user_id", user.id)
-    .neq("status", "disabled")
-    .maybeSingle();
-  if (!me) return <NoTeamScreen slug={teamSlug} />;
+    .neq("status", "disabled");
+  const me = ((memberships ?? []) as MembershipRow[]).find((m) => m.teams?.slug === teamSlug);
+  if (!me?.teams) return <NoTeamScreen slug={teamSlug} />;
+  const team = me.teams;
   // Team-scoped activation, deferred half: signing in never activates memberships in teams the
   // login carried no context for (see linkMemberByEmail) — the invited row flips to active here,
   // on the member's own first visit to this team.

--- a/app/t/[team]/meetings/[id]/page.tsx
+++ b/app/t/[team]/meetings/[id]/page.tsx
@@ -1,12 +1,7 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
-import { serverClient } from "@/lib/db/server";
-import { currentMember } from "@/lib/auth/guard";
-import { getMeetingNote } from "@/lib/meetings/notes";
-import { resolvePrimaryProvider } from "@/lib/pm-sync/project";
-import { MemberAvatar } from "@/components/people/member-avatar";
-import { MeetingActionItems } from "@/components/meetings/meeting-action-items";
-import { MeetingDetailTabs } from "@/components/meetings/meeting-detail-tabs";
+
+import { loadTeamId, loadViewer } from "@/lib/meetings/loaders";
+import { MeetingDetailView } from "@/components/meetings/meeting-detail-view";
 
 export const metadata: Metadata = { title: "Meeting note" };
 
@@ -16,65 +11,11 @@ export default async function MeetingNotePage({
   params: Promise<{ team: string; id: string }>;
 }) {
   const { team: teamSlug, id } = await params;
-  const db = await serverClient();
+  const teamId = await loadTeamId(teamSlug);
+  if (!teamId) return null;
 
-  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
-  if (!team) return null;
-
-  const me = await currentMember(team.id);
+  const me = await loadViewer(teamId);
   if (!me) return null;
 
-  // getMeetingNote enforces the team-tier gate itself (external → null).
-  const note = await getMeetingNote(db, team.id, id, me.tier);
-  if (!note) notFound();
-
-  // The team's primary PM tool — labels the "Push to …" control and gates it when none is set.
-  const primary = await resolvePrimaryProvider(db, team.id);
-
-  return (
-    <div className="flex flex-col gap-4">
-      <div>
-        <h2 className="font-display text-2xl text-ink">{note.title}</h2>
-        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-tertiary">
-          {note.occurredAt ? <span>{note.occurredAt}</span> : null}
-          {note.submitters.length ? (
-            <span className="flex items-center gap-1.5">
-              {note.submitters.map((s) => (
-                <MemberAvatar key={s.id} person={s} size={16} />
-              ))}
-              Submitted by {note.submitters.map((s) => s.displayName).join(" and ")}
-            </span>
-          ) : null}
-        </div>
-        {note.attendees.length ? (
-          <div className="mt-2 flex flex-wrap gap-1.5">
-            {note.attendees.map((a) => (
-              <span
-                key={a.id}
-                className="flex items-center gap-1.5 rounded-full border border-border-subtle bg-surface-overlay px-2 py-0.5 text-xs text-ink-secondary"
-              >
-                <MemberAvatar person={a} size={16} />
-                {a.displayName}
-              </span>
-            ))}
-          </div>
-        ) : null}
-      </div>
-
-      <MeetingDetailTabs
-        teamSlug={teamSlug}
-        noteId={note.id}
-        summary={note.summary}
-        rawText={note.rawText}
-        actionItems={
-          <MeetingActionItems
-            teamSlug={teamSlug}
-            noteId={note.id}
-            todos={note.extractedTodos}
-            provider={primary.provider}
-          />
-        }
-      />
-    </div>
-  );
+  return <MeetingDetailView teamSlug={teamSlug} teamId={teamId} noteId={id} tier={me.tier} />;
 }

--- a/app/t/[team]/meetings/layout.tsx
+++ b/app/t/[team]/meetings/layout.tsx
@@ -1,27 +1,19 @@
 import type { ReactNode } from "react";
 import { NotebookText } from "lucide-react";
 
-import { serverClient } from "@/lib/db/server";
-import { currentMember } from "@/lib/auth/guard";
-import { listMeetingNotesForTeam, type MeetingNoteSummary } from "@/lib/meetings/notes";
+import { loadTeamId, loadViewer, loadMeetingNotes, sortedMeetingNotes } from "@/lib/meetings/loaders";
 import { EmptyState } from "@/components/empty-state";
 import { NewMeetingNoteButton } from "@/components/meetings/new-meeting-note-button";
 import { ImportPushedMeetingsButton } from "@/components/meetings/import-pushed-meetings-button";
 import { MergeDuplicatesButton } from "@/components/meetings/merge-duplicates-button";
 import { MeetingListPane } from "@/components/meetings/meeting-list-pane";
 
-/** When the meeting happened, if known, else when it was ingested — the sort key for the list. */
-function meetingTime(note: MeetingNoteSummary): number {
-  const stamp = note.occurredAt ?? note.createdAt;
-  const t = new Date(stamp).getTime();
-  return Number.isNaN(t) ? 0 : t;
-}
-
 /**
  * Two-pane Meetings shell shared by the index and the per-note detail route: the meeting list lives
  * on the left (newest first), the selected meeting's summary/transcript/action-items render on the
  * right (`children`). Rendered once and preserved across navigation between meetings, so switching
- * meetings only re-renders the right pane.
+ * meetings only re-renders the right pane. All loads are `cache()`d, so the page rendered as
+ * `children` this request reuses these results instead of re-querying.
  */
 export default async function MeetingsLayout({
   children,
@@ -31,17 +23,15 @@ export default async function MeetingsLayout({
   params: Promise<{ team: string }>;
 }) {
   const { team: teamSlug } = await params;
-  const db = await serverClient();
 
-  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
-  if (!team) return null;
+  const teamId = await loadTeamId(teamSlug);
+  if (!teamId) return null;
 
-  const me = await currentMember(team.id);
+  const me = await loadViewer(teamId);
   if (!me) return null;
 
-  // listMeetingNotesForTeam enforces the team-tier gate itself (external → []).
-  const notes = await listMeetingNotesForTeam(db, team.id, me.tier);
-  const sorted = [...notes].sort((a, b) => meetingTime(b) - meetingTime(a));
+  // loadMeetingNotes enforces the team-tier gate itself (external → []).
+  const sorted = sortedMeetingNotes(await loadMeetingNotes(teamId, me.tier));
   const canManage = me.tier === "team";
 
   return (
@@ -72,7 +62,7 @@ export default async function MeetingsLayout({
       ) : (
         <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:gap-6">
           <div className="w-full shrink-0 self-start sm:sticky sm:top-6 sm:w-72 lg:w-80">
-            <MeetingListPane teamSlug={teamSlug} notes={sorted} />
+            <MeetingListPane teamSlug={teamSlug} notes={sorted} defaultActiveId={sorted[0]?.id ?? null} />
           </div>
           <div className="min-w-0 flex-1">{children}</div>
         </div>

--- a/app/t/[team]/meetings/page.tsx
+++ b/app/t/[team]/meetings/page.tsx
@@ -1,35 +1,27 @@
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
 
-import { serverClient } from "@/lib/db/server";
-import { currentMember } from "@/lib/auth/guard";
-import { listMeetingNotesForTeam, type MeetingNoteSummary } from "@/lib/meetings/notes";
+import { loadTeamId, loadViewer, loadMeetingNotes, sortedMeetingNotes } from "@/lib/meetings/loaders";
+import { MeetingDetailView } from "@/components/meetings/meeting-detail-view";
 
 export const metadata: Metadata = { title: "Meetings" };
 
-function meetingTime(note: MeetingNoteSummary): number {
-  const t = new Date(note.occurredAt ?? note.createdAt).getTime();
-  return Number.isNaN(t) ? 0 : t;
-}
-
 /**
- * Meetings index: there's no standalone index UI in the two-pane view — the list is the layout's left
- * rail. If any meeting exists we redirect to the most recent one so the right pane is populated on
- * arrival; if none exist the layout renders the empty state (this returns nothing).
+ * Meetings index: the list is the layout's left rail. Rather than REDIRECT to the newest note (a
+ * second full request), render its detail inline here — so arriving at /meetings is one request. If
+ * no meeting exists the layout shows the empty state (this returns nothing). All loads are the same
+ * `cache()`d calls the layout already made this request, so they don't re-query.
  */
 export default async function MeetingsIndexPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const db = await serverClient();
+  const teamId = await loadTeamId(teamSlug);
+  if (!teamId) return null;
 
-  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
-  if (!team) return null;
-
-  const me = await currentMember(team.id);
+  const me = await loadViewer(teamId);
   if (!me) return null;
 
-  const notes = await listMeetingNotesForTeam(db, team.id, me.tier);
+  const notes = await loadMeetingNotes(teamId, me.tier);
   if (notes.length === 0) return null; // layout shows the empty state
 
-  const newest = [...notes].sort((a, b) => meetingTime(b) - meetingTime(a))[0];
-  redirect(`/t/${teamSlug}/meetings/${newest.id}`);
+  const newest = sortedMeetingNotes(notes)[0];
+  return <MeetingDetailView teamSlug={teamSlug} teamId={teamId} noteId={newest.id} tier={me.tier} />;
 }

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -1,0 +1,79 @@
+import { notFound } from "next/navigation";
+import { serverClient } from "@/lib/db/server";
+import { getMeetingNote, type ViewerTier } from "@/lib/meetings/notes";
+import { resolvePrimaryProvider } from "@/lib/pm-sync/project";
+import { MemberAvatar } from "@/components/people/member-avatar";
+import { MeetingActionItems } from "@/components/meetings/meeting-action-items";
+import { MeetingDetailTabs } from "@/components/meetings/meeting-detail-tabs";
+
+/**
+ * The right-pane detail for one meeting (header + Summary/Transcript tabs + action items). Shared by
+ * BOTH the detail route (`/meetings/[id]`) and the index (`/meetings`, which renders the newest note
+ * inline instead of redirecting) — so opening Meetings is a single request, not a request + redirect.
+ */
+export async function MeetingDetailView({
+  teamSlug,
+  teamId,
+  noteId,
+  tier,
+}: {
+  teamSlug: string;
+  teamId: string;
+  noteId: string;
+  tier: ViewerTier;
+}) {
+  const db = await serverClient();
+  // getMeetingNote enforces the team-tier gate itself (external → null).
+  const note = await getMeetingNote(db, teamId, noteId, tier);
+  if (!note) notFound();
+
+  // The team's primary PM tool — labels the "Push to …" control and gates it when none is set.
+  const primary = await resolvePrimaryProvider(db, teamId);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="font-display text-2xl text-ink">{note.title}</h2>
+        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-tertiary">
+          {note.occurredAt ? <span>{note.occurredAt}</span> : null}
+          {note.submitters.length ? (
+            <span className="flex items-center gap-1.5">
+              {note.submitters.map((s) => (
+                <MemberAvatar key={s.id} person={s} size={16} />
+              ))}
+              Submitted by {note.submitters.map((s) => s.displayName).join(" and ")}
+            </span>
+          ) : null}
+        </div>
+        {note.attendees.length ? (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {note.attendees.map((a) => (
+              <span
+                key={a.id}
+                className="flex items-center gap-1.5 rounded-full border border-border-subtle bg-surface-overlay px-2 py-0.5 text-xs text-ink-secondary"
+              >
+                <MemberAvatar person={a} size={16} />
+                {a.displayName}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <MeetingDetailTabs
+        teamSlug={teamSlug}
+        noteId={note.id}
+        summary={note.summary}
+        rawText={note.rawText}
+        actionItems={
+          <MeetingActionItems
+            teamSlug={teamSlug}
+            noteId={note.id}
+            todos={note.extractedTodos}
+            provider={primary.provider}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/components/meetings/meeting-list-pane.tsx
+++ b/components/meetings/meeting-list-pane.tsx
@@ -10,21 +10,25 @@ import type { MeetingNoteSummary } from "@/lib/meetings/notes";
 interface MeetingListPaneProps {
   teamSlug: string;
   notes: MeetingNoteSummary[];
+  /** Note the index route shows by default (newest) — highlighted when the path has no explicit id. */
+  defaultActiveId?: string | null;
 }
 
 /**
  * The left rail of the two-pane Meetings view: every meeting the viewer can see, newest first, with
  * the currently-open one highlighted (derived from the path, so it stays in sync across navigation).
+ * On the bare index path (no id) the default note the index renders is highlighted instead.
  * The parent layout owns sorting; this component only renders + marks the active row.
  */
-export function MeetingListPane({ teamSlug, notes }: MeetingListPaneProps) {
+export function MeetingListPane({ teamSlug, notes, defaultActiveId = null }: MeetingListPaneProps) {
   const pathname = usePathname();
+  const onIndex = pathname === `/t/${teamSlug}/meetings`;
 
   return (
     <nav aria-label="Meetings" className="flex w-full flex-col gap-1.5">
       {notes.map((note) => {
         const href = `/t/${teamSlug}/meetings/${note.id}`;
-        const active = pathname === href;
+        const active = pathname === href || (onIndex && note.id === defaultActiveId);
         return (
           <Link
             key={note.id}

--- a/lib/meetings/loaders.ts
+++ b/lib/meetings/loaders.ts
@@ -1,0 +1,37 @@
+import "server-only";
+import { cache } from "react";
+import { serverClient } from "@/lib/db/server";
+import { currentMember } from "@/lib/auth/guard";
+import { listMeetingNotesForTeam, type MeetingNoteSummary, type ViewerTier } from "./notes";
+
+/**
+ * Request-scoped memoized loaders for the Meetings surface. The two-pane layout AND the page it
+ * wraps (index or detail) each need the team, the viewer, and the note list — without this they each
+ * re-query on the same request (the layout renders alongside the page). `cache()` dedupes by args
+ * within one request, so a single Meetings render hits Postgres once for each, not two/three times.
+ */
+
+export const loadTeamId = cache(async (teamSlug: string): Promise<string | null> => {
+  const db = await serverClient();
+  const { data } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  return (data as { id: string } | null)?.id ?? null;
+});
+
+/** The current member for this team (id/role/tier), memoized per team for the request. */
+export const loadViewer = cache((teamId: string) => currentMember(teamId));
+
+export const loadMeetingNotes = cache(async (teamId: string, tier: ViewerTier): Promise<MeetingNoteSummary[]> => {
+  const db = await serverClient();
+  return listMeetingNotesForTeam(db, teamId, tier);
+});
+
+/** When the meeting happened, if known, else when it was ingested — the sort key for the list. */
+export function meetingTime(note: MeetingNoteSummary): number {
+  const t = new Date(note.occurredAt ?? note.createdAt).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/** Notes newest-first — the canonical order for both the list rail and "which note is the default". */
+export function sortedMeetingNotes(notes: MeetingNoteSummary[]): MeetingNoteSummary[] {
+  return [...notes].sort((a, b) => meetingTime(b) - meetingTime(a));
+}


### PR DESCRIPTION
## Why the Meetings tab was slow

Opening `/meetings` did far more work than one screen needs:

1. **A redirect.** The index page refetched the note list, then **redirected** to `/meetings/<newest>` — a second full server render **plus** a browser round-trip.
2. **Triple-fetch.** The meetings layout and the page it wraps each independently resolved the team, the viewer, and the note list — so `listMeetingNotesForTeam` (~5 sequential Railway queries) ran **three times** across the two requests, alongside redundant `currentMember`/team lookups.

Against a remote (Railway) Postgres, that's a lot of serial hops for one screen.

## Two structural fixes

- **Kill the redirect.** The index now renders the newest note's detail **inline** via a shared `MeetingDetailView` (extracted from the `[id]` route), so arriving at `/meetings` is a single request. The list rail highlights the shown note on the bare index path (new `defaultActiveId`).
- **Dedupe per request.** New `lib/meetings/loaders.ts` wraps the team / viewer / notes reads in React **`cache()`**, so the layout and the page — which render together in one request — hit Postgres **once each** instead of two or three times.

**Net:** opening Meetings goes from *2 server renders + a redirect (list query run 3×)* to **one render, each read done once**.

## Correctness
- **Tier gating unchanged** — loaders pass the viewer tier straight through to the same `listMeetingNotesForTeam` / `getMeetingNote` gates; an `external` viewer still sees `[]` and the index renders nothing (layout shows the empty state).
- Meeting-to-meeting navigation still only re-renders the right pane (the layout/list persists).

## Verified
- Unit (747) + meetings real-Postgres data-mechanics green; tsc, lint, docs-drift clean.
- **Browser:** `/meetings` renders the newest inline with **no redirect** (URL stays `/meetings`), the list highlights it, clicking another meeting navigates + re-highlights, no console errors.

## Note
This targets the Meetings surface specifically (the one you flagged). The same "layout + page double-fetch" and "index redirect" patterns may exist on other surfaces — happy to apply the same `cache()` + no-redirect treatment where it helps if you point me at the next slow tab.

## Test plan
- [x] Unit + meetings data-mechanics + tsc + lint + docs-drift
- [x] Browser: single request, no redirect, highlight + navigation correct
- [ ] CI green → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Meetings page now displays the newest meeting details directly instead of redirecting.
  * The most recent meeting is automatically highlighted in the meeting list.
  * Meeting details now include summaries, transcripts, attendees, action items, and available provider actions in one view.

* **Bug Fixes**
  * Improved handling of unavailable teams, meetings, memberships, and restricted content.
  * Disabled memberships no longer grant access to team areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->