### PR TITLE
feat(nav): instant loading feedback on tab navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -292,3 +292,16 @@ h3 {
   border-top: 1px solid var(--color-border-subtle);
   margin: 1.5em 0;
 }
+
+/* ── Nav pending indicator ─────────────────────────────────────────────────
+   The per-link spinner (useLinkStatus) only mounts while a tab navigation is
+   pending. It starts invisible and fades in AFTER a short delay, so a fast
+   transition (which unmounts it before the delay elapses) never flashes a
+   spinner — only navigations slow enough to notice get one. */
+@keyframes nav-pending-in {
+  to { opacity: 1; }
+}
+.nav-pending-in {
+  opacity: 0;
+  animation: nav-pending-in 120ms ease-out 140ms forwards;
+}

--- a/app/t/[team]/loading.tsx
+++ b/app/t/[team]/loading.tsx
@@ -1,0 +1,51 @@
+/**
+ * Instant navigation feedback for every `/t/[team]/*` tab. `/t/[team]` is a dynamic route, so
+ * without a `loading.tsx` a click waits on the full server render before anything paints — which
+ * reads as "the app froze" (see the Next.js "dynamic routes without loading.tsx" guidance). Next
+ * wraps each page in a Suspense boundary with this as the prefetched fallback, so the sidebar stays
+ * put and interactive while the content area shows this skeleton the instant a tab is clicked.
+ *
+ * Deliberately generic (title + KPI row + card grid) — it stands in for any surface without
+ * pretending to know its exact shape; the goal is immediate "something is loading," not a
+ * pixel-match of the destination.
+ */
+function Shimmer({ className = "" }: { className?: string }) {
+  return <div className={`animate-pulse rounded-lg bg-surface-inset ${className}`} />;
+}
+
+export default function TeamSectionLoading() {
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-6" aria-busy="true" aria-label="Loading">
+      {/* header */}
+      <div className="flex flex-col gap-2">
+        <Shimmer className="h-7 w-48" />
+        <Shimmer className="h-4 w-80 max-w-full" />
+      </div>
+
+      {/* KPI-ish row */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="prism-card flex flex-col gap-3 px-5 py-5">
+            <Shimmer className="h-3 w-20" />
+            <Shimmer className="h-6 w-16" />
+          </div>
+        ))}
+      </div>
+
+      {/* content cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="prism-card flex flex-col gap-3 px-5 py-5">
+            <Shimmer className="h-5 w-2/3" />
+            <Shimmer className="h-4 w-full" />
+            <Shimmer className="h-4 w-5/6" />
+            <div className="mt-2 flex items-center gap-2">
+              <Shimmer className="size-6 rounded-full" />
+              <Shimmer className="h-3 w-24" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/team-nav.tsx
+++ b/components/team-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link, { useLinkStatus } from "next/link";
 import { usePathname } from "next/navigation";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
@@ -13,6 +13,7 @@ import {
   GitBranch,
   Home,
   ListTodo,
+  Loader2,
   Megaphone,
   NotebookText,
   Shield,
@@ -55,6 +56,18 @@ function isSection(entry: NavEntry): entry is NavSection {
   return (entry as NavSection).children !== undefined;
 }
 
+/**
+ * Immediate feedback on the clicked tab while its route renders. `useLinkStatus` is `pending` for
+ * the enclosing `<Link>` during a client-side transition; the spinner debounces its own appearance
+ * via `.nav-pending-in` (fades in after ~140ms) so a fast tab never flashes it. Must be rendered
+ * inside the `<Link>` subtree — that's how the hook scopes to that link.
+ */
+function NavPending() {
+  const { pending } = useLinkStatus();
+  if (!pending) return null;
+  return <Loader2 aria-hidden className="nav-pending-in size-3.5 shrink-0 animate-spin text-ink-tertiary" />;
+}
+
 function Leaf({ item, indent = false }: { item: NavLeaf; indent?: boolean }) {
   const pathname = usePathname();
   const active = item.exact
@@ -72,8 +85,9 @@ function Leaf({ item, indent = false }: { item: NavLeaf; indent?: boolean }) {
           : "text-ink-secondary hover:bg-surface-card-hover hover:text-ink"
       }`}
     >
-      <Icon className="size-4" strokeWidth={active ? 2 : 1.5} />
-      {item.label}
+      <Icon className="size-4 shrink-0" strokeWidth={active ? 2 : 1.5} />
+      <span className="min-w-0 flex-1 truncate">{item.label}</span>
+      <NavPending />
     </Link>
   );
 }


### PR DESCRIPTION
## Problem
Clicking a left-nav tab felt slow/frozen: `/t/[team]` is a dynamic route with **no `loading.tsx`**, so the client waited on the full server render before anything painted. Measured warm server-render (dev, seeded team): Meetings ~1.7s, Codebases ~1.3s, Social ~1.2s, Learning/Query/Admin ~0.7s — all with zero visual feedback. This is the exact "dynamic routes without `loading.tsx`" case the Next.js docs call out as reading like "the app is not responding."

## Fix (the loading-feedback prong of "quicken it OR show a loading icon")
- **`app/t/[team]/loading.tsx`** — a branded content-area skeleton (title + KPI row + card grid). Next wraps each page in a Suspense boundary with this as the *prefetched* fallback, so the **sidebar stays put and interactive** and the content area paints a skeleton the instant a tab is clicked. One boundary covers every `/t/[team]/*` surface.
- **Per-link pending spinner** via `useLinkStatus` on each nav item, **debounced** (`.nav-pending-in` fades in after ~140ms) so fast/cached navigations never flash it — only genuinely slow ones get the extra cue.

Because the skeleton is now prefetched, transitions also *feel* instant (something paints immediately), not just clearer.

## Evidence
Dogfooded locally against a seeded demo team (screenshots in the PR thread): mid-transition the sidebar is fully intact while the content area shows the shimmer skeleton, then swaps to real content.

## Test plan
- [x] `tsc` clean · `eslint` clean on changed files · guard suite 88 green · docs-drift in sync
- [x] Live: verified the Suspense skeleton renders during navigation (aria-busy region present) and the layout stays interactive
- UI-only; no schema, no server logic, no API surface change

## Not in scope (follow-up)
Actually *shortening* the slow routes' server work (Meetings/Codebases/Social do the heaviest per-tab queries). The skeleton makes them feel responsive now; trimming their render cost is a separate, per-route perf pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)