### PR TITLE
fix(meetings): salvage attendees on truncation + safe-default the backfill script

### DIFF
--- a/lib/meetings/llm-extract.ts
+++ b/lib/meetings/llm-extract.ts
@@ -106,6 +106,33 @@ export function salvageSummaryBullets(raw: string): string[] {
   return bullets;
 }
 
+/**
+ * Recover attendee names from a malformed/truncated meetings JSON response — the companion to
+ * `salvageSummaryBullets`. Without this, a salvaged upload kept its summary but silently lost attendee
+ * linking even when the `attendees` array was complete in the response. Scoped to the strings inside
+ * the `"attendees":[ … ]` array (bounded at the first `]`, else whatever arrived before truncation) so
+ * summary bullets aren't mistaken for names; a truncated trailing name has no closing quote and is
+ * dropped. Returned names are still filtered against the real roster by `matchAttendees`, so junk can't
+ * invent an attendee. Pure + exported for tests.
+ */
+export function salvageAttendeeNames(raw: string): string[] {
+  const marker = raw.search(/"attendees"\s*:\s*\[/);
+  if (marker === -1) return [];
+  const afterOpen = raw.slice(raw.indexOf("[", marker) + 1);
+  const close = afterOpen.indexOf("]");
+  const body = close === -1 ? afterOpen : afterOpen.slice(0, close);
+  const names: string[] = [];
+  for (const m of body.matchAll(/"(?:[^"\\]|\\.)*"/g)) {
+    try {
+      const v: unknown = JSON.parse(m[0]);
+      if (typeof v === "string" && v.trim()) names.push(v.trim());
+    } catch {
+      /* skip an unparseable literal */
+    }
+  }
+  return names;
+}
+
 /** Normalize a name for tolerant matching: lowercase, collapse whitespace, drop punctuation. */
 function normalizeName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9\s]/g, "").replace(/\s+/g, " ").trim();
@@ -172,8 +199,13 @@ export function parseTranscriptExtraction(raw: string, roster: RosterPerson[]): 
     // complete bullets we can rather than saving the note blank. Need ≥2 to count as a real summary.
     const salvaged = salvageSummaryBullets(raw);
     if (salvaged.length >= 2) {
-      console.warn(`[meetings] recovered summary from malformed/truncated JSON (${salvaged.length} bullets)`);
-      return { summary: normalizeSummaryField(salvaged), attendeeMemberIds: [] };
+      // Salvage attendees too — they're often complete even when the summary string was truncated;
+      // matchAttendees still filters to the real roster, so nothing is invented.
+      const names = salvageAttendeeNames(raw);
+      console.warn(
+        `[meetings] recovered from malformed/truncated JSON (${salvaged.length} bullets, ${names.length} attendee names)`
+      );
+      return { summary: normalizeSummaryField(salvaged), attendeeMemberIds: matchAttendees(names, roster) };
     }
     console.error("[meetings] LLM response was not valid JSON:", err instanceof Error ? err.message : err, raw.slice(0, 300));
     return empty;

--- a/scripts/backfill-meeting-summaries.ts
+++ b/scripts/backfill-meeting-summaries.ts
@@ -5,11 +5,13 @@
  * model (incl. OpenRouter) exactly like a live upload, and uses the same single-writer writers, so
  * there is no second write path. Idempotent and safe to re-run.
  *
- * Run (all teams, full refresh):
+ * Run (all teams, heal only blank summaries — the SAFE default):
  *   DATABASE_URL=… SECRETS_KEY=… npx tsx --conditions react-server scripts/backfill-meeting-summaries.ts
  * Options:
  *   [teamSlug]     limit to one team
- *   --only-blank   only heal notes whose summary is currently blank (skip ones already populated)
+ *   --all / --full re-run over EVERY note, OVERWRITING existing summaries with fresh LLM output
+ *                  (nondeterministic — can replace good summaries with worse ones; opt in deliberately)
+ *   --only-blank   accepted as a no-op (this is now the default)
  *   --limit=N      cap notes processed per team
  */
 import { adminClient } from "@/lib/db/admin";
@@ -20,7 +22,11 @@ type TeamRow = { id: string; slug: string; name: string };
 
 async function main() {
   const argv = process.argv.slice(2);
-  const onlyBlank = argv.includes("--only-blank");
+  // Default to the SAFE mode: heal only notes whose summary is currently blank. A full refresh re-runs
+  // the LLM over EVERY note and overwrites good summaries with fresh (nondeterministic) output, so it
+  // must be opted into explicitly (`--all`/`--full`). `--only-blank` remains accepted as a no-op.
+  const fullRefresh = argv.includes("--all") || argv.includes("--full");
+  const onlyBlank = !fullRefresh;
   const limitArg = argv.find((a) => a.startsWith("--limit="));
   const limit = limitArg ? Number(limitArg.split("=")[1]) : undefined;
   const timeoutArg = argv.find((a) => a.startsWith("--timeout="));

--- a/test/meetings-truncated-json.test.ts
+++ b/test/meetings-truncated-json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseTranscriptExtraction, salvageSummaryBullets } from "@/lib/meetings/llm-extract";
+import { parseTranscriptExtraction, salvageSummaryBullets, salvageAttendeeNames } from "@/lib/meetings/llm-extract";
 import { summaryBullets } from "@/lib/meetings/summary-format";
 
 /**
@@ -68,5 +68,38 @@ describe("parseTranscriptExtraction recovers a summary from malformed/truncated 
   it("well-formed JSON is unaffected (no regression through the salvage path)", () => {
     const raw = '{"summary":"- a\\n- b","attendees":[]}';
     expect(summaryBullets(parseTranscriptExtraction(raw, []).summary)).toEqual(["a", "b"]);
+  });
+});
+
+describe("salvageAttendeeNames — attendees survive the salvage path, not just the summary", () => {
+  it("recovers names from the attendees array in a malformed response", () => {
+    const raw = '{"summary":"- a","- b","attendees":["Alex Rivera","John Ellison"]}';
+    expect(salvageAttendeeNames(raw)).toEqual(["Alex Rivera", "John Ellison"]);
+  });
+
+  it("recovers the complete names when the attendees array is token-truncated", () => {
+    const raw = '{"summary":"- a","attendees":["Alex Rivera","John Elli';
+    expect(salvageAttendeeNames(raw)).toEqual(["Alex Rivera"]);
+  });
+
+  it("returns [] when there is no attendees array", () => {
+    expect(salvageAttendeeNames('{"summary":"- a","- b"}')).toEqual([]);
+  });
+
+  it("does not mistake summary bullets for names (scoped to the attendees array)", () => {
+    const raw = '{"summary":"- bullet one","- bullet two","attendees":["Real Person"]}';
+    expect(salvageAttendeeNames(raw)).toEqual(["Real Person"]);
+  });
+
+  it("parseTranscriptExtraction matches salvaged names against the roster (was dropping them)", () => {
+    const roster = [
+      { id: "m1", displayName: "Alex Rivera" },
+      { id: "m2", displayName: "John Ellison" },
+    ];
+    const raw =
+      '{"summary":"- Point one is complete.","- Point two is complete.",' +
+      '"attendees":["Alex Rivera","John Ellison"]}';
+    const out = parseTranscriptExtraction(raw, roster);
+    expect([...out.attendeeMemberIds].sort()).toEqual(["m1", "m2"]);
   });
 });


### PR DESCRIPTION
Fable-review follow-ups on the meetings cluster (#280/#283/#284).

## Fixes
- **MED — attendee loss on truncation.** The malformed/truncated-JSON salvage path recovered the summary bullets but returned `attendeeMemberIds: []` unconditionally — silently losing attendee linking even when the `attendees` array was complete in the response. New `salvageAttendeeNames(raw)` recovers names scoped to the `"attendees":[…]` array (bounded, truncation-safe); `matchAttendees` still filters to the real roster so nothing is invented.
- **MED — destructive backfill default.** `scripts/backfill-meeting-summaries.ts` DEFAULTED to a full refresh, overwriting every good summary with fresh nondeterministic LLM output. Flipped: heal-only-blank is now the default; the full refresh requires an explicit `--all`/`--full` (`--only-blank` accepted as a no-op).

## Deliberately not addressed (product call)
The interactive upload chains two 60s meeting-LLM caps (~120s worst case on a wedged provider). Choosing an interactive-vs-background timeout budget is a UX decision, left for a deliberate call rather than picking a number here.

## Review
Reviewed by **Fable** (required pre-push gate) — verdict *ship it*. It verified the salvage scoping/bounding empirically (a `]` inside an attendee name only degrades to the pre-fix no-attendees behavior, never invents), the roster filter, no well-formed-path regression, and the backfill default flip across all `onlyBlank` call sites. Three LOWs, all loss-bounded; none block.

## Test plan
- [x] tsc · eslint · 12 unit tests (new: salvageAttendeeNames scoping/truncation + roster-match through the salvage path); existing truncated-json specs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery of attendee names when meeting transcript extraction responses are incomplete or malformed.
  - Recovered attendee names are now matched against the meeting roster to preserve participant associations.

- **Maintenance**
  - Meeting summary backfills now preserve existing summaries by default.
  - Use `--all` or `--full` to explicitly refresh all summaries.

- **Tests**
  - Added coverage for attendee recovery, malformed responses, and roster matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->