### PR TITLE
feat(observability): dismissable pipeline-health alert (✕ to hide, re-shows on a new break)

### DIFF
--- a/components/admin/pipeline-health-banner.tsx
+++ b/components/admin/pipeline-health-banner.tsx
@@ -1,6 +1,9 @@
+"use client";
+import { useEffect, useState } from "react";
 import Link from "next/link";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, X } from "lucide-react";
 import type { PipelineHealth } from "@/lib/ingest/pipeline-health";
+import { alertSignature } from "@/lib/ingest/pipeline-alert";
 import { timeAgo } from "@/components/format";
 
 /** Human labels for the ingest_runs `source` slugs. */
@@ -25,12 +28,52 @@ const LABEL: Record<string, string> = {
  * graph projector 422'ing for weeks) can't hide as one red row in a table. Renders nothing when the
  * pipeline is healthy. Meant to sit at the TOP of the admin surface (and the home dashboard for
  * admins), above everything else. `href` links to the full runs detail.
+ *
+ * Dismissible: the ✕ hides it (persisted in localStorage), but ONLY for the exact current failure set
+ * (see `alertSignature`) — a new/different break re-shows it, so you can't permanently hide a broken
+ * pipeline. Dismissal is per-surface (`href`) and shared across pages that pass the same href.
  */
 export function PipelineHealthBanner({ health, href }: { health: PipelineHealth; href: string }) {
+  const signature = alertSignature(health.failing);
+  const storageKey = `pipeline-alert-dismissed:${href}`;
+  // `hydrated` false during SSR + first client render (matching markup); the mount effect reads the
+  // client-only localStorage to decide if THIS exact alert was already dismissed.
+  const [state, setState] = useState<{ hydrated: boolean; dismissed: boolean }>({ hydrated: false, dismissed: false });
+  useEffect(() => {
+    let dismissed = false;
+    try {
+      dismissed = window.localStorage.getItem(storageKey) === signature;
+    } catch {
+      /* localStorage unavailable (private mode) → treat as not dismissed, still show the alert */
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time hydration read of a client-only store
+    setState({ hydrated: true, dismissed });
+  }, [storageKey, signature]);
+
   if (health.healthy || health.failing.length === 0) return null;
+  // Show by default (incl. SSR); hide only after hydration confirms this exact alert was dismissed.
+  if (state.hydrated && state.dismissed) return null;
+
+  const dismiss = () => {
+    try {
+      window.localStorage.setItem(storageKey, signature);
+    } catch {
+      /* ignore — dismissal just won't persist */
+    }
+    setState((s) => ({ ...s, dismissed: true }));
+  };
 
   return (
-    <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-red-700 dark:text-red-300">
+    <div className="relative rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 pr-9 text-red-700 dark:text-red-300">
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss alert"
+        title="Dismiss (re-appears if a different leg breaks)"
+        className="absolute right-1.5 top-1.5 rounded p-1 text-red-600/70 transition-colors hover:bg-red-500/15 hover:text-red-700 dark:text-red-300/70 dark:hover:text-red-200"
+      >
+        <X className="size-4" />
+      </button>
       <div className="flex items-center gap-2">
         <AlertTriangle className="size-4 shrink-0" />
         <p className="text-sm font-semibold">

--- a/lib/ingest/pipeline-alert.ts
+++ b/lib/ingest/pipeline-alert.ts
@@ -1,0 +1,16 @@
+import type { PipelineLeg } from "./pipeline-health";
+
+/**
+ * Stable signature of the CURRENT failing-leg set, used to persist a banner dismissal. Dismissing the
+ * pipeline-health alert stores this string; the banner stays hidden only while the signature matches.
+ * A DIFFERENT set of failures (a new leg breaks, an error message changes, or a leg recovers) yields a
+ * new signature, so the alert re-appears — you can ack the problem you've seen but can't permanently
+ * blind yourself to a new one. Order-independent (sorted) so leg ordering never changes the key.
+ * Pure + unit-tested. (Type-only import of `PipelineLeg` — no server-only runtime pulled into the client.)
+ */
+export function alertSignature(failing: PipelineLeg[]): string {
+  return failing
+    .map((l) => `${l.source}:${l.ok ? "stale" : "fail"}:${(l.error ?? "").trim()}`)
+    .sort()
+    .join("|");
+}

--- a/test/pipeline-alert.test.ts
+++ b/test/pipeline-alert.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { alertSignature } from "@/lib/ingest/pipeline-alert";
+import type { PipelineLeg } from "@/lib/ingest/pipeline-health";
+
+const leg = (over: Partial<PipelineLeg>): PipelineLeg => ({
+  source: "plane",
+  ok: false,
+  error: null,
+  at: "2026-07-21T00:00:00Z",
+  stale: false,
+  ...over,
+});
+
+/**
+ * The banner dismissal is keyed on this signature: acking the CURRENT failure hides it, but a
+ * different failure set must re-show (you can't permanently blind yourself to a new break).
+ */
+describe("alertSignature", () => {
+  it("is stable + order-independent for the same failure set", () => {
+    const a = [leg({ source: "plane", error: "timeout" }), leg({ source: "graph_extract", error: "no facts" })];
+    const b = [leg({ source: "graph_extract", error: "no facts" }), leg({ source: "plane", error: "timeout" })];
+    expect(alertSignature(a)).toBe(alertSignature(b));
+  });
+
+  it("changes when a NEW leg breaks (so the alert re-appears)", () => {
+    const before = [leg({ source: "plane", error: "timeout" })];
+    const after = [leg({ source: "plane", error: "timeout" }), leg({ source: "slack", error: "401" })];
+    expect(alertSignature(after)).not.toBe(alertSignature(before));
+  });
+
+  it("changes when the error message changes for the same leg", () => {
+    expect(alertSignature([leg({ error: "timeout" })])).not.toBe(alertSignature([leg({ error: "429 quota" })]));
+  });
+
+  it("distinguishes a stale leg from a hard-failing one", () => {
+    const stale = [leg({ source: "github", ok: true, stale: true, error: null })];
+    const failing = [leg({ source: "github", ok: false, error: null })];
+    expect(alertSignature(stale)).not.toBe(alertSignature(failing));
+  });
+
+  it("empty failing set → empty signature", () => {
+    expect(alertSignature([])).toBe("");
+  });
+});


### PR DESCRIPTION
You asked for an **✕** to dismiss the pipeline-health alert banner. Done — with a twist so it can't hide a real problem.

## What
- The red "N ingestion legs are broken" banner now has a **✕** dismiss button.
- Dismissal is **persisted** (localStorage) so it stays hidden across reloads/navigation.
- **But it's keyed to the exact current failure** (`alertSignature` = the set of failing legs + their errors). If a **new** leg breaks, an error message **changes**, or the set otherwise differs, the alert **re-appears**. So you can ack the Plane-sync timeout you've seen, but you won't be blinded when something new breaks.

## How
- `lib/ingest/pipeline-alert.alertSignature` — pure, order-independent signature (unit-tested).
- The banner is now a client component: shows by default (incl. SSR), hides only after a mount effect confirms *this* signature was dismissed. No localStorage (private mode) → always shows.

## Verified
924 unit tests (5 new `alertSignature` specs — stable/order-independent, re-shows on new break, stale≠fail), tsc, lint, docs-drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)