### PR TITLE
fix(build): compute Turbopack root as common ancestor of worktree + node_modules

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,23 +1,40 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
-import { lstatSync } from "node:fs";
+import { lstatSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, sep } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
-// Worktree dev-ops: agents (and humans) do all work in git worktrees, where node_modules is
-// a symlink to ../<primary>/node_modules (shared deps). Turbopack refuses a node_modules
-// symlink that points OUTSIDE the project root and panics ("Symlink … points out of the
-// filesystem root"), breaking `npm run dev`. When node_modules is a symlink, widen the
-// Turbopack root to the parent dir that contains both the worktree and the symlink target.
-// Guarded on the symlink so the primary checkout, CI, and prod builds (real node_modules
-// inside the repo) are completely unaffected — the root stays the repo there.
-const nodeModulesIsSymlink = (() => {
+// Deepest directory that contains both paths (component-wise longest common prefix). Used to pick a
+// Turbopack root that encloses both the worktree and its out-of-tree node_modules.
+function commonAncestor(a: string, b: string): string {
+  const as = a.split(sep);
+  const bs = b.split(sep);
+  const out: string[] = [];
+  for (let i = 0; i < Math.min(as.length, bs.length) && as[i] === bs[i]; i++) out.push(as[i]);
+  return out.join(sep) || sep;
+}
+
+// Worktree dev-ops: agents (and humans) do all work in git worktrees, where node_modules is a
+// symlink to the primary checkout's node_modules (shared deps). Turbopack refuses a node_modules
+// symlink whose target is OUTSIDE the project root and panics ("Symlink … points out of the
+// filesystem root"), breaking `npm run dev` AND `next build`. When node_modules is a symlink, widen
+// the Turbopack root to the common ancestor of THIS dir and the symlink's real target, so the shared
+// deps are always inside the root — for any layout. (The mandated `<repo>-worktrees/<task>` layout
+// points at a sibling `<repo>/node_modules`, whose common ancestor is the grandparent, not `..` —
+// the earlier hardcoded `resolve(here, "..")` didn't enclose it and the build failed.) Guarded on the
+// symlink so the primary checkout, CI, and prod builds (real node_modules in the repo) are untouched.
+const turbopackRoot = (() => {
   try {
-    return lstatSync(resolve(here, "node_modules")).isSymbolicLink();
+    const nm = resolve(here, "node_modules");
+    if (!lstatSync(nm).isSymbolicLink()) return null;
+    // Canonicalize BOTH sides: if the worktree path itself traverses a symlink (e.g. macOS
+    // /tmp → /private/tmp) while the target is already canonical, the common prefix would
+    // otherwise collapse toward "/". realpath both so they compare in the same namespace.
+    return commonAncestor(realpathSync(here), realpathSync(nm));
   } catch {
-    return false;
+    return null;
   }
 })();
 
@@ -27,7 +44,7 @@ const nextConfig: NextConfig = {
   // websocket, so pages served on 127.0.0.1 never hydrate (buttons stay dead).
   // Trust both so the dashboard works regardless of which host you open.
   allowedDevOrigins: ["127.0.0.1", "localhost"],
-  ...(nodeModulesIsSymlink ? { turbopack: { root: resolve(here, "..") } } : {}),
+  ...(turbopackRoot ? { turbopack: { root: turbopackRoot } } : {}),
 };
 
 // Wrap with Sentry. This build-time wrapper enables source-map upload (so


### PR DESCRIPTION
## What
The symlink-guarded Turbopack `root` in `next.config.ts` was hardcoded to `resolve(here, "..")` (the worktree's parent). That only encloses the shared `node_modules` when the worktree is a **direct sibling** of the primary checkout. In the repo's mandated `<repo>-worktrees/<task>` layout, `node_modules` symlinks to `<repo>/node_modules` — a sibling of the `-worktrees` container — so `..` does **not** contain it, and `next build` fails with:

```
Symlink [project]/…/node_modules is invalid, it points out of the filesystem root
```

(This is why `npm run build` / `npm run test:http:local` couldn't run in an agent worktree; I hit it during the #319 fix and had to widen the root by hand.)

## Fix
Compute `root` as the **common ancestor of this dir and the symlink's real target** (`realpathSync`), so the shared deps are always inside the root for any worktree layout. Both sides are canonicalized so a worktree path that itself traverses a symlink (e.g. macOS `/tmp`→`/private/tmp`) can't collapse the root toward `/`. Still guarded on the symlink, so the primary checkout / CI / prod (real `node_modules` in the repo) keep the default repo root unchanged.

- Direct-sibling layout: common ancestor == old `..` (byte-identical, no regression).
- `<repo>-worktrees/<task>` layout: widens to the grandparent that actually encloses `node_modules` (the fix).

## Verification
- Full `next build` **succeeds** in a real `<repo>-worktrees/<task>` worktree that failed on `main`.
- `tsc --noEmit` ✓ · `eslint next.config.ts` ✓
- Computed root for this worktree: `/Users/iamjohndass/Projects/aios` (encloses both worktree and `node_modules`).

## Review — Reviewed by **Fable** — verdict: READY
Fable (`code-reviewer` agent) verified `commonAncestor` across edge cases (identical paths, prefix, root `/`, `join(sep) || sep`), confirmed the primary/CI/prod no-op is provably unchanged, and confirmed no regression for the legacy sibling layout. It raised two Low/optional notes: (1) canonicalize `here` as well as the target — **applied** in this PR; (2) add a unit test for `commonAncestor` — **deferred**: it'd require exporting a helper from `next.config.ts`, and a full `next build` in a worktree is the real integration test for this guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/dev config only; behavior is unchanged unless `node_modules` is a symlink, and the direct-sibling worktree layout still matches the old `..` root.
> 
> **Overview**
> Fixes **Turbopack** failing in git worktrees when `node_modules` is a symlink to shared deps outside the project root (invalid symlink / points out of filesystem root), which broke **`npm run dev`** and **`next build`**.
> 
> Instead of widening `turbopack.root` to a fixed parent (`resolve(here, "..")`), the config now sets it to the **common ancestor** of the project dir and the symlink target, with **`realpathSync`** on both paths so layouts like `<repo>-worktrees/<task>` and macOS `/tmp` vs `/private/tmp` resolve correctly. The override still applies **only when** `node_modules` is a symlink; primary checkout, CI, and prod with a real in-repo `node_modules` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb18f35c6934a5a40a35f1a3233991f68bc9316a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with projects using symlinked dependencies.
  * Updated development tooling to select a more reliable project root in these setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->