### PR TITLE
fix(timeline): a version bump no longer blanks the daily synopsis

### DIFF
--- a/lib/dashboard/timeline-cache.ts
+++ b/lib/dashboard/timeline-cache.ts
@@ -88,6 +88,13 @@ async function buildTimeline(db: DbClient, teamId: string, tier: ViewerTier): Pr
  * A salvaged sentence is only defensible as a BRIDGE to the next background refresh — it was written
  * about a day's work as it stood then. Two days is long enough to cover a bump plus a quiet weekend,
  * short enough that nobody reads a stale description of an active day.
+ *
+ * HONEST LIMIT: this measures age since the row was last PERSISTED, not since the sentence was
+ * authored — a cold miss re-stamps `computed_at`, so carrying a summary resets its clock. It is not an
+ * absolute shelf life. What actually bounds it is `attachPersonDaySummaries`, which rebuilds every
+ * person-day's summary from scratch and never preserves an existing one: any completed background pass
+ * either replaces the sentence or drops it. Riding past 48h would need every cycle's deploy to kill the
+ * in-flight LLM fan-out, repeatedly. Bounded in practice, not by this constant.
  */
 const SALVAGE_MAX_AGE_MS = 48 * 3_600_000;
 
@@ -133,9 +140,14 @@ export function attachSalvagedSummaries(days: TimelineDay[], salvaged: SalvagedS
   if (!salvaged.size) return days;
   return days.map((d) => ({
     ...d,
-    people: d.people.map((p) =>
-      p.summary ? p : { ...p, ...(salvaged.get(salvageKey(d.date, p.memberId)) ? { summary: salvaged.get(salvageKey(d.date, p.memberId))! } : {}) }
-    ),
+    people: d.people.map((p) => {
+      if (p.summary) return p;
+      // Read ONCE into a local. A conditional spread that calls `.get` twice is correct and is exactly
+      // the line a later edit turns into `summary: undefined` — which would ADD the key to the payload
+      // and put it out of step with the shape the version pins.
+      const carried = salvaged.get(salvageKey(d.date, p.memberId));
+      return carried ? { ...p, summary: carried } : p;
+    }),
   }));
 }
 
@@ -263,6 +275,13 @@ export async function bustTeamTimeline(db: DbClient, teamId: string): Promise<vo
  * served: it holds item/task TITLES and the LLM per-person-day summaries built from the tier-filtered
  * set at compute time, so after an item is narrowed external→team the external row still names it.
  * A stale-mark won't do — the read path serves the stale ledger first and rebuilds behind it.
+ *
+ * The DELETE is what closes it, and that matters more since `salvageSummaries`: if this delete fails
+ * (swallowed below) the surviving row's summaries are no longer merely served for one TTL — a later
+ * version bump can carry those sentences into the fresh payload and re-stamp them, so the caller's
+ * stale-mark no longer bounds them. Salvage is same-tier, so this is a compound failure (a failed
+ * delete AND a bump) rather than a new path, and the immediate background refresh overwrites it — but
+ * "one TTL" is no longer the true bound, and the comment below used to claim it was.
  */
 export async function purgeTimelineCacheTier(
   db: DbClient,
@@ -273,7 +292,8 @@ export async function purgeTimelineCacheTier(
   try {
     await db.from("work_timeline_cache").delete().eq("team_id", teamId).eq("group_key", tier);
   } catch {
-    // best-effort — the caller's stale-mark backstop still bounds the exposure to one TTL
+    // best-effort — the caller's stale-mark backstop bounds a SERVED stale payload to one TTL (see the
+    // header for why that is no longer the whole story for the summaries)
   }
 }
 

--- a/lib/dashboard/timeline-cache.ts
+++ b/lib/dashboard/timeline-cache.ts
@@ -82,6 +82,63 @@ async function buildTimeline(db: DbClient, teamId: string, tier: ViewerTier): Pr
   return attachPersonDaySummaries(db, teamId, await getWorkTimeline(db, teamId, tier));
 }
 
+/**
+ * How old a payload may be and still lend its synopsis across a version bump.
+ *
+ * A salvaged sentence is only defensible as a BRIDGE to the next background refresh — it was written
+ * about a day's work as it stood then. Two days is long enough to cover a bump plus a quiet weekend,
+ * short enough that nobody reads a stale description of an active day.
+ */
+const SALVAGE_MAX_AGE_MS = 48 * 3_600_000;
+
+/** `${date}|${memberId}` → that person-day's synopsis. */
+export type SalvagedSummaries = Map<string, string>;
+
+const salvageKey = (date: string, memberId: string): string => `${date}|${memberId}`;
+
+/**
+ * Pull the per-person-day summaries out of a cache payload of ANY version.
+ *
+ * Why this ignores `PAYLOAD_VERSION` when everything else treats a mismatch as a miss: the version
+ * guards the SHAPE the panel renders, and rendering a stale shape is what strands a wrong card. A
+ * `summary` is not shape — it is a sentence about what a person did on a day, and a field moving
+ * elsewhere in the tree doesn't make that sentence untrue. Dropping it is what makes the synopsis
+ * vanish for everyone on every bump.
+ */
+export function salvageSummaries(payload: unknown, computedAtMs: number, nowMs: number): SalvagedSummaries {
+  const out: SalvagedSummaries = new Map();
+  if (!Number.isFinite(computedAtMs) || nowMs - computedAtMs > SALVAGE_MAX_AGE_MS) return out;
+  const days = (payload as { days?: unknown } | null)?.days;
+  if (!Array.isArray(days)) return out;
+  for (const d of days as { date?: unknown; people?: unknown }[]) {
+    if (typeof d?.date !== "string" || !Array.isArray(d.people)) continue;
+    for (const p of d.people as { memberId?: unknown; summary?: unknown }[]) {
+      // Keyed on the PERSON and the DAY together. Keying on either alone would smear one person's
+      // sentence across the team, or one day's across the week — a confidently wrong synopsis is
+      // worse than none, which is the whole reason this is a bridge and not a cache.
+      if (typeof p?.memberId === "string" && typeof p.summary === "string" && p.summary)
+        out.set(salvageKey(d.date, p.memberId), p.summary);
+    }
+  }
+  return out;
+}
+
+/**
+ * Re-attach salvaged summaries to freshly built days. Immutable — returns new objects.
+ *
+ * NEVER overwrites: a day the builder already summarised keeps its own. Only the gap left by the
+ * cold-miss path (which skips the LLM by design) gets filled.
+ */
+export function attachSalvagedSummaries(days: TimelineDay[], salvaged: SalvagedSummaries): TimelineDay[] {
+  if (!salvaged.size) return days;
+  return days.map((d) => ({
+    ...d,
+    people: d.people.map((p) =>
+      p.summary ? p : { ...p, ...(salvaged.get(salvageKey(d.date, p.memberId)) ? { summary: salvaged.get(salvageKey(d.date, p.memberId))! } : {}) }
+    ),
+  }));
+}
+
 interface CacheEntry {
   days: TimelineDay[];
   at: number; // epoch ms computed
@@ -98,6 +155,40 @@ const dirty = new Set<string>();
 
 const memKey = (teamId: string, tier: ViewerTier): string => `${teamId}:${tier}`;
 
+/** The raw persisted row, version and all. Two readers want it for different questions: the ledger
+ *  read below (which rejects a foreign version) and the synopsis salvage (which doesn't care). */
+async function readTimelineCacheRow(
+  db: DbClient,
+  teamId: string,
+  tier: ViewerTier
+): Promise<{ payload: unknown; computed_at: string | Date } | null> {
+  const { data } = await db
+    .from("work_timeline_cache")
+    .select("payload, computed_at")
+    .eq("team_id", teamId)
+    .eq("group_key", tier)
+    .maybeSingle();
+  return (data as { payload: unknown; computed_at: string | Date } | null) ?? null;
+}
+
+/** The previous payload's per-person-day summaries, whatever version wrote them. Empty on any error —
+ *  a missing synopsis is a cosmetic loss and must never fail the panel. */
+async function readSalvageableSummaries(
+  db: DbClient,
+  teamId: string,
+  tier: ViewerTier
+): Promise<SalvagedSummaries> {
+  try {
+    const row = await readTimelineCacheRow(db, teamId, tier);
+    if (!row) return new Map();
+    const at =
+      typeof row.computed_at === "string" ? Date.parse(row.computed_at) : new Date(row.computed_at).getTime();
+    return salvageSummaries(row.payload, at, Date.now());
+  } catch {
+    return new Map();
+  }
+}
+
 /** Read the cached ledger for one team+tier. Null on miss/any error (best-effort — a cache read must
  *  never fail the panel; the caller builds inline). */
 export async function readTimelineCache(
@@ -106,14 +197,8 @@ export async function readTimelineCache(
   tier: ViewerTier
 ): Promise<CacheEntry | null> {
   try {
-    const { data } = await db
-      .from("work_timeline_cache")
-      .select("payload, computed_at")
-      .eq("team_id", teamId)
-      .eq("group_key", tier)
-      .maybeSingle();
-    if (!data) return null;
-    const row = data as { payload: unknown; computed_at: string | Date };
+    const row = await readTimelineCacheRow(db, teamId, tier);
+    if (!row) return null;
     // Payload is `{ v, days }`. A missing/older version = a shape from a previous deploy → treat as a
     // MISS so the caller rebuilds (never render a stale wrong shape).
     const p = row.payload as { v?: number; days?: unknown } | null;
@@ -273,7 +358,14 @@ export async function getCachedWorkTimeline(
   // add the per-person-day synopsis in the background. The first viewer sees the timeline immediately;
   // summaries appear on the next view once the background pass writes them (kept off the request path so
   // a big team's fan-out can't blow the page / route budget).
-  const days = await getWorkTimeline(db, teamId, tier);
+  const built = await getWorkTimeline(db, teamId, tier);
+  // …but a cold miss is USUALLY A VERSION BUMP, not a genuinely empty cache — and that path was
+  // silently deleting the synopsis from every person-day until a background pass finished. Twice the
+  // user's report was "we've lost the summaries at the top of each person's day", both times right
+  // after a deploy of mine. The previous row's sentences still describe those same person-days, so
+  // carry them across as a bridge; the background pass overwrites them with freshly computed ones.
+  // Best-effort by construction: no salvageable row → `built`, unchanged.
+  const days = attachSalvagedSummaries(built, await readSalvageableSummaries(db, teamId, tier));
   mem.set(key, { days, at: Date.now() });
   await writeTimelineCache(db, teamId, tier, days);
   refreshInBackground(teamId, tier);

--- a/test/datamechanics/timeline-synopsis-salvage.datamechanics.test.ts
+++ b/test/datamechanics/timeline-synopsis-salvage.datamechanics.test.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+import { getCachedWorkTimeline, PAYLOAD_VERSION } from "@/lib/dashboard/timeline-cache";
+
+/**
+ * Spec: a PAYLOAD_VERSION bump must not blank the daily synopsis.
+ *
+ * THE OUTCOME THIS REPRODUCES. Summaries are attached only on the BACKGROUND refresh path — the
+ * cold-miss path deliberately returns the pure ledger fast, with no LLM. A version bump makes every
+ * stored row read as a MISS, so the next viewer gets a summary-less timeline, that summary-less
+ * payload is persisted stamped `computed_at = now`, and the synopsis stays gone until a background
+ * pass finishes. Twice now the visible symptom has been "we've lost the summaries at the top of each
+ * person's day", reported by the user, after a bump I shipped.
+ *
+ * The rule: a synopsis describes WHAT A PERSON DID ON A DAY. A change to the payload's SHAPE does not
+ * make that sentence untrue, so it should be carried across the bump and then replaced by the
+ * background pass — not dropped on the floor.
+ *
+ * Assertions are derived from that rule, not from the implementation:
+ *   1. after a bump, the first view still carries the previous row's per-person-day summaries;
+ *   2. a summary is matched to ITS OWN person and day, never smeared across people;
+ *   3. an ancient row is NOT resurrected — a synopsis has a shelf life;
+ *   4. a freshly computed summary always wins over a salvaged one.
+ */
+
+async function seedLinkedTeam(): Promise<Seed> {
+  const seed = await seedTeam();
+  const { data: proj } = await db()
+    .from("projects")
+    .insert({ team_id: seed.teamId, slug: `p-${randomUUID().slice(0, 6)}`, name: "P" })
+    .select("id")
+    .single();
+  await db().from("tasks").insert({
+    team_id: seed.teamId,
+    project_id: (proj as { id: string }).id,
+    row_key: "SALV-1",
+    title: "Carried work",
+    status: "in_progress",
+    assignee: "Tester",
+    origin: "sync",
+    audience: "external",
+  });
+  return seed;
+}
+
+async function seedCommit(seed: Seed, title: string, whenIso: string) {
+  return ingest(seed, {
+    path: `commits/x/${title}.md`,
+    project: "commits",
+    kind: "artifact",
+    frontmatter: { source: "git", title, committed_at: whenIso, source_url: "https://example.com/c" },
+    body: `# ${title} (SALV-1)`,
+    access: "team",
+  });
+}
+
+/** Write a cache row from a PREVIOUS payload version that carries a synopsis for one person-day. */
+async function seedPriorRow(args: {
+  teamId: string;
+  memberId: string;
+  date: string;
+  summary: string;
+  version?: number;
+  computedAt?: string;
+}) {
+  const payload = {
+    v: args.version ?? PAYLOAD_VERSION - 1,
+    days: [
+      {
+        date: args.date,
+        label: "Today",
+        people: [
+          {
+            memberId: args.memberId,
+            name: "Tester",
+            handle: "tester",
+            summary: args.summary,
+            total: 1,
+            tasks: [],
+            other: [],
+            unlinked: 0,
+            signals: [],
+          },
+        ],
+      },
+    ],
+  };
+  const { error } = await db().from("work_timeline_cache").upsert(
+    {
+      team_id: args.teamId,
+      group_key: "team",
+      payload: JSON.stringify(payload),
+      computed_at: args.computedAt ?? new Date().toISOString(),
+    },
+    { onConflict: "team_id,group_key" }
+  );
+  if (error) throw new Error(`prior row seed failed: ${error.message}`);
+}
+
+// ONE timestamp for both the commit and the prior row's date. `dayOf` slices the ISO string, so the
+// day is UTC — deriving the date from `new Date()` instead put the fixture on the wrong day for eight
+// hours a day, which looks exactly like the feature not working.
+const WHEN = new Date(Date.now() - 3_600_000).toISOString();
+const dayOfWhen = WHEN.slice(0, 10);
+
+function summaryFor(days: Awaited<ReturnType<typeof getCachedWorkTimeline>>, memberId: string): string | undefined {
+  for (const d of days) for (const p of d.people) if (p.memberId === memberId) return p.summary;
+  return undefined;
+}
+
+describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", () => {
+  it("carries the previous version's summary into the first post-bump view", async () => {
+    const seed = await seedLinkedTeam();
+    await seedCommit(seed, "carried", WHEN);
+    await seedPriorRow({
+      teamId: seed.teamId,
+      memberId: seed.memberId,
+      date: dayOfWhen,
+      summary: "Shipped the carried work.",
+    });
+
+    // Cold miss by version mismatch — exactly what every deploy that bumps the version produces.
+    const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    expect(summaryFor(days, seed.memberId)).toBe("Shipped the carried work.");
+  });
+
+  it("matches a summary to ITS OWN person-day, never another's", async () => {
+    const seed = await seedLinkedTeam();
+    await seedCommit(seed, "carried", WHEN);
+    // A summary stored against a DIFFERENT member on the same day must not land on ours.
+    await seedPriorRow({
+      teamId: seed.teamId,
+      memberId: randomUUID(),
+      date: dayOfWhen,
+      summary: "Someone else's day.",
+    });
+
+    const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    expect(summaryFor(days, seed.memberId)).toBeUndefined();
+  });
+
+  it("does NOT resurrect an ancient synopsis", async () => {
+    // A shelf life, because a salvaged sentence is only defensible as a bridge to the next refresh.
+    const seed = await seedLinkedTeam();
+    await seedCommit(seed, "carried", WHEN);
+    await seedPriorRow({
+      teamId: seed.teamId,
+      memberId: seed.memberId,
+      date: dayOfWhen,
+      summary: "Stale from last week.",
+      computedAt: new Date(Date.now() - 8 * 24 * 3600_000).toISOString(),
+    });
+
+    const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    expect(summaryFor(days, seed.memberId)).toBeUndefined();
+  });
+});

--- a/test/datamechanics/timeline-synopsis-salvage.datamechanics.test.ts
+++ b/test/datamechanics/timeline-synopsis-salvage.datamechanics.test.ts
@@ -44,14 +44,14 @@ async function seedLinkedTeam(): Promise<Seed> {
   return seed;
 }
 
-async function seedCommit(seed: Seed, title: string, whenIso: string) {
+async function seedCommit(seed: Seed, title: string, whenIso: string, access: "team" | "external" = "team") {
   return ingest(seed, {
     path: `commits/x/${title}.md`,
     project: "commits",
     kind: "artifact",
     frontmatter: { source: "git", title, committed_at: whenIso, source_url: "https://example.com/c" },
     body: `# ${title} (SALV-1)`,
-    access: "team",
+    access,
   });
 }
 
@@ -63,6 +63,7 @@ async function seedPriorRow(args: {
   summary: string;
   version?: number;
   computedAt?: string;
+  tier?: "team" | "external";
 }) {
   const payload = {
     v: args.version ?? PAYLOAD_VERSION - 1,
@@ -89,7 +90,7 @@ async function seedPriorRow(args: {
   const { error } = await db().from("work_timeline_cache").upsert(
     {
       team_id: args.teamId,
-      group_key: "team",
+      group_key: args.tier ?? "team",
       payload: JSON.stringify(payload),
       computed_at: args.computedAt ?? new Date().toISOString(),
     },
@@ -104,9 +105,23 @@ async function seedPriorRow(args: {
 const WHEN = new Date(Date.now() - 3_600_000).toISOString();
 const dayOfWhen = WHEN.slice(0, 10);
 
-function summaryFor(days: Awaited<ReturnType<typeof getCachedWorkTimeline>>, memberId: string): string | undefined {
-  for (const d of days) for (const p of d.people) if (p.memberId === memberId) return p.summary;
+type Days = Awaited<ReturnType<typeof getCachedWorkTimeline>>;
+
+function personDay(days: Days, memberId: string) {
+  for (const d of days) for (const p of d.people) if (p.memberId === memberId) return p;
   return undefined;
+}
+
+/**
+ * ARMS every "no summary" assertion below. Each of those is an ABSENCE, and an absence passes just as
+ * happily when the person-day isn't rendered at all — a fixture or attribution regression would
+ * silently disarm the test rather than fail it. Assert the row EXISTS first, then that it carries no
+ * synopsis, so the only variable left is the one under test.
+ */
+function summaryOfRenderedDay(days: Days, memberId: string): string | undefined {
+  const p = personDay(days, memberId);
+  expect(p, "the member's person-day must be rendered, or this assertion proves nothing").toBeDefined();
+  return p!.summary;
 }
 
 describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", () => {
@@ -122,7 +137,7 @@ describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", (
 
     // Cold miss by version mismatch — exactly what every deploy that bumps the version produces.
     const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
-    expect(summaryFor(days, seed.memberId)).toBe("Shipped the carried work.");
+    expect(summaryOfRenderedDay(days, seed.memberId)).toBe("Shipped the carried work.");
   });
 
   it("matches a summary to ITS OWN person-day, never another's", async () => {
@@ -137,7 +152,7 @@ describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", (
     });
 
     const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
-    expect(summaryFor(days, seed.memberId)).toBeUndefined();
+    expect(summaryOfRenderedDay(days, seed.memberId)).toBeUndefined();
   });
 
   it("does NOT resurrect an ancient synopsis", async () => {
@@ -153,6 +168,26 @@ describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", (
     });
 
     const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
-    expect(summaryFor(days, seed.memberId)).toBeUndefined();
+    expect(summaryOfRenderedDay(days, seed.memberId)).toBeUndefined();
+  });
+
+  it("TIER: an external viewer never receives a summary written for the TEAM tier", async () => {
+    // The sharpest risk in this change. `work_timeline_cache` is keyed by tier because the synopsis is
+    // LLM TEXT generated from the tier-filtered set — a team-tier sentence describes work an external
+    // viewer may not see. The salvage read is the newest path that touches those rows, and nothing
+    // else pins its scoping: reading the "team" row here instead of the viewer's own survives the
+    // whole suite. Tier isolation is app-code only; there is no RLS backstop.
+    const seed = await seedLinkedTeam();
+    await seedCommit(seed, "external-work", WHEN, "external");
+    await seedPriorRow({
+      teamId: seed.teamId,
+      memberId: seed.memberId,
+      date: dayOfWhen,
+      summary: "Team-tier sentence about work an external viewer must not learn about.",
+      tier: "team",
+    });
+
+    const days = await getCachedWorkTimeline(db(), seed.teamId, "external");
+    expect(summaryOfRenderedDay(days, seed.memberId)).toBeUndefined();
   });
 });

--- a/test/timeline-synopsis-salvage.test.ts
+++ b/test/timeline-synopsis-salvage.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { salvageSummaries, attachSalvagedSummaries } from "@/lib/dashboard/timeline-cache";
+import type { TimelineDay } from "@/lib/dashboard/timeline-group";
+
+/**
+ * The pure half of "a version bump must not blank the synopsis".
+ *
+ * The per-person-day summary is attached only on the background refresh path, so every
+ * `PAYLOAD_VERSION` bump makes the stored row read as a miss and the next viewer gets a
+ * summary-less timeline — twice reported as "we've lost the summaries at the top of each
+ * person's day". A summary describes what a person DID ON A DAY; a change to the payload's
+ * shape doesn't make that sentence untrue, so it bridges the gap until the background pass
+ * recomputes it.
+ */
+
+const NOW = Date.parse("2026-07-28T00:00:00Z");
+const payload = (v: number, people: { memberId: string; summary?: string }[]) => ({
+  v,
+  days: [{ date: "2026-07-27", label: "Today", people }],
+});
+
+const day = (people: { memberId: string; summary?: string }[]): TimelineDay =>
+  ({
+    date: "2026-07-27",
+    label: "Today",
+    people: people.map((p) => ({
+      memberId: p.memberId,
+      name: p.memberId,
+      handle: p.memberId,
+      total: 1,
+      tasks: [],
+      other: [],
+      unlinked: 0,
+      signals: [],
+      ...(p.summary ? { summary: p.summary } : {}),
+    })),
+  }) as TimelineDay;
+
+describe("salvageSummaries — a sentence about a day outlives the shape that held it", () => {
+  it("reads summaries out of a FOREIGN payload version", () => {
+    // The whole point: every other reader rejects a version mismatch, and that rejection is what
+    // was deleting the synopsis on each deploy.
+    const got = salvageSummaries(payload(3, [{ memberId: "m1", summary: "Shipped X." }]), NOW - 1000, NOW);
+    expect(got.get("2026-07-27|m1")).toBe("Shipped X.");
+  });
+
+  it("keys on person AND day together", () => {
+    const got = salvageSummaries(
+      payload(9, [
+        { memberId: "m1", summary: "Alice's day." },
+        { memberId: "m2", summary: "Bob's day." },
+      ]),
+      NOW - 1000,
+      NOW
+    );
+    expect(got.get("2026-07-27|m1")).toBe("Alice's day.");
+    expect(got.get("2026-07-27|m2")).toBe("Bob's day.");
+    expect(got.size).toBe(2);
+  });
+
+  it("refuses an ancient row — a salvaged sentence is a bridge, not an archive", () => {
+    const old = salvageSummaries(payload(9, [{ memberId: "m1", summary: "Last week." }]), NOW - 8 * 24 * 3600_000, NOW);
+    expect(old.size).toBe(0);
+  });
+
+  it("survives junk instead of throwing — a lost synopsis must never fail the panel", () => {
+    for (const junk of [null, undefined, {}, { days: "nope" }, { days: [{ people: 3 }] }, { days: [{ date: 1 }] }]) {
+      expect(salvageSummaries(junk, NOW - 1000, NOW).size).toBe(0);
+    }
+    // A person-day with no summary contributes nothing rather than an empty string.
+    expect(salvageSummaries(payload(9, [{ memberId: "m1" }]), NOW - 1000, NOW).size).toBe(0);
+    expect(salvageSummaries(payload(9, [{ memberId: "m1", summary: "" }]), NOW - 1000, NOW).size).toBe(0);
+  });
+});
+
+describe("attachSalvagedSummaries — fills the gap, never overwrites", () => {
+  it("a FRESHLY COMPUTED summary always wins over a salvaged one", () => {
+    // Otherwise the bridge would outlive its purpose and pin yesterday's sentence on today's work.
+    const days = [day([{ memberId: "m1", summary: "Fresh." }])];
+    const out = attachSalvagedSummaries(days, new Map([["2026-07-27|m1", "Salvaged."]]));
+    expect(out[0].people[0].summary).toBe("Fresh.");
+  });
+
+  it("fills only the person-day it belongs to", () => {
+    const days = [day([{ memberId: "m1" }, { memberId: "m2" }])];
+    const out = attachSalvagedSummaries(days, new Map([["2026-07-27|m2", "Bob's day."]]));
+    expect(out[0].people[0].summary).toBeUndefined();
+    expect(out[0].people[1].summary).toBe("Bob's day.");
+  });
+
+  it("does not mutate the input", () => {
+    const days = [day([{ memberId: "m1" }])];
+    attachSalvagedSummaries(days, new Map([["2026-07-27|m1", "Salvaged."]]));
+    expect(days[0].people[0].summary).toBeUndefined();
+  });
+
+  it("is a no-op with nothing to salvage", () => {
+    const days = [day([{ memberId: "m1" }])];
+    expect(attachSalvagedSummaries(days, new Map())).toBe(days);
+  });
+});


### PR DESCRIPTION
> we've lost the summaries at the top of an individuals per day updates on the timeline. let's bring it back

Found the cause, and it's mine — twice now, both times right after a deploy of mine, which is the tell I missed.

## Why it keeps happening

Summaries are attached **only on the background refresh path**; the cold-miss path deliberately returns the pure ledger fast with no LLM. A `PAYLOAD_VERSION` bump makes every stored row read as a **miss** — so the next viewer gets a summary-less timeline, and that summary-less payload is then persisted stamped `computed_at = now`, so it looks fresh. The synopsis stays gone until a background pass finishes.

I bumped the version to 10 yesterday. Nothing about this was visible in the diff that caused it — which is why it's now a test and not a note.

## The rule

A synopsis describes **what a person did on a day**. A change to the payload's *shape* doesn't make that sentence untrue. So it's carried across the bump and replaced by the background pass, instead of dropped. Every other reader still rejects a foreign version — that rejection guards the shape the panel renders, and a `summary` is not shape.

Three constraints, each with a test that kills its own mutation:

- **Keyed on person AND day together.** Keying on either alone smears one person's sentence across the team. A confidently wrong synopsis is worse than none — that's why this is a bridge, not a cache.
- **A shelf life**, so a bump never resurrects last week's description of an active day.
- **A freshly computed summary always wins**, so the bridge can't outlive its purpose.

Best-effort throughout: no salvageable row, a junk payload or a failed read all return the timeline unchanged. A missing synopsis is cosmetic; failing the panel is not.

## Review — Reviewed by Fable (`code-reviewer` subagent) — verdict CLEAR (after one BLOCKED round)

**Fable blocked it on a real tier leak**, and the way I nearly dismissed it is worth recording: the mutation *it* suggested was caught by an existing test, because both readers share the helper I refactored. The **precise** mutation — making only the salvage read the `"team"` row while the ledger read stays correct — survived **all 30 timeline tests**. Under it the new test fails holding the actual leaked sentence:

```
expected 'Team-tier sentence about work an exte…' to be undefined
```

`work_timeline_cache` is keyed by tier because the synopsis is LLM text generated from the tier-filtered set, so a team-tier sentence describes work an external viewer may not see. Tier isolation here is app-code only — no RLS — so the newest path touching those rows now has a guard.

Also fixed from the review:

- **Three absence assertions were unarmed.** Each asserted "no summary", which passes just as happily when the person-day isn't rendered at all. They now assert the row exists first — verified by deleting the fixture commit, which turns all three red instead of green. That's a lesson I'd already written down and didn't apply.
- **`SALVAGE_MAX_AGE_MS` claimed a shelf life it doesn't enforce** — a cold miss re-stamps `computed_at`, so carrying a summary resets its clock. What actually bounds it is `attachPersonDaySummaries` never preserving an existing summary. Documented as the real mechanism rather than the one I assumed.
- **`purgeTimelineCacheTier`'s "one TTL" comment** was true before this change and isn't now: a failed delete plus a later bump lets those sentences ride into the fresh payload.

Consciously deferred: a cold-miss whose salvage read completes before `purgeTimelineCacheTier`'s delete lands but whose write lands after can re-stamp a purged external summary. Same class as the documented in-flight-rebuild race, same-tier only, and mopped up by the second purge plus the background refresh.

## Verified

unit 1319 · data-mechanics 761 (own container) · tsc 0 · lint clean (2 pre-existing warnings) · docs-drift green. No schema change, no payload shape change (the v10 pin is unchanged — `summary` is allowed-not-required).

AIOS-Work: AIO-484