### PR TITLE
feat(tasks): sync-origin writeback mode for the workspace return leg (AIO-537)

### DIFF
--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -55,7 +55,13 @@ export async function moveTaskAction(
 
   const { error } = await db
     .from("tasks")
-    .update({ status, updated_at: new Date().toISOString() })
+    // `raw_status: null` is REQUIRED on every authoritative status write (brain-api 1.13, AIO-537).
+    // It holds the original unmapped markdown string that produced the CURRENT status (a pushed
+    // `todo` → status=backlog, raw_status="todo"); leaving it behind makes the sync-origin return
+    // leg read this dashboard move as a normalization echo of the workspace's own push and refuse
+    // to write it back — the markdown would sit on `todo` forever. Guarded by
+    // test/guards/task-status-raw-status.test.ts.
+    .update({ status, raw_status: null, updated_at: new Date().toISOString() })
     .eq("id", taskId);
   if (error) return { ok: false, error: error.message };
   scheduleProjection(taskId);

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -10,6 +10,7 @@ export const runtime = "nodejs";
 export type TaskFeedMode = "writeback" | "table" | "sync-origin";
 
 const EPOCH = "1970-01-01T00:00:00Z";
+const PAGE = 500;
 
 /**
  * Resolve the feed mode (brain-api 1.13). `mode` is the explicit, versioned selector; the legacy
@@ -27,6 +28,21 @@ export function parseTaskFeedMode(
   if (mode === "writeback" || mode === "table" || mode === "sync-origin")
     return mode;
   return null;
+}
+
+/**
+ * sync-origin PAGES (1.13). The feed is ordered by `updated_at` ascending and capped at `PAGE`, so
+ * a full page may be a truncation — and the client advances its cursor after a merge, which would
+ * skip the remainder forever. Hand back the last row's `updated_at` as `next_cursor` so the client
+ * can drain the backlog; null means "you have everything". The writeback/table modes keep their
+ * historical `next_cursor: null` (pre-1.13 clients never page here).
+ */
+export function nextCursorFor(
+  mode: TaskFeedMode,
+  rows: { updated_at: string }[],
+): string | null {
+  if (mode !== "sync-origin" || rows.length < PAGE) return null;
+  return new Date(rows[rows.length - 1].updated_at).toISOString();
 }
 
 /**
@@ -105,7 +121,7 @@ export async function GET(req: NextRequest) {
   if (mode === "sync-origin") query = query.eq("origin", "sync");
 
   const { data, error } = await visibleTasks(
-    query.order("updated_at", { ascending: true }).limit(500),
+    query.order("updated_at", { ascending: true }).limit(PAGE),
     auth.memberTier,
   );
   if (error) return errorResponse("internal", error.message, 500);
@@ -173,6 +189,6 @@ export async function GET(req: NextRequest) {
       project,
       rows,
     })),
-    next_cursor: null,
+    next_cursor: nextCursorFor(mode, (data ?? []) as { updated_at: string }[]),
   });
 }

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -7,10 +7,40 @@ import { visibleTasks } from "@/lib/auth/visibility";
 
 export const runtime = "nodejs";
 
+export type TaskFeedMode = "writeback" | "table" | "sync-origin";
+
+const EPOCH = "1970-01-01T00:00:00Z";
+
 /**
- * Task writeback for `aios pull`: rows created or modified IN THE DASHBOARD since the cursor.
- * `?all=1` is the explicit tier-filtered full tasks-table read (brain-api v1.9); without it this
- * endpoint remains the writeback feed and must not be interpreted as the complete task table.
+ * Resolve the feed mode (brain-api 1.13). `mode` is the explicit, versioned selector; the legacy
+ * `?all=1` flag stays honoured so old clients get their exact response. Returns `null` for an
+ * unrecognized `mode` value (→ 400) so a typo can't silently degrade into the writeback feed.
+ *
+ * Forward-compat: a PRE-1.13 brain ignores `mode` entirely and answers with `mode:"writeback"`,
+ * which is how a 1.13 client feature-detects (it checks the echoed mode, not a version header).
+ */
+export function parseTaskFeedMode(
+  mode: string | null,
+  all: string | null,
+): TaskFeedMode | null {
+  if (mode === null || mode === "") return all === "1" ? "table" : "writeback";
+  if (mode === "writeback" || mode === "table" || mode === "sync-origin")
+    return mode;
+  return null;
+}
+
+/**
+ * Task feed for `aios pull`.
+ *
+ *  • `writeback` (default) — rows created or modified IN THE DASHBOARD since the cursor.
+ *  • `table` (`?all=1` or `?mode=table`) — the explicit tier-filtered full tasks-table read.
+ *  • `sync-origin` (`?mode=sync-origin&project=<slug>`, brain-api 1.13, AIO-537) — the RETURN LEG:
+ *    sync-origin rows (pushed from a workspace) for ONE project, so a workspace can merge brain/
+ *    Linear status + assignee changes back into its markdown. Without it the markdown decays —
+ *    the projection is one-way and the writeback feed is dashboard-origin only.
+ *
+ * Tier isolation (audit H1) applies to every mode: `tasks.audience` is filtered through the
+ * `visibleTasks` choke-point, so an external-tier key never reads a team board. There is no RLS.
  */
 export async function GET(req: NextRequest) {
   const auth = await authenticateApiKey(req);
@@ -23,30 +53,70 @@ export async function GET(req: NextRequest) {
   }
 
   const url = new URL(req.url);
-  const all = url.searchParams.get("all") === "1";
-  const since = all
-    ? "1970-01-01T00:00:00Z"
-    : url.searchParams.get("since") || "1970-01-01T00:00:00Z";
+  const mode = parseTaskFeedMode(
+    url.searchParams.get("mode"),
+    url.searchParams.get("all"),
+  );
+  if (!mode)
+    return errorResponse(
+      "invalid_request",
+      "mode must be one of: writeback, table, sync-origin",
+      400,
+    );
+  const all = mode === "table";
+  const since = all ? EPOCH : url.searchParams.get("since") || EPOCH;
 
-  // Tier isolation (audit H1): an external-tier key must never pull internal task boards. `tasks`
-  // carries `audience` (inherited from the source item's access) — filter it via the choke-point.
-  const { data, error } = await visibleTasks(
-    db
-      .from("tasks")
-      .select(
-        "row_key, title, assignee, status, sprint, due_date, parent_row_key, labels, priority, origin, updated_at, projects(slug), items:source_item_id(synced_at)",
-      )
+  // sync-origin is deliberately single-project: the return leg answers "what changed on MY
+  // workspace's rows", and a workspace only ever merges its own project's markdown table.
+  let projectId: string | null = null;
+  if (mode === "sync-origin") {
+    const projectSlug = url.searchParams.get("project");
+    if (!projectSlug)
+      return errorResponse(
+        "invalid_request",
+        "project is required in sync-origin mode",
+        400,
+      );
+    const { data: project, error: projectError } = await db
+      .from("projects")
+      .select("id")
       .eq("team_id", auth.teamId)
-      .gt("updated_at", since)
-      .not("row_key", "is", null)
-      .order("updated_at", { ascending: true })
-      .limit(500),
+      .eq("slug", projectSlug)
+      .maybeSingle();
+    if (projectError)
+      return errorResponse("internal", projectError.message, 500);
+    // Unknown project → an empty feed, not an error: a workspace may legitimately have nothing
+    // pushed yet, and an error here would be indistinguishable from "this brain predates 1.13".
+    if (!project) return Response.json({ mode, tasks: [], next_cursor: null });
+    projectId = (project as { id: string }).id;
+  }
+
+  let query = db
+    .from("tasks")
+    .select(
+      "row_key, title, assignee, status, raw_status, sprint, due_date, parent_row_key, labels, priority, origin, updated_at, projects(slug), items:source_item_id(synced_at)",
+    )
+    .eq("team_id", auth.teamId)
+    .gt("updated_at", since)
+    .not("row_key", "is", null);
+  if (projectId) query = query.eq("project_id", projectId);
+  // Only rows a workspace pushed. Dashboard-origin rows stay the writeback feed's job, so the
+  // two feeds never double-merge the same row.
+  if (mode === "sync-origin") query = query.eq("origin", "sync");
+
+  const { data, error } = await visibleTasks(
+    query.order("updated_at", { ascending: true }).limit(500),
     auth.memberTier,
   );
   if (error) return errorResponse("internal", error.message, 500);
 
   const selected = (data ?? []).filter((t) => {
     if (all) return true;
+    // sync-origin rows are already scoped by project + origin in SQL; the writeback feed's
+    // "changed after our push" test does not apply — the point is to surface drift that
+    // accumulated at ANY time, bounded only by the caller's `since` cursor. The client's own
+    // echo guard (raw_status / status equality) decides what is a real change.
+    if (mode === "sync-origin") return true;
     if (t.origin === "ui") return true;
     const synced = (t.items as unknown as { synced_at: string } | null)
       ?.synced_at;
@@ -65,12 +135,13 @@ export async function GET(req: NextRequest) {
       parent: string | null;
       labels: string[];
       priority: string;
+      raw_status?: string | null;
     }[]
   >();
   for (const t of selected) {
     const slug = (t.projects as unknown as { slug: string })?.slug ?? "unknown";
     if (!byProject.has(slug)) byProject.set(slug, []);
-    byProject.get(slug)!.push({
+    const row = {
       row_key: t.row_key!,
       title: t.title,
       assignee: t.assignee,
@@ -81,11 +152,23 @@ export async function GET(req: NextRequest) {
       parent: t.parent_row_key ?? null,
       labels: (t.labels as string[] | null) ?? [],
       priority: t.priority ?? "none",
-    });
+    };
+    // `raw_status` is 1.13 and sync-origin-ONLY: the original markdown status string the workspace
+    // pushed when it didn't map onto a canonical status (normalizeTaskStatus → backlog +
+    // raw_status). The client uses it to tell a normalization echo ("todo" → backlog) apart from a
+    // real brain-side change and must not overwrite the author's word for the former. Kept out of
+    // the other modes so their responses stay byte-identical for pre-1.13 clients.
+    byProject
+      .get(slug)!
+      .push(
+        mode === "sync-origin"
+          ? { ...row, raw_status: (t.raw_status as string | null) ?? null }
+          : row,
+      );
   }
 
   return Response.json({
-    mode: all ? "table" : "writeback",
+    mode,
     tasks: [...byProject.entries()].map(([project, rows]) => ({
       project,
       rows,

--- a/app/t/[team]/meetings/actions.ts
+++ b/app/t/[team]/meetings/actions.ts
@@ -372,7 +372,13 @@ export async function pushMeetingTasksAction(
     ? (targetStatus as MeetingTaskStatus)
     : null;
   if (applied) {
-    await admin.from("tasks").update({ status: applied }).eq("team_id", team.id).in("id", eligible.map((t) => t.id));
+    // `raw_status: null` — authoritative status write (AIO-537 echo guard; the extract-todos
+    // `"extracted"` marker is intentionally dropped once a real status is chosen).
+    await admin
+      .from("tasks")
+      .update({ status: applied, raw_status: null })
+      .eq("team_id", team.id)
+      .in("id", eligible.map((t) => t.id));
   }
 
   const rows: ProjectionTaskRow[] = eligible.map((t) => ({

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -383,9 +383,15 @@ Done). `app/api/v1/tasks/route.ts` now takes an explicit `mode`: `writeback` (de
 `table` (`?all=1`), and **`sync-origin`** — `origin='sync'` rows for ONE `project` slug, tier-filtered
 through `visibleTasks` exactly as before, carrying `raw_status` so the client can tell a real change
 from a normalization echo of its own push. Because that guard depends on `raw_status` describing the
-CURRENT status, `applyStatusTx()` now clears `raw_status` in the same statement that writes the
-provider's status. Old clients are byte-unaffected (they never send `mode`); new clients feature-detect
-on the echoed `mode` and tolerate 400/404.
+CURRENT status, **every authoritative status writer now clears `raw_status`** — the inbound apply +
+adopt (`lib/pm-sync/inbound.ts`), the dashboard board move (`app/actions/tasks.ts`), work-event
+completion (`lib/work-events/ingest.ts`) and the meetings bulk apply — leaving `lib/ingest/tasks.ts`
+(the push path) as the ONLY writer of a non-null `raw_status`. Build-enforced by
+`test/guards/task-status-raw-status.test.ts`: miss one and a real change looks like an echo, so the
+workspace markdown sits on `todo` forever. The feed pages at 500 rows ordered by `updated_at`, and a
+full page returns a `next_cursor` (the last row's `updated_at`) so the client drains the backlog
+instead of advancing past it. Old clients are byte-unaffected (they never send `mode`); new clients
+feature-detect on the echoed `mode` and tolerate 400/404.
 
 **Inbound Plane import (Plane → brain, in-app runner).** The _opposite_ direction from the
 projection engine: `lib/ingest/sources/plane.ts` + `plane-normalize.ts` pull a Plane project's

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,7 +142,7 @@ flowchart LR
 
 ## Auth & access tiers
 
-This server **implements brain-api v1.12** (the shipped member-facing wire contract; source of truth:
+This server **implements brain-api v1.13** (the shipped member-facing wire contract; source of truth:
 `aios-workspace/docs/brain-api.md`; v1.8 added the subscriptions endpoint,
 `POST /api/v1/subscriptions`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`), asserted against this sentence by
@@ -375,6 +375,17 @@ surface-only/brain-wins. This is **opt-in per team** (`config.inboundApply` on t
 integration, default off, toggled in Admin) and runs automatically after each ingestion cycle via
 the scheduler (`lib/ingest/scheduler.ts`), plus on manual sync (`lib/ingest/manual-sync.ts`). Full
 two-way write-back for fields beyond status, and PM-triggered agent actions, remain out of scope.
+
+**Return leg to the workspace markdown (brain-api v1.13, AIO-537).** An applied inbound status only
+reached Postgres/Linear — `GET /api/v1/tasks` emitted dashboard-origin rows only, so the workspace
+file that PUSHED the row never learned it moved (field audit: rows reading `todo` while Linear said
+Done). `app/api/v1/tasks/route.ts` now takes an explicit `mode`: `writeback` (default, unchanged),
+`table` (`?all=1`), and **`sync-origin`** — `origin='sync'` rows for ONE `project` slug, tier-filtered
+through `visibleTasks` exactly as before, carrying `raw_status` so the client can tell a real change
+from a normalization echo of its own push. Because that guard depends on `raw_status` describing the
+CURRENT status, `applyStatusTx()` now clears `raw_status` in the same statement that writes the
+provider's status. Old clients are byte-unaffected (they never send `mode`); new clients feature-detect
+on the echoed `mode` and tolerate 400/404.
 
 **Inbound Plane import (Plane → brain, in-app runner).** The _opposite_ direction from the
 projection engine: `lib/ingest/sources/plane.ts` + `plane-normalize.ts` pull a Plane project's

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -9,7 +9,7 @@
  * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
  */
-export const BRAIN_API_VERSION = "1.12";
+export const BRAIN_API_VERSION = "1.13";
 
 /** Server-only Executor gateway negotiation; independent of the member API surface. */
 export const GATEWAY_CONTRACT_VERSION = "1.10";

--- a/lib/pm-sync/inbound.ts
+++ b/lib/pm-sync/inbound.ts
@@ -239,8 +239,14 @@ async function applyStatusTx(args: {
   );
   return withTransaction(async (client) => {
     if (newStatus !== task.status) {
+      // `raw_status` is cleared with the status write (brain-api 1.13, AIO-537). It holds the
+      // ORIGINAL unmapped markdown string that produced the CURRENT status (e.g. "todo" →
+      // backlog); once the provider sets the status authoritatively, that string no longer
+      // describes this row and keeping it would make the sync-origin return leg misread a REAL
+      // Linear change as a normalization echo of the workspace's own push — the exact drift
+      // (file says `todo`, Linear says Done) AIO-537 closes.
       const res = await client.query(
-        `update tasks set status = $1, updated_at = now() where id = $2 and status = $3`,
+        `update tasks set status = $1, raw_status = null, updated_at = now() where id = $2 and status = $3`,
         [newStatus, task.id, task.status]
       );
       if ((res.rowCount ?? 0) === 0) return false; // concurrent brain edit → conflict, no write

--- a/lib/pm-sync/inbound.ts
+++ b/lib/pm-sync/inbound.ts
@@ -473,7 +473,7 @@ async function adoptInbound(
       // origin 'ui': once owned, ingest excludes this issue from the mirror push, and only
       // origin='sync' rows are diff-deleted — the flip is what makes the adopted task durable.
       await client.query(
-        `update tasks set origin = 'ui', status = $1, body = $2, updated_at = now() where id = $3`,
+        `update tasks set origin = 'ui', status = $1, raw_status = null, body = $2, updated_at = now() where id = $3`,
         [status, body, task.id]
       );
       return true;

--- a/lib/work-events/ingest.ts
+++ b/lib/work-events/ingest.ts
@@ -134,7 +134,10 @@ export async function ingestWorkEvent(
 
     const { error: taskErr } = await db
       .from("tasks")
-      .update({ status: "done", updated_at: now })
+      // `raw_status: null` — an authoritative status write must not leave the pushed raw string
+      // behind, or the 1.13 sync-origin return leg reads it as an echo (AIO-537; guarded by
+      // test/guards/task-status-raw-status.test.ts).
+      .update({ status: "done", raw_status: null, updated_at: now })
       .eq("id", outcome.taskId)
       .eq("team_id", auth.teamId);
     if (taskErr) throw new Error(`task completion update failed: ${taskErr.message}`);

--- a/test/datamechanics/pm-sync-inbound.datamechanics.test.ts
+++ b/test/datamechanics/pm-sync-inbound.datamechanics.test.ts
@@ -138,6 +138,7 @@ async function seedLinkedTask(
     parentResourceId?: string | null;
     body?: string;
     origin?: string;
+    rawStatus?: string | null;
   }
 ) {
   const baseline = args.baselineStatus === undefined ? args.status : args.baselineStatus;
@@ -149,6 +150,7 @@ async function seedLinkedTask(
       row_key: args.rowKey,
       title: args.rowKey,
       status: args.status,
+      raw_status: args.rawStatus ?? null,
       origin: args.origin ?? "ui",
       body: args.body ?? "",
       parent_row_key: args.parentRowKey ?? null,
@@ -203,8 +205,18 @@ async function readLink(teamId: string, rowKey: string) {
 }
 
 async function readTask(taskId: string) {
-  const { data } = await db().from("tasks").select("status, body, origin, updated_at").eq("id", taskId).single();
-  return data as { status: string; body: string; origin: string; updated_at: string };
+  const { data } = await db()
+    .from("tasks")
+    .select("status, raw_status, body, origin, updated_at")
+    .eq("id", taskId)
+    .single();
+  return data as {
+    status: string;
+    raw_status: string | null;
+    body: string;
+    origin: string;
+    updated_at: string;
+  };
 }
 
 const issue = (id: string, stateId: string, over: Partial<MockIssue> = {}): MockIssue => ({
@@ -246,6 +258,33 @@ describe("inbound apply — pm-wins-if-brain-unchanged (real Postgres)", () => {
     expect(link.projection_fingerprint).toBe(fp({ row_key: "P1", status: "done" }));
     // Apply is inbound-only: zero provider mutations.
     expect(mutations).toEqual([]);
+  });
+
+  // AIO-537 / brain-api 1.13. `raw_status` records the ORIGINAL unmapped markdown string that
+  // produced the current status (a workspace pushing `todo` stores status=backlog,
+  // raw_status="todo"). Once Linear sets the status authoritatively that string is stale, and the
+  // sync-origin return leg would otherwise read `raw_status === "todo"` as "the brain is only
+  // echoing my own push" and refuse to write Done into the markdown — the exact drift AIO-537 closes.
+  it("clears raw_status when a Linear move sets the status authoritatively", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await seedProject(seed.teamId);
+    const taskId = await seedLinkedTask(seed, project, {
+      rowKey: "P-RAW",
+      resourceId: "li-raw",
+      status: "backlog",
+      rawStatus: "todo", // pushed from a workspace as the free-text `todo`
+      origin: "sync",
+      lastProjected: "Todo",
+    });
+
+    const { fetchImpl } = linearMock([issue("li-raw", "ls-done", { identifier: "P-RAW" })]);
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl });
+    expect(result.applied).toHaveLength(1);
+
+    const task = await readTask(taskId);
+    expect(task.status).toBe("done");
+    expect(task.raw_status).toBeNull();
   });
 
   it("no-echo: the projection pass after an apply makes ZERO provider mutations", async () => {

--- a/test/datamechanics/tasks-sync-origin-feed.datamechanics.test.ts
+++ b/test/datamechanics/tasks-sync-origin-feed.datamechanics.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { GET as tasksGET } from "@/app/api/v1/tasks/route";
+import { issueApiKey } from "@/lib/admin/keys";
+import { db, seedTeam, type Seed } from "./helpers";
+
+/**
+ * Spec for AIO-537 (brain-api 1.13) — the task-writeback RETURN LEG.
+ *
+ * Before 1.13 the only rows `GET /api/v1/tasks` emitted were dashboard-origin (`origin='ui'`) or
+ * rows whose `updated_at` post-dated the pushing item's `synced_at`. A workspace-pushed
+ * (`origin='sync'`) row whose status later changed in Linear therefore never reached the
+ * workspace markdown, and `3-log/tasks-team.md` decayed (the field audit: 6 rows said `todo`
+ * while Linear said Done/In Progress).
+ *
+ * These assertions are derived from the contract in `../aios-workspace/docs/brain-api.md` §
+ * "sync-origin return leg", not from the implementation:
+ *   1. sync-origin rows are returned ONLY in the new explicit mode (old clients see no change),
+ *   2. the mode is scoped to ONE project (a workspace merges only its own table),
+ *   3. tier isolation holds (an external key never sees a team-audience row — no RLS backstop),
+ *   4. `raw_status` rides along in this mode only (the client's normalization-echo guard).
+ */
+
+const URL = "http://test/api/v1/tasks";
+
+async function issueKeyFor(seed: Seed, tier: "team" | "external"): Promise<string> {
+  let memberId = seed.memberId;
+  if (tier === "external") {
+    const { data, error } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `ext-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "External",
+        actor_handle: `ext-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "external",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`external member seed failed: ${error?.message}`);
+    memberId = (data as { id: string }).id;
+  }
+  const { key } = await issueApiKey(db(), seed.teamId, memberId, `${tier} key`);
+  return key;
+}
+
+function get(key: string, teamSlug: string, qs: string) {
+  const req = new Request(`${URL}?${qs}`, {
+    headers: { Authorization: `Bearer ${key}`, "X-AIOS-Team": teamSlug },
+  }) as unknown as NextRequest;
+  return tasksGET(req);
+}
+
+type FeedRow = {
+  row_key: string;
+  status: string;
+  assignee: string;
+  raw_status?: string | null;
+};
+type Feed = { mode: string; tasks: { project: string; rows: FeedRow[] }[] };
+
+function rowsOf(feed: Feed, project?: string): FeedRow[] {
+  return feed.tasks
+    .filter((g) => (project ? g.project === project : true))
+    .flatMap((g) => g.rows);
+}
+
+async function seedProject(teamId: string, slug: string): Promise<string> {
+  const { data } = await db()
+    .from("projects")
+    .insert({ team_id: teamId, slug, name: slug })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+async function seedTask(args: {
+  teamId: string;
+  projectId: string;
+  rowKey: string;
+  origin: "sync" | "ui";
+  status?: string;
+  rawStatus?: string | null;
+  assignee?: string;
+  audience?: "team" | "external";
+}): Promise<void> {
+  const { error } = await db()
+    .from("tasks")
+    .insert({
+      team_id: args.teamId,
+      project_id: args.projectId,
+      row_key: args.rowKey,
+      title: `task ${args.rowKey}`,
+      status: args.status ?? "done",
+      raw_status: args.rawStatus ?? null,
+      assignee: args.assignee ?? "",
+      origin: args.origin,
+      audience: args.audience ?? "team",
+      updated_at: "2026-07-01T10:00:00Z",
+    });
+  if (error) throw new Error(`task seed failed: ${error.message}`);
+}
+
+describe("tasks sync-origin return leg (real handler, real Postgres)", () => {
+  it("returns workspace-pushed rows ONLY in sync-origin mode — the default feed is unchanged", async () => {
+    const seed = await seedTeam();
+    const proj = await seedProject(seed.teamId, "acme");
+    const key = await issueKeyFor(seed, "team");
+    await seedTask({ teamId: seed.teamId, projectId: proj, rowKey: "T-01", origin: "sync", status: "done" });
+    await seedTask({ teamId: seed.teamId, projectId: proj, rowKey: "T-UI", origin: "ui", status: "ready" });
+
+    // Old client (no `mode`): sync-origin row stays invisible; the UI row still comes through.
+    const legacy = (await (await get(key, seed.teamSlug, "since=1970-01-01T00:00:00Z")).json()) as Feed;
+    expect(legacy.mode).toBe("writeback");
+    expect(rowsOf(legacy).map((r) => r.row_key)).toEqual(["T-UI"]);
+
+    // New client: gets the sync-origin row, and NOT the dashboard-origin one (no double merge).
+    const res = await get(key, seed.teamSlug, "mode=sync-origin&project=acme&since=1970-01-01T00:00:00Z");
+    const feed = (await res.json()) as Feed;
+    expect(res.status).toBe(200);
+    expect(feed.mode).toBe("sync-origin");
+    expect(rowsOf(feed, "acme").map((r) => r.row_key)).toEqual(["T-01"]);
+    expect(rowsOf(feed, "acme")[0].status).toBe("done");
+  });
+
+  it("scopes sync-origin rows to the requested project", async () => {
+    const seed = await seedTeam();
+    const mine = await seedProject(seed.teamId, "mine");
+    const theirs = await seedProject(seed.teamId, "theirs");
+    const key = await issueKeyFor(seed, "team");
+    await seedTask({ teamId: seed.teamId, projectId: mine, rowKey: "M-1", origin: "sync" });
+    await seedTask({ teamId: seed.teamId, projectId: theirs, rowKey: "X-1", origin: "sync" });
+
+    const feed = (await (await get(key, seed.teamSlug, "mode=sync-origin&project=mine")).json()) as Feed;
+    expect(rowsOf(feed).map((r) => r.row_key)).toEqual(["M-1"]);
+    expect(feed.tasks.map((g) => g.project)).toEqual(["mine"]);
+
+    // An unknown project is an EMPTY feed, not an error (indistinguishable from a pre-1.13 brain).
+    const unknown = await get(key, seed.teamSlug, "mode=sync-origin&project=nope");
+    expect(unknown.status).toBe(200);
+    expect(((await unknown.json()) as Feed).tasks).toEqual([]);
+  });
+
+  it("never leaks a team-audience row to an external-tier key in sync-origin mode", async () => {
+    const seed = await seedTeam();
+    const proj = await seedProject(seed.teamId, "acme");
+    await seedTask({ teamId: seed.teamId, projectId: proj, rowKey: "T-INTERNAL", origin: "sync", audience: "team" });
+    await seedTask({ teamId: seed.teamId, projectId: proj, rowKey: "T-SHARED", origin: "sync", audience: "external" });
+
+    const ext = await issueKeyFor(seed, "external");
+    const extFeed = (await (await get(ext, seed.teamSlug, "mode=sync-origin&project=acme")).json()) as Feed;
+    expect(rowsOf(extFeed).map((r) => r.row_key)).toEqual(["T-SHARED"]);
+
+    // Not over-restrictive: the team key sees both.
+    const team = await issueKeyFor(seed, "team");
+    const teamFeed = (await (await get(team, seed.teamSlug, "mode=sync-origin&project=acme")).json()) as Feed;
+    expect(rowsOf(teamFeed).map((r) => r.row_key).sort()).toEqual(["T-INTERNAL", "T-SHARED"]);
+  });
+
+  it("carries raw_status + assignee in sync-origin mode only", async () => {
+    const seed = await seedTeam();
+    const proj = await seedProject(seed.teamId, "acme");
+    const key = await issueKeyFor(seed, "team");
+    // An unmapped markdown status ("todo") normalizes to backlog with raw_status preserved —
+    // the client uses it to skip a normalization echo instead of clobbering the author's word.
+    await seedTask({
+      teamId: seed.teamId,
+      projectId: proj,
+      rowKey: "T-01",
+      origin: "sync",
+      status: "backlog",
+      rawStatus: "todo",
+      assignee: "riley",
+    });
+    await seedTask({ teamId: seed.teamId, projectId: proj, rowKey: "T-UI", origin: "ui", status: "ready" });
+
+    const feed = (await (await get(key, seed.teamSlug, "mode=sync-origin&project=acme")).json()) as Feed;
+    expect(rowsOf(feed)[0]).toMatchObject({ raw_status: "todo", assignee: "riley", status: "backlog" });
+
+    // The pre-1.13 shapes gain no new key (byte-compatible for old clients).
+    const legacy = (await (await get(key, seed.teamSlug, "")).json()) as Feed;
+    expect(rowsOf(legacy)[0]).not.toHaveProperty("raw_status");
+    const table = (await (await get(key, seed.teamSlug, "all=1")).json()) as Feed;
+    expect(table.mode).toBe("table");
+    expect(rowsOf(table)[0]).not.toHaveProperty("raw_status");
+  });
+
+  it("rejects an unknown mode and a sync-origin call without a project (400, never a silent downgrade)", async () => {
+    const seed = await seedTeam();
+    const key = await issueKeyFor(seed, "team");
+
+    const bogus = await get(key, seed.teamSlug, "mode=everything");
+    expect(bogus.status).toBe(400);
+    expect((await bogus.json()).error.code).toBe("invalid_request");
+
+    const noProject = await get(key, seed.teamSlug, "mode=sync-origin");
+    expect(noProject.status).toBe(400);
+    expect((await noProject.json()).error.code).toBe("invalid_request");
+  });
+});

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -1,7 +1,7 @@
 {
   "$schema": "aios-brain-contract/v1",
   "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: node scripts/gen-contract-fixture.mjs.",
-  "version": "1.12",
+  "version": "1.13",
   "tierAliases": {
     "shared": {
       "team": "team",
@@ -99,5 +99,5 @@
       "sha256": "9862e47581b9bdd68ecfd7aa92216011a6b56bc9dc7abaee3bd5e301240bfbea"
     }
   },
-  "contentHash": "b9974f1381e490888b1063f57e34a22bd63c4b88009fe6a8bc4cf03e3cd9701b"
+  "contentHash": "01f9de6c4fababe1f3075b6a3724e4c14cead4a1f2deeddfed831679d0e0e390"
 }

--- a/test/guards/contract-conformance.test.ts
+++ b/test/guards/contract-conformance.test.ts
@@ -96,8 +96,10 @@ describe("brain-api tier + SSE conformance", () => {
     expect(fixture.version).toBe(BRAIN_API_VERSION);
   });
 
+  // The item-payload contract carries its OWN version (last changed at 1.12) and is decoupled from
+  // the API revision: 1.13 (the sync-origin task return leg) changed the tasks feed, not the item
+  // payload, so these fixtures stay pinned at 1.12 while `fixture.version` tracks BRAIN_API_VERSION.
   it("content-addresses the Brain API 1.12 item schema and fixtures", () => {
-    expect(fixture.version).toBe("1.12");
     expect(fixture.itemPayloadContract.version).toBe("1.12");
     for (const key of ["schema", "fixtures"] as const) {
       const ref = fixture.itemPayloadContract[key] as {

--- a/test/guards/task-status-raw-status.test.ts
+++ b/test/guards/task-status-raw-status.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Guard for brain-api 1.13 / AIO-537 (CLAUDE.md §2.2 — one rule + a build-failing guard beats
+ * discipline you have to remember).
+ *
+ * `tasks.raw_status` holds the ORIGINAL unmapped markdown status string that produced the CURRENT
+ * `tasks.status` — a workspace pushing `todo` stores `status='backlog', raw_status='todo'`
+ * (`normalizeTaskStatus`). The 1.13 sync-origin return leg hands `raw_status` to the workspace so
+ * it can tell a real brain-side change from the brain merely normalizing the push: if
+ * `raw_status` still equals the local cell, the client must NOT clobber the author's word.
+ *
+ * That guard only holds if EVERY authoritative status write clears `raw_status`. It was already
+ * missed once per writer: the Linear inbound apply, the dashboard board move, work-event
+ * completion, the meetings bulk apply. Any one of them left stale makes the return leg refuse a
+ * real change and the markdown sits on `todo` forever — the exact drift AIO-537 closes.
+ *
+ * Only `lib/ingest/tasks.ts` (materializeTasks) may SET a non-null raw_status: it is the sole
+ * writer of the pushed markdown value.
+ */
+
+const ROOT = path.resolve(__dirname, "../..");
+const SCAN_DIRS = ["app", "lib"];
+const SKIP = new Set(["node_modules", ".next", "dist"]);
+// The one legal writer of a non-null raw_status (the push path that also computes it).
+const RAW_STATUS_OWNER = "lib/ingest/tasks.ts";
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  const visit = (abs: string) => {
+    for (const entry of readdirSync(abs)) {
+      if (SKIP.has(entry)) continue;
+      const full = path.join(abs, entry);
+      if (statSync(full).isDirectory()) visit(full);
+      else if (/\.tsx?$/.test(entry)) out.push(full);
+    }
+  };
+  visit(path.join(ROOT, dir));
+  return out;
+}
+
+/** `.from("tasks") … .update({ … })` object literals, and raw `update tasks set …` statements. */
+function statusWrites(text: string): string[] {
+  const found: string[] = [];
+  // Split on `.from(` so each segment belongs to exactly ONE table: a `.update({…})` inside a
+  // `"tasks")` segment is a tasks write, and a later update on a different table (e.g.
+  // work_events' own `status`) can never be mis-attributed. Distance-based pairing got both wrong.
+  for (const segment of text.split(/\.from\(/)) {
+    if (!/^\s*["']tasks["']\s*\)/.test(segment)) continue;
+    const m = segment.match(/\.update\(\s*\{([\s\S]{0,400}?)\}\s*\)/);
+    if (m) found.push(m[1]);
+  }
+  const raw = /update\s+tasks\s+set\s+([^`;]{0,300})/g;
+  for (const m of text.matchAll(raw)) found.push(m[1]);
+  // `status:` / `status =` (raw SQL) AND the ES shorthand `{ status, … }` — the shorthand is how
+  // the dashboard board move writes it, and an earlier draft of this guard missed exactly that.
+  return found.filter((body) => /(^|[\s,({])status\s*([:=,}]|$)/.test(body));
+}
+
+describe("every authoritative tasks.status write clears raw_status (AIO-537)", () => {
+  const files = SCAN_DIRS.flatMap(sourceFiles);
+
+  it("scans a non-trivial surface (the guard is not vacuous)", () => {
+    expect(files.length).toBeGreaterThan(50);
+    const writers = files.filter((f) => statusWrites(readFileSync(f, "utf8")).length > 0);
+    expect(writers.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("finds no status write that leaves raw_status behind", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const rel = path.relative(ROOT, file);
+      if (rel === RAW_STATUS_OWNER) continue;
+      for (const body of statusWrites(readFileSync(file, "utf8"))) {
+        if (!/raw_status/.test(body)) offenders.push(`${rel}: ${body.trim().slice(0, 120)}`);
+      }
+    }
+    expect(
+      offenders,
+      `These writes set tasks.status without clearing raw_status. Add \`raw_status: null\` ` +
+        `(or \`raw_status = null\` in raw SQL) — otherwise the brain-api 1.13 sync-origin return ` +
+        `leg reads the change as a normalization echo and never reaches the workspace markdown.`,
+    ).toEqual([]);
+  });
+});

--- a/test/tasks-feed-mode.test.ts
+++ b/test/tasks-feed-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseTaskFeedMode } from "@/app/api/v1/tasks/route";
+import { nextCursorFor, parseTaskFeedMode } from "@/app/api/v1/tasks/route";
 
 /**
  * brain-api 1.13 (AIO-537). The mode selector must keep every pre-1.13 request shape mapping to
@@ -25,5 +25,34 @@ describe("task feed mode parsing", () => {
     expect(parseTaskFeedMode("sync_origin", null)).toBeNull();
     expect(parseTaskFeedMode("SYNC-ORIGIN", null)).toBeNull();
     expect(parseTaskFeedMode("all", "1")).toBeNull();
+  });
+});
+
+/**
+ * A full page is indistinguishable from a truncation, and the client advances its cursor after a
+ * successful merge — without a cursor the 501st+ changed row would be skipped forever (the first
+ * pull runs from EPOCH over a whole project, so this is reachable, not theoretical).
+ */
+describe("sync-origin pagination cursor", () => {
+  const page = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      updated_at: `2026-07-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+    }));
+
+  it("returns the last row's updated_at when the page is full", () => {
+    const rows = page(500);
+    expect(nextCursorFor("sync-origin", rows)).toBe(
+      new Date(rows[499].updated_at).toISOString(),
+    );
+  });
+
+  it("returns null when the page is short (nothing left to drain)", () => {
+    expect(nextCursorFor("sync-origin", page(499))).toBeNull();
+    expect(nextCursorFor("sync-origin", [])).toBeNull();
+  });
+
+  it("never pages the pre-1.13 modes", () => {
+    expect(nextCursorFor("writeback", page(500))).toBeNull();
+    expect(nextCursorFor("table", page(500))).toBeNull();
   });
 });

--- a/test/tasks-feed-mode.test.ts
+++ b/test/tasks-feed-mode.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseTaskFeedMode } from "@/app/api/v1/tasks/route";
+
+/**
+ * brain-api 1.13 (AIO-537). The mode selector must keep every pre-1.13 request shape mapping to
+ * exactly the response it got before, and must FAIL a typo rather than silently answering with
+ * the writeback feed (a client that thinks it asked for the return leg would merge nothing and
+ * report success).
+ */
+describe("task feed mode parsing", () => {
+  it("keeps the pre-1.13 defaults", () => {
+    expect(parseTaskFeedMode(null, null)).toBe("writeback");
+    expect(parseTaskFeedMode(null, "1")).toBe("table");
+    expect(parseTaskFeedMode(null, "0")).toBe("writeback");
+    expect(parseTaskFeedMode("", null)).toBe("writeback");
+  });
+
+  it("accepts the explicit modes", () => {
+    expect(parseTaskFeedMode("writeback", null)).toBe("writeback");
+    expect(parseTaskFeedMode("table", null)).toBe("table");
+    expect(parseTaskFeedMode("sync-origin", null)).toBe("sync-origin");
+  });
+
+  it("rejects anything else", () => {
+    expect(parseTaskFeedMode("sync_origin", null)).toBeNull();
+    expect(parseTaskFeedMode("SYNC-ORIGIN", null)).toBeNull();
+    expect(parseTaskFeedMode("all", "1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

The brain→Linear projection is one-way and `GET /api/v1/tasks` only ever emitted **dashboard-origin** rows — so a task row a workspace PUSHED could move to Done in Linear and never come back. `3-log/tasks-team.md` decayed until someone hand-reconciled (field audit 2026-07-27: 6 rows read `todo` while Linear said Done/In Progress), and a stale file plus a brain-wins push could drag completed issues backwards.

This is the brain half of **brain-api 1.13** — the contract is bumped first in the workspace repo (`aios-workspace` PR, `docs/brain-api.md` § "sync-origin return leg").

## Contract (1.13, additive)

- Explicit `mode` selector: `writeback` (default, unchanged), `table` (`?all=1`), and new **`sync-origin`**. An unrecognized value is `400 invalid_request` — never a silent downgrade. Requests without `mode` are answered exactly as before, so **pre-1.13 clients are byte-unaffected**; new clients feature-detect on the echoed `mode` and tolerate 400/404.
- `mode=sync-origin&project=<slug>` → `origin='sync'` rows for ONE project, filtered in SQL (not post-limit), tier-scoped through the same `visibleTasks` choke-point. Unknown slug ⇒ empty feed, not an error.
- Rows carry `raw_status` (sync-origin only) so the client can tell a real change from a normalization echo of its own push.
- Paged: a full 500-row page returns `next_cursor` (last row's `updated_at`) so the client drains the backlog instead of advancing past it.

## Invariant work found by review

`raw_status` only means "no authoritative writer has touched this row" if **every** authoritative writer clears it. The inbound apply/adopt, dashboard board move, work-event completion and meetings bulk apply now all do — leaving `lib/ingest/tasks.ts` (the push path) as the sole writer of a non-null value — and `test/guards/task-status-raw-status.test.ts` build-fails on the next writer that forgets.

## Verification

- `npm test` (unit): **1280 passed**, 11 skipped — incl. the new mode/pagination guards and the raw_status writer guard (each shown red before green).
- `npm run test:datamechanics:local` (real Postgres): **757 passed**, 4 skipped — incl. `tasks-sync-origin-feed` (mode isolation, project scoping, external-tier gate, `raw_status` presence/absence, the 400s) and the inbound `raw_status`-clearing case.
- `npm run check:docs` ✓ · `npm run lint` ✓ (2 pre-existing warnings) · `npx tsc --noEmit` ✓
- `docs/ARCHITECTURE.md` updated in this PR (build-loop rule).

## Review

Reviewed by Fable `code-reviewer` (local pre-push diff review) — verdict BLOCKED on the stale-`raw_status` writers and the 500-row truncation; both fixed in `6bbe1a3` with new guards/tests. Re-verified green after the fix.

## Deploy

**Prod deploy is owner-gated and NOT done here.** Merging to `main` triggers Railway; no schema change is involved (no migration), so `npm run pg:schema` is not required.

AIO-537

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the member-facing tasks API and multiple status write paths; incorrect `raw_status` handling could block markdown updates, but behavior is guarded by tests and pre-1.13 clients stay unchanged without `mode`.
> 
> **Overview**
> Implements **brain-api v1.13** so workspace markdown can pull **brain/Linear drift** on rows the workspace originally pushed—closing the one-way projection gap (AIO-537).
> 
> `GET /api/v1/tasks` gains an explicit **`mode`**: default **`writeback`** and **`table`** (`?all=1`) behave as before; new **`sync-origin`** (`?mode=sync-origin&project=<slug>`) returns `origin='sync'` rows for one project, tier-filtered via `visibleTasks`, with **`raw_status`** only in this mode for the client’s normalization-echo guard. Invalid `mode` → **400**; unknown project → empty feed. **`next_cursor`** is set when a sync-origin page hits 500 rows so clients can page the backlog.
> 
> **Every authoritative `tasks.status` write now sets `raw_status: null`** (dashboard move, Linear inbound apply/adopt, work-event completion, meetings bulk status)—so the return leg does not treat real changes as echoes of the workspace push. Only the ingest push path may set non-null `raw_status`. Contract version bumps to **1.13** with architecture docs, datamechanics tests, and **`test/guards/task-status-raw-status.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bbe1a3158738ee9aa95f801cf4e2fa082368a3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->