### PR TITLE
fix(meetings): survive max-tokens truncation / malformed summary JSON

### DIFF
--- a/lib/meetings/llm-extract.ts
+++ b/lib/meetings/llm-extract.ts
@@ -59,6 +59,14 @@ export function extractJsonObject(raw: string): string {
 export const MEETINGS_LLM_TIMEOUT_MS = 60_000;
 
 /**
+ * Token budget for the meetings passes. A detailed 4–8 bullet summary + attendees on a long
+ * transcript can run past 1024 tokens; when it did, the JSON was cut off mid-string and `JSON.parse`
+ * threw → the note saved blank. 2048 gives headroom, and `salvageSummaryBullets` backstops the rare
+ * overrun that still truncates.
+ */
+export const MEETINGS_LLM_MAX_TOKENS = 2048;
+
+/**
  * Best-effort JSON completion for the meetings LLM passes (summary/attendees AND action items),
  * through the shared settings-aware primitive. Never throws — any transport failure returns null so
  * a caller degrades gracefully.
@@ -69,7 +77,33 @@ export async function callMeetingsLLM(
   keys: ProviderKeys,
   timeoutMs: number = MEETINGS_LLM_TIMEOUT_MS
 ): Promise<string | null> {
-  return completeTextOrNull({ system, prompt: userContent }, { keys, jsonObject: true, maxTokens: 1024, timeoutMs });
+  return completeTextOrNull(
+    { system, prompt: userContent },
+    { keys, jsonObject: true, maxTokens: MEETINGS_LLM_MAX_TOKENS, timeoutMs }
+  );
+}
+
+/**
+ * Recover complete bullet lines from a malformed or truncated meetings JSON response. Some models
+ * emit the summary as bare comma-separated strings (`{"summary":"- a","- b"}`, invalid JSON) or
+ * overrun the token limit and cut off mid-string. Both make `JSON.parse` throw. This scavenges every
+ * COMPLETE double-quoted string that reads as a bullet (a truncated trailing string has no closing
+ * quote, so it's naturally excluded) — enough to still show a summary instead of a blank.
+ */
+export function salvageSummaryBullets(raw: string): string[] {
+  const bullets: string[] = [];
+  const stringLiteral = /"(?:[^"\\]|\\.)*"/g; // complete quoted strings only
+  let m: RegExpExecArray | null;
+  while ((m = stringLiteral.exec(raw)) !== null) {
+    let value: unknown;
+    try {
+      value = JSON.parse(m[0]); // unescape \n, \" etc.
+    } catch {
+      continue;
+    }
+    if (typeof value === "string" && /^\s*[-*•]\s+/.test(value)) bullets.push(value.trim());
+  }
+  return bullets;
 }
 
 /** Normalize a name for tolerant matching: lowercase, collapse whitespace, drop punctuation. */
@@ -134,6 +168,13 @@ export function parseTranscriptExtraction(raw: string, roster: RosterPerson[]): 
   try {
     parsed = JSON.parse(extractJsonObject(raw));
   } catch (err) {
+    // Malformed (bullets as bare comma-separated strings) or token-truncated JSON — recover whatever
+    // complete bullets we can rather than saving the note blank. Need ≥2 to count as a real summary.
+    const salvaged = salvageSummaryBullets(raw);
+    if (salvaged.length >= 2) {
+      console.warn(`[meetings] recovered summary from malformed/truncated JSON (${salvaged.length} bullets)`);
+      return { summary: normalizeSummaryField(salvaged), attendeeMemberIds: [] };
+    }
     console.error("[meetings] LLM response was not valid JSON:", err instanceof Error ? err.message : err, raw.slice(0, 300));
     return empty;
   }

--- a/test/meetings-llm-timeout.test.ts
+++ b/test/meetings-llm-timeout.test.ts
@@ -13,12 +13,18 @@ const { completeTextOrNull } = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/llm/complete", () => ({ completeTextOrNull, completeText: vi.fn() }));
 
-import { callMeetingsLLM, extractFromTranscript, MEETINGS_LLM_TIMEOUT_MS } from "@/lib/meetings/llm-extract";
+import {
+  callMeetingsLLM,
+  extractFromTranscript,
+  MEETINGS_LLM_TIMEOUT_MS,
+  MEETINGS_LLM_MAX_TOKENS,
+} from "@/lib/meetings/llm-extract";
 import { extractActionItems } from "@/lib/meetings/action-items";
 
 afterEach(() => completeTextOrNull.mockClear());
 
 const timeoutOf = () => completeTextOrNull.mock.calls.at(-1)?.[1]?.timeoutMs;
+const maxTokensOf = () => completeTextOrNull.mock.calls.at(-1)?.[1]?.maxTokens;
 
 describe("meetings extraction timeout", () => {
   it("defaults to the 60s meetings budget, not the query box's 30s", async () => {
@@ -40,5 +46,11 @@ describe("meetings extraction timeout", () => {
   it("extractActionItems forwards its timeout to the model call", async () => {
     await extractActionItems("text", [], {}, 90_000);
     expect(timeoutOf()).toBe(90_000);
+  });
+
+  it("asks for a generous token budget so long summaries aren't truncated mid-JSON", async () => {
+    expect(MEETINGS_LLM_MAX_TOKENS).toBeGreaterThanOrEqual(2048);
+    await callMeetingsLLM("s", "u", {});
+    expect(maxTokensOf()).toBe(MEETINGS_LLM_MAX_TOKENS);
   });
 });

--- a/test/meetings-truncated-json.test.ts
+++ b/test/meetings-truncated-json.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { parseTranscriptExtraction, salvageSummaryBullets } from "@/lib/meetings/llm-extract";
+import { summaryBullets } from "@/lib/meetings/summary-format";
+
+/**
+ * Spec (the max-tokens truncation / malformed-JSON recovery). On a long transcript, qwen sometimes
+ * (a) emits bullets as bare comma-separated strings — `{"summary":"- a","- b"}` — which is invalid
+ * JSON, and/or (b) overruns the token budget and the JSON is cut off mid-string. Before the fix,
+ * `JSON.parse` threw and the note silently saved BLANK. The product intent: recover whatever
+ * complete bullets the model did produce so the note shows a summary. These assertions are derived
+ * from that intent (real shapes captured from prod), not the implementation.
+ */
+
+describe("salvageSummaryBullets", () => {
+  it("recovers complete bullets from a truncated response, dropping the cut-off tail", () => {
+    // The exact prod shape: summary starts as a string, more bullets follow as bare strings, and the
+    // final bullet is truncated (no closing quote) by the token limit.
+    const raw =
+      '{"summary":"- Chetan discusses his upcoming visa appointment and John offers advice.",' +
+      '"- Chetan details recent updates to Aios including OpenRouter as a context engine.",' +
+      '"- They review the meeting note interface and the social dashboard.",' +
+      '"- The team plans to extend tool integrations to distribution ski';
+    expect(salvageSummaryBullets(raw)).toEqual([
+      "- Chetan discusses his upcoming visa appointment and John offers advice.",
+      "- Chetan details recent updates to Aios including OpenRouter as a context engine.",
+      "- They review the meeting note interface and the social dashboard.",
+    ]);
+  });
+
+  it("recovers from a truncated JSON ARRAY summary", () => {
+    const raw = '{"summary":["- alpha point","- beta point","- gam';
+    expect(salvageSummaryBullets(raw)).toEqual(["- alpha point", "- beta point"]);
+  });
+
+  it("ignores non-bullet strings (keys, prose)", () => {
+    expect(salvageSummaryBullets('{"summary":"just prose, no bullets","attendees":["Alex"]}')).toEqual([]);
+  });
+});
+
+describe("parseTranscriptExtraction recovers a summary from malformed/truncated JSON", () => {
+  it("malformed comma-separated bullets (invalid JSON) -> bulleted summary", () => {
+    const raw = '{"summary":"- Shipped the job queue","- Aligned on the rollout plan","- Next: analytics"}';
+    const out = parseTranscriptExtraction(raw, []);
+    expect(summaryBullets(out.summary)).toEqual([
+      "Shipped the job queue",
+      "Aligned on the rollout plan",
+      "Next: analytics",
+    ]);
+  });
+
+  it("token-truncated response -> the complete bullets survive", () => {
+    const raw =
+      '{"summary":"- Point one is complete.","- Point two is complete.","- Point three is complete.",' +
+      '"- Point four was cut off mid-sen';
+    const out = parseTranscriptExtraction(raw, []);
+    expect(summaryBullets(out.summary)).toEqual([
+      "Point one is complete.",
+      "Point two is complete.",
+      "Point three is complete.",
+    ]);
+  });
+
+  it("returns empty when fewer than two bullets can be recovered (not a real summary)", () => {
+    const raw = '{"summary":"- one lonely complete bullet","- the rest got trunca';
+    expect(parseTranscriptExtraction(raw, []).summary).toBe("");
+  });
+
+  it("well-formed JSON is unaffected (no regression through the salvage path)", () => {
+    const raw = '{"summary":"- a\\n- b","attendees":[]}';
+    expect(summaryBullets(parseTranscriptExtraction(raw, []).summary)).toEqual(["a", "b"]);
+  });
+});


### PR DESCRIPTION
## Why

The final blank-summary cause, seen during the backfill: on a long transcript, `qwen/qwen3.7-plus` sometimes
1. emits the summary as **bare comma-separated strings** — `{"summary":"- a","- b"}` — which is **invalid JSON**, and/or
2. **overruns the token budget** (1024) so the JSON is cut off mid-string.

Either way `JSON.parse` threw → the note saved **blank**. (One note hit this during the backfill; a retry happened to fit under the limit.)

## Fix (two layers)

- **Token budget 1024 → `MEETINGS_LLM_MAX_TOKENS` (2048)** so a detailed 4–8 bullet summary + attendees doesn't truncate in the common case.
- **`salvageSummaryBullets`** — when `JSON.parse` fails, scavenge every *complete* quoted bullet from the raw text (a truncated trailing string has no closing quote, so it's naturally dropped) and, with **≥2** recovered, build the summary via `normalizeSummaryField` instead of returning blank. Backstops any overrun that still truncates and the malformed comma-separated shape.

## Tests (spec-first — red before the fix)

`test/meetings-truncated-json.test.ts` uses the **real prod shapes**: comma-separated bullets (invalid JSON), a token-truncated trailing string, and a truncated JSON array. Asserts ≥2-bullet recovery renders as a list, that <2 bullets stays empty (not a fake one-liner), and that well-formed JSON is unaffected. Plus a max-tokens assertion in the timeout test.

## Verification
- unit tier **795 passed**; `tsc` clean; lint 0 errors; docs congruent.

Third and final piece for the meetings blank-summary issue, after #280 (array shape) and #283 (timeout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved meeting transcript extraction for longer and more detailed conversations.
  * Added recovery for incomplete or malformed AI-generated responses, preserving valid summary bullet points when possible.
  * Incomplete responses now produce a usable summary when enough information can be recovered, rather than failing entirely.
  * Meeting extraction timeout and processing limits are now applied consistently across related actions.

* **Tests**
  * Added coverage for truncated responses, summary recovery, timeout handling, and token limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->