### PR TITLE
fix(slack): key item paths on the immutable channel ID, not the display name

### DIFF
--- a/components/library/data-browser.tsx
+++ b/components/library/data-browser.tsx
@@ -55,13 +55,24 @@ export async function DataBrowser({
   // 1) Channel list — group a bounded recent window of visible items by path prefix.
   let chQuery = db
     .from("items")
-    .select("path, synced_at")
+    // `frontmatter` supplies the channel's DISPLAY name: Slack paths are keyed on the immutable
+    // channel ID (so a rename can't re-key threads into duplicates), which means the path segment is
+    // an opaque id and the readable `#name` lives in frontmatter.
+    .select("path, synced_at, frontmatter")
     .eq("team_id", team.id)
     .order("synced_at", { ascending: false })
     .limit(CHANNEL_SCAN_CAP);
   chQuery = visibleItems(chQuery, tier); // external viewers never see team/admin content
   const { data: chRows } = await chQuery;
-  const channels = groupChannels((chRows ?? []) as ChannelRow[]);
+  const channels = groupChannels(
+    ((chRows ?? []) as { path: string; synced_at: string | Date; frontmatter: Record<string, unknown> | null }[]).map(
+      (r) => ({
+        path: r.path,
+        synced_at: r.synced_at,
+        label: typeof r.frontmatter?.channel === "string" ? r.frontmatter.channel : null,
+      })
+    ) as ChannelRow[]
+  );
 
   const selected =
     channelParam && channels.some((c) => c.key === channelParam) ? channelParam : channels[0]?.key ?? null;

--- a/lib/ingest/sources/slack-normalize.ts
+++ b/lib/ingest/sources/slack-normalize.ts
@@ -86,7 +86,18 @@ function threadTitle(thread: FetchedThread, opts: NormalizeOpts): string {
 
 export function normalizeThread(thread: FetchedThread, opts: NormalizeOpts): ItemPayload {
   const { root, replies } = thread;
-  const channelSeg = safeSegment(opts.channelName || opts.channelId);
+  // PATH IDENTITY = the immutable channel ID, never the display name. The name is mutable and
+  // lossy, and the path is the item's identity, so keying on it meant:
+  //  • a channel RENAME re-keyed every thread → a duplicate item per thread, and nothing ever
+  //    diff-deletes those, so both copies persist in retrieval, credit and the timeline forever;
+  //  • `safeSegment` strips everything outside [a-z0-9_-], so a CJK/emoji channel name collapsed to
+  //    the empty string and fell back to a shared folder — and Slack `ts` is unique only WITHIN a
+  //    channel, so two such channels could collide on one path and overwrite each other's content.
+  // The display name stays in `frontmatter.channel` (what the Data page and titles render).
+  // `safeSegment` already supplies its own non-empty fallback, so this is the whole identity: a
+  // channel id that somehow stripped to nothing lands in the shared fallback folder (unreachable —
+  // channelIds is schema-validated non-empty and Slack ids are uppercase alphanumeric).
+  const channelSeg = safeSegment(opts.channelId);
 
   const parts = [renderMessage(root, opts)];
   for (const r of replies) parts.push(renderMessage(r, opts));

--- a/lib/ingest/sources/slack.ts
+++ b/lib/ingest/sources/slack.ts
@@ -85,11 +85,11 @@ export class SlackClient {
       });
       return r.channel.name ?? channelId;
     } catch (err) {
-      // A missing scope is stable: this channel always resolves to its id, so its thread paths are
-      // consistent tick over tick. A TRANSIENT failure is not — and the blast radius here is worse
-      // than anywhere else in this client, because the name is the PATH KEY: falling back to the id
-      // for one tick re-keys every thread to `slack/<C0123>/…` and CREATES a duplicate item per
-      // thread. Nothing diff-deletes those, so unlike a churned body they pollute retrieval forever.
+      // Paths are keyed on the immutable channel ID now, so a name flake no longer re-keys threads —
+      // it only affects the DISPLAY name (`frontmatter.channel`, the thread title, the Data page). We
+      // still skip on a transient failure rather than persist a wrong name: the frontmatter heal
+      // rewrites `channel` on every unchanged re-push, so one bad tick would relabel the whole
+      // channel's items (and the Data page picks the most recently synced name).
       if (!isMissingScopeError(err)) throw err;
       return channelId; // private channel without the scope — a stable fallback
     }

--- a/lib/library/channels.ts
+++ b/lib/library/channels.ts
@@ -13,6 +13,14 @@ export interface ChannelRow {
   // The pg adapter returns timestamptz as a Date, not an ISO string (the #134 gotcha) — accept
   // both so the caller can pass rows straight through. Normalized to an ISO string internally.
   synced_at: string | Date;
+  /**
+   * Human display name for the channel, when the source knows one the PATH doesn't carry. Slack keys
+   * its paths on the immutable channel ID (a rename must not re-key every thread into duplicate
+   * items), so `slack/c0b8v119g4d` has no readable segment — the real `#all-vibrana` comes from the
+   * item's `frontmatter.channel`. Sources whose segment is already readable (linear/github/plane)
+   * pass nothing and keep deriving the name from the path.
+   */
+  label?: string | null;
 }
 
 export interface Channel {
@@ -23,7 +31,8 @@ export interface Channel {
   lastSyncedAt: string;
 }
 
-/** `slack/eng/123.md` → { key: "slack/eng", source: "slack", name: "eng" }. */
+/** `slack/eng/123.md` → { key: "slack/eng", source: "slack", name: "eng" }. `key` stays the PATH
+ *  prefix (it's also the feed query `<key>/%`); only the display `name` may be overridden by a label. */
 export function parseChannel(path: string): { key: string; source: string; name: string } {
   const segs = path.split("/").filter(Boolean);
   if (segs.length >= 2) return { key: `${segs[0]}/${segs[1]}`, source: segs[0], name: segs[1] };
@@ -39,16 +48,27 @@ function isoOf(v: string | Date): string {
 /** Group rows into channels with item counts + most-recent arrival, sorted by recency (newest first). */
 export function groupChannels(rows: ChannelRow[]): Channel[] {
   const byKey = new Map<string, Channel>();
+  // Tracks WHEN each channel's current display label was observed, so the most recently synced name
+  // wins. Input order is not assumed (a caller may pass rows in any order), and after a rename the
+  // older rows still carry the old name — picking by recency is what makes the new name show.
+  const labelAt = new Map<string, number>();
   for (const row of rows) {
     const { key, source, name } = parseChannel(row.path);
+    const label = row.label?.trim() || "";
     const syncedAt = isoOf(row.synced_at);
+    const ms = Date.parse(syncedAt);
     const existing = byKey.get(key);
     if (!existing) {
-      byKey.set(key, { key, source, name, count: 1, lastSyncedAt: syncedAt });
+      byKey.set(key, { key, source, name: label || name, count: 1, lastSyncedAt: syncedAt });
+      if (label) labelAt.set(key, ms);
     } else {
       existing.count += 1;
+      if (label && ms >= (labelAt.get(key) ?? -Infinity)) {
+        existing.name = label;
+        labelAt.set(key, ms);
+      }
       // Compare by epoch ms — mixed "Z"/offset ISO forms don't sort lexicographically.
-      if (Date.parse(syncedAt) > Date.parse(existing.lastSyncedAt)) existing.lastSyncedAt = syncedAt;
+      if (ms > Date.parse(existing.lastSyncedAt)) existing.lastSyncedAt = syncedAt;
     }
   }
   return [...byKey.values()].sort((a, b) => Date.parse(b.lastSyncedAt) - Date.parse(a.lastSyncedAt));

--- a/lib/query/fts-search.ts
+++ b/lib/query/fts-search.ts
@@ -36,9 +36,15 @@ export async function rankedFtsSearch(
   let where = "i.team_id = $2 and i.search @@ websearch_to_tsquery('english', $1)";
   if (isRestrictedTier(tier)) where += " and i.access = 'external'";
   if (channel) {
-    // Channel scope (Gap #4): the channel is a path's 2nd segment, `<source>/<name>/…`.
+    // Channel scope (Gap #4). The channel NAME appears in a path's 2nd segment for sources that key
+    // paths by name (`linear/aio/…`) — but NOT for Slack, whose path is keyed on the immutable
+    // channel ID so a rename can't re-key every thread into duplicate items. Slack carries its
+    // readable name in `frontmatter.channel`, so match EITHER. Without the frontmatter arm a
+    // "#growth" question silently retrieves zero Slack threads (and the scope phrase is stripped
+    // from the query, so the word doesn't even survive as a content term).
     params.push(channel);
-    where += ` and split_part(i.path, '/', 2) = $${params.length}`;
+    const idx = params.length;
+    where += ` and (split_part(i.path, '/', 2) = $${idx} or lower(i.frontmatter->>'channel') = lower($${idx}))`;
   }
   params.push(limit);
   const limitIdx = params.length;

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -256,6 +256,36 @@ export function parseChannelScope(question: string): { channel: string | null; c
 }
 
 /**
+ * The PATH SEGMENT a channel name lives under, for the soft recency legs.
+ *
+ * `parseChannelScope` yields a NAME ("#growth" → `growth`), and for sources that key paths by name
+ * (`linear/aio/…`) that name IS the 2nd path segment. Slack is different: its paths are keyed on the
+ * immutable channel ID so a rename can't re-key every thread into duplicate items, which leaves the
+ * segment opaque (`slack/c0b8v119g4d/…`) and the readable name in `frontmatter.channel`. So resolve
+ * name → segment once; a name that resolves to nothing (non-Slack sources) falls back to itself,
+ * preserving the previous behavior exactly.
+ *
+ * One small indexed lookup, and ONLY when the question actually names a channel. It exists because
+ * the pg adapter has no `.or()` — the precise FTS leg matches both arms in one SQL predicate.
+ */
+async function resolveChannelSegment(
+  db: DbClient,
+  teamId: string,
+  tier: "team" | "external",
+  channel: string
+): Promise<string> {
+  // Tier-filtered like every other read (CLAUDE.md §5 — no RLS backstop). The legs this feeds are
+  // themselves tier-scoped, so nothing leaks either way; re-applying it here keeps the invariant
+  // "every items read carries the filter" true by inspection rather than by argument.
+  let q = db.from("items").select("path").eq("team_id", teamId).eq("frontmatter->>channel", channel).limit(1);
+  if (isRestrictedTier(tier)) q = q.eq("access", "external");
+  const { data } = await q;
+  const path = (data as { path: string }[] | null)?.[0]?.path;
+  const seg = path ? path.split("/")[1] : "";
+  return seg || channel;
+}
+
+/**
  * Detect an explicit SOURCE scope — a query naming an ingestion source it wants the recent content
  * FROM ("what's the conversation in slack right now", "latest notion docs", "what's on linear"). Generic
  * content-similarity ranking BURIES such items: a Slack thread matches the query only on the single word
@@ -507,9 +537,11 @@ async function nativeRetrieve(
     .order("synced_at", { ascending: false })
     .limit(8);
   if (isRestrictedTier(tier)) recentB = recentB.eq("access", "external");
-  // Channel scope (Gap #4) — keep the recency fallback inside the same channel. LIKE on the 2nd
-  // path segment; the FTS leg uses a precise split_part match, this soft filter is fine for padding.
-  if (channel) recentB = recentB.like("path", `%/${channel}/%`);
+  // Channel scope (Gap #4) — keep the recency fallback inside the same channel. LIKE on the 2nd path
+  // segment, resolved from the name first (Slack's segment is its channel ID — see
+  // resolveChannelSegment); the FTS leg does the precise matching, this soft filter is padding.
+  const channelSeg = channel ? await resolveChannelSegment(db, teamId, tier, channel) : null;
+  if (channelSeg) recentB = recentB.like("path", `%/${channelSeg}/%`);
 
   // 2a. SOURCE-scoped recency: when the question names a source, pull its most-recent items by
   // `synced_at` REGARDLESS of keyword rank (the recall fix for "what's the conversation in slack" —
@@ -525,7 +557,7 @@ async function nativeRetrieve(
       .order("synced_at", { ascending: false })
       .limit(SOURCE_RECENCY_LIMIT);
     if (isRestrictedTier(tier)) sourceRecencyB = sourceRecencyB.eq("access", "external");
-    if (channel) sourceRecencyB = sourceRecencyB.like("path", `%/${channel}/%`);
+    if (channelSeg) sourceRecencyB = sourceRecencyB.like("path", `%/${channelSeg}/%`);
   }
 
   // 3. Structured-context query builders (awaited together with the above).

--- a/postgres/migrations/20260725180000_slack_paths_by_channel_id.sql
+++ b/postgres/migrations/20260725180000_slack_paths_by_channel_id.sql
@@ -1,0 +1,62 @@
+-- Re-key Slack item paths from the channel NAME to the immutable channel ID.
+--
+-- WHY: `path` is an item's identity (`unique (team_id, project_id, path)`). Keying it on the display
+-- name meant a channel RENAME re-keyed every thread → a duplicate item per thread, and nothing
+-- diff-deletes those, so both copies persisted in retrieval, credit and the timeline forever. A
+-- non-Latin name was worse: `safeSegment` strips everything outside [a-z0-9_-], so CJK/emoji channels
+-- collapsed into one shared folder where a Slack `ts` (unique only WITHIN a channel) could collide and
+-- overwrite another channel's thread.
+--
+-- This migration moves existing rows onto the new scheme IN PLACE, preserving each item's id — so
+-- `item_versions` (the work ledger that drives credit), `item_chunks` and `graph_episodes` all keep
+-- pointing at the same item. A delete-and-reingest would have thrown that history away.
+--
+-- MERGE-STYLE + IDEMPOTENT: the new code may already have pushed an ID-keyed copy before this runs
+-- (a deploy tick between release and schema load). Where BOTH exist, the older name-keyed row is the
+-- one with history, so the fresh duplicate is removed first — otherwise the UPDATE would violate the
+-- uniqueness constraint. Safe to re-run: after the first pass nothing matches.
+
+begin;
+
+-- The ID-keyed path an item SHOULD have. Mirrors `safeSegment(channelId)` in slack-normalize:
+-- Slack ids are uppercase alphanumeric, so lower() is the whole transformation.
+create temporary view slack_repath as
+select
+  i.id,
+  i.team_id,
+  i.project_id,
+  i.path as old_path,
+  'slack/' || lower(i.frontmatter ->> 'channel_id') || '/' || split_part(i.path, '/', 3) as new_path
+from items i
+where i.frontmatter ->> 'source' = 'slack'
+  and coalesce(i.frontmatter ->> 'channel_id', '') <> ''
+  and split_part(i.path, '/', 1) = 'slack'
+  and split_part(i.path, '/', 2) <> lower(i.frontmatter ->> 'channel_id'); -- already migrated → skip
+
+-- 1. Drop any ID-keyed DUPLICATE the new code created in the window. The name-keyed row is older and
+--    carries the version history, so it wins; this fresh copy is what would block the UPDATE.
+--    `graph_episodes` has NO FK to items (it is an idempotency ledger keyed by source_id), so its rows
+--    must be removed explicitly or the duplicate's facts are orphaned in Graphiti forever.
+delete from graph_episodes ge
+using items dup, slack_repath r
+where ge.source_table = 'items'
+  and ge.source_id = dup.id
+  and dup.team_id = r.team_id
+  and dup.project_id = r.project_id
+  and dup.path = r.new_path
+  and dup.id <> r.id;
+
+delete from items dup
+using slack_repath r
+where dup.team_id = r.team_id
+  and dup.project_id = r.project_id
+  and dup.path = r.new_path
+  and dup.id <> r.id; -- item_versions / item_chunks cascade on delete
+
+-- 2. Move the surviving (history-carrying) rows onto the ID-keyed path.
+update items i
+set path = r.new_path
+from slack_repath r
+where i.id = r.id;
+
+commit;

--- a/test/datamechanics/channel-scope.datamechanics.test.ts
+++ b/test/datamechanics/channel-scope.datamechanics.test.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { retrieve } from "@/lib/query/retrieve";
+import { db, seedTeam, ingest } from "./helpers";
+
+/**
+ * Spec: a channel-scoped question ("what did we decide in #growth") must retrieve that channel's
+ * Slack threads.
+ *
+ * The scope is matched against a path's 2nd segment, which worked only while Slack keyed its paths on
+ * the channel NAME. Keying them on the immutable channel ID (so a rename can't re-key every thread
+ * into duplicate items) makes that segment opaque — and the readable name moves to
+ * `frontmatter.channel`. Without matching that too, a "#channel" question silently returns ZERO Slack
+ * items: worse than a miss, because `parseChannelScope` STRIPS the channel word from the query, so it
+ * doesn't even survive as a content term. Real Postgres — the observable outcome is what retrieval
+ * returns.
+ */
+describe("channel-scoped retrieval with ID-keyed Slack paths (real Postgres)", () => {
+  it("finds a thread by its channel NAME even though the path is keyed on the channel ID", async () => {
+    const seed = await seedTeam();
+    const ts = `171890${Math.floor(Math.random() * 100000)}.000100`;
+
+    // Exactly the shape the connector now writes: opaque id segment, readable name in frontmatter.
+    await ingest(seed, {
+      path: `slack/c0b8v119g4d/${ts}.md`,
+      project: "slack",
+      kind: "transcript",
+      access: "team",
+      body: "# growth thread\n\nAlice: we decided to sunset the legacy pricing page.",
+      frontmatter: { source: "slack", channel: "growth", channel_id: "C0B8V119G4D", title: "pricing decision" },
+    });
+    // A same-team thread in ANOTHER channel — the scope must exclude it.
+    await ingest(seed, {
+      path: `slack/c0other0000/${ts}.md`,
+      project: "slack",
+      kind: "transcript",
+      access: "team",
+      body: "# random thread\n\nBob: we decided to order more coffee.",
+      frontmatter: { source: "slack", channel: "random", channel_id: "C0OTHER0000", title: "coffee decision" },
+    });
+
+    const ctx = await retrieve(db(), seed.teamId, "team", "what did we decide in #growth");
+    const paths = ctx.sources.map((s) => s.path);
+
+    expect(paths.some((p) => p.includes("c0b8v119g4d"))).toBe(true); // the scoped channel IS reachable
+    expect(paths.some((p) => p.includes("c0other0000"))).toBe(false); // and the scope still excludes others
+  });
+
+  it("still scopes a source whose path segment IS the readable name (linear/github)", async () => {
+    const seed = await seedTeam();
+    await ingest(seed, {
+      path: `linear/aio/AIO-${randomUUID().slice(0, 6)}.md`,
+      project: "linear-aio",
+      kind: "deliverable",
+      access: "team",
+      body: "Ticket: migrate the billing webhooks.",
+      frontmatter: { source: "linear", identifier: "AIO-1", source_ts: new Date().toISOString() },
+    });
+
+    // No frontmatter.channel here — the name must still resolve via the path segment (unchanged path).
+    const ctx = await retrieve(db(), seed.teamId, "team", "what is happening in the aio channel");
+    expect(ctx.sources.some((s) => s.path.includes("linear/aio/"))).toBe(true);
+  });
+});

--- a/test/ingest-slack-normalize.test.ts
+++ b/test/ingest-slack-normalize.test.ts
@@ -21,7 +21,8 @@ describe("normalizeThread", () => {
     // conforms to the brain contract
     expect(() => itemPayloadSchema.parse(p)).not.toThrow();
     expect(p.kind).toBe("transcript");
-    expect(p.path).toBe("slack/eng/1718900000.000100.md");
+    // Keyed on the immutable channel ID, not the display name (which is mutable — see the rename spec).
+    expect(p.path).toBe("slack/c0b8v119g4d/1718900000.000100.md");
     expect(p.content_sha256).toMatch(/^[a-f0-9]{64}$/);
     expect(p.actor).toBe("Alex");
     expect(p.body).toContain("shipping the dual-backend today");
@@ -116,5 +117,35 @@ describe("threadParticipants", () => {
       users
     );
     expect(parts.map((p) => p.author_id)).toEqual(["U1"]);
+  });
+});
+
+/**
+ * Spec: an item's PATH is its identity, so it must be keyed on something immutable. The Slack display
+ * name is neither immutable nor lossless, and both properties caused real corruption:
+ *  • RENAME — every thread re-keys to a new path, creating a duplicate item per thread. Nothing
+ *    diff-deletes those, so both copies live on in retrieval, credit and the timeline forever.
+ *  • NON-LATIN — `safeSegment` strips everything outside [a-z0-9_-], so a CJK/emoji name collapsed to
+ *    a shared fallback folder; Slack `ts` is unique only WITHIN a channel, so two such channels could
+ *    land on the SAME path and overwrite each other's content every tick.
+ * The display name lives in `frontmatter.channel`, which is what surfaces render.
+ */
+describe("normalizeThread path identity", () => {
+  const thread = { root: { ts: "1718900000.000100", user: "U1", text: "hi" }, replies: [] };
+
+  it("is STABLE across a channel rename", () => {
+    const before = normalizeThread(thread, { channelId: "C0B8V119G4D", channelName: "growth", users: {} });
+    const after = normalizeThread(thread, { channelId: "C0B8V119G4D", channelName: "marketing", users: {} });
+    expect(after.path).toBe(before.path); // same thread → same item, no duplicate
+    expect(after.frontmatter.channel).toBe("marketing"); // the new name still surfaces for display
+  });
+
+  it("keeps two non-Latin-named channels on DISTINCT paths", () => {
+    // Same thread ts in two different channels — previously both collapsed to one folder and could
+    // overwrite each other, because ts is only unique within a channel.
+    const a = normalizeThread(thread, { channelId: "C0AAA", channelName: "日本語", users: {} });
+    const b = normalizeThread(thread, { channelId: "C0BBB", channelName: "🚀", users: {} });
+    expect(a.path).not.toBe(b.path);
+    expect(a.frontmatter.channel).toBe("日本語"); // the real name is preserved for display
   });
 });

--- a/test/library-channels.test.ts
+++ b/test/library-channels.test.ts
@@ -69,3 +69,33 @@ describe("previewLine", () => {
     expect(out.length).toBeLessThanOrEqual(51);
   });
 });
+
+/**
+ * Slack keys its item paths on the immutable channel ID (a rename must not re-key every thread into
+ * duplicate items), so `slack/c0b8v119g4d` has no readable segment. The real `#name` rides on the
+ * item's `frontmatter.channel` and is passed through as `label` — otherwise the Data page would list
+ * a raw Slack ID. Sources whose path segment is already readable pass no label and are unaffected.
+ */
+describe("groupChannels — display label", () => {
+  it("shows the source's real name instead of an opaque path segment", () => {
+    const [ch] = groupChannels([
+      { path: "slack/c0b8v119g4d/1.md", synced_at: "2026-07-01T00:00:00Z", label: "all-vibrana" },
+    ]);
+    expect(ch.name).toBe("all-vibrana");
+    expect(ch.key).toBe("slack/c0b8v119g4d"); // key stays the PATH prefix — it's the feed query
+  });
+
+  it("prefers the most recently synced name, so a rename surfaces", () => {
+    const [ch] = groupChannels([
+      { path: "slack/c1/2.md", synced_at: "2026-07-02T00:00:00Z", label: "marketing" }, // newer
+      { path: "slack/c1/1.md", synced_at: "2026-07-01T00:00:00Z", label: "growth" }, // older
+    ]);
+    expect(ch.name).toBe("marketing");
+    expect(ch.count).toBe(2); // one channel, not two — the rename did NOT split it
+  });
+
+  it("falls back to the path segment when no label is supplied", () => {
+    const [ch] = groupChannels([{ path: "linear/aio/AIO-1.md", synced_at: "2026-07-01T00:00:00Z" }]);
+    expect(ch.name).toBe("aio");
+  });
+});


### PR DESCRIPTION
Pass-2 finding **H5** — the last item of the cheap batch.

## Problem
`path` is an item's identity (`unique (team_id, project_id, path)`), and Slack keyed it on the **display name**:

- **Rename** — `#growth` → `#marketing` re-keys every thread → **a duplicate item per thread**. Nothing diff-deletes those, so both copies live on in retrieval, credit and the timeline forever.
- **Non-Latin** — `safeSegment` strips everything outside `[a-z0-9_-]`, so a CJK/emoji channel collapsed into a shared folder; a Slack `ts` is unique only *within* a channel, so two such channels could land on the **same path and overwrite each other** every tick.

Paths are now `slack/<channelId>/<ts>.md`. The readable name stays in `frontmatter.channel`.

## Two couplings that made this more than a one-liner
**1. The Data page** derived the channel's display name from the path segment — it would have shown `c0b8v119g4d`. `ChannelRow` gains an optional `label`, and `groupChannels` prefers it **keyed by recency**, so a rename surfaces the new name *without splitting the channel* (`key` stays the path prefix — it's the feed query).

**2. Channel-scoped retrieval** matched the name against the path's 2nd segment. With an opaque segment, a `#growth` question would have returned **zero** Slack items — *silently*, because `parseChannelScope` strips the channel word from the query, so it doesn't even survive as a content term. Fixed: the precise FTS leg matches the path segment **or** `frontmatter.channel`; the two soft recency legs (the pg adapter has no `.or()`) resolve the name to its actual path segment first, falling back to the name so linear/github behave exactly as before.

## Migration — carried in this PR, deliberately
`postgres/migrations/20260725180000_slack_paths_by_channel_id.sql`, **merge-style and idempotent**, so the standard post-merge `pg:schema` closes the duplicate window at one tick instead of leaving it open for days.

It keeps the **older, history-carrying** row, deletes any ID-keyed copy the new code created in the window, and deletes that copy's `graph_episodes` row **first** — that table has no FK to `items` and no purge path, so its facts would orphan in Graphiti *permanently*. Updating `path` in place preserves the item id, so `item_versions` (credit), chunks and episodes keep pointing at the same item.

**Exercised against a real DB on the exact collision** (name-keyed row *with* a version + ID-keyed duplicate *with* an episode): surviving row repathed carrying the **old body**, 1 version kept, orphan episodes **1 → 0**, second run a no-op.

## Tests
- Rename-stability + non-Latin-distinctness specs — **red on the old code** (the two non-Latin channels collided on one path).
- Label recency (a rename shows the new name, `count: 2` proves the channel didn't split).
- **`test/datamechanics/channel-scope`** (real Postgres) — a `#growth` question retrieves an ID-keyed thread and excludes another channel; plus a linear/aio case proving name-keyed sources still scope. **Verified red without the retrieval fix.**

Unit **1133 green**, tsc 0, lint + docs-drift clean, data-mechanics 33/33 on the touched surfaces; migration applies from zero.

## Review — Reviewed by Fable `code-reviewer`
It **BLOCKED** the first revision on the channel-scoped retrieval regression — a genuine catch I'd missed, and the one consumer that would have traded a data-corruption bug for a silent permanent retrieval break. Fixed here, along with its two mediums (a dead fallback chain that promised an unreachable fallback order; a now-obsolete comment in `slack.ts`), and its recommendation to carry the migration in this PR rather than ship code-first.

A re-review was cut short by an API spend limit, so I verified its three follow-up questions myself: **all four** `channel` consumers are covered (the semantic-expansion leg routes through `rankedFtsSearch`, so it inherits the OR fix — not a separate path); the new lookup is now **tier-filtered** for defense-in-depth per CLAUDE.md §5; and the migration behavior is proven on a real DB as above.

## Known / accepted
- `resolveChannelSegment` takes `limit 1`: if two channels ever shared a name it picks one arbitrarily. It only narrows *soft padding* legs — the precise FTS leg matches both arms — so the blast radius is padding selection.
- Rows with no `frontmatter.channel_id` are skipped by the migration (nothing to compute a path from). Not reachable here: all 13 prod Slack items carry one.