### PR TITLE
fix(learning): de-noise + rebalance the arc fact pool so varied work surfaces (Phase A)

### DIFF
--- a/docs/design/brain-learning-panel.md
+++ b/docs/design/brain-learning-panel.md
@@ -70,8 +70,34 @@ ORDER BY ep.created_at DESC
 `ep.name = "items:<id>"` → join to `items`/`members` for the real source icon, avatars, and a link
 into the library. This is the ladder rung Layer 3 consumes.
 
-**Layer 3 — narrative arcs:** gather the 7-day node+edge substrate (Cypher), send to Claude with the
+**Layer 3 — narrative arcs:** gather the recent fact substrate (Cypher), send to Claude with the
 arc-synthesis prompt, cache 10 min. Arcs = `{id, title, confidence, summary, participants, sources}`.
+
+**Fair representation (why a contributor's varied work must not vanish).** Synthesis feeds the model a
+bounded set of `MAX_FACTS` facts. Getting that set right is the whole game — a contributor invisible in
+the input is invisible in the arcs. Four safeguards, all in `lib/graph/arcs.ts` unless noted:
+
+- **De-noise at the source** (`lib/graph/learning.ts` `recentFacts`): Graphiti records entity-dedup as
+  `RELATES_TO {name:'IS_DUPLICATE_OF'}` edges ("_x_ is a duplicate of _x_") and leaves superseded edges
+  in the graph stamped `expired_at`. Both carry fresh `created_at`, so they flood a newest-first read
+  (measured ~26% + ~8% of one team's edges). A shared `FACT_NOISE_FILTER` is ANDed onto BOTH graph
+  reads (Layer 1 `recentFacts` and Layer 2 `recentEvents`' fact-lists), so no layer surfaces the noise.
+- **Deep pool, not the newest slice** (`FACT_POOL`): fetch far more than `MAX_FACTS`, because the
+  newest-N is dominated by whoever extracted the most recently — others fall off the cliff *before*
+  balancing runs.
+- **Two-level balance — contributor → item** (`balanceFacts`): round-robin across contributors so a
+  high-volume person can't crowd out a low-volume one, AND within each contributor round-robin across
+  their source items (capped at `PER_ITEM_CAP`) so one huge document (a 257k-char `ARCHITECTURE.md`
+  extracted into 159 facts) can't BE its author's entire share and bury their real varied work.
+- **Request arcs ∝ contributors + split distinct threads** (`arcsRequested`, `buildSystemPrompt`): the
+  requested arc count scales with the number of distinct contributors in the balanced set (not a flat
+  ceiling), and the prompt tells the model to split ONE person's distinct workstreams into separate arcs
+  rather than merging them.
+
+Note attribution vs. narrative: a fact is attributed to the item's `member_id` (its author), which is
+correct for authorship but means a big reference doc's facts describe the *system*, not the author's
+*work* — the per-item cap blunts this; a fuller fix (down-weighting reference docs; ingesting per-PR
+narrative rather than thin per-commit facts) is the follow-up substrate work.
 
 ---
 

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -49,10 +49,19 @@ export interface ArcCorrection {
 export type ProviderKeys = LlmBackendKeys;
 
 const MAX_FACTS = 200;
-const MAX_ARCS = 8;
-// Fetch a much deeper pool than we feed the model, so lower-volume contributors' facts are reachable
-// for balancing (a high-volume person's recent burst can otherwise push everyone else past MAX_FACTS).
-const FACT_POOL = MAX_FACTS * 6;
+// HARD ceiling on arcs parsed from the model. The count actually REQUESTED is derived per-synthesis
+// from the number of distinct contributors (see `arcsRequested`), so a varied team isn't pinned to a
+// flat 8 — one person working six distinct threads can get six arcs instead of one merged blob.
+const MAX_ARCS = 12;
+// Fetch a MUCH deeper pool than we feed the model, so a lower-volume contributor's facts are reachable
+// for balancing. Measured too shallow at MAX_FACTS*6 (1200): one high-volume contributor held 84% of
+// the newest-1200 and everyone below the cut fell off the cliff BEFORE balancing could run. A deeper
+// pool + a per-item cap keeps the whole active team reachable.
+const FACT_POOL = MAX_FACTS * 20;
+// Cap the facts any ONE source item contributes to a person's balanced share, BEFORE balancing — so a
+// single huge document (a 257k-char ARCHITECTURE.md extracted into 159 facts) can't BE its author's
+// entire representation and bury their actual varied work.
+const PER_ITEM_CAP = 20;
 const CACHE_TTL_MS = 10 * 60_000;
 // How long the empty-clobber guard keeps trusting a prior non-empty arc set. Within this window an
 // empty synthesis is treated as a transient failure (keep the prior); beyond it, a persistently-empty
@@ -64,18 +73,33 @@ const EMPTY_CLOBBER_MAX_AGE_MS = (() => {
   return Number.isFinite(n) && n > 0 ? n : 48 * 60 * 60_000;
 })();
 
-const SYSTEM_PROMPT =
-  `You are analyzing a team knowledge graph. Identify ${MAX_ARCS} active narrative arcs — ongoing ` +
-  "storylines about what this team is working through. Favor RECENT activity and give every active " +
-  "contributor visible representation — don't let one person's arcs crowd out others who've been " +
-  "working. Each fact below is numbered [F1], [F2], … — for every arc, cite the 2-5 fact numbers that " +
-  "support it in `supporting_facts`. A parenthesized name at the START of a fact — e.g. \"(Chetan) …\" " +
-  "— is the human RESPONSIBLE for that work (it may not appear in the fact text itself): include those " +
-  "humans in `participants` for every arc citing their facts. Never invent names not present in the " +
-  "facts or their attributions. Return ONLY a JSON object of the form " +
-  '{"arcs":[{"title":"short","confidence":"high|medium|low","summary":"2-3 sentences, present tense, ' +
-  'specific","participants":["names"],"supporting_facts":[1,2,3]}]}. Use only fact numbers that appear ' +
-  "below. No prose, no markdown code fences — the raw JSON object only.";
+/** Requested arc count for one synthesis: scale with the number of distinct contributors in the
+ *  balanced facts (≈2 arcs each) so a varied, multi-person team isn't pinned to a flat number —
+ *  floored at 6, capped at MAX_ARCS. Pure + unit-tested. */
+export function arcsRequested(contributorCount: number): number {
+  return Math.min(MAX_ARCS, Math.max(6, 2 * contributorCount));
+}
+
+/** The synthesis system prompt, parameterized by how many arcs to request. Explicitly instructs the
+ *  model to split ONE contributor's distinct workstreams into separate arcs (the fix for a person's
+ *  varied work collapsing into a single arc) rather than merging them. */
+function buildSystemPrompt(requested: number): string {
+  return (
+    `You are analyzing a team knowledge graph. Identify up to ${requested} active narrative arcs — ongoing ` +
+    "storylines about what this team is working through. Favor RECENT activity and give every active " +
+    "contributor visible representation — don't let one person's arcs crowd out others who've been " +
+    "working. If ONE contributor's facts span multiple DISTINCT workstreams (e.g. social vs security vs " +
+    "meetings vs graph vs performance), produce a SEPARATE arc per workstream — never merge one person's " +
+    "unrelated efforts into a single arc. Each fact below is numbered [F1], [F2], … — for every arc, cite " +
+    "the 2-5 fact numbers that support it in `supporting_facts`. A parenthesized name at the START of a " +
+    'fact — e.g. "(Chetan) …" — is the human RESPONSIBLE for that work (it may not appear in the fact ' +
+    "text itself): include those humans in `participants` for every arc citing their facts. Never invent " +
+    "names not present in the facts or their attributions. Return ONLY a JSON object of the form " +
+    '{"arcs":[{"title":"short","confidence":"high|medium|low","summary":"2-3 sentences, present tense, ' +
+    'specific","participants":["names"],"supporting_facts":[1,2,3]}]}. Use only fact numbers that appear ' +
+    "below. No prose, no markdown code fences — the raw JSON object only."
+  );
+}
 
 function stableId(title: string): string {
   return "arc-" + createHash("sha256").update(title.trim().toLowerCase()).digest("hex").slice(0, 10);
@@ -97,35 +121,92 @@ export function stripTaskKeys(text: string): string {
     .trim();
 }
 
-/**
- * Balance a fact pool ACROSS its contributors so synthesis input represents everyone active — not just
- * whoever pushed the most recent volume. Without this, arc synthesis fed the globally-newest MAX_FACTS
- * facts, so a high-volume contributor's recent burst crowded every lower-volume person out of the
- * prompt entirely (their work then never appeared in Learning even though it's in the graph). We group
- * the pool by the human behind each fact and round-robin one-per-contributor per round (each person's
- * facts consumed newest-first) until `budget` is filled. Unattributed facts ("") are their own bucket.
- * Pure + unit-tested; `humanOf` is injected so the DB/Neo4j resolution stays in the caller.
- */
-export function balanceFactsByContributor<T>(facts: T[], humanOf: (f: T) => string, budget: number): T[] {
+/** Group items by a string key, preserving first-seen order of both the keys and each key's members.
+ *  Pure — the shared primitive under both balancing levels. */
+function groupByKey<T>(items: T[], key: (t: T) => string): T[][] {
   const buckets = new Map<string, T[]>();
-  for (const f of facts) {
-    const key = humanOf(f);
-    const arr = buckets.get(key);
-    if (arr) arr.push(f);
-    else buckets.set(key, [f]);
+  for (const it of items) {
+    const k = key(it);
+    const arr = buckets.get(k);
+    if (arr) arr.push(it);
+    else buckets.set(k, [it]);
   }
-  const lists = [...buckets.values()]; // insertion order ≈ first-seen recency, newest bucket first
+  return [...buckets.values()];
+}
+
+/** Interleave a set of buckets one-per-bucket-per-round until `budget` is filled or all exhaust,
+ *  preserving each bucket's internal order. Pure. */
+function roundRobin<T>(buckets: T[][], budget: number): T[] {
   const out: T[] = [];
   for (let round = 0; out.length < budget; round++) {
     let progressed = false;
-    for (const list of lists) {
+    for (const b of buckets) {
       if (out.length >= budget) break;
-      if (round < list.length) {
-        out.push(list[round]);
+      if (round < b.length) {
+        out.push(b[round]);
         progressed = true;
       }
     }
     if (!progressed) break; // every bucket exhausted
+  }
+  return out;
+}
+
+/**
+ * Balance a fact pool ACROSS its contributors so synthesis input represents everyone active — not just
+ * whoever pushed the most recent volume (the #303 fix). Group by the human behind each fact and
+ * round-robin one-per-contributor per round (each person's facts newest-first) until `budget` is
+ * filled. Unattributed facts ("") are their own bucket. Pure; `humanOf` injected so DB/Neo4j resolution
+ * stays in the caller. Superseded by `balanceFacts` in the synthesis path (kept for direct callers/tests).
+ */
+export function balanceFactsByContributor<T>(facts: T[], humanOf: (f: T) => string, budget: number): T[] {
+  return roundRobin(groupByKey(facts, humanOf), budget);
+}
+
+/**
+ * Two-level balance — contributor → item. Round-robining by contributor alone is blind to a person
+ * whose facts are dominated by ONE giant document: a 257k-char ARCHITECTURE.md extracted into 159 facts
+ * would fill that author's entire balanced share and bury their actual varied work. So within each
+ * contributor we FIRST cap every source item at `perItemCap` and interleave the person's facts ACROSS
+ * their items, THEN round-robin across contributors. The result: each person's slice is a diverse spread
+ * of their real items, and no single doc can be someone's whole story. Pure; `itemOf` returns a stable
+ * per-item key ("" when unresolved — those share one bucket, matching the unattributed convention).
+ */
+export function balanceFacts<T>(
+  facts: T[],
+  humanOf: (f: T) => string,
+  itemOf: (f: T) => string,
+  budget: number,
+  perItemCap = Infinity
+): T[] {
+  const perContributor = groupByKey(facts, humanOf).map((hb) => {
+    const items = groupByKey(hb, itemOf).map((ib) =>
+      perItemCap === Infinity ? ib : ib.slice(0, perItemCap)
+    );
+    // Reorder this contributor's (capped) facts interleaved by item, so item diversity leads.
+    return roundRobin(items, Number.POSITIVE_INFINITY);
+  });
+  return roundRobin(perContributor, budget);
+}
+
+/**
+ * Drop facts that add no signal before they're numbered into the prompt: (1) self-referential noise
+ * where subject === object (Graphiti's "user is a duplicate of user" bookkeeping — a defense-in-depth
+ * backstop even though `recentFacts` already filters `IS_DUPLICATE_OF` at the query), and (2) exact
+ * repeats of an already-seen fact text (keep the first = newest, since the pool is newest-first). Each
+ * duplicate would otherwise consume a numbered slot and hand the model redundant input. Pure + tested.
+ */
+export function dedupeFacts(facts: AtomicFact[]): AtomicFact[] {
+  const seen = new Set<string>();
+  const out: AtomicFact[] = [];
+  for (const f of facts) {
+    const subj = (f.subject ?? "").trim().toLowerCase();
+    const obj = (f.object ?? "").trim().toLowerCase();
+    if (subj && subj === obj) continue; // self-referential noise
+    const key = (f.fact ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(f);
   }
   return out;
 }
@@ -213,7 +294,7 @@ function buildEvidence(
 }
 
 /**
- * Parse + normalize the LLM's JSON into safe arcs: caps at 5, coerces confidence, defaults missing
+ * Parse + normalize the LLM's JSON into safe arcs: caps at MAX_ARCS, coerces confidence, defaults missing
  * fields, assigns a stable id from the title, stamps `derived_at`, and resolves cited `supporting_facts`
  * indices → verifiable `evidence` (falls back to any free-text `supporting_sources` as unlinked
  * evidence). Returns [] on malformed input. Pure + exported so the fragile parsing is unit-tested.
@@ -277,12 +358,13 @@ function extractJsonObject(raw: string): string {
  *  through the shared settings-aware primitive, so arcs honor the team's answering-provider (incl.
  *  OpenRouter) exactly like the Query box. */
 async function callLLMRaw(
+  system: string,
   userContent: string,
   keys: ProviderKeys,
   record?: { db: DbClient; teamId: string }
 ): Promise<string | null> {
   return completeTextOrNull(
-    { system: SYSTEM_PROMPT, prompt: userContent },
+    { system, prompt: userContent },
     {
       keys,
       jsonObject: true,
@@ -368,7 +450,9 @@ async function synthesizeArcs(
   // or a stalled projector, must not blank the panel). `null` = no window. Fetch a DEEP pool (not just
   // MAX_FACTS), so we can balance it across contributors — otherwise the globally-newest MAX_FACTS are
   // dominated by whoever pushed the most volume and everyone else's work is invisible in Learning.
-  const pool = await recentFacts(groups, null, FACT_POOL);
+  // Dedupe the raw pool up front — drops exact-repeat fact texts and self-referential noise so neither
+  // balancing counts nor prompt slots are wasted on redundant/garbage facts.
+  const pool = dedupeFacts(await recentFacts(groups, null, FACT_POOL));
   // No facts and nothing to correct → nothing to synthesize. (A correction with no facts still runs
   // the LLM, preserving the pre-cache recompute behavior.)
   if (pool.length === 0 && correctionTexts.length === 0) return [];
@@ -377,18 +461,42 @@ async function synthesizeArcs(
   const epToItem = await resolveEpisodeItems(groups, pool.flatMap((f) => f.episodeUuids), FACT_POOL * 3);
   const allItemIds = [...new Set([...epToItem.values()].map((v) => v.itemId).filter((id): id is string => !!id))];
   const humanByItem = await resolveHumanActorsByItem(db, teamId, allItemIds);
-  // The human behind a fact = the first resolvable human among its source episodes' items ("" if none).
-  const humanOfFact = (f: AtomicFact): string => {
+  // Resolve a fact's (item, human) TOGETHER, preferring the first source item that resolves a HUMAN and
+  // only falling back to the first resolvable item when none has one. Resolving them independently would
+  // regress attribution: a fact whose episodes are [connector item (no human), John's item] must be
+  // balanced under John — not dropped into the unattributed bucket because a human-less item came first
+  // (which would also undercount `contributorCount` and disagree with `attributedFactTexts`, which
+  // unions humans across ALL episodes). Memoized per fact — both closures below read the same result.
+  const actorCache = new Map<string, { item: string; human: string }>();
+  const actorOfFact = (f: AtomicFact): { item: string; human: string } => {
+    const cached = actorCache.get(f.id);
+    if (cached) return cached;
+    let firstItem = "";
+    let resolved = { item: "", human: "" };
     for (const u of f.episodeUuids) {
-      const itemId = epToItem.get(u)?.itemId;
-      const h = itemId ? humanByItem.get(itemId) : undefined;
-      if (h) return h;
+      const id = epToItem.get(u)?.itemId;
+      if (!id) continue;
+      if (!firstItem) firstItem = id;
+      const h = humanByItem.get(id);
+      if (h) {
+        resolved = { item: id, human: h };
+        break;
+      }
     }
-    return "";
+    if (!resolved.item) resolved = { item: firstItem, human: "" };
+    actorCache.set(f.id, resolved);
+    return resolved;
   };
-  // Balance the deep pool → a representative MAX_FACTS so every active contributor is in the prompt.
-  const facts = balanceFactsByContributor(pool, humanOfFact, MAX_FACTS);
+  const itemOfFact = (f: AtomicFact): string => actorOfFact(f).item;
+  const humanOfFact = (f: AtomicFact): string => actorOfFact(f).human;
+  // Two-level balance (contributor → item, per-item capped) → a representative MAX_FACTS so every active
+  // contributor is in the prompt AND no single giant document dominates its author's share.
+  const facts = balanceFacts(pool, humanOfFact, itemOfFact, MAX_FACTS, PER_ITEM_CAP);
+  // Request arcs proportional to how many distinct contributors actually made the balanced cut, so a
+  // varied team gets more than a flat ceiling and each person's distinct threads have room to surface.
+  const contributorCount = new Set(facts.map(humanOfFact).filter(Boolean)).size;
   const raw = await callLLMRaw(
+    buildSystemPrompt(arcsRequested(contributorCount)),
     buildPrompt(attributedFactTexts(facts, epToItem, humanByItem), correctionTexts),
     keys,
     { db, teamId }

--- a/lib/graph/learning.ts
+++ b/lib/graph/learning.ts
@@ -19,6 +19,21 @@ import { itemIdFromEpisodeName } from "./episode-name";
  * group_id tier filter is NEVER dropped — only the time bound is — so tier isolation still holds.
  */
 
+/**
+ * Two noise filters ANDed onto EVERY RELATES_TO read (Layer 1 facts AND Layer 2 event fact-lists), so
+ * a third of this team's graph — non-knowledge that was flooding the recency pool and starving real
+ * work of representation — never reaches any layer (measured: ~26% IS_DUPLICATE_OF, ~8% expired):
+ *   • `r.name <> 'IS_DUPLICATE_OF'` — Graphiti records entity-dedup as a RELATES_TO edge whose fact
+ *     text is literally "<x> is a duplicate of <x>"; it carries a fresh created_at so it rides the top
+ *     of the newest-first pool. Bookkeeping, never knowledge → drop it. (`r.name IS NULL` kept
+ *     defensively so a graph without the property still returns real facts.)
+ *   • `r.expired_at IS NULL` — Graphiti's temporal model invalidates superseded edges by stamping
+ *     expired_at but leaves them in the graph; a "recent" read must not resurface stale copies.
+ * A leading AND is baked in — always used inside an existing `WHERE r.group_id IN $groups …`.
+ */
+const FACT_NOISE_FILTER =
+  "AND (r.name IS NULL OR r.name <> 'IS_DUPLICATE_OF') AND r.expired_at IS NULL";
+
 /** Layer 1 — one recently-extracted fact (a RELATES_TO edge). */
 export interface AtomicFact {
   id: string; // edge uuid
@@ -43,7 +58,8 @@ export async function recentFacts(
   // `withSince` gates ONLY the time bound; the group_id tier filter is present either way.
   const factsCypher = (withSince: boolean) =>
     `MATCH (a:Entity)-[r:RELATES_TO]->(b:Entity)
-     WHERE r.group_id IN $groups${withSince ? " AND r.created_at >= datetime($since)" : ""}
+     WHERE r.group_id IN $groups
+       ${FACT_NOISE_FILTER}${withSince ? " AND r.created_at >= datetime($since)" : ""}
      RETURN r.uuid AS id,
             r.fact AS fact,
             toString(r.created_at) AS at,
@@ -147,7 +163,7 @@ export async function recentEvents(
      WHERE ep.group_id IN $groups${withSince ? " AND ep.created_at >= datetime($since)" : ""}
      OPTIONAL MATCH (ep)-[:MENTIONS]->(p:Entity)
      OPTIONAL MATCH (a:Entity)-[r:RELATES_TO]->(b:Entity)
-       WHERE r.group_id IN $groups AND ep.uuid IN r.episodes
+       WHERE r.group_id IN $groups AND ep.uuid IN r.episodes ${FACT_NOISE_FILTER}
      RETURN ep.uuid AS id, ep.name AS name, ep.source AS source,
             ep.source_description AS title, toString(ep.created_at) AS at,
             collect(DISTINCT p.name) AS participants,

--- a/test/graph-arcs-parse.test.ts
+++ b/test/graph-arcs-parse.test.ts
@@ -5,12 +5,16 @@ import {
   rankArcs,
   newestEvidenceAt,
   balanceFactsByContributor,
+  balanceFacts,
+  dedupeFacts,
+  arcsRequested,
   type NarrativeArc,
 } from "@/lib/graph/arcs";
+import type { AtomicFact } from "@/lib/graph/learning";
 
 /**
  * Spec for the arc JSON normalizer (the fragile bit — an LLM's JSON is untrusted). Derived from the
- * contract the panel needs: safe defaults, capped at 8, coerced confidence, stable ids, never throws.
+ * contract the panel needs: safe defaults, capped at MAX_ARCS, coerced confidence, stable ids, never throws.
  */
 
 describe("stripTaskKeys", () => {
@@ -70,9 +74,9 @@ describe("parseArcsJson", () => {
     expect(arc.supporting_sources).toEqual([]);
   });
 
-  it("caps at 8 arcs", () => {
-    const arcs = Array.from({ length: 12 }, (_, i) => ({ title: `A${i}`, confidence: "low" }));
-    expect(parseArcsJson(JSON.stringify({ arcs }), { now: NOW })).toHaveLength(8);
+  it("caps at MAX_ARCS (12) arcs", () => {
+    const arcs = Array.from({ length: 16 }, (_, i) => ({ title: `A${i}`, confidence: "low" }));
+    expect(parseArcsJson(JSON.stringify({ arcs }), { now: NOW })).toHaveLength(12);
   });
 
   it("returns [] for null, malformed JSON, or a missing arcs array (never throws)", () => {
@@ -224,5 +228,78 @@ describe("balanceFactsByContributor — fair representation (the fix for a contr
   it("unattributed facts ('') are their own bucket and still get a fair share", () => {
     const facts = [f("j1", "John"), f("j2", "John"), f("u1", ""), f("u2", "")];
     expect(balanceFactsByContributor(facts, humanOf, 4).map((x) => x.id)).toEqual(["j1", "u1", "j2", "u2"]);
+  });
+});
+
+describe("balanceFacts — contributor→item (one giant doc can't BE a person's whole share)", () => {
+  const f = (id: string, who: string, item: string) => ({ id, who, item });
+  const humanOf = (x: { who: string }) => x.who;
+  const itemOf = (x: { item: string }) => x.item;
+
+  it("a single dominant item does NOT crowd out a contributor's other items in their share", () => {
+    // Chetan: 6 facts from one huge doc (ARCHITECTURE.md) + 1 fact each from 3 real work items.
+    // Per-CONTRIBUTOR balancing alone would fill his slice doc-first; per-ITEM must interleave so his
+    // varied work leads. Budget 4 (single contributor) → one from each of his 4 items, doc no more than
+    // its round-robin share.
+    const facts = [
+      f("d1", "C", "arch"), f("d2", "C", "arch"), f("d3", "C", "arch"),
+      f("d4", "C", "arch"), f("d5", "C", "arch"), f("d6", "C", "arch"),
+      f("w1", "C", "social"), f("w2", "C", "security"), f("w3", "C", "meetings"),
+    ];
+    const out = balanceFacts(facts, humanOf, itemOf, 4).map((x) => x.id);
+    // First four picks are one-per-item (item diversity leads), NOT four arch chunks.
+    expect(out).toEqual(["d1", "w1", "w2", "w3"]);
+    expect(out.filter((id) => id.startsWith("d"))).toHaveLength(1); // the doc contributes ONE, not four
+  });
+
+  it("perItemCap bounds how many facts any one item can contribute before balancing", () => {
+    const facts = [
+      f("d1", "C", "arch"), f("d2", "C", "arch"), f("d3", "C", "arch"), f("d4", "C", "arch"),
+      f("w1", "C", "work"),
+    ];
+    // Cap arch at 2 → arch may appear at most twice regardless of budget.
+    const out = balanceFacts(facts, humanOf, itemOf, 10, 2).map((x) => x.id);
+    expect(out.filter((id) => id.startsWith("d"))).toEqual(["d1", "d2"]);
+    expect(out).toContain("w1");
+  });
+
+  it("still balances ACROSS contributors (a high-volume person can't crowd out a low one)", () => {
+    const facts = [
+      f("j1", "John", "a"), f("j2", "John", "b"), f("j3", "John", "c"),
+      f("c1", "Chetan", "x"),
+    ];
+    const out = balanceFacts(facts, humanOf, itemOf, 2).map((x) => x.id);
+    expect(out).toContain("c1"); // Chetan present despite John's 3:1 volume
+  });
+});
+
+describe("dedupeFacts — no wasted prompt slots on repeats / self-referential noise", () => {
+  const mk = (id: string, fact: string, subject = "s", object = "o"): AtomicFact => ({
+    id, fact, at: "2026-07-20T00:00:00Z", subjectType: "entity", subject, object, episodeUuids: [],
+  });
+
+  it("drops exact-repeat fact text, keeping the first (newest) occurrence", () => {
+    const out = dedupeFacts([mk("1", "Chetan fixed observability"), mk("2", "Chetan fixed observability")]);
+    expect(out.map((f) => f.id)).toEqual(["1"]);
+  });
+
+  it("is case/space-insensitive on the repeat check", () => {
+    const out = dedupeFacts([mk("1", "Chetan  fixed  X"), mk("2", "chetan fixed x")]);
+    expect(out).toHaveLength(1);
+  });
+
+  it("drops self-referential subject===object noise (the 'user is a duplicate of user' backstop)", () => {
+    const out = dedupeFacts([mk("1", "user is a duplicate of user", "user", "user"), mk("2", "real fact", "a", "b")]);
+    expect(out.map((f) => f.id)).toEqual(["2"]);
+  });
+});
+
+describe("arcsRequested — scale requested arcs with distinct contributors (not a flat ceiling)", () => {
+  it("floors at 6 for a small team and scales ~2 per contributor up to the cap", () => {
+    expect(arcsRequested(1)).toBe(6); // floor
+    expect(arcsRequested(2)).toBe(6); // floor still
+    expect(arcsRequested(4)).toBe(8);
+    expect(arcsRequested(6)).toBe(12); // cap (MAX_ARCS)
+    expect(arcsRequested(20)).toBe(12); // never exceeds the cap
   });
 });

--- a/test/graph-neo4j-tier.test.ts
+++ b/test/graph-neo4j-tier.test.ts
@@ -68,6 +68,36 @@ live("Graphiti Neo4j tier isolation (real Neo4j)", () => {
     expect(await recentFacts([], since)).toEqual([]);
   });
 
+  // Noise filter (measured ~1/3 of a real team's edges): Graphiti records entity-dedup as a
+  // RELATES_TO edge named IS_DUPLICATE_OF with fact text "<x> is a duplicate of <x>", and stamps
+  // superseded edges with expired_at but leaves them in the graph. Both carry fresh created_at and were
+  // flooding the recency pool → recentFacts must drop both while keeping real facts. Red before A1.
+  it("drops IS_DUPLICATE_OF bookkeeping + expired edges, keeps real facts", async () => {
+    const s = driver.session();
+    try {
+      await s.run(
+        `MATCH (a1:Entity {name:'Alice'}), (b1:Entity {name:'Payments'})
+         CREATE (a1)-[:RELATES_TO {uuid:'f-dup', name:'IS_DUPLICATE_OF', fact:'user is a duplicate of user', created_at:datetime(), group_id:$team, episodes:['ep1']}]->(b1)
+         CREATE (a1)-[:RELATES_TO {uuid:'f-exp', name:'OWNS', fact:'Alice used to own Billing', created_at:datetime(), expired_at:datetime(), group_id:$team, episodes:['ep1']}]->(b1)
+         CREATE (a1)-[:RELATES_TO {uuid:'f-named', name:'MENTORS', fact:'Alice mentors Bob', created_at:datetime(), group_id:$team, episodes:['ep1']}]->(b1)`,
+        { team: TEAM }
+      );
+      const facts = await recentFacts([TEAM], since);
+      const texts = facts.map((f) => f.fact);
+      expect(texts).toContain("Alice owns Payments"); // real fact survives (no name property)
+      // A named, non-expired edge MUST survive — guards against an over-broad filter (e.g. dropping
+      // every named edge, which would blank a prod graph where every real edge carries a name).
+      expect(texts).toContain("Alice mentors Bob");
+      expect(texts).not.toContain("user is a duplicate of user"); // IS_DUPLICATE_OF dropped
+      expect(texts).not.toContain("Alice used to own Billing"); // expired dropped
+      expect(facts.map((f) => f.id)).not.toContain("f-dup");
+      expect(facts.map((f) => f.id)).not.toContain("f-exp");
+    } finally {
+      await s.run("MATCH ()-[r:RELATES_TO]->() WHERE r.uuid IN ['f-dup','f-exp','f-named'] DELETE r");
+      await s.close();
+    }
+  });
+
   it("events: returns the team's events with participants + grouped facts, item link", async () => {
     const events = await recentEvents([TEAM], since);
     const ev = events.find((e) => e.id === "ep1")!;


### PR DESCRIPTION
## Why

Contributor Chetan's varied work (social, security, meetings, graph, LLM, perf, observability) was collapsing to **one thin narrative arc** on the Learning page while John got 4 and Fatma 3. Root-caused (verified against prod Postgres + Neo4j) to the arc-synthesis **funnel breaking at four stages at once** — which is why prior single-stage fixes (chunking #305, per-contributor round-robin #303, structural participants #312) each left the outcome visibly unchanged.

Measured on prod (aios, team+external tier): of **23,211** graph fact-edges, **6,083 (26%) were `IS_DUPLICATE_OF` bookkeeping** ("user is a duplicate of user") and **1,776 (8%) expired/superseded** — all carrying fresh `created_at`, flooding the newest-first pool. The newest-1200 pool was **84% one contributor** (others fell off the cliff before balancing). Chetan's 188 pool facts were **85% from a single 257k-char `ARCHITECTURE.md`**.

## What (Phase A — de-noise + rebalance)

- **A1 — noise filter at the graph read** (`lib/graph/learning.ts`): shared `FACT_NOISE_FILTER` (`r.name <> 'IS_DUPLICATE_OF'` + `r.expired_at IS NULL`) ANDed onto **both** graph reads (Layer 1 `recentFacts` and Layer 2 `recentEvents`), so no layer surfaces the ~1/3 non-knowledge.
- **A2/A3 — two-level balance** (`balanceFacts`, `lib/graph/arcs.ts`): round-robin contributor → **item**, per-item capped (`PER_ITEM_CAP=20`), on a deeper pool (`FACT_POOL` 1200→4000). One giant doc can no longer be its author's whole share, and low-volume contributors stop falling off the recency cliff.
- **A4 — `dedupeFacts`**: drops exact-repeat fact text + self-referential (`subject===object`) noise before the prompt.
- **A5 — arcs ∝ contributors + thread-splitting**: requested arc count scales with distinct contributors (floor 6, ceiling `MAX_ARCS` 12) instead of a flat 8; the prompt now instructs the model to split one person's distinct workstreams into separate arcs.

## Verification

- unit **872 passed**; new spec-derived unit tests for `balanceFacts` (item-diversity + cap), `dedupeFacts`, `arcsRequested`.
- **real-Neo4j tier 8 passed** — red-first test seeds an `IS_DUPLICATE_OF` + an expired edge and proves `recentFacts` drops both while keeping real facts (incl. a named non-expired edge that must survive, guarding against an over-broad filter).
- tsc clean · lint clean · docs-drift clean · design doc updated in-PR.

## Review — Reviewed by **Fable** — verdict: **ship it** (after 3 Mediums, all fixed)

- **M1** — Layer 2 `recentEvents` still surfaced the garbage; fixed by sharing `FACT_NOISE_FILTER` across both reads (+ corrected the "sole read" doc/comment claim).
- **M2** — `humanOfFact` regressed to "human of first item" (a human-less connector item first in the episode list would drop a fact to the unattributed bucket, undercounting contributors and disagreeing with `attributedFactTexts`); restored "first item that resolves a human, else first item", memoized.
- **M3** — Neo4j test couldn't catch an over-broad filter (only surviving fact had no `name`); added a named non-expired edge asserted to survive.
- Lows (text-only dedup key collapsing cross-contributor identical facts; per-item cap shrinking narrow-input substrate; pool-size latency) consciously deferred — documented.

## Not in this PR (Phase B — structural substrate, separate PRs)

Full commit-message bodies (currently discarded), per-PR narrative ingestion (PR bodies are excluded today), and down-weighting reference docs like `ARCHITECTURE.md` that re-flood the pool on every commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Narrative arc generation now adapts to the number of contributors and supports up to 12 arcs.
  - Arc inputs provide fairer coverage across contributors and work items.
  - Duplicate and self-referential facts are removed from synthesis inputs.

- **Bug Fixes**
  - Expired and duplicate relationship data is excluded from recent activity and narrative results.
  - Arc parsing remains resilient when model output is malformed or exceeds the supported limit.

- **Documentation**
  - Expanded the narrative arc specification with output details, balancing guidelines, and attribution considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->