### PR TITLE
fix(dashboard): render decision titles as plain text + link each to its source

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -177,7 +177,7 @@ export default async function TeamHome({
   const [pulse, { data: decisions }, pipelineHealth] = await Promise.all([
     getPulseMetrics(db, team.id, range, { isAdmin, memberId }),
     visibleDecisions(
-      db.from("decisions").select("id, title, decided_at, tier, still_valid").eq("team_id", team.id).order("decided_at", { ascending: false }).limit(8),
+      db.from("decisions").select("id, title, decided_at, tier, still_valid, source_item_id").eq("team_id", team.id).order("decided_at", { ascending: false }).limit(8),
       tier,
     ),
     // Admins see a loud banner here (the landing page) if any ingestion leg is broken — so a wedged

--- a/components/dashboard/decisions-card.tsx
+++ b/components/dashboard/decisions-card.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Gavel } from "lucide-react";
-import { fmtDate, truncate } from "@/components/format";
+import { fmtDate, truncate, stripMarkdown } from "@/components/format";
 import type { DecisionRow } from "./types";
 
 const TIER_LABEL: Record<number, string> = { 1: "1-way", 2: "2-way", 3: "minor" };
@@ -30,18 +30,27 @@ export function DecisionsCard({
         </p>
       ) : (
         <ul className="flex flex-col gap-2.5">
-          {decisions.map((d) => (
-            <li key={d.id} className="flex items-start justify-between gap-2">
-              <span
-                className={`text-sm ${d.still_valid ? "text-ink-secondary" : "text-ink-tertiary line-through"}`}
-              >
-                {truncate(d.title, 64)}
-              </span>
-              <span className="shrink-0 text-[11px] text-ink-tertiary">
-                {d.tier ? TIER_LABEL[d.tier] ?? `T${d.tier}` : ""} · {fmtDate(d.decided_at)}
-              </span>
-            </li>
-          ))}
+          {decisions.map((d) => {
+            // Link to the source it was recorded in (decision-log doc / meeting); fall back to the log.
+            const href = d.source_item_id
+              ? `/t/${teamSlug}/library/${d.source_item_id}`
+              : `/t/${teamSlug}/decisions`;
+            return (
+              <li key={d.id} className="flex items-start justify-between gap-2">
+                <Link
+                  href={href}
+                  className={`text-sm transition-colors hover:text-violet ${
+                    d.still_valid ? "text-ink-secondary" : "text-ink-tertiary line-through"
+                  }`}
+                >
+                  {truncate(stripMarkdown(d.title), 64)}
+                </Link>
+                <span className="shrink-0 text-[11px] text-ink-tertiary">
+                  {d.tier ? TIER_LABEL[d.tier] ?? `T${d.tier}` : ""} · {fmtDate(d.decided_at)}
+                </span>
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>

--- a/components/dashboard/types.ts
+++ b/components/dashboard/types.ts
@@ -6,4 +6,6 @@ export interface DecisionRow {
   decided_at: string | null;
   tier: number | null;
   still_valid: boolean;
+  /** The item (decision-log doc / meeting) this decision was recorded in — links to /library/<id>. */
+  source_item_id: string | null;
 }

--- a/components/format.ts
+++ b/components/format.ts
@@ -27,3 +27,25 @@ export function fmtDate(iso: string | null | undefined): string {
 export function truncate(s: string, n: number): string {
   return s.length > n ? `${s.slice(0, n - 1)}…` : s;
 }
+
+/**
+ * Flatten inline markdown to plain text for compact UI (e.g. decision titles arrive from a markdown
+ * decision log, so `**Pause GUI**` must render as "Pause GUI", not with literal asterisks). Handles
+ * links/images → their text, inline code, bold/italic/strikethrough, and leading block markers.
+ * Strip BEFORE truncating so a cut title can't leave a dangling `**`. Pure + unit-tested.
+ */
+export function stripMarkdown(s: string | null | undefined): string {
+  return (s ?? "")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // images → alt text
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links → link text
+    .replace(/`+([^`]*)`+/g, "$1") // inline code
+    .replace(/(\*\*|__)(.*?)\1/g, "$2") // bold (** or __)
+    .replace(/\*([^*]+?)\*/g, "$1") // italic (*)
+    // italic (_) ONLY at word boundaries, so mid-word underscores in identifiers (snake_case, MY_VAR)
+    // aren't treated as emphasis and mangled to snakecase / MYVAR (Fable review).
+    .replace(/(^|[^\w])_([^_]+?)_(?=\W|$)/g, "$1$2")
+    .replace(/~~(.*?)~~/g, "$1") // strikethrough
+    .replace(/^\s{0,3}(?:#{1,6}|>|[-*+]|\d+\.)\s+/gm, "") // leading heading/quote/list markers
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { stripMarkdown, truncate } from "@/components/format";
+
+/**
+ * Spec for stripMarkdown: decision titles arrive from a markdown decision log, so the compact card
+ * must render them as PLAIN TEXT (no literal `**`, `[..](..)`, backticks). Derived from the display
+ * intent (the "**Pause unified inbox GUI**" render bug), not the implementation.
+ */
+describe("stripMarkdown", () => {
+  it("removes bold/italic/strikethrough emphasis", () => {
+    expect(stripMarkdown("**Pause unified inbox GUI**")).toBe("Pause unified inbox GUI");
+    expect(stripMarkdown("*ship it* and __done__ and ~~scrap~~")).toBe("ship it and done and scrap");
+  });
+
+  it("keeps link/image text, drops the URL and backticks", () => {
+    expect(stripMarkdown("See [the RFC](https://x.com/rfc) now")).toBe("See the RFC now");
+    expect(stripMarkdown("run `npm test` first")).toBe("run npm test first");
+    expect(stripMarkdown("![diagram](a.png) shows it")).toBe("diagram shows it");
+  });
+
+  it("drops a leading heading/quote/list marker and collapses whitespace", () => {
+    expect(stripMarkdown("## Decision:  keep it")).toBe("Decision: keep it");
+    expect(stripMarkdown("- **Consolidate** assessments")).toBe("Consolidate assessments");
+  });
+
+  it("leaves mid-word underscores in identifiers alone (snake_case, MY_VAR) but still strips _italic_", () => {
+    expect(stripMarkdown("Rename user_id to member_id")).toBe("Rename user_id to member_id");
+    expect(stripMarkdown("set MY_VAR_NAME in env")).toBe("set MY_VAR_NAME in env");
+    expect(stripMarkdown("make it _emphatic_ please")).toBe("make it emphatic please");
+  });
+
+  it("handles empty/null and leaves plain text untouched", () => {
+    expect(stripMarkdown("")).toBe("");
+    expect(stripMarkdown(null)).toBe("");
+    expect(stripMarkdown("Onboard Abdul onto the stack")).toBe("Onboard Abdul onto the stack");
+  });
+
+  it("strips BEFORE truncation so a cut title can't leave a dangling **", () => {
+    const out = truncate(stripMarkdown("**Pause unified inbox GUI** — terminal operator loop remains v1"), 24);
+    expect(out).not.toContain("*");
+    expect(out.endsWith("…")).toBe(true);
+  });
+});


### PR DESCRIPTION
The Home "Recent decisions" card showed **raw markdown** (literal `**asterisks**`) in titles — it truncated the decision-log markdown without rendering/stripping it.

## Changes
1. New pure **`stripMarkdown()`** (`components/format.ts`) — flattens bold/italic/strikethrough/links/images/inline-code + leading block markers to plain text. Underscore-italic is gated to word boundaries so `snake_case` / `MY_VAR` identifiers in technical decision titles aren't mangled (Fable). Strips **before** truncate so a cut title can't leave a dangling `**`.
2. Each decision row now **links to its source** — `/library/<source_item_id>` (the decision-log doc / meeting it was recorded in), falling back to `/decisions`.
3. Threaded `source_item_id` through `DecisionRow` + the home query.

## Context (for the "where does this come from" question)
Decisions aren't brain-extracted — a human-reviewed workflow (`transcript-decisions`) writes them to a markdown decision log, pushed via `aios push` as structured `decision` rows and materialized into the `decisions` table. The card reads the newest 8. The 1-way/2-way "tier" is a reversibility class assigned upstream at extraction.

## Tests & verification
Spec-first unit tests for `stripMarkdown` (bold/italic/links/code, snake_case guard, strip-before-truncate). `tsc`/eslint/docs-drift green; unit 1030.

## Review — Reviewed by **Fable** — verdict SHIP-WITH-CHANGES → addressed
Fable confirmed tier-safety (the `/library/<id>` page enforces its own `canSeeAccess` gate → a 404, not a leak; `visibleDecisions` still applies the audience filter regardless of the added select column) and no ReDoS. Fixed its one Medium (underscore-identifier corruption) with a boundary-gated regex + test; deferred two cosmetic Lows (parenthesized URLs, a leading-number list marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)