### PR TITLE
fix(health): the loud banner cried wolf on a healthy 12h job, and its link went nowhere

### DIFF
--- a/app/t/[team]/admin/integrations/page.tsx
+++ b/app/t/[team]/admin/integrations/page.tsx
@@ -138,7 +138,7 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
 
   return (
     <div className="flex flex-col gap-4">
-      <PipelineHealthBanner health={pipelineHealth} href={`/t/${teamSlug}/admin/integrations`} />
+      <PipelineHealthBanner health={pipelineHealth} href={`/t/${teamSlug}/admin/integrations#ingestion-runs`} />
       <div>
         <h1 className="text-xl font-semibold text-ink">Integrations</h1>
         <p className="mt-1 text-sm text-ink-secondary">
@@ -189,7 +189,9 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ t
         }}
       />
       <MemberOnboardingPanel teamSlug={teamSlug} values={onboardingValues} />
-      <div>
+      {/* `scroll-mt-*` so the sticky-ish header doesn't cover the heading when the banner's
+          `#ingestion-runs` link jumps here — without it the anchor lands with the title clipped. */}
+      <div id="ingestion-runs" className="scroll-mt-6">
         <h2 className="text-sm font-semibold text-ink">Recent ingestion runs</h2>
         <p className="mb-2 mt-1 text-xs text-ink-secondary">
           Every scheduler tick, manual <code>/sync</code>, and codebase scan and its outcome — so a

--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -185,7 +185,7 @@ export default async function TeamHome({
 
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-6">
-      {pipelineHealth ? <PipelineHealthBanner health={pipelineHealth} href={`/t/${teamSlug}/admin/integrations`} /> : null}
+      {pipelineHealth ? <PipelineHealthBanner health={pipelineHealth} href={`/t/${teamSlug}/admin/integrations#ingestion-runs`} /> : null}
 
       <div>
         <h1 className="text-2xl font-semibold text-ink">Pulse</h1>

--- a/components/admin/pipeline-health-banner.tsx
+++ b/components/admin/pipeline-health-banner.tsx
@@ -35,7 +35,11 @@ const LABEL: Record<string, string> = {
  */
 export function PipelineHealthBanner({ health, href }: { health: PipelineHealth; href: string }) {
   const signature = alertSignature(health.failing);
-  const storageKey = `pipeline-alert-dismissed:${href}`;
+  // Key on the PATH, not the whole href: the link now carries a `#ingestion-runs` fragment, and keying
+  // on the full string would silently un-dismiss every already-dismissed banner the moment that anchor
+  // was added (and again on any future fragment change). The fragment picks a scroll position; it isn't
+  // a different surface.
+  const storageKey = `pipeline-alert-dismissed:${href.split("#")[0]}`;
   // `hydrated` false during SSR + first client render (matching markup); the mount effect reads the
   // client-only localStorage to decide if THIS exact alert was already dismissed.
   const [state, setState] = useState<{ hydrated: boolean; dismissed: boolean }>({ hydrated: false, dismissed: false });

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -46,6 +46,21 @@ const STALE_MS_BY_SOURCE: Record<string, number | null> = {
   dense: null,
   linear_inbound: null,
   graph_project: null,
+  // The record-only-when-active rule in its strongest form. `doc_task_infer` IS polled reliably — the
+  // scheduler calls it every tick for every team (`lib/ingest/scheduler.ts`), alongside the timeline's
+  // background rebuild — so this is NOT a case of "maybe nothing triggered it". It is that FIVE of its
+  // eight outcomes write no `ingest_runs` row at all: `cooldown` (12h, `DOC_TASK_INFER_INTERVAL_HOURS`),
+  // `no-llm`, `no-candidates`, `nothing-to-score`, and `unchanged` all return before `record()`. So on a
+  // quiet corpus — no new scoreable docs in the 7-day window — a perfectly healthy leg polled every 30
+  // minutes still writes nothing for days, and its newest row's age is unbounded at ANY threshold. That
+  // is why this is `null` rather than "12h + grace": no finite number is correct.
+  //
+  // Observed in prod flagging a leg that had never failed, on a measured 12.1–12.4h cadence, while every
+  // connector was running on time — the banner said the brain wasn't getting fresh data when it was.
+  // Real failures still surface: the model-null and thrown-error paths DO record (`ok=false`), and since
+  // the cooldown counts failed runs too, a persistent failure keeps re-recording and stays the newest
+  // row. Shortfalls also show as `workers_failed` in the run meta.
+  doc_task_infer: null,
 };
 
 /** The age past which `source` is considered stale, or `null` to never flag it on age. Exported for

--- a/test/guards/banner-deep-link.test.ts
+++ b/test/guards/banner-deep-link.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * BUILD-FAILING GUARD: the pipeline banner's "View ingestion runs →" link must land ON the runs table.
+ *
+ * Reported from prod: clicking it dropped you at the TOP of the admin page, with the runs table far
+ * below and nothing indicating where to look. On the integrations page itself the link pointed at the
+ * page you were already on, so it did visibly nothing at all.
+ *
+ * The failure is a two-part contract with nothing tying the halves together — a fragment in one file
+ * and an `id` in another. Either can be renamed alone, and the result is silent: a link that still
+ * works, still navigates, and just quietly stops arriving anywhere useful. No test fails, no type
+ * breaks, and the only detector is a human clicking it.
+ *
+ * KNOWN BLIND SPOTS:
+ *   • This pins the anchor's existence, not that it renders. An `id` on a conditionally rendered branch
+ *     would satisfy it while the target is absent at runtime.
+ *   • A caller that builds the href indirectly (a variable, a helper) instead of an inline template
+ *     literal isn't matched.
+ *
+ * Callers are DISCOVERED by walking `app/`, not listed: a hardcoded file list is green for exactly the
+ * files you thought of, and the whole point is to catch the NEXT surface that renders this banner.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const RUNS_PAGE = join("app", "t", "[team]", "admin", "integrations", "page.tsx");
+
+function read(rel: string): string {
+  return readFileSync(join(ROOT, rel), "utf8");
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+/** Every file under `app/` that renders the banner — found, not enumerated. */
+function bannerCallers(): string[] {
+  return walk(join(ROOT, "app"))
+    .filter((f) => readFileSync(f, "utf8").includes("<PipelineHealthBanner"))
+    .map((f) => f.slice(ROOT.length + 1))
+    .sort();
+}
+
+/** The `href={...}` passed to every PipelineHealthBanner, in source order. */
+function bannerHrefs(src: string): string[] {
+  return [...src.matchAll(/<PipelineHealthBanner[^>]*?href=\{`([^`]+)`\}/g)].map((m) => m[1]);
+}
+
+describe("guard: the pipeline banner deep-links to the runs table", () => {
+  it("every banner href carries a fragment", () => {
+    const callers = bannerCallers();
+    // Non-vacuity, in two separate senses so a failure says which one broke: the walk must FIND callers,
+    // and the href pattern must MATCH inside them. Either returning empty would make the real assertion
+    // below pass over nothing.
+    expect(callers.length, "no file under app/ renders <PipelineHealthBanner> — the walk is broken").toBeGreaterThan(0);
+    const found = callers.flatMap((rel) => bannerHrefs(read(rel)).map((h) => `${rel}: ${h}`));
+    const unmatched = callers.filter((rel) => bannerHrefs(read(rel)).length === 0);
+    expect(
+      unmatched,
+      `these render the banner but no href={\`…\`} matched — an indirect href, or the pattern has ` +
+        `drifted:\n${unmatched.join("\n")}`
+    ).toEqual([]);
+    const withoutFragment = found.filter((h) => !h.includes("#"));
+    expect(
+      withoutFragment,
+      `these link to a page, not to the runs table — the reported bug (you land at the top of admin ` +
+        `with no idea where the runs are):\n${withoutFragment.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("every fragment resolves to an id that actually exists on the target page", () => {
+    // The half that makes this a contract rather than a style rule: renaming either side alone breaks
+    // the link SILENTLY — navigation still succeeds, it just stops scrolling anywhere.
+    const target = read(RUNS_PAGE);
+    for (const rel of bannerCallers()) {
+      for (const href of bannerHrefs(read(rel))) {
+        const fragment = href.split("#")[1];
+        expect(fragment, `${rel}: href has no fragment`).toBeTruthy();
+        expect(
+          target.includes(`id="${fragment}"`),
+          `${rel} links to #${fragment}, but no id="${fragment}" exists in ${RUNS_PAGE}`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("the anchored section is the one containing the runs table", () => {
+    // Pins WHICH element carries the id. An anchor that exists but sits on the wrong section satisfies
+    // the check above while still landing the reader in the wrong place.
+    const target = read(RUNS_PAGE);
+    const anchorIdx = target.indexOf('id="ingestion-runs"');
+    const panelIdx = target.indexOf("<IngestRunsPanel");
+    expect(anchorIdx, 'no id="ingestion-runs" on the runs page').toBeGreaterThan(-1);
+    expect(panelIdx, "no <IngestRunsPanel> on the runs page").toBeGreaterThan(-1);
+    expect(anchorIdx, "the anchor must come before the runs panel it labels").toBeLessThan(panelIdx);
+    // …and close to it: a match 4000 chars up the file is a different section entirely.
+    expect(panelIdx - anchorIdx).toBeLessThan(1200);
+  });
+
+  it("dismissal state is keyed on the path, not the fragment", () => {
+    // Adding the anchor changed every href. Keying localStorage on the full string would have silently
+    // un-dismissed every banner an admin had already dismissed — and would again on any future
+    // fragment change. The fragment is a scroll position, not a different surface.
+    const banner = read(join("components", "admin", "pipeline-health-banner.tsx"));
+    expect(banner).toContain('href.split("#")[0]');
+  });
+});

--- a/test/pipeline-health-staleness.test.ts
+++ b/test/pipeline-health-staleness.test.ts
@@ -44,4 +44,44 @@ describe("staleThresholdMs — per-source staleness cadence", () => {
       expect(staleThresholdMs(s)).toBeNull();
     }
   });
+
+  it("doc_task_infer is never age-stale — five of its outcomes write no row at all", () => {
+    // Observed in prod: the banner said "1 ingestion leg is broken — the brain isn't getting fresh
+    // data · doc_task_infer, last successful run 10h ago". The leg had never failed. Its four runs sat
+    // on a 12.2h / 12.4h / 12.1h cadence — because `COOLDOWN_MS` defaults to 12h — so a 3h threshold
+    // marked a perfectly healthy job broken for 9 of every 12 hours.
+    //
+    // It is NOT that the leg might go untriggered: the scheduler polls it every tick for every team.
+    // It is that `cooldown`, `no-llm`, `no-candidates`, `nothing-to-score` and `unchanged` all return
+    // BEFORE `record()` — so on a quiet corpus a healthy leg polled every 30 minutes still writes
+    // nothing for days. Its newest row's age is therefore unbounded at ANY threshold, which is why the
+    // answer is `null` rather than "12h + grace". Same criterion that nulls dense/linear_inbound/
+    // graph_project, just more decisive here.
+    //
+    // Real failures still surface: the model-null and thrown-error paths DO record, with `ok=false`.
+    expect(staleThresholdMs("doc_task_infer")).toBeNull();
+  });
+
+  it("the default is only applied to legs that actually record every poll", () => {
+    // Guards the SHAPE of the mistake rather than one more instance of it. Every source that keeps the
+    // 3h default must be one whose last-row age equals its last-POLL age; anything else has to be
+    // listed explicitly. A new leg added without a threshold silently inherits 3h — which is how both
+    // auth_cleanup and doc_task_infer became false alarms.
+    const RECORDS_EVERY_POLL = new Set(["slack", "plane", "linear", "github", "meeting_notes"]);
+    for (const s of RECORDS_EVERY_POLL) expect(staleThresholdMs(s)).toBe(3 * H);
+    // …and every leg observed in prod's `ingest_runs` is accounted for — either listed with its own
+    // threshold, or a record-every-poll poller. (`graph_extract` is deliberately absent: nothing writes
+    // it to `ingest_runs`. It is the SYNTHETIC leg `getPipelineHealth` appends with `stale: false`
+    // hardcoded, so it never reaches `staleThresholdMs`. If that ever starts recording real rows it
+    // must be added here, or it silently inherits the 3h default.)
+    const PROD_SOURCES = [
+      "slack", "linear", "linear_inbound", "github", "meeting_notes", "graph_project",
+      "dense", "doc_task_infer", "auth_cleanup", "llm", "pm_sync", "scan",
+    ];
+    const unlisted = PROD_SOURCES.filter((s) => staleThresholdMs(s) === 3 * H && !RECORDS_EVERY_POLL.has(s));
+    expect(
+      unlisted,
+      `these legs silently inherited the 3h default — give each its own cadence or null:\n${unlisted.join("\n")}`
+    ).toEqual([]);
+  });
 });


### PR DESCRIPTION
Both bugs from one screenshot: the banner claimed an ingestion leg was broken when it wasn't, and its link went nowhere useful.

<img width="600" alt="the banner" src="https://github.com/user-attachments/assets/placeholder" />

> ⚠️ **1 ingestion leg is broken — the brain isn't getting fresh data**
> `doc_task_infer` — last successful run 10h ago (may have stopped)
> [View ingestion runs →]

## 1. The false alarm

`doc_task_infer` **had never failed.** Checked prod directly (read-only):

| runs | all ok? | gaps between them |
|---|---|---|
| 4 | yes, 0 failures | **12.2h · 12.4h · 12.1h** |

`COOLDOWN_MS` defaults to **12h** (`DOC_TASK_INFER_INTERVAL_HOURS`), against this module's blanket **3h** threshold — so a healthy job was reported broken for **9 of every 12 hours**, while every real connector (slack, linear, github, meeting_notes, graph_project) was running on time with zero failures. This is the `auth_cleanup` bug again, which the file's own docstring already records.

**The reason is not that the leg might go untriggered** — the scheduler polls it every tick for every team. It's that **five of its eight outcomes write no `ingest_runs` row at all**: `cooldown`, `no-llm`, `no-candidates`, `nothing-to-score`, `unchanged` all return before `record()`. On a quiet corpus a healthy leg polled every 30 minutes still writes nothing for days — so its newest row's age is **unbounded at any threshold**. That's why `null` and not "12h + grace": no finite number is correct.

Real failures still surface — the model-null and thrown-error paths *do* record `ok=false`, and since the cooldown counts failed runs, a persistent failure keeps re-recording and stays the newest row.

**Accepted tradeoff, stated not implied:** like `linear_inbound`, this leg now has no age-based probe, so a pass that stops being invoked while the scheduler is otherwise fine goes unnoticed. The alternative is a banner that's wrong most of the day — and an alert nobody believes protects nothing.

## 2. The dead link

`href` pointed at `/admin/integrations`, whose "Recent ingestion runs" section sits far down the page with no anchor. On the integrations page *itself* it pointed at the page you were already on, so it did visibly nothing.

Now `#ingestion-runs`, with the id on the section holding `<IngestRunsPanel>` and `scroll-mt-6` so the heading isn't clipped on arrival.

The dismissal key is now keyed on the **path**, not the full href — keying on the whole string would have silently un-dismissed every already-dismissed banner the moment this anchor was added. Old hrefs had no fragment, so the new key is byte-identical: existing dismissals are preserved.

## Guard

The link is a two-part contract — a fragment in one file, an `id` in another — with nothing tying the halves together. Breaking either is **silent**: the link still navigates, it just stops arriving anywhere. The guard pins both halves plus which section carries the anchor, and **discovers callers by walking `app/`** rather than listing them, so it catches the next surface too.

Mutation-checked three ways: the real pre-fix shape (no fragment), a one-sided `id` rename, and a fragmentless banner added in a brand-new file.

The staleness spec also gains a test guarding the **shape** of the mistake — every leg keeping the 3h default must be one that records every poll — so a new leg can't silently inherit a threshold that doesn't fit it. Both specs verified RED first; the shape test named `doc_task_infer` on its own.

## Verification

unit 1388 ✅ · tsc ✅ · lint ✅ · docs-drift ✅ (no routes/tables/sources touched)

## Review — Reviewed by Fable code-reviewer — verdict SHIP WITH FIXES (0 blockers)

**It caught a claim of mine that was simply false.** I'd justified the change partly on `doc_task_infer` being "view-driven" — but `lib/ingest/scheduler.ts` calls it on every tick for every team. I re-derived it from the code before correcting it in all three places it appeared. The true reason turns out to be *stronger*, and it also rules out the 14h-threshold alternative I'd otherwise have considered defensible.

Also fixed:
- a test comment claiming `graph_extract` was "included" in the accounted-for list, justified by a probe that doesn't exist (it's a synthetic leg with `stale` hardcoded false — correctly absent, wrong explanation);
- the guard's hardcoded 2-file caller list, green for exactly the files I thought of;
- "records only when it WORKS" — imprecise in the one direction the rest of the argument depends on: it records on work *or failure*, never on a skip.

Reviewer independently confirmed the skip paths return before `record()` (finding three more than I had), that failure paths record `ok=false`, that no other residual probe exists for this leg, that the dismissal key is preserved by string equality, and that nothing else reads `staleThresholdMs` or builds this href.

## Not included

No `AIOS-Work:` key — I haven't verified a matching Linear issue exists, and a fabricated key would advance an unrelated task to Done on merge.