### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,36 @@
 All notable changes to AIOS Team Brain are documented here. Dates are ISO-8601.
 
 The Brain API sync contract (`docs/brain-api.md` in aios-workspace) is versioned
-separately; it remains **v1** for this release. `ce_band` is an additive **v1.3**
-field on the existing `POST /api/v1/metrics` endpoint.
+separately. The current member-facing major remains **v1**, at additive document
+revision **v1.14**.
 
 ## [Unreleased]
+
+## [0.8.0] — 2026-07-28
+
+### Added
+
+- **Onboarding V2 connection validation** — `GET /api/v1/me` is the canonical
+  proof that an approved Brain origin and API key belong to the expected member
+  and team.
+- **Expanded team context surfaces** — additive v1 contract capabilities for
+  subscriptions, company graph, timeline, attribution, task-key lookup,
+  transcript facts, and stakeholder mentions.
+
+### Changed
+
+- Workstation setup remains discoverable for new members and active teams without
+  blocking access to Pulse. Personal and Create remain valid Workspace outcomes.
+- A successful onboarding validation durably records API-key usage so setup
+  completion survives navigation and later sessions.
+
+### Fixed
+
+- Ordinary API authentication stays available if non-critical usage telemetry
+  fails; `/me` reports a persistence failure as a server error instead of a
+  false invalid-key response.
+- Architecture documentation now points at the landed Brain API v1.14 revision
+  instead of calling it outstanding.
 
 ## [0.7.0] — 2026-07-04
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,8 +143,8 @@ flowchart LR
 ## Auth & access tiers
 
 This server **implements brain-api v1.14** (the shipped member-facing wire contract; source of truth:
-`aios-workspace/docs/brain-api.md` — **its 1.14 revision entry is still outstanding**, see the
-by-key lookup on `GET /api/v1/tasks` below; v1.8 added the subscriptions endpoint,
+`aios-workspace/docs/brain-api.md`; see the v1.14 by-key lookup on
+`GET /api/v1/tasks` below; v1.8 added the subscriptions endpoint,
 `POST /api/v1/subscriptions`). That version is pinned in code as `BRAIN_API_VERSION`
 (`lib/api/version.ts`), asserted against this sentence by
 `test/guards/contract-version.test.ts`, and mirrored by the vendored

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aios-team-brain",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aios-team-brain",
-      "version": "0.1.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@aios-alpha/design": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-team-brain",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump AIOS Team Brain to 0.8.0
- publish the Onboarding V2 connection and completion semantics in the repository changelog
- remove stale documentation claiming Brain API revision 1.14 is outstanding

Release type: minor. Member-facing Brain API remains major v1 at additive document revision 1.14.

## Validation

- `npm run check:docs`
- `npm run lint` (0 errors; 2 pre-existing warnings)
- `npm run typecheck`
- package lock dry-run and exact-diff review

## Review — Reviewed by code-reviewer (Codex) — verdict no blockers; v0.8.0 version, changelog, and Brain API documentation are consistent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no application or API behavior changes in this diff.
> 
> **Overview**
> **Release v0.8.0** — `package.json` and `package-lock.json` move from **0.7.0** to **0.8.0**.
> 
> **CHANGELOG** adds a dated **[0.8.0]** entry (Onboarding V2 via `GET /api/v1/me`, expanded v1 team-context surfaces, setup/telemetry fixes) and updates the intro to describe the Brain API as **v1** at document revision **v1.14** instead of the older **v1.3** `ce_band` note.
> 
> **`docs/ARCHITECTURE.md`** drops the claim that Brain API **1.14** is still outstanding and aligns the contract pointer with the shipped revision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c760fb73db6b2e6ccd15c436d5fa3c90edf35a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->