### PR TITLE
fix(cache): degraded gets its own column, so computed_at stops doubling as a trust dial (R2/M6)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,11 +144,18 @@ flowchart LR
 
 **Freshness contract (R2/M6).** Any surface served out of a cache table reports `{ as_of, stale, degraded }`
 built by **`lib/freshness.ts`** — `as_of` is the cache row's real `computed_at`, `stale` means past TTL and
-served anyway (SWR), `degraded` means a leg THIS REQUEST's computation depended on failed — it is not
-persisted with the cache row, so it describes the work done for this response, not the payload's permanent
-character (a degraded cold-miss reports `true`; the next read of the row it wrote reports `false` for the
-same bytes). Persisting it — a `degraded` column, which would also stop `computed_at` doubling as a trust
-dial — is the follow-up. It is produced by the DATA layer
+served anyway (SWR), `degraded` means a leg the payload's computation depended on failed, and is
+**persisted** on the cache row (`arc_cache.degraded` / `work_timeline_cache.degraded`), so a later reader
+inherits the verdict instead of being handed a partial payload as healthy. That column also ended
+`computed_at`'s double life: `writeArcCache` used to BACKDATE the timestamp by `TTL − 5min` purely to
+shorten an untrusted row's life, so a degraded row claimed a computation time ~4h before it happened. The
+short retry window is now derived from the flag instead (**`arcTtlMs(degraded)`** — the single expression
+of that rule), which reproduces the old window exactly while leaving the timestamp honest. Guarded by
+`test/guards/computed-at-not-a-trust-dial.test.ts`, whose exemption for the legitimate invalidators
+(`staleArcCache`, `bustTeamTimeline`) is scoped per-FUNCTION — a file-level one would have exempted
+`writeArcCache`, which lives in the same file as `staleArcCache` and is where the bug was. For the
+timeline, `degraded` deliberately does NOT fire when a team has no answering model configured (that's a
+setup choice, not a failure) — only when the synopsis pass was expected to produce prose and fell short. It is produced by the DATA layer
 (`getArcs`, `getCachedWorkTimeline`, `commitArcs` all return it beside their payload) and only rendered by
 routes, because only the data layer knows the answer. Before this, four routes answered "how old is this?"
 with `as_of: new Date()` over a cache with a **4-hour** TTL that deliberately serves rows older still — a

--- a/docs/context-management-system.md
+++ b/docs/context-management-system.md
@@ -210,9 +210,13 @@ identity resolution) can disagree with a human's deliberate correction. The reso
   `computedAt` is the row's real `computed_at`; `stale` = past TTL but served (SWR); `degraded` = a leg the
   payload needed failed. Produced by the data layer (`getArcs`, `getCachedWorkTimeline`, `commitArcs`),
   never by the route — routes used to write `as_of: new Date()` over a 4h-TTL cache, which reported
-  hours-old arcs as current. Two non-obvious cases it now names: a cold-miss timeline is `degraded` but NOT
+  hours-old arcs as current. Two non-obvious cases it names: a cold-miss timeline is `degraded` but NOT
   stale (real work data, prose not computed for it), and a refused degraded synthesis returns the PRIOR's
   `computedAt`, so "the recompute returned" stops implying "the arcs are new".
+  **`degraded` is a persisted column** on both cache tables, so a later reader inherits the verdict rather
+  than being handed a partial payload as healthy. It is also what freed `computed_at` from doubling as a
+  trust dial: an untrusted row used to be BACKDATED by `TTL − 5min` to shorten its life, and that short
+  life is now derived from the flag (`arcTtlMs`) — same retry window, honest timestamp.
 
 ---
 

--- a/lib/dashboard/timeline-cache.ts
+++ b/lib/dashboard/timeline-cache.ts
@@ -3,7 +3,7 @@ import { adminClient } from "@/lib/db/admin";
 import type { DbClient } from "@/lib/db/types";
 import type { ViewerTier } from "@/lib/auth/visibility";
 import { getWorkTimeline } from "./work-timeline";
-import { attachPersonDaySummaries } from "./timeline-summary";
+import { attachPersonDaySummaries, type SummaryPassResult } from "./timeline-summary";
 import type { TimelineDay } from "./timeline-group";
 import { freshness, type Freshness } from "@/lib/freshness";
 
@@ -67,7 +67,7 @@ export const PAYLOAD_VERSION = 10;
 /** The timeline WITH the per-person-day synopsis attached. Runs the (up to 7d × roster) best-effort LLM
  *  calls — so it's used ONLY on the BACKGROUND refresh path, never inline on a request (a cold miss
  *  returns the pure ledger fast and schedules this). Never in the raw builder the data-mechanics tier calls. */
-async function buildTimeline(db: DbClient, teamId: string, tier: ViewerTier): Promise<TimelineDay[]> {
+async function buildTimeline(db: DbClient, teamId: string, tier: ViewerTier): Promise<SummaryPassResult> {
   // Refresh the INFERRED doc→task links first, so anything new lands in the payload we're about to write
   // rather than one cycle later. This is the VIEW-DRIVEN trigger: a rebuild happens because somebody
   // looked, which is exactly when an inference is worth paying for — an unread team's timeline shouldn't
@@ -85,6 +85,7 @@ async function buildTimeline(db: DbClient, teamId: string, tier: ViewerTier): Pr
   }
   return attachPersonDaySummaries(db, teamId, await getWorkTimeline(db, teamId, tier));
 }
+
 
 /**
  * How old a payload may be and still lend its synopsis across a version bump.
@@ -158,6 +159,10 @@ export function attachSalvagedSummaries(days: TimelineDay[], salvaged: SalvagedS
 interface CacheEntry {
   days: TimelineDay[];
   at: number; // epoch ms computed
+  /** The synopsis pass didn't produce prose for this ledger. Carried in memory as well as in Postgres:
+   *  this map is read BEFORE the row, so omitting it would report a partial payload as healthy for the
+   *  life of the process (R2/M6). */
+  degraded: boolean;
 }
 
 // In-memory cache (per process), fronting the Postgres row. Keyed by `${teamId}:${tier}`.
@@ -177,14 +182,14 @@ async function readTimelineCacheRow(
   db: DbClient,
   teamId: string,
   tier: ViewerTier
-): Promise<{ payload: unknown; computed_at: string | Date } | null> {
+): Promise<{ payload: unknown; computed_at: string | Date; degraded?: boolean | null } | null> {
   const { data } = await db
     .from("work_timeline_cache")
-    .select("payload, computed_at")
+    .select("payload, computed_at, degraded")
     .eq("team_id", teamId)
     .eq("group_key", tier)
     .maybeSingle();
-  return (data as { payload: unknown; computed_at: string | Date } | null) ?? null;
+  return (data as { payload: unknown; computed_at: string | Date; degraded?: boolean | null } | null) ?? null;
 }
 
 /** The previous payload's per-person-day summaries, whatever version wrote them. Empty on any error —
@@ -222,7 +227,9 @@ export async function readTimelineCache(
     const days = p.days as TimelineDay[];
     const at =
       typeof row.computed_at === "string" ? Date.parse(row.computed_at) : new Date(row.computed_at).getTime();
-    return { days, at: Number.isFinite(at) ? at : 0 };
+    // `=== true` so a row written before the column existed reads false — "no evidence of degradation",
+    // not "verified good". Defaulting the other way would mark every pre-migration team's ledger bad.
+    return { days, at: Number.isFinite(at) ? at : 0, degraded: row.degraded === true };
   } catch {
     return null;
   }
@@ -234,13 +241,23 @@ export async function writeTimelineCache(
   db: DbClient,
   teamId: string,
   tier: ViewerTier,
-  days: TimelineDay[]
+  days: TimelineDay[],
+  /** The per-person-day synopses are missing or carried over, so the prose wasn't computed for this
+   *  ledger. Persisted (R2/M6) so the NEXT reader of this row inherits the verdict instead of being
+   *  handed a partial payload as healthy. Defaults false — the callers that know pass it explicitly. */
+  degraded = false
 ): Promise<void> {
   try {
     // `payload` is a top-level JSON array — serialize it ourselves (the pg adapter binds a raw JS array
     // as a Postgres array literal, which the jsonb column rejects); a text param assignment-casts to jsonb.
     await db.from("work_timeline_cache").upsert(
-      { team_id: teamId, group_key: tier, payload: JSON.stringify({ v: PAYLOAD_VERSION, days }), computed_at: new Date().toISOString() },
+      {
+        team_id: teamId,
+        group_key: tier,
+        payload: JSON.stringify({ v: PAYLOAD_VERSION, days }),
+        computed_at: new Date().toISOString(),
+        degraded,
+      },
       { onConflict: "team_id,group_key" }
     );
   } catch {
@@ -325,9 +342,9 @@ function refreshInBackground(teamId: string, tier: ViewerTier): void {
       const bg = adminClient();
       do {
         dirty.delete(key); // claim the current request; anything arriving from here re-dirties the key
-        const days = await buildTimeline(bg, teamId, tier);
-        mem.set(key, { days, at: Date.now() });
-        await writeTimelineCache(bg, teamId, tier, days);
+        const built = await buildTimeline(bg, teamId, tier);
+        mem.set(key, { days: built.days, at: Date.now(), degraded: built.degraded });
+        await writeTimelineCache(bg, teamId, tier, built.days, built.degraded);
       } while (dirty.has(key));
     } catch (err) {
       console.error("[timeline] background refresh failed:", err instanceof Error ? err.message : err);
@@ -377,15 +394,18 @@ export async function getCachedWorkTimeline(
   const now = Date.now();
 
   const cached = mem.get(key);
-  if (cached && now - cached.at < TTL_MS) return { days: cached.days, freshness: freshness(cached.at, TTL_MS, { now }) };
+  if (cached && now - cached.at < TTL_MS) {
+    return { days: cached.days, freshness: freshness(cached.at, TTL_MS, { now, degraded: cached.degraded }) };
+  }
 
   const persisted = await readTimelineCache(db, teamId, tier);
   if (persisted) {
-    mem.set(key, { days: persisted.days, at: persisted.at });
+    mem.set(key, { days: persisted.days, at: persisted.at, degraded: persisted.degraded });
     // ONE envelope for both the fresh and the stale branch — `freshness()` derives `stale` from the same
     // age comparison the branch below makes, so the reported staleness cannot disagree with the decision
     // actually taken (they were two separate readings of the clock in every earlier draft of this).
-    const f = freshness(persisted.at, TTL_MS, { now });
+    // The PERSISTED verdict — so a reader who didn't do the work still learns the prose is missing.
+    const f = freshness(persisted.at, TTL_MS, { now, degraded: persisted.degraded });
     if (!f.stale) return { days: persisted.days, freshness: f };
     refreshInBackground(teamId, tier); // stale → serve stale, rebuild behind the request
     return { days: persisted.days, freshness: f };
@@ -404,8 +424,12 @@ export async function getCachedWorkTimeline(
   // Best-effort by construction: no salvageable row → `built`, unchanged.
   const days = attachSalvagedSummaries(built, await readSalvageableSummaries(db, teamId, tier));
   const at = Date.now();
-  mem.set(key, { days, at });
-  await writeTimelineCache(db, teamId, tier, days);
+  mem.set(key, { days, at, degraded: true });
+  // PERSISTED as degraded, not just reported. The row this writes is what the next reader gets, and its
+  // prose is either absent or salvaged from an older payload version — so the flag has to live on the row
+  // or the very next request hands the same partial ledger over as healthy. Self-healing: the background
+  // pass below rewrites the row with the real verdict once summaries land.
+  await writeTimelineCache(db, teamId, tier, days, true);
   refreshInBackground(teamId, tier);
   // DEGRADED, deliberately. A cold miss returns the pure ledger: its per-person-day synopses are either
   // absent (the background pass hasn't run) or SALVAGED from an older payload version. Both are "this is

--- a/lib/dashboard/timeline-summary.ts
+++ b/lib/dashboard/timeline-summary.ts
@@ -44,17 +44,33 @@ async function inBatches<T>(jobs: (() => Promise<T>)[]): Promise<T[]> {
 }
 
 /**
- * Return a copy of `days` with a `summary` on each person-day that has work. Best-effort: a team with no
- * LLM, or a per-call failure, leaves that person-day's `summary` unset (the panel falls back to counts).
+ * Return a copy of `days` with a `summary` on each person-day that has work, plus whether the pass was
+ * DEGRADED. Best-effort as before: a per-call failure just leaves that person-day's `summary` unset (the
+ * panel falls back to counts).
+ *
+ * `degraded` distinguishes the two reasons prose can be missing, which used to be indistinguishable
+ * (R2/M6). A team with NO answering model configured is not degraded — that's a deliberate setup, and
+ * reporting it as degradation would mark every LLM-less install permanently unhealthy. A pass that was
+ * SUPPOSED to produce summaries and couldn't — the key lookup threw, or every call failed — is.
  */
-export async function attachPersonDaySummaries(db: DbClient, teamId: string, days: TimelineDay[]): Promise<TimelineDay[]> {
+export interface SummaryPassResult {
+  days: TimelineDay[];
+  degraded: boolean;
+}
+
+export async function attachPersonDaySummaries(
+  db: DbClient,
+  teamId: string,
+  days: TimelineDay[]
+): Promise<SummaryPassResult> {
   let keys: LlmBackendKeys;
   try {
     keys = await resolveAnsweringKeys(db, teamId);
   } catch {
-    return days;
+    // Couldn't even find out which model to use — a failure, not a configuration choice.
+    return { days, degraded: true };
   }
-  if (!llmConfigured(keys)) return days;
+  if (!llmConfigured(keys)) return { days, degraded: false }; // summaries are off by design
 
   // One job per (day, person) with content. Each resolves to the summary text (or null on skip/failure).
   const jobs: (() => Promise<{ di: number; pi: number; text: string | null }>)[] = [];
@@ -72,18 +88,25 @@ export async function attachPersonDaySummaries(db: DbClient, teamId: string, day
       }));
     })
   );
-  if (jobs.length === 0) return days;
+  if (jobs.length === 0) return { days, degraded: false }; // nothing had content to summarize
 
   const results = await inBatches(jobs);
   const byKey = new Map<string, string>();
   for (const r of results) if (r.text && r.text.trim()) byKey.set(`${r.di}:${r.pi}`, r.text.trim());
-  if (byKey.size === 0) return days;
+  // A SHORTFALL is degradation, not just a total failure: the fan-out is per person-day and each call
+  // catches its own error, so "some people have prose and some don't" is the common outcome of a flaky
+  // or rate-limited provider — and it looks identical to a quiet day unless it's reported.
+  const degraded = byKey.size < jobs.length;
+  if (byKey.size === 0) return { days, degraded };
 
-  return days.map((d, di) => ({
-    ...d,
-    people: d.people.map((p, pi) => {
-      const s = byKey.get(`${di}:${pi}`);
-      return s ? { ...p, summary: s } : p;
-    }),
-  }));
+  return {
+    days: days.map((d, di) => ({
+      ...d,
+      people: d.people.map((p, pi) => {
+        const s = byKey.get(`${di}:${pi}`);
+        return s ? { ...p, summary: s } : p;
+      }),
+    })),
+    degraded,
+  };
 }

--- a/lib/freshness.ts
+++ b/lib/freshness.ts
@@ -34,13 +34,22 @@ export interface Freshness {
    * wrong — the case that silently reads as a healthy-but-quiet result. Distinct from `stale`: a degraded
    * payload can be freshly computed, and a stale one can be perfectly trustworthy.
    *
-   * SCOPE, precisely: it describes the computation that ran on THIS request, not the payload's permanent
-   * character, because it is not persisted with the cache row. A request that cold-misses and degrades
-   * reports `degraded: true`; the next request, served the row that computation wrote, reports `false` for
-   * the same bytes. Fixing that means a `degraded` column on `arc_cache`/`work_timeline_cache` — worth
-   * doing (it would also let `computed_at` stop doubling as a trust dial, which is why `writeArcCache`
-   * backdates today) and deliberately not bundled here. Until then, read `degraded: true` as "the work
-   * done for this response was unreliable", and never `degraded: false` as "this payload is verified good".
+   * SCOPE — read it as "don't treat THIS RESPONSE as authoritative". That covers two cases, deliberately:
+   *   • the BYTES are untrustworthy. `arc_cache` and `work_timeline_cache` each carry a `degraded`
+   *     column, so this verdict outlives the computation that discovered it — a later reader of the same
+   *     row is told, instead of being handed the payload as healthy. (It did not always: before that
+   *     column, request A cold-missed and was told `true` while request B, served the row A had just
+   *     written, was told `false` over identical bytes.)
+   *   • the ATTEMPT failed even though the bytes are fine — a refused recompute hands back a healthy
+   *     cached set (H11), and a user who just submitted a correction needs to know it didn't take.
+   *
+   * `stale` does NOT follow the same rule: it always scores the payload against ITS own TTL, so a
+   * healthy prior returned by a failed attempt keeps its full life rather than being aged out by
+   * somebody else's failure.
+   *
+   * Read `degraded: false` as "no evidence of degradation", never as "verified good": rows written
+   * before the column exists read false, and only the failure modes the producer actually checks are
+   * reported.
    */
   degraded: boolean;
 }

--- a/lib/graph/arc-cache.ts
+++ b/lib/graph/arc-cache.ts
@@ -21,12 +21,44 @@ import type { NarrativeArc } from "./arcs";
  *  Shared with `staleArcCache` below so a re-attribution's forced-stale mark stays PAST this window. */
 export const ARC_CACHE_TTL_MS = 4 * 60 * 60_000;
 
+/**
+ * How long an UNTRUSTWORTHY arc set is served before the next view retries it. Short enough that a
+ * transient LLM/graph failure self-heals in minutes rather than hours, long enough that a persistent one
+ * doesn't turn every page view into a recompute.
+ *
+ * Moved here from `arcs.ts` so it sits beside the TTL it is an alternative to — the two are one rule, and
+ * `arcTtlMs` below is the only place that rule is spelled out (H6's drift shape).
+ */
+export const UNTRUSTED_RETRY_AFTER_MS = 5 * 60_000;
+
+/**
+ * The TTL that applies to a row, given whether it is degraded. THE single expression of "an untrusted
+ * result gets a short life".
+ *
+ * This is what replaced backdating `computed_at`. Previously an untrusted row was written with its
+ * timestamp pushed `TTL - RETRY` into the past, so that `now - computed_at >= TTL` came true after
+ * `RETRY` — the same staleness, bought by falsifying the timestamp. Deriving the TTL instead is exactly
+ * equivalent (fresh for `RETRY` either way) and leaves `computed_at` meaning only "when computed".
+ */
+export function arcTtlMs(degraded: boolean): number {
+  return degraded ? UNTRUSTED_RETRY_AFTER_MS : ARC_CACHE_TTL_MS;
+}
+
 export interface ArcCacheEntry {
   arcs: NarrativeArc[];
   /** epoch ms of when this cache row was computed (for TTL/staleness checks in `arcs.ts`). */
   computedAt: number;
   /** Hash of the LLM synthesis input at that compute — the fact-set-hash skip compares against it. */
   factsHash: string | null;
+  /**
+   * The synthesis that produced these arcs could not be trusted — the model failed, or an input leg did.
+   * PERSISTED (R2/M6), so it survives the request that discovered it: before this column, the next reader
+   * of the very same row reported the payload as healthy.
+   *
+   * `false` means "no evidence of degradation", NOT "verified good" — rows predating the column read
+   * false. Also NOT the same as stale: a degraded row can be seconds old.
+   */
+  degraded: boolean;
 }
 
 /** Read the cached arcs for one team+group_key. Null on miss or any error (best-effort — a cache
@@ -35,16 +67,28 @@ export async function readArcCache(db: DbClient, teamId: string, groupKey: strin
   try {
     const { data } = await db
       .from("arc_cache")
-      .select("arcs, computed_at, facts_hash")
+      .select("arcs, computed_at, facts_hash, degraded")
       .eq("team_id", teamId)
       .eq("group_key", groupKey)
       .maybeSingle();
     if (!data) return null;
-    const row = data as { arcs: unknown; computed_at: string | Date; facts_hash: string | null };
+    const row = data as {
+      arcs: unknown;
+      computed_at: string | Date;
+      facts_hash: string | null;
+      degraded?: boolean | null;
+    };
     const arcs = Array.isArray(row.arcs) ? (row.arcs as NarrativeArc[]) : [];
     const computedAt =
       typeof row.computed_at === "string" ? Date.parse(row.computed_at) : new Date(row.computed_at).getTime();
-    return { arcs, computedAt: Number.isFinite(computedAt) ? computedAt : 0, factsHash: row.facts_hash ?? null };
+    return {
+      arcs,
+      computedAt: Number.isFinite(computedAt) ? computedAt : 0,
+      factsHash: row.facts_hash ?? null,
+      // `?? false` covers a row written before the column existed. Defaulting the OTHER way would mark
+      // every pre-migration row untrustworthy and stampede a recompute for every team on deploy.
+      degraded: row.degraded === true,
+    };
   } catch {
     return null;
   }
@@ -101,20 +145,21 @@ export async function writeArcCache(
   arcs: NarrativeArc[],
   factsHash: string | null,
   /**
-   * Give the row a SHORT life instead of the full TTL: `computed_at` is backdated so it reads fresh for
-   * `retryAfterMs` and then goes stale.
+   * `degraded: true` for a result we don't trust enough to serve for a full window but still want
+   * persisted — a synthesis that produced nothing although facts existed (the model failed), or one whose
+   * inputs were degraded. It shortens the row's life via `arcTtlMs`, so the next view retries within
+   * minutes instead of hours: SWR only re-fires on a stale row, so "fresh and wrong" is the one state
+   * that can't self-heal (the H12 incident).
    *
-   * For a result we don't trust enough to serve for a full window but still want persisted — a synthesis
-   * that produced nothing although facts existed (the model failed), or one whose inputs were degraded.
-   * Stamping those `now` is what pinned an empty arc panel for 4h with no retry: SWR only re-fires on a
-   * stale row, so "fresh and wrong" is the one state that can't self-heal. Backdating to *already* stale
-   * would go too far the other way — every page view would fire another recompute for as long as the
-   * failure lasted.
+   * This used to be done by BACKDATING `computed_at` by `TTL - retryAfterMs`, because there was nowhere
+   * to record the fact. Same retry behaviour, but the timestamp lied by ~4 hours — and the flag lived
+   * only for the request that discovered it, so the next reader of the row saw a healthy payload. Now the
+   * timestamp is always the honest write time and the trust verdict is its own column (R2/M6).
    *
-   * The row stays far inside `EMPTY_CLOBBER_MAX_AGE_MS`, so the next attempt still treats it as recent
-   * transient-failure cover rather than "persistently empty, accept it".
+   * `computed_at` stays close to now, so the row remains far inside `EMPTY_CLOBBER_MAX_AGE_MS` and the
+   * next attempt still treats it as recent transient-failure cover rather than "persistently empty".
    */
-  opts: { retryAfterMs?: number } = {}
+  opts: { degraded?: boolean } = {}
 ): Promise<void> {
   try {
     // `arcs` is a top-level JSON array. The pg adapter only auto-casts non-array objects to jsonb, so
@@ -126,11 +171,8 @@ export async function writeArcCache(
         group_key: groupKey,
         arcs: JSON.stringify(arcs),
         facts_hash: factsHash,
-        computed_at: new Date(
-          opts.retryAfterMs === undefined
-            ? Date.now()
-            : Date.now() - Math.max(0, ARC_CACHE_TTL_MS - opts.retryAfterMs)
-        ).toISOString(),
+        computed_at: new Date().toISOString(),
+        degraded: opts.degraded === true,
       },
       { onConflict: "team_id,group_key" }
     );

--- a/lib/graph/arcs.ts
+++ b/lib/graph/arcs.ts
@@ -9,7 +9,13 @@ import { GraphitiClient } from "./graphiti-client";
 import { episodeGroupId, isExternalGroupId, type AccessTier } from "./group";
 import { attributedFactTexts, groundParticipants } from "./arc-attribution";
 import { resolveItemCredit } from "@/lib/attribution/contributor-credit";
-import { readArcCache, writeArcCache, ARC_CACHE_TTL_MS as CACHE_TTL_MS } from "./arc-cache";
+import {
+  readArcCache,
+  writeArcCache,
+  arcTtlMs,
+  ARC_CACHE_TTL_MS as CACHE_TTL_MS,
+  UNTRUSTED_RETRY_AFTER_MS,
+} from "./arc-cache";
 import { freshness, computedNow, type Freshness } from "@/lib/freshness";
 import { listArcCorrections, recordArcCorrections } from "./arc-corrections";
 import { arcIneligibleItemIds } from "./arc-eligibility";
@@ -85,10 +91,8 @@ const COHERENCE_TIMEOUT_MS = Math.max(1_000, Number(process.env.ARC_COHERENCE_TI
 // How long the empty-clobber guard keeps trusting a prior non-empty arc set. Within this window an
 // empty synthesis is treated as a transient failure (keep the prior); beyond it, a persistently-empty
 // result is accepted as genuine so the panel can't be pinned to ancient arcs forever (Fable review).
-/** How long an UNTRUSTWORTHY arc result is served before the next view retries it. Short enough that a
- *  transient LLM/graph failure self-heals in minutes rather than hours, long enough that a persistent one
- *  doesn't turn every page view into a recompute. */
-const UNTRUSTED_RETRY_AFTER_MS = 5 * 60_000;
+// UNTRUSTED_RETRY_AFTER_MS now lives in ./arc-cache beside ARC_CACHE_TTL_MS — the two are one rule
+// ("an untrusted result gets a short life"), expressed once as `arcTtlMs`. Imported above.
 
 const EMPTY_CLOBBER_MAX_AGE_MS = (() => {
   // Guard the parse: a garbage/empty env yields NaN/0, and `ageMs < NaN` is always false → EVERY empty
@@ -606,10 +610,18 @@ export interface SynthesisResult {
  *  to apply, and the prior actually had arcs. This is the stability guard — arcs then change only when the
  *  underlying work does, not on every recompute. A null/empty prior hash never reuses. */
 export function canReuseArcs(
-  prior: { factsHash: string | null; arcCount: number } | null,
+  prior: { factsHash: string | null; arcCount: number; degraded?: boolean } | null,
   factsHash: string,
   hasCorrections: boolean
 ): boolean {
+  // A DEGRADED prior is never reusable, however stable the fact set is. Reuse means "the inputs didn't
+  // change, so keep the previous answer and skip the model" — sound only if that answer was trustworthy.
+  // Reusing an untrustworthy one re-commits the same bad bytes as HEALTHY (and for a full TTL), without
+  // the leg that failed ever getting another chance: the row's `degraded` verdict is laundered away by
+  // the retry that was supposed to heal it. Concretely — an attribution leg throws AFTER the prompt is
+  // built, so the hash is unchanged; unattributed arcs persist degraded; 5 minutes later the retry
+  // hash-skips and stamps them healthy for 4h, with the attribution pass never re-running.
+  if (prior?.degraded) return false;
   return !hasCorrections && !!prior && !!prior.factsHash && prior.factsHash === factsHash && prior.arcCount > 0;
 }
 
@@ -624,7 +636,7 @@ async function synthesizeArcs(
   llmTimeoutMs: number = INLINE_ARC_TIMEOUT_MS,
   // The prior cached arcs + their fact hash (background refresh only). When the freshly-built prompt hashes
   // identically AND there's no correction, we KEEP the prior arcs and skip the LLM (the stability guard).
-  prior?: { arcs: NarrativeArc[]; factsHash: string | null } | null,
+  prior?: { arcs: NarrativeArc[]; factsHash: string | null; degraded?: boolean } | null,
   // Run the extra evidence-COHERENCE LLM pass? Only the non-route-bound BACKGROUND refresh sets this — the
   // route-bound cold-miss + correction paths skip it (a second LLM call would blow the 120s route budget).
   // A cold-miss arc may briefly show a spurious participant; the next SWR refresh prunes it.
@@ -814,7 +826,13 @@ async function synthesizeArcs(
   // STABILITY GUARD: identical input (+ no correction, + a real prior) → keep the prior arcs and SKIP the
   // LLM. This is what stops the day-to-day churn (same facts producing different arcs every recompute from
   // LLM non-determinism). The background refresh still runs (fetch/balance/hash), just not the model.
-  if (canReuseArcs(prior ? { factsHash: prior.factsHash, arcCount: prior.arcs.length } : null, factsHash, correctionTexts.length > 0)) {
+  if (
+    canReuseArcs(
+      prior ? { factsHash: prior.factsHash, arcCount: prior.arcs.length, degraded: prior.degraded } : null,
+      factsHash,
+      correctionTexts.length > 0
+    )
+  ) {
     return { arcs: prior!.arcs, factsHash, degraded };
   }
 
@@ -833,7 +851,12 @@ async function synthesizeArcs(
 
 // In-memory cache (per process). Keyed by the tier-visible group set. Fronts the Postgres `arc_cache`
 // (lib/graph/arc-cache) — the persistent, cross-instance layer that survives restarts.
-const cache = new Map<string, { arcs: NarrativeArc[]; at: number; factsHash: string | null }>();
+// `degraded` is carried here too, not just in Postgres: this map is consulted BEFORE the row, so without
+// it a degraded result would read back healthy — and with the full 4h TTL — for the life of the process.
+const cache = new Map<
+  string,
+  { arcs: NarrativeArc[]; at: number; factsHash: string | null; degraded: boolean }
+>();
 // Group keys currently being recomputed in the background, so concurrent stale reads fire ONE
 // recompute (and thus one LLM call), not N.
 const refreshing = new Set<string>();
@@ -870,10 +893,11 @@ export function evictArcMemoryCache(teamSlug: string): void {
  * on both keep-the-prior branches the arcs handed back date from the earlier synthesis. A caller that
  * assumed "commitArcs returned, so this is current" would re-create exactly the freshness lie R2 removes
  * — one branch deep, where it is hardest to see. `computedAt` is never later than the computation it hands
- * back (an untrustworthy result is deliberately backdated below), so it under-claims freshness rather than
- * over-claiming it. One documented exception: on the `canReuseArcs` revalidation path the row is
- * re-stamped `now()` over arcs the model produced hours earlier — defensible, because the inputs were just
- * hash-verified unchanged (a 304, not a fresh synthesis), but it IS a re-stamp and predates this change.
+ * back, so it names when those bytes were produced rather than when this call ran. On the keep-the-prior
+ * branches that is the PRIOR's time; on a write it is now. One documented exception: on the
+ * `canReuseArcs` revalidation path the row is re-stamped `now()` over arcs the model produced earlier —
+ * defensible, because the inputs were just hash-verified unchanged (a 304, not a fresh synthesis), and
+ * that path now refuses to fire at all when the prior was degraded.
  *
  * `untrustworthy` is returned too, and is BROADER than the caller's `opts.degraded`: it also covers H12's
  * model-failure (empty arcs from a NON-empty fact set), which no input-degradation flag can see. Without
@@ -887,7 +911,17 @@ export async function commitArcs(
   next: NarrativeArc[],
   factsHash: string | null,
   opts: { degraded?: boolean } = {}
-): Promise<{ arcs: NarrativeArc[]; computedAt: number; untrustworthy: boolean }> {
+): Promise<{
+  arcs: NarrativeArc[];
+  computedAt: number;
+  /** THIS attempt was untrustworthy (model failed, or an input leg did) — even if the bytes returned are
+   *  a healthy prior it refused to overwrite. Answers "did the recompute you asked for work?". */
+  untrustworthy: boolean;
+  /** The BYTES returned are untrustworthy. Differs from `untrustworthy` on the keep-the-prior branches,
+   *  where a failed attempt hands back a perfectly good cached set. Answers "can I rely on this payload?"
+   *  — which is what the TTL/staleness must follow. */
+  payloadDegraded: boolean;
+}> {
   // ── Is this result trustworthy enough to serve for a full TTL? ────────────────────────────────────
   // Two ways it isn't, and both used to be committed as FRESH — which is the one state SWR can never
   // heal from, because it only re-fires on a stale row.
@@ -909,7 +943,10 @@ export async function commitArcs(
       console.warn(
         `[arcs] degraded synthesis for ${key}; keeping ${prior.arcs.length} cached arcs rather than overwriting them with a partial set`
       );
-      return { arcs: prior.arcs, computedAt: prior.at, untrustworthy };
+      // `payloadDegraded` is the PRIOR's own verdict, not this computation's: the bytes handed back are
+      // whatever that row was, and their TTL must follow their trust. `untrustworthy` still reports that
+      // THIS attempt failed — the two differ exactly here, which is the point of returning both.
+      return { arcs: prior.arcs, computedAt: prior.at, untrustworthy, payloadDegraded: prior.degraded };
     }
   }
 
@@ -924,7 +961,10 @@ export async function commitArcs(
         console.warn(
           `[arcs] synthesis returned 0 arcs for ${key}; keeping ${prior.arcs.length} cached (${Math.round(ageMs / 3_600_000)}h old; likely transient)`
         );
-        return { arcs: prior.arcs, computedAt: prior.at, untrustworthy };
+        // `payloadDegraded` is the PRIOR's own verdict, not this computation's: the bytes handed back are
+      // whatever that row was, and their TTL must follow their trust. `untrustworthy` still reports that
+      // THIS attempt failed — the two differ exactly here, which is the point of returning both.
+      return { arcs: prior.arcs, computedAt: prior.at, untrustworthy, payloadDegraded: prior.degraded };
       }
       // Prior is too old to keep trusting as "transient-failure cover": a persistently-empty synthesis
       // over this long is more likely GENUINE (quiet team, content deleted, graph reset, or the model
@@ -940,17 +980,22 @@ export async function commitArcs(
   //
   // Not "already stale": that would make every page view fire another recompute for as long as the
   // underlying failure lasted — a rebuild (and, before the early return above, an LLM call) per viewer.
-  // Aging it by `TTL - RETRY_AFTER_MS` instead means the row reads fresh for RETRY_AFTER_MS and then goes
-  // stale, which bounds retries to roughly one per that window while still being far short of the full TTL.
-  const at = untrustworthy ? Date.now() - (CACHE_TTL_MS - UNTRUSTED_RETRY_AFTER_MS) : Date.now();
+  // The short life comes from the persisted `degraded` flag, which `arcTtlMs` turns into a
+  // RETRY_AFTER_MS window: the row reads fresh for that long and then goes stale, bounding retries to
+  // roughly one per window while staying far short of the full TTL. (This used to be done by BACKDATING
+  // the timestamp by `TTL - RETRY_AFTER_MS` — same window, but the row then claimed a computation time
+  // ~4h before it happened, which is the lie R2/M6 removed.)
+  // Honest write time, always. The short life an untrustworthy result needs comes from `arcTtlMs`
+  // reading the persisted `degraded` flag — not from pushing this timestamp into the past (R2/M6).
+  const at = Date.now();
   if (untrustworthy) {
     console.warn(
       `[arcs] ${modelFailed ? "synthesis produced no arcs from a non-empty fact set" : "degraded synthesis"} for ${key}; persisting with a ${Math.round(UNTRUSTED_RETRY_AFTER_MS / 60_000)}min life so it retries soon`
     );
   }
-  cache.set(key, { arcs: next, at, factsHash });
-  await writeArcCache(db, teamId, key, next, factsHash, { retryAfterMs: untrustworthy ? UNTRUSTED_RETRY_AFTER_MS : undefined });
-  return { arcs: next, computedAt: at, untrustworthy };
+  cache.set(key, { arcs: next, at, factsHash, degraded: untrustworthy });
+  await writeArcCache(db, teamId, key, next, factsHash, { degraded: untrustworthy });
+  return { arcs: next, computedAt: at, untrustworthy, payloadDegraded: untrustworthy };
 }
 
 /** The arcs currently cached for a key — in-memory first, then the persisted row. */
@@ -958,11 +1003,11 @@ async function priorArcs(
   db: DbClient,
   teamId: string,
   key: string
-): Promise<{ arcs: NarrativeArc[]; at: number } | null> {
+): Promise<{ arcs: NarrativeArc[]; at: number; degraded: boolean } | null> {
   const mem = cache.get(key);
-  if (mem) return { arcs: mem.arcs, at: mem.at };
+  if (mem) return { arcs: mem.arcs, at: mem.at, degraded: mem.degraded };
   const row = await readArcCache(db, teamId, key);
-  return row ? { arcs: row.arcs, at: row.computedAt } : null;
+  return row ? { arcs: row.arcs, at: row.computedAt, degraded: row.degraded } : null;
 }
 
 /** Fire-and-forget background recompute for a stale cache key (serve-stale-while-revalidate). Uses
@@ -973,7 +1018,7 @@ function refreshArcsInBackground(
   key: string,
   groups: string[],
   keys: ProviderKeys,
-  prior: { arcs: NarrativeArc[]; factsHash: string | null } | null
+  prior: { arcs: NarrativeArc[]; factsHash: string | null; degraded?: boolean } | null
 ): void {
   if (refreshing.has(key)) return;
   refreshing.add(key);
@@ -1026,17 +1071,38 @@ export async function getArcs(
   // 1. In-memory (fastest, same process). `at` is the PERSISTED computed_at (set below), not the time
   //    this process happened to populate its map — so a warm process reports the row's age, not zero.
   const mem = cache.get(key);
-  if (mem && now - mem.at < CACHE_TTL_MS) return { arcs: mem.arcs, freshness: freshness(mem.at, CACHE_TTL_MS, { now }) };
+  if (mem) {
+    // `arcTtlMs(degraded)` — a degraded entry expires in minutes, which is what makes the memo retry as
+    // fast as the row does. Using the flat TTL here would let the process serve an untrustworthy set for
+    // the full 4h while Postgres considered it stale.
+    const f = freshness(mem.at, arcTtlMs(mem.degraded), { now, degraded: mem.degraded });
+    if (!f.stale) return { arcs: mem.arcs, freshness: f };
+  }
 
   // 2. Persistent cache (survives restart, shared across instances).
   const persisted = await readArcCache(db, teamId, key);
   if (persisted) {
-    cache.set(key, { arcs: persisted.arcs, at: persisted.computedAt, factsHash: persisted.factsHash });
-    const f = freshness(persisted.computedAt, CACHE_TTL_MS, { now });
+    cache.set(key, {
+      arcs: persisted.arcs,
+      at: persisted.computedAt,
+      factsHash: persisted.factsHash,
+      degraded: persisted.degraded,
+    });
+    // The persisted verdict, and the TTL derived from it. `degraded` now OUTLIVES the request that
+    // discovered it, so a later reader of the same row is told the payload is untrustworthy instead of
+    // being handed it as healthy.
+    const f = freshness(persisted.computedAt, arcTtlMs(persisted.degraded), {
+      now,
+      degraded: persisted.degraded,
+    });
     if (!f.stale) return { arcs: persisted.arcs, freshness: f };
     // Stale — hand back the stale arcs immediately and refresh behind the request, passing the prior so
     // the refresh can skip the LLM if the facts are unchanged.
-    refreshArcsInBackground(teamId, key, groups, keys, { arcs: persisted.arcs, factsHash: persisted.factsHash });
+    refreshArcsInBackground(teamId, key, groups, keys, {
+      arcs: persisted.arcs,
+      factsHash: persisted.factsHash,
+      degraded: persisted.degraded, // a degraded prior must NOT be hash-reused — see canReuseArcs
+    });
     return { arcs: persisted.arcs, freshness: f };
   }
 
@@ -1052,7 +1118,11 @@ export async function getArcs(
     arcs: committed.arcs,
     // `committed.untrustworthy`, not just `degraded`: H12's model-failure (empty arcs from a NON-empty
     // fact set) is invisible to the input-degradation flag, and that is the commonest failure.
-    freshness: freshness(committed.computedAt, CACHE_TTL_MS, {
+    // TTL follows the PAYLOAD's trust (`payloadDegraded`); `degraded` reports that this ATTEMPT failed.
+    // They differ on the keep-the-prior branches: a refused synthesis hands back a healthy cached set,
+    // which must keep its full 4h life — scoring it against the 5-minute untrusted window would badge a
+    // fresh, good payload as stale and make every viewer re-fire the recompute.
+    freshness: freshness(committed.computedAt, arcTtlMs(committed.payloadDegraded), {
       now: Date.now(),
       degraded: degraded || committed.untrustworthy,
     }),
@@ -1099,7 +1169,10 @@ export async function recomputeArcs(
   // Same rule as getArcs: a recompute whose synthesis was degraded is REFUSED and the prior is kept
   // (H11), so "the user clicked recompute" is not evidence the arcs are new. Report what commitArcs
   // actually made authoritative, and carry `degraded` so the client can tell the edit didn't take.
-  const envelope = freshness(committed.computedAt, CACHE_TTL_MS, {
+  // Same split as getArcs: the window follows the bytes, the flag reports the attempt. This is the path
+  // where it matters most — a refused recompute returns a healthy 1h-old prior, and calling that stale
+  // would tell the user their correction aged the data out.
+  const envelope = freshness(committed.computedAt, arcTtlMs(committed.payloadDegraded), {
     now: Date.now(),
     degraded: degraded || committed.untrustworthy,
   });

--- a/postgres/migrations/20260728100000_cache_degraded_flag.sql
+++ b/postgres/migrations/20260728100000_cache_degraded_flag.sql
@@ -1,0 +1,17 @@
+-- Persist "this cached payload is untrustworthy" as its own column, so `computed_at` can go back to
+-- meaning ONLY "when was this computed" (Pass-1 review R2/M6, follow-up to PR #426).
+--
+-- Until now `arc_cache.computed_at` carried two meanings at once. `writeArcCache` BACKDATED it — by
+-- `TTL - 5min` — for a synthesis it didn't trust, purely to make the row go stale sooner so the next view
+-- retries. That worked, but it meant a degraded row reported a computation time ~4 hours before the
+-- computation actually happened, and the freshness envelope (#426) had no choice but to publish that lie.
+-- The trust dial gets its own column; the retry behaviour is preserved exactly by deriving a SHORTER TTL
+-- from `degraded` instead of falsifying the timestamp (see `arcTtlMs` in lib/graph/arc-cache.ts).
+--
+-- Additive and idempotent. `default false` is the safe reading for pre-existing rows: it says "we have no
+-- evidence this is degraded", not "this is verified good". Rows written before this migration keep their
+-- backdated `computed_at`, so they simply read as stale and refresh on the next view — self-healing, no
+-- backfill needed. Deliberately NO check constraint (see the migration-replay incident: a re-added CHECK
+-- narrower than live data fails the deploy).
+alter table arc_cache add column if not exists degraded boolean not null default false;
+alter table work_timeline_cache add column if not exists degraded boolean not null default false;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1700,9 +1700,14 @@ create table if not exists arc_cache (
   -- work does, killing day-to-day churn. Nullable: pre-existing rows have none until the next recompute.
   facts_hash text,
   computed_at timestamptz not null default now(),
+  -- Was this synthesis trustworthy? Its OWN column, so `computed_at` means only "when computed" (R2/M6).
+  -- Before this, an untrusted result was persisted with a BACKDATED `computed_at` to shorten its life —
+  -- which made the timestamp lie by ~4h. The short life is now derived from this flag instead (`arcTtlMs`).
+  degraded boolean not null default false,
   primary key (team_id, group_key)
 );
 alter table arc_cache add column if not exists facts_hash text;
+alter table arc_cache add column if not exists degraded boolean not null default false;
 
 -- Human corrections to narrative arcs — the ONLY human-authored input in the learning layer, and the
 -- reason it needs a real home. These used to exist solely as Graphiti episodes written inside a
@@ -1736,8 +1741,13 @@ create table if not exists work_timeline_cache (
   group_key text not null,                       -- viewer tier: 'team' | 'external'
   payload jsonb not null default '[]'::jsonb,     -- TimelineDay[] (already attributed + grouped)
   computed_at timestamptz not null default now(),
+  -- The per-person-day synopses are missing or were carried over from an older payload, so the ledger is
+  -- real but its prose isn't computed for it. NOT set when the team simply has no answering model
+  -- configured — that's a choice, not a failure (R2/M6).
+  degraded boolean not null default false,
   primary key (team_id, group_key)
 );
+alter table work_timeline_cache add column if not exists degraded boolean not null default false;
 
 -- ── chat conversations (persistent, owner-scoped chat history) ────────────────
 -- ChatGPT-style threads persisted server-side so history survives across sessions AND interfaces

--- a/test/arcs-commit.test.ts
+++ b/test/arcs-commit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { commitArcs } from "@/lib/graph/arcs";
-import { ARC_CACHE_TTL_MS } from "@/lib/graph/arc-cache";
+import { ARC_CACHE_TTL_MS, arcTtlMs } from "@/lib/graph/arc-cache";
 import type { NarrativeArc } from "@/lib/graph/arcs";
 import type { DbClient } from "@/lib/db/types";
 
@@ -37,8 +37,16 @@ const HOUR = 60 * 60 * 1000;
  * while "already stale" makes every page view fire another recompute for as long as the failure lasts.
  */
 function expectShortLived(row: unknown): void {
-  const at = Date.parse((row as { computed_at: string }).computed_at);
-  const remaining = ARC_CACHE_TTL_MS - (Date.now() - at);
+  const r = row as { computed_at: string; degraded?: boolean };
+  // The mechanism changed (R2/M6) but the REQUIREMENT is identical: an untrustworthy row must go stale in
+  // minutes, not hours. It used to be encoded by backdating `computed_at`; it is now the `degraded`
+  // column plus the shorter TTL `arcTtlMs` derives from it. Asserted through `arcTtlMs` so this test
+  // tracks the rule rather than restating a duration.
+  expect(r.degraded).toBe(true);
+  const at = Date.parse(r.computed_at);
+  // …and the timestamp is now HONEST: written at the time of the write, not pushed into the past.
+  expect(Date.now() - at).toBeLessThan(60_000);
+  const remaining = arcTtlMs(true) - (Date.now() - at);
   expect(remaining).toBeGreaterThan(0); // not already stale — a persistent failure must not thrash
   expect(remaining).toBeLessThanOrEqual(10 * 60_000); // …but it retries within minutes, not hours
 }
@@ -88,22 +96,56 @@ describe("commitArcs — an empty synthesis must never clobber a good cache", ()
     warn.mockRestore();
   });
 
-  it("never reports a computed_at LATER than the real computation (under-claim, never over-claim)", async () => {
-    // The invariant the whole envelope rests on: an untrustworthy result is deliberately BACKDATED so it
-    // retries soon, so `computedAt` can be earlier than the true moment of computation — but it must
-    // never be later, because that is the direction that makes stale data look current.
+  it("reports the HONEST computation time for degraded and healthy alike (R2/M6)", async () => {
+    // This assertion used to allow an untrustworthy result to under-claim its age, because the only way
+    // to shorten its life was to backdate the timestamp. With `degraded` as its own column that trade is
+    // gone: BOTH cases now report when the write actually happened, and the short retry window comes
+    // from `arcTtlMs`. Strictly stronger than the old "never LATER" — this is "exactly right".
     const { db } = fakeDb(null);
     const before = Date.now();
     const healthy = await commitArcs(db, "team-1", "freshness-healthy", [arc("a")], "h1");
+    expect(healthy.untrustworthy).toBe(false);
     expect(healthy.computedAt).toBeGreaterThanOrEqual(before);
     expect(healthy.computedAt).toBeLessThanOrEqual(Date.now());
 
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { db: db2 } = fakeDb(null);
+    const beforeDegraded = Date.now();
     const degraded = await commitArcs(db2, "team-1", "freshness-degraded-cold", [arc("b")], "h1", {
       degraded: true,
     });
-    expect(degraded.computedAt).toBeLessThan(Date.now()); // pre-aged, i.e. under-claimed
+    expect(degraded.untrustworthy).toBe(true);
+    expect(degraded.computedAt).toBeGreaterThanOrEqual(beforeDegraded); // NOT pushed into the past
+    expect(degraded.computedAt).toBeLessThanOrEqual(Date.now());
+    // …and it still expires in minutes, which is the behaviour the backdating existed to produce.
+    expect(arcTtlMs(degraded.untrustworthy)).toBeLessThanOrEqual(10 * 60_000);
+    warn.mockRestore();
+  });
+
+  it("separates 'this attempt failed' from 'these bytes are bad' on the keep-prior branch", async () => {
+    // A refused synthesis hands back a HEALTHY cached set (H11). Both facts are true at once and they
+    // are not the same fact: the attempt failed, the payload is fine. Collapsing them scores a good 1h-old
+    // prior against the 5-minute untrusted window — so the caller badges fresh data stale and every viewer
+    // re-fires the recompute that just failed.
+    const priorAt = Date.now() - 1 * HOUR;
+    const { db } = fakeDb([arc("payments migration")], priorAt);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const kept = await commitArcs(db, "team-1", "split-keep-prior", [arc("noise")], "h9", { degraded: true });
+    expect(kept.arcs.map((a) => a.title)).toEqual(["payments migration"]);
+    expect(kept.untrustworthy).toBe(true); // the attempt
+    expect(kept.payloadDegraded).toBe(false); // …but the bytes are the healthy prior
+    expect(kept.computedAt).toBe(priorAt);
+    warn.mockRestore();
+  });
+
+  it("…and when there is no prior to keep, the bytes ARE the bad ones", async () => {
+    // The control: without it the split could be hardcoded to `false` and the test above still passes.
+    const { db } = fakeDb(null);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const written = await commitArcs(db, "team-1", "split-no-prior", [arc("partial")], "h9", { degraded: true });
+    expect(written.untrustworthy).toBe(true);
+    expect(written.payloadDegraded).toBe(true); // persisted degraded — nothing healthier to fall back to
     warn.mockRestore();
   });
 

--- a/test/arcs-degraded-skips-model.test.ts
+++ b/test/arcs-degraded-skips-model.test.ts
@@ -164,18 +164,25 @@ describe("a degraded synthesis never reaches the model", () => {
     // The leg that still conflated the two until this PR. `recentFacts` returning [] because Neo4j is
     // down looked byte-identical to a genuinely quiet window, so on a cold miss it wrote a blank panel
     // stamped fresh for the full TTL with no retry — H12's shape, on the last leg that had it.
-    const { ARC_CACHE_TTL_MS } = await import("@/lib/graph/arc-cache");
+    const { arcTtlMs } = await import("@/lib/graph/arc-cache");
     factsMock.recentFacts.mockResolvedValue({ facts: [], ok: false });
 
     const { getArcs } = await import("@/lib/graph/arcs");
     const { db, upserts } = fakeDb();
-    await getArcs(db, "team-1", "acme", "external", externalGroups(), KEYS);
+    const res = await getArcs(db, "team-1", "acme", "external", externalGroups(), KEYS);
 
     expect(llmMock.completeTextOrNull).not.toHaveBeenCalled();
     expect(upserts).toHaveLength(1);
-    const remaining = ARC_CACHE_TTL_MS - (Date.now() - Date.parse(upserts[0].computed_at as string));
+    // The requirement is unchanged — retried in minutes, not pinned for 4h — but it is now carried by the
+    // `degraded` COLUMN plus the TTL derived from it, rather than by backdating `computed_at` (R2/M6).
+    expect(upserts[0].degraded).toBe(true);
+    const at = Date.parse(upserts[0].computed_at as string);
+    expect(Date.now() - at).toBeLessThan(60_000); // the timestamp is honest now, not pushed into the past
+    const remaining = arcTtlMs(true) - (Date.now() - at);
     expect(remaining).toBeGreaterThan(0); // not already stale — a persistent outage must not thrash
     expect(remaining).toBeLessThanOrEqual(10 * 60_000); // …retried in minutes, not hours
+    // And the caller is TOLD, which the row alone never conveyed before this change.
+    expect(res.freshness.degraded).toBe(true);
   });
 
   it("still reaches the model when the same legs are healthy", async () => {

--- a/test/arcs-stability.test.ts
+++ b/test/arcs-stability.test.ts
@@ -20,6 +20,18 @@ describe("canReuseArcs (arc stability guard)", () => {
 
   it("never reuses a null/absent prior or a prior without a stored hash (pre-migration rows)", () => {
     expect(canReuseArcs(null, "abc", false)).toBe(false);
+  });
+
+  it("NEVER reuses a DEGRADED prior, however stable the fact set is", () => {
+    // Reuse means "inputs unchanged, keep the previous answer, skip the model" — sound only if that
+    // answer was trustworthy. Reusing an untrustworthy one re-commits the same bad bytes as HEALTHY for a
+    // full TTL, and the leg that failed never gets another chance: the retry that was supposed to heal
+    // the row is what launders its `degraded` verdict away.
+    expect(canReuseArcs({ factsHash: "abc", arcCount: 3, degraded: true }, "abc", false)).toBe(false);
+    // …and the control: identical prior, trustworthy, still reuses (or this just disables the guard).
+    expect(canReuseArcs({ factsHash: "abc", arcCount: 3, degraded: false }, "abc", false)).toBe(true);
+    // Absent flag (a caller that doesn't know) behaves as before — reuse.
+    expect(canReuseArcs({ factsHash: "abc", arcCount: 3 }, "abc", false)).toBe(true);
     expect(canReuseArcs({ factsHash: null, arcCount: 3 }, "abc", false)).toBe(false);
   });
 

--- a/test/datamechanics/degraded-persistence.datamechanics.test.ts
+++ b/test/datamechanics/degraded-persistence.datamechanics.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { db, seedTeam } from "./helpers";
+import {
+  readArcCache,
+  writeArcCache,
+  arcTtlMs,
+  ARC_CACHE_TTL_MS,
+  UNTRUSTED_RETRY_AFTER_MS,
+} from "@/lib/graph/arc-cache";
+import { getArcs, commitArcs, type NarrativeArc } from "@/lib/graph/arcs";
+import {
+  getCachedWorkTimeline,
+  writeTimelineCache,
+  readTimelineCache,
+  settleTimelineRefreshes,
+} from "@/lib/dashboard/timeline-cache";
+
+/**
+ * Spec (R2/M6 follow-up): "this payload is untrustworthy" is PERSISTED, and `computed_at` means only
+ * "when was this computed".
+ *
+ * The state before: `writeArcCache` had nowhere to record that a synthesis was degraded, so it encoded
+ * the fact in the timestamp — backdating `computed_at` by `TTL - 5min` to shorten the row's life. The
+ * retry behaviour was right; the timestamp was a lie, and #426's freshness envelope had no choice but to
+ * publish it. It also meant `degraded` survived exactly one request: the NEXT reader of the same row saw
+ * `degraded: false` over identical untrustworthy bytes.
+ *
+ * So there are two claims to hold at once, and they pull against each other — which is why they're
+ * asserted together: the timestamp is now HONEST, and the short retry window is UNCHANGED.
+ */
+
+function arc(id: string): NarrativeArc {
+  return {
+    id,
+    title: `Arc ${id}`,
+    confidence: "high",
+    summary: "s",
+    participants: ["Tester"],
+    supporting_sources: [],
+    evidence: [{ fact: "f", itemId: "i", source: "slack" }],
+    derived_at: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+/**
+ * A UNIQUE group set per test. `lib/graph/arcs` memoizes in a module-level map keyed by the group-key
+ * ALONE (not by team) — safe in production, where the key embeds the team's unique slug, but a shared
+ * literal here lets one test's arcs be served to the next one's team. Two of these tests failed exactly
+ * that way before this: `commitArcs` found the previous test's entry via `priorArcs` and kept it instead
+ * of writing at all.
+ */
+let n = 0;
+function groupsFor(): { groups: string[]; key: string } {
+  const slug = `degtest${++n}`;
+  const groups = [`${slug}_team`, `${slug}_external`];
+  return { groups, key: groups.slice().sort().join(",") };
+}
+
+describe("degraded is persisted, and computed_at stops doubling as a trust dial (R2/M6)", () => {
+  it("a degraded write stamps computed_at NOW — the honest time — not a backdated one", async () => {
+    const seed = await seedTeam();
+    const { key } = groupsFor();
+    const before = Date.now();
+    await writeArcCache(db(), seed.teamId, key, [arc("a1")], "h1", { degraded: true });
+
+    const row = await readArcCache(db(), seed.teamId, key);
+    expect(row).not.toBeNull();
+    expect(row!.degraded).toBe(true);
+    // The whole point: the row is dated when it was written, NOT ~4h in the past.
+    expect(row!.computedAt).toBeGreaterThanOrEqual(before - 1000);
+    expect(row!.computedAt).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it("…but the SHORT retry window is preserved: a degraded row goes stale in minutes, not hours", async () => {
+    // The behaviour the backdating existed to produce. It must survive the refactor exactly, or a
+    // failed synthesis gets pinned for a full 4h with no retry — the H12 incident.
+    expect(arcTtlMs(true)).toBe(UNTRUSTED_RETRY_AFTER_MS);
+    expect(arcTtlMs(false)).toBe(ARC_CACHE_TTL_MS);
+    expect(arcTtlMs(true)).toBeLessThan(arcTtlMs(false));
+
+    const seed = await seedTeam();
+    const { groups, key } = groupsFor();
+    await writeArcCache(db(), seed.teamId, key, [arc("a2")], "h2", { degraded: true });
+    // Age it past the SHORT window but nowhere near the full TTL.
+    const at = new Date(Date.now() - (UNTRUSTED_RETRY_AFTER_MS + 30_000)).toISOString();
+    await db().from("arc_cache").update({ computed_at: at }).eq("team_id", seed.teamId);
+
+    const res = await getArcs(db(), seed.teamId, "acme", "team", groups, {});
+    expect(res.freshness.stale).toBe(true); // retries soon, exactly as the backdating used to force
+    expect(Date.now() - res.freshness.computedAt).toBeLessThan(ARC_CACHE_TTL_MS); // …while still young
+  });
+
+  it("a trustworthy row of the same age is NOT stale — the flag is what shortens the life", async () => {
+    // The other half of the previous test: proves staleness came from `degraded`, not from the age.
+    const seed = await seedTeam();
+    const { groups, key } = groupsFor();
+    await writeArcCache(db(), seed.teamId, key, [arc("a3")], "h3", { degraded: false });
+    const at = new Date(Date.now() - (UNTRUSTED_RETRY_AFTER_MS + 30_000)).toISOString();
+    await db().from("arc_cache").update({ computed_at: at }).eq("team_id", seed.teamId);
+
+    const res = await getArcs(db(), seed.teamId, "acme", "team", groups, {});
+    expect(res.freshness.stale).toBe(false);
+    expect(res.freshness.degraded).toBe(false);
+  });
+
+  it("degraded SURVIVES the cache — a later reader of the same row still sees it", async () => {
+    // The reviewer's finding on #426: `degraded` described one request's computation, so request B read
+    // the row request A wrote and reported `degraded: false` over identical untrustworthy bytes.
+    const seed = await seedTeam();
+    const { groups, key } = groupsFor();
+    await writeArcCache(db(), seed.teamId, key, [arc("a4")], "h4", { degraded: true });
+
+    const res = await getArcs(db(), seed.teamId, "acme", "team", groups, {});
+    expect(res.arcs.map((a) => a.id)).toEqual(["a4"]);
+    expect(res.freshness.degraded).toBe(true); // read back from the row, not from this call's work
+  });
+
+  it("commitArcs persists its own untrustworthy verdict (H12: empty arcs from a NON-empty fact set)", async () => {
+    // End-to-end: the verdict commitArcs already computes is what lands in the column, so the next
+    // reader inherits it without recomputing anything.
+    const seed = await seedTeam();
+    const { key } = groupsFor();
+    const out = await commitArcs(db(), seed.teamId, key, [], "facts-were-present");
+    expect(out.untrustworthy).toBe(true);
+
+    const row = await readArcCache(db(), seed.teamId, key);
+    expect(row!.degraded).toBe(true);
+    expect(row!.computedAt).toBeGreaterThan(Date.now() - 60_000); // honest timestamp, not backdated
+  });
+
+  it("the timeline's cold miss PERSISTS degraded, so the next reader isn't handed it as healthy", async () => {
+    // The cold-miss row is written with the pure ledger — its per-person-day prose is absent (or salvaged
+    // from an older payload version). Before the column, request A was told `degraded: true` and request
+    // B, served the row A had just written, was told `false` over the identical bytes.
+    const seed = await seedTeam();
+    const first = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    expect(first.freshness.degraded).toBe(true);
+
+    const row = await readTimelineCache(db(), seed.teamId, "team");
+    expect(row!.degraded).toBe(true); // …and it's on the ROW, not just in that response
+    await settleTimelineRefreshes();
+  });
+
+  it("a timeline row written by a healthy summary pass reports degraded=false", async () => {
+    // The other direction — otherwise the flag is stuck on and means nothing.
+    const seed = await seedTeam();
+    await writeTimelineCache(db(), seed.teamId, "team", [], false);
+    const res = await getCachedWorkTimeline(db(), seed.teamId, "team");
+    expect(res.freshness.degraded).toBe(false);
+    await settleTimelineRefreshes();
+  });
+});

--- a/test/guards/computed-at-not-a-trust-dial.test.ts
+++ b/test/guards/computed-at-not-a-trust-dial.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { arcTtlMs, ARC_CACHE_TTL_MS, UNTRUSTED_RETRY_AFTER_MS } from "@/lib/graph/arc-cache";
+
+/**
+ * BUILD-FAILING GUARD: a cache writer may not FABRICATE a timestamp — derive one by subtracting a
+ * DURATION from the clock — to encode something other than when the payload was computed
+ * (Pass-1 review R2/M6, follow-up to PR #426).
+ *
+ * `writeArcCache` used to write `computed_at = now - (TTL - RETRY)` for a synthesis it didn't trust: not
+ * to describe the row's age, but to make it go stale sooner so the next view retries. The behaviour was
+ * right and the timestamp lied by ~4 hours, which #426's freshness envelope then had to publish. The fix
+ * gave the verdict its own column and DERIVED the short life from it (`arcTtlMs`), so the two meanings
+ * stopped sharing one field.
+ *
+ * THE DISCRIMINATOR. Both shapes subtract from `Date.now()`, so "arithmetic on the clock" is too coarse:
+ *   • `Date.now() - prior.at`            → subtracting a TIMESTAMP = computing an AGE. Legitimate.
+ *   • `Date.now() - ARC_CACHE_TTL_MS`    → subtracting a DURATION  = fabricating a TIME. The bug.
+ * So the pattern keys on a `*_MS`-named operand after the minus. Verified against every clock
+ * subtraction in these three files at the buggy commit: it flags exactly the four fabrications and
+ * neither of the two age computations.
+ *
+ * WHY IT'S WRITTEN OVER THE WHOLE FILE, NOT LINE BY LINE. The first version of this guard matched single
+ * lines and reported ZERO offenders against the very commit that contained the bug — because the real
+ * `writeArcCache` fabrication was a prettier-wrapped multi-line ternary, and the real `commitArcs` one
+ * assigned to a local (`const at = untrustworthy ? Date.now() - … : Date.now()`) with no `computed_at:`
+ * on the line at all. Its "non-vacuous" test passed only because it asserted a single-line paraphrase
+ * that never existed in the codebase. The fixtures below are now the VERBATIM shapes from that commit.
+ *
+ * KNOWN BLIND SPOTS:
+ *   • A duration that isn't `*_MS`-named (`Date.now() - 300000`, `Date.now() - FIVE_MINUTES`) is missed.
+ *   • A duration reached through a call (`Date.now() - ttlFor(x)`) is missed.
+ *   • A NEW invalidation helper is exempt only once added to INVALIDATION_FUNCTIONS by hand — which is
+ *     the point: adding a name there is a deliberate, reviewable act.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+
+/**
+ * `Date.now() - …<SOMETHING>_MS…` — the clock minus a named duration.
+ *
+ * The `_MS` token must be the SUBTRACTION'S OPERAND, so the character class forbids `< > =` between the
+ * minus and it. Without that, `Date.now() - prior.at < EMPTY_CLOBBER_MAX_AGE_MS` matches — an age
+ * COMPARISON, the exact thing the discriminator exists to let through. (It did, on the first run.)
+ * Newlines are excluded for the same reason: an operand lives on the line its operator does, even when
+ * the surrounding statement wraps — which is why this still catches the prettier-wrapped original.
+ */
+const FABRICATE_RE = /Date\.now\s*\(\s*\)\s*-[^;<>=\n]{0,120}?\b[A-Za-z_][A-Za-z0-9_]*_MS\b/g;
+
+/** Declaration forms, so a match can be attributed to the function it sits in. */
+const FN_DECL_RE =
+  /(?:export\s+)?(?:async\s+)?function\s+([A-Za-z0-9_]+)|(?:export\s+)?const\s+([A-Za-z0-9_]+)\s*=\s*(?:async\s*)?(?:\(|function)/g;
+
+/**
+ * Functions whose JOB is invalidation: they mean "treat this as stale from now on", which is genuinely
+ * what a timestamp controls — a different mechanism from "don't trust these bytes".
+ */
+const INVALIDATION_FUNCTIONS = new Set(["staleArcCache", "bustTeamTimeline", "purgeTimelineCacheTier"]);
+
+const SCAN = [
+  join("lib", "graph", "arcs.ts"),
+  join("lib", "graph", "arc-cache.ts"),
+  join("lib", "dashboard", "timeline-cache.ts"),
+];
+
+/** The function a character offset falls in — the LAST declaration starting before it. */
+function fnAt(src: string, offset: number): string {
+  let name = "<module>";
+  FN_DECL_RE.lastIndex = 0;
+  for (const m of src.matchAll(FN_DECL_RE)) {
+    if (m.index === undefined || m.index > offset) break;
+    name = m[1] ?? m[2] ?? name;
+  }
+  return name;
+}
+
+/** Offenders in one source string, attributed by offset (works across wrapped/multi-line shapes). */
+export function fabricationsIn(src: string, label = "src"): string[] {
+  const hits: string[] = [];
+  for (const m of src.matchAll(FABRICATE_RE)) {
+    const fn = fnAt(src, m.index ?? 0);
+    if (INVALIDATION_FUNCTIONS.has(fn)) continue;
+    hits.push(`${label}:${fn}: ${m[0].replace(/\s+/g, " ").slice(0, 100)}`);
+  }
+  return hits;
+}
+
+function offenders(): string[] {
+  return [
+    ...new Set(SCAN.flatMap((rel) => fabricationsIn(readFileSync(join(ROOT, rel), "utf8"), rel))),
+  ].sort();
+}
+
+describe("guard: computed_at says when, not whether to trust", () => {
+  it("no cache writer fabricates a timestamp by subtracting a duration from the clock", () => {
+    expect(
+      offenders(),
+      `A cache writer is deriving a timestamp from the clock minus a duration. If the goal is "expire ` +
+        `this sooner because it isn't trustworthy", set the DEGRADED flag and let arcTtlMs() shorten the ` +
+        `window — don't falsify the timestamp:\n${offenders().join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("is non-vacuous against the REAL historical shapes, not a paraphrase of them", () => {
+    // Verbatim from the commit that had the bug. The multi-line wrap and the assign-to-a-local form are
+    // exactly what defeated this guard's first version, so they are the fixture.
+    const realWriteArcCache = [
+      "export async function writeArcCache(db, opts = {}) {",
+      "  await db.from('arc_cache').upsert({",
+      "        computed_at: new Date(",
+      "          opts.retryAfterMs === undefined",
+      "            ? Date.now()",
+      "            : Date.now() - Math.max(0, ARC_CACHE_TTL_MS - opts.retryAfterMs)",
+      "        ).toISOString(),",
+      "  });",
+      "}",
+    ].join("\n");
+    expect(fabricationsIn(realWriteArcCache)).toHaveLength(1);
+    expect(fabricationsIn(realWriteArcCache)[0]).toContain("writeArcCache");
+
+    const realCommitArcs = [
+      "export async function commitArcs(db, next, factsHash, opts = {}) {",
+      "  const at = untrustworthy ? Date.now() - (CACHE_TTL_MS - UNTRUSTED_RETRY_AFTER_MS) : Date.now();",
+      "  cache.set(key, { arcs: next, at, factsHash });",
+      "}",
+    ].join("\n");
+    expect(fabricationsIn(realCommitArcs)).toHaveLength(1);
+    expect(fabricationsIn(realCommitArcs)[0]).toContain("commitArcs");
+
+    // The two legitimate AGE computations from the same file must NOT match — subtracting a timestamp.
+    const ages = [
+      "  if (prior && prior.arcs.length > 0 && Date.now() - prior.at < EMPTY_CLOBBER_MAX_AGE_MS) {",
+      "  const ageMs = Date.now() - prior.at;",
+    ].join("\n");
+    expect(fabricationsIn(ages)).toEqual([]);
+
+    // The honest writes must not match.
+    expect(fabricationsIn("computed_at: new Date().toISOString(),")).toEqual([]);
+    expect(fabricationsIn("const at = Date.now();")).toEqual([]);
+
+    // Exemption is per-FUNCTION: `staleArcCache` fabricates legitimately and lives in the SAME FILE as
+    // `writeArcCache`, so a file-level allowlist would have exempted the bug itself.
+    const sameFile = [
+      "export async function writeArcCache(db) {",
+      "  const at = Date.now() - (ARC_CACHE_TTL_MS - UNTRUSTED_RETRY_AFTER_MS);",
+      "}",
+      "export async function staleArcCache(db) {",
+      "  const staleAt = new Date(Date.now() - (ARC_CACHE_TTL_MS + 60_000)).toISOString();",
+      "}",
+    ].join("\n");
+    const caught = fabricationsIn(sameFile);
+    expect(caught).toHaveLength(1);
+    expect(caught[0]).toContain("writeArcCache");
+
+    // And every scanned file exists, so `offenders()` isn't green because a path went stale.
+    for (const rel of SCAN) expect(() => readFileSync(join(ROOT, rel), "utf8")).not.toThrow();
+  });
+
+  it("the derived TTL reproduces the old backdating's retry window exactly", () => {
+    // The refactor's equivalence claim, pinned. Old: written at `now - (TTL - RETRY)`, so it read fresh
+    // while `age < TTL` — i.e. for RETRY. New: written at `now`, TTL is RETRY — fresh for RETRY. Same
+    // window, honest timestamp. If these diverge, a failed synthesis is either pinned for hours (H12) or
+    // recomputed on every page view.
+    expect(arcTtlMs(true)).toBe(UNTRUSTED_RETRY_AFTER_MS);
+    expect(arcTtlMs(false)).toBe(ARC_CACHE_TTL_MS);
+    const oldFreshWindow = ARC_CACHE_TTL_MS - (ARC_CACHE_TTL_MS - UNTRUSTED_RETRY_AFTER_MS);
+    expect(arcTtlMs(true)).toBe(oldFreshWindow);
+    // And a degraded row must expire well before a healthy one, or the flag buys nothing.
+    expect(arcTtlMs(true)).toBeLessThan(arcTtlMs(false) / 10);
+  });
+});

--- a/test/guards/freshness-no-fabricated-as-of.test.ts
+++ b/test/guards/freshness-no-fabricated-as-of.test.ts
@@ -9,8 +9,10 @@ import { freshness, computedNow, freshnessWire } from "@/lib/freshness";
  * The bug this pins was not a missing field, it was a false one. Four routes answered "how old is this?"
  * with `as_of: new Date().toISOString()` over payloads read from a cache table — `arc_cache` has a FOUR
  * HOUR TTL and deliberately serves rows older still. Worse, it destroyed a signal built on purpose
- * underneath it: `commitArcs` backdates `computed_at` so an untrustworthy synthesis reads stale (H11/H12),
- * and the wire overwrote that with "now".
+ * underneath it: at the time, `commitArcs` BACKDATED `computed_at` so an untrustworthy synthesis read
+ * stale (H11/H12), and the wire overwrote that with "now". (That backdating has since been replaced by a
+ * persisted `degraded` column + `arcTtlMs` — see `computed-at-not-a-trust-dial.test.ts` — so the signal
+ * the wire was destroying now lives in its own field. The rule this guard enforces is unchanged.)
  *
  * Why a guard and not just the four fixes: nothing about writing `as_of: new Date()` looks wrong at the
  * call site. It reads like filling in a required field, it is one line, and it type-checks. The next route

--- a/test/timeline-summary.test.ts
+++ b/test/timeline-summary.test.ts
@@ -85,12 +85,23 @@ describe("attachPersonDaySummaries", () => {
     completeTextOrNull.mockImplementation(async ({ prompt }: { prompt: string }) => (prompt.includes("Alice") ? "Alice shipped X." : null));
     const input = days();
     const out = await attachPersonDaySummaries(fakeDb, "team", input);
-    const [alice, bob] = out[0].people;
+    const [alice, bob] = out.days[0].people;
     expect(alice.summary).toBe("Alice shipped X.");
     expect(bob.summary).toBeUndefined();
+    // A SHORTFALL is degradation (R2/M6): Bob's call failed, so the ledger is persisted with prose for
+    // some people and not others — which is indistinguishable from a quiet day unless it's reported.
+    expect(out.degraded).toBe(true);
     // Immutable — the input array/objects are not mutated.
-    expect(out).not.toBe(input);
+    expect(out.days).not.toBe(input);
     expect(input[0].people[0].summary).toBeUndefined();
+  });
+
+  it("a fully successful pass is NOT degraded", async () => {
+    // The control. Without it the flag could be stuck on and every assertion above would still pass.
+    completeTextOrNull.mockResolvedValue("Everyone shipped things.");
+    const out = await attachPersonDaySummaries(fakeDb, "team", days());
+    expect(out.days[0].people.every((p) => p.summary)).toBe(true);
+    expect(out.degraded).toBe(false);
   });
 
   it("skips entirely (returns the same array) when no LLM is configured", async () => {
@@ -99,8 +110,19 @@ describe("attachPersonDaySummaries", () => {
     resolveAnsweringKeys.mockResolvedValue({});
     const input = days();
     const out = await attachPersonDaySummaries(fakeDb, "team", input);
-    expect(out).toBe(input);
+    expect(out.days).toBe(input);
     expect(completeTextOrNull).not.toHaveBeenCalled();
+    // NOT degraded: having no answering model is a deliberate setup, not a failure. Reporting it as
+    // degradation would mark every LLM-less install permanently unhealthy (R2/M6).
+    expect(out.degraded).toBe(false);
     if (orig) process.env.LLM_BASE_URL = orig;
+  });
+
+  it("IS degraded when the key lookup itself fails — that's a failure, not a choice", async () => {
+    // The distinction the flag exists to draw. Same observable payload (no summaries), opposite meaning.
+    resolveAnsweringKeys.mockRejectedValue(new Error("db down"));
+    const out = await attachPersonDaySummaries(fakeDb, "team", days());
+    expect(out.degraded).toBe(true);
+    expect(out.days[0].people.every((p) => p.summary === undefined)).toBe(true);
   });
 });


### PR DESCRIPTION
Follow-up to #426, and the last structural piece of **R2** for the arc/timeline caches.

## The bug

`writeArcCache` had nowhere to record that a synthesis was untrustworthy, so it encoded the fact in the **timestamp**:

```
computed_at = now - (TTL - 5min)
```

…purely to make the row go stale sooner and retry. The retry behaviour was right; the timestamp lied by **~4 hours**, and #426's freshness envelope then had no choice but to publish that lie.

A second cost, which the review of #426 caught: `degraded` survived exactly **one request**. Request A cold-missed, degraded, and was told so. Request B — served the very row A had just written — was told `degraded: false` over identical untrustworthy bytes.

## The fix

The verdict gets a column on both cache tables, and the short life is *derived* from it:

```ts
arcTtlMs(degraded) = degraded ? UNTRUSTED_RETRY_AFTER_MS : ARC_CACHE_TTL_MS
```

This reproduces the old retry window **exactly** — old: written at `now − (TTL − RETRY)`, fresh while `age < TTL`, i.e. fresh for RETRY; new: written at `now`, TTL *is* RETRY, fresh for RETRY — while leaving `computed_at` meaning only "when computed". The equivalence is pinned by a test, because if the two diverge a failed synthesis is either pinned for 4h with no retry (**H12**) or recomputed on every page view.

`UNTRUSTED_RETRY_AFTER_MS` moves to `arc-cache.ts` beside the TTL it's an alternative to — one rule, spelled once as `arcTtlMs`. The flag is carried in the **in-memory maps** too: both are consulted *before* the row, so omitting it there would report a degraded payload as healthy, with the full 4h TTL, for the life of the process.

### Attempt vs payload

`commitArcs` now returns both `untrustworthy` (this attempt failed) and `payloadDegraded` (the bytes handed back are bad). They differ precisely on the keep-the-prior branches, where a refused synthesis returns a **perfectly healthy** cached set:

- `stale` follows the **payload's** trust → a good 1h-old prior keeps its full 4h life instead of being aged out by somebody else's failure.
- `degraded` follows the **attempt** → a user whose correction was refused still learns it didn't take.

### No reuse of a degraded prior

`canReuseArcs` now refuses when the prior row was degraded. Reuse means *"inputs unchanged, keep the previous answer, skip the model"* — sound only if that answer was trustworthy. Reusing an untrustworthy one re-commits the same bad bytes as **healthy** for a full TTL while the failed leg never re-runs: the retry meant to heal the row is what launders its verdict away. Reachable today — an attribution leg that throws *after* the prompt is built leaves the hash unchanged.

### Timeline half

`attachPersonDaySummaries` returns `{days, degraded}` and draws a distinction that didn't exist: a team with **no answering model configured is NOT degraded** (a deliberate setup; reporting it would mark every LLM-less install permanently unhealthy), while a pass that was supposed to produce prose and fell short **is** — including a *partial* shortfall, the common outcome of a flaky provider, which otherwise looks identical to a quiet day.

## Migration

Additive + idempotent, mirrored into `schema.sql`, no CHECK constraint (the replay incident: a re-added CHECK narrower than live data fails the deploy). `default false` = "no evidence of degradation", not "verified good" — defaulting true would stampede a recompute for every team on deploy. Pre-migration rows keep their backdated `computed_at`, so they read stale and refresh on the next view; no backfill. Verified migrate-from-zero **and** the upgrade path on throwaway containers.

## Verification

unit 1381 ✅ · data-mechanics 781 ✅ · HTTP 45 ✅ · migrate-from-zero ✅ · docs ✅ · lint ✅ · tsc ✅

## Review — Reviewed by Fable code-reviewer — verdict SHIP WITH FIXES (0 blockers)

**The High was that my own guard was vacuous against the real bug.** Run against the commit that contained it, `computed-at-not-a-trust-dial` reported **zero offenders**. The actual `writeArcCache` fabrication was a prettier-wrapped multi-line ternary; the actual `commitArcs` one assigned to a local with no `computed_at:` on the line at all. My line-based regex saw neither.

Worse: my mutation check had "passed" only because I injected a **single-line paraphrase shaped by my own pattern** — a shape that never existed in the codebase. I re-derived the finding by execution before fixing it.

Rewritten to match over the whole file with offset-based function attribution, keyed on the real discriminator:

| Shape | Meaning | Verdict |
|---|---|---|
| `Date.now() - ARC_CACHE_TTL_MS` | subtracting a **duration** → fabricating a time | flagged |
| `Date.now() - prior.at` | subtracting a **timestamp** → computing an age | allowed |

My first attempt at that over-matched an age *comparison* (`Date.now() - prior.at < EMPTY_CLOBBER_MAX_AGE_MS`), which the fixture caught. It's now proven by execution to flag **exactly the two real fabrications** on the buggy commit while exempting both legitimate invalidators — and the fixtures are the verbatim historical shapes, not paraphrases.

Also fixed from the review: the `canReuseArcs` laundering above (Medium); two stale docstrings in `commitArcs` still describing the removed backdating in the present tense (Medium); the fresh-prior-badged-stale case (Low). I'd already caught one stale docstring myself beforehand — `lib/freshness.ts` still said `degraded` was *not* persisted, in the very commit that persists it.

**Confirmed by the reviewer against my claims:** the equivalence holds on all four freshness sites; the migration is safe from zero and on upgrade; the H11/H12 specs are stronger, not weaker (RED-checked on main by execution); no reader breaks on an un-migrated DB (both readers try/catch → recompute, and `pg:schema` is the `preDeployCommand`).

## Known, noted

- Timeline `degraded` can fire when the model legitimately returns empty text for a content-bearing person-day. Bounded — the timeline TTL is 5 min and `degraded` doesn't shorten it — and consistent with "no evidence of degradation, never verified good".
- A degraded prior is now clobber-protected for the full 48h from its honest write vs ~44h before (the backdate made it look older). Arguably more correct; no cliff.

## Not included

No `AIOS-Work:` key — I haven't verified a matching Linear issue exists, and a fabricated key would advance an unrelated task to Done on merge.