### PR TITLE
feat(api): by-key task lookup — the work-key check can prove a key is fake again (brain-api 1.14)

### DIFF
--- a/.github/workflows/pr-task-link.yml
+++ b/.github/workflows/pr-task-link.yml
@@ -41,7 +41,7 @@ jobs:
           // syntax error. A `.catch` keeps the job advisory — an unexpected throw must not fail a PR.
           (async () => {
           const fs = require("node:fs");
-          const { extractWorkKeys, knownKeysFrom, taskRowsFrom, verifyKeys, TASKS_PAGE_BOUND } = await import("./scripts/pr-work-keys.mjs");
+          const { extractWorkKeys, knownKeysFrom, taskRowsFrom, unknownKeysFrom, verifyKeys, TASKS_PAGE_BOUND } = await import("./scripts/pr-work-keys.mjs");
           const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
           const keys = extractWorkKeys(ev.pull_request || {});
           if (!keys.length) {
@@ -60,9 +60,15 @@ jobs:
             console.log("::warning title=Work key not verified::brain credentials not configured — only the FORMAT was checked.");
             return;
           }
-          const res = await fetch(`${brain.replace(/\/$/, "")}/api/v1/tasks?all=1`, {
-            headers: { Authorization: `Bearer ${key}`, "X-AIOS-Team": team },
-          });
+          const base = `${brain.replace(/\/$/, "")}/api/v1/tasks`;
+          const headers = { Authorization: `Bearer ${key}`, "X-AIOS-Team": team };
+          // ASK ABOUT THESE KEYS (brain-api 1.14). Bounded by the keys themselves, so absence is proof
+          // and the brain answers `unknown_keys` outright. `?all=1` cannot answer this: it caps at 500
+          // rows ordered STALEST-first, so the recently-touched tickets people actually cite are exactly
+          // the ones missing. Falls back to the full-table read against a pre-1.14 brain, which is why
+          // the truncation reasoning below stays.
+          let res = await fetch(`${base}?mode=table&keys=${encodeURIComponent(keys.join(","))}`, { headers });
+          if (res.status === 400) res = await fetch(`${base}?all=1`, { headers }); // pre-1.14: no `keys`
           if (!res.ok) {
             // Couldn't ask ≠ the key is fake. Advisory job, so never fail on OUR outage.
             console.log(`::warning title=Work key not verified::brain returned ${res.status} — only the FORMAT was checked.`);
@@ -73,7 +79,7 @@ jobs:
           // PREFIX of the table — the stalest rows, since it orders `updated_at` ascending. Absence from
           // a prefix is not absence from the table; presence in it is still proof.
           const truncated = taskRowsFrom(body).length >= TASKS_PAGE_BOUND;
-          const verdict = verifyKeys(keys, knownKeysFrom(body), { truncated });
+          const verdict = verifyKeys(keys, knownKeysFrom(body), { truncated, unknownKeys: unknownKeysFrom(body) });
           if (verdict.status === "unverified" && verdict.reason === "truncated") {
             console.log(`::warning title=Work key not verified::${verdict.keys.join(", ")} was not in the ${verdict.checked} tasks the brain returned — but that response is capped at ${TASKS_PAGE_BOUND} rows and returns the STALEST first, so the key may simply be past the cap. Only the FORMAT was verified. (To make this provable, the tasks endpoint needs a by-key lookup or a table-mode cursor.)`);
           } else if (verdict.status === "unverified") {

--- a/.github/workflows/pr-task-link.yml
+++ b/.github/workflows/pr-task-link.yml
@@ -30,6 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AIOS_BRAIN_URL: ${{ secrets.AIOS_BRAIN_URL }}
+      # MUST be a TEAM-tier key. The brain correctly refuses to tell an external-tier caller that a
+      # team task exists — it reports it as unknown, indistinguishable from nonexistent — so an
+      # external key here would turn every team ticket into a confident "does not exist".
       AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
       AIOS_TEAM: ${{ secrets.AIOS_TEAM }}
     steps:
@@ -41,7 +44,7 @@ jobs:
           // syntax error. A `.catch` keeps the job advisory — an unexpected throw must not fail a PR.
           (async () => {
           const fs = require("node:fs");
-          const { extractWorkKeys, knownKeysFrom, taskRowsFrom, unknownKeysFrom, verifyKeys, TASKS_PAGE_BOUND } = await import("./scripts/pr-work-keys.mjs");
+          const { extractWorkKeys, knownKeysFrom, taskRowsFrom, unknownKeysFrom, answersByKey, verifyKeys, TASKS_PAGE_BOUND } = await import("./scripts/pr-work-keys.mjs");
           const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
           const keys = extractWorkKeys(ev.pull_request || {});
           if (!keys.length) {
@@ -68,13 +71,18 @@ jobs:
           // the ones missing. Falls back to the full-table read against a pre-1.14 brain, which is why
           // the truncation reasoning below stays.
           let res = await fetch(`${base}?mode=table&keys=${encodeURIComponent(keys.join(","))}`, { headers });
-          if (res.status === 400) res = await fetch(`${base}?all=1`, { headers }); // pre-1.14: no `keys`
-          if (!res.ok) {
+          let body = res.ok ? await res.json().catch(() => null) : null;
+          // `answersByKey` carries the reasoning (and the test): a 400 is only ONE of the ways a brain
+          // says it can't answer — a pre-1.13 brain returns 200 with the writeback feed instead.
+          if (!res.ok || !answersByKey(body)) {
+            res = await fetch(`${base}?all=1`, { headers });
+            body = res.ok ? await res.json().catch(() => null) : null;
+          }
+          if (!res.ok || !body) {
             // Couldn't ask ≠ the key is fake. Advisory job, so never fail on OUR outage.
             console.log(`::warning title=Work key not verified::brain returned ${res.status} — only the FORMAT was checked.`);
             return;
           }
-          const body = await res.json();
           // `?all=1` is bounded at 500 rows (documented) and does NOT paginate, so a full page is a
           // PREFIX of the table — the stalest rows, since it orders `updated_at` ascending. Absence from
           // a prefix is not absence from the table; presence in it is still proof.

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -11,6 +11,16 @@ export type TaskFeedMode = "writeback" | "table" | "sync-origin";
 
 const EPOCH = "1970-01-01T00:00:00Z";
 const PAGE = 500;
+/**
+ * How many `row_key`s one by-key lookup may ask about (brain-api 1.14).
+ *
+ * Deliberately far below `PAGE`, because the whole value of the lookup is that ABSENCE IS PROOF —
+ * and that only holds while the result cannot be truncated. A key may exist in more than one project
+ * (`unique (team_id, project_id, row_key)`), so the row count is keys × projects; 200 leaves room for
+ * that and still cannot plausibly reach 500. If it somehow does, `unknown_keys` comes back `null`
+ * rather than wrong — see `unknownKeysFor`.
+ */
+const KEYS_MAX = 200;
 
 /**
  * Resolve the feed mode (brain-api 1.13). `mode` is the explicit, versioned selector; the legacy
@@ -45,11 +55,64 @@ export function nextCursorFor(
   return new Date(rows[rows.length - 1].updated_at).toISOString();
 }
 
+/** A rejected `keys` request, with the reason the caller should see. */
+export type TaskKeysParse = { keys: string[] } | { error: string };
+
+/**
+ * Parse `?keys=A,B,C` — the by-key existence lookup (brain-api 1.14).
+ *
+ * REFUSES outside table mode instead of answering. `writeback` hides `origin='sync'` rows and
+ * `sync-origin` hides `origin='ui'` ones, so a real key asked about in either would come back
+ * "unknown" — a confident wrong answer, which is precisely the failure this endpoint exists to end.
+ * A caller that has typed the wrong mode wants to be told, not quietly misled.
+ *
+ * Duplicates are collapsed and blanks dropped, so `keys=A,,A` asks about one key; the caller's
+ * accounting of what it asked for still has to match, which is why `unknown_keys` echoes keys rather
+ * than counts.
+ */
+export function parseTaskKeys(raw: string | null, mode: TaskFeedMode): TaskKeysParse | null {
+  if (raw === null) return null; // not a by-key request at all
+  if (mode !== "table")
+    return { error: "keys requires mode=table (or all=1) — other modes filter rows, so a real key would look missing" };
+  const keys = [...new Set(raw.split(",").map((k) => k.trim()).filter(Boolean))];
+  if (!keys.length) return { error: "keys must name at least one row_key" };
+  if (keys.length > KEYS_MAX) return { error: `keys is limited to ${KEYS_MAX} per request` };
+  return { keys };
+}
+
+/**
+ * Which of the requested keys matched nothing the caller may see — the ANSWER to "does this exist?",
+ * so a client never has to infer it from absence and get it wrong.
+ *
+ * `null` means UNDETERMINABLE, never "none": if the read hit the row cap it is a prefix, and a key
+ * missing from a prefix proves nothing. That case is unreachable at `KEYS_MAX` × realistic project
+ * counts, and it still returns null rather than a list that would be quietly wrong — the same rule
+ * the CI consumer applies, kept on the side that actually knows.
+ *
+ * A key hidden by the caller's tier is reported as unknown, deliberately: "it exists but you may not
+ * see it" is itself a disclosure, and `visibleTasks` is the only enforcement (no RLS).
+ */
+export function unknownKeysFor(
+  requested: string[],
+  rows: { row_key: string | null }[],
+  truncated: boolean,
+): string[] | null {
+  if (truncated) return null;
+  const found = new Set(rows.map((r) => r.row_key).filter(Boolean));
+  return requested.filter((k) => !found.has(k));
+}
+
 /**
  * Task feed for `aios pull`.
  *
  *  • `writeback` (default) — rows created or modified IN THE DASHBOARD since the cursor.
  *  • `table` (`?all=1` or `?mode=table`) — the explicit tier-filtered full tasks-table read.
+ *  • `keys` (`?mode=table&keys=AIO-1,AIO-2`, brain-api 1.14) — a BY-KEY lookup, answering "do these
+ *    tickets exist?" in one request. `table` alone cannot answer it: it caps at 500 rows ordered
+ *    `updated_at` ASCENDING with no cursor, so it returns the STALEST prefix — measured on prod, 677
+ *    keyed tasks with `AIO-484` at rank 628, i.e. permanently invisible to the read that was being
+ *    used to verify it. Here the query is bounded by the keys themselves, so ABSENCE IS PROOF, and
+ *    `unknown_keys` states it outright instead of leaving the client to infer it.
  *  • `sync-origin` (`?mode=sync-origin&project=<slug>`, brain-api 1.13, AIO-537) — the RETURN LEG:
  *    sync-origin rows (pushed from a workspace) for ONE project, so a workspace can merge brain/
  *    Linear status + assignee changes back into its markdown. Without it the markdown decays —
@@ -81,6 +144,11 @@ export async function GET(req: NextRequest) {
     );
   const all = mode === "table";
   const since = all ? EPOCH : url.searchParams.get("since") || EPOCH;
+
+  const keysParse = parseTaskKeys(url.searchParams.get("keys"), mode);
+  if (keysParse && "error" in keysParse)
+    return errorResponse("invalid_request", keysParse.error, 400);
+  const keys = keysParse?.keys ?? null;
 
   // sync-origin is deliberately single-project: the return leg answers "what changed on MY
   // workspace's rows", and a workspace only ever merges its own project's markdown table.
@@ -116,6 +184,9 @@ export async function GET(req: NextRequest) {
     .gt("updated_at", since)
     .not("row_key", "is", null);
   if (projectId) query = query.eq("project_id", projectId);
+  // The by-key filter is what makes absence provable: the result is bounded by what was ASKED for,
+  // not by an arbitrary page of the newest-last table.
+  if (keys) query = query.in("row_key", keys);
   // Only rows a workspace pushed. Dashboard-origin rows stay the writeback feed's job, so the
   // two feeds never double-merge the same row.
   if (mode === "sync-origin") query = query.eq("origin", "sync");
@@ -190,5 +261,15 @@ export async function GET(req: NextRequest) {
       rows,
     })),
     next_cursor: nextCursorFor(mode, (data ?? []) as { updated_at: string }[]),
+    // 1.14, by-key requests ONLY — a caller that didn't ask about keys gets a byte-identical body.
+    ...(keys
+      ? {
+          unknown_keys: unknownKeysFor(
+            keys,
+            selected as { row_key: string | null }[],
+            (data ?? []).length >= PAGE,
+          ),
+        }
+      : {}),
   });
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -705,7 +705,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `POST /api/v1/items` — upsert synced content
 - `GET /api/v1/items` — tier-filtered, keyset-paginated pull
 - `GET /api/v1/items/:id` — single item fetch
-- `GET /api/v1/tasks` — dashboard task changes for `aios pull` writeback; `?all=1` selects the tier-filtered full tasks-table read
+- `GET /api/v1/tasks` — dashboard task changes for `aios pull` writeback; `?all=1` selects the tier-filtered full tasks-table read (bounded at 500 rows, `updated_at` ASC, no cursor — a full page is the STALEST prefix, so it can confirm a key but can never prove one absent); `?mode=table&keys=A,B` (brain-api 1.14) is the by-key lookup that can — bounded by the keys asked for, answering `unknown_keys` outright (`null` = couldn't determine, never a wrong list). Refused outside table mode, since the other modes filter rows and a real key would look missing
 - `GET /api/v1/timeline` — the work-timeline context layer (v1.12): last 7d day→person→work ledger, the same payload the dashboard panel reads (SWR `work_timeline_cache`); API-key + tier-scoped (`getCachedWorkTimeline` → `visibleItems`/`visibleTasks`)
 - `GET /api/v1/attribution` — attribution health (brain-api v1.13): the SAME derived read as Admin → Attribution (`lib/attribution/health`), so the CLI/LLM read it too — summary (`bySource`/`byMember`/`lowAttributionSources`), or `?member=<uuid>|unattributed` [+ `?source=`/`?limit=`] for the per-item provenance drill-down. **Team-tier ADMIN only** (all-tier read, member names + admin-content counts, no RLS backstop) — external/non-admin → 403
 - `GET /api/v1/pm-sync/health` — team-tier projection health and recent runs for CLI/agent observability

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,8 +142,9 @@ flowchart LR
 
 ## Auth & access tiers
 
-This server **implements brain-api v1.13** (the shipped member-facing wire contract; source of truth:
-`aios-workspace/docs/brain-api.md`; v1.8 added the subscriptions endpoint,
+This server **implements brain-api v1.14** (the shipped member-facing wire contract; source of truth:
+`aios-workspace/docs/brain-api.md` — **its 1.14 revision entry is still outstanding**, see the
+by-key lookup on `GET /api/v1/tasks` below; v1.8 added the subscriptions endpoint,
 `POST /api/v1/subscriptions`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`), asserted against this sentence by
 `test/guards/contract-version.test.ts`, and mirrored by the vendored

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -79,7 +79,9 @@ Both this workflow and `pr-task-link.yml` (advisory) read a PR for the ticket it
 Two behaviours worth knowing:
 
 - **Quoted keys don't count.** HTML comments, fenced blocks and inline code are stripped from the body before matching, so prose like ``supersedes `AIO-100` `` is not a citation. That direction is deliberate: `/api/v1/work-events` sets `status='done'` on a key matching a task in the pushed project, so over-matching closes the **wrong** ticket silently, while under-matching only leaves the board stale — and the advisory check announces that at open time.
-- **The existence check can say "I don't know."** `GET /api/v1/tasks?all=1` is capped at 500 rows and does not paginate, so on a team with more tasks the answer is a prefix of the stalest ones. A key found there is confirmed; a key absent from a **full** page reports `unverified`, never "invented" — the check is not allowed to accuse on data it never saw. Making it provable for every key needs a by-key lookup or a table-mode cursor on the tasks endpoint.
+- **The existence check asks about the keys, not for the table.** It calls `GET /api/v1/tasks?mode=table&keys=A,B` (brain-api 1.14), which is bounded by the keys asked for, so absence is proof and the brain answers `unknown_keys` outright. That is what lets an invented key be *called* invented.
+
+  The fallback matters as much: against a brain that predates 1.14 (400 on `keys`) it re-asks `?all=1`, which is capped at 500 rows ordered stalest-first. There a key found is confirmed, but a key absent from a **full** page reports `unverified`, never "invented" — the check is not allowed to accuse on data it never saw. That distinction exists because the check's first real run told us a real ticket didn't exist; on this team's data (677 tasks) `?all=1` could never have seen it.
 
 ---
 

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -8,8 +8,16 @@
  *
  * Guarded by `test/guards/contract-version.test.ts` (asserts shape + agreement with the
  * architecture doc). Bumping the contract = bump this constant + the doc in the same PR.
+ *
+ * WHAT THE GUARD CANNOT SEE: it checks that this constant AGREES with the doc's "implements
+ * brain-api vX.Y" sentence. Both can be stale together. 1.14 shipped in review with a new request
+ * param, a new response field and a 200→400 change, while this still said 1.13 and the guard was
+ * green — a wire change is invisible to a consistency check between two things the same edit
+ * forgot. Changing the wire is the trigger to bump; the guard only stops the two drifting apart.
+ *
+ * 1.14 — `GET /api/v1/tasks?mode=table&keys=A,B`: the by-key lookup + `unknown_keys`.
  */
-export const BRAIN_API_VERSION = "1.13";
+export const BRAIN_API_VERSION = "1.14";
 
 /** Server-only Executor gateway negotiation; independent of the member API surface. */
 export const GATEWAY_CONTRACT_VERSION = "1.10";

--- a/scripts/pr-work-keys.mjs
+++ b/scripts/pr-work-keys.mjs
@@ -68,6 +68,22 @@ export function knownKeysFrom(body) {
 }
 
 /**
+ * The 1.14 answer, when the brain gives one: which of the keys we asked about do not exist.
+ *
+ * `?mode=table&keys=…` bounds the query by the keys themselves, so absence IS proof and the brain says
+ * so outright in `unknown_keys` — no inferring from a list that might be a truncated prefix. `null` is
+ * the brain admitting it could not determine them, and is treated exactly like a pre-1.14 brain that
+ * never sent the field: fall back to asking the whole table and reasoning about truncation.
+ *
+ * Returns `null` when this answer isn't available, which is what `verifyKeys` needs to tell "the brain
+ * told me these are fake" apart from "I had to guess".
+ */
+export function unknownKeysFrom(body) {
+  const u = body?.unknown_keys;
+  return Array.isArray(u) ? u.map(String) : null;
+}
+
+/**
  * The documented row bound of `GET /api/v1/tasks?all=1` (brain-api: "up to the endpoint's 500-row bound").
  * Table mode does not paginate — `next_cursor` is null for it by design — so a full page means the answer
  * we got is a PREFIX of the table, ordered by `updated_at` ASCENDING: the STALEST rows. The tasks people
@@ -90,6 +106,17 @@ export const TASKS_PAGE_BOUND = 500;
  * an advisory warning worthless.
  */
 export function verifyKeys(keys, known, opts) {
+  // THE 1.14 PATH: the brain was asked about these keys specifically and answered. Its list is
+  // authoritative — no truncation reasoning applies, because the query was bounded by the keys. This is
+  // what lets the check do the job it was built for again; without it, on a team with more than 500
+  // tasks every verdict degrades to "couldn't verify", including a genuinely invented key.
+  if (Array.isArray(opts?.unknownKeys)) {
+    if (!keys.length) return { status: "none" };
+    const invented = keys.filter((k) => opts.unknownKeys.includes(k));
+    return invented.length
+      ? { status: "invented", invented, checked: keys.length, authoritative: true }
+      : { status: "ok", checked: keys.length, authoritative: true };
+  }
   // MANDATORY, and it throws rather than defaulting. `truncated = false` would be a default that ACCUSES:
   // drop the argument — a plausible merge-conflict resolution, in glue code that lives in a YAML heredoc —
   // and the false accusation comes back with every test still green. That is the exact class this module

--- a/scripts/pr-work-keys.mjs
+++ b/scripts/pr-work-keys.mjs
@@ -84,6 +84,22 @@ export function unknownKeysFrom(body) {
 }
 
 /**
+ * Did this response actually answer the BY-KEY question?
+ *
+ * A brain that can't only sometimes says so with a 400. A PRE-1.13 brain has no `mode` param at all:
+ * it ignores `mode=table&keys=…` and returns 200 with the WRITEBACK feed — a short, dashboard-origin
+ * slice. Reading that as a table answer is how a real `origin='sync'` key gets called INVENTED: the
+ * feed is short so nothing looks truncated, and the key simply isn't in it. That is this project's
+ * signature failure, reachable only because we started asking a narrower question.
+ *
+ * So the test is "did I get a TABLE answer", not "did I avoid a 400". Lives here rather than in the
+ * workflow heredoc because the last decision that produced a false accusation lived there.
+ */
+export function answersByKey(body) {
+  return body?.mode === "table";
+}
+
+/**
  * The documented row bound of `GET /api/v1/tasks?all=1` (brain-api: "up to the endpoint's 500-row bound").
  * Table mode does not paginate — `next_cursor` is null for it by design — so a full page means the answer
  * we got is a PREFIX of the table, ordered by `updated_at` ASCENDING: the STALEST rows. The tasks people

--- a/test/datamechanics/tasks-key-lookup.datamechanics.test.ts
+++ b/test/datamechanics/tasks-key-lookup.datamechanics.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { GET as tasksGET } from "@/app/api/v1/tasks/route";
+import { issueApiKey } from "@/lib/admin/keys";
+import { db, seedTeam, type Seed } from "./helpers";
+
+/**
+ * Spec for the by-key task lookup (brain-api 1.14).
+ *
+ * WHY IT EXISTS. `?all=1` is capped at 500 rows ordered `updated_at` ASCENDING and does not
+ * paginate, so a "full table read" is a prefix of the STALEST rows. The PR work-key CI check used
+ * it to answer "does this ticket exist?" and told us a real ticket did not: measured on prod,
+ * 677 keyed tasks and `AIO-484` at rank 628 — never in the response. The check was corrected to
+ * report "couldn't verify", which is honest but means the failure it was BUILT for (a PR citing an
+ * invented `AIO-48x`) is no longer caught at all.
+ *
+ * The contract these assertions are derived from — written before the implementation:
+ *   1. `mode=table&keys=A,B` returns exactly the rows for those keys, whatever their `updated_at`.
+ *   2. `unknown_keys` names the requested keys that matched nothing — so "does it exist" is an
+ *      ANSWER, not something the client infers from absence and gets wrong.
+ *   3. Absence is PROOF here: the query is bounded by the keys, so no cap can hide a match.
+ *      If that ever stops holding, `unknown_keys` must be `null` — never a wrong list.
+ *   4. `keys` is refused outside table mode: writeback/sync-origin apply extra filters, so a real
+ *      key would look absent. A silent wrong answer is the exact bug this endpoint is fixing.
+ *   5. Tier isolation holds — an external key learns nothing about a team-audience task, including
+ *      whether it exists.
+ *   6. Old clients are byte-unaffected: no `keys` param, no `unknown_keys` field.
+ */
+
+const URL = "http://test/api/v1/tasks";
+
+async function issueKeyFor(seed: Seed, tier: "team" | "external"): Promise<string> {
+  let memberId = seed.memberId;
+  if (tier === "external") {
+    const { data, error } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `ext-${randomUUID().slice(0, 8)}@test.local`,
+        display_name: "External",
+        actor_handle: `ext-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "external",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`external member seed failed: ${error?.message}`);
+    memberId = (data as { id: string }).id;
+  }
+  const { key } = await issueApiKey(db(), seed.teamId, memberId, `${tier} key`);
+  return key;
+}
+
+function get(key: string, teamSlug: string, qs: string) {
+  const req = new Request(`${URL}?${qs}`, {
+    headers: { Authorization: `Bearer ${key}`, "X-AIOS-Team": teamSlug },
+  }) as unknown as NextRequest;
+  return tasksGET(req);
+}
+
+type FeedRow = { row_key: string; title: string; status: string };
+type Feed = { mode: string; tasks: { project: string; rows: FeedRow[] }[]; unknown_keys?: string[] | null };
+
+const rowKeys = (feed: Feed): string[] => feed.tasks.flatMap((g) => g.rows.map((r) => r.row_key)).sort();
+
+async function seedProject(teamId: string, slug: string): Promise<string> {
+  const { data } = await db().from("projects").insert({ team_id: teamId, slug, name: slug }).select("id").single();
+  return (data as { id: string }).id;
+}
+
+/** One batch insert — `updatedAt` is what decides whether `?all=1` would ever reach the row. */
+async function seedTasks(
+  teamId: string,
+  projectId: string,
+  rows: { rowKey: string; updatedAt: string; audience?: "team" | "external" }[]
+): Promise<void> {
+  const { error } = await db()
+    .from("tasks")
+    .insert(
+      rows.map((r) => ({
+        team_id: teamId,
+        project_id: projectId,
+        row_key: r.rowKey,
+        title: `task ${r.rowKey}`,
+        status: "in_progress",
+        assignee: "",
+        origin: "ui",
+        audience: r.audience ?? "team",
+        updated_at: r.updatedAt,
+      }))
+    );
+  if (error) throw new Error(`task seed failed: ${error.message}`);
+}
+
+describe("tasks by-key lookup (real handler, real Postgres)", () => {
+  it("answers for keys the 500-row table read can NEVER reach", async () => {
+    // THE REGRESSION, reproduced: 505 stale tasks fill the page, and the key we ask about is the
+    // NEWEST — so `?all=1` orders it last and the cap drops it. This is prod's AIO-484 at rank 628.
+    const seed = await seedTeam();
+    const proj = await seedProject(seed.teamId, "acme");
+    const key = await issueKeyFor(seed, "team");
+    await seedTasks(
+      seed.teamId,
+      proj,
+      Array.from({ length: 505 }, (_, i) => ({
+        rowKey: `OLD-${i}`,
+        updatedAt: new Date(Date.UTC(2020, 0, 1) + i * 60_000).toISOString(),
+      }))
+    );
+    await seedTasks(seed.teamId, proj, [{ rowKey: "AIO-484", updatedAt: "2026-07-27T10:00:00Z" }]);
+
+    // Proof the fixture is real: the full-table read genuinely cannot see it.
+    const table = (await (await get(key, seed.teamSlug, "all=1")).json()) as Feed;
+    expect(rowKeys(table)).not.toContain("AIO-484");
+
+    // The lookup finds it regardless of how stale-ordered the table is.
+    const feed = (await (await get(key, seed.teamSlug, "mode=table&keys=AIO-484")).json()) as Feed;
+    expect(rowKeys(feed)).toEqual(["AIO-484"]);
+    expect(feed.unknown_keys).toEqual([]);
+  });
+
+  it("names the keys that do not exist, so absence is an ANSWER and not an inference", async () => {
+    const seed = await seedTeam();
+    const proj = await seedProject(seed.teamId, "acme");
+    const key = await issueKeyFor(seed, "team");
+    await seedTasks(seed.teamId, proj, [{ rowKey: "AIO-484", updatedAt: "2026-07-27T10:00:00Z" }]);
+
+    const feed = (await (await get(key, seed.teamSlug, "mode=table&keys=AIO-484,AIO-999,AIO-1000")).json()) as Feed;
+    expect(rowKeys(feed)).toEqual(["AIO-484"]);
+    expect(feed.unknown_keys?.slice().sort()).toEqual(["AIO-1000", "AIO-999"]);
+  });
+
+  it("REFUSES `keys` outside table mode rather than answering from a filtered feed", async () => {
+    // writeback hides `origin='sync'` rows and sync-origin hides `origin='ui'` ones, so a real key
+    // would come back "unknown" — a confident wrong answer, which is the whole failure being fixed.
+    const seed = await seedTeam();
+    await seedProject(seed.teamId, "acme");
+    const key = await issueKeyFor(seed, "team");
+
+    for (const qs of ["keys=AIO-484", "mode=writeback&keys=AIO-484", "mode=sync-origin&project=acme&keys=AIO-484"]) {
+      const res = await get(key, seed.teamSlug, qs);
+      expect(res.status, `${qs} must be refused, not silently answered`).toBe(400);
+    }
+  });
+
+  it("refuses more keys than it can answer without truncating", async () => {
+    const seed = await seedTeam();
+    await seedProject(seed.teamId, "acme");
+    const key = await issueKeyFor(seed, "team");
+    const many = Array.from({ length: 201 }, (_, i) => `AIO-${i}`).join(",");
+    expect((await get(key, seed.teamSlug, `mode=table&keys=${many}`)).status).toBe(400);
+  });
+
+  it("TIER: an external key does not learn that a team task exists", async () => {
+    // No RLS — `visibleTasks` is the only enforcement. The row must not appear, AND the key must be
+    // reported as unknown: "it exists but you can't see it" is itself a disclosure.
+    const seed = await seedTeam();
+    const proj = await seedProject(seed.teamId, "acme");
+    const teamKey = await issueKeyFor(seed, "team");
+    const extKey = await issueKeyFor(seed, "external");
+    await seedTasks(seed.teamId, proj, [
+      { rowKey: "TEAM-1", updatedAt: "2026-07-27T10:00:00Z", audience: "team" },
+      { rowKey: "EXT-1", updatedAt: "2026-07-27T10:00:00Z", audience: "external" },
+    ]);
+
+    const ext = (await (await get(extKey, seed.teamSlug, "mode=table&keys=TEAM-1,EXT-1")).json()) as Feed;
+    expect(rowKeys(ext)).toEqual(["EXT-1"]);
+    expect(ext.unknown_keys).toEqual(["TEAM-1"]);
+
+    // …and the same question from a team key proves the row was really there to leak.
+    const team = (await (await get(teamKey, seed.teamSlug, "mode=table&keys=TEAM-1,EXT-1")).json()) as Feed;
+    expect(rowKeys(team)).toEqual(["EXT-1", "TEAM-1"]);
+    expect(team.unknown_keys).toEqual([]);
+  });
+
+  it("leaves old clients byte-unaffected — no `keys`, no `unknown_keys`", async () => {
+    const seed = await seedTeam();
+    const proj = await seedProject(seed.teamId, "acme");
+    const key = await issueKeyFor(seed, "team");
+    await seedTasks(seed.teamId, proj, [{ rowKey: "AIO-484", updatedAt: "2026-07-27T10:00:00Z" }]);
+
+    for (const qs of ["all=1", "since=1970-01-01T00:00:00Z"]) {
+      const body = (await (await get(key, seed.teamSlug, qs)).json()) as Record<string, unknown>;
+      expect(Object.keys(body).sort(), `${qs} response shape must not change`).toEqual([
+        "mode",
+        "next_cursor",
+        "tasks",
+      ]);
+    }
+  });
+});

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -1,7 +1,7 @@
 {
   "$schema": "aios-brain-contract/v1",
   "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: node scripts/gen-contract-fixture.mjs.",
-  "version": "1.13",
+  "version": "1.14",
   "tierAliases": {
     "shared": {
       "team": "team",
@@ -99,5 +99,5 @@
       "sha256": "9862e47581b9bdd68ecfd7aa92216011a6b56bc9dc7abaee3bd5e301240bfbea"
     }
   },
-  "contentHash": "01f9de6c4fababe1f3075b6a3724e4c14cead4a1f2deeddfed831679d0e0e390"
+  "contentHash": "cd00b0383a9bc959f7939b02593661c598e4eebb84a98d6f4f6f66122fcb8c68"
 }

--- a/test/pr-work-keys.test.ts
+++ b/test/pr-work-keys.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 // @ts-expect-error — plain .mjs shared by the two PR workflows; no types, deliberately dependency-free.
-import { extractWorkKeys, knownKeysFrom, taskRowsFrom, unknownKeysFrom, verifyKeys, TASKS_PAGE_BOUND } from "../scripts/pr-work-keys.mjs";
+import { extractWorkKeys, knownKeysFrom, taskRowsFrom, unknownKeysFrom, answersByKey, verifyKeys, TASKS_PAGE_BOUND } from "../scripts/pr-work-keys.mjs";
 
 /**
  * The PR work-key check, which shipped broken because it lived in a YAML heredoc no test tier could reach.
@@ -206,5 +206,22 @@ describe("unknownKeysFrom + the authoritative verdict", () => {
       expect(v.status).toBe("unverified");
       expect(v.reason).toBe("truncated");
     }
+  });
+});
+
+describe("answersByKey — a 200 is not an answer", () => {
+  it("accepts only a TABLE-mode response", () => {
+    expect(answersByKey({ mode: "table", tasks: [], unknown_keys: [] })).toBe(true);
+  });
+
+  it("REJECTS a pre-1.13 brain's writeback feed, which is where the false accusation came from", () => {
+    // A pre-1.13 brain ignores `mode` entirely and answers 200 with the dashboard-origin writeback
+    // slice. Short feed → nothing looks truncated → a real `origin='sync'` key absent from it reads as
+    // INVENTED. Verified by simulation against a stub: with this check reverted to "400 only", citing a
+    // real key produced "AIO-484 … no task in the brain has it".
+    expect(answersByKey({ mode: "writeback", tasks: [] })).toBe(false);
+    expect(answersByKey({ tasks: [] })).toBe(false); // pre-1.13: no `mode` field at all
+    expect(answersByKey({ mode: "sync-origin", tasks: [] })).toBe(false);
+    expect(answersByKey(null)).toBe(false);
   });
 });

--- a/test/pr-work-keys.test.ts
+++ b/test/pr-work-keys.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 // @ts-expect-error — plain .mjs shared by the two PR workflows; no types, deliberately dependency-free.
-import { extractWorkKeys, knownKeysFrom, taskRowsFrom, verifyKeys, TASKS_PAGE_BOUND } from "../scripts/pr-work-keys.mjs";
+import { extractWorkKeys, knownKeysFrom, taskRowsFrom, unknownKeysFrom, verifyKeys, TASKS_PAGE_BOUND } from "../scripts/pr-work-keys.mjs";
 
 /**
  * The PR work-key check, which shipped broken because it lived in a YAML heredoc no test tier could reach.
@@ -170,5 +170,41 @@ describe("a truncated read cannot prove a key is fake", () => {
   it("taskRowsFrom counts rows across project groups, so truncation is detectable", () => {
     const body = { tasks: [{ project: "a", rows: [{ row_key: "X-1" }, { row_key: "X-2" }] }, { project: "b", rows: [{ row_key: "X-3" }] }] };
     expect(taskRowsFrom(body).length).toBe(3);
+  });
+});
+
+/**
+ * brain-api 1.14 — the brain now ANSWERS "do these exist?" instead of handing back a page to infer from.
+ * `?mode=table&keys=…` is bounded by the keys, so absence is proof and `unknown_keys` says it outright.
+ * This is what restores the check's original job: on a team with >500 tasks every verdict had degraded
+ * to "couldn't verify", including for a genuinely invented key.
+ */
+describe("unknownKeysFrom + the authoritative verdict", () => {
+  it("reads the brain's answer, and distinguishes 'none unknown' from 'no answer'", () => {
+    expect(unknownKeysFrom({ unknown_keys: ["AIO-999"] })).toEqual(["AIO-999"]);
+    expect(unknownKeysFrom({ unknown_keys: [] })).toEqual([]); // answered: everything exists
+    expect(unknownKeysFrom({ unknown_keys: null })).toBeNull(); // brain couldn't determine
+    expect(unknownKeysFrom({})).toBeNull(); // pre-1.14 brain
+  });
+
+  it("calls a key INVENTED on the brain's word, even though the page looks truncated", () => {
+    // The whole point: a bounded query means truncation reasoning does not apply. Before 1.14 this
+    // exact input produced "couldn't verify" and the check caught nothing.
+    const v = verifyKeys(["AIO-999"], new Set(["AIO-484"]), { truncated: true, unknownKeys: ["AIO-999"] });
+    expect(v).toEqual({ status: "invented", invented: ["AIO-999"], checked: 1, authoritative: true });
+  });
+
+  it("confirms a key the brain did not list as unknown", () => {
+    const v = verifyKeys(["AIO-484"], new Set(), { truncated: true, unknownKeys: [] });
+    expect(v).toEqual({ status: "ok", checked: 1, authoritative: true });
+  });
+
+  it("falls back to truncation reasoning when the brain gives no answer", () => {
+    // A pre-1.14 brain, or one that returned `unknown_keys: null` because it could not determine them.
+    for (const unknownKeys of [null, undefined]) {
+      const v = verifyKeys(["AIO-484"], new Set(["OLD-1"]), { truncated: true, unknownKeys });
+      expect(v.status).toBe("unverified");
+      expect(v.reason).toBe("truncated");
+    }
   });
 });

--- a/test/tasks-feed-mode.test.ts
+++ b/test/tasks-feed-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { nextCursorFor, parseTaskFeedMode } from "@/app/api/v1/tasks/route";
+import { nextCursorFor, parseTaskFeedMode, parseTaskKeys, unknownKeysFor } from "@/app/api/v1/tasks/route";
 
 /**
  * brain-api 1.13 (AIO-537). The mode selector must keep every pre-1.13 request shape mapping to
@@ -54,5 +54,55 @@ describe("sync-origin pagination cursor", () => {
   it("never pages the pre-1.13 modes", () => {
     expect(nextCursorFor("writeback", page(500))).toBeNull();
     expect(nextCursorFor("table", page(500))).toBeNull();
+  });
+});
+
+/**
+ * brain-api 1.14 — the by-key lookup. `?all=1` returns the 500 STALEST rows with no cursor, so it
+ * cannot answer "does this key exist": prod had `AIO-484` at rank 628 of 677. These pin the two
+ * decisions that make the answer trustworthy — refuse the question when the mode would filter rows,
+ * and never report a key list derived from a truncated read.
+ */
+describe("by-key lookup parsing", () => {
+  it("is not a by-key request when `keys` is absent", () => {
+    expect(parseTaskKeys(null, "writeback")).toBeNull();
+    expect(parseTaskKeys(null, "table")).toBeNull();
+  });
+
+  it("REFUSES outside table mode — a filtered feed would call a real key missing", () => {
+    for (const mode of ["writeback", "sync-origin"] as const) {
+      const parsed = parseTaskKeys("AIO-1", mode);
+      expect(parsed && "error" in parsed, `${mode} must be refused`).toBe(true);
+    }
+    expect(parseTaskKeys("AIO-1", "table")).toEqual({ keys: ["AIO-1"] });
+  });
+
+  it("collapses duplicates and blanks", () => {
+    expect(parseTaskKeys("AIO-1, ,AIO-1, AIO-2 ", "table")).toEqual({ keys: ["AIO-1", "AIO-2"] });
+  });
+
+  it("refuses an empty list and an over-long one", () => {
+    expect(parseTaskKeys(",, ", "table")).toEqual({ error: expect.stringContaining("at least one") });
+    const many = Array.from({ length: 201 }, (_, i) => `A-${i}`).join(",");
+    expect(parseTaskKeys(many, "table")).toEqual({ error: expect.stringContaining("limited to 200") });
+    const atCap = Array.from({ length: 200 }, (_, i) => `A-${i}`).join(",");
+    expect(parseTaskKeys(atCap, "table")).toEqual({ keys: expect.any(Array) });
+  });
+});
+
+describe("unknown_keys — an answer, or an admission, never a guess", () => {
+  it("names exactly the requested keys that matched nothing", () => {
+    expect(unknownKeysFor(["A", "B", "C"], [{ row_key: "B" }], false)).toEqual(["A", "C"]);
+    expect(unknownKeysFor(["A"], [{ row_key: "A" }], false)).toEqual([]);
+  });
+
+  it("is NULL when the read was truncated — absence from a prefix proves nothing", () => {
+    // The same rule the CI consumer applies, kept on the side that actually knows whether the
+    // result was capped. A list here would be confidently wrong.
+    expect(unknownKeysFor(["A"], [{ row_key: "B" }], true)).toBeNull();
+  });
+
+  it("ignores null row_keys rather than counting them as a match", () => {
+    expect(unknownKeysFor(["A"], [{ row_key: null }], false)).toEqual(["A"]);
   });
 });


### PR DESCRIPTION
You asked for this: making the PR work-key check able to *prove* a key exists, instead of only ever saying "couldn't verify".

## The problem it closes

`GET /api/v1/tasks?all=1` is capped at **500 rows ordered `updated_at` ASCENDING with no cursor** — so a "full table read" is the **stalest prefix**. Measured on prod: 677 keyed tasks, and `AIO-484` at **rank 628**. It was never in the answer.

That's why the check first accused a real ticket of not existing, and why the honest fix (report `unverified`) meant it could no longer catch a genuinely invented key either — the exact `AIO-48x` failure it was built for would sail through today.

## What's new

`GET /api/v1/tasks?mode=table&keys=A,B` — bounded by the keys asked for, so **absence is proof**, and `unknown_keys` states it outright instead of leaving the client to infer it from a page that might be truncated.

- **Refused outside table mode** (400). `writeback` hides `origin='sync'` rows and `sync-origin` hides `origin='ui'` ones, so a real key asked about in either would come back "unknown" — a confident wrong answer, which is the whole failure being fixed.
- **`unknown_keys` is `null`, never a wrong list**, if the read could have truncated. Unreachable at `KEYS_MAX = 200` (prod max is 1 project per key, so 200 keys ≈ 200 rows against a 500 cap) — and it still refuses to guess rather than returning something quietly wrong.
- **Tier-safe by construction**: `unknown_keys` is computed from the `visibleTasks`-filtered rows, so an external key asking about a team task gets it back as unknown — byte-identical to "does not exist". No existence oracle.
- **Old clients byte-unaffected**: no `keys` param, no `unknown_keys` field; there's a test asserting the response key set.

The CI check now asks the targeted question and falls back to `?all=1` against an older brain.

## Review — Reviewed by Fable (`code-reviewer` subagent) — verdict CLEAR (after one BLOCKED round)

Two findings, both real, both verified before I acted on them:

**I stamped a version I never bumped.** The diff wrote "brain-api 1.14" into two docs, the route and the script while `BRAIN_API_VERSION` still said `1.13` — and the version guard was green, because it only asserts the constant *agrees with* the doc sentence, and both were stale together. A consistency check between two things the same edit forgot cannot see a wire change. And this is one: new request param, new response field, `?mode=writeback&keys=X` going 200→400.

That is the same shape as the finding I fixed yesterday (a guard that couldn't see the level that changed) — so it's worth naming that I repeated it one day later. Bumping then failed a **second** guard I didn't know existed: a conformance fixture pinning its own version behind a content hash. That one did its job.

**A false accusation, through a path I opened.** The fallback fired only on HTTP 400 — but a pre-1.13 brain has no `mode` param at all: it ignores `mode=table&keys=…` and answers **200 with the writeback feed**, which is short and dashboard-origin only. Read as a table answer, nothing looks truncated and a real `origin='sync'` key simply isn't there → **"invented"**. Reproduced against a stub pre-1.13 brain: with the 400-only fallback, citing a real key printed *"AIO-484 … no task in the brain has it"*.

The test is now "did I get a **table** answer", not "did I avoid a 400" — and that decision moved out of the YAML heredoc into `answersByKey` with tests, because the last decision that produced a false accusation was also one that lived in a heredoc.

Also from the review: the CI credential must be **team-tier**, now stated where it's set — the brain correctly refuses to tell an external caller that a team task exists, so an external key would turn every team ticket into "does not exist".

## Verified

Spec-first: all five API behaviours were RED before implementation, including a 505-stale-row fixture that proves `?all=1` genuinely cannot see the key.

End-to-end against a stub brain, all paths:

| brain | cites | result |
|---|---|---|
| 1.14 | real key | `All work key(s) exist (1 checked)` |
| 1.14 | invented | `Work key does not exist … (1 checked)` ← **restored** |
| pre-1.14 | either | `not verified … capped at 500 rows, STALEST first` |
| pre-1.13 | real key | `All work key(s) exist` (was a false accusation before the fix) |

unit 1332 · data-mechanics 767 (own container) · tsc 0 · lint clean (2 pre-existing warnings) · docs-drift green. No schema change.

## Outstanding — cross-repo

The pinned contract `aios-workspace/docs/brain-api.md` is at **1.13** (verified against its `origin/main`, not my 117-commits-stale local checkout) and needs the matching **1.14** revision entry. Not done here because it's a second repo — `docs/ARCHITECTURE.md` says so plainly rather than implying the contract is already updated. Say the word and I'll open that PR.

AIOS-Work: AIO-484