### PR TITLE
fix(graph): date Linear/Plane issue docs so the projector stops stamping them "today"

### DIFF
--- a/lib/dashboard/work-timeline.ts
+++ b/lib/dashboard/work-timeline.ts
@@ -309,6 +309,13 @@ export async function getWorkTimeline(
     if (str(fm.source) === "git") continue; // handled by gitRes — no double-count
     const source = normalizeSource(str(fm.source));
     if (source === "slack" || source === "granola" || r.kind === "transcript") continue; // slack: own query; meetings: excluded
+    // A PM issue's own description doc is the TICKET, not work done on it — and its path/title carry
+    // the issue's own key, so admitting it as evidence would let every assigned ticket self-satisfy
+    // the evidence gate and turn the timeline back into a backlog dump (the property "never the whole
+    // backlog" exists to prevent). The ticket already appears as a TASK; real work on it arrives as
+    // commits/docs that cite the key. (These docs are dated for the GRAPH's sake — see the linear/plane
+    // normalizers — so this exclusion is what keeps the timeline's behavior unchanged.)
+    if (str(fm.identifier) && (source === "linear" || source === "plane")) continue;
     const memberId = primaryOf(r);
     if (!memberId || !members.has(memberId)) continue;
     const at = itemWorkTime(fm);

--- a/lib/ingest/sources/linear-normalize.ts
+++ b/lib/ingest/sources/linear-normalize.ts
@@ -226,6 +226,13 @@ export function normalizeLinearDocs(input: NormalizeLinearInput): ItemPayload[] 
           assignee_id: it.assignee?.id ?? "",
           priority: PRIORITY_BY_INT[it.priority ?? 0] ?? "none",
           project_name: it.project?.name ?? "",
+          // WORK-TIME = the real state transition (the same signal the task row's `worked_at` uses).
+          // Without it the doc resolves to null and the GRAPH stamps the episode `synced_at`, so
+          // first-linking a Linear team dates every issue "today" and arcs narrate old tickets as this
+          // week (the H3 skew). An unstarted/backlog issue has no transition and stays honestly
+          // UNDATED — nobody has worked it yet — rather than being back-dated to its creation.
+          // Deliberately NOT `updatedAt`: that moves on any unrelated field edit (the #346 churn).
+          source_ts: linearWorkedAt(it),
         },
         body,
       };

--- a/lib/ingest/sources/plane-normalize.ts
+++ b/lib/ingest/sources/plane-normalize.ts
@@ -233,6 +233,10 @@ export function normalizePlaneDocs(input: NormalizePlaneInput): ItemPayload[] {
           project_id: input.projectId,
           // First assignee's Plane member id → resolved to a person at ingest (lib/ingest/run).
           assignee_id: (it.assignees ?? [])[0] ?? "",
+          // WORK-TIME = the state transition (same signal the task row's `worked_at` uses). Without it
+          // the GRAPH stamps the episode `synced_at`, dating every issue of a freshly-linked project
+          // "today" (the H3 skew). An incomplete item has no transition and stays honestly UNDATED.
+          source_ts: planeWorkedAt(it),
         },
         body,
       };

--- a/test/datamechanics/work-timeline.datamechanics.test.ts
+++ b/test/datamechanics/work-timeline.datamechanics.test.ts
@@ -232,6 +232,20 @@ describe("work timeline — attributed docs (Notion / Google Docs / deliverables
     expect(titles).toContain("Repo readme");
   });
 
+  it("a PM issue's own description doc is NOT evidence (the evidence gate stays honest)", async () => {
+    const seed = await seedTeam();
+    const day1ago = new Date(Date.now() - 86_400_000).toISOString();
+    // These docs are now DATED (so the graph stops stamping them at sync time), which without an
+    // explicit exclusion would make each ticket its own evidence — its path/title carry its own issue
+    // key — so every assigned ticket would self-satisfy the gate and the timeline would become a
+    // backlog dump. The ticket belongs in the timeline as a TASK, not as work done on itself.
+    await ingest(seed, { kind: "deliverable", path: `linear/aio/AIO-901-${randomUUID()}.md`, access: "team", body: "ticket prose",
+      frontmatter: { source: "linear", identifier: "AIO-901", title: "Ticket description doc", source_ts: day1ago } });
+
+    const titles = evidenceTitles(await getWorkTimeline(db(), seed.teamId, "team"));
+    expect(titles).not.toContain("Ticket description doc");
+  });
+
   it("tier isolation: an external viewer never sees a team-tier doc", async () => {
     const seed = await seedTeam();
     await ingest(seed, { kind: "deliverable", path: `notion/int-${randomUUID()}.md`, access: "team", body: "x",

--- a/test/guards/normalizer-work-time.test.ts
+++ b/test/guards/normalizer-work-time.test.ts
@@ -3,6 +3,8 @@ import { resolveWorkTime } from "@/lib/ingest/work-time";
 import { normalizeThread } from "@/lib/ingest/sources/slack-normalize";
 import { normalizeGithubFiles } from "@/lib/ingest/sources/github-files-normalize";
 import { normalizeCommit } from "@/lib/codebases/commits-to-items";
+import { normalizeLinearDocs } from "@/lib/ingest/sources/linear-normalize";
+import { normalizePlaneDocs } from "@/lib/ingest/sources/plane-normalize";
 
 /**
  * BUILD-FAILING GUARD: each connector's normalized payload either carries a resolvable WORK-TIME or
@@ -27,8 +29,8 @@ import { normalizeCommit } from "@/lib/codebases/commits-to-items";
 /** Producers that emit NO work-time today. Each entry is a known timeline-invisibility bug, not an
  *  exemption on principle — removing an entry (by making the producer emit a time) is the goal. */
 const KNOWN_UNDATED = [
-  "linear-normalize: per-issue doc items (normalizeLinearDocs)",
-  "plane-normalize: per-issue doc items (normalizePlaneDocs)",
+  // The aggregate issues-table item for a repo: one row per repo, not one person's dated work. Arcs
+  // already exclude it (#363) and the timeline never showed it, so it has no work-time to give.
   "github-normalize: the issues table item",
 ] as const;
 
@@ -81,7 +83,38 @@ describe("guard: every normalizer emits a resolvable work-time", () => {
   it("pins the producers that are still undated, so the gap stays visible", () => {
     // Asserting the LIST is the point: shrinking it requires deleting an entry here, which forces the
     // change to be reviewed rather than a producer quietly staying invisible in the product.
-    expect(KNOWN_UNDATED).toHaveLength(3);
+    expect(KNOWN_UNDATED).toHaveLength(1);
+  });
+
+  it("linear issue docs are dated by their state transition, undated when unstarted", () => {
+    const [started] = normalizeLinearDocs({
+      teamKey: "AIO",
+      issues: [{ id: "1", identifier: "AIO-1", title: "t", startedAt: "2026-06-20T10:00:00Z" }],
+    });
+    expect(resolveWorkTime(started.frontmatter as Record<string, unknown>)).toBe("2026-06-20T10:00:00.000Z");
+
+    // An unstarted ticket has no transition: nobody has worked it, so it stays honestly undated
+    // rather than being back-dated (which would date it to sync time in the graph).
+    const [backlog] = normalizeLinearDocs({
+      teamKey: "AIO",
+      issues: [{ id: "2", identifier: "AIO-2", title: "t" }],
+    });
+    expect(resolveWorkTime(backlog.frontmatter as Record<string, unknown>)).toBeNull();
+  });
+
+  it("plane issue docs are dated by completion, undated while incomplete", () => {
+    const base = { projectId: "p1", projectIdentifier: "ENG", workspaceSlug: "w", baseUrl: "https://plane.example", states: [] };
+    const [done] = normalizePlaneDocs({
+      ...base,
+      items: [{ id: "i1", sequence_id: 1, name: "done item", completed_at: "2026-06-22T09:00:00Z" }],
+    } as Parameters<typeof normalizePlaneDocs>[0]);
+    expect(resolveWorkTime(done.frontmatter as Record<string, unknown>)).toBe("2026-06-22T09:00:00.000Z");
+
+    const [open] = normalizePlaneDocs({
+      ...base,
+      items: [{ id: "i2", sequence_id: 2, name: "open item" }],
+    } as Parameters<typeof normalizePlaneDocs>[0]);
+    expect(resolveWorkTime(open.frontmatter as Record<string, unknown>)).toBeNull();
   });
 
   it("a repo file whose last commit could not be fetched stays honestly undated", () => {


### PR DESCRIPTION
Continues the backlog cleanup — shrinks the `KNOWN_UNDATED` list from #380.

## Problem
Linear/Plane **per-issue doc items** emitted no work-time, so `resolveWorkTime` returned null and the graph projector fell back to `synced_at`. First-linking a Linear team dates every issue **"today"**, and arcs narrate old tickets as this week — the H3 skew this series has been closing.

## Fix — two halves, and the second is what makes the first safe

**1. Date them.** The normalizers emit `source_ts` = the **state-transition time**, the same signal the task row's `worked_at` uses. Deliberately **not** `updatedAt` — that moves on any unrelated field edit (the #346 churn class). An unstarted ticket has no transition and stays **honestly undated**: nobody has worked it, so back-dating it would be a lie.

**2. Keep them out of Timeline evidence.** The timeline is **evidence-gated** — a task appears only if the person's in-window evidence cites its issue key. A Linear doc's path is `linear/<team>/AIO-123.md` and it sets **no `fm.title`**, so `title = basename(path)` and the evidence text is `` `${title}\n${r.path}` `` — **it cites its own key**. Dating it without this exclusion would let *every* assigned active ticket self-satisfy the gate and turn the timeline back into a backlog dump — the exact "never the whole backlog" property the design protects.

**Net: graph dating fixed, timeline behavior unchanged.** These docs were dropped before for being undated; now they're dropped by an explicit rule. The exclusion test is verified **red without the rule** (`expected [ 'Ticket description doc' ] to not include 'Ticket description doc'`) — the doc really does become its own evidence.

## Scope, stated honestly
This closes the skew for **Linear**: arc-eligibility only narrates `started` issues, and a started issue always has `startedAt`, so every doc arcs can narrate is now dated. For **Plane** it's partial — `planeWorkedAt` only knows `completed_at`, and arc-eligibility doesn't filter Plane by state, so a freshly-linked Plane project's *incomplete* backlog can still be graph-dated "today". Pre-existing (the Plane payload here carries no other timestamp); **follow-up**, not silently claimed as fixed.

## ⚠️ Forward-only
Same as the earlier work-time PR: episode idempotency is `sha(body)`, so already-projected docs keep their old `synced_at` stamps until their body changes. The deferred backfill (delete from Graphiti first, then reset the projector cursor) still applies.

## Tests
- Guard: linear docs dated by transition / undated when unstarted; **plane docs dated by completion / undated while incomplete** — the plane assertion verified **non-vacuous** (deleting `source_ts` from the normalizer turns it red).
- Data-mechanics: a PM issue doc is **not** evidence (verified red without the exclusion).
- `KNOWN_UNDATED` 3 → 1; the remaining entry (the github issues-table aggregate) is `kind="task"`, never shown by the timeline and already excluded from arcs (#363).

Unit **1116 green**, tsc 0, lint + docs-drift clean, data-mechanics 57/57.

## Review — Reviewed by Fable `code-reviewer` — verdict CLEAR
It exhaustively checked the exclusion predicate against every `identifier` producer (only the doc emitters match; `normalizePlaneProject` is `kind="task"` and filtered in SQL), confirmed timeline behavior is unchanged for all real data via the frontmatter history and heal semantics, and confirmed no sha/version churn. **Fixed here:** its Medium that my guard test was **vacuous for Plane** (titled "linear/plane", exercised only Linear — a deleted `source_ts` would have gone unnoticed). Its second Medium — the Plane scoping — is stated above rather than glossed.