### PR TITLE
fix(graph): detect extraction that STOPPED, not just extraction that never started

### DIFF
--- a/lib/graph/extraction-health.ts
+++ b/lib/graph/extraction-health.ts
@@ -28,6 +28,17 @@ import { neo4jConfigured, runRead } from "./neo4j";
  * appears? Both halves are kept — zero-facts catches a broken install, the lag catches a working
  * install that stopped.
  *
+ * WHAT THIS STILL CANNOT SEE — stated because the failure being corrected was over-claiming:
+ *   • PARTIAL failure. Any single success inside the lag budget reads green, so a 90%-failure rate is
+ *     invisible. Graphiti also writes `IS_DUPLICATE_OF` bookkeeping edges with a fresh `created_at`
+ *     (~26% of the graph) — the same behaviour that protects against false positives means a run
+ *     producing no real knowledge still looks alive.
+ *   • SCOPE ASYMMETRY. Episodes are counted per team; facts are counted globally (the fact probe is
+ *     deliberately not tier-scoped). On an instance with more than one group, one group's extraction
+ *     dying is masked by another group's fresh facts.
+ *   • A missing/unparseable timestamp disarms the recency half silently — safe, but invisible.
+ *   • Detection lags by the budget (6h) by construction.
+ *
  * Best-effort: nulls/`stalled:false` on any error so it never breaks a page render.
  */
 
@@ -105,32 +116,55 @@ export async function countGraphFacts(): Promise<number | null> {
  * Unfiltered, like `countGraphFacts`: an `IS_DUPLICATE_OF` edge is noise for display but is still
  * proof the extractor ran, which is the only question here.
  */
+/**
+ * Parse a timestamp from either probe into epoch ms, or null.
+ *
+ * Pure and exported because this seam has two different producers and no compiler between them:
+ * Postgres `timestamptz::text` (`2026-07-28 12:34:56.789+00`) and Neo4j `toString(datetime)`
+ * (`2026-07-28T12:34:56.789000000Z`). If either format shifts — a Neo4j upgrade emitting a bracketed
+ * named zone parses to NaN — the recency check silently disarms while every other test stays green.
+ * That is the same self-disarming class as the bug this file was rewritten to fix, so the formats are
+ * pinned in the unit tier rather than assumed.
+ */
+export function parseProbeTimestamp(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
 export async function newestFactAtMs(): Promise<number | null> {
   if (!neo4jConfigured()) return null;
   try {
     const rows = await runRead<{ at: string | null }>(
       "MATCH ()-[r:RELATES_TO]->() WHERE r.created_at IS NOT NULL RETURN toString(max(r.created_at)) AS at"
     );
-    const at = rows[0]?.at ?? null;
-    if (!at) return null;
-    const ms = Date.parse(at);
-    return Number.isFinite(ms) ? ms : null;
+    return parseProbeTimestamp(rows[0]?.at ?? null);
   } catch {
     return null;
   }
 }
 
-/** When this team last had an episode projected — the other half of the lag comparison. */
-async function newestEpisodeAtMs(teamId: string): Promise<number | null> {
+/**
+ * When this team last actually PUSHED an episode — the other half of the lag comparison.
+ *
+ * `content_sha256 <> ''` is load-bearing, not tidiness. Two paths in `lib/graph/project.ts` bump
+ * `projected_at` while POSTing nothing to Graphiti: the blanking/redaction path and the tier-vacate
+ * path, both of which park the row on a `""` sentinel sha. A plain `max(projected_at)` therefore
+ * counts a redaction wave as "an episode just landed" — and with no extraction to follow it, the lag
+ * check would go red on a completely healthy extractor six hours later. That is the cry-wolf failure
+ * this whole probe is supposed to avoid, so it must not be the probe's own first bug. Real pushes
+ * always store a 64-char digest (even `sha("")`), so the sentinel is an unambiguous discriminator.
+ *
+ * Exported so the retrieval-health card compares against the SAME quantity — two implementations of
+ * one number is how one surface keeps a bug the other one fixed.
+ */
+export async function newestEpisodeAtMs(teamId: string): Promise<number | null> {
   try {
     const res = await runSql<{ at: string | null }>(
-      "select max(projected_at)::text as at from graph_episodes where team_id = $1",
+      "select max(projected_at)::text as at from graph_episodes where team_id = $1 and content_sha256 <> ''",
       [teamId]
     );
-    const at = res.rows[0]?.at ?? null;
-    if (!at) return null;
-    const ms = Date.parse(at);
-    return Number.isFinite(ms) ? ms : null;
+    return parseProbeTimestamp(res.rows[0]?.at ?? null);
   } catch {
     return null;
   }

--- a/lib/graph/extraction-health.ts
+++ b/lib/graph/extraction-health.ts
@@ -15,8 +15,18 @@ import { neo4jConfigured, runRead } from "./neo4j";
  *   • the projector-freshness check stays green (it IS writing episodes),
  * yet the graph is empty and narrative arcs synthesize from nothing / stale facts. A completely
  * silent failure. This probe compares "episodes projected" (Postgres ledger) against "facts actually
- * extracted" (Neo4j) — many projected but zero extracted ⇒ the extractor is broken. Surfaced loudly
- * on the admin pipeline banner + retrieval-health card.
+ * extracted" (Neo4j). Surfaced loudly on the admin pipeline banner + retrieval-health card.
+ *
+ * TWO failures, and the second one taught us the first check was the wrong question. The original
+ * check was `facts === 0` — "did extraction EVER work?". On 2026-07-28 Graphiti's extraction key hit
+ * `insufficient_quota` and every job failed, but the graph already held weeks of facts, so
+ * `facts === 0` was false and this probe stayed SILENT. The admin card showed green for hours while
+ * extraction was dead; it was found by reading service logs. A count-based check disarms itself
+ * permanently the first time it succeeds.
+ *
+ * So the live question is RECENCY, not existence: are episodes still landing while no new fact
+ * appears? Both halves are kept — zero-facts catches a broken install, the lag catches a working
+ * install that stopped.
  *
  * Best-effort: nulls/`stalled:false` on any error so it never breaks a page render.
  */
@@ -26,21 +36,49 @@ import { neo4jConfigured, runRead } from "./neo4j";
  *  25 accepted episodes reliably yield ≥1 fact; 0 facts past that is unambiguous breakage. */
 export const MIN_EPISODES_FOR_EXTRACTION_SIGNAL = 25;
 
+/** How far the newest FACT may trail the newest EPISODE before extraction counts as stopped.
+ *
+ *  Extraction is serial and roughly 10-20s per episode, so facts always trail — the budget has to
+ *  absorb a normal backlog without paging anyone. Six hours is well past any healthy queue and well
+ *  short of the hours this went unnoticed for. Measured against the newest EPISODE, never against
+ *  `now`: a team that projected nothing for a week has legitimately old facts, and comparing to the
+ *  wall clock would cry stall on every quiet team. */
+export const EXTRACTION_LAG_BUDGET_MS = 6 * 3_600_000;
+
 export interface GraphExtractionHealth {
   episodes: number | null; // projected episodes for this team (Postgres ledger)
   facts: number | null; // extracted RELATES_TO facts in Neo4j (null = Neo4j unreadable)
-  stalled: boolean; // projected a meaningful backlog but zero facts extracted → extractor failing
+  stalled: boolean; // episodes are landing but not becoming facts → extractor failing
   reason: string | null; // human-facing cause when stalled
 }
 
+export interface ExtractionSignals {
+  episodes: number | null;
+  facts: number | null;
+  /** Newest `graph_episodes.projected_at` (ms). */
+  newestEpisodeAtMs?: number | null;
+  /** Newest RELATES_TO `created_at` (ms) — see `newestFactAtMs()` for why it is not `valid_at`. */
+  newestFactAtMs?: number | null;
+}
+
 /**
- * Pure verdict: are episodes reaching Graphiti but not becoming facts? `null` on either side means
- * "can't tell" (Neo4j unreadable, or ledger unreadable) — NOT stalled, since a different leg owns
- * reachability. Exported for unit tests.
+ * Pure verdict: are episodes reaching Graphiti but not becoming facts? `null` anywhere means
+ * "can't tell" (Neo4j unreadable, ledger unreadable, or an older Graphiti that didn't stamp a
+ * timestamp) — NOT stalled, since a different leg owns reachability and "don't know" must never
+ * read as "broken". Exported for unit tests.
  */
-export function deriveGraphExtractionStalled(episodes: number | null, facts: number | null): boolean {
+export function deriveGraphExtractionStalled(input: ExtractionSignals): boolean {
+  const { episodes, facts } = input;
   if (episodes === null || facts === null) return false;
-  return episodes >= MIN_EPISODES_FOR_EXTRACTION_SIGNAL && facts === 0;
+  // Too few episodes to judge either way — a fresh install may still be mid-first-extraction.
+  if (episodes < MIN_EPISODES_FOR_EXTRACTION_SIGNAL) return false;
+  // Never extracted anything: the original 2026-07 failure.
+  if (facts === 0) return true;
+  // Extracted once, then stopped: the 2026-07-28 quota failure the count-based check could not see.
+  const newestEpisode = input.newestEpisodeAtMs ?? null;
+  const newestFact = input.newestFactAtMs ?? null;
+  if (newestEpisode === null || newestFact === null) return false;
+  return newestEpisode - newestFact > EXTRACTION_LAG_BUDGET_MS;
 }
 
 /** Count RELATES_TO facts in the graph. A numeric health probe (no content leaves the graph), so it's
@@ -52,6 +90,49 @@ export async function countGraphFacts(): Promise<number | null> {
     return rows[0]?.n ?? 0;
   } catch {
     return null; // Neo4j unreachable — the reachability leg reports that; here it's just "unknown"
+  }
+}
+
+/**
+ * When the newest RELATES_TO edge was EXTRACTED.
+ *
+ * Deliberately `r.created_at` and NOT the `workTs` expression the Learning panel uses. `workTs`
+ * prefers `valid_at`, which Graphiti backdates to the episode's work time — so a fact extracted five
+ * minutes ago about a month-old Slack thread carries a month-old `valid_at`. Ranking by that is right
+ * for display and catastrophic for a health probe: it would report a stall on a perfectly healthy
+ * extractor that happens to be chewing through a backfill of old content.
+ *
+ * Unfiltered, like `countGraphFacts`: an `IS_DUPLICATE_OF` edge is noise for display but is still
+ * proof the extractor ran, which is the only question here.
+ */
+export async function newestFactAtMs(): Promise<number | null> {
+  if (!neo4jConfigured()) return null;
+  try {
+    const rows = await runRead<{ at: string | null }>(
+      "MATCH ()-[r:RELATES_TO]->() WHERE r.created_at IS NOT NULL RETURN toString(max(r.created_at)) AS at"
+    );
+    const at = rows[0]?.at ?? null;
+    if (!at) return null;
+    const ms = Date.parse(at);
+    return Number.isFinite(ms) ? ms : null;
+  } catch {
+    return null;
+  }
+}
+
+/** When this team last had an episode projected — the other half of the lag comparison. */
+async function newestEpisodeAtMs(teamId: string): Promise<number | null> {
+  try {
+    const res = await runSql<{ at: string | null }>(
+      "select max(projected_at)::text as at from graph_episodes where team_id = $1",
+      [teamId]
+    );
+    const at = res.rows[0]?.at ?? null;
+    if (!at) return null;
+    const ms = Date.parse(at);
+    return Number.isFinite(ms) ? ms : null;
+  } catch {
+    return null;
   }
 }
 
@@ -71,14 +152,35 @@ async function countProjectedEpisodes(teamId: string): Promise<number | null> {
 export async function getGraphExtractionHealth(teamId: string): Promise<GraphExtractionHealth> {
   const empty: GraphExtractionHealth = { episodes: null, facts: null, stalled: false, reason: null };
   if (!neo4jConfigured()) return empty;
-  const [episodes, facts] = await Promise.all([countProjectedEpisodes(teamId), countGraphFacts()]);
-  const stalled = deriveGraphExtractionStalled(episodes, facts);
+  const [episodes, facts, newestEpisode, newestFact] = await Promise.all([
+    countProjectedEpisodes(teamId),
+    countGraphFacts(),
+    newestEpisodeAtMs(teamId),
+    newestFactAtMs(),
+  ]);
+  const signals: ExtractionSignals = {
+    episodes,
+    facts,
+    newestEpisodeAtMs: newestEpisode,
+    newestFactAtMs: newestFact,
+  };
+  const stalled = deriveGraphExtractionStalled(signals);
+  const neverExtracted = stalled && facts === 0;
+  const lagHours =
+    newestEpisode !== null && newestFact !== null
+      ? Math.round((newestEpisode - newestFact) / 3_600_000)
+      : null;
   return {
     episodes,
     facts,
     stalled,
-    reason: stalled
-      ? `${episodes} episodes were projected but the graph has 0 extracted facts — Graphiti is accepting episodes (202) yet its entity-extraction worker is failing on every job (commonly the LLM output-token cap, e.g. "Output length exceeded max tokens"). New activity isn't becoming graph facts, so narrative arcs can't update. Check the graphiti service logs.`
-      : null,
+    // Two distinct causes deserve two distinct sentences — "it never worked" and "it stopped" send an
+    // operator to different places. Both name the graphiti service logs, which is where the actual
+    // error string lives (a token cap, a 429 `insufficient_quota`, an invalid group_id).
+    reason: !stalled
+      ? null
+      : neverExtracted
+        ? `${episodes} episodes were projected but the graph has 0 extracted facts — Graphiti is accepting episodes (202) yet its entity-extraction worker is failing on every job (commonly the LLM output-token cap, e.g. "Output length exceeded max tokens"). New activity isn't becoming graph facts, so narrative arcs can't update. Check the graphiti service logs.`
+        : `Graph extraction has STOPPED: episodes are still being projected, but no new fact has been extracted for about ${lagHours}h (the graph holds ${facts} facts from before). Graphiti keeps returning 202 while its extraction worker fails every job — most often the extraction LLM key is out of quota (a 429 \`insufficient_quota\`), or its output-token cap is being exceeded. Narrative arcs and the Learning panel are running on stale facts. Check the graphiti service logs.`,
   };
 }

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -2,7 +2,12 @@ import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
 import { graphitiConfigured, GraphitiClient } from "@/lib/graph/graphiti-client";
 import { getLlmHealth, type LlmHealth } from "@/lib/query/llm-health";
-import { countGraphFacts, deriveGraphExtractionStalled, newestFactAtMs } from "@/lib/graph/extraction-health";
+import {
+  countGraphFacts,
+  deriveGraphExtractionStalled,
+  newestEpisodeAtMs,
+  newestFactAtMs,
+} from "@/lib/graph/extraction-health";
 import { resolveEmbeddingBackend } from "@/lib/query/embedding-key";
 
 /**
@@ -143,26 +148,30 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
 
   // Graph + dense both hit the network — run them concurrently so the card render isn't serialized.
   const graphConfiguredNow = graphConfigured(process.env.GRAPHITI_URL);
-  const [dense, graphReachable, graphFresh, graphFacts, graphNewestFactAt, llm] = await Promise.all([
+  const [dense, graphReachable, graphFresh, graphFacts, graphNewestFactAt, graphNewestEpisodeAt, llm] =
+    await Promise.all([
     denseHealth(teamId, configured),
     graphConfiguredNow ? new GraphitiClient().healthcheck() : Promise.resolve(false),
     graphConfiguredNow ? graphFreshness(teamId) : Promise.resolve({ episodes: null, lastProjectedAt: null }),
     graphConfiguredNow ? countGraphFacts() : Promise.resolve(null),
     graphConfiguredNow ? newestFactAtMs() : Promise.resolve(null),
+    graphConfiguredNow ? newestEpisodeAtMs(teamId) : Promise.resolve(null),
     getLlmHealth(teamId),
   ]);
   const lastProjectedAtMs = graphFresh.lastProjectedAt ? Date.parse(graphFresh.lastProjectedAt) : null;
   const nowMs = Date.now();
   // Reachable + writing, but projected episodes aren't becoming facts (Graphiti's extractor is failing
   // on every job). Only meaningful when reachable — an unreachable service reports facts=null.
-  // `lastProjectedAtMs` is the newest EPISODE, which is what the lag half compares the newest fact
-  // against — never `now`, or a quiet team reads as broken.
+  // The lag compares against `graphNewestEpisodeAt`, NOT `lastProjectedAtMs`. They differ by exactly
+  // the thing that matters: `lastProjectedAtMs` counts every ledger touch (correct for `isGraphStale`
+  // — "is the projector alive"), while the lag needs the newest episode actually PUSHED, since a
+  // redaction wave bumps the ledger without producing anything for Graphiti to extract.
   const graphExtractionStalled =
     graphReachable &&
     deriveGraphExtractionStalled({
       episodes: graphFresh.episodes,
       facts: graphFacts,
-      newestEpisodeAtMs: lastProjectedAtMs,
+      newestEpisodeAtMs: graphNewestEpisodeAt,
       newestFactAtMs: graphNewestFactAt,
     });
   const graph = deriveGraphState({

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
 import { graphitiConfigured, GraphitiClient } from "@/lib/graph/graphiti-client";
 import { getLlmHealth, type LlmHealth } from "@/lib/query/llm-health";
-import { countGraphFacts, deriveGraphExtractionStalled } from "@/lib/graph/extraction-health";
+import { countGraphFacts, deriveGraphExtractionStalled, newestFactAtMs } from "@/lib/graph/extraction-health";
 import { resolveEmbeddingBackend } from "@/lib/query/embedding-key";
 
 /**
@@ -143,18 +143,28 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
 
   // Graph + dense both hit the network — run them concurrently so the card render isn't serialized.
   const graphConfiguredNow = graphConfigured(process.env.GRAPHITI_URL);
-  const [dense, graphReachable, graphFresh, graphFacts, llm] = await Promise.all([
+  const [dense, graphReachable, graphFresh, graphFacts, graphNewestFactAt, llm] = await Promise.all([
     denseHealth(teamId, configured),
     graphConfiguredNow ? new GraphitiClient().healthcheck() : Promise.resolve(false),
     graphConfiguredNow ? graphFreshness(teamId) : Promise.resolve({ episodes: null, lastProjectedAt: null }),
     graphConfiguredNow ? countGraphFacts() : Promise.resolve(null),
+    graphConfiguredNow ? newestFactAtMs() : Promise.resolve(null),
     getLlmHealth(teamId),
   ]);
   const lastProjectedAtMs = graphFresh.lastProjectedAt ? Date.parse(graphFresh.lastProjectedAt) : null;
   const nowMs = Date.now();
   // Reachable + writing, but projected episodes aren't becoming facts (Graphiti's extractor is failing
   // on every job). Only meaningful when reachable — an unreachable service reports facts=null.
-  const graphExtractionStalled = graphReachable && deriveGraphExtractionStalled(graphFresh.episodes, graphFacts);
+  // `lastProjectedAtMs` is the newest EPISODE, which is what the lag half compares the newest fact
+  // against — never `now`, or a quiet team reads as broken.
+  const graphExtractionStalled =
+    graphReachable &&
+    deriveGraphExtractionStalled({
+      episodes: graphFresh.episodes,
+      facts: graphFacts,
+      newestEpisodeAtMs: lastProjectedAtMs,
+      newestFactAtMs: graphNewestFactAt,
+    });
   const graph = deriveGraphState({
     configured: graphConfiguredNow,
     reachable: graphReachable,

--- a/test/graph-extraction-health.test.ts
+++ b/test/graph-extraction-health.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   deriveGraphExtractionStalled,
+  parseProbeTimestamp,
+  EXTRACTION_LAG_BUDGET_MS,
   MIN_EPISODES_FOR_EXTRACTION_SIGNAL,
 } from "@/lib/graph/extraction-health";
 
@@ -123,5 +125,50 @@ describe("deriveGraphExtractionStalled — extraction that STOPPED, not extracti
     expect(
       deriveGraphExtractionStalled({ episodes: 3, facts: 1, newestEpisodeAtMs: at(0), newestFactAtMs: at(50) })
     ).toBe(false);
+  });
+});
+
+/**
+ * The parsing seam. Two producers, no compiler between them: Postgres `timestamptz::text` and Neo4j
+ * `toString(datetime)`. If either format shifts, the recency check disarms itself silently while every
+ * other test here stays green — the exact class of bug this file was rewritten to fix. So the real
+ * wire formats are pinned rather than assumed.
+ */
+describe("parseProbeTimestamp — the formats the two probes actually emit", () => {
+  it("parses Postgres timestamptz::text, with any offset", () => {
+    expect(parseProbeTimestamp("2026-07-28 12:34:56.789+00")).toBe(Date.parse("2026-07-28T12:34:56.789Z"));
+    expect(parseProbeTimestamp("2026-07-28 05:34:56.789-07")).toBe(Date.parse("2026-07-28T12:34:56.789Z"));
+    expect(parseProbeTimestamp("2026-07-28 18:04:56.789+05:30")).toBe(Date.parse("2026-07-28T12:34:56.789Z"));
+  });
+
+  it("parses Neo4j toString(datetime), including nanosecond precision", () => {
+    expect(parseProbeTimestamp("2026-07-28T12:34:56.789000000Z")).toBe(Date.parse("2026-07-28T12:34:56.789Z"));
+    expect(parseProbeTimestamp("2026-07-28T12:34:56.789+00:00")).toBe(Date.parse("2026-07-28T12:34:56.789Z"));
+  });
+
+  it("returns null — never NaN — for absent or unparseable input", () => {
+    // A bracketed named zone is the realistic future break (a Neo4j upgrade could emit it); it must
+    // read as "don't know", which disarms the check, not as a bogus epoch that fabricates a stall.
+    expect(parseProbeTimestamp("2026-07-28T12:34:56+01:00[Europe/London]")).toBeNull();
+    expect(parseProbeTimestamp(null)).toBeNull();
+    expect(parseProbeTimestamp(undefined)).toBeNull();
+    expect(parseProbeTimestamp("")).toBeNull();
+    expect(parseProbeTimestamp("not a date")).toBeNull();
+  });
+});
+
+describe("the lag budget boundary", () => {
+  const base = { episodes: 1243, facts: 400, newestEpisodeAtMs: 1_000_000_000_000 };
+  it("is exclusive: exactly at budget is healthy, one ms past is stalled", () => {
+    expect(
+      deriveGraphExtractionStalled({ ...base, newestFactAtMs: base.newestEpisodeAtMs - EXTRACTION_LAG_BUDGET_MS })
+    ).toBe(false);
+    expect(
+      deriveGraphExtractionStalled({ ...base, newestFactAtMs: base.newestEpisodeAtMs - EXTRACTION_LAG_BUDGET_MS - 1 })
+    ).toBe(true);
+  });
+
+  it("a fact NEWER than the newest episode is healthy, not negative-lag nonsense", () => {
+    expect(deriveGraphExtractionStalled({ ...base, newestFactAtMs: base.newestEpisodeAtMs + 60_000 })).toBe(false);
   });
 });

--- a/test/graph-extraction-health.test.ts
+++ b/test/graph-extraction-health.test.ts
@@ -14,31 +14,114 @@ describe("deriveGraphExtractionStalled", () => {
   const N = MIN_EPISODES_FOR_EXTRACTION_SIGNAL;
 
   it("STALLED: a real backlog of projected episodes but zero extracted facts (the live bug)", () => {
-    expect(deriveGraphExtractionStalled(1243, 0)).toBe(true);
-    expect(deriveGraphExtractionStalled(N, 0)).toBe(true);
+    expect(deriveGraphExtractionStalled({ episodes: 1243, facts: 0 })).toBe(true);
+    expect(deriveGraphExtractionStalled({ episodes: N, facts: 0 })).toBe(true);
   });
 
   it("healthy: episodes projected AND facts exist — the extractor is working", () => {
-    expect(deriveGraphExtractionStalled(1243, 400)).toBe(false);
-    expect(deriveGraphExtractionStalled(N, 1)).toBe(false);
+    expect(deriveGraphExtractionStalled({ episodes: 1243, facts: 400 })).toBe(false);
+    expect(deriveGraphExtractionStalled({ episodes: N, facts: 1 })).toBe(false);
   });
 
   it("not flagged below the threshold — a fresh install may still be mid-first-extraction", () => {
     // Too few episodes to distinguish "broken" from "Graphiti still processing the first batch".
-    expect(deriveGraphExtractionStalled(N - 1, 0)).toBe(false);
-    expect(deriveGraphExtractionStalled(5, 0)).toBe(false);
+    expect(deriveGraphExtractionStalled({ episodes: N - 1, facts: 0 })).toBe(false);
+    expect(deriveGraphExtractionStalled({ episodes: 5, facts: 0 })).toBe(false);
   });
 
   it("nothing projected yet ⇒ not stalled (zero-vs-zero is a fresh graph, not a failure)", () => {
-    expect(deriveGraphExtractionStalled(0, 0)).toBe(false);
+    expect(deriveGraphExtractionStalled({ episodes: 0, facts: 0 })).toBe(false);
   });
 
   it("unknown facts (Neo4j unreadable) ⇒ not stalled — reachability is a different leg's concern", () => {
-    expect(deriveGraphExtractionStalled(1243, null)).toBe(false);
+    expect(deriveGraphExtractionStalled({ episodes: 1243, facts: null })).toBe(false);
   });
 
   it("unknown episodes (ledger unreadable) ⇒ not stalled — can't tell", () => {
-    expect(deriveGraphExtractionStalled(null, 0)).toBe(false);
-    expect(deriveGraphExtractionStalled(null, null)).toBe(false);
+    expect(deriveGraphExtractionStalled({ episodes: null, facts: 0 })).toBe(false);
+    expect(deriveGraphExtractionStalled({ episodes: null, facts: null })).toBe(false);
+  });
+});
+
+/**
+ * The SECOND prod failure (2026-07-28), which the spec above could not see.
+ *
+ * Graphiti's extraction key hit `insufficient_quota`. Every episode failed extraction — but the
+ * graph already held ~weeks of facts from before the key ran dry, so `facts === 0` was false and
+ * the probe stayed silent. Admin → Integrations showed the graph leg **green** while extraction had
+ * been dead for hours; it was found by reading the service logs, not the dashboard.
+ *
+ * The bug in the detector is a category error: it asks "did extraction EVER work?" when the question
+ * an operator needs answered is "is extraction working NOW?". A non-zero historical fact count
+ * answers the first question forever, so the check disarms itself the moment it has ever succeeded.
+ *
+ * The signal that separates them is RECENCY: episodes keep landing while no new fact appears.
+ */
+describe("deriveGraphExtractionStalled — extraction that STOPPED, not extraction that never started", () => {
+  const N = MIN_EPISODES_FOR_EXTRACTION_SIGNAL;
+  const HOUR = 3_600_000;
+  const now = Date.parse("2026-07-28T12:00:00Z");
+  const at = (hoursAgo: number) => now - hoursAgo * HOUR;
+
+  it("STALLED: episodes still arriving, newest fact far older than the newest episode", () => {
+    // The live case. 400 historical facts is exactly what kept the old check quiet.
+    expect(
+      deriveGraphExtractionStalled({
+        episodes: 1243,
+        facts: 400,
+        newestEpisodeAtMs: at(0.2),
+        newestFactAtMs: at(30),
+      })
+    ).toBe(true);
+  });
+
+  it("healthy: facts trailing episodes by less than the lag budget", () => {
+    // Extraction is serial and ~10-20s per episode, so facts ALWAYS trail. A small gap is normal
+    // and must not page anyone.
+    expect(
+      deriveGraphExtractionStalled({
+        episodes: 1243,
+        facts: 400,
+        newestEpisodeAtMs: at(0),
+        newestFactAtMs: at(1),
+      })
+    ).toBe(false);
+  });
+
+  it("healthy: a QUIET period — both are old together", () => {
+    // Nothing was projected for a week, so of course no facts appeared. Measuring fact age against
+    // `now` instead of against the newest EPISODE would cry stall on every quiet team.
+    expect(
+      deriveGraphExtractionStalled({
+        episodes: 1243,
+        facts: 400,
+        newestEpisodeAtMs: at(200),
+        newestFactAtMs: at(201),
+      })
+    ).toBe(false);
+  });
+
+  it("still catches the ORIGINAL failure — zero facts, whatever the timestamps say", () => {
+    expect(
+      deriveGraphExtractionStalled({ episodes: 1243, facts: 0, newestEpisodeAtMs: at(0), newestFactAtMs: null })
+    ).toBe(true);
+    expect(deriveGraphExtractionStalled({ episodes: N, facts: 0 })).toBe(true);
+  });
+
+  it("cannot tell: a missing timestamp is never evidence of a stall", () => {
+    // Neo4j unreadable, or an older Graphiti that didn't stamp created_at. "Don't know" is not "broken".
+    expect(
+      deriveGraphExtractionStalled({ episodes: 1243, facts: 400, newestEpisodeAtMs: at(0), newestFactAtMs: null })
+    ).toBe(false);
+    expect(
+      deriveGraphExtractionStalled({ episodes: 1243, facts: 400, newestEpisodeAtMs: null, newestFactAtMs: at(30) })
+    ).toBe(false);
+  });
+
+  it("respects the episode threshold for the recency check too", () => {
+    // A handful of episodes on a fresh install can legitimately lag; don't flag what we can't judge.
+    expect(
+      deriveGraphExtractionStalled({ episodes: 3, facts: 1, newestEpisodeAtMs: at(0), newestFactAtMs: at(50) })
+    ).toBe(false);
   });
 });

--- a/test/guards/graph-lag-probe-sentinel.test.ts
+++ b/test/guards/graph-lag-probe-sentinel.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * GUARD: the newest-episode probe must ignore ledger rows that POSTed nothing to Graphiti.
+ *
+ * `lib/graph/project.ts` bumps `projected_at` on two paths that push no episode — the blanking/
+ * redaction path and the tier-vacate path — parking both on a `content_sha256 = ''` sentinel. Without
+ * the filter, a redaction wave reads as "an episode just landed", no extraction follows it, and six
+ * hours later the admin banner calls a perfectly healthy extractor STOPPED. That is the cry-wolf
+ * failure this probe exists to avoid, so it must not be the probe's own bug.
+ *
+ * Pinned as source text because the alternative is a real-Postgres fixture for one SQL predicate.
+ */
+describe("guard: the lag probe excludes no-POST ledger touches", () => {
+  const src = readFileSync(join(process.cwd(), "lib", "graph", "extraction-health.ts"), "utf8");
+
+  it("newestEpisodeAtMs filters out the '' sentinel sha", () => {
+    const q = src.slice(src.indexOf("export async function newestEpisodeAtMs"));
+    expect(q).toContain("content_sha256 <> ''");
+  });
+
+  it("the sentinel is still what the no-POST paths write (or this guard is stale)", () => {
+    const proj = readFileSync(join(process.cwd(), "lib", "graph", "project.ts"), "utf8");
+    expect(proj).toContain('content_sha256: ""');
+  });
+});


### PR DESCRIPTION
The probe built to catch a silent graph failure **stayed silent through one**.

Yesterday Graphiti's extraction key hit `insufficient_quota` and every job failed. Admin → Integrations showed the graph leg **green** for hours. I found it by reading service logs, not the dashboard — which is exactly the outcome this probe exists to prevent.

## Why it missed

```ts
return episodes >= MIN_EPISODES_FOR_EXTRACTION_SIGNAL && facts === 0;
```

That asks *"did extraction ever work?"*. The graph already held weeks of facts, so `facts === 0` was false and it never fired. **A count-based check disarms itself permanently the first time it succeeds** — and the question an operator needs answered is *"is extraction working now?"*.

## The fix

**Recency** is the signal that separates the two: episodes still landing while no new fact appears. Both halves are kept — zero-facts still catches a broken install, the lag catches a working install that stopped.

Two details decide whether this reports the truth rather than noise:

- **The lag is measured against the newest EPISODE, never against `now`.** A team that projected nothing for a week has legitimately old facts; comparing against the wall clock would cry stall on every quiet team.
- **The fact timestamp is `r.created_at`, not the `workTs` expression the Learning panel ranks by.** `workTs` prefers `valid_at`, which Graphiti backdates to the episode's *work* time — so a fact extracted five minutes ago about a month-old Slack thread carries a month-old timestamp. Correct for display, catastrophic here: it would report a stall on a healthy extractor chewing through a backfill.

A missing timestamp is never evidence of a stall. Neo4j unreadable, or an older Graphiti that didn't stamp `created_at`, both mean *"don't know"* — and "don't know" must not read as "broken".

The `reason` string now branches. "Never extracted" and "stopped extracting" send an operator to different places, and the second names **quota exhaustion first**, since that's the one that just happened.

## Verified

Written RED first against the real scenario, then mutation-tested — each of these turns a different test red:

| Mutation | Kills |
|---|---|
| revert to the count-only check | "episodes arriving, newest fact far older" |
| compare against `now` instead of the newest episode | "a QUIET period — both are old together" |
| treat a missing timestamp as a stall | "cannot tell" + "healthy" |

unit 1340 · data-mechanics 767 (own container) · tsc 0 · lint clean (2 pre-existing warnings) · docs-drift green.

## Note

This is step 1 of two. Step 2 is a proxy so the admin console becomes the single place the extraction LLM key is configured — right now it's a second key on a second service, which is both why it ran dry unnoticed and why this detector had to exist in the first place.

## Review — Reviewed by Fable (`code-reviewer` subagent)

Briefed specifically on false positives, since a probe that pages you for a healthy system reproduces the original problem by making the card untrustworthy. Verdict recorded on completion.

AIOS-Work: AIO-484