### PR TITLE
fix(llm): finish reasoning-starvation fix across all transports + de-noise graph-health alert (#281 follow-up)

### DIFF
--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -13,6 +13,8 @@ import {
 import type { AnsweringProvider } from "@/lib/query/llm-backend";
 import { runSlackIngestion, runPlaneIngestion, runLinearIngestion, runGithubIngestion } from "@/lib/ingest/run";
 import { runGraphProjection } from "@/lib/graph/run";
+import { projectionRunInput } from "@/lib/graph/projection-run";
+import { recordIngestRun } from "@/lib/ingest/runs";
 import {
   linkGithubRepo,
   unlinkGithubRepo,
@@ -301,11 +303,15 @@ export async function projectToGraphNow(
 ): Promise<{ ok: boolean; error?: string; message?: string }> {
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
+  const startedAt = Date.now();
   try {
     const s = await runGraphProjection({ teamId: ctx.teamId });
     if (!s.configured) {
       return { ok: false, error: "Graph memory is not configured (set GRAPHITI_URL on the brain)." };
     }
+    // Record the manual run to ingest_runs (like the scheduler) so a successful re-projection clears
+    // the "projector's last run failed" health signal, and a failing one surfaces on the dashboard.
+    await recordIngestRun(adminClient(), projectionRunInput(s, "manual", startedAt, Date.now()));
     if (!s.ok && s.errors.length) return { ok: false, error: s.errors.join("; ") };
     revalidatePath(`/t/${teamSlug}/admin/integrations`);
     return {

--- a/components/admin/retrieval-health-card.tsx
+++ b/components/admin/retrieval-health-card.tsx
@@ -42,9 +42,9 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
     d.state === "off"
       ? undefined
       : `${d.coveragePct}% embedded (${d.embeddedItems}/${d.embeddableItems})${d.pendingItems ? `, ${d.pendingItems} pending` : ""}${d.lastEmbeddedAt ? `, last ${timeAgo(d.lastEmbeddedAt)}` : ""}`;
-  // Reachable but no projection in > 6h ⇒ the projector has stalled even though /healthcheck answers
-  // (the 2026-07 failure: writes 422'd for days while the service stayed "up"). The server flags this
-  // (`graphStalled`) so the banner tells the admin which failure it actually is.
+  // Reachable but the projector's LAST RUN failed ⇒ writes are erroring even though /healthcheck
+  // answers (the 2026-07 failure: Graphiti 422'd every write while the service stayed "up"). The
+  // server flags this (`graphStalled`) so the banner tells the admin which failure it actually is.
   const graphStalled = health.graphStalled;
   const graphFreshness =
     health.graphEpisodes != null
@@ -83,10 +83,10 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
         <p className="mt-2 rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
           {graphStalled ? (
             <>
-              Graph memory is reachable but the <strong>projector has stalled</strong> — no new episodes
-              since {timeAgo(health.graphLastProjectedAt!)}. New activity isn&apos;t reaching the graph
-              (writes may be failing — check the logs for a Graphiti <code>422</code>). Existing memory
-              still answers; keyword and semantic search are unaffected.
+              Graph memory is reachable but the <strong>projector&apos;s last run failed</strong> — new
+              activity isn&apos;t reaching the graph (writes may be failing — check the logs for a
+              Graphiti <code>422</code>){health.graphLastProjectedAt ? `; last successful projection ${timeAgo(health.graphLastProjectedAt)}` : ""}. Existing
+              memory still answers; keyword and semantic search are unaffected.
             </>
           ) : (
             <>

--- a/lib/chat/title.ts
+++ b/lib/chat/title.ts
@@ -3,6 +3,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { DbClient } from "@/lib/db/types";
 import type { ProviderKeys } from "@/lib/query/claude";
 import { selectLlmBackend } from "@/lib/query/llm-backend";
+import { completionMaxTokens, looksLikeTokenLimitError } from "@/lib/llm/limits";
 import { setTitle } from "@/lib/chat/store";
 
 /**
@@ -42,24 +43,32 @@ export async function generateTitle(
     const backend = selectLlmBackend({ LLM_BASE_URL, LLM_MODEL }, keys);
     if (backend.kind !== "anthropic") {
       const apiKey = backend.apiKey ?? process.env.OPENAI_API_KEY ?? "local";
-      const res = await fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-          ...(backend.kind === "openrouter" ? backend.headers : {}),
-        },
-        body: JSON.stringify({
-          model: backend.model,
-          max_tokens: 24,
-          messages: [
-            { role: "system", content: TITLE_SYSTEM },
-            { role: "user", content: prompt },
-          ],
-        }),
-        signal: AbortSignal.timeout(6000), // never hold the response open on a slow title call
-      });
-      if (!res.ok) return null;
+      const postChat = (maxTokensToSend: number): Promise<Response> =>
+        fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+            ...(backend.kind === "openrouter" ? backend.headers : {}),
+          },
+          body: JSON.stringify({
+            model: backend.model,
+            max_tokens: maxTokensToSend,
+            messages: [
+              { role: "system", content: TITLE_SYSTEM },
+              { role: "user", content: prompt },
+            ],
+          }),
+          signal: AbortSignal.timeout(6000), // never hold the response open on a slow title call
+        });
+      // A title is ~24 output tokens, but a reasoning model burns its whole budget on hidden reasoning
+      // first → empty title; add headroom so it isn't starved. If the headroom overshoots a small
+      // model's ceiling (a token-limit 4xx), retry once without it rather than silently killing titles.
+      let res = await postChat(completionMaxTokens(24));
+      if (!res.ok) {
+        if (looksLikeTokenLimitError(res.status, await res.text().catch(() => ""))) res = await postChat(24);
+        if (!res.ok) return null;
+      }
       const j = (await res.json()) as { choices?: { message?: { content?: string } }[] };
       return cleanTitle(j.choices?.[0]?.message?.content ?? "") || null;
     }

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -247,18 +247,21 @@ async function synthesizeArcs(
   groups: string[],
   correctionTexts: string[],
   keys: ProviderKeys
-): Promise<NarrativeArc[]> {
+): Promise<NarrativeArc[] | null> {
+  // Returns `null` on an LLM TRANSPORT FAILURE (outage / reasoning starvation) vs `[]` on a genuine
+  // empty verdict — the caller needs the difference: an explicit recompute applies an empty verdict
+  // but must NOT let a failed call blank the panel.
   // Arcs are NOT time-boxed — synthesize from the most-recent facts regardless of age (a quiet week,
   // or a stalled projector, must not blank the panel). `null` = no window; recentFacts still caps at
   // MAX_FACTS, newest first.
   const facts = await recentFacts(groups, null, MAX_FACTS);
-  // No facts and nothing to correct → nothing to synthesize. (A correction with no facts still runs
-  // the LLM, preserving the pre-cache recompute behavior.)
+  // No facts and nothing to correct → nothing to synthesize (a genuine empty, not a failure).
   if (facts.length === 0 && correctionTexts.length === 0) return [];
   const epToItem = await resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids));
   const allItemIds = [...new Set([...epToItem.values()].map((v) => v.itemId).filter((id): id is string => !!id))];
   const humanByItem = await resolveHumanActorsByItem(db, teamId, allItemIds);
   const raw = await callLLMRaw(buildPrompt(attributedFactTexts(facts, epToItem, humanByItem), correctionTexts), keys);
+  if (raw === null) return null; // transport failure — not a "zero arcs" verdict
   return attributeArcs(parseArcsJson(raw, { facts, epToItem }), humanByItem);
 }
 
@@ -277,19 +280,33 @@ const refreshing = new Set<string>();
  * retries until synthesis recovers. This is the guard that stops one bad LLM call from pinning the
  * Learning page empty for hours (2026-07 incident). Returns what's now authoritative for the key.
  */
+/** How long a good prior may shield an empty result. Past this, an empty synthesis is taken at face
+ *  value (a graph genuinely emptied — content deleted / group migrated — must eventually clear, and
+ *  arcs derived from since-deleted content shouldn't serve forever). */
+const MAX_KEEP_STALE_MS = 24 * 60 * 60 * 1000;
+
 export async function commitArcs(
   db: DbClient,
   teamId: string,
   key: string,
-  next: NarrativeArc[]
+  next: NarrativeArc[],
+  opts: { allowEmpty?: boolean } = {}
 ): Promise<NarrativeArc[]> {
-  if (next.length === 0) {
-    const prior = cache.get(key)?.arcs ?? (await readArcCache(db, teamId, key))?.arcs;
-    if (prior && prior.length > 0) {
+  // An empty result usually means a transient upstream failure (LLM outage / reasoning starvation), so
+  // keep a good prior rather than blanking the panel — BUT only if it's fresh, and NEVER for an
+  // explicit user recompute (`allowEmpty`), whose empty verdict is intentional (a correction that drops
+  // the last arc). Otherwise a failed correction would silently no-op and a genuinely-emptied graph
+  // could serve stale arcs forever.
+  if (next.length === 0 && !opts.allowEmpty) {
+    const priorMem = cache.get(key);
+    const prior =
+      priorMem ??
+      (await readArcCache(db, teamId, key).then((r) => (r ? { arcs: r.arcs, at: r.computedAt } : null)));
+    if (prior && prior.arcs.length > 0 && Date.now() - prior.at < MAX_KEEP_STALE_MS) {
       console.warn(
-        `[arcs] synthesis returned 0 arcs for ${key}; keeping ${prior.length} cached (likely transient upstream failure)`
+        `[arcs] synthesis returned 0 arcs for ${key}; keeping ${prior.arcs.length} cached (likely transient upstream failure)`
       );
-      return prior;
+      return prior.arcs;
     }
   }
   cache.set(key, { arcs: next, at: Date.now() });
@@ -306,8 +323,10 @@ function refreshArcsInBackground(teamId: string, key: string, groups: string[], 
   void (async () => {
     const bg = adminClient();
     try {
+      // Background refresh: a failure (null) or empty verdict both keep the prior (shield) — never
+      // allowEmpty here, so a transient outage can't blank a good cache.
       const arcs = await synthesizeArcs(bg, teamId, groups, [], keys);
-      await commitArcs(bg, teamId, key, arcs);
+      await commitArcs(bg, teamId, key, arcs ?? []);
     } catch (err) {
       console.error("[arcs] background refresh failed:", err instanceof Error ? err.message : err);
     } finally {
@@ -351,8 +370,9 @@ export async function getArcs(
   }
 
   // 3. Cold miss — first-ever load for this key. Compute inline so the user gets a real answer.
+  // A failure (null) → [] (nothing to shield yet; next view retries).
   const arcs = await synthesizeArcs(db, teamId, groups, [], keys);
-  return commitArcs(db, teamId, key, arcs);
+  return commitArcs(db, teamId, key, arcs ?? []);
 }
 
 /**
@@ -372,7 +392,10 @@ export async function recomputeArcs(
   if (groups.length === 0) return [];
   const key = groups.slice().sort().join(",");
   const synthesized = await synthesizeArcs(db, teamId, groups, corrections.map((c) => c.corrected_text), keys);
-  const arcs = await commitArcs(db, teamId, key, synthesized);
+  // Explicit user recompute: apply an empty VERDICT (synthesized === [], e.g. a correction that drops
+  // the last arc) — but if the LLM call FAILED (synthesized === null), keep the prior rather than
+  // blanking the panel on a transient outage. `allowEmpty` iff it wasn't a failure.
+  const arcs = await commitArcs(db, teamId, key, synthesized ?? [], { allowEmpty: synthesized !== null });
 
   // Persist corrections as first-class episodes (team-tier group; corrections are internal).
   const client = new GraphitiClient();

--- a/lib/llm/complete.ts
+++ b/lib/llm/complete.ts
@@ -14,20 +14,10 @@ import { selectLlmBackend, type LlmBackendKeys } from "@/lib/query/llm-backend";
  * (arc/meeting extraction degrade to "no result" rather than failing the request).
  */
 
+import { completionMaxTokens, looksLikeTokenLimitError } from "./limits";
+
 const LLM_BASE_URL = process.env.LLM_BASE_URL;
 const LLM_MODEL = process.env.LLM_MODEL;
-
-/**
- * Reasoning models (e.g. OpenRouter's `qwen/qwen3.7-plus`, o-series) spend completion tokens on
- * HIDDEN reasoning BEFORE emitting any answer, and `max_tokens` caps reasoning+answer TOGETHER. With
- * only the caller's answer-sized budget, reasoning can consume all of it → empty `content` → callers
- * silently degrade (this is exactly what blanked the Learning page in 2026-07). So we give the
- * OpenAI-compatible/OpenRouter path headroom ON TOP of the requested answer budget: you're billed only
- * for tokens actually generated, so this is free for non-reasoning models and makes any model choice
- * work. Override with LLM_REASONING_HEADROOM_TOKENS. (The Anthropic path uses a separate thinking
- * budget and isn't affected.)
- */
-const REASONING_HEADROOM_TOKENS = Number(process.env.LLM_REASONING_HEADROOM_TOKENS ?? 6000);
 
 export interface CompleteArgs {
   system: string;
@@ -56,28 +46,41 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
 
   if (backend.kind !== "anthropic") {
     const apiKey = backend.apiKey ?? process.env.OPENAI_API_KEY ?? "local";
-    const res = await fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-        ...(backend.kind === "openrouter" ? backend.headers : {}),
-      },
-      body: JSON.stringify({
-        model: backend.model,
-        // Answer budget + reasoning headroom (see REASONING_HEADROOM_TOKENS) so a reasoning model's
-        // hidden tokens don't starve the answer to empty.
-        max_tokens: maxTokens + REASONING_HEADROOM_TOKENS,
-        ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),
-        messages: [
-          { role: "system", content: args.system },
-          { role: "user", content: prompt },
-        ],
-      }),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    const postChat = (maxTokensToSend: number): Promise<Response> =>
+      fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          ...(backend.kind === "openrouter" ? backend.headers : {}),
+        },
+        body: JSON.stringify({
+          model: backend.model,
+          max_tokens: maxTokensToSend,
+          ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),
+          messages: [
+            { role: "system", content: args.system },
+            { role: "user", content: prompt },
+          ],
+        }),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+    // Send the answer budget + reasoning headroom so a reasoning model's hidden tokens don't starve
+    // the answer to empty. If that pushes max_tokens past a small model's ceiling (a 4xx naming the
+    // token limit), retry ONCE with just the answer budget — so headroom never turns a working config
+    // into a hard failure (M6).
+    let res = await postChat(completionMaxTokens(maxTokens));
     if (!res.ok) {
-      throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+      const body = await res.text().catch(() => "");
+      if (looksLikeTokenLimitError(res.status, body)) {
+        res = await postChat(maxTokens);
+        if (!res.ok) {
+          throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+        }
+      } else {
+        throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${body}`);
+      }
     }
     const j = (await res.json()) as {
       choices?: { message?: { content?: string }; finish_reason?: string }[];

--- a/lib/llm/limits.ts
+++ b/lib/llm/limits.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared LLM token-budget helpers — the single definition of reasoning headroom, used by ALL three
+ * sanctioned transports (lib/llm/complete, lib/chat/title, lib/query/claude). #281 added headroom to
+ * only `complete.ts`; a reasoning model (e.g. OpenRouter `qwen/qwen3.7-plus`) still starved the title
+ * and streaming-answer paths, which call the chat-completions endpoint directly.
+ *
+ * Reasoning models spend completion tokens on HIDDEN reasoning BEFORE any answer, and `max_tokens`
+ * caps reasoning+answer TOGETHER. With only the answer-sized budget, reasoning can consume all of it →
+ * empty/truncated output. Adding headroom on top is FREE for non-reasoning models (you're billed only
+ * for tokens generated) and unbreaks reasoning ones. Override with LLM_REASONING_HEADROOM_TOKENS.
+ */
+const RAW_HEADROOM = Number(process.env.LLM_REASONING_HEADROOM_TOKENS);
+export const REASONING_HEADROOM_TOKENS = Number.isFinite(RAW_HEADROOM) && RAW_HEADROOM >= 0 ? RAW_HEADROOM : 6000;
+
+/** The `max_tokens` to send for a given answer budget: answer + reasoning headroom. */
+export function completionMaxTokens(answerBudget: number): number {
+  return answerBudget + REASONING_HEADROOM_TOKENS;
+}
+
+/**
+ * A non-OK completion response whose status+body indicate the request exceeded the model's output /
+ * context ceiling — i.e. the headroom pushed `max_tokens` past what this model accepts. The caller
+ * retries once WITHOUT headroom so a ceiling-constrained small model doesn't hard-fail (the inverse
+ * of the starvation the headroom fixes). Provider messages vary; match the common shapes.
+ */
+export function looksLikeTokenLimitError(status: number, body: string): boolean {
+  if (status !== 400 && status !== 422) return false;
+  return /max[_ ]?tokens|max_completion_tokens|maximum context|context length|too many tokens|reduce (?:the )?(?:length|tokens)/i.test(
+    body
+  );
+}

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -2,6 +2,7 @@ import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
 import type { RetrievedContext } from "./retrieve";
 import { selectLlmBackend, type LlmBackend, type LlmBackendKeys } from "./llm-backend";
+import { completionMaxTokens, looksLikeTokenLimitError } from "@/lib/llm/limits";
 
 /**
  * Thin adapter around the Claude API so a future agent backend (e.g. Hermes)
@@ -302,27 +303,44 @@ async function* streamOpenAICompatible(
     `Question: ${question}`;
 
   const apiKey = backend.apiKey ?? process.env.OPENAI_API_KEY ?? "local";
-  const res = await fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-      ...(backend.kind === "openrouter" ? backend.headers : {}),
-    },
-    body: JSON.stringify({
-      model: backend.model,
-      max_tokens: 4096,
-      stream: true,
-      stream_options: { include_usage: true },
-      messages: [
-        { role: "system", content: SYSTEM_PROMPT },
-        { role: "user", content: userContent },
-      ],
-    }),
-  });
+  const postChat = (maxTokensToSend: number): Promise<Response> =>
+    fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        ...(backend.kind === "openrouter" ? backend.headers : {}),
+      },
+      body: JSON.stringify({
+        model: backend.model,
+        // Answer budget + reasoning headroom so a reasoning model doesn't spend the whole budget on
+        // hidden reasoning and stream back an empty answer (the 2026-07 starvation, streaming path).
+        max_tokens: maxTokensToSend,
+        stream: true,
+        stream_options: { include_usage: true },
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: userContent },
+        ],
+      }),
+    });
 
-  if (!res.ok || !res.body) {
-    throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+  let res = await postChat(completionMaxTokens(4096));
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    // If headroom pushed max_tokens past this model's ceiling, retry once with just the answer budget;
+    // any other error surfaces immediately (with its own body).
+    if (looksLikeTokenLimitError(res.status, body)) {
+      res = await postChat(4096);
+      if (!res.ok) {
+        throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+      }
+    } else {
+      throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${body}`);
+    }
+  }
+  if (!res.body) {
+    throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} no stream body`);
   }
 
   const reader = res.body.getReader();
@@ -331,6 +349,7 @@ async function* streamOpenAICompatible(
   let inThink = false;
   let prompt = 0;
   let completion = 0;
+  let emittedChars = 0;
 
   while (true) {
     const { done, value } = await reader.read();
@@ -374,8 +393,21 @@ async function* streamOpenAICompatible(
           inThink = true;
         }
       }
-      if (out) yield { type: "delta", text: out };
+      if (out) {
+        emittedChars += out.length;
+        yield { type: "delta", text: out };
+      }
     }
+  }
+
+  // Zero visible answer text is a silent blank answer — make it diagnosable. The usual cause is a
+  // reasoning model spending the whole budget on hidden reasoning (raise LLM_REASONING_HEADROOM_TOKENS);
+  // a mid-stream error frame (no usage) also lands here. Logged regardless of the token count.
+  if (emittedChars === 0) {
+    console.error(
+      `[query] streamed answer was EMPTY (model=${backend.model}, completion_tokens=${completion}) — ` +
+        `likely a reasoning model starved by max_tokens, or a mid-stream provider error`
+    );
   }
 
   yield {

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -52,34 +52,26 @@ const STALE_MS = 2 * 60 * 60 * 1000; // no embed activity in 2h + incomplete = s
  */
 export const graphConfigured = graphitiConfigured;
 
-// Reachable but no projection in this long ⇒ the graph is going stale even though /healthcheck is
-// green. This is the 2026-07 failure a healthcheck-only probe MISSED: Graphiti's write endpoint
-// 422'd for days (projector wedged) while the service kept answering /healthcheck, so the card read
-// "on" while the Learning page slowly emptied. Freshness of the write path is the real signal.
-const GRAPH_STALE_MS = 6 * 60 * 60 * 1000;
-
-/** A projector that hasn't written in > GRAPH_STALE_MS is stalled. `null` = nothing has ever projected
- *  (fresh install / nothing to project) → NOT a stall. Pure + unit-tested. */
-export function isGraphStale(lastProjectedAtMs: number | null, nowMs: number): boolean {
-  return lastProjectedAtMs !== null && nowMs - lastProjectedAtMs > GRAPH_STALE_MS;
-}
-
 /**
  * Derive the graph-leg state from its raw signals. Pure + unit-tested:
  *   • not configured (no/malformed GRAPHITI_URL)             → "off"
  *   • configured BUT /healthcheck failed (down/unreachable)   → "degraded"
- *   • reachable BUT projector hasn't written in > GRAPH_STALE_MS (writes failing) → "degraded"
- *   • reachable AND recently projected (or nothing to project yet) → "on"
+ *   • reachable BUT the last projection RUN errored (writes failing, e.g. Graphiti 422) → "degraded"
+ *   • reachable AND the projector isn't erroring                → "on"
+ *
+ * Keyed on the last `graph_project` run's ok-flag, NOT time-since-last-projection: a team with nothing
+ * new to ingest is quiet, not broken, so a pure "no writes in 6h" staleness would cry wolf every idle
+ * night/weekend. The run flag only goes false when a projection tick actually errored — which is the
+ * 2026-07 failure (Graphiti 422'd every write while `/healthcheck` stayed green).
  */
 export function deriveGraphState(input: {
   configured: boolean;
   reachable: boolean;
-  lastProjectedAtMs: number | null;
-  nowMs: number;
+  lastRunFailed: boolean;
 }): GraphState {
   if (!input.configured) return "off";
   if (!input.reachable) return "degraded";
-  return isGraphStale(input.lastProjectedAtMs, input.nowMs) ? "degraded" : "on";
+  return input.lastRunFailed ? "degraded" : "on";
 }
 
 /**
@@ -111,17 +103,16 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
 
   // Graph + dense both hit the network — run them concurrently so the card render isn't serialized.
   const graphConfiguredNow = graphConfigured(process.env.GRAPHITI_URL);
-  const [dense, graphReachable, graphFresh] = await Promise.all([
+  const [dense, graphReachable, graphFresh, graphRunFailed] = await Promise.all([
     denseHealth(teamId, configured),
     graphConfiguredNow ? new GraphitiClient().healthcheck() : Promise.resolve(false),
     graphConfiguredNow ? graphFreshness(teamId) : Promise.resolve({ episodes: null, lastProjectedAt: null }),
+    graphConfiguredNow ? lastGraphProjectRunFailed() : Promise.resolve(false),
   ]);
-  const lastProjectedAtMs = graphFresh.lastProjectedAt ? Date.parse(graphFresh.lastProjectedAt) : null;
-  const nowMs = Date.now();
-  const graph = deriveGraphState({ configured: graphConfiguredNow, reachable: graphReachable, lastProjectedAtMs, nowMs });
-  // Degraded specifically because the projector went quiet (reachable, but a stale write path) — the
-  // card renders a different, more actionable banner for this than for a hard-unreachable service.
-  const graphStalled = graph === "degraded" && graphReachable && isGraphStale(lastProjectedAtMs, nowMs);
+  const graph = deriveGraphState({ configured: graphConfiguredNow, reachable: graphReachable, lastRunFailed: graphRunFailed });
+  // Degraded specifically because the projector's last run errored (reachable, but writes failing) —
+  // the card renders a different, more actionable banner for this than for a hard-unreachable service.
+  const graphStalled = graph === "degraded" && graphReachable && graphRunFailed;
   return {
     keyword: "on",
     dense,
@@ -136,6 +127,26 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
 /** Projection freshness from the `graph_episodes` ledger (Postgres, no Graphiti round-trip): how many
  *  episodes this team has projected and when the projector last succeeded. Drives the "reachable but
  *  stalled" degraded state. Best-effort — nulls on any error so the card still renders. */
+/** Is the projector failing RIGHT NOW? The scheduler records each tick with a signal to `ingest_runs`
+ *  (source='graph_project', global). A persistent failure (e.g. Graphiti 422 on every write) re-records
+ *  `ok=false` every tick, so it stays "recent"; a single transient failure ages out of the window (a
+ *  quiet team records nothing on healthy ticks, so without the window one old failure would latch
+ *  "degraded" forever — the false-alarm H7 exists to avoid). Window = a few projector intervals.
+ *  No recent run ⇒ not failing. Best-effort. */
+async function lastGraphProjectRunFailed(): Promise<boolean> {
+  try {
+    const intervalMin = Math.max(1, Number(process.env.GRAPH_PROJECT_MINUTES ?? 60));
+    const windowMin = Math.max(3 * intervalMin, 180);
+    const res = await runSql<{ ok: boolean }>(
+      "select ok from ingest_runs where source = 'graph_project' and finished_at > now() - ($1::int * interval '1 minute') order by finished_at desc limit 1",
+      [windowMin]
+    );
+    return res.rows[0]?.ok === false;
+  } catch {
+    return false;
+  }
+}
+
 async function graphFreshness(teamId: string): Promise<{ episodes: number | null; lastProjectedAt: string | null }> {
   try {
     const res = await runSql<{ n: string; mx: string | null }>(

--- a/test/arcs-commit.test.ts
+++ b/test/arcs-commit.test.ts
@@ -5,15 +5,14 @@ import type { DbClient } from "@/lib/db/types";
 
 /** Minimal fake DbClient covering exactly the arc_cache read (select→eq→eq→maybeSingle) and write
  *  (upsert) paths. Records upserts so we can assert whether a clobber happened. */
-function fakeDb(existing: NarrativeArc[] | null) {
+function fakeDb(existing: NarrativeArc[] | null, computedAt = new Date().toISOString()) {
   const upserts: unknown[] = [];
   const db = {
     from: () => ({
       select: () => ({
         eq: () => ({
           eq: () => ({
-            maybeSingle: async () =>
-              existing ? { data: { arcs: existing, computed_at: new Date().toISOString() } } : { data: null },
+            maybeSingle: async () => (existing ? { data: { arcs: existing, computed_at: computedAt } } : { data: null }),
           }),
         }),
       }),
@@ -61,5 +60,21 @@ describe("commitArcs — an empty synthesis must never clobber a good cache", ()
     const out = await commitArcs(db, "team-1", "cold-empty-1", []);
     expect(out).toEqual([]);
     expect(upserts).toHaveLength(1); // first-ever load may legitimately be empty
+  });
+
+  it("APPLIES an empty result for an explicit recompute (allowEmpty) — a correction that drops the last arc", async () => {
+    const { db, upserts } = fakeDb([arc("stale")]);
+    const out = await commitArcs(db, "team-1", "allow-empty-1", [], { allowEmpty: true });
+    expect(out).toEqual([]); // the user's empty verdict is honored, not silently no-op'd
+    expect(upserts).toHaveLength(1);
+  });
+
+  it("lets an empty result through once the good prior is older than the keep window (no stale-forever)", async () => {
+    // Prior computed 2 days ago (> MAX_KEEP_STALE_MS) — a genuinely-emptied graph must eventually clear.
+    const twoDaysAgo = new Date(Date.parse("2026-07-15T00:00:00Z") - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const { db, upserts } = fakeDb([arc("ancient")], twoDaysAgo);
+    const out = await commitArcs(db, "team-1", "stale-prior-1", []);
+    expect(out).toEqual([]); // stale prior no longer shields the empty
+    expect(upserts).toHaveLength(1);
   });
 });

--- a/test/llm-complete.test.ts
+++ b/test/llm-complete.test.ts
@@ -39,6 +39,25 @@ describe("completeText (OpenAI-compatible path)", () => {
     expect(body.model).toBe("reasoning-model");
   });
 
+  it("retries WITHOUT headroom when the headroom'd request hits the model's token ceiling (M6)", async () => {
+    // A small ceiling-constrained model 400s when max_tokens exceeds its output limit. The fix must not
+    // turn that into a hard failure: retry once with just the answer budget.
+    const ceiling400 = { ok: false, status: 400, text: async () => "max_tokens is greater than the maximum allowed", json: async () => ({}) } as unknown as Response;
+    fetchMock.mockResolvedValueOnce(ceiling400).mockResolvedValueOnce(okResponse("recovered"));
+    const out = await completeText({ system: "s", prompt: "p" }, { maxTokens: 100 });
+    expect(out).toBe("recovered");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+    expect(retryBody.max_tokens).toBe(100); // no headroom on the retry
+  });
+
+  it("does NOT retry a non-ceiling error (e.g. auth) — surfaces it once", async () => {
+    const auth401 = { ok: false, status: 401, text: async () => "invalid api key", json: async () => ({}) } as unknown as Response;
+    fetchMock.mockResolvedValue(auth401);
+    await expect(completeText({ system: "s", prompt: "p" })).rejects.toThrow(/401/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("throws NAMING finish_reason when content is empty — the reasoning-starvation signature, made loud", async () => {
     // 200 OK but empty content + finish_reason:length = all of max_tokens went to hidden reasoning.
     fetchMock.mockResolvedValue(okResponse("", "length"));

--- a/test/llm-limits.test.ts
+++ b/test/llm-limits.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { completionMaxTokens, looksLikeTokenLimitError, REASONING_HEADROOM_TOKENS } from "@/lib/llm/limits";
+
+describe("completionMaxTokens", () => {
+  it("adds reasoning headroom on top of the answer budget", () => {
+    expect(completionMaxTokens(24)).toBe(24 + REASONING_HEADROOM_TOKENS);
+    expect(completionMaxTokens(4096)).toBe(4096 + REASONING_HEADROOM_TOKENS);
+  });
+});
+
+describe("looksLikeTokenLimitError", () => {
+  it("matches 400/422 responses whose body names a token/context ceiling", () => {
+    expect(looksLikeTokenLimitError(400, "max_tokens is too large for this model")).toBe(true);
+    expect(looksLikeTokenLimitError(400, "This model's maximum context length is 8192 tokens")).toBe(true);
+    expect(looksLikeTokenLimitError(422, "max_completion_tokens exceeds the limit")).toBe(true);
+    expect(looksLikeTokenLimitError(400, "please reduce the length of the messages")).toBe(true);
+  });
+  it("does NOT match unrelated errors or other statuses (so we don't retry a real failure)", () => {
+    expect(looksLikeTokenLimitError(401, "invalid api key")).toBe(false);
+    expect(looksLikeTokenLimitError(429, "rate limit exceeded")).toBe(false);
+    expect(looksLikeTokenLimitError(500, "internal error")).toBe(false);
+    expect(looksLikeTokenLimitError(400, "content policy violation")).toBe(false);
+  });
+});

--- a/test/retrieval-health.test.ts
+++ b/test/retrieval-health.test.ts
@@ -56,24 +56,22 @@ describe("graphConfigured", () => {
 });
 
 describe("deriveGraphState", () => {
-  const now = Date.parse("2026-07-15T12:00:00Z");
-  const fresh = Date.parse("2026-07-15T11:00:00Z"); // 1h ago
-  const stale = Date.parse("2026-07-08T12:00:00Z"); // 7d ago
   it("off when not configured (regardless of reachability)", () => {
-    expect(deriveGraphState({ configured: false, reachable: false, lastProjectedAtMs: null, nowMs: now })).toBe("off");
-    expect(deriveGraphState({ configured: false, reachable: true, lastProjectedAtMs: fresh, nowMs: now })).toBe("off");
+    expect(deriveGraphState({ configured: false, reachable: false, lastRunFailed: false })).toBe("off");
+    expect(deriveGraphState({ configured: false, reachable: true, lastRunFailed: true })).toBe("off");
   });
-  it("on when reachable AND recently projected", () => {
-    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: fresh, nowMs: now })).toBe("on");
-  });
-  it("on when reachable and nothing has projected yet (null = fresh install, not a stall)", () => {
-    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: null, nowMs: now })).toBe("on");
+  it("on when reachable AND the projector isn't erroring", () => {
+    expect(deriveGraphState({ configured: true, reachable: true, lastRunFailed: false })).toBe("on");
   });
   it("degraded when configured BUT unreachable — the silent-failure case reviving must surface", () => {
-    expect(deriveGraphState({ configured: true, reachable: false, lastProjectedAtMs: fresh, nowMs: now })).toBe("degraded");
+    expect(deriveGraphState({ configured: true, reachable: false, lastRunFailed: false })).toBe("degraded");
   });
-  it("degraded when reachable BUT projector stalled — the 2026-07 healthcheck-only blind spot", () => {
-    // /healthcheck answers (reachable) yet no episode has landed in a week → writes are failing silently.
-    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: stale, nowMs: now })).toBe("degraded");
+  it("degraded when reachable BUT the last projection run errored — the 2026-07 healthcheck-only blind spot", () => {
+    // /healthcheck answers (reachable) yet the projector's last tick failed (e.g. Graphiti 422 on writes).
+    expect(deriveGraphState({ configured: true, reachable: true, lastRunFailed: true })).toBe("degraded");
+  });
+  it("does NOT degrade a quiet team (reachable, no failing runs) — the false-positive H7 guards against", () => {
+    // Nothing new to project for hours ≠ broken. Only an actual run FAILURE degrades.
+    expect(deriveGraphState({ configured: true, reachable: true, lastRunFailed: false })).toBe("on");
   });
 });


### PR DESCRIPTION
## What & why
Closes the four flaws the PR-audit — and Fable's review of this PR — found in **#281** (my own earlier reasoning-starvation fix).

- **H8 — headroom now covers all 3 sanctioned LLM transports.** #281 only fixed `lib/llm/complete.ts`; a reasoning model (`qwen/qwen3.7-plus`) still starved **`chat/title.ts`** (`max_tokens: 24` → empty titles) and the **streaming Query answer** (`claude.ts`, `max_tokens: 4096` → truncated/empty answers). Extracted the headroom to `lib/llm/limits.ts` and applied it to both; the streaming path also **logs** when it emits zero answer text.
- **M6 — ceiling retry.** Unconditional `+headroom` could push a small model past its output ceiling → 400. All three transports now **retry once without headroom** on a token-limit 4xx, so headroom can't turn a working config into a hard failure.
- **H7 — de-noise the graph-health alert.** The "projector stalled" signal was pure *time-since-projection*, which false-alarms every idle night (a quiet team isn't broken). Re-keyed on the last `graph_project` run's **ok-flag**, bounded to a recent window (one transient failure doesn't latch degraded forever), and the admin **"Project to graph"** action now records its run so a manual re-projection clears the banner.
- **M5 — arcs cache correctness.** `commitArcs` no longer shields a good prior over an empty result *forever* (24h bound → a genuinely-emptied graph clears), and `synthesizeArcs` now distinguishes an **LLM failure (null)** from a **genuine empty verdict ([])** — so an explicit user recompute applies a real "drop that arc" correction, but a transient outage during a recompute can't blank the panel.

## Verification
New/updated tests: `llm-limits` (pure), `llm-complete` M6 retry + non-retry-on-auth-error, `arcs-commit` allowEmpty + stale-age bound, `deriveGraphState` rekeyed (incl. the **quiet-team no-false-positive** case). Full unit tier **802**; retrieval-health + arc-cache data-mechanics green; `tsc`/`eslint`/docs-drift clean.

## Review
Reviewed by **Fable** before push — it found 4 real MEDIUMs (streaming retry threw the wrong response's body; H7 could latch degraded after one transient failure; `allowEmpty` conflated failure vs verdict; title missed the M6 retry) + a NaN-env LOW. **All addressed** in this push.

Depends on nothing; independent of #286 (meetings).