### PR TITLE
fix(ingest): compute the dedup key server-side — the wire sha is advisory

### DIFF
--- a/docs/context-management-system.md
+++ b/docs/context-management-system.md
@@ -71,10 +71,19 @@ validation (before any mutation) → item + version + derived-row materializatio
 
 ### 2.1 Deduplication — content-addressed, at every layer
 
-- **`content_sha256` fast-path** (`index.ts:100`). The hash covers **body + title only** (not
-  frontmatter — `reattribution-decision.ts:2`). If the incoming sha equals the stored sha, we take the
-  "unchanged" branch: no new version, no re-projection, no re-embed. Every connector re-pushes every
-  item every 30-minute tick, so this is what stops a re-sync storm from doing real work.
+- **`content_sha256` fast-path** (`index.ts:127`). The key is computed **server-side** over the
+  **body** the writer is about to store (`contentHash`, `index.ts:31`) — the wire `content_sha256` is
+  **advisory**. Producers all send `sha256(utf8(body))`, so for a correct client the two agree and
+  nothing changes; a disagreement is recorded as `sha_mismatch` in the item's create/update audit meta.
+  Integrity of the change key is the contract's own invariant, not something delegated to each
+  connector: a client hashing a different normalization would mark every push "changed" (endless
+  version/embed/projection churn), and one repeating a **stale** sha while the body changed would hit
+  the unchanged branch and freeze the stored body forever (stale content served with no error).
+  The key covers the **body only** (titles reach it only because producers embed them as a heading;
+  frontmatter is excluded — `reattribution-decision.ts:2`, hence the explicit heal paths below). If the
+  body's hash equals the stored sha, we take the "unchanged" branch: no new version, no re-projection,
+  no re-embed. Every connector re-pushes every item every 30-minute tick, so this is what stops a
+  re-sync storm from doing real work.
 - **Identity constraint** — `items` is unique on `(team_id, project_id, path)` (`schema.sql:931`): one
   live row per path. New content **replaces in place**; history goes to `item_versions`.
 - **Derived-row diff-sync** by `row_key` — `tasks`/`decisions` upsert on `(team_id, project_id,
@@ -148,7 +157,7 @@ identity resolution) can disagree with a human's deliberate correction. The reso
 
 ### 2.5 Crash-safety & integrity
 
-- **PENDING_SHA sentinel** (`index.ts:190`): a brand-new item's `content_sha256` is withheld as `""`
+- **PENDING_SHA sentinel** (`index.ts:277`): a brand-new item's `content_sha256` is withheld as `""`
   and committed **last**. Item write and derived-row materialization aren't one transaction, so a
   mid-materialize crash leaves the old/empty sha → the unchanged fast-path won't fire on retry → rows
   re-materialize. Self-healing.

--- a/ingestion/aios_ingest/payload.py
+++ b/ingestion/aios_ingest/payload.py
@@ -21,8 +21,10 @@ _SHA256_HEX = 64
 
 
 def sha256_hex(body: str) -> str:
-    """content_sha256 over the normalized body. Computed caller-side per contract;
-    the brain only validates the ``^[a-f0-9]{64}$`` format and uses it for dedup."""
+    """content_sha256 over the normalized body. Sent caller-side per contract, but ADVISORY:
+    the brain recomputes this hash server-side over the body it stores and uses THAT as the dedup
+    key, so a client hashing a different normalization can neither churn every push nor freeze a
+    stale body. Keep sending it — a disagreement is recorded server-side for diagnosis."""
     return hashlib.sha256(body.encode("utf-8")).hexdigest()
 
 

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
 import { audit } from "@/lib/api/audit";
 import { decideReattribution } from "@/lib/ingest/reattribution-decision";
 import { recordReassignment, ownerWindowStart } from "@/lib/ingest/reassignment-log";
@@ -22,6 +23,23 @@ export interface IngestResult {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * THE change key: sha256 over the body exactly as we are about to store it. Every producer already
+ * computes `sha256(utf8(body))` (TS normalizers + the Python sidecar's `sha256_hex`), so for a
+ * correct client this equals the wire `content_sha256` and nothing changes.
+ *
+ * It is computed HERE, server-side, because the wire field is untrusted input and dedup integrity is
+ * the contract's own invariant — not something to delegate to every present and future connector. A
+ * client that hashes a slightly different normalization (CRLF, NFC/NFD) would otherwise mark every
+ * push "changed" (endless version/embed/projection churn); worse, a client that repeats a STALE sha
+ * while the body changed would hit the unchanged fast-path and the stored body would silently never
+ * update — permanently stale content served to retrieval with no error anywhere. Hashing the body we
+ * hold makes both impossible by construction.
+ */
+export function contentHash(body: string): string {
+  return createHash("sha256").update(body, "utf8").digest("hex");
 }
 
 function canonicalJson(value: unknown): string {
@@ -75,6 +93,12 @@ export async function ingestItem(
     );
   }
   const payload = parsedPayload.data;
+  // Authoritative change key (see contentHash). The wire `content_sha256` is advisory from here on:
+  // a mismatch means the pushing client hashes something other than the body it sent, which we record
+  // on the item's audit row (below) so a buggy connector is diagnosable instead of silently corrupting
+  // dedup. It is NOT rejected — the body is the source of truth and we can always hash it correctly.
+  const contentSha = contentHash(payload.body);
+  const shaMismatch = contentSha !== payload.content_sha256;
   const now = new Date().toISOString();
   const { data: project, error: projectError } = await db
     .from("projects")
@@ -100,13 +124,13 @@ export async function ingestItem(
     .eq("path", payload.path)
     .maybeSingle();
 
-  if (existing && existing.content_sha256 === payload.content_sha256) {
+  if (existing && existing.content_sha256 === contentSha) {
     // Refresh "last seen this sync"; do NOT write an audit row (audit M4). Every 30-min sync tick
     // re-pushes every unchanged item, so an `item.unchanged` audit here added ~one row/item/tick
     // (~24k/day at 500 items) — unbounded audit_log growth with no diagnostic value. The synced_at
     // bump is the freshness signal; create/update/delete stay audited on the paths below.
     //
-    // RE-ATTRIBUTE on an unchanged re-push: `content_sha256` covers only body+title, so an author signal
+    // RE-ATTRIBUTE on an unchanged re-push: `content_sha256` covers only the body, so an author signal
     // that changed in FRONTMATTER without touching the prose would otherwise be discarded here. Two cases,
     // both decided by `decideReattribution` (which leans on the `member_id_locked` guard, #333):
     //   • null → member: a resolved author that arrived AFTER first ingest (a source that only later
@@ -132,7 +156,7 @@ export async function ingestItem(
       locked
     );
     if (reattr.memberId) patch.member_id = reattr.memberId;
-    // HEAL ACCESS on an unchanged re-push: `content_sha256` covers only body+title, so a source that
+    // HEAL ACCESS on an unchanged re-push: `content_sha256` covers only the body, so a source that
     // RECLASSIFIES an item's tier without touching its prose (a doc shared narrower/wider upstream)
     // would otherwise keep the first-ingest `access` forever. With no RLS backstop (CLAUDE.md §5) a
     // stale `access='external'` on a now-internal item silently keeps serving the body to an external
@@ -288,7 +312,7 @@ export async function ingestItem(
 
   const { error: versionError } = await db.from("item_versions").insert({
     item_id: itemId,
-    content_sha256: payload.content_sha256,
+    content_sha256: contentSha,
     frontmatter: payload.frontmatter,
     body: payload.body,
     member_id: opts ? opts.authorMemberId : auth.memberId,
@@ -341,7 +365,7 @@ export async function ingestItem(
 
   const { error: shaError } = await db
     .from("items")
-    .update({ content_sha256: payload.content_sha256 })
+    .update({ content_sha256: contentSha })
     .eq("id", itemId);
   if (shaError) throw new Error(`item sha commit failed: ${shaError.message}`);
 
@@ -358,6 +382,10 @@ export async function ingestItem(
       kind: payload.kind,
       access,
       rows: payload.rows?.length ?? 0,
+      // Only present when the pusher's `content_sha256` disagreed with the body it sent — a client
+      // bug worth chasing. Recorded on the EXISTING create/update audit row (never its own row, and
+      // never on the unchanged fast-path) so a systematically-wrong connector can't grow audit_log.
+      ...(shaMismatch ? { sha_mismatch: true, client_sha: payload.content_sha256 } : {}),
     },
   });
 

--- a/lib/ingest/ingest.test.ts
+++ b/lib/ingest/ingest.test.ts
@@ -16,7 +16,18 @@ import type { ItemPayload } from "@/lib/api/schemas";
 
 const AUTH = { teamId: "team-1", memberId: "mem-1", apiKeyId: "key-1" };
 
+/**
+ * Every real task producer SERIALIZES the projectable row fields into the body — linear/plane/github
+ * all render `rows` as a markdown table, explicitly "so any change shifts the sha". Since the writer
+ * hashes the body it stores (the change key is server-computed, not client-asserted), a payload whose
+ * rows changed while its body stayed byte-identical is a shape no connector can emit. So derive the
+ * body from `rows` here, keeping these fixtures faithful to the contract; a test that specifically
+ * needs "the body changed elsewhere, rows unchanged" passes an explicit `body`.
+ */
 function payload(over: Partial<ItemPayload> = {}): ItemPayload {
+  const rows = over.rows as unknown[] | undefined;
+  const body =
+    over.body ?? (rows ? `# board\n\n${rows.map((r) => JSON.stringify(r)).join("\n")}\n` : "hello");
   return {
     project: "acme",
     path: "github/o/r/x.md",
@@ -25,8 +36,8 @@ function payload(over: Partial<ItemPayload> = {}): ItemPayload {
     access: "team",
     actor: "github-sync",
     frontmatter: {},
-    body: "hello",
     ...over,
+    body,
   } as ItemPayload;
 }
 
@@ -274,12 +285,13 @@ describe("ingestItem idempotent re-push", () => {
       payload({ kind: "task", path: "b.md", content_sha256: "a".repeat(64), rows }),
       "team"
     );
-    // A different sha (body changed elsewhere) but identical row set re-materializes; row_key is
-    // the diff-sync identity, so re-processing the same rows must not create duplicates.
+    // The body changed elsewhere (a touched header/comment) but the row set is identical, so the
+    // item is "changed" and rows re-materialize; row_key is the diff-sync identity, so re-processing
+    // the same rows must not create duplicates.
     await ingestItem(
       supa,
       AUTH,
-      payload({ kind: "task", path: "b.md", content_sha256: "b".repeat(64), rows }),
+      payload({ kind: "task", path: "b.md", body: "# board (header touched)\n\nsame rows", rows }),
       "team"
     );
     expect(fake.tables.tasks).toHaveLength(2);

--- a/test/datamechanics/ingest-content-hash.datamechanics.test.ts
+++ b/test/datamechanics/ingest-content-hash.datamechanics.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { db, seedTeam, ingest, sha } from "./helpers";
+
+/**
+ * Spec: `content_sha256` is the ingest contract's CHANGE KEY — it decides "new work" vs "no-op
+ * re-sync". Integrity of that key is the contract's own invariant, so the server hashes the body it
+ * is about to store; the wire field is advisory. Derived from the contract (dedup must be correct
+ * for any producer), not from the implementation.
+ *
+ * The wire field was previously trusted verbatim, which delegated dedup integrity to every present
+ * and future connector and produced two silent failures — both reproduced below:
+ *   (a) a client whose hash covers a different normalization marks every push "changed" → endless
+ *       version/embed/projection churn;
+ *   (b) a client that repeats a STALE sha while the body changed hits the unchanged fast-path and
+ *       the stored body NEVER updates — permanently stale content served to retrieval, no error.
+ * Real Postgres is the right tier: the observable outcome is the stored row + the version ledger.
+ */
+
+async function readItem(id: string): Promise<{ body: string; content_sha256: string }> {
+  const { data } = await db().from("items").select("body, content_sha256").eq("id", id).maybeSingle();
+  return data as { body: string; content_sha256: string };
+}
+
+async function countVersions(itemId: string): Promise<number> {
+  const { data } = await db().from("item_versions").select("id").eq("item_id", itemId);
+  return (data ?? []).length;
+}
+
+describe("ingest content hash (server-authoritative change key)", () => {
+  it("stores the body's OWN hash, ignoring a client that lies about it", async () => {
+    const seed = await seedTeam();
+    const { id } = await ingest(seed, {
+      path: "lying-client.md",
+      body: "the real body",
+      access: "team",
+      content_sha256: sha("a completely different body"),
+    });
+
+    const row = await readItem(id);
+    expect(row.body).toBe("the real body");
+    // The stored key is the hash of what we actually hold — not the client's claim.
+    expect(row.content_sha256).toBe(sha("the real body"));
+
+    // …and the disagreement is RECORDED, so a buggy connector is diagnosable rather than silent.
+    // It rides the item's existing create/update audit row (never its own row, never on the
+    // unchanged fast-path) so a systematically-wrong client can't grow audit_log unboundedly.
+    const { data: audits } = await db()
+      .from("audit_log")
+      .select("action, meta")
+      .eq("target_id", id);
+    const created = (audits ?? []).find(
+      (a) => (a as { action: string }).action === "item.created"
+    ) as { meta: Record<string, unknown> } | undefined;
+    expect(created?.meta?.sha_mismatch).toBe(true);
+    expect(created?.meta?.client_sha).toBe(sha("a completely different body"));
+  });
+
+  it("records NO mismatch flag when the client's sha is honest", async () => {
+    const seed = await seedTeam();
+    const { id } = await ingest(seed, { path: "honest-client.md", body: "agreed body", access: "team" });
+    const { data: audits } = await db()
+      .from("audit_log")
+      .select("action, meta")
+      .eq("target_id", id);
+    const created = (audits ?? []).find(
+      (a) => (a as { action: string }).action === "item.created"
+    ) as { meta: Record<string, unknown> } | undefined;
+    expect(created).toBeDefined();
+    expect(created?.meta?.sha_mismatch).toBeUndefined();
+  });
+
+  it("UPDATES a changed body even when the client repeats the stale sha (the frozen-body bug)", async () => {
+    const seed = await seedTeam();
+    const first = await ingest(seed, { path: "frozen.md", body: "v1", access: "team" });
+    expect(first.status).toBe("created");
+
+    // The client edits the body but re-sends v1's sha (a buggy/cached hasher). Trusting the wire
+    // field took the unchanged fast-path here: the stored body stayed "v1" forever, silently.
+    const second = await ingest(seed, {
+      path: "frozen.md",
+      body: "v2 — a real edit",
+      access: "team",
+      content_sha256: sha("v1"),
+    });
+
+    expect(second.status).toBe("updated");
+    const row = await readItem(second.id);
+    expect(row.body).toBe("v2 — a real edit");
+    expect(row.content_sha256).toBe(sha("v2 — a real edit"));
+    // The edit is a real unit of work: it must be recorded in the version ledger.
+    expect(await countVersions(second.id)).toBe(2);
+  });
+
+  it("treats an unchanged body as unchanged even when the client's sha churns", async () => {
+    const seed = await seedTeam();
+    const body = "stable content";
+    const first = await ingest(seed, {
+      path: "churn.md",
+      body,
+      access: "team",
+      content_sha256: sha("client normalization A"),
+    });
+    const second = await ingest(seed, {
+      path: "churn.md",
+      body,
+      access: "team",
+      content_sha256: sha("client normalization B"),
+    });
+
+    // Same body → no new work, regardless of what the client's hasher decided.
+    expect(second.status).toBe("unchanged");
+    expect(await countVersions(first.id)).toBe(1);
+  });
+});


### PR DESCRIPTION
First item of the **Pass-2 ingestion soundness** remediation plan (H4 — highest soundness-per-effort).

## Problem
`content_sha256` is the ingest contract's **change key**: it decides "new work" vs "no-op re-sync" for every connector. It was **client-supplied and never verified** — `ingestItem` compared the stored sha to the payload's sha and never hashed the body. That delegates the contract's own integrity to every present and future connector, with two silent failure modes:

- **(a) churn** — a client hashing a different normalization (CRLF, NFC/NFD) marks *every* push "changed" → endless version / embed / graph-projection churn.
- **(b) frozen body** — a client repeating a **stale** sha while the body changed hits the unchanged fast-path → the stored body **silently never updates**. Permanently stale content served to retrieval, no error anywhere.

This is the acid test for the generic/MCP/Zapier connector class we don't hand-write normalizers for.

## Fix
`ingestItem` computes `contentHash(payload.body)` and uses it as the authoritative key at all sites (fast-path compare, `item_versions` row, final sha commit). The wire field becomes **advisory**.

Back-compat verified: every producer already sends `sha256(utf8(body))` — the five TS normalizers, `commits-to-items`, meetings, actions, seed-demo, and the Python `sha256_hex` — so for a correct client the two agree and the first post-deploy push is a true no-op. A disagreement is recorded as `sha_mismatch` in the item's **existing** create/update audit meta (never its own row, never on the unchanged path) so a buggy connector is diagnosable without growing `audit_log`.

**Crash-safety preserved:** the PENDING_SHA sentinel is untouched — a new item still withholds its sha until after row materialization, so a mid-write crash reprocesses on retry (`ingest-atomicity` passes unmodified).

## Tests
`test/datamechanics/ingest-content-hash.datamechanics.test.ts` (real Postgres — the observable outcome is the stored row + version ledger):
- lying client → stored body + key are the body's own hash;
- **frozen-body repro** → changed body with a stale sha must UPDATE (+ a version);
- **churn repro** → identical body with a churning client sha must stay `unchanged`;
- the `sha_mismatch` / no-mismatch audit signal.

All reproduced **red before the fix** with the exact signatures (`expected 'unchanged' to be 'updated'`, `expected 'updated' to be 'unchanged'`).

**Fixture change (called out for review):** `lib/ingest/ingest.test.ts` previously faked "changed" via hand-written differing shas on a byte-identical `body: "hello"`. Under a server-computed key that shape is *unchanged*. Every real task producer serializes the projectable row fields **into** the body — the Linear normalizer says so explicitly ("so any change shifts the sha") — so rows-changed-but-body-identical is a shape no connector can emit. The fixture now derives the body from `rows`; the one test that models "body changed elsewhere, rows unchanged" passes an explicit body. Fable confirmed no assertion became vacuous (the rewritten one is *stronger*).

## Checks
Unit **1084 green**; ingest data-mechanics **25/25**; `tsc` 0 errors; lint, `py_compile`, docs-drift clean. Docs prose (`context-management-system.md` §2.1/§2.5) updated in-PR per CLAUDE.md §1.

## Review — Reviewed by Fable `code-reviewer` — verdict CLEAR
Adversarial pre-push review of the diff: key-migration completeness (checked `graph/project`, `dense-index`, `reattribute`, the items route, meetings, codebases, the Python contract), sentinel preservation, back-compat across every producer, fixture legitimacy, and the audit-signal tradeoff vs a 422. Its two mediums — docs prose drift and missing `sha_mismatch` coverage — are **fixed in this PR**. Remaining lows noted: the mismatch flag is (deliberately) not recorded on the unchanged path, and `contentHash` is exported but not yet imported elsewhere.