### PR TITLE
feat(observability): surface retrieval-augment + email-delivery on the health card (audit tail)

### DIFF
--- a/components/admin/retrieval-health-card.tsx
+++ b/components/admin/retrieval-health-card.tsx
@@ -92,6 +92,11 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
       <Leg name="Semantic" state={d.state} detail={denseDetail} />
       <Leg name="Graph memory" state={health.graph} detail={graphDetail} />
       <Leg name="Reranker" state={health.rerank} detail={health.rerank === "off" ? "not configured" : undefined} />
+      <Leg
+        name="Augment"
+        state={health.augment}
+        detail={health.augment === "off" ? "no external augment service" : undefined}
+      />
 
       {llm.state === "degraded" && llm.note ? (
         <p className="mt-2 rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
@@ -131,6 +136,13 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
         <p className="mt-2 rounded-lg border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-300">
           Some retrieval legs are off — answers rely on keyword search alone. That&apos;s fine at small
           scale but weaker for paraphrased questions across a large corpus.
+        </p>
+      ) : null}
+      {!health.emailDeliverable ? (
+        <p className="mt-2 rounded-lg border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-300">
+          No email provider is configured (<code>RESEND_API_KEY</code> / <code>SMTP_URL</code>) — member
+          invites and the degraded-stack ops alerts above can&apos;t be delivered, so a problem here
+          won&apos;t reach anyone by email. Password login still works.
         </p>
       ) : null}
     </div>

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -41,7 +41,9 @@ export interface RetrievalHealth {
   graphLastProjectedAt: string | null; // most recent successful projection (null = never)
   graphStalled: boolean; // degraded specifically because the projector stopped writing (vs unreachable)
   rerank: LegState;
+  augment: LegState; // optional external retrieval-augment service (RETRIEVAL_AUGMENT_URL)
   llm: LlmHealth; // answering-model health — did the configured model recently produce output?
+  emailDeliverable: boolean; // a provider is configured (RESEND_API_KEY/SMTP_URL) so alerts/invites can actually send
 }
 
 const COVERAGE_FLOOR = 0.9; // ≥90% embedded = healthy
@@ -124,6 +126,8 @@ export function deriveDenseState(input: {
 
 export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealth> {
   const rerank: LegState = process.env.RERANK_URL ? "on" : "off";
+  const augment: LegState = process.env.RETRIEVAL_AUGMENT_URL ? "on" : "off";
+  const emailDeliverable = !!(process.env.RESEND_API_KEY || process.env.SMTP_URL);
   const configured = !!process.env.EMBEDDINGS_URL;
 
   // Graph + dense both hit the network — run them concurrently so the card render isn't serialized.
@@ -148,7 +152,9 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
     graphLastProjectedAt: graphFresh.lastProjectedAt,
     graphStalled,
     rerank,
+    augment,
     llm,
+    emailDeliverable,
   };
 }
 


### PR DESCRIPTION
The remaining worth-doing silent-failure items from the error-surfacing audit.

## Retrieval augment
`RETRIEVAL_AUGMENT_URL` had **no health signal** — it silently degraded query quality when unset or failing. Added an **"Augment"** leg to the Retrieval health card (on/off, mirroring Reranker).

## Email delivery
Member invites **and** the degraded-stack **ops alerts** (the emails that warn admins the stack is degraded) are silently dropped when no email provider is configured — so a problem the card flags **can't actually reach anyone**. The card now warns when email is undeliverable (`RESEND_API_KEY`/`SMTP_URL` unset), noting password login still works.

## Deliberately skipped
The genuinely-low-value tail the audit itself flagged as *"arguably fine as log-only"* — PM-client JSON swallows, DB-pool `console.error`, chat-title / pg-login best-effort UX. Not worth the noise.

## Verified
- Unit (802) + tsc + lint + docs-drift.

## Test plan
- [x] Unit + tsc + lint + docs
- [ ] CI green → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)