### PR TITLE
feat(graph): chunk large items into multiple episodes — no-loss fix for the extraction cap

### DIFF
--- a/lib/graph/episode-name.ts
+++ b/lib/graph/episode-name.ts
@@ -1,0 +1,26 @@
+/**
+ * Episode naming for the brain→Graphiti projection, shared by the projector, the reconcile pass, and
+ * the Learning reads so every seam agrees on the format. Pure — no server-only deps.
+ *
+ * A large item is projected as SEVERAL episodes (chunks) so each stays small enough for Graphiti's
+ * extractor (its output is hard-capped — an oversized episode overflows it and never becomes facts).
+ * To stay backward-compatible, a single-chunk item keeps the plain `items:<id>` name; only a
+ * multi-chunk item gets a `#<k>` suffix: `items:<id>#0`, `items:<id>#1`, …
+ */
+
+/** The episode name for chunk `index` of `total` chunks of item `itemId`. */
+export function episodeName(itemId: string, index: number, total: number): string {
+  return total <= 1 ? `items:${itemId}` : `items:${itemId}#${index}`;
+}
+
+/**
+ * Parse an episode name back to its brain item id, tolerating the optional `#<chunk>` suffix.
+ * Returns undefined for non-item episodes (e.g. `correction:<arc_id>` writeback episodes), so callers
+ * can link a fact/event to the ONE item behind it regardless of how many chunks it was split into.
+ */
+export function itemIdFromEpisodeName(name: string | null | undefined): string | undefined {
+  if (!name || !name.startsWith("items:")) return undefined;
+  const rest = name.slice("items:".length);
+  const hash = rest.indexOf("#");
+  return hash === -1 ? rest : rest.slice(0, hash);
+}

--- a/lib/graph/learning.ts
+++ b/lib/graph/learning.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { runRead, neo4jConfigured } from "./neo4j";
+import { itemIdFromEpisodeName } from "./episode-name";
 
 /**
  * "What the Brain is Learning" reads over Graphiti's Neo4j graph. Every query is scoped to the
@@ -107,7 +108,7 @@ export async function resolveEpisodeItems(
     for (const r of rows) {
       const name = r.name ?? "";
       out.set(r.uuid, {
-        itemId: name.startsWith("items:") ? name.slice("items:".length) : undefined,
+        itemId: itemIdFromEpisodeName(name), // tolerant of the `#<chunk>` suffix on split items
         source: r.source ? r.source.toLowerCase() : undefined,
       });
     }
@@ -169,7 +170,7 @@ export async function recentEvents(
       const facts = (r.facts ?? []).filter((x): x is string => !!x);
       return {
         id: r.id,
-        itemId: name.startsWith("items:") ? name.slice("items:".length) : null,
+        itemId: itemIdFromEpisodeName(name) ?? null, // tolerant of the `#<chunk>` suffix on split items
         source: (r.source ?? "").toLowerCase(),
         title: r.title ?? name,
         at: r.at,

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import type { DbClient } from "@/lib/db/types";
 import { GraphitiClient, type GraphEpisode } from "./graphiti-client";
 import { episodeGroupId, type AccessTier } from "./group";
+import { episodeName, itemIdFromEpisodeName } from "./episode-name";
 
 /**
  * Brain → Graphiti projector. Reads already-normalized, tier-tagged rows from the brain (`items` —
@@ -18,22 +19,35 @@ import { episodeGroupId, type AccessTier } from "./group";
 const SOURCE_TABLE = "items";
 
 /**
- * Max episode content length pushed to Graphiti. Graphiti extracts entities/edges from each episode
- * with its OWN LLM; that call's OUTPUT was hard-capped at 8192 tokens by the OLD pinned `zepai/graphiti`
- * image (graphiti_core `DEFAULT_MAX_TOKENS` was 8192 there), so a rich/long episode whose extraction
- * overflowed that cap raised `Output length exceeded max tokens 8192` in `resolve_extracted_nodes` and
- * stalled the queue (prod 2026-06-25, 07-03, 07-17). The ROOT FIX is on the Graphiti side: bump the
- * image to one where `DEFAULT_MAX_TOKENS` is 16384 (current graphiti_core) — done in graphiti's
- * docker-compose + the prod service — so extraction has 2× the headroom instead of us shrinking input.
- * With the cap raised to 16384, most episodes extract — but the densest 6000-char ones can STILL
- * overflow even 16384 (`Output length exceeded max tokens 16384`, prod 2026-07-17), especially while a
- * backlog reprojection bloats Graphiti's previous-episode context. gpt-4o's output ceiling IS 16384,
- * so we can't raise the cap further; 4000 keeps the densest episodes' extraction output under it while
- * staying far more faithful than the 2000 stop-gap (full item text still lives in `items`/pgvector/FTS
- * regardless; median item ~240 chars, so this only clips outliers). Env-tunable via
- * `GRAPH_MAX_EPISODE_CHARS`. See the "202 ≠ extracted" note + extraction-health probe in docs/ARCHITECTURE.md.
+ * Graphiti extracts entities/edges from each episode with its OWN LLM, and that call's OUTPUT is
+ * hard-capped (graphiti_core `DEFAULT_MAX_TOKENS`; 16384 on the patched image — gpt-4o's ceiling, can't
+ * go higher). A dense episode whose extraction output overflows that cap raises `Output length exceeded
+ * max tokens` in `resolve_extracted_nodes`, so it's accepted (202) but never becomes facts — the item's
+ * work then never appears in the graph or narrative arcs (prod 2026-06/07). Truncating to fit LOSES
+ * content, so instead we CHUNK: a large item is projected as several small episodes (`items:<id>#0`,
+ * `#1`, …), each ≤ `CHUNK_CHARS`, preserving all content while keeping every episode extractable.
+ * `MAX_EPISODE_CHUNKS` caps a pathologically huge item (full text still lives in `items`/pgvector/FTS
+ * regardless; median item ~240 chars = a single chunk, unchanged from before). Both env-tunable. See
+ * the "202 ≠ extracted" note in docs/ARCHITECTURE.md.
  */
-export const MAX_EPISODE_CHARS = Number(process.env.GRAPH_MAX_EPISODE_CHARS ?? 4000);
+export const CHUNK_CHARS = Number(process.env.GRAPH_CHUNK_CHARS ?? 2500);
+export const MAX_EPISODE_CHUNKS = Number(process.env.GRAPH_MAX_EPISODE_CHUNKS ?? 16);
+
+/**
+ * Split an item's body into ≤ `maxChunks` chunks of ≤ `chunkChars` each, preserving every character
+ * (content beyond `chunkChars * maxChunks` is dropped — a runaway-size backstop, not the common path).
+ * Whitespace-only bodies yield `[]` (nothing to extract). Pure + unit-tested; the chunk boundaries are
+ * deterministic so the content hash (taken over the full body) stays stable across runs.
+ */
+export function chunkContent(body: string, chunkChars = CHUNK_CHARS, maxChunks = MAX_EPISODE_CHUNKS): string[] {
+  const text = body ?? "";
+  if (!text.trim()) return [];
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length && chunks.length < maxChunks; i += chunkChars) {
+    chunks.push(text.slice(i, i + chunkChars));
+  }
+  return chunks;
+}
 
 /** Item kinds worth projecting as graph episodes — content-bearing knowledge, not raw config.
  * `skill`/`blueprint` are configuration manifests, not events/knowledge, so they're excluded. */
@@ -74,36 +88,37 @@ function sha(content: string): string {
 }
 
 /**
- * Resolve our stable episode `name` to Graphiti's server-assigned uuid within `groupId`, then
- * delete it. `/messages` is fire-and-forget and never returns a uuid, so this is the only way to
- * target a specific episode for deletion (audit M6). A no-op if the episode isn't found (already
- * gone, or the async worker never got to it) — the caller treats this as best-effort.
+ * Delete ALL of an item's episodes (every chunk: `items:<id>` and `items:<id>#k`) from `groupId`.
+ * `/messages` is fire-and-forget and never returns a uuid, so we resolve names→uuids via
+ * `listEpisodes` (audit M6). Best-effort: a chunk the async worker never created just isn't found.
  */
-export async function deleteEpisodeByName(
-  client: GraphitiClient,
-  groupId: string,
-  name: string
-): Promise<void> {
+export async function deleteItemEpisodes(client: GraphitiClient, groupId: string, itemId: string): Promise<void> {
   const episodes = await client.listEpisodes(groupId);
-  const match = episodes.find((e) => e.name === name);
-  if (match) await client.deleteEpisode(match.uuid);
+  for (const e of episodes) {
+    if (itemIdFromEpisodeName(e.name) === itemId) await client.deleteEpisode(e.uuid);
+  }
 }
 
-/** Episode content + provenance from an item, labeled by kind. */
-function toEpisode(item: ItemRow): GraphEpisode {
+/**
+ * The episode(s) + provenance for an item, labeled by kind. A normal item → ONE episode (plain
+ * `items:<id>` name, unchanged from before); a large item → SEVERAL chunk episodes (`items:<id>#k`,
+ * each ≤ CHUNK_CHARS, "(part k/N)" in the description) so every chunk stays under Graphiti's extraction
+ * cap. Empty body → `[]` (skipped upstream — nothing to extract).
+ */
+function toEpisodes(item: ItemRow): GraphEpisode[] {
   const fm = item.frontmatter ?? {};
   const title = typeof fm.title === "string" ? fm.title : undefined;
   const url = typeof fm.source_url === "string" ? fm.source_url : undefined;
   const ts = typeof fm.source_ts === "string" ? fm.source_ts : item.synced_at; // when it happened
   const label = KIND_LABEL[item.kind] ?? "Item";
-  return {
-    // Cap content so a large episode can't overflow extraction and wedge getzep's worker (see
-    // MAX_EPISODE_CHARS). The content hash is taken over this capped value, so idempotency holds.
-    content: (item.body ?? "").slice(0, MAX_EPISODE_CHARS),
+  const chunks = chunkContent(item.body ?? "");
+  const total = chunks.length;
+  return chunks.map((content, i) => ({
+    content,
     timestamp: ts,
-    sourceDescription: `${label} — ${title ?? item.path}${url ? ` (${url})` : ""}`,
-    name: `${SOURCE_TABLE}:${item.id}`,
-  };
+    sourceDescription: `${label} — ${title ?? item.path}${total > 1 ? ` (part ${i + 1}/${total})` : ""}${url ? ` (${url})` : ""}`,
+    name: episodeName(item.id, i, total),
+  }));
 }
 
 /**
@@ -142,12 +157,14 @@ export async function projectItemsToGraph(
   let projected = 0;
   let skipped = 0;
   for (const item of rows) {
-    const episode = toEpisode(item);
-    if (!episode.content.trim()) {
+    const episodes = toEpisodes(item);
+    if (episodes.length === 0) {
       skipped++;
-      continue; // nothing to extract
+      continue; // empty body → nothing to extract
     }
-    const contentSha = sha(episode.content);
+    // Idempotency key = the FULL body (chunk boundaries derive deterministically from it), so an
+    // unchanged item is a no-op regardless of how many chunks it splits into.
+    const contentSha = sha(item.body ?? "");
     const groupId = episodeGroupId(args.teamSlug, item.access);
 
     const { data: existing } = await db
@@ -164,15 +181,15 @@ export async function projectItemsToGraph(
       continue; // unchanged content, same tier → no-op (idempotent)
     }
 
-    // Audit M6: a tier reclassification (e.g. external→team) must not leave the old episode
-    // searchable in the old group forever — delete it there before projecting into the new group.
-    // Best-effort: Graphiti's async worker may not have created the node yet, or it may already be
-    // gone; either way we still proceed with the new-group push so projection isn't blocked on it.
+    // Audit M6: a tier reclassification (e.g. external→team) must not leave the old episodes
+    // searchable in the old group forever — delete ALL the item's chunks there before projecting into
+    // the new group. Best-effort: the async worker may not have created a node yet, or it's already
+    // gone; either way we proceed with the new-group push so projection isn't blocked on it.
     if (tierChanged && existingRow) {
-      await deleteEpisodeByName(client, existingRow.group_id, episode.name!).catch(() => {});
+      await deleteItemEpisodes(client, existingRow.group_id, item.id).catch(() => {});
     }
 
-    await client.addEpisodes(groupId, [episode]);
+    await client.addEpisodes(groupId, episodes);
 
     await db.from("graph_episodes").upsert(
       {

--- a/lib/graph/reconcile.ts
+++ b/lib/graph/reconcile.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { GraphitiClient } from "./graphiti-client";
+import { itemIdFromEpisodeName } from "./episode-name";
 
 /**
  * Reconcile pass for the brain→Graphiti seam (audit H3, Option B — chosen over blocking-confirm
@@ -10,7 +11,7 @@ import { GraphitiClient } from "./graphiti-client";
  * ACTUALLY landed in Graphiti (via `GET /episodes/{group}`, matched by our stable `name`). Anything
  * that never landed (a worker crash before/while extracting it) is cleared so the next projector run
  * treats it as unprojected and re-pushes — self-healing, off the hot ingest/push path. Confirmed
- * rows get their `episode_uuid` backfilled (used later for targeted deletes — see deleteEpisodeByName).
+ * rows get their `episode_uuid` backfilled (used later for targeted deletes — see deleteItemEpisodes).
  */
 
 const GRACE_MS = 5 * 60_000; // don't judge a row pushed in the last 5 min — extraction may still be running
@@ -58,11 +59,17 @@ export async function reconcileProjectedEpisodes(
     // treating "couldn't check" as "never landed" and re-pushing everything.
     const episodes = await client.listEpisodes(groupId, 5000).catch(() => null);
     if (episodes === null) continue;
-    const uuidByName = new Map(episodes.map((e) => [e.name, e.uuid]));
+    // An item is projected as one OR MANY chunk episodes (`items:<id>` / `items:<id>#k`) — it "landed"
+    // if ANY of its chunks is present. Map each item id → one of its episode uuids.
+    const uuidByItemId = new Map<string, string>();
+    for (const e of episodes) {
+      const itemId = itemIdFromEpisodeName(e.name);
+      if (itemId && !uuidByItemId.has(itemId)) uuidByItemId.set(itemId, e.uuid);
+    }
 
     for (const row of groupRows) {
       if (new Date(row.projected_at).getTime() > cutoff) continue; // too recent, still may be processing
-      const uuid = uuidByName.get(`items:${row.source_id}`);
+      const uuid = uuidByItemId.get(row.source_id);
       if (uuid) {
         confirmed++;
         if (!row.episode_uuid) {

--- a/test/datamechanics/graph-project.datamechanics.test.ts
+++ b/test/datamechanics/graph-project.datamechanics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GraphitiClient, GraphEpisode, GraphEpisodeRef } from "@/lib/graph/graphiti-client";
-import { projectSlackToGraph, projectItemsToGraph, MAX_EPISODE_CHARS } from "@/lib/graph/project";
+import { projectSlackToGraph, projectItemsToGraph, CHUNK_CHARS, MAX_EPISODE_CHUNKS } from "@/lib/graph/project";
 import { runGraphProjection } from "@/lib/graph/run";
 import { reconcileProjectedEpisodes } from "@/lib/graph/reconcile";
 import { db, ingest, seedTeam } from "./helpers";
@@ -120,22 +120,25 @@ describe("projectItemsToGraph — all ingestions (real Postgres, mocked Graphiti
     expect(fake.pushes).toHaveLength(4);
   });
 
-  // Spec: a large item must be pushed with capped content — getzep's worker dies on any extraction
-  // exception (no per-job catch), and an oversized episode overflows the LLM output-token cap and
-  // wedges the whole queue (prod stalls 2026-06-25 / 2026-07-03). See MAX_EPISODE_CHARS.
-  it("caps oversized episode content so extraction can't overflow and wedge the worker", async () => {
+  // Spec: a large item is CHUNKED into several small episodes (not truncated to one) so each stays
+  // under Graphiti's extraction output cap — an oversized episode overflows it and never becomes facts
+  // (prod 2026-06/07), so its work would be invisible in the graph + arcs. Chunking preserves content.
+  it("chunks an oversized item into ≤ MAX_EPISODE_CHUNKS small episodes so extraction can't overflow", async () => {
     const seed = await seedTeam();
     const slug = await teamSlugFor(seed.teamId);
-    const huge = "x ".repeat(40_000); // ~80k chars, far above the cap
+    const huge = "x ".repeat(40_000); // ~80k chars, far beyond one chunk
     await ingest(seed, { kind: "deliverable", path: "notion/huge.md", body: huge, access: "team" });
 
     const fake = new FakeGraphiti();
     await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
 
-    expect(fake.pushes).toHaveLength(1);
-    const pushed = fake.pushes[0].episodes[0].content;
-    expect(pushed.length).toBe(MAX_EPISODE_CHARS); // truncated to the cap
-    expect(huge.length).toBeGreaterThan(MAX_EPISODE_CHARS); // guard: the input really was oversized
+    expect(fake.pushes).toHaveLength(1); // one addEpisodes call for the item…
+    const eps = fake.pushes[0].episodes;
+    expect(eps.length).toBe(MAX_EPISODE_CHUNKS); // …carrying several chunk episodes, capped
+    for (const e of eps) expect(e.content.length).toBeLessThanOrEqual(CHUNK_CHARS); // each fits the extractor
+    // Multi-chunk items get the `#k` suffix; each chunk still resolves back to the one item.
+    expect(eps[0].name).toMatch(/^items:.+#0$/);
+    expect(eps[1].name).toMatch(/^items:.+#1$/);
   });
 });
 

--- a/test/graph-episode-chunking.test.ts
+++ b/test/graph-episode-chunking.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { chunkContent } from "@/lib/graph/project";
+import { episodeName, itemIdFromEpisodeName } from "@/lib/graph/episode-name";
+
+/**
+ * Chunking is the no-loss fix for Graphiti's extraction cap: a large item becomes several small
+ * episodes instead of one truncated one, so all its content reaches the graph AND each episode stays
+ * extractable. These specs pin the pure boundary behavior + the round-trippable naming.
+ */
+describe("chunkContent", () => {
+  it("keeps a normal item as a single chunk (unchanged from before)", () => {
+    expect(chunkContent("a short note", 2500, 16)).toEqual(["a short note"]);
+  });
+
+  it("splits a large body into ≤ chunkChars pieces, preserving every character in order", () => {
+    const body = "abcdefghij"; // 10 chars
+    const chunks = chunkContent(body, 4, 16);
+    expect(chunks).toEqual(["abcd", "efgh", "ij"]);
+    expect(chunks.join("")).toBe(body); // no content lost
+  });
+
+  it("caps at maxChunks (runaway-size backstop) — content beyond is dropped, not truncated to one", () => {
+    const body = "x".repeat(100);
+    const chunks = chunkContent(body, 10, 3); // 10 chunks worth, capped at 3
+    expect(chunks).toHaveLength(3);
+    expect(chunks.every((c) => c.length === 10)).toBe(true);
+  });
+
+  it("empty / whitespace-only body → no chunks (nothing to extract)", () => {
+    expect(chunkContent("", 2500, 16)).toEqual([]);
+    expect(chunkContent("   \n\t ", 2500, 16)).toEqual([]);
+  });
+});
+
+describe("episodeName / itemIdFromEpisodeName — round-trip", () => {
+  it("single-chunk item keeps the plain name (backward-compatible)", () => {
+    expect(episodeName("abc", 0, 1)).toBe("items:abc");
+    expect(itemIdFromEpisodeName("items:abc")).toBe("abc");
+  });
+
+  it("multi-chunk item uses the #k suffix, and every chunk resolves back to the same item", () => {
+    expect(episodeName("abc", 0, 3)).toBe("items:abc#0");
+    expect(episodeName("abc", 2, 3)).toBe("items:abc#2");
+    expect(itemIdFromEpisodeName("items:abc#0")).toBe("abc");
+    expect(itemIdFromEpisodeName("items:abc#2")).toBe("abc");
+  });
+
+  it("returns undefined for non-item episodes (e.g. correction writeback) and junk", () => {
+    expect(itemIdFromEpisodeName("correction:arc-123")).toBeUndefined();
+    expect(itemIdFromEpisodeName(null)).toBeUndefined();
+    expect(itemIdFromEpisodeName("")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The proper, no-loss fix for "my work isn't in the arcs."

## Why
Graphiti's per-episode extraction output is hard-capped at **16384** (gpt-4o's ceiling — can't go higher). A **dense item** overflowed even that (`Output length exceeded max tokens 16384`), so it was accepted (`202`) but **never became facts** → its work stayed invisible in the graph and in Learning arcs. Truncating to fit *loses content* (the 2000/4000 trims). This chunks instead.

## What
A large item is projected as **several small episodes** instead of one truncated one — all content preserved, every episode extractable.
- **`chunkContent` + `episode-name` helpers** — a normal item keeps the plain `items:<id>` name (backward-compatible, no re-projection churn for the ~median 240-char item); a large one splits into `items:<id>#0`, `#1`, … each ≤ `CHUNK_CHARS` (2500), capped at `MAX_EPISODE_CHUNKS` (16). Both env-tunable.
- **`project.ts`** — `toEpisodes()` returns the chunk set; idempotency hash is over the **full body** (chunk boundaries derive deterministically); a tier-reclassified item deletes **all** its old chunks before re-projecting.
- **`reconcile.ts` + `learning.ts`** — resolve an episode name → item id tolerating the `#k` suffix, so a fact/event links to the one item and reconcile treats *any* chunk present as "landed".

## Verified
840 unit tests (new `chunkContent` + name round-trip specs prove no content is lost), tsc, lint, and the **graph-project real-Postgres data-mechanics tier** (chunking + reconcile) all green.

## Effect after deploy
Items re-project once (hash changes from truncated→full-body), the dense ones now split and extract, and their facts finally land — so the representative-synthesis arcs (from the prior PR) can surface everyone, including you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large items are now split into multiple Graph episodes instead of being truncated.
  * Chunked episodes use consistent names and retain their original item association.
  * Empty item content is skipped during projection.

* **Bug Fixes**
  * Improved reconciliation and event handling for chunked episodes.
  * Tier changes now remove all previously projected chunks before re-projecting updated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->