### PR TITLE
docs: align PR review automation policy

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,69 +1,65 @@
 ---
 name: code-reviewer
-description: AIOS Team Brain code reviewer. Use when Opus builder opens a PR and wait-for-bots has confirmed bot reviews are ready. Reads CI results and all bot comments, then produces a structured finding list the builder can act on.
+description: AIOS Team Brain code reviewer. Consolidates exact-head Local Bugbot evidence, current-head CodeRabbit when required, CI, the PR diff, and the repository's mandatory Fable review.
 tools: Bash, Read
 ---
 
-You are the AIOS Team Brain Code Reviewer. You review pull requests after CI has run and async bot reviews (Cursor Bugbot, CodeRabbit) have posted their comments.
+You are the AIOS Team Brain Code Reviewer. Local Bugbot is canonical when the workspace ship tooling drives the change; the repository's Fable diff review remains mandatory before push. CodeRabbit is label-gated current-head evidence.
 
 ## Your job
 
 1. Read the CI check results for the PR.
-2. Read all `cursor[bot]` and `coderabbitai[bot]` comments from the PR.
+2. Read the exact Local Bugbot artifact and current-head `coderabbitai[bot]` comments/reviews when supplied.
 3. Read the diff yourself.
 4. Produce a **structured finding list** — do not just summarize the bots. Add your own analysis with AIOS-specific rules they don't know.
 
 ## AIOS Team Brain invariants to check
 
 **Sync contract (critical):**
-- `docs/brain-api.md` is pinned at v1.2. Any change to routes, request/response shape, or auth must bump the version. Flag any API change that doesn't.
+
+- `aios-workspace/docs/brain-api.md` is the pinned v1.11 contract. Any change to routes,
+  request/response shape, or auth must update that contract and the matching implementation.
 - The brain rejects `admin`-tier content at the boundary (422). No code path should expose admin-tier data to team-tier callers.
 
 **Docs drift (required by CI):**
+
 - New `app/api/**/route.ts` routes must appear in the `<!-- drift:routes -->` block of `docs/ARCHITECTURE.md`.
 - New `postgres/schema.sql` tables must appear in `<!-- drift:tables -->`.
 - New `ingestion/aios_ingest/sources/registry.py` sources must appear in `<!-- drift:sources -->`.
 - If CI `docs-drift` job failed, call it out explicitly.
 
 **Test tiers:**
+
 - Persistence and RLS changes must have a `test/datamechanics/**/*.datamechanics.test.ts` test using the real Postgres test DB. No mocks for this tier.
 - Unit tests (`test/**/*.test.ts`) must not import from `test/datamechanics/`.
 - Python ingest changes need a `pytest` test.
 
 **Access tier vocabulary:**
+
 - Canonical tiers: `admin` (never syncs), `team` (syncs to brain), `external` (syncs outward).
 - Friendly aliases `private`→admin, `client`/`company`→external are normalized on push — don't introduce new aliases.
 
 **PR hygiene:**
+
 - PR body must include `AIOS-Work: <KEY>` for `aios-work-sync` to close the Linear issue. Flag if missing.
 - No secrets, tokens, or API keys in the diff.
 
 **Stack conventions:**
+
 - Next.js App Router (`app/`), not Pages Router.
 - Vitest for tests — not Jest.
 - Postgres backend uses `postgres/schema.sql` as the canonical schema; do not introduce ad-hoc table creation.
 
-## How to gather inputs
+## Review evidence contract
 
-```bash
-# CI check status
-gh pr checks <PR_NUMBER> --repo AIOS-alpha/aios-team-brain
-
-# Bot issue comments (walkthrough summaries)
-gh api repos/AIOS-alpha/aios-team-brain/issues/<PR_NUMBER>/comments \
-  --jq '[.[] | select(.user.login | test("cursor|coderabbit")) | {user: .user.login, body: .body, created_at: .created_at}]'
-
-# Bot inline diff comments — Bugbot and CodeRabbit post findings here, not in issue comments
-gh api repos/AIOS-alpha/aios-team-brain/pulls/<PR_NUMBER>/comments \
-  --jq '[.[] | select(.user.login | test("cursor|coderabbit")) | {user: .user.login, path: .path, line: .line, body: .body}]'
-
-# Bot PR reviews (submitted review objects)
-gh api repos/AIOS-alpha/aios-team-brain/pulls/<PR_NUMBER>/reviews \
-  --jq '[.[] | select(.user.login | test("cursor|coderabbit")) | {user: .user.login, state: .state, body: .body}]'
-
-# PR diff
-gh pr diff <PR_NUMBER> --repo AIOS-alpha/aios-team-brain
-```
+- Before push, run the mandatory Fable review over `git diff origin/main...HEAD` and record its
+  verdict in the PR body.
+- Local Bugbot markdown is scoped to the exact branch head and verified base SHA. Do not reuse it
+  after a fix commit or base movement.
+- CodeRabbit is triggered by `ready-for-review`. Only substantive issue comments, inline comments,
+  or submitted reviews created at or after the latest PR commit count. A successful check run alone
+  does not count. After a later push, request `@coderabbitai review` because incremental review is off.
+- Remote queries must select only `coderabbitai[bot]`; do not query or wait for `cursor[bot]`.
 
 ## Output format
 
@@ -76,8 +72,8 @@ Return findings as a structured list. Be concise — the builder needs to act on
 [PASS|FAIL] datamechanics-tests
 [PASS|FAIL] ingestion-tests
 
-## Bot Findings (synthesized)
-[severity] file:line — description (source: Bugbot|CodeRabbit)
+## Review Findings (synthesized)
+[severity] file:line — description (source: Local Bugbot|CodeRabbit|Fable)
 
 ## AIOS Rule Violations
 [severity] description — rule violated

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,15 +1,15 @@
 ---
 name: code-reviewer
-description: AIOS Team Brain code reviewer. Consolidates exact-head Local Bugbot evidence, current-head CodeRabbit when required, CI, the PR diff, and the repository's mandatory Fable review.
+description: AIOS Team Brain code reviewer. Consolidates whatever review evidence exists — a local diff review (Local Bugbot or Fable, per author), label-gated CodeRabbit, CI — plus its own diff analysis.
 tools: Bash, Read
 ---
 
-You are the AIOS Team Brain Code Reviewer. Local Bugbot is canonical when the workspace ship tooling drives the change; the repository's Fable diff review remains mandatory before push. CodeRabbit is label-gated current-head evidence.
+You are the AIOS Team Brain Code Reviewer. The team is small and uses different local reviewers (John: Local Bugbot via Cursor; Chetan: Fable) — treat whichever ran as the local evidence; none of them hard-blocks. CodeRabbit is label-gated (`ready-for-review`) current-head evidence.
 
 ## Your job
 
 1. Read the CI check results for the PR.
-2. Read the exact Local Bugbot artifact and current-head `coderabbitai[bot]` comments/reviews when supplied.
+2. Read whatever local review evidence the PR body records (Local Bugbot or Fable) and any current-head `coderabbitai[bot]` comments/reviews.
 3. Read the diff yourself.
 4. Produce a **structured finding list** — do not just summarize the bots. Add your own analysis with AIOS-specific rules they don't know.
 
@@ -52,14 +52,39 @@ You are the AIOS Team Brain Code Reviewer. Local Bugbot is canonical when the wo
 
 ## Review evidence contract
 
-- Before push, run the mandatory Fable review over `git diff origin/main...HEAD` and record its
-  verdict in the PR body.
-- Local Bugbot markdown is scoped to the exact branch head and verified base SHA. Do not reuse it
-  after a fix commit or base movement.
-- CodeRabbit is triggered by `ready-for-review`. Only substantive issue comments, inline comments,
-  or submitted reviews created at or after the latest PR commit count. A successful check run alone
-  does not count. After a later push, request `@coderabbitai review` because incremental review is off.
-- Remote queries must select only `coderabbitai[bot]`; do not query or wait for `cursor[bot]`.
+- A local diff review (Local Bugbot or Fable, whichever the author has) over
+  `git diff origin/main...HEAD` should be recorded in the PR body. If none ran, the
+  `ready-for-review` label should be on the PR (CodeRabbit reviews instead). Flag a PR with
+  neither — but this is advisory; only CI blocks a merge.
+- Local review evidence is scoped to the branch head it reviewed. Treat it as stale after a fix
+  commit or base movement.
+- CodeRabbit auto-review fires only on PRs labeled `ready-for-review`. Only substantive comments
+  or submitted reviews created at or after the latest PR commit count as fresh evidence. After a
+  later push, request `@coderabbitai review` (incremental review is off).
+- When querying remote bots, select `coderabbitai[bot]`; do not wait on `cursor[bot]` (remote
+  Bugbot is disabled for this repo).
+
+## How to gather inputs
+
+```bash
+# CI check status
+gh pr checks <PR_NUMBER> --repo aiosbrain/aios-team-brain
+
+# CodeRabbit issue comments (walkthrough summaries)
+gh api repos/aiosbrain/aios-team-brain/issues/<PR_NUMBER>/comments \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]") | {body: .body, created_at: .created_at}]'
+
+# CodeRabbit inline diff comments — findings land here, NOT in issue comments
+gh api repos/aiosbrain/aios-team-brain/pulls/<PR_NUMBER>/comments \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]") | {path: .path, line: .line, body: .body}]'
+
+# CodeRabbit submitted reviews
+gh api repos/aiosbrain/aios-team-brain/pulls/<PR_NUMBER>/reviews \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]") | {state: .state, body: .body, submitted_at: .submitted_at}]'
+
+# PR diff
+gh pr diff <PR_NUMBER> --repo aiosbrain/aios-team-brain
+```
 
 ## Output format
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
-version: "2"
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 
 reviews:
@@ -9,8 +9,11 @@ reviews:
   review_status: true
   collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
+    labels:
+      - ready-for-review
+    auto_incremental_review: false
     base_branches:
       - main
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,10 @@ reviews:
   review_status: true
   collapse_walkthrough: false
   auto_review:
-    enabled: false
+    # Label-gated: `labels` filters AUTOMATIC reviews, so enabled must stay true —
+    # with enabled:false the label never triggers anything. Reviews fire only on
+    # PRs carrying `ready-for-review`; use `@coderabbitai review` after fix pushes.
+    enabled: true
     drafts: false
     labels:
       - ready-for-review

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # AIOS Team Brain — code owners
 # All PRs require review from core team.
-* @AIOS-alpha/core
+* @aiosbrain/core
 
 # Sync contract — extra scrutiny for API changes
-docs/brain-api.md @AIOS-alpha/core
-app/api/ @AIOS-alpha/core
-postgres/schema.sql @AIOS-alpha/core
+docs/brain-api.md @aiosbrain/core
+app/api/ @aiosbrain/core
+postgres/schema.sql @aiosbrain/core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 * @aiosbrain/core
 
 # Sync contract — extra scrutiny for API changes
-docs/brain-api.md @aiosbrain/core
+# (the pinned contract itself lives in aios-workspace/docs/brain-api.md)
 app/api/ @aiosbrain/core
 postgres/schema.sql @aiosbrain/core

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
      No task yet, and this work should be tracked? Create one FIRST in the Team Brain dashboard
      (→ Tasks; it projects to Linear), then put its key here. Don't hand-edit the Linear issue —
      the brain is the source of truth, Linear is a one-way projection. -->
+
 AIOS-Work: <!-- e.g. AIO-72 -->
 
 ## Checklist
@@ -18,8 +19,12 @@ AIOS-Work: <!-- e.g. AIO-72 -->
 - [ ] Ingestion tests pass if Python changed: `cd ingestion && pytest -q`
 - [ ] `brain-api.md` version bumped if sync protocol changed
 - [ ] No secrets or admin-tier content in diff
+- [ ] Mandatory Fable diff review is recorded below
+- [ ] Exact-head Local Bugbot is clear when workspace ship tooling is used
+- [ ] If safety-sensitive or explicitly selected: `ready-for-review` is applied and current-head CodeRabbit evidence exists
+- [ ] Safety-sensitive PRs use the operator merge gate (never `--auto-merge`)
 
-## Bot review summary
+## Review summary
 
-<!-- After Bugbot + CodeRabbit post, paste a one-line summary of their findings here,
-     or write "no blocking findings." Helps reviewers scan quickly. -->
+<!-- Include: Reviewed by Fable — verdict …; Local Bugbot; and CodeRabbit when required.
+     After a fix push, refresh CodeRabbit with `@coderabbitai review`. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,12 +19,11 @@ AIOS-Work: <!-- e.g. AIO-72 -->
 - [ ] Ingestion tests pass if Python changed: `cd ingestion && pytest -q`
 - [ ] `brain-api.md` version bumped if sync protocol changed
 - [ ] No secrets or admin-tier content in diff
-- [ ] Mandatory Fable diff review is recorded below
-- [ ] Exact-head Local Bugbot is clear when workspace ship tooling is used
-- [ ] If safety-sensitive or explicitly selected: `ready-for-review` is applied and current-head CodeRabbit evidence exists
-- [ ] Safety-sensitive PRs use the operator merge gate (never `--auto-merge`)
+- [ ] Local diff review recorded below (Local Bugbot or Fable — whichever you have), or the
+      `ready-for-review` label is applied so CodeRabbit reviews instead
 
 ## Review summary
 
-<!-- Include: Reviewed by Fable — verdict …; Local Bugbot; and CodeRabbit when required.
-     After a fix push, refresh CodeRabbit with `@coderabbitai review`. -->
+<!-- One line: Reviewed by <Local Bugbot|Fable|CodeRabbit> — verdict …
+     No local reviewer available? Apply the `ready-for-review` label (triggers CodeRabbit).
+     After a fix push, refresh CodeRabbit with `@coderabbitai review` (incremental review is off). -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,23 +26,23 @@ who reads it**. The map only pays off if it's trustworthy, so:
 
 ---
 
-## ⚠️ Review gate — ALWAYS Fable-review before pushing a PR (REQUIRED)
+## Review gate — local review before pushing a PR (flexible, non-blocking)
 
-Many sessions/worktrees ship into this repo in parallel and merge fast — **a Fable review is the
-pre-merge safety net** that catches tier leaks, sync-contract drift, and correctness bugs the
-mandatory Local Bugbot and label-gated CodeRabbit review may miss. It is **not optional**.
+Many sessions/worktrees ship into this repo in parallel and merge fast — a pre-push review of the
+branch diff catches tier leaks, sync-contract drift, and correctness bugs before they land. We are
+a small team on different local tools, so the gate is **tool-flexible and never blocks a push**:
 
-- **Before you `git push` a PR branch:** run a Fable review of the branch diff — spawn the
-  **`code-reviewer` agent on the Fable model** (`Agent(subagent_type: "code-reviewer", model: "fable")`)
-  pointed at `git diff origin/main...HEAD`. Give it the change's intent and let it apply the AIOS
-  invariants (this file + the agent's own checklist).
-- **Address its findings first.** Fix every blocker/HIGH; fix or consciously defer MEDIUM/LOW with a
-  one-line reason. Only push once Fable's verdict is _sound / ship it_ (or its blockers are resolved).
-- **Record it in the PR body** — a short `## Review — Reviewed by **Fable** — verdict …` line (with the
-  findings it caught + how you resolved them), so it's auditable which PRs were Fable-reviewed and
-  which weren't. Absence of that line means the gate was skipped.
-- Fable reviews the **diff you're about to ship**, not the bots' comments — it adds its own analysis.
-  This is in addition to CI, Local Bugbot, and current-head CodeRabbit when required, never a replacement.
+- **Before you `git push` a PR branch:** review `git diff origin/main...HEAD` with whichever local
+  reviewer you have — **Local Bugbot** (John, via Cursor) or a **Fable `code-reviewer` run**
+  (Chetan — `Agent(subagent_type: "code-reviewer", model: "fable")`). Any equivalent local diff
+  review counts; use what's available.
+- **Address blocker/HIGH findings before pushing**; fix or consciously defer MEDIUM/LOW with a
+  one-line reason.
+- **Record what reviewed the diff in the PR body** — one `## Review — Reviewed by <tool> — verdict …`
+  line so it's auditable. If no local reviewer was available, say so and apply the
+  `ready-for-review` label so CodeRabbit reviews the PR instead.
+- The local review examines the **diff you're about to ship**, not the bots' comments. It
+  complements CI and label-gated CodeRabbit; only the required CI checks block a merge.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ who reads it**. The map only pays off if it's trustworthy, so:
   flow. Reason from the source of truth, never from a random call site.
 - **AFTER building:** update the map **in the same PR**. A wrong map is worse than none.
 - The enumerable surfaces (API routes, DB tables, ingestion sources) are **machine-guarded**
-  by `scripts/check-docs-drift.mjs` (CI job *Docs drift guard* + the local `.githooks/pre-push`
+  by `scripts/check-docs-drift.mjs` (CI job _Docs drift guard_ + the local `.githooks/pre-push`
   hook). If you add/remove a route, table, or source, update the `<!-- drift:* -->` blocks in
   the same change or the build fails. Hand-maintained prose/diagrams are on you — keep them honest.
 
@@ -29,27 +29,27 @@ who reads it**. The map only pays off if it's trustworthy, so:
 ## ⚠️ Review gate — ALWAYS Fable-review before pushing a PR (REQUIRED)
 
 Many sessions/worktrees ship into this repo in parallel and merge fast — **a Fable review is the
-pre-merge safety net** that catches tier leaks, sync-contract drift, and correctness bugs the async
-bots (CodeRabbit/Cursor) miss. It is **not optional**.
+pre-merge safety net** that catches tier leaks, sync-contract drift, and correctness bugs the
+mandatory Local Bugbot and label-gated CodeRabbit review may miss. It is **not optional**.
 
 - **Before you `git push` a PR branch:** run a Fable review of the branch diff — spawn the
   **`code-reviewer` agent on the Fable model** (`Agent(subagent_type: "code-reviewer", model: "fable")`)
   pointed at `git diff origin/main...HEAD`. Give it the change's intent and let it apply the AIOS
   invariants (this file + the agent's own checklist).
 - **Address its findings first.** Fix every blocker/HIGH; fix or consciously defer MEDIUM/LOW with a
-  one-line reason. Only push once Fable's verdict is *sound / ship it* (or its blockers are resolved).
+  one-line reason. Only push once Fable's verdict is _sound / ship it_ (or its blockers are resolved).
 - **Record it in the PR body** — a short `## Review — Reviewed by **Fable** — verdict …` line (with the
   findings it caught + how you resolved them), so it's auditable which PRs were Fable-reviewed and
   which weren't. Absence of that line means the gate was skipped.
 - Fable reviews the **diff you're about to ship**, not the bots' comments — it adds its own analysis.
-  This is in addition to CI and the async bot reviews, never a replacement.
+  This is in addition to CI, Local Bugbot, and current-head CodeRabbit when required, never a replacement.
 
 ---
 
 ## 2. Four operating principles (internalize these)
 
 1. **Spec-first testing, never characterization-first.** Write the assertion from what the
-   product *should* do (the brain-api contract, the tier intent, a scenario), then run it.
+   product _should_ do (the brain-api contract, the tier intent, a scenario), then run it.
    A spec-derived test that goes **red** found a real gap — that's the point. Tests that read
    the implementation and assert what it already does are green by construction and forbidden
    as the default. For a confirmed-but-unfixed gap, use `it.fails(...)` so it stays green until
@@ -59,7 +59,7 @@ bots (CodeRabbit/Cursor) miss. It is **not optional**.
    matters ("only `lib/ingest` writes `items`"), make ONE owner the only legal writer and add a
    test that **fails the build** when anything else violates it.
 3. **Verify to the observable outcome.** A claim isn't real until a red test reproduces the bad
-   *outcome* (wrong row in the DB, a leaked cross-tier row, wrong state) — not a name, a proxy,
+   _outcome_ (wrong row in the DB, a leaked cross-tier row, wrong state) — not a name, a proxy,
    or a call-site reading. Treat audits and AI-suggested bugs as hypotheses to re-derive.
 4. **The architecture map is a required step in the build loop** (§1).
 
@@ -76,14 +76,14 @@ the near-term-satisfaction shortcut.
 
 ## 4. Test tiers — which failure mode each catches
 
-Put a spec-derived test in the tier that catches *its* failure mode:
+Put a spec-derived test in the tier that catches _its_ failure mode:
 
-| Tier | Runs against | Catches |
-|---|---|---|
-| **unit** (`vitest.config.ts`) | nothing (pure) | parse/format boundaries, pure logic, **all drift/contract guards** |
-| **data-mechanics** (`vitest.datamechanics.config.ts`) | **real Postgres, stubbed model** | persistence & access: write→store→read, dedup, diff-sync, tier isolation |
+| Tier                                                           | Runs against                                                                                      | Catches                                                                                     |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **unit** (`vitest.config.ts`)                                  | nothing (pure)                                                                                    | parse/format boundaries, pure logic, **all drift/contract guards**                          |
+| **data-mechanics** (`vitest.datamechanics.config.ts`)          | **real Postgres, stubbed model**                                                                  | persistence & access: write→store→read, dedup, diff-sync, tier isolation                    |
 | **integration** (`vitest.http.config.ts`, `npm run test:http`) | the API over a **real socket** (`next start` + real Postgres) + the system-level `scripts/e2e.sh` | routing, auth, tier-422, cookies/headers, the JSON wire format, the cross-process sync loop |
-| **eval** *(not built)* | real model API | model judgment (grounded-answer quality) — exercised live in `e2e.sh` step 9 |
+| **eval** _(not built)_                                         | real model API                                                                                    | model judgment (grounded-answer quality) — exercised live in `e2e.sh` step 9                |
 
 Mental model: **unit = parse/guards · data-mechanics = persistence + access · integration =
 routing/auth · eval = model judgment.** Don't let a tier that stubs the model + clean inputs give
@@ -101,7 +101,7 @@ cannot verify persistence or access to the observable outcome. The real-Postgres
 **Deployment model:** AIOS is **self-hosted per organization** — each org runs its own instance
 against its own database; all rows belong to that one org. So there is **no shared multi-tenant
 DB**, and cross-organization isolation is **not** a concern. The `team_id` scoping is purely
-*internal* (separating teams *within* one org's DB) and only matters if an instance hosts more
+_internal_ (separating teams _within_ one org's DB) and only matters if an instance hosts more
 than one team.
 
 **What still matters regardless of multi-tenancy: TIER isolation.** An `external`-tier principal
@@ -163,7 +163,7 @@ bash scripts/e2e.sh    # system-level integration: seed → push → materialize
 - **Deploy:** Postgres on Railway (self-host portable). **Deploys happen ONLY by merging to `main`** —
   Railway's GitHub integration auto-builds AIOS → `aios-team-brain`. After a merge, run `npm run pg:schema`
   against prod for any schema change, and **confirm the platform started a new build** (`railway deployment
-  list`; CI webhooks can be silently dropped) — re-trigger via the Railway dashboard if the latest deploy
+list`; CI webhooks can be silently dropped) — re-trigger via the Railway dashboard if the latest deploy
   predates the merge.
 - **Inspecting the prod DB (read-only, for diagnostics).** The internal `DATABASE_URL`
   (`postgres.railway.internal`) is unreachable from a laptop; use the **public TCP proxy** the Railway
@@ -177,12 +177,12 @@ bash scripts/e2e.sh    # system-level integration: seed → push → materialize
   write as production data mutation: confirm with the user first.
 - **⛔ NEVER run `railway up` / `railway redeploy` / `railway down` / `railway delete`.** The Railway CLI is
   **read-only** here (`status`, `logs`, `variables`, `deployment list`, `connect`). `railway up` deploys the current
-  worktree's code to whatever project that directory is *linked* to (`~/.railway/config.json`, keyed by
+  worktree's code to whatever project that directory is _linked_ to (`~/.railway/config.json`, keyed by
   absolute path) — and a Conductor worktree that drifted to the wrong link (an aios worktree linked to the
   **Kula** project) once shipped this repo's code into Kula and took it down. The GitHub-merge path is bound
   to the right project and cannot do that. This is **guarded**: `.claude/settings.json` denies those verbs +
   a PreToolUse hook (`scripts/railway-deploy-guard.sh`) blocks them (incl. `cd other && railway up`). Before
-  *any* Railway command, confirm `railway status` shows **Project: AIOS**; audit all worktrees with
+  _any_ Railway command, confirm `railway status` shows **Project: AIOS**; audit all worktrees with
   `bash scripts/railway-link-check.sh`.
 - **Runtime backstop (`scripts/service-guard.mjs`).** The hook above only fires inside the agent's shell; it
   can't stop a human `railway up` or any other path that lands this code on a foreign service. So the schema
@@ -198,5 +198,5 @@ bash scripts/e2e.sh    # system-level integration: seed → push → materialize
 
 Build scaffolding upfront; build **guards and invariants reactively** — each must trace to a real
 bug or a real contract. A guard with no failure mode behind it is ceremony. When you change a
-class of thing the docs/contract describe, ask: *"is there a guard that would catch this drift,
-and if not, that's what to build."*
+class of thing the docs/contract describe, ask: _"is there a guard that would catch this drift,
+and if not, that's what to build."_

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -13,12 +13,12 @@ flowchart TD
     subgraph AgentLoop["Multi-Agent Dev Loop (local)"]
         A1[Opus — Planner\nCreates spec / Linear issue] --> A2[Codex — Critic\nReviews plan]
         A2 --> A3[Opus — Planner\nFinalizes plan]
-        A3 --> A4[Opus — Builder\nImplements + mandatory\nlocal/Fable review]
+        A3 --> A4["Opus — Builder\nImplements + local review\n(Local Bugbot or Fable)"]
         A4 --> A4P[Opens PR via gh]
-        A4P -->|when selected or safety-required| A4W{Current-head\nCodeRabbit landed?}
-        A4W -->|yes| A5[AIOS Code Reviewer\nReads CI + Local Bugbot\n+ CodeRabbit + Fable]
-        A4W -->|timeout| BLOCK[Block; do not merge]
-        A4P -->|Standard without label| A5
+        A4P -->|ready-for-review label| A4W{Current-head\nCodeRabbit landed?}
+        A4W -->|yes| A5["AIOS Code Reviewer\nReads CI + local review\n+ CodeRabbit evidence"]
+        A4W -->|timeout| A5
+        A4P -->|no label| A5
         A5 -->|findings| A4
         A5 -->|clear| MERGE[Human approves\n+ merges]
     end
@@ -76,25 +76,31 @@ Extracts `AIOS-Work: <KEY>` from the PR title/body and POSTs a merge event to `/
 
 ## Review evidence
 
-Local Bugbot is the canonical automated review when the workspace ship tooling drives the change.
-Its markdown artifact is valid only for the exact branch head and verified base SHA. This repository
-also requires the independent Fable diff review before push, recorded in the PR body.
+The team is small and members use different local reviewers — **John runs Local Bugbot (Cursor)**,
+**Chetan runs Fable** (`Agent(subagent_type: "code-reviewer", model: "fable")` from the
+`aios-workspace` ship tooling). Whichever ran is the local evidence, recorded as one line in the
+PR body. Local review evidence is scoped to the branch head it reviewed — treat it as stale after
+a fix commit or base movement. **None of this blocks a push or merge; only the required CI checks
+do.**
 
-CodeRabbit runs outside GitHub Actions and posts to the PR conversation. `.coderabbit.yaml` disables
-automatic review and incremental review; applying `ready-for-review` triggers the initial review.
-CodeRabbit is optional for Standard PRs and mandatory for safety-sensitive PRs. After a fix push,
-post `@coderabbitai review` to obtain fresh evidence.
+CodeRabbit runs outside GitHub Actions and posts to the PR conversation. `.coderabbit.yaml` keeps
+`auto_review.enabled: true` but restricts it with `labels: [ready-for-review]` — auto-review fires
+only on PRs carrying that label (`labels` filters automatic reviews; it is not a trigger on its
+own). Incremental review is off, so after a fix push post `@coderabbitai review` for fresh
+evidence. Apply the label when no local reviewer was available, or whenever you want the extra
+pass.
 
-The shared waiter lives in `aios-workspace` and accepts only substantive `coderabbitai[bot]` issue
-comments, inline comments, or submitted reviews at or after the latest PR commit:
+To wait for CodeRabbit, use the shared waiter from `aios-workspace` **with the `--bots` flag** —
+its default gates on `cursor[bot]` too (remote Bugbot is disabled here, so the default would just
+time out), and a completed check run can satisfy it, so read the printed signal and prefer comment
+or review text as evidence:
 
 ```bash
 node /path/to/aios-workspace/scripts/wait-for-bots.mjs \
-  --pr <n> --repo aiosbrain/aios-team-brain
+  --pr <n> --repo aiosbrain/aios-team-brain --bots 'coderabbitai[bot]'
 ```
 
-A successful check run alone, a rate-limit stub, or pre-push text does not satisfy the gate. The
-tool does not query or wait for `cursor[bot]`.
+Rate-limit stubs and pre-push text are rejected by the waiter automatically.
 
 ---
 
@@ -138,12 +144,12 @@ Repo: `aiosbrain/aios-team-brain` → Settings → Branches → `main`
 1. Opus (Planner)  → creates spec from Linear issue
 2. Codex (Critic)  → reviews plan, requests changes
 3. Opus (Planner)  → finalizes, hands off to builder
-4. Opus (Builder)  → implements, commits, opens PR
-5.                   GitHub Actions CI fires (parallel jobs)
-6. Fable           → reviews the exact branch diff before push; verdict recorded in PR
-7. CodeRabbit      → label-triggered when selected/safety-required; current-head text required
-8. Code Reviewer   → reads CI + Local Bugbot + current-head CodeRabbit + Fable evidence
-9. Opus (Builder)  → addresses findings; a push invalidates prior review evidence
-10. Human/operator → approves + merges (safety work cannot use `--auto-merge`)
+4. Local review    → Local Bugbot (John) or Fable (Chetan) on the branch diff; recorded in PR body
+5. Opus (Builder)  → commits, opens PR
+6.                   GitHub Actions CI fires (parallel jobs)
+7. CodeRabbit      → fires only on PRs labeled ready-for-review (auto_review label filter)
+8. Code Reviewer   → reads CI + whatever local review ran + current-head CodeRabbit evidence
+9. Opus (Builder)  → addresses findings; a push makes prior review evidence stale
+10. Human          → approves + merges (only required CI checks block)
 11.                  aios-work-sync fires → Linear issue closed
 ```

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -13,10 +13,12 @@ flowchart TD
     subgraph AgentLoop["Multi-Agent Dev Loop (local)"]
         A1[Opus — Planner\nCreates spec / Linear issue] --> A2[Codex — Critic\nReviews plan]
         A2 --> A3[Opus — Planner\nFinalizes plan]
-        A3 --> A4[Opus — Builder\nImplements, commits\nopens PR via gh]
-        A4 -->|wait-for-bots.mjs\npoll every 30s ≤10 min| A4W{Bots landed?}
-        A4W -->|yes| A5[AIOS Code Reviewer\nReads CI + Bugbot\n+ CodeRabbit findings]
-        A4W -->|timeout| A5
+        A3 --> A4[Opus — Builder\nImplements + mandatory\nlocal/Fable review]
+        A4 --> A4P[Opens PR via gh]
+        A4P -->|when selected or safety-required| A4W{Current-head\nCodeRabbit landed?}
+        A4W -->|yes| A5[AIOS Code Reviewer\nReads CI + Local Bugbot\n+ CodeRabbit + Fable]
+        A4W -->|timeout| BLOCK[Block; do not merge]
+        A4P -->|Standard without label| A5
         A5 -->|findings| A4
         A5 -->|clear| MERGE[Human approves\n+ merges]
     end
@@ -31,9 +33,7 @@ flowchart TD
     end
 
     subgraph BotReviews["Async Bot Reviews — GitHub Apps"]
-        C1["Cursor Bugbot\nGeneral LLM review\n1–5 min after PR opens"]
-        C2["CodeRabbit\nWalkthrough + inline\n~2 min after PR opens"]
-        C3["Cursor Security Reviewer\nSecurity-focused analysis\n~2–5 min after PR opens"]
+        C1["CodeRabbit\nready-for-review label-gated\ncurrent-head text only"]
     end
 
     subgraph GitHubPR["GitHub PR"]
@@ -42,7 +42,7 @@ flowchart TD
         D3["Security tab\n(SAST — not yet wired)"]
     end
 
-    A4 -->|gh pr create| GitHubPR
+    A4P --> GitHubPR
     GitHubPR --> GitHubActions
     GitHubPR --> BotReviews
     GitHubActions --> D1
@@ -56,13 +56,13 @@ flowchart TD
 
 ### `ci.yml` — required gate on every PR and push to `main`
 
-| Job | What it runs | Blocks merge? |
-|---|---|---|
-| `docs-drift` | `node scripts/check-docs-drift.mjs` — validates routes, tables, sources against `docs/ARCHITECTURE.md` markers | Yes |
-| `brain-tests` | `npm test` — vitest unit tests (pure logic, parse/format, contract guards) | Yes |
-| `datamechanics-tests` | `npm run test:datamechanics` against real Postgres 16 (port 5434) — RLS, persistence, access control | Yes |
-| `http-tests` | `npm run build` + `npm run test:http` — the API over a real socket against Postgres 16: TCP fetch, the Next.js route runtime (cookies/headers), JSON wire format | No (advisory) |
-| `ingestion-tests` | `pytest -q` inside `ingestion/` — Python ingest pipeline | Yes |
+| Job                   | What it runs                                                                                                                                                     | Blocks merge? |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `docs-drift`          | `node scripts/check-docs-drift.mjs` — validates routes, tables, sources against `docs/ARCHITECTURE.md` markers                                                   | Yes           |
+| `brain-tests`         | `npm test` — vitest unit tests (pure logic, parse/format, contract guards)                                                                                       | Yes           |
+| `datamechanics-tests` | `npm run test:datamechanics` against real Postgres 16 (port 5434) — RLS, persistence, access control                                                             | Yes           |
+| `http-tests`          | `npm run build` + `npm run test:http` — the API over a real socket against Postgres 16: TCP fetch, the Next.js route runtime (cookies/headers), JSON wire format | No (advisory) |
+| `ingestion-tests`     | `pytest -q` inside `ingestion/` — Python ingest pipeline                                                                                                         | Yes           |
 
 The four required jobs (`docs-drift`, `brain-tests`, `datamechanics-tests`, `ingestion-tests`) must pass for a PR to merge (enforced via branch protection). `http-tests` runs `continue-on-error` (advisory) until it proves stable — see Branch Protection below.
 
@@ -74,31 +74,34 @@ Extracts `AIOS-Work: <KEY>` from the PR title/body and POSTs a merge event to `/
 
 ---
 
-## Async Bot Reviews
+## Review evidence
 
-These run outside GitHub Actions and post comments to the PR conversation. They are not required checks — they are signals for the Code Reviewer agent.
+Local Bugbot is the canonical automated review when the workspace ship tooling drives the change.
+Its markdown artifact is valid only for the exact branch head and verified base SHA. This repository
+also requires the independent Fable diff review before push, recorded in the PR body.
 
-| Bot | GitHub user | Typical delay | What it covers |
-|---|---|---|---|
-| Cursor Bugbot | `cursor[bot]` | 1–5 min | General logic, naming, patterns |
-| CodeRabbit | `coderabbitai[bot]` | ~2 min | Walkthrough summary + inline suggestions |
-| Cursor Security Reviewer | `cursor[bot]` | 2–5 min | Auth, injection, secrets, access control |
+CodeRabbit runs outside GitHub Actions and posts to the PR conversation. `.coderabbit.yaml` disables
+automatic review and incremental review; applying `ready-for-review` triggers the initial review.
+CodeRabbit is optional for Standard PRs and mandatory for safety-sensitive PRs. After a fix push,
+post `@coderabbitai review` to obtain fresh evidence.
 
-**Polling:** The builder agent runs `wait-for-bots.mjs` from the `aios-workspace` repo, passing `--repo` explicitly to target any AIOS-alpha repo:
+The shared waiter lives in `aios-workspace` and accepts only substantive `coderabbitai[bot]` issue
+comments, inline comments, or submitted reviews at or after the latest PR commit:
 
 ```bash
 node /path/to/aios-workspace/scripts/wait-for-bots.mjs \
-  --pr <n> --repo AIOS-alpha/aios-team-brain
+  --pr <n> --repo aiosbrain/aios-team-brain
 ```
 
-The script lives only in `aios-workspace` (not duplicated here) — it is a shared cross-repo tool. It blocks until `cursor[bot]` and `coderabbitai[bot]` have both posted substantive feedback after the latest push (rate-limit stubs and pre-push comments are rejected), then prints a summary before the Code Reviewer agent runs.
+A successful check run alone, a rate-limit stub, or pre-push text does not satisfy the gate. The
+tool does not query or wait for `cursor[bot]`.
 
 ---
 
 ## Local Development Hooks
 
-| Hook | When | What |
-|---|---|---|
+| Hook                 | When             | What                                                              |
+| -------------------- | ---------------- | ----------------------------------------------------------------- |
 | `.githooks/pre-push` | Every `git push` | Runs `check-docs-drift.mjs` — blocks push if docs are out of sync |
 
 Installed automatically via `npm prepare` → `git config core.hooksPath .githooks`.
@@ -119,7 +122,7 @@ If you add an API route, table, or ingest source, update the corresponding `<!--
 
 ## Branch Protection (required — verify in GitHub Settings)
 
-Repo: `AIOS-alpha/aios-team-brain` → Settings → Branches → `main`
+Repo: `aiosbrain/aios-team-brain` → Settings → Branches → `main`
 
 - [x] Require status checks: `docs-drift`, `brain-tests`, `datamechanics-tests`, `ingestion-tests`
 - [ ] `http-tests` — currently advisory (`continue-on-error`). Graduate to required after 5 consecutive green runs on `main`: drop `continue-on-error` in `ci.yml` and add it to this list.
@@ -137,10 +140,10 @@ Repo: `AIOS-alpha/aios-team-brain` → Settings → Branches → `main`
 3. Opus (Planner)  → finalizes, hands off to builder
 4. Opus (Builder)  → implements, commits, opens PR
 5.                   GitHub Actions CI fires (parallel jobs)
-6.                   Cursor Bugbot + CodeRabbit fire async
-7. wait-for-bots   → polls every 30s until both bots have posted (≤10 min)
-8. Code Reviewer   → reads CI status + all bot comments → structured findings
-9. Opus (Builder)  → addresses findings, pushes fix commits if needed
-10. Human          → approves + merges
+6. Fable           → reviews the exact branch diff before push; verdict recorded in PR
+7. CodeRabbit      → label-triggered when selected/safety-required; current-head text required
+8. Code Reviewer   → reads CI + Local Bugbot + current-head CodeRabbit + Fable evidence
+9. Opus (Builder)  → addresses findings; a push invalidates prior review evidence
+10. Human/operator → approves + merges (safety work cannot use `--auto-merge`)
 11.                  aios-work-sync fires → Linear issue closed
 ```

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -1,8 +1,8 @@
 # Ops hardening — Sentry, CodeRabbit, BugBot
 
-This note covers the observability + automated-review stack added in **W1.4**. The Sentry
-_code_ is wired in this repo; CodeRabbit and BugBot are GitHub/Cursor apps that a human org
-owner must approve (they cannot be enabled from code).
+This note covers the observability + automated-review stack added in **W1.4**. Sentry is wired in
+code; CodeRabbit is configured in-repository but installed as a GitHub App, and the per-repository
+Cursor Bugbot setting is managed manually in Cursor.
 
 ---
 
@@ -83,34 +83,37 @@ stack traces pointing at the original source files.
 
 ---
 
-## 2. CodeRabbit (automated PR review) — W1.4.2 — HUMAN STEP
+## 2. CodeRabbit (label-gated PR review) — W1.4.2
 
-CodeRabbit is a GitHub App; it is **free for public repos**. It cannot be enabled from code —
-an org owner must install it.
+CodeRabbit remains installed on the `aiosbrain` repositories, but `.coderabbit.yaml` disables
+automatic and incremental review. The positive `ready-for-review` label triggers an initial review.
 
-1. Go to <https://github.com/apps/coderabbitai> and click **Install** (or sign in at
-   <https://coderabbit.ai> with GitHub).
-2. Install it on the **AIOS-alpha** org and select the public AIOS repos
-   (`aios-team-brain`, `aios-workspace`, `aios-website`), or "All repositories".
-3. CodeRabbit then auto-reviews new PRs. Optional: add a `.coderabbit.yaml` at repo root later
-   to tune review behavior; the defaults are fine to start.
+1. Ensure the repository label exists:
 
-No env vars or secrets in this repo are required.
+   ```bash
+   gh label create ready-for-review --repo aiosbrain/aios-team-brain \
+     --description "Trigger CodeRabbit review for the current PR head" --color 0E8A16
+   ```
+
+2. Apply it only when CodeRabbit is explicitly selected, or whenever the diff is safety-sensitive.
+3. After any later push, comment `@coderabbitai review`; the label does not trigger incremental
+   reviews while `auto_incremental_review: false`.
+4. Accept only substantive comments/reviews created at or after the latest PR commit. A green check
+   run without review text is not evidence.
+
+No repository secret is required.
 
 ---
 
-## 3. BugBot (Cursor) — W1.4.3 — HUMAN STEP
+## 3. Cursor Bugbot — W1.4.3 — HUMAN STEP
 
-BugBot is Cursor's automated PR bug-finder. Enabling it requires approving the Cursor app for
-the org (John is the **AIOS-alpha** org owner).
+Remote Cursor Bugbot must be disabled for this repository to avoid duplicating the mandatory Local
+Bugbot gate. In the Cursor dashboard, open the GitHub/Bugbot installations list and disable Bugbot
+for `aiosbrain/aios-team-brain` specifically.
 
-1. In Cursor, enable BugBot for the org (Cursor dashboard → BugBot / GitHub integration),
-   which initiates a GitHub App authorization for **AIOS-alpha**.
-2. Approve the Cursor app at **GitHub → AIOS-alpha org → Settings → Third-party Access**
-   (GitHub Apps / OAuth app access). As org owner, John approves the pending Cursor request.
-3. Grant it access to the public AIOS repos. BugBot then comments on PRs with potential bugs.
-
-No env vars or secrets in this repo are required.
+Do not use an undocumented API and do not uninstall the all-repository Cursor GitHub App: other
+Cursor integration access remains in use. After changing the setting, verify on a non-draft PR that
+no `cursor[bot]` review activity appears.
 
 ---
 

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -85,8 +85,10 @@ stack traces pointing at the original source files.
 
 ## 2. CodeRabbit (label-gated PR review) — W1.4.2
 
-CodeRabbit remains installed on the `aiosbrain` repositories, but `.coderabbit.yaml` disables
-automatic and incremental review. The positive `ready-for-review` label triggers an initial review.
+CodeRabbit remains installed on the `aiosbrain` repositories. `.coderabbit.yaml` keeps
+`auto_review.enabled: true` but restricts it with `labels: [ready-for-review]` — the `labels`
+setting **filters automatic reviews** (it is not an independent trigger, which is why `enabled`
+must stay `true`). Result: CodeRabbit auto-reviews only PRs carrying the label.
 
 1. Ensure the repository label exists:
 
@@ -95,11 +97,12 @@ automatic and incremental review. The positive `ready-for-review` label triggers
      --description "Trigger CodeRabbit review for the current PR head" --color 0E8A16
    ```
 
-2. Apply it only when CodeRabbit is explicitly selected, or whenever the diff is safety-sensitive.
+2. Apply it when no local reviewer (Local Bugbot / Fable) was available for the PR, or whenever an
+   extra automated pass is wanted. It never blocks — only the required CI checks gate a merge.
 3. After any later push, comment `@coderabbitai review`; the label does not trigger incremental
    reviews while `auto_incremental_review: false`.
-4. Accept only substantive comments/reviews created at or after the latest PR commit. A green check
-   run without review text is not evidence.
+4. Prefer substantive comments/reviews created at or after the latest PR commit as evidence. A
+   green check run without review text is weak evidence.
 
 No repository secret is required.
 
@@ -107,8 +110,9 @@ No repository secret is required.
 
 ## 3. Cursor Bugbot — W1.4.3 — HUMAN STEP
 
-Remote Cursor Bugbot must be disabled for this repository to avoid duplicating the mandatory Local
-Bugbot gate. In the Cursor dashboard, open the GitHub/Bugbot installations list and disable Bugbot
+Remote Cursor Bugbot should be disabled for this repository — John already runs **Local Bugbot**
+in Cursor as his pre-push reviewer (Chetan uses Fable), so the remote bot only duplicates that
+signal. In the Cursor dashboard, open the GitHub/Bugbot installations list and disable Bugbot
 for `aiosbrain/aios-team-brain` specifically.
 
 Do not use an undocumented API and do not uninstall the all-repository Cursor GitHub App: other

--- a/docs/agent-handoffs.md
+++ b/docs/agent-handoffs.md
@@ -12,6 +12,7 @@ tracks its progress in **Linear** (the canonical PM tool; the brain-tasks CLI is
 projection path) — that's the workflow we're testing.
 
 ## Parallelization waves (respect dependencies)
+
 - **Wave A — start in parallel now (no cross-deps):** `F3`, `W1.1`, `W1.2`, `W1.4`
 - **Wave B — after `F3` merges:** `F4`, `F5`
 - **Wave C — after `F5` merges:** `W1.3`
@@ -23,6 +24,7 @@ projection path) — that's the workflow we're testing.
   `aios-workspace/docs/v1-operator-loop/` for the V1.0 roadmap that superseded Wave 2.
 
 ## Shared caveats for parallel runs
+
 - **Worktrees:** name each uniquely — `../aios-team-brain-<epic>` (e.g. `-f3`, `-w1.1`).
 - **Shared test Postgres:** `npm run db:test:up` **resets** the shared DB on port 5434. Don't run it
   concurrently from two agents. Either (a) one agent brings it up and others just run
@@ -43,6 +45,7 @@ projection path) — that's the workflow we're testing.
 > Postgres via `lib/db/pg`). **First, read** the root `~/Projects/aios/CLAUDE.md`
 > (it MANDATES git worktrees — follow it), this repo's `CLAUDE.md` + `AGENTS.md`, and
 > `docs/ARCHITECTURE.md` §1. Then set up your worktree:
+>
 > ```bash
 > cd ~/Projects/aios/aios-team-brain
 > git fetch origin
@@ -50,6 +53,7 @@ projection path) — that's the workflow we're testing.
 > cd ../aios-team-brain-<epic>
 > ln -sfn ~/Projects/aios/aios-team-brain/node_modules node_modules
 > ```
+>
 > **Linear tracking (brain-tasks CLI, brain→Linear projection):** find the issue and its sub-issues;
 > assign them to yourself; move the issue to **In Progress** when you start; move each sub-issue to
 > **Done** as you finish it; when you open the PR, **reference the issue key** in the PR body (see
@@ -65,7 +69,7 @@ projection path) — that's the workflow we're testing.
 
 ---
 
-## F3 — Integrations auth surfaces + contract bump  (Wave A)
+## F3 — Integrations auth surfaces + contract bump (Wave A)
 
 ```
 You are a senior engineer on AIOS Team Brain (Next.js 16 App Router, React 19, TypeScript, Postgres via lib/db/pg). Read ~/Projects/aios/CLAUDE.md (it MANDATES git worktrees — follow it), this repo's CLAUDE.md + AGENTS.md, and docs/ARCHITECTURE.md §1 before coding.
@@ -92,7 +96,7 @@ CONSTRAINTS: single-writer stays lib/integrations/manage.ts; tier/role isolation
 VERIFY: npx tsc --noEmit; npm run lint; npm test; npm run check:docs; npm run db:test:up && npm run test:datamechanics:local. Then open a PR from feat/f3-integrations-auth against main referencing the Linear issue key.
 ```
 
-## F4 — Sidecar consumes selections  (Wave B — after F3 merges)
+## F4 — Sidecar consumes selections (Wave B — after F3 merges)
 
 ```
 You are a senior engineer on AIOS (the Python ingestion sidecar in aios-team-brain/ingestion + the brain). Read ~/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, docs/ARCHITECTURE.md §1, and the ingestion source pattern (ingestion/aios_ingest/sources/registry.py, engine.py, brain_client.py). Requires F3 (GET /api/v1/integrations) merged to main — confirm it exists before starting.
@@ -115,7 +119,7 @@ SCOPE:
 VERIFY: run the ingestion Python tests; npm run check:docs if you touch ARCHITECTURE. PR from feat/f4-sidecar-selections → main referencing the Linear issue key.
 ```
 
-## F5 — Admin Integrations UI + tier guards  (Wave B — after F3 merges)
+## F5 — Admin Integrations UI + tier guards (Wave B — after F3 merges)
 
 ```
 You are a senior engineer on AIOS Team Brain. Read ~/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, docs/ARCHITECTURE.md §1 and §5 (tier isolation), and these existing patterns: components/admin/admin-tabs.tsx, app/t/[team]/admin/layout.tsx (admin gate), lib/auth/visibility.ts, test/guards/codebases-tier-filter.test.ts. Requires F3 merged.
@@ -140,7 +144,7 @@ SCOPE:
 VERIFY: npx tsc --noEmit; npm run lint; npm test; npm run check:docs; npm run db:test:up && npm run test:datamechanics:local. PR from feat/f5-integrations-ui → main referencing the Linear issue key.
 ```
 
-## W1.1 — Granola → decisions (sanitized, consented)  (Wave A)
+## W1.1 — Granola → decisions (sanitized, consented) (Wave A)
 
 ```
 You are a senior engineer on AIOS (the Python ingestion sidecar + the transcript→decision workflow). Read ~/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, the source pattern (ingestion/aios_ingest/sources/registry.py + base.py + an existing source like slack.py), and the existing granola-digest + transcript-decisions skills. There is already a granola-mcp server configured — reuse its pull/parse logic; do not re-write transcript fetching.
@@ -165,7 +169,7 @@ SCOPE:
 VERIFY: ingestion Python tests; npm run check:docs (drift:sources). PR from feat/w1.1-granola → main referencing the Linear issue key.
 ```
 
-## W1.2 — Token + cost per member (brain spend)  (Wave A)
+## W1.2 — Token + cost per member (brain spend) (Wave A)
 
 ```
 You are a senior engineer on AIOS Team Brain. Read ~/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, and these SHIPPED pieces you build on: lib/auth/visibility.ts (scopeQueryLog — query_log is role-scoped), lib/identity/resolve.ts (shared identity resolver), lib/metrics/pulse.ts (JS day-bucketing pattern), and the codebases contributor-table/chart components.
@@ -189,7 +193,7 @@ SCOPE:
 VERIFY: npx tsc --noEmit; npm run lint; npm test; npm run db:test:up && npm run test:datamechanics:local. PR from feat/w1.2-cost-per-member → main referencing the Linear issue key.
 ```
 
-## W1.3 — GitHub native UI (selection + manual scan)  (Wave C — after F5 merges)
+## W1.3 — GitHub native UI (selection + manual scan) (Wave C — after F5 merges)
 
 ```
 You are a senior engineer on AIOS Team Brain. Read ~/Projects/aios/CLAUDE.md (MANDATES worktrees), this repo's CLAUDE.md/AGENTS.md, and reuse (do NOT fork): lib/codebases/github.ts (fetchGithubUser/listOrgMembers/linkGithub), lib/codebases/ingest.ts (single writer), lib/codebases/visibility.ts (canSeeCodebases). Requires F5 (integrations UI) and F4 (sidecar consumes selections) merged. Heed memory codebase-scan-deploy-race.
@@ -213,7 +217,7 @@ SCOPE:
 VERIFY: npx tsc --noEmit; npm run lint; npm test; npm run check:docs; data-mechanics if persistence touched. PR from feat/w1.3-github-ui → main referencing the Linear issue key.
 ```
 
-## W1.4 — Ops hardening (Sentry, CodeRabbit, BugBot)  (Wave A)
+## W1.4 — Ops hardening (Sentry, CodeRabbit, BugBot) (Wave A)
 
 ```
 You are a senior engineer on AIOS Team Brain (Next.js 16 + Turbopack). Read ~/Projects/aios/CLAUDE.md (MANDATES worktrees) and this repo's CLAUDE.md/AGENTS.md. AGENTS.md warns this Next.js has breaking changes — read node_modules/next/dist/docs as needed.
@@ -231,7 +235,7 @@ OBJECTIVE: error logging + AI code review.
 SCOPE:
 - W1.4.1 Sentry: @sentry/nextjs >=10.13 (Turbopack source-map upload). Add instrumentation-client.ts, sentry.server.config.ts, sentry.edge.config.ts, onRequestError in instrumentation.ts, app/global-error.tsx (app root), withSentryConfig in next.config.ts. DSN + source-map auth token via env (.env.example entries; do NOT commit secrets). Confirm no custom webpack plugins (Turbopack ignores them).
 - W1.4.2 CodeRabbit: document installing the GitHub App on the public AIOS repos (free for public repos). This is a config/ops step — capture instructions in the PR.
-- W1.4.3 BugBot: document John (org owner) approving the Cursor app at AIOS-alpha → Settings → Third-party Access (manual).
+- W1.4.3 BugBot: document the per-repository Cursor setting for the `aiosbrain` organization (manual).
 - W1.4.4 Sentry smoke: a client error and a server error both produce events with resolved source maps (note how to verify).
 
 VERIFY: npx tsc --noEmit; npm run lint; npm run build (Turbopack) succeeds with Sentry wired. PR from feat/w1.4-ops → main referencing the Linear issue key.

--- a/test/datamechanics/work-events.datamechanics.test.ts
+++ b/test/datamechanics/work-events.datamechanics.test.ts
@@ -3,7 +3,11 @@ import { ingestWorkEvent } from "@/lib/work-events/ingest";
 import { db, ingest, seedTeam } from "./helpers";
 
 async function taskStatus(rowKey: string): Promise<string | null> {
-  const { data } = await db().from("tasks").select("status").eq("row_key", rowKey).maybeSingle();
+  const { data } = await db()
+    .from("tasks")
+    .select("status")
+    .eq("row_key", rowKey)
+    .maybeSingle();
   return (data as { status: string } | null)?.status ?? null;
 }
 
@@ -15,13 +19,15 @@ describe("work events (real Postgres)", () => {
       path: "3-log/tasks.md",
       body: "| ID | Task | Assignee | Status | Sprint | Due |\n| W1.2.1 | build metric | alex | in_progress | | |",
       access: "team",
-      rows: [{ row_key: "W1.2.1", title: "build metric", status: "in_progress" }],
+      rows: [
+        { row_key: "W1.2.1", title: "build metric", status: "in_progress" },
+      ],
     } as never);
 
     const payload = {
       project: "acme",
       event_kind: "merged" as const,
-      repo: "AIOS-alpha/aios-team-brain",
+      repo: "aiosbrain/aios-team-brain",
       merged_sha: "abc123456789",
       pr_url: "https://example.test/pr/1",
       pr_title: "W1.2.1 Build metric",
@@ -35,18 +41,23 @@ describe("work events (real Postgres)", () => {
       db(),
       { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: "api-key" },
       payload,
-      { syncPm: false }
+      { syncPm: false },
     );
-    expect(res.applied).toEqual([{ row_key: "W1.2.1", task_id: res.applied[0].task_id }]);
+    expect(res.applied).toEqual([
+      { row_key: "W1.2.1", task_id: res.applied[0].task_id },
+    ]);
     expect(await taskStatus("W1.2.1")).toBe("done");
 
     res = await ingestWorkEvent(
       db(),
       { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: "api-key" },
       payload,
-      { syncPm: false }
+      { syncPm: false },
     );
-    const { data: events } = await db().from("work_events").select("id").eq("team_id", seed.teamId);
+    const { data: events } = await db()
+      .from("work_events")
+      .select("id")
+      .eq("team_id", seed.teamId);
     expect(events ?? []).toHaveLength(1);
     expect(res.unresolved).toEqual([]);
   });
@@ -59,7 +70,7 @@ describe("work events (real Postgres)", () => {
       {
         project: "acme",
         event_kind: "merged",
-        repo: "AIOS-alpha/aios-workspace",
+        repo: "aiosbrain/aios-workspace",
         merged_sha: "def123456789",
         pr_url: "",
         pr_title: "P9 Missing key",
@@ -68,7 +79,7 @@ describe("work events (real Postgres)", () => {
         work_keys: ["P9"],
         actor: "alex",
       },
-      { syncPm: false }
+      { syncPm: false },
     );
 
     expect(res.applied).toEqual([]);
@@ -79,20 +90,34 @@ describe("work events (real Postgres)", () => {
       .eq("team_id", seed.teamId)
       .eq("row_key", "P9")
       .single();
-    expect(data).toMatchObject({ status: "unresolved", error: "no matching task row" });
+    expect(data).toMatchObject({
+      status: "unresolved",
+      error: "no matching task row",
+    });
   });
 
   it("records provider sync errors on the PM link without losing task completion", async () => {
     const seed = await seedTeam();
     // v1.2: projection targets the team's primary PM tool. Declare it so the work-events done path
     // knows the intended provider even though no integration is enabled (→ missing_integration).
-    await db().from("teams").update({ primary_pm_provider: "plane" }).eq("id", seed.teamId);
+    await db()
+      .from("teams")
+      .update({ primary_pm_provider: "plane" })
+      .eq("id", seed.teamId);
     await ingest(seed, {
       kind: "task",
       path: "3-log/tasks.md",
       body: "| ID | Task | Assignee | Status | Sprint | Due | PM |\n| P0 | plane seed | alex | ready | | | plane:P0 |",
       access: "team",
-      rows: [{ row_key: "P0", title: "plane seed", status: "ready", pm_provider: "plane", pm_external_id: "P0" }],
+      rows: [
+        {
+          row_key: "P0",
+          title: "plane seed",
+          status: "ready",
+          pm_provider: "plane",
+          pm_external_id: "P0",
+        },
+      ],
     } as never);
 
     const res = await ingestWorkEvent(
@@ -101,7 +126,7 @@ describe("work events (real Postgres)", () => {
       {
         project: "acme",
         event_kind: "merged",
-        repo: "AIOS-alpha/aios-team-brain",
+        repo: "aiosbrain/aios-team-brain",
         merged_sha: "feed12345678",
         pr_url: "",
         pr_title: "P0 Finish Plane seed",
@@ -109,12 +134,16 @@ describe("work events (real Postgres)", () => {
         branch: "",
         work_keys: ["P0"],
         actor: "alex",
-      }
+      },
     );
 
     expect(await taskStatus("P0")).toBe("done");
     expect(res.pm_sync).toEqual([
-      expect.objectContaining({ row_key: "P0", provider: "plane", status: "missing_integration" }),
+      expect.objectContaining({
+        row_key: "P0",
+        provider: "plane",
+        status: "missing_integration",
+      }),
     ]);
     const { data: link } = await db()
       .from("task_pm_links")
@@ -122,7 +151,9 @@ describe("work events (real Postgres)", () => {
       .eq("team_id", seed.teamId)
       .eq("row_key", "P0")
       .single();
-    expect((link as { last_error: string }).last_error).toMatch(/plane integration/i);
+    expect((link as { last_error: string }).last_error).toMatch(
+      /plane integration/i,
+    );
   });
 
   it("creates a PM link row when none exists yet (insert-returning path against real PG)", async () => {
@@ -130,7 +161,10 @@ describe("work events (real Postgres)", () => {
     // primary provider set, integration absent, and NO markdown PM column ⇒ no pre-existing link.
     // The work-events done path must INSERT a task_pm_links row to record the error — this exercises
     // ensureLink's insert-returning, which the prod pg adapter rejects with a bare "*" select.
-    await db().from("teams").update({ primary_pm_provider: "plane" }).eq("id", seed.teamId);
+    await db()
+      .from("teams")
+      .update({ primary_pm_provider: "plane" })
+      .eq("id", seed.teamId);
     await ingest(seed, {
       kind: "task",
       path: "3-log/tasks.md",
@@ -145,7 +179,7 @@ describe("work events (real Postgres)", () => {
       {
         project: "acme",
         event_kind: "merged",
-        repo: "AIOS-alpha/aios-team-brain",
+        repo: "aiosbrain/aios-team-brain",
         merged_sha: "abcdef987654",
         pr_url: "",
         pr_title: "P7 done",
@@ -153,12 +187,16 @@ describe("work events (real Postgres)", () => {
         branch: "",
         work_keys: ["P7"],
         actor: "alex",
-      }
+      },
     );
 
     expect(await taskStatus("P7")).toBe("done");
     expect(res.pm_sync).toEqual([
-      expect.objectContaining({ row_key: "P7", provider: "plane", status: "missing_integration" }),
+      expect.objectContaining({
+        row_key: "P7",
+        provider: "plane",
+        status: "missing_integration",
+      }),
     ]);
     // The link was created (not pre-existing) and carries the error.
     const { data: link } = await db()
@@ -167,10 +205,18 @@ describe("work events (real Postgres)", () => {
       .eq("team_id", seed.teamId)
       .eq("row_key", "P7")
       .single();
-    expect(link as { provider: string; provider_external_id: string; last_error: string }).toMatchObject({
+    expect(
+      link as {
+        provider: string;
+        provider_external_id: string;
+        last_error: string;
+      },
+    ).toMatchObject({
       provider: "plane",
       provider_external_id: "P7",
     });
-    expect((link as { last_error: string }).last_error).toMatch(/plane integration/i);
+    expect((link as { last_error: string }).last_error).toMatch(
+      /plane integration/i,
+    );
   });
 });

--- a/test/http/work-events.http.test.ts
+++ b/test/http/work-events.http.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { ingest } from "../datamechanics/helpers";
-import { BASE_URL, db, issueKeyFor, keyHeaders, seedTeam } from "./http-helpers";
+import {
+  BASE_URL,
+  db,
+  issueKeyFor,
+  keyHeaders,
+  seedTeam,
+} from "./http-helpers";
 
 // HTTP edge of POST /api/v1/work-events: the route the merge-sync GitHub Action
 // (aios-work-sync.yml) calls to close a task. We assert the HTTP contract and the
@@ -9,7 +15,10 @@ import { BASE_URL, db, issueKeyFor, keyHeaders, seedTeam } from "./http-helpers"
 
 const WORK_EVENTS = `${BASE_URL}/api/v1/work-events`;
 
-async function seedTask(seed: Awaited<ReturnType<typeof seedTeam>>, rowKey: string) {
+async function seedTask(
+  seed: Awaited<ReturnType<typeof seedTeam>>,
+  rowKey: string,
+) {
   await ingest(seed, {
     kind: "task",
     path: "3-log/tasks.md",
@@ -23,7 +32,7 @@ function eventPayload(rowKey: string) {
   return {
     project: "acme",
     event_kind: "merged",
-    repo: "AIOS-alpha/aios-team-brain",
+    repo: "aiosbrain/aios-team-brain",
     merged_sha: "abc123456789",
     pr_url: "https://example.test/pr/1",
     pr_title: `${rowKey} build it`,
@@ -46,13 +55,18 @@ describe("POST /api/v1/work-events (HTTP)", () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.status).toBe("ok");
-    expect(body.applied).toEqual([{ row_key: "W1.2.1", task_id: body.applied[0]?.task_id }]);
+    expect(body.applied).toEqual([
+      { row_key: "W1.2.1", task_id: body.applied[0]?.task_id },
+    ]);
     expect(body.unresolved).toEqual([]);
     // The done path runs the brain→PM projection engine (lib/pm-sync/project). The test
     // team has no enabled PM integration, so projection reports missing_integration and
     // makes no external call — the task is still completed (asserted below).
     expect(body.pm_sync).toHaveLength(1);
-    expect(body.pm_sync[0]).toMatchObject({ row_key: "W1.2.1", status: "missing_integration" });
+    expect(body.pm_sync[0]).toMatchObject({
+      row_key: "W1.2.1",
+      status: "missing_integration",
+    });
 
     const { data } = await db()
       .from("tasks")

--- a/test/ingest-github-normalize.test.ts
+++ b/test/ingest-github-normalize.test.ts
@@ -8,8 +8,9 @@ import { itemPayloadSchema, taskRowSchema } from "@/lib/api/schemas";
 // Spec (GitHub inbound import): a repo's issues → ONE kind="task" ItemPayload, rows keyed GH-<number>.
 // PRs excluded; open→backlog (or a workflow label), closed→done; milestone→sprint; assignees→assignee.
 
+// Mixed-case owner on purpose: keeps the slug lowercasing in normalizeGithubRepo covered.
 const base: NormalizeGithubInput = {
-  owner: "aiosbrain",
+  owner: "AIOSbrain",
   repo: "aios-team-brain",
   issues: [],
 };

--- a/test/ingest-github-normalize.test.ts
+++ b/test/ingest-github-normalize.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { normalizeGithubRepo, type NormalizeGithubInput } from "@/lib/ingest/sources/github-normalize";
+import {
+  normalizeGithubRepo,
+  type NormalizeGithubInput,
+} from "@/lib/ingest/sources/github-normalize";
 import { itemPayloadSchema, taskRowSchema } from "@/lib/api/schemas";
 
 // Spec (GitHub inbound import): a repo's issues → ONE kind="task" ItemPayload, rows keyed GH-<number>.
 // PRs excluded; open→backlog (or a workflow label), closed→done; milestone→sprint; assignees→assignee.
 
-const base: NormalizeGithubInput = { owner: "AIOS-alpha", repo: "aios-team-brain", issues: [] };
+const base: NormalizeGithubInput = {
+  owner: "aiosbrain",
+  repo: "aios-team-brain",
+  issues: [],
+};
 
 describe("normalizeGithubRepo", () => {
   it("maps issues to one valid kind=task ItemPayload in a dedicated repo project", () => {
@@ -24,8 +31,8 @@ describe("normalizeGithubRepo", () => {
     });
     expect(() => itemPayloadSchema.parse(p)).not.toThrow();
     expect(p.kind).toBe("task");
-    expect(p.project).toBe("github-aios-alpha-aios-team-brain");
-    expect(p.path).toBe("github/aios-alpha-aios-team-brain/issues.md");
+    expect(p.project).toBe("github-aiosbrain-aios-team-brain");
+    expect(p.path).toBe("github/aiosbrain-aios-team-brain/issues.md");
     expect(p.rows).toHaveLength(1);
 
     const row = p.rows![0] as Record<string, unknown>;
@@ -43,7 +50,12 @@ describe("normalizeGithubRepo", () => {
       ...base,
       issues: [
         { number: 1, title: "Real issue", state: "open" },
-        { number: 2, title: "A PR", state: "open", pull_request: { url: "https://..." } },
+        {
+          number: 2,
+          title: "A PR",
+          state: "open",
+          pull_request: { url: "https://..." },
+        },
       ],
     });
     const keys = (p.rows as Record<string, unknown>[]).map((r) => r.row_key);
@@ -55,11 +67,18 @@ describe("normalizeGithubRepo", () => {
       ...base,
       issues: [
         { number: 1, title: "Closed", state: "closed" },
-        { number: 2, title: "Working", state: "open", labels: [{ name: "In Progress" }] },
+        {
+          number: 2,
+          title: "Working",
+          state: "open",
+          labels: [{ name: "In Progress" }],
+        },
         { number: 3, title: "Stuck", state: "open", labels: ["blocked"] },
       ],
     });
-    const byKey = Object.fromEntries((p.rows as Record<string, unknown>[]).map((r) => [r.row_key, r]));
+    const byKey = Object.fromEntries(
+      (p.rows as Record<string, unknown>[]).map((r) => [r.row_key, r]),
+    );
     expect(byKey["GH-1"].status).toBe("done");
     expect(byKey["GH-2"].status).toBe("in_progress");
     expect(byKey["GH-3"].status).toBe("blocked");
@@ -67,7 +86,10 @@ describe("normalizeGithubRepo", () => {
 
   it("serializes projectable fields so a changed field shifts content_sha256", () => {
     const mk = (state: string) =>
-      normalizeGithubRepo({ ...base, issues: [{ number: 1, title: "T", state }] });
+      normalizeGithubRepo({
+        ...base,
+        issues: [{ number: 1, title: "T", state }],
+      });
     expect(mk("open").content_sha256).not.toBe(mk("closed").content_sha256);
   });
 });

--- a/test/integration-config.test.ts
+++ b/test/integration-config.test.ts
@@ -1,21 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { validateIntegrationConfig, IntegrationConfigError } from "@/lib/api/schemas";
+import {
+  validateIntegrationConfig,
+  IntegrationConfigError,
+} from "@/lib/api/schemas";
 
 // Spec for the integration config gate. The `integrations.config` jsonb must hold NON-SECRET
 // selection only — secrets stay in the sidecar's local config. These assertions are the contract.
 
 describe("validateIntegrationConfig()", () => {
   it("accepts a valid per-type config and normalizes defaults", () => {
-    expect(validateIntegrationConfig("github", { repos: ["AIOS-alpha/aios-team-brain"] })).toEqual({
-      repos: ["AIOS-alpha/aios-team-brain"],
+    expect(
+      validateIntegrationConfig("github", {
+        repos: ["aiosbrain/aios-team-brain"],
+      }),
+    ).toEqual({
+      repos: ["aiosbrain/aios-team-brain"],
     });
     expect(validateIntegrationConfig("github", {})).toEqual({ repos: [] }); // default applied
   });
 
   it("rejects unknown keys (strict allowlist)", () => {
-    expect(() => validateIntegrationConfig("slack", { channelIds: ["C1"], extra: 1 })).toThrow(
-      IntegrationConfigError
-    );
+    expect(() =>
+      validateIntegrationConfig("slack", { channelIds: ["C1"], extra: 1 }),
+    ).toThrow(IntegrationConfigError);
   });
 
   it("rejects a secret-like key anywhere, even if otherwise well-formed", () => {
@@ -27,31 +34,45 @@ describe("validateIntegrationConfig()", () => {
       { bearer: "b" },
       { client_secret: "c" },
     ]) {
-      expect(() => validateIntegrationConfig("wise", bad), JSON.stringify(bad)).toThrow(
-        /secret-like key/i
-      );
+      expect(
+        () => validateIntegrationConfig("wise", bad),
+        JSON.stringify(bad),
+      ).toThrow(/secret-like key/i);
     }
   });
 
   it("rejects a secret-like key nested inside an allowed structure", () => {
     // even within github.repos shape, a nested token key is caught by the recursive scan
     expect(() =>
-      validateIntegrationConfig("granola", { participantEmails: [], secretToken: "x" })
+      validateIntegrationConfig("granola", {
+        participantEmails: [],
+        secretToken: "x",
+      }),
     ).toThrow(/secret-like key/i);
   });
 
   it("rejects oversized config (byte cap)", () => {
-    const huge = { repos: Array.from({ length: 5000 }, (_, i) => `org/repo-${i}`) };
+    const huge = {
+      repos: Array.from({ length: 5000 }, (_, i) => `org/repo-${i}`),
+    };
     expect(() => validateIntegrationConfig("github", huge)).toThrow(/exceeds/);
   });
 
   it("validates email shape in granola participant allowlist", () => {
     expect(() =>
-      validateIntegrationConfig("granola", { participantEmails: ["not-an-email"] })
+      validateIntegrationConfig("granola", {
+        participantEmails: ["not-an-email"],
+      }),
     ).toThrow(IntegrationConfigError);
     expect(
-      validateIntegrationConfig("granola", { participantEmails: ["john@aios.dev"], matchKeywords: ["AIOS"] })
-    ).toEqual({ participantEmails: ["john@aios.dev"], matchKeywords: ["AIOS"] });
+      validateIntegrationConfig("granola", {
+        participantEmails: ["john@aios.dev"],
+        matchKeywords: ["AIOS"],
+      }),
+    ).toEqual({
+      participantEmails: ["john@aios.dev"],
+      matchKeywords: ["AIOS"],
+    });
   });
 
   it("accepts Plane and Linear PM sync mapping hints", () => {
@@ -61,7 +82,7 @@ describe("validateIntegrationConfig()", () => {
         projectId: "plane-project",
         doneStateName: "DONE",
         externalSource: "aios-backlog",
-      })
+      }),
     ).toEqual({
       workspaceSlug: "aios-alpha",
       projectId: "plane-project",
@@ -69,72 +90,133 @@ describe("validateIntegrationConfig()", () => {
       externalSource: "aios-backlog",
     });
     expect(
-      validateIntegrationConfig("linear", { teamId: "team-uuid", projectId: "project-uuid", doneStateName: "Done" })
-    ).toEqual({ teamId: "team-uuid", projectId: "project-uuid", doneStateName: "Done" });
+      validateIntegrationConfig("linear", {
+        teamId: "team-uuid",
+        projectId: "project-uuid",
+        doneStateName: "Done",
+      }),
+    ).toEqual({
+      teamId: "team-uuid",
+      projectId: "project-uuid",
+      doneStateName: "Done",
+    });
   });
 
   it("accepts the Linear inboundApply opt-in (brain-api v1.4) but still no secret-like keys", () => {
-    expect(validateIntegrationConfig("linear", { teamId: "team-uuid", inboundApply: true })).toEqual({
+    expect(
+      validateIntegrationConfig("linear", {
+        teamId: "team-uuid",
+        inboundApply: true,
+      }),
+    ).toEqual({
       teamId: "team-uuid",
       inboundApply: true,
     });
     // Boundary regression for the DEFERRED webhook work: a webhook signing secret has no home in
     // config — the secret-key scan must keep rejecting it (it belongs in an encrypted column).
-    expect(() => validateIntegrationConfig("linear", { webhookSecret: "whsec_x" })).toThrow(/secret-like key/i);
+    expect(() =>
+      validateIntegrationConfig("linear", { webhookSecret: "whsec_x" }),
+    ).toThrow(/secret-like key/i);
     // …and any other webhook-ish key is rejected by the strict allowlist.
-    expect(() => validateIntegrationConfig("linear", { webhookUrl: "https://x" })).toThrow(IntegrationConfigError);
+    expect(() =>
+      validateIntegrationConfig("linear", { webhookUrl: "https://x" }),
+    ).toThrow(IntegrationConfigError);
   });
 
   it("accepts the member-onboarding provisioning keys (linear/slack/github) but rejects secret-like ones", () => {
     // Linear invite hints
     expect(
-      validateIntegrationConfig("linear", { teamId: "t", inviteTeamIds: ["T1", "T2"], inviteRole: "guest" })
-    ).toEqual({ teamId: "t", inviteTeamIds: ["T1", "T2"], inviteRole: "guest" });
+      validateIntegrationConfig("linear", {
+        teamId: "t",
+        inviteTeamIds: ["T1", "T2"],
+        inviteRole: "guest",
+      }),
+    ).toEqual({
+      teamId: "t",
+      inviteTeamIds: ["T1", "T2"],
+      inviteRole: "guest",
+    });
     // an invalid role is rejected by the enum
-    expect(() => validateIntegrationConfig("linear", { inviteRole: "owner" })).toThrow(IntegrationConfigError);
+    expect(() =>
+      validateIntegrationConfig("linear", { inviteRole: "owner" }),
+    ).toThrow(IntegrationConfigError);
     // Slack invite link (must be a URL)
-    expect(validateIntegrationConfig("slack", { inviteLink: "https://join.slack.com/t/x/abc" })).toEqual({
+    expect(
+      validateIntegrationConfig("slack", {
+        inviteLink: "https://join.slack.com/t/x/abc",
+      }),
+    ).toEqual({
       channelIds: [],
       inviteLink: "https://join.slack.com/t/x/abc",
     });
-    expect(() => validateIntegrationConfig("slack", { inviteLink: "not-a-url" })).toThrow(IntegrationConfigError);
+    expect(() =>
+      validateIntegrationConfig("slack", { inviteLink: "not-a-url" }),
+    ).toThrow(IntegrationConfigError);
     // GitHub org
-    expect(validateIntegrationConfig("github", { org: "acme" })).toEqual({ repos: [], org: "acme" });
+    expect(validateIntegrationConfig("github", { org: "acme" })).toEqual({
+      repos: [],
+      org: "acme",
+    });
     // The new keys must not trip the secret-key scan, but a real secret-like sibling still does.
-    expect(() => validateIntegrationConfig("github", { org: "acme", token: "ghp_x" })).toThrow(/secret-like key/i);
+    expect(() =>
+      validateIntegrationConfig("github", { org: "acme", token: "ghp_x" }),
+    ).toThrow(/secret-like key/i);
   });
 
   it("keeps the key itself in secret_ciphertext — config holds only the optional answer model", () => {
-    for (const type of ["openai", "anthropic", "openrouter", "google"] as const) {
+    for (const type of [
+      "openai",
+      "anthropic",
+      "openrouter",
+      "google",
+    ] as const) {
       // Empty config is always valid (the key lives in secret_ciphertext).
       expect(validateIntegrationConfig(type, {})).toEqual({});
       // A key-like field is caught by the secret-key scan before the allowlist.
-      expect(() => validateIntegrationConfig(type, { apiKey: "sk-1" })).toThrow(/secret-like key/i);
+      expect(() => validateIntegrationConfig(type, { apiKey: "sk-1" })).toThrow(
+        /secret-like key/i,
+      );
       // Unknown non-secret keys are still rejected by the strict allowlist.
-      expect(() => validateIntegrationConfig(type, { temperature: 0.5 })).toThrow(IntegrationConfigError);
+      expect(() =>
+        validateIntegrationConfig(type, { temperature: 0.5 }),
+      ).toThrow(IntegrationConfigError);
     }
     // openai/anthropic/openrouter carry a NON-secret answer-model slug; google stays config-less.
     for (const type of ["openai", "anthropic", "openrouter"] as const) {
-      expect(validateIntegrationConfig(type, { model: "some-model" })).toEqual({ model: "some-model" });
+      expect(validateIntegrationConfig(type, { model: "some-model" })).toEqual({
+        model: "some-model",
+      });
     }
-    expect(() => validateIntegrationConfig("google", { model: "gemini" })).toThrow(IntegrationConfigError);
+    expect(() =>
+      validateIntegrationConfig("google", { model: "gemini" }),
+    ).toThrow(IntegrationConfigError);
   });
 });
 
 describe("INTEGRATION_TYPES", () => {
   it("includes the LLM provider key types", async () => {
-    const { INTEGRATION_TYPES, PROVIDER_INTEGRATION_TYPES } = await import("@/lib/api/schemas");
+    const { INTEGRATION_TYPES, PROVIDER_INTEGRATION_TYPES } =
+      await import("@/lib/api/schemas");
     for (const t of PROVIDER_INTEGRATION_TYPES) {
       expect(INTEGRATION_TYPES).toContain(t);
     }
-    expect([...PROVIDER_INTEGRATION_TYPES].sort()).toEqual(["anthropic", "google", "openai", "openrouter"]);
+    expect([...PROVIDER_INTEGRATION_TYPES].sort()).toEqual([
+      "anthropic",
+      "google",
+      "openai",
+      "openrouter",
+    ]);
   });
 
   it("openrouter carries a NON-secret model config (rejects unknown keys, allows model)", async () => {
     const { validateIntegrationConfig } = await import("@/lib/api/schemas");
-    expect(validateIntegrationConfig("openrouter", { model: "openai/gpt-4o-mini" })).toEqual({
+    expect(
+      validateIntegrationConfig("openrouter", { model: "openai/gpt-4o-mini" }),
+    ).toEqual({
       model: "openai/gpt-4o-mini",
     });
-    expect(() => validateIntegrationConfig("openrouter", { apiKey: "sk-or-x" })).toThrow(); // secret rejected
+    expect(() =>
+      validateIntegrationConfig("openrouter", { apiKey: "sk-or-x" }),
+    ).toThrow(); // secret rejected
   });
 });


### PR DESCRIPTION
## Summary
- align Team Brain review and CI documentation with the team's real setup: a **flexible, non-blocking local review** — Local Bugbot (John, via Cursor) or Fable (Chetan) — recorded in the PR body, with label-gated CodeRabbit as the shared fallback
- fix `.coderabbit.yaml` so the `ready-for-review` label gate actually fires (`labels` only filters *automatic* reviews, so `auto_review.enabled` must stay `true`)
- describe `wait-for-bots.mjs` as it actually behaves and document the `--bots 'coderabbitai[bot]'` invocation
- org rename `AIOS-alpha` → `aiosbrain` in CODEOWNERS, docs, and test fixtures (remote already renamed); drop the dead `docs/brain-api.md` CODEOWNERS path; restore mixed-case slug-lowercasing test coverage
- nothing in the review policy blocks a push or merge — only the required CI checks do

## Review — Reviewed by **Claude Opus (/code-review high)** — verdict: findings fixed in a402b83
The original head (d2345d9) had 10 findings; the two HIGH ones were that the documented label gate could never fire (`enabled: false`) and that the waiter docs contradicted the actual shared script. All fixed or consciously resolved in a402b83; the prettier-continuation cosmetic finding was withdrawn (it's prettier's canonical output).

## Verification
- `npm test` — 937 passed
- `npm run check:docs` — congruent
- `npm run lint` — 0 errors (2 pre-existing warnings in untouched files)
- `npx prettier --check` on all edited files — clean
