### PR TITLE
fix(graph): my 120s proxy timeout was killing every extraction

### DIFF
--- a/app/api/internal/llm/v1/chat/completions/route.ts
+++ b/app/api/internal/llm/v1/chat/completions/route.ts
@@ -11,8 +11,9 @@ import {
 } from "@/lib/llm/graph-proxy";
 
 export const runtime = "nodejs";
-/** Graphiti's extraction calls are slow (structured output over a long episode). */
-export const maxDuration = 120;
+/** Graphiti's extraction calls are slow (structured output over a long episode, plus resolution
+ *  context). 120 was too low and silently failed every job in prod — see `PROXY_TIMEOUT_MS`. */
+export const maxDuration = 300;
 
 /**
  * The OpenAI-compatible chat endpoint for the Graphiti service ONLY (its path is this file's

--- a/lib/llm/graph-proxy.ts
+++ b/lib/llm/graph-proxy.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { timingSafeEqual } from "node:crypto";
 import type { DbClient } from "@/lib/db/types";
 import { rateLimit } from "@/lib/api/rate-limit";
+import { resolvePositiveInt } from "@/lib/util/env";
 import { resolveAnsweringKeys } from "@/lib/query/answering";
 import { selectLlmBackend, type LlmBackend } from "@/lib/query/llm-backend";
 import { resolveEmbeddingBackend } from "@/lib/query/embedding-key";
@@ -207,6 +208,22 @@ export const isRefusal = (v: unknown): v is ProxyRefusal =>
  */
 const PROXY_CALLS_PER_MINUTE = 120;
 
+/**
+ * How long we wait on the provider before giving up.
+ *
+ * Was 120s, and that was WRONG in a way only production showed: Graphiti's extraction prompts carry
+ * the episode plus resolution context, and real ones exceeded it — while a hand-built 16KB probe
+ * returned in 32s, so nothing local reproduced it. The OpenAI SDK then retried twice, so every job
+ * burned ~7-9 minutes and died, the queue drained, and NOT ONE fact was created.
+ *
+ * The caller should own the deadline. Graphiti's client has its own (the OpenAI SDK defaults to
+ * 600s non-streaming), so this sits generously below that: high enough never to be the binding
+ * constraint on a legitimately slow extraction, low enough to release a truly hung connection.
+ */
+const PROXY_TIMEOUT_MS = resolvePositiveInt(process.env.GRAPH_PROXY_TIMEOUT_MS, 300_000);
+/** Exported for the guard test only — the value is a production incident, not a taste preference. */
+export const PROXY_TIMEOUT_MS_FOR_TEST = PROXY_TIMEOUT_MS;
+
 /** Shared bucket for both halves of the proxy: one credential, one budget. */
 export async function graphProxyWithinRateLimit(db: DbClient): Promise<boolean> {
   return rateLimit(db, "graph-llm-proxy", PROXY_CALLS_PER_MINUTE);
@@ -284,9 +301,10 @@ export async function forwardUpstream(
   body: Record<string, unknown>,
   opts: { timeoutMs?: number; meter?: GraphMeterCtx } = {}
 ): Promise<Response> {
-  const { timeoutMs = 120_000, meter } = opts;
+  const { timeoutMs = PROXY_TIMEOUT_MS, meter } = opts;
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  const startedAt = Date.now();
   try {
     const res = await fetch(target.url, {
       method: "POST",
@@ -304,7 +322,18 @@ export async function forwardUpstream(
     // exactly how long to wait — needless load on the way out of the failure this module exists for.
     const retryAfter = res.headers.get("retry-after");
     if (retryAfter) headers["Retry-After"] = retryAfter;
+    // ONE line per call, with the duration. The first real outage on this path took log forensics
+    // across two services to attribute (an abort here surfaced only as an opaque 502 in Graphiti's
+    // traceback); a timing line makes "the proxy timed out" self-evident next time.
+    console.log(`[graph-proxy] ${target.url} -> ${res.status} in ${Date.now() - startedAt}ms`);
     return new Response(text, { status: res.status, headers });
+  } catch (err) {
+    const ms = Date.now() - startedAt;
+    const aborted = err instanceof Error && err.name === "AbortError";
+    console.warn(
+      `[graph-proxy] ${target.url} -> ${aborted ? `ABORTED by our own ${timeoutMs}ms timeout` : "failed"} after ${ms}ms`
+    );
+    throw err;
   } finally {
     clearTimeout(timer);
   }

--- a/test/graph-llm-proxy.test.ts
+++ b/test/graph-llm-proxy.test.ts
@@ -267,3 +267,29 @@ describe("resolveGraphProxyTeamId — the default production path", () => {
     expect(got.code).toBe("graph_proxy_no_team");
   });
 });
+
+/**
+ * The timeout that silently broke extraction in production.
+ *
+ * 120s looked generous and was not: Graphiti's extraction prompts carry the episode plus resolution
+ * context, and real ones exceeded it — while a hand-built 16KB probe returned in 32s, so nothing
+ * local reproduced it. The OpenAI SDK then retried twice, so every job burned ~7-9 minutes and died.
+ * The queue drained and NOT ONE fact was created, and the only symptom was an opaque 502 inside
+ * another service's traceback.
+ *
+ * The caller should own the deadline (Graphiti's SDK defaults to 600s non-streaming), so ours must
+ * sit generously below that without being the binding constraint on a legitimately slow extraction.
+ */
+describe("the proxy's upstream timeout", () => {
+  it("is well clear of a slow extraction, and below the caller's own deadline", async () => {
+    const { PROXY_TIMEOUT_MS_FOR_TEST } = (await import("@/lib/llm/graph-proxy")) as unknown as {
+      PROXY_TIMEOUT_MS_FOR_TEST: number;
+    };
+    // Measured in prod: a 16KB structured-output call returns in ~32s. 120s was still too low for
+    // real prompts, so the floor here is deliberately far above the observed happy path.
+    expect(PROXY_TIMEOUT_MS_FOR_TEST).toBeGreaterThan(120_000);
+    // …and strictly under the OpenAI SDK's 600s default, so the CALLER's deadline is the outer bound
+    // and ours only releases a genuinely hung connection.
+    expect(PROXY_TIMEOUT_MS_FOR_TEST).toBeLessThan(600_000);
+  });
+});


### PR DESCRIPTION
**Direct answer to "has extraction processed a real episode": no — and the reason was mine.**

Episodes *are* flowing since the proxy went live: queue at 131, zero `insufficient_quota`, the old second key out of the picture. But every job failed:

```
openai.InternalServerError: Error code: 502 -
  {'error': {'message': 'This operation was aborted', 'type': 'api_error'}}
```

That 502 body is **our** shape, and that message is **our own `AbortController`** firing. The failures sit **7–9 minutes apart** — exactly the OpenAI SDK's three attempts against a 120s ceiling plus backoff. The queue drained and **not one fact was created**.

## Why nothing local would have caught it

A hand-built 16KB structured-output probe returns in **32s**; a small one in **13s**. Graphiti's real prompts carry the episode *plus* resolution context and exceed the ceiling. I only found it by reading the queue depth and timestamping the failures.

## The fix

The **caller** should own the deadline. Graphiti's SDK defaults to 600s non-streaming, so ours now sits at **300s** (`GRAPH_PROXY_TIMEOUT_MS`) — high enough never to bind a legitimately slow extraction, low enough to release a genuinely hung connection. `maxDuration` raised to match.

Pinned by a test that fails at 120s *and* fails above the SDK's own bound, because this value is a production incident, not a taste preference.

**Every call now logs one line with its duration**, and on failure says plainly whether *our* timeout aborted it. Attributing this took log forensics across two services to turn an opaque 502 into a cause; it should take one grep next time.

Composed with #437's cost metering, which landed on this same function meanwhile — metering and timing are independent and both run.

## Verified

unit 1403 · tsc 0 · lint clean (2 pre-existing warnings) · docs-drift green. Measured against production twice (13s small, 32s at 16KB) before choosing the number.

AIOS-Work: AIO-484