### PR TITLE
fix(skills): the sync script was corrupting the YAML it generates (AIO-484)

### DIFF
--- a/scripts/sync-skill-runtimes.sh
+++ b/scripts/sync-skill-runtimes.sh
@@ -115,7 +115,13 @@ cursor_rule_content() {
   local name="$1" src="$2" desc
   desc="$(skill_description "$src/SKILL.md")"
   # Single-quoted YAML: the only escape needed is doubling a single quote.
-  desc="${desc//\'/\'\'}"
+  #
+  # Via variables, NOT an inline `${desc//\'/\'\'}`: inside double quotes a backslash before `'` is
+  # LITERAL, so that form emitted `\'\'` — a stray backslash that YAML then reads as part of the text
+  # ("repo\'s"). It also made the guard unfixable-by-running-the-script, since the script's own output
+  # never matched the correct committed file.
+  local q="'" qq="''"
+  desc="${desc//$q/$qq}"
   printf -- '---\n'
   printf -- "description: '%s'\n" "$desc"
   printf -- 'alwaysApply: false\n'


### PR DESCRIPTION
`main` is currently **red**: `test/guards/skill-runtime-sync.test.ts` fails, and running the command it tells you to run (`bash scripts/sync-skill-runtimes.sh --all --prune`) does **not** fix it — the script's own output never matches a correct file.

## The bug

```bash
desc="${desc//\'/\'\'}"
```

doesn't do what it reads like. Inside double quotes a backslash before `'` is **literal**, so the replacement emitted `\'\'` instead of `''`. In a single-quoted YAML scalar that stray backslash is part of the text, so every generated `.mdc` rendered its description as `repo\'s`.

The checked-in `.cursor/rules/*.mdc` files were **correct**. The script was the drift — and because the guard compares committed files against script output, correct files looked broken and "fixing" them would have committed the corruption.

## The fix

Do the doubling via variables (`q="'" qq="''"`), which is what the comment above it always claimed. Re-running the sync now produces **zero file changes** — that's the real proof the checked-in copies were right the whole time.

## Verified

`npm test` **1263 passed** (guard green, 11/11) · zero file churn from a full `--all --prune` run.

Found while rebasing an unrelated PR onto a red main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)