### PR TITLE
feat(dashboard): help "?" on Recent decisions explaining how they're made

### DIFF
--- a/components/dashboard/decisions-card.tsx
+++ b/components/dashboard/decisions-card.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Gavel } from "lucide-react";
 import { fmtDate, truncate, stripMarkdown } from "@/components/format";
+import { HelpHint } from "@/components/help-hint";
 import type { DecisionRow } from "./types";
 
 const TIER_LABEL: Record<number, string> = { 1: "1-way", 2: "2-way", 3: "minor" };
@@ -16,6 +17,20 @@ export function DecisionsCard({
     <section className="prism-card px-5 py-4">
       <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
         <Gavel className="size-3.5 text-amber" /> Recent decisions
+        <HelpHint label="How these decisions are made">
+          <span className="font-medium text-ink">How these are made</span>
+          <br />
+          Decisions aren&apos;t auto-detected from raw meetings. A person reviews the meeting
+          transcripts and records each decision in a decision log that syncs to the brain — so what
+          you see here is human-curated, not machine-guessed.
+          <br />
+          <br />
+          The <span className="font-medium text-ink">1-way / 2-way</span> tag is the decision&apos;s
+          reversibility, set by that reviewer: <span className="font-medium text-ink">1-way</span> = a
+          hard-to-reverse call, <span className="font-medium text-ink">2-way</span> = easily
+          reversible, <span className="font-medium text-ink">minor</span> = trivial. A struck-through
+          title means the decision was later superseded.
+        </HelpHint>
       </h2>
       {decisions.length === 0 ? (
         <p className="text-sm text-ink-tertiary">

--- a/components/help-hint.tsx
+++ b/components/help-hint.tsx
@@ -1,0 +1,45 @@
+import { HelpCircle } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * A tiny "?" help affordance that reveals an explanatory popover on hover/focus. CSS-only (no client
+ * JS), so it can sit inside a server component; keyboard-accessible via `group-focus-within` on the
+ * focusable icon button. The popover resets the parent's uppercase/tracking so prose reads normally,
+ * and is `pointer-events-none` so it never blocks the content beneath it.
+ */
+export function HelpHint({
+  label,
+  children,
+  align = "left",
+}: {
+  label: string;
+  children: ReactNode;
+  /** Which edge the popover aligns to (use "right" near the right edge of a card). */
+  align?: "left" | "right";
+}) {
+  const tipId = `help-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")}`;
+  return (
+    <span className="group/hint relative inline-flex align-middle">
+      <button
+        type="button"
+        aria-label={label}
+        aria-describedby={tipId}
+        className="inline-flex size-4 items-center justify-center rounded-full text-ink-tertiary transition-colors hover:text-ink focus-visible:text-ink focus:outline-none focus-visible:ring-1 focus-visible:ring-violet/40"
+      >
+        <HelpCircle className="size-3.5" aria-hidden />
+      </button>
+      {/* `hidden` → `block` (not opacity): a hidden popover must NOT take layout — else this 18rem box
+          triggers permanent horizontal scroll on a phone AND screen readers read the prose as heading
+          text. max-w caps it on narrow screens. */}
+      <span
+        id={tipId}
+        role="tooltip"
+        className={`pointer-events-none absolute top-6 z-20 hidden w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-border-subtle bg-surface-overlay p-3 text-left text-xs font-normal normal-case leading-relaxed tracking-normal text-ink-secondary shadow-lg group-hover/hint:block group-focus-within/hint:block ${
+          align === "right" ? "right-0" : "left-0"
+        }`}
+      >
+        {children}
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
Adds a **"?" help hint** next to the Pulse "Recent decisions" header. On hover/focus it pops up an explanation of how these decisions are produced (the thing that wasn't obvious from the card):

> Decisions aren't auto-detected from raw meetings. A person reviews the meeting transcripts and records each decision in a decision log that syncs to the brain — human-curated, not machine-guessed. The **1-way / 2-way** tag is the reviewer-assigned reversibility (1-way = hard to reverse, 2-way = easily reversible, minor = trivial). Struck-through = superseded.

## Implementation
New reusable **`components/help-hint.tsx`** — a CSS-only tooltip (`HelpHint`, `label` + `children` + `align`): a `HelpCircle` button + an absolutely-positioned `role="tooltip"` popover revealed via `group-hover`/`group-focus-within`. No client JS, so it renders inside the server-rendered `DecisionsCard`; keyboard-accessible. First tooltip primitive in the repo (previously only native `title=`).

## Verification
`tsc`/eslint/docs-drift green. Presentational only — no schema/route/data changes.

## Review — Reviewed by **Fable** — verdict SHIP-WITH-CHANGES → addressed
Fable confirmed the RSC boundary, named-group Tailwind syntax, no card-clip, correct h2 case-reset, and the explanation's accuracy against the pipeline (`granola.py` human-review comment + `materializeDecisions`). Fixed its Medium: the hidden popover used `opacity-0` only, so it stayed in layout (permanent mobile horizontal scroll) and in the a11y tree (screen readers read the tooltip as heading text) — switched to `hidden`→`block` + `max-w-[calc(100vw-2rem)]`, and added `aria-describedby`. Softened the wording per its Low (decisions can also be logged directly, not only via `aios push`). Known CSS-only limitation: no reveal on iOS tap (desktop/Android fine) — acceptable for an internal dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)