### PR TITLE
fix(learning): resilient narrative arcs (reasoning-model headroom, no empty-clobber, projector observability)

### DIFF
--- a/app/t/[team]/learning/page.tsx
+++ b/app/t/[team]/learning/page.tsx
@@ -35,7 +35,7 @@ export default async function LearningPage({ params }: { params: Promise<{ team:
 
       <section className="flex flex-col gap-2">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
-          Narrative arcs · last 7 days
+          Narrative arcs · most recent
         </h2>
         <ArcsPanel teamSlug={teamSlug} />
       </section>

--- a/components/admin/retrieval-health-card.tsx
+++ b/components/admin/retrieval-health-card.tsx
@@ -42,14 +42,24 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
     d.state === "off"
       ? undefined
       : `${d.coveragePct}% embedded (${d.embeddedItems}/${d.embeddableItems})${d.pendingItems ? `, ${d.pendingItems} pending` : ""}${d.lastEmbeddedAt ? `, last ${timeAgo(d.lastEmbeddedAt)}` : ""}`;
+  // Reachable but no projection in > 6h ⇒ the projector has stalled even though /healthcheck answers
+  // (the 2026-07 failure: writes 422'd for days while the service stayed "up"). The server flags this
+  // (`graphStalled`) so the banner tells the admin which failure it actually is.
+  const graphStalled = health.graphStalled;
+  const graphFreshness =
+    health.graphEpisodes != null
+      ? `${health.graphEpisodes} episodes${health.graphLastProjectedAt ? ` · last projected ${timeAgo(health.graphLastProjectedAt)}` : " · none projected yet"}`
+      : undefined;
   const graphDetail =
     health.graph === "off"
       ? "not configured"
-      : health.graph === "degraded"
-        ? "configured but unreachable"
-        : undefined;
-  // A configured-but-unreachable graph is a real failure (set GRAPHITI_URL but the service is down),
-  // distinct from simply "off" — flag it loudly (red), like a degraded semantic leg.
+      : graphStalled
+        ? `projector stalled — ${graphFreshness}`
+        : health.graph === "degraded"
+          ? "configured but unreachable"
+          : graphFreshness;
+  // A configured-but-unreachable OR stalled-projector graph is a real failure — flag it loudly (red),
+  // like a degraded semantic leg.
   const graphDegraded = health.graph === "degraded";
   const worst = d.state === "degraded" || health.graph === "off";
 
@@ -71,9 +81,20 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
 
       {graphDegraded ? (
         <p className="mt-2 rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
-          Graph memory is configured but not responding — <code>GRAPHITI_URL</code> is set, but its
-          <code> /healthcheck</code> failed (service down or unreachable). Keyword and semantic search
-          are unaffected; check the Graphiti service.
+          {graphStalled ? (
+            <>
+              Graph memory is reachable but the <strong>projector has stalled</strong> — no new episodes
+              since {timeAgo(health.graphLastProjectedAt!)}. New activity isn&apos;t reaching the graph
+              (writes may be failing — check the logs for a Graphiti <code>422</code>). Existing memory
+              still answers; keyword and semantic search are unaffected.
+            </>
+          ) : (
+            <>
+              Graph memory is configured but not responding — <code>GRAPHITI_URL</code> is set, but its
+              <code> /healthcheck</code> failed (service down or unreachable). Keyword and semantic search
+              are unaffected; check the Graphiti service.
+            </>
+          )}
         </p>
       ) : null}
       {d.note ? (

--- a/components/learning/arcs-panel.tsx
+++ b/components/learning/arcs-panel.tsx
@@ -108,7 +108,7 @@ export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
       <div className="prism-card flex flex-col items-center gap-2 px-4 py-8 text-center">
         <Sparkles className="size-5 text-violet" />
         <p className="max-w-sm text-sm text-ink-secondary">
-          No active narrative arcs yet — they emerge once the graph has a week of activity to synthesize.
+          No active narrative arcs yet — they emerge once the graph has enough team activity to synthesize.
         </p>
       </div>
     );

--- a/docs/design/graph-arc-resilience.md
+++ b/docs/design/graph-arc-resilience.md
@@ -1,0 +1,50 @@
+# Narrative-graph & arc resilience (2026-07 incident)
+
+## What happened
+The Learning page's narrative-arcs panel went blank. The scary first hypotheses — the graph was
+**wiped** or **rename-orphaned** — were **disproven by live prod** (via the Railway CLI + in-container
+probes): Neo4j held **4,130 nodes / 956 episodes / 10,747 facts** under the correct current
+`group_id`s (`aios_team`), fully reachable. No data was lost. There were two *independent* problems:
+
+### Problem 1 — empty arcs (the visible symptom): reasoning-model token starvation
+- On 2026-07-13 an OpenRouter provider was configured with model `qwen/qwen3.7-plus` (a **reasoning**
+  model). #268 routes all generation through `lib/llm/complete.ts`, OpenRouter taking precedence.
+- Reasoning models spend the `max_tokens` budget on **hidden reasoning before any answer**. Arc
+  synthesis passed `maxTokens: 2048`; a live test of the real key+model showed the model burning
+  hundreds of reasoning tokens first, so the large arc prompt returned **empty/truncated content**.
+- `complete.ts` returned `""` → `parseArcsJson` failed → `[]` → and the empty result was **cached**,
+  pinning the page blank for hours. Same failure silently hit every generation path #268 re-routed.
+
+### Problem 2 — the graph stopped updating (separate): projector 422
+- `graph_episodes.max(projected_at)` was stuck at 2026-07-09; projector logs showed
+  `graphiti POST /messages → 422` every tick. No new episodes since. The pre-July-9 data remained,
+  which is why *reads* weren't empty.
+- Follow-up finding: a **minimal** `/messages` POST now returns **202** — so this is **payload-specific**
+  (a particular episode's content/field, or the reconcile re-push), NOT a blanket API-contract break.
+  Isolating the exact rejected payload is deferred to the separate Graphiti-side fix.
+
+## Fixes shipped in this PR
+1. **`lib/llm/complete.ts` — reasoning headroom + loud failure.** Send `maxTokens + REASONING_HEADROOM_TOKENS`
+   (default 6000, env-overridable) on the OpenAI-compatible/OpenRouter path — you're billed only for
+   tokens generated, so it's free for non-reasoning models and unbreaks reasoning ones. Empty content
+   now throws **naming `finish_reason`** (the starvation signature) instead of a bare "empty".
+2. **`lib/graph/arcs.ts` — an empty synthesis never clobbers a good cache** (`commitArcs`). One bad LLM
+   call can no longer pin the panel empty; a stale-but-real arc set is kept and retried on next view.
+3. **`lib/graph/arcs.ts` — arcs are no longer time-boxed.** Dropped the hard 7-day window; synthesize
+   from the most-recent `MAX_FACTS` regardless of age (a quiet week / stalled projector can't blank it).
+4. **Health card — graph *freshness*, not just reachability.** `deriveGraphState` now reads **degraded**
+   when the projector hasn't written in > 6h even if `/healthcheck` is green — the exact blind spot that
+   let Problem 2 hide behind a green "Graph: on". The card shows episode count + last-projected and a
+   distinct "projector stalled" banner (vs "unreachable").
+5. **Projector observability.** Each scheduler tick with a signal records a `graph_project` run to
+   `ingest_runs` (`lib/graph/projection-run.ts`), so a silently-failing projector (the 422) surfaces in
+   Admin → Integrations → Recent ingestion runs instead of only ephemeral logs.
+
+## Deferred (separate work)
+- **Problem 2 root cause** — isolate the payload that 422s (reconcile re-push vs a specific field), then
+  fix Graphiti-side. Now observable via #5 + the freshness card.
+- **Neo4j durability guard.** The wipe hypothesis was wrong (the volume clearly persists — 956 episodes
+  survived), but the repo still doesn't *guard* the prod Neo4j volume config. Low urgency; documented so
+  a future detached-volume can't silently wipe undetected. The graph is fully regenerable from Postgres
+  (clear `graph_episodes` → re-project) as a recovery path.
+- **Email alert on graph degrade** — mirror the dense-leg edge alert once the freshness signal has soaked.

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -48,7 +48,6 @@ export interface ArcCorrection {
 /** Full backend keys — resolve via `lib/query/answering.resolveAnsweringKeys` at the call site. */
 export type ProviderKeys = LlmBackendKeys;
 
-const WINDOW_DAYS = 7;
 const MAX_FACTS = 200;
 const CACHE_TTL_MS = 10 * 60_000;
 
@@ -249,8 +248,10 @@ async function synthesizeArcs(
   correctionTexts: string[],
   keys: ProviderKeys
 ): Promise<NarrativeArc[]> {
-  const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
-  const facts = await recentFacts(groups, since, MAX_FACTS);
+  // Arcs are NOT time-boxed — synthesize from the most-recent facts regardless of age (a quiet week,
+  // or a stalled projector, must not blank the panel). `null` = no window; recentFacts still caps at
+  // MAX_FACTS, newest first.
+  const facts = await recentFacts(groups, null, MAX_FACTS);
   // No facts and nothing to correct → nothing to synthesize. (A correction with no facts still runs
   // the LLM, preserving the pre-cache recompute behavior.)
   if (facts.length === 0 && correctionTexts.length === 0) return [];
@@ -268,6 +269,34 @@ const cache = new Map<string, { arcs: NarrativeArc[]; at: number }>();
 // recompute (and thus one LLM call), not N.
 const refreshing = new Set<string>();
 
+/**
+ * Persist a freshly-synthesized arc set to both caches — but NEVER let an EMPTY result clobber a
+ * non-empty one. An empty synthesis is almost always a transient upstream failure (LLM outage, a
+ * reasoning model starving its own output, a graph blip), and a stale-but-real arc set beats a blank
+ * panel. On that case we keep the prior value and DON'T refresh its timestamp, so the next view
+ * retries until synthesis recovers. This is the guard that stops one bad LLM call from pinning the
+ * Learning page empty for hours (2026-07 incident). Returns what's now authoritative for the key.
+ */
+export async function commitArcs(
+  db: DbClient,
+  teamId: string,
+  key: string,
+  next: NarrativeArc[]
+): Promise<NarrativeArc[]> {
+  if (next.length === 0) {
+    const prior = cache.get(key)?.arcs ?? (await readArcCache(db, teamId, key))?.arcs;
+    if (prior && prior.length > 0) {
+      console.warn(
+        `[arcs] synthesis returned 0 arcs for ${key}; keeping ${prior.length} cached (likely transient upstream failure)`
+      );
+      return prior;
+    }
+  }
+  cache.set(key, { arcs: next, at: Date.now() });
+  await writeArcCache(db, teamId, key, next);
+  return next;
+}
+
 /** Fire-and-forget background recompute for a stale cache key (serve-stale-while-revalidate). Uses
  *  its own adminClient so it doesn't depend on the request's client lifecycle. Deduped via
  *  `refreshing`; errors are logged, never thrown (nothing awaits this). */
@@ -278,8 +307,7 @@ function refreshArcsInBackground(teamId: string, key: string, groups: string[], 
     const bg = adminClient();
     try {
       const arcs = await synthesizeArcs(bg, teamId, groups, [], keys);
-      cache.set(key, { arcs, at: Date.now() });
-      await writeArcCache(bg, teamId, key, arcs);
+      await commitArcs(bg, teamId, key, arcs);
     } catch (err) {
       console.error("[arcs] background refresh failed:", err instanceof Error ? err.message : err);
     } finally {
@@ -324,9 +352,7 @@ export async function getArcs(
 
   // 3. Cold miss — first-ever load for this key. Compute inline so the user gets a real answer.
   const arcs = await synthesizeArcs(db, teamId, groups, [], keys);
-  cache.set(key, { arcs, at: Date.now() });
-  await writeArcCache(db, teamId, key, arcs);
-  return arcs;
+  return commitArcs(db, teamId, key, arcs);
 }
 
 /**
@@ -345,9 +371,8 @@ export async function recomputeArcs(
 ): Promise<NarrativeArc[]> {
   if (groups.length === 0) return [];
   const key = groups.slice().sort().join(",");
-  const arcs = await synthesizeArcs(db, teamId, groups, corrections.map((c) => c.corrected_text), keys);
-  cache.set(key, { arcs, at: Date.now() });
-  await writeArcCache(db, teamId, key, arcs);
+  const synthesized = await synthesizeArcs(db, teamId, groups, corrections.map((c) => c.corrected_text), keys);
+  const arcs = await commitArcs(db, teamId, key, synthesized);
 
   // Persist corrections as first-class episodes (team-tier group; corrections are internal).
   const client = new GraphitiClient();

--- a/lib/graph/learning.ts
+++ b/lib/graph/learning.ts
@@ -35,7 +35,7 @@ export interface AtomicFact {
  */
 export async function recentFacts(
   groups: string[],
-  sinceISO: string,
+  sinceISO: string | null,
   limit = 15
 ): Promise<AtomicFact[]> {
   if (!neo4jConfigured() || groups.length === 0) return [];
@@ -73,9 +73,11 @@ export async function recentFacts(
     }));
   };
   try {
+    // `sinceISO === null` means "no time box — just the most-recent N" (arcs aren't time-boxed).
+    // With a window, fall back to most-recent-N (still tier-scoped) only when the window is empty —
+    // preserves the "recent" intent when the graph is fresh, degrades gracefully when it's stale/sparse.
+    if (sinceISO === null) return await query(false);
     const windowed = await query(true);
-    // Fall back to most-recent-N (still tier-scoped) only when the window is empty — preserves the
-    // "recent" intent when the graph is fresh, degrades gracefully when it's stale/sparse.
     return windowed.length > 0 ? windowed : await query(false);
   } catch {
     return []; // degrade — panel shows empty rather than erroring

--- a/lib/graph/projection-run.ts
+++ b/lib/graph/projection-run.ts
@@ -1,0 +1,36 @@
+import type { IngestRunInput, IngestTrigger } from "@/lib/ingest/runs";
+import type { GraphProjectionSummary } from "./run";
+
+/**
+ * Map a graph-projection summary → an `ingest_runs` record so the projector is as observable as every
+ * other ingestion leg. This is the fix for the 2026-07 silent stall: the projector wrote NOTHING
+ * durable, so a Graphiti `422` on writes wedged it for days with only ephemeral log lines. Recording
+ * to `ingest_runs` surfaces it in Admin → Integrations → Recent ingestion runs (and makes an alert
+ * possible). Pure so the mapping is unit-tested without a timer or a DB.
+ *
+ * `source: "graph_project"` is the stable ledger key for this leg. `ok` is false whenever a team
+ * errored — that's what turns the row red in the panel.
+ */
+export function projectionRunInput(
+  summary: GraphProjectionSummary,
+  trigger: IngestTrigger,
+  startedAt: number,
+  finishedAt: number
+): IngestRunInput {
+  return {
+    source: "graph_project",
+    trigger,
+    ok: summary.errors.length === 0,
+    created: summary.projected,
+    unchanged: summary.skipped,
+    errors: summary.errors,
+    meta: {
+      scanned: summary.scanned,
+      teams: summary.teams,
+      reconciled: summary.reconciled,
+      requeued: summary.requeued,
+    },
+    startedAt,
+    finishedAt,
+  };
+}

--- a/lib/graph/scheduler.ts
+++ b/lib/graph/scheduler.ts
@@ -1,6 +1,9 @@
 import "server-only";
 import { GraphitiClient } from "./graphiti-client";
 import { runGraphProjection } from "./run";
+import { projectionRunInput } from "./projection-run";
+import { recordIngestRun } from "@/lib/ingest/runs";
+import { adminClient } from "@/lib/db/admin";
 
 /**
  * In-process projector poller — the automated half of the graph trigger (the admin action is the
@@ -23,6 +26,7 @@ export function startGraphScheduler(): void {
   const intervalMs = Math.max(1, minutes) * 60_000;
 
   const tick = async () => {
+    const startedAt = Date.now();
     try {
       const s = await runGraphProjection();
       if (s.projected || s.errors.length) {
@@ -31,8 +35,22 @@ export function startGraphScheduler(): void {
             (s.errors.length ? ` errors: ${s.errors.join("; ")}` : "")
         );
       }
+      // Record any tick with a signal (projected / errors / requeued) to ingest_runs so a silently-
+      // failing projector — e.g. Graphiti 422'ing every write — is visible on the dashboard, not just
+      // in ephemeral logs. recordIngestRun is best-effort (swallows its own errors).
+      if (s.projected || s.errors.length || s.requeued) {
+        await recordIngestRun(adminClient(), projectionRunInput(s, "scheduler", startedAt, Date.now()));
+      }
     } catch (err) {
       console.error("[graph] projection tick failed:", err instanceof Error ? err.message : err);
+      await recordIngestRun(adminClient(), {
+        source: "graph_project",
+        trigger: "scheduler",
+        ok: false,
+        errors: [err instanceof Error ? err.message : String(err)],
+        startedAt,
+        finishedAt: Date.now(),
+      }).catch(() => {});
     }
   };
 

--- a/lib/llm/complete.ts
+++ b/lib/llm/complete.ts
@@ -17,6 +17,18 @@ import { selectLlmBackend, type LlmBackendKeys } from "@/lib/query/llm-backend";
 const LLM_BASE_URL = process.env.LLM_BASE_URL;
 const LLM_MODEL = process.env.LLM_MODEL;
 
+/**
+ * Reasoning models (e.g. OpenRouter's `qwen/qwen3.7-plus`, o-series) spend completion tokens on
+ * HIDDEN reasoning BEFORE emitting any answer, and `max_tokens` caps reasoning+answer TOGETHER. With
+ * only the caller's answer-sized budget, reasoning can consume all of it → empty `content` → callers
+ * silently degrade (this is exactly what blanked the Learning page in 2026-07). So we give the
+ * OpenAI-compatible/OpenRouter path headroom ON TOP of the requested answer budget: you're billed only
+ * for tokens actually generated, so this is free for non-reasoning models and makes any model choice
+ * work. Override with LLM_REASONING_HEADROOM_TOKENS. (The Anthropic path uses a separate thinking
+ * budget and isn't affected.)
+ */
+const REASONING_HEADROOM_TOKENS = Number(process.env.LLM_REASONING_HEADROOM_TOKENS ?? 6000);
+
 export interface CompleteArgs {
   system: string;
   prompt: string;
@@ -53,7 +65,9 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
       },
       body: JSON.stringify({
         model: backend.model,
-        max_tokens: maxTokens,
+        // Answer budget + reasoning headroom (see REASONING_HEADROOM_TOKENS) so a reasoning model's
+        // hidden tokens don't starve the answer to empty.
+        max_tokens: maxTokens + REASONING_HEADROOM_TOKENS,
         ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),
         messages: [
           { role: "system", content: args.system },
@@ -65,9 +79,19 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
     if (!res.ok) {
       throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
     }
-    const j = (await res.json()) as { choices?: { message?: { content?: string } }[] };
-    const text = j.choices?.[0]?.message?.content ?? "";
-    if (!text.trim()) throw new Error("LLM returned empty content");
+    const j = (await res.json()) as {
+      choices?: { message?: { content?: string }; finish_reason?: string }[];
+    };
+    const choice = j.choices?.[0];
+    const text = choice?.message?.content ?? "";
+    if (!text.trim()) {
+      // Name WHY it's empty — `finish_reason:"length"` on empty content is the reasoning-model
+      // starvation signature (all of max_tokens went to hidden reasoning). Loud so a blank panel is
+      // never a silent, undiagnosable one.
+      throw new Error(
+        `LLM returned empty content (model=${backend.model}, finish_reason=${choice?.finish_reason ?? "?"})`
+      );
+    }
     return text.trim();
   }
 

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -36,6 +36,9 @@ export interface RetrievalHealth {
   keyword: LegState; // always "on"
   dense: DenseHealth;
   graph: GraphState;
+  graphEpisodes: number | null; // projected episodes for this team (null when graph off/unreadable)
+  graphLastProjectedAt: string | null; // most recent successful projection (null = never)
+  graphStalled: boolean; // degraded specifically because the projector stopped writing (vs unreachable)
   rerank: LegState;
 }
 
@@ -49,15 +52,34 @@ const STALE_MS = 2 * 60 * 60 * 1000; // no embed activity in 2h + incomplete = s
  */
 export const graphConfigured = graphitiConfigured;
 
+// Reachable but no projection in this long ⇒ the graph is going stale even though /healthcheck is
+// green. This is the 2026-07 failure a healthcheck-only probe MISSED: Graphiti's write endpoint
+// 422'd for days (projector wedged) while the service kept answering /healthcheck, so the card read
+// "on" while the Learning page slowly emptied. Freshness of the write path is the real signal.
+const GRAPH_STALE_MS = 6 * 60 * 60 * 1000;
+
+/** A projector that hasn't written in > GRAPH_STALE_MS is stalled. `null` = nothing has ever projected
+ *  (fresh install / nothing to project) → NOT a stall. Pure + unit-tested. */
+export function isGraphStale(lastProjectedAtMs: number | null, nowMs: number): boolean {
+  return lastProjectedAtMs !== null && nowMs - lastProjectedAtMs > GRAPH_STALE_MS;
+}
+
 /**
  * Derive the graph-leg state from its raw signals. Pure + unit-tested:
- *   • not configured (no/malformed GRAPHITI_URL)         → "off"
- *   • configured AND /healthcheck answered                → "on"
- *   • configured BUT /healthcheck failed (down/unreachable) → "degraded"
+ *   • not configured (no/malformed GRAPHITI_URL)             → "off"
+ *   • configured BUT /healthcheck failed (down/unreachable)   → "degraded"
+ *   • reachable BUT projector hasn't written in > GRAPH_STALE_MS (writes failing) → "degraded"
+ *   • reachable AND recently projected (or nothing to project yet) → "on"
  */
-export function deriveGraphState(input: { configured: boolean; reachable: boolean }): GraphState {
+export function deriveGraphState(input: {
+  configured: boolean;
+  reachable: boolean;
+  lastProjectedAtMs: number | null;
+  nowMs: number;
+}): GraphState {
   if (!input.configured) return "off";
-  return input.reachable ? "on" : "degraded";
+  if (!input.reachable) return "degraded";
+  return isGraphStale(input.lastProjectedAtMs, input.nowMs) ? "degraded" : "on";
 }
 
 /**
@@ -89,12 +111,42 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
 
   // Graph + dense both hit the network — run them concurrently so the card render isn't serialized.
   const graphConfiguredNow = graphConfigured(process.env.GRAPHITI_URL);
-  const [dense, graphReachable] = await Promise.all([
+  const [dense, graphReachable, graphFresh] = await Promise.all([
     denseHealth(teamId, configured),
     graphConfiguredNow ? new GraphitiClient().healthcheck() : Promise.resolve(false),
+    graphConfiguredNow ? graphFreshness(teamId) : Promise.resolve({ episodes: null, lastProjectedAt: null }),
   ]);
-  const graph = deriveGraphState({ configured: graphConfiguredNow, reachable: graphReachable });
-  return { keyword: "on", dense, graph, rerank };
+  const lastProjectedAtMs = graphFresh.lastProjectedAt ? Date.parse(graphFresh.lastProjectedAt) : null;
+  const nowMs = Date.now();
+  const graph = deriveGraphState({ configured: graphConfiguredNow, reachable: graphReachable, lastProjectedAtMs, nowMs });
+  // Degraded specifically because the projector went quiet (reachable, but a stale write path) — the
+  // card renders a different, more actionable banner for this than for a hard-unreachable service.
+  const graphStalled = graph === "degraded" && graphReachable && isGraphStale(lastProjectedAtMs, nowMs);
+  return {
+    keyword: "on",
+    dense,
+    graph,
+    graphEpisodes: graphFresh.episodes,
+    graphLastProjectedAt: graphFresh.lastProjectedAt,
+    graphStalled,
+    rerank,
+  };
+}
+
+/** Projection freshness from the `graph_episodes` ledger (Postgres, no Graphiti round-trip): how many
+ *  episodes this team has projected and when the projector last succeeded. Drives the "reachable but
+ *  stalled" degraded state. Best-effort — nulls on any error so the card still renders. */
+async function graphFreshness(teamId: string): Promise<{ episodes: number | null; lastProjectedAt: string | null }> {
+  try {
+    const res = await runSql<{ n: string; mx: string | null }>(
+      "select count(*)::int as n, max(projected_at) as mx from graph_episodes where team_id = $1",
+      [teamId]
+    );
+    const row = res.rows[0];
+    return { episodes: row ? Number(row.n) : 0, lastProjectedAt: row?.mx ?? null };
+  } catch {
+    return { episodes: null, lastProjectedAt: null };
+  }
 }
 
 async function denseHealth(teamId: string, configured: boolean): Promise<DenseHealth> {

--- a/test/arcs-commit.test.ts
+++ b/test/arcs-commit.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { commitArcs } from "@/lib/graph/arcs";
+import type { NarrativeArc } from "@/lib/graph/arcs";
+import type { DbClient } from "@/lib/db/types";
+
+/** Minimal fake DbClient covering exactly the arc_cache read (select→eq→eq→maybeSingle) and write
+ *  (upsert) paths. Records upserts so we can assert whether a clobber happened. */
+function fakeDb(existing: NarrativeArc[] | null) {
+  const upserts: unknown[] = [];
+  const db = {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            maybeSingle: async () =>
+              existing ? { data: { arcs: existing, computed_at: new Date().toISOString() } } : { data: null },
+          }),
+        }),
+      }),
+      upsert: async (row: unknown) => {
+        upserts.push(row);
+        return { error: null };
+      },
+    }),
+  } as unknown as DbClient;
+  return { db, upserts };
+}
+
+const arc = (title: string): NarrativeArc => ({
+  id: "arc-" + title,
+  title,
+  confidence: "low",
+  summary: "",
+  participants: [],
+  supporting_sources: [],
+  evidence: [],
+  derived_at: "2026-07-15T00:00:00Z",
+});
+
+describe("commitArcs — an empty synthesis must never clobber a good cache", () => {
+  it("keeps the persisted non-empty arcs when synthesis returns [] (transient upstream failure)", async () => {
+    const { db, upserts } = fakeDb([arc("payments migration")]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Unique key so the module-level in-memory cache from other tests can't leak in.
+    const out = await commitArcs(db, "team-1", "keep-good-1", []);
+    expect(out.map((a) => a.title)).toEqual(["payments migration"]); // prior kept
+    expect(upserts).toHaveLength(0); // NOT overwritten
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("keeping 1 cached"));
+    warn.mockRestore();
+  });
+
+  it("writes through when synthesis returns real arcs", async () => {
+    const { db, upserts } = fakeDb(null);
+    const out = await commitArcs(db, "team-1", "write-good-1", [arc("a"), arc("b")]);
+    expect(out).toHaveLength(2);
+    expect(upserts).toHaveLength(1); // persisted
+  });
+
+  it("writes empty on a genuine cold miss (no prior to protect)", async () => {
+    const { db, upserts } = fakeDb(null);
+    const out = await commitArcs(db, "team-1", "cold-empty-1", []);
+    expect(out).toEqual([]);
+    expect(upserts).toHaveLength(1); // first-ever load may legitimately be empty
+  });
+});

--- a/test/graph-projection-run.test.ts
+++ b/test/graph-projection-run.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { projectionRunInput } from "@/lib/graph/projection-run";
+import type { GraphProjectionSummary } from "@/lib/graph/run";
+
+const base: GraphProjectionSummary = {
+  ok: true,
+  configured: true,
+  teams: 1,
+  scanned: 12,
+  projected: 5,
+  skipped: 7,
+  reconciled: 0,
+  requeued: 0,
+  errors: [],
+};
+
+describe("projectionRunInput", () => {
+  it("maps a clean projection to an ok ingest_runs record under the graph_project source", () => {
+    const run = projectionRunInput(base, "scheduler", 1000, 2000);
+    expect(run.source).toBe("graph_project");
+    expect(run.trigger).toBe("scheduler");
+    expect(run.ok).toBe(true);
+    expect(run.created).toBe(5); // projected → created
+    expect(run.unchanged).toBe(7); // skipped → unchanged
+    expect(run.errors).toEqual([]);
+    expect(run.meta).toMatchObject({ scanned: 12, teams: 1, requeued: 0 });
+    expect(run.startedAt).toBe(1000);
+    expect(run.finishedAt).toBe(2000);
+  });
+
+  it("marks the run NOT ok when any team errored — this is what turns the 422 red on the dashboard", () => {
+    // The exact 2026-07 failure: nothing projected, a Graphiti 422 on every write.
+    const summary: GraphProjectionSummary = {
+      ...base,
+      ok: false,
+      projected: 0,
+      skipped: 0,
+      errors: ["aios: graphiti POST /messages → 422"],
+    };
+    const run = projectionRunInput(summary, "scheduler", 0, 10);
+    expect(run.ok).toBe(false);
+    expect(run.created).toBe(0);
+    expect(run.errors).toEqual(["aios: graphiti POST /messages → 422"]);
+  });
+});

--- a/test/llm-complete.test.ts
+++ b/test/llm-complete.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the backend resolver so we exercise the OpenAI-compatible/OpenRouter path deterministically.
+vi.mock("@/lib/query/llm-backend", () => ({
+  selectLlmBackend: () => ({
+    kind: "openai-compatible" as const,
+    provider: "openai" as const,
+    baseUrl: "https://api.example.com/v1",
+    model: "reasoning-model",
+    apiKey: "test-key",
+    headers: {},
+  }),
+}));
+
+import { completeText, completeTextOrNull } from "@/lib/llm/complete";
+
+const okResponse = (content: string, finish = "stop") =>
+  ({
+    ok: true,
+    json: async () => ({ choices: [{ message: { content }, finish_reason: finish }] }),
+    text: async () => "",
+  }) as unknown as Response;
+
+describe("completeText (OpenAI-compatible path)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("adds reasoning headroom on top of the caller's answer budget so a reasoning model isn't starved", async () => {
+    fetchMock.mockResolvedValue(okResponse('{"ok":true}'));
+    await completeText({ system: "s", prompt: "p" }, { maxTokens: 2048 });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    // 2048 answer budget + 6000 default headroom — the whole point of the fix: a reasoning model can
+    // burn thousands of hidden tokens and still have the 2048 left to actually answer.
+    expect(body.max_tokens).toBe(2048 + 6000);
+    expect(body.model).toBe("reasoning-model");
+  });
+
+  it("throws NAMING finish_reason when content is empty — the reasoning-starvation signature, made loud", async () => {
+    // 200 OK but empty content + finish_reason:length = all of max_tokens went to hidden reasoning.
+    fetchMock.mockResolvedValue(okResponse("", "length"));
+    await expect(completeText({ system: "s", prompt: "p" }, { maxTokens: 100 })).rejects.toThrow(
+      /empty content.*finish_reason=length/
+    );
+  });
+
+  it("completeTextOrNull degrades empty content to null (best-effort callers) and logs the reason", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockResolvedValue(okResponse("", "length"));
+    const out = await completeTextOrNull({ system: "s", prompt: "p" });
+    expect(out).toBeNull();
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("[llm]"), expect.stringMatching(/finish_reason=length/));
+    err.mockRestore();
+  });
+
+  it("returns trimmed content on a normal completion", async () => {
+    fetchMock.mockResolvedValue(okResponse("  hello  "));
+    expect(await completeText({ system: "s", prompt: "p" })).toBe("hello");
+  });
+});

--- a/test/retrieval-health.test.ts
+++ b/test/retrieval-health.test.ts
@@ -56,14 +56,24 @@ describe("graphConfigured", () => {
 });
 
 describe("deriveGraphState", () => {
+  const now = Date.parse("2026-07-15T12:00:00Z");
+  const fresh = Date.parse("2026-07-15T11:00:00Z"); // 1h ago
+  const stale = Date.parse("2026-07-08T12:00:00Z"); // 7d ago
   it("off when not configured (regardless of reachability)", () => {
-    expect(deriveGraphState({ configured: false, reachable: false })).toBe("off");
-    expect(deriveGraphState({ configured: false, reachable: true })).toBe("off");
+    expect(deriveGraphState({ configured: false, reachable: false, lastProjectedAtMs: null, nowMs: now })).toBe("off");
+    expect(deriveGraphState({ configured: false, reachable: true, lastProjectedAtMs: fresh, nowMs: now })).toBe("off");
   });
-  it("on when configured AND /healthcheck answered", () => {
-    expect(deriveGraphState({ configured: true, reachable: true })).toBe("on");
+  it("on when reachable AND recently projected", () => {
+    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: fresh, nowMs: now })).toBe("on");
+  });
+  it("on when reachable and nothing has projected yet (null = fresh install, not a stall)", () => {
+    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: null, nowMs: now })).toBe("on");
   });
   it("degraded when configured BUT unreachable — the silent-failure case reviving must surface", () => {
-    expect(deriveGraphState({ configured: true, reachable: false })).toBe("degraded");
+    expect(deriveGraphState({ configured: true, reachable: false, lastProjectedAtMs: fresh, nowMs: now })).toBe("degraded");
+  });
+  it("degraded when reachable BUT projector stalled — the 2026-07 healthcheck-only blind spot", () => {
+    // /healthcheck answers (reachable) yet no episode has landed in a week → writes are failing silently.
+    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: stale, nowMs: now })).toBe("degraded");
   });
 });


### PR DESCRIPTION
## What & why
The Learning page's narrative-arcs panel went blank. Using the Railway CLI I confirmed **live in prod** that the graph was **fully intact** (4,130 nodes / 956 episodes / 10,747 facts under the correct `group_id`s) — no data loss. The scary wipe/rename-orphan hypotheses were disproven. There were two independent problems:

1. **Empty arcs (visible symptom):** an OpenRouter **reasoning** model (`qwen/qwen3.7-plus`, configured 2026-07-13) routed through `complete.ts` per #268. Reasoning models spend the `max_tokens` budget on hidden reasoning *before* answering; arc synthesis passed `maxTokens: 2048`, so the model returned **empty content** → `[]` → **cached**, pinning the panel blank. (Verified with a live call against the real key+model.)
2. **Graph stopped updating (separate):** the projector 422'd on every `POST /messages` since 2026-07-09, invisible behind a green `/healthcheck`. A minimal `/messages` POST now returns 202, so the 422 is **payload-specific** — isolating it is deferred to a Graphiti-side fix.

## Changes
- **`complete.ts`** — add reasoning headroom to `max_tokens` (billed only for tokens generated → free for non-reasoning models, unbreaks reasoning ones); throw **naming `finish_reason`** on empty content.
- **`arcs.ts`** — an empty synthesis **never clobbers a non-empty cache** (`commitArcs`); one bad LLM call can't pin the panel empty. Retries on next view.
- **`arcs.ts`** — arcs are **no longer time-boxed** to 7 days → most-recent facts regardless of age.
- **`retrieval-health`** — graph leg reads **degraded** when the projector hasn't written in >6h even if `/healthcheck` is green; card shows episode count + last-projected and a distinct "projector stalled" banner.
- **`scheduler`** — records each projection tick to `ingest_runs` so a silently-failing projector surfaces on the dashboard.

## Verification
- Unit: new `llm-complete` (4), `arcs-commit` (3), `graph-projection-run` (2), extended `retrieval-health` (staleness). Full unit tier **775 passed**.
- Data-mechanics (real PG): `retrieval-health` 3/3.
- `tsc`, `eslint`, docs-drift all clean.
- Not browser-verified (no dev server here); the health-card visuals are presentational over tested functions.

## Deferred (documented in `docs/design/graph-arc-resilience.md`)
- Isolate the exact 422 payload (now observable) + Graphiti-side fix.
- Neo4j durability volume-guard (wipe hypothesis was wrong; low urgency) and an email alert on graph degrade.

Note: the OpenRouter model misconfig itself is being addressed in a separate worktree.