### PR TITLE
feat(observability+graph): fail loudly on a broken pipeline; unblock + rank narrative arcs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,8 +145,18 @@ bash scripts/e2e.sh    # system-level integration: seed → push → materialize
   against prod for any schema change, and **confirm the platform started a new build** (`railway deployment
   list`; CI webhooks can be silently dropped) — re-trigger via the Railway dashboard if the latest deploy
   predates the merge.
+- **Inspecting the prod DB (read-only, for diagnostics).** The internal `DATABASE_URL`
+  (`postgres.railway.internal`) is unreachable from a laptop; use the **public TCP proxy** the Railway
+  Postgres service exposes. Always confirm `railway status` shows **Project: AIOS** first, then:
+  ```bash
+  PUBURL=$(railway variables -s Postgres --json | python3 -c "import sys,json;print(json.load(sys.stdin)['DATABASE_PUBLIC_URL'])")
+  psql "$PUBURL" -c "select count(*) from members;"     # e.g. host thomas.proxy.rlwy.net:33781
+  ```
+  This is the same DB the app uses (self-host = one Postgres). **Read-only for diagnosis** — do NOT
+  run schema loads or migrations through it (that's `npm run pg:schema` as the deploy step). Treat any
+  write as production data mutation: confirm with the user first.
 - **⛔ NEVER run `railway up` / `railway redeploy` / `railway down` / `railway delete`.** The Railway CLI is
-  **read-only** here (`status`, `logs`, `variables`, `deployment list`). `railway up` deploys the current
+  **read-only** here (`status`, `logs`, `variables`, `deployment list`, `connect`). `railway up` deploys the current
   worktree's code to whatever project that directory is *linked* to (`~/.railway/config.json`, keyed by
   absolute path) — and a Conductor worktree that drifted to the wrong link (an aios worktree linked to the
   **Kula** project) once shipped this repo's code into Kula and took it down. The GitHub-merge path is bound

--- a/app/t/[team]/admin/integrations/page.tsx
+++ b/app/t/[team]/admin/integrations/page.tsx
@@ -12,6 +12,8 @@ import { listRecentIngestRuns } from "@/lib/ingest/runs";
 import { IngestRunsPanel } from "@/components/admin/ingest-runs-panel";
 import { getRetrievalHealth } from "@/lib/query/retrieval-health";
 import { RetrievalHealthCard } from "@/components/admin/retrieval-health-card";
+import { getPipelineHealth } from "@/lib/ingest/pipeline-health";
+import { PipelineHealthBanner } from "@/components/admin/pipeline-health-banner";
 import { describeAnswering } from "@/lib/query/llm-backend";
 import { normalizeAnsweringProvider } from "@/lib/query/answering";
 
@@ -48,9 +50,10 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
     : { data: null };
 
   const db = adminClient();
-  const [integrations, ingestRuns, freshness, retrievalHealth] = await Promise.all([
+  const [integrations, ingestRuns, pipelineHealth, freshness, retrievalHealth] = await Promise.all([
     listIntegrations(db, team.id, { role: me?.role as string | undefined }) as Promise<IntegrationRow[]>,
     listRecentIngestRuns(db, team.id, 30),
+    getPipelineHealth(team.id),
     // Already-scanned repos (from codebase scans) → offered as one-click link suggestions. Read
     // through the tier-gated codebases choke point (CLAUDE.md §5), never the table directly.
     getCodebaseFreshness(db, team.id, (me?.tier as "team" | "external") ?? "external"),
@@ -105,6 +108,7 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
 
   return (
     <div className="flex flex-col gap-4">
+      <PipelineHealthBanner health={pipelineHealth} href={`/t/${teamSlug}/admin/integrations`} />
       <div>
         <h1 className="text-xl font-semibold text-ink">Integrations</h1>
         <p className="mt-1 text-sm text-ink-secondary">

--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -3,6 +3,8 @@ import { Rocket } from "lucide-react";
 import { serverClient } from "@/lib/db/server";
 import { visibleItems, visibleDecisions } from "@/lib/auth/visibility";
 import { resolveTeamContext } from "@/lib/auth/team-context";
+import { getPipelineHealth } from "@/lib/ingest/pipeline-health";
+import { PipelineHealthBanner } from "@/components/admin/pipeline-health-banner";
 import { CopySnippet } from "@/components/copy-snippet";
 import { getPulseMetrics } from "@/lib/metrics/pulse";
 import { parseRange } from "@/lib/metrics/range";
@@ -168,7 +170,7 @@ export default async function TeamHome({
     );
   }
 
-  const [pulse, { data: decisions }] = await Promise.all([
+  const [pulse, { data: decisions }, pipelineHealth] = await Promise.all([
     getPulseMetrics(db, team.id, range, { isAdmin, memberId }),
     visibleDecisions(
       db
@@ -179,10 +181,16 @@ export default async function TeamHome({
         .limit(8),
       tier,
     ),
+    // Admins see a loud banner here (the landing page) if any ingestion leg is broken — so a wedged
+    // pipeline surfaces without digging into Admin. Non-admins don't fetch it.
+    isAdmin ? getPipelineHealth(team.id) : Promise.resolve(null),
   ]);
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6">
+      {pipelineHealth ? (
+        <PipelineHealthBanner health={pipelineHealth} href={`/t/${teamSlug}/admin/integrations`} />
+      ) : null}
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-2xl font-semibold text-ink">Home</h1>
         <RangeSelector value={range} />

--- a/components/admin/pipeline-health-banner.tsx
+++ b/components/admin/pipeline-health-banner.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+import type { PipelineHealth } from "@/lib/ingest/pipeline-health";
+import { timeAgo } from "@/components/format";
+
+/** Human labels for the ingest_runs `source` slugs. */
+const LABEL: Record<string, string> = {
+  slack: "Slack sync",
+  plane: "Plane sync",
+  linear: "Linear sync",
+  linear_inbound: "Linear inbound",
+  github: "GitHub sync",
+  dense: "Semantic index",
+  graph_project: "Graph projector",
+  graph_extract: "Graph extraction",
+  meeting_notes: "Meeting notes",
+  auth_cleanup: "Auth cleanup",
+  pm_sync: "PM projection",
+  scan: "Codebase scan",
+  llm: "Answering model",
+};
+
+/**
+ * LOUD, hard-to-miss banner when any ingestion leg is broken or stale — so a wedged pipeline (the
+ * graph projector 422'ing for weeks) can't hide as one red row in a table. Renders nothing when the
+ * pipeline is healthy. Meant to sit at the TOP of the admin surface (and the home dashboard for
+ * admins), above everything else. `href` links to the full runs detail.
+ */
+export function PipelineHealthBanner({ health, href }: { health: PipelineHealth; href: string }) {
+  if (health.healthy || health.failing.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-red-700 dark:text-red-300">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="size-4 shrink-0" />
+        <p className="text-sm font-semibold">
+          {health.failing.length} ingestion {health.failing.length === 1 ? "leg is" : "legs are"} broken
+          — the brain isn&apos;t getting fresh data
+        </p>
+      </div>
+      <ul className="mt-2 flex flex-col gap-1 pl-6">
+        {health.failing.map((l) => (
+          <li key={l.source} className="text-xs">
+            <span className="font-medium">{LABEL[l.source] ?? l.source}</span>{" "}
+            {l.stale && l.ok ? (
+              <span>— no successful run in {timeAgo(l.at)} (may have stopped)</span>
+            ) : (
+              <span>
+                — failing{l.at ? ` since ${timeAgo(l.at)}` : ""}
+                {l.error ? <span className="text-red-600/80 dark:text-red-300/80">: {l.error}</span> : null}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+      <Link href={href} className="mt-2 inline-block pl-6 text-xs font-medium underline">
+        View ingestion runs →
+      </Link>
+    </div>
+  );
+}

--- a/components/admin/retrieval-health-card.tsx
+++ b/components/admin/retrieval-health-card.tsx
@@ -46,6 +46,10 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
   // (the 2026-07 failure: writes 422'd for days while the service stayed "up"). The server flags this
   // (`graphStalled`) so the banner tells the admin which failure it actually is.
   const graphStalled = health.graphStalled;
+  // Reachable + writing episodes, but the extractor turns none of them into facts (Graphiti's
+  // entity-extraction worker is failing on every job). A distinct, more specific cause than a stalled
+  // projector, so it gets its own detail + banner and takes priority.
+  const graphExtractionStalled = health.graphExtractionStalled;
   const graphFreshness =
     health.graphEpisodes != null
       ? `${health.graphEpisodes} episodes${health.graphLastProjectedAt ? ` · last projected ${timeAgo(health.graphLastProjectedAt)}` : " · none projected yet"}`
@@ -53,11 +57,13 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
   const graphDetail =
     health.graph === "off"
       ? "not configured"
-      : graphStalled
-        ? `projector stalled — ${graphFreshness}`
-        : health.graph === "degraded"
-          ? "configured but unreachable"
-          : graphFreshness;
+      : graphExtractionStalled
+        ? `accepting episodes but extracting 0 facts — ${graphFreshness}`
+        : graphStalled
+          ? `projector stalled — ${graphFreshness}`
+          : health.graph === "degraded"
+            ? "configured but unreachable"
+            : graphFreshness;
   // A configured-but-unreachable OR stalled-projector graph is a real failure — flag it loudly (red),
   // like a degraded semantic leg.
   const graphDegraded = health.graph === "degraded";
@@ -105,7 +111,16 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
       ) : null}
       {graphDegraded ? (
         <p className="mt-2 rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
-          {graphStalled ? (
+          {graphExtractionStalled ? (
+            <>
+              Graph memory is reachable and <strong>accepting episodes, but its extractor is producing no
+              facts</strong> ({health.graphEpisodes} projected · {health.graphFacts ?? 0} facts). Graphiti
+              returns <code>202</code> then fails entity extraction on every job — commonly the LLM
+              output-token cap (<code>Output length exceeded max tokens</code>). New activity isn&apos;t
+              becoming graph facts, so narrative arcs can&apos;t update. Check the Graphiti service logs.
+              Keyword and semantic search are unaffected.
+            </>
+          ) : graphStalled ? (
             <>
               Graph memory is reachable but the <strong>projector has stalled</strong> — no new episodes
               since {timeAgo(health.graphLastProjectedAt!)}. New activity isn&apos;t reaching the graph

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -588,6 +588,25 @@ guard enforces it, it's named.
   schema loader (`scripts/pg-load-schema.mjs`, the Railway `preDeployCommand`) sets `lock_timeout`
   so a migration fails fast instead of wedging the lock queue behind a stuck reader.
   _Guards:_ `test/pg-pool-config.test.ts` + `test/pg-load-schema.test.ts`.
+- **A 202 from Graphiti does NOT mean facts were extracted.** The projector POSTs episodes and
+  records `graph_project`=OK on a `202 Accepted`, but 202 only means "queued" — Graphiti then runs
+  its own LLM to extract entities/`RELATES_TO` facts asynchronously. When that step fails on every
+  job (prod 2026-07: `Output length exceeded max tokens 8192` in `resolve_extracted_nodes`, ~800 jobs
+  backed up), episodes are accepted while zero facts are created, and `graph_project`=OK,
+  `/healthcheck`=green, and projector-freshness all stay green — a fully silent failure that blanks
+  narrative arcs. `lib/graph/extraction-health.getGraphExtractionHealth` closes the blind spot by
+  comparing projected episodes (Postgres ledger) vs extracted facts (Neo4j `count(RELATES_TO)`): many
+  projected + zero extracted ⇒ **degraded**, surfaced on the Admin retrieval-health card (Graph memory
+  leg) **and** the loud pipeline-health banner (synthetic `graph_extract` leg) on Home + Integrations.
+  The extractor's 8192 output-token cap is **not** raisable via env on the pinned `zepai/graphiti` image
+  (verified 2026-07-17 against getzep/graphiti `config.py` — only api_key/base_url/model_name/embedding
+  are configurable; `zep_graphiti.py` overrides nothing else). So the only app-side lever is
+  `MAX_EPISODE_CHARS` in `lib/graph/project` (2000, `GRAPH_MAX_EPISODE_CHARS`-tunable) — a smaller
+  episode extracts fewer nodes → smaller structured output → stays under the cap. The deeper durable fix
+  (a newer image that raises the cap or handles the length error) is a Graphiti-service image bump, which
+  carries rebuild + Neo4j-schema-coupling risk — see the graphiti memory note. _Guards:_
+  `test/graph-extraction-health.test.ts` + the `deriveGraphState` extraction-stall case in
+  `test/retrieval-health.test.ts` + the `MAX_EPISODE_CHARS` cap spec in the graph-project data-mechanics tier.
 
 ## Changing X? read this
 

--- a/graphiti/README.md
+++ b/graphiti/README.md
@@ -33,7 +33,10 @@ may see. See `lib/graph/group.ts`.
 Two callers: the admin **"Project to graph"** button on the Integrations page (on-demand) and
 `lib/graph/scheduler` (an interval poller registered in `instrumentation.ts`). Both are inert
 unless `GRAPHITI_URL` is set. Tune with `GRAPH_PROJECT_MINUTES` (default 60), `GRAPH_PROJECT_LIMIT`
-(default 500 items/run), `GRAPH_PROJECT_ENABLED=false` to disable.
+(default 500 items/run), `GRAPH_PROJECT_ENABLED=false` to disable, and `GRAPH_MAX_EPISODE_CHARS`
+(default 2000) — the per-episode content cap that keeps Graphiti's extraction output under its
+hard-coded 8192-token limit (a bigger episode extracts more nodes → overflow → the extractor fails
+and no facts are created; see the "202 ≠ extracted" gotcha in `docs/ARCHITECTURE.md`).
 
 ## LLM note
 Extraction quality depends on structured-output support. Start with a strong cloud model; a local

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -49,12 +49,15 @@ export interface ArcCorrection {
 export type ProviderKeys = LlmBackendKeys;
 
 const MAX_FACTS = 200;
+const MAX_ARCS = 8;
 const CACHE_TTL_MS = 10 * 60_000;
 
 const SYSTEM_PROMPT =
-  "You are analyzing a team knowledge graph. Identify 3-5 active narrative arcs — ongoing storylines " +
-  "about what this team is working through. Each fact below is numbered [F1], [F2], … — for every arc, " +
-  "cite the 2-5 fact numbers that support it in `supporting_facts`. Return ONLY a JSON object of the form " +
+  `You are analyzing a team knowledge graph. Identify ${MAX_ARCS} active narrative arcs — ongoing ` +
+  "storylines about what this team is working through. Favor RECENT activity and give every active " +
+  "contributor visible representation — don't let one person's arcs crowd out others who've been " +
+  "working. Each fact below is numbered [F1], [F2], … — for every arc, cite the 2-5 fact numbers that " +
+  "support it in `supporting_facts`. Return ONLY a JSON object of the form " +
   '{"arcs":[{"title":"short","confidence":"high|medium|low","summary":"2-3 sentences, present tense, ' +
   'specific","participants":["names"],"supporting_facts":[1,2,3]}]}. Use only fact numbers that appear ' +
   "below. No prose, no markdown code fences — the raw JSON object only.";
@@ -77,6 +80,45 @@ export function stripTaskKeys(text: string): string {
     .replace(/\(\s*\)/g, "") // empty parens left behind
     .replace(/\s{2,}/g, " ")
     .trim();
+}
+
+const CONFIDENCE_WEIGHT: Record<NarrativeArc["confidence"], number> = { high: 3, medium: 2, low: 1 };
+
+/** The newest dated evidence timestamp in an arc (ms), or -Infinity if it cites no dated evidence.
+ *  This is the arc's "recency" — how recently the work it describes actually happened. Pure. */
+export function newestEvidenceAt(arc: NarrativeArc): number {
+  let max = -Infinity;
+  for (const e of arc.evidence) {
+    if (!e.at) continue;
+    const t = Date.parse(e.at);
+    if (!Number.isNaN(t) && t > max) max = t;
+  }
+  return max;
+}
+
+/**
+ * Order arcs for display by RECENCY then RELEVANCE, so a contributor's recent work surfaces above
+ * stale storylines instead of being buried under whoever was loudest weeks ago:
+ *   1. newest cited evidence first (recency — arcs with no dated evidence sort last),
+ *   2. then confidence high→low (relevance),
+ *   3. then more supporting evidence first (depth),
+ *   4. stable on the model's original order as the final tiebreak.
+ * Pure + unit-tested.
+ */
+export function rankArcs(arcs: NarrativeArc[]): NarrativeArc[] {
+  return arcs
+    .map((arc, i) => ({ arc, i }))
+    .sort((a, b) => {
+      const ra = newestEvidenceAt(a.arc);
+      const rb = newestEvidenceAt(b.arc);
+      if (rb !== ra) return rb - ra; // recency desc
+      const ca = CONFIDENCE_WEIGHT[a.arc.confidence];
+      const cb = CONFIDENCE_WEIGHT[b.arc.confidence];
+      if (cb !== ca) return cb - ca; // confidence desc
+      if (b.arc.evidence.length !== a.arc.evidence.length) return b.arc.evidence.length - a.arc.evidence.length;
+      return a.i - b.i; // stable
+    })
+    .map((x) => x.arc);
 }
 
 /** Options for `parseArcsJson`: the numbered facts + episode→item map used to resolve cited evidence. */
@@ -136,7 +178,7 @@ export function parseArcsJson(raw: string | null, opts: ParseArcsOptions = {}): 
       arcs?: (Partial<NarrativeArc> & { supporting_facts?: unknown })[];
     };
     if (!Array.isArray(obj.arcs)) return [];
-    return obj.arcs.slice(0, 5).map((a) => {
+    return obj.arcs.slice(0, MAX_ARCS).map((a) => {
       const supporting_sources = Array.isArray(a.supporting_sources) ? a.supporting_sources.map(String) : [];
       const cited = buildEvidence(a.supporting_facts, facts, epToItem);
       // Fall back to free-text sources (unlinked) if the model didn't cite fact numbers.
@@ -283,7 +325,9 @@ async function synthesizeArcs(
     keys,
     { db, teamId }
   );
-  return attributeArcs(parseArcsJson(raw, { facts, epToItem }), humanByItem);
+  // Rank by recency → relevance so recent contributors' arcs lead, then attribute AI-agent names to
+  // the humans behind each arc's own evidence.
+  return rankArcs(attributeArcs(parseArcsJson(raw, { facts, epToItem }), humanByItem));
 }
 
 // In-memory cache (per process). Keyed by the tier-visible group set. Fronts the Postgres `arc_cache`

--- a/lib/graph/extraction-health.ts
+++ b/lib/graph/extraction-health.ts
@@ -1,0 +1,84 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+import { neo4jConfigured, runRead } from "./neo4j";
+
+/**
+ * Graphiti EXTRACTION health — the one graph failure mode the existing signals miss.
+ *
+ * The projector (`lib/graph/project`) POSTs episodes to Graphiti and records `graph_project` in
+ * `ingest_runs` as OK on a `202 Accepted`. But 202 only means "queued" — Graphiti then runs its own
+ * LLM to extract entities/RELATES_TO facts asynchronously. When THAT step fails on every job (prod
+ * 2026-07: `Output length exceeded max tokens 8192` in `resolve_extracted_nodes`, ~800 jobs backed
+ * up), episodes are accepted but NO facts are created. So:
+ *   • `graph_project` ingest_runs stays green (the POST succeeded),
+ *   • Graphiti `/healthcheck` stays green (the service is up),
+ *   • the projector-freshness check stays green (it IS writing episodes),
+ * yet the graph is empty and narrative arcs synthesize from nothing / stale facts. A completely
+ * silent failure. This probe compares "episodes projected" (Postgres ledger) against "facts actually
+ * extracted" (Neo4j) — many projected but zero extracted ⇒ the extractor is broken. Surfaced loudly
+ * on the admin pipeline banner + retrieval-health card.
+ *
+ * Best-effort: nulls/`stalled:false` on any error so it never breaks a page render.
+ */
+
+/** Below this many projected episodes we can't distinguish "extractor broken" from "fresh install
+ *  still mid-first-extraction" (Graphiti processes async), so we don't flag. With a working extractor,
+ *  25 accepted episodes reliably yield ≥1 fact; 0 facts past that is unambiguous breakage. */
+export const MIN_EPISODES_FOR_EXTRACTION_SIGNAL = 25;
+
+export interface GraphExtractionHealth {
+  episodes: number | null; // projected episodes for this team (Postgres ledger)
+  facts: number | null; // extracted RELATES_TO facts in Neo4j (null = Neo4j unreadable)
+  stalled: boolean; // projected a meaningful backlog but zero facts extracted → extractor failing
+  reason: string | null; // human-facing cause when stalled
+}
+
+/**
+ * Pure verdict: are episodes reaching Graphiti but not becoming facts? `null` on either side means
+ * "can't tell" (Neo4j unreadable, or ledger unreadable) — NOT stalled, since a different leg owns
+ * reachability. Exported for unit tests.
+ */
+export function deriveGraphExtractionStalled(episodes: number | null, facts: number | null): boolean {
+  if (episodes === null || facts === null) return false;
+  return episodes >= MIN_EPISODES_FOR_EXTRACTION_SIGNAL && facts === 0;
+}
+
+/** Count RELATES_TO facts in the graph. A numeric health probe (no content leaves the graph), so it's
+ *  deliberately not tier-scoped — "is the extractor producing ANY facts?" is a global question. */
+export async function countGraphFacts(): Promise<number | null> {
+  if (!neo4jConfigured()) return null;
+  try {
+    const rows = await runRead<{ n: number }>("MATCH ()-[r:RELATES_TO]->() RETURN count(r) AS n");
+    return rows[0]?.n ?? 0;
+  } catch {
+    return null; // Neo4j unreachable — the reachability leg reports that; here it's just "unknown"
+  }
+}
+
+/** Projected episodes for a team from the Postgres ledger (no Graphiti round-trip). */
+async function countProjectedEpisodes(teamId: string): Promise<number | null> {
+  try {
+    const res = await runSql<{ n: number }>(
+      "select count(*)::int as n from graph_episodes where team_id = $1",
+      [teamId]
+    );
+    return res.rows[0]?.n ?? 0;
+  } catch {
+    return null;
+  }
+}
+
+export async function getGraphExtractionHealth(teamId: string): Promise<GraphExtractionHealth> {
+  const empty: GraphExtractionHealth = { episodes: null, facts: null, stalled: false, reason: null };
+  if (!neo4jConfigured()) return empty;
+  const [episodes, facts] = await Promise.all([countProjectedEpisodes(teamId), countGraphFacts()]);
+  const stalled = deriveGraphExtractionStalled(episodes, facts);
+  return {
+    episodes,
+    facts,
+    stalled,
+    reason: stalled
+      ? `${episodes} episodes were projected but the graph has 0 extracted facts — Graphiti is accepting episodes (202) yet its entity-extraction worker is failing on every job (commonly the LLM output-token cap, e.g. "Output length exceeded max tokens"). New activity isn't becoming graph facts, so narrative arcs can't update. Check the graphiti service logs.`
+      : null,
+  };
+}

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -18,15 +18,21 @@ import { episodeGroupId, type AccessTier } from "./group";
 const SOURCE_TABLE = "items";
 
 /**
- * Max episode content length pushed to Graphiti. getzep's ingest worker has NO per-job exception
- * handling (`graph_service/routers/ingest.py` catches only `CancelledError`), so ANY exception from
- * `add_episode` permanently kills the worker and wedges the whole queue. A large episode whose
- * entity/edge extraction overflows the LLM's output-token cap raises exactly such an exception (seen
- * in prod 2026-06-25 and again 2026-07-03: `Output length exceeded max tokens 8192`). Capping content
- * keeps extraction output well under that limit. Full item text still lives in `items`/pgvector/FTS —
- * only the graph episode is truncated (affects a handful of outlier docs; median item is ~240 chars).
+ * Max episode content length pushed to Graphiti. Graphiti extracts entities/edges from each episode
+ * with its OWN LLM, and that call's OUTPUT is hard-capped at 8192 tokens by the pinned `zepai/graphiti`
+ * image (graphiti_core's `DEFAULT_MAX_TOKENS`). The image's `graph_service` exposes NO env to raise it
+ * (verified 2026-07-17 against getzep/graphiti `config.py`: only api_key/base_url/model_name/embedding
+ * are configurable) — so the ONLY app-side lever is to keep extraction output under 8192 by bounding
+ * what we send. A richer/longer episode extracts more nodes → larger structured output → overflow:
+ *   `Output length exceeded max tokens 8192` in `resolve_extracted_nodes` (prod 2026-06-25, 07-03, and
+ *   again 07-17 where a 6000-char cap STILL overflowed and stalled the whole backlog — no facts, blank
+ *   arcs). 2000 chars (~500 tokens) keeps extraction output comfortably bounded. Full item text still
+ *   lives in `items`/pgvector/FTS — only the graph episode is truncated (median item is ~240 chars, so
+ *   this clips only outlier docs). Tunable via `GRAPH_MAX_EPISODE_CHARS` without a redeploy; the deeper
+ *   durable fix (a newer image that raises the cap / handles the length error) is a Graphiti-service
+ *   bump, which carries rebuild/schema-coupling risk — see docs/ARCHITECTURE.md + the graphiti memory.
  */
-export const MAX_EPISODE_CHARS = 6000;
+export const MAX_EPISODE_CHARS = Number(process.env.GRAPH_MAX_EPISODE_CHARS ?? 2000);
 
 /** Item kinds worth projecting as graph episodes — content-bearing knowledge, not raw config.
  * `skill`/`blueprint` are configuration manifests, not events/knowledge, so they're excluded. */

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -1,0 +1,101 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+import { getGraphExtractionHealth } from "@/lib/graph/extraction-health";
+
+/**
+ * Aggregate ingestion-pipeline health for a LOUD admin surface. Every pipeline leg (slack/plane/
+ * linear/github ingest, dense index, graph projection, meeting-notes backfill, linear-inbound, …)
+ * records its outcome to `ingest_runs`. The retrieval-health card + runs table already show detail,
+ * but a persistent failure (the graph projector 422'ing for WEEKS) hid as one red row nobody watched.
+ * This collapses the pipeline to a single "is anything broken?" verdict + the offending legs, so a
+ * broken pipeline is impossible to miss instead of buried.
+ *
+ * Best-effort: a healthy/empty verdict on any error, so it never breaks a page render.
+ */
+
+/** A leg is stale if its newest run is older than this — it was running, then went quiet (poller
+ *  wedged / a source that silently stopped). Comfortably past the 30m ingest + 60m graph cadence. */
+const STALE_MS = 3 * 60 * 60 * 1000; // 3h
+
+/** Sources WITHOUT a fixed poll schedule — a long gap is normal, not a stall (would cry wolf). Their
+ *  real failures still surface via `ok=false`; we just don't flag them on age. `llm` is event-driven
+ *  (already on the retrieval card); `scan` is manual/CI; `pm_sync` is reactive (its own staleness
+ *  heuristic lives in `lib/pm-sync/runs`). Everything else is a scheduled poller and IS stale-able. */
+const UNSCHEDULED_SOURCES = new Set(["llm", "scan", "pm_sync"]);
+
+export interface PipelineLeg {
+  source: string;
+  ok: boolean;
+  error: string | null;
+  at: string; // finished_at ISO
+  stale: boolean; // ran before, but not recently
+}
+
+export interface PipelineHealth {
+  legs: PipelineLeg[];
+  /** Legs that failed (latest run ok=false) or went stale — what the loud banner names. */
+  failing: PipelineLeg[];
+  healthy: boolean;
+}
+
+type Row = { source: string; ok: boolean; errors: unknown; finished_at: string | Date };
+
+function firstError(errors: unknown): string | null {
+  const arr = Array.isArray(errors)
+    ? errors
+    : typeof errors === "string"
+      ? (() => {
+          try {
+            const p = JSON.parse(errors);
+            return Array.isArray(p) ? p : [];
+          } catch {
+            return [];
+          }
+        })()
+      : [];
+  return typeof arr[0] === "string" ? (arr[0] as string) : null;
+}
+
+export async function getPipelineHealth(teamId: string): Promise<PipelineHealth> {
+  const empty: PipelineHealth = { legs: [], failing: [], healthy: true };
+  try {
+    const now = Date.now();
+    // Latest run per source for this team (team-scoped rows) OR global (team_id is null, e.g. dense).
+    // The graph-extraction probe hits Neo4j, so run it concurrently with the ledger read.
+    const [res, extraction] = await Promise.all([
+      runSql<Row>(
+        `select distinct on (source) source, ok, errors, finished_at
+           from ingest_runs
+          where team_id = $1 or team_id is null
+          order by source, finished_at desc`,
+        [teamId]
+      ),
+      getGraphExtractionHealth(teamId).catch(() => null),
+    ]);
+    const legs: PipelineLeg[] = res.rows.map((r) => {
+      const at = r.finished_at instanceof Date ? r.finished_at.toISOString() : String(r.finished_at);
+      // Only SCHEDULED pollers can be "stale" — a reactive/manual source with a long gap is normal.
+      const stale = !UNSCHEDULED_SOURCES.has(r.source) && now - Date.parse(at) > STALE_MS;
+      return { source: r.source, ok: r.ok, error: r.ok ? null : firstError(r.errors), at, stale };
+    });
+
+    // Synthetic leg for the ONE failure ingest_runs structurally can't see: the projector records
+    // graph_project=OK on a 202, but Graphiti then fails entity extraction asynchronously, so
+    // episodes are accepted while zero facts are created. Append it as a failing leg so the loud
+    // banner names it just like a real broken poller.
+    if (extraction?.stalled) {
+      legs.push({
+        source: "graph_extract",
+        ok: false,
+        error: extraction.reason,
+        at: "", // not a point-in-time failure — the banner shows the cause, not a "since" time
+        stale: false,
+      });
+    }
+
+    const failing = legs.filter((l) => !l.ok || l.stale);
+    return { legs, failing, healthy: failing.length === 0 };
+  } catch {
+    return empty;
+  }
+}

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
 import { graphitiConfigured, GraphitiClient } from "@/lib/graph/graphiti-client";
 import { getLlmHealth, type LlmHealth } from "@/lib/query/llm-health";
+import { countGraphFacts, deriveGraphExtractionStalled } from "@/lib/graph/extraction-health";
 
 /**
  * Retrieval-stack health for the admin dashboard (Phase 1 of the retrieval-observability plan).
@@ -40,6 +41,8 @@ export interface RetrievalHealth {
   graphEpisodes: number | null; // projected episodes for this team (null when graph off/unreadable)
   graphLastProjectedAt: string | null; // most recent successful projection (null = never)
   graphStalled: boolean; // degraded specifically because the projector stopped writing (vs unreachable)
+  graphExtractionStalled: boolean; // episodes are reaching Graphiti (202) but its extractor makes no facts
+  graphFacts: number | null; // extracted RELATES_TO facts in Neo4j (null = unreadable)
   rerank: LegState;
   augment: LegState; // optional external retrieval-augment service (RETRIEVAL_AUGMENT_URL)
   llm: LlmHealth; // answering-model health — did the configured model recently produce output?
@@ -88,17 +91,21 @@ export function isGraphStale(lastProjectedAtMs: number | null, nowMs: number): b
  *   • not configured (no/malformed GRAPHITI_URL)             → "off"
  *   • configured BUT /healthcheck failed (down/unreachable)   → "degraded"
  *   • reachable BUT projector hasn't written in > GRAPH_STALE_MS (writes failing) → "degraded"
+ *   • reachable + writing BUT the extractor makes no facts from projected episodes → "degraded"
  *   • reachable AND recently projected (or nothing to project yet) → "on"
  */
 export function deriveGraphState(input: {
   configured: boolean;
   reachable: boolean;
   lastProjectedAtMs: number | null;
+  extractionStalled: boolean;
   nowMs: number;
 }): GraphState {
   if (!input.configured) return "off";
   if (!input.reachable) return "degraded";
-  return isGraphStale(input.lastProjectedAtMs, input.nowMs) ? "degraded" : "on";
+  if (isGraphStale(input.lastProjectedAtMs, input.nowMs)) return "degraded";
+  if (input.extractionStalled) return "degraded"; // accepting episodes but extracting no facts
+  return "on";
 }
 
 /**
@@ -132,15 +139,25 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
 
   // Graph + dense both hit the network — run them concurrently so the card render isn't serialized.
   const graphConfiguredNow = graphConfigured(process.env.GRAPHITI_URL);
-  const [dense, graphReachable, graphFresh, llm] = await Promise.all([
+  const [dense, graphReachable, graphFresh, graphFacts, llm] = await Promise.all([
     denseHealth(teamId, configured),
     graphConfiguredNow ? new GraphitiClient().healthcheck() : Promise.resolve(false),
     graphConfiguredNow ? graphFreshness(teamId) : Promise.resolve({ episodes: null, lastProjectedAt: null }),
+    graphConfiguredNow ? countGraphFacts() : Promise.resolve(null),
     getLlmHealth(teamId),
   ]);
   const lastProjectedAtMs = graphFresh.lastProjectedAt ? Date.parse(graphFresh.lastProjectedAt) : null;
   const nowMs = Date.now();
-  const graph = deriveGraphState({ configured: graphConfiguredNow, reachable: graphReachable, lastProjectedAtMs, nowMs });
+  // Reachable + writing, but projected episodes aren't becoming facts (Graphiti's extractor is failing
+  // on every job). Only meaningful when reachable — an unreachable service reports facts=null.
+  const graphExtractionStalled = graphReachable && deriveGraphExtractionStalled(graphFresh.episodes, graphFacts);
+  const graph = deriveGraphState({
+    configured: graphConfiguredNow,
+    reachable: graphReachable,
+    lastProjectedAtMs,
+    extractionStalled: graphExtractionStalled,
+    nowMs,
+  });
   // Degraded specifically because the projector went quiet (reachable, but a stale write path) — the
   // card renders a different, more actionable banner for this than for a hard-unreachable service.
   const graphStalled = graph === "degraded" && graphReachable && isGraphStale(lastProjectedAtMs, nowMs);
@@ -151,6 +168,8 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
     graphEpisodes: graphFresh.episodes,
     graphLastProjectedAt: graphFresh.lastProjectedAt,
     graphStalled,
+    graphExtractionStalled,
+    graphFacts,
     rerank,
     augment,
     llm,

--- a/test/graph-arcs-parse.test.ts
+++ b/test/graph-arcs-parse.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseArcsJson, stripTaskKeys } from "@/lib/graph/arcs";
+import { parseArcsJson, stripTaskKeys, rankArcs, newestEvidenceAt, type NarrativeArc } from "@/lib/graph/arcs";
 
 /**
  * Spec for the arc JSON normalizer (the fragile bit — an LLM's JSON is untrusted). Derived from the
- * contract the panel needs: safe defaults, capped at 5, coerced confidence, stable ids, never throws.
+ * contract the panel needs: safe defaults, capped at 8, coerced confidence, stable ids, never throws.
  */
 
 describe("stripTaskKeys", () => {
@@ -63,9 +63,9 @@ describe("parseArcsJson", () => {
     expect(arc.supporting_sources).toEqual([]);
   });
 
-  it("caps at 5 arcs", () => {
-    const arcs = Array.from({ length: 9 }, (_, i) => ({ title: `A${i}`, confidence: "low" }));
-    expect(parseArcsJson(JSON.stringify({ arcs }), { now: NOW })).toHaveLength(5);
+  it("caps at 8 arcs", () => {
+    const arcs = Array.from({ length: 12 }, (_, i) => ({ title: `A${i}`, confidence: "low" }));
+    expect(parseArcsJson(JSON.stringify({ arcs }), { now: NOW })).toHaveLength(8);
   });
 
   it("returns [] for null, malformed JSON, or a missing arcs array (never throws)", () => {
@@ -143,5 +143,46 @@ describe("parseArcsJson evidence (verifiable, linkable)", () => {
     const raw = JSON.stringify({ arcs: [{ title: "T", confidence: "low", supporting_sources: ["Slack #eng", "a PR"] }] });
     const [arc] = parseArcsJson(raw, { facts, epToItem, now: NOW });
     expect(arc.evidence).toEqual([{ fact: "Slack #eng" }, { fact: "a PR" }]);
+  });
+});
+
+describe("rankArcs — recency then relevance (surfaces recent contributors' work)", () => {
+  const arc = (title: string, confidence: NarrativeArc["confidence"], ats: (string | undefined)[]): NarrativeArc => ({
+    id: `arc-${title}`,
+    title,
+    confidence,
+    summary: "",
+    participants: [],
+    supporting_sources: [],
+    evidence: ats.map((at) => ({ fact: `f-${title}`, at })),
+    derived_at: "2026-07-17T00:00:00.000Z",
+  });
+
+  it("newestEvidenceAt returns the max dated evidence, -Infinity when none is dated", () => {
+    expect(newestEvidenceAt(arc("a", "low", ["2026-07-01T00:00:00Z", "2026-07-10T00:00:00Z"]))).toBe(
+      Date.parse("2026-07-10T00:00:00Z")
+    );
+    expect(newestEvidenceAt(arc("b", "low", [undefined]))).toBe(-Infinity);
+  });
+
+  it("orders the most-recent arc first even when it's lower confidence (recency wins)", () => {
+    const stale = arc("stale-high", "high", ["2026-06-01T00:00:00Z"]);
+    const recent = arc("recent-low", "low", ["2026-07-16T00:00:00Z"]);
+    expect(rankArcs([stale, recent]).map((a) => a.title)).toEqual(["recent-low", "stale-high"]);
+  });
+
+  it("breaks recency ties by confidence, then by evidence depth", () => {
+    const day = "2026-07-15T00:00:00Z";
+    const lowThin = arc("low-thin", "low", [day]);
+    const highAny = arc("high", "high", [day]);
+    const lowDeep = arc("low-deep", "low", [day, day]);
+    expect(rankArcs([lowThin, highAny, lowDeep]).map((a) => a.title)).toEqual(["high", "low-deep", "low-thin"]);
+  });
+
+  it("sorts arcs with no dated evidence last, stably", () => {
+    const dated = arc("dated", "low", ["2026-07-10T00:00:00Z"]);
+    const undated1 = arc("undated1", "high", [undefined]);
+    const undated2 = arc("undated2", "high", [undefined]);
+    expect(rankArcs([undated1, dated, undated2]).map((a) => a.title)).toEqual(["dated", "undated1", "undated2"]);
   });
 });

--- a/test/graph-extraction-health.test.ts
+++ b/test/graph-extraction-health.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveGraphExtractionStalled,
+  MIN_EPISODES_FOR_EXTRACTION_SIGNAL,
+} from "@/lib/graph/extraction-health";
+
+/**
+ * The exact prod failure (2026-07): the projector POSTs episodes, Graphiti returns 202 and records
+ * graph_project=OK, then its extractor fails every job ("Output length exceeded max tokens 8192") so
+ * NO facts get created. `graph_project` stays green, /healthcheck stays green — the only observable
+ * signal is "many episodes projected, zero facts extracted". This is that spec.
+ */
+describe("deriveGraphExtractionStalled", () => {
+  const N = MIN_EPISODES_FOR_EXTRACTION_SIGNAL;
+
+  it("STALLED: a real backlog of projected episodes but zero extracted facts (the live bug)", () => {
+    expect(deriveGraphExtractionStalled(1243, 0)).toBe(true);
+    expect(deriveGraphExtractionStalled(N, 0)).toBe(true);
+  });
+
+  it("healthy: episodes projected AND facts exist — the extractor is working", () => {
+    expect(deriveGraphExtractionStalled(1243, 400)).toBe(false);
+    expect(deriveGraphExtractionStalled(N, 1)).toBe(false);
+  });
+
+  it("not flagged below the threshold — a fresh install may still be mid-first-extraction", () => {
+    // Too few episodes to distinguish "broken" from "Graphiti still processing the first batch".
+    expect(deriveGraphExtractionStalled(N - 1, 0)).toBe(false);
+    expect(deriveGraphExtractionStalled(5, 0)).toBe(false);
+  });
+
+  it("nothing projected yet ⇒ not stalled (zero-vs-zero is a fresh graph, not a failure)", () => {
+    expect(deriveGraphExtractionStalled(0, 0)).toBe(false);
+  });
+
+  it("unknown facts (Neo4j unreadable) ⇒ not stalled — reachability is a different leg's concern", () => {
+    expect(deriveGraphExtractionStalled(1243, null)).toBe(false);
+  });
+
+  it("unknown episodes (ledger unreadable) ⇒ not stalled — can't tell", () => {
+    expect(deriveGraphExtractionStalled(null, 0)).toBe(false);
+    expect(deriveGraphExtractionStalled(null, null)).toBe(false);
+  });
+});

--- a/test/retrieval-health.test.ts
+++ b/test/retrieval-health.test.ts
@@ -59,21 +59,29 @@ describe("deriveGraphState", () => {
   const now = Date.parse("2026-07-15T12:00:00Z");
   const fresh = Date.parse("2026-07-15T11:00:00Z"); // 1h ago
   const stale = Date.parse("2026-07-08T12:00:00Z"); // 7d ago
+  const base = { extractionStalled: false as boolean, nowMs: now };
   it("off when not configured (regardless of reachability)", () => {
-    expect(deriveGraphState({ configured: false, reachable: false, lastProjectedAtMs: null, nowMs: now })).toBe("off");
-    expect(deriveGraphState({ configured: false, reachable: true, lastProjectedAtMs: fresh, nowMs: now })).toBe("off");
+    expect(deriveGraphState({ ...base, configured: false, reachable: false, lastProjectedAtMs: null })).toBe("off");
+    expect(deriveGraphState({ ...base, configured: false, reachable: true, lastProjectedAtMs: fresh })).toBe("off");
   });
   it("on when reachable AND recently projected", () => {
-    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: fresh, nowMs: now })).toBe("on");
+    expect(deriveGraphState({ ...base, configured: true, reachable: true, lastProjectedAtMs: fresh })).toBe("on");
   });
   it("on when reachable and nothing has projected yet (null = fresh install, not a stall)", () => {
-    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: null, nowMs: now })).toBe("on");
+    expect(deriveGraphState({ ...base, configured: true, reachable: true, lastProjectedAtMs: null })).toBe("on");
   });
   it("degraded when configured BUT unreachable — the silent-failure case reviving must surface", () => {
-    expect(deriveGraphState({ configured: true, reachable: false, lastProjectedAtMs: fresh, nowMs: now })).toBe("degraded");
+    expect(deriveGraphState({ ...base, configured: true, reachable: false, lastProjectedAtMs: fresh })).toBe("degraded");
   });
   it("degraded when reachable BUT projector stalled — the 2026-07 healthcheck-only blind spot", () => {
     // /healthcheck answers (reachable) yet no episode has landed in a week → writes are failing silently.
-    expect(deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: stale, nowMs: now })).toBe("degraded");
+    expect(deriveGraphState({ ...base, configured: true, reachable: true, lastProjectedAtMs: stale })).toBe("degraded");
+  });
+  it("degraded when reachable + writing BUT the extractor makes no facts — the 202-then-silent-fail case", () => {
+    // Projector is fresh (writing episodes) and the service is up, but Graphiti's extractor fails every
+    // job so nothing becomes a fact. This is the blind spot ingest_runs=graph_project(ok) can't see.
+    expect(
+      deriveGraphState({ configured: true, reachable: true, lastProjectedAtMs: fresh, extractionStalled: true, nowMs: now })
+    ).toBe("degraded");
   });
 });


### PR DESCRIPTION
## Why
Two user-reported problems, one root cause chain:
1. **"These problems should fail loudly on the admin panel."** The pipeline had a silent failure class — a leg could break with no loud signal.
2. **"Why aren't there any arcs with my name? all belong to john."** The graph stopped being fed: after the 422→202 timestamp fix, Graphiti was **accepting episodes (202) but failing entity extraction on every job** (`Output length exceeded max tokens 8192`, ~800 jobs backed up) — so no facts, and arcs synthesized from stale, John-skewed data. `graph_project` recorded OK the whole time (202 ≠ extracted).

## What shipped
**Fail loudly**
- Loud **pipeline-health banner** on Home (admins) + Integrations, over `ingest_runs` — names every failing/stale scheduled leg. Unscheduled sources (`scan`/`pm_sync`/`llm`) don't cry-wolf on age.
- New `lib/graph/extraction-health` closes the one blind spot `ingest_runs` structurally can't see: compares **projected episodes (Postgres ledger) vs extracted facts (Neo4j)**. Many projected + zero facts ⇒ **degraded**, surfaced on the retrieval-health card (Graph memory leg) *and* the loud banner (synthetic `graph_extract` leg).

**Unblock the graph (the real arc fix)**
- The pinned `zepai/graphiti` image exposes **no `max_tokens` env** (verified against getzep `config.py` — only api_key/base_url/model_name/embedding). So the app-side lever is episode size: **`MAX_EPISODE_CHARS` 6000 → 2000** (`GRAPH_MAX_EPISODE_CHARS`-tunable). A smaller episode extracts fewer nodes → smaller structured output → under the hard 8192 cap. Overflowing items re-project at the smaller size over the next projection cycles.

**Arcs surface recent work**
- Show **8 arcs (was 5)** and **rank by recency → relevance** (newest cited evidence first, then confidence, then evidence depth) so a recent contributor's work isn't buried under stale storylines. Prompt also nudges balanced contributor representation.

**Docs / ops**
- `CLAUDE.md`: read-only prod DB access via the Railway public proxy.
- `docs/ARCHITECTURE.md` + `graphiti/README.md` + graphiti memory updated per the build loop.

## Verified
- **826 unit tests** pass (new: `graph-extraction-health`, `deriveGraphState` extraction-stall case, `rankArcs`/`newestEvidenceAt` ranking, caps-at-8). `tsc`, lint, docs-drift all clean.
- Rebased clean onto current `main` (the #296 timestamp fix already there; dropped the duplicate commit).

## Notes
- No schema change → auto-deploys on merge. After deploy, the projector re-projects overflowing items at 2000 chars; the graph repopulates over a cycle or two and recency-ranked arcs should start reflecting recent contributors (incl. Chetan, whose identity/aliases are already correctly mapped).
- The deeper durable extraction fix (a newer Graphiti image that raises the cap / handles `LengthFinishReasonError`) is a **service image bump** with rebuild + Neo4j-schema-coupling risk — deliberately out of this PR; documented as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin pipeline health banners to team home and integrations pages, highlighting stale or failing ingestion sources.
  * Added detection and reporting for graph extraction stalls, including cases where episodes are accepted but produce no facts.
  * Increased supported narrative arcs to eight and improved ordering by recency, confidence, and evidence depth.
  * Added configurable episode-length limits for graph processing.

* **Documentation**
  * Documented read-only production database inspection and graph extraction failure modes.

* **Tests**
  * Added coverage for pipeline, graph extraction, retrieval health, and narrative arc ranking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->