### PR TITLE
fix(query): surface recent items from a named source (Slack, Notion, …) in retrieval

### DIFF
--- a/docs/context-management-system.md
+++ b/docs/context-management-system.md
@@ -183,6 +183,13 @@ returns `{ sources, structured, grounded }`.
 - **Conjunctive AND** (`conjunctiveTerms`, `retrieve.ts:212`): an explicit **upper-cased** `AND` is an
   opt-in precision operator ("auth AND payments" → docs about both). Only upper-case, because lowercase
   "and" is a ubiquitous stopword and treating it as conjunction would gut recall.
+- **Source scoping** (`parseSourceScope`): when a question names an ingestion source with a recency/
+  content intent ("what's the conversation in **slack** right now", "latest **notion** docs"), a
+  source-scoped recency leg pulls that source's newest items **regardless of keyword rank**. Fixes the
+  "we ingest Slack but the answer says we don't" failure — a Slack thread matches such a query only on
+  the word "slack" in its heading, so it ranks below `FTS_CANDIDATE_LIMIT` and never reaches the model.
+  Conservative (concrete source name + a recency/scope signal), and it counts as grounding evidence so
+  the stay-quiet guard can't abstain the answer away.
 - **First-person + timezone** — "how about me?" resolves to the signed-in member; relative dates
   ("today" = last 24h) resolve in the asker's timezone.
 
@@ -200,7 +207,9 @@ returns `{ sources, structured, grounded }`.
    with no surface-term overlap; we harvest salient entity/fact words (≤ `MAX_EXPANSION_TERMS = 24`) and
    run a second FTS pass to reach the *source items* a literal search missed (paraphrase/synonym recall).
 4. **Recency net** — newest 8 items (`synced_at DESC`), so fresh content always has a shot even when
-   FTS is capped/unranked. This is why single-topic queries feel reliable.
+   FTS is capped/unranked. This is why single-topic queries feel reliable. A **source-scoped** variant
+   (`SOURCE_RECENCY_LIMIT = 8`, when `parseSourceScope` fires) pulls a named source's newest items ahead
+   of the generic net, so "what's in slack" surfaces recent Slack threads the keyword rank buries.
 5. **Structured extras** — always-included compact blocks (below).
 6. **Graph temporal facts** — up to `GRAPH_FACTS_LIMIT = 12` Graphiti facts, tier-scoped by group id.
 

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -27,6 +27,9 @@ const MAX_TOTAL_CHARS = 160_000; // ~40k tokens context cap
 // larger candidate pool just lets more of a many-small-item corpus through, best-ranked first. Tune
 // via FTS_CANDIDATE_LIMIT. (The recall CEILING beyond this is the dense/rerank job, not keyword FTS.)
 const FTS_CANDIDATE_LIMIT = Number(process.env.FTS_CANDIDATE_LIMIT ?? 50);
+// When the question names a source (`parseSourceScope`), how many of its MOST-RECENT items to pull in
+// by recency (bypassing FTS rank) so "what's the conversation in slack" surfaces the latest threads.
+const SOURCE_RECENCY_LIMIT = Number(process.env.SOURCE_RECENCY_LIMIT ?? 8);
 const GIT_WINDOW_DAYS = 90; // recency window for the per-contributor git-activity digest
 const PEOPLE_WINDOW_DAYS = 90; // recency window for the per-person cross-tool activity digest
 
@@ -252,6 +255,45 @@ export function parseChannelScope(question: string): { channel: string | null; c
   return { channel: null, cleaned: question };
 }
 
+/**
+ * Detect an explicit SOURCE scope — a query naming an ingestion source it wants the recent content
+ * FROM ("what's the conversation in slack right now", "latest notion docs", "what's on linear"). Generic
+ * content-similarity ranking BURIES such items: a Slack thread matches the query only on the single word
+ * "slack" in its `— Slack thread` heading, so it ranks below the FTS candidate cut (`FTS_CANDIDATE_LIMIT`)
+ * and never reaches the model — which then truthfully says it has no Slack, even though we ingest it.
+ * When a source is named, `nativeRetrieve` adds a RECENCY leg for it (most-recent items of that source,
+ * by `synced_at`, bypassing FTS rank). The source word is NOT stripped from the query (unlike a channel
+ * scope) — it's also a legit content term. Conservative: a concrete source brand-name as a whole word
+ * AND a recency/scope signal ("in/on/from/latest/recent/now/conversation/messages/…"), so ordinary prose
+ * ("the notion of causality", "linear algebra") never wrongly scopes. Returns the `frontmatter.source`
+ * value to filter on, or null. Pure + unit-tested.
+ */
+const SOURCE_SCOPE: Record<string, string> = {
+  slack: "slack",
+  notion: "notion",
+  granola: "granola",
+  linear: "linear",
+  plane: "plane",
+  confluence: "confluence",
+};
+// Scope requires ADJACENCY, not just a source word somewhere (a bare-word gate scoped "growth linear in
+// Q3" / "linear regression" / "plane ticket"). Two forms:
+//   • `<prep> [the] <source>`     — "in slack", "from notion"          (BRAND-only sources)
+//   • `<source> <content-noun>`   — "notion docs", "linear issues"     (ALL sources)
+// `linear`/`notion`/`plane` are also common English words, so they scope ONLY via the content-noun form
+// (never bare "on the linear regression"); the brand-only names (slack/granola/confluence) also take a
+// preposition. Deliberately NOT scopeable yet: gdrive, git/github (github activity is served by the
+// per-contributor git digest). Pure + unit-tested (positives + the common-word false-positives).
+const BRAND_ONLY_SOURCES = ["slack", "granola", "confluence"];
+const SOURCE_NOUNS = "conversations?|messages?|threads?|chats?|discussions?|posts?|docs?|notes?|updates?|channels?|activity|issues?";
+const PREP_SOURCE_RE = new RegExp(`\\b(?:in|on|from|to)\\s+(?:the\\s+)?(${BRAND_ONLY_SOURCES.join("|")})\\b`, "i");
+const SOURCE_NOUN_RE = new RegExp(`\\b(${Object.keys(SOURCE_SCOPE).join("|")})\\s+(?:${SOURCE_NOUNS})\\b`, "i");
+
+export function parseSourceScope(question: string): { source: string | null } {
+  const m = question.match(PREP_SOURCE_RE) ?? question.match(SOURCE_NOUN_RE);
+  return { source: m ? SOURCE_SCOPE[m[1].toLowerCase()] : null };
+}
+
 const MAX_EXPANSION_TERMS = 24;
 
 /**
@@ -425,6 +467,10 @@ async function nativeRetrieve(
   // item retrieval to it and strip the phrase so the channel word isn't also a content search term.
   const { channel, cleaned } = parseChannelScope(question);
   const q = channel ? cleaned : question;
+  // Source scope (this fix): if the question names a source it wants recent content FROM ("what's the
+  // conversation in slack"), we add a recency leg for that source below — such items are buried by
+  // content-ranking (they match only on the source word in their heading) and never reach the model.
+  const { source: scopedSource } = parseSourceScope(question);
 
   // Kick off the Graphiti graph-memory search concurrently with Postgres retrieval.
   const graphFactsP = fetchGraphFacts(db, teamId, tier, q);
@@ -464,6 +510,23 @@ async function nativeRetrieve(
   // Channel scope (Gap #4) — keep the recency fallback inside the same channel. LIKE on the 2nd
   // path segment; the FTS leg uses a precise split_part match, this soft filter is fine for padding.
   if (channel) recentB = recentB.like("path", `%/${channel}/%`);
+
+  // 2a. SOURCE-scoped recency: when the question names a source, pull its most-recent items by
+  // `synced_at` REGARDLESS of keyword rank (the recall fix for "what's the conversation in slack" —
+  // Slack threads rank below the FTS cut, so they never reached the model). Tier-filtered like every
+  // leg; also channel-scoped when both are named. `null` → no source query (resolves to empty rows).
+  let sourceRecencyB: typeof recentB | null = null;
+  if (scopedSource) {
+    sourceRecencyB = db
+      .from("items")
+      .select("id, path, kind, body, synced_at, projects(slug)")
+      .eq("team_id", teamId)
+      .eq("frontmatter->>source", scopedSource)
+      .order("synced_at", { ascending: false })
+      .limit(SOURCE_RECENCY_LIMIT);
+    if (isRestrictedTier(tier)) sourceRecencyB = sourceRecencyB.eq("access", "external");
+    if (channel) sourceRecencyB = sourceRecencyB.like("path", `%/${channel}/%`);
+  }
 
   // 3. Structured-context query builders (awaited together with the above).
   let decisionsB = db
@@ -523,6 +586,7 @@ async function nativeRetrieve(
   const [
     ftsHits,
     { data: recentHits },
+    { data: sourceRecentHits },
     { data: decisions },
     { data: tasks },
     { data: commitments },
@@ -532,6 +596,7 @@ async function nativeRetrieve(
   ] = await Promise.all([
     ftsP,
     recentB,
+    sourceRecencyB ?? Promise.resolve({ data: [] as unknown[] }),
     decisionsB,
     tasksB,
     commitmentsB,
@@ -546,14 +611,18 @@ async function nativeRetrieve(
   type MergeHit = { id: string; path: string; kind: string; body: string; synced_at: string; slug: string };
   const iso = (v: string | Date): string => (v instanceof Date ? v.toISOString() : String(v ?? ""));
   const rankedHits: MergeHit[] = ftsHits.map((h) => ({ id: h.id, path: h.path, kind: h.kind, body: h.body, synced_at: h.synced_at, slug: h.project }));
-  const recencyHits: MergeHit[] = ((recentHits ?? []) as { id: string; path: string; kind: string; body: string | null; synced_at: string | Date; projects: unknown }[]).map(
-    (h) => ({ id: h.id, path: h.path, kind: h.kind, body: h.body ?? "", synced_at: iso(h.synced_at), slug: (h.projects as { slug: string })?.slug ?? "" })
-  );
+  type RecencyRow = { id: string; path: string; kind: string; body: string | null; synced_at: string | Date; projects: unknown };
+  const toMergeHit = (h: RecencyRow): MergeHit => ({ id: h.id, path: h.path, kind: h.kind, body: h.body ?? "", synced_at: iso(h.synced_at), slug: (h.projects as { slug: string })?.slug ?? "" });
+  const recencyHits: MergeHit[] = ((recentHits ?? []) as RecencyRow[]).map(toMergeHit);
+  // Source-scoped recent items (when the question named a source) — placed AHEAD of the generic recency
+  // padding so a named source's latest content beats arbitrary fresh items, but AFTER the ranked FTS
+  // hits so query-specific relevance still leads. Dedup by id handles any overlap.
+  const sourceRecencyHits: MergeHit[] = ((sourceRecentHits ?? []) as RecencyRow[]).map(toMergeHit);
   const seen = new Set<string>();
   const sources: Source[] = [];
   let total = 0;
   let n = 1;
-  for (const hit of [...rankedHits, ...recencyHits]) {
+  for (const hit of [...rankedHits, ...sourceRecencyHits, ...recencyHits]) {
     if (seen.has(hit.id)) continue;
     seen.add(hit.id);
     if (projectSlug && hit.slug !== projectSlug) continue;
@@ -602,6 +671,13 @@ async function nativeRetrieve(
   const hadFtsHit = ftsHits.length > 0;
   const spec = await specificityP;
   let grounded = spec.specificMatching ? true : spec.allCommon ? hadFtsHit : false;
+  // A named-source recency item that actually made it INTO `sources` (survived the project filter + char
+  // budget — not merely returned by the leg) IS query-specific evidence: the user asked about that source
+  // and its recent content reached the model, so don't let the IDF grounding abstain it away (that would
+  // reproduce the "we ingest Slack but the answer says we don't" bug this leg fixes). Checking membership
+  // in `sources`, not the raw leg length, avoids claiming grounded when every scoped hit was filtered out.
+  const includedItemIds = new Set(sources.map((s) => s.item_id).filter(Boolean));
+  if (sourceRecencyHits.some((h) => includedItemIds.has(h.id))) grounded = true;
 
   // 2c. Semantic expansion via Graphiti (the graph search ran in parallel above). Use the facts'
   // entity/relationship terms to expand the FTS and surface items the literal keyword search missed.

--- a/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
+++ b/test/datamechanics/multichannel-adversarial.datamechanics.test.ts
@@ -257,3 +257,41 @@ describe("multi-channel adversarial retrieval (real Postgres)", () => {
     expect(orHits).toContain("slack/platform/both.md");
   });
 });
+
+describe("source-scope recency leg (real Postgres — the 'we ingest Slack but the answer said we don't' fix)", () => {
+  beforeEach(async () => {
+    seed = await seedTeam();
+  });
+
+  it("STRENGTH: a source-scoped query surfaces a recent Slack thread the keyword+recency legs miss", async () => {
+    // Slack thread: OLDEST item, and its BODY carries none of the query's content terms — so neither the
+    // FTS leg (no term overlap) nor the generic 8-item recency (it's the oldest) can surface it. The ONLY
+    // thing that can is the source-scoped recency leg (filters on frontmatter.source='slack').
+    await post("slack/general", "thread", "# general\n\n**Ada**: shipping the onboarding flow, who can review it?");
+    // Newer non-slack docs that own the content terms → they win FTS and the recency window.
+    for (let i = 0; i < 30; i++) {
+      await ingest(seed, {
+        kind: "deliverable",
+        path: `notion/doc-${i}.md`,
+        body: `conversation design notes ${i}: a conversation about conversation patterns`,
+        access: "team",
+        frontmatter: { source: "notion" },
+      });
+    }
+
+    // Contrast — a NON-source query sharing the "conversation" term does NOT surface the Slack thread
+    // (its body doesn't match, and it's not recent), proving the leg is what makes the difference.
+    const plain = await paths("conversation design patterns");
+    expect(plain.some((p) => p.startsWith("slack/general/"))).toBe(false);
+
+    // WITH the source scope, the recency leg pulls the latest Slack thread in regardless of keyword rank.
+    const scoped = await paths("what's the conversation in slack right now?");
+    expect(scoped.some((p) => p.startsWith("slack/general/"))).toBe(true);
+  });
+
+  it("tier isolation: an external viewer's source-scoped Slack query never returns team-tier threads", async () => {
+    await post("slack/general", "internal", "# #general — Slack thread\n\n internal-only chatter", "team");
+    const ext = await paths("what's the conversation in slack right now?", "external");
+    expect(ext.some((p) => p.startsWith("slack/general/"))).toBe(false);
+  });
+});

--- a/test/query-adversarial.test.ts
+++ b/test/query-adversarial.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toOrQuery, parseChannelScope } from "@/lib/query/retrieve";
+import { toOrQuery, parseChannelScope, parseSourceScope } from "@/lib/query/retrieve";
 
 /**
  * ADVERSARIAL — query-transformation limits (pure, deterministic). These probe the FTS query builder
@@ -93,6 +93,33 @@ describe("adversarial: a channel name is treated as a content term, not a scope"
 
   it("documents: the channel name leaks in as a plain search term", () => {
     expect(toOrQuery("what was decided in the payments channel").split(" or ")).toContain("payments");
+  });
+});
+
+describe("source scope parsing (recency leg — 'we ingest Slack but the answer said we don't')", () => {
+  it("scopes on <prep> <source> (brand names) or <source> <content-noun> (any source)", () => {
+    expect(parseSourceScope("what's the conversation in slack right now?").source).toBe("slack"); // in slack
+    expect(parseSourceScope("recent messages in slack").source).toBe("slack"); // in slack
+    expect(parseSourceScope("latest notion docs?").source).toBe("notion"); // notion docs
+    expect(parseSourceScope("any new linear issues this week?").source).toBe("linear"); // linear issues
+    expect(parseSourceScope("what changed in the slack threads?").source).toBe("slack"); // slack threads
+  });
+  it("does NOT scope on ordinary prose where the source word is a common English word (adjacency guard)", () => {
+    // These all contain a source word but NOT in an adjacency form → no false scope (Fable's cases).
+    expect(parseSourceScope("explain the notion of causality").source).toBeNull();
+    expect(parseSourceScope("help me with my linear algebra homework").source).toBeNull();
+    expect(parseSourceScope("is our growth linear in Q3?").source).toBeNull();
+    expect(parseSourceScope("any updates on the linear regression model?").source).toBeNull();
+    expect(parseSourceScope("book a plane ticket for the offsite today").source).toBeNull();
+  });
+  it("does NOT scope the common-word sources via a bare preposition (only brand names take a prep)", () => {
+    // "on linear" alone is too ambiguous (linear regression/algebra) — it needs a content noun.
+    expect(parseSourceScope("what's happening on linear?").source).toBeNull();
+    expect(parseSourceScope("in the plane of the UI grid").source).toBeNull();
+  });
+  it("does NOT scope when no source is named", () => {
+    expect(parseSourceScope("what's the latest on the Atlas launch?").source).toBeNull();
+    expect(parseSourceScope("who is working on payments right now?").source).toBeNull();
   });
 });
 


### PR DESCRIPTION
## The bug
The chat answered *"I don't have access to Slack conversations… no Slack message history is included in what I was given"* — even though **Slack is fully ingested** (verified in prod: **13 embedded threads**, connector running clean every ~30 min). It wasn't claiming we don't ingest Slack; the **retrieval step handed the model no Slack** for that query.

## Root cause (measured against prod)
Retrieval takes the top `FTS_CANDIDATE_LIMIT=50` keyword hits + 8 generic-recency items. A Slack thread matches *"what's the conversation in slack right now?"* only on the single word "slack" in its `— Slack thread` heading, so its `ts_rank` is tiny — I measured the first Slack thread landing at **rank #65** (below the 50 cut), and it's not among the 8 most-recent either. So no Slack content reached the model, which then truthfully reported none.

## The fix (`lib/query/retrieve.ts`)
- **`parseSourceScope`** (pure): detects a source named with **adjacency** — `"<prep> <source>"` (`in slack`) for brand names, or `"<source> <content-noun>"` (`notion docs`, `linear issues`) for any source. The common-word sources (linear/notion/plane) scope **only** via the content-noun form, so `"linear regression"` / `"the notion of X"` / `"plane ticket"` / `"growth linear in Q3"` never wrongly scope.
- **Source-scoped recency leg**: when a source is named, pull its `SOURCE_RECENCY_LIMIT=8` newest items by `synced_at` **regardless of keyword rank**, tier-filtered (external → `access='external'`) and channel-scoped when both present, merged between ranked FTS and the generic recency net (dedup by id).
- **Grounding**: a source-scoped item that *actually reached* `sources` (survived project filter + char budget) counts as grounding evidence, so the stay-quiet/IDF-abstention guard can't drop the answer.

## Safety
- **Tier isolation** (CLAUDE §5, no RLS backstop): the leg uses the same `isRestrictedTier → .eq("access","external")` pattern as the existing recency leg; a data-mechanics test proves an external viewer's Slack query returns no team-tier threads. `.eq("frontmatter->>source", …)` is parameterized (same pattern as work-timeline).
- **No-op for non-source queries**: `scopedSource=null` → empty rows → merge order + grounding byte-for-byte unchanged.
- No schema/route/table/source change (docs-drift green).

## Tests
- Unit: `parseSourceScope` positives + the common-word false-positives (Fable's cases: `"linear regression model"`, `"plane ticket"`, `"growth linear in Q3"`).
- Data-mechanics (real Postgres): a Slack thread the keyword+recency legs miss surfaces for `"what's the conversation in slack right now?"`; tier isolation holds.
- tsc/eslint/docs-drift green; full unit tier **1029 passed**.

## Review — Reviewed by Fable code-reviewer — verdict SHIP-WITH-CHANGES → addressed
Fable verified tier isolation (mutation-proven), injection safety, and the no-op default path. Fixed its **High** (the signal gate was vacuous → switched to an adjacency gate that rejects common-word false-positives) and **Medium** (set `grounded` from source hits that actually reached `sources`, not the raw leg length). Deferred Lows noted: `gdrive`/`git` not scopeable yet (github is served by the git digest); multi-source queries scope the first match.

_Note: no dedicated AIOS work-key attached (consistent with recent PRs in this area) — not guessing one to avoid auto-closing an unrelated task on merge._