### PR TITLE
fix: retire the phantom connectors — sidecar GitHub, Drive watch, and `wise`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,6 @@ by hand). A missing `channels:read` is diagnosed by name in the ingest error.
 > selection. The UI encrypts and stores both, but only the Slack/GitHub/Linear/Plane runners read
 > stored secrets, and the sidecar's selection merge maps Notion to a no-op, so neither the token nor
 > the page IDs reach anything. Configure Notion in the sidecar's own `.env` + `connections.yaml`.
-> A `wise` option also appears in the Admin dropdown — it has no connector behind it and produces
-> nothing. Ignore it.
 
 ---
 

--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -230,7 +230,6 @@ function RolePicker(props: {
 type IntegrationType =
   | "github"
   | "slack"
-  | "wise"
   | "linear"
   | "plane"
   | "openai"
@@ -251,7 +250,7 @@ export interface IntegrationRow {
 // Data-source connectors shown in the generic "Add an integration" form. Provider keys get their
 // own panel (PROVIDER_TYPES); GitHub gets its own repo panel (GithubReposPanel) — so both are
 // excluded here to avoid two places to manage the same thing.
-const TYPES: IntegrationType[] = ["slack", "notion", "linear", "plane", "wise"];
+const TYPES: IntegrationType[] = ["slack", "notion", "linear", "plane"];
 
 // LLM provider API keys — one set for the team, managed in the dedicated "AI provider keys" panel.
 const PROVIDER_TYPES = ["anthropic", "openai", "google"] as const;
@@ -273,7 +272,6 @@ const SELECTION_HINT: Partial<Record<IntegrationType, string>> = {
   notion: "page IDs (comma-separated), or databaseId=<id>",
   linear: "teamId=..., projectId=..., doneStateName=Done",
   plane: "workspaceSlug=..., projectId=..., doneStateName=DONE, externalSource=aios-backlog",
-  wise: "profile ID",
 };
 
 function summarizeConfig(type: IntegrationType, config: Record<string, unknown>): string {

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -43,12 +43,13 @@ brain admin UI and issue it an API key — that key goes in `AIOS_API_KEY`.
 
 ```bash
 aios-ingest list-sources
-# Backfill one source (e.g. a Notion database):
-aios-ingest backfill --source notion --opt database_id=<id>
+# Backfill one source (e.g. a Notion database) — every option the adapter needs is a --opt:
+aios-ingest backfill --source notion --opt token=$NOTION_TOKEN --opt database_id=<id>
 # Run all configured connections:
 aios-ingest sync --config connections.yaml
 
-# Webhooks (Notion-beta):
+# Webhook receiver — SCAFFOLDING ONLY: every registered source is pull-only
+# (PullOnlySource.supports_webhook = False), so nothing it receives can be ingested yet.
 uvicorn aios_ingest.webhook_app:app --port 8088
 
 # Scheduled polling:

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -1,11 +1,16 @@
 # aios-ingest — ingestion sidecar (Organ 2)
 
-Pulls content from external systems (GitHub, Slack, Notion, Google Drive, Confluence,
-Linear, web pages, local files, …)
+Pulls content from external systems (Notion, Google Drive, Confluence, RSS feeds, web
+pages, local files)
 using **open-source readers** ([LlamaHub](https://llamahub.ai), MIT; [Unstructured](https://github.com/Unstructured-IO/unstructured), Apache-2.0),
 normalizes each document into the brain's `ItemPayload`, and **POSTs to `/api/v1/items`** —
 reusing the brain's audited, dedup-by-sha256, tier-enforcing write path. No new write path;
 the sidecar talks to the brain over HTTP only, so it can be split into its own repo later.
+
+> **Not here:** Slack, GitHub, Linear and Plane are ingested by the brain's own in-app runners
+> and are configured in **Admin → Integrations**, not in this sidecar. The sidecar's `slack`
+> source is a registered no-op kept only so a legacy `connections.yaml` degrades to a warning
+> (same for `granola`, whose connector was removed). There is no sidecar GitHub source at all.
 
 ```
 fetch (reader)  ─►  normalize (RawDoc → ItemPayload)  ─►  BrainClient.push  ─►  POST /api/v1/items
@@ -17,7 +22,7 @@ fetch (reader)  ─►  normalize (RawDoc → ItemPayload)  ─►  BrainClient.
 ```bash
 cd ingestion
 uv sync                       # core only
-uv pip install '.[github]'    # + a source extra (github needs no extra to run on public repos)
+uv pip install '.[docs]'      # + a source extra (see pyproject's optional-dependencies)
 uv pip install '.[all]'       # everything (heavy: pulls Unstructured)
 ```
 
@@ -31,35 +36,39 @@ cp .env.example .env          # BRAIN_URL, AIOS_API_KEY (issued to a connector m
 cp connections.yaml.example connections.yaml
 ```
 
-Create a dedicated **connector member** (e.g. `actor_handle: github-sync`, tier `team`) in the
+Create a dedicated **connector member** (e.g. `actor_handle: notion-sync`, tier `team`) in the
 brain admin UI and issue it an API key — that key goes in `AIOS_API_KEY`.
 
 ## Use
 
 ```bash
 aios-ingest list-sources
-# Backfill a public GitHub repo (no token needed):
-aios-ingest backfill --source github --opt repo=run-llama/llama_index --opt 'path_glob=*.md'
+# Backfill one source (e.g. a Notion database):
+aios-ingest backfill --source notion --opt database_id=<id>
 # Run all configured connections:
 aios-ingest sync --config connections.yaml
 
-# Webhooks (Slack/GitHub/Notion-beta):
+# Webhooks (Notion-beta):
 uvicorn aios_ingest.webhook_app:app --port 8088
 
-# Scheduled polling + Drive watch-channel renewal:
+# Scheduled polling:
 aios-ingest schedule --config connections.yaml --poll-interval 300
 ```
 
-`schedule` polls each connection on an interval (sha256 dedup makes re-polls cheap no-ops)
-and, when a Drive `WatchManager` is wired, renews push-notification channels before they
-expire. Cursors and channel state live in a local sqlite file (`--state-db`).
+`schedule` polls each connection on an interval (sha256 dedup makes re-polls cheap no-ops).
+Cursors live in a local sqlite file (`--state-db`).
+
+> **Drive watch-channel renewal is NOT wired.** `sources/gdrive_watch.py` exists and
+> `build_scheduler` will register a renewal job — but only `if watch_manager is not None`, and
+> the `schedule` command never constructs one. Google Drive is therefore **pull-on-a-schedule
+> only**; push notifications are unimplemented, not merely unconfigured.
 
 ## How content maps (the "unit of knowledge")
 
 | source | brain `kind` | `path` | `access` |
 |--------|--------------|--------|----------|
 | Slack / meeting notes | `transcript` | `slack/<channel>/<ts>.md` | per-connection (default `team`) |
-| Drive / Notion / Confluence / GitHub | `deliverable` | `<source>/<external-id>.md` | per-connection |
+| Drive / Notion / Confluence | `deliverable` | `<source>/<external-id>.md` | per-connection |
 
 Provenance (`source`, `source_id`, `source_url`, `author`, `source_ts`) is stored in the
 item's `frontmatter`. Re-reads of unchanged content are no-ops (sha256 dedup at the brain).

--- a/ingestion/THIRD_PARTY_LICENSES.md
+++ b/ingestion/THIRD_PARTY_LICENSES.md
@@ -5,8 +5,6 @@ permissive (MIT / Apache-2.0 / BSD) and compatible with redistribution under MIT
 
 | Component | Purpose | License |
 |-----------|---------|---------|
-| llama-index-readers-github | GitHub reader (optional alternative path) | MIT |
-| llama-index-readers-slack | Slack reader | MIT |
 | llama-index-readers-google | Google Drive reader | MIT |
 | llama-index-readers-notion | Notion reader | MIT |
 | llama-index-readers-confluence | Confluence reader | MIT |

--- a/ingestion/aios_ingest/cli.py
+++ b/ingestion/aios_ingest/cli.py
@@ -2,7 +2,7 @@
 
 Examples:
   aios-ingest list-sources
-  aios-ingest backfill --source github --opt repo=run-llama/llama_index --opt 'path_glob=*.md'
+  aios-ingest backfill --source notion --opt token=$NOTION_TOKEN --opt database_id=<id>
   aios-ingest sync --config connections.yaml
 """
 
@@ -185,10 +185,15 @@ def scan(repo_path, slug, full_name, window_days, backfill, rubric_path) -> None
 @main.command()
 @click.option("--config", "config_path", required=True, help="connections.yaml path")
 @click.option("--poll-interval", default=300, type=int, help="seconds between polls")
-@click.option("--renewal-interval", default=1800, type=int, help="seconds between watch-channel sweeps")
+@click.option("--renewal-interval", default=1800, type=int, help="(inert) reserved for Drive watch-channel sweeps — no watch manager is wired")
 @click.option("--state-db", default="aios_ingest_state.sqlite", help="sqlite path for cursors/channels")
 def schedule(config_path, poll_interval, renewal_interval, state_db) -> None:
-    """Run the background scheduler: poll connections + renew Drive watch channels."""
+    """Run the background scheduler: poll every configured connection on an interval.
+
+    NOTE: Drive watch-channel renewal is NOT wired. `build_scheduler` registers that job only
+    when a `WatchManager` is passed, and this command never constructs one — so Google Drive is
+    pull-on-a-schedule only and `--renewal-interval` is currently inert.
+    """
     from .scheduler import run as run_scheduler
     from .state import StateStore
 

--- a/ingestion/aios_ingest/selections.py
+++ b/ingestion/aios_ingest/selections.py
@@ -32,7 +32,7 @@ def _translate_slack(config: dict[str, Any]) -> dict[str, Any]:
 
 
 def _no_op(config: dict[str, Any]) -> dict[str, Any]:
-    # No consuming adapter field yet (linear teamId/projectId, plane, wise, notion).
+    # No consuming adapter field yet (linear teamId/projectId, plane, notion).
     # Translate to nothing so we never inject a key the adapter would reject.
     # Adapter wiring for these selection fields is future work.
     return {}
@@ -44,7 +44,6 @@ _SELECTION_TRANSLATORS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = 
     "slack": _translate_slack,
     "linear": _no_op,
     "plane": _no_op,
-    "wise": _no_op,
     "notion": _no_op,
 }
 

--- a/ingestion/connections.yaml.example
+++ b/ingestion/connections.yaml.example
@@ -5,7 +5,7 @@
 #   When you run `aios-ingest sync --use-brain-selections` (or set
 #   AIOS_BRAIN_SELECTIONS=1), the sidecar fetches the team's enabled integration
 #   selections from the brain (Admin → Integrations) and OVERLAYS their non-secret
-#   selection — slack channel ids, github repos — onto the matching
+#   selection — slack channel ids — onto the matching
 #   local connection. Matching is by (source == brain type) AND (name == brain name).
 #   The brain rejects secret-like keys at write time, so secrets ALWAYS stay local:
 #   the token / signing_secret / webhook_secret / api_key you set below via ${ENV_VAR}
@@ -14,15 +14,19 @@
 #   With the flag OFF (the default), there is NO brain call and behavior is exactly as
 #   the entries below describe — local options are used unchanged.
 connections:
+  # NOTE: there is no sidecar `github` source — GitHub is ingested by the brain's own runner
+  # (Admin → Integrations → GitHub repos). Same for Slack, Linear and Plane.
   - name: eng-handbook
-    source: github
+    source: local
     project: handbook
     access: team
     options:
-      repo: run-llama/llama_index
-      path_glob: "docs/**/*.md"
-      webhook_secret: ${GITHUB_WEBHOOK_SECRET}
+      root: ~/handbook          # a real directory on the machine running the sidecar
+      glob: "**/*.md"
 
+  # DEPRECATED: the sidecar `slack` source is a registered NO-OP — Slack is ingested by the
+  # brain's in-app runner. Kept here only to show how a brain selection merges onto a local
+  # connection (see the header); it ingests nothing.
   - name: eng-slack
     source: slack
     project: slack

--- a/ingestion/pyproject.toml
+++ b/ingestion/pyproject.toml
@@ -18,16 +18,12 @@ dependencies = [
 # Reader/parsers are heavy and license-varied, so they are opt-in extras.
 # Adapters lazy-import them and raise a clear "install extra" error if missing.
 [project.optional-dependencies]
-github = ["llama-index-readers-github>=0.1"]
-slack = ["llama-index-readers-slack>=0.1"]
 gdrive = ["llama-index-readers-google>=0.1"]
 notion = ["llama-index-readers-notion>=0.1"]
 confluence = ["llama-index-readers-confluence>=0.1"]
 radar = ["feedparser>=6.0"]
 docs = ["unstructured>=0.13"]
 all = [
-  "llama-index-readers-github>=0.1",
-  "llama-index-readers-slack>=0.1",
   "llama-index-readers-google>=0.1",
   "llama-index-readers-notion>=0.1",
   "llama-index-readers-confluence>=0.1",

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -567,7 +567,15 @@ export function validateIntegrationConfig(
       );
     }
   }
-  const parsed = integrationConfigSchemas[type].safeParse(value);
+  // A RETIRED type (`wise`, `granola`) or any forged value has no schema. The DB CHECK still
+  // tolerates the retired ones so a self-host's legacy row can't break a schema load — but nothing
+  // may CREATE one, and dereferencing the missing schema would surface a raw TypeError instead of
+  // a clean validation failure.
+  const schema = integrationConfigSchemas[type];
+  if (!schema) {
+    throw new IntegrationConfigError(`unknown or retired integration type "${type}"`);
+  }
+  const parsed = schema.safeParse(value);
   if (!parsed.success) {
     throw new IntegrationConfigError(
       parsed.error.issues

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -388,7 +388,6 @@ export const INTEGRATION_TYPES = [
   // The connector already exists (ingestion/aios_ingest/sources/notion.py + notion_authors.py, which
   // resolves created_by/last_edited_by → the item's authors) — it just had nowhere to read a token from.
   "notion",
-  "wise",
   "linear",
   "plane",
   // LLM provider API keys. The key is stored encrypted in secret_ciphertext, same path as the
@@ -469,7 +468,6 @@ const integrationConfigSchemas: Record<IntegrationType, z.ZodType> = {
       inviteLink: z.string().url().max(500).optional(),
     })
     .strict(),
-  wise: z.object({ profileId: z.string().max(64).optional() }).strict(),
   // Either pageIds OR databaseId — the connector requires one (it raises if both are absent). Not
   // enforced here: a half-configured integration must be savable, and the connector reports the error.
   notion: z

--- a/lib/integrations/build-config.ts
+++ b/lib/integrations/build-config.ts
@@ -41,8 +41,6 @@ export function buildConfig(
       return { channelIds: list };
     case "github":
       return { repos: list };
-    case "wise":
-      return list[0] ? { profileId: list[0] } : {};
     case "notion":
       // `databaseId=<id>` selects a whole database; otherwise the entries are page ids.
       return kv.databaseId ? { databaseId: kv.databaseId } : { pageIds: list };

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1647,6 +1647,10 @@ create index if not exists subscriptions_team_idx on subscriptions (team_id);
 create table if not exists integrations (
   id uuid primary key default gen_random_uuid(),
   team_id uuid not null references teams(id) on delete cascade,
+  -- 'wise' and 'granola' are RETIRED: no runner, no source, absent from the Admin dropdown and
+  -- from the app's zod type union, so nothing can create one. The values stay in this CHECK on
+  -- PURPOSE — narrowing an enumerated CHECK is the #251 incident shape, and a self-host holding a
+  -- legacy row would fail its next schema load. Dead here is harmless; a failed deploy is not.
   type text not null check (type in ('github','granola','slack','wise','linear','plane','openai','anthropic','google','openrouter','typefully','notion')),
   name text not null,
   config jsonb not null default '{}',

--- a/test/integration-config.test.ts
+++ b/test/integration-config.test.ts
@@ -35,9 +35,20 @@ describe("validateIntegrationConfig()", () => {
       { client_secret: "c" },
     ]) {
       expect(
-        () => validateIntegrationConfig("wise", bad),
+        () => validateIntegrationConfig("slack", bad),
         JSON.stringify(bad),
       ).toThrow(/secret-like key/i);
+    }
+  });
+
+  it("rejects a RETIRED type with a clean error, not a raw TypeError", () => {
+    // `wise` and `granola` are gone from the app's schema map but remain in the DB CHECK (a
+    // self-host's legacy row must not break its schema load). Nothing may CREATE one — and the
+    // refusal has to be a validation error, not a crash from dereferencing a missing schema.
+    for (const retired of ["wise", "granola"]) {
+      expect(() => validateIntegrationConfig(retired, { anything: "x" })).toThrow(
+        /unknown or retired integration type/i,
+      );
     }
   });
 


### PR DESCRIPTION
The three follow-ups from the connector audit in #424. All one class of bug: **documentation and UI promising capability that does not exist**, which costs a reader real debugging time before they conclude the product is broken.

## 1. Phantom sidecar GitHub source

`ingestion/README.md` handed you a copy-pasteable command that fails:

```
$ aios-ingest backfill --source github --opt repo=run-llama/llama_index
ValueError: unknown source 'github'. Available: confluence, gdrive, granola, local, notion, radar, slack, web
```

There is no `sources/github.py` and no registry key — only a `github` extra in `pyproject.toml` kept the illusion alive. **GitHub ingestion itself is fine**: it's a brain-side runner configured in Admin → Integrations. So the fix is to stop the *sidecar* docs claiming it, and say plainly where Slack/GitHub/Linear/Plane actually live. The dead `github` and `slack` reader extras are dropped (nothing imports either, including from the `all` extra).

## 2. Drive watch renewal was never wired

`schedule`'s docs promised push-notification channel renewal. `build_scheduler` does register that job — but only `if watch_manager is not None`, and the `schedule` command never constructs one. So it has never run. Now stated plainly: Drive is **pull-on-a-schedule only**, and push is *unimplemented* rather than merely unconfigured. `--renewal-interval` is marked inert.

## 3. `wise` deleted

A scaffolding placeholder from the first integrations commit (config `{ profileId }`, i.e. wise.com) that was never built — yet it sat in the Admin **"Add an integration"** dropdown looking identical to the working connectors. A user could select it, paste a credential, have it encrypted and stored, and nothing would ever read it. Removed from the dropdown, the type union, the zod config schema, the config builder, and the sidecar's selection map. Prod has **zero** `wise` rows.

**The `integrations.type` CHECK keeps both retired values** (`wise`, `granola`) and now carries a comment saying why: narrowing an enumerated CHECK is the #251 incident shape, and a self-host holding a legacy row would fail its next schema load. Nothing can create either type any more — the app-side union rejects them — so dead values in the constraint are harmless where a failed deploy is not.

## Review — Reviewed by Fable (`code-reviewer`) — verdict BLOCKED → resolved

It caught me **committing the exact bug this PR retires**, twice:

- **My replacement example was itself broken.** I swapped the failing `--source github` for `--source notion --opt database_id=<id>` — but `NotionSource` has a required keyword-only `token` and no env fallback, so the new command dies with a `TypeError`. Fixed, and this time I ran the option names against the adapter instead of assuming them.
- **`connections.yaml.example` still shipped `source: github` as its first connection** — the most copy-pasteable artifact in the sidecar, and an unknown source aborts the operator's *entire* sync run.

MEDIUMs were the same phantom claim one layer below where I'd fixed it: `cli.py`'s docstring and `schedule --help` (the surface an operator actually reads), the "Webhooks (Notion-beta)" line promising a receiver with zero webhook-capable sources behind it, and a `"wise"` fixture still sitting in the test file — in the PR that retires `wise`.

It also confirmed the part I most wanted checked: **a stored `wise`/`granola` row is safe** now the app union rejects the type. Every read path casts without re-validation, every mutation is id-scoped and type-blind, `summarizeConfig` falls through, and the sidecar dispatches unknown types to a no-op. No render-fine-but-throws-on-delete trap.

## Verification

unit **1374 ✅** (+1 spec: a retired type returns a clean validation error, not a raw TypeError) · ingestion pytest **84 ✅** · data-mechanics **774 ✅** (dedicated container) · lint ✅ (2 pre-existing warnings, unrelated) · `tsc --noEmit` ✅ · docs-drift ✅