### PR TITLE
feat(timeline): chip a commit's Linear task even when the ticket is Done (restore the association)

### DIFF
--- a/components/dashboard/person-work-card.tsx
+++ b/components/dashboard/person-work-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { GitBranch } from "lucide-react";
 import { MemberAvatar } from "@/components/people/member-avatar";
 import { SourceIcon, sourceLabel } from "@/components/icons/source-icon";
 import type { PersonDay, SourceGroup, TaskGroup } from "@/lib/dashboard/timeline-group";
@@ -51,15 +52,28 @@ function EvidenceList({ group }: { group: SourceGroup }) {
       </div>
       <ul className="flex flex-col gap-1 border-l border-border-subtle pl-3">
         {group.items.map((it) => (
-          <li key={it.id} className="flex items-baseline justify-between gap-3">
-            {it.url ? (
-              <a href={it.url} target="_blank" rel="noreferrer" className="truncate text-sm text-ink hover:text-violet">
-                {it.title}
-              </a>
-            ) : (
-              <span className="truncate text-sm text-ink">{it.title}</span>
-            )}
-            <span className="shrink-0 text-[11px] text-ink-tertiary">{timeOf(it.at)}</span>
+          <li key={it.id} className="flex flex-col gap-0.5">
+            <div className="flex items-baseline justify-between gap-3">
+              {it.url ? (
+                <a href={it.url} target="_blank" rel="noreferrer" className="truncate text-sm text-ink hover:text-violet">
+                  {it.title}
+                </a>
+              ) : (
+                <span className="truncate text-sm text-ink">{it.title}</span>
+              )}
+              <span className="shrink-0 text-[11px] text-ink-tertiary">{timeOf(it.at)}</span>
+            </div>
+            {it.linkedTask ? (
+              <span
+                className="inline-flex max-w-full items-center gap-1 self-start rounded border border-border-subtle bg-surface-sunken px-1.5 py-0.5 text-[11px] text-ink-secondary"
+                title={`References ${it.linkedTask.key} (${it.linkedTask.status}): ${it.linkedTask.title}`}
+              >
+                <GitBranch className="size-3 shrink-0 text-ink-tertiary" />
+                <span className="shrink-0 font-medium text-ink-secondary">{it.linkedTask.key}</span>
+                <span className="truncate text-ink-tertiary">· {it.linkedTask.title}</span>
+                {it.linkedTask.status ? <span className="shrink-0 text-ink-tertiary/70">· {it.linkedTask.status}</span> : null}
+              </span>
+            ) : null}
           </li>
         ))}
         {group.count > group.items.length ? (

--- a/lib/dashboard/timeline-group.ts
+++ b/lib/dashboard/timeline-group.ts
@@ -15,6 +15,15 @@
  */
 
 /** One piece of a person's work — a commit or a dated deliverable. `taskId` links it to a task. */
+/** A PM task an "Other"-bucket item references but which is NOT active (done/backlog), so it can't be a
+ *  nesting header (#350 keeps headers active-only). Shown as a chip so the commit↔task association is still
+ *  visible — e.g. a commit for a ticket that just went Done. */
+export interface EvidenceTaskRef {
+  key: string; // the task's issue key / row_key, e.g. AIO-138
+  title: string;
+  status: string; // done / backlog / ready — why it isn't a nesting header
+}
+
 export interface EvidenceItem {
   id: string;
   title: string;
@@ -24,6 +33,9 @@ export interface EvidenceItem {
   kind: string;
   /** WORK time — ISO. Its date places the row on a day. */
   at: string;
+  /** Set only for an "Other"-bucket item that references a real but NON-active task (done/backlog) — the
+   *  commit↔task association shown as a chip, since the task can't be an active nesting header. */
+  linkedTask?: EvidenceTaskRef;
 }
 
 export interface EvidenceWithMember extends EvidenceItem {
@@ -240,7 +252,7 @@ export function groupTimeline(
     byDay.set(date, people);
     const b: PersonBucket = people.get(ev.memberId) ?? { tasks: new Map<string, EvidenceItem[]>(), other: [] };
     people.set(ev.memberId, b);
-    const item: EvidenceItem = { id: ev.id, title: ev.title, url: ev.url, source: ev.source, kind: ev.kind, at: ev.at };
+    const item: EvidenceItem = { id: ev.id, title: ev.title, url: ev.url, source: ev.source, kind: ev.kind, at: ev.at, linkedTask: ev.linkedTask };
     if (ev.taskId && taskInfo.has(ev.taskId)) {
       const arr = b.tasks.get(ev.taskId) ?? [];
       arr.push(item);

--- a/lib/dashboard/work-timeline.ts
+++ b/lib/dashboard/work-timeline.ts
@@ -7,6 +7,7 @@ import {
   normalizeSource,
   itemWorkTime,
   type EvidenceItem,
+  type EvidenceTaskRef,
   type EvidenceWithMember,
   type TaskInfo,
   type TimelineDay,
@@ -308,15 +309,46 @@ export async function getWorkTimeline(
     evItems.map((e) => ({ id: e.id, text: e.text }))
   );
 
+  // CHIP linkage for the "Other" bucket: a commit often cites a task that just went DONE/backlog, which
+  // #350 keeps out of the active nesting headers — so it lands in "Other" looking unassociated. Resolve
+  // those references against ALL tasks (any status, tier-gated) so the commit↔task link is still SHOWN as
+  // a chip, WITHOUT reintroducing done/backlog tasks as headers (nesting still uses `links`/active only).
+  const allTaskRes = await visibleTasks(
+    db
+      .from("tasks")
+      .select("id, row_key, title, status")
+      .eq("team_id", teamId)
+      .not("row_key", "is", null)
+      .order("updated_at", { ascending: false })
+      .limit(TASK_LIMIT),
+    tier
+  );
+  // Chips are ENRICHMENT (not a core ledger leg) — a failed read must NOT blank the ledger, but it also
+  // must not be silent (the swallowed-error trap this file warns about). WARN, like the Slack leg.
+  if (allTaskRes.error) console.warn("[work-timeline] chip-task read failed:", allTaskRes.error.message);
+  const allTasks = (allTaskRes.data ?? []) as TaskRow[];
+  const chipInfo = new Map<string, EvidenceTaskRef>();
+  for (const t of allTasks) if (t.row_key) chipInfo.set(t.id, { key: t.row_key.toUpperCase(), title: t.title || "(untitled task)", status: t.status ?? "" });
+  const allLinks = computeTaskLinks(
+    allTasks.map((t) => ({ id: t.id, row_key: t.row_key })),
+    evItems.map((e) => ({ id: e.id, text: e.text }))
+  );
+
   // One evidence row per (item, linked active task); unlinked items carry taskId=null (→ the "Other"
-  // bucket). A commit citing two issues appears under both. The grouper then evidence-gates: a task
-  // shows ONLY where it has ≥1 of this person's evidence that day (no empty headers).
+  // bucket) + a `linkedTask` chip when they reference a real non-active task. A commit citing two issues
+  // appears under both active tasks. The grouper then evidence-gates: a task shows ONLY where it has ≥1 of
+  // this person's evidence that day (no empty headers).
   const evidence: EvidenceWithMember[] = [];
   for (const e of evItems) {
     const base: EvidenceItem & { memberId: string } = { id: e.id, memberId: e.memberId, source: e.source, kind: e.kind, title: e.title, url: e.url, at: e.at };
     const taskIds = links.get(e.id);
-    if (taskIds && taskIds.length) for (const taskId of taskIds) evidence.push({ ...base, taskId });
-    else evidence.push({ ...base, taskId: null });
+    if (taskIds && taskIds.length) {
+      for (const taskId of taskIds) evidence.push({ ...base, taskId });
+    } else {
+      // In "Other" (no ACTIVE task): chip the first non-active task it references (done/backlog), if any.
+      const chip = (allLinks.get(e.id) ?? []).map((id) => chipInfo.get(id)).find((c): c is EvidenceTaskRef => !!c);
+      evidence.push({ ...base, taskId: null, ...(chip ? { linkedTask: chip } : {}) });
+    }
   }
 
   return groupTimeline(evidence, taskInfo, members, todayISO);

--- a/test/datamechanics/work-timeline.datamechanics.test.ts
+++ b/test/datamechanics/work-timeline.datamechanics.test.ts
@@ -222,4 +222,47 @@ describe("work timeline — attribution oracle (credits the worker, not the reas
     expect(names).not.toContain("Person B"); // B never worked → not credited
     expect(evidenceTitles(days)).toContain("feat: did the actual work");
   });
+
+  it("chips a commit that references a DONE task (association shown in Other, not nested — #350 stays active-only)", async () => {
+    const seed = await seedTeam();
+    const anchor = await commit(seed, "seed");
+    // A task that just shipped (Done) — excluded from the active nesting headers by #350.
+    await insertTask(seed, anchor.projectId!, { row_key: "AIO-777", title: "Ship the widget", status: "done" });
+    // A commit for it, landing today.
+    await commit(seed, "fix: polish the widget (AIO-777)");
+
+    const days = await getWorkTimeline(db(), seed.teamId, "team");
+    // The done task is NOT a nesting header…
+    expect(taskTitles(days)).not.toContain("Ship the widget");
+    // …but the commit still shows the association as a chip in the Other bucket.
+    const chips = days
+      .flatMap((d) => d.people)
+      .flatMap((p) => p.other.flatMap((g) => g.items))
+      .filter((i) => i.title.includes("polish the widget"))
+      .map((i) => i.linkedTask);
+    expect(chips).toEqual([{ key: "AIO-777", title: "Ship the widget", status: "done" }]);
+  });
+
+  it("TIER: a chip never leaks a team-audience task to an external viewer (but an external task DOES chip)", async () => {
+    const seed = await seedTeam();
+    const anchor = await commit(seed, "seed");
+    // A TEAM-audience done task and a PUBLIC (external-audience) done task, both referenced by
+    // external-ACCESS commits (so the commit itself is visible to an external viewer).
+    await insertTask(seed, anchor.projectId!, { row_key: "SEC-99", title: "Team secret ticket", status: "done", audience: "team" });
+    await insertTask(seed, anchor.projectId!, { row_key: "PUB-1", title: "Public ticket", status: "done", audience: "external" });
+    const extCommit = (body: string) =>
+      ingest(seed, { kind: "artifact", path: `commits/repo/${randomUUID()}.md`, access: "external", body, frontmatter: { source: "git", committed_at: recentIso } });
+    await extCommit("fix: touch the secret (SEC-99)");
+    await extCommit("fix: touch the public thing (PUB-1)");
+
+    const chipKeys = (days: TimelineDay[]): (string | undefined)[] =>
+      days.flatMap((d) => d.people).flatMap((p) => p.other.flatMap((g) => g.items)).map((i) => i.linkedTask?.key);
+
+    const asExternal = await getWorkTimeline(db(), seed.teamId, "external");
+    expect(chipKeys(asExternal)).toContain("PUB-1"); // external task → external viewer DOES get the chip (non-vacuous)
+    expect(chipKeys(asExternal)).not.toContain("SEC-99"); // team task → NEVER leaked to an external viewer
+
+    const asTeam = await getWorkTimeline(db(), seed.teamId, "team");
+    expect(chipKeys(asTeam)).toEqual(expect.arrayContaining(["SEC-99", "PUB-1"])); // team viewer sees both
+  });
 });


### PR DESCRIPTION
## What
Restores the **commit ↔ Linear-task association** in the Timeline for commits whose ticket has already shipped. The timeline nests a person's evidence under the **active** task it references (`#349`/`#350`), but a lot of recent commits reference a task that just went **Done** — `#350` deliberately keeps done/backlog tasks out of the nesting headers, so those commits fall into "Other" looking unassociated. This shows the association back as a **chip** (`⎇ AIO-138 · title · done`), without reintroducing done/backlog tasks as headers.

## Diagnosis (prod, last 7 days)
Of 126 commits: **1** references an active task (nests today), **22** reference a Done/backlog task (were unassociated → now **chipped**), and **103** carry **no Linear key at all** (they cite PR numbers). The 103 need PR→task ingestion — a separate, bigger piece, **not** in this PR.

## Change
- **`lib/dashboard/work-timeline.ts`**: for "Other"-bucket items, resolve their issue-key references against **all** tasks (any status) in **one tier-gated query** (`visibleTasks`), and attach `linkedTask`. Active nesting is untouched — still `links`/active-only, so `#350`'s headers stay active-only; only the chip is new. The chip read is enrichment → **warns** (never throws/blanks the ledger) on a query error.
- **`lib/dashboard/timeline-group.ts`**: `EvidenceItem` gains `linkedTask?`; `groupTimeline` now carries it through (it was reconstructing the item and silently dropping the field — a real bug, fixed).
- **`components/dashboard/person-work-card.tsx`**: renders the chip — shared card, so both the **Timeline** and the Home **"Working on"** section show it.

Additive + optional (like `summary`) → no `PAYLOAD_VERSION` bump; chips appear on the next SWR rebuild.

## Tier isolation
The chip query goes through the same `visibleTasks` choke-point as the active-task query, so an **external** viewer never receives a team-audience task's key/title. Proven by a data-mechanics test (external viewer gets **no** chip for a team task; a public-audience task **does** chip — non-vacuous).

## Tests
data-mechanics (real items + tasks): a commit citing a Done task is **not** nested (headers stay active-only) but carries the chip in "Other"; + the tier-isolation assertions above. Full unit 1069, work-timeline dm 11/11.

## Review — Reviewed by **Fable code-reviewer** — verdict: CLEAR
Independently (empirically) verified the tier-isolation invariant, that active nesting is byte-identical, and XSS-safety. Fixed both its MEDIUMs before merge: warn on the swallowed chip-query error + the tier-leak test assertions.

## Note
The Timeline area is actively iterated in a parallel worktree (`wellington`, cosmetic branch); this change is additive and doesn't touch its files' logic, but flagging for merge awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
