### PR TITLE
feat(codebases): full-width trend + side-by-side score/readiness + collapsible Issues & PRs

### DIFF
--- a/app/t/[team]/codebases/[slug]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/page.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, Star, GitFork, CircleDot } from "lucide-react";
+import { ArrowLeft, Star, GitFork, CircleDot, ChevronRight } from "lucide-react";
 import { serverClient } from "@/lib/db/server";
 import { currentMember } from "@/lib/auth/guard";
 import { getCodebaseDetail } from "@/lib/metrics/codebases";
 import { parseRange } from "@/lib/metrics/range";
 import { timeAgo } from "@/components/format";
 import { RangeSelector } from "@/components/dashboard/range-selector";
-import { AgenticBreakdownCard } from "@/components/codebases/agentic-breakdown";
+import { AgenticScoreCard, AgentReadinessCard } from "@/components/codebases/agentic-breakdown";
 import { ContributorTable } from "@/components/codebases/contributor-table";
 import { IssuesList } from "@/components/codebases/issues-list";
 import { AgenticTrend } from "@/components/charts/agentic-trend";
@@ -97,10 +97,19 @@ export default async function CodebaseDetailPage({
         </div>
       ) : null}
 
-      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
-        {cb.breakdown ? <AgenticBreakdownCard b={cb.breakdown} /> : null}
-        <AgenticTrend data={cb.trend} />
-      </div>
+      {/* Trend spans the full page width; the score + readiness bar cards sit side-by-side below it. */}
+      <AgenticTrend data={cb.trend} />
+
+      {cb.breakdown ? (
+        cb.breakdown.readiness_level ? (
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+            <AgenticScoreCard b={cb.breakdown} />
+            <AgentReadinessCard b={cb.breakdown} />
+          </div>
+        ) : (
+          <AgenticScoreCard b={cb.breakdown} />
+        )
+      ) : null}
 
       <ContributionsTrend data={cb.commitVolume} />
 
@@ -111,12 +120,17 @@ export default async function CodebaseDetailPage({
         <ContributorTable rows={cb.contributors} teamSlug={teamSlug} codebaseSlug={cb.slug} />
       </section>
 
-      <section className="flex flex-col gap-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
+      {/* Issues & PRs collapsed by default (native <details> — no client JS). */}
+      <details className="group flex flex-col gap-3">
+        <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-semibold uppercase tracking-wider text-ink-tertiary hover:text-ink-secondary">
+          <ChevronRight className="size-4 shrink-0 transition-transform group-open:rotate-90" />
           Issues &amp; PRs
-        </h2>
-        <IssuesList issues={cb.issues} />
-      </section>
+          <span className="font-normal normal-case text-ink-tertiary/70">({cb.issues.length})</span>
+        </summary>
+        <div className="mt-3">
+          <IssuesList issues={cb.issues} />
+        </div>
+      </details>
     </div>
   );
 }

--- a/components/codebases/agentic-breakdown.tsx
+++ b/components/codebases/agentic-breakdown.tsx
@@ -34,46 +34,9 @@ function humanizePillar(key: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-// AEM agent-readiness — rubric-scored scanner-side; the brain only persists + surfaces it.
-// Renders only when a scan carried a readiness level (older scans / unscored repos are null).
-function ReadinessSection({ b }: { b: Breakdown }) {
-  if (!b.readiness_level) return null;
-  const pillars = Object.entries(b.readiness_pillars ?? {});
-  return (
-    <div className="flex flex-col gap-3 border-t border-border-subtle pt-3">
-      <div className="flex items-baseline justify-between gap-3">
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-ink-tertiary">
-          Agent readiness
-        </h3>
-        <span className="inline-flex items-baseline gap-2 font-mono text-xs">
-          <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5 font-semibold text-ink-secondary">
-            {b.readiness_level}
-          </span>
-          {b.readiness_pct == null ? null : (
-            <span className="text-ink-tertiary">{b.readiness_pct}%</span>
-          )}
-        </span>
-      </div>
-      {pillars.length > 0 ? (
-        <div className="flex flex-col gap-2">
-          {pillars.map(([key, { passed, total }]) => (
-            <div key={key} className="flex flex-col gap-1">
-              <div className="flex items-baseline justify-between text-xs">
-                <span className="text-ink-secondary">{humanizePillar(key)}</span>
-                <span className="text-ink-tertiary">
-                  {passed}/{total}
-                </span>
-              </div>
-              <Bar value={total > 0 ? (passed / total) * 100 : 0} />
-            </div>
-          ))}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-export function AgenticBreakdownCard({ b }: { b: Breakdown }) {
+/** The agentic-score breakdown as a standalone card (score ring + weighted bars + scaffolding checks).
+ *  Split from the readiness card so the two sit side-by-side under the full-width trend. */
+export function AgenticScoreCard({ b }: { b: Breakdown }) {
   return (
     <section className="prism-card flex flex-col gap-4 px-5 py-4">
       <div className="flex items-center justify-between gap-3">
@@ -124,8 +87,44 @@ export function AgenticBreakdownCard({ b }: { b: Breakdown }) {
           label={b.test_coverage_branches_pct == null ? "no branch coverage" : `${b.test_coverage_branches_pct}% branches`}
         />
       </div>
+    </section>
+  );
+}
 
-      <ReadinessSection b={b} />
+/** AEM agent-readiness as its own card (rubric-scored scanner-side; the brain persists + surfaces it).
+ *  Returns null when a scan carried no readiness level (older scans / unscored repos) so the caller
+ *  can render the score card full-width instead of leaving a dead column. */
+export function AgentReadinessCard({ b }: { b: Breakdown }) {
+  if (!b.readiness_level) return null;
+  const pillars = Object.entries(b.readiness_pillars ?? {});
+  return (
+    <section className="prism-card flex flex-col gap-4 px-5 py-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
+          Agent readiness
+        </h2>
+        <span className="inline-flex items-baseline gap-2 font-mono text-xs">
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5 font-semibold text-ink-secondary">
+            {b.readiness_level}
+          </span>
+          {b.readiness_pct == null ? null : <span className="text-ink-tertiary">{b.readiness_pct}%</span>}
+        </span>
+      </div>
+      {pillars.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          {pillars.map(([key, { passed, total }]) => (
+            <div key={key} className="flex flex-col gap-1">
+              <div className="flex items-baseline justify-between text-xs">
+                <span className="text-ink-secondary">{humanizePillar(key)}</span>
+                <span className="text-ink-tertiary">
+                  {passed}/{total}
+                </span>
+              </div>
+              <Bar value={total > 0 ? (passed / total) * 100 : 0} />
+            </div>
+          ))}
+        </div>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
Fixes the codebase detail page layout from your screenshot.

## Changes
1. **Issues & PRs collapsed by default** — native `<details>`/`<summary>` (no client JS), with a count and a rotating chevron. Expand on click.
2. **Trend graph is now full-width** across the top of the page.
3. **The two bar cards sit side-by-side underneath it** — I split the single breakdown card into **Agentic score** + **Agent readiness** cards rendered in a 2-column grid. This removes the big empty gray column (which existed because the short Trend chart sat next to the tall breakdown card). If a scan has no readiness level, the score card renders full-width instead (no dead column).

## Verified
937 unit tests, tsc, lint, docs-drift green.

## Note
This is a presentational change (standard Tailwind grid + native `<details>`), verified via tsc/lint/tests — I didn't run a live browser screenshot (would need a seeded local instance), so if any spacing needs a nudge on the deploy, say the word and I'll tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)