### PR TITLE
fix(graph): normalize episode timestamps to ISO-8601 — unwedge the projector (422 → 202)

### DIFF
--- a/lib/graph/graphiti-client.ts
+++ b/lib/graph/graphiti-client.ts
@@ -44,6 +44,21 @@ export interface GraphEpisode {
   role?: string | null;
 }
 
+/**
+ * Coerce a timestamp to strict ISO-8601 (what Graphiti's Pydantic `datetime` accepts). Postgres
+ * `timestamptz` strings ("2026-07-09 10:39:17.281+00" — space separator, 2-digit offset) parse fine
+ * in JS `Date` but are rejected by Pydantic → 422. `new Date(...).toISOString()` yields a canonical
+ * `…Z` instant. Unparseable input falls back to now() so one bad row never wedges the whole push.
+ * Pure + exported so the fix is unit-tested.
+ */
+export function toIsoTimestamp(v: string | undefined | null): string {
+  if (v) {
+    const d = new Date(v);
+    if (!Number.isNaN(d.getTime())) return d.toISOString();
+  }
+  return new Date().toISOString();
+}
+
 /** An episode as listed by Graphiti — enough to resolve our stable `name` to its server uuid. */
 export interface GraphEpisodeRef {
   uuid: string;
@@ -140,7 +155,11 @@ export class GraphitiClient {
       group_id: groupId,
       messages: episodes.map((e) => ({
         content: e.content,
-        timestamp: e.timestamp,
+        // Graphiti's Message schema parses `timestamp` with strict Pydantic ISO-8601. A raw Postgres
+        // `timestamptz` string (space separator + `+00` offset, e.g. "2026-07-09 10:39:17.281+00")
+        // fails with "unexpected extra characters" → HTTP 422 on EVERY push, wedging the projector
+        // (2026-07 incident). Normalize to a real ISO-8601 instant; fall back to now() if unparseable.
+        timestamp: toIsoTimestamp(e.timestamp),
         source_description: e.sourceDescription,
         name: e.name,
         role_type: e.roleType ?? "user",

--- a/test/graphiti-timestamp.test.ts
+++ b/test/graphiti-timestamp.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { GraphitiClient, toIsoTimestamp } from "@/lib/graph/graphiti-client";
+
+// Spec (projector 422 fix): Graphiti's Pydantic datetime rejects a raw Postgres timestamptz string
+// ("2026-07-09 10:39:17.281+00") with "unexpected extra characters" → 422 on every push. The client
+// must normalize timestamps to strict ISO-8601 before sending.
+
+describe("toIsoTimestamp", () => {
+  it("normalizes a Postgres timestamptz string to ISO-8601", () => {
+    expect(toIsoTimestamp("2026-07-09 10:39:17.281+00")).toBe("2026-07-09T10:39:17.281Z");
+  });
+  it("passes a valid ISO instant through", () => {
+    expect(toIsoTimestamp("2026-07-09T10:39:17.281Z")).toBe("2026-07-09T10:39:17.281Z");
+  });
+  it("falls back to a valid ISO instant for empty/garbage input", () => {
+    expect(toIsoTimestamp(undefined)).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+    expect(toIsoTimestamp("not a date")).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+  });
+});
+
+describe("addEpisodes wire format", () => {
+  it("sends a normalized ISO timestamp (never the raw Postgres string that 422s)", async () => {
+    const fetchMock = vi.fn(async () => new Response("", { status: 202 })) as unknown as typeof fetch;
+    const client = new GraphitiClient({ baseUrl: "http://graphiti.test", fetchImpl: fetchMock });
+    await client.addEpisodes("aios:team", [
+      { name: "items:1", content: "x", timestamp: "2026-07-09 10:39:17.281+00", sourceDescription: "s" },
+    ]);
+    const body = JSON.parse(String((fetchMock as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0][1].body));
+    expect(body.messages[0].timestamp).toBe("2026-07-09T10:39:17.281Z");
+  });
+});


### PR DESCRIPTION
**The root cause of the empty Learning arcs**, confirmed from the Graphiti 422 body that #294 just made visible:

```
POST /messages → 422: timestamp "2026-07-09 10:39:17.281+00" —
"Input should be a valid datetime, unexpected extra characters at the end of the input"
```

## What happened to your graph data
The episode `timestamp` was passed straight from an item's `source_ts` frontmatter — a raw **Postgres `timestamptz` string** (space separator, 2-digit `+00` offset). JS `Date` accepts it, but **Graphiti's Pydantic `datetime` rejects it** → `422` on *every* push that has a `source_ts`. So the projector has been failing for weeks (mostly 422; the rare 202 was an item with no `source_ts`), **no new facts reached the graph**, and arcs went empty. It wasn't a data wipe or a model problem — the graph simply stopped being fed.

## Fix
`toIsoTimestamp()` normalizes any date-ish string to a canonical ISO-8601 instant (`new Date(v).toISOString()` → `…Z`), applied in `addEpisodes` before the wire send. Unparseable input falls back to `now()` so one bad row can't wedge a batch.

## Verified
- Unit (807) incl. new specs: Postgres string → `…Z`, valid-ISO passthrough, garbage → fallback, and `addEpisodes` sends the normalized value.
- tsc / lint / docs-drift clean.

## After this deploys
- The projector should start returning **202** and repopulate the graph from the backlog (the ledger was reconciled/cleared, so items re-project).
- Once facts land, Learning arcs synthesize again and the #290 "the knowledge graph has no facts yet" message clears.
- The `graph_project` health on Admin → Integrations should flip from degraded to healthy.

I'll watch the projector logs after merge to confirm 202s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)