### PR TITLE
fix(security): fail-closed tier gate across every tier-scoped read (audit #275 finish)

### DIFF
--- a/app/api/brain/arcs/route.ts
+++ b/app/api/brain/arcs/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { serverClient } from "@/lib/db/server";
 import { adminClient } from "@/lib/db/admin";
 import { getSessionUser } from "@/lib/auth/session";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 import { errorResponse } from "@/lib/api/schemas";
 import { resolveAnsweringKeys } from "@/lib/query/answering";
 import { visibleGroupIds } from "@/lib/graph/group";
@@ -84,7 +85,7 @@ export async function POST(req: NextRequest) {
     arcs,
     degraded: reason === "model_failing", // back-compat flag
     reason,
-    note: tier === "external" ? undefined : note,
+    note: isRestrictedTier(tier) ? undefined : note,
     as_of: new Date().toISOString(),
   });
 }

--- a/app/api/dashboard/query/route.ts
+++ b/app/api/dashboard/query/route.ts
@@ -5,6 +5,7 @@ import { adminClient } from "@/lib/db/admin";
 import { getSessionUser } from "@/lib/auth/session";
 import { rateLimit } from "@/lib/api/rate-limit";
 import { errorResponse } from "@/lib/api/schemas";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 import { formatSseFrame } from "@/lib/api/sse";
 import { retrieve } from "@/lib/query/retrieve";
 import { streamAnswer } from "@/lib/query/claude";
@@ -137,7 +138,7 @@ export async function POST(req: NextRequest) {
   // connector instead of asking the LLM. team-tier only (external collaborators can't trigger a
   // sync of internal data); its own tighter rate limit; doesn't consume the daily LLM query budget.
   if (isSyncCommand(question)) {
-    if (memberTier === "external") {
+    if (isRestrictedTier(memberTier)) {
       return errorResponse("forbidden", "scraping is available to team members only", 403);
     }
     if (!(await rateLimit(db, `${me.id}:sync`, 2))) {

--- a/app/api/v1/items/[id]/route.ts
+++ b/app/api/v1/items/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { adminClient } from "@/lib/db/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 import { rateLimit } from "@/lib/api/rate-limit";
 import { errorResponse } from "@/lib/api/schemas";
 
@@ -25,7 +26,7 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string 
     .eq("team_id", auth.teamId)
     .eq("id", id)
     .limit(1);
-  if (auth.memberTier === "external") q = q.eq("access", "external");
+  if (isRestrictedTier(auth.memberTier)) q = q.eq("access", "external");
 
   const { data, error } = await q;
   if (error) return errorResponse("internal", error.message, 500);

--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, after } from "next/server";
 import { adminClient } from "@/lib/db/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 import { rateLimit } from "@/lib/api/rate-limit";
 import {
   itemPayloadSchema,
@@ -120,7 +121,7 @@ export async function GET(req: NextRequest) {
     .order("updated_at", { ascending: true })
     .order("id", { ascending: true })
     .limit(PAGE_SIZE);
-  if (auth.memberTier === "external") q = q.eq("access", "external");
+  if (isRestrictedTier(auth.memberTier)) q = q.eq("access", "external");
   if (kinds?.length) q = q.in("kind", kinds);
   // On-demand fetch of one skill/deliverable folder: match path by prefix.
   if (pathPrefix) q = q.like("path", `${pathPrefix.replace(/[%_\\]/g, "\\$&")}%`);

--- a/app/api/v1/okf-bundle/route.ts
+++ b/app/api/v1/okf-bundle/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { adminClient } from "@/lib/db/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 import { rateLimit } from "@/lib/api/rate-limit";
 import { errorResponse } from "@/lib/api/schemas";
 import { extractLinks, extractTitle, resolveLink } from "@/lib/okf/links";
@@ -83,7 +84,7 @@ export async function GET(req: NextRequest) {
     .order("updated_at", { ascending: true })
     .order("path", { ascending: true })
     .limit(PAGE_SIZE);
-  if (effectiveTier === "external") q = q.eq("access", "external");
+  if (isRestrictedTier(effectiveTier)) q = q.eq("access", "external");
   if (projectId) q = q.eq("project_id", projectId);
   const { data: rows, error } = await q;
   if (error) return errorResponse("internal", error.message, 500);

--- a/lib/auth/visibility.ts
+++ b/lib/auth/visibility.ts
@@ -10,6 +10,18 @@ import "server-only";
 export type ViewerTier = "team" | "external";
 
 /**
+ * Fail-CLOSED tier check (audit #275 hardening). Only the `team` tier is unrestricted; EVERY other
+ * value — `external` today, and any future/unknown tier the enum might grow (e.g. `admin`) or a bad
+ * cast might smuggle in — is treated as restricted and gets the external-only filter. Use this at every
+ * tier-scoped read that can't route through the query-builder choke-points above (raw-SQL builders,
+ * API routes), instead of the fail-OPEN `tier === "external"` idiom (which leaves an unknown tier
+ * unfiltered → leak). There is no RLS backstop, so this is sole enforcement.
+ */
+export function isRestrictedTier(tier: string): boolean {
+  return tier !== "team";
+}
+
+/**
  * Restrict an items query to what `tier` may see: external → only `access='external'`.
  * `Q` is a free generic (no recursive constraint) so the supabase-js builder's deeply
  * recursive type doesn't trigger TS2589; the `.eq` shape is asserted by a localized cast.

--- a/lib/provisioning/linear.ts
+++ b/lib/provisioning/linear.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import type { DbClient } from "@/lib/db/types";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 import { linearGraphql } from "@/lib/pm-sync/linear-client";
 import { enabledIntegration } from "./integration";
 import type { ProvisioningAdapter, ProvisioningMember, ProvisioningResult } from "./types";
@@ -43,7 +44,7 @@ export const linearAdapter: ProvisioningAdapter = {
     const config = integ.config ?? {};
     const role =
       (typeof config.inviteRole === "string" && config.inviteRole) ||
-      (member.tier === "external" ? "guest" : "user");
+      (isRestrictedTier(member.tier) ? "guest" : "user"); // unknown/future tier → least-privileged guest
     const teamIds = Array.isArray(config.inviteTeamIds) ? (config.inviteTeamIds as string[]) : [];
     const input: Record<string, unknown> = { email: member.email, role };
     if (teamIds.length) input.teamIds = teamIds; // omit the field entirely when unset/empty

--- a/lib/query/dense-search.ts
+++ b/lib/query/dense-search.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 import { embed, toVectorLiteral } from "./embeddings";
 import { denseIndexAvailable } from "./dense-index";
 import { resolveEmbeddingKey } from "./embedding-key";
@@ -49,7 +50,7 @@ export async function denseSearch(
 
     const params: unknown[] = [qv, teamId];
     let where = "c.team_id = $2";
-    if (tier === "external") where += " and i.access = 'external'";
+    if (isRestrictedTier(tier)) where += " and i.access = 'external'";
     if (projectSlug) {
       params.push(projectSlug);
       where += ` and p.slug = $${params.length}`;

--- a/lib/query/fts-search.ts
+++ b/lib/query/fts-search.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 
 /**
  * Ranked keyword (FTS) retrieval over `items.search`. The builder path emits a bare
@@ -33,7 +34,7 @@ export async function rankedFtsSearch(
   if (!orQuery.trim()) return [];
   const params: unknown[] = [orQuery, teamId];
   let where = "i.team_id = $2 and i.search @@ websearch_to_tsquery('english', $1)";
-  if (tier === "external") where += " and i.access = 'external'";
+  if (isRestrictedTier(tier)) where += " and i.access = 'external'";
   if (channel) {
     // Channel scope (Gap #4): the channel is a path's 2nd segment, `<source>/<name>/…`.
     params.push(channel);

--- a/lib/query/grounding.ts
+++ b/lib/query/grounding.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 
 /**
  * Term-specificity analysis for the grounding signal (Gap #3). The old signal was
@@ -33,7 +34,7 @@ export async function analyzeTermSpecificity(
 ): Promise<TermSpecificity> {
   if (terms.length === 0) return { specificMatching: false, allCommon: true };
   try {
-    const access = tier === "external" ? "and access = 'external'" : "";
+    const access = isRestrictedTier(tier) ? "and access = 'external'" : "";
     // One row per term: corpus total + that term's document frequency, both tier-scoped.
     const sql = `
       select t.term,

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { GraphitiClient, type GraphFact } from "@/lib/graph/graphiti-client";
 import { visibleGroupIds } from "@/lib/graph/group";
-import { visibleTasks } from "@/lib/auth/visibility";
+import { visibleTasks, isRestrictedTier } from "@/lib/auth/visibility";
 import {
   selectedProviderName,
   type RetrievalProvider,
@@ -460,7 +460,7 @@ async function nativeRetrieve(
     .eq("team_id", teamId)
     .order("synced_at", { ascending: false })
     .limit(8);
-  if (tier === "external") recentB = recentB.eq("access", "external");
+  if (isRestrictedTier(tier)) recentB = recentB.eq("access", "external");
   // Channel scope (Gap #4) — keep the recency fallback inside the same channel. LIKE on the 2nd
   // path segment; the FTS leg uses a precise split_part match, this soft filter is fine for padding.
   if (channel) recentB = recentB.like("path", `%/${channel}/%`);
@@ -472,7 +472,7 @@ async function nativeRetrieve(
     .eq("team_id", teamId)
     .order("decided_at", { ascending: false })
     .limit(50);
-  if (tier === "external") decisionsB = decisionsB.eq("audience", "external");
+  if (isRestrictedTier(tier)) decisionsB = decisionsB.eq("audience", "external");
   // ALL statuses (incl. `done`), most-recently-updated first — so "what got completed today?"
   // can ground on finished tasks. `tasks.updated_at` is bumped on every sync upsert (incl. a
   // status→done transition), so recency ordering surfaces today's completions. (Was active-only:
@@ -493,7 +493,7 @@ async function nativeRetrieve(
   // internal commitments/actors/reporting lines. `emptyRows` resolves to the same `{ data }` shape.
   const emptyRows = Promise.resolve({ data: [] as unknown[] });
   const commitmentsB =
-    tier === "external"
+    isRestrictedTier(tier)
       ? emptyRows
       : db
           .from("graph_entities")
@@ -502,7 +502,7 @@ async function nativeRetrieve(
           .eq("entity_type", "commitment")
           .limit(30);
   const relsB =
-    tier === "external"
+    isRestrictedTier(tier)
       ? emptyRows
       : db
           .from("graph_relationships")
@@ -511,7 +511,7 @@ async function nativeRetrieve(
           .in("relationship_type", ["REPORTS_TO", "OWNS", "BLOCKS"])
           .limit(80);
   const actorsB =
-    tier === "external"
+    isRestrictedTier(tier)
       ? emptyRows
       : db
           .from("graph_entities")

--- a/lib/query/structured-extras.ts
+++ b/lib/query/structured-extras.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 
 /**
  * Structured-context helpers that fix the "digests are recency-capped" scaling gaps (Gaps #5, #6).
@@ -21,7 +22,7 @@ export interface TaskCounts {
 /** Count ALL tasks by status (uncapped), tier-scoped. Powers a correct "how many open tasks" answer. */
 export async function taskStatusCounts(teamId: string, tier: "team" | "external"): Promise<TaskCounts> {
   try {
-    const access = tier === "external" ? "and audience = 'external'" : "";
+    const access = isRestrictedTier(tier) ? "and audience = 'external'" : "";
     const sql = `select status, count(*)::int as n from tasks where team_id = $1 ${access} group by status`;
     const res = await runSql<{ status: string; n: number }>(sql, [teamId]);
     const byStatus: Record<string, number> = {};
@@ -62,7 +63,7 @@ export async function matchingDecisions(
 ): Promise<DecisionMatch[]> {
   if (!orQuery.trim()) return [];
   try {
-    const access = tier === "external" ? "and d.audience = 'external'" : "";
+    const access = isRestrictedTier(tier) ? "and d.audience = 'external'" : "";
     const params: unknown[] = [orQuery, teamId, limit];
     const sql = `
       select d.row_key, d.decided_at, d.title, d.decided_by, d.still_valid, coalesce(p.slug, '') as slug,

--- a/lib/sync/decisions.ts
+++ b/lib/sync/decisions.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import type { DbClient } from "@/lib/db/types";
+import { isRestrictedTier } from "@/lib/auth/visibility";
 
 /** Tier of the pulling principal (the API key's member tier). */
 export type ViewerTier = "team" | "external";
@@ -45,7 +46,7 @@ export async function getDecisionWriteback(
     .gt("updated_at", since)
     .order("updated_at", { ascending: true })
     .limit(500);
-  if (tier === "external") query = query.eq("audience", "external");
+  if (isRestrictedTier(tier)) query = query.eq("audience", "external");
 
   const { data, error } = await query;
   if (error) throw new Error(error.message);

--- a/test/auth-visibility.test.ts
+++ b/test/auth-visibility.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { isRestrictedTier, canSeeAccess } from "@/lib/auth/visibility";
+
+/**
+ * Fail-CLOSED tier semantics (audit #275 hardening). There is NO RLS, so every tier-scoped read is
+ * sole-enforced in app code. The invariant: ONLY `team` is unrestricted; `external` today AND any
+ * future/unknown tier the enum might grow (e.g. `admin`) or a bad cast might smuggle in must be
+ * treated as restricted. These assertions pin that a NON-team value never falls through to the
+ * unfiltered path — the fail-OPEN `tier === "external"` idiom this replaced would.
+ */
+describe("isRestrictedTier — only team is unrestricted (fail closed)", () => {
+  it("team is NOT restricted", () => {
+    expect(isRestrictedTier("team")).toBe(false);
+  });
+
+  it("external is restricted", () => {
+    expect(isRestrictedTier("external")).toBe(true);
+  });
+
+  it("an unknown / future / malformed tier is restricted (the whole point)", () => {
+    for (const t of ["admin", "client", "private", "", "TEAM", " team", "unknown"]) {
+      expect(isRestrictedTier(t)).toBe(true);
+    }
+  });
+});
+
+describe("canSeeAccess — the single-item mirror of the same rule", () => {
+  it("team sees any access; a non-team tier sees only external", () => {
+    expect(canSeeAccess("team", "team")).toBe(true);
+    expect(canSeeAccess("team", "external")).toBe(true);
+    expect(canSeeAccess("external", "team")).toBe(false);
+    expect(canSeeAccess("external", "external")).toBe(true);
+    // an unknown viewer tier is restricted to external content only
+    expect(canSeeAccess("admin" as unknown as "team" | "external", "team")).toBe(false);
+    expect(canSeeAccess("admin" as unknown as "team" | "external", "external")).toBe(true);
+  });
+});


### PR DESCRIPTION
Finishes the fail-closed hardening flagged on #275. That PR made only `lib/auth/visibility.ts` fail closed; ~13 other tier-scoped reads still used the fail-**open** `tier === "external"` idiom — an unknown/future tier (or a bad cast) fell through **unfiltered**, leaking team content.

Not exploitable today (`members.tier` is a Postgres enum), but the same enum protects the choke-point #275 hardened; this converges the rest so the day the enum grows (e.g. `admin`), nothing leaks.

## Change
New **`isRestrictedTier(tier) = tier !== "team"`** in `lib/auth/visibility.ts` (only `team` is unrestricted; every other value → external-only), applied to:
- `retrieve.ts` — recent items, decisions, and the **3 untiered graph-entity reads** (commitments/rels/actors now empty for *any* non-team tier, not just `external` — these tables have no tier column)
- `fts-search`, `dense-search`, `grounding`, `structured-extras` (raw-SQL filter strings)
- `sync/decisions`, `/api/v1/items` (+`[id]`), `okf-bundle` (page filter only — ceiling logic untouched)
- `/api/dashboard/query` (sync-command gate → 403), `/api/brain/arcs` (note redaction), `provisioning/linear` (unknown tier → least-privileged `guest`)

Behavior for the two real tiers (`team`/`external`) is **identical by construction**; only the out-of-enum path is now fail-closed.

## Review
Reviewed by **Fable** (required pre-push gate) — verdict *ship it*, no CRITICAL/HIGH/MEDIUM. It confirmed each site is behavior-preserving on the real enum (no inverted branches), that the fix actually fails closed for out-of-enum values, that **no tier-scoped read was missed**, and that the unit test is non-vacuous (mutating the helper back to fail-open turns it red). LOWs (a couple of already-fail-closed `=== "team"` idioms that could consolidate through the helper) are deferred.

## Test plan
- [x] tsc · eslint · full unit suite 855 green · new `test/auth-visibility.test.ts` locks the fail-closed semantics (team unrestricted; external + unknown/future/malformed restricted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)