### PR TITLE
fix(gateway): approval-expiry can't corrupt a claimed execution + gate pm-sync page (audit H1/M9)

### DIFF
--- a/app/t/[team]/admin/pm-sync/page.tsx
+++ b/app/t/[team]/admin/pm-sync/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { serverClient } from "@/lib/db/server";
 import { adminClient } from "@/lib/db/admin";
+import { requireTeamAdmin } from "@/lib/auth/guard";
 import { classifyInboundRow, loadInboundRows } from "@/lib/pm-sync/inbound";
 import { getProjectionHealth, listRecentProjectionRuns } from "@/lib/pm-sync/runs";
 import { ProjectionHealthCard } from "@/components/admin/projection-health-card";
@@ -12,6 +14,10 @@ export const metadata: Metadata = { title: "PM sync" };
 
 export default async function PmSyncPage({ params }: { params: Promise<{ team: string }> }) {
   const { team: teamSlug } = await params;
+  // Self-gate at the page (not just the admin layout): this page reads sensitive PM data via the
+  // service-role client, which has no RLS backstop. Next's layout gate isn't guaranteed to re-run on
+  // client-side partial navigation, so re-check admin here (matches the PM-sync server actions).
+  if (!(await requireTeamAdmin(teamSlug))) notFound();
   const db = await serverClient();
   const { data: team } = await db
     .from("teams")

--- a/lib/gateway/admin-persistence.ts
+++ b/lib/gateway/admin-persistence.ts
@@ -77,6 +77,11 @@ async function expireGatewayApprovals(
          from gateway_approvals a
          join gateway_executions e on e.id=a.execution_id and e.team_id=a.team_id
         where a.team_id=$1 and a.status in ('pending','approved') and a.expires_at<=now()
+          -- Only expire executions still AWAITING a decision. A claim leaves the approval row
+          -- 'approved' (claims don't retire it), so without this the sweep would flip an already
+          -- claimed/succeeded/failed execution back to 'expired' + write a false approval_expired
+          -- audit row (audit-integrity bug). Mirrors the resume path's state guard.
+          and e.state in ('approval_required','approved')
         for update of a,e
      ), approvals as (
        update gateway_approvals a
@@ -132,13 +137,14 @@ export async function decideGatewayApproval(
     const found = await client.query<{
       execution_id: string;
       status: string;
+      execution_state: string;
       expired: boolean;
       member_id: string;
       service_identity_id: string;
       subject_binding_id: string;
       connection_id: string;
     }>(
-      `select a.execution_id,a.status,(a.expires_at<=now()) expired,
+      `select a.execution_id,a.status,e.state execution_state,(a.expires_at<=now()) expired,
               e.member_id,e.service_identity_id,e.subject_binding_id,e.connection_id
          from gateway_approvals a
          join gateway_executions e on e.id=a.execution_id and e.team_id=a.team_id
@@ -148,25 +154,35 @@ export async function decideGatewayApproval(
     const row = found.rows[0];
     if (!row) throw new GatewayAdminError("gateway_not_found", 404);
     if (row.expired) {
+      // Record the approval's own expiry (it IS expired) — but only from a pre-decision state. The
+      // `gateway_approval_protect` trigger only permits pending/approved → expired, so an already
+      // denied/cancelled approval would raise a raw trigger error (500); the status guard makes that
+      // a clean no-op (the caller still gets the 410 below). Mirrors persistence.ts:637.
       await client.query(
         `update gateway_approvals set status='expired',decided_at=coalesce(decided_at,now()),
            decision_correlation_id=coalesce(decision_correlation_id,$1),updated_at=now()
-         where id=$2`,
+         where id=$2 and status in ('pending','approved')`,
         [correlationId, approvalId],
       );
-      await client.query(
-        `update gateway_executions set state='expired',updated_at=now() where id=$1`,
-        [row.execution_id],
-      );
-      await client.query(
-        `insert into gateway_audit_log(
-          team_id,member_id,service_identity_id,subject_binding_id,connection_id,
-          execution_id,approval_id,event,correlation_id
-        ) values($1,$2,$3,$4,$5,$6,$7,'approval_expired',$8)
-        on conflict do nothing`,
-        [ctx.teamId,row.member_id,row.service_identity_id,row.subject_binding_id,
-         row.connection_id,row.execution_id,approvalId,correlationId],
-      );
+      // … but only expire the EXECUTION (and write the approval_expired audit) when it's still
+      // awaiting a decision. If it was already claimed/succeeded/failed, that terminal state is the
+      // source of truth and must not be clobbered back to 'expired' with a false audit row.
+      if (row.execution_state === "approval_required" || row.execution_state === "approved") {
+        await client.query(
+          `update gateway_executions set state='expired',updated_at=now()
+             where id=$1 and state in ('approval_required','approved')`,
+          [row.execution_id],
+        );
+        await client.query(
+          `insert into gateway_audit_log(
+            team_id,member_id,service_identity_id,subject_binding_id,connection_id,
+            execution_id,approval_id,event,correlation_id
+          ) values($1,$2,$3,$4,$5,$6,$7,'approval_expired',$8)
+          on conflict do nothing`,
+          [ctx.teamId,row.member_id,row.service_identity_id,row.subject_binding_id,
+           row.connection_id,row.execution_id,approvalId,correlationId],
+        );
+      }
       return { expired: true as const };
     }
     if (row.status !== "pending")

--- a/test/datamechanics/gateway-approval.datamechanics.test.ts
+++ b/test/datamechanics/gateway-approval.datamechanics.test.ts
@@ -568,4 +568,53 @@ describe("gateway durable approval and resume", () => {
     expect(row.rows[0]).toEqual({ state: "expired", status: "expired", audits: 1 });
     service.secretBytes.fill(0);
   });
+
+  // A claim leaves the approval row 'approved' (claims never retire it). Model that end-state directly:
+  // an approved-then-expired approval whose execution advanced to a claimed/terminal state.
+  async function claimedThenExpired() {
+    const res = await approvedExecution({ approve: true, approvalTtlMilliseconds: 400 });
+    await new Promise((r) => setTimeout(r, 500)); // approval now past its TTL
+    // The execution was claimed while the approval was still valid (executions permit state transitions).
+    await getPool().query(`update gateway_executions set state='claimed',updated_at=now() where id=$1`, [res.executionId]);
+    return res;
+  }
+  const stateAndFalseAudits = (executionId: string) =>
+    getPool().query(
+      `select state,
+         (select count(*)::int from gateway_audit_log where execution_id=$1 and event='approval_expired') audits
+       from gateway_executions where id=$1`,
+      [executionId],
+    );
+
+  it("the expiry SWEEP does not clobber an already-claimed execution back to 'expired' (H1 audit-integrity)", async () => {
+    const { ctx, executionId, service } = await claimedThenExpired();
+    await listGatewayApprovals(ctx); // runs the sweep
+    // Pre-fix the sweep flipped it to 'expired' + wrote a false approval_expired row; both must not happen.
+    expect((await stateAndFalseAudits(executionId)).rows[0]).toEqual({ state: "claimed", audits: 0 });
+    service.secretBytes.fill(0);
+  });
+
+  it("deciding an expired approval does not clobber an already-claimed execution (H1 audit-integrity)", async () => {
+    const { ctx, executionId, approvalId, service } = await claimedThenExpired();
+    // decide() enters its expired branch (it rejects with 410 after committing) — but must leave the
+    // claimed execution's terminal state alone.
+    await expect(decideGatewayApproval(ctx, approvalId, "approve", randomUUID())).rejects.toMatchObject({
+      code: "gateway_approval_expired",
+    });
+    expect((await stateAndFalseAudits(executionId)).rows[0]).toEqual({ state: "claimed", audits: 0 });
+    service.secretBytes.fill(0);
+  });
+
+  it("deciding an already-denied approval after expiry returns a clean 410, not a raw trigger 500", async () => {
+    const { ctx, approvalId, service } = await approvedExecution({ approve: false, approvalTtlMilliseconds: 400 });
+    await decideGatewayApproval(ctx, approvalId, "deny", randomUUID()); // pending → denied (while valid)
+    await new Promise((r) => setTimeout(r, 500)); // now past TTL
+    // The expired branch must NOT attempt a denied → expired transition (trigger-illegal → 500); the
+    // status-guarded no-op keeps it a clean 410.
+    await expect(decideGatewayApproval(ctx, approvalId, "approve", randomUUID())).rejects.toMatchObject({
+      code: "gateway_approval_expired",
+      status: 410,
+    });
+    service.secretBytes.fill(0);
+  });
 });


### PR DESCRIPTION
## What & why (H1 — compliance/audit integrity, reproduced on real Postgres)
A claim leaves the `gateway_approvals` row **`'approved'`** (claims never retire it). But both the expiry **sweep** (`expireGatewayApprovals`, run on *every* approvals-list view) and `decideGatewayApproval`'s expired branch flipped the **execution** to `state='expired'` and wrote a false `approval_expired` audit row — with **no guard on the execution's current state**. So ~15 min after approval, an admin merely *viewing the approvals list* corrupted an already **claimed/succeeded/failed** execution's terminal state and its audit trail. The gateway is behind `AIOS_GATEWAY_INTERNAL_ENABLED` (off in prod) → latent; fixed before enable.

## Fix
- **Sweep:** the `due` CTE now also requires `e.state in ('approval_required','approved')` — a claimed/terminal execution's approval isn't selected, so no state clobber and no false audit. Genuine (unclaimed) expiries still work (existing test unchanged).
- **`decideGatewayApproval` expired branch:** selects `e.state` and only expires the execution + writes the `approval_expired` audit when it's still awaiting a decision; the approval row's own expiry is still recorded. The approval-status UPDATE is now `… and status in ('pending','approved')` so an already **denied/cancelled** approval past its TTL returns a clean **410** instead of a raw trigger **500** (a Fable-review catch in this same branch). Mirrors the resume path's `state in ('approval_required','approved')` / `status in ('pending','approved')` guards.
- **M9:** the pm-sync admin page reads sensitive PM data via the service-role client (no RLS) but relied solely on the admin *layout* gate (Next 16 doesn't guarantee layout re-run on client navigation). It now self-gates with `requireTeamAdmin → notFound()`, matching the PM-sync server actions.

## Verification
3 new real-Postgres regressions (sweep + decide can't clobber a claimed execution — `state` stays `claimed`, zero false audits; denied-then-expired decide → clean 410). **Fable proved them non-vacuous** by running against the pre-fix code (both the H1 tests fail with the `expired` clobber + false audit). Full gateway data-mechanics suite **36 green**; unit tier **802**; `tsc`/`eslint`/docs-drift clean.

## Review
Reviewed by **Fable** — verdict *sound, ship it*. It verified the state-guard set is exactly right (blocked is unreachable via the approvals join; `approval_required`/`approved` match the resume guards), the sweep/claim race is correctly serialized under `FOR UPDATE` + the new predicate's EPQ recheck, and the stale-`approved` approval is coherent with every reader. Its one MEDIUM (the denied→expired 500) is fixed here.

## Note (not fixed — flagged for follow-up)
Fable noted the same layout-gate-only pattern on other admin pages reading service-role data (`admin/members`, `admin/integrations`) — same M9 class, worth a consistent sweep in a separate change.