### PR TITLE
chore(deps): add dependabot groups to reduce PR conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      prod-dependencies:
+        dependency-type: "production"
 
   - package-ecosystem: "pip"
     directory: "/ingestion"
@@ -32,3 +37,7 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add groups for github-actions and npm dependencies (dev/prod split) to collapse related updates into single PRs
- Reduces lockfile conflicts

## Verification
- [x] dependabot.yml syntax valid
- [x] github-actions group consolidates all action updates
- [x] npm root entry split by dependency-type to avoid concurrent lockfile edits

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Dependabot scheduling/grouping metadata changes; no application runtime or CI workflow logic is modified.
> 
> **Overview**
> Configures **Dependabot grouping** so related updates land in fewer PRs and compete less over the same lockfiles.
> 
> For **npm** at the repo root, updates are split into **`dev-dependencies`** and **`prod-dependencies`** groups by `dependency-type`, so dev and prod bumps are less likely to open separate PRs that both edit the root lockfile.
> 
> For **github-actions**, a single **`actions`** group with pattern `*` bundles all action version bumps into one weekly PR.
> 
> The **pip** `/ingestion` entry is unchanged (no groups added).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e3dfd7ddabb6aff6a94a8766c3fafb5e99e6a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->