### PR TITLE
docs(claude): require a Fable review before pushing any PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,26 @@ who reads it**. The map only pays off if it's trustworthy, so:
 
 ---
 
+## ⚠️ Review gate — ALWAYS Fable-review before pushing a PR (REQUIRED)
+
+Many sessions/worktrees ship into this repo in parallel and merge fast — **a Fable review is the
+pre-merge safety net** that catches tier leaks, sync-contract drift, and correctness bugs the async
+bots (CodeRabbit/Cursor) miss. It is **not optional**.
+
+- **Before you `git push` a PR branch:** run a Fable review of the branch diff — spawn the
+  **`code-reviewer` agent on the Fable model** (`Agent(subagent_type: "code-reviewer", model: "fable")`)
+  pointed at `git diff origin/main...HEAD`. Give it the change's intent and let it apply the AIOS
+  invariants (this file + the agent's own checklist).
+- **Address its findings first.** Fix every blocker/HIGH; fix or consciously defer MEDIUM/LOW with a
+  one-line reason. Only push once Fable's verdict is *sound / ship it* (or its blockers are resolved).
+- **Record it in the PR body** — a short `## Review — Reviewed by **Fable** — verdict …` line (with the
+  findings it caught + how you resolved them), so it's auditable which PRs were Fable-reviewed and
+  which weren't. Absence of that line means the gate was skipped.
+- Fable reviews the **diff you're about to ship**, not the bots' comments — it adds its own analysis.
+  This is in addition to CI and the async bot reviews, never a replacement.
+
+---
+
 ## 2. Four operating principles (internalize these)
 
 1. **Spec-first testing, never characterization-first.** Write the assertion from what the


### PR DESCRIPTION
Adds a **Review gate** section to `CLAUDE.md` (the operating manual): always run the `code-reviewer` agent on the **Fable** model against `git diff origin/main...HEAD` before pushing a PR, fix its blockers, and record a `Reviewed by **Fable** — verdict …` line in the PR body (matching the convention already present on recent PRs like #286/#291/#293/#295). It's the pre-merge safety net for the many parallel worktrees, in addition to CI + the async bots.

Placed as an unnumbered section between §1 and §2 deliberately — no renumbering, so the `§2`/`§4`/`§5` cross-references in `RESOLVER.md` and elsewhere stay valid.

**Note:** doc-only markdown change (no code), so exempt from its own code-review gate — the gate exists to catch code correctness/tier/sync-contract bugs, of which a manual edit has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)