### PR TITLE
fix(learning): diagnose why arcs are empty + give the reasoning model time

### DIFF
--- a/app/api/brain/arcs/route.ts
+++ b/app/api/brain/arcs/route.ts
@@ -8,9 +8,15 @@ import { resolveAnsweringKeys } from "@/lib/query/answering";
 import { visibleGroupIds } from "@/lib/graph/group";
 import { getArcs } from "@/lib/graph/arcs";
 import { getLlmHealth } from "@/lib/query/llm-health";
+import { graphHasFacts } from "@/lib/query/retrieval-health";
 
 export const runtime = "nodejs";
-export const maxDuration = 60;
+// Arc synthesis with a reasoning model can be slow (it reasons over ~200 facts). Give the inline
+// cold-compute path headroom; the SWR background refresh isn't bound by this anyway.
+export const maxDuration = 120;
+
+/** Why the arc panel is empty — so the UI shows the actual cause instead of a benign "no arcs yet". */
+type EmptyReason = "no_facts" | "model_failing" | "synthesis_empty" | null;
 
 const schema = z.object({ team: z.string().min(1).max(120) });
 
@@ -45,10 +51,35 @@ export async function POST(req: NextRequest) {
   const keys = await resolveAnsweringKeys(admin, team.id);
   const arcs = await getArcs(admin, team.id, teamSlug, tier, visibleGroupIds(teamSlug, tier), keys);
 
-  // Empty arcs are ambiguous: a genuinely quiet week vs. a broken answering model. When there are
-  // none AND the LLM leg is degraded, tell the client so the panel shows "the model is failing"
-  // instead of a benign "no arcs yet" — the silent-blank case that started all this.
-  const degraded = arcs.length === 0 ? (await getLlmHealth(team.id)).state === "degraded" : false;
+  // Empty arcs are ambiguous — tell the client the ACTUAL cause so the panel stops showing a benign
+  // "no arcs yet" for what is really a broken graph or a failing model:
+  //   • no facts in the graph        → the projector hasn't populated it (graph/projector issue)
+  //   • facts exist + LLM degraded   → the answering/reasoning model is failing (empty/timeout)
+  //   • facts exist + LLM ok         → synthesis produced nothing this time (usually transient)
+  let reason: EmptyReason = null;
+  let note: string | undefined;
+  if (arcs.length === 0) {
+    const [hasFacts, llm] = await Promise.all([graphHasFacts(team.id), getLlmHealth(team.id)]);
+    if (!hasFacts) {
+      reason = "no_facts";
+      note =
+        "The knowledge graph has no facts yet, so there's nothing to synthesize. The graph projector may not have run or is failing — an admin can check Admin → Integrations → Retrieval health (Graph memory).";
+    } else if (llm.state === "degraded") {
+      reason = "model_failing";
+      note =
+        llm.note ??
+        "The answering model recently failed to produce output — check Admin → Integrations and the Active answering model.";
+    } else {
+      reason = "synthesis_empty";
+      note = "The graph has facts but synthesis returned nothing this time — this is usually transient; try again shortly.";
+    }
+  }
 
-  return Response.json({ arcs, degraded, as_of: new Date().toISOString() });
+  return Response.json({
+    arcs,
+    degraded: reason === "model_failing", // back-compat flag
+    reason,
+    note,
+    as_of: new Date().toISOString(),
+  });
 }

--- a/components/learning/arcs-panel.tsx
+++ b/components/learning/arcs-panel.tsx
@@ -34,7 +34,9 @@ type Status = "loading" | "ready" | "error";
 export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
   const [arcs, setArcs] = useState<Arc[]>([]);
   const [status, setStatus] = useState<Status>("loading");
-  const [degraded, setDegraded] = useState(false); // empty because the answering model is failing
+  // Why the panel is empty (server-diagnosed): no_facts | model_failing | synthesis_empty | null.
+  const [emptyReason, setEmptyReason] = useState<string | null>(null);
+  const [emptyNote, setEmptyNote] = useState<string | null>(null);
   const [edited, setEdited] = useState<Record<string, string>>({}); // arc_id → corrected text
   const [editing, setEditing] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
@@ -50,10 +52,11 @@ export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
           body: JSON.stringify({ team: teamSlug }),
         });
         if (!res.ok) throw new Error();
-        const data = (await res.json()) as { arcs?: Arc[]; degraded?: boolean };
+        const data = (await res.json()) as { arcs?: Arc[]; reason?: string | null; note?: string | null };
         if (alive) {
           setArcs(data.arcs ?? []);
-          setDegraded(!!data.degraded);
+          setEmptyReason(data.reason ?? null);
+          setEmptyNote(data.note ?? null);
           setStatus("ready");
         }
       } catch {
@@ -105,24 +108,23 @@ export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
       </p>
     );
   }
-  if (arcs.length === 0 && degraded) {
-    // Empty because the answering model is failing (not a quiet week) — say so and point to the fix,
-    // instead of the benign "no arcs yet" that made a broken model look like normal emptiness.
-    return (
-      <div className="rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-600 dark:text-red-300">
-        Arcs can&apos;t be generated right now — the answering model is failing to produce output. An
-        admin can check <span className="font-medium">Admin → Integrations → Retrieval health</span> and
-        the <span className="font-medium">Active answering model</span> (a reasoning model can starve
-        its own answer; try a non-reasoning one).
-      </div>
-    );
-  }
   if (arcs.length === 0) {
+    // A real problem (no graph facts, or a failing model) is shown as an actionable red card; a
+    // transient/quiet-week empty stays a benign note. The server diagnoses which (see the arcs route).
+    const isProblem = emptyReason === "no_facts" || emptyReason === "model_failing";
+    if (isProblem && emptyNote) {
+      return (
+        <div className="rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-600 dark:text-red-300">
+          {emptyNote}
+        </div>
+      );
+    }
     return (
       <div className="prism-card flex flex-col items-center gap-2 px-4 py-8 text-center">
         <Sparkles className="size-5 text-violet" />
         <p className="max-w-sm text-sm text-ink-secondary">
-          No active narrative arcs yet — they emerge once the graph has enough team activity to synthesize.
+          {emptyNote ??
+            "No active narrative arcs yet — they emerge once the graph has enough team activity to synthesize."}
         </p>
       </div>
     );

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -201,6 +201,11 @@ async function callLLMRaw(
       // query model when unset), with reasoning left ON and extra headroom for it.
       role: "reasoning",
       maxTokens: 4096,
+      // A reasoning model reasoning over ~200 facts routinely needs far more than completeText's 30s
+      // default — at 30s the call was aborted (timeout) and arcs came back empty. 110s covers the
+      // observed latency while staying under the route's 120s maxDuration; the fire-and-forget
+      // background refresh (SWR) isn't route-bound, so it can use the full window.
+      timeoutMs: 110_000,
       // Record the outcome so a broken answering model (e.g. a reasoning model returning empty) shows
       // as "degraded" on the dashboard instead of silently blanking the Learning page.
       record: record ? { db: record.db, teamId: record.teamId, task: "arcs" } : undefined,

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -54,6 +54,21 @@ const STALE_MS = 2 * 60 * 60 * 1000; // no embed activity in 2h + incomplete = s
  */
 export const graphConfigured = graphitiConfigured;
 
+/** Whether the graph has any projected episodes for this team — the proxy for "facts exist to
+ *  synthesize arcs from." Empty ⇒ the projector never populated the graph (a graph/projector issue),
+ *  as opposed to a synthesis/model failure. Best-effort: false on any error. */
+export async function graphHasFacts(teamId: string): Promise<boolean> {
+  try {
+    const res = await runSql<{ n: number }>(
+      "select count(*)::int as n from graph_episodes where team_id = $1",
+      [teamId]
+    );
+    return (res.rows[0]?.n ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
 // Reachable but no projection in this long ⇒ the graph is going stale even though /healthcheck is
 // green. This is the 2026-07 failure a healthcheck-only probe MISSED: Graphiti's write endpoint
 // 422'd for days (projector wedged) while the service kept answering /healthcheck, so the card read

--- a/test/datamechanics/graph-has-facts.datamechanics.test.ts
+++ b/test/datamechanics/graph-has-facts.datamechanics.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db, seedTeam } from "./helpers";
+import { graphHasFacts } from "@/lib/query/retrieval-health";
+
+// Spec (arcs empty-reason diagnosis): graphHasFacts distinguishes "the graph has no facts yet"
+// (projector never populated it → the arcs panel says so) from "facts exist but synthesis failed"
+// (→ points at the model). Team-scoped.
+
+describe("graphHasFacts (data-mechanics)", () => {
+  it("false when the team has no projected episodes", async () => {
+    const seed = await seedTeam();
+    expect(await graphHasFacts(seed.teamId)).toBe(false);
+  });
+
+  it("true once at least one episode is projected; team-scoped", async () => {
+    const mine = await seedTeam();
+    const other = await seedTeam();
+    const { error } = await db().from("graph_episodes").insert({
+      team_id: mine.teamId,
+      source_table: "items",
+      source_id: randomUUID(),
+      group_id: `${mine.teamSlug}:team`,
+      content_sha256: "abc",
+    });
+    if (error) throw new Error(error.message);
+    expect(await graphHasFacts(mine.teamId)).toBe(true);
+    expect(await graphHasFacts(other.teamId)).toBe(false); // other team unaffected
+  });
+});


### PR DESCRIPTION
Learning arcs "still not working" — two real causes, both now handled, plus the panel will now **tell you which one it is**.

## Root causes
1. **The panel couldn't tell you what's wrong.** It showed a benign *"No active narrative arcs yet"* whether the graph was genuinely quiet, the **projector was wedged** (no facts), or the **model was failing**. So a real outage looked like normal emptiness. (Your screenshot showed exactly this benign state.)
2. **The reasoning model was timing out.** Arc synthesis is now routed to the reasoning model (per the two-model config), but it used `completeText`'s **30s** default. A reasoning model reasoning over ~200 facts blows past 30s → aborted (`[llm] ... aborted due to timeout`) → empty arcs.

## Fixes
- **Diagnose the empty case.** The arcs route now returns a `reason` + actionable `note`:
  - `no_facts` — the graph has no projected episodes → *"The knowledge graph has no facts yet… check Admin → Integrations → Retrieval health (Graph memory)."*
  - `model_failing` — facts exist + LLM leg degraded → points at the answering/reasoning model.
  - `synthesis_empty` — facts exist, model ok, nothing produced (transient).
  New `graphHasFacts(teamId)` (`graph_episodes` count) is the facts-exist proxy.
- **Panel renders the real cause** — a red actionable card for `no_facts`/`model_failing`, benign note otherwise.
- **Timeout 30s → 110s** for arc synthesis; route `maxDuration` 60 → 120. The SWR background refresh isn't route-bound, so it gets the full window.

## What you'll now see on prod
Your prod logs show the **Graphiti projector 422-ing** (`POST /messages`) every tick — so the graph likely has **no facts**, which is why arcs are empty (a reasoning model can't reason over an empty graph). With this change the panel will say **"the knowledge graph has no facts yet…"** and point at the Graph memory health, instead of the misleading "no arcs yet." The app already sends Graphiti's required `role: null`, so the 422 is a **Graphiti-side issue** — this surfaces it. FYI on your model config: with only a reasoning model set, extraction correctly falls back to the provider default and arcs use the reasoning model — the fallback works; the blocker was the graph + the timeout.

## Verified
- Unit (802) + new real-Postgres data-mechanics spec for `graphHasFacts` (empty→false, one episode→true, team-scoped) + tsc/lint/docs.
- Browser-confirmed the panel shows the accurate "no facts" diagnosis when the graph is empty.

## Test plan
- [x] Unit + data-mechanics + tsc + lint + docs
- [ ] CI green → merge → on prod, Learning shows the real cause (likely "no facts — check Graph memory"), and if facts exist the reasoning model has time to synthesize

🤖 Generated with [Claude Code](https://claude.com/claude-code)