### PR TITLE
feat(admin): Notion credentials in Admin → Integrations

### DIFF
--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -237,7 +237,8 @@ type IntegrationType =
   | "openai"
   | "anthropic"
   | "openrouter"
-  | "google";
+  | "google"
+  | "notion";
 
 export interface IntegrationRow {
   id: string;
@@ -251,7 +252,7 @@ export interface IntegrationRow {
 // Data-source connectors shown in the generic "Add an integration" form. Provider keys get their
 // own panel (PROVIDER_TYPES); GitHub gets its own repo panel (GithubReposPanel) — so both are
 // excluded here to avoid two places to manage the same thing.
-const TYPES: IntegrationType[] = ["slack", "granola", "linear", "plane", "wise"];
+const TYPES: IntegrationType[] = ["slack", "notion", "granola", "linear", "plane", "wise"];
 
 // LLM provider API keys — one set for the team, managed in the dedicated "AI provider keys" panel.
 const PROVIDER_TYPES = ["anthropic", "openai", "google"] as const;
@@ -268,6 +269,10 @@ const SELECTION_HINT: Partial<Record<IntegrationType, string>> = {
   slack: "channel IDs (comma-separated)",
   github: "repos owner/name (comma-separated)",
   granola: "match keywords (comma-separated)",
+  // The Notion connector (ingestion/aios_ingest/sources/notion.py) needs a token (stored as the secret)
+  // plus EITHER page ids or a database id. Pages are the common case, so that's what this field holds;
+  // a `databaseId=<id>` entry is accepted for the whole-database case.
+  notion: "page IDs (comma-separated), or databaseId=<id>",
   linear: "teamId=..., projectId=..., doneStateName=Done",
   plane: "workspaceSlug=..., projectId=..., doneStateName=DONE, externalSource=aios-backlog",
   wise: "profile ID",
@@ -278,6 +283,10 @@ function summarizeConfig(type: IntegrationType, config: Record<string, unknown>)
   if (type === "slack") return `${arr("channelIds").length} channel(s)`;
   if (type === "github") return `${arr("repos").length} repo(s)`;
   if (type === "granola") return `${arr("matchKeywords").length} keyword(s)`;
+  if (type === "notion") {
+    if (config.databaseId) return `database ${config.databaseId}`;
+    return `${arr("pageIds").length} page(s)`;
+  }
   if (type === "linear") {
     return [
       config.teamId ? `team ${config.teamId}` : null,

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -385,6 +385,10 @@ export const INTEGRATION_TYPES = [
   "github",
   "granola",
   "slack",
+  // Notion: the token is the SECRET; the non-secret selection is which pages (or one database) to pull.
+  // The connector already exists (ingestion/aios_ingest/sources/notion.py + notion_authors.py, which
+  // resolves created_by/last_edited_by → the item's authors) — it just had nowhere to read a token from.
+  "notion",
   "wise",
   "linear",
   "plane",
@@ -477,6 +481,14 @@ const integrationConfigSchemas: Record<IntegrationType, z.ZodType> = {
     })
     .strict(),
   wise: z.object({ profileId: z.string().max(64).optional() }).strict(),
+  // Either pageIds OR databaseId — the connector requires one (it raises if both are absent). Not
+  // enforced here: a half-configured integration must be savable, and the connector reports the error.
+  notion: z
+    .object({
+      pageIds: z.array(z.string().min(1).max(120)).max(200).default([]),
+      databaseId: z.string().max(120).optional(),
+    })
+    .strict(),
   linear: z
     .object({
       teamId: z.string().max(64).optional(),

--- a/lib/integrations/build-config.ts
+++ b/lib/integrations/build-config.ts
@@ -45,6 +45,9 @@ export function buildConfig(
       return { matchKeywords: list };
     case "wise":
       return list[0] ? { profileId: list[0] } : {};
+    case "notion":
+      // `databaseId=<id>` selects a whole database; otherwise the entries are page ids.
+      return kv.databaseId ? { databaseId: kv.databaseId } : { pageIds: list };
     case "linear": {
       const base = Object.keys(kv).length
         ? { teamId: kv.teamId, projectId: kv.projectId, doneStateName: kv.doneStateName }

--- a/postgres/migrations/20260624120000_ai_provider_integration_types.sql
+++ b/postgres/migrations/20260624120000_ai_provider_integration_types.sql
@@ -11,4 +11,4 @@
 -- test/guards/integrations-type-check-replay.test.ts fails the build if these ever drift apart.
 alter table integrations drop constraint if exists integrations_type_check;
 alter table integrations add constraint integrations_type_check
-  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully'));
+  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully','notion'));

--- a/postgres/migrations/20260710140000_integrations_openrouter_type.sql
+++ b/postgres/migrations/20260710140000_integrations_openrouter_type.sql
@@ -8,4 +8,4 @@
 -- is intentionally listed here; the replay-consistency guard fails the build if these drift apart.
 alter table integrations drop constraint if exists integrations_type_check;
 alter table integrations add constraint integrations_type_check
-  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully'));
+  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully','notion'));

--- a/postgres/migrations/20260711160000_publishing.sql
+++ b/postgres/migrations/20260711160000_publishing.sql
@@ -5,7 +5,7 @@
 
 alter table integrations drop constraint if exists integrations_type_check;
 alter table integrations add constraint integrations_type_check
-  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully'));
+  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully','notion'));
 
 alter table social_settings add column if not exists publish_dry_run boolean not null default true;
 

--- a/postgres/migrations/20260725160000_integrations_notion_type.sql
+++ b/postgres/migrations/20260725160000_integrations_notion_type.sql
@@ -1,0 +1,11 @@
+-- Add 'notion' to integrations.type so Notion credentials can be stored from Admin → Integrations.
+-- The Notion CONNECTOR already exists (ingestion/aios_ingest/sources/notion.py, with author enrichment
+-- via notion_authors.py); it just had nowhere to read a team's token from.
+--
+-- ⚠️ #251 replay rule: `npm run pg:schema` replays every migration in filename order on each deploy, so a
+-- CHECK re-add must carry the FULL value set — a narrower re-add fails against live rows. Keep this list
+-- identical to the one in postgres/schema.sql and to any later re-add
+-- (guarded by test/guards/enum-check-replay.test.ts).
+alter table integrations drop constraint if exists integrations_type_check;
+alter table integrations add constraint integrations_type_check
+  check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully','notion'));

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1615,7 +1615,7 @@ create index if not exists subscriptions_team_idx on subscriptions (team_id);
 create table if not exists integrations (
   id uuid primary key default gen_random_uuid(),
   team_id uuid not null references teams(id) on delete cascade,
-  type text not null check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully')),
+  type text not null check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully','notion')),
   name text not null,
   config jsonb not null default '{}',
   secret_ciphertext text,                 -- AES-256-GCM blob (base64); null if no secret set

--- a/test/build-integration-config.test.ts
+++ b/test/build-integration-config.test.ts
@@ -49,3 +49,17 @@ describe("buildConfig()", () => {
     });
   });
 });
+
+describe("notion — the token is the secret, the selection is what to pull", () => {
+  it("treats plain entries as page ids", () => {
+    expect(buildConfig("notion", "abc123, def456")).toEqual({ pageIds: ["abc123", "def456"] });
+  });
+
+  it("`databaseId=<id>` selects a whole database INSTEAD of pages (the connector takes one or the other)", () => {
+    expect(buildConfig("notion", "databaseId=db_42")).toEqual({ databaseId: "db_42" });
+  });
+
+  it("an empty selection is savable — a half-configured integration must not be un-persistable", () => {
+    expect(buildConfig("notion", "")).toEqual({ pageIds: [] });
+  });
+});


### PR DESCRIPTION
Requested: put Notion credentials in the integrations tab so the connector can be wired up. (Google deliberately excluded — see below.)

## Why nothing was flowing

The Notion **connector already exists** — `ingestion/aios_ingest/sources/notion.py`, with `notion_authors.py` resolving `created_by` → author and `last_edited_by` → editor into the `authors[]` the brain maps to a roster member (bots excluded). The sidecar even already knows `notion` as a selection type. It simply had **nowhere to read a team's token from**: `integrations.type`'s CHECK didn't allow `'notion'`, so it couldn't be stored. Prod has **0 Notion items** as a result.

## What this adds

- **`integrations.type` allows `'notion'`** — migration + `schema.sql` mirror.
- **Config schema** (`lib/api/schemas.ts`): `pageIds[]` or `databaseId` — the connector requires one or the other. Kept permissive on purpose: a half-configured integration must still be savable, and the connector reports the real error rather than the form silently blocking a save.
- **`buildConfig`**: plain entries are page ids; `databaseId=<id>` selects a whole database.
- **Admin UI**: Notion appears in the connector form with a selection hint and a config summary.

The token is stored as the integration **secret**, on the same encrypted path as the other connectors; the brain rejects secret-like keys inside `config` at write time, so the non-secret selection can never carry one.

## The migration-replay guards earned their keep

Adding the value made `enum-check-replay` and `integrations-type-check-replay` go red: three **earlier** migrations re-add `integrations_type_check` with the older, narrower set. Since `pg:schema` replays every migration in filename order on each deploy, leaving them would reproduce the **#251 incident** — a replayed migration re-adding a CHECK that rejects rows the live constraint allows, failing the deploy. All four definitions are now converged to the identical full set.

## Verification

unit **1112 ✅** (incl. 3 new spec tests for the Notion selection: page ids, `databaseId=`, and empty-is-savable) · `tsc --noEmit` ✅ — it caught the server-side type union I'd missed, which is the actual validation boundary · lint ✅ (2 pre-existing warnings, unrelated files) · docs-drift ✅ · migration/enum-replay guards ✅

## Google Drive deliberately not included

Beyond "don't worry about Google right now": `gdrive.py` is a 50-line llama-index wrapper with **no owner enrichment** — no `owners` / `lastModifyingUser` handling — so a Drive doc arrives with no author and could never be attributed to a person, let alone assigned to a task. It needs a `gdrive_authors` pass mirroring the Notion one first. Tracked in `docs/design/doc-task-assignment.md`.

## Review

Pre-push local review: guards + typecheck + unit suite. This is a small, additive schema+form change with no new read path; the risky part (the CHECK replay) is covered by two build-failing guards that were exercised in this PR. Applying `ready-for-review` for CodeRabbit.