### PR TITLE
fix(ci): the work-key check accused a real ticket of not existing

### DIFF
--- a/.github/workflows/aios-work-sync.yml
+++ b/.github/workflows/aios-work-sync.yml
@@ -56,7 +56,10 @@ jobs:
           };
 
           const url = `${brain.replace(/\/$/, "")}/api/v1/work-events`;
-          fetch(url, {
+          // AWAITED. An un-awaited fetch does keep the loop alive, so this worked — but it worked by
+          // relying on an in-flight socket being an active handle, which is not a property to bet the
+          // only task-closing step on. Now the IIFE cannot resolve before the POST has answered.
+          await fetch(url, {
             method: "POST",
             headers: {
               "Authorization": `Bearer ${key}`,

--- a/.github/workflows/aios-work-sync.yml
+++ b/.github/workflows/aios-work-sync.yml
@@ -18,10 +18,17 @@ jobs:
       AIOS_TEAM: ${{ secrets.AIOS_TEAM }}
       AIOS_PROJECT: aios-team-brain
     steps:
+      - uses: actions/checkout@v4
       - name: Post merged work event
         run: |
           node <<'NODE'
+          // Async IIFE so the shared ESM helper can be `await import`ed from this CommonJS heredoc.
+          (async () => {
           const fs = require("node:fs");
+          // ONE matcher, shared with pr-task-link.yml (`scripts/pr-work-keys.mjs`) and unit-tested. These
+          // were two inline copies: the advisory check could clear a PR whose keys THIS step — the one
+          // that actually closes tickets — then read differently.
+          const { extractWorkKeys } = await import("./scripts/pr-work-keys.mjs");
 
           const brain = process.env.AIOS_BRAIN_URL;
           const key = process.env.AIOS_API_KEY;
@@ -33,14 +40,7 @@ jobs:
 
           const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
           const pr = event.pull_request;
-          // Strip HTML comments first so PR-template placeholders (e.g. `<!-- e.g. AIO-72 -->`) aren't matched.
-          const text = [
-            pr.title || "",
-            (pr.body || "").replace(/<!--[\s\S]*?-->/g, " "),
-            pr.head?.ref || "",
-          ].join("\n");
-          const re = /\b(?:AIOS-Work:\s*)?([A-Z][A-Z0-9]+-\d+|[A-Z]\d+(?:\.\d+)*)\b/g;
-          const workKeys = [...new Set([...text.matchAll(re)].map((m) => m[1]))];
+          const workKeys = extractWorkKeys(pr);
 
           const payload = {
             project: process.env.AIOS_PROJECT,
@@ -75,4 +75,7 @@ jobs:
             console.error(err);
             process.exit(1);
           });
+          // Unlike the advisory check, this step FAILS loudly: it is the only thing that closes a task, so
+          // a silent skip would leave the board wrong with a green tick next to it.
+          })().catch((err) => { console.error(err); process.exit(1); });
           NODE

--- a/.github/workflows/pr-task-link.yml
+++ b/.github/workflows/pr-task-link.yml
@@ -8,6 +8,15 @@ name: PR task link (advisory)
 # aios-work-sync.yml and unit-tested. They used to be inline here, where no tier could
 # reach them — and shipped reading the tasks response in a shape it never returns, so the
 # check reported a REAL key as nonexistent on its first run.
+#
+# ⛔ THIS MUST STAY ON `pull_request`. NEVER `pull_request_target`.
+# The job checks out the PR's head and EXECUTES a script from it (`scripts/pr-work-keys.mjs`)
+# with `AIOS_API_KEY` in the environment. On `pull_request`, GitHub withholds secrets from
+# fork-PR runs, so a fork that edits that script gets an empty key and there is nothing to
+# steal. `pull_request_target` runs with secrets AND the base repo's permissions — switching
+# it would turn this into a textbook pwn-request: edit the script in a fork, exfiltrate the
+# key. Fork PRs correctly reporting "credentials not configured" is the intended behaviour,
+# not a bug to fix by changing the trigger. (This repo is public.)
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
@@ -32,7 +41,7 @@ jobs:
           // syntax error. A `.catch` keeps the job advisory — an unexpected throw must not fail a PR.
           (async () => {
           const fs = require("node:fs");
-          const { extractWorkKeys, knownKeysFrom, verifyKeys } = await import("./scripts/pr-work-keys.mjs");
+          const { extractWorkKeys, knownKeysFrom, taskRowsFrom, verifyKeys, TASKS_PAGE_BOUND } = await import("./scripts/pr-work-keys.mjs");
           const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
           const keys = extractWorkKeys(ev.pull_request || {});
           if (!keys.length) {
@@ -59,8 +68,15 @@ jobs:
             console.log(`::warning title=Work key not verified::brain returned ${res.status} — only the FORMAT was checked.`);
             return;
           }
-          const verdict = verifyKeys(keys, knownKeysFrom(await res.json()));
-          if (verdict.status === "unverified") {
+          const body = await res.json();
+          // `?all=1` is bounded at 500 rows (documented) and does NOT paginate, so a full page is a
+          // PREFIX of the table — the stalest rows, since it orders `updated_at` ascending. Absence from
+          // a prefix is not absence from the table; presence in it is still proof.
+          const truncated = taskRowsFrom(body).length >= TASKS_PAGE_BOUND;
+          const verdict = verifyKeys(keys, knownKeysFrom(body), { truncated });
+          if (verdict.status === "unverified" && verdict.reason === "truncated") {
+            console.log(`::warning title=Work key not verified::${verdict.keys.join(", ")} was not in the ${verdict.checked} tasks the brain returned — but that response is capped at ${TASKS_PAGE_BOUND} rows and returns the STALEST first, so the key may simply be past the cap. Only the FORMAT was verified. (To make this provable, the tasks endpoint needs a by-key lookup or a table-mode cursor.)`);
+          } else if (verdict.status === "unverified") {
             console.log(`::warning title=Work key not verified::the brain returned no task keys, so ${verdict.keys.join(", ")} could not be checked — only the FORMAT was verified. (If the brain really has tasks, this check is misreading the response.)`);
           } else if (verdict.status === "invented") {
             console.log(

--- a/.github/workflows/pr-task-link.yml
+++ b/.github/workflows/pr-task-link.yml
@@ -3,6 +3,11 @@ name: PR task link (advisory)
 # Nudge, not a gate: warns when a PR has no brain task work-key, so untracked work is
 # visible at review time. The actual close happens on merge via aios-work-sync.yml
 # (→ POST /api/v1/work-events → tasks.status=done → pm-sync projects to Linear).
+#
+# The matching and the response parsing live in `scripts/pr-work-keys.mjs`, shared with
+# aios-work-sync.yml and unit-tested. They used to be inline here, where no tier could
+# reach them — and shipped reading the tasks response in a shape it never returns, so the
+# check reported a REAL key as nonexistent on its first run.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
@@ -19,6 +24,7 @@ jobs:
       AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
       AIOS_TEAM: ${{ secrets.AIOS_TEAM }}
     steps:
+      - uses: actions/checkout@v4
       - name: Check for an AIOS work-key
         run: |
           node <<'NODE'
@@ -26,53 +32,44 @@ jobs:
           // syntax error. A `.catch` keeps the job advisory — an unexpected throw must not fail a PR.
           (async () => {
           const fs = require("node:fs");
+          const { extractWorkKeys, knownKeysFrom, verifyKeys } = await import("./scripts/pr-work-keys.mjs");
           const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
-          const pr = ev.pull_request || {};
-          // Strip HTML comments first so PR-template placeholders (e.g. `<!-- e.g. AIO-72 -->`) aren't matched.
-          const text = [
-            pr.title || "",
-            (pr.body || "").replace(/<!--[\s\S]*?-->/g, " "),
-            pr.head?.ref || "",
-          ].join("\n");
-          // Same matcher aios-work-sync uses (lib/pm-sync/work-keys): AIO-12 / W2.5.8 / etc.
-          const re = /\b(?:AIOS-Work:\s*)?([A-Z][A-Z0-9]+-\d+|[A-Z]\d+(?:\.\d+)*)\b/g;
-          const keys = [...new Set([...text.matchAll(re)].map((m) => m[1]))];
-          if (keys.length) {
-            console.log(`Found work key(s): ${keys.join(", ")}`);
-            // A key that matches the PATTERN is not a key that EXISTS. Every PR in one recent session
-            // carried an invented `AIO-48x` that no task had: the work looked tracked, this check went
-            // green, and none of it could ever link to a task on the timeline. Shape alone is not a
-            // check, so ask the brain whether the key is real.
-            const brain = process.env.AIOS_BRAIN_URL;
-            const key = process.env.AIOS_API_KEY;
-            const team = process.env.AIOS_TEAM;
-            if (!brain || !key || !team) {
-              console.log("::warning title=Work key not verified::brain credentials not configured — only the FORMAT was checked.");
-            } else {
-              const res = await fetch(`${brain.replace(/\/$/, "")}/api/v1/tasks?all=1`, {
-                headers: { Authorization: `Bearer ${key}`, "X-AIOS-Team": team },
-              });
-              if (!res.ok) {
-                // Couldn't ask ≠ the key is fake. Advisory job, so never fail on OUR outage.
-                console.log(`::warning title=Work key not verified::brain returned ${res.status} — only the FORMAT was checked.`);
-              } else {
-                const body = await res.json();
-                const rows = Array.isArray(body) ? body : (body.tasks ?? body.data ?? []);
-                const known = new Set(rows.map((t) => String(t.row_key ?? t.rowKey ?? "")).filter(Boolean));
-                const invented = keys.filter((k) => !known.has(k));
-                if (invented.length) {
-                  console.log(
-                    `::warning title=Work key does not exist::${invented.join(", ")} matches the key format but ` +
-                      `no task in the brain has it, so this work will link to nothing on the timeline. ` +
-                      `Use a real key or create the task. (${known.size} task keys checked.)`
-                  );
-                } else {
-                  console.log(`All work key(s) exist in the brain — merge will advance the matching task(s) to Done.`);
-                }
-              }
-            }
-          } else {
+          const keys = extractWorkKeys(ev.pull_request || {});
+          if (!keys.length) {
             console.log("::warning title=No brain task linked::This PR has no AIOS work-key (e.g. `AIOS-Work: W2.5.8`). Merge won't auto-close a task in Linear. If this work should be tracked, link or create a brain task first. (Advisory — not blocking.)");
+            return;
+          }
+          console.log(`Found work key(s): ${keys.join(", ")}`);
+          // A key that matches the PATTERN is not a key that EXISTS. Every PR in one recent session
+          // carried an invented `AIO-48x` that no task had: the work looked tracked, this check went
+          // green, and none of it could ever link to a task on the timeline. Shape alone is not a
+          // check, so ask the brain whether the key is real.
+          const brain = process.env.AIOS_BRAIN_URL;
+          const key = process.env.AIOS_API_KEY;
+          const team = process.env.AIOS_TEAM;
+          if (!brain || !key || !team) {
+            console.log("::warning title=Work key not verified::brain credentials not configured — only the FORMAT was checked.");
+            return;
+          }
+          const res = await fetch(`${brain.replace(/\/$/, "")}/api/v1/tasks?all=1`, {
+            headers: { Authorization: `Bearer ${key}`, "X-AIOS-Team": team },
+          });
+          if (!res.ok) {
+            // Couldn't ask ≠ the key is fake. Advisory job, so never fail on OUR outage.
+            console.log(`::warning title=Work key not verified::brain returned ${res.status} — only the FORMAT was checked.`);
+            return;
+          }
+          const verdict = verifyKeys(keys, knownKeysFrom(await res.json()));
+          if (verdict.status === "unverified") {
+            console.log(`::warning title=Work key not verified::the brain returned no task keys, so ${verdict.keys.join(", ")} could not be checked — only the FORMAT was verified. (If the brain really has tasks, this check is misreading the response.)`);
+          } else if (verdict.status === "invented") {
+            console.log(
+              `::warning title=Work key does not exist::${verdict.invented.join(", ")} matches the key format but ` +
+                `no task in the brain has it, so this work will link to nothing on the timeline. ` +
+                `Use a real key or create the task. (${verdict.checked} task keys checked.)`
+            );
+          } else {
+            console.log(`All work key(s) exist in the brain (${verdict.checked} checked) — merge will advance the matching task(s) to Done.`);
           }
           })().catch((err) => console.log(`::warning title=Work-key check errored::${err && err.message}`));
           NODE

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -68,9 +68,18 @@ The four required jobs (`docs-drift`, `brain-tests`, `datamechanics-tests`, `ing
 
 ### `aios-work-sync.yml` — fires on merge to `main`
 
-Extracts `AIOS-Work: <KEY>` from the PR title/body and POSTs a merge event to `/api/v1/work-events`. This closes the matching issue in the team's primary PM tool automatically — currently **Linear** (the brain projects the merge event to whichever provider `teams.primary_pm_provider` names; the sync path itself is provider-neutral).
+Extracts work keys from the PR **title, body and branch ref** and POSTs a merge event to `/api/v1/work-events`. This closes the matching issue in the team's primary PM tool automatically — currently **Linear** (the brain projects the merge event to whichever provider `teams.primary_pm_provider` names; the sync path itself is provider-neutral).
 
 **Required secrets:** `AIOS_BRAIN_URL`, `AIOS_API_KEY`, `AIOS_TEAM`
+
+### Work-key extraction — `scripts/pr-work-keys.mjs` (ONE copy)
+
+Both this workflow and `pr-task-link.yml` (advisory) read a PR for the ticket it cites, and both call the same module — guarded by `test/guards/work-key-single-matcher.test.ts`, which discovers workflows from disk so a new one can't inline its own copy. They used to have one each, so the advisory check could clear a PR whose keys the merge step then read differently.
+
+Two behaviours worth knowing:
+
+- **Quoted keys don't count.** HTML comments, fenced blocks and inline code are stripped from the body before matching, so prose like ``supersedes `AIO-100` `` is not a citation. That direction is deliberate: `/api/v1/work-events` sets `status='done'` on a key matching a task in the pushed project, so over-matching closes the **wrong** ticket silently, while under-matching only leaves the board stale — and the advisory check announces that at open time.
+- **The existence check can say "I don't know."** `GET /api/v1/tasks?all=1` is capped at 500 rows and does not paginate, so on a team with more tasks the answer is a prefix of the stalest ones. A key found there is confirmed; a key absent from a **full** page reports `unverified`, never "invented" — the check is not allowed to accuse on data it never saw. Making it provable for every key needs a by-key lookup or a table-mode cursor on the tasks endpoint.
 
 ---
 

--- a/scripts/pr-work-keys.mjs
+++ b/scripts/pr-work-keys.mjs
@@ -10,6 +10,14 @@
  *
  * Pure and testable on purpose: the response parser here shipped broken (see `knownKeysFrom`) precisely
  * because it lived in a YAML heredoc that no tier could reach.
+ *
+ * ONE DELIBERATE ASYMMETRY. `prSearchText` NARROWS what counts as a citation, which means a key written
+ * inside backticks stops closing its task on merge. That is the safe direction: over-matching posts a key
+ * the author never claimed, and `/api/v1/work-events` sets `status='done'` on a task that matches in the
+ * pushed project — so prose like "supersedes `AIO-100`" would have CLOSED AIO-100. Under-matching leaves
+ * the board stale, which the advisory check announces at open time ("No brain task linked"). A wrongly
+ * closed ticket is silent; a missed one is warned about. The PR template asks for a bare
+ * `AIOS-Work: AIO-72` line, and the title and branch are never stripped.
  */
 
 /** Same shape `lib/pm-sync/work-keys` accepts: `AIO-12`, `W2.5.8`, optionally after an `AIOS-Work:` label. */
@@ -26,7 +34,10 @@ const WORK_KEY_RE = /\b(?:AIOS-Work:\s*)?([A-Z][A-Z0-9]+-\d+|[A-Z]\d+(?:\.\d+)*)
 export function prSearchText(pr) {
   const prose = String(pr?.body ?? "")
     .replace(/<!--[\s\S]*?-->/g, " ")
-    .replace(/```[\s\S]*?```/g, " ")
+    // Fences: ``` or ~~~, and an UNCLOSED fence swallows the rest of the body. A lazy `[\s\S]*?` needs a
+    // closing fence, so one stray ``` left everything after it matchable — failing toward over-match,
+    // which is the direction that closes someone else's ticket.
+    .replace(/(^|\n)(```|~~~)[\s\S]*?(\n\2|$)/g, " ")
     .replace(/`[^`\n]*`/g, " ");
   return [String(pr?.title ?? ""), prose, String(pr?.head?.ref ?? "")].join("\n");
 }
@@ -46,11 +57,28 @@ export function extractWorkKeys(pr) {
  *
  * Tolerates a flat array and a bare `{rows}` group too: the caller must not care which of those it got.
  */
-export function knownKeysFrom(body) {
+export function taskRowsFrom(body) {
   const groups = Array.isArray(body) ? body : (body?.tasks ?? body?.data ?? []);
-  const rows = (Array.isArray(groups) ? groups : []).flatMap((g) => (Array.isArray(g?.rows) ? g.rows : [g]));
-  return new Set(rows.map((t) => String(t?.row_key ?? t?.rowKey ?? "")).filter(Boolean));
+  return (Array.isArray(groups) ? groups : []).flatMap((g) => (Array.isArray(g?.rows) ? g.rows : [g]));
 }
+
+export function knownKeysFrom(body) {
+  return new Set(taskRowsFrom(body).map((t) => String(t?.row_key ?? t?.rowKey ?? "")).filter(Boolean));
+}
+
+/**
+ * The documented row bound of `GET /api/v1/tasks?all=1` (brain-api: "up to the endpoint's 500-row bound").
+ * Table mode does not paginate — `next_cursor` is null for it by design — so a full page means the answer
+ * we got is a PREFIX of the table, ordered by `updated_at` ASCENDING: the STALEST rows. The tasks people
+ * actually cite in PRs are the recently-touched ones, i.e. exactly the ones missing.
+ *
+ * Measured when this was found: prod had 677 keyed tasks, and AIO-484 — cited by the PR that exposed all
+ * this — sat at rank 628 of 677. It was never in the answer, so "no task has this key" was a confident
+ * statement about data the check had never seen.
+ *
+ * A full page therefore only ever justifies a POSITIVE: a key we DID see is real. Absence proves nothing.
+ */
+export const TASKS_PAGE_BOUND = 500;
 
 /**
  * Verdict for the advisory check: what do we actually know about these keys?
@@ -60,9 +88,14 @@ export function knownKeysFrom(body) {
  * indistinguishable from a brain with no tasks. Accusing the author on no evidence is exactly what makes
  * an advisory warning worthless.
  */
-export function verifyKeys(keys, known) {
+export function verifyKeys(keys, known, { truncated = false } = {}) {
   if (!keys.length) return { status: "none" };
-  if (!known.size) return { status: "unverified", keys };
+  if (!known.size) return { status: "unverified", keys, reason: "empty" };
   const invented = keys.filter((k) => !known.has(k));
-  return invented.length ? { status: "invented", invented, checked: known.size } : { status: "ok", checked: known.size };
+  if (!invented.length) return { status: "ok", checked: known.size };
+  // A missing key is only evidence of a FAKE key when we can see the whole table. On a truncated read the
+  // same absence is equally explained by "it's in the part we didn't get" — and on this team's data that
+  // is what it always was. Verifying the keys we CAN see still works: `ok` above is unaffected.
+  if (truncated) return { status: "unverified", keys: invented, reason: "truncated", checked: known.size };
+  return { status: "invented", invented, checked: known.size };
 }

--- a/scripts/pr-work-keys.mjs
+++ b/scripts/pr-work-keys.mjs
@@ -34,10 +34,11 @@ const WORK_KEY_RE = /\b(?:AIOS-Work:\s*)?([A-Z][A-Z0-9]+-\d+|[A-Z]\d+(?:\.\d+)*)
 export function prSearchText(pr) {
   const prose = String(pr?.body ?? "")
     .replace(/<!--[\s\S]*?-->/g, " ")
-    // Fences: ``` or ~~~, and an UNCLOSED fence swallows the rest of the body. A lazy `[\s\S]*?` needs a
-    // closing fence, so one stray ``` left everything after it matchable — failing toward over-match,
-    // which is the direction that closes someone else's ticket.
-    .replace(/(^|\n)(```|~~~)[\s\S]*?(\n\2|$)/g, " ")
+    // Fences: ``` or ~~~, indented up to 3 spaces (GitHub still renders those as a fence — a block nested
+    // under a list item is the common case), and an UNCLOSED fence swallows the rest of the body. A lazy
+    // `[\s\S]*?` needs a closing fence, so one stray ``` left everything after it matchable. Both gaps
+    // failed toward OVER-match, the direction that closes someone else's ticket on merge.
+    .replace(/(^|\n)[ ]{0,3}(```|~~~)[\s\S]*?(\n[ ]{0,3}\2|$)/g, " ")
     .replace(/`[^`\n]*`/g, " ");
   return [String(pr?.title ?? ""), prose, String(pr?.head?.ref ?? "")].join("\n");
 }
@@ -88,7 +89,15 @@ export const TASKS_PAGE_BOUND = 500;
  * indistinguishable from a brain with no tasks. Accusing the author on no evidence is exactly what makes
  * an advisory warning worthless.
  */
-export function verifyKeys(keys, known, { truncated = false } = {}) {
+export function verifyKeys(keys, known, opts) {
+  // MANDATORY, and it throws rather than defaulting. `truncated = false` would be a default that ACCUSES:
+  // drop the argument — a plausible merge-conflict resolution, in glue code that lives in a YAML heredoc —
+  // and the false accusation comes back with every test still green. That is the exact class this module
+  // exists to end, so the omission has to fail loudly instead of quietly picking the unsafe branch.
+  if (typeof opts?.truncated !== "boolean") {
+    throw new Error("verifyKeys requires an explicit { truncated } — defaulting it would silently accuse");
+  }
+  const truncated = opts.truncated;
   if (!keys.length) return { status: "none" };
   if (!known.size) return { status: "unverified", keys, reason: "empty" };
   const invented = keys.filter((k) => !known.has(k));

--- a/scripts/pr-work-keys.mjs
+++ b/scripts/pr-work-keys.mjs
@@ -1,0 +1,68 @@
+/**
+ * Work-key extraction and verification for the two PR workflows — ONE copy, because there were two and
+ * they were about to disagree.
+ *
+ * `pr-task-link.yml` (advisory, on open/edit) warns when a PR cites no brain task or cites one that
+ * doesn't exist. `aios-work-sync.yml` (on merge) posts those same keys to `/api/v1/work-events`, which
+ * moves the matching task to Done. Both had their own inline copy of the matcher, so a fix to what counts
+ * as a "cited key" landed in the warning and not in the thing that actually closes tickets — the check
+ * would clear a PR whose keys the merge step then read differently.
+ *
+ * Pure and testable on purpose: the response parser here shipped broken (see `knownKeysFrom`) precisely
+ * because it lived in a YAML heredoc that no tier could reach.
+ */
+
+/** Same shape `lib/pm-sync/work-keys` accepts: `AIO-12`, `W2.5.8`, optionally after an `AIOS-Work:` label. */
+const WORK_KEY_RE = /\b(?:AIOS-Work:\s*)?([A-Z][A-Z0-9]+-\d+|[A-Z]\d+(?:\.\d+)*)\b/g;
+
+/**
+ * The parts of a PR that CLAIM a work key, with the parts that merely DISCUSS one removed: HTML comments
+ * (the template's `<!-- e.g. AIO-72 -->` placeholder), fenced blocks, and inline code.
+ *
+ * A PR body explaining that the model "sees `T1…Tn`" was read as citing a work key called `T1`: the
+ * advisory check warned about it, and the merge step would have posted it as a key to close. Prose noise
+ * is how an advisory warning earns its way onto everyone's ignore list.
+ */
+export function prSearchText(pr) {
+  const prose = String(pr?.body ?? "")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`\n]*`/g, " ");
+  return [String(pr?.title ?? ""), prose, String(pr?.head?.ref ?? "")].join("\n");
+}
+
+/** Every distinct work key the PR cites, in first-seen order. */
+export function extractWorkKeys(pr) {
+  return [...new Set([...prSearchText(pr).matchAll(WORK_KEY_RE)].map((m) => m[1]))];
+}
+
+/**
+ * The set of key strings a `GET /api/v1/tasks` response actually contains.
+ *
+ * THE BUG THIS EXISTS FOR: that endpoint answers `{tasks: [{project, rows: [{row_key, …}]}]}` — grouped
+ * BY PROJECT, not a flat row list. The original one-liner read `body.tasks` as rows, found `row_key` on
+ * none of them, and produced an empty set — so every key was reported as invented, including real ones.
+ * It cried wolf on its own first run, on a PR citing a task that exists.
+ *
+ * Tolerates a flat array and a bare `{rows}` group too: the caller must not care which of those it got.
+ */
+export function knownKeysFrom(body) {
+  const groups = Array.isArray(body) ? body : (body?.tasks ?? body?.data ?? []);
+  const rows = (Array.isArray(groups) ? groups : []).flatMap((g) => (Array.isArray(g?.rows) ? g.rows : [g]));
+  return new Set(rows.map((t) => String(t?.row_key ?? t?.rowKey ?? "")).filter(Boolean));
+}
+
+/**
+ * Verdict for the advisory check: what do we actually know about these keys?
+ *
+ * `unverified` is a DISTINCT outcome from `invented`, and keeping them apart is the whole point. Zero
+ * known keys means "we couldn't ask" — an empty response, a shape change, a tier that sees nothing — each
+ * indistinguishable from a brain with no tasks. Accusing the author on no evidence is exactly what makes
+ * an advisory warning worthless.
+ */
+export function verifyKeys(keys, known) {
+  if (!keys.length) return { status: "none" };
+  if (!known.size) return { status: "unverified", keys };
+  const invented = keys.filter((k) => !known.has(k));
+  return invented.length ? { status: "invented", invented, checked: known.size } : { status: "ok", checked: known.size };
+}

--- a/test/guards/work-key-single-matcher.test.ts
+++ b/test/guards/work-key-single-matcher.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * BUILD-FAILING GUARD: exactly ONE work-key matcher, in `scripts/pr-work-keys.mjs`.
+ *
+ * Two workflows read a PR for the ticket it cites — `pr-task-link.yml` warns about it, and
+ * `aios-work-sync.yml` posts it on merge to move the task to Done. Each carried its own inline copy of
+ * the regex and the body-stripping, so they could disagree about what counts as a cited key: the check
+ * clears a PR, and the step that actually closes tickets then reads it differently. Both copies also sat
+ * in YAML heredocs no test tier could reach, which is how the tasks-response parser shipped reading a
+ * shape the endpoint never returns and reported a REAL key as nonexistent.
+ *
+ * Discovered from the workflow files rather than a hardcoded list, so a NEW workflow that inlines its own
+ * copy fails this too.
+ */
+
+const WORKFLOWS = join(process.cwd(), ".github", "workflows");
+
+/** The distinctive fragment of the matcher — any inline re-implementation contains it. */
+const INLINE_MATCHER = "AIOS-Work:\\s*";
+
+describe("guard: one work-key matcher, shared and tested", () => {
+  const files = readdirSync(WORKFLOWS).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+
+  it("finds the workflows to check (or this guard is vacuous)", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("no workflow inlines its own copy of the work-key regex", () => {
+    const offenders = files.filter((f) => readFileSync(join(WORKFLOWS, f), "utf8").includes(INLINE_MATCHER));
+    expect(
+      offenders,
+      `these workflows inline the work-key matcher instead of importing scripts/pr-work-keys.mjs — two ` +
+        `copies can disagree about which ticket a PR cites, and an inline copy is untestable`
+    ).toEqual([]);
+  });
+
+  it("every workflow that reads work keys imports the shared module", () => {
+    const readers = files.filter((f) => readFileSync(join(WORKFLOWS, f), "utf8").includes("work_keys") || readFileSync(join(WORKFLOWS, f), "utf8").includes("work-key"));
+    expect(readers.length, "no workflow reads work keys — has the feature moved?").toBeGreaterThan(0);
+    for (const f of readers) {
+      expect(readFileSync(join(WORKFLOWS, f), "utf8"), `${f} reads work keys without the shared matcher`).toContain(
+        "scripts/pr-work-keys.mjs"
+      );
+    }
+  });
+});

--- a/test/guards/workflow-heredoc-syntax.test.ts
+++ b/test/guards/workflow-heredoc-syntax.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * BUILD-FAILING GUARD: every `node <<'NODE'` heredoc in a workflow is at least SYNTACTICALLY valid.
+ *
+ * These heredocs are real programs that no test tier can reach — they only ever run on GitHub's runners,
+ * on a PR event, often on the merge path. A typo in one is invisible locally and shows up as a workflow
+ * that either warns nothing or fails to close a task, both of which look like "fine" from here.
+ *
+ * The class is real: today's work rewrote two of these by hand. This does not prove the logic (the logic
+ * belongs in `scripts/`, which is the point of `pr-work-keys.mjs`) — it proves the file parses, which is
+ * the failure that costs a round-trip through CI to discover.
+ */
+
+const WORKFLOWS = join(process.cwd(), ".github", "workflows");
+
+/** Every `node <<'NODE' … NODE` block in a workflow, de-indented back to real source. */
+function heredocs(yaml: string): string[] {
+  const out: string[] = [];
+  const lines = yaml.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const open = lines[i].match(/^(\s*)node\s+<<'(\w+)'\s*$/);
+    if (!open) continue;
+    const [, indent, marker] = open;
+    const body: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j].trim() === marker) break;
+      body.push(lines[j].startsWith(indent) ? lines[j].slice(indent.length) : lines[j]);
+    }
+    out.push(body.join("\n"));
+  }
+  return out;
+}
+
+describe("guard: workflow node heredocs parse", () => {
+  const files = readdirSync(WORKFLOWS).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+  // Numbered PER FILE, so a failure names the block you have to go and look at.
+  const blocks = files.flatMap((f) => heredocs(readFileSync(join(WORKFLOWS, f), "utf8")).map((src, n) => ({ f, src, n: n + 1 })));
+
+  it("finds the heredocs (or this guard is vacuous)", () => {
+    expect(blocks.length, "no `node <<'NODE'` blocks found — has the pattern changed?").toBeGreaterThan(0);
+  });
+
+  it.each(blocks.map((b) => [`${b.f} heredoc #${b.n}`, b.src]))("%s is valid JavaScript", (_label, src) => {
+    const file = join(mkdtempSync(join(tmpdir(), "wf-heredoc-")), "block.js");
+    writeFileSync(file, src as string);
+    // `node --check` parses without executing — no network, no side effects.
+    expect(() => execFileSync(process.execPath, ["--check", file], { stdio: "pipe" })).not.toThrow();
+  });
+});

--- a/test/pr-work-keys.test.ts
+++ b/test/pr-work-keys.test.ts
@@ -45,8 +45,27 @@ describe("extractWorkKeys — what the PR CLAIMS, not what it discusses", () => 
     expect(extractWorkKeys({ title: "", body: "x:\n~~~\nAIO-999\n~~~\n", head: { ref: "" } })).toEqual([]);
   });
 
+  it("ignores keys inside an INDENTED fence (a block nested under a list item)", () => {
+    // GitHub renders up to 3 spaces of indentation as a fence. Missing them is the over-match direction:
+    // a key merely quoted in a nested example would be POSTed on merge and could close the wrong ticket.
+    expect(extractWorkKeys({ title: "", body: "- example:\n  ```\n  AIOS-Work: AIO-999\n  ```\n", head: { ref: "" } })).toEqual([]);
+  });
+
   it("ignores the PR template's commented-out placeholder", () => {
     expect(extractWorkKeys({ title: "", body: "<!-- e.g. AIO-72 -->", head: { ref: "" } })).toEqual([]);
+  });
+
+  it("does NOT over-strip: a real claim between two fenced blocks survives", () => {
+    // The stripping must only remove the quoted parts. Over-stripping is the direction that silently
+    // stops closing tasks on merge, with a green tick — so it gets its own tests, not just the under
+    // -stripping ones above.
+    const body = "```\nAIO-900\n```\n\nAIOS-Work: AIO-1\n\n```\nAIO-901\n```";
+    expect(extractWorkKeys({ title: "", body, head: { ref: "" } })).toEqual(["AIO-1"]);
+  });
+
+  it("does NOT over-strip: a key AFTER a closed fence, or BEFORE an unclosed one, survives", () => {
+    expect(extractWorkKeys({ title: "", body: "```\nx\n```\nAIOS-Work: AIO-7", head: { ref: "" } })).toEqual(["AIO-7"]);
+    expect(extractWorkKeys({ title: "", body: "AIOS-Work: AIO-8\n\n```\nAIO-999 blah", head: { ref: "" } })).toEqual(["AIO-8"]);
   });
 
   it("still finds a real key in a body that ALSO discusses keys in code spans", () => {
@@ -87,19 +106,19 @@ describe("verifyKeys — 'we couldn't ask' is NOT 'your key is fake'", () => {
     // failure that trains everyone to ignore the warning.
     // `reason` distinguishes the two ways we can fail to know: nothing came back at all vs. a full page
     // that may not contain it. The warning text differs, because the fix differs.
-    expect(verifyKeys(["AIO-484"], new Set())).toEqual({ status: "unverified", keys: ["AIO-484"], reason: "empty" });
+    expect(verifyKeys(["AIO-484"], new Set(), { truncated: false })).toEqual({ status: "unverified", keys: ["AIO-484"], reason: "empty" });
   });
 
   it("reports INVENTED only when the brain demonstrably has other keys", () => {
-    expect(verifyKeys(["AIO-999"], new Set(["AIO-484"]))).toEqual({ status: "invented", invented: ["AIO-999"], checked: 1 });
+    expect(verifyKeys(["AIO-999"], new Set(["AIO-484"]), { truncated: false })).toEqual({ status: "invented", invented: ["AIO-999"], checked: 1 });
   });
 
   it("reports OK when every cited key exists", () => {
-    expect(verifyKeys(["AIO-484"], new Set(["AIO-484", "AIO-537"]))).toEqual({ status: "ok", checked: 2 });
+    expect(verifyKeys(["AIO-484"], new Set(["AIO-484", "AIO-537"]), { truncated: false })).toEqual({ status: "ok", checked: 2 });
   });
 
   it("reports NONE when the PR cites nothing", () => {
-    expect(verifyKeys([], new Set(["AIO-484"]))).toEqual({ status: "none" });
+    expect(verifyKeys([], new Set(["AIO-484"]), { truncated: false })).toEqual({ status: "none" });
   });
 });
 
@@ -138,6 +157,14 @@ describe("a truncated read cannot prove a key is fake", () => {
     // detecting truncation and goes back to accusing.
     const route = readFileSync(join(process.cwd(), "app", "api", "v1", "tasks", "route.ts"), "utf8");
     expect(route).toContain(`const PAGE = ${TASKS_PAGE_BOUND};`);
+  });
+
+  it("THROWS if the caller omits `truncated` — a default would silently accuse", () => {
+    // The glue that computes `truncated` lives in a YAML heredoc, which is where this whole bug came
+    // from. Dropping the argument is a plausible merge-conflict resolution; with a `false` default that
+    // brings the false accusation back with every test still green. It has to fail loudly instead.
+    expect(() => verifyKeys(["AIO-484"], new Set(["X-1"]))).toThrow(/explicit \{ truncated \}/);
+    expect(() => verifyKeys(["AIO-484"], new Set(["X-1"]), {})).toThrow(/explicit \{ truncated \}/);
   });
 
   it("taskRowsFrom counts rows across project groups, so truncation is detectable", () => {

--- a/test/pr-work-keys.test.ts
+++ b/test/pr-work-keys.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 // @ts-expect-error — plain .mjs shared by the two PR workflows; no types, deliberately dependency-free.
-import { extractWorkKeys, knownKeysFrom, verifyKeys } from "../scripts/pr-work-keys.mjs";
+import { extractWorkKeys, knownKeysFrom, taskRowsFrom, verifyKeys, TASKS_PAGE_BOUND } from "../scripts/pr-work-keys.mjs";
 
 /**
  * The PR work-key check, which shipped broken because it lived in a YAML heredoc no test tier could reach.
@@ -31,6 +33,16 @@ describe("extractWorkKeys — what the PR CLAIMS, not what it discusses", () => 
   it("ignores keys inside a fenced block", () => {
     const keys = extractWorkKeys({ title: "", body: "example:\n```\nAIOS-Work: AIO-999\n```\n", head: { ref: "" } });
     expect(keys).toEqual([]);
+  });
+
+  it("ignores keys after an UNCLOSED fence", () => {
+    // A lazy `[\s\S]*?` needs a closing fence, so one stray ``` used to leave the whole rest of the body
+    // matchable. Failing toward over-match is the direction that closes someone else's ticket on merge.
+    expect(extractWorkKeys({ title: "", body: "example:\n```\nAIOS-Work: AIO-999\nand more prose", head: { ref: "" } })).toEqual([]);
+  });
+
+  it("ignores keys inside a ~~~ fence", () => {
+    expect(extractWorkKeys({ title: "", body: "x:\n~~~\nAIO-999\n~~~\n", head: { ref: "" } })).toEqual([]);
   });
 
   it("ignores the PR template's commented-out placeholder", () => {
@@ -73,7 +85,9 @@ describe("verifyKeys — 'we couldn't ask' is NOT 'your key is fake'", () => {
     // Zero known keys means an empty response, a shape change, or a tier that sees nothing — each
     // indistinguishable from a brain with no tasks. Calling a real key invented on that evidence is the
     // failure that trains everyone to ignore the warning.
-    expect(verifyKeys(["AIO-484"], new Set())).toEqual({ status: "unverified", keys: ["AIO-484"] });
+    // `reason` distinguishes the two ways we can fail to know: nothing came back at all vs. a full page
+    // that may not contain it. The warning text differs, because the fix differs.
+    expect(verifyKeys(["AIO-484"], new Set())).toEqual({ status: "unverified", keys: ["AIO-484"], reason: "empty" });
   });
 
   it("reports INVENTED only when the brain demonstrably has other keys", () => {
@@ -86,5 +100,48 @@ describe("verifyKeys — 'we couldn't ask' is NOT 'your key is fake'", () => {
 
   it("reports NONE when the PR cites nothing", () => {
     expect(verifyKeys([], new Set(["AIO-484"]))).toEqual({ status: "none" });
+  });
+});
+
+/**
+ * The blocker the first version of this fix still had.
+ *
+ * `?all=1` is bounded at 500 rows, ordered `updated_at` ASCENDING, and table mode does not paginate. Prod
+ * had 677 keyed tasks and AIO-484 sat at rank 628 — so the check downloaded the 500 STALEST tasks, never
+ * saw the one it was asked about, and would have announced "AIO-484 does not exist (500 task keys
+ * checked)". Fixing the response SHAPE alone would have re-run the same false accusation with a bigger,
+ * more convincing number attached.
+ */
+describe("a truncated read cannot prove a key is fake", () => {
+  const fullPage = new Set(Array.from({ length: TASKS_PAGE_BOUND }, (_, i) => `OLD-${i}`));
+
+  it("reports UNVERIFIED, not invented, when the page is full and the key wasn't in it", () => {
+    const v = verifyKeys(["AIO-484"], fullPage, { truncated: true });
+    expect(v.status).toBe("unverified");
+    expect(v.reason).toBe("truncated");
+    expect(v.keys).toEqual(["AIO-484"]);
+  });
+
+  it("STILL confirms a key that IS in the truncated page — absence proves nothing, presence proves it", () => {
+    // The check must not degrade to useless: a full page is still positive evidence for what it contains.
+    const withIt = new Set([...fullPage, "AIO-484"]);
+    expect(verifyKeys(["AIO-484"], withIt, { truncated: true }).status).toBe("ok");
+  });
+
+  it("still calls a key invented when the read was NOT truncated", () => {
+    // The whole point of the check survives: a short page is the whole table, so absence is real evidence.
+    expect(verifyKeys(["AIO-999"], new Set(["AIO-484"]), { truncated: false }).status).toBe("invented");
+  });
+
+  it("TASKS_PAGE_BOUND matches the bound the API actually enforces", () => {
+    // Pinned against the route's own constant — if PAGE moves and this doesn't, the check silently stops
+    // detecting truncation and goes back to accusing.
+    const route = readFileSync(join(process.cwd(), "app", "api", "v1", "tasks", "route.ts"), "utf8");
+    expect(route).toContain(`const PAGE = ${TASKS_PAGE_BOUND};`);
+  });
+
+  it("taskRowsFrom counts rows across project groups, so truncation is detectable", () => {
+    const body = { tasks: [{ project: "a", rows: [{ row_key: "X-1" }, { row_key: "X-2" }] }, { project: "b", rows: [{ row_key: "X-3" }] }] };
+    expect(taskRowsFrom(body).length).toBe(3);
   });
 });

--- a/test/pr-work-keys.test.ts
+++ b/test/pr-work-keys.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — plain .mjs shared by the two PR workflows; no types, deliberately dependency-free.
+import { extractWorkKeys, knownKeysFrom, verifyKeys } from "../scripts/pr-work-keys.mjs";
+
+/**
+ * The PR work-key check, which shipped broken because it lived in a YAML heredoc no test tier could reach.
+ *
+ * It exists to answer one question honestly — "does the ticket this PR cites actually exist?" — after a
+ * session of PRs cited invented `AIO-48x` keys, passed a format-only check, and linked to nothing on the
+ * timeline. Its first real run then reported a REAL key as nonexistent, which is the worse failure: an
+ * advisory warning that accuses on no evidence gets ignored, and then it protects nothing.
+ */
+
+describe("extractWorkKeys — what the PR CLAIMS, not what it discusses", () => {
+  it("takes keys from the title, body and branch name", () => {
+    const keys = extractWorkKeys({
+      title: "fix(timeline): something (AIO-484)",
+      body: "AIOS-Work: AIO-500",
+      head: { ref: "feat/AIO-501-thing" },
+    });
+    expect(keys.sort()).toEqual(["AIO-484", "AIO-500", "AIO-501"]);
+  });
+
+  it("ignores a key inside INLINE CODE — prose about keys is not a claim", () => {
+    // The real regression: a PR explaining that the model "sees `T1…Tn`" was read as citing `T1`, so the
+    // check warned that T1 doesn't exist AND the merge step would have posted T1 as a key to close.
+    const keys = extractWorkKeys({ title: "", body: "the model sees `T1` and `T2` with no way to know whose is whose", head: { ref: "" } });
+    expect(keys).toEqual([]);
+  });
+
+  it("ignores keys inside a fenced block", () => {
+    const keys = extractWorkKeys({ title: "", body: "example:\n```\nAIOS-Work: AIO-999\n```\n", head: { ref: "" } });
+    expect(keys).toEqual([]);
+  });
+
+  it("ignores the PR template's commented-out placeholder", () => {
+    expect(extractWorkKeys({ title: "", body: "<!-- e.g. AIO-72 -->", head: { ref: "" } })).toEqual([]);
+  });
+
+  it("still finds a real key in a body that ALSO discusses keys in code spans", () => {
+    // The stripping must not swallow the claim: this is the shape of every PR that explains its own work.
+    const keys = extractWorkKeys({ title: "", body: "the model sees `T1`.\n\nAIOS-Work: AIO-484", head: { ref: "" } });
+    expect(keys).toEqual(["AIO-484"]);
+  });
+});
+
+describe("knownKeysFrom — the response shape the endpoint actually returns", () => {
+  it("reads keys out of the PROJECT-GROUPED response", () => {
+    // `GET /api/v1/tasks` answers `{tasks: [{project, rows: [...]}]}`. Reading `tasks` as rows is what
+    // produced an empty set — and therefore "every key you cited is invented" — on real data.
+    const body = {
+      mode: "table",
+      tasks: [
+        { project: "aios-team-brain", rows: [{ row_key: "AIO-484" }, { row_key: "AIO-537" }] },
+        { project: "other", rows: [{ row_key: "OTH-1" }] },
+      ],
+    };
+    expect([...knownKeysFrom(body)].sort()).toEqual(["AIO-484", "AIO-537", "OTH-1"]);
+  });
+
+  it("tolerates a flat array of rows", () => {
+    expect([...knownKeysFrom([{ row_key: "AIO-1" }, { rowKey: "AIO-2" }])].sort()).toEqual(["AIO-1", "AIO-2"]);
+  });
+
+  it("is empty — not a crash — for a shape it doesn't recognise", () => {
+    expect(knownKeysFrom({ unexpected: true }).size).toBe(0);
+    expect(knownKeysFrom(null).size).toBe(0);
+  });
+});
+
+describe("verifyKeys — 'we couldn't ask' is NOT 'your key is fake'", () => {
+  it("reports UNVERIFIED when no keys came back at all", () => {
+    // Zero known keys means an empty response, a shape change, or a tier that sees nothing — each
+    // indistinguishable from a brain with no tasks. Calling a real key invented on that evidence is the
+    // failure that trains everyone to ignore the warning.
+    expect(verifyKeys(["AIO-484"], new Set())).toEqual({ status: "unverified", keys: ["AIO-484"] });
+  });
+
+  it("reports INVENTED only when the brain demonstrably has other keys", () => {
+    expect(verifyKeys(["AIO-999"], new Set(["AIO-484"]))).toEqual({ status: "invented", invented: ["AIO-999"], checked: 1 });
+  });
+
+  it("reports OK when every cited key exists", () => {
+    expect(verifyKeys(["AIO-484"], new Set(["AIO-484", "AIO-537"]))).toEqual({ status: "ok", checked: 2 });
+  });
+
+  it("reports NONE when the PR cites nothing", () => {
+    expect(verifyKeys([], new Set(["AIO-484"]))).toEqual({ status: "none" });
+  });
+});


### PR DESCRIPTION
Found by reading the log of the check's own first real run — on PR #415, which cited a ticket that exists:

```
Found work key(s): T1, AIO-484
##[warning] T1, AIO-484 matches the key format but no task in the brain has it … (0 task keys checked.)
```

`AIO-484` is real. Verified read-only against prod: 677 keyed tasks, AIO-484 among them.

This check was added earlier today (#410) precisely because a session of PRs had cited invented `AIO-48x` keys, passed a format-only check, and linked to nothing on the timeline. Its first real run accused a real ticket — which is the worse failure. A warning that accuses on no evidence gets ignored, and then it protects nothing.

## Three defects, all mine

**Shape.** `GET /api/v1/tasks` answers `{tasks: [{project, rows: [{row_key, …}]}]}` — grouped **by project**. The check read `body.tasks` as the row list, found `row_key` on nothing, and built an empty set. It could never verify any key.

**Truncation — and this is the one that mattered.** Fixing the shape alone would have re-run the same false accusation with a *more convincing* number attached. `?all=1` is bounded at 500 rows (documented), orders `updated_at` **ascending**, and table mode does not paginate. So the check reads the 500 **stalest** tasks. Measured, not reasoned about: AIO-484 sits at **rank 628 of 677**. It was never in the answer. A full page now only ever justifies a *positive* — a key present is confirmed; absence from a prefix reports `unverified`, naming the cap.

**Prose.** The matcher pulled `T1` out of #415's own body explaining that the model "sees `T1…Tn`". Code spans and fences are now stripped like HTML comments already were. This is not cosmetic: `/api/v1/work-events` sets `status='done'` on a key matching a task in the pushed project, so a PR that merely mentions a teammate's ticket inside backticks would have **closed that ticket** on merge. The merge of #415 did POST `T1` as a work key.

(An earlier draft of this very PR body named an example key in plain prose, and the check duly reported it — it doesn't exist, so nothing would have closed, but that is exactly the hazard, demonstrated on itself.)

## The durable part

Both defects were unreachable by any test tier because they lived in a YAML heredoc — and there were **two inline copies** of the matcher: this advisory check and `aios-work-sync.yml`, the step that actually closes tickets. They could disagree about which ticket a PR cites: the check clears it, the closer reads it differently.

One `scripts/pr-work-keys.mjs`, imported by both, with 22 unit tests and two guards:
- `work-key-single-matcher` discovers workflows from disk, so a third inline copy fails the build.
- `workflow-heredoc-syntax` extracts every `node <<'NODE'` block and `node --check`s it. These are real programs that only run on a runner; I hand-edited two today and a typo is invisible locally.

`verifyKeys` **throws** without an explicit `{ truncated }` rather than defaulting it — the default was the accusing branch, so dropping the argument would have restored the bug with every test green.

⛔ `pr-task-link.yml` now checks out and executes a script from the PR head with `AIOS_API_KEY` in env. Safe on `pull_request` (GitHub withholds secrets from fork runs) and an instant pwn-request on `pull_request_target`. Before this change there was no checkout, so the trigger swap was harmless; now it isn't, and the `on:` block says so.

## Review — Reviewed by Fable (`code-reviewer` subagent) — verdict CLEAR (after one BLOCKED round)

**Fable BLOCKED the first version**, and it was right: I had fixed the response shape and would have shipped the truncation false-accusation unchanged. I re-derived its claim against prod before acting on it (rank 628/677) rather than taking it on trust.

On re-review it also caught that **two of my tests were never committed** — the over-strip cases existed only in my working tree, so the diff under review didn't contain them. That is the same index-vs-tree mistake as the `git add -A` blocker earlier today.

Every behaviour here was mutation-tested — dropping the truncation branch, over-correcting so truncation swallows the positive case, drifting `TASKS_PAGE_BOUND` from the route's `PAGE`, reverting the fence regex, breaking a heredoc — each reproduces its bug.

## Verified

Beyond units: end-to-end against a stub brain, running the real extracted heredoc. Full page missing the key → "not verified, capped at 500". Same page containing it → "exists (500 checked)". Short page missing it → "does not exist (12 checked)". Empty → "returned no task keys". `T1` matched in none.

unit 1311 · tsc 0 · lint clean (2 pre-existing warnings) · docs-drift green. No schema change.

## Knowingly left open — your call

With 677 tasks behind a 500-row cap, an **invented** key now reads as `unverified` too. That is honest and strictly better than accusing, but it means the original `AIO-48x` failure would not be caught today. Making it provable needs a by-key lookup (`?keys=…`) or a table-mode cursor on `/api/v1/tasks` — an API plus contract change, deliberately not bundled here.

Also noted, not fixed: a *mismatched* fence pair (`~~~` opened, ``` closed) swallows the rest of the body — the missed-key direction, which is warned about at open time.

AIOS-Work: AIO-484