### PR TITLE
feat(learning): order narrative arcs by work time, not extraction time

### DIFF
--- a/docs/design/arcs-work-time-chronology.md
+++ b/docs/design/arcs-work-time-chronology.md
@@ -1,0 +1,105 @@
+# Narrative arcs — order by WORK time, not extraction time
+
+**Status:** design. **Grounds:** the arcs recency/chronology question — "are we collating the data by
+the real chronology of the work?" Measured on prod (Neo4j, team `aios`) 2026-07-21.
+
+## Problem
+
+Arc synthesis, the fact pool, evidence timestamps, and arc ranking all key off `r.created_at` — the
+RELATES_TO edge's **extraction** time (when Graphiti pulled the fact out), NOT when the work happened:
+
+- `recentFacts` (`lib/graph/learning.ts`) → `ORDER BY r.created_at DESC` and `at = toString(r.created_at)`.
+- `recentEvents` (Layer 2) → `ORDER BY ep.created_at`.
+- `newestEvidenceAt` / `rankArcs` (`lib/graph/arcs.ts`) rank arcs by the newest evidence `at` — i.e. by
+  extraction time.
+
+Two consequences:
+1. **A re-projected old document looks "recent."** `ARCHITECTURE.md`, re-extracted on every PR (CLAUDE §1
+   requires updating it), gets a fresh `created_at` each time and floods the "recent" window — the RC4
+   the arcs root-cause analysis flagged. The recency signal is *ingestion* recency, not *work* recency.
+2. **No true chronology.** "What happened, in the order it happened" isn't expressible — the ordering is
+   ingestion order.
+
+## The data supports the fix (measured, prod, tier `aios_team`+`aios_external`)
+
+Graphiti stores a second timestamp — `valid_at` — which is the **episode reference time** we set from the
+item's `source_ts` via `pickEpisodeTimestamp` (`lib/graph/project.ts`), i.e. **work time**:
+
+| | populated | notes |
+|---|---|---|
+| RELATES_TO `valid_at` | **15,663 / 15,793 (99.2%)** | fallback needed for the 0.8% |
+| RELATES_TO `created_at` | 15,793 / 15,793 | always present (extraction) |
+| Episodic `valid_at` | **2,181 / 2,181 (100%)** | the reference time we set |
+| `valid_at` differs from `created_at` by >2 days | **6,073 edges (38%)** | the bias is large, not marginal |
+
+Sample: an episode `created_at` 2026-07-03 with `valid_at` 2026-06-24 — extracted 9 days after the work.
+
+## Crux: what `valid_at` actually is (corrected after design review)
+
+`valid_at` is **not** guaranteed to be the episode reference verbatim. Graphiti's `extract_edge_dates`
+LLM step sets edge `valid_at` = the episode reference for present-tense facts, but for facts with an
+explicit/relative date in their *text* ("last week we decided…", "launching in Sept") it extracts THAT
+date, and null when undeterminable. So `valid_at` is an *LLM-dated* value anchored to the reference — not
+a pure reference copy.
+
+What the prod probe establishes is therefore a **bounded empirical property of today's corpus, not an
+invariant**: comparing each edge's `valid_at` to the max `valid_at` of its source episodes (the
+reference we set), 15,684 edges — **82% match within 1 minute** (present-tense → reference), **0.8% null**
+(undeterminable), the **18% between 1min–30d** are content-relative dates + multi-episode dedup (a
+re-observed edge keeps its first `valid_at` as `episodes` grows), and **0 diverge by >30d, 0 before 2020**.
+A ≤30d, past-directed skew is **strictly better** than the 38% extraction-time bias, and a "since 2019"
+fact sinking *down* the pool is a mild, arguably-correct outcome. Accepted — but the future-date direction
+must be closed (below).
+
+## Fix (surgical)
+
+Order + timestamp by a **`created_at`-clamped work-time**, not a bare coalesce. Work always precedes
+extraction, so `created_at` is a valid upper bound that (a) supplies the null fallback and (b) forecloses
+a future-dated `valid_at` (from either a future `source_ts` OR the LLM date path stamping planning
+language) — which, under recency-ranking, would otherwise pin the top of the pool until the date passed:
+
+```cypher
+CASE WHEN r.valid_at IS NULL OR r.valid_at > r.created_at THEN r.created_at ELSE r.valid_at END
+```
+
+1. **`recentFacts`** (no aggregation → may order on the datetime expr directly): use the CASE as the
+   `ORDER BY … DESC` key, as `toString(CASE …) AS at`, and in the `withSince` predicate (`… >= datetime($since)`).
+   Sparse-data fallback unchanged.
+2. **`recentEvents`** (aggregates via `collect` → `ORDER BY` runs post-projection on the ALIAS): today it
+   sorts the **string** `at` — accidentally safe for `ep.created_at` (uniform `…Z`) but NOT for `ep.valid_at`,
+   which carries our `source_ts` and can hold non-UTC offsets (`+02:00`); lexicographic string compare across
+   mixed offsets misorders. **Project a datetime sort key** — `CASE … AS sortAt`, `ORDER BY sortAt DESC`
+   (Neo4j datetime compare is instant-based, offset-safe) — and keep `at = toString(CASE …)` for display.
+3. **No change in `lib/graph/arcs.ts`** — `buildEvidence`→`evidence.at`→`newestEvidenceAt`→`rankArcs`, and the
+   pool order feeding `dedupeFacts`/`balanceFacts` (bucket order preserved → newest-*work*-first per
+   contributor), all inherit it via the fact `at`. Verified `learning.ts` is the only Cypher reader of these
+   timestamps; nothing else becomes inconsistent. Arc cache keeps its extraction-era `at`s until the next SWR
+   refresh — no mixed-era compare (`rankArcs` only runs at synthesis), no migration.
+
+Net effect: "recency" means recent **work**; a re-projected old doc keeps its old `valid_at` and no longer
+jumps to the top — **de-biasing the re-projection problem at its source** (complements Phase A's per-item cap).
+
+## Comment drift to fix in the same PR
+
+`AtomicFact.at` says "ISO created_at" (`learning.ts:41`); the module-header schema comment; `dedupeFacts`'
+"keep the first = newest" (`arcs.ts`) now means newest-*work*. Update all three.
+
+## Out of scope
+
+A dedicated **chronological timeline view** (facts/events/arcs on a work-time axis) — separate UI surface;
+this change makes the *data* correct first.
+
+## Verification (real-Neo4j tier, `test/graph-neo4j-tier.test.ts`)
+
+Note: this tier is `NEO4J_TEST`-gated and **not in `ci.yml`** (only unit/datamechanics/http run in CI) — the
+red-before proof is local (`npm run db:test:neo4j:up && npm run test:neo4j`); paste the red run in the PR body.
+
+1. **Ordering** — two facts whose `valid_at` order REVERSES their `created_at` order → `recentFacts` orders by
+   work-time and returns `valid_at` as `at`. (Red today: `ORDER BY created_at` gives the wrong order.)
+2. **Null fallback** — a fact with no `valid_at` → sorts/timestamps by `created_at`.
+3. **Future clamp** — a fact with `valid_at` in the future → clamped to `created_at` (not pinned to the top).
+4. **Window exclusion** (the re-projection de-bias, the headline claim) — a fact `created_at = now`,
+   `valid_at = 8d ago` → a 24h-window `recentFacts` **excludes** it.
+5. **`recentEvents` offset ordering** — two events whose `valid_at` carry different UTC offsets (`Z` vs `+02:00`)
+   in an order that a *string* sort would get wrong → asserts the datetime-key sort orders them correctly.
+   Also assert seeded `valid_at` are datetimes (guards the mixed-type ordering foot-gun).

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -193,7 +193,7 @@ export function balanceFacts<T>(
  * Drop facts that add no signal before they're numbered into the prompt: (1) self-referential noise
  * where subject === object (Graphiti's "user is a duplicate of user" bookkeeping — a defense-in-depth
  * backstop even though `recentFacts` already filters `IS_DUPLICATE_OF` at the query), and (2) exact
- * repeats of an already-seen fact text (keep the first = newest, since the pool is newest-first). Each
+ * repeats of an already-seen fact text (keep the first = newest WORK, since the pool is work-time-first). Each
  * duplicate would otherwise consume a numbered slot and hand the model redundant input. Pure + tested.
  */
 export function dedupeFacts(facts: AtomicFact[]): AtomicFact[] {

--- a/lib/graph/learning.ts
+++ b/lib/graph/learning.ts
@@ -9,8 +9,9 @@ import { itemIdFromEpisodeName } from "./episode-name";
  * from seeing team facts (no RLS backstop, CLAUDE.md §5). Guarded by test/guards/graph-tier-filter.
  *
  * Best-effort: returns [] when Neo4j is unconfigured/unreachable so the panel degrades gracefully.
- * Graphiti schema: `(:Entity)-[:RELATES_TO {fact, created_at, group_id, episodes}]->(:Entity)`,
- * `(:Episodic {name:"items:<id>", created_at, group_id})`, `(:Episodic)-[:MENTIONS]->(:Entity)`.
+ * Graphiti schema: `(:Entity)-[:RELATES_TO {fact, created_at, valid_at, group_id, episodes}]->(:Entity)`,
+ * `(:Episodic {name:"items:<id>", created_at, valid_at, group_id})`, `(:Episodic)-[:MENTIONS]->(:Entity)`.
+ * We order/timestamp by WORK time (`valid_at` clamped to `created_at`, see `workTs`), not extraction time.
  *
  * SPARSE-DATA FALLBACK: the `sinceISO` window is a SOFT preference, not a hard cutoff. When the
  * windowed query returns nothing (a stale graph — e.g. Graphiti's extractor stalled and the newest
@@ -34,11 +35,23 @@ import { itemIdFromEpisodeName } from "./episode-name";
 const FACT_NOISE_FILTER =
   "AND (r.name IS NULL OR r.name <> 'IS_DUPLICATE_OF') AND r.expired_at IS NULL";
 
+/**
+ * WORK time for ordering/timestamping — so "recent" means recent WORK, not recent extraction (a
+ * re-projected old doc no longer looks new; see docs/design/arcs-work-time-chronology.md). Uses the
+ * Graphiti `valid_at` (the episode reference we set from the item's `source_ts`), CLAMPED to
+ * `created_at` (extraction) as an upper bound: work always precedes extraction, so this both supplies
+ * the null fallback AND forecloses a future-dated `valid_at` (a bad `source_ts` or an LLM-extracted
+ * planning date) from pinning the top of the recency-ranked pool. `v` is the pattern variable
+ * (`r` for a fact edge, `ep` for an episode). Returns a Cypher datetime expression.
+ */
+const workTs = (v: string): string =>
+  `(CASE WHEN ${v}.valid_at IS NULL OR ${v}.valid_at > ${v}.created_at THEN ${v}.created_at ELSE ${v}.valid_at END)`;
+
 /** Layer 1 — one recently-extracted fact (a RELATES_TO edge). */
 export interface AtomicFact {
   id: string; // edge uuid
   fact: string;
-  at: string; // ISO created_at
+  at: string; // ISO WORK time (valid_at clamped to created_at; see workTs) — NOT extraction time
   subjectType: string; // subject entity's label → the type badge
   subject: string;
   object: string;
@@ -46,8 +59,9 @@ export interface AtomicFact {
 }
 
 /**
- * Layer 1 — recent atomic facts for the given tier-visible groups, newest first. `groups` MUST be
- * the caller's `visibleGroupIds(teamSlug, tier)`. `sinceISO` bounds the window (e.g. last 24h).
+ * Layer 1 — recent atomic facts for the given tier-visible groups, newest WORK first (`workTs`, not
+ * extraction time). `groups` MUST be the caller's `visibleGroupIds(teamSlug, tier)`. `sinceISO` bounds
+ * the window (e.g. last 24h of work).
  */
 export async function recentFacts(
   groups: string[],
@@ -59,15 +73,15 @@ export async function recentFacts(
   const factsCypher = (withSince: boolean) =>
     `MATCH (a:Entity)-[r:RELATES_TO]->(b:Entity)
      WHERE r.group_id IN $groups
-       ${FACT_NOISE_FILTER}${withSince ? " AND r.created_at >= datetime($since)" : ""}
+       ${FACT_NOISE_FILTER}${withSince ? ` AND ${workTs("r")} >= datetime($since)` : ""}
      RETURN r.uuid AS id,
             r.fact AS fact,
-            toString(r.created_at) AS at,
+            toString(${workTs("r")}) AS at,
             head([l IN labels(a) WHERE l <> 'Entity']) AS subjectType,
             a.name AS subject,
             b.name AS object,
             r.episodes AS episodeUuids
-     ORDER BY r.created_at DESC
+     ORDER BY ${workTs("r")} DESC
      LIMIT toInteger($limit)`;
   const query = async (withSince: boolean): Promise<AtomicFact[]> => {
     const rows = await runRead<{
@@ -160,15 +174,16 @@ export async function recentEvents(
   // `withSince` gates ONLY the time bound; both group_id tier filters are present either way.
   const eventsCypher = (withSince: boolean) =>
     `MATCH (ep:Episodic)
-     WHERE ep.group_id IN $groups${withSince ? " AND ep.created_at >= datetime($since)" : ""}
+     WHERE ep.group_id IN $groups${withSince ? ` AND ${workTs("ep")} >= datetime($since)` : ""}
      OPTIONAL MATCH (ep)-[:MENTIONS]->(p:Entity)
      OPTIONAL MATCH (a:Entity)-[r:RELATES_TO]->(b:Entity)
        WHERE r.group_id IN $groups AND ep.uuid IN r.episodes ${FACT_NOISE_FILTER}
      RETURN ep.uuid AS id, ep.name AS name, ep.source AS source,
-            ep.source_description AS title, toString(ep.created_at) AS at,
+            ep.source_description AS title, toString(${workTs("ep")}) AS at,
+            ${workTs("ep")} AS sortAt,
             collect(DISTINCT p.name) AS participants,
             collect(DISTINCT r.fact) AS facts
-     ORDER BY at DESC
+     ORDER BY sortAt DESC
      LIMIT toInteger($limit)`;
   const query = async (withSince: boolean): Promise<GraphEvent[]> => {
     const rows = await runRead<{

--- a/test/graph-neo4j-tier.test.ts
+++ b/test/graph-neo4j-tier.test.ts
@@ -132,3 +132,90 @@ live("Graphiti Neo4j tier isolation (real Neo4j)", () => {
     expect(events.map((e) => e.id)).not.toContain("ep2"); // external event never leaks
   });
 });
+
+/**
+ * Work-time ordering (docs/design/arcs-work-time-chronology.md): facts/events order + timestamp by
+ * WORK time (`valid_at` clamped to `created_at`), not extraction time — so "recent" means recent work
+ * and a re-projected old doc stops looking new. Self-skips unless NEO4J_TEST is set (local-only tier).
+ */
+live("Brain-Learning work-time ordering (real Neo4j)", () => {
+  const WT = "wt_order";
+  let driver: Driver;
+
+  beforeAll(async () => {
+    driver = neo4j.driver(
+      process.env.NEO4J_URL as string,
+      neo4j.auth.basic(process.env.NEO4J_USER as string, process.env.NEO4J_PASSWORD as string)
+    );
+    const s = driver.session();
+    try {
+      await s.run("MATCH (n) WHERE n.group_id = $wt DETACH DELETE n", { wt: WT });
+      // Realistic: work (valid_at) precedes extraction (created_at). created-order (desc): A,B,D,C —
+      // but WORK-order (desc, by valid_at; D's future date clamped to its created_at; C has no valid_at
+      // → created_at): D(Jun8), A(Jun4), B(Jun3), C(Jun2). The two orders differ → proves work-time sort.
+      await s.run(
+        `CREATE (:Entity {name:'sA',group_id:$wt})-[:RELATES_TO {uuid:'wA',fact:'fact A',group_id:$wt,episodes:[],created_at:datetime('2026-06-10T00:00:00Z'),valid_at:datetime('2026-06-04T00:00:00Z')}]->(:Entity {name:'oA',group_id:$wt})
+         CREATE (:Entity {name:'sB',group_id:$wt})-[:RELATES_TO {uuid:'wB',fact:'fact B',group_id:$wt,episodes:[],created_at:datetime('2026-06-09T00:00:00Z'),valid_at:datetime('2026-06-03T00:00:00Z')}]->(:Entity {name:'oB',group_id:$wt})
+         CREATE (:Entity {name:'sC',group_id:$wt})-[:RELATES_TO {uuid:'wC',fact:'fact C',group_id:$wt,episodes:[],created_at:datetime('2026-06-02T00:00:00Z')}]->(:Entity {name:'oC',group_id:$wt})
+         CREATE (:Entity {name:'sD',group_id:$wt})-[:RELATES_TO {uuid:'wD',fact:'fact D',group_id:$wt,episodes:[],created_at:datetime('2026-06-08T00:00:00Z'),valid_at:datetime('2030-01-01T00:00:00Z')}]->(:Entity {name:'oD',group_id:$wt})`,
+        { wt: WT }
+      );
+    } finally {
+      await s.close();
+    }
+  });
+
+  afterAll(async () => {
+    await driver?.close();
+    await closeNeo4j();
+  });
+
+  it("orders by WORK time (valid_at), returns it as `at`, falls back to created_at, clamps a future valid_at", async () => {
+    const facts = await recentFacts([WT], null);
+    expect(facts.map((f) => f.fact)).toEqual(["fact D", "fact A", "fact B", "fact C"]); // work-order, not created-order (A,B,D,C)
+    expect(facts.find((f) => f.fact === "fact A")!.at).toMatch(/^2026-06-04/); // valid_at (not created 2026-06-10)
+    expect(facts.find((f) => f.fact === "fact C")!.at).toMatch(/^2026-06-02/); // no valid_at → created_at fallback
+    expect(facts.find((f) => f.fact === "fact D")!.at).toMatch(/^2026-06-08/); // future valid_at (2030) clamped to created_at
+  });
+
+  it("a WORK-time window excludes a re-projected old fact (extracted now, worked 8d ago)", async () => {
+    const WW = "wt_window";
+    const now = new Date().toISOString();
+    const d8 = new Date(Date.now() - 8 * 86400_000).toISOString();
+    const d1h = new Date(Date.now() - 3600_000).toISOString();
+    const s = driver.session();
+    try {
+      await s.run("MATCH (n) WHERE n.group_id=$wt DETACH DELETE n", { wt: WW });
+      await s.run(
+        `CREATE (:Entity {name:'se',group_id:$wt})-[:RELATES_TO {uuid:'wE',fact:'reprojected old',group_id:$wt,episodes:[],created_at:datetime($now),valid_at:datetime($d8)}]->(:Entity {name:'oe',group_id:$wt})
+         CREATE (:Entity {name:'sf',group_id:$wt})-[:RELATES_TO {uuid:'wF',fact:'fresh work',group_id:$wt,episodes:[],created_at:datetime($now),valid_at:datetime($d1h)}]->(:Entity {name:'of',group_id:$wt})`,
+        { wt: WW, now, d8, d1h }
+      );
+    } finally {
+      await s.close();
+    }
+    const facts = await recentFacts([WW], new Date(Date.now() - 86400_000).toISOString());
+    expect(facts.map((f) => f.fact)).toContain("fresh work");
+    expect(facts.map((f) => f.fact)).not.toContain("reprojected old"); // worked 8d ago → outside the 24h WORK window
+  });
+
+  it("recentEvents orders by the work-time INSTANT, not the raw offset string", async () => {
+    const WE = "wt_events";
+    const now = new Date().toISOString();
+    const s = driver.session();
+    try {
+      // epX valid = 10:00+02:00 = 08:00Z; epY valid = 09:00Z → epY is the later INSTANT. A raw-string
+      // sort ("10:00+02:00" > "09:00Z") would wrongly put epX first; the datetime sort key must not.
+      await s.run("MATCH (n) WHERE n.group_id=$wt DETACH DELETE n", { wt: WE });
+      await s.run(
+        `CREATE (:Episodic {uuid:'epX',name:'items:x',source:'notion',source_description:'X',group_id:$wt,created_at:datetime($now),valid_at:datetime('2026-06-01T10:00:00+02:00')})
+         CREATE (:Episodic {uuid:'epY',name:'items:y',source:'notion',source_description:'Y',group_id:$wt,created_at:datetime($now),valid_at:datetime('2026-06-01T09:00:00Z')})`,
+        { wt: WE, now }
+      );
+    } finally {
+      await s.close();
+    }
+    const events = await recentEvents([WE], "2026-01-01T00:00:00Z");
+    expect(events.map((e) => e.id)).toEqual(["epY", "epX"]); // later instant first, offset-safe
+  });
+});


### PR DESCRIPTION
## Why

Narrative arcs, the fact pool, evidence timestamps, and arc ranking all keyed off `r.created_at` — Graphiti's **extraction** time (when a fact was pulled out), not when the work happened. Two costs: (1) a re-projected old doc (e.g. `ARCHITECTURE.md`, re-extracted on every PR) got a fresh timestamp and looked "recent" — the RC4 the arcs root-cause analysis flagged; (2) no true work chronology. Prod-measured: `valid_at` (the episode reference we set from the item's `source_ts` = **work time**) is populated on 99.2% of edges, and **38% of edges have work-time diverging from extraction-time by >2 days** — the bias is large.

## What

Order + timestamp by a shared `workTs` = **`valid_at` clamped to `created_at`** (`lib/graph/learning.ts`):
```cypher
(CASE WHEN v.valid_at IS NULL OR v.valid_at > v.created_at THEN v.created_at ELSE v.valid_at END)
```
Work always precedes extraction, so `created_at` is a valid upper bound that both supplies the null fallback **and** forecloses a future-dated `valid_at` (a bad `source_ts`, or an LLM-extracted planning date like "launching in Sept") from pinning the recency-ranked pool.
- **`recentFacts`** — `workTs` in `ORDER BY`, as `toString(workTs) AS at`, and the `withSince` predicate.
- **`recentEvents`** — projects a **datetime** `sortAt` key and `ORDER BY sortAt DESC` (its `collect` aggregation was sorting the *string* `at`, which misorders non-UTC offsets like `+02:00` vs `Z`), keeping `at` as the display string.
- **`arcs.ts`** — no logic change: `buildEvidence`→`newestEvidenceAt`→`rankArcs` and the pool→`balanceFacts` order all inherit work-time via the fact `at`. Net: "recency" means recent **work**, and a re-projected old doc stops jumping to the top — de-biasing the re-projection problem at its source.

## Review — Reviewed by **Fable** — verdict: **CLEAR** (design review + code review)

- **Design review ("sound with changes")** caught two real improvements, both implemented: the **future-date pathology** (→ the `created_at` clamp) and a **`recentEvents` string-sort bug** on mixed UTC offsets (→ the datetime `sortAt` key). Spec revised on all 5 points.
- **Code review: CLEAR** — verified all four edits landed; only non-blocking Low notes (a NULL-both-timestamps edge = pre-existing, non-regression; hypothetical legacy-type `valid_at`; a nice-to-have events-window assertion).

## Verification

Real-Neo4j tier (`test/graph-neo4j-tier.test.ts`) — **RED before / GREEN after**: work-order ≠ created-order, null→created_at fallback, future `valid_at` clamped, work-time **window exclusion** (a fact extracted now but worked 8d ago is excluded from a 24h window — the re-projection de-bias), and offset-safe `recentEvents` ordering. The 3 new tests fail on the old code and pass on the new; the 8 tier-isolation tests stay green.

> **Honest note:** this tier is `NEO4J_TEST`-gated and **not in `ci.yml`** — the red/green proof is local (`npm run db:test:neo4j:up && npm run test:neo4j`). unit **924** · tsc · lint · docs-drift all green in CI. Design + reviews: `docs/design/arcs-work-time-chronology.md`.

## Follow-up (out of scope)
A dedicated chronological **timeline view** (facts/events/arcs on a work-time axis) — this change makes the *data* correct first; the timeline is a consumer of it.
