### PR TITLE
fix(query): reasoning headroom for the streaming answer (stop reasoning models streaming an empty answer)

### DIFF
--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -23,6 +23,26 @@ const CACHE_READ_PER_TOKEN = 0.5 / 1_000_000;
 const LLM_BASE_URL = process.env.LLM_BASE_URL;
 const LLM_MODEL = process.env.LLM_MODEL ?? "llama3.1-8b-64k:latest";
 
+// A reasoning model spends completion tokens on HIDDEN reasoning before any answer, and `max_tokens`
+// caps reasoning+answer together — so a bare answer budget can be fully consumed by reasoning, leaving
+// an EMPTY streamed answer (the 2026-07 starvation, on the streaming Query path #285 left able to
+// reason). Add headroom on top of the answer budget: free for non-reasoning models (billed only for
+// tokens generated). Mirrors lib/llm/complete.ts's constant/env; kept local to avoid coupling this
+// streaming path to that churny module. Override with LLM_REASONING_HEADROOM_TOKENS.
+const STREAM_REASONING_HEADROOM = (() => {
+  const n = Number(process.env.LLM_REASONING_HEADROOM_TOKENS);
+  return Number.isFinite(n) && n >= 0 ? n : 6000;
+})();
+
+/** A non-OK completion whose status+body say the request exceeded the model's output/context ceiling —
+ *  i.e. the headroom pushed max_tokens past what this small model accepts. Retry once WITHOUT headroom. */
+export function looksLikeTokenLimit(status: number, body: string): boolean {
+  if (status !== 400 && status !== 422) return false;
+  return /max[_ ]?tokens|max_completion_tokens|maximum context|context length|too many tokens|reduce (?:the )?(?:length|tokens)/i.test(
+    body
+  );
+}
+
 const SYSTEM_PROMPT = `You are the Team Brain — the shared memory and coordination assistant for a team using AIOS.
 
 Rules:
@@ -278,7 +298,7 @@ export async function* streamAnswer(
  * path. Strips any `<think>…</think>` reasoning spans so the answer stays clean on reasoning models.
  * Cost is reported as $0 here (token counts are accurate); per-model OpenRouter cost is a follow-up.
  */
-async function* streamOpenAICompatible(
+export async function* streamOpenAICompatible(
   backend: Extract<LlmBackend, { kind: "openrouter" | "openai-compatible" }>,
   note: string,
   who: string,
@@ -302,27 +322,46 @@ async function* streamOpenAICompatible(
     `Question: ${question}`;
 
   const apiKey = backend.apiKey ?? process.env.OPENAI_API_KEY ?? "local";
-  const res = await fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-      ...(backend.kind === "openrouter" ? backend.headers : {}),
-    },
-    body: JSON.stringify({
-      model: backend.model,
-      max_tokens: 4096,
-      stream: true,
-      stream_options: { include_usage: true },
-      messages: [
-        { role: "system", content: SYSTEM_PROMPT },
-        { role: "user", content: userContent },
-      ],
-    }),
-  });
+  const ANSWER_BUDGET = 4096;
+  const postChat = (maxTokensToSend: number): Promise<Response> =>
+    fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        ...(backend.kind === "openrouter" ? backend.headers : {}),
+      },
+      body: JSON.stringify({
+        model: backend.model,
+        // Caller passes answer-budget + headroom on the first attempt, bare answer-budget on retry —
+        // headroom keeps a reasoning model from spending the whole budget on hidden reasoning and
+        // streaming back an empty answer.
+        max_tokens: maxTokensToSend,
+        stream: true,
+        stream_options: { include_usage: true },
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: userContent },
+        ],
+      }),
+    });
 
-  if (!res.ok || !res.body) {
-    throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+  let res = await postChat(ANSWER_BUDGET + STREAM_REASONING_HEADROOM);
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    // If headroom pushed max_tokens past this model's ceiling, retry once with just the answer budget;
+    // any other error surfaces immediately (with its own body).
+    if (looksLikeTokenLimit(res.status, body)) {
+      res = await postChat(ANSWER_BUDGET);
+      if (!res.ok) {
+        throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+      }
+    } else {
+      throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${body}`);
+    }
+  }
+  if (!res.body) {
+    throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} no stream body`);
   }
 
   const reader = res.body.getReader();
@@ -331,6 +370,7 @@ async function* streamOpenAICompatible(
   let inThink = false;
   let prompt = 0;
   let completion = 0;
+  let emittedChars = 0;
 
   while (true) {
     const { done, value } = await reader.read();
@@ -374,8 +414,21 @@ async function* streamOpenAICompatible(
           inThink = true;
         }
       }
-      if (out) yield { type: "delta", text: out };
+      if (out) {
+        emittedChars += out.length;
+        yield { type: "delta", text: out };
+      }
     }
+  }
+
+  // Zero visible answer text is a silent blank answer — make it diagnosable. Usual cause: a reasoning
+  // model spent the whole budget on hidden reasoning (raise LLM_REASONING_HEADROOM_TOKENS); a mid-stream
+  // provider error frame also lands here.
+  if (emittedChars === 0) {
+    console.error(
+      `[query] streamed answer was EMPTY (model=${backend.model}, completion_tokens=${completion}) — ` +
+        `likely a reasoning model starved by max_tokens, or a mid-stream provider error`
+    );
   }
 
   yield {

--- a/test/query-stream-headroom.test.ts
+++ b/test/query-stream-headroom.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { streamOpenAICompatible, looksLikeTokenLimit } from "@/lib/query/claude";
+import type { LlmBackend } from "@/lib/query/llm-backend";
+
+const backend = {
+  kind: "openai-compatible",
+  provider: "openai",
+  baseUrl: "https://api.example.com/v1",
+  model: "reasoning-model",
+  apiKey: "test-key",
+  headers: {},
+} as unknown as Extract<LlmBackend, { kind: "openrouter" | "openai-compatible" }>;
+
+/** A mock streamed (SSE) completion response from `frames` (each an already-formatted `data: …\n\n`). */
+function streamResponse(frames: string[], init: { ok?: boolean; status?: number } = {}): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      const enc = new TextEncoder();
+      for (const f of frames) c.enqueue(enc.encode(f));
+      c.close();
+    },
+  });
+  return { ok: init.ok ?? true, status: init.status ?? 200, body, text: async () => "" } as unknown as Response;
+}
+const delta = (s: string) => `data: ${JSON.stringify({ choices: [{ delta: { content: s } }] })}\n\n`;
+const usage = (n: number) => `data: ${JSON.stringify({ usage: { completion_tokens: n } })}\n\n`;
+
+// Derive the headroom the SAME way the module does, so the assertion holds whether or not the CI env
+// exports LLM_REASONING_HEADROOM_TOKENS (the module captures it at import; process.env is stable here).
+const HEADROOM = (() => {
+  const n = Number(process.env.LLM_REASONING_HEADROOM_TOKENS);
+  return Number.isFinite(n) && n >= 0 ? n : 6000;
+})();
+
+async function drain(gen: AsyncGenerator<{ type: string; text?: string }>): Promise<string> {
+  let out = "";
+  for await (const ev of gen) if (ev.type === "delta") out += ev.text ?? "";
+  return out;
+}
+
+describe("looksLikeTokenLimit", () => {
+  it("matches 400/422 token-ceiling errors, not other failures", () => {
+    expect(looksLikeTokenLimit(400, "max_tokens is greater than the maximum")).toBe(true);
+    expect(looksLikeTokenLimit(422, "maximum context length is 8192")).toBe(true);
+    expect(looksLikeTokenLimit(401, "invalid api key")).toBe(false);
+    expect(looksLikeTokenLimit(429, "rate limited")).toBe(false);
+  });
+});
+
+describe("streamOpenAICompatible — reasoning headroom (the streaming Query answer path)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("sends the answer budget PLUS reasoning headroom so a reasoning model isn't starved", async () => {
+    fetchMock.mockResolvedValue(streamResponse([delta("Hello"), delta(" world"), usage(3), "data: [DONE]\n\n"]));
+    const text = await drain(streamOpenAICompatible(backend, "", "", "", "", "", "q", "UTC"));
+    expect(text).toBe("Hello world");
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.max_tokens).toBe(4096 + HEADROOM); // answer budget + reasoning headroom
+    expect(body.stream).toBe(true);
+  });
+
+  it("logs when the stream yields ZERO answer text (starvation / mid-stream error), instead of a silent blank", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Usage present (model ran) but no content deltas — reasoning ate the whole budget.
+    fetchMock.mockResolvedValue(streamResponse([usage(4096), "data: [DONE]\n\n"]));
+    const text = await drain(streamOpenAICompatible(backend, "", "", "", "", "", "q", "UTC"));
+    expect(text).toBe("");
+    expect(err).toHaveBeenCalledWith(expect.stringMatching(/streamed answer was EMPTY/));
+    err.mockRestore();
+  });
+
+  it("retries WITHOUT headroom when the headroom'd request hits the model's token ceiling", async () => {
+    const ceiling = { ok: false, status: 400, text: async () => "max_tokens exceeds the model maximum", body: null } as unknown as Response;
+    fetchMock.mockResolvedValueOnce(ceiling).mockResolvedValueOnce(streamResponse([delta("ok"), "data: [DONE]\n\n"]));
+    const text = await drain(streamOpenAICompatible(backend, "", "", "", "", "", "q", "UTC"));
+    expect(text).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string).max_tokens).toBe(4096); // no headroom
+  });
+
+  it("surfaces a non-ceiling error immediately without retrying", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401, text: async () => "invalid api key", body: null } as unknown as Response);
+    await expect(drain(streamOpenAICompatible(backend, "", "", "", "", "", "q", "UTC"))).rejects.toThrow(/401/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What & why
The **streaming Query answer** — the main user-facing path — still sent a bare `max_tokens: 4096`. A reasoning model (via OpenRouter, e.g. `qwen/qwen3.7-plus`, or the team's dedicated reasoning model from #289) spends completion tokens on **hidden reasoning before any answer**, and `max_tokens` caps reasoning+answer together — so it could consume the whole budget and stream back an **empty answer, silently**.

#285 fixed the *non-streaming* extraction path by turning reasoning off, but **explicitly left the streaming answer able to reason** (correct — interactive answers should reason; the `<think>` stripper already hides the reasoning spans). So the streaming path needed the *other* lever: headroom, not disable.

## Change (surgical, single file + test)
- `streamOpenAICompatible` now sends `4096 + LLM_REASONING_HEADROOM_TOKENS` (default 6000) — free for non-reasoning models (billed only for tokens generated).
- **Ceiling retry:** on a token-limit 4xx, retry once with just the 4096 answer budget, so headroom can't hard-fail a small-ceiling model.
- **Loud on empty:** logs `[query] streamed answer was EMPTY …` when the stream yields zero answer text — a blank answer is now diagnosable instead of silent.

## Verification
5 behavioral tests over a mocked SSE stream: headroom-on-wire (first attempt) + bare-budget-on-retry, empty-stream log, ceiling retry, non-ceiling error surfaced once; test is env-robust (passes with `LLM_REASONING_HEADROOM_TOKENS` set or unset). Full unit tier **807**; `tsc`/`eslint`/docs-drift clean. The `llm-single-caller` guard still passes (claude.ts is a sanctioned transport).

## Review
Reviewed by **Fable** — verdict *sound, ship it* (no blockers/HIGHs). It verified the retry/body-read discipline, the empty-log can't false-fire, and #289-consistency (this path stays on the query model with reasoning on, so headroom is the right lever). Its LOW-3 (env-sensitive test) fixed here.

## Context / follow-ups
- This is the re-scoped survivor of #287 — the only piece #285/#289 didn't already cover. #287 is annotated "do not merge as-is."
- **Documented follow-up (Fable LOW-2):** `lib/llm/complete.ts` sends `maxTokens + 6000` with **no** ceiling retry (and a NaN-env edge) — worth lifting `looksLikeTokenLimit` + the retry into a shared helper so the non-streaming path is equally robust. Left out here to keep this surgical and avoid colliding with the parallel session's active `complete.ts` rework (#285/#289).