### PR TITLE
fix(llm): disable reasoning for extraction tasks on OpenRouter (unblank Learning arcs)

### DIFF
--- a/components/admin/retrieval-health-card.tsx
+++ b/components/admin/retrieval-health-card.tsx
@@ -63,6 +63,19 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
   const graphDegraded = health.graph === "degraded";
   const worst = d.state === "degraded" || health.graph === "off";
 
+  // Answering-model leg: map the LLM health state onto the shared leg vocabulary (unknown → the grey
+  // "off" dot, since nothing's been recorded yet). This is the leg that was missing when a reasoning
+  // model silently blanked Learning.
+  const llm = health.llm;
+  const llmLeg: DenseState | LegState =
+    llm.state === "healthy" ? "healthy" : llm.state === "degraded" ? "degraded" : "off";
+  const llmDetail =
+    llm.state === "healthy"
+      ? `${llm.lastModel ?? "model"}${llm.lastOkAt ? ` · last ok ${timeAgo(llm.lastOkAt)}` : ""}`
+      : llm.state === "degraded"
+        ? `${llm.lastModel ?? "model"} returned no output${llm.lastFailedAt ? ` · ${timeAgo(llm.lastFailedAt)}` : ""}`
+        : "no recent activity recorded";
+
   return (
     <div className="prism-card flex flex-col gap-1 p-4">
       <div className="flex items-center justify-between">
@@ -74,11 +87,17 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
         depend on external services, so a quiet failure is flagged here.
       </p>
 
+      <Leg name="Answering model" state={llmLeg} detail={llmDetail} />
       <Leg name="Keyword" state="on" detail="always on (local Postgres FTS)" />
       <Leg name="Semantic" state={d.state} detail={denseDetail} />
       <Leg name="Graph memory" state={health.graph} detail={graphDetail} />
       <Leg name="Reranker" state={health.rerank} detail={health.rerank === "off" ? "not configured" : undefined} />
 
+      {llm.state === "degraded" && llm.note ? (
+        <p className="mt-2 rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
+          {llm.note}
+        </p>
+      ) : null}
       {graphDegraded ? (
         <p className="mt-2 rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
           {graphStalled ? (

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -186,10 +186,21 @@ function extractJsonObject(raw: string): string {
  *  outage or a stale model id must degrade to "no arcs" instead of failing the whole request). Routes
  *  through the shared settings-aware primitive, so arcs honor the team's answering-provider (incl.
  *  OpenRouter) exactly like the Query box. */
-async function callLLMRaw(userContent: string, keys: ProviderKeys): Promise<string | null> {
+async function callLLMRaw(
+  userContent: string,
+  keys: ProviderKeys,
+  record?: { db: DbClient; teamId: string }
+): Promise<string | null> {
   return completeTextOrNull(
     { system: SYSTEM_PROMPT, prompt: userContent },
-    { keys, jsonObject: true, maxTokens: 2048 }
+    {
+      keys,
+      jsonObject: true,
+      maxTokens: 2048,
+      // Record the outcome so a broken answering model (e.g. a reasoning model returning empty) shows
+      // as "degraded" on the dashboard instead of silently blanking the Learning page.
+      record: record ? { db: record.db, teamId: record.teamId, task: "arcs" } : undefined,
+    }
   );
 }
 
@@ -258,7 +269,11 @@ async function synthesizeArcs(
   const epToItem = await resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids));
   const allItemIds = [...new Set([...epToItem.values()].map((v) => v.itemId).filter((id): id is string => !!id))];
   const humanByItem = await resolveHumanActorsByItem(db, teamId, allItemIds);
-  const raw = await callLLMRaw(buildPrompt(attributedFactTexts(facts, epToItem, humanByItem), correctionTexts), keys);
+  const raw = await callLLMRaw(
+    buildPrompt(attributedFactTexts(facts, epToItem, humanByItem), correctionTexts),
+    keys,
+    { db, teamId }
+  );
   return attributeArcs(parseArcsJson(raw, { facts, epToItem }), humanByItem);
 }
 

--- a/lib/llm/complete.ts
+++ b/lib/llm/complete.ts
@@ -1,6 +1,8 @@
 import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
 import { selectLlmBackend, type LlmBackendKeys } from "@/lib/query/llm-backend";
+import { recordIngestRun } from "@/lib/ingest/runs";
+import type { DbClient } from "@/lib/db/types";
 
 /**
  * THE single-shot text-completion primitive for every non-streaming LLM task in the brain — meeting
@@ -41,6 +43,30 @@ export interface CompleteOptions {
   timeoutMs?: number;
   /** Ask for strict JSON: sets `response_format` on OpenAI-compatible + nudges every provider. */
   jsonObject?: boolean;
+  /**
+   * Durably record this call's outcome (ok/fail + model) to `ingest_runs` (source `llm`), so the
+   * answering-model health leg on the dashboard can show when the model is failing (empty output /
+   * transport / auth) instead of the failure being an invisible `null`. Opt-in per caller (needs a
+   * db + teamId), so high-frequency incidental calls (e.g. chat titles) don't flood the ledger.
+   */
+  record?: { db: DbClient; teamId: string; task: string };
+}
+
+/** Best-effort durable record of one LLM outcome — never throws (observability can't break the call). */
+async function recordLlmOutcome(
+  record: CompleteOptions["record"],
+  outcome: { ok: boolean; model: string; error?: string; startedAt: number }
+): Promise<void> {
+  if (!record) return;
+  await recordIngestRun(record.db, {
+    teamId: record.teamId,
+    source: "llm",
+    trigger: "api",
+    ok: outcome.ok,
+    errors: outcome.ok ? [] : [outcome.error ?? "llm failed"],
+    meta: { task: record.task, model: outcome.model },
+    startedAt: outcome.startedAt,
+  });
 }
 
 /** Run one completion; returns the model's text. Throws on transport/model error or empty output. */
@@ -49,74 +75,86 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
   const maxTokens = opts.maxTokens ?? 1024;
   const timeoutMs = opts.timeoutMs ?? 30_000;
   const backend = selectLlmBackend({ LLM_BASE_URL, LLM_MODEL }, keys);
+  const startedAt = Date.now();
 
   // For JSON mode, nudge every provider (OpenAI's json_object mode also requires "json" in the
   // messages, which this satisfies) — harmless when the system prompt already asks for JSON.
   const prompt = opts.jsonObject ? `${args.prompt}\n\nReturn ONLY the JSON object.` : args.prompt;
 
-  if (backend.kind !== "anthropic") {
-    const apiKey = backend.apiKey ?? process.env.OPENAI_API_KEY ?? "local";
-    const res = await fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-        ...(backend.kind === "openrouter" ? backend.headers : {}),
-      },
-      body: JSON.stringify({
-        model: backend.model,
-        // Answer budget + reasoning headroom (see REASONING_HEADROOM_TOKENS) so a reasoning model's
-        // hidden tokens don't starve the answer to empty.
-        max_tokens: maxTokens + REASONING_HEADROOM_TOKENS,
-        // These are structured extraction/short-generation tasks (arcs, summaries, social, titles) —
-        // NOT chain-of-thought. On OpenRouter, turn reasoning OFF so a reasoning model (e.g.
-        // qwen/qwen3.7-plus) can't spend the whole budget on hidden thinking and return empty content
-        // (what blanked the Learning page). Headroom stays as a belt-and-suspenders. The streaming
-        // Query path (lib/query/claude.ts) is separate and can still reason. Ignored by non-reasoning
-        // models. Override with LLM_DISABLE_REASONING=0.
-        ...(backend.kind === "openrouter" && process.env.LLM_DISABLE_REASONING !== "0"
-          ? { reasoning: { enabled: false } }
-          : {}),
-        ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),
-        messages: [
-          { role: "system", content: args.system },
-          { role: "user", content: prompt },
-        ],
-      }),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!res.ok) {
-      throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
-    }
-    const j = (await res.json()) as {
-      choices?: { message?: { content?: string }; finish_reason?: string }[];
-    };
-    const choice = j.choices?.[0];
-    const text = choice?.message?.content ?? "";
-    if (!text.trim()) {
-      // Name WHY it's empty — `finish_reason:"length"` on empty content is the reasoning-model
-      // starvation signature (all of max_tokens went to hidden reasoning). Loud so a blank panel is
-      // never a silent, undiagnosable one.
-      throw new Error(
-        `LLM returned empty content (model=${backend.model}, finish_reason=${choice?.finish_reason ?? "?"})`
+  try {
+    let text: string;
+    if (backend.kind !== "anthropic") {
+      const apiKey = backend.apiKey ?? process.env.OPENAI_API_KEY ?? "local";
+      const res = await fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          ...(backend.kind === "openrouter" ? backend.headers : {}),
+        },
+        body: JSON.stringify({
+          model: backend.model,
+          // Answer budget + reasoning headroom (see REASONING_HEADROOM_TOKENS) so a reasoning model's
+          // hidden tokens don't starve the answer to empty.
+          max_tokens: maxTokens + REASONING_HEADROOM_TOKENS,
+          // These are structured extraction/short-generation tasks (arcs, summaries, social, titles) —
+          // NOT chain-of-thought. On OpenRouter, turn reasoning OFF so a reasoning model (e.g.
+          // qwen/qwen3.7-plus) can't spend the whole budget on hidden thinking and return empty content
+          // (what blanked the Learning page). Headroom stays as a belt-and-suspenders. The streaming
+          // Query path (lib/query/claude.ts) is separate and can still reason. Ignored by non-reasoning
+          // models. Override with LLM_DISABLE_REASONING=0.
+          ...(backend.kind === "openrouter" && process.env.LLM_DISABLE_REASONING !== "0"
+            ? { reasoning: { enabled: false } }
+            : {}),
+          ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),
+          messages: [
+            { role: "system", content: args.system },
+            { role: "user", content: prompt },
+          ],
+        }),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!res.ok) {
+        throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+      }
+      const j = (await res.json()) as {
+        choices?: { message?: { content?: string }; finish_reason?: string }[];
+      };
+      const choice = j.choices?.[0];
+      text = (choice?.message?.content ?? "").trim();
+      if (!text) {
+        // Name WHY it's empty — `finish_reason:"length"` on empty content is the reasoning-model
+        // starvation signature (all of max_tokens went to hidden reasoning). Loud so a blank panel is
+        // never a silent, undiagnosable one.
+        throw new Error(
+          `LLM returned empty content (model=${backend.model}, finish_reason=${choice?.finish_reason ?? "?"})`
+        );
+      }
+    } else {
+      const client = new Anthropic(keys.anthropicKey ? { apiKey: keys.anthropicKey } : undefined);
+      const msg = await client.messages.create(
+        {
+          model: backend.model,
+          max_tokens: maxTokens,
+          system: args.system,
+          messages: [{ role: "user", content: prompt }],
+        },
+        { timeout: timeoutMs, maxRetries: 1 }
       );
+      text = msg.content.map((b) => (b.type === "text" ? b.text : "")).join("").trim();
+      if (!text) throw new Error("LLM returned empty content");
     }
-    return text.trim();
-  }
-
-  const client = new Anthropic(keys.anthropicKey ? { apiKey: keys.anthropicKey } : undefined);
-  const msg = await client.messages.create(
-    {
+    await recordLlmOutcome(opts.record, { ok: true, model: backend.model, startedAt });
+    return text;
+  } catch (err) {
+    await recordLlmOutcome(opts.record, {
+      ok: false,
       model: backend.model,
-      max_tokens: maxTokens,
-      system: args.system,
-      messages: [{ role: "user", content: prompt }],
-    },
-    { timeout: timeoutMs, maxRetries: 1 }
-  );
-  const text = msg.content.map((b) => (b.type === "text" ? b.text : "")).join("").trim();
-  if (!text) throw new Error("LLM returned empty content");
-  return text;
+      error: err instanceof Error ? err.message : String(err),
+      startedAt,
+    });
+    throw err;
+  }
 }
 
 /** Best-effort variant: returns null on any failure (transport, empty, no key) instead of throwing. */

--- a/lib/llm/complete.ts
+++ b/lib/llm/complete.ts
@@ -68,6 +68,15 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
         // Answer budget + reasoning headroom (see REASONING_HEADROOM_TOKENS) so a reasoning model's
         // hidden tokens don't starve the answer to empty.
         max_tokens: maxTokens + REASONING_HEADROOM_TOKENS,
+        // These are structured extraction/short-generation tasks (arcs, summaries, social, titles) —
+        // NOT chain-of-thought. On OpenRouter, turn reasoning OFF so a reasoning model (e.g.
+        // qwen/qwen3.7-plus) can't spend the whole budget on hidden thinking and return empty content
+        // (what blanked the Learning page). Headroom stays as a belt-and-suspenders. The streaming
+        // Query path (lib/query/claude.ts) is separate and can still reason. Ignored by non-reasoning
+        // models. Override with LLM_DISABLE_REASONING=0.
+        ...(backend.kind === "openrouter" && process.env.LLM_DISABLE_REASONING !== "0"
+          ? { reasoning: { enabled: false } }
+          : {}),
         ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),
         messages: [
           { role: "system", content: args.system },

--- a/lib/query/llm-health.ts
+++ b/lib/query/llm-health.ts
@@ -1,0 +1,102 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+
+/**
+ * Answering-model health for the admin dashboard. Every non-streaming LLM task funnels through
+ * `lib/llm/complete`, which (when the caller opts in) records each outcome to `ingest_runs` with
+ * source `llm`. This reads the most recent such row so "is the configured model actually producing
+ * output right now?" is answerable on the dashboard — the blind spot that let a reasoning model
+ * blank the Learning page with zero signal.
+ *
+ * Best-effort: "unknown" on any error or when nothing has been recorded yet; never throws into a
+ * page render.
+ */
+
+export type LlmHealthState = "unknown" | "healthy" | "degraded";
+
+export interface LlmHealth {
+  state: LlmHealthState;
+  lastModel: string | null;
+  lastError: string | null;
+  lastOkAt: string | null;
+  lastFailedAt: string | null;
+  note?: string;
+}
+
+function asObject(v: unknown): Record<string, unknown> {
+  if (v && typeof v === "object") return v as Record<string, unknown>;
+  if (typeof v === "string") {
+    try {
+      const p = JSON.parse(v);
+      return p && typeof p === "object" ? (p as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function asArray(v: unknown): unknown[] {
+  if (Array.isArray(v)) return v;
+  if (typeof v === "string") {
+    try {
+      const p = JSON.parse(v);
+      return Array.isArray(p) ? p : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+/** Derive the pure state from the latest recorded LLM outcome. Exported for unit tests. */
+export function deriveLlmState(lastRun: { ok: boolean } | null): LlmHealthState {
+  if (!lastRun) return "unknown";
+  return lastRun.ok ? "healthy" : "degraded";
+}
+
+export async function getLlmHealth(teamId: string): Promise<LlmHealth> {
+  const empty: LlmHealth = {
+    state: "unknown",
+    lastModel: null,
+    lastError: null,
+    lastOkAt: null,
+    lastFailedAt: null,
+  };
+  try {
+    const res = await runSql<{ ok: boolean; meta: unknown; errors: unknown; finished_at: string | Date }>(
+      `select ok, meta, errors, finished_at from ingest_runs
+       where source = 'llm' and team_id = $1 order by finished_at desc limit 1`,
+      [teamId]
+    );
+    const row = res.rows[0];
+    if (!row) return empty;
+
+    const meta = asObject(row.meta);
+    const model = typeof meta.model === "string" ? meta.model : null;
+    const finishedAt = row.finished_at instanceof Date ? row.finished_at.toISOString() : String(row.finished_at);
+
+    if (row.ok) {
+      return { state: "healthy", lastModel: model, lastError: null, lastOkAt: finishedAt, lastFailedAt: null };
+    }
+
+    const errors = asArray(row.errors);
+    const lastError = typeof errors[0] === "string" ? (errors[0] as string) : "the answering model returned an error";
+    const isEmptyOutput = /empty content|finish_reason/i.test(lastError);
+    return {
+      state: "degraded",
+      lastModel: model,
+      lastError,
+      lastOkAt: null,
+      lastFailedAt: finishedAt,
+      note:
+        `The answering model${model ? ` (${model})` : ""} recently failed to produce output — Learning arcs and meeting summaries may be blank.` +
+        (isEmptyOutput
+          ? " It returned empty output, which is the signature of a reasoning model starving its own answer; pick a non-reasoning model in Admin → Active answering model."
+          : " Check the model and key in Admin → Active answering model.") +
+        ` (${lastError})`,
+    };
+  } catch {
+    return empty;
+  }
+}

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
 import { graphitiConfigured, GraphitiClient } from "@/lib/graph/graphiti-client";
+import { getLlmHealth, type LlmHealth } from "@/lib/query/llm-health";
 
 /**
  * Retrieval-stack health for the admin dashboard (Phase 1 of the retrieval-observability plan).
@@ -40,6 +41,7 @@ export interface RetrievalHealth {
   graphLastProjectedAt: string | null; // most recent successful projection (null = never)
   graphStalled: boolean; // degraded specifically because the projector stopped writing (vs unreachable)
   rerank: LegState;
+  llm: LlmHealth; // answering-model health — did the configured model recently produce output?
 }
 
 const COVERAGE_FLOOR = 0.9; // ≥90% embedded = healthy
@@ -111,10 +113,11 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
 
   // Graph + dense both hit the network — run them concurrently so the card render isn't serialized.
   const graphConfiguredNow = graphConfigured(process.env.GRAPHITI_URL);
-  const [dense, graphReachable, graphFresh] = await Promise.all([
+  const [dense, graphReachable, graphFresh, llm] = await Promise.all([
     denseHealth(teamId, configured),
     graphConfiguredNow ? new GraphitiClient().healthcheck() : Promise.resolve(false),
     graphConfiguredNow ? graphFreshness(teamId) : Promise.resolve({ episodes: null, lastProjectedAt: null }),
+    getLlmHealth(teamId),
   ]);
   const lastProjectedAtMs = graphFresh.lastProjectedAt ? Date.parse(graphFresh.lastProjectedAt) : null;
   const nowMs = Date.now();
@@ -130,6 +133,7 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
     graphLastProjectedAt: graphFresh.lastProjectedAt,
     graphStalled,
     rerank,
+    llm,
   };
 }
 

--- a/test/datamechanics/llm-health.datamechanics.test.ts
+++ b/test/datamechanics/llm-health.datamechanics.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { db, seedTeam } from "./helpers";
+import { recordIngestRun } from "@/lib/ingest/runs";
+import { getLlmHealth } from "@/lib/query/llm-health";
+
+// Spec (answering-model observability): the shared completion primitive records each LLM outcome to
+// ingest_runs(source='llm'); getLlmHealth reads the most recent one so a broken answering model shows
+// as "degraded" on the dashboard instead of silently blanking Learning. This is the leg that was
+// missing when a reasoning model returned empty output.
+
+describe("LLM answering-model health (data-mechanics)", () => {
+  it("reports unknown when nothing has been recorded", async () => {
+    const seed = await seedTeam();
+    const h = await getLlmHealth(seed.teamId);
+    expect(h.state).toBe("unknown");
+  });
+
+  it("reports degraded with the model + a reasoning-model hint after an empty-output failure", async () => {
+    const seed = await seedTeam();
+    await recordIngestRun(db(), {
+      teamId: seed.teamId,
+      source: "llm",
+      trigger: "api",
+      ok: false,
+      errors: ["LLM returned empty content (model=qwen/qwen3.7-plus, finish_reason=length)"],
+      meta: { model: "qwen/qwen3.7-plus", task: "arcs" },
+      startedAt: Date.now() - 100,
+    });
+
+    const h = await getLlmHealth(seed.teamId);
+    expect(h.state).toBe("degraded");
+    expect(h.lastModel).toBe("qwen/qwen3.7-plus");
+    expect(h.lastFailedAt).not.toBeNull();
+    expect(h.note).toContain("qwen/qwen3.7-plus");
+    expect(h.note).toMatch(/reasoning model/i); // the actionable "pick a non-reasoning model" hint
+  });
+
+  it("reports healthy after a later successful run (recovery flips the state)", async () => {
+    const seed = await seedTeam();
+    await recordIngestRun(db(), {
+      teamId: seed.teamId,
+      source: "llm",
+      trigger: "api",
+      ok: false,
+      errors: ["boom"],
+      meta: { model: "m", task: "arcs" },
+      startedAt: Date.now() - 2000,
+    });
+    await recordIngestRun(db(), {
+      teamId: seed.teamId,
+      source: "llm",
+      trigger: "api",
+      ok: true,
+      meta: { model: "m", task: "arcs" },
+      startedAt: Date.now() - 100,
+    });
+
+    const h = await getLlmHealth(seed.teamId);
+    expect(h.state).toBe("healthy");
+    expect(h.lastOkAt).not.toBeNull();
+  });
+
+  it("is team-scoped — another team's failure doesn't degrade this one", async () => {
+    const mine = await seedTeam();
+    const other = await seedTeam();
+    await recordIngestRun(db(), {
+      teamId: other.teamId,
+      source: "llm",
+      trigger: "api",
+      ok: false,
+      errors: ["boom"],
+      meta: { model: "m", task: "arcs" },
+      startedAt: Date.now() - 100,
+    });
+    expect((await getLlmHealth(mine.teamId)).state).toBe("unknown");
+  });
+});

--- a/test/llm-complete-reasoning.test.ts
+++ b/test/llm-complete-reasoning.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { completeText } from "@/lib/llm/complete";
+
+/**
+ * Spec (Learning-blank incident): the shared completion primitive runs structured extraction/short-
+ * generation tasks (arcs, meeting summaries, social, titles) — NOT chain-of-thought. A reasoning
+ * model (e.g. OpenRouter's qwen/qwen3.7-plus) otherwise spends its whole token budget on hidden
+ * reasoning and returns empty content, blanking the panel. So the OpenRouter request must turn
+ * reasoning OFF; a plain OpenAI-compatible endpoint must NOT get the field (it would reject it).
+ */
+
+function mock(content: string) {
+  const fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify({ choices: [{ message: { content }, finish_reason: "stop" }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("completeText reasoning control", () => {
+  it("disables reasoning on the OpenRouter path", async () => {
+    const fetchMock = mock('{"ok":true}');
+    await completeText(
+      { system: "s", prompt: "p" },
+      { keys: { openrouterKey: "or", openrouterModel: "qwen/qwen3.7-plus", activeProvider: "openrouter" }, jsonObject: true }
+    );
+    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body));
+    expect(body.reasoning).toEqual({ enabled: false });
+  });
+
+  it("does NOT send a reasoning field to a plain OpenAI-compatible endpoint", async () => {
+    const fetchMock = mock('{"ok":true}');
+    await completeText(
+      { system: "s", prompt: "p" },
+      { keys: { openaiKey: "sk", openaiModel: "gpt-4o", activeProvider: "openai" } }
+    );
+    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body));
+    expect(body.reasoning).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Root cause (this is why Learning is blank)

The answering model is **`qwen/qwen3.7-plus` — a reasoning model**. Reasoning models spend their token budget on hidden "thinking" *before* emitting any answer, and `max_tokens` caps thinking + answer **together**. On the brain's structured-extraction prompts (arc synthesis reads ~200 facts; meeting summaries), the model burns the whole budget reasoning and returns **empty content** → arcs cache empty → the Learning panel shows nothing. Same mechanism no-ops the "Regenerate summary" button.

#281 tried a 6000-token "reasoning headroom" band-aid, but for these big prompts it's evidently not enough.

## Fix

These tasks (arcs, meeting summary/action-items, social, titles) are structured extraction / short generation — they don't need chain-of-thought. So the shared completion primitive (`lib/llm/complete.ts`) now tells OpenRouter to **turn reasoning off** (`reasoning: { enabled: false }`). That makes *any* model work, and it's faster + cheaper.

- Only the **OpenRouter** branch gets the field (a plain OpenAI endpoint would reject it).
- The 6000 headroom stays as belt-and-suspenders.
- The **streaming Query path** (`lib/query/claude.ts`) is separate and can still reason.
- Escape hatch: `LLM_DISABLE_REASONING=0`.

`test/llm-complete-reasoning.test.ts` asserts the OpenRouter body carries `reasoning:{enabled:false}` and a plain OpenAI body does not.

## ⚠️ Honest caveat
I **couldn't live-test OpenRouter's acceptance** of the field (no OpenRouter key locally). The `reasoning` param is documented and OpenRouter ignores unknown fields rather than rejecting, so risk is low — but **confirm on the deploy that arcs populate**. If anything looks off, `LLM_DISABLE_REASONING=0` reverts the behavior without a redeploy.

## Faster unblock (no deploy)
Switching **Admin → Active answering model** to a **non-reasoning** model fixes this instantly (arcs, summaries, everything) — reasoning models are the wrong tool for extraction regardless. This PR is so a reasoning model *also* works if you want to keep it for Query.

## Test plan
- [x] Unit (785) + tsc + lint
- [x] Structural test: OpenRouter disables reasoning, OpenAI doesn't
- [ ] CI green → merge → **confirm arcs populate on prod** (or set a non-reasoning model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)