### PR TITLE
feat(api): attribution health as an admin-gated context layer (GET /api/v1/attribution)

### DIFF
--- a/app/api/v1/attribution/route.ts
+++ b/app/api/v1/attribution/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from "next/server";
+import { adminClient } from "@/lib/db/admin";
+import { authenticateApiKey } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/api/rate-limit";
+import { errorResponse } from "@/lib/api/schemas";
+import { getAttributionHealth, getMemberItems } from "@/lib/attribution/health";
+
+export const runtime = "nodejs";
+
+/**
+ * Attribution health over HTTP (brain-api v1.13) — "is each data stream landing on the right person?",
+ * the SAME derived read the Admin → Attribution page renders (`lib/attribution/health`), so the CLI and
+ * other machines get it without a web view. Two levels, mirroring the page:
+ *   • no `member` param → the summary: `{ bySource, byMember, lowAttributionSources }`.
+ *   • `?member=<uuid>` (or `?member=unattributed` for the null bucket) [+ `?source=`, `?limit=`] → the
+ *     per-person drill-down: `{ member, items }` (each item's provenance — signal/method/resolvesTo/mismatch).
+ *
+ * ⚠️ ADMIN-ONLY, ALL TIERS (CLAUDE §5). The health read spans every access tier — it exposes member
+ * names + per-source counts of team/admin content — and there is NO RLS backstop. So this route gates
+ * to a **team-tier ADMIN** key and never runs the read otherwise; an `external` or non-admin principal
+ * gets 403. This gate is the sole reason the `attribution-health-admin-only` guard allowlists this file
+ * (it asserts the gate string is present), so do NOT relax it.
+ *
+ * ERROR SEMANTICS: the summary path is best-effort (inherits `getAttributionHealth` — a DB error yields
+ * a 200 with empty arrays, matching the web banner so a page never breaks; a machine consumer thus can't
+ * distinguish "healthy but quiet" from "read failed"). The drill-down path THROWS → 500 (a chip that
+ * says "14" must not silently expand to []). Documented so a CLI/agent treats an empty summary as "quiet".
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiKey(req);
+  if (!auth) return errorResponse("unauthorized", "invalid API key or team", 401);
+  // Team-tier ADMIN only — attribution health spans all tiers with no RLS backstop (see header).
+  if (auth.memberTier !== "team" || auth.memberRole !== "admin") {
+    return errorResponse("forbidden", "attribution health is team-admin only", 403);
+  }
+
+  const db = adminClient();
+  if (!(await rateLimit(db, `${auth.apiKeyId}:attribution:get`, 60))) {
+    return errorResponse("rate_limited", "60 reads/min per key", 429);
+  }
+
+  const params = new URL(req.url).searchParams;
+  const memberParam = params.get("member");
+
+  try {
+    // Drill-down: the actual items attributed to one member (or the unattributed bucket).
+    if (memberParam !== null) {
+      const memberId = memberParam === "unattributed" ? null : memberParam;
+      if (memberId !== null && !UUID_RE.test(memberId)) {
+        return errorResponse("bad_request", "member must be a UUID or 'unattributed'", 400);
+      }
+      const source = params.get("source") ?? undefined;
+      const limitRaw = Math.floor(Number(params.get("limit")));
+      const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : undefined;
+      const items = await getMemberItems(auth.teamId, memberId, { source, limit });
+      return Response.json({ member: memberParam, items });
+    }
+
+    // Summary: the per-source + per-person breakdowns + the low-attribution alert list.
+    const health = await getAttributionHealth(auth.teamId);
+    return Response.json(health);
+  } catch (err) {
+    return errorResponse("internal", err instanceof Error ? err.message : "attribution read failed", 500);
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -673,6 +673,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/items/:id` — single item fetch
 - `GET /api/v1/tasks` — dashboard task changes for `aios pull` writeback; `?all=1` selects the tier-filtered full tasks-table read
 - `GET /api/v1/timeline` — the work-timeline context layer (v1.12): last 7d day→person→work ledger, the same payload the dashboard panel reads (SWR `work_timeline_cache`); API-key + tier-scoped (`getCachedWorkTimeline` → `visibleItems`/`visibleTasks`)
+- `GET /api/v1/attribution` — attribution health (brain-api v1.13): the SAME derived read as Admin → Attribution (`lib/attribution/health`), so the CLI/LLM read it too — summary (`bySource`/`byMember`/`lowAttributionSources`), or `?member=<uuid>|unattributed` [+ `?source=`/`?limit=`] for the per-item provenance drill-down. **Team-tier ADMIN only** (all-tier read, member names + admin-content counts, no RLS backstop) — external/non-admin → 403
 - `GET /api/v1/pm-sync/health` — team-tier projection health and recent runs for CLI/agent observability
 - `GET /api/v1/decisions` — dashboard decision changes for `aios pull` writeback (tier-scoped)
 - `GET /api/v1/projects` — team project list for `aios pull` brain-project registration (team-tier only)

--- a/test/guards/attribution-health-admin-only.test.ts
+++ b/test/guards/attribution-health-admin-only.test.ts
@@ -15,6 +15,13 @@ import { join } from "node:path";
 const ROOT = join(import.meta.dirname, "..", "..");
 const SCAN_DIRS = [join(ROOT, "app"), join(ROOT, "components")];
 const ADMIN_PREFIX = join("app", "t", "[team]", "admin") + "/";
+// The single non-page exception — the admin-gated attribution API route (posix path for matching). It's
+// allowlisted ONLY because it self-gates to a team-tier ADMIN key (asserted in the last test below), so
+// the CLI/LLM can read the same data as the web view (brain-api v1.13) without opening a non-admin leak.
+const ADMIN_API_ROUTE = "app/api/v1/attribution/route.ts";
+const posix = (f: string): string => f.replaceAll("\\", "/");
+const isAllowed = (f: string): boolean =>
+  posix(f).includes(posix(ADMIN_PREFIX)) || posix(f).endsWith(ADMIN_API_ROUTE);
 // A VALUE import of the health module — `import { getAttributionHealth } …`. Excludes `import type …`
 // (a component taking the AttributionHealth shape never touches the tier-spanning read).
 const VALUE_IMPORT = /import\s+(?!type\s)[^;]*?from\s+["']@\/lib\/attribution\/health["']/;
@@ -52,8 +59,19 @@ describe("attribution-health read is admin-gated", () => {
     expect(valueImporters.some((f) => f.includes(join("admin", "attribution")))).toBe(true);
   });
 
-  it("is CALLED only from under app/t/[team]/admin/ (self-gated pages), never an api route or shared component", () => {
-    const offenders = valueImporters.filter((f) => !f.replaceAll("\\", "/").includes(ADMIN_PREFIX.replaceAll("\\", "/")));
+  it("is CALLED only from the allowlist (self-gated admin pages + the admin-gated attribution API route)", () => {
+    const offenders = valueImporters.filter((f) => !isAllowed(f));
     expect(offenders).toEqual([]);
+  });
+
+  it("the attribution API route exception genuinely gates to a team-tier ADMIN key (the allowlist can't become a leak)", () => {
+    const route = valueImporters.find((f) => posix(f).endsWith(ADMIN_API_ROUTE));
+    // If the route is present in the tree, it MUST self-gate; if it's absent, the allowlist entry is
+    // simply dormant (no leak). Either way the tier-spanning read stays admin-only.
+    if (route) {
+      const src = readFileSync(route, "utf8");
+      expect(src).toMatch(/memberRole\s*!==\s*["']admin["']/);
+      expect(src).toMatch(/memberTier\s*!==\s*["']team["']/);
+    }
   });
 });

--- a/test/http/attribution.http.test.ts
+++ b/test/http/attribution.http.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { BASE_URL, issueAdminKey, issueKeyFor, keyHeaders, seedTeam } from "./http-helpers";
+import { ingest } from "../datamechanics/helpers";
+
+// HTTP edge of GET /api/v1/attribution (attribution health context layer, brain-api v1.13): auth, the
+// team-ADMIN gate (all-tier read, no RLS backstop — an external or non-admin principal must never reach
+// it), the summary wire shape, and the per-member drill-down. Seeding uses the shared test DB.
+
+const ATTRIBUTION = `${BASE_URL}/api/v1/attribution`;
+
+async function seedCommit(seed: Awaited<ReturnType<typeof seedTeam>>, title: string) {
+  await ingest(seed, {
+    path: `commits/x/${title}.md`,
+    project: "commits",
+    kind: "artifact",
+    frontmatter: { source: "git", title, committed_at: new Date().toISOString() },
+    body: `# ${title}`,
+    access: "team",
+  });
+}
+
+describe("GET /api/v1/attribution (HTTP)", () => {
+  it("rejects a missing/invalid API key with 401", async () => {
+    const res = await fetch(ATTRIBUTION, { headers: { Authorization: "Bearer nope", "X-AIOS-Team": "x" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("forbids an external-tier key with 403 (all-tier read is admin-only, no RLS backstop)", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "external");
+    const res = await fetch(ATTRIBUTION, { headers: keyHeaders(key, seed.teamSlug) });
+    expect(res.status).toBe(403);
+  });
+
+  it("forbids a NON-admin team key with 403", async () => {
+    const seed = await seedTeam(); // seeded member is role=member
+    const { key } = await issueKeyFor(seed, "team");
+    const res = await fetch(ATTRIBUTION, { headers: keyHeaders(key, seed.teamSlug) });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the health summary for a team-admin key ({ bySource, byMember, lowAttributionSources })", async () => {
+    const seed = await seedTeam();
+    await seedCommit(seed, "shipped-it");
+    const { key } = await issueAdminKey(seed);
+
+    const res = await fetch(ATTRIBUTION, { headers: keyHeaders(key, seed.teamSlug) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.bySource)).toBe(true);
+    expect(Array.isArray(body.byMember)).toBe(true);
+    expect(Array.isArray(body.lowAttributionSources)).toBe(true);
+    const git = body.bySource.find((s: { source: string }) => s.source === "git");
+    expect(git).toBeDefined();
+    expect(git.items).toBeGreaterThan(0);
+  });
+
+  it("drill-down: ?member=<uuid> returns that member's attributed items ({ member, items })", async () => {
+    const seed = await seedTeam();
+    await seedCommit(seed, "my-commit");
+    const { key } = await issueAdminKey(seed);
+
+    const res = await fetch(`${ATTRIBUTION}?member=${seed.memberId}`, { headers: keyHeaders(key, seed.teamSlug) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.member).toBe(seed.memberId);
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items.some((i: { title: string }) => i.title === "my-commit")).toBe(true);
+  });
+
+  it("drill-down: ?member=unattributed returns the null bucket (200, array)", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueAdminKey(seed);
+    const res = await fetch(`${ATTRIBUTION}?member=unattributed`, { headers: keyHeaders(key, seed.teamSlug) });
+    expect(res.status).toBe(200);
+    expect(Array.isArray((await res.json()).items)).toBe(true);
+  });
+
+  it("rejects a non-UUID member param with 400", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueAdminKey(seed);
+    const res = await fetch(`${ATTRIBUTION}?member=not-a-uuid`, { headers: keyHeaders(key, seed.teamSlug) });
+    expect(res.status).toBe(400);
+  });
+});

--- a/test/http/http-helpers.ts
+++ b/test/http/http-helpers.ts
@@ -38,6 +38,26 @@ export async function issueKeyFor(seed: Seed, tier: "team" | "external"): Promis
   return { key };
 }
 
+/** Issue a key for a fresh team-tier ADMIN member on the seeded team (for admin-gated route tests). */
+export async function issueAdminKey(seed: Seed): Promise<{ key: string }> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      email: `admin-${randomUUID().slice(0, 8)}@test.local`,
+      display_name: "Admin",
+      actor_handle: `admin-${randomUUID().slice(0, 8)}`,
+      role: "admin",
+      tier: "team",
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`admin member seed failed: ${error?.message}`);
+  const { key } = await issueApiKey(db(), seed.teamId, (data as { id: string }).id, "admin key");
+  return { key };
+}
+
 /** Seed a member with a known email + password under the seeded team (for login tests). */
 export async function seedMemberEmail(seed: Seed): Promise<{ email: string; password: string }> {
   const email = `login-${randomUUID().slice(0, 8)}@test.local`;


### PR DESCRIPTION
## The gap
The **Admin → Attribution** health data ("is each data stream landing on the right person?") was already a good **derived read** — `lib/attribution/health` computes it live from the source of truth `items.member_id` + `members`, no bespoke store. But it was reachable **only from the admin web page**: no API route, so the CLI, the LLM, and any future client couldn't read it. A build guard even actively *forbade* any API route from touching the health lib.

Per the "design for multiple surfaces — push derived facts to the lowest shared layer" principle, this exposes it so every surface reads the **same** payload.

## What changed
- **`GET /api/v1/attribution`** (new, brain-api v1.13) — API-key auth, returns:
  - **summary** (no params) → `{ bySource, byMember, lowAttributionSources }`
  - **drill-down** → `?member=<uuid>` (or `?member=unattributed`) `[+ ?source= / ?limit=]` → `{ member, items }` with each item's provenance (`signal` / `method` / `resolvesToName` / `mismatch`).
  - Rate-limited 60/min; `member` UUID-validated (400 on bad input); `limit` floored + clamped.
- **Team-tier ADMIN only** — external/non-admin → **403**. The health read spans **all** access tiers (member names + admin-content counts) with **no RLS backstop** (CLAUDE §5), so this gate is load-bearing, not cosmetic. It's strictly tighter than the web page's role-only `requireTeamAdmin`.
- **Guard evolved, not weakened** — `attribution-health-admin-only` still fails the build if *any other* app/component value-imports the health lib; it now allowlists this **one** route **and** asserts the route file actually contains the `memberRole !== "admin"` + `memberTier !== "team"` gate strings, so the exception can never silently become a non-admin leak. The HTTP tier additionally asserts the real 403 behavior (layered: unit tripwire + behavioral test).

## Scope decision
Deliberately **not** auto-injected into the LLM retrieval prompt — it's an admin-only, all-tier diagnostic, so injecting it into general query context would be a tier leak. The LLM/CLI reach it through the admin-gated API instead. **No new table / no persistence** — it's a cheap SQL aggregate already read identically by the banner + dashboard; the only gap was the API surface.

## Error semantics (documented in the route header)
Summary path is best-effort (inherits `getAttributionHealth` → 200 with empty arrays on DB error, matching the web banner). Drill-down **throws → 500** (a count that says "14" must not silently expand to `[]`).

## Tests
- **HTTP tier** `test/http/attribution.http.test.ts` (7/7 over a real socket): 401 / external-403 / non-admin-403 / admin-200 summary + drill-down + 400 bad-param.
- **Guard** updated + kept non-vacuous (scans >50 files, still one-file allowlist, gate-string assertion).
- Unit (1017), typecheck, lint, docs-drift (58 routes) all green.

## Review — Reviewed by Fable code-reviewer — verdict CLEAR
Fable re-derived the admin gate (airtight — no external/non-admin path to the lib), injection safety (member UUID-validated + all params parameterized), and the guard evolution (not a weakening) against the actual code, and ran the HTTP tier itself. Applied its cheap Lows (documented summary best-effort semantics, `Math.floor` on limit). Its one Medium is the cross-repo contract note below.

## Follow-up (cross-repo, non-blocking)
- **brain-api v1.13** — the pinned wire contract lives in `aios-workspace/docs/brain-api.md` (I can't touch it from here). This route is additive/non-breaking; it needs a companion doc entry there so the CLI has a contract to build against. (Same pattern as the timeline v1.12 addition.) `BRAIN_API_VERSION`/ARCHITECTURE line 128 intentionally left at the last workspace-synced version.

_Note: no dedicated AIOS work-key attached (consistent with the recent PRs in this area) — not guessing one to avoid auto-closing an unrelated task on merge._