### PR TITLE
fix(slack): ingest only public channels, and give the brain a real removal path (AIO-484)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 
 # Tessera: local direnv config, not committed
 .envrc
+
+# Supabase CLI local stack artifacts — this repo is Postgres-only (see CLAUDE.md §6)
+supabase/

--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -8,6 +8,7 @@ import {
   setIntegrationSecret,
   setIntegrationStatus,
   deleteIntegration,
+  getEnabledIntegrationsWithSecrets,
   saveProviderModel as saveProviderModel_,
 } from "@/lib/integrations/manage";
 import type { AnsweringProvider } from "@/lib/query/llm-backend";
@@ -21,6 +22,7 @@ import {
 } from "@/lib/integrations/github-link";
 import { saveProvisioningSettings as saveProvisioningSettings_ } from "@/lib/provisioning/settings";
 import { validateGithubToken, checkRepoAccess, type RepoAccess } from "@/lib/integrations/github-validate";
+import { checkSlackChannels, privateChannelRejection } from "@/lib/integrations/slack-validate";
 import { RepoFormatError } from "@/lib/integrations/github-repos";
 import { validateOpenrouterKey, saveOpenrouterSettings } from "@/lib/integrations/openrouter";
 import { MEETING_TASK_STATUSES, type MeetingTaskStatus } from "@/lib/meetings/target-status";
@@ -37,6 +39,36 @@ import { buildConfig, toList } from "@/lib/integrations/build-config";
 import { audit } from "@/lib/api/audit";
 
 export type PrimaryPmProvider = "plane" | "linear" | null;
+
+/**
+ * The admin-facing error when a Slack save names a private channel, or null to let it through.
+ *
+ * Token resolution mirrors the ingester's (`runSlackIngestion`): the secret being submitted, else the
+ * one already stored for this integration, else `SLACK_BOT_TOKEN`. With no token we cannot ask Slack,
+ * so the save proceeds — the ingester fails closed on every channel it can't PROVE is public, which
+ * is where the rule is actually enforced. Never throws: a Slack outage must not block admin work.
+ */
+async function rejectPrivateSlackChannels(
+  teamId: string,
+  name: string,
+  submittedSecret: string,
+  config: Record<string, unknown>
+): Promise<string | null> {
+  const channelIds = (config.channelIds as string[] | undefined) ?? [];
+  if (channelIds.length === 0) return null;
+  try {
+    let token = submittedSecret.trim();
+    if (!token) {
+      const existing = await getEnabledIntegrationsWithSecrets(adminClient(), teamId);
+      token = existing.find((i) => i.type === "slack" && i.name === name)?.secret ?? "";
+    }
+    if (!token) token = process.env.SLACK_BOT_TOKEN ?? "";
+    if (!token) return null;
+    return privateChannelRejection(await checkSlackChannels(token, channelIds));
+  } catch {
+    return null; // couldn't verify → not evidence of privacy; the ingester still fails closed
+  }
+}
 
 export async function saveIntegration(
   teamSlug: string,
@@ -55,10 +87,17 @@ export async function saveIntegration(
   if (!name) return { ok: false, error: "name is required" };
   const auth = { teamId: ctx.teamId, memberId: ctx.memberId };
   try {
+    const config = buildConfig(form.type, form.selection, { inboundApply: form.inboundApply });
+    // Only channels PUBLIC to the workspace may be ingested — refuse the save rather than accept a
+    // private channel the ingester will silently skip forever (see `slack-validate`).
+    if (form.type === "slack") {
+      const rejection = await rejectPrivateSlackChannels(ctx.teamId, name, form.secret, config);
+      if (rejection) return { ok: false, error: rejection };
+    }
     const { id } = await upsertIntegration(adminClient(), auth, {
       type: form.type,
       name,
-      config: buildConfig(form.type, form.selection, { inboundApply: form.inboundApply }),
+      config,
       status: "enabled",
     });
     if (form.secret) await setIntegrationSecret(adminClient(), auth, id, form.secret);
@@ -115,8 +154,16 @@ export async function syncSlackNow(
   if (!ctx) return { ok: false, error: "admins only" };
   try {
     const s = await runSlackIngestion({ teamId: ctx.teamId });
-    if (!s.ok && s.errors.length) return { ok: false, error: s.errors.join("; ") };
+    // Revalidate BEFORE the error return: a failed run is not a no-op run — a confirmed-private
+    // channel reports as an error AND purges its items, so skipping the revalidation would show the
+    // admin the pre-purge data alongside the error.
     revalidatePath(`/t/${teamSlug}/admin/integrations`);
+    if (!s.ok && s.errors.length) return { ok: false, error: s.errors.join("; ") };
+    // NOTE: `s.ok` is `errors.length === 0`, so a private/unverifiable channel among otherwise
+    // healthy ones makes the whole run report as failed above, with the per-channel lines as the
+    // error text. That is the intended loudness — a configured channel the brain refuses to ingest
+    // is a configuration error the admin has to resolve, not a notice to file away — and it's why
+    // the messages from `privateChannelAction` say what to do, not just what happened.
     return {
       ok: true,
       message: `Synced ${s.channels} channel(s): +${s.created} new, ~${s.updated} updated, =${s.unchanged} unchanged.`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -767,6 +767,60 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 > and decisions reach the `decisions` table solely through the human-reviewed
 > decision-log.md → `aios push` → `materializeDecisions` flow. See `docs/GRANOLA.md`.
 
+> **`slack` public-channel invariant:** the in-app Slack connector ingests **only channels that are
+> public within the workspace**. There are exactly two tiers (`team` / `external`) and no stricter
+> one, so anything ingested from a private channel becomes readable by the whole team — which is not
+> what "private" means to the people in it. Enforced in two places, both **fail-closed**:
+> `SlackClient.channelInfo` (`lib/ingest/sources/slack.ts`) resolves `is_private`/`is_im`/`is_mpim`
+> and `fetchSlackChannel` returns **before reading any message**, so private content never enters the
+> process; and the admin save path (`lib/integrations/slack-validate.ts`) rejects a private channel id
+> at the moment it's added. A channel we cannot *prove* is public is treated as private and skipped
+> (unverifiable ≠ public), but only a **confirmed**-private channel triggers the purge below — deleting
+> a public channel's history on a transient scope failure would be the worse error.
+>
+> **Stated residue:** because the purge needs proof, content ingested from a channel the bot can no
+> longer describe (kicked from it, `channel_not_found`, or the channel removed from the config) is
+> **retained**, not removed — the run log says so per channel rather than implying the store is clean.
+> Restore the bot's access, or purge deliberately. When *every* configured channel comes back
+> unverifiable the runner emits one integration-level error ("no channel could be verified public")
+> instead of N per-channel lines, because that shape is almost always a missing `channels:read` scope
+> and it means Slack ingestion has stopped entirely.
+
+### Removal — `lib/ingest/purge.ts`
+
+Sync only ever adds or replaces, so until now nothing could leave the brain: a private channel added
+by mistake, or a message deleted at the source, stayed in the store, in retrieval, in credit, and in
+the graph forever (`item_versions` retains every superseded body, so a deleted message survives the
+re-render that drops it from the current body). `purgeItemsByPathPrefix` / `purgeItemIds` are the
+counterpart to `ingestItem` and live under the same single-writer rule — `lib/ingest` is the only
+writer of `items`, deletes included.
+
+Removal is a fan-out, because an item's derivatives have three different lifetimes:
+
+| Derivative                                                                                  | On purge                                                                                                                                       |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `item_versions`, `item_chunks`, `extracted_facts`, `stakeholder_mentions`, `task_evidence`, `meeting_notes` | FK **cascade** — the body and its whole history go with the row                                                                                |
+| `graph_episodes` **+ the facts in Graphiti**                                                | Explicit, via `lib/graph.retireEpisodesForItems` — no FK, and the facts live outside Postgres. Deletes inline, then leaves a `pending_delete_group_id` **tombstone** so `reconcileProjectedEpisodes` retries a Graphiti blip and drops the row only once the group is verified empty |
+| `tasks.source_item_id`, `decisions.source_item_id`                                          | `set null` — deliberately kept: independently authored records that merely cite the item                                                       |
+
+Every purge is audited (`items.purged`, with its reason and scope). Callers derive a path prefix from
+the same helper that writes the path (e.g. `slackChannelPathPrefix`); a hand-formatted prefix that
+stops matching fails as a silent no-op, not an error. LIKE wildcards in a prefix are escaped, so a
+path segment containing `_` can never widen a purge onto a neighbouring source.
+
+**Orphan-ness, not a marker, is the invariant.** `reconcileProjectedEpisodes` re-flags every
+unflagged ledger row whose item no longer exists and purges its group. That is deliberate: the
+projector runs on its own scheduler, so it can hold an item in memory when the purge deletes it and
+then re-push the body — clearing the pending flag and leaving a row that *looks* healthy. Detecting
+the missing item catches that race, and any other path that deletes an item, without a marker column.
+There is only ONE flag slot, so an orphan that already owed a *different* group's cleanup is
+converged over two passes (the old group is verified, then the flag re-points at the row's own group)
+rather than dropped after checking only one.
+
+**Eventually consistent downstream.** A purge removes the item, its versions/chunks/facts and its
+graph episodes. Derived snapshots recomputed on a schedule — `work_timeline_cache`, narrative-arc
+snapshots — can still quote purged content until their next recompute.
+
 ## Docs drift guard
 
 `scripts/check-docs-drift.mjs` derives the three inventories above from code

--- a/docs/context-management-system.md
+++ b/docs/context-management-system.md
@@ -99,6 +99,15 @@ validation (before any mutation) → item + version + derived-row materializatio
   changed (`project.ts:194`).
 - **Meeting notes** — unique on `source_item_id` (`schema.sql:1100`); a re-run returns
   `{created:false}` rather than duplicating (`notes.ts:178`).
+- **Removal** — `lib/ingest/purge.ts` is the counterpart to `ingestItem` (same single-writer rule) and
+  the only way content LEAVES the brain. Versions/chunks/facts/mentions cascade; `graph_episodes` and
+  the facts in Graphiti are retired explicitly (`lib/graph.retireEpisodesForItems`) with a
+  `pending_delete_group_id` tombstone so a Graphiti blip is retried by `reconcileProjectedEpisodes`
+  rather than silently abandoned; `tasks`/`decisions` citations are `set null`, not deleted. Every
+  purge is audited (`items.purged`) with its reason and scope. Wired today to the **private Slack
+  channel** case — a channel that turns out to be private is skipped AND anything ingested from it
+  before is removed, but only on a **confirmed**-private answer (an unverifiable channel is skipped,
+  never purged).
 
 ### 2.2 Chunking — two independent strategies for two indexes
 

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -20,6 +20,20 @@ import { resolveWorkTime } from "@/lib/ingest/work-time";
 const SOURCE_TABLE = "items";
 
 /**
+ * How many ids go into one `.in(...)` filter. The pg adapter binds each element separately and
+ * Postgres hard-caps a statement at 65535 binds, so an unbounded list is a query that simply stops
+ * working once a team's corpus grows — silently, at exactly the scale where it matters most.
+ */
+export const IN_CLAUSE_BATCH = 1000;
+
+/** Split into fixed-size batches. Pure. */
+export function chunk<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
  * Graphiti extracts entities/edges from each episode with its OWN LLM, and that call's OUTPUT is
  * hard-capped (graphiti_core `DEFAULT_MAX_TOKENS`; 16384 on the patched image — gpt-4o's ceiling, can't
  * go higher). A dense episode whose extraction output overflows that cap raises `Output length exceeded
@@ -146,6 +160,99 @@ type ItemRow = {
 
 function sha(content: string): string {
   return createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * RETIRE the graph episodes of items being REMOVED from the brain (the purge path). `graph_episodes`
+ * is written only from this module (single-writer guarded), so removal lives here too and
+ * `lib/ingest/purge` calls in.
+ *
+ * Deleting the `items` rows alone is not enough, and the ledger row is the smaller half of why:
+ * `graph_episodes` has no FK to `items`, so the row is orphaned — but the real leak is that the
+ * extracted FACTS stay searchable in Graphiti forever. For a private channel or a message the author
+ * deleted at the source, removing the brain's copy while the graph still answers questions from it
+ * is not a removal at all.
+ *
+ * Durability follows the tier-reclassification cleanup (Pass-1 B2) exactly, for the same reason: the
+ * inline delete is best-effort — Graphiti can blip, and its async worker can create a straggler chunk
+ * AFTER we listed the group. So the ledger row is KEPT and flagged `pending_delete_group_id`;
+ * `reconcileProjectedEpisodes` retries until the group is verified empty and only then drops the row
+ * (it recognises a purge tombstone by the item being gone). Deleting the row here would leave nothing
+ * to retry — the failure mode B2 exists to prevent, arriving through a new door.
+ *
+ * Returns the number of ledger rows retired.
+ */
+export async function retireEpisodesForItems(
+  db: DbClient,
+  teamId: string,
+  itemIds: string[],
+  opts: { client?: GraphitiClient } = {}
+): Promise<number> {
+  if (itemIds.length === 0) return 0;
+  type LedgerRow = {
+    id: string;
+    source_id: string;
+    group_id: string;
+    pending_delete_group_id: string | null;
+  };
+  // Chunked: the pg adapter expands `.in()` to one bind per element, and Postgres refuses a statement
+  // past 65535 of them. A whole-channel purge can easily exceed a single readable batch.
+  const rows: LedgerRow[] = [];
+  for (const batch of chunk(itemIds, IN_CLAUSE_BATCH)) {
+    const { data, error: readError } = await db
+      .from("graph_episodes")
+      .select("id, source_id, group_id, pending_delete_group_id")
+      .eq("team_id", teamId)
+      .eq("source_table", SOURCE_TABLE)
+      .in("source_id", batch);
+    if (readError) throw new Error(`episode ledger read: ${readError.message}`);
+    rows.push(...((data ?? []) as LedgerRow[]));
+  }
+  if (rows.length === 0) return 0;
+
+  const client = opts.client ?? new GraphitiClient();
+  // No Graphiti configured → nothing was ever pushed, so there is nothing to retry and no reconcile
+  // pass will ever run to clear a tombstone. Drop the rows outright instead of parking flags that
+  // would sit "pending" forever and read as a stuck cleanup.
+  //
+  // Narrow residue, stated rather than hidden: if Graphiti was configured EARLIER and has since been
+  // unset, episodes it holds outlive the ledger row that pointed at them. Re-configuring the same
+  // Graphiti and re-projecting is the recovery; there is no in-band way to reach a service the
+  // process has no address for.
+  if (!client.configured) {
+    for (const r of rows) {
+      const { error } = await db.from("graph_episodes").delete().eq("id", r.id);
+      if (error) throw new Error(`episode ledger delete ${r.id}: ${error.message}`);
+    }
+    return rows.length;
+  }
+
+  const at = new Date().toISOString();
+  for (const r of rows) {
+    await deleteItemEpisodes(client, r.group_id, r.source_id).catch(() => {});
+    // There is exactly ONE flag slot, so a row that already owed a cleanup for a DIFFERENT group is
+    // about to have that debt overwritten. Purge that group first: otherwise an item reclassified
+    // external→team (whose inline delete blipped) and then purged would clean the team group, lose
+    // the pointer to the external one, and leave the purged content searchable at the OLD tier
+    // forever with nothing to retry. Best-effort like the rest; if it fails, reconcile re-derives the
+    // orphan every pass and the flag is re-pointed there once this group verifies empty.
+    if (r.pending_delete_group_id && r.pending_delete_group_id !== r.group_id) {
+      await deleteItemEpisodes(client, r.pending_delete_group_id, r.source_id).catch(() => {});
+    }
+    const { error } = await db
+      .from("graph_episodes")
+      .update({
+        // The "" sentinel marks the content as no longer projected (same as the redaction path), so
+        // nothing treats this row as a live projection while the cleanup is outstanding.
+        content_sha256: "",
+        projected_at: at,
+        pending_delete_group_id: r.group_id,
+        pending_delete_at: at,
+      })
+      .eq("id", r.id);
+    if (error) throw new Error(`episode retire ${r.id}: ${error.message}`);
+  }
+  return rows.length;
 }
 
 /**

--- a/lib/graph/reconcile.ts
+++ b/lib/graph/reconcile.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { GraphitiClient } from "./graphiti-client";
 import { itemIdFromEpisodeName } from "./episode-name";
-import { GROUP_SCAN_DEPTH, resolvePositiveInt } from "./project";
+import { GROUP_SCAN_DEPTH, IN_CLAUSE_BATCH, chunk, resolvePositiveInt } from "./project";
 import { isExternalGroupId } from "./group";
 
 /**
@@ -55,6 +55,7 @@ export interface ReconcileSummary {
 type EpisodeRow = {
   id: string;
   source_id: string;
+  source_table: string;
   group_id: string;
   content_sha256: string;
   projected_at: string;
@@ -62,6 +63,68 @@ type EpisodeRow = {
   pending_delete_group_id: string | null;
   pending_delete_at: string | null;
 };
+
+/**
+ * The `source_id`s in `rows` whose row in `items` is GONE — the orphan set (see the call site).
+ *
+ * Returns an EMPTY set when the lookup fails, and only ever classifies `source_table='items'` rows:
+ * "couldn't check" must stay inconclusive here, exactly as an unreachable Graphiti does below. A
+ * swallowed DB error would otherwise read as "every pending row is an orphan" and delete healthy
+ * tier-cleanup bookkeeping, which the projector would answer by re-pushing — duplicate episodes,
+ * double-weighted facts.
+ */
+async function findOrphanSourceIds(
+  db: DbClient,
+  teamId: string,
+  rows: readonly EpisodeRow[]
+): Promise<Set<string>> {
+  const ids = [...new Set(rows.filter((r) => r.source_table === "items").map((r) => r.source_id))];
+  if (ids.length === 0) return new Set();
+  const alive = new Set<string>();
+  // Chunked: this passes EVERY projected item's id, and the pg adapter binds one per element — past
+  // Postgres' 65535-bind ceiling the statement is refused outright, which would silently switch off
+  // the whole orphan-repair safety net at exactly the corpus size where it matters.
+  for (const batch of chunk(ids, IN_CLAUSE_BATCH)) {
+    const { data, error } = await db.from("items").select("id").eq("team_id", teamId).in("id", batch);
+    if (error) {
+      // LOUD: returning an empty set is the right direction (nothing is judged an orphan), but a
+      // silent one means the repair is off and no signal says so.
+      console.error(`[graph] orphan check failed — orphan repair skipped this pass: ${error.message}`);
+      return new Set();
+    }
+    for (const r of (data ?? []) as { id: string }[]) alive.add(r.id);
+  }
+  return new Set(ids.filter((id) => !alive.has(id)));
+}
+
+/**
+ * Flag every orphan row that isn't already carrying a cleanup, and return the rows as they now stand
+ * (new objects — the caller's snapshot must not silently disagree with the DB). The flag reuses the
+ * tier-cleanup mechanism wholesale: the loop below purges the group and drops the row once it's
+ * verified empty, retrying across passes if Graphiti is down.
+ */
+async function repairOrphans(
+  db: DbClient,
+  rows: readonly EpisodeRow[],
+  orphans: ReadonlySet<string>
+): Promise<EpisodeRow[]> {
+  const at = new Date().toISOString();
+  const out: EpisodeRow[] = [];
+  for (const row of rows) {
+    if (!orphans.has(row.source_id) || row.pending_delete_group_id) {
+      out.push(row);
+      continue;
+    }
+    const patch = {
+      content_sha256: "", // no longer a live projection
+      pending_delete_group_id: row.group_id,
+      pending_delete_at: at,
+    };
+    const { error } = await db.from("graph_episodes").update(patch).eq("id", row.id);
+    out.push(error ? row : { ...row, ...patch });
+  }
+  return out;
+}
 
 export async function reconcileProjectedEpisodes(
   db: DbClient,
@@ -82,10 +145,25 @@ export async function reconcileProjectedEpisodes(
   const { data } = await db
     .from("graph_episodes")
     .select(
-      "id, source_id, group_id, content_sha256, projected_at, episode_uuid, pending_delete_group_id, pending_delete_at"
+      "id, source_id, source_table, group_id, content_sha256, projected_at, episode_uuid, pending_delete_group_id, pending_delete_at"
     )
     .eq("team_id", teamId);
-  const rows = (data ?? []) as EpisodeRow[];
+  const rawRows = (data ?? []) as EpisodeRow[];
+
+  // ── Orphan repair, BEFORE anything else judges these rows ────────────────────────────────────
+  // A ledger row whose ITEM is gone is an orphan, and an orphan's episodes are content the brain no
+  // longer holds still answering questions in Graphiti. `lib/ingest/purge` retires what it can see,
+  // but it cannot see a projector batch already in flight: the projector loads an item, the purge
+  // deletes it, and the projector then re-pushes the body it still holds in memory AND clears the
+  // pending-delete flag (the `purgeBeforeRepush` branch). That row looks perfectly healthy
+  // afterwards — fresh sha, no flag — so nothing would ever revisit it and the purged content would
+  // stay searchable forever.
+  //
+  // So orphan-ness, not the flag, is the invariant: any row with no item is re-flagged here and the
+  // ordinary cleanup loop below purges it and drops the row. This also covers orphans from any other
+  // door (a hand-deleted item, a future diff-delete) for free.
+  const orphans = await findOrphanSourceIds(db, teamId, rawRows);
+  const rows = await repairOrphans(db, rawRows, orphans);
 
   const byGroup = new Map<string, EpisodeRow[]>();
   for (const row of rows) {
@@ -203,10 +281,27 @@ export async function reconcileProjectedEpisodes(
       const flaggedAt = new Date(row.pending_delete_at ?? row.projected_at).getTime();
       const pastCleanupGrace = flaggedAt <= Date.now() - CLEANUP_GRACE_MS;
       if (uuids.length === 0 && !deleteFailed && pastCleanupGrace && !saturated) {
-        await db
-          .from("graph_episodes")
-          .update({ pending_delete_group_id: null, pending_delete_at: null })
-          .eq("id", row.id);
+        if (orphans.has(row.source_id) && oldGroup === row.group_id) {
+          // Orphan, cleanup verified: the item is gone and the group it lives in is empty of it, so
+          // the ledger row has nothing left to describe. Clearing the flag instead would leave the
+          // row forever (the projector only ever visits rows whose item still exists).
+          await db.from("graph_episodes").delete().eq("id", row.id);
+        } else if (orphans.has(row.source_id)) {
+          // Orphan whose flag pointed at a DIFFERENT group (a tier move whose cleanup was still
+          // outstanding when the item was purged). That group is now verified empty — but the row's
+          // OWN group has never been checked, and dropping the row here would delete the only pointer
+          // to those episodes. Re-point the flag instead; the next pass verifies the second group and
+          // then takes the branch above.
+          await db
+            .from("graph_episodes")
+            .update({ pending_delete_group_id: row.group_id, pending_delete_at: new Date().toISOString() })
+            .eq("id", row.id);
+        } else {
+          await db
+            .from("graph_episodes")
+            .update({ pending_delete_group_id: null, pending_delete_at: null })
+            .eq("id", row.id);
+        }
         cleaned++;
         if (isExternalGroupId(oldGroup)) cleanedExternal++;
       }

--- a/lib/ingest/purge.ts
+++ b/lib/ingest/purge.ts
@@ -1,0 +1,118 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { audit } from "@/lib/api/audit";
+import type { GraphitiClient } from "@/lib/graph/graphiti-client";
+import { retireEpisodesForItems } from "@/lib/graph/project";
+
+/**
+ * REMOVAL of already-ingested content — the counterpart to `ingestItem`, and part of the same
+ * single-writer contract (`items` is written only from `lib/ingest`).
+ *
+ * The brain has had no removal path at all: sync only ever adds or replaces, so content that should
+ * no longer exist — a private channel that was configured by mistake, a message deleted at the
+ * source — stayed in the store, in retrieval, in credit, and in the graph indefinitely. "Keep
+ * everything forever" is a reasonable default for a knowledge base right up until the content is
+ * something the source deliberately took back.
+ *
+ * Removal is a FAN-OUT, not a `delete from items`, because an item's derivatives live in four places
+ * with three different lifetimes:
+ *   • `item_versions` / `item_chunks` / `extracted_facts` / `stakeholder_mentions` / `task_evidence` /
+ *     `meeting_notes` — FK ON DELETE CASCADE, so the stored body and its whole history go with the row.
+ *     (`item_versions` is what makes this matter: it retains every superseded body, so a message the
+ *     author deleted survives the re-render that dropped it from the current body.)
+ *   • `graph_episodes` — NO FK, and the facts themselves live in Graphiti, not Postgres. Retired
+ *     explicitly via `lib/graph` (see `retireEpisodesForItems`), which also owns the durable retry.
+ *   • `tasks.source_item_id` / `decisions.source_item_id` — ON DELETE SET NULL. Deliberately kept:
+ *     those rows are independently authored records that merely cite the item, and a UI-authored task
+ *     must not vanish because its evidence was purged.
+ */
+
+export interface PurgeResult {
+  items: number;
+  /** Ledger rows retired — the graph cleanup is then finished durably by `reconcileProjectedEpisodes`. */
+  episodes: number;
+}
+
+export interface PurgeOptions {
+  /** Injectable for tests; defaults to the configured Graphiti (or a no-op when it isn't configured). */
+  client?: GraphitiClient;
+  actor?: { memberId?: string | null; apiKeyId?: string | null };
+}
+
+/**
+ * Neutralize LIKE wildcards in a literal prefix. `path` segments legitimately contain `_`
+ * (`safeSegment` keeps it), and in LIKE `_` matches ANY single character — so an unescaped
+ * `github/my_repo/` would also match `github/myXrepo/` and delete a different source's items. A
+ * removal primitive that can delete MORE than it was asked to is the one bug class here with no
+ * recovery, so the escaping is unconditional rather than left to each caller. Postgres' default
+ * LIKE escape character is `\`, which is why it needs escaping first.
+ */
+function escapeLike(literal: string): string {
+  return literal.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+/**
+ * Purge every item under a path PREFIX for one team (e.g. `slack/c0b8v119g4d/` — one channel).
+ * The prefix is matched with `like`, so it must end in `/`: `slack/c0b8v` would otherwise take out
+ * every channel whose id merely starts the same way. Callers should build the prefix with the same
+ * helper that writes the path (`slackChannelPathPrefix`) rather than formatting it by hand.
+ */
+export async function purgeItemsByPathPrefix(
+  db: DbClient,
+  teamId: string,
+  pathPrefix: string,
+  reason: string,
+  opts: PurgeOptions = {}
+): Promise<PurgeResult> {
+  if (!pathPrefix.endsWith("/")) {
+    throw new Error(`purgeItemsByPathPrefix: prefix must end in "/" (got "${pathPrefix}")`);
+  }
+  const { data: rows, error: readError } = await db
+    .from("items")
+    .select("id")
+    .eq("team_id", teamId)
+    .like("path", `${escapeLike(pathPrefix)}%`);
+  if (readError) throw new Error(`purge read: ${readError.message}`);
+  const ids = ((rows ?? []) as { id: string }[]).map((r) => r.id);
+  return purgeItemIds(db, teamId, ids, reason, { ...opts, scope: pathPrefix });
+}
+
+/**
+ * Purge an explicit set of item ids. The shared core: prefix-purge and (next) source-diff deletion
+ * both land here so there is ONE removal implementation to keep correct.
+ */
+export async function purgeItemIds(
+  db: DbClient,
+  teamId: string,
+  itemIds: string[],
+  reason: string,
+  opts: PurgeOptions & { scope?: string } = {}
+): Promise<PurgeResult> {
+  if (itemIds.length === 0) return { items: 0, episodes: 0 };
+
+  // Graph FIRST. Deleting the items first would strand the ledger rows AND leave the extracted facts
+  // answering questions in Graphiti with nothing left pointing at them — the graph is the one
+  // derivative Postgres can't clean up for us. If this throws, nothing has been deleted yet: the
+  // purge fails loudly and is retried, rather than half-removing content.
+  const episodes = await retireEpisodesForItems(db, teamId, itemIds, { client: opts.client });
+
+  for (const id of itemIds) {
+    const { error } = await db.from("items").delete().eq("id", id); // versions + chunks + facts cascade
+    if (error) throw new Error(`purge item ${id}: ${error.message}`);
+  }
+
+  // Removal is destructive and irreversible — it is exactly the thing an operator will later need to
+  // explain, so it is always audited with its reason and scope.
+  await audit(db, {
+    team_id: teamId,
+    actor_kind: opts.actor?.memberId ? "member" : "system",
+    member_id: opts.actor?.memberId ?? null,
+    api_key_id: opts.actor?.apiKeyId ?? null,
+    action: "items.purged",
+    target_type: opts.scope ? "path_prefix" : "item_ids",
+    target_id: opts.scope ?? `${itemIds.length} item(s)`,
+    meta: { reason, items: itemIds.length, episodes },
+  });
+
+  return { items: itemIds.length, episodes };
+}

--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -4,9 +4,10 @@ import { timeoutFetch } from "@/lib/http";
 import type { DbClient } from "@/lib/db/types";
 import { adminClient } from "@/lib/db/admin";
 import { ingestItem } from "@/lib/ingest";
+import { purgeItemsByPathPrefix } from "@/lib/ingest/purge";
 import { getEnabledIntegrationsWithSecrets } from "@/lib/integrations/manage";
-import { SlackClient, fetchSlackChannel } from "./sources/slack";
-import { normalizeThread } from "./sources/slack-normalize";
+import { SlackClient, fetchSlackChannel, privateChannelAction } from "./sources/slack";
+import { normalizeThread, slackChannelPathPrefix } from "./sources/slack-normalize";
 import { syncSlackIdentities } from "./sources/slack-identity";
 import { syncProviderIdentities } from "@/lib/identity/provider-sync";
 import { buildIdentityMap, resolveByProviderId, resolveMember } from "@/lib/identity/resolve";
@@ -193,10 +194,39 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
         }
         const idMap = await buildIdentityMap(db, teamId);
         const users = Object.fromEntries(detailed.map((u) => [u.id, u.displayName]));
+        let unverifiable = 0; // channels this token couldn't establish as public, per integration
         for (const channelId of channelIds) {
           summary.channels++;
           try {
             const channel = await fetchSlackChannel(client, channelId, { users, maxMessages: 300 });
+            // A channel the brain refuses to read is deliberately not ingested — say so, or the admin
+            // sees a channel in the list that silently never produces anything.
+            if (channel.skippedPrivate) {
+              const action = privateChannelAction(channel);
+              summary.errors.push(action.message);
+              if (!action.purge) unverifiable++;
+              if (action.purge) {
+                try {
+                  const purged = await purgeItemsByPathPrefix(
+                    db,
+                    teamId,
+                    slackChannelPathPrefix(channelId),
+                    "slack channel is private",
+                    { actor: { memberId: auth.memberId, apiKeyId: auth.apiKeyId } }
+                  );
+                  if (purged.items > 0) {
+                    summary.errors.push(
+                      `${channelId}: purged ${purged.items} previously-ingested private item(s)`
+                    );
+                  }
+                } catch (err) {
+                  summary.errors.push(
+                    `${channelId}: private-channel purge failed — ${err instanceof Error ? err.message : "unknown"}`
+                  );
+                }
+              }
+              continue;
+            }
             // A thread whose replies couldn't be fetched is dropped rather than truncated — make that
             // visible so a systematic failure doesn't read as a quiet channel.
             if (channel.skippedThreads > 0) {
@@ -225,6 +255,16 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
               `${channelId}: ${err instanceof Error ? err.message : "fetch failed"}`
             );
           }
+        }
+        // EVERY channel unverifiable is one diagnosis, not N: the token almost certainly lacks
+        // `channels:read`, and Slack ingestion for this integration has stopped entirely. Left as N
+        // per-channel lines it reads as N unrelated permission oddities, which is how a fail-closed
+        // check turns into a silent outage.
+        if (unverifiable > 0 && unverifiable === channelIds.length) {
+          summary.errors.push(
+            `integration "${integ.name}": NO channel could be verified public (${unverifiable}/${channelIds.length}) — ` +
+              `nothing was ingested. The bot token most likely lacks the channels:read scope.`
+          );
         }
       }
     }

--- a/lib/ingest/sources/slack-normalize.ts
+++ b/lib/ingest/sources/slack-normalize.ts
@@ -26,6 +26,17 @@ function safeSegment(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "channel";
 }
 
+/**
+ * The path PREFIX every item of one Slack channel lives under (`slack/<channel-seg>/`). Exported so
+ * the removal path (`purgeItemsByPathPrefix`) derives it from the SAME function that writes it —
+ * hand-rolling `slack/${channelId.toLowerCase()}/` at a call site would silently stop matching the
+ * day `safeSegment` changes, and a purge that matches nothing fails as a no-op, not as an error.
+ * Always ends in `/` so it can't catch a sibling channel whose id merely starts the same.
+ */
+export function slackChannelPathPrefix(channelId: string): string {
+  return `slack/${safeSegment(channelId)}/`;
+}
+
 function tsToIso(ts: string): string {
   const ms = Math.round(parseFloat(ts) * 1000);
   return Number.isFinite(ms) ? new Date(ms).toISOString() : "";

--- a/lib/ingest/sources/slack.ts
+++ b/lib/ingest/sources/slack.ts
@@ -33,6 +33,12 @@ export interface FetchedChannel {
   threads: FetchedThread[];
   /** user id → display name (best-effort) */
   users: Record<string, string>;
+  /** True when the channel is PRIVATE (or a DM) and was therefore not read at all. The brain only
+   *  ingests channels that are public within the workspace. */
+  skippedPrivate?: boolean;
+  /** True when Slack CONFIRMED the channel is private; false when we merely couldn't verify it was
+   *  public. Only a confirmed-private channel may have its already-stored content purged. */
+  privacyVerified?: boolean;
   /** Threads DROPPED this tick because their replies couldn't be fetched — see fetchSlackChannel.
    *  Surfaced so a systematic failure is visible in the run log instead of looking like a quiet sync. */
   skippedThreads: number;
@@ -43,6 +49,48 @@ export interface FetchedChannel {
 }
 
 export class SlackError extends Error {}
+
+/** What the runner does about a channel `fetchSlackChannel` refused to read. */
+export interface PrivateChannelAction {
+  /** Remove content already stored for this channel. */
+  purge: boolean;
+  /** The operator-facing line for the run log — it must say what happened AND what to do. */
+  message: string;
+}
+
+/**
+ * The private-channel policy, as a pure function so the branch that decides whether to DELETE data is
+ * pinned by a test rather than buried in the runner's loop.
+ *
+ * The asymmetry is the whole point, and it is deliberate in both directions:
+ *  • **Confirmed private** (Slack said `is_private`/`is_im`/`is_mpim`) → skip AND purge. Skipping
+ *    alone only stops us adding more; content ingested before the channel went private, or before
+ *    this check existed, would sit in a team-readable store — the exact thing being prevented.
+ *  • **Unverifiable** (missing scope, `channel_not_found`, bot removed) → skip, NEVER purge. A
+ *    transient permission failure on a PUBLIC channel would otherwise delete its whole history, and
+ *    that is unrecoverable. The residue is stated in the message rather than hidden: previously
+ *    ingested content is retained until we can actually establish the channel is private.
+ */
+export function privateChannelAction(channel: {
+  channelId: string;
+  privacyVerified?: boolean;
+}): PrivateChannelAction {
+  if (channel.privacyVerified) {
+    return {
+      purge: true,
+      message:
+        `${channel.channelId}: private channel — not ingested, and previously-ingested content removed ` +
+        `(the brain only syncs channels that are public in the workspace; remove it from this integration)`,
+    };
+  }
+  return {
+    purge: false,
+    message:
+      `${channel.channelId}: could not verify this channel is public — skipped (the brain only syncs ` +
+      `channels that are public in the workspace). Anything ingested earlier is RETAINED, since a ` +
+      `permission failure is not proof of privacy. Check the bot's channels:read scope and membership.`,
+  };
+}
 
 /**
  * True when a users.list failure means the TOKEN LACKS THE SCOPE — a stable, expected configuration
@@ -59,6 +107,20 @@ function isMissingScopeError(err: unknown): boolean {
   // calling it a graceful degrade would be a lie — they rethrow and the integration is skipped with
   // one crisp error instead of a per-channel pile of downstream failures.
   return /missing_scope|not_allowed_token_type|no_permission/i.test(msg);
+}
+
+/**
+ * True when a `conversations.info` failure means we CANNOT ESTABLISH the channel's visibility —
+ * as opposed to a transient blip. A missing scope is one case; the other is a channel Slack won't
+ * describe to this token at all: `channel_not_found` is what Slack returns for a private channel the
+ * bot isn't in (it deliberately doesn't distinguish that from a bad id), and `not_in_channel` is the
+ * membership variant. Left to the generic `throw`, those produced a bare per-tick error and the
+ * channel's PRIVACY was never decided — the "kicked the bot, then made it private" case, where the
+ * honest answer is "unverifiable, so treat as private."
+ */
+function isUnverifiableChannelError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return isMissingScopeError(err) || /channel_not_found|not_in_channel/i.test(msg);
 }
 
 export class SlackClient {
@@ -78,20 +140,38 @@ export class SlackClient {
     return json;
   }
 
-  async channelName(channelId: string): Promise<string> {
+  /**
+   * A channel's display name AND whether it is PRIVATE. Privacy is load-bearing, not cosmetic: the
+   * brain only ingests channels that are public within the workspace, so this decides whether the
+   * channel is read at all (see `fetchSlackChannel`).
+   *
+   * Fails CLOSED. A missing scope (or a channel Slack won't describe to this token) means we cannot
+   * verify the channel is public, and "unverified" must not be treated as "public" — a token without
+   * `channels:read` would otherwise pull whatever it can reach, including private conversations. DMs
+   * and group DMs (`is_im`/`is_mpim`) are private by definition and count the same.
+   */
+  async channelInfo(channelId: string): Promise<{ name: string; isPrivate: boolean; verified: boolean }> {
     try {
-      const r = await this.call<{ channel: { name?: string } }>("conversations.info", {
-        channel: channelId,
-      });
-      return r.channel.name ?? channelId;
+      const r = await this.call<{
+        channel: { name?: string; is_private?: boolean; is_im?: boolean; is_mpim?: boolean };
+      }>("conversations.info", { channel: channelId });
+      const c = r.channel ?? {};
+      return {
+        name: c.name ?? channelId,
+        isPrivate: Boolean(c.is_private || c.is_im || c.is_mpim),
+        verified: true, // Slack told us directly
+      };
     } catch (err) {
       // Paths are keyed on the immutable channel ID now, so a name flake no longer re-keys threads —
       // it only affects the DISPLAY name (`frontmatter.channel`, the thread title, the Data page). We
       // still skip on a transient failure rather than persist a wrong name: the frontmatter heal
       // rewrites `channel` on every unchanged re-push, so one bad tick would relabel the whole
       // channel's items (and the Data page picks the most recently synced name).
-      if (!isMissingScopeError(err)) throw err;
-      return channelId; // private channel without the scope — a stable fallback
+      if (!isUnverifiableChannelError(err)) throw err;
+      // Can't read the channel's metadata → can't prove it's public → treat it as private and SKIP.
+      // `verified: false` matters downstream: skipping on a guess is safe, but DELETING already-stored
+      // content on a guess is not — an unverifiable public channel would lose its history.
+      return { name: channelId, isPrivate: true, verified: false };
     }
   }
 
@@ -202,10 +282,29 @@ export async function fetchSlackChannel(
   opts: { maxMessages?: number; users?: Record<string, string> } = {}
 ): Promise<FetchedChannel> {
   const max = opts.maxMessages ?? 300;
-  const [channelName, users] = await Promise.all([
-    client.channelName(channelId),
+  const [info, users] = await Promise.all([
+    client.channelInfo(channelId),
     opts.users ? Promise.resolve(opts.users) : client.usersMap(),
   ]);
+  const channelName = info.name;
+
+  // PRIVATE CHANNELS ARE NEVER INGESTED. The brain is a shared team memory with exactly two tiers
+  // (team / external) and no stricter one — so anything ingested from a private channel becomes
+  // readable by the whole team, which is not what "private" means to the people in it. An admin
+  // adding a channel id can't be relied on to have checked, and `conversations.info` tells us
+  // directly, so we check rather than trust. Returns before ANY message is read: nothing private
+  // enters the process, let alone the store.
+  if (info.isPrivate) {
+    return {
+      channelId,
+      channelName,
+      threads: [],
+      users,
+      skippedThreads: 0,
+      skippedPrivate: true,
+      privacyVerified: info.verified,
+    };
+  }
 
   const history = await client.history(channelId, max);
   // Top-level messages only (a reply has thread_ts !== ts). Roots keep their thread.

--- a/lib/integrations/slack-validate.ts
+++ b/lib/integrations/slack-validate.ts
@@ -1,0 +1,91 @@
+/**
+ * Slack channel checks for the Admin → Integrations save flow — the mirror of `github-validate`,
+ * and kept out of the ingest source for the same reason: the UI must be able to check a channel
+ * WITHOUT running a sync.
+ *
+ * Why this exists at all, given `fetchSlackChannel` already fails closed on a private channel: the
+ * ingester's refusal is silent until someone reads a run log, so an admin who pastes a private
+ * channel id gets a saved integration that simply never produces anything. The brain's rule is that
+ * only channels PUBLIC to the workspace are ingested, so the honest place to say so is the moment
+ * the admin adds one. Ingest-time enforcement stays the backstop (it covers the env-token path and
+ * a channel that turns private later) — this is the message, not the gate.
+ *
+ * Pure transport + mapping; `fetchImpl` is injectable so it unit-tests without a live Slack.
+ */
+
+const API = "https://slack.com/api";
+type Fetch = typeof fetch;
+
+/** public = readable by the whole workspace · private = private channel/DM · unknown = couldn't tell. */
+export type ChannelVisibility = "public" | "private" | "unknown";
+
+export interface ChannelCheck {
+  channelId: string;
+  visibility: ChannelVisibility;
+  /** Display name when Slack told us, for a message the admin can recognise. */
+  name?: string;
+  /** Slack's error code / transport failure, when `visibility` is "unknown". */
+  error?: string;
+}
+
+/**
+ * Probe one channel via `conversations.info`. Never throws.
+ *
+ * `is_im`/`is_mpim` are reported by Slack SEPARATELY from `is_private`, so a DM must be tested for
+ * explicitly or it reads as public. Anything we cannot resolve is `unknown`, never `public` — the
+ * caller decides what to do with an unverifiable channel, and defaulting to "public" here would turn
+ * a missing scope into consent to ingest private conversations.
+ */
+export async function checkSlackChannel(
+  token: string,
+  channelId: string,
+  fetchImpl: Fetch = fetch
+): Promise<ChannelCheck> {
+  try {
+    const res = await fetchImpl(`${API}/conversations.info?channel=${encodeURIComponent(channelId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await res.json()) as {
+      ok?: boolean;
+      error?: string;
+      channel?: { name?: string; is_private?: boolean; is_im?: boolean; is_mpim?: boolean };
+    };
+    if (!body.ok || !body.channel) {
+      return { channelId, visibility: "unknown", error: body.error ?? `HTTP ${res.status}` };
+    }
+    const c = body.channel;
+    const isPrivate = Boolean(c.is_private || c.is_im || c.is_mpim);
+    return { channelId, visibility: isPrivate ? "private" : "public", name: c.name };
+  } catch (e) {
+    return { channelId, visibility: "unknown", error: e instanceof Error ? e.message : "could not reach Slack" };
+  }
+}
+
+/** Probe every configured channel. Sequential — this runs on a form submit of at most a few ids. */
+export async function checkSlackChannels(
+  token: string,
+  channelIds: readonly string[],
+  fetchImpl: Fetch = fetch
+): Promise<ChannelCheck[]> {
+  const out: ChannelCheck[] = [];
+  for (const id of channelIds) out.push(await checkSlackChannel(token, id, fetchImpl));
+  return out;
+}
+
+/**
+ * The admin-facing reason to REJECT a save, or null to allow it. Pure — unit-tested.
+ *
+ * Only a CONFIRMED-private channel blocks. An `unknown` result (no scope, Slack down, a typo'd id)
+ * is not evidence of privacy, and blocking on it would make an unreachable Slack an unusable admin
+ * page; those are left to the ingester, which fails closed and reports per run.
+ */
+export function privateChannelRejection(checks: readonly ChannelCheck[]): string | null {
+  const priv = checks.filter((c) => c.visibility === "private");
+  if (priv.length === 0) return null;
+  const named = priv.map((c) => (c.name ? `#${c.name} (${c.channelId})` : c.channelId)).join(", ");
+  return (
+    `${priv.length === 1 ? "That channel is" : "Those channels are"} private in Slack: ${named}. ` +
+    `The brain only syncs channels that are public to the workspace — everything it ingests is ` +
+    `readable by the whole team, so private conversations are never added.`
+  );
+}

--- a/test/datamechanics/graph-project.datamechanics.test.ts
+++ b/test/datamechanics/graph-project.datamechanics.test.ts
@@ -3,6 +3,7 @@ import type { GraphitiClient, GraphEpisode, GraphEpisodeRef } from "@/lib/graph/
 import { projectSlackToGraph, projectItemsToGraph, deleteItemEpisodes, CHUNK_CHARS, MAX_EPISODE_CHUNKS, GROUP_SCAN_DEPTH } from "@/lib/graph/project";
 import { runGraphProjection } from "@/lib/graph/run";
 import { reconcileProjectedEpisodes, LANDED_SCAN_DEPTH } from "@/lib/graph/reconcile";
+import { purgeItemsByPathPrefix } from "@/lib/ingest/purge";
 import { db, ingest, seedTeam } from "./helpers";
 
 // Spec: the projector reads Slack transcripts from the brain and pushes them to Graphiti as
@@ -789,5 +790,130 @@ describe("reconcileProjectedEpisodes (audit H3, real Postgres)", () => {
 
     const { data } = await db().from("graph_episodes").select("id").eq("team_id", seed.teamId).eq("source_id", item.id).maybeSingle();
     expect(data).not.toBeNull();
+  });
+});
+
+/**
+ * Spec: content PURGED from the brain must leave the graph too, durably.
+ *
+ * `graph_episodes` has no FK to `items`, so deleting an item on its own strands the ledger row — and,
+ * far worse, leaves the extracted facts answering questions in Graphiti with nothing pointing at
+ * them. For a private channel or a message the author deleted at the source, a removal that stops at
+ * Postgres is not a removal. The purge therefore deletes the episodes inline and leaves a TOMBSTONE
+ * (the same `pending_delete_group_id` mechanism the tier cleanup uses) so a Graphiti blip is retried
+ * rather than silently abandoned.
+ */
+describe("purge → graph cleanup (real Postgres, mocked Graphiti)", () => {
+  it("retires the episodes and converges — even when the inline delete fails", async () => {
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const group = `${slug}_team`;
+    const item = await ingest(seed, { kind: "transcript", path: "slack/c0priv/1.md", body: "private thread", access: "team" });
+
+    const fake = new FakeGraphiti();
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+    expect(await fake.listEpisodes(group)).toHaveLength(1);
+
+    // Purge while Graphiti is blipping: the inline delete fails, so the facts are STILL in the graph.
+    fake.failDeletes = true;
+    await purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0priv/", "slack channel is private", {
+      client: client(fake),
+    });
+    expect(await fake.listEpisodes(group)).toHaveLength(1); // not gone yet — this is the leak window
+
+    // The item is gone from the brain, but the ledger row SURVIVES carrying the cleanup debt.
+    const { data: gone } = await db().from("items").select("id").eq("id", item.id).maybeSingle();
+    expect(gone).toBeNull();
+    const { data: row } = await db()
+      .from("graph_episodes")
+      .select("pending_delete_group_id")
+      .eq("team_id", seed.teamId)
+      .maybeSingle();
+    expect((row as { pending_delete_group_id: string | null }).pending_delete_group_id).toBe(group);
+
+    // Graphiti recovers: reconcile finishes the delete, and once the group is verified empty the
+    // tombstone itself is dropped (clearing the flag instead would orphan the row forever — the
+    // projector only ever revisits rows whose item still exists).
+    fake.failDeletes = false;
+    await backdateCleanup(seed.teamId);
+    await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+    expect(await fake.listEpisodes(group)).toHaveLength(0); // facts gone from the graph
+    await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+    const { data: after } = await db().from("graph_episodes").select("id").eq("team_id", seed.teamId);
+    expect(after ?? []).toHaveLength(0); // no orphan ledger row left behind
+  });
+});
+
+/**
+ * Spec: the purge must survive a CONCURRENT projector batch.
+ *
+ * The projector runs on its own scheduler, so it can already hold an item's body in memory when the
+ * ingest tick purges that item. It then re-pushes the content and — via the `purgeBeforeRepush`
+ * branch — CLEARS the pending-delete flag. The ledger row afterwards looks perfectly healthy (fresh
+ * sha, no flag), the projector never revisits it (its item is gone), and the purged content stays
+ * searchable in Graphiti forever with nothing to retry. Flag-based detection can't see this; only
+ * orphan-ness can.
+ */
+describe("purge vs a racing projector (real Postgres, mocked Graphiti)", () => {
+  it("re-purges an orphan whose episodes were re-pushed after the item was deleted", async () => {
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const group = `${slug}_team`;
+    const item = await ingest(seed, { kind: "transcript", path: "slack/c0priv/1.md", body: "private thread", access: "team" });
+
+    const fake = new FakeGraphiti();
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+    await purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0priv/", "private", { client: client(fake) });
+    expect(await fake.listEpisodes(group)).toHaveLength(0);
+
+    // The racing projector lands: it re-pushes the body it still held and clears the flag. Written
+    // directly because the projector can no longer reach this item (its row is gone) — this is the
+    // exact end state of `projectItemsToGraph`'s `purgeBeforeRepush` branch: `addEpisodes(groupId, …)`
+    // followed by the upsert whose `pending` object is `{pending_delete_group_id: null,
+    // pending_delete_at: null}`. If that branch's bookkeeping changes, this must change with it.
+    await fake.addEpisodes(group, [ep(`items:${item.id}`)]);
+    await db()
+      .from("graph_episodes")
+      .update({ content_sha256: "f".repeat(64), pending_delete_group_id: null, pending_delete_at: null })
+      .eq("team_id", seed.teamId);
+    expect(await fake.listEpisodes(group)).toHaveLength(1); // private content is BACK in the graph
+
+    // Reconcile notices the row has no item and retires it again.
+    await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+    expect(await fake.listEpisodes(group)).toHaveLength(0);
+
+    // …and converges: once the group is verified empty past the grace, the row goes too.
+    await backdateCleanup(seed.teamId);
+    await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+    const { data: after } = await db().from("graph_episodes").select("id").eq("team_id", seed.teamId);
+    expect(after ?? []).toHaveLength(0);
+  });
+
+  it("leaves a HEALTHY tier-cleanup row alone (orphan detection must not misfire)", async () => {
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const externalGroup = `${slug}_external`;
+    await ingest(seed, { kind: "deliverable", path: "docs/spec.md", body: "the spec", access: "external" });
+
+    const fake = new FakeGraphiti();
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+    fake.failDeletes = true;
+    await ingest(seed, { kind: "deliverable", path: "docs/spec.md", body: "the spec, team-tier", access: "team" });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+    fake.failDeletes = false;
+    await backdateCleanup(seed.teamId);
+
+    // The item is ALIVE, so this is a tier cleanup, not an orphan: the flag clears and the row STAYS.
+    await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+    await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+    const { data } = await db()
+      .from("graph_episodes")
+      .select("group_id, pending_delete_group_id")
+      .eq("team_id", seed.teamId)
+      .maybeSingle();
+    expect(data).not.toBeNull();
+    const r = data as { group_id: string; pending_delete_group_id: string | null };
+    expect(r.pending_delete_group_id).toBeNull();
+    expect(r.group_id).not.toBe(externalGroup);
   });
 });

--- a/test/datamechanics/purge-items.datamechanics.test.ts
+++ b/test/datamechanics/purge-items.datamechanics.test.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { purgeItemsByPathPrefix } from "@/lib/ingest/purge";
+import type { GraphitiClient } from "@/lib/graph/graphiti-client";
+import { db, seedTeam, ingest } from "./helpers";
+
+/**
+ * Spec: REMOVAL of already-ingested content. The brain had no removal path at all — sync only adds or
+ * replaces — so content that should no longer exist (a private channel configured by mistake, a
+ * message deleted at the source) stayed in the store, in retrieval, and in the graph forever.
+ *
+ * Two things only real Postgres can prove, and both are the point of the feature:
+ *  • `item_versions` CASCADES. That table retains every superseded body, so a deleted message
+ *    survives the re-render that dropped it from the current body — deleting the item is what
+ *    actually removes it.
+ *  • `graph_episodes` does NOT cascade (no FK to `items`; it's an idempotency ledger keyed by
+ *    `source_id`), so an item deleted on its own strands the row AND leaves the extracted facts
+ *    answering questions in Graphiti with nothing pointing at them.
+ */
+async function episodeRows(teamId: string) {
+  const { data } = await db()
+    .from("graph_episodes")
+    .select("id, source_id, content_sha256, pending_delete_group_id")
+    .eq("team_id", teamId);
+  return (data ?? []) as {
+    id: string;
+    source_id: string;
+    content_sha256: string;
+    pending_delete_group_id: string | null;
+  }[];
+}
+
+async function versionCount(itemId: string): Promise<number> {
+  const { data } = await db().from("item_versions").select("id").eq("item_id", itemId);
+  return (data ?? []).length;
+}
+
+async function seedEpisode(teamId: string, itemId: string, groupId = "acme_team") {
+  await db().from("graph_episodes").insert({
+    team_id: teamId,
+    source_table: "items",
+    source_id: itemId,
+    group_id: groupId,
+    content_sha256: "a".repeat(64),
+    episode_uuid: randomUUID(),
+  });
+}
+
+/** A Graphiti stub recording what was deleted — enough for `deleteItemEpisodes`. */
+function stubGraphiti(episodes: { uuid: string; name: string }[]) {
+  const deleted: string[] = [];
+  const client = {
+    configured: true,
+    listEpisodes: async () => episodes.filter((e) => !deleted.includes(e.uuid)),
+    deleteEpisode: async (uuid: string) => {
+      deleted.push(uuid);
+    },
+  } as unknown as GraphitiClient;
+  return { client, deleted };
+}
+
+describe("purgeItemsByPathPrefix (real Postgres)", () => {
+  it("removes the items under the prefix and their versions, leaving siblings untouched", async () => {
+    const seed = await seedTeam();
+    const priv = await ingest(seed, { path: "slack/c0priv/1.md", project: "slack", kind: "transcript", access: "team", body: "secret" });
+    await ingest(seed, { path: "slack/c0pub/1.md", project: "slack", kind: "transcript", access: "team", body: "public" });
+    expect(await versionCount(priv.id)).toBe(1);
+
+    const res = await purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0priv/", "test");
+
+    expect(res.items).toBe(1);
+    expect(await versionCount(priv.id)).toBe(0); // cascaded — the retained bodies go too
+    const { data: survivors } = await db().from("items").select("path").eq("team_id", seed.teamId);
+    expect((survivors ?? []).map((r) => (r as { path: string }).path)).toEqual(["slack/c0pub/1.md"]);
+  });
+
+  it("deletes the item's episodes from Graphiti and keeps a tombstone until cleanup is verified", async () => {
+    const seed = await seedTeam();
+    const item = await ingest(seed, { path: "slack/c0priv/1.md", project: "slack", kind: "transcript", access: "team", body: "secret" });
+    await seedEpisode(seed.teamId, item.id);
+    const { client, deleted } = stubGraphiti([
+      { uuid: "u-1", name: `items:${item.id}` },
+      { uuid: "u-other", name: `items:${randomUUID()}` },
+    ]);
+
+    const res = await purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0priv/", "private", { client });
+
+    // The FACTS are what a purge has to remove — the ledger row is only bookkeeping.
+    expect(deleted).toEqual(["u-1"]); // and only this item's
+    expect(res.episodes).toBe(1);
+    // The row SURVIVES, flagged: the inline delete is best-effort (Graphiti blips; its async worker
+    // can create a straggler chunk after we listed), so reconcile must have something to retry.
+    const rows = await episodeRows(seed.teamId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].pending_delete_group_id).toBe("acme_team");
+    expect(rows[0].content_sha256).toBe(""); // no longer a live projection
+  });
+
+  it("drops the ledger row outright when Graphiti isn't configured (nothing to retry)", async () => {
+    const seed = await seedTeam();
+    const item = await ingest(seed, { path: "slack/c0priv/1.md", project: "slack", kind: "transcript", access: "team", body: "secret" });
+    await seedEpisode(seed.teamId, item.id);
+    const client = { configured: false } as unknown as GraphitiClient;
+
+    await purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0priv/", "private", { client });
+
+    expect(await episodeRows(seed.teamId)).toHaveLength(0); // no tombstone left "pending" forever
+  });
+
+  it("treats '_' in a prefix as a literal, not a LIKE wildcard", async () => {
+    // `_` matches ANY single character in LIKE, and `safeSegment` keeps `_` in paths — so an
+    // unescaped prefix silently widens the purge onto a neighbouring source. Deleting MORE than
+    // asked is the one failure here with no recovery.
+    const seed = await seedTeam();
+    await ingest(seed, { path: "slack/a_b/1.md", project: "slack", kind: "transcript", access: "team", body: "target" });
+    await ingest(seed, { path: "slack/axb/1.md", project: "slack", kind: "transcript", access: "team", body: "bystander" });
+
+    const res = await purgeItemsByPathPrefix(db(), seed.teamId, "slack/a_b/", "test");
+
+    expect(res.items).toBe(1);
+    const { data: survivors } = await db().from("items").select("path").eq("team_id", seed.teamId);
+    expect((survivors ?? []).map((r) => (r as { path: string }).path)).toEqual(["slack/axb/1.md"]);
+  });
+
+  it("refuses a prefix that doesn't end in '/' (it would catch sibling channels)", async () => {
+    const seed = await seedTeam();
+    await expect(purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0pri", "test")).rejects.toThrow(/must end in/);
+  });
+
+  it("is a no-op when nothing matches", async () => {
+    const seed = await seedTeam();
+    expect(await purgeItemsByPathPrefix(db(), seed.teamId, "slack/nothing/", "test")).toEqual({ items: 0, episodes: 0 });
+  });
+
+  it("audits the removal with its reason and scope", async () => {
+    const seed = await seedTeam();
+    await ingest(seed, { path: "slack/c0gone/1.md", project: "slack", kind: "transcript", access: "team", body: "x" });
+    await purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0gone/", "slack channel is private");
+    const { data } = await db().from("audit_log").select("action, meta").eq("team_id", seed.teamId);
+    const row = (data ?? []).find((r) => (r as { action: string }).action === "items.purged") as
+      | { meta: Record<string, unknown> }
+      | undefined;
+    expect(row?.meta?.reason).toBe("slack channel is private");
+    expect(row?.meta?.items).toBe(1);
+  });
+});

--- a/test/ingest-slack-normalize.test.ts
+++ b/test/ingest-slack-normalize.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { normalizeThread, threadParticipants, type NormalizeOpts } from "@/lib/ingest/sources/slack-normalize";
+import {
+  normalizeThread,
+  threadParticipants,
+  slackChannelPathPrefix,
+  type NormalizeOpts,
+} from "@/lib/ingest/sources/slack-normalize";
 import { itemPayloadSchema } from "@/lib/api/schemas";
 import type { FetchedThread } from "@/lib/ingest/sources/slack";
 
@@ -147,5 +152,25 @@ describe("normalizeThread path identity", () => {
     const b = normalizeThread(thread, { channelId: "C0BBB", channelName: "🚀", users: {} });
     expect(a.path).not.toBe(b.path);
     expect(a.frontmatter.channel).toBe("日本語"); // the real name is preserved for display
+  });
+});
+
+/**
+ * The removal path finds a channel's items by PATH PREFIX, so the prefix helper and the path writer
+ * must agree exactly. They did not, once: the caller hand-rolled `slack/${channelId.toLowerCase()}/`
+ * while the path came from `safeSegment`. A prefix that stops matching doesn't error — the purge
+ * reports "0 items" and the content it was supposed to remove quietly stays.
+ */
+describe("slackChannelPathPrefix", () => {
+  const thread = { root: { ts: "1719878400.000100", user: "U1", text: "hi" }, replies: [] };
+  it("is a prefix of the path the normalizer writes", () => {
+    for (const channelId of ["C0B8V119G4D", "c0lower", "C-weird.id"]) {
+      const path = normalizeThread(thread, { channelId, channelName: "n", users: {} }).path;
+      expect(path.startsWith(slackChannelPathPrefix(channelId))).toBe(true);
+    }
+  });
+
+  it("always ends in '/' so a purge can't reach a sibling channel", () => {
+    expect(slackChannelPathPrefix("C0AAA").endsWith("/")).toBe(true);
   });
 });

--- a/test/ingest-slack-resilience.test.ts
+++ b/test/ingest-slack-resilience.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   fetchSlackChannel,
+  privateChannelAction,
   SlackError,
   SlackClient as SlackClientCtor,
   type SlackClient,
@@ -20,9 +21,9 @@ import {
  */
 
 /** A client stub exposing only what `fetchSlackChannel` calls. */
-function stubClient(over: Partial<Record<"channelName" | "usersMap" | "history" | "replies", unknown>>): SlackClient {
+function stubClient(over: Partial<Record<"channelInfo" | "usersMap" | "history" | "replies", unknown>>): SlackClient {
   return {
-    channelName: over.channelName ?? (async () => "general"),
+    channelInfo: over.channelInfo ?? (async () => ({ name: "general", isPrivate: false, verified: true })),
     usersMap: over.usersMap ?? (async () => ({ U1: "Alice", U2: "Bob" })),
     history: over.history ?? (async () => []),
     replies: over.replies ?? (async () => []),
@@ -112,7 +113,7 @@ describe("SlackClient users lookup — missing scope degrades, transient failure
  * and the timeline permanently. A missing scope is different: it resolves to the id every tick, so
  * paths stay consistent.
  */
-describe("SlackClient.channelName — transient failures must not re-key every thread path", () => {
+describe("SlackClient.channelInfo — transient failures must not re-key every thread path", () => {
   const resp = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
 
   async function withFetch<T>(body: unknown, fn: () => Promise<T>): Promise<T> {
@@ -125,22 +126,22 @@ describe("SlackClient.channelName — transient failures must not re-key every t
     }
   }
 
-  it("falls back to the id ONLY for a missing scope (a stable, consistent path)", async () => {
+  it("falls back to the id for a missing scope AND fails closed (cannot prove it is public)", async () => {
     const name = await withFetch({ ok: false, error: "missing_scope" }, () =>
-      new SlackClientCtor("xoxb-test").channelName("C0123")
+      new SlackClientCtor("xoxb-test").channelInfo("C0123")
     );
-    expect(name).toBe("C0123");
+    expect(name).toEqual({ name: "C0123", isPrivate: true, verified: false }); // unverifiable → private, but NOT confirmed (so nothing is purged on it)
   });
 
   it("THROWS on a transient failure instead of silently duplicating the channel", async () => {
     await withFetch({ ok: false, error: "ratelimited" }, async () => {
-      await expect(new SlackClientCtor("xoxb-test").channelName("C0123")).rejects.toThrow(/ratelimited/);
+      await expect(new SlackClientCtor("xoxb-test").channelInfo("C0123")).rejects.toThrow(/ratelimited/);
     });
   });
 
   it("a dead token is NOT treated as a graceful degrade", async () => {
     await withFetch({ ok: false, error: "invalid_auth" }, async () => {
-      await expect(new SlackClientCtor("xoxb-test").channelName("C0123")).rejects.toThrow(/invalid_auth/);
+      await expect(new SlackClientCtor("xoxb-test").channelInfo("C0123")).rejects.toThrow(/invalid_auth/);
     });
   });
 });
@@ -155,5 +156,169 @@ describe("fetchSlackChannel — the skip carries its cause for triage", () => {
     });
     const channel = await fetchSlackChannel(client, "C1", { users: {} });
     expect(channel.skippedThreadsReason).toMatch(/ratelimited/);
+  });
+});
+
+/**
+ * Spec: the brain only ingests channels that are PUBLIC in the workspace.
+ *
+ * There are exactly two tiers (team / external) and no stricter one, so anything pulled from a
+ * private channel becomes readable by the whole team — which is not what "private" means to the
+ * people in it. An admin pasting a channel id can't be relied on to have checked, and
+ * `conversations.info` answers directly, so the ingester checks rather than trusts. It must decide
+ * BEFORE reading any message, so private content never enters the process at all.
+ */
+describe("fetchSlackChannel — private channels are never ingested", () => {
+  const noRead = async () => {
+    throw new SlackError("history must not be called for a private channel");
+  };
+
+  it("returns nothing and reads NO history for a private channel", async () => {
+    const channel = await fetchSlackChannel(
+      stubClient({
+        channelInfo: async () => ({ name: "managers", isPrivate: true, verified: true }),
+        history: noRead,
+      }),
+      "C0PRIV",
+      { users: {} }
+    );
+    expect(channel.skippedPrivate).toBe(true);
+    expect(channel.threads).toHaveLength(0);
+  });
+
+  it("treats a DM / group DM as private too", async () => {
+    for (const info of [
+      { name: "dm", isPrivate: true, verified: true },
+      { name: "mpdm", isPrivate: true, verified: true },
+    ]) {
+      const channel = await fetchSlackChannel(
+        stubClient({ channelInfo: async () => info, history: noRead }),
+        "D0123",
+        { users: {} }
+      );
+      expect(channel.skippedPrivate).toBe(true);
+    }
+  });
+
+  /**
+   * `privacyVerified` decides whether already-stored content is DELETED, so losing it in transit is
+   * the one regression here that destroys data. Without this the field could be dropped from
+   * `fetchSlackChannel`'s return and every other test would still pass — silently disabling the
+   * purge (safe) or, if it defaulted the other way, deleting a public channel's history (not).
+   */
+  it("propagates whether Slack CONFIRMED the privacy, in both directions", async () => {
+    const confirmed = await fetchSlackChannel(
+      stubClient({
+        channelInfo: async () => ({ name: "managers", isPrivate: true, verified: true }),
+        history: noRead,
+      }),
+      "C0PRIV",
+      { users: {} }
+    );
+    expect(confirmed.privacyVerified).toBe(true);
+
+    const guessed = await fetchSlackChannel(
+      stubClient({
+        // What `channelInfo` returns when it can't establish visibility at all.
+        channelInfo: async () => ({ name: "C0MAYBE", isPrivate: true, verified: false }),
+        history: noRead,
+      }),
+      "C0MAYBE",
+      { users: {} }
+    );
+    expect(guessed.skippedPrivate).toBe(true);
+    expect(guessed.privacyVerified).toBe(false);
+  });
+
+  it("ingests a public channel normally", async () => {
+    const channel = await fetchSlackChannel(
+      stubClient({
+        channelInfo: async () => ({ name: "general", isPrivate: false, verified: true }),
+        history: async () => [{ ts: "1719878400.000100", user: "U1", text: "hello" }],
+      }),
+      "C0PUB",
+      { users: {} }
+    );
+    expect(channel.skippedPrivate).toBeUndefined();
+    expect(channel.threads).toHaveLength(1);
+  });
+});
+
+/**
+ * `is_private` comes off the raw Slack payload, so pin the mapping — including the DM flags, which
+ * Slack reports separately from `is_private`.
+ */
+describe("SlackClient.channelInfo — privacy mapping", () => {
+  const resp = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+  async function info(channel: Record<string, unknown>) {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => resp({ ok: true, channel })) as unknown as typeof fetch;
+    try {
+      return await new SlackClientCtor("xoxb-test").channelInfo("C1");
+    } finally {
+      globalThis.fetch = orig;
+    }
+  }
+
+  it("maps is_private / is_im / is_mpim all to private", async () => {
+    expect((await info({ name: "a", is_private: true })).isPrivate).toBe(true);
+    expect((await info({ name: "b", is_im: true })).isPrivate).toBe(true);
+    expect((await info({ name: "c", is_mpim: true })).isPrivate).toBe(true);
+  });
+
+  it("a plain public channel is not private", async () => {
+    expect(await info({ name: "general", is_private: false })).toEqual({ name: "general", isPrivate: false, verified: true });
+  });
+});
+
+/**
+ * Spec: the branch that decides whether to DELETE stored data.
+ *
+ * The asymmetry is the safety property and it runs both ways: a CONFIRMED-private channel must be
+ * purged (skipping alone leaves private content sitting in a team-readable store), while an
+ * UNVERIFIABLE one must never be — a missing scope or a bot removed from a PUBLIC channel would
+ * otherwise delete that channel's entire history, which nothing can undo. Extracted from the runner
+ * loop precisely so this branch is pinned rather than reasoned about.
+ */
+describe("privateChannelAction — purge only on proof", () => {
+  it("purges when Slack CONFIRMED the channel is private", () => {
+    const action = privateChannelAction({ channelId: "C0PRIV", privacyVerified: true });
+    expect(action.purge).toBe(true);
+    expect(action.message).toContain("C0PRIV");
+    expect(action.message).toMatch(/removed/i);
+  });
+
+  it("never purges when privacy could not be verified, and says the content was RETAINED", () => {
+    for (const privacyVerified of [false, undefined]) {
+      const action = privateChannelAction({ channelId: "C0MAYBE", privacyVerified });
+      expect(action.purge).toBe(false);
+      expect(action.message).toMatch(/retained/i); // the residue is stated, not hidden
+    }
+  });
+});
+
+/**
+ * A channel Slack won't describe to this token is UNVERIFIABLE, not transient: `channel_not_found`
+ * is what Slack returns for a private channel the bot isn't in (it deliberately won't distinguish
+ * that from a bad id). Left to the generic throw it produced a bare error every tick and the
+ * channel's privacy was never decided at all.
+ */
+describe("SlackClient.channelInfo — unverifiable vs transient", () => {
+  const resp = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+  async function withError<T>(error: string, fn: () => Promise<T>): Promise<T> {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => resp({ ok: false, error })) as unknown as typeof fetch;
+    try {
+      return await fn();
+    } finally {
+      globalThis.fetch = orig;
+    }
+  }
+
+  it("treats channel_not_found / not_in_channel as unverifiable-private, not an error", async () => {
+    for (const error of ["channel_not_found", "not_in_channel"]) {
+      const info = await withError(error, () => new SlackClientCtor("xoxb-test").channelInfo("C0123"));
+      expect(info).toEqual({ name: "C0123", isPrivate: true, verified: false });
+    }
   });
 });

--- a/test/integrations-slack-validate.test.ts
+++ b/test/integrations-slack-validate.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkSlackChannel,
+  checkSlackChannels,
+  privateChannelRejection,
+  type ChannelCheck,
+} from "@/lib/integrations/slack-validate";
+
+/**
+ * Spec: an admin must not be able to ADD a private Slack channel. Everything the brain ingests is
+ * readable by the whole team (there are exactly two tiers, `team` and `external`, and no stricter
+ * one), so a private channel's content would become team-wide readable — which is not what "private"
+ * means to the people in it.
+ *
+ * The load-bearing rule is the failure direction: anything we cannot resolve must NOT read as public.
+ * A missing scope or a Slack outage is not consent.
+ */
+
+function fetchStub(body: unknown, status = 200): typeof fetch {
+  return (async () => ({ status, json: async () => body })) as unknown as typeof fetch;
+}
+
+describe("checkSlackChannel", () => {
+  it("reports a plain channel as public, with its name", async () => {
+    const c = await checkSlackChannel("t", "C1", fetchStub({ ok: true, channel: { name: "general", is_private: false } }));
+    expect(c).toEqual({ channelId: "C1", visibility: "public", name: "general" });
+  });
+
+  it("reports is_private as private", async () => {
+    const c = await checkSlackChannel("t", "C1", fetchStub({ ok: true, channel: { name: "managers", is_private: true } }));
+    expect(c.visibility).toBe("private");
+  });
+
+  it("treats a DM and a group DM as private — Slack reports those separately from is_private", async () => {
+    for (const channel of [{ is_im: true }, { is_mpim: true }]) {
+      const c = await checkSlackChannel("t", "D1", fetchStub({ ok: true, channel }));
+      expect(c.visibility).toBe("private");
+    }
+  });
+
+  it("is UNKNOWN, never public, when Slack refuses to answer", async () => {
+    const c = await checkSlackChannel("t", "C1", fetchStub({ ok: false, error: "missing_scope" }));
+    expect(c.visibility).toBe("unknown");
+    expect(c.error).toBe("missing_scope");
+  });
+
+  it("is UNKNOWN, never public, when the request throws", async () => {
+    const boom = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    expect((await checkSlackChannel("t", "C1", boom)).visibility).toBe("unknown");
+  });
+});
+
+describe("checkSlackChannels", () => {
+  it("probes every configured id", async () => {
+    const seen: string[] = [];
+    const f = (async (url: string) => {
+      seen.push(url);
+      return { status: 200, json: async () => ({ ok: true, channel: { name: "n" } }) };
+    }) as unknown as typeof fetch;
+    const out = await checkSlackChannels("t", ["C1", "C2"], f);
+    expect(out).toHaveLength(2);
+    expect(seen.join(" ")).toContain("channel=C1");
+    expect(seen.join(" ")).toContain("channel=C2");
+  });
+});
+
+describe("privateChannelRejection", () => {
+  const check = (over: Partial<ChannelCheck>): ChannelCheck => ({
+    channelId: "C1",
+    visibility: "public",
+    ...over,
+  });
+
+  it("allows a save when every channel is public", () => {
+    expect(privateChannelRejection([check({}), check({ channelId: "C2" })])).toBeNull();
+  });
+
+  it("blocks the save and names the private channel so the admin recognises it", () => {
+    const msg = privateChannelRejection([check({ channelId: "C9", visibility: "private", name: "managers" })]);
+    expect(msg).toContain("#managers");
+    expect(msg).toContain("C9");
+    expect(msg).toMatch(/only syncs channels that are public/i);
+  });
+
+  it("does NOT block on an unverifiable channel — that isn't evidence of privacy", () => {
+    // The ingester still fails closed on this one; blocking here would make a Slack outage or a
+    // missing scope an unusable admin page.
+    expect(privateChannelRejection([check({ visibility: "unknown", error: "missing_scope" })])).toBeNull();
+  });
+});


### PR DESCRIPTION
Two of the three asks from the Pass-2 follow-up: **only public Slack channels may be ingested**, and **content removed at the source can actually be removed from the store**. This PR builds the removal primitive and wires it to the private-channel case; the Slack message/thread diff-delete follows in the next PR.

## The problem

The brain has exactly two access tiers (`team` / `external`) and no stricter one, so anything ingested from a private channel becomes readable by the whole team — which is not what "private" means to the people in it. An admin pasting a channel id couldn't be relied on to have checked, and nothing verified it.

Separately, **nothing could ever leave the brain.** Sync only adds or replaces, so a private channel added by mistake — or a message deleted at the source — stayed in the store, in retrieval, in credit, and in the graph indefinitely. `item_versions` retains every superseded body, so a deleted message survives the re-render that drops it from the current body.

## Public-only, fail-closed at two layers

- **Ingest (the gate).** `SlackClient.channelInfo` resolves `is_private` / `is_im` / `is_mpim`, and `fetchSlackChannel` returns **before reading any message** — private content never enters the process, let alone the store. A channel we cannot *prove* is public (`missing_scope`, `channel_not_found`, `not_in_channel`) is treated as private and skipped: unverifiable ≠ public.
- **Admin save (the message).** `lib/integrations/slack-validate.ts` rejects a private channel id at the moment it's added, rather than saving an integration that silently never produces anything. Only a *confirmed*-private channel blocks; an unreachable Slack must not make the admin page unusable.

When *every* configured channel comes back unverifiable, the runner emits one integration-level error instead of N per-channel lines — that shape is almost always a missing `channels:read` scope, and it means Slack ingestion has stopped entirely.

## Removal — `lib/ingest/purge.ts`

The counterpart to `ingestItem`, under the same single-writer rule. It's a fan-out, because an item's derivatives have three different lifetimes:

| Derivative | On purge |
|---|---|
| `item_versions`, `item_chunks`, `extracted_facts`, `stakeholder_mentions`, `task_evidence`, `meeting_notes` | FK **cascade** |
| `graph_episodes` **+ the facts in Graphiti** | Explicit (`retireEpisodesForItems`) — no FK, and the facts live outside Postgres |
| `tasks.source_item_id`, `decisions.source_item_id` | `set null` — independently authored records that merely cite the item |

Purge is asymmetric by design: a **confirmed**-private channel has its already-ingested content removed; an **unverifiable** one never does, because deleting a public channel's history on a transient scope failure is unrecoverable. The residue is stated in the run log rather than implied away.

**Orphan-ness, not a marker, is the invariant.** The projector runs on its own scheduler, so it can hold an item in memory when the purge deletes it — then re-push the private body *and clear the pending-delete flag*, leaving a row that looks healthy and that nothing ever revisits. Reconcile now re-flags any ledger row whose item is gone, which closes that race and covers every future removal path.

## Verification

Four specs verified **red before green**:
- the Graphiti retire (`expected [] to deeply equal ['u-1']` — the facts were left behind)
- the reconcile tombstone drop (orphan ledger row survived)
- the resurrection race (private episode back in the group)
- the LIKE escape (an unescaped `_` in a prefix purged a bystander item — `expected 2 to be 1`)

`npm test` **1155 passed** · `tsc` 0 · lint clean (2 pre-existing warnings) · docs-drift green · **full data-mechanics tier 691 passed** on a dedicated Postgres container.

**Prod safety, checked read-only rather than assumed:** the fail-closed change would halt Slack ingestion if the bot token lacked `channels:read`. Stored items carry `frontmatter.channel = all-vibrana` (the real display name), so `conversations.info` already succeeds — the scope exists, and `#all-vibrana` is public, so no purge fires on deploy. No schema change.

## Review — Reviewed by Fable (`code-reviewer`) — verdict CLEAR (after one BLOCKED round)

Fable **blocked the first revision** and was right: the purge/projector race above would have left private facts searchable in Graphiti permanently, with the bookkeeping cleared so nothing could self-heal. It also caught an unchecked DB error that would have deleted healthy tier-cleanup rows, unescaped LIKE metacharacters, a dead code path I'd added, and a `channel_not_found` case that left privacy undecided every tick. Second round returned CLEAR; its three recommended follow-ups (the single-flag-slot group check, chunking + logging the orphan query, and the missing escape test) are all in this diff.

## Follow-ups (next PRs)

- **Slack diff-delete** — deleted threads/messages removed from the store. Must bound the diff by the fetched window's oldest `ts` (a naive diff would delete everything past the 300-message window) and build the set from *history roots*, not `channel.threads`, or a transient replies failure deletes the item.
- **The per-source rules layer** — keyed on `frontmatter.source`; first rule is M2's fork ("is a work-time move on an unchanged body evidence of work?" — `local` mtime says no, a Linear status transition says yes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)