### PR TITLE
feat(meetings): instant skeleton when navigating between meetings

### DIFF
--- a/app/t/[team]/meetings/[id]/loading.tsx
+++ b/app/t/[team]/meetings/[id]/loading.tsx
@@ -1,0 +1,12 @@
+import { MeetingDetailSkeleton } from "@/components/meetings/meeting-detail-skeleton";
+
+/**
+ * Instant right-pane feedback when switching meetings. The Meetings `layout.tsx` (list rail + header)
+ * is shared and preserved across `/meetings/[id]` navigations, so Next resets only THIS segment's
+ * Suspense boundary when the id changes — showing this skeleton in the right pane immediately while
+ * the selected note's summary/transcript/action-items stream in. Without it, clicking a meeting left
+ * the previous note (or a blank pane) on screen until the fetch finished.
+ */
+export default function MeetingDetailLoading() {
+  return <MeetingDetailSkeleton />;
+}

--- a/app/t/[team]/meetings/loading.tsx
+++ b/app/t/[team]/meetings/loading.tsx
@@ -1,0 +1,11 @@
+import { MeetingDetailSkeleton } from "@/components/meetings/meeting-detail-skeleton";
+
+/**
+ * Right-pane fallback for the Meetings index (`/meetings`, which renders the newest note inline). The
+ * shared `layout.tsx` already painted the list rail + header; this covers the detail pane while the
+ * newest note's data streams in, so arriving at Meetings shows structure immediately rather than a
+ * blank right pane. (`[id]/loading.tsx` covers the same pane when switching between meetings.)
+ */
+export default function MeetingsIndexLoading() {
+  return <MeetingDetailSkeleton />;
+}

--- a/components/meetings/meeting-detail-skeleton.tsx
+++ b/components/meetings/meeting-detail-skeleton.tsx
@@ -1,0 +1,65 @@
+/**
+ * Right-pane skeleton for a meeting's detail (`MeetingDetailView`). The Meetings shell is a two-pane
+ * layout whose async `layout.tsx` fetches the note list ONCE and is preserved across navigation — so
+ * clicking a different meeting only re-renders the right pane (`children`). Without a loading boundary
+ * below that shared layout, the right pane sat on the old note (or blank) until the new note's
+ * summary/transcript/action-items finished loading, which reads as "the app is slow." This stands in
+ * for the detail the instant a meeting is clicked; the real content swaps in when it streams.
+ *
+ * Mirrors the detail layout — title + meta, the Summary/Transcript tab bar, a bulleted summary, and
+ * the action-items card — closely enough to avoid a jarring reflow, without pretending to know the
+ * exact copy. Used by both meetings `loading.tsx` files (index + `[id]`).
+ */
+function Shimmer({ className = "" }: { className?: string }) {
+  return <div className={`animate-pulse rounded-lg bg-surface-inset ${className}`} />;
+}
+
+export function MeetingDetailSkeleton() {
+  return (
+    <div className="flex flex-col gap-4" role="status" aria-busy="true" aria-label="Loading meeting">
+      {/* header: title + meta line + attendee chips */}
+      <div className="flex flex-col gap-2">
+        <Shimmer className="h-7 w-2/3 max-w-sm" />
+        <div className="flex items-center gap-3">
+          <Shimmer className="h-3 w-24" />
+          <Shimmer className="size-4 rounded-full" />
+          <Shimmer className="h-3 w-40" />
+        </div>
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Shimmer key={i} className="h-6 w-24 rounded-full" />
+          ))}
+        </div>
+      </div>
+
+      {/* tab bar: Summary / Transcript */}
+      <div className="flex gap-4 border-b border-border-subtle pb-2">
+        <Shimmer className="h-5 w-20" />
+        <Shimmer className="h-5 w-24" />
+      </div>
+
+      {/* summary card (bullets live inside a prism-card, like the real Summary tab) */}
+      <div className="prism-card flex flex-col gap-3 px-5 py-4">
+        <Shimmer className="h-3 w-24" />
+        {["w-11/12", "w-10/12", "w-full", "w-9/12", "w-10/12"].map((w, i) => (
+          <div key={i} className="flex items-start gap-2">
+            <Shimmer className="mt-1.5 size-1.5 shrink-0 rounded-full" />
+            <Shimmer className={`h-4 ${w}`} />
+          </div>
+        ))}
+      </div>
+
+      {/* action-items card */}
+      <div className="prism-card flex flex-col gap-3 px-5 py-5">
+        <Shimmer className="h-4 w-32" />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <Shimmer className="size-4 rounded" />
+            <Shimmer className="h-4 flex-1" />
+            <Shimmer className="h-6 w-16 rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Clicking around the **Meetings** tab felt slow. The Meetings UI is a two-pane shell: `meetings/layout.tsx` is an async server component that fetches the note list and is **preserved across navigation**, so switching meetings only re-renders the right pane (`children` = the index/`[id]` detail). There was **no loading boundary below the shared layout**, so the right pane sat on the *previous* note (or blank) until the new note's summary/transcript/action-items finished loading.

The generic `t/[team]/loading.tsx` can't fix this: on a client navigation Next.js only re-renders **below the shared layout**, so a boundary *above* it never triggers (confirmed against the Next 16 docs).

## The fix

Dedicated `loading.tsx` boundaries that reset with the changing segment:
- **`meetings/[id]/loading.tsx`** — the key one: when a meeting is clicked, the `[id]` segment resets its Suspense boundary and shows a right-pane skeleton **instantly** while the note streams in. Covers both index→detail and detail→detail (different id).
- **`meetings/loading.tsx`** — the same skeleton for the index (newest-note) pane.
- **`components/meetings/meeting-detail-skeleton.tsx`** — a shared skeleton mirroring `MeetingDetailView` (title + meta + attendee chips, the 2-tab bar, a summary card with bullets, an action-items card) so there's no jarring reflow. Reuses the existing `Shimmer` style from `t/[team]/loading.tsx`.

Classic App Router `loading.tsx` model — `cacheComponents` is **off**, so `unstable_instant`/Suspense would be inert; this matches the existing `t/[team]/loading.tsx`. The list rail + header (in the layout) stay put; only the right pane shows the skeleton.

## Review — Reviewed by **Fable** — verdict: **CLEAR**

Fable verified the loading-model choice (classic `loading.tsx` correct with cacheComponents off), that the boundary scopes to the right pane (layout's list rail intact, no double-skeleton, empty-state safe), and that the design tokens exist. Its polish findings were applied: skeleton now shows **2** tabs (not 3) and wraps the summary bullets in a `prism-card` to match the real render, and the root uses `role="status"` for the a11y label. (One low note left per existing precedent: the 3-line `Shimmer` helper is duplicated from `t/[team]/loading.tsx` — extract to a shared `ui/shimmer` if a third copy appears.)

## Verify
`next build` compiles both meetings routes · `tsc` · `lint` clean. Presentational only — no data/tier/route/table surface, no schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading placeholders for meeting details while navigating between meetings.
  * Added a responsive loading state for the Meetings index, including title, attendee, summary, transcript, and action-item placeholders.
  * Improved accessibility of loading states with status and busy indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->