### PR TITLE
test(ingestion): prove Notion/Drive/Confluence fetch() without an account — and fix the TypeError it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,5 +144,16 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v7
-      - run: uv pip install --system -e '.[dev,radar]'
+      # The reader extras are opt-in for operators but REQUIRED here: tests/test_reader_api_conformance.py
+      # checks the kwargs our Notion/Drive/Confluence adapters pass against the real installed classes,
+      # which is the only tier that catches a reader renaming a kwarg (we have no accounts to test against).
+      # Without them those checks turn into silent skips — which `test_conformance_is_not_silently_skipped_in_ci`
+      # fails the build for, via CI=true.
+      #
+      # DELIBERATELY UNPINNED (pyproject says `>=0.1`), which means a new reader release can turn this
+      # job red on an UNRELATED PR. That is the intended trade: an operator installing today gets the
+      # latest reader, so testing anything else would prove nothing about what they run. Such a red is
+      # real information — the connector is broken against the current library. Fix the adapter (or pin
+      # the reader in pyproject and say why); do not just re-run.
+      - run: uv pip install --system -e '.[dev,radar,notion,gdrive,confluence]'
       - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -180,10 +180,16 @@ All connector APIs are free. Cost shows up downstream in embeddings and LLM spen
 | **RSS/Radar**, **Web**, **Local files** | none | — | **Sidecar** `connections.yaml` |
 
 **Maturity, honestly.** Slack, GitHub, Linear and Plane are the proven path — each has a real runner
-wired into the scheduler and unit coverage. **Notion, Google Drive and Confluence are wired but
-unproven**: the code is real and registered, but none has a test of its `fetch()`, and Confluence
-has no `connections.yaml` example either (Notion and Google Drive do — see
-`ingestion/connections.yaml.example`). Expect to debug your first run. Google Drive's watch-channel *renewal* advertised in
+wired into the scheduler and unit coverage. **Notion, Google Drive and Confluence are tested but not
+account-proven.** Their `fetch()` now runs in CI against stand-in readers, and every kwarg the
+adapters pass is checked against the real installed reader classes — which is what caught a live
+`TypeError` in Notion's *database* branch, the one `connections.yaml.example` ships. What no test
+here can cover is a credential actually authenticating, real pagination, or the live API returning
+the metadata keys we map; expect to debug your first run for those. Confluence also has no
+`connections.yaml` example (Notion and Google Drive do — see `ingestion/connections.yaml.example`).
+**Google Drive additionally has no owner enrichment** — unlike Notion it emits no mappable
+`authors[]`, so a Drive doc is ingested and searchable but credited to nobody: it never appears
+under a person on the timeline. Google Drive's watch-channel *renewal* advertised in
 `ingestion/README.md` is never constructed by `aios-ingest schedule` — Drive is pull-on-a-schedule
 only. `gdrive`/`confluence`/`web`/`local`/`radar` cannot be stored as brain integrations at all (the
 `integrations.type` CHECK has no such values) — they are `connections.yaml`-only by construction.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -197,3 +197,60 @@ emails/roles on `members` — worse than the attribution page's names+counts).
 **Fix:** each admin page should self-check via `requireTeamAdmin(teamSlug)` before any privileged read
 (as `app/t/[team]/admin/attribution/page.tsx` now does), returning null when it's null. A guard test that
 every `admin/*/page.tsx` calls `requireTeamAdmin` would make it build-enforced.
+
+---
+
+## Google Drive docs arrive unattributable (no owner enrichment) — the real Drive gap
+
+**Status:** open, and it is the blocker for Drive, not the missing test. Surfaced while adding the
+reader-adapter tests (`ingestion/tests/test_reader_adapters.py`).
+
+Notion has `sources/notion_authors.py`: it resolves `created_by` / `last_edited_by` to a name +
+email and emits the structured `authors[]` the brain maps to a roster member. **Drive has no
+equivalent.** `GoogleDriveReader`'s document metadata is exactly six keys — `file id`, `author`,
+`file path`, `mime type`, `created at`, `modified at` — and its `author` is a bare display string,
+not an email or a stable id, so `lib/attribution/resolve-authors` cannot map it to a person.
+
+**Why that matters more than it sounds:** a Drive document therefore lands with no credited worker.
+It is ingested and searchable, but it never appears under anyone on the timeline, never counts
+toward a person's work, and can never be picked up by the LLM doc→task pass (#394), which only
+scores *attributed* work docs. So "connect Drive" currently buys retrieval and nothing else — and
+the fetch tests now passing must not be read as "Drive works".
+
+**Why deferred:** it needs Drive API fields the reader does not surface (`owners[]`,
+`lastModifyingUser`), which means a second API pass with its own credentials — mirroring
+`notion_authors.py` — and we have no Drive account to develop it against.
+
+**When to revisit:** the moment a Drive account exists to test with, or before Drive is recommended
+to anyone as a work-attribution source.
+
+**How:** add `sources/gdrive_authors.py` mirroring the Notion pass — `files.get(fileId, fields=
+"owners(displayName,emailAddress),lastModifyingUser(displayName,emailAddress)")` → `authors[]` with
+`role: "author"` / `"editor"`, `provider: "google"`, and the email as the mappable key. Same
+best-effort contract: any API failure yields no authors and never breaks the sync.
+
+**Two smaller mapping gaps in the same place**, worth fixing in that PR rather than alone:
+`docs_to_raw` reads `url` from `file_path` and `title` from `file_name`, but the reader spells the
+former `file path` (with a space) and omits a name entirely — so every Drive item has a **null
+title and null URL**. (`source_ts` is fine: the work-time lookup is spelling-insensitive and
+matches `modified at`.)
+
+---
+
+## Connector proof that genuinely needs a live account
+
+**Status:** open by necessity. `ingestion/tests/test_reader_adapters.py` +
+`test_reader_api_conformance.py` (2026-07-29) close the part that can be tested without one — the
+adapter body, branch selection, metadata → `RawDoc` mapping, and the kwargs we pass checked against
+the real installed reader classes. That pairing already caught a live TypeError in Notion's
+database branch.
+
+**Still unproven, and not provable without credentials:** that a token/service-account key actually
+authenticates, that the documented Confluence credential recipe works against Atlassian Cloud, that
+pagination behaves over a real corpus, and that the live APIs return the metadata keys the fakes
+assert. Read the green suite as "our code is right given the reader's shape", not "the connector
+works end to end".
+
+**When to revisit:** when an org account exists for any of the three. **How:** record one real
+response per connector with `respx` (already a dev dependency) and replay it — the fake-reader seam
+in `tests/_reader_fakes.py` is where a recorded fixture drops in.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -88,11 +88,36 @@ vendored so the deployed sidecar is self-contained; every scan records
 - Score against a different rubric ad hoc: `aios-ingest scan … --readiness-rubric PATH`.
 - Readiness is scored on the live scan only; `--backfill` historical points carry null readiness.
 
+## Testing the connectors without an account
+
+We have no Notion / Drive / Confluence org accounts, so the reader-backed connectors are covered in
+two tiers — neither needs a credential, and the pairing is what makes either one worth trusting:
+
+| tier | file | proves |
+|------|------|--------|
+| adapter | `tests/test_reader_adapters.py` | `fetch()` end to end against stand-in readers swapped in at the `lazy_reader` seam — reader construction, branch selection (`space_key` vs `page_ids`, …), and the metadata → `RawDoc` mapping incl. **work-time**, whose absence silently drops a doc from the timeline |
+| conformance | `tests/test_reader_api_conformance.py` | every kwarg those adapters pass **exists on the real installed reader class**, and the stand-ins in `tests/_reader_fakes.py` accept nothing the real class rejects |
+
+The conformance tier needs the reader extras and CI installs them
+(`.[dev,radar,notion,gdrive,confluence]`); locally without them it skips, and a guard fails the
+build if CI ever loses them so the checks can't vanish into a green run. It earns its keep: it
+caught `NotionPageReader.load_data` having no `database_id` (only `database_ids`, a list) — the
+branch `connections.yaml.example` ships, which raised `TypeError` and, since `sync` has no
+per-connection try/except, would have aborted the operator's entire run.
+
+**What neither tier can prove:** that a credential authenticates, that pagination behaves over a
+real corpus, or that the live API returns the metadata keys we map. Recorded-fixture replay is the
+next step (see `docs/TODO.md`).
+
 ## Limitations (MVP)
 
 - **No deletes** — the brain has no DELETE endpoint yet; removing a source doc won't remove the item.
 - **Notion webhooks** (beta) fire on page properties, not block edits → content relies on polling.
 - **Drive watch-channels** expire and must be renewed by the scheduler.
+- **Drive documents are unattributable** — unlike Notion (`sources/notion_authors.py`), `gdrive.py`
+  has no owner-enrichment pass, and the reader's `author` is a bare display string. So a Drive doc
+  is ingested and searchable but credited to nobody, and never appears under a person on the
+  timeline. Tracked in `docs/TODO.md`.
 - Large backfills are throttled under the brain's 120 POST/min/key limit.
 
 See `THIRD_PARTY_LICENSES.md` for imported-dependency licenses. This package is MIT.

--- a/ingestion/aios_ingest/sources/notion.py
+++ b/ingestion/aios_ingest/sources/notion.py
@@ -30,7 +30,9 @@ class NotionSource(PullOnlySource, Source):
         )
         reader = NotionPageReader(integration_token=self._token)
         if self._database_id:
-            docs = reader.load_data(database_id=self._database_id)
+            # `database_ids`, plural and a LIST — the reader has no single-valued `database_id`
+            # kwarg, so passing one is a TypeError that aborts the connection on its first tick.
+            docs = reader.load_data(database_ids=[self._database_id])
         else:
             docs = reader.load_data(page_ids=self._page_ids)
         raws = docs_to_raw(docs, source=self.name, id_keys=("page_id", "id"), fallback_prefix="notion")

--- a/ingestion/tests/_reader_fakes.py
+++ b/ingestion/tests/_reader_fakes.py
@@ -1,0 +1,203 @@
+"""Fake LlamaHub readers — the shape our adapters BELIEVE the real readers have.
+
+Notion, Google Drive and Confluence can't be exercised against a live account in CI (no
+org accounts, and credentials in CI is the wrong trade anyway). These fakes stand in for
+the reader classes so `fetch()` itself is testable end to end:
+
+    test_reader_adapters.py       drives fetch() through these — proves OUR code is right
+                                  GIVEN this shape.
+    test_reader_api_conformance.py checks these signatures against the INSTALLED reader
+                                  classes — proves the shape is real.
+
+The pairing is the point. A fake with `**kwargs`, or one hand-copied from a neighbouring
+file, would accept a call the real library rejects and grant false confidence: exactly the
+failure that shipped a `--source github` example that always failed. So every parameter
+name below is mirrored from the real signature and pinned by the conformance tier; if a
+reader renames a kwarg in a minor bump, that tier goes red and names this file.
+
+Defaults are NOT mirrored (only names are compared) — the real
+`NotionPageReader.load_data` has a mutable `page_ids=[]` default we don't want to copy.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class FakeDoc:
+    """Stands in for `llama_index.core.schema.Document` — `.text` + `.metadata` is all
+    `docs_to_raw` reads."""
+
+    def __init__(self, text: str = "", metadata: dict[str, Any] | None = None):
+        self.text = text
+        self.metadata = metadata or {}
+
+
+#: Sentinel for "the adapter did not pass this kwarg".
+#:
+#: `None` cannot serve here. A fake defaulting a parameter to `None` and forwarding it
+#: unconditionally CANONICALIZES an omitted kwarg into an explicitly-passed `None`, so
+#: "passed nothing" and "passed None" become indistinguishable — which made the Drive
+#: service-account test green against the very bug it described. Only what the adapter
+#: actually passed is recorded.
+_UNSET: Any = object()
+
+
+def _passed(**kwargs: Any) -> dict[str, Any]:
+    return {k: v for k, v in kwargs.items() if v is not _UNSET}
+
+
+class _RecordingReader:
+    """Base: records how the adapter constructed it and how it called `load_data`."""
+
+    #: (module, class) of the real reader this fake stands in for — read by the
+    #: conformance tier, so adding a fake here automatically gets it checked.
+    real: tuple[str, str] = ("", "")
+
+    def __init__(self, **kwargs: Any):
+        self.init_kwargs = kwargs
+        self.load_kwargs: dict[str, Any] | None = None
+        self.docs: list[FakeDoc] = []
+
+    def _record(self, **kwargs: Any) -> list[FakeDoc]:
+        # Only the kwargs actually passed — a default the adapter never set must not read
+        # back as "the adapter chose this".
+        self.load_kwargs = _passed(**kwargs)
+        return self.docs
+
+
+class FakeNotionPageReader(_RecordingReader):
+    real = ("llama_index.readers.notion", "NotionPageReader")
+
+    def __init__(self, integration_token: str | None = _UNSET):
+        super().__init__(**_passed(integration_token=integration_token))
+
+    def load_data(
+        self,
+        page_ids: list[str] | None = _UNSET,
+        database_ids: list[str] | None = _UNSET,
+        load_all_if_empty: bool = _UNSET,
+    ) -> list[FakeDoc]:
+        return self._record(
+            page_ids=page_ids, database_ids=database_ids, load_all_if_empty=load_all_if_empty
+        )
+
+
+class FakeConfluenceReader(_RecordingReader):
+    real = ("llama_index.readers.confluence", "ConfluenceReader")
+
+    def __init__(
+        self,
+        base_url: str | None = _UNSET,
+        api_token: str | None = _UNSET,
+        user_name: str | None = _UNSET,
+        password: str | None = _UNSET,
+        cloud: bool = _UNSET,
+    ):
+        super().__init__(
+            **_passed(
+                base_url=base_url,
+                api_token=api_token,
+                user_name=user_name,
+                password=password,
+                cloud=cloud,
+            )
+        )
+
+    def load_data(
+        self,
+        space_key: str | None = _UNSET,
+        page_ids: list[str] | None = _UNSET,
+        max_num_results: int | None = _UNSET,
+    ) -> list[FakeDoc]:
+        return self._record(
+            space_key=space_key, page_ids=page_ids, max_num_results=max_num_results
+        )
+
+
+class FakeGoogleDriveReader(_RecordingReader):
+    real = ("llama_index.readers.google", "GoogleDriveReader")
+
+    def __init__(
+        self,
+        folder_id: str | None = _UNSET,
+        file_ids: list[str] | None = _UNSET,
+        service_account_key_path: str | None = _UNSET,
+    ):
+        super().__init__(
+            **_passed(
+                folder_id=folder_id,
+                file_ids=file_ids,
+                service_account_key_path=service_account_key_path,
+            )
+        )
+
+    def load_data(
+        self,
+        folder_id: str | None = _UNSET,
+        file_ids: list[str] | None = _UNSET,
+        mime_types: list[str] | None = _UNSET,
+    ) -> list[FakeDoc]:
+        return self._record(folder_id=folder_id, file_ids=file_ids, mime_types=mime_types)
+
+
+ALL_FAKES = (FakeNotionPageReader, FakeConfluenceReader, FakeGoogleDriveReader)
+
+
+class ReaderSpy:
+    """Handle on the reader the adapter built. `reader` is None until `fetch()` runs —
+    the adapters construct lazily, and asserting on a reader that was never built would
+    be a vacuous pass."""
+
+    def __init__(self) -> None:
+        self.reader: _RecordingReader | None = None
+
+    @property
+    def init_kwargs(self) -> dict[str, Any]:
+        assert self.reader is not None, "adapter never constructed its reader"
+        return self.reader.init_kwargs
+
+    @property
+    def load_kwargs(self) -> dict[str, Any]:
+        assert self.reader is not None, "adapter never constructed its reader"
+        assert self.reader.load_kwargs is not None, "adapter never called load_data"
+        return self.reader.load_kwargs
+
+
+def install(
+    monkeypatch,
+    adapter_module: str,
+    fake_cls: type[_RecordingReader],
+    docs: list[FakeDoc] | None = None,
+) -> ReaderSpy:
+    """Swap the adapter's `lazy_reader` for one that yields `fake_cls`.
+
+    `lazy_reader` is the single seam every LlamaHub-backed adapter resolves its reader
+    through, and each adapter imports it into its own namespace — so patching it there
+    replaces the reader with no extra installed and no network call. The fake is
+    constructed with the adapter's real kwargs, so an unexpected one raises TypeError
+    exactly as the live reader would.
+    """
+    spy = ReaderSpy()
+
+    def factory(**init: Any) -> _RecordingReader:
+        reader = fake_cls(**init)
+        reader.docs = list(docs or [])
+        spy.reader = reader
+        return reader
+
+    def fake_lazy_reader(module: str, cls: str, *_a: Any, **_kw: Any):
+        # The fake must stand in for the class the adapter ACTUALLY asked for. Ignoring these
+        # arguments would let a typo'd module/class name — an AttributeError on the first live
+        # run, exactly this PR's failure class — pass both tiers green, because the conformance
+        # tier reads `fake_cls.real`, not the adapter's source.
+        assert (module, cls) == fake_cls.real, (
+            f"aios_ingest.sources.{adapter_module} resolves {(module, cls)}, but the fake stands "
+            f"in for {fake_cls.real}. One of the two is wrong."
+        )
+        return factory
+
+    monkeypatch.setattr(
+        f"aios_ingest.sources.{adapter_module}.lazy_reader", fake_lazy_reader
+    )
+    return spy

--- a/ingestion/tests/test_reader_adapters.py
+++ b/ingestion/tests/test_reader_adapters.py
@@ -1,0 +1,265 @@
+"""`fetch()` tests for the three reader-backed connectors — Notion, Google Drive, Confluence.
+
+These were the connectors described as "wired but unproven": real registered code, no test of
+`fetch()` for any of them, so their happy path had never run anywhere. We have no org account
+for any of the three, so the reader is replaced at the `lazy_reader` seam (see `_reader_fakes`)
+and the whole adapter body runs — reader construction, branch selection, and the metadata →
+`RawDoc` mapping.
+
+What this tier proves: our code is correct GIVEN the reader shape in `_reader_fakes`.
+What it can NOT prove: that the shape is real, that a token authenticates, or that the live API
+returns these metadata keys. The first of those is covered by `test_reader_api_conformance.py`
+against the installed library; the rest genuinely need an account and are recorded as such in
+`docs/TODO.md`.
+
+The mapping assertions matter more than they look: `source_ts` is the item's WORK-TIME, and a
+document that reaches the brain without one is ingested, attributed, and then silently dropped
+from the timeline. Each reader spells that field differently, so each spelling is pinned here.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from _reader_fakes import (
+    FakeConfluenceReader,
+    FakeDoc,
+    FakeGoogleDriveReader,
+    FakeNotionPageReader,
+    install,
+)
+from aios_ingest.sources.base import MissingExtraError
+from aios_ingest.sources.confluence import ConfluenceSource
+from aios_ingest.sources.gdrive import GoogleDriveSource
+from aios_ingest.sources.notion import NotionSource
+
+_REAL_CLIENT = httpx.Client  # captured before any monkeypatch rebinds httpx.Client
+
+
+def _no_notion_api(monkeypatch):
+    """Notion's author enrichment calls the Notion API per page. Point it at a transport that
+    fails every request, so the enrichment's best-effort contract is what's exercised — a page
+    still yields, just unattributed. Tests that care about enrichment install their own."""
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    monkeypatch.setattr(
+        httpx, "Client", lambda **kw: _REAL_CLIENT(transport=httpx.MockTransport(handler))
+    )
+
+
+# -- Notion ---------------------------------------------------------------------------------
+def test_notion_passes_the_token_and_loads_the_requested_pages(monkeypatch):
+    _no_notion_api(monkeypatch)
+    spy = install(
+        monkeypatch,
+        "notion",
+        FakeNotionPageReader,
+        docs=[FakeDoc(text="body text", metadata={"page_id": "p1"})],
+    )
+
+    docs = list(NotionSource(token="secret-tok", page_ids=["p1"]).fetch())
+
+    assert spy.init_kwargs == {"integration_token": "secret-tok"}
+    assert spy.load_kwargs == {"page_ids": ["p1"]}
+    assert [(d.source, d.external_id, d.body) for d in docs] == [("notion", "p1", "body text")]
+
+
+def test_notion_database_selection_reaches_the_reader(monkeypatch):
+    """A `database_id` connection must actually load that database.
+
+    Not a hypothetical branch: `connections.yaml.example` ships `database_id` as THE Notion
+    example, so the copy-pasteable config is this path. The reader takes `database_ids` (plural,
+    a LIST); a single-valued `database_id=` is not an alias, it is a TypeError — and `sync` has
+    no per-connection try/except, so it aborts the operator's whole run and silently stops every
+    connection listed after it. Same shape as the `--source github` example retired in #431.
+    """
+    _no_notion_api(monkeypatch)
+    spy = install(
+        monkeypatch,
+        "notion",
+        FakeNotionPageReader,
+        docs=[FakeDoc(text="from db", metadata={"page_id": "p9"})],
+    )
+
+    docs = list(NotionSource(token="t", database_id="db-1").fetch())
+
+    assert spy.load_kwargs == {"database_ids": ["db-1"]}
+    assert [d.external_id for d in docs] == ["p9"]
+
+
+def test_notion_requires_a_selection():
+    with pytest.raises(ValueError):
+        NotionSource(token="t")
+
+
+def test_notion_enriches_authors_and_backfills_work_time(monkeypatch):
+    """The reader's metadata carries only `page_id` — no author, no timestamp. Both come from
+    the Notion API pass, and both are load-bearing: without authors the item lands on the
+    connector account, without a work-time the timeline drops it."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/pages/p1":
+            return httpx.Response(
+                200,
+                json={
+                    "created_by": {"id": "u1"},
+                    "last_edited_by": {"id": "u2"},
+                    "last_edited_time": "2026-07-20T10:00:00.000Z",
+                },
+            )
+        if req.url.path == "/v1/users/u1":
+            return httpx.Response(
+                200, json={"type": "person", "name": "Ada", "person": {"email": "ada@x.co"}}
+            )
+        if req.url.path == "/v1/users/u2":
+            return httpx.Response(200, json={"type": "bot", "name": "AIOS sync"})
+        return httpx.Response(404)
+
+    monkeypatch.setattr(
+        httpx, "Client", lambda **kw: _REAL_CLIENT(transport=httpx.MockTransport(handler))
+    )
+    install(
+        monkeypatch,
+        "notion",
+        FakeNotionPageReader,
+        docs=[FakeDoc(text="b", metadata={"page_id": "p1"})],
+    )
+
+    (doc,) = list(NotionSource(token="t", page_ids=["p1"]).fetch())
+
+    assert doc.source_ts == "2026-07-20T10:00:00.000Z"  # work-time, else the timeline drops it
+    assert doc.authors == [
+        {
+            "role": "author",
+            "provider": "notion",
+            "external_id": "u1",
+            "email": "ada@x.co",
+            "display_name": "Ada",
+        }
+    ]  # the bot editor is excluded — it is never a mappable human
+
+
+def test_notion_page_still_yields_when_the_api_pass_fails(monkeypatch):
+    """Enrichment is best-effort by contract: an API hiccup must cost attribution, not the
+    document. Losing the page instead would turn a transient 500 into missing content."""
+    _no_notion_api(monkeypatch)
+    install(
+        monkeypatch,
+        "notion",
+        FakeNotionPageReader,
+        docs=[FakeDoc(text="b", metadata={"page_id": "p1"})],
+    )
+
+    (doc,) = list(NotionSource(token="t", page_ids=["p1"]).fetch())
+
+    assert doc.external_id == "p1"
+    assert doc.authors is None and doc.source_ts is None
+
+
+# -- Google Drive ---------------------------------------------------------------------------
+def test_gdrive_folder_branch_and_metadata_mapping(monkeypatch):
+    """Drive's reader spells its metadata with SPACES (`file id`, `modified at`). The work-time
+    lookup is spelling-insensitive and must match `modified at`; a miss here is silent — the
+    doc ingests and never appears on the timeline."""
+    spy = install(
+        monkeypatch,
+        "gdrive",
+        FakeGoogleDriveReader,
+        docs=[
+            FakeDoc(
+                text="drive body",
+                metadata={
+                    "file id": "f1",
+                    # A DISPLAY NAME, not an email — the reader emits `owners[0].displayName`
+                    # (or literally "Shared Drive"). The brain resolves the bare `author` string
+                    # only as an email, which is why Drive items are unattributable and why the
+                    # fix is an owner-enrichment pass, not a mapping tweak (docs/TODO.md).
+                    "author": "Ada Lovelace",
+                    "file path": "Team/Notes.docx",
+                    "mime type": "application/vnd.google-apps.document",
+                    "created at": "2026-07-01T00:00:00Z",
+                    "modified at": "2026-07-20T09:00:00Z",
+                },
+            )
+        ],
+    )
+
+    (doc,) = list(GoogleDriveSource(folder_id="fold-1").fetch())
+
+    assert spy.load_kwargs == {"folder_id": "fold-1"}
+    assert doc.source == "gdrive" and doc.external_id == "f1"
+    assert doc.author == "Ada Lovelace"
+    assert doc.authors is None  # no owner enrichment for Drive — the item is credited to nobody
+    assert doc.source_ts == "2026-07-20T09:00:00Z"  # edit time beats creation time
+
+
+def test_gdrive_service_account_key_is_only_passed_when_set(monkeypatch):
+    """The reader defaults `service_account_key_path` to a literal `service_account_key.json`.
+    Forwarding `None` would override that default with a value it cannot open, so an
+    unconfigured connection must not send the kwarg at all."""
+    spy = install(monkeypatch, "gdrive", FakeGoogleDriveReader, docs=[])
+    list(GoogleDriveSource(file_ids=["f1"]).fetch())
+    assert spy.init_kwargs == {}  # nothing passed at all — not `service_account_key_path=None`
+    assert spy.load_kwargs == {"file_ids": ["f1"]}
+
+    spy2 = install(monkeypatch, "gdrive", FakeGoogleDriveReader, docs=[])
+    list(GoogleDriveSource(file_ids=["f1"], service_account_key_path="/k.json").fetch())
+    assert spy2.init_kwargs["service_account_key_path"] == "/k.json"
+
+
+def test_gdrive_requires_a_selection():
+    with pytest.raises(ValueError):
+        GoogleDriveSource()
+
+
+# -- Confluence -----------------------------------------------------------------------------
+def test_confluence_space_and_page_branches(monkeypatch):
+    spy = install(
+        monkeypatch,
+        "confluence",
+        FakeConfluenceReader,
+        docs=[FakeDoc(text="page body", metadata={"page_id": "c1", "title": "Runbook"})],
+    )
+
+    (doc,) = list(ConfluenceSource(base_url="https://x.atlassian.net/wiki", space_key="ENG").fetch())
+
+    # Exact, not subset: forwarding an extra kwarg would slip through a subset check, and
+    # `cloud=None` in particular overrides the reader's `cloud=True` default and changes which
+    # Atlassian API dialect the client speaks.
+    assert spy.init_kwargs == {"base_url": "https://x.atlassian.net/wiki"}
+    assert spy.load_kwargs == {"space_key": "ENG"}
+    assert (doc.source, doc.external_id, doc.title) == ("confluence", "c1", "Runbook")
+
+    spy2 = install(monkeypatch, "confluence", FakeConfluenceReader, docs=[])
+    list(ConfluenceSource(base_url="https://x/wiki", page_ids=["c9"]).fetch())
+    assert spy2.load_kwargs == {"page_ids": ["c9"]}
+
+
+def test_confluence_requires_a_selection():
+    with pytest.raises(ValueError):
+        ConfluenceSource(base_url="https://x/wiki")
+
+
+# -- shared -------------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("module", "build"),
+    [
+        ("notion", lambda: NotionSource(token="t", page_ids=["p"])),
+        ("gdrive", lambda: GoogleDriveSource(folder_id="f")),
+        ("confluence", lambda: ConfluenceSource(base_url="https://x/wiki", space_key="S")),
+    ],
+)
+def test_a_missing_extra_surfaces_as_the_install_hint(monkeypatch, module, build):
+    """The extras are opt-in, so "reader not installed" is a normal operator state. It must
+    reach them as the actionable MissingExtraError, not an ImportError from deep inside a
+    generator — and because `fetch` is a generator, it only raises once iterated."""
+
+    def raise_missing(*a, **kw):
+        raise MissingExtraError(module, f"llama-index-readers-{module}")
+
+    monkeypatch.setattr(f"aios_ingest.sources.{module}.lazy_reader", raise_missing)
+    with pytest.raises(MissingExtraError, match=module):
+        list(build().fetch())

--- a/ingestion/tests/test_reader_api_conformance.py
+++ b/ingestion/tests/test_reader_api_conformance.py
@@ -1,0 +1,181 @@
+"""Conformance: the reader APIs our adapters call must exist in the INSTALLED libraries.
+
+`test_reader_adapters.py` drives `fetch()` through hand-written fakes, which proves our code
+is right given a believed reader shape. This tier proves the belief — no account, no network,
+just the real classes' signatures.
+
+It is the tier that catches the failure mode that actually bites on a first run: a kwarg the
+library does not take, or one it renamed in a minor bump. It caught a live one when it was
+written — `NotionPageReader.load_data` has no `database_id`, only `database_ids` (a list), so
+every Notion *database* connection raised TypeError on its first tick.
+
+What it still cannot cover: authentication, scopes, pagination and the live API's metadata
+keys. Those need a real account; `docs/TODO.md` records them as open rather than implying this
+tier closed them.
+
+Requires the reader extras (`.[notion,gdrive,confluence]`), which CI installs. Locally without
+them the checks skip — so `test_conformance_is_not_silently_skipped_in_ci` fails the build if
+CI ever loses the extras and these vanish into a green run.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import re
+
+import pytest
+
+from _reader_fakes import ALL_FAKES
+
+# Every reader kwarg our adapters actually pass, with the call site that passes it. Kept
+# explicit rather than derived: a check that reads the same source it is checking cannot fail.
+ADAPTER_CALLS = [
+    # aios_ingest/sources/notion.py
+    ("llama_index.readers.notion", "NotionPageReader", "__init__", ["integration_token"]),
+    ("llama_index.readers.notion", "NotionPageReader", "load_data", ["page_ids", "database_ids"]),
+    # aios_ingest/sources/gdrive.py
+    ("llama_index.readers.google", "GoogleDriveReader", "__init__", ["service_account_key_path"]),
+    ("llama_index.readers.google", "GoogleDriveReader", "load_data", ["folder_id", "file_ids"]),
+    # aios_ingest/sources/confluence.py
+    ("llama_index.readers.confluence", "ConfluenceReader", "__init__", ["base_url"]),
+    ("llama_index.readers.confluence", "ConfluenceReader", "load_data", ["space_key", "page_ids"]),
+]
+
+# The reader-extra → import module map, so a skip names the extra an operator would install.
+EXTRA_FOR_MODULE = {
+    "llama_index.readers.notion": "notion",
+    "llama_index.readers.google": "gdrive",
+    "llama_index.readers.confluence": "confluence",
+}
+
+
+def _reader_class(module: str, cls: str):
+    mod = pytest.importorskip(
+        module, reason=f"needs the '{EXTRA_FOR_MODULE[module]}' extra (CI installs it)"
+    )
+    return getattr(mod, cls)
+
+
+def _params(func) -> tuple[set[str], bool]:
+    """(parameter names, accepts **kwargs). A `**kwargs` reader — GoogleDriveReader has one —
+    would swallow any name, so a bind-based check passes vacuously there; only an explicit
+    name comparison is non-vacuous."""
+    sig = inspect.signature(func)
+    names = {
+        p.name
+        for p in sig.parameters.values()
+        if p.kind in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+    }
+    var_kw = any(p.kind is p.VAR_KEYWORD for p in sig.parameters.values())
+    return names, var_kw
+
+
+@pytest.mark.parametrize(
+    ("module", "cls", "method", "kwargs"),
+    ADAPTER_CALLS,
+    ids=[f"{c}.{m}" for _, c, m, _ in ADAPTER_CALLS],
+)
+def test_adapter_kwargs_exist_on_the_real_reader(module, cls, method, kwargs):
+    reader = _reader_class(module, cls)
+    names, _ = _params(getattr(reader, method))
+    missing = [k for k in kwargs if k not in names]
+    assert not missing, (
+        f"{cls}.{method} does not accept {missing} — the adapter passes it, so this connection "
+        f"raises TypeError on its first run. Real parameters: {sorted(names)}"
+    )
+
+
+@pytest.mark.parametrize("fake", ALL_FAKES, ids=[f.__name__ for f in ALL_FAKES])
+def test_the_fakes_are_not_a_lie(fake):
+    """Every parameter a fake accepts must exist on the real class.
+
+    Without this, the adapter tier is only as true as a hand-copied signature — and a fake that
+    accepts a kwarg the library rejects grants exactly the false confidence this whole PR exists
+    to remove. A rename in a minor bump fails HERE, naming `_reader_fakes.py`.
+    """
+    module, cls = fake.real
+    real = _reader_class(module, cls)
+    for method in ("__init__", "load_data"):
+        fake_names, fake_var_kw = _params(getattr(fake, method))
+        # A real `**kwargs` (GoogleDriveReader.__init__ has one) can only make this check
+        # weaker, never wrong: it would let a bad name through here and fail on the live call
+        # instead. A `**kwargs` on the FAKE is fatal, though — it accepts everything.
+        real_names, _ = _params(getattr(real, method))
+        assert not fake_var_kw, f"{fake.__name__}.{method} takes **kwargs — it would accept anything"
+        extra = fake_names - real_names - {"self"}
+        assert not extra, (
+            f"{fake.__name__}.{method} accepts {sorted(extra)}, which {cls}.{method} does not. "
+            f"Update _reader_fakes.py to the real signature: {sorted(real_names - {'self'})}"
+        )
+
+
+def test_confluence_credentials_are_read_the_way_the_docs_claim():
+    """The adapter passes only `base_url` and lets the reader read credentials from the
+    environment. That contract is what the README documents to operators, and it was WRONG once
+    already (it told people to combine a token with a username, which the reader never accepts).
+    So pin both halves: the env names, and the fact that token and user+password are mutually
+    exclusive branches rather than a combination.
+    """
+    reader_cls = _reader_class("llama_index.readers.confluence", "ConfluenceReader")
+    base_url = "https://example.atlassian.net/wiki"
+
+    # Constructing the reader builds an HTTP client object; it makes no request, so this is
+    # offline. Asserted behaviourally rather than by reading the library's source, so a
+    # reformatting of the reader can't turn this red on an unrelated PR.
+    with pytest.MonkeyPatch.context() as mp:
+        for var in ("CONFLUENCE_API_TOKEN", "CONFLUENCE_USERNAME", "CONFLUENCE_PASSWORD"):
+            mp.delenv(var, raising=False)
+        with pytest.raises(ValueError):
+            reader_cls(base_url=base_url)  # no credential anywhere → refuses to construct
+
+        mp.setenv("CONFLUENCE_API_TOKEN", "tok")
+        assert reader_cls(base_url=base_url) is not None  # token ALONE is sufficient
+
+    with pytest.MonkeyPatch.context() as mp:
+        # All three, not just the token: a developer who actually uses Confluence would have
+        # CONFLUENCE_PASSWORD set, and the reader would pair it with the fake username below —
+        # constructing successfully and failing this test on their machine only.
+        for var in ("CONFLUENCE_API_TOKEN", "CONFLUENCE_USERNAME", "CONFLUENCE_PASSWORD"):
+            mp.delenv(var, raising=False)
+        mp.setenv("CONFLUENCE_USERNAME", "ada@x.co")
+        with pytest.raises(ValueError):
+            reader_cls(base_url=base_url)  # a username WITHOUT a password is not a credential
+        mp.setenv("CONFLUENCE_PASSWORD", "pw")
+        assert reader_cls(base_url=base_url) is not None  # username + password is the other branch
+
+
+def test_notion_reader_carries_no_timestamp_so_the_api_backfill_is_load_bearing():
+    """`NotionSource` makes an extra API call per page purely to recover `last_edited_time`,
+    because the reader's Document metadata has only `page_id`. If the reader ever starts
+    emitting timestamps that call becomes removable — and if someone deletes it believing the
+    reader supplies one, pages lose their work-time and drop off the timeline silently.
+    """
+    notion = pytest.importorskip("llama_index.readers.notion", reason="needs the 'notion' extra")
+    # Whitespace-normalized so reformatting the library can't turn this red on an unrelated PR.
+    load = re.sub(r"\s+", "", inspect.getsource(notion.NotionPageReader.load_data))
+    assert 'extra_info={"page_id":page_id}' in load, (
+        "NotionPageReader's document metadata changed — re-check whether "
+        "NotionAuthorClient.page_edit_time is still needed for work-time"
+    )
+
+
+def test_conformance_is_not_silently_skipped_in_ci():
+    """A skipped conformance tier is indistinguishable from a passing one in a green CI run.
+
+    The reader extras are opt-in, so skipping is right on a laptop — but if the CI job ever
+    drops them, every check above turns into a silent skip and this file stops guarding
+    anything. In CI the extras are mandatory.
+    """
+    if not os.environ.get("CI"):
+        pytest.skip("local run — the reader extras are optional off CI")
+    import importlib
+
+    for module, extra in EXTRA_FOR_MODULE.items():
+        try:
+            importlib.import_module(module)
+        except ImportError as e:  # pragma: no cover - only on a broken CI install
+            pytest.fail(
+                f"CI must install the '{extra}' extra or the reader conformance checks skip "
+                f"silently: {e}"
+            )


### PR DESCRIPTION
Notion, Google Drive and Confluence were the connectors the README called **"wired but unproven"** — real registered code, no test of `fetch()` for any of them. We have no org accounts for the three, so this closes everything that *is* coverable without one, and says plainly what still isn't.

It found a live bug on the way in.

## The bug

`NotionPageReader.load_data` has no `database_id` parameter — only **`database_ids`**, plural, a list. `sources/notion.py` passed the singular form, so a Notion **database** connection raised `TypeError` on its first tick. That's the branch `connections.yaml.example` ships as *the* Notion example, and since `sync` (`cli.py:125`) runs a bare `for` loop with no per-connection `try/except`, it aborted the operator's entire run and silently stopped every connection after it.

Same shape as the `--source github` example retired in #431: a copy-pasteable config that always failed.

## Two tiers, and why neither is worth much alone

| tier | file | proves |
|---|---|---|
| adapter | `ingestion/tests/test_reader_adapters.py` | `fetch()` end to end against stand-in readers swapped in at the `lazy_reader` seam — reader construction, branch selection, and the metadata → `RawDoc` mapping including **work-time**, whose absence silently drops a document from the timeline |
| conformance | `ingestion/tests/test_reader_api_conformance.py` | every kwarg those adapters pass **exists on the real installed reader class**, and the stand-ins accept nothing the real class rejects |

The adapter tier alone is only as true as a hand-copied signature — a fake with `**kwargs` would accept calls the library rejects and grant exactly the false confidence this PR exists to remove. The conformance tier is what makes it honest, and it's what caught the Notion bug.

CI installs the reader extras so the conformance tier actually runs; `test_conformance_is_not_silently_skipped_in_ci` fails the build if CI ever loses them, because a skipped tier is indistinguishable from a passing one in a green run. The extras are **deliberately unpinned** — operators install unpinned, so testing a pinned version would prove nothing about what they run; the reasoning and what to do about a resulting red are recorded in `ci.yml`.

## What this does NOT prove — stated so a green suite can't be misread

That a credential authenticates, that the documented Confluence recipe works against Atlassian Cloud, that pagination behaves over a real corpus, or that the live APIs return the metadata keys the fakes assert. Recorded in `docs/TODO.md` with the respx-replay path for when an account exists.

## The real Drive gap, filed not papered over

Drive's blocker isn't the missing test. Unlike Notion (`notion_authors.py`), `gdrive.py` has **no owner-enrichment pass**, and the reader's `author` is a bare display string — so a Drive doc is ingested and searchable but **credited to nobody**: never under a person on the timeline, never eligible for the LLM doc→task pass. Filed in `docs/TODO.md` with the implementation, plus the two mapping gaps beside it (Drive items get a null title and null URL — the reader spells it `file path`, with a space).

README and `ingestion/README.md` updated so neither implies these connectors are done.

## Review — Reviewed by Fable (`code-reviewer`) — verdict BLOCKED → CLEAR

Round 1 was **BLOCKED**, and it was right: it mutation-proved that one of my own tests was **vacuous**. `test_gdrive_service_account_key_is_only_passed_when_set` stayed green under the exact bug its docstring described, because the fake defaulted params to `None` and forwarded them unconditionally — canonicalizing "omitted" into "explicitly passed `None`". Fixed with an `_UNSET` sentinel; I re-ran Fable's mutation and it now goes red. Also fixed: the seam ignored *which* reader class the adapter asked for, so a typo'd class name would have passed both tiers and `AttributeError`d on the first live run.

Round 2 returned **CLEAR** and found two more one-liners in the same class, both folded in: the Confluence credential test read the developer's real env (a spurious failure on the machine of anyone who actually uses Confluence), and its init assertion was subset-only, so an extra `cloud=None` — which changes the Atlassian API dialect — slipped through.

Every guard here was mutation-tested, including the CI-skip guard (simulated a CI run without the extras: fails loudly; laptop without them: skips cleanly).

## Verification

- ingestion pytest **108 passed** (laptop) / **109 passed** with `CI=true` (conformance tier live)
- unit **1402** ✅ · lint ✅ · typecheck ✅ · docs-drift ✅
- data-mechanics not run: no TS, schema, or persistence changes in the diff