### PR TITLE
feat(llm): two configurable models — query model + distinct reasoning model, routed per task

### DIFF
--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -399,6 +399,37 @@ export async function setAnsweringProvider(
   return { ok: true };
 }
 
+/**
+ * Set (or clear) the team's distinct REASONING model (`teams.reasoning_model`) — the model used for
+ * reasoning-heavy tasks (narrative arc synthesis) on whatever provider answers. Empty string clears
+ * it → reasoning tasks reuse the query model. Admins only; audited.
+ */
+export async function setReasoningModel(
+  teamSlug: string,
+  model: string
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireAdmin(teamSlug);
+  if (!ctx) return { ok: false, error: "admins only" };
+  const trimmed = model.trim().slice(0, 200);
+  const db = adminClient();
+  const { error } = await db
+    .from("teams")
+    .update({ reasoning_model: trimmed || null })
+    .eq("id", ctx.teamId);
+  if (error) return { ok: false, error: error.message };
+  await audit(db, {
+    team_id: ctx.teamId,
+    actor_kind: "member",
+    member_id: ctx.memberId,
+    action: "team.reasoning_model_set",
+    target_type: "team",
+    target_id: ctx.teamId,
+    meta: { model: trimmed || null },
+  });
+  revalidatePath(`/t/${teamSlug}/admin/integrations`);
+  return { ok: true };
+}
+
 export async function removeIntegration(
   teamSlug: string,
   id: string

--- a/app/t/[team]/admin/integrations/page.tsx
+++ b/app/t/[team]/admin/integrations/page.tsx
@@ -33,7 +33,7 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
   const user = await getSessionUser();
   const { data: team } = await sessionDb
     .from("teams")
-    .select("id, primary_pm_provider, answering_provider")
+    .select("id, primary_pm_provider, answering_provider, reasoning_model")
     .eq("slug", teamSlug)
     .maybeSingle();
   if (!team) return null;
@@ -136,6 +136,7 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
           localConfigured,
           openrouterConfigured: hasKey("openrouter"),
           openaiConfigured: hasKey("openai"),
+          reasoningModel: (team.reasoning_model as string | null) ?? null,
         }}
       />
       <MemberOnboardingPanel teamSlug={teamSlug} values={onboardingValues} />

--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -16,6 +16,7 @@ import {
   setPrimaryPmProvider,
   saveProviderModel,
   setAnsweringProvider,
+  setReasoningModel,
   type PrimaryPmProvider,
 } from "@/app/t/[team]/admin/integrations/actions";
 import type { AnsweringProvider } from "@/lib/query/llm-backend";
@@ -34,6 +35,8 @@ export interface AnsweringState {
   localConfigured: boolean;
   openrouterConfigured: boolean;
   openaiConfigured: boolean;
+  /** The team's distinct reasoning-model slug (teams.reasoning_model), or null to reuse the query model. */
+  reasoningModel: string | null;
 }
 
 const PROVIDER_LABEL: Record<AnsweringProvider, string> = {
@@ -210,6 +213,12 @@ export function IntegrationsManager({
     run(() => saveProviderModel(teamSlug, p, modelDraft[p].trim()));
   }
 
+  // Distinct reasoning model (teams.reasoning_model) — used for reasoning-heavy tasks (arc synthesis).
+  const [reasoningDraft, setReasoningDraft] = useState(answering.reasoningModel ?? "");
+  function saveReasoning() {
+    run(() => setReasoningModel(teamSlug, reasoningDraft.trim()));
+  }
+
   function chooseBackend(p: AnsweringProvider | null) {
     run(() => setAnsweringProvider(teamSlug, p));
   }
@@ -282,6 +291,33 @@ export function IntegrationsManager({
             below (or in the OpenRouter panel) to activate it.
           </p>
         ) : null}
+
+        <div className="mt-1 flex flex-col gap-1.5 border-t border-border-subtle pt-3">
+          <p className="text-xs font-medium text-ink">Reasoning model (optional)</p>
+          <p className="text-xs text-ink-secondary">
+            A distinct model for reasoning-heavy tasks (narrative arc synthesis), on the same provider.
+            Leave blank to reuse the answering model above. Extraction tasks (summaries, action items,
+            drafts) always use the answering model with reasoning off, so a reasoning model here can
+            improve arcs without blanking the rest.
+          </p>
+          <div className="flex items-center gap-2">
+            <input
+              value={reasoningDraft}
+              onChange={(e) => setReasoningDraft(e.target.value)}
+              placeholder="e.g. qwen/qwen3.7-plus (blank = same as answering model)"
+              disabled={pending}
+              className="min-w-0 flex-1 rounded-md border border-ink/15 bg-transparent px-2.5 py-1.5 font-mono text-xs text-ink outline-none focus:border-ink/30 disabled:opacity-50"
+            />
+            <button
+              type="button"
+              onClick={saveReasoning}
+              disabled={pending || reasoningDraft.trim() === (answering.reasoningModel ?? "")}
+              className="btn-prism shrink-0 text-xs disabled:opacity-50"
+            >
+              Save
+            </button>
+          </div>
+        </div>
       </div>
 
       <div className="prism-card flex flex-col gap-3 p-4">

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -196,7 +196,11 @@ async function callLLMRaw(
     {
       keys,
       jsonObject: true,
-      maxTokens: 2048,
+      // Arc synthesis reasons over ~200 facts to find storylines — the one task that genuinely
+      // benefits from a reasoning model. Route it to the team's reasoning model (falls back to the
+      // query model when unset), with reasoning left ON and extra headroom for it.
+      role: "reasoning",
+      maxTokens: 4096,
       // Record the outcome so a broken answering model (e.g. a reasoning model returning empty) shows
       // as "degraded" on the dashboard instead of silently blanking the Learning page.
       record: record ? { db: record.db, teamId: record.teamId, task: "arcs" } : undefined,

--- a/lib/llm/complete.ts
+++ b/lib/llm/complete.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
-import { selectLlmBackend, type LlmBackendKeys } from "@/lib/query/llm-backend";
+import { selectLlmBackend, type LlmBackendKeys, type LlmRole } from "@/lib/query/llm-backend";
 import { recordIngestRun } from "@/lib/ingest/runs";
 import type { DbClient } from "@/lib/db/types";
 
@@ -44,6 +44,13 @@ export interface CompleteOptions {
   /** Ask for strict JSON: sets `response_format` on OpenAI-compatible + nudges every provider. */
   jsonObject?: boolean;
   /**
+   * Which team model to use. `"query"` (default) = the direct/extraction model, with reasoning turned
+   * OFF on OpenRouter (extraction doesn't need chain-of-thought and a reasoning model would starve
+   * the answer). `"reasoning"` = the team's distinct reasoning model (`teams.reasoning_model`) with
+   * reasoning left ON — for genuinely reasoning-heavy tasks like narrative arc synthesis.
+   */
+  role?: LlmRole;
+  /**
    * Durably record this call's outcome (ok/fail + model) to `ingest_runs` (source `llm`), so the
    * answering-model health leg on the dashboard can show when the model is failing (empty output /
    * transport / auth) instead of the failure being an invisible `null`. Opt-in per caller (needs a
@@ -74,7 +81,7 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
   const keys = opts.keys ?? {};
   const maxTokens = opts.maxTokens ?? 1024;
   const timeoutMs = opts.timeoutMs ?? 30_000;
-  const backend = selectLlmBackend({ LLM_BASE_URL, LLM_MODEL }, keys);
+  const backend = selectLlmBackend({ LLM_BASE_URL, LLM_MODEL }, keys, { role: opts.role });
   const startedAt = Date.now();
 
   // For JSON mode, nudge every provider (OpenAI's json_object mode also requires "json" in the
@@ -97,13 +104,14 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
           // Answer budget + reasoning headroom (see REASONING_HEADROOM_TOKENS) so a reasoning model's
           // hidden tokens don't starve the answer to empty.
           max_tokens: maxTokens + REASONING_HEADROOM_TOKENS,
-          // These are structured extraction/short-generation tasks (arcs, summaries, social, titles) —
-          // NOT chain-of-thought. On OpenRouter, turn reasoning OFF so a reasoning model (e.g.
-          // qwen/qwen3.7-plus) can't spend the whole budget on hidden thinking and return empty content
-          // (what blanked the Learning page). Headroom stays as a belt-and-suspenders. The streaming
-          // Query path (lib/query/claude.ts) is separate and can still reason. Ignored by non-reasoning
-          // models. Override with LLM_DISABLE_REASONING=0.
-          ...(backend.kind === "openrouter" && process.env.LLM_DISABLE_REASONING !== "0"
+          // For the QUERY role (the default — extraction/short generation), turn reasoning OFF on
+          // OpenRouter so a reasoning model can't spend the whole budget on hidden thinking and return
+          // empty content (what blanked the Learning page). The REASONING role deliberately leaves it
+          // ON — that's the point of the separate reasoning model (e.g. arc synthesis). Ignored by
+          // non-reasoning models. Override with LLM_DISABLE_REASONING=0.
+          ...(backend.kind === "openrouter" &&
+          opts.role !== "reasoning" &&
+          process.env.LLM_DISABLE_REASONING !== "0"
             ? { reasoning: { enabled: false } }
             : {}),
           ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),

--- a/lib/query/answering.ts
+++ b/lib/query/answering.ts
@@ -25,9 +25,9 @@ export async function resolveAnsweringKeys(db: DbClient, teamId: string): Promis
     getProviderSettings(db, teamId, "anthropic"),
     getProviderSettings(db, teamId, "openai"),
     getProviderSettings(db, teamId, "openrouter"),
-    db.from("teams").select("answering_provider").eq("id", teamId).maybeSingle(),
+    db.from("teams").select("answering_provider, reasoning_model").eq("id", teamId).maybeSingle(),
   ]);
-  const teamRow = teamRes.data as { answering_provider: string | null } | null;
+  const teamRow = teamRes.data as { answering_provider: string | null; reasoning_model: string | null } | null;
   return {
     anthropicKey: anthropic.key,
     anthropicModel: anthropic.model,
@@ -36,5 +36,6 @@ export async function resolveAnsweringKeys(db: DbClient, teamId: string): Promis
     openrouterKey: openrouter.key,
     openrouterModel: openrouter.model,
     activeProvider: normalizeAnsweringProvider(teamRow?.answering_provider),
+    reasoningModel: teamRow?.reasoning_model ?? null,
   };
 }

--- a/lib/query/llm-backend.ts
+++ b/lib/query/llm-backend.ts
@@ -46,7 +46,16 @@ export interface LlmBackendKeys {
   openrouterModel?: string | null;
   /** Explicit override (`teams.answering_provider`); null/undefined = auto precedence. */
   activeProvider?: AnsweringProvider | null;
+  /**
+   * Optional distinct model for reasoning-heavy tasks (`teams.reasoning_model`). When set, a
+   * `role: "reasoning"` selection uses it (on whatever provider answers) instead of the query model.
+   * Null/undefined → reasoning tasks reuse the query model.
+   */
+  reasoningModel?: string | null;
 }
+
+/** Which model to select: the default interactive/extraction model, or the reasoning model. */
+export type LlmRole = "query" | "reasoning";
 
 export type LlmBackend =
   | { kind: "openrouter"; provider: "openrouter"; baseUrl: string; model: string; apiKey: string; headers: Record<string, string> }
@@ -113,16 +122,23 @@ function candidate(
  * auto precedence (OpenRouter → LLM_BASE_URL → Anthropic). `anthropic` is always available, so
  * auto never returns null.
  */
-export function selectLlmBackend(env: LlmBackendEnv, keys: LlmBackendKeys): LlmBackend {
-  if (keys.activeProvider) {
-    const forced = candidate(keys.activeProvider, env, keys);
-    if (forced) return forced;
-  }
-  return (
+export function selectLlmBackend(
+  env: LlmBackendEnv,
+  keys: LlmBackendKeys,
+  opts?: { role?: LlmRole }
+): LlmBackend {
+  const backend =
+    (keys.activeProvider ? candidate(keys.activeProvider, env, keys) : null) ??
     candidate("openrouter", env, keys) ??
     candidate("local", env, keys) ??
-    candidate("anthropic", env, keys)!
-  );
+    candidate("anthropic", env, keys)!;
+
+  // For a reasoning-role task, swap in the team's distinct reasoning model (on whatever provider
+  // answers). Unset → the query model already on `backend` stands, so reasoning falls back cleanly.
+  if (opts?.role === "reasoning" && nonEmpty(keys.reasoningModel)) {
+    return { ...backend, model: keys.reasoningModel.trim() };
+  }
+  return backend;
 }
 
 /**

--- a/postgres/migrations/20260716130000_teams_reasoning_model.sql
+++ b/postgres/migrations/20260716130000_teams_reasoning_model.sql
@@ -1,0 +1,4 @@
+-- Two-model config: a team can set a distinct REASONING model (used for reasoning-heavy tasks like
+-- narrative arc synthesis) alongside the default "query" model (the per-provider config.model / the
+-- Active answering model). Nullable — when unset, reasoning-role tasks fall back to the query model.
+alter table teams add column if not exists reasoning_model text;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -111,11 +111,15 @@ create table if not exists teams (
   -- Explicit answering-backend override for the Query box. Null = auto precedence
   -- (OpenRouter → LLM_BASE_URL → Anthropic); otherwise force that backend (lib/query/llm-backend).
   answering_provider text check (answering_provider in ('anthropic', 'openai', 'openrouter', 'local')),
+  -- Optional distinct model for reasoning-heavy tasks (narrative arc synthesis). Null = reuse the
+  -- query model (the active provider's config.model). See lib/query/llm-backend (role="reasoning").
+  reasoning_model text,
   created_at timestamptz not null default now()
 );
 -- Additive columns for existing deployments.
 alter table teams add column if not exists primary_pm_provider text;
 alter table teams add column if not exists answering_provider text;
+alter table teams add column if not exists reasoning_model text;
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'teams_primary_pm_provider_check') then
     alter table teams add constraint teams_primary_pm_provider_check check (primary_pm_provider in ('plane', 'linear'));

--- a/test/datamechanics/reasoning-model.datamechanics.test.ts
+++ b/test/datamechanics/reasoning-model.datamechanics.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { db, seedTeam } from "./helpers";
+import { resolveAnsweringKeys } from "@/lib/query/answering";
+import { selectLlmBackend } from "@/lib/query/llm-backend";
+
+// Spec (two-model config, real Postgres): a team's reasoning_model round-trips through
+// resolveAnsweringKeys and drives selectLlmBackend's reasoning-role model — so arc synthesis uses it
+// while the query role keeps the answering model.
+
+describe("reasoning model config (data-mechanics)", () => {
+  it("null by default; reasoning role falls back to the query model", async () => {
+    const seed = await seedTeam();
+    const keys = await resolveAnsweringKeys(db(), seed.teamId);
+    expect(keys.reasoningModel).toBeNull();
+    // With an OpenRouter key + model, reasoning role reuses the query model when none is set.
+    const withOr = { ...keys, openrouterKey: "or", openrouterModel: "openai/gpt-4o-mini", activeProvider: "openrouter" as const };
+    expect(selectLlmBackend({}, withOr, { role: "reasoning" }).model).toBe("openai/gpt-4o-mini");
+  });
+
+  it("a saved reasoning_model round-trips and drives the reasoning-role model", async () => {
+    const seed = await seedTeam();
+    await db().from("teams").update({ reasoning_model: "qwen/qwen3.7-plus" }).eq("id", seed.teamId);
+
+    const keys = await resolveAnsweringKeys(db(), seed.teamId);
+    expect(keys.reasoningModel).toBe("qwen/qwen3.7-plus");
+
+    const withOr = { ...keys, openrouterKey: "or", openrouterModel: "openai/gpt-4o-mini", activeProvider: "openrouter" as const };
+    expect(selectLlmBackend({}, withOr, { role: "query" }).model).toBe("openai/gpt-4o-mini"); // extraction
+    expect(selectLlmBackend({}, withOr, { role: "reasoning" }).model).toBe("qwen/qwen3.7-plus"); // arcs
+  });
+});

--- a/test/llm-backend-role.test.ts
+++ b/test/llm-backend-role.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { selectLlmBackend } from "@/lib/query/llm-backend";
+
+// Spec (two-model config): a team can set a distinct reasoning model. `role: "reasoning"` selects it
+// (on whatever provider answers); unset or `role: "query"` uses the query model. This is what lets
+// arc synthesis use a reasoning model while extraction stays on a fast, direct one.
+
+const OR = {
+  openrouterKey: "or",
+  openrouterModel: "openai/gpt-4o-mini",
+  activeProvider: "openrouter" as const,
+};
+
+describe("selectLlmBackend role → model", () => {
+  it("query role (default) uses the query model", () => {
+    expect(selectLlmBackend({}, OR).model).toBe("openai/gpt-4o-mini");
+    expect(selectLlmBackend({}, OR, { role: "query" }).model).toBe("openai/gpt-4o-mini");
+  });
+
+  it("reasoning role uses the reasoning model when set", () => {
+    const b = selectLlmBackend({}, { ...OR, reasoningModel: "qwen/qwen3.7-plus" }, { role: "reasoning" });
+    expect(b.provider).toBe("openrouter"); // same provider
+    expect(b.model).toBe("qwen/qwen3.7-plus");
+  });
+
+  it("reasoning role falls back to the query model when no reasoning model is set", () => {
+    expect(selectLlmBackend({}, OR, { role: "reasoning" }).model).toBe("openai/gpt-4o-mini");
+  });
+
+  it("the reasoning model applies on whatever provider answers (here Anthropic auto-fallback)", () => {
+    // No provider configured → auto lands on anthropic; reasoning role still swaps the model.
+    const b = selectLlmBackend({}, { reasoningModel: "claude-sonnet-5" }, { role: "reasoning" });
+    expect(b.kind).toBe("anthropic");
+    expect(b.model).toBe("claude-sonnet-5");
+  });
+});

--- a/test/llm-complete-reasoning.test.ts
+++ b/test/llm-complete-reasoning.test.ts
@@ -42,4 +42,23 @@ describe("completeText reasoning control", () => {
     const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body));
     expect(body.reasoning).toBeUndefined();
   });
+
+  it("the reasoning role leaves reasoning ON and uses the reasoning model", async () => {
+    const fetchMock = mock('{"arcs":[]}');
+    await completeText(
+      { system: "s", prompt: "p" },
+      {
+        role: "reasoning",
+        keys: {
+          openrouterKey: "or",
+          openrouterModel: "openai/gpt-4o-mini",
+          reasoningModel: "qwen/qwen3.7-plus",
+          activeProvider: "openrouter",
+        },
+      }
+    );
+    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body));
+    expect(body.reasoning).toBeUndefined(); // NOT disabled — reasoning is the point of this role
+    expect(body.model).toBe("qwen/qwen3.7-plus"); // the reasoning model, not the query model
+  });
 });


### PR DESCRIPTION
Implements the two-model setup you asked for. Instead of one answering model (where a reasoning model blanked extraction) or globally disabling reasoning, you now set **two models** and each LLM task uses the right one.

## Admin → Integrations → Active answering model
- **Query model** (the existing answering model) — powers the **Query box** and all **direct extraction/generation**: meeting summaries, action items, social drafts, chat titles. Reasoning stays **off** on OpenRouter so a reasoning model can't starve these to empty.
- **Reasoning model** (new, optional — `teams.reasoning_model`) — powers **reasoning-heavy tasks**: **narrative arc synthesis**, with reasoning left **on**. Blank → reuses the query model.

So you can run a reasoning model for arcs (where it genuinely helps, reasoning over ~200 facts) while extraction stays fast + direct.

## Mapping (as approved)
| Task | Model |
|---|---|
| Query box, chat titles | Query model |
| Meeting summaries / action items / merge | Query model |
| Social drafts | Query model |
| **Narrative arc synthesis** | **Reasoning model** (falls back to query) |

Each is a one-line `role` tag — trivial to move any task.

## How it works
- `teams.reasoning_model` column (migration + schema; **applies from zero** — verified).
- `resolveAnsweringKeys` returns `reasoningModel`; `selectLlmBackend(env, keys, { role })` swaps the model for the reasoning role **on whatever provider answers**.
- `completeText` gains `role` ("query" default | "reasoning"); reasoning role keeps reasoning ON.
- Arc synthesis opts into `role: "reasoning"`.
- Admin UI reasoning-model input + audited `setReasoningModel` action.

## Verified
- Unit (802) incl. new `selectLlmBackend`-role specs + "reasoning role keeps reasoning on & uses the reasoning model."
- Real-Postgres **data-mechanics round-trip**: `reasoning_model` → `resolveAnsweringKeys` → `selectLlmBackend` (query → answering model, reasoning → reasoning model).
- Migration replay from zero; tsc / lint / docs-drift clean.
- Browser-confirmed the **Reasoning model** input renders on the panel. (The save action is a thin audited `teams` update mirroring the working `setAnsweringProvider`; the browser click for saving timed out on the server-action transition, so I proved the read/routing path via data-mechanics instead — happy to click-verify on the deploy.)

## Test plan
- [x] Unit + data-mechanics + migration-from-zero + tsc + lint + docs
- [ ] CI green → merge → set a reasoning model in Admin and confirm arcs populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional team-level reasoning model setting in Integrations administration.
  * Reasoning tasks can now use a dedicated model while standard queries retain the default model.
  * Reasoning model settings are saved, audited, and automatically reflected in the admin interface.
  * Increased capacity for complex arc synthesis tasks.

* **Tests**
  * Added coverage for reasoning-model selection, fallback behavior, and provider-specific reasoning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->