### PR TITLE
perf(dashboard): share one auth query across layout + page; parallelize Home counts

### DIFF
--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -1,20 +1,9 @@
 import Link from "next/link";
 import { CircleAlert } from "lucide-react";
-import { serverClient } from "@/lib/db/server";
-import { getSessionUser } from "@/lib/auth/session";
 import { activateInvitedMembership } from "@/lib/auth/pg-login";
+import { resolveTeamContext } from "@/lib/auth/team-context";
 import { TeamNav, type NavEntry, type NavLeaf } from "@/components/team-nav";
 import { SignOutButton } from "@/components/account/sign-out-button";
-
-/** The caller's membership row + its embedded team, as returned by the single collapsed auth query. */
-type MembershipRow = {
-  id: string;
-  role: "admin" | "lead" | "member";
-  display_name: string;
-  tier: "team" | "external";
-  status: string;
-  teams: { id: string; slug: string; name: string } | null;
-};
 
 function NoTeamScreen({ slug }: { slug: string }) {
   return (
@@ -43,27 +32,16 @@ export default async function TeamLayout({
   params: Promise<{ team: string }>;
 }) {
   const { team: teamSlug } = await params;
-  const db = await serverClient();
 
-  const user = await getSessionUser();
-  if (!user) return <NoTeamScreen slug={teamSlug} />;
-
-  // One round-trip for auth: the caller's membership for THIS team + the team itself (embedded),
-  // instead of two sequential queries (team-by-slug, then member-by-team). This runs on every nav
-  // AND every router.refresh(), so collapsing it directly cuts the per-refresh latency. A user is
-  // normally in one team (self-hosted per org), so this returns a tiny row set we filter by slug.
-  const { data: memberships } = await db
-    .from("members")
-    .select("id, role, display_name, tier, status, teams(id, slug, name)")
-    .eq("auth_user_id", user.id)
-    .neq("status", "disabled");
-  const me = ((memberships ?? []) as MembershipRow[]).find((m) => m.teams?.slug === teamSlug);
-  if (!me?.teams) return <NoTeamScreen slug={teamSlug} />;
-  const team = me.teams;
+  // Shared, request-scoped auth: one collapsed query, memoized so the page rendered as `children`
+  // this request reuses it instead of re-resolving team + member itself.
+  const ctx = await resolveTeamContext(teamSlug);
+  if (!ctx) return <NoTeamScreen slug={teamSlug} />;
+  const { team, me } = ctx;
   // Team-scoped activation, deferred half: signing in never activates memberships in teams the
   // login carried no context for (see linkMemberByEmail) — the invited row flips to active here,
   // on the member's own first visit to this team.
-  if (me.status === "invited") await activateInvitedMembership(team.id, user.id);
+  if (me.status === "invited") await activateInvitedMembership(team.id, ctx.userId);
 
   const base = `/t/${team.slug}`;
 
@@ -107,7 +85,7 @@ export default async function TeamLayout({
         </div>
         <TeamNav items={items} />
         <div className="mt-auto border-t border-border-subtle px-3 pt-4">
-          <p className="truncate text-sm font-medium text-ink">{me.display_name}</p>
+          <p className="truncate text-sm font-medium text-ink">{me.displayName}</p>
           <p className="text-xs capitalize text-ink-tertiary">
             {me.role} · {me.tier} tier
           </p>

--- a/app/t/[team]/learning/page.tsx
+++ b/app/t/[team]/learning/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { ChevronRight } from "lucide-react";
-import { serverClient } from "@/lib/db/server";
-import { currentMember } from "@/lib/auth/guard";
+import { resolveTeamContext } from "@/lib/auth/team-context";
 import { FactsFeed } from "@/components/learning/facts-feed";
 import { EventsFeed } from "@/components/learning/events-feed";
 import { ArcsPanel } from "@/components/learning/arcs-panel";
@@ -17,11 +16,9 @@ export const metadata: Metadata = { title: "Learning" };
  */
 export default async function LearningPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
-  const db = await serverClient();
-  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
-  if (!team) return null;
-  const me = await currentMember(team.id);
-  if (!me) return null;
+  // Shared request-scoped auth — reuses the team layout's resolution (no extra team/member queries).
+  const ctx = await resolveTeamContext(teamSlug);
+  if (!ctx) return null;
 
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-6">

--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Rocket } from "lucide-react";
 import { serverClient } from "@/lib/db/server";
 import { visibleItems, visibleDecisions } from "@/lib/auth/visibility";
-import { getSessionUser } from "@/lib/auth/session";
+import { resolveTeamContext } from "@/lib/auth/team-context";
 import { CopySnippet } from "@/components/copy-snippet";
 import { getPulseMetrics } from "@/lib/metrics/pulse";
 import { parseRange } from "@/lib/metrics/range";
@@ -104,43 +104,29 @@ export default async function TeamHome({
   const range = parseRange(rangeParam);
   const db = await serverClient();
 
-  const [{ data: team }, user] = await Promise.all([
-    db.from("teams").select("id, name").eq("slug", teamSlug).maybeSingle(),
-    getSessionUser(),
-  ]);
-  if (!team) return null; // layout already rendered the no-team screen
+  // Shared request-scoped auth — reuses the team layout's resolution (no extra team/member queries).
+  const ctx = await resolveTeamContext(teamSlug);
+  if (!ctx) return null; // layout already rendered the no-team screen
+  const { team, me } = ctx;
+  const isAdmin = me.role === "admin";
+  const tier = me.tier;
+  const memberId = me.id;
+  const firstName = me.displayName.trim().split(/\s+/)[0] || "there";
 
-  const { data: me } = await db
-    .from("members")
-    .select("id, role, tier, display_name")
-    .eq("team_id", team.id)
-    .eq("auth_user_id", user?.id ?? "")
-    .eq("status", "active")
-    .maybeSingle();
-  const isAdmin = me?.role === "admin";
-  const tier = (me?.tier as "team" | "external" | undefined) ?? "external";
-  const memberId = (me?.id as string | undefined) ?? "";
-  const firstName =
-    ((me?.display_name as string | undefined) ?? "").trim().split(/\s+/)[0] ||
-    "there";
-
-  // Tier-filtered count (no RLS backstop in postgres mode).
-  const { count: itemCount } = await visibleItems(
+  // Both counts are independent — run them together. itemCount is the tier-filtered visible-items
+  // count (no RLS backstop in postgres mode); ownKeyCount is whether this member has EVER issued
+  // their own key (the proxy for "has their workstation setup even started").
+  const [{ count: itemCount }, { count: ownKeyCount }] = await Promise.all([
+    visibleItems(
+      db.from("items").select("id", { count: "exact", head: true }).eq("team_id", team.id),
+      tier,
+    ),
     db
-      .from("items")
+      .from("api_keys")
       .select("id", { count: "exact", head: true })
-      .eq("team_id", team.id),
-    tier,
-  );
-
-  // Has this member EVER issued their own key (revoked or not) — the proxy for "has this
-  // person's workstation setup even started," independent of whether the TEAM has synced
-  // anything yet (a member invited into an already-active team must still see this).
-  const { count: ownKeyCount } = await db
-    .from("api_keys")
-    .select("id", { count: "exact", head: true })
-    .eq("team_id", team.id)
-    .eq("member_id", memberId);
+      .eq("team_id", team.id)
+      .eq("member_id", memberId),
+  ]);
 
   const homeState = pickHomeState({
     isAdmin,

--- a/lib/auth/team-context.ts
+++ b/lib/auth/team-context.ts
@@ -1,0 +1,57 @@
+import "server-only";
+import { cache } from "react";
+import { serverClient } from "@/lib/db/server";
+import { getSessionUser } from "@/lib/auth/session";
+
+export interface TeamContext {
+  team: { id: string; slug: string; name: string };
+  me: {
+    id: string;
+    role: "admin" | "lead" | "member";
+    tier: "team" | "external";
+    displayName: string;
+    status: string;
+  };
+  userId: string;
+}
+
+type MemberWithTeam = {
+  id: string;
+  role: TeamContext["me"]["role"];
+  display_name: string;
+  tier: TeamContext["me"]["tier"];
+  status: string;
+  teams: TeamContext["team"] | null;
+};
+
+/**
+ * Request-scoped auth+team resolution shared by the team layout AND every page under it. One
+ * collapsed query — the caller's membership for this team, with the team embedded — memoized per
+ * `teamSlug` for the request (React `cache()`), so the layout and the page it wraps resolve auth
+ * ONCE instead of each running their own team + member lookups. The session user is fixed within a
+ * request, so keying on the slug alone is correct.
+ *
+ * Returns null when the caller isn't a non-disabled member of the slug's team. `me.status` may be
+ * `invited` (the layout activates it on first visit); pages should trust the id/role/tier and not
+ * re-gate on `active` — the layout is the access gate.
+ */
+export const resolveTeamContext = cache(async (teamSlug: string): Promise<TeamContext | null> => {
+  const user = await getSessionUser();
+  if (!user) return null;
+
+  const db = await serverClient();
+  const { data } = await db
+    .from("members")
+    .select("id, role, tier, display_name, status, teams(id, slug, name)")
+    .eq("auth_user_id", user.id)
+    .neq("status", "disabled");
+
+  const m = ((data ?? []) as MemberWithTeam[]).find((r) => r.teams?.slug === teamSlug);
+  if (!m?.teams) return null;
+
+  return {
+    team: m.teams,
+    me: { id: m.id, role: m.role, tier: m.tier, displayName: m.display_name, status: m.status },
+    userId: user.id,
+  };
+});


### PR DESCRIPTION
Profiled the two tabs you flagged. Both had the **layout+page auth double-fetch** — each page re-resolved the team + member the team layout had *already* looked up — and Home also ran two independent counts back-to-back.

## Findings
- **Home**: re-queried `teams` + `members` (layout already did), then `itemCount` → `ownKeyCount` **sequentially** (they're independent). Content queries (pulse, decisions) were already parallel.
- **Learning**: the page shell just re-did auth (`teams` + `currentMember`). The arcs/events/facts are **client-fetched** and arcs are already SWR-cached (in-memory → Postgres → LLM), so the duplicate auth was the only server-side waste.

## Fix
- **New `lib/auth/team-context.ts` → `resolveTeamContext(teamSlug)`** — the collapsed "member for this user + embedded team" query, wrapped in React **`cache()`**. The team layout **and** the page it wraps now resolve auth **once per request** instead of each doing its own team + member lookups. The layout is extracted onto it (keeps the invited→active activation).
- **Home** — uses `resolveTeamContext` (drops 2 queries) and runs `itemCount` + `ownKeyCount` in one `Promise.all`.
- **Learning** — uses `resolveTeamContext` (drops team + `currentMember`).

**Net per page load:** auth goes from *layout query + page's own team + member* (3 lookups) to **one shared query**; Home's counts go from 2 serial hops to 1 parallel wave.

## Access control — verified in a browser (auth path)
- ✅ **Admin** loads Home + Learning; Admin + Social nav present.
- ✅ **External-tier member** loads Home with **no** Admin/Social nav and the **"external tier"** badge — tier resolves correctly through the shared context.
- ✅ **Non-member** gets the **"No team here for you"** screen (no leak).

## Verified
- Unit (747, incl. the `dashboard-tier-filter` guard) + tsc + lint + docs-drift green.
- Browser: admin/external/non-member all correct.
- Note: local data-mechanics has a **pre-existing `gateway-*` parallel-truncate flake** that fails identically on clean `main` (unrelated to this change); those pass in CI.

## Follow-up
`resolveTeamContext` is the reusable primitive — other pages under `/t/[team]` (Codebases, Query, admin subpages) still do their own auth and can adopt it incrementally for the same saving.

## Test plan
- [x] Unit + tsc + lint + docs-drift
- [x] Browser: admin / external-tier / non-member access control
- [ ] CI green → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)