### PR TITLE
fix(attribution): credit every Slack participant, not just the thread root

### DIFF
--- a/lib/attribution/contributor-credit.ts
+++ b/lib/attribution/contributor-credit.ts
@@ -12,6 +12,11 @@ import type { DbClient } from "@/lib/db/types";
  * the ownership-timeline design calls for (docs/design/attribution-ownership-timeline.md) — a mislabeled
  * assigned-but-never-worked owner leaves no version, so it earns no credit automatically. A LOCKED
  * attribution (an admin correction) is the authoritative override: credit collapses to the corrected owner.
+ *
+ * EXCEPTION — CONVERSATION sources: a Slack thread is one item rewritten on every reply, and each of
+ * those versions is stamped with the thread-ROOT author, so version authors there are NOT the workers.
+ * Such a source carries its own ledger in frontmatter (`participants[]`) which takes precedence — see
+ * `slackContributors`.
  */
 
 /**
@@ -69,11 +74,50 @@ export interface ItemCredit {
 }
 
 /** Prefetched item shape a caller can pass so the oracle skips its own `items` read (the timeline already
- *  holds these rows). `id, member_id, member_id_locked` — the only item fields the credit rule needs. */
+ *  holds these rows). `frontmatter` is optional — supply it for CONVERSATION sources, whose work ledger
+ *  lives there rather than in `item_versions` (see `slackContributors`). */
 export interface CreditItemRow {
   id: string;
   member_id: string | null;
   member_id_locked: boolean | null;
+  frontmatter?: Record<string, unknown> | null;
+}
+
+/** One entry of a Slack thread's `participants[]` ledger (written by `lib/ingest/sources/slack-normalize`). */
+interface SlackParticipantRef {
+  author_id?: unknown;
+  last_ts?: unknown;
+}
+
+/**
+ * The CONTRIBUTION ledger for a Slack thread, in work order (earliest last-message first), as Slack
+ * user ids. Empty for a non-Slack item or one carrying no participants ledger.
+ *
+ * Why conversations need their own ledger: a Slack thread is ONE item whose body is REWRITTEN on every
+ * new reply, and every one of those versions is stamped with the THREAD-ROOT author. So the
+ * `item_versions` premise this module rests on — "distinct version authors ARE the people who produced
+ * work" — is FALSE here: someone who posts a one-line question and receives twenty substantive replies
+ * absorbs all twenty versions, while every replier stays invisible in arcs, credit, and the admin page.
+ * `participants[]` records each distinct author with their first/last message time, so it is the honest
+ * work ledger for a thread — and unlike version-stamping it can't lose people when one sync tick happens
+ * to pick up several repliers at once. The Timeline already reads it; reading it HERE means arcs, the
+ * credit oracle, and the admin drill-down agree instead of drifting. Pure.
+ */
+export function slackContributors(fm: Record<string, unknown> | null | undefined): string[] {
+  if (!fm || fm.source !== "slack") return [];
+  const raw = fm.participants;
+  if (!Array.isArray(raw)) return [];
+  const entries: { id: string; last: string }[] = [];
+  for (const p of raw as SlackParticipantRef[]) {
+    const id = typeof p?.author_id === "string" ? p.author_id.trim() : "";
+    if (!id) continue;
+    entries.push({ id, last: typeof p?.last_ts === "string" ? p.last_ts : "" });
+  }
+  // Work order — oldest contribution first — so the LAST entry is the most recent worker, matching how
+  // version order is consumed downstream (`latestWorkerId`).
+  entries.sort((a, b) => (a.last < b.last ? -1 : a.last > b.last ? 1 : 0));
+  const seen = new Set<string>();
+  return entries.filter((e) => (seen.has(e.id) ? false : (seen.add(e.id), true))).map((e) => e.id);
 }
 
 interface CreditCore {
@@ -101,7 +145,8 @@ async function resolveCreditCore(
   const run = async (): Promise<CreditCore> => {
     const itemsP = opts.items
       ? Promise.resolve({ data: opts.items, error: null })
-      : db.from("items").select("id, member_id, member_id_locked").eq("team_id", teamId).in("id", ids);
+      : // `frontmatter` carries the CONVERSATION work ledger (Slack `participants[]`) — see below.
+        db.from("items").select("id, member_id, member_id_locked, frontmatter").eq("team_id", teamId).in("id", ids);
     const [itemsRes, versionsRes] = await Promise.all([
       itemsP,
       db
@@ -122,8 +167,46 @@ async function resolveCreditCore(
 
     // members → {label, is_connector} for every referenced id (current owners + version authors). Label =
     // display_name ?? actor_handle, so a HUMAN with no display name is still credited (was excluded).
+    // CONVERSATION ledger: Slack threads keep their real contributor list in `participants[]` because
+    // every version is root-stamped (see `slackContributors`). Resolve those Slack user ids to members
+    // once, for all items, via the same `member_identities` map the Timeline uses — so the two surfaces
+    // credit identically. Best-effort ENRICHMENT: a failed/absent map just leaves versions in charge.
+    const slackIdsByItem = new Map<string, string[]>();
+    for (const it of items) {
+      const authors = slackContributors(it.frontmatter);
+      if (authors.length) slackIdsByItem.set(it.id, authors);
+    }
+    let memberBySlackId = new Map<string, string>();
+    if (slackIdsByItem.size) {
+      const identRes = await db
+        .from("member_identities")
+        .select("external_id, member_id")
+        .eq("team_id", teamId)
+        .eq("provider", "slack");
+      if (opts.strict && identRes.error) {
+        throw new Error(`resolveItemCredit slack identities: ${identRes.error.message}`);
+      }
+      // Case-FOLDED on both sides, matching `lib/identity/resolve.providerKey` and the Timeline leg.
+      // `setMemberIdentity` stores the id case-preserved and an admin can type it any way, so a raw
+      // comparison silently drops that person from credit — reviving this very bug per-identity, and
+      // (if the ROOT is the mismatched one) flipping `primary` to a replier.
+      memberBySlackId = new Map(
+        ((identRes.data ?? []) as { external_id: string | null; member_id: string | null }[])
+          .filter((r) => r.external_id && r.member_id)
+          .map((r) => [r.external_id!.trim().toLowerCase(), r.member_id!])
+      );
+    }
+
     const memberIds = [
-      ...new Set([...items.map((i) => i.member_id), ...versions.map((v) => v.member_id)].filter((m): m is string => !!m)),
+      ...new Set(
+        [
+          ...items.map((i) => i.member_id),
+          ...versions.map((v) => v.member_id),
+          // Slack participants own nothing and write no version, so without this a replier is absent
+          // from memberMap and `isHuman` would silently reject them — the very bug this fixes.
+          ...memberBySlackId.values(),
+        ].filter((m): m is string => !!m)
+      ),
     ];
     const memberMap = new Map<string, { label: string; connector: boolean }>();
     if (memberIds.length) {
@@ -158,14 +241,27 @@ async function resolveCreditCore(
     const byItem = new Map<string, ItemCreditIds>();
     for (const it of items) {
       const currentMemberId = isHuman(it.member_id) ? it.member_id : null;
-      const versionMemberIds = versionMembersByItem.get(it.id) ?? [];
+      // Slack: the participants ledger REPLACES the (root-stamped, therefore wrong) version authors —
+      // it is the honest record of who spoke. The root is normally a participant too, so in practice
+      // repliers are gained and nobody is lost; the exception is a root whose Slack identity is absent
+      // (unlinked after the fact), who then drops out despite owning the item. Falls back to versions
+      // when a thread predates the ledger or no participant maps to a member.
+      const slackMemberIds = (slackIdsByItem.get(it.id) ?? [])
+        .map((sid) => memberBySlackId.get(sid.trim().toLowerCase()) ?? null)
+        .filter((m): m is string => isHuman(m));
+      const versionMemberIds = slackMemberIds.length
+        ? [...new Set(slackMemberIds)]
+        : versionMembersByItem.get(it.id) ?? [];
       const locked = it.member_id_locked === true;
       const contributorIds = [...new Set(creditedContributorIds({ locked, currentMemberId, versionMemberIds }))];
       const primaryId = creditedPrimaryId({
         locked,
         currentMemberId,
         versionMemberIds,
-        latestWorkerId: latestWorkerByItem.get(it.id) ?? null,
+        // Slack: work order is oldest-last-message first, so the final entry is the most recent worker.
+        latestWorkerId: slackMemberIds.length
+          ? versionMemberIds[versionMemberIds.length - 1]
+          : latestWorkerByItem.get(it.id) ?? null,
       });
       if (contributorIds.length || primaryId) byItem.set(it.id, { contributorIds, primaryId });
     }

--- a/lib/dashboard/work-timeline.ts
+++ b/lib/dashboard/work-timeline.ts
@@ -270,11 +270,18 @@ export async function getWorkTimeline(
   // primary == owner for ~all items, so this is a near-no-op today but correct as handoffs grow. Slack is
   // EXEMPT — its per-participant `participants[]` ledger IS its evidence-gated credit (see its leg below).
   const gitOtherRows = [...((gitRes.data ?? []) as ItemRow[]), ...((otherRes.data ?? []) as ItemRow[])];
-  // Pass the already-fetched rows so the oracle skips a redundant `items` re-read (it only needs
-  // id/member_id/member_id_locked, all selected above); it still reads item_versions + members.
+  // Pass the already-fetched rows so the oracle skips a redundant `items` re-read; it still reads
+  // item_versions + members. `frontmatter` is forwarded (already selected, so it costs nothing): a
+  // CONVERSATION source keeps its work ledger there, and omitting it would silently hand the oracle
+  // the root-stamped version authors instead — wrong credit with no signal.
   const credit = await resolveItemCreditIds(db, teamId, gitOtherRows.map((r) => r.id), {
     strict: true,
-    items: gitOtherRows.map((r) => ({ id: r.id, member_id: r.member_id, member_id_locked: r.member_id_locked ?? null })),
+    items: gitOtherRows.map((r) => ({
+      id: r.id,
+      member_id: r.member_id,
+      member_id_locked: r.member_id_locked ?? null,
+      frontmatter: r.frontmatter ?? null,
+    })),
   });
   // Primary contributor for an item, falling back to the current owner when the oracle has no opinion
   // (e.g. no human version history). Kept the `.not("member_id","is",null)` prefetch prefilter on the leg

--- a/test/attribution-contributor-credit.test.ts
+++ b/test/attribution-contributor-credit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { creditedContributorIds, creditedPrimaryId, resolveItemCreditIds } from "@/lib/attribution/contributor-credit";
+import { creditedContributorIds, creditedPrimaryId, resolveItemCreditIds, slackContributors } from "@/lib/attribution/contributor-credit";
 import type { DbClient } from "@/lib/db/types";
 
 /** Minimal chainable fake db: each `from(table)` resolves to a preset `{data, error}` for that table. */
@@ -84,5 +84,40 @@ describe("resolveItemCreditIds strict vs best-effort error handling", () => {
     const out = await resolveItemCreditIds(db, "team", ["i1"]); // no strict
     // Versions unreadable → treated as no version history → credit falls back to the current owner.
     expect(out.get("i1")?.primaryId).toBe("m1");
+  });
+});
+
+/**
+ * Spec for the CONVERSATION work ledger. A Slack thread is ONE item rewritten on every reply, and each
+ * version is stamped with the thread-ROOT author — so version authors are not the people who worked.
+ * `participants[]` is, and this pins the extraction the credit oracle relies on.
+ */
+describe("slackContributors (the conversation work ledger)", () => {
+  it("returns every distinct participant in work order (oldest last-message first)", () => {
+    expect(
+      slackContributors({
+        source: "slack",
+        participants: [
+          { author_id: "UROOT", last_ts: "2026-07-01T10:00:00Z" },
+          { author_id: "UREPLY", last_ts: "2026-07-03T10:00:00Z" },
+          { author_id: "UMID", last_ts: "2026-07-02T10:00:00Z" },
+        ],
+      })
+    ).toEqual(["UROOT", "UMID", "UREPLY"]);
+  });
+
+  it("is empty for a non-Slack item (versions stay in charge)", () => {
+    expect(slackContributors({ source: "github", participants: [{ author_id: "U1" }] })).toEqual([]);
+  });
+
+  it("is empty for a Slack thread with no participants ledger (pre-ledger items)", () => {
+    expect(slackContributors({ source: "slack" })).toEqual([]);
+    expect(slackContributors(null)).toEqual([]);
+  });
+
+  it("ignores malformed entries rather than crediting a blank", () => {
+    expect(
+      slackContributors({ source: "slack", participants: [{ author_id: "" }, { author_id: 42 }, { author_id: "U9" }] })
+    ).toEqual(["U9"]);
   });
 });

--- a/test/datamechanics/contributor-credit.datamechanics.test.ts
+++ b/test/datamechanics/contributor-credit.datamechanics.test.ts
@@ -175,3 +175,150 @@ describe("resolveItemCreditIds (the ID oracle every surface reads)", () => {
     expect(viaPrefetch.contributorIds).toEqual([a]);
   });
 });
+
+/**
+ * Spec for SLACK credit on real Postgres. A thread is ONE item whose body is rewritten on every new
+ * reply, and every version is stamped with the thread-ROOT author — so the version ledger says the root
+ * did all the work. The observable bug: someone posts a one-line question, a colleague writes the
+ * substantive replies, and the replier is credited NOWHERE (arcs, credit oracle, admin drill-down all
+ * read this one function). The `participants[]` ledger is the honest record and must drive credit.
+ */
+async function addSlackIdentity(seed: Seed, memberId: string, slackUserId: string): Promise<void> {
+  const { error } = await db()
+    .from("member_identities")
+    .insert({ team_id: seed.teamId, member_id: memberId, provider: "slack", external_id: slackUserId });
+  if (error) throw new Error(`addSlackIdentity failed: ${error.message}`);
+}
+
+function slackPayload(
+  body: string,
+  path: string,
+  participants: { author_id: string; last_ts: string }[]
+): ItemPayload {
+  return {
+    project: "slack",
+    kind: "transcript",
+    actor: "slack-sync",
+    frontmatter: { source: "slack", author_id: participants[0]?.author_id ?? "", participants },
+    content_sha256: sha(body),
+    body,
+    path,
+  } as ItemPayload;
+}
+
+describe("resolveItemCredit — Slack threads credit every participant, not just the root", () => {
+  it("credits a REPLIER whose messages only ever produced root-stamped versions", async () => {
+    const seed = await seedTeam(); // root author = "Tester"
+    const root = seed.memberId;
+    const replier = await addMember(seed, "Replier");
+    await addSlackIdentity(seed, root, "UROOT");
+    await addSlackIdentity(seed, replier, "UREPLY");
+    const auth = { teamId: seed.teamId, memberId: root, apiKeyId: randomUUID() };
+    const path = `slack/general/${randomUUID()}.md`;
+
+    // v1: the root's one-line question. Every version is attributed to the ROOT (as the connector does).
+    const first = await ingestItem(
+      db(), auth,
+      slackPayload("root question", path, [{ author_id: "UROOT", last_ts: "2026-07-01T10:00:00Z" }]),
+      "team", { authorMemberId: root }
+    );
+    // v2: the replier's substantive answer rewrites the thread — still stamped to the ROOT.
+    await ingestItem(
+      db(), auth,
+      slackPayload("root question\nreplier's long answer", path, [
+        { author_id: "UROOT", last_ts: "2026-07-01T10:00:00Z" },
+        { author_id: "UREPLY", last_ts: "2026-07-02T10:00:00Z" },
+      ]),
+      "team", { authorMemberId: root }
+    );
+
+    const c = (await resolveItemCredit(db(), seed.teamId, [first.id])).get(first.id)!;
+    expect(new Set(c.contributors)).toEqual(new Set(["Tester", "Replier"])); // the replier is NOT invisible
+    // PRIMARY is unchanged by this fix: the root owns the thread AND genuinely contributed (the root
+    // message), so they stay the single balancing representative — same rule as every other source.
+    // Only the CONTRIBUTOR set was wrong before, and that's what H1 was about.
+    expect(c.primary).toBe("Tester");
+  });
+
+  it("still credits a mapped replier when the thread ROOT doesn't map to a member", async () => {
+    // A thread started by someone outside the roster (or an unmapped Slack id) previously credited
+    // NOBODY. The participants ledger still names the mapped replier, so their work is no longer lost.
+    const seed = await seedTeam();
+    const replier = await addMember(seed, "Only Replier");
+    await addSlackIdentity(seed, replier, "UREPLY3");
+    const auth = { teamId: seed.teamId, memberId: seed.memberId, apiKeyId: randomUUID() };
+    const path = `slack/general/${randomUUID()}.md`;
+    const res = await ingestItem(
+      db(), auth,
+      slackPayload("outsider question\nreplier answer", path, [
+        { author_id: "UNMAPPED_ROOT", last_ts: "2026-07-01T10:00:00Z" },
+        { author_id: "UREPLY3", last_ts: "2026-07-02T10:00:00Z" },
+      ]),
+      "team", { authorMemberId: null } // root unresolved → honestly unattributed owner
+    );
+
+    const c = (await resolveItemCredit(db(), seed.teamId, [res.id])).get(res.id)!;
+    expect(c.contributors).toEqual(["Only Replier"]); // the work is credited
+    // PRIMARY stays null: the pure rule is "no current owner → unattributed for balancing", shared by
+    // every source, and this PR deliberately doesn't widen it. So an owner-less thread credits its
+    // contributors but represents nobody in arc balancing — a real remaining gap, tracked separately.
+    expect(c.primary).toBeNull();
+  });
+
+  it("a LOCKED admin correction still wins over the participants ledger", async () => {
+    const seed = await seedTeam();
+    const root = seed.memberId;
+    const replier = await addMember(seed, "Replier2");
+    await addSlackIdentity(seed, root, "UROOT2");
+    await addSlackIdentity(seed, replier, "UREPLY2");
+    const auth = { teamId: seed.teamId, memberId: root, apiKeyId: randomUUID() };
+    const path = `slack/general/${randomUUID()}.md`;
+    const res = await ingestItem(
+      db(), auth,
+      slackPayload("q\na", path, [
+        { author_id: "UROOT2", last_ts: "2026-07-01T10:00:00Z" },
+        { author_id: "UREPLY2", last_ts: "2026-07-02T10:00:00Z" },
+      ]),
+      "team", { authorMemberId: root }
+    );
+    await db().from("items").update({ member_id: root, member_id_locked: true }).eq("id", res.id);
+
+    const c = (await resolveItemCredit(db(), seed.teamId, [res.id])).get(res.id)!;
+    expect(c.contributors).toEqual(["Tester"]); // the correction is authoritative
+  });
+
+  it("resolves a participant whose stored Slack id differs in CASE from the thread's", async () => {
+    // Identities are stored case-preserved (an admin may type them by hand), and every other resolver
+    // in the repo case-folds. A raw comparison here would drop that person from credit — resurrecting
+    // this very bug per-identity, and flipping `primary` when it's the ROOT that mismatches.
+    const seed = await seedTeam();
+    const root = seed.memberId;
+    const replier = await addMember(seed, "Cased Replier");
+    await addSlackIdentity(seed, root, "uroot4"); // stored lower-case…
+    await addSlackIdentity(seed, replier, "ureply4");
+    const auth = { teamId: seed.teamId, memberId: root, apiKeyId: randomUUID() };
+    const path = `slack/general/${randomUUID()}.md`;
+    const res = await ingestItem(
+      db(), auth,
+      slackPayload("q\na", path, [
+        { author_id: "UROOT4", last_ts: "2026-07-01T10:00:00Z" }, // …thread reports UPPER-case
+        { author_id: "UREPLY4", last_ts: "2026-07-02T10:00:00Z" },
+      ]),
+      "team", { authorMemberId: root }
+    );
+
+    const c = (await resolveItemCredit(db(), seed.teamId, [res.id])).get(res.id)!;
+    expect(new Set(c.contributors)).toEqual(new Set(["Tester", "Cased Replier"]));
+    expect(c.primary).toBe("Tester"); // the root is still recognized → primary does NOT flip
+  });
+
+  it("falls back to the version ledger for a thread with no participants (pre-ledger items)", async () => {
+    const seed = await seedTeam();
+    const root = seed.memberId;
+    const auth = { teamId: seed.teamId, memberId: root, apiKeyId: randomUUID() };
+    const path = `slack/general/${randomUUID()}.md`;
+    const res = await ingestItem(db(), auth, slackPayload("old thread", path, []), "team", { authorMemberId: root });
+    const c = (await resolveItemCredit(db(), seed.teamId, [res.id])).get(res.id)!;
+    expect(c.contributors).toEqual(["Tester"]);
+  });
+});


### PR DESCRIPTION
Item #3 of the **Pass-2 ingestion soundness** remediation plan (H1). Builds on #378 and #380.

## Problem: the credit oracle's premise is false for Slack, and it erased people

`lib/attribution/contributor-credit.ts` is **the single credit oracle** — arcs, the admin attribution drill-down, and the work timeline all resolve "who did the work" through it (guarded by `attribution-single-source`). Its stated premise:

> the work ledger is `item_versions` … an item's distinct version authors ARE the people who produced work on it

**That is false for Slack.** A thread is ONE item whose body is **rewritten on every new reply**, and the runner resolves the author from `thread.root.user` on *every* re-push — so every version row is stamped with the thread **root**.

Concrete failure: you post a one-line question, a colleague writes twenty substantive replies → **twenty versions all credit you**, and the replier appears in **no** credit surface. The `participants[]` ledger from #356 fixed only the Timeline leg; nothing in `lib/graph` or `lib/attribution` ever read it.

## Fix — the participants ledger becomes the conversation work ledger
- **`slackContributors`** (pure) — a thread's `participants[]` as Slack ids in work order.
- **`resolveCreditCore`** selects `frontmatter`, resolves those ids → members via `member_identities` (**case-folded**, matching `lib/identity/resolve.providerKey` and the Timeline leg), and for a Slack item the ledger **replaces** the root-stamped version authors. Falls back to versions when there's no ledger or nothing maps.
- Slack-resolved ids join the members lookup — a replier owns nothing and writes no version, so without that `isHuman()` silently rejected them (I hit exactly this).
- **`work-timeline`** now forwards the `frontmatter` it *already fetched* into the oracle prefetch; omitting it quietly handed back root-stamped credit.

## Deliberately NOT changed
- **`creditedPrimaryId` is untouched.** A normal thread's root owns it *and* genuinely contributed (the root message), so they stay the balancing representative — the same rule as every other source. Only the **contributor set** was wrong, which is what H1 was about.
- **An owner-less thread still returns `primary: null`.** Widening that would change a rule every source depends on. The test asserts current behavior and names it a **remaining gap**: such a thread credits its contributors but represents nobody in arc balancing.

## Tests
Pure extraction (work order, dedup, malformed entries, non-Slack) + real-Postgres cases: the replier, a **LOCKED** admin correction still winning, an unmapped root, a pre-ledger thread, and a **mixed-case identity**. The two headline cases verified **RED without the fix** (`expected Set{'Tester'} to deeply equal Set{'Tester','Replier'}`).

Unit **1112 green**, tsc 0, lint + docs-drift clean, attribution/timeline/credit/timeline-cache data-mechanics **50/50**, `attribution-single-source` guard 3/3.

## Review — Reviewed by Fable `code-reviewer`
It confirmed arcs + admin get the fix (they don't prefetch), the tier/DB scoping and the strict-mode `#249` contract, and that both deliberate non-changes are the right calls. **Fixed here:** its HIGH — my Slack-id lookup was **case-sensitive** while every other resolver folds, which would have resurrected this bug per-identity and could flip `primary` when the *root* is the mismatched one (regression test added) — plus the timeline-prefetch MEDIUM.

**Noted, not fixed (follow-ups):**
- A root whose Slack identity is later unlinked drops from contributors despite owning the item (the ledger replaces rather than unions).
- Two parallel "participants → members" implementations now exist (Timeline leg vs this oracle); they should share one helper — the drift the single-source guard exists to prevent.
- A member with two Slack identities can lose `latestWorkerId` (edge-of-edge).
- Forgeability: `participants[]` is unsigned frontmatter, but so is every other attribution signal — consistent with the trusted-team threat model.