### PR TITLE
perf(nav): prefetch meeting data + client-cache visited segments

### DIFF
--- a/components/meetings/meeting-list-pane.tsx
+++ b/components/meetings/meeting-list-pane.tsx
@@ -33,6 +33,12 @@ export function MeetingListPane({ teamSlug, notes, defaultActiveId = null }: Mee
           <Link
             key={note.id}
             href={href}
+            // Full prefetch (data, not just the loading skeleton) so clicking a meeting is served
+            // from the client cache instead of a fresh ~0.5s+ server round-trip. Fires in the
+            // background as items enter the viewport; a full prefetch is cached under the `static`
+            // staleTimes bucket (300s). Meeting notes are near-immutable, so 5-min freshness is fine;
+            // any edit calls revalidatePath and purges the entry anyway.
+            prefetch
             aria-current={active ? "page" : undefined}
             className={`flex flex-col gap-1.5 rounded-lg border px-3.5 py-3 transition-colors ${
               active

--- a/next.config.ts
+++ b/next.config.ts
@@ -45,6 +45,18 @@ const nextConfig: NextConfig = {
   // Trust both so the dashboard works regardless of which host you open.
   allowedDevOrigins: ["127.0.0.1", "localhost"],
   ...(turbopackRoot ? { turbopack: { root: turbopackRoot } } : {}),
+  experimental: {
+    // The app is served from Railway (US edge) with a ~0.9s round-trip floor for far-away users —
+    // measured identical for a static favicon and a 307 redirect, so it's the network path, not the
+    // DB (sub-ms) or render. Every client navigation that hits the server therefore feels slow. Cache
+    // visited page segments in the client Router Cache so revisiting a route (back/forward, or
+    // clicking around a set of meetings) is served locally and instant. Within the window the cache
+    // is reused with NO request (it doesn't SWR-revalidate); it only refetches on the next navigation
+    // after the entry expires. Next 15 changed the `dynamic` default to 0 (no caching); restore a
+    // modest window. Mutations call `router.refresh()` / `revalidatePath`, which purge this cache, so
+    // a stale read can't linger past an edit.
+    staleTimes: { dynamic: 30, static: 300 },
+  },
 };
 
 // Wrap with Sentry. This build-time wrapper enables source-map upload (so


### PR DESCRIPTION
## Why it's still slow (measured, not guessed)

The skeleton (#323) fixed first-paint, but the **content** still waited a full server round-trip on every meeting click. I profiled prod:
- **DB is not the bottleneck** — `EXPLAIN ANALYZE` on the meeting queries is **0.36ms** (the ~322ms I saw earlier was just laptop→proxy latency).
- The real floor is the **per-navigation round-trip to Railway**: network **RTT ≈ 265ms**, and even a warm-connection **static favicon TTFB ≈ 470ms** (≈1 RTT + ~200ms container/Next overhead). A real meeting render is ~0.5–1s. `x-railway-edge: sjc1` (US edge) — the app is far from the user.

No query optimization beats a ~0.5s network floor. The fix is to **not make the round-trip** on navigation.

## The change (2 files)

1. **`experimental.staleTimes: { dynamic: 30, static: 300 }`** — cache visited page segments in the client Router Cache so revisiting a route (back/forward, clicking around a set of meetings, and app-wide) is served **locally, instantly** with no request for the window. Next 15 changed the `dynamic` default to 0; this restores a modest window. Mutations call `router.refresh()` / `revalidatePath`, which **purge** this cache, so a stale read can't outlive an edit. The Router Cache is per-session/in-memory and flushed on sign-out — staleness, **never a cross-auth/tier leak** (server authz still runs on every real fetch).
2. **`prefetch` on the meeting-list `<Link>`s** — Next's default only prefetches the *loading skeleton* for dynamic routes; a full `prefetch` fetches the **note data** in the background as items enter the viewport (cached under the 300s `static` bucket), so the **first** click on each meeting is also served from cache.

Result: within a session, clicking around Meetings feels **instant**; a cold/expired click still shows the `[id]/loading.tsx` skeleton then streams (unchanged).

## Review — Reviewed by **Fable** — verdict: **CLEAR**
Fable verified: (a) no new leak class — Router Cache is per-session, flushed on sign-out, only holds already-authorized payloads; (b) mutation flows across the app call `revalidatePath`/`router.refresh()` so the cache is busted after edits (30/300 is sane); (c) `prefetch` viewport cost is background/deprioritized — net-positive here, with the transcript-payload slim as the recommended follow-up; (d) the `loading.tsx` skeleton still shows on a cold click. Applied its two comment-accuracy fixes (cache is reused-without-request, not SWR; full-prefetch uses the 300s bucket).

## The honest part
The **durable floor** fix is **infrastructure**, not code: the app is served from a US region (`sjc1`) while the user is far away (~265ms RTT). A Railway **region/edge closer to the user** would cut the base latency of *every* request (including the first load, which no client cache can help). This PR makes in-session navigation instant; pairing it with a closer region is the complete fix.

## Verify
`next build` compiles · `tsc` · `lint` · docs-drift green. Presentational/config only — no schema/route/table/tier surface.

_(Perf/config — advisory brain-task nudge only.)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Meeting pages now load more quickly when selected from the meeting list.
  * Improved route caching helps reduce loading delays when navigating between pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->