### PR TITLE
fix(ingest): a transient Slack failure must never corrupt stored content

### DIFF
--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -171,7 +171,19 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
         if (channelIds.length === 0) continue;
 
         const client = new SlackClient(token);
-        const detailed = await client.usersDetailed(); // one pass per integration token (incl. emails when scoped)
+        // One pass per integration token (incl. emails when scoped). A TRANSIENT failure here now
+        // throws (a missing scope still returns []): rendering raw ids for one tick would rewrite
+        // EVERY thread body in every channel — a version + re-embed + re-projection each, churned
+        // back on the next good tick. Skip the integration instead; the existing items stand.
+        let detailed;
+        try {
+          detailed = await client.usersDetailed();
+        } catch (err) {
+          summary.errors.push(
+            `integration "${integ.name}": slack users lookup failed — skipped this tick (${err instanceof Error ? err.message : "unknown"})`
+          );
+          continue;
+        }
         // Best-effort reconcile Slack users → members by email, then build the resolver map so
         // each thread's author is attributed to the real person (manual mappings included).
         try {
@@ -185,6 +197,15 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
           summary.channels++;
           try {
             const channel = await fetchSlackChannel(client, channelId, { users, maxMessages: 300 });
+            // A thread whose replies couldn't be fetched is dropped rather than truncated — make that
+            // visible so a systematic failure doesn't read as a quiet channel.
+            if (channel.skippedThreads > 0) {
+              summary.errors.push(
+                `${channelId}: ${channel.skippedThreads} thread(s) skipped — replies fetch failed` +
+                  `${channel.skippedThreadsReason ? ` (${channel.skippedThreadsReason})` : ""}` +
+                  ` — any already-stored version stands`
+              );
+            }
             for (const thread of channel.threads) {
               const payload = normalizeThread(thread, {
                 channelId: channel.channelId,

--- a/lib/ingest/sources/slack.ts
+++ b/lib/ingest/sources/slack.ts
@@ -33,9 +33,33 @@ export interface FetchedChannel {
   threads: FetchedThread[];
   /** user id → display name (best-effort) */
   users: Record<string, string>;
+  /** Threads DROPPED this tick because their replies couldn't be fetched — see fetchSlackChannel.
+   *  Surfaced so a systematic failure is visible in the run log instead of looking like a quiet sync. */
+  skippedThreads: number;
+  /** One sample cause for `skippedThreads`. Carries the real Slack code so an operator can tell
+   *  "wait a tick" (`ratelimited`) from "frozen forever" (lost access / `thread_not_found`) — which
+   *  is the entire triage question a skip raises. */
+  skippedThreadsReason?: string;
 }
 
 export class SlackError extends Error {}
+
+/**
+ * True when a users.list failure means the TOKEN LACKS THE SCOPE — a stable, expected configuration
+ * (the workspace simply never gets display names; `normalizeThread` renders raw ids consistently, so
+ * bodies don't churn). Every OTHER failure is transient (network, rate limit, 5xx, timeout) and must
+ * NOT be treated as "no users": rendering ids for one tick rewrites every thread body in the channel
+ * → a new sha → a new version + re-embed + re-projection for the whole channel, which the next
+ * successful tick churns straight back. Callers skip instead.
+ */
+function isMissingScopeError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  // ONLY genuine scope/permission conditions. Token-dead codes (`invalid_auth`, `account_inactive`,
+  // `token_revoked`, …) are deliberately NOT here: nothing renders at all under a dead token, so
+  // calling it a graceful degrade would be a lie — they rethrow and the integration is skipped with
+  // one crisp error instead of a per-channel pile of downstream failures.
+  return /missing_scope|not_allowed_token_type|no_permission/i.test(msg);
+}
 
 export class SlackClient {
   constructor(private readonly token: string) {}
@@ -60,8 +84,14 @@ export class SlackClient {
         channel: channelId,
       });
       return r.channel.name ?? channelId;
-    } catch {
-      return channelId; // private channel without scope, or renamed — fall back to id
+    } catch (err) {
+      // A missing scope is stable: this channel always resolves to its id, so its thread paths are
+      // consistent tick over tick. A TRANSIENT failure is not — and the blast radius here is worse
+      // than anywhere else in this client, because the name is the PATH KEY: falling back to the id
+      // for one tick re-keys every thread to `slack/<C0123>/…` and CREATES a duplicate item per
+      // thread. Nothing diff-deletes those, so unlike a churned body they pollute retrieval forever.
+      if (!isMissingScopeError(err)) throw err;
+      return channelId; // private channel without the scope — a stable fallback
     }
   }
 
@@ -121,8 +151,10 @@ export class SlackClient {
         }
         cursor = r.response_metadata?.next_cursor || undefined;
       } while (cursor);
-    } catch {
-      // users:read[.email] not granted — caller degrades gracefully.
+    } catch (err) {
+      // users:read[.email] not granted — caller degrades gracefully to ids (stable across ticks).
+      // A TRANSIENT failure must surface so the caller can skip rather than rewrite every body.
+      if (!isMissingScopeError(err)) throw err;
     }
     return out;
   }
@@ -145,8 +177,9 @@ export class SlackClient {
         }
         cursor = r.response_metadata?.next_cursor || undefined;
       } while (cursor);
-    } catch {
-      // users:read not granted — fall back to ids at normalize time.
+    } catch (err) {
+      // users:read not granted — fall back to ids at normalize time (stable across ticks).
+      if (!isMissingScopeError(err)) throw err; // transient → caller skips, never a churned rewrite
     }
     return map;
   }
@@ -179,16 +212,25 @@ export async function fetchSlackChannel(
   const roots = history.filter((m) => isContentMessage(m) && (!m.thread_ts || m.thread_ts === m.ts));
 
   const threads: FetchedThread[] = [];
+  let skippedThreads = 0;
+  let skippedThreadsReason: string | undefined;
   for (const root of roots) {
     let replies: SlackMessage[] = [];
     if (root.reply_count && root.reply_count > 0) {
       try {
         replies = (await client.replies(channelId, root.ts)).filter(isContentMessage);
-      } catch {
-        replies = [];
+      } catch (err) {
+        // SKIP the thread this tick — do NOT fall back to root-only. A thread's body is the whole
+        // conversation, so ingesting it without its replies is a CONTENT REGRESSION: the stored item
+        // is rewritten to a truncated body (a real version), retrieval serves the shortened thread,
+        // and the next successful tick writes another version restoring it. Freshness costs nothing
+        // here — the existing full item simply stands until the next tick.
+        skippedThreads++;
+        skippedThreadsReason ??= err instanceof Error ? err.message : String(err);
+        continue;
       }
     }
     threads.push({ root, replies });
   }
-  return { channelId, channelName, threads, users };
+  return { channelId, channelName, threads, users, skippedThreads, skippedThreadsReason };
 }

--- a/test/ingest-slack-resilience.test.ts
+++ b/test/ingest-slack-resilience.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  fetchSlackChannel,
+  SlackError,
+  SlackClient as SlackClientCtor,
+  type SlackClient,
+} from "@/lib/ingest/sources/slack";
+
+/**
+ * Spec: a TRANSIENT Slack failure must never corrupt already-good stored content.
+ *
+ * A Slack thread is ONE item whose body is the whole conversation, rewritten on every sync. So any
+ * path that produces a PARTIAL body writes a real `item_version`, serves a truncated thread to
+ * retrieval, and gets churned back on the next good tick. Two such paths existed:
+ *  • a `conversations.replies` failure fell back to root-only → the thread lost every reply;
+ *  • a `users.list` failure returned an empty map → every author/mention rendered as a raw id, so
+ *    EVERY thread body in the workspace changed at once (a version + re-embed + re-projection each).
+ * Both must degrade by SKIPPING, not by writing a degraded body — freshness costs nothing here
+ * because the previously-stored full item simply stands until the next tick.
+ */
+
+/** A client stub exposing only what `fetchSlackChannel` calls. */
+function stubClient(over: Partial<Record<"channelName" | "usersMap" | "history" | "replies", unknown>>): SlackClient {
+  return {
+    channelName: over.channelName ?? (async () => "general"),
+    usersMap: over.usersMap ?? (async () => ({ U1: "Alice", U2: "Bob" })),
+    history: over.history ?? (async () => []),
+    replies: over.replies ?? (async () => []),
+  } as unknown as SlackClient;
+}
+
+const rootWithReplies = { ts: "1719878400.000100", user: "U1", text: "question?", reply_count: 2 };
+
+describe("fetchSlackChannel — a replies failure skips the thread, never truncates it", () => {
+  it("drops the thread and counts it, rather than emitting a root-only body", async () => {
+    const client = stubClient({
+      history: async () => [rootWithReplies],
+      replies: async () => {
+        throw new SlackError("slack conversations.replies failed: ratelimited");
+      },
+    });
+
+    const channel = await fetchSlackChannel(client, "C1", { users: {} });
+
+    // The thread is ABSENT — ingesting it now would rewrite the stored item to a body missing every
+    // reply (a content regression), then restore it next tick with a second bogus version.
+    expect(channel.threads).toHaveLength(0);
+    expect(channel.skippedThreads).toBe(1);
+  });
+
+  it("still returns threads whose replies fetched fine", async () => {
+    const client = stubClient({
+      history: async () => [rootWithReplies],
+      replies: async () => [{ ts: "1719878500.000200", user: "U2", text: "answer" }],
+    });
+    const channel = await fetchSlackChannel(client, "C1", { users: {} });
+    expect(channel.threads).toHaveLength(1);
+    expect(channel.threads[0].replies).toHaveLength(1);
+    expect(channel.skippedThreads).toBe(0);
+  });
+
+  it("a root with no replies is unaffected (never calls replies at all)", async () => {
+    const client = stubClient({
+      history: async () => [{ ts: "1719878400.000100", user: "U1", text: "standalone" }],
+      replies: async () => {
+        throw new SlackError("should not be called");
+      },
+    });
+    const channel = await fetchSlackChannel(client, "C1", { users: {} });
+    expect(channel.threads).toHaveLength(1);
+    expect(channel.skippedThreads).toBe(0);
+  });
+});
+
+/**
+ * The users map is the other partial-body vector. An empty map is a LEGITIMATE steady state when the
+ * token lacks `users:read` (every tick renders raw ids, consistently — no churn). A transient failure
+ * looks identical from the outside but is NOT stable: one bad tick rewrites every body, the next good
+ * one rewrites them all back. So the two must be distinguished at the source.
+ */
+describe("SlackClient users lookup — missing scope degrades, transient failures surface", () => {
+  const okJson = (body: unknown) => ({ ok: true, json: async () => body, status: 200 });
+
+  it("returns [] when the token simply lacks the scope (stable — ids every tick)", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => okJson({ ok: false, error: "missing_scope" })) as unknown as typeof fetch;
+    try {
+      await expect(new SlackClientCtor("xoxb-test").usersDetailed()).resolves.toEqual([]);
+      await expect(new SlackClientCtor("xoxb-test").usersMap()).resolves.toEqual({});
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it("THROWS on a transient failure so the caller skips instead of rewriting every body", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => okJson({ ok: false, error: "ratelimited" })) as unknown as typeof fetch;
+    try {
+      await expect(new SlackClientCtor("xoxb-test").usersDetailed()).rejects.toThrow(/ratelimited/);
+      await expect(new SlackClientCtor("xoxb-test").usersMap()).rejects.toThrow(/ratelimited/);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+});
+
+/**
+ * The channel NAME is the PATH KEY (`slack/<channel>/<ts>.md`), so this vector is the worst of the
+ * three: a one-tick fallback to the raw channel id re-keys every thread and CREATES a duplicate item
+ * per thread. Unlike a churned body, nothing ever diff-deletes those — they pollute retrieval, credit
+ * and the timeline permanently. A missing scope is different: it resolves to the id every tick, so
+ * paths stay consistent.
+ */
+describe("SlackClient.channelName — transient failures must not re-key every thread path", () => {
+  const resp = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+
+  async function withFetch<T>(body: unknown, fn: () => Promise<T>): Promise<T> {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => resp(body)) as unknown as typeof fetch;
+    try {
+      return await fn();
+    } finally {
+      globalThis.fetch = orig;
+    }
+  }
+
+  it("falls back to the id ONLY for a missing scope (a stable, consistent path)", async () => {
+    const name = await withFetch({ ok: false, error: "missing_scope" }, () =>
+      new SlackClientCtor("xoxb-test").channelName("C0123")
+    );
+    expect(name).toBe("C0123");
+  });
+
+  it("THROWS on a transient failure instead of silently duplicating the channel", async () => {
+    await withFetch({ ok: false, error: "ratelimited" }, async () => {
+      await expect(new SlackClientCtor("xoxb-test").channelName("C0123")).rejects.toThrow(/ratelimited/);
+    });
+  });
+
+  it("a dead token is NOT treated as a graceful degrade", async () => {
+    await withFetch({ ok: false, error: "invalid_auth" }, async () => {
+      await expect(new SlackClientCtor("xoxb-test").channelName("C0123")).rejects.toThrow(/invalid_auth/);
+    });
+  });
+});
+
+describe("fetchSlackChannel — the skip carries its cause for triage", () => {
+  it("reports the underlying Slack error so 'retry' vs 'frozen' is distinguishable", async () => {
+    const client = stubClient({
+      history: async () => [rootWithReplies],
+      replies: async () => {
+        throw new SlackError("slack conversations.replies failed: ratelimited");
+      },
+    });
+    const channel = await fetchSlackChannel(client, "C1", { users: {} });
+    expect(channel.skippedThreadsReason).toMatch(/ratelimited/);
+  });
+});


### PR DESCRIPTION
Pass-2 item #4 — findings **H6 + H7**, plus the same failure class in `channelName` (surfaced in review).

## The shape of the bug
A Slack thread is **one item whose body is the whole conversation**, rewritten on every sync. So any path that yields a **partial body** writes a real `item_version`, serves a truncated thread to retrieval, and gets churned back on the next good tick. Three paths did exactly that:

| | What it did | Blast radius |
|---|---|---|
| **H7** `replies` | `catch { replies = [] }` → shipped a **root-only** body | that thread loses every reply, restored next tick (2 bogus versions) |
| **H6** `users.list` | swallowed all errors → empty map → authors/mentions render as raw ids | **every thread body in the workspace** rewritten at once; also could return a *partial* map mid-pagination |
| **`channelName`** (pre-existing) | swallowed all errors → falls back to the channel id | the name is the **PATH KEY** → re-keys every thread to `slack/<C0123>/…` and **creates a duplicate item per thread** |

The third is the worst: unlike a churned body, **nothing diff-deletes those duplicates** — they pollute retrieval, credit, and the timeline *permanently*.

## Fix — skip, never write a degraded body
All three now degrade by **skipping**. Freshness costs nothing here: the already-stored full item simply stands until the next tick.

- A genuine **missing scope** stays a graceful degrade — it renders ids *consistently every tick*, so paths and bodies are stable and nothing churns.
- **Everything else rethrows**, and the caller skips the thread / channel / integration for one tick, recording why.
- **Token-dead codes are deliberately not degrades.** Nothing renders under a dead token, so one crisp `skipped this tick (invalid_auth)` beats a pile of downstream per-channel failures. (This was a correction from review — I'd initially lumped them with missing-scope.)
- Skips surface into `ingest_runs` **with the underlying Slack code**, so an operator can tell "wait a tick" (`ratelimited`) from "frozen forever" (lost access).

## Tests
Nine specs pinning each vector, verified **red without the fix** — the truncated root-only thread *was* being emitted (`expected [ { root: …, replies: [] } ] to have a length of +0 but got 1`), and `channelName` silently returned the id.

Unit **1125 green**, tsc 0, lint + docs-drift clean.

## Known / deferred (not silently absorbed)
- A **permanently** unfetchable thread now makes the slack leg red every tick. Visible beats silent, but it can desensitize the banner — worth a count-with-threshold later.
- `call()` still has **no Retry-After backoff**; a 429 costs one tick's freshness. Safe now that skipping is the failure mode, and cheap to add later.
- **H5 proper** (a channel **rename** → duplicate paths) still needs its own path-migration PR. This fixes only the *transient-failure* route to the same symptom.

## Review — Reviewed by Fable `code-reviewer` — verdict CLEAR
It confirmed the skip is safe (absence ≠ deletion: nothing prunes a transcript item, and this is already the steady state for threads aged out by the 300-message cap), that the rethrow has no other callers, and that the missing-scope path is byte-identical to today. **Fixed here:** its two mediums (the token-dead misclassification; carrying the skip's cause) **and** the pre-existing `channelName` High it found — which I pulled in rather than deferring, since it's the same helper and the damage is permanent.