### PR TITLE
feat(learning): only active Linear issues (In Progress/In Review) inform arcs

### DIFF
--- a/docs/design/attribution-architecture.md
+++ b/docs/design/attribution-architecture.md
@@ -172,8 +172,7 @@ admin correction** from an **auto-resolved** value. Two consequences (both narro
 
 **Durable fix (follow-up):** an authority marker on the shared layer — `items.attributed_via:
 'manual' | 'resolved'` — where `manual` (NL correction / admin) always wins and the heal/batch only
-touch `resolved` rows. That closes both gaps at the data layer for every surface at once. Also: the
-unchanged-repush path doesn't persist changed `frontmatter`, so a pre-enrichment item's stored
-`authors[]` stays empty until a body edit — the reattribute *button* (reads stored frontmatter) can't
-see it, though the live heal does; persisting frontmatter on the unchanged-when-differs path would
-converge them.
+touch `resolved` rows. That closes both gaps at the data layer for every surface at once. Also **RESOLVED**: the unchanged-repush
+fast-path now heals `frontmatter` when the source metadata changed even though the body didn't (a
+Linear state transition, a source later exposing `authors[]`), so stored frontmatter no longer freezes
+at first ingest — the reattribute *button* + status-gated reads (arc eligibility) see current metadata.

--- a/docs/design/brain-learning-panel.md
+++ b/docs/design/brain-learning-panel.md
@@ -279,3 +279,5 @@ on that), so the fire-and-forget promise is not at risk of serverless request-te
 - **Fallback** — if direct Neo4j proves unviable in prod, Layer 2 can fall back to `GET /episodes` +
   `items`/`graph_episodes` (event = item, participants = `member_id`), and Layer 1 to `/search`; Layer 3
   synthesis is unaffected. Kept as the degrade path, not the primary.
+
+**Arc eligibility (Layer 3 only).** Not all graph facts inform arcs. A Linear issue informs arcs only while it's ACTIVE work — gated on the canonical Linear workflow-state `type` (`started`; persisted as `frontmatter.state_type`), with the display-name regex (`ARCS_LINEAR_ACTIVE_STATE_RE`, default `progress|review`) as fallback for rows ingested before `state_type`. Backlog/Todo/Done/Canceled — and the terse `kind:"task"` board mirror (`issues.md`, which carries no state) — stay in the graph + facts panel as context but are filtered from the arc substrate at synthesis (`lib/graph/arc-eligibility`). A fact dedup'd across sources is kept if ANY of its items is eligible (a Done ticket co-cited with a meeting stays). Non-Linear content is unaffected.

--- a/lib/graph/arc-eligibility.ts
+++ b/lib/graph/arc-eligibility.ts
@@ -1,0 +1,76 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+
+/**
+ * Which items' facts are eligible to inform NARRATIVE ARCS (Layer 3) — a filter applied at arc
+ * synthesis only, NOT at ingest/projection, so the excluded content stays in the graph and the
+ * facts/events panels (it's still context, still searchable) but doesn't shape the "what the team is
+ * working through" storylines.
+ *
+ * Rule (per product): a Linear issue informs arcs ONLY while it's ACTIVE work — In Progress / In Review.
+ * Backlog, Todo, Done, Canceled are context, not narrative — a done or not-yet-started ticket isn't
+ * something the team is "working through". Non-Linear content is unaffected (always arc-eligible).
+ * Matched on the raw Linear state NAME (the per-issue `deliverable` frontmatter carries the Linear
+ * display name, e.g. "In Progress", not a normalized enum). See docs/design/brain-learning-panel.md.
+ */
+
+// "In Progress" / "In Review" (and "Reviewing"). Overridable per deployment; a name matching this is
+// active. Deliberately a substring regex, not an exact set, to tolerate team-configured state names.
+const ACTIVE_LINEAR_STATE = (() => {
+  const raw = (process.env.ARCS_LINEAR_ACTIVE_STATE_RE ?? "progress|review").trim();
+  try {
+    return new RegExp(raw || "progress|review", "i");
+  } catch {
+    return /progress|review/i;
+  }
+})();
+
+export function isArcActiveLinearState(state: string): boolean {
+  return ACTIVE_LINEAR_STATE.test(state);
+}
+
+/**
+ * Is an item's fact eligible for arc synthesis? Only Linear items are status-gated; everything else is
+ * always eligible. Prefers the CANONICAL Linear workflow-state `type` (`started` = active work —
+ * team-vocabulary-agnostic, covers In Progress / In Review / Blocked / QA etc.); falls back to the
+ * display-name regex for rows ingested before `state_type` was persisted. A Linear item with neither a
+ * type nor a matching state name is NOT active (arcs = active work). Pure.
+ */
+export function isArcEligible(
+  source: string | null | undefined,
+  state: string | null | undefined,
+  stateType?: string | null
+): boolean {
+  if ((source ?? "").trim().toLowerCase() !== "linear") return true;
+  const type = (stateType ?? "").trim().toLowerCase();
+  if (type) return type === "started"; // canonical: active work
+  return !!state && isArcActiveLinearState(state); // fallback (pre-state_type rows)
+}
+
+/**
+ * The subset of `itemIds` whose facts must be EXCLUDED from arc synthesis — Linear issues that aren't
+ * active (In Progress / In Review). Reads `items.frontmatter` (source + state); non-Linear items are
+ * never returned. Best-effort (empty set on error, so a hiccup can't blank arcs). `itemIds` are already
+ * tier-scoped by the caller (they came out of the tier-visible fact pool).
+ */
+export async function arcIneligibleItemIds(
+  teamId: string,
+  itemIds: string[]
+): Promise<Set<string>> {
+  const ids = [...new Set(itemIds)].filter(Boolean);
+  if (ids.length === 0) return new Set();
+  try {
+    const { rows } = await runSql<{ id: string; state: string | null; state_type: string | null }>(
+      `select id, frontmatter->>'state' as state, frontmatter->>'state_type' as state_type
+         from items
+        where team_id = $1 and id::text = any($2) and frontmatter->>'source' = 'linear'`,
+      [teamId, ids]
+    );
+    const out = new Set<string>();
+    for (const r of rows) if (!isArcEligible("linear", r.state, r.state_type)) out.add(r.id);
+    return out;
+  } catch (err) {
+    console.error("[arcs] arcIneligibleItemIds failed:", err instanceof Error ? err.message : err);
+    return new Set();
+  }
+}

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -10,6 +10,7 @@ import { episodeGroupId, type AccessTier } from "./group";
 import { attributeParticipants, attributedFactTexts, withEvidenceParticipants } from "./arc-attribution";
 import { resolveHumanActorsByItem } from "./human-actors";
 import { readArcCache, writeArcCache } from "./arc-cache";
+import { arcIneligibleItemIds } from "./arc-eligibility";
 
 /**
  * Layer 3 — narrative arcs. Gathers the recent graph substrate (facts, last 7d, tier-scoped),
@@ -197,18 +198,30 @@ export function balanceFacts<T>(
  * duplicate would otherwise consume a numbered slot and hand the model redundant input. Pure + tested.
  */
 export function dedupeFacts(facts: AtomicFact[]): AtomicFact[] {
-  const seen = new Set<string>();
-  const out: AtomicFact[] = [];
+  const byKey = new Map<string, { fact: AtomicFact; eps: Set<string> }>();
+  const order: string[] = [];
   for (const f of facts) {
     const subj = (f.subject ?? "").trim().toLowerCase();
     const obj = (f.object ?? "").trim().toLowerCase();
     if (subj && subj === obj) continue; // self-referential noise
     const key = (f.fact ?? "").trim().toLowerCase().replace(/\s+/g, " ");
-    if (!key || seen.has(key)) continue;
-    seen.add(key);
-    out.push(f);
+    if (!key) continue;
+    const kept = byKey.get(key);
+    if (kept) {
+      // Same fact text from another source → keep the first (newest) but UNION its source episodes, so
+      // downstream (arc eligibility, evidence) sees ALL of the fact's sources, not just the first copy's
+      // (e.g. a fact cited by both a Done Linear ticket AND a meeting must retain the meeting episode).
+      for (const u of f.episodeUuids) kept.eps.add(u);
+      continue;
+    }
+    byKey.set(key, { fact: f, eps: new Set(f.episodeUuids) });
+    order.push(key);
   }
-  return out;
+  // New objects (immutability) with the unioned episode set.
+  return order.map((k) => {
+    const e = byKey.get(k)!;
+    return { ...e.fact, episodeUuids: [...e.eps] };
+  });
 }
 
 const CONFIDENCE_WEIGHT: Record<NarrativeArc["confidence"], number> = { high: 3, medium: 2, low: 1 };
@@ -489,9 +502,28 @@ async function synthesizeArcs(
   };
   const itemOfFact = (f: AtomicFact): string => actorOfFact(f).item;
   const humanOfFact = (f: AtomicFact): string => actorOfFact(f).human;
+  // Drop facts whose evidence is ONLY non-active Linear issues (arcs are "what the team is working
+  // through", so backlog/todo/done tickets are context, not narrative). A fact dedup'd across sources is
+  // KEPT if ANY of its source items is eligible (or none resolve) — e.g. a fact cited by both a Done
+  // Linear issue AND a meeting transcript stays, since the meeting is eligible evidence (filtering on the
+  // single attribution item would wrongly drop it). Arc-synthesis-only; excluded content stays in the
+  // graph + facts panel. Non-Linear facts pass through.
+  const ineligible = await arcIneligibleItemIds(teamId, allItemIds);
+  const factItemIds = (f: AtomicFact): string[] =>
+    f.episodeUuids.map((u) => epToItem.get(u)?.itemId).filter((id): id is string => !!id);
+  const eligiblePool = ineligible.size
+    ? pool.filter((f) => {
+        const items = factItemIds(f);
+        return items.length === 0 || items.some((id) => !ineligible.has(id));
+      })
+    : pool;
+  // If every recent fact traces ONLY to non-active Linear work, there's nothing to synthesize — return
+  // [] so it flows into the empty-clobber guard (keep a recent prior, else honest blank), rather than
+  // firing a zero-fact LLM call whose fabricated (evidence-less) arcs would clobber the real prior set.
+  if (eligiblePool.length === 0 && correctionTexts.length === 0) return [];
   // Two-level balance (contributor → item, per-item capped) → a representative MAX_FACTS so every active
   // contributor is in the prompt AND no single giant document dominates its author's share.
-  const facts = balanceFacts(pool, humanOfFact, itemOfFact, MAX_FACTS, PER_ITEM_CAP);
+  const facts = balanceFacts(eligiblePool, humanOfFact, itemOfFact, MAX_FACTS, PER_ITEM_CAP);
   // Request arcs proportional to how many distinct contributors actually made the balanced cut, so a
   // varied team gets more than a flat ceiling and each person's distinct threads have room to surface.
   const contributorCount = new Set(facts.map(humanOfFact).filter(Boolean)).size;

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -37,6 +37,24 @@ export interface IngestResult {
   changedTaskRowKeys?: string[];
 }
 
+/** Order-insensitive JSON for comparing frontmatter to its jsonb-stored form (Postgres normalizes
+ *  object key order; the normalizers emit insertion order). Recursively sorts object keys; array order
+ *  is preserved (meaningful + jsonb-preserved). So `canonicalJson(a) === canonicalJson(b)` iff the two
+ *  frontmatters are semantically equal, avoiding a needless rewrite on every unchanged re-push. */
+function canonicalJson(value: unknown): string {
+  const norm = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(norm);
+    if (v && typeof v === "object") {
+      const o = v as Record<string, unknown>;
+      return Object.keys(o)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, k) => ((acc[k] = norm(o[k])), acc), {});
+    }
+    return v;
+  };
+  return JSON.stringify(norm(value));
+}
+
 export async function ingestItem(
   db: DbClient,
   auth: { teamId: string; memberId: string; apiKeyId: string },
@@ -69,7 +87,7 @@ export async function ingestItem(
   // 2. existing item?
   const { data: existing } = await db
     .from("items")
-    .select("id, content_sha256, member_id")
+    .select("id, content_sha256, member_id, frontmatter")
     .eq("team_id", auth.teamId)
     .eq("project_id", project.id)
     .eq("path", payload.path)
@@ -92,9 +110,27 @@ export async function ingestItem(
     // clobber a human self-push's own attribution. Re-pointing an existing (wrong) attribution stays the
     // job of the explicit, admin-triggered `reattributeItems` batch. Never clears to null either (a
     // connector's unresolved re-push passes `authorMemberId: null`).
-    const patch: { synced_at: string; member_id?: string } = { synced_at: now };
+    const patch: { synced_at: string; member_id?: string; frontmatter?: Record<string, unknown> } = { synced_at: now };
     if (opts?.authorMemberId && existing.member_id === null) {
       patch.member_id = opts.authorMemberId;
+    }
+    // HEAL FRONTMATTER on an unchanged re-push: `content_sha256` covers only the body, but source-derived
+    // metadata in frontmatter can change while the body doesn't — a Linear issue transitions Backlog →
+    // In Progress (its prose unchanged), or a source later exposes richer `authors[]`. Without this, the
+    // stored frontmatter is frozen at first ingest, so status-gated reads (arc eligibility) and the
+    // reattribute batch (reads stored frontmatter) act on stale metadata forever.
+    const existingFm = (existing as { frontmatter: Record<string, unknown> | null }).frontmatter ?? {};
+    const healedFm: Record<string, unknown> = { ...(payload.frontmatter ?? {}) };
+    // Preserve BEST-EFFORT/backfilled author keys the store has but this push omits (e.g. github-files'
+    // commits-lookup or the author backfill script populated them, and a transient lookup failure this
+    // tick left them off the payload) — refreshing must not wipe them.
+    for (const k of ["author", "author_email", "author_login"]) {
+      if (existingFm[k] !== undefined && healedFm[k] === undefined) healedFm[k] = existingFm[k];
+    }
+    // Compare canonically (jsonb normalizes object key order; the normalizer emits insertion order), so we
+    // write ONLY on a real metadata change — not every tick on a key-order-only mismatch.
+    if (canonicalJson(existingFm) !== canonicalJson(healedFm)) {
+      patch.frontmatter = healedFm;
     }
     await db.from("items").update(patch).eq("id", existing.id);
     // Audit the rare heal (a genuine attribution change — unlike the per-tick synced_at bump, so it

--- a/lib/ingest/sources/linear-normalize.ts
+++ b/lib/ingest/sources/linear-normalize.ts
@@ -194,6 +194,10 @@ export function normalizeLinearDocs(input: NormalizeLinearInput): ItemPayload[] 
           team_key: input.teamKey,
           url: it.url ?? "",
           state: it.state?.name ?? "",
+          // Canonical Linear workflow-state TYPE (backlog|unstarted|started|completed|canceled) — the
+          // team-vocabulary-agnostic signal for arc eligibility (`started` = active work). Preferred over
+          // the display-name regex; the name stays as fallback for rows ingested before this field.
+          state_type: it.state?.type ?? "",
           assignee: it.assignee?.displayName ?? "",
           // Assignee's Linear user id → resolved to a person at ingest (lib/ingest/run).
           assignee_id: it.assignee?.id ?? "",

--- a/test/arc-eligibility.test.ts
+++ b/test/arc-eligibility.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { isArcActiveLinearState, isArcEligible } from "@/lib/graph/arc-eligibility";
+
+/**
+ * Spec: only ACTIVE Linear work (In Progress / In Review) informs narrative arcs; other states are
+ * context, not narrative. Non-Linear content is never status-gated. Pure, no DB.
+ */
+
+describe("isArcActiveLinearState", () => {
+  it("treats In Progress / In Review (+ Reviewing) as active", () => {
+    expect(isArcActiveLinearState("In Progress")).toBe(true);
+    expect(isArcActiveLinearState("In Review")).toBe(true);
+    expect(isArcActiveLinearState("Reviewing")).toBe(true);
+  });
+  it("treats Backlog / Todo / Done / Canceled as NOT active", () => {
+    for (const s of ["Backlog", "Todo", "Done", "Canceled", "Duplicate"]) {
+      expect(isArcActiveLinearState(s)).toBe(false);
+    }
+  });
+});
+
+describe("isArcEligible", () => {
+  it("gates ONLY Linear items by status; everything else is always eligible", () => {
+    expect(isArcEligible("git", "whatever")).toBe(true);
+    expect(isArcEligible("notion", null)).toBe(true);
+    expect(isArcEligible(null, null)).toBe(true); // unknown source → eligible
+  });
+  it("prefers the canonical state_type ('started' = active) over the display name", () => {
+    // A completed-type state NAMED "Reviewed" (name regex would keep it) is correctly dropped by type.
+    expect(isArcEligible("linear", "Reviewed", "completed")).toBe(false);
+    // A started-type state with an unusual name ("Doing"/"Blocked") the name regex would miss → kept.
+    expect(isArcEligible("linear", "Blocked", "started")).toBe(true);
+    expect(isArcEligible("linear", "In Progress", "started")).toBe(true);
+    expect(isArcEligible("linear", "Backlog", "backlog")).toBe(false);
+  });
+  it("falls back to the state-name regex when no state_type is present (pre-migration rows)", () => {
+    expect(isArcEligible("linear", "In Progress")).toBe(true);
+    expect(isArcEligible("linear", "In Review", "")).toBe(true);
+    expect(isArcEligible("linear", "Backlog")).toBe(false);
+    expect(isArcEligible("linear", null)).toBe(false); // Linear + no type + no state → not active
+    expect(isArcEligible("LINEAR", "Backlog")).toBe(false); // source case-insensitive
+  });
+});

--- a/test/datamechanics/arc-eligibility.datamechanics.test.ts
+++ b/test/datamechanics/arc-eligibility.datamechanics.test.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { arcIneligibleItemIds } from "@/lib/graph/arc-eligibility";
+import { db, seedTeam, ingest, type Seed } from "./helpers";
+
+/**
+ * Spec: `arcIneligibleItemIds` returns exactly the Linear issues NOT in active work (In Progress /
+ * In Review) — the facts to exclude from arc synthesis — and never a non-Linear item. Real Postgres
+ * (reads items.frontmatter).
+ */
+
+async function seedItem(seed: Seed, source: string, state: string | null, stateType?: string): Promise<string> {
+  const path = `${source}/${randomUUID()}.md`;
+  const fm: Record<string, unknown> = { source };
+  if (state !== null) fm.state = state;
+  if (stateType !== undefined) fm.state_type = stateType;
+  const { id } = await ingest(seed, { body: `b ${path}`, path, access: "team", frontmatter: fm });
+  return id;
+}
+
+describe("arc eligibility (real Postgres)", () => {
+  it("gates Linear by canonical state_type ('started'), falls back to state name, keeps non-Linear", async () => {
+    const seed = await seedTeam();
+    const startedType = await seedItem(seed, "linear", "Blocked", "started"); // canonical active (name regex would miss)
+    const completedType = await seedItem(seed, "linear", "Reviewed", "completed"); // name regex would keep — type drops it
+    const activeName = await seedItem(seed, "linear", "In Progress"); // no type → name fallback → active
+    const backlogName = await seedItem(seed, "linear", "Backlog"); // no type → name fallback → not active
+    const boardMirror = await seedItem(seed, "linear", null); // kind-agnostic: source=linear, no state/type → not active (the issues.md board mirror)
+    const notion = await seedItem(seed, "notion", null); // non-Linear → never gated
+
+    const ids = [startedType, completedType, activeName, backlogName, boardMirror, notion];
+    const ineligible = await arcIneligibleItemIds(seed.teamId, ids);
+
+    expect(ineligible.has(completedType)).toBe(true);
+    expect(ineligible.has(backlogName)).toBe(true);
+    expect(ineligible.has(boardMirror)).toBe(true);
+    expect(ineligible.has(startedType)).toBe(false); // started type kept despite "Blocked" name
+    expect(ineligible.has(activeName)).toBe(false);
+    expect(ineligible.has(notion)).toBe(false);
+    expect(ineligible.size).toBe(3);
+  });
+
+  it("returns an empty set for no items", async () => {
+    const seed = await seedTeam();
+    expect((await arcIneligibleItemIds(seed.teamId, [])).size).toBe(0);
+  });
+
+  it("tracks a live Linear status change on an unchanged-body re-push (frontmatter heal)", async () => {
+    // A Linear issue's state isn't in its body, so a Backlog→In Progress transition is an UNCHANGED
+    // re-push (same content_sha256). The fast-path must refresh frontmatter so eligibility isn't frozen
+    // at first ingest — else active work stays suppressed from arcs forever.
+    const seed = await seedTeam();
+    const body = `issue prose ${randomUUID()}`;
+    const path = `linear/${randomUUID()}.md`;
+    const fm = (state: string, type: string) => ({ source: "linear", identifier: "AIO-1", state, state_type: type });
+
+    const r1 = await ingest(seed, { body, path, access: "team", frontmatter: fm("Backlog", "backlog") });
+    expect((await arcIneligibleItemIds(seed.teamId, [r1.id])).has(r1.id)).toBe(true); // Backlog → ineligible
+
+    const r2 = await ingest(seed, { body, path, access: "team", frontmatter: fm("In Progress", "started") });
+    expect(r2.status).toBe("unchanged"); // same body → unchanged re-push
+    expect(r2.id).toBe(r1.id);
+    expect((await arcIneligibleItemIds(seed.teamId, [r1.id])).has(r1.id)).toBe(false); // healed → now eligible
+  });
+});

--- a/test/datamechanics/items-author-attribution.datamechanics.test.ts
+++ b/test/datamechanics/items-author-attribution.datamechanics.test.ts
@@ -118,4 +118,21 @@ describe("author attribution at ingest → stored member_id (real Postgres)", ()
     await ingestItem(db(), auth, p, "team", { authorMemberId: null }); // unchanged, unresolved
     expect(await stored()).toBe(seed.memberId); // NOT cleared
   });
+
+  it("frontmatter heal refreshes changed keys but PRESERVES best-effort author keys the re-push omits", async () => {
+    const seed = await seedTeam();
+    const auth = { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: randomUUID() };
+    const p1 = payload({ source: "github", state: "old", author: "Alice", author_email: "alice@corp.com", author_login: "alice" });
+    const r1 = await ingestItem(db(), auth, p1, "team"); // first ingest WITH best-effort author keys
+    const fmOf = async () =>
+      ((await db().from("items").select("frontmatter").eq("id", r1.id).single()).data as { frontmatter: Record<string, unknown> }).frontmatter;
+
+    // same body (unchanged) but a real key changed AND the author keys are omitted (transient lookup miss)
+    const r2 = await ingestItem(db(), auth, { ...p1, frontmatter: { source: "github", state: "new" } }, "team");
+    expect(r2.status).toBe("unchanged");
+    const fm = await fmOf();
+    expect(fm.state).toBe("new"); // real change healed
+    expect(fm.author_email).toBe("alice@corp.com"); // best-effort author key PRESERVED, not wiped
+    expect(fm.author).toBe("Alice");
+  });
 });

--- a/test/graph-arcs-parse.test.ts
+++ b/test/graph-arcs-parse.test.ts
@@ -274,13 +274,20 @@ describe("balanceFacts — contributor→item (one giant doc can't BE a person's
 });
 
 describe("dedupeFacts — no wasted prompt slots on repeats / self-referential noise", () => {
-  const mk = (id: string, fact: string, subject = "s", object = "o"): AtomicFact => ({
-    id, fact, at: "2026-07-20T00:00:00Z", subjectType: "entity", subject, object, episodeUuids: [],
+  const mk = (id: string, fact: string, subject = "s", object = "o", episodeUuids: string[] = []): AtomicFact => ({
+    id, fact, at: "2026-07-20T00:00:00Z", subjectType: "entity", subject, object, episodeUuids,
   });
 
   it("drops exact-repeat fact text, keeping the first (newest) occurrence", () => {
     const out = dedupeFacts([mk("1", "Chetan fixed observability"), mk("2", "Chetan fixed observability")]);
     expect(out.map((f) => f.id)).toEqual(["1"]);
+  });
+
+  it("UNIONS the source episodes of the dropped duplicate into the kept fact", () => {
+    const out = dedupeFacts([mk("1", "same fact", "s", "o", ["epA"]), mk("2", "same fact", "s", "o", ["epB"])]);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("1"); // first kept
+    expect([...out[0].episodeUuids].sort()).toEqual(["epA", "epB"]); // both sources retained
   });
 
   it("is case/space-insensitive on the repeat check", () => {


### PR DESCRIPTION
## Why

You flagged that for narrative arcs, only **in-progress / in-review** Linear tasks are relevant — the rest are good context but shouldn't shape "what the team is working through". Grounded in prod: Linear issues arrive as **~3,063 per-issue `deliverable` items** carrying `frontmatter.state` (Backlog 237, Todo 51, **In Progress 30, In Review 4**, Done 21…), and **all** of them fed arc synthesis — so backlog/done/not-started tickets were shaping the storylines.

## What

A synthesis-time arc-eligibility filter (`lib/graph/arc-eligibility.ts`): drop facts whose source item is a Linear issue **not** In Progress / In Review, **before** balancing. Deliberately arc-synthesis-only — the excluded issues stay in the graph and the Layer-1/2 facts+events panels as **context** (still searchable); they're just removed from the arc substrate. Non-Linear content is never gated. Matched on the raw Linear state name (what the per-issue frontmatter carries), overridable via `ARCS_LINEAR_ACTIVE_STATE_RE`.

## Verification

unit (predicate: active vs backlog/done/todo; only-Linear-gated) + real-Postgres data-mechanics (`arcIneligibleItemIds` returns exactly the non-active Linear ids, never a non-Linear or active one) · tsc · lint · unit **928** · drift clean.

## Review
_Fable review pending — will update._
