### PR TITLE
docs(todo): record why #327 was closed — the arc-precompute residual

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -64,6 +64,13 @@ it isn't forgotten, not scheduled.
 ## Arc-cache proactive warming (timer-driven) — deferred follow-up
 
 **Status:** Deferred (2026-07-10). SWR (demand-driven refresh, #217) covers the common case.
+**Re-confirmed 2026-07-27** on closing **#327** ("narrative arcs as a precomputed background layer"),
+which proposed exactly this. Its *problem* — an ~80s synthesis on the read path blocking the Learning
+page — is solved on main by SWR + `refreshArcsInBackground` + the 4h TTL + the facts-hash skip, and
+`lib/social/discover-arcs` reads the same cached layer, so Learning and Social Brain already share it.
+The single residual is below: `getArcs`'s **cold-miss branch still synthesizes inline**, so a
+first-ever load for a group-key waits on the model. #327 was closed rather than merged because its
+88-line doc described the plan as unbuilt — a stale map next to shipped behavior is worse than none.
 
 **What:** A scheduled job that proactively recomputes each active team's arcs on an interval so even a
 team's *first* view of the day is warm (SWR only warms a team once someone has viewed it). **Why


### PR DESCRIPTION
Closes the loop on **#327** ("narrative arcs as a precomputed background layer"), which I'm closing rather than merging.

## Why #327 isn't being merged

Its **problem** is already solved on main. #327 was opened because arcs were synthesized on the read path — an ~80s LLM call inside the Learning page request, able to blow the 120s route budget. Today `getArcs` is serve-stale-while-revalidate: a stale hit returns immediately and refreshes behind the request, backed by a 4h TTL, a durable `arc_cache` that keeps last-good, a **facts-hash skip** so an unchanged re-synthesis never calls the model, and an evidence-coherence pass that runs *only* on the background path. Its secondary claim is satisfied too — `lib/social/discover-arcs` calls the same `getArcs`, so Learning and Social Brain already share one precomputed layer.

So the outcome shipped; the specific mechanism (a scheduler leg) was not adopted — SWR was chosen instead.

Merging the PR would add an 88-line design doc that presents this as an unbuilt proposal ("design only — no code"), sitting next to four existing arc design docs and the shipped behavior it describes. A wrong map is worse than none.

## The one real residual

`getArcs`'s **cold-miss branch still synthesizes inline**, so a first-ever load for a group-key waits on the model. That is genuinely the last read-path synthesis.

It turns out this was **already tracked** — `docs/TODO.md` has had an *"Arc-cache proactive warming (timer-driven)"* entry since 2026-07-10, filed before #327 was opened, and it already records the sharper reasoning: a scheduler would fire LLM calls for teams nobody is looking at, and needs each team's provider keys available in the background.

So this PR **cross-references #327 into that existing entry** rather than opening a duplicate — the residual is named precisely (cold-miss inline), with the rationale for closing #327 recorded so the decision isn't re-litigated.

Docs-only. `npm run check:docs` ✅