### PR TITLE
fix(observability): per-source staleness so the pipeline banner stops crying wolf on auth_cleanup

### DIFF
--- a/components/admin/pipeline-health-banner.tsx
+++ b/components/admin/pipeline-health-banner.tsx
@@ -34,8 +34,8 @@ export function PipelineHealthBanner({ health, href }: { health: PipelineHealth;
       <div className="flex items-center gap-2">
         <AlertTriangle className="size-4 shrink-0" />
         <p className="text-sm font-semibold">
-          {health.failing.length} ingestion {health.failing.length === 1 ? "leg is" : "legs are"} broken
-          — the brain isn&apos;t getting fresh data
+          {health.failing.length} ingestion {health.failing.length === 1 ? "leg is broken" : "legs are broken"} —
+          the brain isn&apos;t getting fresh data
         </p>
       </div>
       <ul className="mt-2 flex flex-col gap-1 pl-6">
@@ -43,7 +43,7 @@ export function PipelineHealthBanner({ health, href }: { health: PipelineHealth;
           <li key={l.source} className="text-xs">
             <span className="font-medium">{LABEL[l.source] ?? l.source}</span>{" "}
             {l.stale && l.ok ? (
-              <span>— no successful run in {timeAgo(l.at)} (may have stopped)</span>
+              <span>— last successful run {timeAgo(l.at)} (may have stopped)</span>
             ) : (
               <span>
                 — failing{l.at ? ` since ${timeAgo(l.at)}` : ""}

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -13,15 +13,31 @@ import { getGraphExtractionHealth } from "@/lib/graph/extraction-health";
  * Best-effort: a healthy/empty verdict on any error, so it never breaks a page render.
  */
 
-/** A leg is stale if its newest run is older than this — it was running, then went quiet (poller
- *  wedged / a source that silently stopped). Comfortably past the 30m ingest + 60m graph cadence. */
-const STALE_MS = 3 * 60 * 60 * 1000; // 3h
+/** A leg is stale if its newest run is older than its cadence — it was running, then went quiet
+ *  (poller wedged / a source that silently stopped). Default comfortably past the 30m ingest + 60m
+ *  graph cadence. */
+const STALE_MS = 3 * 60 * 60 * 1000; // 3h default
 
-/** Sources WITHOUT a fixed poll schedule — a long gap is normal, not a stall (would cry wolf). Their
- *  real failures still surface via `ok=false`; we just don't flag them on age. `llm` is event-driven
- *  (already on the retrieval card); `scan` is manual/CI; `pm_sync` is reactive (its own staleness
- *  heuristic lives in `lib/pm-sync/runs`). Everything else is a scheduled poller and IS stale-able. */
-const UNSCHEDULED_SOURCES = new Set(["llm", "scan", "pm_sync"]);
+/**
+ * Per-source staleness overrides. A blanket 3h threshold cries wolf on legs that legitimately run
+ * less often (a 24h housekeeping job is "stale" 21h/day under 3h). So each infrequent/irregular leg
+ * gets its OWN threshold = its cadence + grace, and `null` means "never flag on age" (unscheduled /
+ * reactive / event-driven — real failures still surface via `ok=false`). Anything not listed uses the
+ * 3h default. `auth_cleanup` runs every 24h (`lib/ingest/scheduler` housekeeping) — 3h was the bug
+ * that fired this banner on a healthy job.
+ */
+const STALE_MS_BY_SOURCE: Record<string, number | null> = {
+  llm: null, // event-driven (also surfaced on the retrieval-health card)
+  scan: null, // manual / CI
+  pm_sync: null, // reactive — its own staleness heuristic lives in lib/pm-sync/runs
+  auth_cleanup: 26 * 60 * 60 * 1000, // 24h cadence + 2h grace (genuinely-stuck still surfaces)
+};
+
+/** The age past which `source` is considered stale, or `null` to never flag it on age. Exported for
+ *  unit tests (a wrong threshold here fires the loud banner on a healthy job — the auth_cleanup bug). */
+export function staleThresholdMs(source: string): number | null {
+  return source in STALE_MS_BY_SOURCE ? STALE_MS_BY_SOURCE[source] : STALE_MS;
+}
 
 export interface PipelineLeg {
   source: string;
@@ -74,8 +90,9 @@ export async function getPipelineHealth(teamId: string): Promise<PipelineHealth>
     ]);
     const legs: PipelineLeg[] = res.rows.map((r) => {
       const at = r.finished_at instanceof Date ? r.finished_at.toISOString() : String(r.finished_at);
-      // Only SCHEDULED pollers can be "stale" — a reactive/manual source with a long gap is normal.
-      const stale = !UNSCHEDULED_SOURCES.has(r.source) && now - Date.parse(at) > STALE_MS;
+      // Stale only past THIS source's own cadence — a 24h job isn't stale at 3h (would cry wolf).
+      const threshold = staleThresholdMs(r.source);
+      const stale = threshold !== null && now - Date.parse(at) > threshold;
       return { source: r.source, ok: r.ok, error: r.ok ? null : firstError(r.errors), at, stale };
     });
 

--- a/test/pipeline-health-staleness.test.ts
+++ b/test/pipeline-health-staleness.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { staleThresholdMs } from "@/lib/ingest/pipeline-health";
+
+/**
+ * Regression for the false-positive that fired the loud "1 ingestion leg is broken" banner on a
+ * HEALTHY job: `auth_cleanup` runs every 24h, but the blanket 3h staleness threshold flagged it as
+ * broken ~21h/day. A leg's staleness must be judged against ITS OWN cadence.
+ */
+describe("staleThresholdMs — per-source staleness cadence", () => {
+  const H = 60 * 60 * 1000;
+
+  it("auth_cleanup (24h job) is NOT stale at 3h — its threshold is well past 24h", () => {
+    const t = staleThresholdMs("auth_cleanup");
+    expect(t).not.toBeNull();
+    expect(t!).toBeGreaterThan(24 * H); // must clear a normal 24h cycle
+    // Concretely: a run 7h ago (what fired the banner) is NOT stale.
+    expect(7 * H > t!).toBe(false);
+  });
+
+  it("frequent pollers use the 3h default and DO go stale when quiet", () => {
+    for (const s of ["slack", "linear", "github", "dense", "graph_project", "meeting_notes"]) {
+      expect(staleThresholdMs(s)).toBe(3 * H);
+    }
+  });
+
+  it("unscheduled/reactive/event-driven legs are never age-stale (real failures still show via ok=false)", () => {
+    for (const s of ["llm", "scan", "pm_sync"]) {
+      expect(staleThresholdMs(s)).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## What you saw
The red **"1 ingestion leg is broken — Auth cleanup, no successful run in 7h"** banner on Home was a **false alarm from my own #300 banner**, not a real breakage.

## Cause
`auth_cleanup` (housekeeping that purges expired login tokens / OAuth states) runs **once every 24h** by design (`AUTH_CLEANUP_INTERVAL_MS = 24h`), but the banner marked any leg "broken" after **3h**. I'd exempted the other irregular sources (`scan`/`pm_sync`/`llm`) but missed this one, so it cried wolf ~21h/day — the exact thing that erodes a fail-loud signal.

## Fix
- **Per-source staleness cadence** (`staleThresholdMs`): `auth_cleanup` = 24h + 2h grace (a *genuinely* stuck job still surfaces past 26h); `llm`/`scan`/`pm_sync` = never age-stale (real failures still show via `ok=false`); everything else = 3h default.
- **Copy:** "leg is broken" spacing + "last successful run 7h ago" (was the awkward "no successful run in 7h ago").
- **Regression test** `test/pipeline-health-staleness.test.ts` — would have caught this.

No behavior change for the real legs (slack/linear/github/dense/graph_project/meeting_notes still stale at 3h). Verified: tsc + the new test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)