### PR TITLE
fix(meetings): 60s LLM timeout for background extraction (not the query box's 30s)

### DIFF
--- a/lib/meetings/action-items.ts
+++ b/lib/meetings/action-items.ts
@@ -71,7 +71,8 @@ function dedupe(todos: ExtractedTodo[]): ExtractedTodo[] {
 export async function extractActionItems(
   rawText: string,
   roster: RosterPerson[],
-  keys: ProviderKeys
+  keys: ProviderKeys,
+  timeoutMs?: number
 ): Promise<ExtractedTodo[]> {
   const fallback = () => dedupe(extractTodosFromNotes(rawText));
 
@@ -79,7 +80,7 @@ export async function extractActionItems(
   const rosterHint = roster.length
     ? `\n\nKnown team members (resolve first-name mentions against these full names): ${roster.map((p) => p.displayName).join(", ")}.`
     : "";
-  const raw = await callMeetingsLLM(SYSTEM_PROMPT, `Transcript:\n\n${truncated}${rosterHint}`, keys);
+  const raw = await callMeetingsLLM(SYSTEM_PROMPT, `Transcript:\n\n${truncated}${rosterHint}`, keys, timeoutMs);
   if (!raw) return fallback();
 
   let parsed: unknown;
@@ -117,9 +118,12 @@ export async function extractAndStoreActionItems(
   roster: RosterPerson[],
   keys: ProviderKeys,
   // Injectable so the backfill/tests can stub the LLM step; defaults to the real extractor.
-  extract: (rawText: string, roster: RosterPerson[], keys: ProviderKeys) => Promise<ExtractedTodo[]> = extractActionItems
+  extract?: (rawText: string, roster: RosterPerson[], keys: ProviderKeys) => Promise<ExtractedTodo[]>,
+  // Extra timeout for the default extractor (background/backfill can allow a slower model).
+  timeoutMs?: number
 ): Promise<number> {
-  const todos = await extract(rawText, roster, keys);
+  const run = extract ?? ((t: string, r: RosterPerson[], k: ProviderKeys) => extractActionItems(t, r, k, timeoutMs));
+  const todos = await run(rawText, roster, keys);
   const rows = toExtractedTodoRows(item, todos);
   if (rows.length) await createMeetingTodoTasks(db, teamId, rows);
   return rows.length;

--- a/lib/meetings/llm-extract.ts
+++ b/lib/meetings/llm-extract.ts
@@ -50,12 +50,26 @@ export function extractJsonObject(raw: string): string {
 }
 
 /**
+ * Meetings extraction is a background, best-effort pass — not the interactive query box — so it gets
+ * a more generous timeout than `completeText`'s 30s default. Reasoning models a team may select
+ * (e.g. qwen via OpenRouter) can spend 30–45s on a full transcript; at 30s the call was aborted and
+ * the summary/attendees/action-items silently came back empty. 60s covers the observed latency while
+ * still bounding a truly wedged provider. The backfill can pass a larger value for slow networks.
+ */
+export const MEETINGS_LLM_TIMEOUT_MS = 60_000;
+
+/**
  * Best-effort JSON completion for the meetings LLM passes (summary/attendees AND action items),
  * through the shared settings-aware primitive. Never throws — any transport failure returns null so
  * a caller degrades gracefully.
  */
-export async function callMeetingsLLM(system: string, userContent: string, keys: ProviderKeys): Promise<string | null> {
-  return completeTextOrNull({ system, prompt: userContent }, { keys, jsonObject: true, maxTokens: 1024 });
+export async function callMeetingsLLM(
+  system: string,
+  userContent: string,
+  keys: ProviderKeys,
+  timeoutMs: number = MEETINGS_LLM_TIMEOUT_MS
+): Promise<string | null> {
+  return completeTextOrNull({ system, prompt: userContent }, { keys, jsonObject: true, maxTokens: 1024, timeoutMs });
 }
 
 /** Normalize a name for tolerant matching: lowercase, collapse whitespace, drop punctuation. */
@@ -95,14 +109,15 @@ export function matchAttendees(names: string[], roster: RosterPerson[]): string[
 export async function extractFromTranscript(
   rawText: string,
   roster: RosterPerson[],
-  keys: ProviderKeys
+  keys: ProviderKeys,
+  timeoutMs?: number
 ): Promise<TranscriptExtraction> {
   const empty: TranscriptExtraction = { summary: "", attendeeMemberIds: [] };
   const truncated = rawText.slice(0, MAX_TRANSCRIPT_CHARS);
   const rosterHint = roster.length
     ? `\n\nKnown team members (for reference, not exhaustive): ${roster.map((p) => p.displayName).join(", ")}.`
     : "";
-  const raw = await callMeetingsLLM(SYSTEM_PROMPT, `Transcript:\n\n${truncated}${rosterHint}`, keys);
+  const raw = await callMeetingsLLM(SYSTEM_PROMPT, `Transcript:\n\n${truncated}${rosterHint}`, keys, timeoutMs);
   if (!raw) return empty;
   return parseTranscriptExtraction(raw, roster);
 }

--- a/lib/meetings/refresh.ts
+++ b/lib/meetings/refresh.ts
@@ -36,6 +36,9 @@ export interface RefreshOptions {
   /** Only heal notes whose summary is currently blank; skip ones that already have one. Default false
    *  (a full refresh — every note re-extracted, matching "as if just uploaded"). */
   onlyBlank?: boolean;
+  /** Override the per-note LLM timeout (default: the meetings 60s). A backfill over a slow network
+   *  can raise it so a genuinely-slow-but-successful model response isn't aborted. */
+  timeoutMs?: number;
   /** Inject the summary/attendee extractor (tests avoid a real LLM). */
   extract?: (rawText: string, roster: RosterPerson[]) => Promise<{ summary: string; attendeeMemberIds: string[] }>;
   /** Inject the action-item extractor (tests avoid a real LLM). */
@@ -91,7 +94,8 @@ export async function refreshMeetingNoteExtraction(
   }));
 
   const extract =
-    opts.extract ?? ((rawText: string, r: RosterPerson[]) => extractFromTranscript(rawText, r, opts.keys ?? {}));
+    opts.extract ??
+    ((rawText: string, r: RosterPerson[]) => extractFromTranscript(rawText, r, opts.keys ?? {}, opts.timeoutMs));
 
   for (const note of notes) {
     result.scanned++;
@@ -126,7 +130,8 @@ export async function refreshMeetingNoteExtraction(
           body,
           roster,
           opts.keys ?? {},
-          opts.extractActionItems
+          opts.extractActionItems,
+          opts.timeoutMs
         );
       } catch {
         // action-item extraction is a bonus on top of the refreshed summary

--- a/scripts/backfill-meeting-summaries.ts
+++ b/scripts/backfill-meeting-summaries.ts
@@ -23,6 +23,10 @@ async function main() {
   const onlyBlank = argv.includes("--only-blank");
   const limitArg = argv.find((a) => a.startsWith("--limit="));
   const limit = limitArg ? Number(limitArg.split("=")[1]) : undefined;
+  const timeoutArg = argv.find((a) => a.startsWith("--timeout="));
+  // The app LLM path over a slow local network can take ~45s per call; default generously so a
+  // successful-but-slow response isn't aborted mid-backfill. In prod the default 60s is plenty.
+  const timeoutMs = timeoutArg ? Number(timeoutArg.split("=")[1]) : 120_000;
   const teamSlug = argv.find((a) => !a.startsWith("--"));
 
   const admin = adminClient();
@@ -47,7 +51,7 @@ async function main() {
     const provider = keys.activeProvider ?? "auto";
     process.stdout.write(`• ${t.name} (${t.slug}) — answering=${provider} … `);
     try {
-      const res = await refreshMeetingNoteExtraction(admin, t.id, { keys, onlyBlank, limit });
+      const res = await refreshMeetingNoteExtraction(admin, t.id, { keys, onlyBlank, limit, timeoutMs });
       totalSummarized += res.summarized;
       totalActionItems += res.actionItems;
       console.log(

--- a/test/meetings-llm-timeout.test.ts
+++ b/test/meetings-llm-timeout.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Spec (the silent-blank-on-slow-model fix): meetings extraction is a background, best-effort pass,
+ * so it must give the model MORE time than the interactive query box's 30s default. A reasoning
+ * model (e.g. qwen via OpenRouter) can spend 30–45s on a full transcript; at 30s the call was
+ * aborted and the summary/attendees/action-items silently came back empty. We assert the timeout
+ * the meetings path hands the shared primitive — 60s by default, and any explicit override.
+ */
+
+const { completeTextOrNull } = vi.hoisted(() => ({
+  completeTextOrNull: vi.fn(async () => '{"summary":"ok","attendees":[]}'),
+}));
+vi.mock("@/lib/llm/complete", () => ({ completeTextOrNull, completeText: vi.fn() }));
+
+import { callMeetingsLLM, extractFromTranscript, MEETINGS_LLM_TIMEOUT_MS } from "@/lib/meetings/llm-extract";
+import { extractActionItems } from "@/lib/meetings/action-items";
+
+afterEach(() => completeTextOrNull.mockClear());
+
+const timeoutOf = () => completeTextOrNull.mock.calls.at(-1)?.[1]?.timeoutMs;
+
+describe("meetings extraction timeout", () => {
+  it("defaults to the 60s meetings budget, not the query box's 30s", async () => {
+    expect(MEETINGS_LLM_TIMEOUT_MS).toBe(60_000);
+    await callMeetingsLLM("s", "u", {});
+    expect(timeoutOf()).toBe(60_000);
+  });
+
+  it("honors an explicit override (backfill over a slow network)", async () => {
+    await callMeetingsLLM("s", "u", {}, 120_000);
+    expect(timeoutOf()).toBe(120_000);
+  });
+
+  it("extractFromTranscript forwards its timeout to the model call", async () => {
+    await extractFromTranscript("text", [], {}, 90_000);
+    expect(timeoutOf()).toBe(90_000);
+  });
+
+  it("extractActionItems forwards its timeout to the model call", async () => {
+    await extractActionItems("text", [], {}, 90_000);
+    expect(timeoutOf()).toBe(90_000);
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #280. Investigating the blank-summary reports surfaced a **second** cause: meeting extraction (summary / attendees / action items) is a best-effort **background** pass, but it shared `completeText`'s **30s** default timeout. The team's answering model — `qwen/qwen3.7-plus`, a reasoning model via OpenRouter — spends **30–45s** on a full transcript. At 30s the call was aborted, `completeTextOrNull` swallowed it to `null`, and the note saved **blank** — the same "No summary" symptom as the array-shape bug, from a different angle. One such timeout is already in prod logs.

Measured directly: the same call that returns in ~2s from a plain client took **44s** through the app's server-fetch path — comfortably over 30s, comfortably under 60s.

## Change

- **`MEETINGS_LLM_TIMEOUT_MS = 60s`** — `callMeetingsLLM` now defaults to it (was the implicit 30s). Meetings/arcs/social-style background extraction can tolerate a slower model than the interactive query box; a longer timeout strictly reduces silent-blank failures.
- `extractFromTranscript` and `extractActionItems` accept + forward an optional `timeoutMs`.
- `refreshMeetingNoteExtraction` threads `timeoutMs`; the backfill script passes **120s** (`--timeout=`) so a slow-network run isn't aborted. **Prod keeps the 60s default.**
- Unit test asserts the 60s default and that overrides propagate through all three entry points.

## Verification
- unit tier **776 passed**; `tsc` clean; lint 0 errors.
- Scope is timeout-only; no schema, no behavior change beyond the larger budget.

Together with #280 (parser) this closes both blank-summary causes: wrong-shape responses are now parsed, and slow-but-valid responses are no longer aborted.