### PR TITLE
ci(staging): run CI on the staging branch + document the two-environment setup (AIO-483)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, staging]
   push:
-    branches: [main]
+    branches: [main, staging]
 
 # Cancel superseded runs on the same ref so rapid pushes don't pile up parallel
 # Postgres/build jobs. Each job already caches npm via setup-node (cache: "npm").

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -138,6 +138,62 @@ Repo: `aiosbrain/aios-team-brain` → Settings → Branches → `main`
 
 ---
 
+## Environments — `production` and `staging` (AIO-483)
+
+Railway project **AIOS** holds **two environments**, each with its **own Postgres, own volumes,
+and own variables**. Nothing is shared between them.
+
+| | `production` | `staging` |
+| --- | --- | --- |
+| Deploy trigger branch | `main` | `staging` |
+| App URL | `aios-team-brain-production.up.railway.app` | `aios-team-brain-staging.up.railway.app` |
+| Postgres | own instance | **separate** instance (empty at creation) |
+| Services | `aios-team-brain`, `graphiti`, `neo4j`, `Postgres` | same four, duplicated |
+
+**How a deploy happens (unchanged model): only by pushing/merging to the branch.** Railway's GitHub
+integration auto-deploys `main` → `production` and `staging` → `staging`. There is no GitHub Actions
+deploy job, and the Railway CLI stays read-only in this repo (see `CLAUDE.md` §6).
+
+`ci.yml` runs on PRs and pushes to **both** `main` and `staging`, so `staging` carries the same
+required-check bar. `aios-work-sync.yml` stays scoped to `main` only — a staging merge must not
+close Linear issues.
+
+### Staging variable boundary
+
+`DATABASE_URL` is a Railway **reference** (`${{Postgres.DATABASE_URL}}`), so each environment
+resolves it to its own database — staging can never write to the production DB. Staging overrides
+`APP_URL` and `SLACK_OAUTH_REDIRECT` to the staging domain and carries **its own freshly generated
+`AUTH_SECRET` and `SECRETS_KEY`** (never production's). The `SLACK_*` credentials are **deleted**
+from staging so it cannot act on the real Slack workspace.
+
+### Staging membership is the access gate
+
+Staging is invite-only through the app's existing membership system — the staging DB is seeded with
+only the repo's collaborators. Seeding uses the existing admin CLI (no bespoke script), pointed at
+the staging database:
+
+```bash
+# DATABASE_URL = the staging Postgres DATABASE_PUBLIC_URL (Railway → staging → Postgres)
+npx tsx --conditions react-server scripts/admin.ts create-team aios --name AIOS
+npx tsx --conditions react-server scripts/admin.ts create-member <email> \
+  --name "<Name>" --handle <handle> --role <admin|lead|member> --team aios --upsert
+npx tsx --conditions react-server scripts/admin.ts login-link <email> --team aios \
+  --base-url https://aios-team-brain-staging.up.railway.app
+```
+
+A seeded member is `status=invited` and **cannot authenticate until first login flips it to
+`active`** (`lib/api/auth.ts` requires `active`) — that is the invite gate, and it applies to API
+keys too.
+
+### Branch protection on `staging`
+
+Settings → Branches → `staging` mirrors `main`'s required status checks and PR requirement, and
+additionally **restricts who can push** to the named repo collaborators. Note GitHub silently drops
+any user without write access from that restriction list, so a read-only collaborator must be
+granted write before they appear.
+
+---
+
 ## Optimized Agent Pipeline Sequencing
 
 ```


### PR DESCRIPTION
Closes out the code/docs half of **AIO-483** (staging branch + collaborator-gated deploy). The
infrastructure half (Railway `staging` environment, its own Postgres, branch protection, member
seeding) is already built and verified — see the AIO-483 comment for evidence.

## What this changes

- **`.github/workflows/ci.yml`** — `pull_request` and `push` triggers now cover `[main, staging]`
  so the `staging` branch gets the same required-check gate as `main`. One workflow, not a fork.
  `aios-work-sync.yml` is intentionally **not** extended: a staging merge must never close a
  Linear issue early.
- **`docs/CI-ARCHITECTURE.md`** — new "Environments — `production` and `staging`" section: the
  per-environment table, the deploy model (still branch-push only; Railway CLI stays read-only),
  the staging variable boundary, the invite-only seeding commands, and `staging` branch protection.

## Already live (not in this diff)

- Railway project **AIOS** now has a `staging` environment duplicated from `production`, with its
  **own Postgres** (empty at creation — verified 0 tables before first deploy), own volumes, and
  the domain `aios-team-brain-staging.up.railway.app`.
- Staging deploy trigger branch = `staging`; **production's trigger is still `main`** (verified).
- Staging `DATABASE_URL` resolves through the `${{Postgres.DATABASE_URL}}` reference to the
  staging DB; `APP_URL`/`SLACK_OAUTH_REDIRECT` point at staging; `AUTH_SECRET` + `SECRETS_KEY`
  are freshly generated; `SLACK_*` credentials deleted from staging.
- `staging` branch protection mirrors `main`'s checks + PR requirement, plus a push restriction.

## Verification

- `node scripts/check-docs-drift.mjs` → green (routes 59 / tables 70 / sources 8 in sync).
- Staging app live: `GET /api/v1/items` → **200** `{"items":[],"next_cursor":null}` with a
  staging-issued key, proving the app reads the **staging** DB (empty).
- Same staging key against **production** → **401**, proving the environments are isolated.
- Production untouched: trigger still `main`, variables unchanged, latest prod deployment
  predates this work, prod endpoints still respond as before.

## Review

Reviewed by Fable (this change's author agent) on the full branch diff — verdict: clear. The diff
is a 4-character workflow trigger change plus additive documentation; no runtime code, no schema,
no secrets. Applying `ready-for-review` is reasonable if a bot pass is wanted.

Deliberately **no `AIOS-Work:` key** so merging does not auto-close AIO-483 — the issue should be
closed by hand once the remaining human steps in its comment are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4d3918363eb6575808dbb45ed9ab94356f219f04. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->