### PR TITLE
fix(timeline): bump PAYLOAD_VERSION to 8 — two payload shapes shipped as v7 (AIO-489)

### DIFF
--- a/lib/dashboard/timeline-cache.ts
+++ b/lib/dashboard/timeline-cache.ts
@@ -38,7 +38,16 @@ const TTL_MS = 5 * 60_000; // 5-min freshness; the ledger is cheap, so refresh o
 // self-contradicting chips) for a full TTL after deploy. Same rule as v5 — bump on a meaning change.
 // v7: evidence can now be linked by the LLM doc→task pass (`linkVia:"inferred"`). A v6 row would keep
 // serving those docs in "Other" for a full TTL after deploy — same meaning-change rule as v5/v6.
-export const PAYLOAD_VERSION = 7;
+// v8: `PersonDay.other[]` is REPLACED by `unlinked: number` — unlinked evidence is omitted, `total`
+// counts only rendered work, and a person-day with nothing left is dropped. A v7 row therefore carries
+// a shape this build does not render AND person-days it would have dropped, so the card shows a name
+// with an empty body under it — the exact thing the omission was meant to prevent.
+//
+// This bump was MISSED once and it is worth saying why: the change was authored on v6→v7, then rebased
+// onto a branch that had already taken 7 for its own shape change, so two incompatible payloads shipped
+// under one version and prod served a stale row as a HIT. When rebasing, re-check that the version you
+// bumped TO is still unclaimed on the new base.
+export const PAYLOAD_VERSION = 8;
 
 /** The timeline WITH the per-person-day synopsis attached. Runs the (up to 7d × roster) best-effort LLM
  *  calls — so it's used ONLY on the BACKGROUND refresh path, never inline on a request (a cold miss

--- a/test/datamechanics/timeline-cache.datamechanics.test.ts
+++ b/test/datamechanics/timeline-cache.datamechanics.test.ts
@@ -68,9 +68,10 @@ describe("work-timeline cache layer (real Postgres)", () => {
     // It persisted the versioned payload { v, days } to the 'team' row, matching what was returned.
     const row = await readRow(seed.teamId, "team");
     expect(row?.group_key).toBe("team");
-    // v7: unlinked evidence is OMITTED and inferred (LLM) links join the ledger — a v6 row would keep
-    // serving an "other" lane this build no longer renders, so a stale row must read as a MISS.
-    expect((row?.payload as { v: number; days: unknown[] }).v).toBe(7);
+    // A LITERAL, deliberately: it forces a conscious edit every time the version moves, which is the
+    // moment to ask "did the payload shape or meaning change?". v8 = unlinked evidence omitted
+    // (`other[]` → `unlinked`), so a v7 row carries a shape this build does not render.
+    expect((row?.payload as { v: number; days: unknown[] }).v).toBe(8);
     expect((row?.payload as { days: unknown[] }).days.length).toBe(days.length);
 
     // readTimelineCache round-trips it.

--- a/test/guards/timeline-payload-shape.test.ts
+++ b/test/guards/timeline-payload-shape.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { PAYLOAD_VERSION } from "@/lib/dashboard/timeline-cache";
+import { groupTimeline } from "@/lib/dashboard/timeline-group";
+
+/**
+ * BUILD-FAILING GUARD: the cached timeline payload's SHAPE is pinned to its version.
+ *
+ * `work_timeline_cache` is served stale-while-revalidate, so a row written by the previous build is
+ * rendered by this one for a full TTL. `PAYLOAD_VERSION` is what makes that safe — a version the reader
+ * doesn't recognise is treated as a miss. The mechanism only works if the version is bumped whenever
+ * the shape changes, and that is a human step with nothing enforcing it.
+ *
+ * It has already failed once: the `other[]` → `unlinked` change was authored on v6→v7, then REBASED onto
+ * a branch that had already taken 7 for its own shape change. Both shipped as v7, so prod served a
+ * stale-shaped row as a fresh hit and rendered person-days with a name and an empty body.
+ *
+ * This test pins the key set against the version. Changing the shape turns it red, and the only way to
+ * green it is to update BOTH — which is exactly the moment to bump.
+ */
+
+const SHAPE_BY_VERSION: Record<number, string[]> = {
+  8: ["memberId", "name", "handle", "avatarUrl", "total", "tasks", "unlinked", "signals"],
+};
+
+describe("guard: the cached timeline payload shape matches its PAYLOAD_VERSION", () => {
+  it("a PersonDay carries exactly the keys this version promises", () => {
+    const expected = SHAPE_BY_VERSION[PAYLOAD_VERSION];
+    expect(
+      expected,
+      `PAYLOAD_VERSION is ${PAYLOAD_VERSION} but no shape is pinned for it. If you changed the payload, ` +
+        `add its key set here; if you bumped without a shape change, copy the previous entry.`
+    ).toBeDefined();
+
+    const days = groupTimeline(
+      [{ id: "e1", memberId: "m1", title: "t", source: "github", kind: "commit", at: "2026-07-22T09:00:00Z", taskId: "t1" }],
+      new Map([["t1", { title: "Task", status: "in_progress", source: "tasks" }]]),
+      new Map([["m1", { name: "Alice", handle: "alice", avatarUrl: undefined }]]),
+      "2026-07-22"
+    );
+    const person = days[0]?.people[0];
+    expect(person, "the fixture must produce a person-day, or this guard is vacuous").toBeDefined();
+
+    // `avatarUrl` is optional and absent here, so compare on the REQUIRED subset plus a check that no
+    // unexpected key appeared — a new field is a shape change even when it is additive.
+    const actual = Object.keys(person!).sort();
+    const allowed = expected.slice().sort();
+    expect(actual.filter((k) => !allowed.includes(k)), "unexpected key(s) — bump PAYLOAD_VERSION").toEqual([]);
+    for (const required of ["tasks", "unlinked", "total", "signals"]) {
+      expect(actual, `missing ${required}`).toContain(required);
+    }
+  });
+});


### PR DESCRIPTION
Found by checking prod after merging #404, not by a test.

## What happened

`PersonDay.other[]` → `unlinked: number` was authored as **v6→v7**. That branch was then **rebased** onto one that had already taken 7 for its own shape change (inferred links, #394). The bump collapsed into theirs, so two incompatible payloads shipped under one version.

Consequence: the live cache row, written ~18 minutes before the deploy, was served as a **fresh hit**. It carries person-days this build would have dropped — so the card renders a name, a summary, and nothing under it. Exactly what omitting unlinked work was meant to prevent.

Small window (5-minute TTL, and it self-heals), but the versioning mechanism was silently disarmed and would have stayed disarmed for the next shape change too.

## The fix, and the guard

`PAYLOAD_VERSION` → 8.

More importantly: **`test/guards/timeline-payload-shape.test.ts`** pins the `PersonDay` key set *against* the version. Changing the shape turns it red, and the only way to green it is to update both — which is precisely the moment to ask whether to bump. Verified red by adding a field without bumping.

The cache data-mechanics test also goes back to a **literal** version assertion. I'd changed it to `toBe(PAYLOAD_VERSION)`, which reads tidier and can never detect a missing bump — it agrees with whatever the code says. A literal forces a conscious edit.

## Why it wasn't caught

Nothing enforced the bump; it's a human step. Fable checked the diff and saw `6 → 7`, which was true *of the diff* — the base having already claimed 7 isn't visible there. That's the class of thing only a guard catches, so there's now a guard.

The lesson is in the code comment: **when rebasing, re-check that the version you bumped TO is still unclaimed on the new base.**

## Verified

`npm test` **1249 passed** (incl. the new guard) · `tsc` 0 · lint clean · docs-drift green · timeline-cache dm 4 passed. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)