### PR TITLE
fix(graph): capture the Graphiti error body so the projector 422 is diagnosable

### DIFF
--- a/lib/graph/graphiti-client.ts
+++ b/lib/graph/graphiti-client.ts
@@ -113,7 +113,13 @@ export class GraphitiClient {
         body: body !== undefined ? JSON.stringify(body) : undefined,
         signal: ctrl.signal,
       });
-      if (!res.ok) throw new Error(`graphiti ${method} ${path} → ${res.status}`);
+      if (!res.ok) {
+        // Capture the response body — a FastAPI 422 carries the exact Pydantic validation detail
+        // (which field/why). Without it, a wedged projector is an undiagnosable "→ 422". Bounded so a
+        // huge error page can't blow up the log line.
+        const detail = await res.text().catch(() => "");
+        throw new Error(`graphiti ${method} ${path} → ${res.status}${detail ? `: ${detail.slice(0, 400)}` : ""}`);
+      }
       // /messages returns 202 with no useful body; /search + /episodes return JSON; DELETE returns
       // a small ack body.
       const text = await res.text();

--- a/test/graphiti-client-error.test.ts
+++ b/test/graphiti-client-error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { GraphitiClient } from "@/lib/graph/graphiti-client";
+
+// Spec (diagnosability): a non-2xx from Graphiti must carry the response BODY in the thrown error —
+// a FastAPI 422 on POST /messages includes the exact Pydantic validation detail (which field/why).
+// Without it, a wedged projector is an undiagnosable "→ 422". This is what surfaces the real cause
+// in the graph_project ingest_runs error + logs.
+
+function clientWithFetch(status: number, body: string): GraphitiClient {
+  const fetchImpl = (async () =>
+    new Response(body, { status, headers: { "Content-Type": "application/json" } })) as unknown as typeof fetch;
+  return new GraphitiClient({ baseUrl: "http://graphiti.test", fetchImpl });
+}
+
+describe("GraphitiClient error surfacing", () => {
+  it("includes the 422 response body (Pydantic detail) in the thrown error", async () => {
+    const detail = '{"detail":[{"loc":["body","messages",0,"timestamp"],"msg":"Input should be a valid datetime","type":"datetime_type"}]}';
+    const client = clientWithFetch(422, detail);
+    await expect(
+      client.addEpisodes("aios:team", [
+        { name: "items:1", content: "hi", timestamp: "not-a-date", sourceDescription: "x" },
+      ])
+    ).rejects.toThrow(/422.*timestamp|422.*Input should be a valid datetime/);
+  });
+});


### PR DESCRIPTION
Investigating "we had graph data in the graph — what happened?" + the projector `422`.

## What I found
- The graph **projector 422s on every `POST /messages`** to Graphiti — so new activity stops reaching the graph and Learning arcs go empty.
- Graphiti's own logs show **mostly 422 with the occasional 202** → a **data-dependent validation failure** (a specific field in most episodes trips Graphiti's Pydantic schema; a few well-formed ones get through).
- **Not a redeploy wipe**: Graphiti last deployed 2026-07-06, Neo4j 2026-06-25 — neither recently. The app already sends the required `role: null`, so it's a *different* field.
- **The blocker to diagnosing it**: the Graphiti client threw a bare `graphiti POST /messages → 422` and **discarded the response body** — the FastAPI 422 carries the exact Pydantic detail (which field, why), and we were throwing it away.

## Fix
The client now includes the response body (bounded to 400 chars) in the thrown error. On the next projection tick that surfaces the precise validation error in the **`graph_project` ingest_runs error** (Admin → Integrations health card) and the logs — instead of an opaque status code. That tells us exactly which field to fix.

## Next step (after this deploys)
Read the now-detailed `graph_project` error → fix the offending episode field → the projector writes again → facts repopulate → arcs return. (My leading guess from the payload is the `timestamp` field — some items' `source_ts` frontmatter isn't a valid datetime — but this change will confirm rather than guess.)

## On the missing data
The facts live in **Neo4j** (arcs read it directly). Since the projector has been failing writes, no *new* facts have landed; whether the *old* facts are still in Neo4j vs. were cleared I'll be able to confirm once writes work again and reconcile reports confirmed-vs-requeued. Neither service was redeployed, so a volume wipe is unlikely — more likely the graph simply stopped being fed weeks ago when this 422 started.

## Verified
- Unit (803) incl. a new spec asserting the 422 body is surfaced in the thrown error; tsc, lint, docs-drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)