### PR TITLE
fix(ingest): close four contract mediums — authors heal, decision diff-delete, slack no-op, id fallback

### DIFF
--- a/docs/context-management-system.md
+++ b/docs/context-management-system.md
@@ -87,8 +87,10 @@ validation (before any mutation) → item + version + derived-row materializatio
 - **Identity constraint** — `items` is unique on `(team_id, project_id, path)` (`schema.sql:931`): one
   live row per path. New content **replaces in place**; history goes to `item_versions`.
 - **Derived-row diff-sync** by `row_key` — `tasks`/`decisions` upsert on `(team_id, project_id,
-  row_key)`; sync-originated rows absent from a push are **diff-deleted**, but `origin='ui'` rows
-  survive (`index.ts:455`).
+  row_key)`; sync-originated rows absent from a push are **diff-deleted** (`lib/ingest/tasks`,
+  `lib/ingest/decisions`), so a retracted row stops being served as current. Hand-made rows survive:
+  tasks by `origin='ui'`, decisions by `source_item_id IS NULL` (a decision's diff is scoped to the
+  item that produced it).
 - **Semantic chunks** — `item_chunks` unique on `(item_id, chunk_idx)`; `indexItem` is idempotent on
   the item's sha and only re-embeds when the sha moved (never re-charges the embedding API for
   unchanged text — `dense-index.ts:62`).

--- a/ingestion/aios_ingest/sources/_llamahub.py
+++ b/ingestion/aios_ingest/sources/_llamahub.py
@@ -8,10 +8,13 @@ lazy-import-with-helpful-error pattern so each adapter stays tiny.
 from __future__ import annotations
 
 import importlib
+import logging
 from typing import Any, Iterable
 
 from ..normalize import RawDoc
 from .base import MissingExtraError
+
+logger = logging.getLogger(__name__)
 
 
 def lazy_reader(module: str, cls: str, extra: str, package: str):
@@ -70,11 +73,24 @@ def docs_to_raw(
     id_keys: tuple[str, ...],
     fallback_prefix: str,
 ) -> list[RawDoc]:
-    """Convert LlamaHub Documents to RawDocs, deriving a stable external_id."""
+    """Convert LlamaHub Documents to RawDocs, deriving a stable external_id.
+
+    A document with NO id in its metadata is SKIPPED, not given a positional id. `external_id`
+    becomes the item's PATH, i.e. its identity: a positional `<prefix>-<i>` makes that identity
+    depend on iteration order, so deleting one document shifts every later one down a slot — each
+    then overwrites its neighbour's item, swapping bodies and mis-attributing version history across
+    unrelated documents. Skipping loses one document (loudly, in the run log); the fallback silently
+    corrupts the rest. Readers we use today always carry an id, so this is a trap for the NEXT
+    reader someone adds, not a live path.
+    """
     out: list[RawDoc] = []
-    for i, d in enumerate(documents):
+    skipped = 0
+    for d in documents:
         meta: dict[str, Any] = getattr(d, "metadata", None) or {}
-        external_id = _first(meta, *id_keys) or f"{fallback_prefix}-{i}"
+        external_id = _first(meta, *id_keys)
+        if not external_id:
+            skipped += 1
+            continue
         out.append(
             RawDoc(
                 source=source,
@@ -103,5 +119,14 @@ def docs_to_raw(
                 ),
                 extra_frontmatter={k: v for k, v in meta.items() if isinstance(v, (str, int, float, bool))},
             )
+        )
+    if skipped:
+        # Loud, not silent: a reader that stops emitting ids would otherwise look like a quiet source.
+        logger.warning(
+            "%s: skipped %d document(s) with no stable id in metadata (looked for %s) — "
+            "a positional fallback would corrupt item identity, so they are not ingested",
+            fallback_prefix,
+            skipped,
+            ", ".join(id_keys),
         )
     return out

--- a/ingestion/aios_ingest/sources/registry.py
+++ b/ingestion/aios_ingest/sources/registry.py
@@ -20,6 +20,11 @@ from .web import WebSource
 
 Builder = Callable[..., Source]
 
+# "slack" stays registered but is a DEPRECATED NO-OP (see SlackSource.fetch). Slack is ingested by
+# the IN-APP runner, which models a thread as one item; the sidecar source models a whole CHANNEL as
+# one item, so running both double-ingests Slack under two incompatible units of knowledge. It is
+# kept in the registry (rather than removed) so an existing `type: "slack"` connection degrades to a
+# warning instead of failing the operator's entire sidecar run with "unknown source".
 _REGISTRY: dict[str, Builder] = {
     "slack": SlackSource,
     "notion": NotionSource,

--- a/ingestion/aios_ingest/sources/slack.py
+++ b/ingestion/aios_ingest/sources/slack.py
@@ -1,24 +1,34 @@
-"""Slack source — wraps llama-index-readers-slack.
+"""Slack source — DEPRECATED, ingests nothing.
 
-Pull via SlackReader over channel ids. Webhooks use Slack's signing-secret scheme
-(HMAC-SHA256 over ``v0:{timestamp}:{body}``); the Events API also requires echoing the
-``url_verification`` challenge, handled in webhook_app.
+Slack is synced by the brain's IN-APP runner (`lib/ingest/run.runSlackIngestion`), which models a
+THREAD as one item: per-participant credit, per-thread work-time, and paths keyed on the immutable
+channel id. This source modelled a whole CHANNEL as one document, so running both double-ingests
+every conversation under two incompatible units of knowledge.
+
+The class stays registered so an existing ``type: "slack"`` connection degrades to a warning rather
+than failing the operator's entire sidecar run with "unknown source". The signing-secret helpers are
+kept because they are the documented Slack webhook scheme and cost nothing to retain.
 """
 
 from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 from typing import Any, Iterator
 
 from ..normalize import RawDoc
 from .base import Source
-from ._llamahub import docs_to_raw, lazy_reader
+
+logger = logging.getLogger(__name__)
 
 
 class SlackSource(Source):
     name = "slack"
-    supports_webhook = True
+    # False since the source was deprecated: `fetch` ingests nothing, so advertising webhook support
+    # would make the receiver verify a signature, drop the payload, and return 2xx to Slack — an
+    # accept-and-discard that looks healthy from both sides. Reject explicitly instead.
+    supports_webhook = False
 
     def __init__(
         self,
@@ -32,14 +42,24 @@ class SlackSource(Source):
         self._signing_secret = signing_secret
 
     def fetch(self, *, since: str | None = None) -> Iterator[RawDoc]:
-        SlackReader = lazy_reader(
-            "llama_index.readers.slack", "SlackReader", "slack", "llama-index-readers-slack"
+        """DEPRECATED — yields nothing.
+
+        Slack is ingested by the brain's IN-APP runner (`lib/ingest/run.runSlackIngestion`), which
+        models a THREAD as one item: per-participant credit, per-thread work-time, and paths keyed on
+        the immutable channel id. This source models a whole CHANNEL as one document, so enabling it
+        alongside the runner double-ingests every conversation under an incompatible unit of
+        knowledge — one giant, ever-churning, unattributed item per channel.
+
+        It degrades to a no-op rather than raising so an existing `type: "slack"` connection doesn't
+        fail the operator's whole sidecar run; the warning says what to do instead.
+        """
+        logger.warning(
+            "slack: the sidecar Slack source is deprecated and ingests nothing. Slack is synced by "
+            "the brain's in-app runner (Admin → Integrations → Slack); remove this connection."
         )
-        reader = SlackReader(slack_token=self._token)
-        docs = reader.load_data(channel_ids=self._channel_ids)
-        yield from docs_to_raw(
-            docs, source=self.name, id_keys=("channel", "channel_id", "ts"), fallback_prefix="slack"
-        )
+        return
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
 
     def verify_webhook(self, headers: dict[str, str], raw_body: bytes) -> bool:
         if not self._signing_secret:

--- a/ingestion/tests/test_sources_more.py
+++ b/ingestion/tests/test_sources_more.py
@@ -49,3 +49,19 @@ def test_web_fetch_mocked(monkeypatch):
     assert len(docs) == 1
     assert docs[0].external_id == "https://example.com/a"
     assert "Content here" in docs[0].body
+
+
+def test_sidecar_slack_source_is_a_registered_no_op():
+    """Slack is synced by the brain's IN-APP runner (one item per THREAD). This sidecar source models
+    a whole CHANNEL as one document, so enabling both double-ingests every conversation under two
+    incompatible units of knowledge.
+
+    It must stay REGISTERED — an existing `type: "slack"` connection would otherwise fail the
+    operator's entire sidecar run with "unknown source" — but ingest nothing. Without this test a
+    future "fix" that restores the reader would silently reintroduce the double-ingest.
+    """
+    from aios_ingest.sources.registry import build_source
+
+    src = build_source("slack", {"token": "xoxb-x", "channel_ids": ["C1"]})
+    assert list(src.fetch()) == []          # ingests nothing
+    assert src.supports_webhook is False    # and doesn't accept-then-discard webhook payloads

--- a/ingestion/tests/test_work_time_metadata.py
+++ b/ingestion/tests/test_work_time_metadata.py
@@ -46,3 +46,14 @@ def test_creation_time_used_when_never_edited():
 def test_no_timestamp_metadata_stays_honestly_undated():
     # We must NOT invent a time (that would date the doc to sync-time and resurface old content).
     assert _one({"page_id": "p6"}).source_ts is None
+
+
+def test_document_without_a_stable_id_is_skipped_not_positionally_numbered():
+    """`external_id` becomes the item's PATH, i.e. its identity. A positional `<prefix>-<i>` makes
+    that identity depend on ITERATION ORDER: delete one document and every later one shifts down a
+    slot, overwriting its neighbour's item — bodies swap and version history is mis-attributed
+    across unrelated documents. Losing one document loudly beats corrupting the rest silently."""
+    docs = [FakeDoc("a", {"page_id": "p1"}), FakeDoc("b", {}), FakeDoc("c", {"page_id": "p3"})]
+    out = docs_to_raw(docs, source="notion", id_keys=("page_id",), fallback_prefix="notion")
+    assert [r.external_id for r in out] == ["p1", "p3"]  # no "notion-1" invented
+    assert [r.body for r in out] == ["a", "c"]  # and the survivors keep THEIR own bodies

--- a/lib/ingest/decisions.ts
+++ b/lib/ingest/decisions.ts
@@ -31,4 +31,23 @@ export async function materializeDecisions(
     );
     if (error) throw new Error(`decision row ${row.row_key}: ${error.message}`);
   }
+
+  // DIFF-DELETE, mirroring tasks: a decision this item used to carry but no longer does is gone at the
+  // source, so it must stop being served as CURRENT. Without this a removed/retracted decision lived
+  // forever — still cited by retrieval and still shown on the dashboard — and the docs already claimed
+  // the behavior existed. Scoped to THIS item's own rows (`source_item_id`), so a UI-created decision
+  // (`source_item_id` null) and other items' rows are never touched.
+  const incomingKeys = new Set(rows.map((r) => r.row_key));
+  const { data: current, error: readError } = await db
+    .from("decisions")
+    .select("id, row_key")
+    .eq("team_id", teamId)
+    .eq("project_id", projectId)
+    .eq("source_item_id", itemId);
+  if (readError) throw new Error(`decision diff read: ${readError.message}`);
+  for (const existing of (current ?? []) as { id: string; row_key: string | null }[]) {
+    if (!existing.row_key || incomingKeys.has(existing.row_key)) continue;
+    const { error: deleteError } = await db.from("decisions").delete().eq("id", existing.id);
+    if (deleteError) throw new Error(`decision delete ${existing.row_key}: ${deleteError.message}`);
+  }
 }

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -231,7 +231,11 @@ export async function ingestItem(
       const healedFrontmatter: Record<string, unknown> = {
         ...(payload.frontmatter ?? {}),
       };
-      for (const key of ["author", "author_email", "author_login"]) {
+      // Author signals a connector may LOSE on a later tick. `authors[]` matters most: Notion's
+      // author enrichment is best-effort (the API returns [] on any hiccup), so without preserving it
+      // an unchanged re-push ERASES the structured authors we already resolved — and the
+      // re-attribution pass then has no raw material until the API happens to succeed again.
+      for (const key of ["author", "author_email", "author_login", "authors"]) {
         if (
           existingFrontmatter[key] !== undefined &&
           healedFrontmatter[key] === undefined

--- a/test/datamechanics/decision-diff-sync.datamechanics.test.ts
+++ b/test/datamechanics/decision-diff-sync.datamechanics.test.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { db, ingest, seedTeam } from "./helpers";
+
+/**
+ * Spec: a decision removed at the SOURCE must stop being served as current. Sync rows are diff-deleted
+ * exactly like tasks — the contract the docs already described — while a UI-created decision
+ * (`source_item_id` null) and other items' rows are untouched. Real Postgres: the observable outcome
+ * is which rows survive.
+ */
+describe("decision diff-sync (real Postgres)", () => {
+  it("deletes a sync row dropped from a later push, keeps the surviving one", async () => {
+    const seed = await seedTeam();
+    const path = `decisions/${randomUUID()}.md`;
+    const push = (rows: { row_key: string; title: string }[], body: string) =>
+      ingest(seed, { path, project: "acme", kind: "decision", access: "team", body, rows });
+
+    await push(
+      [
+        { row_key: "D-1", title: "adopt postgres" },
+        { row_key: "D-2", title: "retracted later" },
+      ],
+      "v1"
+    );
+    let { data } = await db().from("decisions").select("row_key").eq("team_id", seed.teamId);
+    expect((data ?? []).map((r) => (r as { row_key: string }).row_key).sort()).toEqual(["D-1", "D-2"]);
+
+    // D-2 is gone at the source → it must not keep being cited as a current decision.
+    await push([{ row_key: "D-1", title: "adopt postgres" }], "v2");
+    ({ data } = await db().from("decisions").select("row_key").eq("team_id", seed.teamId));
+    expect((data ?? []).map((r) => (r as { row_key: string }).row_key)).toEqual(["D-1"]);
+  });
+
+  it("never deletes a UI-created decision (source_item_id null)", async () => {
+    const seed = await seedTeam();
+    const path = `decisions/${randomUUID()}.md`;
+    await ingest(seed, {
+      path, project: "acme", kind: "decision", access: "team", body: "v1",
+      rows: [{ row_key: "D-9", title: "synced" }],
+    });
+    const { data: proj } = await db().from("projects").select("id").eq("team_id", seed.teamId).eq("slug", "acme").maybeSingle();
+    await db().from("decisions").insert({
+      team_id: seed.teamId, project_id: (proj as { id: string }).id, source_item_id: null,
+      row_key: "UI-1", title: "hand-written", rationale: "", decided_by: "me", impact: "", audience: "team",
+    });
+
+    // A later push that drops every sync row must leave the UI row alone.
+    await ingest(seed, { path, project: "acme", kind: "decision", access: "team", body: "v2", rows: [] });
+    const { data } = await db().from("decisions").select("row_key").eq("team_id", seed.teamId);
+    expect((data ?? []).map((r) => (r as { row_key: string }).row_key)).toEqual(["UI-1"]);
+  });
+});

--- a/test/datamechanics/ingest-content-hash.datamechanics.test.ts
+++ b/test/datamechanics/ingest-content-hash.datamechanics.test.ts
@@ -112,3 +112,27 @@ describe("ingest content hash (server-authoritative change key)", () => {
     expect(await countVersions(first.id)).toBe(1);
   });
 });
+
+/**
+ * Spec: the unchanged-push frontmatter heal must not ERASE author signals a connector already
+ * resolved. Notion's author enrichment is best-effort (the API returns [] on any hiccup), so a push
+ * whose `authors[]` came back empty would otherwise wipe the structured authors already stored —
+ * leaving the re-attribution pass with no raw material until the API happens to succeed again.
+ */
+describe("frontmatter heal preserves resolved author signals", () => {
+  it("keeps a previously-stored authors[] when a later push omits it", async () => {
+    const seed = await seedTeam();
+    const body = "notion page body";
+    const path = `notion/${sha(body).slice(0, 8)}.md`;
+    const authors = [{ provider: "notion", external_id: "u1", email: "a@corp.com", role: "author" }];
+
+    await ingest(seed, { path, body, access: "team", frontmatter: { source: "notion", authors } });
+    // Same body → unchanged path → the heal runs. This push lost its authors (API hiccup).
+    const second = await ingest(seed, { path, body, access: "team", frontmatter: { source: "notion" } });
+    expect(second.status).toBe("unchanged");
+
+    const { data } = await db().from("items").select("frontmatter").eq("id", second.id).maybeSingle();
+    const fm = (data as { frontmatter: Record<string, unknown> }).frontmatter;
+    expect(fm.authors).toEqual(authors); // preserved, not erased
+  });
+});


### PR DESCRIPTION
**Item 5 of the Pass-2 remediation plan** — the four MEDIUMs I'd skipped when I reported the cheap batch as complete. Four independent fixes.

## M3 — the heal erased resolved authors
The unchanged-push frontmatter heal preserved only `author`/`author_email`/`author_login`. Notion's author enrichment is **best-effort** (the API returns `[]` on any hiccup), so an ordinary tick whose `authors[]` came back empty **erased the structured authors already resolved** — leaving the re-attribution pass with no raw material until the API happened to succeed again. `authors` is now preserved.

## M4b — decisions were never diff-deleted
Tasks diff-delete; decisions didn't. A decision **retracted at the source kept being served as current forever**, still cited by retrieval — and `context-management-system.md` already claimed the behavior existed.

Now diff-deleted, scoped to `source_item_id = itemId`, so UI-authored decisions (`source_item_id IS NULL` — SQL `NULL = x` is never true) and other items' rows are **structurally** unreachable. Docs corrected to describe the real behavior, including the asymmetry: tasks survive by `origin='ui'`, decisions by a null source item.

## M6 — the legacy sidecar Slack source was still registered
It models a whole **channel** as one document; the in-app runner models a **thread** as one item. Both enabled = double-ingest under two incompatible units of knowledge.

I first de-registered it — but that turned an existing `type:"slack"` connection into `ValueError: unknown source`, **failing the operator's entire sidecar run** (a test caught this). So it stays registered as a **loud no-op**. `supports_webhook` is now `False` too: with `fetch()` inert, advertising support meant verifying a signature, dropping the payload, and returning 2xx — accept-and-discard that looks healthy from both sides.

## M7 — positional ids were path poison
A document with no id got `<prefix>-<i>` as its `external_id`, which becomes the item's **path — its identity**. Delete one document and every later one shifts down a slot, **overwriting its neighbour's item**: bodies swap and version history mis-attributes across unrelated documents. Such documents are now skipped with a warning count. Not a live path (today's readers all carry ids) — a trap for the next reader added.

## Tests
M3 and M4b have **real-Postgres** specs, both verified **RED without the fix** (`expected undefined to deeply equal [{provider:'notion'…}]`; `expected ['D-1','D-2'] to deeply equal ['D-1']`). M6 and M7 have pytest specs — the M6 one pins the no-op so a future "fix" can't silently restore the double-ingest.

Unit **1133 green**, tsc 0, lint + docs-drift clean, pytest **88 passed**.

## Deferred, with reason
- The **changed-body** path still writes frontmatter wholesale, so the same enrichment hiccup can erase `authors[]` when it coincides with a real body edit. Pre-existing; M3 covers the common unchanged tick.
- Sidecar `logger.warning` is **stderr-only** — skipped-document counts don't reach `IngestSummary`/`ingest_runs`, so an operator reading the summary sees a clean run that silently undercounts.

## Review — Reviewed by Fable `code-reviewer` — verdict CLEAR
It stress-tested the risky one (M4b **deletes production rows**): confirmed the scoping is airtight against zero-row pushes, cross-item `row_key` collisions, orphaned `source_item_id` (`on delete set null`), and no FK cascades; confirmed decisions materialize on exactly the same path as tasks so the delete can't fire more often than intended; and argued delete-vs-supersede — `still_valid` is the *human* flag and survives re-sync, so source retraction is correctly a hard delete with content history preserved in `item_versions`. Its three recommendations are all done in this PR.