### PR TITLE
fix(purge): removal reaches the derived caches, not just the rows (AIO-488)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -813,9 +813,14 @@ There is only ONE flag slot, so an orphan that already owed a *different* group'
 converged over two passes (the old group is verified, then the flag re-points at the row's own group)
 rather than dropped after checking only one.
 
-**Eventually consistent downstream.** A purge removes the item, its versions/chunks/facts and its
-graph episodes. Derived snapshots recomputed on a schedule — `work_timeline_cache`, narrative-arc
-snapshots — can still quote purged content until their next recompute.
+**Derived caches are busted too.** `work_timeline_cache` and the narrative-arc snapshots are
+precomputed FROM `items`, so removing the rows alone leaves both quoting content the brain no longer
+has until their next scheduled recompute — for a private channel purged by mistake, exactly the
+window the purge exists to close. The purge routes through the shared `bustTeamLearningCaches`
+choke-point (rather than staling the two tables itself, so a cache added there later is busted too),
+marking them stale so the next read rebuilds from what survives. Best-effort and LOUD: the content is
+already gone, so a bust failure must not fail or retry the purge — but it is logged, because the
+visible symptom is purged content still on screen and the caches otherwise self-heal only on TTL.
 
 ### Slack deletions — `lib/ingest/slack-cleanup.ts` + `sources/slack-deletions.ts`
 

--- a/lib/ingest/purge.ts
+++ b/lib/ingest/purge.ts
@@ -188,5 +188,27 @@ export async function purgeItemIds(
     meta: buildPurgeMeta({ reason, items: itemIds.length, episodes, paths, readFailed }),
   });
 
+  // DERIVED CACHES. Removing the rows is not the whole removal: `work_timeline_cache` and the arc
+  // snapshots are precomputed FROM them, so until their next scheduled recompute both still quote
+  // content the brain no longer has — for a private channel purged by mistake, exactly the window the
+  // purge exists to close. Busting them makes the next read rebuild from what survives.
+  //
+  // Routed through the shared `bustTeamLearningCaches` choke-point rather than staling the two tables
+  // here, so a cache added there later is busted by the purge too instead of quietly outliving it.
+  //
+  // Best-effort and LOUD: the content is already gone, so a bust failure must not fail (or retry) the
+  // purge — but it must not be silent either, because the visible symptom is purged content still on
+  // screen, and the caches self-heal only on their own TTL.
+  try {
+    const { data: team } = await db.from("teams").select("slug").eq("id", teamId).maybeSingle();
+    const { bustTeamLearningCaches } = await import("@/lib/ingest/reconcile-attribution");
+    await bustTeamLearningCaches(db, teamId, (team as { slug: string } | null)?.slug ?? "");
+  } catch (err) {
+    console.error(
+      `[purge] derived-cache bust failed for team ${teamId} — timeline/arcs may quote purged content ` +
+        `until their TTL: ${err instanceof Error ? err.message : err}`
+    );
+  }
+
   return { items: itemIds.length, episodes };
 }

--- a/test/datamechanics/purge-items.datamechanics.test.ts
+++ b/test/datamechanics/purge-items.datamechanics.test.ts
@@ -144,6 +144,35 @@ describe("purgeItemsByPathPrefix (real Postgres)", () => {
     expect(row?.meta?.items).toBe(1);
   });
 
+  /**
+   * Spec: a purge reaches the DERIVED caches, not just the rows.
+   *
+   * `work_timeline_cache` and the arc snapshots are precomputed FROM `items`, so removing the rows
+   * alone leaves both quoting content the brain no longer has until their next scheduled recompute —
+   * for a private channel purged by mistake, exactly the window the purge exists to close. Staleness
+   * is asserted on the stored `computed_at`, which is the thing the readers actually branch on.
+   */
+  it("marks the timeline and arc caches stale so they stop serving purged content", async () => {
+    const seed = await seedTeam();
+    await ingest(seed, { path: "slack/c0priv/1.md", project: "slack", kind: "transcript", access: "team", body: "secret" });
+
+    const fresh = new Date().toISOString();
+    await db().from("work_timeline_cache").insert({ team_id: seed.teamId, group_key: "team", payload: { v: 1, days: [] }, computed_at: fresh });
+    await db().from("arc_cache").insert({ team_id: seed.teamId, group_key: "team", arcs: [], computed_at: fresh });
+
+    await purgeItemsByPathPrefix(db(), seed.teamId, "slack/c0priv/", "slack channel is private");
+
+    const staleness = async (table: string): Promise<number> => {
+      const { data } = await db().from(table).select("computed_at").eq("team_id", seed.teamId).maybeSingle();
+      const at = new Date((data as { computed_at: string | Date }).computed_at).getTime();
+      return Date.now() - at;
+    };
+    // Both are pushed back past their TTL — a bust, not a delete: the stale-but-real payload still
+    // serves while the rebuild runs behind it.
+    expect(await staleness("work_timeline_cache")).toBeGreaterThan(60_000);
+    expect(await staleness("arc_cache")).toBeGreaterThan(60_000);
+  });
+
   it("records WHICH paths went, not just how many", async () => {
     // The rows are the only record of their own paths, so a count-and-prefix audit makes the question
     // "what did this purge remove?" unanswerable the moment the cascade runs. That's the wrong trade


### PR DESCRIPTION
Closing the residue I flagged when the removal path shipped.

`work_timeline_cache` and the narrative-arc snapshots are precomputed **from** `items`, so a purge removed the rows and left both surfaces still quoting the content until their next scheduled recompute. For a private channel purged by mistake that's exactly the window the purge exists to close — the data was gone and the screen still showed it.

## The change

`purgeItemIds` now busts them, routed through the shared **`bustTeamLearningCaches`** choke-point rather than staling the two tables inline — so a cache added there later is busted by the purge too instead of quietly outliving it. That function already existed for the re-attribution path; the purge simply never called it.

**Best-effort and loud.** The content is already deleted, so a bust failure must not fail or retry the purge — but it must not be silent either, because the visible symptom is purged content still on screen and the caches otherwise self-heal only on TTL.

## Verified

Red-before-green against the stored `computed_at` — the value the readers actually branch on — rather than against the call being made. Without the bust, both rows stay fresh and the test fails.

`npm test` **1249 passed** · `tsc` 0 · lint clean (2 pre-existing) · docs-drift green · **data-mechanics 745 passed** on a dedicated container. No schema change.

## Review

Fable is still inside its session limit (resets 12:40pm), so this had no local reviewer — saying so rather than implying otherwise, and applying `ready-for-review` for CodeRabbit. Small and additive; the risky part (deleting data) shipped earlier and is unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)