### PR TITLE
fix(graph): representative arc synthesis (surface every contributor) + fit episodes under the 16384 cap

### DIFF
--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -50,6 +50,9 @@ export type ProviderKeys = LlmBackendKeys;
 
 const MAX_FACTS = 200;
 const MAX_ARCS = 8;
+// Fetch a much deeper pool than we feed the model, so lower-volume contributors' facts are reachable
+// for balancing (a high-volume person's recent burst can otherwise push everyone else past MAX_FACTS).
+const FACT_POOL = MAX_FACTS * 6;
 const CACHE_TTL_MS = 10 * 60_000;
 
 const SYSTEM_PROMPT =
@@ -80,6 +83,39 @@ export function stripTaskKeys(text: string): string {
     .replace(/\(\s*\)/g, "") // empty parens left behind
     .replace(/\s{2,}/g, " ")
     .trim();
+}
+
+/**
+ * Balance a fact pool ACROSS its contributors so synthesis input represents everyone active — not just
+ * whoever pushed the most recent volume. Without this, arc synthesis fed the globally-newest MAX_FACTS
+ * facts, so a high-volume contributor's recent burst crowded every lower-volume person out of the
+ * prompt entirely (their work then never appeared in Learning even though it's in the graph). We group
+ * the pool by the human behind each fact and round-robin one-per-contributor per round (each person's
+ * facts consumed newest-first) until `budget` is filled. Unattributed facts ("") are their own bucket.
+ * Pure + unit-tested; `humanOf` is injected so the DB/Neo4j resolution stays in the caller.
+ */
+export function balanceFactsByContributor<T>(facts: T[], humanOf: (f: T) => string, budget: number): T[] {
+  const buckets = new Map<string, T[]>();
+  for (const f of facts) {
+    const key = humanOf(f);
+    const arr = buckets.get(key);
+    if (arr) arr.push(f);
+    else buckets.set(key, [f]);
+  }
+  const lists = [...buckets.values()]; // insertion order ≈ first-seen recency, newest bucket first
+  const out: T[] = [];
+  for (let round = 0; out.length < budget; round++) {
+    let progressed = false;
+    for (const list of lists) {
+      if (out.length >= budget) break;
+      if (round < list.length) {
+        out.push(list[round]);
+        progressed = true;
+      }
+    }
+    if (!progressed) break; // every bucket exhausted
+  }
+  return out;
 }
 
 const CONFIDENCE_WEIGHT: Record<NarrativeArc["confidence"], number> = { high: 3, medium: 2, low: 1 };
@@ -311,15 +347,29 @@ async function synthesizeArcs(
   keys: ProviderKeys
 ): Promise<NarrativeArc[]> {
   // Arcs are NOT time-boxed — synthesize from the most-recent facts regardless of age (a quiet week,
-  // or a stalled projector, must not blank the panel). `null` = no window; recentFacts still caps at
-  // MAX_FACTS, newest first.
-  const facts = await recentFacts(groups, null, MAX_FACTS);
+  // or a stalled projector, must not blank the panel). `null` = no window. Fetch a DEEP pool (not just
+  // MAX_FACTS), so we can balance it across contributors — otherwise the globally-newest MAX_FACTS are
+  // dominated by whoever pushed the most volume and everyone else's work is invisible in Learning.
+  const pool = await recentFacts(groups, null, FACT_POOL);
   // No facts and nothing to correct → nothing to synthesize. (A correction with no facts still runs
   // the LLM, preserving the pre-cache recompute behavior.)
-  if (facts.length === 0 && correctionTexts.length === 0) return [];
-  const epToItem = await resolveEpisodeItems(groups, facts.flatMap((f) => f.episodeUuids));
+  if (pool.length === 0 && correctionTexts.length === 0) return [];
+  // Resolve attribution for the WHOLE pool (higher uuid cap to match) so balancing sees each fact's
+  // human. epToItem/humanByItem stay supersets of the balanced set — safe for evidence + attribution.
+  const epToItem = await resolveEpisodeItems(groups, pool.flatMap((f) => f.episodeUuids), FACT_POOL * 3);
   const allItemIds = [...new Set([...epToItem.values()].map((v) => v.itemId).filter((id): id is string => !!id))];
   const humanByItem = await resolveHumanActorsByItem(db, teamId, allItemIds);
+  // The human behind a fact = the first resolvable human among its source episodes' items ("" if none).
+  const humanOfFact = (f: AtomicFact): string => {
+    for (const u of f.episodeUuids) {
+      const itemId = epToItem.get(u)?.itemId;
+      const h = itemId ? humanByItem.get(itemId) : undefined;
+      if (h) return h;
+    }
+    return "";
+  };
+  // Balance the deep pool → a representative MAX_FACTS so every active contributor is in the prompt.
+  const facts = balanceFactsByContributor(pool, humanOfFact, MAX_FACTS);
   const raw = await callLLMRaw(
     buildPrompt(attributedFactTexts(facts, epToItem, humanByItem), correctionTexts),
     keys,

--- a/lib/graph/learning.ts
+++ b/lib/graph/learning.ts
@@ -91,10 +91,11 @@ export async function recentFacts(
  */
 export async function resolveEpisodeItems(
   groups: string[],
-  uuids: string[]
+  uuids: string[],
+  maxUuids = 500
 ): Promise<Map<string, { itemId?: string; source?: string }>> {
   const out = new Map<string, { itemId?: string; source?: string }>();
-  const unique = [...new Set(uuids.filter(Boolean))].slice(0, 500);
+  const unique = [...new Set(uuids.filter(Boolean))].slice(0, maxUuids);
   if (!neo4jConfigured() || groups.length === 0 || unique.length === 0) return out;
   try {
     const rows = await runRead<{ uuid: string; name: string | null; source: string | null }>(

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -25,12 +25,15 @@ const SOURCE_TABLE = "items";
  * stalled the queue (prod 2026-06-25, 07-03, 07-17). The ROOT FIX is on the Graphiti side: bump the
  * image to one where `DEFAULT_MAX_TOKENS` is 16384 (current graphiti_core) — done in graphiti's
  * docker-compose + the prod service — so extraction has 2× the headroom instead of us shrinking input.
- * With the cap raised, 6000 is the intended episode size (full item text still lives in
- * `items`/pgvector/FTS regardless; median item ~240 chars, so this only clips outliers). Still
- * env-tunable via `GRAPH_MAX_EPISODE_CHARS` as a safety valve. See the "202 ≠ extracted" note +
- * extraction-health probe in docs/ARCHITECTURE.md.
+ * With the cap raised to 16384, most episodes extract — but the densest 6000-char ones can STILL
+ * overflow even 16384 (`Output length exceeded max tokens 16384`, prod 2026-07-17), especially while a
+ * backlog reprojection bloats Graphiti's previous-episode context. gpt-4o's output ceiling IS 16384,
+ * so we can't raise the cap further; 4000 keeps the densest episodes' extraction output under it while
+ * staying far more faithful than the 2000 stop-gap (full item text still lives in `items`/pgvector/FTS
+ * regardless; median item ~240 chars, so this only clips outliers). Env-tunable via
+ * `GRAPH_MAX_EPISODE_CHARS`. See the "202 ≠ extracted" note + extraction-health probe in docs/ARCHITECTURE.md.
  */
-export const MAX_EPISODE_CHARS = Number(process.env.GRAPH_MAX_EPISODE_CHARS ?? 6000);
+export const MAX_EPISODE_CHARS = Number(process.env.GRAPH_MAX_EPISODE_CHARS ?? 4000);
 
 /** Item kinds worth projecting as graph episodes — content-bearing knowledge, not raw config.
  * `skill`/`blueprint` are configuration manifests, not events/knowledge, so they're excluded. */

--- a/test/graph-arcs-parse.test.ts
+++ b/test/graph-arcs-parse.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { parseArcsJson, stripTaskKeys, rankArcs, newestEvidenceAt, type NarrativeArc } from "@/lib/graph/arcs";
+import {
+  parseArcsJson,
+  stripTaskKeys,
+  rankArcs,
+  newestEvidenceAt,
+  balanceFactsByContributor,
+  type NarrativeArc,
+} from "@/lib/graph/arcs";
 
 /**
  * Spec for the arc JSON normalizer (the fragile bit — an LLM's JSON is untrusted). Derived from the
@@ -184,5 +191,38 @@ describe("rankArcs — recency then relevance (surfaces recent contributors' wor
     const undated1 = arc("undated1", "high", [undefined]);
     const undated2 = arc("undated2", "high", [undefined]);
     expect(rankArcs([undated1, dated, undated2]).map((a) => a.title)).toEqual(["dated", "undated1", "undated2"]);
+  });
+});
+
+describe("balanceFactsByContributor — fair representation (the fix for a contributor going invisible)", () => {
+  const f = (id: string, who: string) => ({ id, who });
+  const humanOf = (x: { who: string }) => x.who;
+
+  it("round-robins so a high-volume contributor can't crowd out a low-volume one", () => {
+    // John has 5 facts, Chetan 1. With the OLD global-newest slice(0,4) Chetan would be dropped;
+    // balancing must keep him in.
+    const facts = [
+      f("j1", "John"), f("j2", "John"), f("j3", "John"), f("j4", "John"), f("j5", "John"),
+      f("c1", "Chetan"),
+    ];
+    const out = balanceFactsByContributor(facts, humanOf, 4);
+    expect(out.map((x) => x.id)).toContain("c1");
+    expect(out.map((x) => x.id)).toEqual(["j1", "c1", "j2", "j3"]);
+  });
+
+  it("consumes each contributor's facts newest-first (per-bucket input order preserved)", () => {
+    const facts = [f("j1", "John"), f("j2", "John"), f("c1", "Chetan"), f("c2", "Chetan")];
+    expect(balanceFactsByContributor(facts, humanOf, 4).map((x) => x.id)).toEqual(["j1", "c1", "j2", "c2"]);
+  });
+
+  it("respects the budget and returns [] for an empty pool", () => {
+    const facts = Array.from({ length: 20 }, (_, i) => f(`x${i}`, i % 2 ? "A" : "B"));
+    expect(balanceFactsByContributor(facts, humanOf, 5)).toHaveLength(5);
+    expect(balanceFactsByContributor([], humanOf, 5)).toEqual([]);
+  });
+
+  it("unattributed facts ('') are their own bucket and still get a fair share", () => {
+    const facts = [f("j1", "John"), f("j2", "John"), f("u1", ""), f("u2", "")];
+    expect(balanceFactsByContributor(facts, humanOf, 4).map((x) => x.id)).toEqual(["j1", "u1", "j2", "u2"]);
   });
 });


### PR DESCRIPTION
## Why
"Why are there no arcs with me? there used to be." All 8 Learning arcs came out **John Ellison**, zero Chetan — even though **173 of Chetan's items are projected into the graph**. Not an attribution bug: arc synthesis fed the LLM the **200 globally-newest facts**, and John has ~4× the volume and slightly more-recent activity, so that window was *entirely* his. The model literally never saw Chetan's facts. Recency-ranking the output (my earlier change) can't fix an input that doesn't contain you.

## Fix
- **`balanceFactsByContributor`** — fetch a deep pool (6×`MAX_FACTS`), resolve each fact's human via episode→item, then **round-robin one-per-contributor** (each person newest-first) down to `MAX_FACTS`. Every active contributor is guaranteed a fair slice of the synthesis input, so a high-volume person can't crowd everyone else out. Pure + unit-tested.
- **`resolveEpisodeItems`** — uuid cap is now a param, so the deeper pool can be fully attributed.
- **`MAX_EPISODE_CHARS` 6000 → 4000** (`GRAPH_MAX_EPISODE_CHARS`-tunable) — the densest 6000-char episodes still overflowed **even the raised 16384 cap** (`Output length exceeded max tokens 16384`; gpt-4o's output ceiling *is* 16384, so we can't raise it further), stalling a slice of the backlog. 4000 keeps extraction under the cap while staying far more faithful than the 2000 stop-gap. Full item text still lives in `items`/pgvector/FTS.

## Verified
833 unit tests (new `balanceFactsByContributor` specs prove a 1-fact contributor survives a 5-fact one), tsc, lint, docs-drift green.

## Note
This lands the **synthesis** fix; the graph also needs to finish repopulating (the 4000 trim clears the stuck dense episodes). After deploy + a projection cycle, your work should appear in the recency-ranked, now-representative arcs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved narrative synthesis so contributions from lower-volume contributors receive fairer representation.
  - Added configurable limits for processing episode references.

- **Bug Fixes**
  - Reduced the default episode content size sent for processing, helping prevent oversized inputs while preserving relevant context.

- **Tests**
  - Added coverage for fair contributor representation, ordering, budget limits, empty inputs, and unattributed contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->