### PR TITLE
fix(api): freshness stops being a guess — cache-backed routes report the row's real age (R2/M6)

### DIFF
--- a/app/api/brain/arcs/recompute/route.ts
+++ b/app/api/brain/arcs/recompute/route.ts
@@ -7,6 +7,7 @@ import { errorResponse } from "@/lib/api/schemas";
 import { resolveAnsweringKeys } from "@/lib/query/answering";
 import { visibleGroupIds } from "@/lib/graph/group";
 import { recomputeArcs } from "@/lib/graph/arcs";
+import { freshnessWire } from "@/lib/freshness";
 
 export const runtime = "nodejs";
 export const maxDuration = 120; // arc synthesis (LLM) inline path can take up to ~110s on a cold cache
@@ -57,7 +58,7 @@ export async function POST(req: NextRequest) {
 
   const admin = adminClient();
   const keys = await resolveAnsweringKeys(admin, team.id);
-  const arcs = await recomputeArcs(
+  const { arcs, freshness } = await recomputeArcs(
     admin,
     team.id,
     teamSlug,
@@ -68,5 +69,8 @@ export async function POST(req: NextRequest) {
     memberId
   );
 
-  return Response.json({ arcs, as_of: new Date().toISOString() });
+  // WAS `new Date()`. A recompute can legitimately return arcs it did NOT compute: `canReuseArcs` skips
+  // the model when facts are unchanged, and a degraded synthesis is refused in favour of the prior (H11).
+  // Stamping "now" told the user their correction had landed in a fresh set when it may not have.
+  return Response.json({ arcs, ...freshnessWire(freshness) });
 }

--- a/app/api/brain/arcs/route.ts
+++ b/app/api/brain/arcs/route.ts
@@ -10,6 +10,7 @@ import { visibleGroupIds } from "@/lib/graph/group";
 import { getArcs } from "@/lib/graph/arcs";
 import { getLlmHealth } from "@/lib/query/llm-health";
 import { graphHasFacts } from "@/lib/query/retrieval-health";
+import { freshnessWire } from "@/lib/freshness";
 
 export const runtime = "nodejs";
 // Arc synthesis with a reasoning model can be slow (it reasons over ~200 facts). Give the inline
@@ -50,7 +51,7 @@ export async function POST(req: NextRequest) {
   const tier = (me as { tier: "team" | "external" }).tier;
   const admin = adminClient();
   const keys = await resolveAnsweringKeys(admin, team.id);
-  const arcs = await getArcs(admin, team.id, teamSlug, tier, visibleGroupIds(teamSlug, tier), keys);
+  const { arcs, freshness } = await getArcs(admin, team.id, teamSlug, tier, visibleGroupIds(teamSlug, tier), keys);
 
   // Empty arcs are ambiguous — tell the client the ACTUAL cause so the panel stops showing a benign
   // "no arcs yet" for what is really a broken graph or a failing model:
@@ -81,11 +82,22 @@ export async function POST(req: NextRequest) {
   // That's team-internal infra detail: redact it for `external`-tier collaborators (who can't act on it
   // and shouldn't see the config), keeping only the coarse `reason` category. Team tier still gets the
   // actionable note.
+  const wire = freshnessWire(freshness);
   return Response.json({
     arcs,
-    degraded: reason === "model_failing", // back-compat flag
+    // `degraded` is the ENVELOPE's now (R2/M6): "a leg this payload depended on failed". It subsumes the
+    // old back-compat flag, which was `reason === "model_failing"` — i.e. only ever true when arcs were
+    // EMPTY, since `reason` is computed solely on the empty path. The envelope's is strictly wider and
+    // catches the case that flag structurally could not: a NON-empty arc set synthesized from degraded
+    // inputs (H11), which is the dangerous one because it looks fine. Kept truthy-compatible for any
+    // consumer reading the old meaning; the panel reads `reason`, not this.
+    degraded: wire.degraded || reason === "model_failing",
     reason,
     note: isRestrictedTier(tier) ? undefined : note,
-    as_of: new Date().toISOString(),
+    // WAS `new Date().toISOString()` — a lie. `arc_cache` has a 4h TTL and the SWR branch deliberately
+    // serves rows OLDER than that, so this stamped hours-old arcs as current, and destroyed the
+    // backdating H11/H12 built to mark an untrustworthy synthesis. Now the row's real time.
+    as_of: wire.as_of,
+    stale: wire.stale,
   });
 }

--- a/app/api/brain/facts/route.ts
+++ b/app/api/brain/facts/route.ts
@@ -39,7 +39,17 @@ export async function GET(req: NextRequest) {
   const tier = (me as { tier: "team" | "external" }).tier;
   const groups = visibleGroupIds(teamSlug, tier);
   const since = new Date(Date.now() - WINDOW_HOURS * 3600 * 1000).toISOString();
-  const { facts } = await recentFacts(groups, since, LIMIT);
+  const { facts, ok } = await recentFacts(groups, since, LIMIT);
 
-  return Response.json({ facts, as_of: new Date().toISOString(), window_hours: WINDOW_HOURS });
+  // `as_of` is honest here — this is a live Neo4j read, not a cache. The bug was `ok`: `recentFacts`
+  // already distinguishes "the window is genuinely quiet" from "the read FAILED" (its own comment says
+  // "treating as degraded, not as an empty window"), and the route dropped it — so a Neo4j outage
+  // rendered as a benign empty fact list. `stale` is structurally false for a live read.
+  return Response.json({
+    facts,
+    as_of: new Date().toISOString(),
+    stale: false,
+    degraded: !ok,
+    window_hours: WINDOW_HOURS,
+  });
 }

--- a/app/api/dashboard/team-work/route.ts
+++ b/app/api/dashboard/team-work/route.ts
@@ -3,6 +3,7 @@ import { serverClient } from "@/lib/db/server";
 import { adminClient } from "@/lib/db/admin";
 import { getSessionUser } from "@/lib/auth/session";
 import { errorResponse } from "@/lib/api/schemas";
+import { freshnessWire } from "@/lib/freshness";
 import { getCachedWorkTimeline } from "@/lib/dashboard/timeline-cache";
 import { mostRecentPerPerson } from "@/lib/dashboard/timeline-group";
 
@@ -36,7 +37,9 @@ export async function GET(req: NextRequest) {
   if (!me) return errorResponse("forbidden", "not a member of this team", 403);
 
   const tier = (me as { tier: "team" | "external" }).tier;
-  const days = await getCachedWorkTimeline(adminClient(), team.id, tier);
+  const { days, freshness } = await getCachedWorkTimeline(adminClient(), team.id, tier);
   const people = mostRecentPerPerson(days);
-  return Response.json({ people, as_of: new Date().toISOString() });
+  // WAS `new Date()` over a 5-min-TTL cache that also serves PAST the TTL while rebuilding — so this
+  // reported a stale ledger as current. Now the cache row's own time (R2/M6).
+  return Response.json({ people, ...freshnessWire(freshness) });
 }

--- a/app/api/dashboard/timeline/route.ts
+++ b/app/api/dashboard/timeline/route.ts
@@ -44,9 +44,13 @@ export async function GET(req: NextRequest) {
   if (!me) return errorResponse("forbidden", "not a member of this team", 403);
 
   const tier = (me as { tier: "team" | "external" }).tier;
+  // Both branches must yield a bare `TimelineDay[]`: the cached one now returns `{ days, freshness }`, and
+  // the two arms only have to AGREE for `Response.json` (typed `any`) to accept a nested shape silently.
+  // Note `Number(null) === 0`, so a request with no `days` param clamps to 7 and takes the cached arm —
+  // i.e. the default request is the one that would have broken.
   const timeline =
     days <= WINDOW_DAYS
-      ? await getCachedWorkTimeline(adminClient(), team.id, tier)
+      ? (await getCachedWorkTimeline(adminClient(), team.id, tier)).days
       : await getWorkTimeline(adminClient(), team.id, tier, days);
   return Response.json({ days: timeline, window_days: days });
 }

--- a/app/api/v1/timeline/route.ts
+++ b/app/api/v1/timeline/route.ts
@@ -27,7 +27,12 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const days = await getCachedWorkTimeline(db, auth.teamId, auth.memberTier);
+    // Payload ONLY. `getCachedWorkTimeline` returns `{ days, freshness }`, and the freshness envelope is
+    // deliberately NOT on the v1 wire yet — putting it here is a brain-api change (it needs the 1.15 bump
+    // plus the canonical doc in aios-workspace). Destructured rather than passed through: `Response.json`
+    // takes `any`, so serializing the whole object type-checks and silently nests `days` one level deeper,
+    // breaking every v1.12 consumer (`aios timeline`, MCP). Caught by review, not by tsc.
+    const { days } = await getCachedWorkTimeline(db, auth.teamId, auth.memberTier);
     return Response.json({ window_days: 7, days });
   } catch (err) {
     return errorResponse("internal", err instanceof Error ? err.message : "timeline read failed", 500);

--- a/components/learning/timeline-panel.tsx
+++ b/components/learning/timeline-panel.tsx
@@ -25,7 +25,10 @@ export async function TimelinePanel({
   teamSlug: string;
   tier: "team" | "external";
 }) {
-  const days = await getCachedWorkTimeline(adminClient(), teamId, tier);
+  // Payload only: this panel renders the ledger and has no freshness affordance today. Surfacing
+  // `freshness.stale` here (a "last updated" line) is a UI change, deliberately not bundled with the
+  // wire fix — see the PR's follow-ups.
+  const { days } = await getCachedWorkTimeline(adminClient(), teamId, tier);
   const shownDates = days.map((d) => d.date);
 
   return (

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,6 +142,26 @@ flowchart LR
 
 ## Auth & access tiers
 
+**Freshness contract (R2/M6).** Any surface served out of a cache table reports `{ as_of, stale, degraded }`
+built by **`lib/freshness.ts`** — `as_of` is the cache row's real `computed_at`, `stale` means past TTL and
+served anyway (SWR), `degraded` means a leg THIS REQUEST's computation depended on failed — it is not
+persisted with the cache row, so it describes the work done for this response, not the payload's permanent
+character (a degraded cold-miss reports `true`; the next read of the row it wrote reports `false` for the
+same bytes). Persisting it — a `degraded` column, which would also stop `computed_at` doubling as a trust
+dial — is the follow-up. It is produced by the DATA layer
+(`getArcs`, `getCachedWorkTimeline`, `commitArcs` all return it beside their payload) and only rendered by
+routes, because only the data layer knows the answer. Before this, four routes answered "how old is this?"
+with `as_of: new Date()` over a cache with a **4-hour** TTL that deliberately serves rows older still — a
+false contract, not a missing one, which also destroyed the deliberate backdating H11/H12 use to mark an
+untrustworthy synthesis. `computedAt` may UNDER-claim freshness (an untrustworthy arc set is pre-aged on
+purpose) but never over-claims it. Guarded by `test/guards/freshness-no-fabricated-as-of.test.ts`, which
+fails the build if a route stamps its own freshness; genuinely live reads are allowlisted there with a
+reason. Envelope fields carry no diagnostic prose, so adding one can't leak internal detail to an
+`external`-tier caller — that redaction stays per-route on the free-text `note`. Currently on the
+unversioned `/api/brain/*` + `/api/dashboard/*` surfaces; `GET /api/v1/timeline` still drops `computed_at`
+and `GET /api/v1/tasks` still discards its computed `truncated` (both need a brain-api bump, so they are
+deliberately not in this change).
+
 This server **implements brain-api v1.14** (the shipped member-facing wire contract; source of truth:
 `aios-workspace/docs/brain-api.md`; see the v1.14 by-key lookup on
 `GET /api/v1/tasks` below; v1.8 added the subscriptions endpoint,

--- a/docs/context-management-system.md
+++ b/docs/context-management-system.md
@@ -205,6 +205,14 @@ identity resolution) can disagree with a human's deliberate correction. The reso
   them drift and silently reopen the loop, so it's build-guarded.
 - **Single-flight** — each connector runner and the projector hold a module-level in-flight guard so a
   scheduler tick and an admin action can't duplicate work.
+- **Freshness is data, not a guess** (`lib/freshness.ts`, R2/M6): every cache-backed surface returns
+  `{ computedAt, stale, degraded }` beside its payload, rendered on the wire as `{ as_of, stale, degraded }`.
+  `computedAt` is the row's real `computed_at`; `stale` = past TTL but served (SWR); `degraded` = a leg the
+  payload needed failed. Produced by the data layer (`getArcs`, `getCachedWorkTimeline`, `commitArcs`),
+  never by the route — routes used to write `as_of: new Date()` over a 4h-TTL cache, which reported
+  hours-old arcs as current. Two non-obvious cases it now names: a cold-miss timeline is `degraded` but NOT
+  stale (real work data, prose not computed for it), and a refused degraded synthesis returns the PRIOR's
+  `computedAt`, so "the recompute returned" stops implying "the arcs are new".
 
 ---
 

--- a/lib/dashboard/timeline-cache.ts
+++ b/lib/dashboard/timeline-cache.ts
@@ -5,6 +5,7 @@ import type { ViewerTier } from "@/lib/auth/visibility";
 import { getWorkTimeline } from "./work-timeline";
 import { attachPersonDaySummaries } from "./timeline-summary";
 import type { TimelineDay } from "./timeline-group";
+import { freshness, type Freshness } from "@/lib/freshness";
 
 /**
  * The persisted, queryable work-timeline LAYER. `lib/dashboard/work-timeline.getWorkTimeline` is the
@@ -26,6 +27,9 @@ import type { TimelineDay } from "./timeline-group";
  */
 
 const TTL_MS = 5 * 60_000; // 5-min freshness; the ledger is cheap, so refresh often.
+/** The same TTL, exported: it's the threshold that decides `freshness.stale`, so a consumer reasoning
+ *  about staleness must be able to read the number rather than re-declare it (H6's drift shape). */
+export const TIMELINE_TTL_MS = TTL_MS;
 // Bump when the TimelineDay[] SHAPE changes: a cached row from an older deploy is then treated as a
 // cache MISS (rebuilt), so the panel never renders a stale wrong shape. `summary` was ADDITIVE + optional
 // (no bump — a v3 row renders fine). v4 adds a REQUIRED `PersonDay.signals[]` (the Context lane): an old
@@ -348,6 +352,15 @@ export async function settleTimelineRefreshes(): Promise<void> {
 }
 
 /**
+ * The ledger plus how much it can be trusted (R2/M6). The envelope sits BESIDE `days`, not around it, so
+ * `TimelineDay[]` — and the shape guard that pins it — are untouched.
+ */
+export interface CachedTimeline {
+  days: TimelineDay[];
+  freshness: Freshness;
+}
+
+/**
  * Return the work-timeline for a team+tier, serve-stale-while-revalidate:
  *   1. fresh in-memory → return instantly;
  *   2. Postgres `work_timeline_cache` — fresh → return; stale → return stale NOW + rebuild behind the request;
@@ -359,19 +372,23 @@ export async function getCachedWorkTimeline(
   db: DbClient,
   teamId: string,
   tier: ViewerTier
-): Promise<TimelineDay[]> {
+): Promise<CachedTimeline> {
   const key = memKey(teamId, tier);
   const now = Date.now();
 
   const cached = mem.get(key);
-  if (cached && now - cached.at < TTL_MS) return cached.days;
+  if (cached && now - cached.at < TTL_MS) return { days: cached.days, freshness: freshness(cached.at, TTL_MS, { now }) };
 
   const persisted = await readTimelineCache(db, teamId, tier);
   if (persisted) {
     mem.set(key, { days: persisted.days, at: persisted.at });
-    if (now - persisted.at < TTL_MS) return persisted.days;
+    // ONE envelope for both the fresh and the stale branch — `freshness()` derives `stale` from the same
+    // age comparison the branch below makes, so the reported staleness cannot disagree with the decision
+    // actually taken (they were two separate readings of the clock in every earlier draft of this).
+    const f = freshness(persisted.at, TTL_MS, { now });
+    if (!f.stale) return { days: persisted.days, freshness: f };
     refreshInBackground(teamId, tier); // stale → serve stale, rebuild behind the request
-    return persisted.days;
+    return { days: persisted.days, freshness: f };
   }
 
   // Cold miss — return the PURE ledger FAST (no inline LLM), persist it so there's always a row, then
@@ -386,8 +403,14 @@ export async function getCachedWorkTimeline(
   // carry them across as a bridge; the background pass overwrites them with freshly computed ones.
   // Best-effort by construction: no salvageable row → `built`, unchanged.
   const days = attachSalvagedSummaries(built, await readSalvageableSummaries(db, teamId, tier));
-  mem.set(key, { days, at: Date.now() });
+  const at = Date.now();
+  mem.set(key, { days, at });
   await writeTimelineCache(db, teamId, tier, days);
   refreshInBackground(teamId, tier);
-  return days;
+  // DEGRADED, deliberately. A cold miss returns the pure ledger: its per-person-day synopses are either
+  // absent (the background pass hasn't run) or SALVAGED from an older payload version. Both are "this is
+  // real work data with prose that wasn't computed for it", which is precisely the plausible-but-partial
+  // state R2 exists to name. Freshly computed, so `stale` is false — the two flags are independent, and
+  // this is the case that proves it: newest possible payload, least trustworthy prose.
+  return { days, freshness: freshness(at, TTL_MS, { now: at, degraded: true }) };
 }

--- a/lib/freshness.ts
+++ b/lib/freshness.ts
@@ -1,0 +1,87 @@
+/**
+ * The freshness envelope — how old a payload is, and whether it can be trusted.
+ *
+ * Pass-1 review R2 ("silent-degrade-by-default") / M6. Several surfaces are served
+ * stale-while-revalidate out of a cache table, so "when was this computed" is a real fact the data
+ * layer knows and the wire had no way to say. Routes filled the gap with `as_of: new Date()` — which is
+ * not a missing contract but a FALSE one: a 4-hour-old arc set stamped as current.
+ *
+ * Lives at `lib/` rather than `lib/api/` deliberately. It is produced by the DATA layer (the module that
+ * knows when the row was written) and only rendered by the API layer, so putting it under `lib/api`
+ * would make `lib/dashboard` and `lib/graph` import the API layer to describe their own results. Same
+ * lowest-shared-layer rule the caches themselves follow.
+ *
+ * The envelope is deliberately NOT a wrapper around the payload. Wrapping would force every caller,
+ * component, and test to unwrap; returning it alongside (`{ days, freshness }`) keeps the payload's own
+ * shape — and its shape guards — untouched.
+ */
+
+/** Epoch-ms + two booleans; no strings, so a consumer can't accidentally render a lie. */
+export interface Freshness {
+  /**
+   * When the payload was ACTUALLY computed (epoch ms) — the cache row's `computed_at`, not the time it
+   * was served. This is the field the lie was in.
+   */
+  computedAt: number;
+  /**
+   * Past its TTL and served anyway (stale-while-revalidate), with a refresh usually in flight. Not an
+   * error: the payload is real, just old. A consumer that needs current data should re-poll rather than
+   * treat this as a failure.
+   */
+  stale: boolean;
+  /**
+   * A leg **this request's computation** depended on failed, so the payload is plausible but incomplete or
+   * wrong — the case that silently reads as a healthy-but-quiet result. Distinct from `stale`: a degraded
+   * payload can be freshly computed, and a stale one can be perfectly trustworthy.
+   *
+   * SCOPE, precisely: it describes the computation that ran on THIS request, not the payload's permanent
+   * character, because it is not persisted with the cache row. A request that cold-misses and degrades
+   * reports `degraded: true`; the next request, served the row that computation wrote, reports `false` for
+   * the same bytes. Fixing that means a `degraded` column on `arc_cache`/`work_timeline_cache` — worth
+   * doing (it would also let `computed_at` stop doubling as a trust dial, which is why `writeArcCache`
+   * backdates today) and deliberately not bundled here. Until then, read `degraded: true` as "the work
+   * done for this response was unreliable", and never `degraded: false` as "this payload is verified good".
+   */
+  degraded: boolean;
+}
+
+/**
+ * Build an envelope for a payload computed at `computedAt`, given the TTL that defines staleness.
+ *
+ * `stale` is DERIVED here rather than passed in so the age→stale rule can't be spelled differently by
+ * each caller — the drift shape that made "is this task active" five different predicates (H6).
+ */
+export function freshness(
+  computedAt: number,
+  ttlMs: number,
+  opts: { now?: number; degraded?: boolean } = {}
+): Freshness {
+  const now = opts.now ?? Date.now();
+  // A non-finite `computed_at` (an unparseable row) is treated as INFINITELY old rather than as `now`.
+  // The alternative — defaulting to now — would report a row we can't date as fresh, which is the exact
+  // class of lie this module exists to remove.
+  const at = Number.isFinite(computedAt) ? computedAt : 0;
+  return { computedAt: at, stale: now - at >= ttlMs, degraded: opts.degraded === true };
+}
+
+/** An envelope for something computed right now, inline, with nothing cached behind it. */
+export function computedNow(opts: { now?: number; degraded?: boolean } = {}): Freshness {
+  return { computedAt: opts.now ?? Date.now(), stale: false, degraded: opts.degraded === true };
+}
+
+/**
+ * The wire rendering: `{ as_of, stale, degraded }`.
+ *
+ * `as_of` keeps the key the routes already publish. Renaming it to `computed_at` would be gratuitous
+ * churn on a contract whose VALUE — not whose name — was wrong, and would break any consumer that reads
+ * it today. Every other wire field in this codebase is snake_case, so `stale`/`degraded` fit as-is.
+ *
+ * Note there is no reason/detail string here, by design: `degraded` names THAT a payload is untrustworthy
+ * without naming which internal subsystem failed. Diagnostic prose (LLM base URLs, model slugs, provider
+ * error bodies) is team-internal and is redacted per-route for `external` tier — see the `note` handling
+ * in `app/api/brain/arcs/route.ts`. Keeping this serializer detail-free means adding the envelope to a
+ * route can never introduce a tier leak.
+ */
+export function freshnessWire(f: Freshness): { as_of: string; stale: boolean; degraded: boolean } {
+  return { as_of: new Date(f.computedAt).toISOString(), stale: f.stale, degraded: f.degraded };
+}

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -10,6 +10,7 @@ import { episodeGroupId, isExternalGroupId, type AccessTier } from "./group";
 import { attributedFactTexts, groundParticipants } from "./arc-attribution";
 import { resolveItemCredit } from "@/lib/attribution/contributor-credit";
 import { readArcCache, writeArcCache, ARC_CACHE_TTL_MS as CACHE_TTL_MS } from "./arc-cache";
+import { freshness, computedNow, type Freshness } from "@/lib/freshness";
 import { listArcCorrections, recordArcCorrections } from "./arc-corrections";
 import { arcIneligibleItemIds } from "./arc-eligibility";
 
@@ -864,6 +865,20 @@ export function evictArcMemoryCache(teamSlug: string): void {
  * panel. On that case we keep the prior value and DON'T refresh its timestamp, so the next view
  * retries until synthesis recovers. This is the guard that stops one bad LLM call from pinning the
  * Learning page empty for hours (2026-07 incident). Returns what's now authoritative for the key.
+ *
+ * Returns `computedAt` alongside, because "what's authoritative" is often NOT what was just computed:
+ * on both keep-the-prior branches the arcs handed back date from the earlier synthesis. A caller that
+ * assumed "commitArcs returned, so this is current" would re-create exactly the freshness lie R2 removes
+ * — one branch deep, where it is hardest to see. `computedAt` is never later than the computation it hands
+ * back (an untrustworthy result is deliberately backdated below), so it under-claims freshness rather than
+ * over-claiming it. One documented exception: on the `canReuseArcs` revalidation path the row is
+ * re-stamped `now()` over arcs the model produced hours earlier — defensible, because the inputs were just
+ * hash-verified unchanged (a 304, not a fresh synthesis), but it IS a re-stamp and predates this change.
+ *
+ * `untrustworthy` is returned too, and is BROADER than the caller's `opts.degraded`: it also covers H12's
+ * model-failure (empty arcs from a NON-empty fact set), which no input-degradation flag can see. Without
+ * it a timed-out recompute answers with the kept prior and `degraded: false` — "your correction landed"
+ * when it didn't.
  */
 export async function commitArcs(
   db: DbClient,
@@ -872,7 +887,7 @@ export async function commitArcs(
   next: NarrativeArc[],
   factsHash: string | null,
   opts: { degraded?: boolean } = {}
-): Promise<NarrativeArc[]> {
+): Promise<{ arcs: NarrativeArc[]; computedAt: number; untrustworthy: boolean }> {
   // ── Is this result trustworthy enough to serve for a full TTL? ────────────────────────────────────
   // Two ways it isn't, and both used to be committed as FRESH — which is the one state SWR can never
   // heal from, because it only re-fires on a stale row.
@@ -894,7 +909,7 @@ export async function commitArcs(
       console.warn(
         `[arcs] degraded synthesis for ${key}; keeping ${prior.arcs.length} cached arcs rather than overwriting them with a partial set`
       );
-      return prior.arcs;
+      return { arcs: prior.arcs, computedAt: prior.at, untrustworthy };
     }
   }
 
@@ -909,7 +924,7 @@ export async function commitArcs(
         console.warn(
           `[arcs] synthesis returned 0 arcs for ${key}; keeping ${prior.arcs.length} cached (${Math.round(ageMs / 3_600_000)}h old; likely transient)`
         );
-        return prior.arcs;
+        return { arcs: prior.arcs, computedAt: prior.at, untrustworthy };
       }
       // Prior is too old to keep trusting as "transient-failure cover": a persistently-empty synthesis
       // over this long is more likely GENUINE (quiet team, content deleted, graph reset, or the model
@@ -935,7 +950,7 @@ export async function commitArcs(
   }
   cache.set(key, { arcs: next, at, factsHash });
   await writeArcCache(db, teamId, key, next, factsHash, { retryAfterMs: untrustworthy ? UNTRUSTED_RETRY_AFTER_MS : undefined });
-  return next;
+  return { arcs: next, computedAt: at, untrustworthy };
 }
 
 /** The arcs currently cached for a key — in-memory first, then the persisted row. */
@@ -969,13 +984,22 @@ function refreshArcsInBackground(
       // fact-set-hash guard skip the LLM when nothing changed. Run the extra evidence-COHERENCE pass HERE
       // (background only — the route-bound cold-miss/correction paths can't afford the second LLM call).
       const { arcs, factsHash, degraded } = await synthesizeArcs(bg, teamId, groups, [], keys, BG_ARC_TIMEOUT_MS, prior, true);
-      await commitArcs(bg, teamId, key, arcs, factsHash, { degraded });
+      await commitArcs(bg, teamId, key, arcs, factsHash, { degraded }); // fire-and-forget: nobody awaits its freshness
     } catch (err) {
       console.error("[arcs] background refresh failed:", err instanceof Error ? err.message : err);
     } finally {
       refreshing.delete(key);
     }
   })();
+}
+
+/**
+ * Arcs plus how much they can be trusted (R2/M6). Beside the payload, not wrapping it, so `NarrativeArc[]`
+ * and everything that reads it are unchanged.
+ */
+export interface CachedArcs {
+  arcs: NarrativeArc[];
+  freshness: Freshness;
 }
 
 /**
@@ -993,29 +1017,46 @@ export async function getArcs(
   tier: AccessTier,
   groups: string[],
   keys: ProviderKeys
-): Promise<NarrativeArc[]> {
-  if (groups.length === 0) return [];
+): Promise<CachedArcs> {
+  // No visible groups is not a degraded read — it's a correct empty answer, computed now.
+  if (groups.length === 0) return { arcs: [], freshness: computedNow() };
   const key = groups.slice().sort().join(",");
   const now = Date.now();
 
-  // 1. In-memory (fastest, same process).
+  // 1. In-memory (fastest, same process). `at` is the PERSISTED computed_at (set below), not the time
+  //    this process happened to populate its map — so a warm process reports the row's age, not zero.
   const mem = cache.get(key);
-  if (mem && now - mem.at < CACHE_TTL_MS) return mem.arcs;
+  if (mem && now - mem.at < CACHE_TTL_MS) return { arcs: mem.arcs, freshness: freshness(mem.at, CACHE_TTL_MS, { now }) };
 
   // 2. Persistent cache (survives restart, shared across instances).
   const persisted = await readArcCache(db, teamId, key);
   if (persisted) {
     cache.set(key, { arcs: persisted.arcs, at: persisted.computedAt, factsHash: persisted.factsHash });
-    if (now - persisted.computedAt < CACHE_TTL_MS) return persisted.arcs;
+    const f = freshness(persisted.computedAt, CACHE_TTL_MS, { now });
+    if (!f.stale) return { arcs: persisted.arcs, freshness: f };
     // Stale — hand back the stale arcs immediately and refresh behind the request, passing the prior so
     // the refresh can skip the LLM if the facts are unchanged.
     refreshArcsInBackground(teamId, key, groups, keys, { arcs: persisted.arcs, factsHash: persisted.factsHash });
-    return persisted.arcs;
+    return { arcs: persisted.arcs, freshness: f };
   }
 
   // 3. Cold miss — first-ever load for this key. Compute inline so the user gets a real answer.
   const { arcs, factsHash, degraded } = await synthesizeArcs(db, teamId, groups, [], keys);
-  return commitArcs(db, teamId, key, arcs, factsHash, { degraded });
+  const committed = await commitArcs(db, teamId, key, arcs, factsHash, { degraded });
+  // `computedAt` comes from commitArcs, NOT from `Date.now()`: on a degraded synthesis it hands back the
+  // healthy PRIOR (H11), which is hours old, and stamping that "now" is the M6 lie one branch deep.
+  // `degraded` is reported from the SYNTHESIS rather than re-derived from the result, because those
+  // deliberately differ — the arcs served can be trustworthy while THIS computation failed, and that is
+  // what tells a consumer "the refresh you triggered didn't work" instead of looking silently fine.
+  return {
+    arcs: committed.arcs,
+    // `committed.untrustworthy`, not just `degraded`: H12's model-failure (empty arcs from a NON-empty
+    // fact set) is invisible to the input-degradation flag, and that is the commonest failure.
+    freshness: freshness(committed.computedAt, CACHE_TTL_MS, {
+      now: Date.now(),
+      degraded: degraded || committed.untrustworthy,
+    }),
+  };
 }
 
 /**
@@ -1033,8 +1074,8 @@ export async function recomputeArcs(
   keys: ProviderKeys,
   /** Who made the edit — stored for attribution. Null only if the caller genuinely has no member. */
   memberId: string | null = null
-): Promise<NarrativeArc[]> {
-  if (groups.length === 0) return [];
+): Promise<CachedArcs> {
+  if (groups.length === 0) return { arcs: [], freshness: computedNow() };
   const key = groups.slice().sort().join(",");
 
   // PERSIST FIRST, and let a failure surface. Everything else on this path degrades quietly because a
@@ -1053,7 +1094,15 @@ export async function recomputeArcs(
   );
 
   const { arcs: synthesized, factsHash, degraded } = await synthesizeArcs(db, teamId, groups, corrections.map((c) => c.corrected_text), keys);
-  const arcs = await commitArcs(db, teamId, key, synthesized, factsHash, { degraded });
+  const committed = await commitArcs(db, teamId, key, synthesized, factsHash, { degraded });
+  const arcs = committed.arcs;
+  // Same rule as getArcs: a recompute whose synthesis was degraded is REFUSED and the prior is kept
+  // (H11), so "the user clicked recompute" is not evidence the arcs are new. Report what commitArcs
+  // actually made authoritative, and carry `degraded` so the client can tell the edit didn't take.
+  const envelope = freshness(committed.computedAt, CACHE_TTL_MS, {
+    now: Date.now(),
+    degraded: degraded || committed.untrustworthy,
+  });
 
   // Project the corrections into the graph so they also read as facts to future extraction. This is now
   // a DERIVED copy — Postgres above is the record — so it stays best-effort: losing it costs some graph
@@ -1075,5 +1124,5 @@ export async function recomputeArcs(
       // writeback is best-effort — the recompute still returns fresh arcs
     }
   }
-  return arcs;
+  return { arcs, freshness: envelope };
 }

--- a/lib/social/discover-arcs.ts
+++ b/lib/social/discover-arcs.ts
@@ -85,7 +85,11 @@ export async function discoverOpportunitiesFromArcs(
   opts: DiscoverArcsOptions = {}
 ): Promise<DiscoverSummary> {
   const now = opts.now ?? new Date();
-  const arcs = opts.arcs ?? (await getArcs(db, teamId, teamSlug, tier, groups, keys));
+  // Discovery only needs the payload — an opportunity is derived from an arc's content, and a stale or
+  // degraded arc set produces fewer/older opportunities rather than wrong ones (each is reviewed before
+  // publish). Called out rather than silently destructured so a future author sees the envelope was
+  // considered and dropped on purpose, not missed.
+  const arcs = opts.arcs ?? (await getArcs(db, teamId, teamSlug, tier, groups, keys)).arcs;
 
   // Resolve every arc's evidence-item tiers in one pass so per-arc access is a pure in-memory calc.
   const allItemIds = arcs.flatMap((a) => a.evidence.map((e) => e.itemId).filter((id): id is string => !!id));

--- a/test/arcs-commit.test.ts
+++ b/test/arcs-commit.test.ts
@@ -60,23 +60,64 @@ describe("commitArcs — an empty synthesis must never clobber a good cache", ()
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     // Unique key so the module-level in-memory cache from other tests can't leak in.
     const out = await commitArcs(db, "team-1", "keep-good-1", [], null);
-    expect(out.map((a) => a.title)).toEqual(["payments migration"]); // prior kept
+    expect(out.arcs.map((a) => a.title)).toEqual(["payments migration"]); // prior kept
     expect(upserts).toHaveLength(0); // NOT overwritten
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("keeping 1 cached"));
+    warn.mockRestore();
+  });
+
+  it("reports the PRIOR's computed_at when it keeps the prior — not the commit time (R2/M6)", async () => {
+    // The freshness contract, at the branch most likely to break it. When commitArcs refuses a bad
+    // synthesis and hands back the cached set, those arcs are hours old; a caller that assumed
+    // "commitArcs returned, so this is current" would re-create the exact M6 lie one branch deep —
+    // which is what `getArcs`/`recomputeArcs` build their envelope from.
+    const priorAt = Date.now() - 3 * HOUR;
+    const { db } = fakeDb([arc("payments migration")], priorAt);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const kept = await commitArcs(db, "team-1", "freshness-keep-prior", [], null);
+    expect(kept.arcs.map((a) => a.title)).toEqual(["payments migration"]);
+    expect(kept.computedAt).toBe(priorAt); // the prior's time, to the millisecond
+
+    // Same rule on the DEGRADED keep-prior branch (H11), which is a separate early return.
+    const { db: db2 } = fakeDb([arc("payments migration")], priorAt);
+    const keptDegraded = await commitArcs(db2, "team-1", "freshness-keep-degraded", [arc("noise")], "h9", {
+      degraded: true,
+    });
+    expect(keptDegraded.computedAt).toBe(priorAt);
+    warn.mockRestore();
+  });
+
+  it("never reports a computed_at LATER than the real computation (under-claim, never over-claim)", async () => {
+    // The invariant the whole envelope rests on: an untrustworthy result is deliberately BACKDATED so it
+    // retries soon, so `computedAt` can be earlier than the true moment of computation — but it must
+    // never be later, because that is the direction that makes stale data look current.
+    const { db } = fakeDb(null);
+    const before = Date.now();
+    const healthy = await commitArcs(db, "team-1", "freshness-healthy", [arc("a")], "h1");
+    expect(healthy.computedAt).toBeGreaterThanOrEqual(before);
+    expect(healthy.computedAt).toBeLessThanOrEqual(Date.now());
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { db: db2 } = fakeDb(null);
+    const degraded = await commitArcs(db2, "team-1", "freshness-degraded-cold", [arc("b")], "h1", {
+      degraded: true,
+    });
+    expect(degraded.computedAt).toBeLessThan(Date.now()); // pre-aged, i.e. under-claimed
     warn.mockRestore();
   });
 
   it("writes through when synthesis returns real arcs", async () => {
     const { db, upserts } = fakeDb(null);
     const out = await commitArcs(db, "team-1", "write-good-1", [arc("a"), arc("b")], "h1");
-    expect(out).toHaveLength(2);
+    expect(out.arcs).toHaveLength(2);
     expect(upserts).toHaveLength(1); // persisted
   });
 
   it("writes empty on a genuine cold miss (no prior to protect)", async () => {
     const { db, upserts } = fakeDb(null);
     const out = await commitArcs(db, "team-1", "cold-empty-1", [], null);
-    expect(out).toEqual([]);
+    expect(out.arcs).toEqual([]);
     expect(upserts).toHaveLength(1); // first-ever load may legitimately be empty
   });
 
@@ -88,7 +129,7 @@ describe("commitArcs — an empty synthesis must never clobber a good cache", ()
     const { db, upserts } = fakeDb(null);
     const out = await commitArcs(db, "team-1", "h12-model-failed", [], "facts-were-present");
 
-    expect(out).toEqual([]); // nothing to show right now — honest
+    expect(out.arcs).toEqual([]); // nothing to show right now — honest
     expect(upserts).toHaveLength(1);
     expectShortLived(upserts[0]);
   });
@@ -115,7 +156,7 @@ describe("commitArcs — an empty synthesis must never clobber a good cache", ()
     const out = await commitArcs(db, "team-1", "h11-degraded-prior", [arc("unattributed noise")], "h9", {
       degraded: true,
     });
-    expect(out.map((a) => a.title)).toEqual(["payments migration"]); // prior wins
+    expect(out.arcs.map((a) => a.title)).toEqual(["payments migration"]); // prior wins
     expect(upserts).toHaveLength(0);
     warn.mockRestore();
   });
@@ -136,7 +177,7 @@ describe("commitArcs — an empty synthesis must never clobber a good cache", ()
     const { db, upserts } = fakeDb([arc("ancient migration")], Date.now() - 50 * HOUR);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const out = await commitArcs(db, "team-1", "old-prior-1", [], null);
-    expect(out).toEqual([]); // empty accepted
+    expect(out.arcs).toEqual([]); // empty accepted
     expect(upserts).toHaveLength(1); // written through, not kept
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("accepting empty"));
     warn.mockRestore();

--- a/test/datamechanics/freshness-contract.datamechanics.test.ts
+++ b/test/datamechanics/freshness-contract.datamechanics.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { db, seedTeam } from "./helpers";
+import { writeArcCache, ARC_CACHE_TTL_MS } from "@/lib/graph/arc-cache";
+import { getArcs, type NarrativeArc } from "@/lib/graph/arcs";
+import {
+  getCachedWorkTimeline,
+  writeTimelineCache,
+  settleTimelineRefreshes,
+  TIMELINE_TTL_MS,
+} from "@/lib/dashboard/timeline-cache";
+
+/**
+ * Spec (Pass-1 review R2 / M6 — the freshness contract): a payload served out of a cache table must
+ * report WHEN IT WAS COMPUTED, not when it was served.
+ *
+ * Both of these layers are serve-stale-while-revalidate: `arc_cache` has a 4-HOUR TTL and explicitly
+ * hands back arcs older than that while refreshing behind the request. The routes above them filled in
+ * `as_of: new Date().toISOString()`. That isn't an absent contract, it's a false one — and it defeats
+ * machinery built deliberately downstream of it: `commitArcs` BACKDATES `computed_at` for an
+ * untrustworthy synthesis (H11/H12) precisely so the row reads stale, and stamping `now()` at the wire
+ * threw that away. An agent re-reading right after a correction gets the old attribution, marked current.
+ *
+ * These assert the DATA layer, because that is the layer that knows the answer — a route can only be
+ * honest if the function it calls hands it the truth. Written against real Postgres so the assertion is
+ * about the actual cache row's `computed_at`, not a mocked clock.
+ */
+
+function arc(id: string): NarrativeArc {
+  return {
+    id,
+    title: `Arc ${id}`,
+    confidence: "high",
+    summary: "s",
+    participants: ["Tester"],
+    supporting_sources: [],
+    evidence: [{ fact: "f", itemId: "i", source: "slack" }],
+    derived_at: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+/** getArcs needs a key set; no Graphiti/LLM is reachable here, so every test seeds the cache first. */
+const GROUPS = ["acme_team", "acme_external"];
+const KEY = GROUPS.slice().sort().join(",");
+
+/** Backdate a cache row so it is genuinely old in Postgres, rather than faking a clock. */
+async function backdateArcCache(teamId: string, ageMs: number): Promise<string> {
+  const at = new Date(Date.now() - ageMs).toISOString();
+  await db().from("arc_cache").update({ computed_at: at }).eq("team_id", teamId).eq("group_key", KEY);
+  return at;
+}
+
+describe("freshness contract: a cached payload reports when it was COMPUTED (R2/M6)", () => {
+  it("getArcs on a STALE row reports the row's computed_at and stale=true — not now()", async () => {
+    const seed = await seedTeam();
+    await writeArcCache(db(), seed.teamId, KEY, [arc("a1")], "hash-1");
+    // Older than the 4h TTL: the SWR branch hands these back while refreshing behind the request.
+    const ageMs = ARC_CACHE_TTL_MS + 30 * 60_000;
+    const backdatedIso = await backdateArcCache(seed.teamId, ageMs);
+
+    const res = await getArcs(db(), seed.teamId, "acme", "team", GROUPS, {});
+
+    expect(res.arcs.map((a) => a.id)).toEqual(["a1"]); // still serves the real payload
+    // The whole point: the reported time is the ROW's, hours back — not the moment of the call.
+    expect(res.freshness.computedAt).toBe(Date.parse(backdatedIso));
+    expect(Date.now() - res.freshness.computedAt).toBeGreaterThanOrEqual(ARC_CACHE_TTL_MS);
+    expect(res.freshness.stale).toBe(true);
+  });
+
+  it("getArcs on a FRESH row reports that row's time and stale=false", async () => {
+    const seed = await seedTeam();
+    await writeArcCache(db(), seed.teamId, KEY, [arc("a2")], "hash-2");
+    const backdatedIso = await backdateArcCache(seed.teamId, 60_000); // 1 min old — well inside 4h
+
+    const res = await getArcs(db(), seed.teamId, "acme", "team", GROUPS, {});
+
+    expect(res.freshness.computedAt).toBe(Date.parse(backdatedIso));
+    expect(res.freshness.stale).toBe(false);
+    // Fresh must NOT mean "now" — a minute-old row reports a minute ago, or the field is decorative.
+    expect(res.freshness.computedAt).toBeLessThan(Date.now() - 30_000);
+  });
+
+  it("getCachedWorkTimeline reports the cache row's computed_at, not the serve time", async () => {
+    const seed = await seedTeam();
+    // Seed Postgres DIRECTLY rather than via a cold-miss call. `getCachedWorkTimeline` populates a
+    // process-local memo keyed by (team, tier) and consults it first, so a call-then-backdate sequence
+    // reads the memo and never exercises the persisted branch this test is about — the first draft of
+    // this test did exactly that and passed against a `computedAt` of `now`.
+    await writeTimelineCache(db(), seed.teamId, "team", []);
+    const ageMs = TIMELINE_TTL_MS + 60_000; // past the 5-min TTL → the stale-serve branch
+    const at = new Date(Date.now() - ageMs).toISOString();
+    await db().from("work_timeline_cache").update({ computed_at: at }).eq("team_id", seed.teamId);
+
+    const res = await getCachedWorkTimeline(db(), seed.teamId, "team");
+
+    expect(res.freshness.computedAt).toBe(Date.parse(at));
+    expect(res.freshness.stale).toBe(true);
+    await settleTimelineRefreshes(); // the stale branch fires a rebuild; don't leak it into the next test
+  });
+
+  it("the in-memory memo reports the PERSISTED time, not when this process cached it", async () => {
+    // The subtle half. A second process (or a restart) repopulates its memo from a row that may be
+    // hours old; if the memo stamped its own fill time, freshness would reset to zero on every deploy —
+    // the same lie, just harder to see. So the memo carries the row's `computed_at` through.
+    const seed = await seedTeam();
+    await writeTimelineCache(db(), seed.teamId, "team", []);
+    const at = new Date(Date.now() - 2 * 60_000).toISOString(); // 2 min old: inside the 5-min TTL
+    await db().from("work_timeline_cache").update({ computed_at: at }).eq("team_id", seed.teamId);
+
+    await getCachedWorkTimeline(db(), seed.teamId, "team"); // fills the memo from Postgres
+    const res = await getCachedWorkTimeline(db(), seed.teamId, "team"); // …and this one is the memo hit
+
+    expect(res.freshness.computedAt).toBe(Date.parse(at));
+    expect(res.freshness.stale).toBe(false);
+    expect(res.freshness.computedAt).toBeLessThan(Date.now() - 60_000);
+  });
+});

--- a/test/datamechanics/timeline-cache.datamechanics.test.ts
+++ b/test/datamechanics/timeline-cache.datamechanics.test.ts
@@ -59,7 +59,7 @@ describe("work-timeline cache layer (real Postgres)", () => {
     const seed = await seedLinkedTeam();
     await seedCommit(seed, "shipped-the-thing", recentIso());
 
-    const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    const { days } = await getCachedWorkTimeline(db(), seed.teamId, "team");
     // The build found the commit → a day with the seed member, nested under the task it cites.
     expect(days.length).toBeGreaterThan(0);
     const people = days.flatMap((d) => d.people);
@@ -83,8 +83,8 @@ describe("work-timeline cache layer (real Postgres)", () => {
     const seed = await seedLinkedTeam();
     await seedCommit(seed, "internal-work", recentIso()); // team-tier item
 
-    const teamDays = await getCachedWorkTimeline(db(), seed.teamId, "team");
-    const extDays = await getCachedWorkTimeline(db(), seed.teamId, "external");
+    const { days: teamDays } = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    const { days: extDays } = await getCachedWorkTimeline(db(), seed.teamId, "external");
 
     expect(teamDays.length).toBeGreaterThan(0); // team viewer sees it
     expect(extDays).toEqual([]); // external viewer does NOT see team-tier work
@@ -99,7 +99,7 @@ describe("work-timeline cache layer (real Postgres)", () => {
   it("SWR: a stale row is served immediately, and the background rebuild picks up new work", async () => {
     const seed = await seedLinkedTeam();
     await seedCommit(seed, "commit-a", recentIso());
-    const first = await getCachedWorkTimeline(db(), seed.teamId, "team"); // cold miss → builds [A], persists
+    const { days: first } = await getCachedWorkTimeline(db(), seed.teamId, "team"); // cold miss → builds [A], persists
     // Count the RENDERED evidence — task-nested only.
     const evCount = (people: { tasks: { evidenceCount: number }[] }[]): number =>
       people.reduce((n, p) => n + p.tasks.reduce((a, t) => a + t.evidenceCount, 0), 0);
@@ -117,7 +117,7 @@ describe("work-timeline cache layer (real Postgres)", () => {
     await bustTeamTimeline(db(), seed.teamId);
 
     // Next read returns the STALE payload immediately (still 1 item) and fires the background rebuild.
-    const staleServe = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    const { days: staleServe } = await getCachedWorkTimeline(db(), seed.teamId, "team");
     expect(evCount(staleServe.flatMap((d) => d.people))).toBe(1); // served stale, not yet rebuilt
 
     // The deduped background rebuild lands the new payload (2 items) into the persisted row. Await the

--- a/test/datamechanics/timeline-synopsis-salvage.datamechanics.test.ts
+++ b/test/datamechanics/timeline-synopsis-salvage.datamechanics.test.ts
@@ -105,7 +105,7 @@ async function seedPriorRow(args: {
 const WHEN = new Date(Date.now() - 3_600_000).toISOString();
 const dayOfWhen = WHEN.slice(0, 10);
 
-type Days = Awaited<ReturnType<typeof getCachedWorkTimeline>>;
+type Days = Awaited<ReturnType<typeof getCachedWorkTimeline>>["days"];
 
 function personDay(days: Days, memberId: string) {
   for (const d of days) for (const p of d.people) if (p.memberId === memberId) return p;
@@ -136,7 +136,7 @@ describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", (
     });
 
     // Cold miss by version mismatch — exactly what every deploy that bumps the version produces.
-    const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    const { days } = await getCachedWorkTimeline(db(), seed.teamId, "team");
     expect(summaryOfRenderedDay(days, seed.memberId)).toBe("Shipped the carried work.");
   });
 
@@ -151,7 +151,7 @@ describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", (
       summary: "Someone else's day.",
     });
 
-    const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    const { days } = await getCachedWorkTimeline(db(), seed.teamId, "team");
     expect(summaryOfRenderedDay(days, seed.memberId)).toBeUndefined();
   });
 
@@ -167,7 +167,7 @@ describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", (
       computedAt: new Date(Date.now() - 8 * 24 * 3600_000).toISOString(),
     });
 
-    const days = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    const { days } = await getCachedWorkTimeline(db(), seed.teamId, "team");
     expect(summaryOfRenderedDay(days, seed.memberId)).toBeUndefined();
   });
 
@@ -187,7 +187,7 @@ describe("the daily synopsis survives a PAYLOAD_VERSION bump (real Postgres)", (
       tier: "team",
     });
 
-    const days = await getCachedWorkTimeline(db(), seed.teamId, "external");
+    const { days } = await getCachedWorkTimeline(db(), seed.teamId, "external");
     expect(summaryOfRenderedDay(days, seed.memberId)).toBeUndefined();
   });
 });

--- a/test/guards/freshness-no-fabricated-as-of.test.ts
+++ b/test/guards/freshness-no-fabricated-as-of.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { freshness, computedNow, freshnessWire } from "@/lib/freshness";
+
+/**
+ * BUILD-FAILING GUARD: a route may not FABRICATE its own freshness stamp (Pass-1 review R2 / M6).
+ *
+ * The bug this pins was not a missing field, it was a false one. Four routes answered "how old is this?"
+ * with `as_of: new Date().toISOString()` over payloads read from a cache table — `arc_cache` has a FOUR
+ * HOUR TTL and deliberately serves rows older still. Worse, it destroyed a signal built on purpose
+ * underneath it: `commitArcs` backdates `computed_at` so an untrustworthy synthesis reads stale (H11/H12),
+ * and the wire overwrote that with "now".
+ *
+ * Why a guard and not just the four fixes: nothing about writing `as_of: new Date()` looks wrong at the
+ * call site. It reads like filling in a required field, it is one line, and it type-checks. The next route
+ * to serve cached data will reach for it again — so the durable artifact is a rule that the freshness a
+ * route publishes must come from the data layer that knows it.
+ *
+ * KNOWN BLIND SPOTS (a source scan can't be complete; named rather than implied):
+ *   • A route could assign `new Date()` to a local and publish that local — two statements, not matched.
+ *   • A NEW freshness key name (`fresh_as_of`, `generated_at` on a cached payload) is not in KEYS below.
+ *     `generated_at` is deliberately absent: `/api/v1/okf-bundle` builds it from a live read, where
+ *     stamping now() is correct. Adding a cached surface under that name would slip past.
+ *   • A route can fabricate THROUGH this module — `...freshnessWire(computedNow())` over cache-backed
+ *     data reads as legitimate and matches nothing here. The primitive makes the honest path easy, not
+ *     the dishonest path impossible.
+ * All three are places a reviewer should still look by hand.
+ *
+ * The allowlist below is deliberately SHORT and each entry is asserted to still exist (below), so a
+ * renamed route can't leave an exemption behind that quietly covers a real offender under the old path.
+ * `/api/v1/okf-bundle` is NOT listed: it only uses `generated_at`, which isn't in KEYS, so listing it
+ * would exempt nothing today while pre-authorising a real `as_of: new Date()` there tomorrow.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const ROUTES = join(ROOT, "app", "api");
+
+/** The wire keys that mean "this is how old the payload is". */
+const KEYS = ["as_of", "computed_at", "computedAt"];
+
+/**
+ * `<key>: new Date()…` / `Date.now()` on one line — the exact shape all four instances had.
+ * `[^,;]{0,40}` allows the `.toISOString()` tail without spanning to the next property.
+ */
+const FABRICATED_RE = new RegExp(
+  String.raw`\b(${KEYS.join("|")})\s*:\s*(new\s+Date\s*\([^)]*\)|Date\.now\s*\(\s*\))[^,;]{0,40}`,
+  "g"
+);
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Routes allowed to stamp their own time, with the reason. Each is a LIVE read — there is no cache row
+ * whose age could be reported instead, so `now()` is the honest answer rather than a stand-in for one.
+ */
+const LIVE_READ_ALLOWLIST: Record<string, string> = {
+  [join("app", "api", "brain", "facts", "route.ts")]:
+    "live Neo4j read; degradation comes from recentFacts().ok, which IS now reported",
+  [join("app", "api", "brain", "events", "route.ts")]: "live Neo4j read, no cache behind it",
+};
+
+function offenders(): string[] {
+  const hits: string[] = [];
+  for (const file of walk(ROUTES)) {
+    const rel = file.slice(ROOT.length + 1);
+    if (rel in LIVE_READ_ALLOWLIST) continue;
+    const src = readFileSync(file, "utf8");
+    for (const m of src.matchAll(FABRICATED_RE)) hits.push(`${rel}: ${m[0].replace(/\s+/g, " ")}`);
+  }
+  return [...new Set(hits)].sort();
+}
+
+describe("guard: routes report freshness, they don't invent it", () => {
+  it("no route stamps its own as_of/computed_at over cache-backed data", () => {
+    expect(
+      offenders(),
+      `A route is fabricating a freshness stamp. If the payload came from a cache/data layer, return that ` +
+        `layer's Freshness (lib/freshness) and render it with freshnessWire() — a computed_at read from ` +
+        `the row is the only honest answer. If it is genuinely a LIVE read, add it to ` +
+        `LIVE_READ_ALLOWLIST in this file with the reason:\n${offenders().join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("is non-vacuous: the pattern it looks for is detectable, and the scan reaches real routes", () => {
+    // Pins the regex against the four shapes that actually shipped, plus plausible variants. A broken
+    // pattern would leave this guard green forever while the lie walked back in.
+    for (const drift of [
+      `as_of: new Date().toISOString(),`, // the exact line removed from /api/brain/arcs
+      `return Response.json({ people, as_of: new Date().toISOString() });`,
+      `computed_at: new Date().toISOString(),`,
+      `computedAt: Date.now(),`,
+      `as_of: new Date(Date.now()).toISOString(),`,
+    ]) {
+      expect([...drift.matchAll(FABRICATED_RE)], drift).toHaveLength(1);
+    }
+    // Legitimate shapes must NOT match: reporting a value the data layer supplied, or a non-freshness
+    // timestamp field.
+    for (const ok of [
+      `as_of: wire.as_of,`,
+      `...freshnessWire(freshness),`,
+      `const wire = freshnessWire(f);`,
+      `derived_at: new Date().toISOString(),`, // per-arc provenance, not a cache age
+      `expires_at: new Date(Date.now() + TTL).toISOString(),`,
+    ]) {
+      expect([...ok.matchAll(FABRICATED_RE)], ok).toHaveLength(0);
+    }
+    // The scan reaches the file the bug was actually in — otherwise `offenders()` is green because it
+    // walked nothing.
+    const scanned = walk(ROUTES);
+    expect(scanned).toContain(join(ROOT, "app", "api", "brain", "arcs", "route.ts"));
+    expect(scanned.length).toBeGreaterThan(20);
+    // …and every allowlisted path exists, so a rename can't silently turn an exemption into dead weight
+    // that hides a real offender under the old name.
+    for (const rel of Object.keys(LIVE_READ_ALLOWLIST)) {
+      expect(scanned, `${rel} is allowlisted but not found — stale exemption`).toContain(join(ROOT, rel));
+    }
+  });
+});
+
+describe("freshness primitive", () => {
+  it("derives stale from age vs TTL, at the boundary", () => {
+    const now = 1_000_000;
+    expect(freshness(now - 99, 100, { now }).stale).toBe(false);
+    expect(freshness(now - 100, 100, { now }).stale).toBe(true); // >= TTL is stale
+    expect(freshness(now - 500, 100, { now }).computedAt).toBe(now - 500);
+  });
+
+  it("treats an undateable row as INFINITELY old, never as now", () => {
+    // The failure direction matters: defaulting to `now` would report a row we cannot date as fresh —
+    // the exact class of lie this module removes.
+    const now = 1_000_000;
+    expect(freshness(NaN, 100, { now }).stale).toBe(true);
+    expect(freshness(NaN, 100, { now }).computedAt).toBe(0);
+  });
+
+  it("keeps stale and degraded independent", () => {
+    const now = 1_000_000;
+    // Freshly computed but untrustworthy — the cold-miss timeline case.
+    const f = computedNow({ now, degraded: true });
+    expect(f.stale).toBe(false);
+    expect(f.degraded).toBe(true);
+    // Old but perfectly trustworthy.
+    const g = freshness(now - 10_000, 100, { now });
+    expect(g.stale).toBe(true);
+    expect(g.degraded).toBe(false);
+  });
+
+  it("renders the wire shape without any diagnostic detail (tier safety)", () => {
+    const wire = freshnessWire(freshness(0, 100, { now: 1000, degraded: true }));
+    expect(Object.keys(wire).sort()).toEqual(["as_of", "degraded", "stale"]);
+    expect(wire.as_of).toBe(new Date(0).toISOString());
+    // No free-text field exists to leak an internal subsystem name to an external-tier caller.
+    expect(Object.values(wire).some((v) => typeof v === "string" && v.length > 30)).toBe(false);
+  });
+});


### PR DESCRIPTION
First slice of **R2** ("silent-degrade-by-default") from the Pass-1 soundness review, and its named symptom **M6** ("the freshness contract is absent or lying").

## The bug

Four routes answered *"how old is this payload?"* with `as_of: new Date().toISOString()` over data read from a cache table. `arc_cache` has a **4-hour** TTL and its stale-while-revalidate branch deliberately serves rows **older still**. So hours-old arcs were stamped as current.

Not a missing contract — a **false** one. And it destroyed a signal built on purpose underneath it: `commitArcs` *backdates* `computed_at` so an untrustworthy synthesis reads stale and retries soon (H11/H12, #402). The mechanism worked; the wire overwrote it with `now()`.

The review's scenario: an agent re-reading right after a human correction gets the old attribution, marked current.

## The fix

`lib/freshness.ts` — `{ computedAt, stale, degraded }`, on the wire as `{ as_of, stale, degraded }`.

It lives at `lib/` rather than `lib/api/` because it is **produced by the data layer** (only that layer knows when the row was written) and merely *rendered* by routes — the same lowest-shared-layer rule the caches follow. It sits **beside** the payload, never wrapping it, so `TimelineDay[]` / `NarrativeArc[]` and the shape guards pinning them are untouched.

`stale` is derived *inside* the primitive from age-vs-TTL rather than passed in, so the rule can't be spelled differently per caller (H6's drift shape). An undateable row reports as **infinitely old**, never as `now` — defaulting to now would report a row we can't date as fresh, which is the class of lie being removed.

**The invariant:** `computedAt` under-claims freshness rather than over-claiming it.

Two non-obvious cases it now names:
- a **cold-miss timeline is `degraded` but not `stale`** — newest possible payload, least trustworthy prose (summaries absent, or salvaged from an older payload version);
- a **refused degraded synthesis returns the prior's `computedAt`**, so "the recompute returned" stops implying "the arcs are new".

That second case is why `commitArcs` now returns `{arcs, computedAt, untrustworthy}` — it has three exits and two hand back the prior. Stamping `now()` at the call site would have relocated the very lie this removes, one branch deep.

Also wires up a signal already computed and thrown away: `/api/brain/facts` dropped `recentFacts().ok`, whose own comment reads *"treating as degraded, not as an empty window"* — so a Neo4j outage rendered as a benign empty fact list.

## Scope

Unversioned surfaces only (`/api/brain/*`, `/api/dashboard/*`) → **no `BRAIN_API_VERSION` bump, no cross-repo contract work.** `GET /api/v1/timeline` and `GET /api/v1/tasks` keep their exact current wire shape; putting the envelope there needs a 1.15 bump plus the canonical doc in `aios-workspace`, so it's deliberately a separate change.

**Honest note on severity:** the arcs panel reads `reason`/`note` and never read `as_of`, so no dashboard was visibly wrong. The harm was to machine consumers — which is exactly what R2/agent-readiness is about.

## Verification

- Specs RED first. One was initially green **for the wrong reason** — the process-local memo shadowed the DB backdating — so it now seeds Postgres directly, plus a second test pinning that the memo carries the row's time rather than its own fill time.
- Guard mutation-checked by restoring the original lie.
- unit 1355 ✅ · data-mechanics 771 ✅ · **HTTP 45** ✅ · docs-drift ✅ · lint ✅ · tsc ✅

## Review — Reviewed by Fable code-reviewer — verdict BLOCKED, then fixed

It caught a **Critical I introduced** — and one I had explicitly asked it to hunt for.

`Response.json` is typed `any`, so passing the changed return value straight through **type-checked** while silently nesting the payload. `GET /api/v1/timeline` would have served `days: { days: [...], freshness: {...} }`, breaking the pinned brain-api **v1.12** shape for `aios timeline` and MCP. `/api/dashboard/timeline` broke the same way on its *default* request (`Number(null) === 0` clamps to the cached arm). An earlier draft of my commit message claimed v1/timeline was "deliberately not in this change" — the opposite of the truth; I had corrupted it.

Verified by execution both ways: with the break, `test/http/timeline.http.test.ts` fails **both** the shape assertion **and** the external-tier isolation assertion. With the fix, the full HTTP tier is green. **That tier is the net for this class — CI runs it, the default local gate does not.**

| Finding | Fix |
|---|---|
| **Critical** — `/api/v1/timeline` nested the payload, breaking the v1.12 contract | destructure `.days` |
| **High** — `/api/dashboard/timeline` same, on the default request | destructure `.days` |
| **Med** — `commitArcs`'s own `untrustworthy` never reached the envelope, so a model-failure recompute reported `degraded: false` | returned and OR'd in |
| **Med** — `degraded` isn't persisted, so it describes *this request's computation*, not the payload; the docstring claimed the stronger thing | narrowed, with the `degraded` column named as follow-up |
| **Low** — "never LATER than the real computation" had a real exception (`canReuseArcs` re-stamps `now()`) | documented, not claimed away |
| **Low** — dead `okf-bundle` allowlist entry pre-authorising a future offender | removed; third blind spot named |

It independently **confirmed** the claims I asked it to attack: no tier leak (the envelope is one ISO string + two booleans, and `external` already receives `reason`), the `degraded` widening is strictly wider by construction, the panel never read `as_of`, and every other exit path under-claims.

## Follow-ups (deliberately not here)

1. **`degraded` column** on `arc_cache` / `work_timeline_cache` — would let `computed_at` stop doubling as a trust dial (`writeArcCache` backdates *solely* because there's nowhere to persist `degraded`).
2. **`/api/v1/*`** — timeline's `computed_at`, tasks' already-computed `truncated`; needs the 1.15 bump.
3. **`truncated`** — the survey found ~40 silent caps; `ExternalCostsSummary.truncated` is the shipped reference implementation to copy.

## Not included

No `AIOS-Work:` key — I haven't verified a matching Linear issue exists, and a fabricated key would advance an unrelated task to Done on merge.