### PR TITLE
fix(learning): reasoning-fallback starvation, ceiling retry, stale-arc cap, tier redaction

### DIFF
--- a/app/api/brain/arcs/route.ts
+++ b/app/api/brain/arcs/route.ts
@@ -75,11 +75,16 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // The diagnostic `note` names internal admin surfaces and — for `model_failing` — embeds the raw
+  // provider error (`llm.note` → internal LLM base URL, model slug, and the provider's error body).
+  // That's team-internal infra detail: redact it for `external`-tier collaborators (who can't act on it
+  // and shouldn't see the config), keeping only the coarse `reason` category. Team tier still gets the
+  // actionable note.
   return Response.json({
     arcs,
     degraded: reason === "model_failing", // back-compat flag
     reason,
-    note,
+    note: tier === "external" ? undefined : note,
     as_of: new Date().toISOString(),
   });
 }

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -54,6 +54,10 @@ const MAX_ARCS = 8;
 // for balancing (a high-volume person's recent burst can otherwise push everyone else past MAX_FACTS).
 const FACT_POOL = MAX_FACTS * 6;
 const CACHE_TTL_MS = 10 * 60_000;
+// How long the empty-clobber guard keeps trusting a prior non-empty arc set. Within this window an
+// empty synthesis is treated as a transient failure (keep the prior); beyond it, a persistently-empty
+// result is accepted as genuine so the panel can't be pinned to ancient arcs forever (Fable review).
+const EMPTY_CLOBBER_MAX_AGE_MS = Number(process.env.ARCS_EMPTY_CLOBBER_MAX_AGE_MS ?? 48 * 60 * 60_000);
 
 const SYSTEM_PROMPT =
   `You are analyzing a team knowledge graph. Identify ${MAX_ARCS} active narrative arcs — ongoing ` +
@@ -402,12 +406,28 @@ export async function commitArcs(
   next: NarrativeArc[]
 ): Promise<NarrativeArc[]> {
   if (next.length === 0) {
-    const prior = cache.get(key)?.arcs ?? (await readArcCache(db, teamId, key))?.arcs;
-    if (prior && prior.length > 0) {
+    const mem = cache.get(key);
+    const prior =
+      mem ??
+      (await readArcCache(db, teamId, key).then((r) => (r ? { arcs: r.arcs, at: r.computedAt } : null)));
+    if (prior && prior.arcs.length > 0) {
+      const ageMs = Date.now() - prior.at;
+      if (ageMs < EMPTY_CLOBBER_MAX_AGE_MS) {
+        // Recent prior → an empty synthesis is almost always a transient upstream failure (LLM outage,
+        // a reasoning model starving its output, a graph blip). Keep the stale-but-real set and DON'T
+        // refresh the timestamp, so the next view retries until synthesis recovers.
+        console.warn(
+          `[arcs] synthesis returned 0 arcs for ${key}; keeping ${prior.arcs.length} cached (${Math.round(ageMs / 3_600_000)}h old; likely transient)`
+        );
+        return prior.arcs;
+      }
+      // Prior is too old to keep trusting as "transient-failure cover": a persistently-empty synthesis
+      // over this long is more likely GENUINE (quiet team, content deleted, graph reset, or the model
+      // correctly concluding "no active arcs"). Let the empty through so the panel reflects reality
+      // instead of pinning ancient arcs — and re-arming the background refresh loop — forever.
       console.warn(
-        `[arcs] synthesis returned 0 arcs for ${key}; keeping ${prior.length} cached (likely transient upstream failure)`
+        `[arcs] synthesis returned 0 arcs for ${key}; prior ${prior.arcs.length} arcs are ${Math.round(ageMs / 3_600_000)}h old (> cap) — accepting empty`
       );
-      return prior;
     }
   }
   cache.set(key, { arcs: next, at: Date.now() });

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -57,7 +57,12 @@ const CACHE_TTL_MS = 10 * 60_000;
 // How long the empty-clobber guard keeps trusting a prior non-empty arc set. Within this window an
 // empty synthesis is treated as a transient failure (keep the prior); beyond it, a persistently-empty
 // result is accepted as genuine so the panel can't be pinned to ancient arcs forever (Fable review).
-const EMPTY_CLOBBER_MAX_AGE_MS = Number(process.env.ARCS_EMPTY_CLOBBER_MAX_AGE_MS ?? 48 * 60 * 60_000);
+const EMPTY_CLOBBER_MAX_AGE_MS = (() => {
+  // Guard the parse: a garbage/empty env yields NaN/0, and `ageMs < NaN` is always false → EVERY empty
+  // synthesis would clobber, silently reverting the incident fix. Fall back unless it's finite and >0.
+  const n = Number(process.env.ARCS_EMPTY_CLOBBER_MAX_AGE_MS);
+  return Number.isFinite(n) && n > 0 ? n : 48 * 60 * 60_000;
+})();
 
 const SYSTEM_PROMPT =
   `You are analyzing a team knowledge graph. Identify ${MAX_ARCS} active narrative arcs — ongoing ` +

--- a/lib/llm/complete.ts
+++ b/lib/llm/complete.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
-import { selectLlmBackend, type LlmBackendKeys, type LlmRole } from "@/lib/query/llm-backend";
+import { selectLlmBackend, reasoningActive, type LlmBackendKeys, type LlmRole } from "@/lib/query/llm-backend";
+import { looksLikeTokenLimit } from "@/lib/query/claude";
 import { recordIngestRun } from "@/lib/ingest/runs";
 import type { DbClient } from "@/lib/db/types";
 
@@ -92,38 +93,53 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
     let text: string;
     if (backend.kind !== "anthropic") {
       const apiKey = backend.apiKey ?? process.env.OPENAI_API_KEY ?? "local";
-      const res = await fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-          ...(backend.kind === "openrouter" ? backend.headers : {}),
-        },
-        body: JSON.stringify({
-          model: backend.model,
-          // Answer budget + reasoning headroom (see REASONING_HEADROOM_TOKENS) so a reasoning model's
-          // hidden tokens don't starve the answer to empty.
-          max_tokens: maxTokens + REASONING_HEADROOM_TOKENS,
-          // For the QUERY role (the default — extraction/short generation), turn reasoning OFF on
-          // OpenRouter so a reasoning model can't spend the whole budget on hidden thinking and return
-          // empty content (what blanked the Learning page). The REASONING role deliberately leaves it
-          // ON — that's the point of the separate reasoning model (e.g. arc synthesis). Ignored by
-          // non-reasoning models. Override with LLM_DISABLE_REASONING=0.
-          ...(backend.kind === "openrouter" &&
-          opts.role !== "reasoning" &&
-          process.env.LLM_DISABLE_REASONING !== "0"
-            ? { reasoning: { enabled: false } }
-            : {}),
-          ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),
-          messages: [
-            { role: "system", content: args.system },
-            { role: "user", content: prompt },
-          ],
-        }),
-        signal: AbortSignal.timeout(timeoutMs),
-      });
+      const doPost = (maxTokensToSend: number) =>
+        fetch(`${backend.baseUrl.replace(/\/$/, "")}/chat/completions`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+            ...(backend.kind === "openrouter" ? backend.headers : {}),
+          },
+          body: JSON.stringify({
+            model: backend.model,
+            max_tokens: maxTokensToSend,
+            // Turn reasoning OFF on OpenRouter unless it's genuinely ACTIVE (`reasoningActive`: a
+            // reasoning-role task that resolved to a DISTINCT reasoning model). This covers the query
+            // role (extraction/short generation) AND — critically — a reasoning role that fell back to
+            // the query model because `teams.reasoning_model` is unset: if that model is itself a
+            // reasoning model, leaving reasoning on would spend the whole budget on hidden thinking and
+            // return empty (what blanked the Learning arcs). Only a real distinct reasoning model keeps
+            // reasoning on. Ignored by non-reasoning models. Override with LLM_DISABLE_REASONING=0.
+            ...(backend.kind === "openrouter" &&
+            !reasoningActive(opts.role, keys) &&
+            process.env.LLM_DISABLE_REASONING !== "0"
+              ? { reasoning: { enabled: false } }
+              : {}),
+            ...(opts.jsonObject ? { response_format: { type: "json_object" } } : {}),
+            messages: [
+              { role: "system", content: args.system },
+              { role: "user", content: prompt },
+            ],
+          }),
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+
+      // First attempt: answer budget + reasoning headroom (so a reasoning model's hidden tokens don't
+      // starve the answer to empty). If the headroom pushes max_tokens past a SMALL model's ceiling
+      // (400), retry once with just the answer budget — mirrors the streaming path (lib/query/claude);
+      // without this, every non-streaming task 400s on a small local backend while Query still works.
+      let res = await doPost(maxTokens + REASONING_HEADROOM_TOKENS);
       if (!res.ok) {
-        throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+        const firstErrBody = await res.text().catch(() => "");
+        if (looksLikeTokenLimit(res.status, firstErrBody)) {
+          res = await doPost(maxTokens);
+          if (!res.ok) {
+            throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+          }
+        } else {
+          throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${firstErrBody}`);
+        }
       }
       const j = (await res.json()) as {
         choices?: { message?: { content?: string }; finish_reason?: string }[];

--- a/lib/query/llm-backend.test.ts
+++ b/lib/query/llm-backend.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   selectLlmBackend,
   describeAnswering,
+  reasoningActive,
   OPENROUTER_BASE_URL,
   OPENAI_BASE_URL,
   DEFAULT_OPENROUTER_MODEL,
@@ -133,5 +134,36 @@ describe("describeAnswering — the admin indicator", () => {
   it("honored override is not a fallback", () => {
     const d = describeAnswering({}, { activeProvider: "openai", openaiKey: "sk-x" });
     expect(d).toEqual({ requested: "openai", provider: "openai", model: DEFAULT_OPENAI_MODEL, usedFallback: false });
+  });
+});
+
+describe("reasoningActive — reasoning stays ON only for a DISTINCT reasoning model", () => {
+  it("true only when role is reasoning AND a non-empty reasoningModel is set", () => {
+    expect(reasoningActive("reasoning", { reasoningModel: "qwen/qwen3-thinking" })).toBe(true);
+  });
+
+  it("false when the reasoning role falls back to the query model (no reasoningModel) — the fix", () => {
+    // teams.reasoning_model unset → role:reasoning uses the query model; if THAT is a reasoning model,
+    // leaving reasoning on would starve the answer to empty (the arcs-blanking bug). So: reasoning OFF.
+    expect(reasoningActive("reasoning", {})).toBe(false);
+    expect(reasoningActive("reasoning", { reasoningModel: "" })).toBe(false);
+    expect(reasoningActive("reasoning", { reasoningModel: "   " })).toBe(false);
+    expect(reasoningActive("reasoning", { reasoningModel: null })).toBe(false);
+  });
+
+  it("false for the query role regardless of reasoningModel, and for an undefined role", () => {
+    expect(reasoningActive("query", { reasoningModel: "qwen/qwen3-thinking" })).toBe(false);
+    expect(reasoningActive(undefined, { reasoningModel: "qwen/qwen3-thinking" })).toBe(false);
+  });
+
+  it("selectLlmBackend swaps in the reasoning model only when reasoningActive, else keeps the query model", () => {
+    const keys = { openrouterKey: "sk-or", openrouterModel: "openai/gpt-4o-mini", reasoningModel: "qwen/qwen3-thinking" };
+    // distinct reasoning model set → used for the reasoning role
+    expect(selectLlmBackend({}, keys, { role: "reasoning" }).model).toBe("qwen/qwen3-thinking");
+    // query role → the query model
+    expect(selectLlmBackend({}, keys, { role: "query" }).model).toBe("openai/gpt-4o-mini");
+    // reasoning role but NO reasoning model → falls back to the query model (reasoning off downstream)
+    const noReasoning = { openrouterKey: "sk-or", openrouterModel: "openai/gpt-4o-mini" };
+    expect(selectLlmBackend({}, noReasoning, { role: "reasoning" }).model).toBe("openai/gpt-4o-mini");
   });
 });

--- a/lib/query/llm-backend.ts
+++ b/lib/query/llm-backend.ts
@@ -57,6 +57,20 @@ export interface LlmBackendKeys {
 /** Which model to select: the default interactive/extraction model, or the reasoning model. */
 export type LlmRole = "query" | "reasoning";
 
+/**
+ * Whether chain-of-thought reasoning should be left ON for this call. TRUE only when a reasoning-role
+ * task actually resolved to a DISTINCT reasoning model (`teams.reasoning_model` set). When it's unset,
+ * `role:"reasoning"` falls back to the QUERY model (see selectLlmBackend) — and if that model is itself
+ * a reasoning model, leaving reasoning on lets it spend the whole token budget on hidden thinking and
+ * return empty (the starvation that blanks the Learning arcs; the query role turns reasoning off for
+ * exactly this reason). So a fallen-back reasoning role is treated like the query role: reasoning OFF.
+ * Single source of truth for the reasoning toggle — used by both selectLlmBackend (model swap) and the
+ * completion primitive (the `reasoning:{enabled:false}` flag).
+ */
+export function reasoningActive(role: LlmRole | undefined, keys: LlmBackendKeys): boolean {
+  return role === "reasoning" && nonEmpty(keys.reasoningModel);
+}
+
 export type LlmBackend =
   | { kind: "openrouter"; provider: "openrouter"; baseUrl: string; model: string; apiKey: string; headers: Record<string, string> }
   | { kind: "openai-compatible"; provider: "openai" | "local"; baseUrl: string; model: string; apiKey: string | null }
@@ -134,9 +148,11 @@ export function selectLlmBackend(
     candidate("anthropic", env, keys)!;
 
   // For a reasoning-role task, swap in the team's distinct reasoning model (on whatever provider
-  // answers). Unset → the query model already on `backend` stands, so reasoning falls back cleanly.
-  if (opts?.role === "reasoning" && nonEmpty(keys.reasoningModel)) {
-    return { ...backend, model: keys.reasoningModel.trim() };
+  // answers). Unset → `reasoningActive` is false, the query model already on `backend` stands, and the
+  // completion primitive turns reasoning OFF (so a query model that happens to be a reasoning model
+  // can't starve the answer — the whole point).
+  if (reasoningActive(opts?.role, keys)) {
+    return { ...backend, model: keys.reasoningModel!.trim() };
   }
   return backend;
 }

--- a/test/arcs-commit.test.ts
+++ b/test/arcs-commit.test.ts
@@ -5,7 +5,7 @@ import type { DbClient } from "@/lib/db/types";
 
 /** Minimal fake DbClient covering exactly the arc_cache read (select→eq→eq→maybeSingle) and write
  *  (upsert) paths. Records upserts so we can assert whether a clobber happened. */
-function fakeDb(existing: NarrativeArc[] | null) {
+function fakeDb(existing: NarrativeArc[] | null, computedAtMs = Date.now()) {
   const upserts: unknown[] = [];
   const db = {
     from: () => ({
@@ -13,7 +13,9 @@ function fakeDb(existing: NarrativeArc[] | null) {
         eq: () => ({
           eq: () => ({
             maybeSingle: async () =>
-              existing ? { data: { arcs: existing, computed_at: new Date().toISOString() } } : { data: null },
+              existing
+                ? { data: { arcs: existing, computed_at: new Date(computedAtMs).toISOString() } }
+                : { data: null },
           }),
         }),
       }),
@@ -25,6 +27,8 @@ function fakeDb(existing: NarrativeArc[] | null) {
   } as unknown as DbClient;
   return { db, upserts };
 }
+
+const HOUR = 60 * 60 * 1000;
 
 const arc = (title: string): NarrativeArc => ({
   id: "arc-" + title,
@@ -61,5 +65,17 @@ describe("commitArcs — an empty synthesis must never clobber a good cache", ()
     const out = await commitArcs(db, "team-1", "cold-empty-1", []);
     expect(out).toEqual([]);
     expect(upserts).toHaveLength(1); // first-ever load may legitimately be empty
+  });
+
+  it("ACCEPTS empty when the prior is older than the clobber cap (persistently-empty is genuine)", async () => {
+    // A prior beyond the 48h cap is no longer trustworthy as transient-failure cover — a quiet team /
+    // deleted content / graph reset should be allowed to blank the panel instead of pinning stale arcs.
+    const { db, upserts } = fakeDb([arc("ancient migration")], Date.now() - 50 * HOUR);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = await commitArcs(db, "team-1", "old-prior-1", []);
+    expect(out).toEqual([]); // empty accepted
+    expect(upserts).toHaveLength(1); // written through, not kept
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("accepting empty"));
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
Fable-review follow-ups on the learning/LLM cluster (#281/#285/#289/#290).

## Fixes
- **HIGH — reasoning-fallback starvation.** With `teams.reasoning_model` unset, a `role:"reasoning"` task (arc synthesis) falls back to the QUERY model, but `complete.ts` still left reasoning ON — so if the query model is itself a reasoning model (the original-incident config), it spends the whole token budget on hidden thinking and returns empty → blank arcs. New shared **`reasoningActive(role, keys)`** (single source of truth for both `selectLlmBackend`'s model swap and `complete.ts`'s `reasoning:{enabled:false}` flag): reasoning stays on **only** for a distinct configured reasoning model; a fallen-back reasoning role is treated like the query role.
- **MED — small-model ceiling retry.** `complete.ts` sent `max_tokens+headroom` with no retry (the streaming path has one), so a small local backend 400'd on *every* non-streaming task while Query worked. Now retries once without headroom on a token-limit 400 (reuses `looksLikeTokenLimit`).
- **MED — stale-arc cap.** `commitArcs`' empty-clobber guard had no age bound — a legitimately-empty synthesis (quiet team, deleted content, graph reset) could never blank the panel. Now accepts empty once the prior is >48h old (`ARCS_EMPTY_CLOBBER_MAX_AGE_MS`, hardened parse); within the window it still keeps the prior as transient cover.
- **MED — external-tier redaction.** `/api/brain/arcs` returned the diagnostic `note` (embeds `llm.lastError` → internal base URL, model, provider error body) to any tier. Redacted for `external`; team keeps it.

## Review
Reviewed by **Fable** (required pre-push gate) — verdict *ship it*. It confirmed the reasoning toggle (TDZ safe, no divergence between the two call sites), the retry body-consumption/no-cycle correctness, the age-cap branches, and the redaction; caught one MEDIUM (the `ARCS_EMPTY_CLOBBER_MAX_AGE_MS` NaN parse hole) — **fixed** in the follow-up commit. Two LOWs (ceiling-retry-with-a-genuine-reasoning-model, `readArcCache` NaN→0) both fail safe.

## Test plan
- [x] tsc · eslint · full unit suite 845 green · new specs: reasoningActive truth table + selectLlmBackend swap; commitArcs age-cap accept-empty branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)