### PR TITLE
fix(purge): the audit records WHICH items went, not just how many (AIO-486)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -820,6 +820,78 @@ rather than dropped after checking only one.
 graph episodes. Derived snapshots recomputed on a schedule — `work_timeline_cache`, narrative-arc
 snapshots — can still quote purged content until their next recompute.
 
+### Slack deletions — `lib/ingest/slack-cleanup.ts` + `sources/slack-deletions.ts`
+
+What Slack no longer has, the brain no longer has. Two halves, because a Slack thread is ONE item
+whose body is the whole conversation:
+
+**A deleted THREAD** → the item is purged. Slack emits no deletion event, so the only signal is
+"stored here, absent there" — and read naively that signal is catastrophic, because a thread is
+*also* absent for the innocent reason that it is older than the 300-message window we read. Guards
+(`planSlackDeletions`, pure + unit-tested), each tracing to a way live data would be destroyed:
+
+- the stored thread must be strictly **newer than the oldest message actually read**;
+- the live set is **every top-level message in `history`** — NOT the ingestible `threads` (a thread
+  whose replies failed to fetch is skipped from ingestion while demonstrably alive) and NOT the
+  content-filtered roots (a **tombstoned** root — what Slack leaves when a thread's first message is
+  deleted while its replies live on — or one edited down to a file with no text still *exists*;
+  purging those would take `item_versions` with them and destroy the credit of every replier whose
+  messages are still in Slack). Keeping such a thread is only half the answer, though: it must also
+  stay **ingestible**, or it is never re-rendered and `items.body` — the served surface — goes on
+  quoting the deleted root forever. A text-less root that still has replies is therefore normalized
+  with a `_[message deleted]_` placeholder; a bare text-less message is not a conversation and never
+  becomes an item. A real tombstone carries `text: "This message was deleted."`, so the marker tested
+  is `subtype`, not emptiness — testing the text was an assumption about the wire format;
+- a channel that returned no history, or wasn't read at all, disables deletion entirely.
+
+**Absence is the candidate, not the verdict.** Every condition above still only *infers* deletion from
+a thread being missing, and that inference rests on our model of what Slack puts in `history` — an
+assumption about a wire format, holding up an irreversible cascade through `item_versions`. So before
+anything is removed, each candidate is confirmed against the source: **`SlackClient.threadExists`**
+asks Slack directly, and only a definite "gone" (`thread_not_found` / `message_not_found`) authorizes
+the delete. A live thread, a rate-limit, a lost scope — all spare it, and an unconfirmable candidate
+is reported rather than silently kept. The client parameter is **required, not optional**, so no
+caller can quietly fall back to inference alone.
+
+> `threadExists` counts the **raw** `conversations.replies` response and must never be "hardened" into
+> matching the requested `ts`. `SlackClient.replies` strips the root by design (callers want the
+> replies *around* a root they already hold), and reusing it here read a **live standalone message** —
+> which Slack returns as exactly one message, the root — as "nothing there", confirming a deletion that
+> never happened. Non-empty is the correct asymmetry: if Slack ever hides a deleted parent while its
+> replies live on, identity matching would delete a thread that still has live content.
+
+
+**A deleted MESSAGE** → the current body self-heals on the next sync (it is re-rendered without it),
+but `item_versions` retains every superseded body, so the erased text would live on. Handled in the
+writer by the per-source rule **`retainSupersededBodies`** (`lib/ingest/source-rules`): for a source
+whose body is a re-render of retractable, source-owned content — Slack, the only one today — every
+push clears the bodies it supersedes (`lib/ingest/forget-bodies`). The **rows are kept**:
+`item_versions` is the work ledger (`member_id` + `created_at`) behind contributor credit, the
+timeline and arcs, so deleting them would silently rewrite who did what. Both content columns go —
+`body` **and** `frontmatter`, because Slack's `title` is the root message's first 100 characters —
+and nothing reads either; they are history, not a served surface.
+
+The graph is the third place the text lives, and it *is* served: `addEpisodes` does not overwrite by
+name, so Graphiti keeps the pre-deletion episode and the facts extracted from it. The projector
+therefore calls `deleteItemEpisodes` before re-pushing an item from a `retainSupersededBodies: false`
+source — otherwise a deleted message keeps answering questions through the graph after Postgres has
+forgotten it. That delete is **watched, not fire-and-forget**: `addEpisodes` lands regardless, so a
+swallowed failure would leave the pre-deletion episode behind a fresh sha where nothing revisits it
+(the landed check is satisfied by the new push; orphan repair needs the item to be gone). A failure
+records `pending_delete_group_id`, which routes into the `purgeBeforeRepush` retry on the next pass. (`item_chunks` needs no special handling: `dense-index` already deletes an item's
+chunks before re-inserting.)
+
+That trigger is **structural, not event-driven, on purpose.** The obvious version — "did the reply
+count drop?" — has two silent holes: a delete and a new reply within the same 30-minute tick cancel
+out, and once the count heals there is no signal left to retry on, so one failed attempt strands the
+text permanently. Relatedly, `SlackClient.replies` now **paginates to completion** and treats
+`has_more` with no cursor as a failure: a short page would otherwise store a truncated thread body
+(the `#388` class, arriving through a *successful* response).
+
+Deletions land in the run's `ingest_runs.meta` as `deleted` — destructive work must not be the one
+outcome the run log can't show. Threads too old to judge are counted inside the plan
+(`outOfWindow`) but not yet surfaced in the run log.
+
 ## Docs drift guard
 
 `scripts/check-docs-drift.mjs` derives the three inventories above from code

--- a/docs/context-management-system.md
+++ b/docs/context-management-system.md
@@ -102,7 +102,10 @@ validation (before any mutation) → item + version + derived-row materializatio
 - **Per-source rules** — `lib/ingest/source-rules.ts` is the one table saying how a source's metadata
   should be READ, consulted by the writer. The ingest contract is uniform; sources are not, and the
   same wire field carries different evidence depending on who emitted it. Today it answers one
-  question — *is a work-time that moved on an unchanged body evidence of work?* `local` emits mtime
+  question — *is a work-time that moved on an unchanged body evidence of work?* — plus
+  *may superseded bodies be retained?* (`slack` says no: its item body is a re-render of retractable
+  source-owned content, so a message deleted in Slack would otherwise survive verbatim in
+  `item_versions` forever; only the body is cleared, the ledger rows stay). `local` emits mtime
   (moved by `touch`/`rsync`/`chmod`, no author, no edit → **noise**, so the stored `work_at` stands);
   Linear/Plane emit the issue's last state transition (a ticket reaching `completed` is **work** with
   a byte-identical body). One behaviour is right for one source and wrong for the other — the shape

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -5,6 +5,7 @@ import { GraphitiClient, type GraphEpisode } from "./graphiti-client";
 import { episodeGroupId, isExternalGroupId, type AccessTier } from "./group";
 import { episodeName, itemIdFromEpisodeName } from "./episode-name";
 import { resolvePositiveInt } from "@/lib/util/env";
+import { sourceRules } from "@/lib/ingest/source-rules";
 // Re-exported so the graph module's existing importers (and their specs) keep one import path.
 export { resolvePositiveInt };
 
@@ -419,6 +420,42 @@ export async function projectItemsToGraph(
       if (isExternalGroupId(existingRow.group_id)) externalGroupVacated++;
       await deleteItemEpisodes(client, existingRow.group_id, item.id).catch(() => {});
     }
+    // RETRACTABLE SOURCES: replace, don't append. `addEpisodes` does not overwrite by name — Graphiti
+    // keeps the old episode and the facts extracted from it — so for a source whose body is a
+    // re-render of content the source can retract (Slack: `retainSupersededBodies: false`), a deleted
+    // message would go on answering questions through the graph after Postgres had forgotten it. That
+    // is the same leak `forget-bodies` closes in `item_versions`, on the surface that is actually
+    // served. Shrinking past a chunk boundary is worse still: the orphan tail episode isn't even
+    // overwritten in name. Best-effort like the other inline deletes; the re-push below is
+    // authoritative and reconcile re-derives anything left behind.
+    // Skipped when `purgeBeforeRepush` already deletes from this exact group below — that branch
+    // watches its own result to decide whether the pending flag may clear, and a redundant deep scan
+    // here would only cost a second full listing of the group.
+    let retractFailed = false;
+    if (
+      existingRow &&
+      !purgeBeforeRepush &&
+      !sourceRules((item.frontmatter ?? {}).source).retainSupersededBodies
+    ) {
+      // WATCHED, not fire-and-forget. Every other inline delete here is backed by a durable flag,
+      // and this one needs it most: `addEpisodes` below lands regardless, so a swallowed failure
+      // leaves the pre-deletion episode in the graph with a fresh sha on the ledger — the landed
+      // check is satisfied by the new push, orphan repair needs the item to be GONE, and no flag was
+      // recorded. Nothing would ever revisit it, so one blip (and `deleteItemEpisodes` opens with a
+      // deep `listEpisodes`, which is exactly what times out under load) strands retracted text
+      // answering questions forever. Recording the group (see `pending` below) routes it into
+      // `purgeBeforeRepush` on the next pass, which retries and converges.
+      //
+      // `tierChanged` can in principle also be true here and wins the `pending` ternary below,
+      // dropping this debt — considered, and empty in practice: for both to be live the item must
+      // already have resided in the NEW group, and any outstanding debt for that group would have set
+      // `purgeBeforeRepush`, which skips this branch entirely. What's left is the straggler-chunk
+      // residue the module documents already.
+      retractFailed = await deleteItemEpisodes(client, groupId, item.id).then(
+        () => false,
+        () => true
+      );
+    }
     // Independent of the tier check, NOT an else-arm: on a double flip (A→B→A while A's cleanup is
     // still outstanding) both are true, and the push target is exactly the group holding the stale
     // episodes the flag was recorded for. Skipping it there would leave them beside the fresh push.
@@ -430,7 +467,17 @@ export async function projectItemsToGraph(
       );
     }
 
-    await client.addEpisodes(groupId, episodes);
+    // A failed purge with UNCHANGED content must not re-push. The prior push is still in the group
+    // (that is why the delete was attempted), so pushing again adds a duplicate — and because the
+    // flag stays set, the next pass forces past the sha skip and does it again: one duplicate per
+    // item per hourly pass while Graphiti's delete path is unhealthy, growing the group until the
+    // deep `listEpisodes` times out and the delete can never succeed. That self-amplifying shape is
+    // exactly what reconcile's saturated-group guard refuses to feed. Skipping the push leaves the
+    // existing episodes and the outstanding flag, so the retry converges instead of compounding.
+    const contentUnchanged = existingRow?.content_sha256 === contentSha;
+    if (!(purgeFailed && contentUnchanged)) {
+      await client.addEpisodes(groupId, episodes);
+    }
 
     const projectedAt = new Date().toISOString();
     // Pending-delete bookkeeping for THIS push. Written only when it changes; an ordinary content
@@ -445,9 +492,14 @@ export async function projectItemsToGraph(
     const pending: Record<string, string | null> =
       tierChanged && existingRow
         ? { pending_delete_group_id: existingRow.group_id, pending_delete_at: projectedAt }
-        : purgeBeforeRepush && !purgeFailed
-          ? { pending_delete_group_id: null, pending_delete_at: null } // purge confirmed + re-pushed
-          : {};
+        : // A retract-delete we watched FAIL records this group as owing a cleanup, so the pre-deletion
+          // episode isn't stranded. It routes into `purgeBeforeRepush` on the next pass, which retries
+          // the delete and only then clears the flag — the same convergence the tier path uses.
+          retractFailed
+          ? { pending_delete_group_id: groupId, pending_delete_at: projectedAt }
+          : purgeBeforeRepush && !purgeFailed
+            ? { pending_delete_group_id: null, pending_delete_at: null } // purge confirmed + re-pushed
+            : {};
 
     await db.from("graph_episodes").upsert(
       {

--- a/lib/ingest/forget-bodies.ts
+++ b/lib/ingest/forget-bodies.ts
@@ -1,0 +1,60 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+
+/**
+ * Clear the RETAINED bodies of an item's superseded versions, keeping the version rows.
+ *
+ * For a source whose item body is a re-render of live, source-owned content — Slack, today the only
+ * one (`lib/ingest/source-rules`.`retainSupersededBodies`) — `item_versions` is where a deletion
+ * leaks: a thread's body is the whole conversation, so deleting one message self-heals the CURRENT
+ * body on the next sync while every superseded body still quotes it, verbatim, indefinitely. The
+ * brain ends up holding a copy the source deliberately retracted.
+ *
+ * Two deliberate narrownesses:
+ *  • **Only the content columns** (`body` + `frontmatter` — the latter because Slack's `title` is the
+ *    root message's first 100 characters). `item_versions` is the WORK LEDGER — `member_id` + `created_at` are what
+ *    attribute contributor credit, the timeline and narrative arcs. Deleting rows would silently
+ *    rewrite who did what, which is exactly the harm the deletion feature is meant to avoid.
+ *    Nothing reads `item_versions.body`; it is history, not a served surface.
+ *  • **Only the superseded ones.** The row matching `keepSha` is the version just written — it holds
+ *    the body that is currently live in `items`, so clearing it would forget content the source
+ *    still has.
+ *
+ * Returns how many bodies were cleared.
+ */
+/** Does this retained frontmatter still hold anything? `{}` is the forgotten state. */
+function hasContent(fm: Record<string, unknown> | null): boolean {
+  return Boolean(fm) && Object.keys(fm ?? {}).length > 0;
+}
+
+export async function forgetSupersededBodies(
+  db: DbClient,
+  itemId: string,
+  keepSha: string
+): Promise<number> {
+  const { data, error } = await db
+    .from("item_versions")
+    .select("id, body, frontmatter, content_sha256")
+    .eq("item_id", itemId);
+  if (error) throw new Error(`superseded-body read: ${error.message}`);
+  const rows = (data ?? []) as {
+    id: string;
+    body: string;
+    frontmatter: Record<string, unknown> | null;
+    content_sha256: string;
+  }[];
+  const stale = rows.filter(
+    (r) => r.content_sha256 !== keepSha && (r.body !== "" || hasContent(r.frontmatter))
+  );
+  for (const row of stale) {
+    const { error: updateError } = await db
+      .from("item_versions")
+      // `frontmatter` goes too, not just `body`: Slack's `title` is the root message's first 100
+      // characters, so a retracted message would otherwise survive — quoted, verbatim — in exactly
+      // the rows this pass exists to clear. Nothing reads `item_versions.frontmatter` either.
+      .update({ body: "", frontmatter: {} })
+      .eq("id", row.id);
+    if (updateError) throw new Error(`superseded-body forget ${row.id}: ${updateError.message}`);
+  }
+  return stale.length;
+}

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -13,6 +13,7 @@ import {
 import type { DbClient } from "@/lib/db/types";
 import { materializeDecisions } from "@/lib/ingest/decisions";
 import { sourceRules } from "@/lib/ingest/source-rules";
+import { forgetSupersededBodies } from "@/lib/ingest/forget-bodies";
 import { workTimeKeysIn } from "@/lib/ingest/work-time";
 import {
   materializeFacts,
@@ -445,6 +446,20 @@ export async function ingestItem(
   });
   if (versionError) {
     throw new Error(`item version insert failed: ${versionError.message}`);
+  }
+
+  // FORGET the bodies this push just superseded, where the source's rule says they may not be
+  // retained (`lib/ingest/source-rules`). Slack is the case: one item holds a whole conversation and
+  // is re-rendered every sync, so a message deleted at the source disappears from the current body
+  // while every retained body still quotes it verbatim, forever.
+  //
+  // Structural rather than event-driven ON PURPOSE. The obvious trigger — "did the reply count
+  // drop?" — has two silent holes: a delete and a new reply in the same 30-minute tick cancel out,
+  // and once the count heals there is no signal left to retry on, so a single failed attempt strands
+  // the text permanently. Forgetting on every body change has neither, and costs nothing: only the
+  // BODY is cleared (the rows are the work ledger that attributes credit) and nothing reads it.
+  if (!sourceRules(payload.frontmatter?.source).retainSupersededBodies) {
+    await forgetSupersededBodies(db, itemId, contentSha);
   }
 
   let changedTaskRowKeys: string[] | undefined;

--- a/lib/ingest/purge.ts
+++ b/lib/ingest/purge.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { audit } from "@/lib/api/audit";
 import type { GraphitiClient } from "@/lib/graph/graphiti-client";
-import { retireEpisodesForItems } from "@/lib/graph/project";
+import { retireEpisodesForItems, chunk, IN_CLAUSE_BATCH } from "@/lib/graph/project";
 
 /**
  * REMOVAL of already-ingested content — the counterpart to `ingestItem`, and part of the same
@@ -37,6 +37,70 @@ export interface PurgeOptions {
   /** Injectable for tests; defaults to the configured Graphiti (or a no-op when it isn't configured). */
   client?: GraphitiClient;
   actor?: { memberId?: string | null; apiKeyId?: string | null };
+}
+
+/** How many paths an audit row records inline. A record, not a backup — the count stays authoritative. */
+const AUDIT_PATH_SAMPLE = 200;
+
+/**
+ * The paths of the items about to be purged, for the audit record. Best-effort by design: failing to
+ * READ the paths must never block the removal itself (the content still has to go), so a read error
+ * degrades to an empty list rather than throwing. Sorted so two audits of the same purge compare.
+ */
+async function purgedPaths(
+  db: DbClient,
+  teamId: string,
+  itemIds: string[]
+): Promise<{ paths: string[]; readFailed: boolean }> {
+  const out: string[] = [];
+  let readFailed = false;
+  for (const batch of chunk(itemIds, IN_CLAUSE_BATCH)) {
+    const { data, error } = await db
+      .from("items")
+      .select("path")
+      .eq("team_id", teamId)
+      .in("id", batch);
+    // Keep what we DID read — discarding earlier batches because a later one failed would throw away
+    // the only record of those paths for no gain.
+    if (error) {
+      readFailed = true;
+      continue;
+    }
+    for (const r of (data ?? []) as { path: string }[]) out.push(r.path);
+  }
+  return { paths: out.sort(), readFailed };
+}
+
+/**
+ * The audit meta for a purge. Pure, and separated for that reason: the truncation branch is otherwise
+ * only reachable by seeding 201 rows in the real-DB tier, so an off-by-one (or an accidental
+ * `paths_truncated: 0`) would ship green.
+ *
+ * `paths` is capped — an audit row is a record, not a backup, and a whole-channel purge would
+ * otherwise write thousands of strings into one jsonb column. The count stays authoritative. Note the
+ * recorded slice is the lexicographic HEAD, not a sample: deterministic, and for Slack that means the
+ * oldest thread timestamps.
+ */
+export function buildPurgeMeta(args: {
+  reason: string;
+  items: number;
+  episodes: number;
+  paths: string[];
+  readFailed: boolean;
+}): Record<string, unknown> {
+  const extra = args.paths.length - AUDIT_PATH_SAMPLE;
+  return {
+    reason: args.reason,
+    items: args.items,
+    episodes: args.episodes,
+    paths: args.paths.slice(0, AUDIT_PATH_SAMPLE),
+    ...(extra > 0 ? { paths_truncated: extra } : {}),
+    // MARKED, not silent. `paths: []` with no marker is indistinguishable from a build that never
+    // recorded paths — which would recreate, on any transient read error, the exact prod blind spot
+    // this field exists to close. "We deleted nothing" and "we couldn't record what we deleted" must
+    // not look identical.
+    ...(args.readFailed ? { paths_read_failed: true } : {}),
+  };
 }
 
 /**
@@ -90,6 +154,13 @@ export async function purgeItemIds(
 ): Promise<PurgeResult> {
   if (itemIds.length === 0) return { items: 0, episodes: 0 };
 
+  // WHAT we are about to delete, read BEFORE deleting it — the rows are the only record of their own
+  // paths, so after the cascade the question "what did this purge remove?" has no answer anywhere.
+  // A count and a prefix are enough to notice a purge happened and not enough to explain it, which is
+  // the wrong trade for the one operation in the ingest path that cannot be undone. (Found by watching
+  // the first live purge in prod: 13 items → 12, and nothing on the box could say which one went.)
+  const { paths, readFailed } = await purgedPaths(db, teamId, itemIds);
+
   // Graph FIRST. Deleting the items first would strand the ledger rows AND leave the extracted facts
   // answering questions in Graphiti with nothing left pointing at them — the graph is the one
   // derivative Postgres can't clean up for us. If this throws, nothing has been deleted yet: the
@@ -97,7 +168,10 @@ export async function purgeItemIds(
   const episodes = await retireEpisodesForItems(db, teamId, itemIds, { client: opts.client });
 
   for (const id of itemIds) {
-    const { error } = await db.from("items").delete().eq("id", id); // versions + chunks + facts cascade
+    // Team-scoped like the audit read above, deliberately: without it the delete's scope and the
+    // AUDIT's scope could diverge — a caller passing another team's id would have the row removed but
+    // its path filtered out of the record, so the primitive would delete more than it documents.
+    const { error } = await db.from("items").delete().eq("id", id).eq("team_id", teamId); // versions + chunks + facts cascade
     if (error) throw new Error(`purge item ${id}: ${error.message}`);
   }
 
@@ -111,7 +185,7 @@ export async function purgeItemIds(
     action: "items.purged",
     target_type: opts.scope ? "path_prefix" : "item_ids",
     target_id: opts.scope ?? `${itemIds.length} item(s)`,
-    meta: { reason, items: itemIds.length, episodes },
+    meta: buildPurgeMeta({ reason, items: itemIds.length, episodes, paths, readFailed }),
   });
 
   return { items: itemIds.length, episodes };

--- a/lib/ingest/purge.ts
+++ b/lib/ingest/purge.ts
@@ -47,7 +47,7 @@ export interface PurgeOptions {
  * recovery, so the escaping is unconditional rather than left to each caller. Postgres' default
  * LIKE escape character is `\`, which is why it needs escaping first.
  */
-function escapeLike(literal: string): string {
+export function escapeLike(literal: string): string {
   return literal.replace(/[\\%_]/g, (c) => `\\${c}`);
 }
 

--- a/lib/ingest/run.ts
+++ b/lib/ingest/run.ts
@@ -5,6 +5,7 @@ import type { DbClient } from "@/lib/db/types";
 import { adminClient } from "@/lib/db/admin";
 import { ingestItem } from "@/lib/ingest";
 import { purgeItemsByPathPrefix } from "@/lib/ingest/purge";
+import { purgeDeletedSlackThreads } from "@/lib/ingest/slack-cleanup";
 import { getEnabledIntegrationsWithSecrets } from "@/lib/integrations/manage";
 import { SlackClient, fetchSlackChannel, privateChannelAction } from "./sources/slack";
 import { normalizeThread, slackChannelPathPrefix } from "./sources/slack-normalize";
@@ -41,6 +42,8 @@ export interface IngestSummary {
   created: number;
   updated: number;
   unchanged: number;
+  /** Items REMOVED because the source no longer has them (a deleted Slack thread). */
+  deleted: number;
   errors: string[];
   skipped?: boolean;
 }
@@ -127,6 +130,7 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
     created: 0,
     updated: 0,
     unchanged: 0,
+    deleted: 0,
     errors: [],
   };
   if (running) return { ...empty, skipped: true };
@@ -249,6 +253,23 @@ export async function runSlackIngestion(opts: { teamId?: string } = {}): Promise
               if (res.status === "created") summary.created++;
               else if (res.status === "updated") summary.updated++;
               else summary.unchanged++;
+            }
+            // DELETED THREADS. Slack reports no deletion event, so "stored here, absent there" is
+            // the only signal — and it is trustworthy ONLY inside the window we actually read
+            // (see `planSlackDeletions`, where every guard is a bug that would otherwise happen).
+            try {
+              summary.deleted += await purgeDeletedSlackThreads(
+                db,
+                teamId,
+                channel,
+                client,
+                { memberId: auth.memberId, apiKeyId: auth.apiKeyId },
+                (notice) => summary.errors.push(notice)
+              );
+            } catch (err) {
+              summary.errors.push(
+                `${channelId}: deleted-thread cleanup failed — ${err instanceof Error ? err.message : "unknown"}`
+              );
             }
           } catch (err) {
             summary.errors.push(

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -132,12 +132,22 @@ export function startIngestScheduler(): void {
       // Source-specific extras: slack reports channels; the task importers report items/projects.
       const meta: Record<string, unknown> =
         "channels" in s
-          ? { integrations: s.integrations, channels: s.channels }
+          ? // `deleted` counts REMOVALS of stored content (threads deleted at the source).
+            // Recorded because destructive work must
+            // never be the one outcome the run log can't show — a purge that fires wrongly would
+            // otherwise be indistinguishable from a quiet sync.
+            {
+              integrations: s.integrations,
+              channels: s.channels,
+              ...(s.deleted ? { deleted: s.deleted } : {}),
+            }
           : { integrations: s.integrations, items: s.items, projects: s.projects };
-      if (s.created || s.updated || s.errors.length) {
+      const removed = "channels" in s ? s.deleted : 0;
+      if (s.created || s.updated || removed || s.errors.length) {
         const detail = "channels" in s ? `${s.channels} channels` : `${s.items} items, ${s.projects} projects`;
+        const removedNote = removed ? ` -${removed} deleted` : "";
         console.info(
-          `[ingest] ${label}: +${s.created} ~${s.updated} =${s.unchanged} (${detail}, ${s.integrations} integrations)` +
+          `[ingest] ${label}: +${s.created} ~${s.updated} =${s.unchanged}${removedNote} (${detail}, ${s.integrations} integrations)` +
             (s.errors.length ? ` errors: ${s.errors.join("; ")}` : "")
         );
       }

--- a/lib/ingest/slack-cleanup.ts
+++ b/lib/ingest/slack-cleanup.ts
@@ -1,0 +1,104 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { SlackError, type FetchedChannel, type SlackClient } from "./sources/slack";
+import { slackChannelPathPrefix } from "./sources/slack-normalize";
+import { planSlackDeletions, type StoredSlackThread } from "./sources/slack-deletions";
+import { escapeLike, purgeItemIds, type PurgeOptions } from "./purge";
+
+/**
+ * Remove the Slack threads a channel no longer has — the DB half of the deletion path (the decision
+ * itself is pure, in `slack-deletions`).
+ *
+ * This is the deleted-THREAD half. The deleted-MESSAGE half lives in the writer
+ * (`lib/ingest/forget-bodies`, driven by the source's `retainSupersededBodies` rule), because a
+ * thread's item body is the whole conversation: deleting one message self-heals the current body on
+ * the next sync, and what doesn't self-heal is the retained bodies in `item_versions`.
+ *
+ * Until now nothing removed a deleted thread at all: it stayed searchable, quotable in answers, and
+ * counted as credit, indefinitely. For a product ingesting a team's conversations, "the brain
+ * remembers what the source erased" is the wrong default.
+ */
+
+/** Threads currently stored for one channel, keyed by their Slack root `ts`. */
+export async function storedSlackThreads(
+  db: DbClient,
+  teamId: string,
+  channelId: string
+): Promise<StoredSlackThread[]> {
+  const { data, error } = await db
+    .from("items")
+    .select("id, frontmatter")
+    .eq("team_id", teamId)
+    .like("path", `${escapeLike(slackChannelPathPrefix(channelId))}%`);
+  if (error) throw new Error(`slack stored-thread read: ${error.message}`);
+  return ((data ?? []) as { id: string; frontmatter: Record<string, unknown> | null }[])
+    .map((r) => ({ id: r.id, ts: typeof r.frontmatter?.ts === "string" ? r.frontmatter.ts : "" }))
+    .filter((t) => t.ts !== "");
+}
+
+/**
+ * Purge every stored thread of `channel` that the source no longer has, and return how many went.
+ *
+ * Deliberately conservative at every turn: nothing is deleted unless the channel was actually read
+ * this tick, the thread is newer than the oldest message we saw, and it is absent from EVERY
+ * top-level message history returned (not the thinner ingestible set, and not the content-filtered
+ * roots). Keeping content a moment too long is recoverable; deleting a live thread is not.
+ *
+ * And then, having inferred all that, it ASKS SLACK before acting. `client` is required rather than
+ * optional precisely so no caller can quietly fall back to inference alone.
+ */
+export async function purgeDeletedSlackThreads(
+  db: DbClient,
+  teamId: string,
+  channel: FetchedChannel,
+  client: SlackClient,
+  actor?: PurgeOptions["actor"],
+  onNotice?: (message: string) => void
+): Promise<number> {
+  const stored = await storedSlackThreads(db, teamId, channel.channelId);
+  const plan = planSlackDeletions(channel, stored);
+  if (plan.itemIds.length === 0) return 0;
+
+  // POSITIVE CONFIRMATION before anything is deleted. Everything above infers deletion from ABSENCE,
+  // and absence is only as trustworthy as our model of what Slack puts in `history` — an assumption
+  // about a wire format, holding up an irreversible cascade through `item_versions` that would destroy
+  // the credit of every replier whose messages are still in Slack. So each candidate is checked
+  // against the source directly (`client.threadExists`) — Slack answers "is this really gone?"
+  // instead of us deducing it. Only a definite NO authorizes the delete; a live thread, or any error
+  // that means we couldn't ask, spares it.
+  const byId = new Map(stored.map((t) => [t.id, t.ts]));
+  const confirmed: string[] = [];
+  let unconfirmed = 0;
+  for (const id of plan.itemIds) {
+    const ts = byId.get(id);
+    if (!ts) continue;
+    try {
+      if (!(await client.threadExists(channel.channelId, ts))) confirmed.push(id);
+    } catch (err) {
+      // We failed to ASK Slack (ratelimited, a network blip, a lost scope). Never evidence of
+      // deletion, so the thread is spared and re-judged next tick.
+      //
+      // Narrowed to SlackError deliberately: a bare `catch {}` also swallows a TypeError from a
+      // client missing `threadExists`, which would turn this whole guard into a permanent silent
+      // no-op — safe in direction, but rotted with no signal and still green under most tests.
+      if (!(err instanceof SlackError)) throw err;
+      unconfirmed++;
+    }
+  }
+  // A confirmation that never succeeds means deletion is switched off for this channel. Silence there
+  // is the same failure as a silent purge, one sign flipped: "we deleted nothing" and "we could not
+  // check" must not look identical in the run log.
+  if (unconfirmed > 0) {
+    onNotice?.(
+      `${channel.channelId}: ${unconfirmed} deletion candidate(s) could not be confirmed with Slack — ` +
+        `kept (a failed check is not evidence of deletion)`
+    );
+  }
+  if (confirmed.length === 0) return 0;
+
+  const res = await purgeItemIds(db, teamId, confirmed, "deleted at the source (slack)", {
+    actor,
+    scope: slackChannelPathPrefix(channel.channelId),
+  });
+  return res.items;
+}

--- a/lib/ingest/source-rules.ts
+++ b/lib/ingest/source-rules.ts
@@ -35,6 +35,24 @@ export type WorkTimeEvidence = "work" | "noise";
 
 export interface SourceRules {
   workTimeOnUnchangedBody: WorkTimeEvidence;
+  /**
+   * May superseded bodies be RETAINED in `item_versions`?
+   *
+   * The default is `true` — history is worth keeping, and for a document whose old revisions were
+   * genuinely authored, the retained body is a real record.
+   *
+   * `false` is for sources whose item body is a **re-render of live, source-owned content that the
+   * source can retract**. A Slack thread is one item holding the whole conversation, rewritten every
+   * sync: delete a message and the current body self-heals, but every retained body still contains
+   * it — so the brain keeps, verbatim and indefinitely, text the author erased at the source. That
+   * isn't history, it's a copy the source no longer consents to.
+   *
+   * Only the BODY is cleared; the rows stay. `item_versions` is the work ledger — `member_id` +
+   * `created_at` attribute contributor credit, the timeline and arcs — and dropping rows would
+   * silently rewrite who did what. Nothing reads `item_versions.body`; it is history, not a served
+   * surface.
+   */
+  retainSupersededBodies: boolean;
 }
 
 /**
@@ -46,32 +64,37 @@ export interface SourceRules {
  */
 export const SOURCE_RULES: Readonly<Record<string, SourceRules>> = {
   // ── Event-shaped timestamps: the move IS the work ──────────────────────────────────────────────
-  /** Thread `ts` — immutable per thread; a new message changes the body anyway. */
-  slack: { workTimeOnUnchangedBody: "work" },
+  /** Thread `ts` — immutable per thread; a new message changes the body anyway.
+   *
+   *  `retainSupersededBodies: false` — the ONLY source that opts out today, and the reason is
+   *  deletion, not tidiness: one item holds the whole conversation and is re-rendered every sync, so
+   *  a message deleted at the source vanishes from the current body while every retained body still
+   *  quotes it verbatim, forever. */
+  slack: { workTimeOnUnchangedBody: "work", retainSupersededBodies: false },
   /** `committed_at` — immutable per commit. */
-  git: { workTimeOnUnchangedBody: "work" },
+  git: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
   /** Issue activity / a repo file's last commit. */
-  github: { workTimeOnUnchangedBody: "work" },
+  github: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
   /** `linearWorkedAt` = last state transition. A ticket reaching `completed` is work, and its doc
    *  body is unchanged — the exact case that makes "always preserve" wrong. */
-  linear: { workTimeOnUnchangedBody: "work" },
+  linear: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
   /** `planeWorkedAt` — same shape as Linear. */
-  plane: { workTimeOnUnchangedBody: "work" },
+  plane: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
   /** Meeting occurrence time. */
-  granola: { workTimeOnUnchangedBody: "work" },
+  granola: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
   /** The feed entry's own published/updated time — an event, not the scan's clock. */
-  radar: { workTimeOnUnchangedBody: "work" },
+  radar: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
 
   // ── Edit-shaped timestamps: a human edited the document, so still work ─────────────────────────
   // These bump on a metadata-only edit too (a Notion property, a Drive rename), which is weaker
   // evidence — but a human did touch the document, and demoting them would hide real editing work.
   // Left as "work" deliberately rather than guessed into "noise".
-  notion: { workTimeOnUnchangedBody: "work" },
-  gdrive: { workTimeOnUnchangedBody: "work" },
-  confluence: { workTimeOnUnchangedBody: "work" },
+  notion: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
+  gdrive: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
+  confluence: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
   /** Moot today — `web.py` emits no timestamp at all. Classified so the guard stays satisfied;
    *  revisit if it ever grows one, since a FETCH time would be noise-shaped, not work-shaped. */
-  web: { workTimeOnUnchangedBody: "work" },
+  web: { workTimeOnUnchangedBody: "work", retainSupersededBodies: true },
 
   // ── Storage-shaped timestamps: not evidence of anything ────────────────────────────────────────
   /** mtime. `touch`, `rsync`, `chmod`, a checkout, a backup restore — all move it with no author and
@@ -81,7 +104,7 @@ export const SOURCE_RULES: Readonly<Record<string, SourceRules>> = {
    *  freeze is direction-agnostic, so an item whose stored frontmatter carries NO work-time (a row
    *  pushed before `local.py` emitted `source_ts`) stays on the `created_at` fallback until someone
    *  actually edits the file. A backward correction is refused for the same reason. */
-  local: { workTimeOnUnchangedBody: "noise" },
+  local: { workTimeOnUnchangedBody: "noise", retainSupersededBodies: true },
 };
 
 /**
@@ -92,5 +115,5 @@ export const SOURCE_RULES: Readonly<Record<string, SourceRules>> = {
  */
 export function sourceRules(source: unknown): SourceRules {
   const key = typeof source === "string" ? source.toLowerCase().trim() : "";
-  return SOURCE_RULES[key] ?? { workTimeOnUnchangedBody: "work" };
+  return SOURCE_RULES[key] ?? { workTimeOnUnchangedBody: "work", retainSupersededBodies: true };
 }

--- a/lib/ingest/sources/slack-deletions.ts
+++ b/lib/ingest/sources/slack-deletions.ts
@@ -1,0 +1,85 @@
+import type { FetchedChannel } from "./slack";
+
+/**
+ * WHICH STORED SLACK THREADS WERE DELETED AT THE SOURCE — pure, so the branch that deletes user data
+ * is pinned by tests rather than reasoned about inside the runner's loop.
+ *
+ * Slack does not report deletions; a deleted message is simply absent from the next `history` call.
+ * So the signal is "stored here, not there" — and read naively that signal is catastrophic, because
+ * a thread is ALSO absent for the entirely innocent reason that it is older than the 300-message
+ * window we read. A bare set-difference would delete the channel's whole history on the first tick,
+ * every tick.
+ *
+ * Three conditions therefore gate every deletion, and each one is a bug that would otherwise happen:
+ *
+ *  1. **The window must have a floor.** Only a stored thread strictly NEWER than the oldest message
+ *     actually read can be judged; everything older was never looked at. A channel that returned no
+ *     history at all has no floor, so nothing is deletable.
+ *  2. **The live set is EVERY top-level message in history** — not the ingestible `threads`, and not
+ *     even the content-filtered roots. A thread whose replies failed to fetch is dropped from
+ *     `threads` (#388) while being demonstrably alive; a TOMBSTONED root (what Slack leaves when a
+ *     thread's first message is deleted but its replies live on) fails the render filter while the
+ *     thread plainly still exists. Judging existence by either narrower list deletes live data —
+ *     and in the tombstone case it cascades `item_versions`, destroying the credit of every replier
+ *     whose messages are still in Slack.
+ */
+
+export interface StoredSlackThread {
+  id: string;
+  /** The thread root's Slack `ts` — `frontmatter.ts`, which is also the item's path segment. */
+  ts: string;
+}
+
+export interface DeletionPlan {
+  /** Item ids whose thread is gone from the source and is inside the window we can judge. */
+  itemIds: string[];
+  /** Stored threads that were NOT judged, because they predate the window. Reported, not hidden:
+   *  it is the difference between "nothing was deleted" and "we couldn't see that far back". */
+  outOfWindow: number;
+  /** Set when deletion was disabled wholesale this tick, with the reason. */
+  disabledReason?: string;
+}
+
+/**
+ * Compare what the source still has against what we stored. Never throws; returns an empty plan
+ * whenever the evidence is insufficient, because the failure direction matters: keeping content a
+ * moment too long is recoverable, deleting a live thread is not.
+ */
+export function planSlackDeletions(
+  channel: Pick<FetchedChannel, "liveRootTs" | "oldestTs" | "skippedPrivate">,
+  stored: readonly StoredSlackThread[]
+): DeletionPlan {
+  if (channel.skippedPrivate) {
+    // The channel was never read this tick, so absence means nothing. (A confirmed-private channel
+    // is purged wholesale by its own path — that is a privacy decision, not a deletion diff.)
+    return { itemIds: [], outOfWindow: stored.length, disabledReason: "channel not read this tick" };
+  }
+  if (!channel.oldestTs || !channel.liveRootTs) {
+    return {
+      itemIds: [],
+      outOfWindow: stored.length,
+      disabledReason: "no history read — every stored thread would look deleted",
+    };
+  }
+
+  const live = new Set(channel.liveRootTs);
+  const floor = Number.parseFloat(channel.oldestTs);
+  if (!Number.isFinite(floor)) {
+    return { itemIds: [], outOfWindow: stored.length, disabledReason: "unparseable window floor" };
+  }
+
+  const itemIds: string[] = [];
+  let outOfWindow = 0;
+  for (const item of stored) {
+    if (live.has(item.ts)) continue;
+    const ts = Number.parseFloat(item.ts);
+    // An unparseable stored ts can't be placed in the window, so it can't be judged — treat it the
+    // same as out-of-window rather than guessing it away.
+    if (!Number.isFinite(ts) || ts <= floor) {
+      outOfWindow++;
+      continue;
+    }
+    itemIds.push(item.id);
+  }
+  return { itemIds, outOfWindow };
+}

--- a/lib/ingest/sources/slack-normalize.ts
+++ b/lib/ingest/sources/slack-normalize.ts
@@ -50,10 +50,16 @@ function renderText(text: string, users: Record<string, string>): string {
     .replace(/<(https?:[^>]+)>/g, (_m, url: string) => url);
 }
 
+/** Stands in for a message that exists at the source but whose text is gone (deleted, or edited
+ *  away). Rendering the placeholder — rather than skipping the message — is what makes the stored
+ *  body stop serving retracted text while keeping the conversation's shape and its repliers. */
+export const REDACTED_MESSAGE = "_[message deleted]_";
+
 function renderMessage(m: SlackMessage, opts: NormalizeOpts): string {
   const author = (m.user && opts.users[m.user]) || m.user || "unknown";
   const when = tsToIso(m.ts);
-  return `**${author}**${when ? ` · ${when}` : ""}\n\n${renderText(m.text ?? "", opts.users)}`;
+  const text = m.text?.trim() ? renderText(m.text, opts.users) : REDACTED_MESSAGE;
+  return `**${author}**${when ? ` · ${when}` : ""}\n\n${text}`;
 }
 
 /** One thread PARTICIPANT — a distinct message author across the root + replies, with how much and when

--- a/lib/ingest/sources/slack.ts
+++ b/lib/ingest/sources/slack.ts
@@ -46,9 +46,22 @@ export interface FetchedChannel {
    *  "wait a tick" (`ratelimited`) from "frozen forever" (lost access / `thread_not_found`) — which
    *  is the entire triage question a skip raises. */
   skippedThreadsReason?: string;
+  /** EVERY top-level message seen in this window's history — the "still EXISTS at the source" set
+   *  the deletion diff reads. Deliberately wider than `threads` (which drops a thread whose replies
+   *  wouldn't fetch) and wider than the render filter (a tombstoned or text-less root is still a
+   *  thread): either narrower list would delete live data. */
+  liveRootTs?: string[];
+  /** Timestamp of the OLDEST message read this tick — the deletion diff's floor. Undefined when the
+   *  channel returned no history at all, which must disable deletion entirely. */
+  oldestTs?: string;
 }
 
 export class SlackError extends Error {}
+
+/** Page cap for a single thread's replies — a backstop against a pathological thread, not a limit
+ *  we expect to reach (200 replies per page). Hitting it throws, so the thread is skipped rather
+ *  than stored truncated. */
+const REPLIES_MAX_PAGES = 25;
 
 /** What the runner does about a channel `fetchSlackChannel` refused to read. */
 export interface PrivateChannelAction {
@@ -196,13 +209,66 @@ export class SlackClient {
     return out;
   }
 
-  /** Thread replies (excludes the root message). */
+  /**
+   * Thread replies (excludes the root message), PAGINATED to completion.
+   *
+   * Following the cursor is not an optimization — a thread's body is the whole conversation, so a
+   * short page is a silent content regression: the stored item is rewritten missing its tail, and
+   * (worse, now) the shrink it fakes looks exactly like someone deleting messages at the source.
+   * That is the same failure #388 closed for a THROWN replies error, arriving through a successful
+   * response. A page cap bounds a pathological thread rather than looping forever; hitting it throws,
+   * so the caller skips the thread instead of storing a truncated body.
+   */
   async replies(channelId: string, threadTs: string): Promise<SlackMessage[]> {
-    const r = await this.call<{ messages: SlackMessage[] }>("conversations.replies", {
-      channel: channelId,
-      ts: threadTs,
-    });
-    return (r.messages ?? []).filter((m) => m.ts !== threadTs);
+    const out: SlackMessage[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < REPLIES_MAX_PAGES; page++) {
+      const params: Record<string, string> = { channel: channelId, ts: threadTs, limit: "200" };
+      if (cursor) params.cursor = cursor;
+      const r = await this.call<{
+        messages: SlackMessage[];
+        has_more?: boolean;
+        response_metadata?: { next_cursor?: string };
+      }>("conversations.replies", params);
+      out.push(...(r.messages ?? []));
+      cursor = r.response_metadata?.next_cursor || undefined;
+      if (!cursor) {
+        // `has_more` with no cursor to follow means we CANNOT complete the thread. Throwing routes
+        // it into the existing skip-the-thread path rather than storing what we happen to have.
+        if (r.has_more) throw new SlackError(`slack conversations.replies incomplete: has_more with no cursor`);
+        return out.filter((m) => m.ts !== threadTs);
+      }
+    }
+    throw new SlackError(`slack conversations.replies exceeded ${REPLIES_MAX_PAGES} pages`);
+  }
+
+  /**
+   * Does anything still exist at `ts` in this channel? The DELETION CONFIRMATION — the only thing
+   * that authorizes removing stored content, so it is deliberately a separate method rather than a
+   * flag on `replies()`.
+   *
+   * The distinction matters and is easy to get wrong: `replies()` strips the root (`m.ts !== threadTs`)
+   * because callers want the replies *around* a root they already hold. Reusing it here would read a
+   * LIVE STANDALONE message — which `conversations.replies` returns as exactly one message, the root —
+   * as "nothing there", and confirm a deletion that never happened. That is the precise case the
+   * confirmation exists to prevent, so this counts the RAW response.
+   *
+   * `thread_not_found` / `message_not_found` is Slack stating the content is gone → false. Every other
+   * error propagates: not being able to ask is never evidence, and the caller must spare the thread.
+   */
+  async threadExists(channelId: string, ts: string): Promise<boolean> {
+    try {
+      const r = await this.call<{ messages?: SlackMessage[] }>("conversations.replies", {
+        channel: channelId,
+        ts,
+        limit: "1",
+      });
+      return (r.messages ?? []).length > 0;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "";
+      if (/thread_not_found|message_not_found/i.test(msg)) return false;
+      throw err;
+    }
   }
 
   /**
@@ -307,15 +373,50 @@ export async function fetchSlackChannel(
   }
 
   const history = await client.history(channelId, max);
-  // Top-level messages only (a reply has thread_ts !== ts). Roots keep their thread.
-  const roots = history.filter((m) => isContentMessage(m) && (!m.thread_ts || m.thread_ts === m.ts));
+  const isTopLevel = (m: SlackMessage) => !m.thread_ts || m.thread_ts === m.ts;
+  // A top-level message that still EXISTS but has no renderable text: Slack leaves this behind when
+  // a thread's root is deleted while its replies live on (a tombstone), or when the author edits the
+  // text away. It must stay INGESTIBLE — the item's body is the served surface, so a thread that is
+  // kept (correctly) but never re-rendered would go on quoting the deleted root forever, which is a
+  // worse leak than the version history this feature is about. `reply_count > 0` bounds it to threads
+  // that actually exist: a bare text-less message is not a conversation and must not become an item.
+  // Slack's structural events (channel_join/topic/…) all carry text, so they are excluded already.
+  //
+  // Recognised by ANY of three signals, because none is guaranteed and requiring all of them drops
+  // silently back to the frozen-body bug:
+  //  • `subtype === "tombstone"` — Slack's own marker, and the one that matters most: a REAL tombstone
+  //    carries `text: "This message was deleted."`, so a `!text` test alone never fires on the actual
+  //    payload. Testing the text was an assumption about the wire format; this tests what Slack says.
+  //  • no renderable text — a root edited down to a file/attachment with no caption.
+  //  • `reply_count > 0` / `thread_ts === ts` — "this is a conversation, not a bare message". A
+  //    standalone message carries no `thread_ts` at all (see `isTopLevel`), so the self-reference is
+  //    an independent root signal for the case where Slack drops `reply_count`.
+  // Structural events (channel_join/topic/…) carry text and a non-tombstone subtype, so they stay out.
+  const isThreadRoot = (m: SlackMessage) => (m.reply_count ?? 0) > 0 || m.thread_ts === m.ts;
+  const isRedactedRoot = (m: SlackMessage) =>
+    (m.subtype === "tombstone" || !m.text?.trim()) && isThreadRoot(m);
+  // Two DIFFERENT questions, and conflating them deletes live data:
+  //  • `liveTopLevelTs` — "does this thread still EXIST at the source?" Every top-level message
+  //    counts, with NO content filter. Slack leaves a tombstone in history when a thread root is
+  //    deleted while its replies live on, and an author can edit a root down to a file with no text
+  //    — both fail `isContentMessage`. Judging existence by the render filter would purge those
+  //    threads, taking `item_versions` with them and destroying the credit of every replier whose
+  //    messages are still in Slack.
+  //  • `roots` — "is this thread INGESTIBLE this tick?" That one is content-filtered, as before.
+  const liveTopLevelTs = history.filter(isTopLevel).map((m) => m.ts);
+  const roots = history.filter((m) => isTopLevel(m) && (isContentMessage(m) || isRedactedRoot(m)));
 
   const threads: FetchedThread[] = [];
   let skippedThreads = 0;
   let skippedThreadsReason: string | undefined;
   for (const root of roots) {
     let replies: SlackMessage[] = [];
-    if (root.reply_count && root.reply_count > 0) {
+    // Admitting a root WITHOUT fetching its replies is worse than not admitting it at all: the
+    // re-render would produce a placeholder-only body, overwrite the stored full conversation, and
+    // `forgetSupersededBodies` would then blank the superseded body — erasing replies that are still
+    // live in Slack from every stored surface. A redacted root is admitted precisely when
+    // `reply_count` may be missing, so it must drive the fetch too.
+    if ((root.reply_count ?? 0) > 0 || isRedactedRoot(root)) {
       try {
         replies = (await client.replies(channelId, root.ts)).filter(isContentMessage);
       } catch (err) {
@@ -331,5 +432,24 @@ export async function fetchSlackChannel(
     }
     threads.push({ root, replies });
   }
-  return { channelId, channelName, threads, users, skippedThreads, skippedThreadsReason };
+  // The DELETION WINDOW. A thread stored under this channel but absent from `liveRootTs` is either
+  // (a) deleted at the source or (b) simply older than the `maxMessages` window — and treating (b)
+  // as (a) would delete the channel's entire history on every tick. `oldestTs` is what separates
+  // them: only a stored thread NEWER than the oldest message we actually read can be judged.
+  //
+  // `liveRootTs` is EVERY top-level message in history, not `threads` and not even `roots` — a
+  // thread whose replies failed to fetch is skipped from `threads` but is demonstrably still alive,
+  // and a tombstoned/text-less root is still a thread that exists. Both narrower lists would delete
+  // live data.
+  const oldest = history.length > 0 ? history[history.length - 1].ts : undefined;
+  return {
+    channelId,
+    channelName,
+    threads,
+    users,
+    skippedThreads,
+    skippedThreadsReason,
+    liveRootTs: liveTopLevelTs,
+    oldestTs: oldest,
+  };
 }

--- a/test/datamechanics/graph-project.datamechanics.test.ts
+++ b/test/datamechanics/graph-project.datamechanics.test.ts
@@ -976,3 +976,93 @@ describe("purge vs a racing projector (real Postgres, mocked Graphiti)", () => {
     expect(r.group_id).not.toBe(externalGroup);
   });
 });
+
+/**
+ * Spec: for a source whose body is a re-render of content the source can RETRACT (Slack), a re-push
+ * must REPLACE its episodes, not append to them.
+ *
+ * `addEpisodes` does not overwrite by name — Graphiti keeps the old episode and the facts extracted
+ * from it. So a message deleted in Slack would keep answering questions through the graph after
+ * Postgres had forgotten it, on the surface that is actually served. Shrinking past a chunk boundary
+ * is worse: the orphan tail episode isn't even overwritten in name.
+ */
+describe("retractable sources replace their episodes (real Postgres, mocked Graphiti)", () => {
+  it("drops the pre-edit episode when a slack thread's body changes", async () => {
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const group = `${slug}_team`;
+    const fake = new FakeGraphiti();
+
+    await ingest(seed, {
+      kind: "transcript", path: "slack/c0pub/1.md", access: "team",
+      body: "root\n\n---\n\nsecret reply", frontmatter: { source: "slack" },
+    });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+    expect(await fake.listEpisodes(group)).toHaveLength(1);
+
+    // The reply is deleted at the source; the next sync re-renders the thread without it.
+    await ingest(seed, {
+      kind: "transcript", path: "slack/c0pub/1.md", access: "team",
+      body: "root", frontmatter: { source: "slack" },
+    });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    const after = await fake.listEpisodes(group);
+    expect(after).toHaveLength(1); // replaced, not appended
+    expect(fake.pushes.at(-1)?.episodes[0].content).toContain("root");
+    expect(fake.pushes.at(-1)?.episodes[0].content).not.toContain("secret reply");
+  });
+
+  it("records a pending cleanup when the retract-delete FAILS, so it isn't stranded", async () => {
+    // `addEpisodes` lands regardless, so a swallowed failure leaves the pre-deletion episode in the
+    // graph with a fresh sha on the ledger: the landed check is satisfied by the new push, orphan
+    // repair needs the item to be GONE, and no flag was recorded — nothing would ever revisit it, and
+    // the retracted text keeps answering questions forever.
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const group = `${slug}_team`;
+    const fake = new FakeGraphiti();
+
+    await ingest(seed, {
+      kind: "transcript", path: "slack/c0pub/1.md", access: "team",
+      body: "root\n\n---\n\nsecret reply", frontmatter: { source: "slack" },
+    });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    fake.failDeletes = true; // Graphiti blips exactly when the retract-delete runs
+    await ingest(seed, {
+      kind: "transcript", path: "slack/c0pub/1.md", access: "team",
+      body: "root", frontmatter: { source: "slack" },
+    });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    const { data: row } = await db()
+      .from("graph_episodes")
+      .select("pending_delete_group_id")
+      .eq("team_id", seed.teamId)
+      .maybeSingle();
+    expect((row as { pending_delete_group_id: string | null }).pending_delete_group_id).toBe(group);
+
+    // …and it converges: the next pass retries the delete and only then clears the flag.
+    fake.failDeletes = false;
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+    const remaining = await fake.listEpisodes(group);
+    expect(remaining).toHaveLength(1);
+    expect(fake.pushes.at(-1)?.episodes[0].content).not.toContain("secret reply");
+  });
+
+  it("keeps appending for an ordinary source (the rule is per-source, not global)", async () => {
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const group = `${slug}_team`;
+    const fake = new FakeGraphiti();
+
+    await ingest(seed, { kind: "deliverable", path: "docs/spec.md", access: "team", body: "v1", frontmatter: { source: "notion" } });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+    await ingest(seed, { kind: "deliverable", path: "docs/spec.md", access: "team", body: "v2", frontmatter: { source: "notion" } });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    // Unchanged behaviour: a document's revisions are genuine history, so nothing is retracted.
+    expect(await fake.listEpisodes(group)).toHaveLength(2);
+  });
+});

--- a/test/datamechanics/purge-items.datamechanics.test.ts
+++ b/test/datamechanics/purge-items.datamechanics.test.ts
@@ -143,4 +143,24 @@ describe("purgeItemsByPathPrefix (real Postgres)", () => {
     expect(row?.meta?.reason).toBe("slack channel is private");
     expect(row?.meta?.items).toBe(1);
   });
+
+  it("records WHICH paths went, not just how many", async () => {
+    // The rows are the only record of their own paths, so a count-and-prefix audit makes the question
+    // "what did this purge remove?" unanswerable the moment the cascade runs. That's the wrong trade
+    // for the one irreversible operation in the ingest path.
+    const seed = await seedTeam();
+    for (const p of ["slack/c0x/2.md", "slack/c0x/1.md"]) {
+      await ingest(seed, { path: p, project: "slack", kind: "transcript", access: "team", body: p });
+    }
+    await ingest(seed, { path: "slack/c0keep/1.md", project: "slack", kind: "transcript", access: "team", body: "keep" });
+
+    await purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0x/", "deleted at the source (slack)");
+
+    const { data } = await db().from("audit_log").select("action, meta").eq("team_id", seed.teamId);
+    const row = (data ?? []).find((r) => (r as { action: string }).action === "items.purged") as
+      | { meta: Record<string, unknown> }
+      | undefined;
+    expect(row?.meta?.paths).toEqual(["slack/c0x/1.md", "slack/c0x/2.md"]); // sorted, and only these
+    expect(row?.meta?.paths_truncated).toBeUndefined();
+  });
 });

--- a/test/datamechanics/slack-deletions.datamechanics.test.ts
+++ b/test/datamechanics/slack-deletions.datamechanics.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import type { FetchedChannel } from "@/lib/ingest/sources/slack";
+import { purgeDeletedSlackThreads, storedSlackThreads } from "@/lib/ingest/slack-cleanup";
+import { SlackError, type SlackClient } from "@/lib/ingest/sources/slack";
+import { db, seedTeam, ingest, type Seed } from "./helpers";
+
+/**
+ * A Slack stub for the CONFIRMATION step. `purgeDeletedSlackThreads` doesn't act on the absence
+ * inference alone — it asks Slack whether each candidate thread is really gone — so every test here
+ * must say what Slack would answer. `gone` is the confirming answer (`thread_not_found`).
+ */
+function slackStub(answer: "gone" | "alive" | "error"): SlackClient & { calls: () => number } {
+  let calls = 0;
+  const stub = {
+    threadExists: async () => {
+      calls++;
+      if (answer === "error") throw new SlackError("slack conversations.replies failed: ratelimited");
+      return answer === "alive";
+    },
+    calls: () => calls,
+  };
+  return stub as unknown as SlackClient & { calls: () => number };
+}
+
+/**
+ * Spec: what Slack no longer has, the brain no longer has.
+ *
+ * Two halves, because a Slack thread is ONE item whose body is the whole conversation:
+ *  • a deleted THREAD leaves nothing behind to re-render, so the item itself must go;
+ *  • a deleted MESSAGE self-heals in the current body on the next sync — but `item_versions`
+ *    retains every superseded body, so the erased text lives on in the store. That retention is
+ *    invisible except against a real database, which is why this is here and not a unit test.
+ */
+
+const CHANNEL = "C0PUB";
+const PREFIX = "slack/c0pub/";
+const T = { old: "1750000000.000100", mid: "1780000000.000100", new: "1790000000.000100" };
+
+function channel(over: Partial<FetchedChannel>): FetchedChannel {
+  return {
+    channelId: CHANNEL,
+    channelName: "general",
+    threads: [],
+    users: {},
+    skippedThreads: 0,
+    ...over,
+  };
+}
+
+async function ingestThread(seed: Seed, ts: string, body: string) {
+  return ingest(seed, {
+    path: `${PREFIX}${ts}.md`,
+    project: "slack",
+    kind: "transcript",
+    access: "team",
+    body,
+    frontmatter: { source: "slack", channel_id: CHANNEL, ts },
+  });
+}
+
+async function paths(seed: Seed): Promise<string[]> {
+  const { data } = await db().from("items").select("path").eq("team_id", seed.teamId);
+  return (data ?? []).map((r) => (r as { path: string }).path).sort();
+}
+
+describe("slack deletions (real Postgres)", () => {
+  it("removes a thread the source no longer has", async () => {
+    const seed = await seedTeam();
+    await ingestThread(seed, T.mid, "still there");
+    await ingestThread(seed, T.new, "deleted at the source");
+
+    const removed = await purgeDeletedSlackThreads(
+      db(),
+      seed.teamId,
+      channel({ liveRootTs: [T.mid], oldestTs: T.old }),
+      slackStub("gone")
+    );
+
+    expect(removed).toBe(1);
+    expect(await paths(seed)).toEqual([`${PREFIX}${T.mid}.md`]);
+  });
+
+  it("keeps every thread older than the window, even though all are 'absent'", async () => {
+    // The failure this exists to prevent: reading "absent" as "deleted" wipes the channel's whole
+    // history on the very first tick, because the 300-message window never reaches back that far.
+    const seed = await seedTeam();
+    await ingestThread(seed, T.old, "ancient but alive");
+    await ingestThread(seed, T.mid, "also alive");
+
+    const removed = await purgeDeletedSlackThreads(
+      db(),
+      seed.teamId,
+      channel({ liveRootTs: [], oldestTs: T.new }),
+      slackStub("gone")
+    );
+
+    expect(removed).toBe(0);
+    expect(await paths(seed)).toHaveLength(2);
+  });
+
+  it("reads the stored threads' ts back off the frontmatter", async () => {
+    const seed = await seedTeam();
+    await ingestThread(seed, T.mid, "body");
+    const stored = await storedSlackThreads(db(), seed.teamId, CHANNEL);
+    expect(stored).toEqual([{ id: expect.any(String), ts: T.mid }]);
+  });
+
+  it("a message deleted at the source leaves NO copy in the retained bodies", async () => {
+    const seed = await seedTeam();
+    const item = await ingestThread(seed, T.mid, "root\n\n---\n\nsecret reply nobody should keep");
+    // The next sync re-renders the thread WITHOUT the deleted reply. The current body self-heals…
+    await ingestThread(seed, T.mid, "root");
+
+    const { data } = await db()
+      .from("item_versions")
+      .select("id, body, member_id")
+      .eq("item_id", item.id);
+    const rows = (data ?? []) as { id: string; body: string; member_id: string | null }[];
+
+    // …and the superseded body no longer quotes it. Without the rule this row still holds the text
+    // the author erased, verbatim, forever.
+    expect(rows).toHaveLength(2);
+    expect(rows.some((r) => r.body.includes("secret reply"))).toBe(false);
+
+    // The ROWS survive with their attribution: `item_versions` is the work ledger behind contributor
+    // credit, the timeline and arcs — dropping rows would silently rewrite who did what.
+    expect(rows.every((r) => r.member_id !== null)).toBe(true);
+    // The CURRENT version keeps its body — that content is still live at the source.
+    expect(rows.filter((r) => r.body === "root")).toHaveLength(1);
+    const { data: live } = await db().from("items").select("body").eq("id", item.id).maybeSingle();
+    expect((live as { body: string }).body).toBe("root");
+  });
+
+  it("does NOT forget history for a source whose old revisions were genuinely authored", async () => {
+    // The rule is per-source, and the default is to keep history. A document's superseded revisions
+    // are a real record; only a re-render of retractable source-owned content opts out.
+    const seed = await seedTeam();
+    const doc = await ingest(seed, {
+      path: "docs/spec.md", project: "acme", kind: "deliverable", access: "team",
+      body: "draft one", frontmatter: { source: "notion" },
+    });
+    await ingest(seed, {
+      path: "docs/spec.md", project: "acme", kind: "deliverable", access: "team",
+      body: "draft two", frontmatter: { source: "notion" },
+    });
+    const { data } = await db().from("item_versions").select("body").eq("item_id", doc.id);
+    expect((data ?? []).map((r) => (r as { body: string }).body).sort()).toEqual(["draft one", "draft two"]);
+  });
+
+  it("a body that REVERTS to an earlier one leaves only content that is still live", async () => {
+    // A→B→A is the exact Slack shape (reply added, then deleted). `keepSha` spares every row matching
+    // the just-written sha rather than just the newest, which is what keeps this coherent: the older
+    // A row is spared too, and its body is byte-identical to what is live. (It was already blanked
+    // when B superseded it — forgetting is one-way — so what survives is only ever content the source
+    // still has, which is the invariant that actually matters.)
+    const seed = await seedTeam();
+    const item = await ingestThread(seed, T.mid, "root");
+    await ingestThread(seed, T.mid, "root\n\n---\n\ntransient reply");
+    await ingestThread(seed, T.mid, "root");
+
+    const { data } = await db().from("item_versions").select("body").eq("item_id", item.id);
+    const bodies = (data ?? []).map((r) => (r as { body: string }).body);
+    expect(bodies.some((b) => b.includes("transient reply"))).toBe(false); // retracted → gone
+    expect(bodies).toContain("root"); // live content → kept
+    expect(bodies).toHaveLength(3); // three pushes, three ledger rows: credit is never rewritten
+  });
+
+  it("a purged thread takes its retained bodies with it (cascade), not just the live row", async () => {
+    const seed = await seedTeam();
+    const gone = await ingestThread(seed, T.new, "v1");
+    await ingestThread(seed, T.new, "v2 — edited");
+
+    await purgeDeletedSlackThreads(db(), seed.teamId, channel({ liveRootTs: [], oldestTs: T.mid }), slackStub("gone"));
+
+    const { data } = await db().from("item_versions").select("id").eq("item_id", gone.id);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  /**
+   * The absence inference is only as good as our model of what Slack puts in `history` — an
+   * assumption about a wire format holding up an irreversible cascade through `item_versions`. So the
+   * purge ASKS. Only Slack saying the thread is gone authorizes the delete.
+   */
+  it("spares a candidate that Slack says is still there", async () => {
+    const seed = await seedTeam();
+    const alive = await ingestThread(seed, T.mid, "absent from history, but not actually deleted");
+
+    const slack = slackStub("alive");
+    const removed = await purgeDeletedSlackThreads(
+      db(),
+      seed.teamId,
+      channel({ liveRootTs: [], oldestTs: T.old }),
+      slack
+    );
+
+    // Assert the confirmation actually RAN. Without this the test passes for the wrong reason — a
+    // renamed/missing `threadExists` throws, the catch spares everything, and "spared" looks correct
+    // while the guard is gone.
+    expect(slack.calls()).toBe(1);
+    expect(removed).toBe(0);
+    const { data } = await db().from("items").select("id").eq("id", alive.id);
+    expect(data ?? []).toHaveLength(1);
+  });
+
+  it("spares a candidate when Slack could not be asked (an error is not evidence)", async () => {
+    const seed = await seedTeam();
+    const spared = await ingestThread(seed, T.mid, "unconfirmed");
+
+    const slack = slackStub("error");
+    const removed = await purgeDeletedSlackThreads(
+      db(),
+      seed.teamId,
+      channel({ liveRootTs: [], oldestTs: T.old }),
+      slack
+    );
+
+    expect(slack.calls()).toBe(1); // it asked, and the ASKING failed — not a skipped check
+    expect(removed).toBe(0);
+    const { data } = await db().from("items").select("id").eq("id", spared.id);
+    expect(data ?? []).toHaveLength(1);
+  });
+});

--- a/test/ingest-purge-meta.test.ts
+++ b/test/ingest-purge-meta.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { buildPurgeMeta } from "@/lib/ingest/purge";
+
+/**
+ * Spec: a purge's audit row must be able to answer "what did this remove?".
+ *
+ * The rows are the only record of their own paths, so once the cascade runs the question has no answer
+ * anywhere else. This was found the hard way — the first live purge in prod took a Slack thread and
+ * nothing on the box could say which one — so the recorded shape is pinned here rather than left to
+ * whatever the writer happens to emit.
+ *
+ * Unit tier because the meta is pure: the truncation and read-failure branches are otherwise only
+ * reachable by seeding hundreds of rows or forcing a DB error in the real-DB tier, which is how an
+ * off-by-one ships green.
+ */
+
+const base = { reason: "deleted at the source (slack)", episodes: 0, readFailed: false };
+
+describe("buildPurgeMeta", () => {
+  it("records every path when the list is small, and no truncation marker", () => {
+    const meta = buildPurgeMeta({ ...base, items: 2, paths: ["slack/c/1.md", "slack/c/2.md"] });
+    expect(meta.paths).toEqual(["slack/c/1.md", "slack/c/2.md"]);
+    expect(meta.paths_truncated).toBeUndefined();
+    expect(meta.paths_read_failed).toBeUndefined();
+  });
+
+  it("caps the list and reports exactly how many it left out", () => {
+    const paths = Array.from({ length: 250 }, (_, i) => `slack/c/${String(i).padStart(4, "0")}.md`);
+    const meta = buildPurgeMeta({ ...base, items: 250, paths });
+    expect((meta.paths as string[]).length).toBe(200);
+    expect(meta.paths_truncated).toBe(50); // 250 - 200, not an off-by-one
+    expect(meta.items).toBe(250); // the COUNT stays authoritative
+  });
+
+  it("emits no truncation marker at exactly the cap (the off-by-one boundary)", () => {
+    const paths = Array.from({ length: 200 }, (_, i) => `slack/c/${i}.md`);
+    const meta = buildPurgeMeta({ ...base, items: 200, paths });
+    expect((meta.paths as string[]).length).toBe(200);
+    expect(meta.paths_truncated).toBeUndefined(); // NOT `0` — an absent marker means "nothing omitted"
+  });
+
+  it("MARKS a failed path read instead of leaving an empty list to be misread", () => {
+    // `paths: []` with no marker is indistinguishable from a build that never recorded paths — which
+    // would recreate the exact blind spot this field exists to close.
+    const meta = buildPurgeMeta({ ...base, items: 3, paths: [], readFailed: true });
+    expect(meta.paths).toEqual([]);
+    expect(meta.paths_read_failed).toBe(true);
+    expect(meta.items).toBe(3); // we still know how much went
+  });
+
+  it("marks a PARTIAL read too — what was read is kept, and the gap is still flagged", () => {
+    const meta = buildPurgeMeta({ ...base, items: 5, paths: ["slack/c/1.md"], readFailed: true });
+    expect(meta.paths).toEqual(["slack/c/1.md"]);
+    expect(meta.paths_read_failed).toBe(true);
+  });
+});

--- a/test/ingest-slack-deletions.test.ts
+++ b/test/ingest-slack-deletions.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { planSlackDeletions, type StoredSlackThread } from "@/lib/ingest/sources/slack-deletions";
+
+/**
+ * Spec: a Slack thread deleted at the source must leave the brain — and NOTHING else may.
+ *
+ * Slack reports no deletion event, so the only available signal is "stored here, absent there". Read
+ * naively that signal is catastrophic: a thread is also absent for the entirely innocent reason that
+ * it is older than the 300-message window we read, so a bare set-difference deletes the channel's
+ * whole history on the first tick, and every tick after.
+ *
+ * These cases are therefore mostly about what must NOT be deleted. The asymmetry is deliberate:
+ * keeping content a moment too long is recoverable; deleting a live thread is not.
+ */
+
+const stored = (ts: string, id = `item-${ts}`): StoredSlackThread => ({ id, ts });
+
+/** Slack `ts` is "<epoch seconds>.<sequence>" and sorts numerically. */
+const T = {
+  ancient: "1700000000.000100",
+  old: "1750000000.000100",
+  mid: "1780000000.000100",
+  new: "1790000000.000100",
+};
+
+describe("planSlackDeletions", () => {
+  it("deletes a thread the source no longer has, inside the window", () => {
+    const plan = planSlackDeletions(
+      { liveRootTs: [T.mid], oldestTs: T.old },
+      [stored(T.mid), stored(T.new)]
+    );
+    expect(plan.itemIds).toEqual([`item-${T.new}`]);
+  });
+
+  it("NEVER deletes a thread older than the oldest message it read", () => {
+    // The whole reason a floor exists: `ancient` is absent only because the 300-message window
+    // didn't reach it. Without the bound this deletes the channel's entire history, every tick.
+    const plan = planSlackDeletions(
+      { liveRootTs: [T.new], oldestTs: T.mid },
+      [stored(T.ancient), stored(T.old), stored(T.new)]
+    );
+    expect(plan.itemIds).toEqual([]);
+    expect(plan.outOfWindow).toBe(2); // counted, not silently ignored
+  });
+
+  it("deletes nothing when the channel returned no history at all", () => {
+    // Every stored thread would look deleted. A quiet tick, a bad cursor, a channel the bot just
+    // lost read access to — all produce this, and none of them mean "the team deleted everything".
+    const plan = planSlackDeletions({ liveRootTs: [], oldestTs: undefined }, [stored(T.new)]);
+    expect(plan.itemIds).toEqual([]);
+    expect(plan.disabledReason).toMatch(/no history/i);
+  });
+
+  it("deletes nothing for a channel that was skipped, not read", () => {
+    const plan = planSlackDeletions(
+      { skippedPrivate: true, liveRootTs: undefined, oldestTs: undefined },
+      [stored(T.new)]
+    );
+    expect(plan.itemIds).toEqual([]);
+    expect(plan.disabledReason).toMatch(/not read/i);
+  });
+
+  it("keeps a thread that is alive but was skipped from ingestion this tick", () => {
+    // The live set is every TOP-LEVEL message in history, not the ingestible `threads` — a thread
+    // whose replies failed to fetch is dropped from `threads` (#388) while being demonstrably alive.
+    // Diffing against the thinner list would delete a live thread on a transient Slack hiccup.
+    const plan = planSlackDeletions(
+      { liveRootTs: [T.mid, T.new], oldestTs: T.old }, // both alive; only one was ingestible
+      [stored(T.mid), stored(T.new)]
+    );
+    expect(plan.itemIds).toEqual([]);
+  });
+
+  it("does not judge a stored thread whose ts can't be placed in the window", () => {
+    const plan = planSlackDeletions({ liveRootTs: [T.new], oldestTs: T.old }, [
+      stored("not-a-timestamp", "item-weird"),
+    ]);
+    expect(plan.itemIds).toEqual([]);
+    expect(plan.outOfWindow).toBe(1);
+  });
+
+  it("does not delete on an unparseable window floor", () => {
+    const plan = planSlackDeletions({ liveRootTs: [], oldestTs: "garbage" }, [stored(T.new)]);
+    expect(plan.itemIds).toEqual([]);
+    expect(plan.disabledReason).toMatch(/floor/i);
+  });
+
+  it("treats a thread exactly AT the floor as out of window (the boundary is inclusive-safe)", () => {
+    const plan = planSlackDeletions({ liveRootTs: [], oldestTs: T.mid }, [stored(T.mid, "at-floor")]);
+    expect(plan.itemIds).toEqual([]);
+  });
+});

--- a/test/ingest-slack-normalize.test.ts
+++ b/test/ingest-slack-normalize.test.ts
@@ -174,3 +174,35 @@ describe("slackChannelPathPrefix", () => {
     expect(slackChannelPathPrefix("C0AAA").endsWith("/")).toBe(true);
   });
 });
+
+/**
+ * A message that still EXISTS at the source but whose text is gone (deleted, or edited away) renders
+ * as a placeholder rather than being dropped. Dropping it would keep the stored body quoting the
+ * retracted text; rendering it keeps the conversation's shape and every replier's contribution.
+ */
+describe("normalizeThread — a retracted message renders as a placeholder", () => {
+  it("replaces a deleted ROOT's text while keeping the replies", () => {
+    const payload = normalizeThread(
+      {
+        root: { ts: "1719878400.000100", user: "U1", text: "", subtype: "tombstone", reply_count: 1 },
+        replies: [{ ts: "1719878500.000200", user: "U2", text: "still here" }],
+      },
+      opts
+    );
+    expect(payload.body).toContain("_[message deleted]_");
+    expect(payload.body).toContain("still here");
+    expect(payload.body).not.toContain("tombstone");
+  });
+
+  it("replaces a deleted REPLY's text", () => {
+    const payload = normalizeThread(
+      {
+        root: { ts: "1719878400.000100", user: "U1", text: "question?" },
+        replies: [{ ts: "1719878500.000200", user: "U2", text: "   " }],
+      },
+      opts
+    );
+    expect(payload.body).toContain("question?");
+    expect(payload.body).toContain("_[message deleted]_");
+  });
+});

--- a/test/ingest-slack-resilience.test.ts
+++ b/test/ingest-slack-resilience.test.ts
@@ -5,6 +5,7 @@ import {
   SlackError,
   SlackClient as SlackClientCtor,
   type SlackClient,
+  type SlackMessage,
 } from "@/lib/ingest/sources/slack";
 
 /**
@@ -319,6 +320,260 @@ describe("SlackClient.channelInfo — unverifiable vs transient", () => {
     for (const error of ["channel_not_found", "not_in_channel"]) {
       const info = await withError(error, () => new SlackClientCtor("xoxb-test").channelInfo("C0123"));
       expect(info).toEqual({ name: "C0123", isPrivate: true, verified: false });
+    }
+  });
+});
+
+/**
+ * Spec: the DELETION WINDOW that `fetchSlackChannel` hands to `planSlackDeletions`.
+ *
+ * `planSlackDeletions` is pure and well-tested, but it is only as safe as the inputs assembled here —
+ * and every one of these is a way to delete a LIVE thread. A refactor to
+ * `liveRootTs: threads.map(...)` would pass every test in the deletion suite and start destroying
+ * data, which is exactly why the wiring is pinned at this layer too.
+ */
+describe("fetchSlackChannel — the deletion window", () => {
+  const msg = (ts: string, over: Partial<SlackMessage> = {}): SlackMessage => ({
+    ts,
+    user: "U1",
+    text: "hello",
+    ...over,
+  });
+
+  it("reports the OLDEST message read as the window floor (history is newest→oldest)", async () => {
+    const channel = await fetchSlackChannel(
+      stubClient({ history: async () => [msg("300.0"), msg("200.0"), msg("100.0")] }),
+      "C1",
+      { users: {} }
+    );
+    expect(channel.oldestTs).toBe("100.0");
+  });
+
+  it("counts a thread whose REPLIES failed as ALIVE (it is only unsafe to ingest, not gone)", async () => {
+    const channel = await fetchSlackChannel(
+      stubClient({
+        history: async () => [rootWithReplies],
+        replies: async () => {
+          throw new SlackError("slack conversations.replies failed: ratelimited");
+        },
+      }),
+      "C1",
+      { users: {} }
+    );
+    expect(channel.threads).toHaveLength(0); // not ingested this tick…
+    expect(channel.liveRootTs).toContain(rootWithReplies.ts); // …but NOT deletable
+  });
+
+  it("counts a TOMBSTONED root as alive — deleting a root must not purge its repliers' ledger", async () => {
+    // Slack leaves the parent in history when a thread root is deleted while replies live on. It
+    // fails the render filter, so judging existence by that filter would purge the whole item —
+    // taking `item_versions` with it and destroying the credit of every replier whose messages are
+    // still in Slack.
+    const channel = await fetchSlackChannel(
+      stubClient({ history: async () => [msg("500.0", { subtype: "tombstone", text: "" })] }),
+      "C1",
+      { users: {} }
+    );
+    expect(channel.liveRootTs).toEqual(["500.0"]); // the thread EXISTS
+  });
+
+  it("counts a root edited down to no text (a file-only message) as alive", async () => {
+    const channel = await fetchSlackChannel(
+      stubClient({ history: async () => [msg("500.0", { text: "" })] }),
+      "C1",
+      { users: {} }
+    );
+    expect(channel.liveRootTs).toEqual(["500.0"]);
+  });
+
+  it("still INGESTS a thread whose root was deleted, so the live body stops serving it", async () => {
+    // Keeping the thread (above) is only half the answer. If it is never re-normalized it is never
+    // re-rendered either, so `items.body` — the surface retrieval and answers read — goes on quoting
+    // the deleted root forever, with no future trigger. That is a worse leak than the version
+    // history this feature is about, and it is the one the tombstone fix would otherwise create.
+    const channel = await fetchSlackChannel(
+      stubClient({
+        history: async () => [msg("500.0", { subtype: "tombstone", text: "", reply_count: 2 })],
+        replies: async () => [msg("501.0", { text: "a reply that still exists" })],
+      }),
+      "C1",
+      { users: {} }
+    );
+    expect(channel.threads).toHaveLength(1);
+    expect(channel.threads[0].replies).toHaveLength(1);
+  });
+
+  it("does NOT invent an item for a text-less message that is not a conversation", () => {
+    // A bare text-less top-level message (a file post with no caption) has no thread to maintain;
+    // rendering it would create an item that never existed. Bounded by `reply_count`.
+    return fetchSlackChannel(
+      stubClient({ history: async () => [msg("500.0", { text: "" })] }),
+      "C1",
+      { users: {} }
+    ).then((channel) => expect(channel.threads).toHaveLength(0));
+  });
+
+  it("excludes replies from the live set — only top-level messages are threads", async () => {
+    const channel = await fetchSlackChannel(
+      stubClient({
+        history: async () => [msg("500.0"), msg("450.0", { thread_ts: "400.0" }), msg("400.0")],
+      }),
+      "C1",
+      { users: {} }
+    );
+    expect(channel.liveRootTs).toEqual(["500.0", "400.0"]);
+  });
+
+  it("has NO floor when the channel returned nothing (deletion must be disabled)", async () => {
+    const channel = await fetchSlackChannel(stubClient({ history: async () => [] }), "C1", { users: {} });
+    expect(channel.oldestTs).toBeUndefined();
+  });
+});
+
+/**
+ * A SUCCESSFUL but truncated replies page is the one way a "message was deleted" signal can be
+ * forged, and the one way a thread body can still be stored short — `#388` only closed the THROWN
+ * case. `has_more` with no cursor to follow means we cannot complete the thread, so it must fail
+ * like a fetch error (the caller then skips the thread) rather than return what it happens to have.
+ */
+describe("SlackClient.replies — completeness", () => {
+  function pagedFetch(pages: { messages: unknown[]; has_more?: boolean; cursor?: string }[]) {
+    let i = 0;
+    return (async () => {
+      const p = pages[Math.min(i++, pages.length - 1)];
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          messages: p.messages,
+          has_more: p.has_more,
+          response_metadata: p.cursor ? { next_cursor: p.cursor } : {},
+        }),
+      };
+    }) as unknown as typeof fetch;
+  }
+
+  async function withFetch<T>(f: typeof fetch, fn: () => Promise<T>): Promise<T> {
+    const orig = globalThis.fetch;
+    globalThis.fetch = f;
+    try {
+      return await fn();
+    } finally {
+      globalThis.fetch = orig;
+    }
+  }
+
+  it("follows the cursor to the end instead of storing a short thread", async () => {
+    const replies = await withFetch(
+      pagedFetch([
+        { messages: [{ ts: "1.0" }, { ts: "2.0" }], has_more: true, cursor: "c1" },
+        { messages: [{ ts: "3.0" }] },
+      ]),
+      () => new SlackClientCtor("xoxb-test").replies("C1", "1.0")
+    );
+    // Root excluded; both pages present — a single-page read would silently drop "3.0".
+    expect(replies.map((m) => m.ts)).toEqual(["2.0", "3.0"]);
+  });
+
+  it("THROWS when Slack says there is more but gives no cursor (incomplete, not empty)", async () => {
+    await withFetch(pagedFetch([{ messages: [{ ts: "1.0" }, { ts: "2.0" }], has_more: true }]), async () => {
+      await expect(new SlackClientCtor("xoxb-test").replies("C1", "1.0")).rejects.toThrow(/incomplete/);
+    });
+  });
+});
+
+/**
+ * `isRedactedRoot` decides whether a thread whose root was deleted still gets RE-RENDERED. It must not
+ * hinge on a single Slack field: `reply_count` is the obvious signal but Slack doesn't promise to keep
+ * it on a tombstone, and losing the signal means the live body silently keeps serving the deleted
+ * message. `thread_ts === ts` marks a thread root independently (a standalone message has no
+ * `thread_ts` at all), so either signal suffices.
+ */
+describe("fetchSlackChannel — a redacted root is recognised by either thread signal", () => {
+  it("re-renders AND fetches replies when only thread_ts identifies it as a root", async () => {
+    const channel = await fetchSlackChannel(
+      stubClient({
+        history: async () => [{ ts: "500.0", user: "U1", text: "", thread_ts: "500.0" }],
+        replies: async () => [{ ts: "501.0", user: "U2", text: "a reply that still exists" }],
+      }),
+      "C1",
+      { users: {} }
+    );
+    expect(channel.threads).toHaveLength(1);
+    // Asserting the REPLIES land is the whole point. Admitting the root without fetching them is
+    // worse than not admitting it: the re-render would be placeholder-only, overwrite the stored
+    // conversation, and the forget pass would then blank the superseded body — erasing replies that
+    // are still live in Slack. Stopping at `threads.length === 1` passed while that bug was present.
+    expect(channel.threads[0].replies).toHaveLength(1);
+  });
+
+  it("recognises Slack's REAL tombstone payload, which carries text", async () => {
+    // The actual wire format is `{subtype: "tombstone", text: "This message was deleted."}` — a
+    // `!text` test never fires on it, so the thread would be kept alive but never re-rendered and
+    // `items.body` would serve the deleted root forever. Testing the subtype tests what Slack says,
+    // not what we assumed it says.
+    const channel = await fetchSlackChannel(
+      stubClient({
+        history: async () => [
+          { ts: "500.0", user: "USLACKBOT", text: "This message was deleted.", subtype: "tombstone", reply_count: 1 },
+        ],
+        replies: async () => [{ ts: "501.0", user: "U2", text: "reply still here" }],
+      }),
+      "C1",
+      { users: {} }
+    );
+    expect(channel.threads).toHaveLength(1);
+    expect(channel.threads[0].replies).toHaveLength(1);
+    expect(channel.liveRootTs).toEqual(["500.0"]); // and still counted as alive
+  });
+});
+
+/**
+ * `threadExists` is the ONLY thing that authorizes deleting stored content, so its failure direction
+ * is the whole safety property.
+ *
+ * The trap it exists to avoid: `replies()` strips the root (callers want the replies *around* a root
+ * they already hold), and reusing it here would read a LIVE STANDALONE message — which
+ * `conversations.replies` returns as exactly one message, the root — as "nothing there", confirming a
+ * deletion that never happened. That is precisely the case the confirmation is for.
+ */
+describe("SlackClient.threadExists — the deletion confirmation", () => {
+  const resp = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+  async function withBody<T>(body: unknown, fn: (c: SlackClientCtor) => Promise<T>): Promise<T> {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => resp(body)) as unknown as typeof fetch;
+    try {
+      return await fn(new SlackClientCtor("xoxb-test"));
+    } finally {
+      globalThis.fetch = orig;
+    }
+  }
+
+  it("says a LIVE STANDALONE message exists — the root alone counts", async () => {
+    const alive = await withBody({ ok: true, messages: [{ ts: "500.0", user: "U1", text: "solo" }] }, (c) =>
+      c.threadExists("C1", "500.0")
+    );
+    expect(alive).toBe(true);
+  });
+
+  it("says a thread with replies exists", async () => {
+    const alive = await withBody(
+      { ok: true, messages: [{ ts: "500.0", text: "root" }, { ts: "501.0", text: "reply" }] },
+      (c) => c.threadExists("C1", "500.0")
+    );
+    expect(alive).toBe(true);
+  });
+
+  it("confirms deletion ONLY when Slack says the content is gone", async () => {
+    for (const error of ["thread_not_found", "message_not_found"]) {
+      expect(await withBody({ ok: false, error }, (c) => c.threadExists("C1", "500.0"))).toBe(false);
+    }
+  });
+
+  it("THROWS on any other failure — not being able to ask is not evidence", async () => {
+    for (const error of ["ratelimited", "invalid_auth", "internal_error"]) {
+      await expect(withBody({ ok: false, error }, (c) => c.threadExists("C1", "500.0"))).rejects.toThrow();
     }
   });
 });


### PR DESCRIPTION
Found by watching the first live purge in production, not by reading code.

After #399 deployed, prod went from 13 Slack items to 12 on the first tick. The purge was correct — Slack had confirmed the thread was gone, and the next tick didn't re-create it — but **nothing on the box could tell me which thread had been removed.** The rows are the only record of their own paths, so once the cascade runs the question has no answer anywhere. The audit had `{reason, items: 1, episodes: 1}` and a channel prefix: enough to notice a purge happened, not enough to explain it. That's the wrong trade for the one operation in the ingest path that can't be undone.

## The change

`purgeItemIds` reads the paths before deleting and records them in the audit meta, capped at 200 with the omitted count (an audit row is a record, not a backup — `items` stays authoritative).

## Two details that matter more than the feature

**A failed path read is marked, not silent.** `paths: []` with no marker is indistinguishable from a build that never recorded paths — so a transient read error would silently recreate the exact blind spot this field exists to close. It now writes `paths_read_failed: true`, and a partial read keeps what it got rather than discarding earlier batches because a later one failed.

**The delete is now team-scoped, like the audit read.** Without it the two scopes could diverge: a future caller passing another team's id would have the row removed but its path filtered out of the record — the removal primitive documenting less than it deletes. Defense-in-depth; both current callers derive ids team-scoped.

## Verified

Red-before-green (the dm test fails without the `paths` field). The meta builder is pure and unit-tested including the **off-by-one boundary at exactly the cap** — the truncation branch is otherwise only reachable by seeding 201 rows in the real-DB tier, which is how that class of bug ships green.

`npm test` **1210 passed** · `tsc` 0 · lint clean (2 pre-existing) · docs-drift green · **data-mechanics 724 passed** on a dedicated container. No schema change.

## Review — Reviewed by Fable `code-reviewer` — verdict CLEAR

Both of its Mediums are in this diff: the silent-`[]` marker (its point — that the omission hollows out the change's own purpose in precisely the failure mode it was built for — was correct) and the delete/audit scope divergence. It also caught that the truncation branch was untested, which is why the meta builder was extracted and unit-tested.

Conscious choice it flagged: the recorded 200 are the lexicographic **head**, not a sample, so for Slack that's the oldest thread timestamps. Deterministic, and the count stays authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)