### PR TITLE
docs(readme): give the setup order per-step timings, matching the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,20 @@ LLM key if you run the context engine. Self-host the model and all of it is zero
   the connectors feed the brain on their own. See
   [the quickstart](https://aiosbrain.dev/guides/quickstart).
 
-**Roughly:** deploy the app → set the env vars → load the schema → load the vector schema → create
-the first admin → connect one source. Add Neo4j + Graphiti later, or never. Everything below is that,
-in dependency order, with the failure modes called out.
+**The order, and roughly what each costs you** (~15 minutes to a first answer, excluding the
+optional context engine):
+
+| | | |
+|---|---|---|
+| 1 | Deploy the app | ~5 min |
+| 2 | Set the environment variables | ~3 min |
+| 3 | Load the schema (`npm run pg:schema`) | ~1 min |
+| 4 | Load the vector schema (`npm run pg:schema:vector`) | ~1 min |
+| 5 | Create the first admin | ~1 min |
+| 6 | Connect one source | ~4 min |
+| + | Add Neo4j + Graphiti | later, or never |
+
+Everything below is that, in dependency order, with the failure modes called out.
 
 > **Joining a team that already runs one?** You don't need any of this — you need an invite. See
 > [Onboarding a contributor](https://aiosbrain.dev/guides/quickstart#part-2--connect-to-a-team-brain).


### PR DESCRIPTION
Keeps the README's setup block in step with the redesigned `/team-brain` Getting Started section (aiosbrain/aios-alpha.github.io#84).

That section now shows the order of operations as a numbered stepper with a per-step estimate and a **~15 min to first answer** badge. The README's equivalent was a run-on arrow sentence with no timing signal at all, so a reader could not tell whether this was a coffee-break job or an afternoon.

Same six steps, same numbers, with the optional graph as a trailing `+` row so it reads as *outside* the 15 minutes rather than a seventh step. The two `pg:schema` commands are named inline, since those are the steps most likely to be skipped.

No technical claims changed.

`npm test` ✅ (1388) · docs-drift ✅