### PR TITLE
fix(timeline): de-flake the SWR test deterministically + one shared Slack participants reader

### DIFF
--- a/lib/attribution/contributor-credit.ts
+++ b/lib/attribution/contributor-credit.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import type { DbClient } from "@/lib/db/types";
+import { slackContributors, foldProviderId } from "@/lib/ingest/slack-participants";
 
 /**
  * Evidence-gated per-item CONTRIBUTOR credit — "who actually did work on this item", not merely its
@@ -83,43 +84,6 @@ export interface CreditItemRow {
   frontmatter?: Record<string, unknown> | null;
 }
 
-/** One entry of a Slack thread's `participants[]` ledger (written by `lib/ingest/sources/slack-normalize`). */
-interface SlackParticipantRef {
-  author_id?: unknown;
-  last_ts?: unknown;
-}
-
-/**
- * The CONTRIBUTION ledger for a Slack thread, in work order (earliest last-message first), as Slack
- * user ids. Empty for a non-Slack item or one carrying no participants ledger.
- *
- * Why conversations need their own ledger: a Slack thread is ONE item whose body is REWRITTEN on every
- * new reply, and every one of those versions is stamped with the THREAD-ROOT author. So the
- * `item_versions` premise this module rests on — "distinct version authors ARE the people who produced
- * work" — is FALSE here: someone who posts a one-line question and receives twenty substantive replies
- * absorbs all twenty versions, while every replier stays invisible in arcs, credit, and the admin page.
- * `participants[]` records each distinct author with their first/last message time, so it is the honest
- * work ledger for a thread — and unlike version-stamping it can't lose people when one sync tick happens
- * to pick up several repliers at once. The Timeline already reads it; reading it HERE means arcs, the
- * credit oracle, and the admin drill-down agree instead of drifting. Pure.
- */
-export function slackContributors(fm: Record<string, unknown> | null | undefined): string[] {
-  if (!fm || fm.source !== "slack") return [];
-  const raw = fm.participants;
-  if (!Array.isArray(raw)) return [];
-  const entries: { id: string; last: string }[] = [];
-  for (const p of raw as SlackParticipantRef[]) {
-    const id = typeof p?.author_id === "string" ? p.author_id.trim() : "";
-    if (!id) continue;
-    entries.push({ id, last: typeof p?.last_ts === "string" ? p.last_ts : "" });
-  }
-  // Work order — oldest contribution first — so the LAST entry is the most recent worker, matching how
-  // version order is consumed downstream (`latestWorkerId`).
-  entries.sort((a, b) => (a.last < b.last ? -1 : a.last > b.last ? 1 : 0));
-  const seen = new Set<string>();
-  return entries.filter((e) => (seen.has(e.id) ? false : (seen.add(e.id), true))).map((e) => e.id);
-}
-
 interface CreditCore {
   byItem: Map<string, ItemCreditIds>;
   /** member id → display label (`display_name ?? actor_handle`), non-connector only. */
@@ -193,7 +157,7 @@ async function resolveCreditCore(
       memberBySlackId = new Map(
         ((identRes.data ?? []) as { external_id: string | null; member_id: string | null }[])
           .filter((r) => r.external_id && r.member_id)
-          .map((r) => [r.external_id!.trim().toLowerCase(), r.member_id!])
+          .map((r) => [foldProviderId(r.external_id!), r.member_id!])
       );
     }
 
@@ -247,7 +211,7 @@ async function resolveCreditCore(
       // (unlinked after the fact), who then drops out despite owning the item. Falls back to versions
       // when a thread predates the ledger or no participant maps to a member.
       const slackMemberIds = (slackIdsByItem.get(it.id) ?? [])
-        .map((sid) => memberBySlackId.get(sid.trim().toLowerCase()) ?? null)
+        .map((sid) => memberBySlackId.get(foldProviderId(sid)) ?? null)
         .filter((m): m is string => isHuman(m));
       const versionMemberIds = slackMemberIds.length
         ? [...new Set(slackMemberIds)]

--- a/lib/dashboard/timeline-cache.ts
+++ b/lib/dashboard/timeline-cache.ts
@@ -49,8 +49,9 @@ interface CacheEntry {
 
 // In-memory cache (per process), fronting the Postgres row. Keyed by `${teamId}:${tier}`.
 const mem = new Map<string, CacheEntry>();
-// Keys refreshing in the background, so N concurrent stale reads fire ONE rebuild.
-const refreshing = new Set<string>();
+// Keys refreshing in the background, so N concurrent stale reads fire ONE rebuild. The PROMISE is
+// retained (not just the key) so an in-flight rebuild can be awaited — see `settleTimelineRefreshes`.
+const refreshing = new Map<string, Promise<void>>();
 
 const memKey = (teamId: string, tier: ViewerTier): string => `${teamId}:${tier}`;
 
@@ -125,10 +126,13 @@ export async function bustTeamTimeline(db: DbClient, teamId: string): Promise<vo
 function refreshInBackground(teamId: string, tier: ViewerTier): void {
   const key = memKey(teamId, tier);
   if (refreshing.has(key)) return;
-  refreshing.add(key);
-  void (async () => {
-    const bg = adminClient();
+  const task = (async () => {
+    // EVERYTHING inside the try, including client construction: the promise must not settle before
+    // `refreshing.set(key, task)` below runs. A synchronous throw here would settle it immediately,
+    // stranding a settled promise in the map — which would suppress that key's rebuilds for the life
+    // of the process and make `settleTimelineRefreshes` reject. Cheap to make structurally impossible.
     try {
+      const bg = adminClient();
       const days = await buildTimeline(bg, teamId, tier);
       mem.set(key, { days, at: Date.now() });
       await writeTimelineCache(bg, teamId, tier, days);
@@ -138,6 +142,19 @@ function refreshInBackground(teamId: string, tier: ViewerTier): void {
       refreshing.delete(key);
     }
   })();
+  refreshing.set(key, task);
+}
+
+/**
+ * Await every in-flight background rebuild. Callers of `getCachedWorkTimeline` never need this — the
+ * whole point of SWR is that they don't wait — but a test asserting the REBUILT payload otherwise has
+ * to poll on a timeout, which is a race dressed up as a test (it failed ~1 in 3 on a loaded runner,
+ * costing real CI cycles). Awaiting the actual promise makes that deterministic. Also the honest hook
+ * for a graceful shutdown that wants in-flight writes to land. Never throws: the task swallows its own
+ * errors, so this resolves even when a rebuild failed.
+ */
+export async function settleTimelineRefreshes(): Promise<void> {
+  await Promise.all([...refreshing.values()]);
 }
 
 /**

--- a/lib/dashboard/work-timeline.ts
+++ b/lib/dashboard/work-timeline.ts
@@ -17,6 +17,7 @@ import {
 } from "./timeline-group";
 import { computeTaskLinks } from "./issue-ref";
 import { resolveItemCreditIds } from "@/lib/attribution/contributor-credit";
+import { slackParticipations, foldProviderId } from "@/lib/ingest/slack-participants";
 
 // Only ACTIVE tasks are considered work "in progress" — Linear In Progress/In Review both normalize to
 // `in_progress`; `blocked` is active-but-stuck. Backlog/ready/done are context, excluded from the timeline.
@@ -166,7 +167,7 @@ export async function getWorkTimeline(
   if (slackIdRes.error) console.warn("[work-timeline] slack identities read failed:", slackIdRes.error.message);
   const slackIdToMember = new Map<string, string>();
   for (const r of (slackIdRes.data ?? []) as { external_id: string | null; member_id: string | null }[]) {
-    if (r.external_id && r.member_id) slackIdToMember.set(r.external_id.toLowerCase(), r.member_id);
+    if (r.external_id && r.member_id) slackIdToMember.set(foldProviderId(r.external_id), r.member_id);
   }
 
   // A task's source = the team's PM provider (linear/plane). With none configured, use a generic
@@ -324,15 +325,15 @@ export async function getWorkTimeline(
   for (const r of (slackRes.data ?? []) as ItemRow[]) {
     const fm = r.frontmatter ?? {};
     const title = str(fm.title) || `#${str(fm.channel) ?? "slack"} thread`;
-    const participants = Array.isArray(fm.participants) ? (fm.participants as { author_id?: unknown; last_ts?: unknown }[]) : [];
-    const seen = new Set<string>(); // stored frontmatter is pusher-shaped — dedup so a duplicate author entry can't emit two rows with the same synthetic id (React key collision).
-    for (const p of participants) {
-      const authorId = str(p?.author_id);
-      const memberId = authorId ? slackIdToMember.get(authorId.toLowerCase()) : undefined;
+    // Parsed by the SHARED ledger reader (`lib/ingest/slack-participants`) — the same one the credit
+    // oracle uses, so the two surfaces can't drift on dedup or id case again. It already returns one
+    // entry per distinct author (their latest contribution time), which also keeps the synthetic row
+    // id unique per (thread, participant).
+    for (const p of slackParticipations(fm)) {
+      const authorId = p.authorId;
+      const memberId = slackIdToMember.get(foldProviderId(authorId));
       if (!memberId || !members.has(memberId)) continue;
-      if (seen.has(authorId!)) continue;
-      seen.add(authorId!);
-      const at = str(p?.last_ts);
+      const at = p.lastTs;
       if (!at || !inWindow(at)) continue;
       // One row per (thread, participant); text = title (no body fetch — a thread citing an issue key in
       // its first line still links to a task, else it lands in "Other").

--- a/lib/ingest/slack-participants.ts
+++ b/lib/ingest/slack-participants.ts
@@ -1,0 +1,69 @@
+/**
+ * The reader side of a Slack thread's `participants[]` frontmatter ledger — written by
+ * `lib/ingest/sources/slack-normalize`, consumed by BOTH the work timeline and the credit oracle.
+ *
+ * Why this is its own module: a Slack thread is one item whose body is rewritten on every reply, and
+ * each version is stamped with the thread-ROOT author — so `item_versions` cannot answer "who worked
+ * on this". `participants[]` can, which makes it the conversation work ledger, and therefore a fact
+ * two independent surfaces need. They previously each parsed and resolved it inline and had already
+ * drifted (different dedup and case-folding), which is precisely the divergence the single-source
+ * attribution guard exists to prevent. One parser, one fold, here.
+ *
+ * Pure — no DB, no server-only — so both a server module and a test can use it directly.
+ */
+
+/** One participant's contribution to a thread, normalized. */
+export interface SlackParticipation {
+  /** Slack user id exactly as the source reported it (fold with `foldProviderId` before matching). */
+  authorId: string;
+  /** ISO time of their LAST message in the thread — their contribution time. "" when absent. */
+  lastTs: string;
+}
+
+interface RawParticipant {
+  author_id?: unknown;
+  last_ts?: unknown;
+}
+
+/**
+ * Canonical fold for a provider external id. Mirrors `lib/identity/resolve.providerKey`, which stores
+ * and matches ids case-insensitively — `setMemberIdentity` keeps the original case and an admin may
+ * type one by hand, so any raw comparison silently fails to match that person.
+ */
+export function foldProviderId(id: string): string {
+  return id.trim().toLowerCase();
+}
+
+/**
+ * Parsed participants in WORK ORDER (oldest last-message first), one entry per distinct author,
+ * keeping their LATEST contribution time. Malformed entries are dropped rather than credited as a
+ * blank. `[]` for a non-Slack item or one carrying no ledger (e.g. a thread ingested before it
+ * existed) — callers then fall back to their own evidence.
+ */
+export function slackParticipations(fm: Record<string, unknown> | null | undefined): SlackParticipation[] {
+  if (!fm || fm.source !== "slack") return [];
+  const raw = fm.participants;
+  if (!Array.isArray(raw)) return [];
+
+  const byAuthor = new Map<string, string>(); // authorId → latest lastTs
+  for (const p of raw as RawParticipant[]) {
+    const authorId = typeof p?.author_id === "string" ? p.author_id.trim() : "";
+    if (!authorId) continue;
+    const lastTs = typeof p?.last_ts === "string" ? p.last_ts : "";
+    const prior = byAuthor.get(authorId);
+    // Keep the LATEST time if a payload somehow repeats an author (the producer already dedupes).
+    if (prior === undefined || lastTs > prior) byAuthor.set(authorId, lastTs);
+  }
+  return [...byAuthor.entries()]
+    .map(([authorId, lastTs]) => ({ authorId, lastTs }))
+    .sort((a, b) => (a.lastTs < b.lastTs ? -1 : a.lastTs > b.lastTs ? 1 : 0));
+}
+
+/**
+ * The conversation WORK LEDGER: the thread's distinct contributors as Slack user ids, oldest
+ * contribution first — so the LAST entry is the most recent worker, matching how version order is
+ * consumed downstream (`latestWorkerId`).
+ */
+export function slackContributors(fm: Record<string, unknown> | null | undefined): string[] {
+  return slackParticipations(fm).map((p) => p.authorId);
+}

--- a/test/attribution-contributor-credit.test.ts
+++ b/test/attribution-contributor-credit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { creditedContributorIds, creditedPrimaryId, resolveItemCreditIds, slackContributors } from "@/lib/attribution/contributor-credit";
+import { creditedContributorIds, creditedPrimaryId, resolveItemCreditIds } from "@/lib/attribution/contributor-credit";
 import type { DbClient } from "@/lib/db/types";
 
 /** Minimal chainable fake db: each `from(table)` resolves to a preset `{data, error}` for that table. */
@@ -84,40 +84,5 @@ describe("resolveItemCreditIds strict vs best-effort error handling", () => {
     const out = await resolveItemCreditIds(db, "team", ["i1"]); // no strict
     // Versions unreadable → treated as no version history → credit falls back to the current owner.
     expect(out.get("i1")?.primaryId).toBe("m1");
-  });
-});
-
-/**
- * Spec for the CONVERSATION work ledger. A Slack thread is ONE item rewritten on every reply, and each
- * version is stamped with the thread-ROOT author — so version authors are not the people who worked.
- * `participants[]` is, and this pins the extraction the credit oracle relies on.
- */
-describe("slackContributors (the conversation work ledger)", () => {
-  it("returns every distinct participant in work order (oldest last-message first)", () => {
-    expect(
-      slackContributors({
-        source: "slack",
-        participants: [
-          { author_id: "UROOT", last_ts: "2026-07-01T10:00:00Z" },
-          { author_id: "UREPLY", last_ts: "2026-07-03T10:00:00Z" },
-          { author_id: "UMID", last_ts: "2026-07-02T10:00:00Z" },
-        ],
-      })
-    ).toEqual(["UROOT", "UMID", "UREPLY"]);
-  });
-
-  it("is empty for a non-Slack item (versions stay in charge)", () => {
-    expect(slackContributors({ source: "github", participants: [{ author_id: "U1" }] })).toEqual([]);
-  });
-
-  it("is empty for a Slack thread with no participants ledger (pre-ledger items)", () => {
-    expect(slackContributors({ source: "slack" })).toEqual([]);
-    expect(slackContributors(null)).toEqual([]);
-  });
-
-  it("ignores malformed entries rather than crediting a blank", () => {
-    expect(
-      slackContributors({ source: "slack", participants: [{ author_id: "" }, { author_id: 42 }, { author_id: "U9" }] })
-    ).toEqual(["U9"]);
   });
 });

--- a/test/datamechanics/timeline-cache.datamechanics.test.ts
+++ b/test/datamechanics/timeline-cache.datamechanics.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { db, ingest, seedTeam, type Seed } from "./helpers";
 import {
   getCachedWorkTimeline,
+  settleTimelineRefreshes,
   readTimelineCache,
   bustTeamTimeline,
 } from "@/lib/dashboard/timeline-cache";
@@ -84,6 +85,13 @@ describe("work-timeline cache layer (real Postgres)", () => {
       people.reduce((n, p) => n + p.tasks.reduce((a, t) => a + t.evidenceCount, 0) + p.other.reduce((a, g) => a + g.count, 0), 0);
     expect(evCount(first.flatMap((d) => d.people))).toBe(1);
 
+    // Settle the COLD-MISS path's own background pass (it adds per-person synopses) before going on.
+    // Rebuilds are deduped by key, so a still-in-flight one makes the next stale read a NO-OP — the
+    // payload would then never pick up commit-b and this test would fail ~1 in 5 for a reason that has
+    // nothing to do with what it asserts. (That dedup is deliberate SWR behavior in production: the
+    // work lands on the following read instead.)
+    await settleTimelineRefreshes();
+
     // New work lands, then the row is marked stale (+ in-memory evicted) — the re-attribution path.
     await seedCommit(seed, "commit-b", recentIso());
     await bustTeamTimeline(db(), seed.teamId);
@@ -92,15 +100,13 @@ describe("work-timeline cache layer (real Postgres)", () => {
     const staleServe = await getCachedWorkTimeline(db(), seed.teamId, "team");
     expect(evCount(staleServe.flatMap((d) => d.people))).toBe(1); // served stale, not yet rebuilt
 
-    // The deduped background rebuild lands the new payload (2 items) into the persisted row.
-    await vi.waitFor(
-      async () => {
-        const row = await readRow(seed.teamId, "team");
-        const days = ((row?.payload as { days?: { people: { tasks: { evidenceCount: number }[]; other: { count: number }[] }[] }[] })?.days) ?? [];
-        expect(evCount(days.flatMap((d) => d.people))).toBe(2);
-      },
-      { timeout: 3_000, interval: 50 }
-    );
+    // The deduped background rebuild lands the new payload (2 items) into the persisted row. Await the
+    // actual in-flight promise rather than polling a timeout — the rebuild does real DB work, so a fixed
+    // budget is a race, not an assertion (this failed ~1 in 3 on a loaded runner).
+    await settleTimelineRefreshes();
+    const row = await readRow(seed.teamId, "team");
+    const days = ((row?.payload as { days?: { people: { tasks: { evidenceCount: number }[]; other: { count: number }[] }[] }[] })?.days) ?? [];
+    expect(evCount(days.flatMap((d) => d.people))).toBe(2);
   });
 
   it("bustTeamTimeline marks the row stale (computed_at older than the TTL)", async () => {

--- a/test/slack-participants.test.ts
+++ b/test/slack-participants.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { slackParticipations, slackContributors, foldProviderId } from "@/lib/ingest/slack-participants";
+
+/**
+ * Spec for the CONVERSATION work ledger. A Slack thread is ONE item rewritten on every reply, and each
+ * version is stamped with the thread-ROOT author — so version authors are not the people who worked.
+ * `participants[]` is, and this pins the extraction the credit oracle relies on.
+ */
+describe("slackContributors (the conversation work ledger)", () => {
+  it("returns every distinct participant in work order (oldest last-message first)", () => {
+    expect(
+      slackContributors({
+        source: "slack",
+        participants: [
+          { author_id: "UROOT", last_ts: "2026-07-01T10:00:00Z" },
+          { author_id: "UREPLY", last_ts: "2026-07-03T10:00:00Z" },
+          { author_id: "UMID", last_ts: "2026-07-02T10:00:00Z" },
+        ],
+      })
+    ).toEqual(["UROOT", "UMID", "UREPLY"]);
+  });
+
+  it("is empty for a non-Slack item (versions stay in charge)", () => {
+    expect(slackContributors({ source: "github", participants: [{ author_id: "U1" }] })).toEqual([]);
+  });
+
+  it("is empty for a Slack thread with no participants ledger (pre-ledger items)", () => {
+    expect(slackContributors({ source: "slack" })).toEqual([]);
+    expect(slackContributors(null)).toEqual([]);
+  });
+
+  it("ignores malformed entries rather than crediting a blank", () => {
+    expect(
+      slackContributors({ source: "slack", participants: [{ author_id: "" }, { author_id: 42 }, { author_id: "U9" }] })
+    ).toEqual(["U9"]);
+  });
+});
+
+describe("slackParticipations (entries the timeline needs)", () => {
+  it("keeps each author's LATEST contribution time and orders oldest-first", () => {
+    expect(
+      slackParticipations({
+        source: "slack",
+        participants: [
+          { author_id: "UA", last_ts: "2026-07-01T10:00:00Z" },
+          { author_id: "UB", last_ts: "2026-07-03T10:00:00Z" },
+          { author_id: "UA", last_ts: "2026-07-04T10:00:00Z" }, // duplicate author, later message
+        ],
+      })
+    ).toEqual([
+      { authorId: "UB", lastTs: "2026-07-03T10:00:00Z" },
+      { authorId: "UA", lastTs: "2026-07-04T10:00:00Z" },
+    ]);
+  });
+});
+
+describe("foldProviderId", () => {
+  it("folds case and trims, matching lib/identity/resolve.providerKey", () => {
+    expect(foldProviderId("  U0123ABC ")).toBe("u0123abc");
+  });
+});


### PR DESCRIPTION
**Backlog cleanup** — two follow-ups from my own #380/#381, taken before moving on to new work. Both were costing something real.

## A — the `timeline-cache` SWR test was a race, not an assertion
It failed **~1 in 3 on CI** (it burned a full cycle on #380) and ~1 in 5 locally.

**The root cause was not just a tight timeout.** The **cold-miss** path in `getCachedWorkTimeline` *also* fires a background rebuild, and rebuilds are **deduped by key** — so if that first pass was still in flight when the test's stale read happened, `refreshing.has(key)` made the second rebuild a **no-op** and the payload never picked up `commit-b`. Review surfaced a second mode with the same cure: the in-flight cold-miss pass could finish *after* `bustTeamTimeline`, rewriting `computed_at = now` and **un-staling** the row so no rebuild ever fired.

That dedup is **correct production SWR** (the work lands on the next read), so the fix belongs in the test: settle the cold-miss pass *before* seeding new work.

To be able to settle it at all, `refreshing` now retains the rebuild **promise** (`Map`) rather than just the key (`Set`), and a new `settleTimelineRefreshes()` awaits them. **Production callers are unchanged** — still fire-and-forget. The whole task body sits inside the `try` so the promise can't settle before it's registered in the map (hardening from review).

**Result: 8/8 consecutive clean**, and the test still proves SWR — `staleServe === 1` would fail if the read rebuilt inline, and the row only reaches 2 via the background pass.

## B — two parallel "participants[] → members" implementations
#381 (mine) added `slackContributors` inside the credit oracle while `work-timeline` already had an inline participants loop. **They had already drifted** — different dedup and id case-folding — which is exactly the divergence the single-source attribution guard exists to prevent, and I'd have to keep re-fixing it per consumer.

New pure `lib/ingest/slack-participants` owns it:
- `slackParticipations(fm)` — one entry per distinct author, keeping their **latest** contribution time, work-ordered.
- `slackContributors(fm)` — the ids (the credit oracle's work ledger).
- `foldProviderId(id)` — the canonical fold, mirroring `lib/identity/resolve.providerKey`.

Both consumers read it; the local copy is deleted. Side benefits: the timeline now folds ids consistently (it only lowercased, didn't trim) and no longer lets an out-of-window duplicate entry suppress a later in-window one.

## Verification
Unit **1114 green**, tsc 0, lint + docs-drift clean; timeline-cache + work-timeline + contributor-credit + attribution data-mechanics **50/50**; timeline-cache **8/8 consecutive** (was ~1 in 3). Test coverage moved, not weakened — all four original specs preserved verbatim plus two new ones.

## Review — Reviewed by Fable `code-reviewer` — verdict CLEAR
No blocker/high. It traced the promise set/delete ordering (safe today), confirmed no memory delta vs the old Set, verified the timeline's behavior change is unreachable via the producer and the new semantics are the better reading, checked the guards still hold, and confirmed the de-flaked test still asserts SWR. Its one actionable Low — the set-before-settle invariant being implicit — is hardened here.

**Not fixed (noted):** `lib/ingest/slack-participants` is a *reader* living under the write-path directory; `lib/attribution` was also defensible. Kept, with the docstring explaining why.