### PR TITLE
fix(observability): stop the pipeline banner crying wolf on quiet legs + harden projector env/timestamp

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -605,8 +605,10 @@ guard enforces it, it's named.
   **patched image** — `graphiti/Dockerfile` builds FROM the exact prod-pinned digest and bumps only that
   constant to 16384 (gpt-4o's max output). No version jump ⇒ the Neo4j schema our `lib/graph/learning`
   Cypher reads and the REST API the projector uses stay byte-identical; only the token ceiling moves.
-  `MAX_EPISODE_CHARS` stays at 6000 (its intended size; `GRAPH_MAX_EPISODE_CHARS`-tunable as a safety
-  valve). Deploying the patched image is a `graphiti`-service rebuild (roll back to deployment `6208aed5`
+  `MAX_EPISODE_CHARS` default is **4000** (lowered from 6000: a dense 6000-char episode's structured
+  output could still overflow even the 16384 ceiling and silently kill getzep's per-job-exception-less
+  ingest worker; `GRAPH_MAX_EPISODE_CHARS`-tunable, and a malformed value falls back to 4000 rather than
+  blanking projection). Deploying the patched image is a `graphiti`-service rebuild (roll back to deployment `6208aed5`
   if unhealthy). _Guards:_ `test/graph-extraction-health.test.ts` + the `deriveGraphState` extraction-stall
   case in `test/retrieval-health.test.ts`.
 

--- a/docs/design/brain-learning-panel.md
+++ b/docs/design/brain-learning-panel.md
@@ -226,9 +226,11 @@ on that), so the fire-and-forget promise is not at risk of serverless request-te
   `add_episode` permanently kills the worker and freezes the whole ingest queue (silent — the HTTP API
   keeps 202-ing). The trigger seen twice in prod (2026-06-25, 2026-07-03) is a large episode whose
   entity/edge extraction overflows the LLM output-token cap (`Output length exceeded max tokens 8192`).
-  *Mitigate (our side, since we can't patch their image):* `lib/graph/project.ts` caps episode content
-  at `MAX_EPISODE_CHARS` (6000) so extraction output stays under the limit; full item text still lives
-  in `items`/pgvector/FTS. Only a few outlier docs are truncated (median item ~240 chars). If the worker
+  *Mitigate (our side, since we can't patch their image):* `lib/graph/project.ts` **chunks** a large
+  item into ≤`GRAPH_MAX_EPISODE_CHUNKS` (16) episodes of ≤`GRAPH_CHUNK_CHARS` (2500) chars each
+  (superseded the old single-episode truncation cap in #305 — chunking preserves all content instead of
+  losing it), so each chunk's extraction output stays under the limit; full item text still lives in
+  `items`/pgvector/FTS. Median item ~240 chars = a single chunk. If the worker
   ever wedges anyway, restart graphiti (it's an image-based service; the Custom Start Command below persists).
 - **Graphiti start command (Railway)** — the `zepai/graphiti:latest` image declares a non-root `USER app`
   but its default CMD launches via `uv` at `/root/.local/bin/uv`, which `app` can't exec once Railway

--- a/graphiti/README.md
+++ b/graphiti/README.md
@@ -34,10 +34,12 @@ Two callers: the admin **"Project to graph"** button on the Integrations page (o
 `lib/graph/scheduler` (an interval poller registered in `instrumentation.ts`). Both are inert
 unless `GRAPHITI_URL` is set. Tune with `GRAPH_PROJECT_MINUTES` (default 60), `GRAPH_PROJECT_LIMIT`
 (default 500 items/run), `GRAPH_PROJECT_ENABLED=false` to disable, and `GRAPH_MAX_EPISODE_CHARS`
-(default 6000) — the per-episode content cap. A bigger episode extracts more nodes → larger structured
-output; the extractor's output ceiling is raised to 16384 by the patched image (see `Dockerfile` +
-the "202 ≠ extracted" gotcha in `docs/ARCHITECTURE.md`), so 6000 is safe. The env is a safety valve if
-you run the stock (8192-cap) image instead.
+(default **4000**) — the per-episode content cap. A bigger episode extracts more nodes → larger
+structured output; the extractor's output ceiling is raised to 16384 by the patched image (see
+`Dockerfile` + the "202 ≠ extracted" gotcha in `docs/ARCHITECTURE.md`). The cap was lowered 6000→4000
+because a dense 6000-char episode's structured output could still overflow even the 16384 ceiling and
+silently kill getzep's (per-job-exception-less) ingest worker. A malformed `GRAPH_MAX_EPISODE_CHARS`
+(empty/non-numeric/≤0) falls back to 4000 rather than blanking projection.
 
 ## LLM note
 Extraction quality depends on structured-output support. Start with a strong cloud model; a local

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -42,8 +42,10 @@ const DEFAULT_MAX_EPISODE_CHARS = 4000;
  * parses to a finite, positive number. Pure + exported so the landmine is unit-tested.
  */
 export function resolveMaxEpisodeChars(raw: string | undefined | null): number {
-  const n = Number(raw);
-  return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_EPISODE_CHARS;
+  // `Math.floor` closes the fractional hole: a value like `0.5` is finite and >0 but `slice(0, 0.5)`
+  // truncates the end index to 0 → every episode blanks. Require an integer ≥ 1.
+  const n = Math.floor(Number(raw));
+  return Number.isFinite(n) && n >= 1 ? n : DEFAULT_MAX_EPISODE_CHARS;
 }
 export const MAX_EPISODE_CHARS = resolveMaxEpisodeChars(process.env.GRAPH_MAX_EPISODE_CHARS);
 

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -37,7 +37,7 @@ const SOURCE_TABLE = "items";
  * 0/NaN chunk CAP makes it emit none — either way the projector "succeeds" feeding the graph nothing
  * (or garbage). `Math.floor` also closes the fractional hole (0.5 → 0). Pure + exported, unit-tested.
  */
-export function resolvePositiveInt(raw: string | undefined | null, fallback: number): number {
+export function resolvePositiveInt(raw: unknown, fallback: number): number {
   const n = Math.floor(Number(raw));
   return Number.isFinite(n) && n >= 1 ? n : fallback;
 }
@@ -66,9 +66,13 @@ export function pickEpisodeTimestamp(sourceTs: unknown, syncedAt: string): strin
 export function chunkContent(body: string, chunkChars = CHUNK_CHARS, maxChunks = MAX_EPISODE_CHUNKS): string[] {
   const text = body ?? "";
   if (!text.trim()) return [];
+  // Clamp the params too (not just the env at module load) so a direct caller passing 0/NaN can't
+  // emit empty/garbage chunks or stall the loop — belt-and-suspenders around the same landmine.
+  const size = resolvePositiveInt(chunkChars, CHUNK_CHARS);
+  const cap = resolvePositiveInt(maxChunks, MAX_EPISODE_CHUNKS);
   const chunks: string[] = [];
-  for (let i = 0; i < text.length && chunks.length < maxChunks; i += chunkChars) {
-    chunks.push(text.slice(i, i + chunkChars));
+  for (let i = 0; i < text.length && chunks.length < cap; i += size) {
+    chunks.push(text.slice(i, i + size));
   }
   return chunks;
 }

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -33,7 +33,32 @@ const SOURCE_TABLE = "items";
  * regardless; median item ~240 chars, so this only clips outliers). Env-tunable via
  * `GRAPH_MAX_EPISODE_CHARS`. See the "202 ≠ extracted" note + extraction-health probe in docs/ARCHITECTURE.md.
  */
-export const MAX_EPISODE_CHARS = Number(process.env.GRAPH_MAX_EPISODE_CHARS ?? 4000);
+const DEFAULT_MAX_EPISODE_CHARS = 4000;
+
+/**
+ * A malformed `GRAPH_MAX_EPISODE_CHARS` override must NOT silently blank all projection: `Number("")`
+ * is 0 and `Number("abc")` is NaN, either of which would slice every episode's content to "" and make
+ * the projector "succeed" while feeding the graph nothing. Fall back to the default unless the value
+ * parses to a finite, positive number. Pure + exported so the landmine is unit-tested.
+ */
+export function resolveMaxEpisodeChars(raw: string | undefined | null): number {
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_EPISODE_CHARS;
+}
+export const MAX_EPISODE_CHARS = resolveMaxEpisodeChars(process.env.GRAPH_MAX_EPISODE_CHARS);
+
+/**
+ * "When it happened" for an episode: prefer the item's own `source_ts`, but only if it actually parses.
+ * A present-but-garbage `source_ts` must fall back to `synced_at` (always a real timestamptz), NOT to
+ * graphiti-client's last-resort now() — otherwise an old/undated doc gets stamped "today" and floats to
+ * the top of the recency-ranked arcs (rankArcs). (Locale-ambiguous strings like "09/07/2026" still parse
+ * — wrongly — under JS Date; we can't disambiguate DD/MM here, so connectors should emit ISO.) Pure +
+ * exported for tests.
+ */
+export function pickEpisodeTimestamp(sourceTs: unknown, syncedAt: string): string {
+  const raw = typeof sourceTs === "string" ? sourceTs : syncedAt;
+  return Number.isNaN(new Date(raw).getTime()) ? syncedAt : raw;
+}
 
 /** Item kinds worth projecting as graph episodes — content-bearing knowledge, not raw config.
  * `skill`/`blueprint` are configuration manifests, not events/knowledge, so they're excluded. */
@@ -94,7 +119,7 @@ function toEpisode(item: ItemRow): GraphEpisode {
   const fm = item.frontmatter ?? {};
   const title = typeof fm.title === "string" ? fm.title : undefined;
   const url = typeof fm.source_url === "string" ? fm.source_url : undefined;
-  const ts = typeof fm.source_ts === "string" ? fm.source_ts : item.synced_at; // when it happened
+  const ts = pickEpisodeTimestamp(fm.source_ts, item.synced_at); // when it happened (see helper)
   const label = KIND_LABEL[item.kind] ?? "Item";
   return {
     // Cap content so a large episode can't overflow extraction and wedge getzep's worker (see

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -32,18 +32,20 @@ const STALE_MS_BY_SOURCE: Record<string, number | null> = {
   pm_sync: null, // reactive — its own staleness heuristic lives in lib/pm-sync/runs
   auth_cleanup: 26 * 60 * 60 * 1000, // 24h cadence + 2h grace (genuinely-stuck still surfaces)
   // Record-only-when-active legs: their scheduler writes an `ingest_runs` row ONLY when the tick did
-  // something (indexed/projected/applied/created) or errored — a quiet pass writes nothing. So the
-  // newest row's age reflects "last time there was work", NOT "last time the poller ran", and an
-  // age-based staleness check cries wolf on any normal quiet window (a weekend, an idle board). Real
-  // failures still surface via `ok=false` on their actual runs, plus the dedicated probes: `dense`
-  // via the retrieval-health card, `graph_project` via the `graph_extract` synthetic leg below.
-  // (Contrast slack/plane/linear/github, which DO record every configured poll — see lib/ingest/
-  // scheduler.runImport "still record configured sources (proves the poller ran)" — so they keep the
-  // meaningful 3h default.)
+  // something (indexed/projected/applied) or errored — a quiet pass writes nothing. So the newest
+  // row's age reflects "last time there was work", NOT "last time the poller ran", and an age-based
+  // staleness check cries wolf on any normal quiet window (a weekend, an idle board). Real failures
+  // still surface via `ok=false` on their actual runs, plus the residual probes on the retrieval-health
+  // card: `dense` via its `pendingItems` backlog, `graph_project` via `isGraphStale` (6h-no-writes →
+  // degraded). `linear_inbound` has no dedicated probe (a silently-wedged inbound lock is invisible) —
+  // an accepted tradeoff since it's per-team opt-in and any throw records `ok=false`.
+  // (Contrast slack/plane/linear/github AND meeting_notes, which record EVERY tick — the first four via
+  // scheduler.runImport "still record configured sources (proves the poller ran)", meeting_notes
+  // unconditionally per team (scheduler.ts:222) — so last-row age == last-poll age and the 3h default
+  // is meaningful there; nulling meeting_notes would have removed a real dead-scheduler heartbeat.)
   dense: null,
   linear_inbound: null,
   graph_project: null,
-  meeting_notes: null,
 };
 
 /** The age past which `source` is considered stale, or `null` to never flag it on age. Exported for

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -31,6 +31,19 @@ const STALE_MS_BY_SOURCE: Record<string, number | null> = {
   scan: null, // manual / CI
   pm_sync: null, // reactive — its own staleness heuristic lives in lib/pm-sync/runs
   auth_cleanup: 26 * 60 * 60 * 1000, // 24h cadence + 2h grace (genuinely-stuck still surfaces)
+  // Record-only-when-active legs: their scheduler writes an `ingest_runs` row ONLY when the tick did
+  // something (indexed/projected/applied/created) or errored — a quiet pass writes nothing. So the
+  // newest row's age reflects "last time there was work", NOT "last time the poller ran", and an
+  // age-based staleness check cries wolf on any normal quiet window (a weekend, an idle board). Real
+  // failures still surface via `ok=false` on their actual runs, plus the dedicated probes: `dense`
+  // via the retrieval-health card, `graph_project` via the `graph_extract` synthetic leg below.
+  // (Contrast slack/plane/linear/github, which DO record every configured poll — see lib/ingest/
+  // scheduler.runImport "still record configured sources (proves the poller ran)" — so they keep the
+  // meaningful 3h default.)
+  dense: null,
+  linear_inbound: null,
+  graph_project: null,
+  meeting_notes: null,
 };
 
 /** The age past which `source` is considered stale, or `null` to never flag it on age. Exported for

--- a/test/graph-episode-guards.test.ts
+++ b/test/graph-episode-guards.test.ts
@@ -9,15 +9,17 @@ import { resolveMaxEpisodeChars, pickEpisodeTimestamp } from "@/lib/graph/projec
  *    floating it to the top of the recency-ranked arcs.
  */
 describe("resolveMaxEpisodeChars — malformed env can't blank projection", () => {
-  it("falls back to 4000 on empty / non-numeric / zero / negative / nullish", () => {
-    for (const bad of ["", "abc", "0", "-100", "  ", undefined, null, "NaN"]) {
+  it("falls back to 4000 on empty / non-numeric / zero / negative / fractional<1 / nullish", () => {
+    // `0.5` is the sneaky one: finite and >0, but slice(0, 0.5) truncates to 0 → blank episodes.
+    for (const bad of ["", "abc", "0", "-100", "  ", "0.5", "0.9", undefined, null, "NaN"]) {
       expect(resolveMaxEpisodeChars(bad)).toBe(4000);
     }
   });
 
-  it("honors a finite positive override", () => {
+  it("honors a finite positive override (floored to an integer)", () => {
     expect(resolveMaxEpisodeChars("6000")).toBe(6000);
     expect(resolveMaxEpisodeChars("500")).toBe(500);
+    expect(resolveMaxEpisodeChars("4000.9")).toBe(4000); // floored, still ≥1
   });
 });
 

--- a/test/graph-episode-guards.test.ts
+++ b/test/graph-episode-guards.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { resolveMaxEpisodeChars, pickEpisodeTimestamp } from "@/lib/graph/project";
+
+/**
+ * Two silent-corruption landmines in the projector, both flagged by review:
+ *  - a malformed `GRAPH_MAX_EPISODE_CHARS` env would slice every episode to "" (projector "succeeds"
+ *    while feeding the graph nothing);
+ *  - a present-but-garbage `source_ts` would fall through to now(), stamping an old doc "today" and
+ *    floating it to the top of the recency-ranked arcs.
+ */
+describe("resolveMaxEpisodeChars — malformed env can't blank projection", () => {
+  it("falls back to 4000 on empty / non-numeric / zero / negative / nullish", () => {
+    for (const bad of ["", "abc", "0", "-100", "  ", undefined, null, "NaN"]) {
+      expect(resolveMaxEpisodeChars(bad)).toBe(4000);
+    }
+  });
+
+  it("honors a finite positive override", () => {
+    expect(resolveMaxEpisodeChars("6000")).toBe(6000);
+    expect(resolveMaxEpisodeChars("500")).toBe(500);
+  });
+});
+
+describe("pickEpisodeTimestamp — a bad source_ts falls back to synced_at, not now()", () => {
+  const syncedAt = "2026-07-09T10:39:17.281Z";
+
+  it("uses a valid source_ts when present", () => {
+    expect(pickEpisodeTimestamp("2024-01-02T03:04:05Z", syncedAt)).toBe("2024-01-02T03:04:05Z");
+  });
+
+  it("falls back to synced_at for a present-but-unparseable source_ts (never now())", () => {
+    for (const garbage of ["not a date", "", "13/45/2026", "??? "]) {
+      expect(pickEpisodeTimestamp(garbage, syncedAt)).toBe(syncedAt);
+    }
+  });
+
+  it("uses synced_at when source_ts is absent / non-string", () => {
+    for (const absent of [undefined, null, 12345, {}]) {
+      expect(pickEpisodeTimestamp(absent, syncedAt)).toBe(syncedAt);
+    }
+  });
+});

--- a/test/pipeline-health-staleness.test.ts
+++ b/test/pipeline-health-staleness.test.ts
@@ -2,9 +2,16 @@ import { describe, it, expect } from "vitest";
 import { staleThresholdMs } from "@/lib/ingest/pipeline-health";
 
 /**
- * Regression for the false-positive that fired the loud "1 ingestion leg is broken" banner on a
- * HEALTHY job: `auth_cleanup` runs every 24h, but the blanket 3h staleness threshold flagged it as
- * broken ~21h/day. A leg's staleness must be judged against ITS OWN cadence.
+ * Regression for the false-positive that fired the loud "N ingestion legs are broken" banner on
+ * HEALTHY jobs. Two flavors:
+ *   1. `auth_cleanup` runs every 24h, but the blanket 3h threshold flagged it ~21h/day — fixed with a
+ *      per-cadence threshold.
+ *   2. `dense` / `linear_inbound` / `graph_project` / `meeting_notes` record an `ingest_runs` row
+ *      ONLY when a tick did work — a quiet pass writes nothing, so the newest row's age reflects
+ *      "last time there was work", not "last poll". An age-based staleness check there cries wolf on
+ *      any normal quiet window. They must be `null` (never age-stale); real failures still surface via
+ *      `ok=false` on their actual runs (+ the dense retrieval-health card / graph_extract probe).
+ * A leg's staleness must be judged against ITS OWN cadence — or not at all when age ≠ poll age.
  */
 describe("staleThresholdMs — per-source staleness cadence", () => {
   const H = 60 * 60 * 1000;
@@ -17,9 +24,17 @@ describe("staleThresholdMs — per-source staleness cadence", () => {
     expect(7 * H > t!).toBe(false);
   });
 
-  it("frequent pollers use the 3h default and DO go stale when quiet", () => {
-    for (const s of ["slack", "linear", "github", "dense", "graph_project", "meeting_notes"]) {
+  it("record-every-poll pollers use the 3h default and DO go stale when quiet", () => {
+    // slack/plane/linear/github record a run every configured tick (scheduler.runImport "still record
+    // configured sources"), so last-run age == last-poll age → age-based staleness is meaningful.
+    for (const s of ["slack", "plane", "linear", "github"]) {
       expect(staleThresholdMs(s)).toBe(3 * H);
+    }
+  });
+
+  it("record-only-when-active legs are never age-stale (age ≠ poll age; failures show via ok=false + probes)", () => {
+    for (const s of ["dense", "linear_inbound", "graph_project", "meeting_notes"]) {
+      expect(staleThresholdMs(s)).toBeNull();
     }
   });
 

--- a/test/pipeline-health-staleness.test.ts
+++ b/test/pipeline-health-staleness.test.ts
@@ -25,15 +25,16 @@ describe("staleThresholdMs — per-source staleness cadence", () => {
   });
 
   it("record-every-poll pollers use the 3h default and DO go stale when quiet", () => {
-    // slack/plane/linear/github record a run every configured tick (scheduler.runImport "still record
-    // configured sources"), so last-run age == last-poll age → age-based staleness is meaningful.
-    for (const s of ["slack", "plane", "linear", "github"]) {
+    // slack/plane/linear/github record every configured tick (scheduler.runImport "still record
+    // configured sources"); meeting_notes records unconditionally per team every tick (scheduler.ts:222).
+    // Last-run age == last-poll age → age-based staleness is meaningful (a wedged scheduler flags in 3h).
+    for (const s of ["slack", "plane", "linear", "github", "meeting_notes"]) {
       expect(staleThresholdMs(s)).toBe(3 * H);
     }
   });
 
   it("record-only-when-active legs are never age-stale (age ≠ poll age; failures show via ok=false + probes)", () => {
-    for (const s of ["dense", "linear_inbound", "graph_project", "meeting_notes"]) {
+    for (const s of ["dense", "linear_inbound", "graph_project"]) {
       expect(staleThresholdMs(s)).toBeNull();
     }
   });


### PR DESCRIPTION
Fable-review follow-ups on the graph/observability cluster (#294/#296/#300/#302/#303).

## Fixes
- **HIGH — cry-wolf staleness.** `dense`, `linear_inbound`, `graph_project` write an `ingest_runs` row *only* when a tick did work, so their newest-row age reflects "last work", not "last poll" — the 3h staleness default then flagged them broken on any normal quiet window (the red "brain isn't getting fresh data" banner, daily). #302 fixed only `auth_cleanup`; this nulls staleness for that whole record-only-when-active class. Real failures still surface via `ok=false` + the retrieval-health probes (`dense` backlog, `graph_project` `isGraphStale`). slack/plane/linear/github **and meeting_notes** keep the 3h default — they record every tick.
- **MED — malformed `GRAPH_MAX_EPISODE_CHARS` blanked projection.** `Number("")`=0 / `Number("abc")`=NaN → every episode sliced to `""` → projector "succeeds" feeding the graph nothing. `resolveMaxEpisodeChars` falls back to 4000 (integer ≥1).
- **MED — unparseable `source_ts` stamped now().** An old doc floated to the top of the recency-ranked arcs. `pickEpisodeTimestamp` falls back to the always-valid `synced_at`.
- **MED — doc drift** 6000→4000 (graphiti/README, ARCHITECTURE.md).

Both projector guards are pure exported helpers + unit-tested; the staleness test previously asserted the *buggy* behavior and is corrected.

## Review
Reviewed by **Fable** (required pre-push gate). It caught a real bug in the first pass — I had wrongly nulled `meeting_notes` (it records every tick, so nulling removed a genuine dead-scheduler heartbeat) — plus a wrong-probe comment and a fractional-env hole (`0.5`). **All three fixed** in the second commit; verdict then *ship it*.

## Known tradeoff
`linear_inbound` (per-team opt-in, reactive) now has no age-based signal if it silently wedges without throwing — accepted; any throw still records `ok=false`.

## Test plan
- [x] tsc · eslint · docs-drift clean · 9 unit tests (staleness cadence + projector env/timestamp guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Graphiti episode processing reliability by safely handling invalid configuration values.
  - Reduced the default episode size limit to 4,000 characters to help prevent extraction failures.
  - Invalid episode timestamps now fall back to the synchronization time.
  - Reduced false stale-status alerts for processing steps that only record activity when work occurs.

- **Documentation**
  - Updated architecture and Graphiti setup guidance for episode limits, configuration fallbacks, and staleness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->