### PR TITLE
perf(app): parallelize Social + admin data waterfalls; instant admin tab skeleton

### DIFF
--- a/app/t/[team]/admin/approvals/page.tsx
+++ b/app/t/[team]/admin/approvals/page.tsx
@@ -17,33 +17,37 @@ export default async function ApprovalsAdminPage({ params }: { params: Promise<{
   const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
   if (!team) return null;
 
-  const { data: pending } = await db
-    .from("approval_requests")
-    .select("id, requested_by_actor, action, resource, context, created_at")
-    .eq("team_id", team.id)
-    .eq("status", "pending")
-    .order("created_at", { ascending: false });
-
-  const { data: recent } = await db
-    .from("approval_requests")
-    .select("id, requested_by_actor, action, resource, status, decided_at, decision_note")
-    .eq("team_id", team.id)
-    .in("status", ["approved", "denied", "expired"])
-    .order("decided_at", { ascending: false })
-    .limit(10);
-
-  let managed: ManagedGatewayApprovalRow[] | null = null;
-  if (process.env.AIOS_GATEWAY_INTERNAL_ENABLED === "true") {
-    const user = await getSessionUser();
-    if (user) {
+  // The pending queue, the recently-decided list, and the (optional) managed-gateway approvals are
+  // independent reads — load them concurrently instead of in series. `managed` keeps its own
+  // env-gated auth sub-chain inside a self-contained async so it can't slow the two queue reads.
+  const [pendingRes, recentRes, managed] = await Promise.all([
+    db
+      .from("approval_requests")
+      .select("id, requested_by_actor, action, resource, context, created_at")
+      .eq("team_id", team.id)
+      .eq("status", "pending")
+      .order("created_at", { ascending: false }),
+    db
+      .from("approval_requests")
+      .select("id, requested_by_actor, action, resource, status, decided_at, decision_note")
+      .eq("team_id", team.id)
+      .in("status", ["approved", "denied", "expired"])
+      .order("decided_at", { ascending: false })
+      .limit(10),
+    (async (): Promise<ManagedGatewayApprovalRow[] | null> => {
+      if (process.env.AIOS_GATEWAY_INTERNAL_ENABLED !== "true") return null;
+      const user = await getSessionUser();
+      if (!user) return null;
       try {
         const ctx = await authorizeGatewayAdmin(teamSlug, user.id);
-        managed = (await listGatewayApprovals(ctx)) as ManagedGatewayApprovalRow[];
+        return (await listGatewayApprovals(ctx)) as ManagedGatewayApprovalRow[];
       } catch {
-        managed = null;
+        return null;
       }
-    }
-  }
+    })(),
+  ]);
+  const pending = pendingRes.data;
+  const recent = recentRes.data;
 
   return (
     <div className="flex flex-col gap-4">

--- a/app/t/[team]/admin/layout.tsx
+++ b/app/t/[team]/admin/layout.tsx
@@ -13,13 +13,12 @@ export default async function AdminLayout({
   const { team: teamSlug } = await params;
   const db = await serverClient();
 
-  const user = await getSessionUser();
-
-  const { data: team } = await db
-    .from("teams")
-    .select("id")
-    .eq("slug", teamSlug)
-    .maybeSingle();
+  // The session and the team lookup are independent — resolve them together so the admin shell's
+  // own auth doesn't add a serial round-trip on top of each tab's queries.
+  const [user, { data: team }] = await Promise.all([
+    getSessionUser(),
+    db.from("teams").select("id").eq("slug", teamSlug).maybeSingle(),
+  ]);
 
   const { data: me } = team
     ? await db

--- a/app/t/[team]/admin/loading.tsx
+++ b/app/t/[team]/admin/loading.tsx
@@ -1,0 +1,39 @@
+/**
+ * Instant feedback when switching admin tabs. The admin area is a shared layout (`admin/layout.tsx`)
+ * with the tab bar + `{children}`; each tab is its own server-rendered route that runs several DB
+ * queries before it can paint. Without a `loading.tsx` at this level, a tab click either waited on
+ * the full render or fell back to the page-level skeleton (which would blank the tabs too). This
+ * boundary sits *below* the tab bar, so the tabs stay put and interactive while the content area
+ * shows a table/panel skeleton the instant a tab is clicked.
+ */
+function Bar({ className = "" }: { className?: string }) {
+  return <div className={`animate-pulse rounded-md bg-surface-inset ${className}`} />;
+}
+
+export default function AdminTabLoading() {
+  return (
+    <div className="flex flex-col gap-4" aria-busy="true" aria-label="Loading">
+      {/* an intro line most admin tabs render */}
+      <Bar className="h-4 w-72 max-w-full" />
+
+      {/* table/panel skeleton — admin surfaces are mostly rows of records */}
+      <div className="prism-card flex flex-col overflow-hidden">
+        <div className="flex items-center gap-4 border-b border-border-subtle px-4 py-3">
+          <Bar className="h-3 w-24" />
+          <Bar className="h-3 w-20" />
+          <Bar className="ml-auto h-3 w-16" />
+        </div>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 border-b border-border-subtle px-4 py-4 last:border-0">
+            <Bar className="size-8 shrink-0 rounded-full" />
+            <div className="flex flex-1 flex-col gap-2">
+              <Bar className="h-3.5 w-1/3" />
+              <Bar className="h-3 w-1/4" />
+            </div>
+            <Bar className="h-7 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/t/[team]/admin/members/page.tsx
+++ b/app/t/[team]/admin/members/page.tsx
@@ -27,14 +27,22 @@ export default async function MembersAdminPage({
     .maybeSingle();
   if (!team) return null;
 
-  const { data: members } = await db
-    .from("members")
-    .select(
-      "id, display_name, email, actor_handle, role, tier, status, github_login, avatar_url, created_at, manager_member_id"
-    )
-    .eq("team_id", team.id)
-    .eq("is_connector", false)
-    .order("created_at");
+  const adminDb = adminClient();
+
+  // The member roster and the per-tool provisioning availability (invite checkboxes) are
+  // independent, so load them concurrently rather than one-after-the-other.
+  const [membersRes, provisioningAvailability] = await Promise.all([
+    db
+      .from("members")
+      .select(
+        "id, display_name, email, actor_handle, role, tier, status, github_login, avatar_url, created_at, manager_member_id"
+      )
+      .eq("team_id", team.id)
+      .eq("is_connector", false)
+      .order("created_at"),
+    getProvisioningAvailabilityAction(teamSlug),
+  ]);
+  const members = membersRes.data;
 
   // Candidate managers for the "Reports to" selector: any other non-disabled, non-connector
   // member (setMemberManager rejects disabled/connector targets server-side too).
@@ -42,21 +50,19 @@ export default async function MembersAdminPage({
     .filter((m) => m.status !== "disabled")
     .map((m) => ({ id: m.id as string, displayName: m.display_name as string }));
 
-  // Per-tool provisioning availability (drives the invite checkboxes) + each member's current
-  // provisioning rows (drives the compact retry badges). Reads go through the admin service client
-  // and the single-writer's read helpers — the members subtree is already admin-gated by the layout.
-  const adminDb = adminClient();
-  const provisioningAvailability = await getProvisioningAvailabilityAction(teamSlug);
-  const provisioningByMember = new Map(
-    await Promise.all(
+  // Each member's provisioning rows (compact retry badges) and the linked-identities panel are
+  // independent once the roster is known — fan out the per-member reads and the identities read
+  // together. Reads go through the admin service client + single-writer read helpers; the members
+  // subtree is already admin-gated by the layout.
+  const [provisioningEntries, identities] = await Promise.all([
+    Promise.all(
       (members ?? []).map(
         async (m) => [m.id, await getMemberProvisioning(adminDb, team.id, m.id as string)] as const
       )
-    )
-  );
-
-  // All linked identities (email aliases + slack/linear/plane provider ids) for the panel.
-  const identities = await listMemberIdentities(db, team.id);
+    ),
+    listMemberIdentities(db, team.id),
+  ]);
+  const provisioningByMember = new Map(provisioningEntries);
   const providerOf = (memberId: string, provider: string): ProviderLink | null => {
     const p = identities.get(memberId)?.providers.find((x) => x.provider === provider);
     return p ? { externalId: p.externalId, handle: p.handle } : null;

--- a/app/t/[team]/social/page.tsx
+++ b/app/t/[team]/social/page.tsx
@@ -44,15 +44,46 @@ export default async function SocialPage({ params }: { params: Promise<{ team: s
     );
   }
 
-  const opportunities = await listOpportunities(db, team.id, "team", 100);
+  // Every read below is independent — all the derived structures are pure JS post-processing done
+  // after the awaits — so fire them concurrently instead of in a ~13-deep request waterfall (each
+  // round-trip to Railway Postgres has real latency; serial they stacked into most of the render).
+  const [
+    opportunities,
+    plansRes,
+    variantsRes,
+    media,
+    budget,
+    jobsHealth,
+    autonomy,
+    pendingRows,
+    tf,
+    publishDryRun,
+    pubs,
+    analyticsRows,
+    analytics,
+  ] = await Promise.all([
+    listOpportunities(db, team.id, "team", 100),
+    db.from("content_plans").select("id, opportunity_id").eq("team_id", team.id),
+    db
+      .from("content_variants")
+      .select("id, plan_id, platform, status, body, validation")
+      .eq("team_id", team.id)
+      .order("created_at", { ascending: true }),
+    listTeamMediaMeta(db, team.id, 200),
+    imageBudget(db, team.id),
+    getSocialJobsHealth(db, team.id),
+    getAutonomy(db, team.id),
+    listPendingApprovals(db, team.id),
+    typefullyStatus(db, team.id),
+    getPublishDryRun(db, team.id),
+    listPublications(db, team.id, 200),
+    listTeamAnalytics(db, team.id, 500),
+    teamAnalyticsSummary(db, team.id),
+  ]);
 
-  const { data: plans } = await db.from("content_plans").select("id, opportunity_id").eq("team_id", team.id);
+  const plans = plansRes.data;
+  const variants = variantsRes.data;
   const planToOpp = new Map((plans ?? []).map((p: { id: string; opportunity_id: string }) => [p.id, p.opportunity_id]));
-  const { data: variants } = await db
-    .from("content_variants")
-    .select("id, plan_id, platform, status, body, validation")
-    .eq("team_id", team.id)
-    .order("created_at", { ascending: true });
 
   const byOpportunity: Record<string, VariantView[]> = {};
   const allVariants = (variants ?? []) as (VariantView & { plan_id: string })[];
@@ -61,14 +92,9 @@ export default async function SocialPage({ params }: { params: Promise<{ team: s
     if (oppId) (byOpportunity[oppId] ??= []).push(v);
   }
 
-  const media = await listTeamMediaMeta(db, team.id, 200);
   const mediaByVariant: Record<string, string[]> = {};
   for (const m of media) (mediaByVariant[m.variant_id] ??= []).push(m.id);
-  const budget = await imageBudget(db, team.id);
 
-  const jobsHealth = await getSocialJobsHealth(db, team.id);
-  const autonomy = await getAutonomy(db, team.id);
-  const pendingRows = await listPendingApprovals(db, team.id);
   const variantCtx: Record<string, { platform: string; body: string; oppTitle: string }> = {};
   for (const [oppId, vs] of Object.entries(byOpportunity)) {
     const oppTitle = opportunities.find((o) => o.id === oppId)?.title ?? "";
@@ -83,12 +109,6 @@ export default async function SocialPage({ params }: { params: Promise<{ team: s
     oppTitle: variantCtx[a.variant_id]?.oppTitle ?? "",
   }));
 
-  const [tf, publishDryRun, pubs] = await Promise.all([
-    typefullyStatus(db, team.id),
-    getPublishDryRun(db, team.id),
-    listPublications(db, team.id, 200),
-  ]);
-  const analyticsRows = await listTeamAnalytics(db, team.id, 500);
   const analyticsByPublication = new Map(analyticsRows.map((a) => [a.publication_id, a]));
   const publicationsByVariant: Record<string, PublicationView[]> = {};
   for (const p of pubs) {
@@ -105,7 +125,6 @@ export default async function SocialPage({ params }: { params: Promise<{ team: s
   }
 
   const publishedCount = pubs.filter((p) => p.status === "published").length;
-  const analytics = await teamAnalyticsSummary(db, team.id);
 
   return (
     <div className="flex flex-col gap-5">


### PR DESCRIPTION
Follow-up to the nav loading feedback (#298). That fixed *perceived* speed with a skeleton; this fixes *actual* server-render latency on the heaviest surfaces by collapsing serial query waterfalls into concurrent batches. On Railway's networked Postgres each round-trip has real latency, so serial `await`s stacked into most of the render.

## Changes
- **Social page** — the ~13 top-level reads were fully serial, yet every derived structure is pure JS post-processing done *after* the awaits. Collapsed into one `Promise.all` (**13 round-trips → 1 concurrent batch**).
- **Admin → Members** (the landing tab) — 5 serial stages → **2 parallel ones**: roster ∥ provisioning-availability, then the per-member provisioning fan-out ∥ identities.
- **Admin → Approvals** — pending queue ∥ recently-decided ∥ the env-gated managed-gateway chain (kept self-contained so its auth sub-chain can't slow the two queue reads).
- **Admin layout** — session ∥ team lookup, so the admin shell's own auth doesn't add a serial round-trip on top of every tab.
- **`admin/loading.tsx`** — instant table/panel skeleton on tab clicks, rendered *below* the persistent tab bar (the page-level `[team]` skeleton would otherwise blank the tabs too).

The other admin tabs (integrations / usage / pm-sync / brand / keys) were already parallelized; policies / audit / data are genuine dependency chains with nothing independent to batch (documented in the commit).

## Correctness
Pure read reordering — no writes, no data-shape changes; every JS post-processing step is preserved verbatim.

## Test plan
- [x] tsc + eslint clean · 815 unit tests green
- [x] Dogfooded locally against a seeded team: Social + all admin tabs render with **no console errors**; admin skeleton fires on tab click (`aria-busy`) while the tab bar stays put
- UI/data-fetching only; no schema, no API surface change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Admin approval, member, and social pages now load data more quickly by processing independent information simultaneously.
  * Faster navigation across social dashboards and administrative sections.

* **User Experience**
  * Added loading placeholders for admin tab content, providing immediate visual feedback while pages load.
  * Loading indicators include accessible status information for assistive technologies.

* **Reliability**
  * Managed gateway approval sections now handle unavailable or unauthorized access gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->