### PR TITLE
fix(learning): structural arc participants — union in the humans behind cited evidence

### DIFF
--- a/lib/graph/arc-attribution.ts
+++ b/lib/graph/arc-attribution.ts
@@ -134,6 +134,29 @@ export function attributedFactTexts(
   });
 }
 
+/**
+ * Union an arc's LLM-written `participants` with the humans resolved from the arc's OWN cited
+ * evidence (via `items.member_id`) — so being named on an arc is STRUCTURAL, not LLM luck. Without
+ * this, a participant chip appears only when the model happens to echo a name out of the fact text:
+ * fine for people whose docs literally say "John is coordinating…", invisible for people whose work
+ * is commit-shaped (fact subjects are features/repos; the human exists only in the `(Name)`
+ * attribution prefix). It also puts names on arcs the model returned with `participants: []`.
+ *
+ * A human is skipped when their name already appears (case-insensitive) INSIDE any existing
+ * participant string — covering the exact name and the rewritten agent tag "Claude Code (Name)"
+ * from `attributeParticipants` — so no duplicate chips. LLM participants keep their order; evidence
+ * humans append after. Pure; evidence humans come from the roster (`members.display_name`,
+ * connectors already excluded), so nothing here can invent a person.
+ */
+export function withEvidenceParticipants(participants: string[], evidenceHumans: string[]): string[] {
+  const out = [...participants];
+  for (const human of [...new Set(evidenceHumans.map((h) => (h ?? "").trim()).filter(Boolean))]) {
+    const needle = human.toLowerCase();
+    if (!out.some((p) => p.toLowerCase().includes(needle))) out.push(human);
+  }
+  return out;
+}
+
 /** The minimal shape of a Layer-2 event `attributeEventParticipants` needs — structurally compatible
  *  with `GraphEvent` (lib/graph/learning.ts) without importing it. */
 export interface EventParticipantsRef {

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -7,7 +7,7 @@ import { adminClient } from "@/lib/db/admin";
 import { recentFacts, resolveEpisodeItems, type AtomicFact } from "./learning";
 import { GraphitiClient } from "./graphiti-client";
 import { episodeGroupId, type AccessTier } from "./group";
-import { attributeParticipants, attributedFactTexts } from "./arc-attribution";
+import { attributeParticipants, attributedFactTexts, withEvidenceParticipants } from "./arc-attribution";
 import { resolveHumanActorsByItem } from "./human-actors";
 import { readArcCache, writeArcCache } from "./arc-cache";
 
@@ -69,7 +69,10 @@ const SYSTEM_PROMPT =
   "storylines about what this team is working through. Favor RECENT activity and give every active " +
   "contributor visible representation — don't let one person's arcs crowd out others who've been " +
   "working. Each fact below is numbered [F1], [F2], … — for every arc, cite the 2-5 fact numbers that " +
-  "support it in `supporting_facts`. Return ONLY a JSON object of the form " +
+  "support it in `supporting_facts`. A parenthesized name at the START of a fact — e.g. \"(Chetan) …\" " +
+  "— is the human RESPONSIBLE for that work (it may not appear in the fact text itself): include those " +
+  "humans in `participants` for every arc citing their facts. Never invent names not present in the " +
+  "facts or their attributions. Return ONLY a JSON object of the form " +
   '{"arcs":[{"title":"short","confidence":"high|medium|low","summary":"2-3 sentences, present tense, ' +
   'specific","participants":["names"],"supporting_facts":[1,2,3]}]}. Use only fact numbers that appear ' +
   "below. No prose, no markdown code fences — the raw JSON object only.";
@@ -327,17 +330,23 @@ function humansForItems(itemIds: (string | undefined)[], humanByItem: Map<string
   ];
 }
 
-/** Rewrite each arc's `participants` to tag recognized AI-agent names with the human(s) behind that
- *  arc's own evidence items (never cross-arc — an arc's attribution must trace to ITS OWN work).
- *  Pure over an already-resolved `humanByItem` map — no DB access here. */
+/** Attribute each arc's `participants` from its OWN evidence (never cross-arc — an arc's attribution
+ *  must trace to ITS OWN work): first tag recognized AI-agent names with the human(s) behind the
+ *  evidence items, then UNION in any evidence human the model didn't name (`withEvidenceParticipants`)
+ *  — so a contributor whose facts an arc cites is on the chip even when their name never appears in
+ *  the fact text (commit-shaped work), and an arc the model returned with `participants: []` still
+ *  names the people it's actually about. Pure over an already-resolved `humanByItem` map. */
 function attributeArcs(arcs: NarrativeArc[], humanByItem: Map<string, string>): NarrativeArc[] {
-  return arcs.map((arc) => ({
-    ...arc,
-    participants: attributeParticipants(
-      arc.participants,
-      humansForItems(arc.evidence.map((e) => e.itemId), humanByItem)
-    ),
-  }));
+  return arcs.map((arc) => {
+    const evidenceHumans = humansForItems(arc.evidence.map((e) => e.itemId), humanByItem);
+    return {
+      ...arc,
+      participants: withEvidenceParticipants(
+        attributeParticipants(arc.participants, evidenceHumans),
+        evidenceHumans
+      ),
+    };
+  });
 }
 
 /**

--- a/test/arc-attribution.test.ts
+++ b/test/arc-attribution.test.ts
@@ -5,6 +5,7 @@ import {
   attributeFactText,
   attributeEventParticipants,
   isAiAgentName,
+  withEvidenceParticipants,
 } from "@/lib/graph/arc-attribution";
 
 /**
@@ -184,5 +185,30 @@ describe("attributeEventParticipants (Layer 2)", () => {
     expect(attributeEventParticipants(events, humanByItem)).toEqual([
       { itemId: "item-aaa", participants: ["Claude Code (Chetan Nandakumar)"], source: "github", factCount: 3 },
     ]);
+  });
+});
+
+describe("withEvidenceParticipants — evidence humans are on the chip, structurally", () => {
+  it("appends evidence humans the model didn't name (commit-shaped work: name absent from fact text)", () => {
+    expect(withEvidenceParticipants(["John Ellison"], ["Chetan"])).toEqual(["John Ellison", "Chetan"]);
+  });
+
+  it("names the people behind an arc the model returned with participants: [] (the blank-chip arcs)", () => {
+    expect(withEvidenceParticipants([], ["Chetan", "John Ellison"])).toEqual(["Chetan", "John Ellison"]);
+  });
+
+  it("never duplicates: exact, case-insensitive, and embedded in a rewritten agent tag", () => {
+    expect(withEvidenceParticipants(["Chetan"], ["Chetan"])).toEqual(["Chetan"]);
+    expect(withEvidenceParticipants(["chetan"], ["Chetan"])).toEqual(["chetan"]);
+    // attributeParticipants may have rewritten an agent name to embed the human — no extra chip then.
+    expect(withEvidenceParticipants(["Claude Code (Chetan)"], ["Chetan"])).toEqual(["Claude Code (Chetan)"]);
+  });
+
+  it("keeps LLM participant order first, dedupes evidence humans, drops blanks", () => {
+    expect(withEvidenceParticipants(["Fatma"], ["Chetan", "Chetan", "", "  "])).toEqual(["Fatma", "Chetan"]);
+  });
+
+  it("no evidence humans → participants unchanged", () => {
+    expect(withEvidenceParticipants(["John Ellison"], [])).toEqual(["John Ellison"]);
   });
 });


### PR DESCRIPTION
## Problem
An arc's participant chips appeared only when the synthesis LLM happened to echo a name out of the fact **text**. That works for people whose docs literally say "John is coordinating…", and fails for people whose work is commit-shaped — fact subjects are features/repos, the human exists only in the `(Name)` attribution prefix — the "why am I not in the arcs" diagnosis (2026-07-18). It also left arcs over under-attributed content with an empty chip row. Names on arcs were LLM luck.

## Fix
- **`withEvidenceParticipants(participants, evidenceHumans)`** (pure, `lib/graph/arc-attribution.ts`): unions each arc's participants with the humans resolved from that arc's **own cited evidence** (`items.member_id` → roster `display_name`, connectors excluded — nothing can be invented). Case-insensitive containment dedup so a rewritten "Claude Code (Chetan)" tag doesn't also grow a separate "Chetan" chip. LLM order preserved, evidence humans append after.
- **`attributeArcs`** applies it per-arc after the existing AI-agent rewrite — never cross-arc.
- **SYSTEM_PROMPT** now explains the `(Name)` prefix is the responsible human, to credit those humans in `participants`, and never to invent names (belt-and-suspenders; the deterministic union is the guarantee).

## Review
Reviewed by **Fable** (required pre-push gate) — verdict *ship it*. Verified: no cross-arc bleed, roster-only name source (no connector reintroduction), rewrite→union order correct, prompt concatenation intact, rankArcs/commitArcs untouched, specs non-vacuous. Deferred per its recommendation:
- containment dedup is substring-based and one-directional — an LLM short-form ("John") next to roster "John Ellison" can render near-duplicate chips; a token-boundary match is the follow-up if observed (the new prompt line pushes exact roster names, so the common path dedups exactly). No roster collision exists today for the inverse (false-suppression) case.
- arcs where the model cites no `supporting_facts` (free-text sources → no itemIds) keep old behavior — residual gap, not a regression.
- the `attributeArcs` wiring itself is untested (function is unexported); the logic-carrying helper is fully specced.

## Test plan
- [x] 5 new specs (union, blank-chip fill, three dedup modes, order/blank handling) · arc suites 28+22 green · tsc · eslint · full unit 865 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arc participants now include relevant human names identified from cited evidence.
  * Participant lists preserve their original order while avoiding duplicate or blank entries.
  * Responsible humans are more consistently represented in arc attribution.

* **Bug Fixes**
  * Improved handling of missing, repeated, or embedded participant names in attributed arcs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->