### PR TITLE
feat(timeline): Linear brand logomark for Linear items (not a checkbox)

### DIFF
--- a/components/icons/source-icon.tsx
+++ b/components/icons/source-icon.tsx
@@ -2,10 +2,11 @@ import { SquareCheckBig, SquareKanban, Hash, FileText, Mic, HardDrive } from "lu
 import type { ComponentType } from "react";
 
 /**
- * Per-source icon + label for the Timeline evidence. GitHub uses its real brand mark (inline — recent
- * lucide dropped the `Github` glyph); the rest map to a representative lucide icon tinted with the
- * brand's color (a checked square for Linear/tasks, a kanban board for Plane, a hash for Slack, …).
- * Swap to a full brand-logo set (e.g. simple-icons) later for pixel-accurate marks without touching callers.
+ * Per-source icon + label for the Timeline evidence. GitHub and Linear use their real brand marks
+ * (inline SVGs — recent lucide dropped `Github`, and Linear has no lucide glyph); the rest map to a
+ * representative lucide icon tinted with the brand's color (a kanban board for Plane, a hash for
+ * Slack, …). Swap the remaining ones to a full brand-logo set (e.g. simple-icons) later without
+ * touching callers.
  */
 
 function GithubMark({ className }: { className?: string }) {
@@ -16,11 +17,20 @@ function GithubMark({ className }: { className?: string }) {
   );
 }
 
+/** Linear's official logomark (simple-icons), `currentColor` so it inherits the brand tint. */
+function LinearMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden>
+      <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z" />
+    </svg>
+  );
+}
+
 type IconCmp = ComponentType<{ className?: string }>;
 
 const MAP: Record<string, { Icon: IconCmp; color: string; label: string }> = {
   github: { Icon: GithubMark, color: "text-ink", label: "GitHub" },
-  linear: { Icon: SquareCheckBig, color: "text-[#5E6AD2]", label: "Linear" },
+  linear: { Icon: LinearMark, color: "text-[#5E6AD2]", label: "Linear" },
   plane: { Icon: SquareKanban, color: "text-[#3f76ff]", label: "Plane" },
   tasks: { Icon: SquareCheckBig, color: "text-violet", label: "Tasks" }, // PM tasks, no provider configured
   slack: { Icon: Hash, color: "text-[#611f69] dark:text-[#e01e5a]", label: "Slack" },


### PR DESCRIPTION
The Timeline source icon for Linear was a generic lucide checked-square (`SquareCheckBig`), which reads as a checkbox. This swaps it for Linear's official logomark.

## Change
`components/icons/source-icon.tsx` (the single source→icon map the timeline reads):
- Added `LinearMark` inline SVG (Linear's official logomark, `fill="currentColor"`) — mirrors the existing `GithubMark`.
- Pointed the `linear` entry at it; kept the Linear-purple tint (`text-[#5E6AD2]`) so it stays on-brand and adapts to light/dark.
- The generic `tasks` source (PM tasks, no provider configured) keeps the checked-square — that's a separate, non-Linear case.

Used the official vector (theme-adaptive, sharp) rather than embedding the PNG, which would be invisible in dark mode.

## Verified
`tsc` clean · `eslint` clean · no tests pinned the old icon. Presentational-only change, no logic/data paths touched.

## Review
Trivial single-file presentational change (icon glyph swap) — no correctness surface. Reviewed by author; CI gates below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)