### PR TITLE
feat(attribution): admin dashboard — per-source + per-person attribution health

### DIFF
--- a/app/t/[team]/admin/attribution/page.tsx
+++ b/app/t/[team]/admin/attribution/page.tsx
@@ -1,0 +1,30 @@
+import { requireTeamAdmin } from "@/lib/auth/guard";
+import { getAttributionHealth } from "@/lib/attribution/health";
+import { AttributionHealthView } from "@/components/admin/attribution-health-view";
+
+/**
+ * Admin → Attribution. Per-source + per-person attribution health (who each data stream lands on), so
+ * misattribution is visible and troubleshootable. `lib/attribution/health` spans ALL access tiers and
+ * there is no RLS backstop (CLAUDE §5), so this page enforces admin ITSELF via `requireTeamAdmin`
+ * (a Next layout's conditional UI does not stop a child page's server component from running) — that
+ * also scopes `teamId` to the caller's own admin membership rather than resolving any team by slug.
+ * A build guard (`test/guards/attribution-health-admin-only`) additionally forbids reading the health
+ * lib from any non-admin surface.
+ */
+export default async function AttributionAdminPage({ params }: { params: Promise<{ team: string }> }) {
+  const { team: teamSlug } = await params;
+  const ctx = await requireTeamAdmin(teamSlug);
+  if (!ctx) return null; // not an admin — the admin layout renders the "Admins only" card
+
+  const health = await getAttributionHealth(ctx.teamId);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-lg font-semibold text-ink">Attribution health</h2>
+        <p className="text-sm text-ink-secondary">Is each data stream landing on the right person?</p>
+      </div>
+      <AttributionHealthView health={health} />
+    </div>
+  );
+}

--- a/components/admin/admin-tabs.tsx
+++ b/components/admin/admin-tabs.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 
 const TABS = [
   { slug: "members", label: "Members" },
+  { slug: "attribution", label: "Attribution" },
   { slug: "data", label: "Data" },
   { slug: "usage", label: "Usage" },
   { slug: "keys", label: "API keys" },

--- a/components/admin/attribution-health-view.tsx
+++ b/components/admin/attribution-health-view.tsx
@@ -1,0 +1,128 @@
+import { AlertTriangle, Radio } from "lucide-react";
+import type { AttributionHealth, SourceAttribution } from "@/lib/attribution/health";
+
+/**
+ * Admin → Attribution. Renders the attribution-health read (per-source + per-person) so misattribution
+ * is visible at a glance: which data streams land on a real human vs a connector/nobody, and what each
+ * person actually "owns". Presentational — data comes from `lib/attribution/health.getAttributionHealth`
+ * (admin-gated by the admin layout). See docs/design/attribution-architecture.md.
+ */
+
+function pctTone(s: SourceAttribution): string {
+  if (s.isSignal) return "text-ink-tertiary";
+  if (s.pctHuman >= 90) return "text-emerald";
+  if (s.pctHuman >= 50) return "text-amber";
+  return "text-rose";
+}
+
+function AttributionBar({ s }: { s: SourceAttribution }) {
+  const seg = (n: number) => (s.items > 0 ? `${(100 * n) / s.items}%` : "0%");
+  return (
+    <div className="flex h-2 w-28 overflow-hidden rounded-full bg-surface-sunken" title={`${s.human} human · ${s.connector} connector · ${s.unattributed} unattributed`}>
+      <div className="bg-emerald" style={{ width: seg(s.human) }} />
+      <div className="bg-amber" style={{ width: seg(s.connector) }} />
+      <div className="bg-rose/60" style={{ width: seg(s.unattributed) }} />
+    </div>
+  );
+}
+
+export function AttributionHealthView({ health }: { health: AttributionHealth }) {
+  const { bySource, byMember, lowAttributionSources } = health;
+
+  if (bySource.length === 0) {
+    return <p className="text-sm text-ink-secondary">No ingested content yet — attribution health will appear once items are synced.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-ink-secondary">
+        Who each data stream is attributed to. <span className="text-emerald">Green</span> = a real person,{" "}
+        <span className="text-amber">amber</span> = a connector service-account, <span className="text-rose">red</span> = nobody.
+        Meeting/calendar streams are <span className="inline-flex items-center gap-0.5"><Radio className="size-3" />signal</span> — evidence about who is doing what, not one person&apos;s output.
+      </p>
+
+      {lowAttributionSources.length > 0 && (
+        <div className="prism-card flex items-start gap-3 border-amber/40 px-4 py-3">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber" strokeWidth={2} />
+          <div className="text-sm text-ink">
+            <span className="font-medium">{lowAttributionSources.length} stream{lowAttributionSources.length > 1 ? "s" : ""} mostly cannot be attributed to a person:</span>{" "}
+            {lowAttributionSources.map((s) => `${s.source} (${s.pctHuman}%)`).join(", ")}. These need an author mapping or a source normalizer.
+          </div>
+        </div>
+      )}
+
+      {/* Per-source */}
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-ink">By source</h2>
+        <div className="prism-card overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border-subtle text-left text-xs uppercase tracking-wide text-ink-tertiary">
+                <th className="px-4 py-2 font-medium">Source</th>
+                <th className="px-4 py-2 text-right font-medium">Items</th>
+                <th className="px-4 py-2 text-right font-medium">Human</th>
+                <th className="px-4 py-2 text-right font-medium">Connector</th>
+                <th className="px-4 py-2 text-right font-medium">None</th>
+                <th className="px-4 py-2 font-medium">Attribution</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bySource.map((s) => (
+                <tr key={s.source} className="border-b border-border-subtle/50 last:border-0">
+                  <td className="px-4 py-2">
+                    <span className="inline-flex items-center gap-1.5 text-ink">
+                      {s.source}
+                      {s.isSignal && <Radio className="size-3 text-ink-tertiary" aria-label="signal source" />}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums text-ink-secondary">{s.items}</td>
+                  <td className="px-4 py-2 text-right tabular-nums text-ink-secondary">{s.human}</td>
+                  <td className="px-4 py-2 text-right tabular-nums text-ink-secondary">{s.connector || "—"}</td>
+                  <td className="px-4 py-2 text-right tabular-nums text-ink-secondary">{s.unattributed || "—"}</td>
+                  <td className="px-4 py-2">
+                    <div className="flex items-center gap-2">
+                      <AttributionBar s={s} />
+                      <span className={`tabular-nums text-xs ${pctTone(s)}`}>{s.isSignal ? "signal" : `${s.pctHuman}%`}</span>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Per-person */}
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-ink">By person</h2>
+        <p className="mb-3 text-xs text-ink-tertiary">What each member owns, by source — a person carrying the wrong kind of work (e.g. many meeting transcripts) is a misattribution clue.</p>
+        {byMember.length === 0 ? (
+          <p className="text-sm text-ink-secondary">Nothing is attributed to a person yet — every ingested item resolved to a connector or nobody.</p>
+        ) : (
+        <div className="flex flex-col gap-2">
+          {byMember.map((m) => (
+            <div key={m.memberId} className="prism-card flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3">
+              <span className="font-medium text-ink">{m.displayName}</span>
+              <span className="text-xs tabular-nums text-ink-tertiary">{m.total} items</span>
+              <span className="ml-auto flex flex-wrap gap-1.5">
+                {m.bySource.map((b) => (
+                  <span
+                    key={b.source}
+                    className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${
+                      b.isSignal ? "border-border-subtle text-ink-tertiary" : "border-border-subtle text-ink-secondary"
+                    }`}
+                  >
+                    {b.isSignal && <Radio className="size-2.5" />}
+                    {b.source}
+                    <span className="tabular-nums text-ink-tertiary">{b.items}</span>
+                  </span>
+                ))}
+              </span>
+            </div>
+          ))}
+        </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -173,3 +173,20 @@ corpus), or if a manual backfill alongside the scheduler becomes routine.
 **How:** Make the replace atomic — wrap DELETE+INSERT in a transaction and/or take a per-item
 advisory lock (`pg_advisory_xact_lock(hashtext(item_id))`), or switch to an upsert on
 `(item_id, chunk_idx)` with a trailing delete of now-excess chunk indexes.
+
+---
+
+## Admin pages that rely on the layout alone for authz (harden to self-check)
+
+**Status:** flagged (Fable review of #attribution-dashboard). Pre-existing, not introduced by that PR.
+
+Several `app/t/[team]/admin/*` pages (`members`, `data`, `keys`, …) gate solely on `admin/layout.tsx`'s
+role check. Per Next.js's own bundled docs (`authentication.md`, "Layouts and auth checks"), a layout is
+NOT a reliable auth boundary — it doesn't re-render on client-side navigation, so a page segment can be
+rendered/served without the layout's check re-running. With no RLS backstop (CLAUDE §5), a non-admin who
+soft-navigates from `/admin` to one of these tabs could get the page's flight payload (roster
+emails/roles on `members` — worse than the attribution page's names+counts).
+
+**Fix:** each admin page should self-check via `requireTeamAdmin(teamSlug)` before any privileged read
+(as `app/t/[team]/admin/attribution/page.tsx` now does), returning null when it's null. A guard test that
+every `admin/*/page.tsx` calls `requireTeamAdmin` would make it build-enforced.

--- a/docs/design/attribution-architecture.md
+++ b/docs/design/attribution-architecture.md
@@ -124,7 +124,9 @@ re-attributes affected items. Sits on top of the existing reattribution engine (
 1. ✅ **Attribution-health data layer + read** (no contract change) — durable version of the §1
    measurement: per-source + per-person breakdown, confidence, unresolved identities. Backs §5 + §6.
    *(Shipped: `lib/attribution/health.ts`, PR #316.)*
-2. **Per-person dashboard visual** (§6) on that read.
+2. ✅ **Per-person dashboard visual** (§6) on that read — **Admin → Attribution**
+   (`app/t/[team]/admin/attribution`), per-source health bars + per-person source breakdown; admin-gated
+   by the admin layout, enforced by `test/guards/attribution-health-admin-only`.
 3. ✅ **Resolve-at-ingest choke-point** (§2) — `lib/attribution/resolve-authors.attributeIncomingItem`
    resolves an incoming push's author from its frontmatter at ingest and passes the real member through
    (unresolved ⇒ `null`, **never the connector**); the same resolver replaced the per-source `switch` in

--- a/test/guards/attribution-health-admin-only.test.ts
+++ b/test/guards/attribution-health-admin-only.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Attribution-health is an ADMIN-ONLY read (CLAUDE.md §5). `lib/attribution/health` spans ALL access
+ * tiers — it exposes per-member names + per-source counts of team/admin-tier content — and there is no
+ * RLS backstop. Any surface that CALLS the read must be admin-gated in its own code (a Next layout is
+ * not an auth boundary — the page must self-check; see `app/t/[team]/admin/attribution/page.tsx`). This
+ * guard fails the build if any file under `app/` (pages AND api routes) or `components/` performs a
+ * VALUE import of the read from OUTSIDE `app/t/[team]/admin/`. Type-only imports are fine (a
+ * presentational component may take the shape without touching the DB).
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCAN_DIRS = [join(ROOT, "app"), join(ROOT, "components")];
+const ADMIN_PREFIX = join("app", "t", "[team]", "admin") + "/";
+// A VALUE import of the health module — `import { getAttributionHealth } …`. Excludes `import type …`
+// (a component taking the AttributionHealth shape never touches the tier-spanning read).
+const VALUE_IMPORT = /import\s+(?!type\s)[^;]*?from\s+["']@\/lib\/attribution\/health["']/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    let isDir = false;
+    try {
+      isDir = statSync(p).isDirectory();
+    } catch {
+      continue; // dangling symlink etc. — skip, never crash the guard
+    }
+    if (isDir) walk(p, out);
+    else if (p.endsWith(".tsx") || p.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+describe("attribution-health read is admin-gated", () => {
+  const files = SCAN_DIRS.flatMap((d) => walk(d));
+  const valueImporters = files.filter((f) => VALUE_IMPORT.test(readFileSync(f, "utf8")));
+
+  it("scans a non-trivial number of files (guard is not vacuous)", () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it("is actually called somewhere (the admin attribution page reads it)", () => {
+    expect(valueImporters.some((f) => f.includes(join("admin", "attribution")))).toBe(true);
+  });
+
+  it("is CALLED only from under app/t/[team]/admin/ (self-gated pages), never an api route or shared component", () => {
+    const offenders = valueImporters.filter((f) => !f.replaceAll("\\", "/").includes(ADMIN_PREFIX.replaceAll("\\", "/")));
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

Phase B step 2 (`docs/design/attribution-architecture.md`): a troubleshooting surface for misattribution, built on the shipped `lib/attribution/health` read. So you can *see* who each data stream lands on and catch a person carrying the wrong kind of work.

## What

- **Admin → Attribution** (`app/t/[team]/admin/attribution/page.tsx` + `components/admin/attribution-health-view.tsx`):
  - **By source** — table with an attribution bar (green=real person / amber=connector / red=nobody) + %.
  - **By person** — each member's source mix as chips (a person owning many meeting transcripts is a misattribution clue).
  - Low-attribution alert banner; meetings/calendar marked **signal** and excluded from the alert.
- **`test/guards/attribution-health-admin-only`** — build guard: the tier-spanning health read may be *called* only from under `app/t/[team]/admin/`.

## Authz (the crux — no RLS backstop, §5)

A Next.js layout is **not** an auth boundary (its check doesn't re-render on client-side navigation — per Next's own bundled docs). So the page **self-enforces**: `requireTeamAdmin(teamSlug)` runs before `getAttributionHealth`, returning null for non-admins — which also scopes `teamId` to the caller's own admin membership (no resolving arbitrary teams by slug).

## Review — Reviewed by **Fable** — verdict: **BLOCKED → resolved**

Fable reviewed the first commit and returned **BLOCKED** on a HIGH: relying on the admin *layout* alone is not a real auth boundary (a soft-navigation can render the page segment without the layout's check) → a non-admin/external member could get the flight payload. **I had already applied the recommended fix before the verdict landed** (the page now self-checks via `requireTeamAdmin` before any privileged read). Also applied from the review:
- **MEDIUM** — widened the guard to scan all of `app/` (incl. api routes) + `components/`, and to flag only *value* imports (a type-only import in a presentational component is fine).
- **LOW** — empty state for "By person"; `statSync` hardened against dangling symlinks in the guard.
- **Follow-up filed** (`docs/TODO.md`) — the *pre-existing* repo-wide pattern of admin pages (`members`, `data`, `keys`) gating on the layout alone (worse payloads, e.g. roster emails). Not fixed here (out of scope); flagged so it isn't extended.

## Verification

- tsc · lint · `next build` compiles `/t/[team]/admin/attribution` · unit **905** (guard included, non-vacuous) · docs-drift clean.
- **Honest caveat:** no live authenticated browser QA (no seeded admin session in this workspace); proven to build/type/guard level, and the underlying read is data-mechanics tested.

## Next
Notion → Google Docs sidecar normalizers · the NL correction box.
