### PR TITLE
fix(learning): exclude the GitHub issues-backlog aggregate from narrative arcs

### DIFF
--- a/lib/graph/arc-eligibility.ts
+++ b/lib/graph/arc-eligibility.ts
@@ -7,11 +7,16 @@ import { runSql } from "@/lib/db/pg/pool";
  * facts/events panels (it's still context, still searchable) but doesn't shape the "what the team is
  * working through" storylines.
  *
- * Rule (per product): a Linear issue informs arcs ONLY while it's ACTIVE work — In Progress / In Review.
- * Backlog, Todo, Done, Canceled are context, not narrative — a done or not-yet-started ticket isn't
- * something the team is "working through". Non-Linear content is unaffected (always arc-eligible).
- * Matched on the raw Linear state NAME (the per-issue `deliverable` frontmatter carries the Linear
- * display name, e.g. "In Progress", not a normalized enum). See docs/design/brain-learning-panel.md.
+ * Rules (per product):
+ *   1. A Linear issue informs arcs ONLY while it's ACTIVE work — In Progress / In Review. Backlog,
+ *      Todo, Done, Canceled are context, not narrative — a done or not-yet-started ticket isn't
+ *      something the team is "working through". Matched on the raw Linear state NAME (the per-issue
+ *      `deliverable` frontmatter carries the display name, e.g. "In Progress", not a normalized enum).
+ *   2. The GitHub issues-BACKLOG aggregate (`github/<repo>/issues.md`) is excluded too — it's ONE
+ *      connector-owned `kind=task` document snapshotting every repo issue, so it has no human author
+ *      and produces an author-less, low-signal arc (this is what a "no person assigned" arc traces to).
+ *      A backlog snapshot is context, not "what a person is working through" — same rationale as (1).
+ * Non-Linear, non-issue-backlog content is unaffected (always arc-eligible). See docs/design/brain-learning-panel.md.
  */
 
 // "In Progress" / "In Review" (and "Reviewing"). Overridable per deployment; a name matching this is
@@ -48,10 +53,29 @@ export function isArcEligible(
 }
 
 /**
- * The subset of `itemIds` whose facts must be EXCLUDED from arc synthesis — Linear issues that aren't
- * active (In Progress / In Review). Reads `items.frontmatter` (source + state); non-Linear items are
- * never returned. Best-effort (empty set on error, so a hiccup can't blank arcs). `itemIds` are already
- * tier-scoped by the caller (they came out of the tier-visible fact pool).
+ * The GitHub issues-BACKLOG aggregate: one connector-owned `kind=task` document at `github/<repo>/issues.md`
+ * that lists every issue in a repo. It's a machine snapshot with no single human author, so it can only
+ * produce an author-less arc — excluded from arc synthesis (kept in the graph/facts/search). GitHub issues
+ * are ingested ONLY as this aggregate (not per-issue), so `source=github` + `kind=task` + the `issues.md`
+ * path pins it precisely. Pure.
+ */
+export function isGithubIssueBacklog(
+  source: string | null | undefined,
+  kind: string | null | undefined,
+  path: string | null | undefined
+): boolean {
+  return (
+    (source ?? "").trim().toLowerCase() === "github" &&
+    (kind ?? "").trim().toLowerCase() === "task" &&
+    /(^|\/)issues\.md$/i.test((path ?? "").trim())
+  );
+}
+
+/**
+ * The subset of `itemIds` whose facts must be EXCLUDED from arc synthesis — inactive Linear issues
+ * (not In Progress / In Review) AND the GitHub issues-backlog aggregate. Reads `items` (source/kind/
+ * path/state); other content is never returned. Best-effort (empty set on error, so a hiccup can't
+ * blank arcs). `itemIds` are already tier-scoped by the caller (they came out of the tier-visible pool).
  */
 export async function arcIneligibleItemIds(
   teamId: string,
@@ -60,14 +84,27 @@ export async function arcIneligibleItemIds(
   const ids = [...new Set(itemIds)].filter(Boolean);
   if (ids.length === 0) return new Set();
   try {
-    const { rows } = await runSql<{ id: string; state: string | null; state_type: string | null }>(
-      `select id, frontmatter->>'state' as state, frontmatter->>'state_type' as state_type
+    const { rows } = await runSql<{
+      id: string;
+      source: string | null;
+      kind: string | null;
+      path: string | null;
+      state: string | null;
+      state_type: string | null;
+    }>(
+      `select id, frontmatter->>'source' as source, kind::text as kind, path,
+              frontmatter->>'state' as state, frontmatter->>'state_type' as state_type
          from items
-        where team_id = $1 and id::text = any($2) and frontmatter->>'source' = 'linear'`,
+        where team_id = $1 and id::text = any($2)
+          and (frontmatter->>'source' = 'linear'
+               or (frontmatter->>'source' = 'github' and kind = 'task'))`,
       [teamId, ids]
     );
     const out = new Set<string>();
-    for (const r of rows) if (!isArcEligible("linear", r.state, r.state_type)) out.add(r.id);
+    for (const r of rows) {
+      if (isGithubIssueBacklog(r.source, r.kind, r.path)) out.add(r.id);
+      else if (!isArcEligible(r.source, r.state, r.state_type)) out.add(r.id);
+    }
     return out;
   } catch (err) {
     console.error("[arcs] arcIneligibleItemIds failed:", err instanceof Error ? err.message : err);

--- a/test/arc-eligibility.test.ts
+++ b/test/arc-eligibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isArcActiveLinearState, isArcEligible } from "@/lib/graph/arc-eligibility";
+import { isArcActiveLinearState, isArcEligible, isGithubIssueBacklog } from "@/lib/graph/arc-eligibility";
 
 /**
  * Spec: only ACTIVE Linear work (In Progress / In Review) informs narrative arcs; other states are
@@ -39,5 +39,23 @@ describe("isArcEligible", () => {
     expect(isArcEligible("linear", "Backlog")).toBe(false);
     expect(isArcEligible("linear", null)).toBe(false); // Linear + no type + no state → not active
     expect(isArcEligible("LINEAR", "Backlog")).toBe(false); // source case-insensitive
+  });
+});
+
+/**
+ * Spec: the GitHub issues-backlog aggregate (`github/<repo>/issues.md`, one connector-owned kind=task
+ * doc) is author-less machine context, not narrative — excluded from arcs (the "no person assigned" arc).
+ */
+describe("isGithubIssueBacklog", () => {
+  it("matches the connector issues.md aggregate (github + task + issues.md path)", () => {
+    expect(isGithubIssueBacklog("github", "task", "github/aiosbrain-aios-team-brain/issues.md")).toBe(true);
+    expect(isGithubIssueBacklog("GitHub", "task", "github/acme-repo/ISSUES.MD")).toBe(true); // case-insensitive
+  });
+  it("leaves other GitHub content alone (repo-file deliverables, commit artifacts, other tasks)", () => {
+    expect(isGithubIssueBacklog("github", "deliverable", "github/acme/readme.md")).toBe(false); // repo file
+    expect(isGithubIssueBacklog("git", "artifact", "commits/abc.md")).toBe(false); // commit
+    expect(isGithubIssueBacklog("github", "task", "github/acme/roadmap.md")).toBe(false); // not the issues digest
+    expect(isGithubIssueBacklog("linear", "task", "issues.md")).toBe(false); // not github
+    expect(isGithubIssueBacklog(null, null, null)).toBe(false);
   });
 });

--- a/test/datamechanics/arc-eligibility.datamechanics.test.ts
+++ b/test/datamechanics/arc-eligibility.datamechanics.test.ts
@@ -4,9 +4,9 @@ import { arcIneligibleItemIds } from "@/lib/graph/arc-eligibility";
 import { db, seedTeam, ingest, type Seed } from "./helpers";
 
 /**
- * Spec: `arcIneligibleItemIds` returns exactly the Linear issues NOT in active work (In Progress /
- * In Review) — the facts to exclude from arc synthesis — and never a non-Linear item. Real Postgres
- * (reads items.frontmatter).
+ * Spec: `arcIneligibleItemIds` returns the facts to exclude from arc synthesis — Linear issues NOT in
+ * active work (In Progress / In Review) AND the GitHub issues-backlog aggregate (author-less connector
+ * doc) — and leaves other content (repo files, docs) arc-eligible. Real Postgres (reads items).
  */
 
 async function seedItem(seed: Seed, source: string, state: string | null, stateType?: string): Promise<string> {
@@ -43,6 +43,35 @@ describe("arc eligibility (real Postgres)", () => {
   it("returns an empty set for no items", async () => {
     const seed = await seedTeam();
     expect((await arcIneligibleItemIds(seed.teamId, [])).size).toBe(0);
+  });
+
+  it("excludes the GitHub issues-backlog aggregate (author-less connector doc), keeps other github content", async () => {
+    const seed = await seedTeam();
+    // The single connector-owned issues digest — this is what a "no person assigned" arc traces to.
+    const issuesBacklog = (
+      await ingest(seed, {
+        body: "# GitHub issues — acme/repo\n\n| GH-1 | Adopt the AIO-<n> naming convention |",
+        path: "github/acme-repo/issues.md",
+        access: "team",
+        kind: "task",
+        frontmatter: { source: "github" },
+      })
+    ).id;
+    // A real GitHub repo-file deliverable (has a human author) — must stay arc-eligible.
+    const repoFile = (
+      await ingest(seed, {
+        body: "# Readme\n\nhow to build",
+        path: "github/acme-repo/README.md",
+        access: "team",
+        kind: "deliverable",
+        frontmatter: { source: "github" },
+      })
+    ).id;
+
+    const ineligible = await arcIneligibleItemIds(seed.teamId, [issuesBacklog, repoFile]);
+    expect(ineligible.has(issuesBacklog)).toBe(true);
+    expect(ineligible.has(repoFile)).toBe(false);
+    expect(ineligible.size).toBe(1);
   });
 
   it("tracks a live Linear status change on an unchanged-body re-push (frontmatter heal)", async () => {


### PR DESCRIPTION
## The bug
A narrative arc on the Pulse home — "Workspace Maturity and Convention Parity" — had **no person assigned** (empty participant chip).

## Diagnosis (verified in prod)
That arc was synthesized **entirely from one connector-owned item**: the GitHub **issues-backlog aggregate** `github/<repo>/issues.md` (`kind=task`) — a machine snapshot of every repo issue, with `items.member_id` null and only the **"GitHub Sync" connector** in its version ledger. Arc participants are attributed from the humans behind the evidence items (`resolveItemCredit`), so an author-less backlog aggregate yields an author-less arc. It was the only arc built from a single item; the other five all have participants.

## The fix
The arc-synthesis eligibility filter (`lib/graph/arc-eligibility.ts` `arcIneligibleItemIds`) already excludes **inactive Linear issues** ("context, not narrative"). Extended it to also exclude the **GitHub issues-backlog aggregate**, on the same rationale — a backlog snapshot isn't "what a person is working through". New pure `isGithubIssueBacklog(source, kind, path)` predicate (`github` + `kind=task` + `issues.md` path). **Arc-synthesis only** — the item stays fully in the graph/facts/search. (Nice symmetry: the Linear board aggregate `linear/<slug>/issues.md` was already excluded via the no-state path, so this makes GitHub consistent.)

## Tests & verification
Spec-first: pure predicate unit tests + a real-Postgres test (the `issues.md` aggregate is excluded; a GitHub repo-file deliverable stays eligible) — both fail without the change. `tsc`/eslint/docs-drift green; unit 1037 + data-mechanics.

## Review — Reviewed by **Fable** — verdict CLEAR
Fable traced the drop-out path (an arc whose evidence is only the now-ineligible item loses its facts and drops out; the empty-clobber guard prevents any all-arcs-blank hazard), confirmed the predicate precisely pins the aggregate (GitHub issues ingest ONLY as this one doc per repo; repo files are `kind=deliverable`), and confirmed no Linear/non-github regression. Fixed its cosmetic Low (stale test comment). **Noted out-of-scope Low (follow-up):** a repo with a *root* file literally named `issues.md` could collide with the aggregate on the item path key at ingest — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)