### PR TITLE
feat(observability): percolate more silent failures to the dashboard (audit items 2-5)

### DIFF
--- a/app/api/brain/arcs/route.ts
+++ b/app/api/brain/arcs/route.ts
@@ -7,6 +7,7 @@ import { errorResponse } from "@/lib/api/schemas";
 import { resolveAnsweringKeys } from "@/lib/query/answering";
 import { visibleGroupIds } from "@/lib/graph/group";
 import { getArcs } from "@/lib/graph/arcs";
+import { getLlmHealth } from "@/lib/query/llm-health";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -44,5 +45,10 @@ export async function POST(req: NextRequest) {
   const keys = await resolveAnsweringKeys(admin, team.id);
   const arcs = await getArcs(admin, team.id, teamSlug, tier, visibleGroupIds(teamSlug, tier), keys);
 
-  return Response.json({ arcs, as_of: new Date().toISOString() });
+  // Empty arcs are ambiguous: a genuinely quiet week vs. a broken answering model. When there are
+  // none AND the LLM leg is degraded, tell the client so the panel shows "the model is failing"
+  // instead of a benign "no arcs yet" — the silent-blank case that started all this.
+  const degraded = arcs.length === 0 ? (await getLlmHealth(team.id)).state === "degraded" : false;
+
+  return Response.json({ arcs, degraded, as_of: new Date().toISOString() });
 }

--- a/app/t/[team]/social/page.tsx
+++ b/app/t/[team]/social/page.tsx
@@ -6,6 +6,7 @@ import { listOpportunities } from "@/lib/social/store";
 import { listTeamMediaMeta } from "@/lib/media/store";
 import { imageBudget } from "@/lib/media/generate-image";
 import { getAutonomy, getPublishDryRun } from "@/lib/social/settings";
+import { getSocialJobsHealth } from "@/lib/jobs/store";
 import { listPendingApprovals } from "@/lib/social/approvals";
 import { listPublications } from "@/lib/social/publications";
 import { listTeamAnalytics, teamAnalyticsSummary } from "@/lib/social/analytics";
@@ -65,6 +66,7 @@ export default async function SocialPage({ params }: { params: Promise<{ team: s
   for (const m of media) (mediaByVariant[m.variant_id] ??= []).push(m.id);
   const budget = await imageBudget(db, team.id);
 
+  const jobsHealth = await getSocialJobsHealth(db, team.id);
   const autonomy = await getAutonomy(db, team.id);
   const pendingRows = await listPendingApprovals(db, team.id);
   const variantCtx: Record<string, { platform: string; body: string; oppTitle: string }> = {};
@@ -121,6 +123,17 @@ export default async function SocialPage({ params }: { params: Promise<{ team: s
           Brand settings
         </Link>
       </div>
+
+      {jobsHealth.dead > 0 ? (
+        <p className="rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
+          <strong>
+            {jobsHealth.dead} background job{jobsHealth.dead === 1 ? "" : "s"} failed permanently
+          </strong>{" "}
+          (dead-lettered after retries) — image generation, publishing, or analytics may not be
+          running.
+          {jobsHealth.lastDeadError ? ` Most recent error: ${jobsHealth.lastDeadError}` : ""}
+        </p>
+      ) : null}
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
         <Kpi label="Opportunities" value={opportunities.length} />

--- a/components/learning/arcs-panel.tsx
+++ b/components/learning/arcs-panel.tsx
@@ -34,6 +34,7 @@ type Status = "loading" | "ready" | "error";
 export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
   const [arcs, setArcs] = useState<Arc[]>([]);
   const [status, setStatus] = useState<Status>("loading");
+  const [degraded, setDegraded] = useState(false); // empty because the answering model is failing
   const [edited, setEdited] = useState<Record<string, string>>({}); // arc_id → corrected text
   const [editing, setEditing] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
@@ -49,9 +50,10 @@ export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
           body: JSON.stringify({ team: teamSlug }),
         });
         if (!res.ok) throw new Error();
-        const data = (await res.json()) as { arcs?: Arc[] };
+        const data = (await res.json()) as { arcs?: Arc[]; degraded?: boolean };
         if (alive) {
           setArcs(data.arcs ?? []);
+          setDegraded(!!data.degraded);
           setStatus("ready");
         }
       } catch {
@@ -101,6 +103,18 @@ export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
       <p className="rounded-lg border border-border-subtle px-4 py-3 text-sm text-ink-tertiary">
         Couldn&apos;t synthesize arcs right now.
       </p>
+    );
+  }
+  if (arcs.length === 0 && degraded) {
+    // Empty because the answering model is failing (not a quiet week) — say so and point to the fix,
+    // instead of the benign "no arcs yet" that made a broken model look like normal emptiness.
+    return (
+      <div className="rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-600 dark:text-red-300">
+        Arcs can&apos;t be generated right now — the answering model is failing to produce output. An
+        admin can check <span className="font-medium">Admin → Integrations → Retrieval health</span> and
+        the <span className="font-medium">Active answering model</span> (a reasoning model can starve
+        its own answer; try a non-reasoning one).
+      </div>
     );
   }
   if (arcs.length === 0) {

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -209,14 +209,35 @@ export function startIngestScheduler(): void {
     try {
       const { backfillMeetingNotesFromItems } = await import("@/lib/meetings/from-items");
       const { resolveAnsweringKeys } = await import("@/lib/query/answering");
+      const { recordIngestRun } = await import("@/lib/ingest/runs");
       const { data: teams } = await db.from("teams").select("id");
       for (const t of ((teams ?? []) as { id: string }[])) {
+        const startedAt = Date.now();
         try {
           const keys = await resolveAnsweringKeys(db, t.id);
           const s = await backfillMeetingNotesFromItems(db, t.id, { keys });
           if (s.created) console.info(`[ingest] meeting-notes: created ${s.created} for team ${t.id}`);
+          // Record the run so this LLM-driven leg is diagnosable on the dashboard like its siblings —
+          // it was the one scheduler loop with no durable trace (a broken model silently made no notes).
+          await recordIngestRun(db, {
+            teamId: t.id,
+            source: "meeting_notes",
+            trigger: "scheduler",
+            ok: true,
+            created: s.created ?? 0,
+            meta: { scanned: s.scanned ?? 0 },
+            startedAt,
+          });
         } catch (err) {
           console.error(`[ingest] meeting-notes backfill (team ${t.id}) failed:`, err instanceof Error ? err.message : err);
+          await recordIngestRun(db, {
+            teamId: t.id,
+            source: "meeting_notes",
+            trigger: "scheduler",
+            ok: false,
+            errors: [err instanceof Error ? err.message : String(err)],
+            startedAt,
+          });
         }
       }
     } catch (err) {

--- a/lib/jobs/store.ts
+++ b/lib/jobs/store.ts
@@ -17,6 +17,34 @@ import { nextRunAfter } from "./backoff";
 const COLS =
   "id, team_id, kind, payload, status, attempts, max_attempts, run_after, locked_at, last_error, dedup_key, created_at, updated_at";
 
+export interface SocialJobsHealth {
+  dead: number; // jobs that exhausted max_attempts and gave up (permanently failed)
+  queued: number; // jobs waiting to run
+  lastDeadError: string | null; // the most recent dead job's error, for an actionable banner
+}
+
+/**
+ * Dead-letter / queue health for the Social admin surface. `social_jobs` already persists a `dead`
+ * status + `last_error`, but nothing read it — a fully dead queue (images never generate, nothing
+ * publishes) was invisible. Best-effort: zeros on any error so it never breaks the page render.
+ */
+export async function getSocialJobsHealth(db: DbClient, teamId: string): Promise<SocialJobsHealth> {
+  try {
+    const { data } = await db
+      .from("social_jobs")
+      .select("status, last_error, updated_at")
+      .eq("team_id", teamId)
+      .in("status", ["dead", "queued"]);
+    const rows = (data ?? []) as { status: string; last_error: string | null; updated_at: string }[];
+    const dead = rows.filter((r) => r.status === "dead");
+    const lastDeadError =
+      [...dead].sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1))[0]?.last_error ?? null;
+    return { dead: dead.length, queued: rows.filter((r) => r.status === "queued").length, lastDeadError };
+  } catch {
+    return { dead: 0, queued: 0, lastDeadError: null };
+  }
+}
+
 /**
  * Enqueue a job. Idempotent when `dedupKey` is set: a second enqueue for the same (team, key)
  * returns the existing job instead of creating a duplicate (the partial unique index is the

--- a/lib/pm-sync/after-write.ts
+++ b/lib/pm-sync/after-write.ts
@@ -94,7 +94,18 @@ export async function projectChangedTasksAfterWrite(
     // changed-rows tail) that the "task edit doesn't appear in Linear" gap was about.
     await recordProjectionRun(db, { teamId, provider: primary.provider, trigger: "api", reports, startedAt });
     return reports;
-  } catch {
+  } catch (err) {
+    // A throw BEFORE recordProjectionRun (e.g. resolvePrimaryProvider / the tasks select) would
+    // otherwise make a failed projection invisible. Record it so "the edit never reached Linear/Plane"
+    // is diagnosable on the PM-sync health card instead of a silent empty return.
+    await recordProjectionRun(db, {
+      teamId,
+      provider: null,
+      trigger: "api",
+      reports: [],
+      reason: err instanceof Error ? err.message : String(err),
+      startedAt,
+    });
     return [];
   }
 }

--- a/test/datamechanics/social-jobs-health.datamechanics.test.ts
+++ b/test/datamechanics/social-jobs-health.datamechanics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { db, seedTeam } from "./helpers";
+import { getSocialJobsHealth } from "@/lib/jobs/store";
+
+// Spec (dead-letter visibility): social_jobs already persists a 'dead' status + last_error when a job
+// exhausts its retries, but nothing read it — a fully dead queue (images never generate, nothing
+// publishes) was invisible. getSocialJobsHealth surfaces the dead + queued counts for a dashboard banner.
+
+async function insertJob(teamId: string, status: string, lastError?: string, updatedAt?: string) {
+  const { error } = await db()
+    .from("social_jobs")
+    .insert({
+      team_id: teamId,
+      kind: "publish",
+      status,
+      last_error: lastError ?? null,
+      updated_at: updatedAt ?? new Date().toISOString(),
+    });
+  if (error) throw new Error(`insert job: ${error.message}`);
+}
+
+describe("social jobs dead-letter health (data-mechanics)", () => {
+  it("counts dead + queued jobs and surfaces the most recent dead error", async () => {
+    const seed = await seedTeam();
+    await insertJob(seed.teamId, "dead", "publish failed: 401", "2026-07-16T00:00:00Z");
+    await insertJob(seed.teamId, "dead", "render timed out", "2026-07-16T01:00:00Z"); // newer
+    await insertJob(seed.teamId, "queued");
+    await insertJob(seed.teamId, "done"); // ignored
+
+    const h = await getSocialJobsHealth(db(), seed.teamId);
+    expect(h.dead).toBe(2);
+    expect(h.queued).toBe(1);
+    expect(h.lastDeadError).toBe("render timed out"); // most recent by updated_at
+  });
+
+  it("reports zeros for a healthy/empty queue", async () => {
+    const seed = await seedTeam();
+    const h = await getSocialJobsHealth(db(), seed.teamId);
+    expect(h).toEqual({ dead: 0, queued: 0, lastDeadError: null });
+  });
+
+  it("is team-scoped — another team's dead jobs don't count", async () => {
+    const mine = await seedTeam();
+    const other = await seedTeam();
+    await insertJob(other.teamId, "dead", "boom");
+    expect((await getSocialJobsHealth(db(), mine.teamId)).dead).toBe(0);
+  });
+});


### PR DESCRIPTION
Follows the LLM-health leg (#285) with the next tier of silent-failure sites from the error-surfacing audit. Each was a place where something breaks but the dashboard showed nothing.

## 2 · Meeting-notes backfill has no durable trace
`lib/ingest/scheduler.ts` — the one scheduler loop that only `console.error`'d. Now records an `ingest_runs` row per team per tick (`source: "meeting_notes"`), so a broken model silently creating no notes shows in the **Recent ingestion runs** table like every other leg.

## 3 · Social dead-letter was stored but never read
`social_jobs` already persists `status='dead'` + `last_error`, but nothing surfaced it — a fully dead queue (images never generate, nothing publishes) was invisible. New **`getSocialJobsHealth`** counts dead/queued; the **Social Brain page** shows a red banner (*"N background jobs failed permanently…"* + the latest error) when there are dead jobs.

## 4 · PM after-write could fail invisibly
`lib/pm-sync/after-write.ts` — a throw **before** `recordProjectionRun` (e.g. `resolvePrimaryProvider` / the tasks select) made a failed task→Linear/Plane projection invisible. The batch catch now records a failed run (reason attached) → visible on the PM-sync health card.

## 5 · "Empty arcs" looked the same whether broken or quiet
The arcs route now returns **`degraded: true`** when arcs are empty **and** the LLM leg is degraded, and the Learning arcs panel shows an actionable *"the answering model is failing — check Admin → Integrations / Active answering model"* instead of the benign *"no arcs yet."* Closes the exact silent-blank that started this.

## Verified
- Unit (797) + a new real-Postgres data-mechanics spec for the dead-letter reader (counts dead/queued, newest error by `updated_at`, team-scoped) + tsc + lint + docs-drift.

## Test plan
- [x] Unit + data-mechanics + tsc + lint + docs
- [ ] CI green → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)