### PR TITLE
feat(pulse): bound the Pulse header into a one-screen snapshot

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -39,9 +39,12 @@ import { TaskFunnel } from "@/components/charts/task-funnel";
 export const metadata: Metadata = { title: "Pulse" };
 
 /** A collapsed section that defers its heavy/secondary content behind a disclosure. */
-function Section({ title, subtitle, defaultOpen = false, children }: { title: string; subtitle?: string; defaultOpen?: boolean; children: React.ReactNode }) {
+function Section({ id, title, subtitle, defaultOpen = false, children }: { id?: string; title: string; subtitle?: string; defaultOpen?: boolean; children: React.ReactNode }) {
   return (
-    <details open={defaultOpen} className="group/sec rounded-lg border border-border-subtle px-4 py-3">
+    // `id` is the anchor target for the snapshot's "Full timeline →" — it scrolls the disclosure into
+    // view (still one click to open). Deliberately not auto-opened: fragment auto-expansion of <details>
+    // is not portable across browsers, so relying on it would work in Chrome and silently do nothing else.
+    <details id={id} open={defaultOpen} className="group/sec scroll-mt-4 rounded-lg border border-border-subtle px-4 py-3">
       <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
         <ChevronRight className="size-3.5 shrink-0 transition-transform group-open/sec:rotate-90" />
         {title}
@@ -184,7 +187,7 @@ export default async function TeamHome({
   ]);
 
   return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+    <div className="mx-auto flex max-w-6xl flex-col gap-6">
       {pipelineHealth ? <PipelineHealthBanner health={pipelineHealth} href={`/t/${teamSlug}/admin/integrations#ingestion-runs`} /> : null}
 
       <div>
@@ -203,19 +206,37 @@ export default async function TeamHome({
 
       <AskBar teamSlug={teamSlug} teamName={team.name} />
 
-      {/* HERO — narrative arcs: the story of the team right now. */}
+      {/* ── SNAPSHOT ─────────────────────────────────────────────────────────────────────────────────
+          The bounded "one screen" answer to *what's happening right now*. Every band here is capped, so
+          the header's height is CONSTANT regardless of how many arcs/people exist — the property that
+          separates a dashboard from the feed this page used to be. Everything below is a disclosure. */}
+
+      {/* The three numbers, promoted out of the Metrics disclosure. The range selector comes with them
+          because it's what scopes them; the charts it also drives stay collapsed below. */}
       <section className="flex flex-col gap-3">
-        <BandHeading title="Narrative arcs · most recent" />
-        <ArcsPanel teamSlug={teamSlug} />
+        <div className="flex items-center justify-between gap-3">
+          <BandHeading title="At a glance" />
+          <RangeSelector value={range} />
+        </div>
+        <KpiBand kpis={pulse.kpis} teamSlug={teamSlug} />
       </section>
 
-      {/* Who's doing what — reads the SAME work-timeline layer as the Timeline below (shared card), so
-          they agree by construction. The consistency fix (#358) lives inside this component, which
-          renders its own "Working on" heading. */}
-      <WorkingOn teamSlug={teamSlug} />
+      {/* Story beside people, not above them — the single column was leaving ~half the width empty while
+          pushing "who's on what" a full screen down. */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <section className="flex flex-col gap-3 lg:col-span-2">
+          <BandHeading title="What's happening" />
+          <ArcsPanel teamSlug={teamSlug} variant="digest" />
+        </section>
+
+        {/* Who's doing what — reads the SAME work-timeline layer as the Timeline below (shared card), so
+            they agree by construction. The consistency fix (#358) lives inside this component, which
+            renders its own "Working on" heading. */}
+        <WorkingOn teamSlug={teamSlug} variant="roster" timelineHref="#timeline" />
+      </div>
 
       {/* Timeline — the per-day drill-down (absorbed from the old Learning tab), collapsed by default. */}
-      <Section title="Timeline" subtitle="recent work, by day">
+      <Section id="timeline" title="Timeline" subtitle="recent work, by day">
         <Suspense
           fallback={
             <p className="flex items-center gap-2 px-1 py-4 text-sm text-ink-tertiary">
@@ -227,14 +248,12 @@ export default async function TeamHome({
         </Suspense>
       </Section>
 
-      {/* Operational metrics — subordinate to the story; open for admins, collapsed for members. The
-          range selector lives here because it only drives these charts. */}
-      <Section title="Metrics" subtitle="knowledge, usage, and tasks" defaultOpen={isAdmin}>
+      {/* Operational charts — subordinate to the story, and now collapsed for EVERYONE. The headline
+          numbers were promoted to the "At a glance" ribbon (with the range selector that scopes them);
+          what's left is ~700px of charts, which is drill-down, not snapshot. Opening it by default for
+          admins was pushing the fold down for exactly the people who look at this page most. */}
+      <Section title="Metrics" subtitle="knowledge, usage, and tasks">
         <div className="flex flex-col gap-6">
-          <div className="flex items-center justify-end">
-            <RangeSelector value={range} />
-          </div>
-          <KpiBand kpis={pulse.kpis} teamSlug={teamSlug} />
           {/* Brain usage (queries + spend) is the primary signal, so it gets the width; knowledge
               growth is a smaller secondary visual beside it. */}
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/components/dashboard/person-work-card.tsx
+++ b/components/dashboard/person-work-card.tsx
@@ -6,6 +6,7 @@ import { GitBranch, Gavel } from "lucide-react";
 import { MemberAvatar } from "@/components/people/member-avatar";
 import { SourceIcon, sourceLabel } from "@/components/icons/source-icon";
 import type { PersonDay, SignalGroup, SourceGroup, TaskGroup } from "@/lib/dashboard/timeline-group";
+import { headlineTask } from "@/lib/dashboard/pulse-digest";
 
 /**
  * One person's work card — the shared presentational unit behind BOTH the Pulse Timeline panel
@@ -125,8 +126,40 @@ function TaskCard({ task }: { task: TaskGroup }) {
   );
 }
 
-export function PersonWorkCard({ person }: { person: PersonDay }) {
+/**
+ * The SNAPSHOT row — one person in ~56px instead of the full card's ~300px. Shows who, their counts, and
+ * the single task they're most active on (`headlineTask`); the evidence tree stays in the full card. Both
+ * variants render the same `PersonDay`, so the Pulse roster and the Timeline still agree by construction
+ * (the #358 invariant) — this is the same data at a second density, not a second implementation.
+ */
+function PersonWorkRow({ person }: { person: PersonDay }) {
   const p = person;
+  const lead = headlineTask(p);
+  return (
+    <div className="flex items-center gap-2.5 rounded-md border border-border-subtle/60 px-3 py-2">
+      <MemberAvatar person={{ displayName: p.name, avatarUrl: p.avatarUrl }} size={24} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <p className="truncate text-sm font-medium text-ink">{p.name}</p>
+          <p className="shrink-0 text-[11px] text-ink-tertiary">{personSummary(p)}</p>
+        </div>
+        {lead ? (
+          <div className="mt-0.5 flex items-center gap-1.5">
+            <SourceIcon source={lead.source} className="size-3 shrink-0" />
+            <span className="min-w-0 flex-1 truncate text-[12px] text-ink-secondary">{lead.title}</span>
+          </div>
+        ) : p.summary ? (
+          <p className="mt-0.5 truncate text-[12px] text-ink-secondary">{p.summary}</p>
+        ) : null}
+      </div>
+      {lead ? <StatusPill status={lead.status} /> : null}
+    </div>
+  );
+}
+
+export function PersonWorkCard({ person, variant = "full" }: { person: PersonDay; variant?: "full" | "row" }) {
+  const p = person;
+  if (variant === "row") return <PersonWorkRow person={p} />;
   return (
     <div className="prism-card flex flex-col gap-3 p-4">
       <div className="flex items-center gap-2.5">

--- a/components/dashboard/working-on.tsx
+++ b/components/dashboard/working-on.tsx
@@ -4,14 +4,26 @@ import { useEffect, useState } from "react";
 import { Users } from "lucide-react";
 import type { PersonDay } from "@/lib/dashboard/timeline-group";
 import { PersonWorkCard } from "@/components/dashboard/person-work-card";
+import { digest, DIGEST_PEOPLE_LIMIT } from "@/lib/dashboard/pulse-digest";
 
 /**
- * Consolidated "Working On" — one card per person showing what they were MOST RECENTLY working on.
+ * Consolidated "Working On" — one entry per person showing what they were MOST RECENTLY working on.
  * Fetches `/api/dashboard/team-work`, which collapses the SAME work-timeline the Pulse Timeline
  * disclosure renders to each person's most recent day — so the two surfaces are IDENTICAL (shared
  * `PersonWorkCard`). Client-fetched so a cold-cache rebuild never blocks the home page render.
+ *
+ * `variant="roster"` is the Pulse snapshot density: compact rows capped at `DIGEST_PEOPLE_LIMIT`, so a
+ * growing team can't push the fold down. The full cards remain the Timeline's rendering.
  */
-export function WorkingOn({ teamSlug }: { teamSlug: string }) {
+export function WorkingOn({
+  teamSlug,
+  variant = "cards",
+  timelineHref,
+}: {
+  teamSlug: string;
+  variant?: "cards" | "roster";
+  timelineHref?: string;
+}) {
   const [people, setPeople] = useState<PersonDay[] | null>(null);
   const [failed, setFailed] = useState(false);
 
@@ -32,10 +44,21 @@ export function WorkingOn({ teamSlug }: { teamSlug: string }) {
     };
   }, [teamSlug]);
 
+  const isRoster = variant === "roster";
+  const view = isRoster ? digest(people ?? [], DIGEST_PEOPLE_LIMIT) : null;
+
   return (
-    <section className="prism-card px-5 py-4">
-      <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
-        <Users className="size-3.5 text-violet" /> Working on
+    <section className="prism-card flex h-full flex-col px-5 py-4">
+      <h2 className="mb-3 flex flex-wrap items-center gap-x-2 text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
+        <span className="flex items-center gap-2">
+          <Users className="size-3.5 text-violet" /> Working on
+        </span>
+        {/* The band only ever covers each person's MOST RECENT day. Saying so matters: unlabelled, a
+            roster of 2 out of 9 members reads as "the team is idle" rather than "2 people have activity
+            in this window" — a wrong impression the compact density would only sharpen. */}
+        {isRoster ? (
+          <span className="font-normal normal-case tracking-normal text-ink-tertiary/70">· most recent activity</span>
+        ) : null}
       </h2>
 
       {people === null && !failed ? (
@@ -44,6 +67,20 @@ export function WorkingOn({ teamSlug }: { teamSlug: string }) {
         <p className="text-sm text-ink-tertiary">Couldn&apos;t load team activity right now.</p>
       ) : people && people.length === 0 ? (
         <p className="text-sm text-ink-tertiary">No recent team activity to show yet.</p>
+      ) : view ? (
+        <div className="flex flex-col gap-2">
+          {view.shown.map((p) => (
+            <PersonWorkCard key={p.memberId} person={p} variant="row" />
+          ))}
+          {view.hidden > 0 ? (
+            <p className="text-[11px] text-ink-tertiary">+{view.hidden} more with recent activity</p>
+          ) : null}
+          {timelineHref ? (
+            <a href={timelineHref} className="mt-1 w-fit text-xs font-medium text-violet hover:underline">
+              Full timeline →
+            </a>
+          ) : null}
+        </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           {(people ?? []).map((p) => (

--- a/components/learning/arcs-panel.tsx
+++ b/components/learning/arcs-panel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Loader2, Sparkles, RefreshCw, ChevronRight, ExternalLink } from "lucide-react";
+import { digest, DIGEST_ARC_LIMIT } from "@/lib/dashboard/pulse-digest";
 
 interface ArcEvidence {
   fact: string;
@@ -30,9 +31,18 @@ const CONF: Record<string, string> = {
 
 type Status = "loading" | "ready" | "error";
 
-/** Layer 3 — narrative arcs, with inline-editable summaries + human-correction recompute. */
-export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
+/**
+ * Layer 3 — narrative arcs, with inline-editable summaries + human-correction recompute.
+ *
+ * `variant="digest"` is the Pulse SNAPSHOT rendering: the top `DIGEST_ARC_LIMIT` arcs as clamped
+ * headlines, so the band that answers "what's happening" has a fixed height instead of one proportional
+ * to `MAX_ARCS`. It expands to the full editable list in place ("Show all N") — deliberately ONE panel
+ * rather than a digest up top plus a duplicate list below, so there is no second fetch and no way for
+ * the two to disagree. Editing is a full-view affordance: a two-line clamp is not an editing surface.
+ */
+export function ArcsPanel({ teamSlug, variant = "full" }: { teamSlug: string; variant?: "full" | "digest" }) {
   const [arcs, setArcs] = useState<Arc[]>([]);
+  const [expanded, setExpanded] = useState(false);
   const [status, setStatus] = useState<Status>("loading");
   // Why the panel is empty (server-diagnosed): no_facts | model_failing | synthesis_empty | null.
   const [emptyReason, setEmptyReason] = useState<string | null>(null);
@@ -146,6 +156,75 @@ export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
     );
   }
 
+  // Unsaved corrections must follow the user across the collapse. The digest renders `edited[...]` text,
+  // so without this a collapsed panel showed a correction as if it had been applied while the only save
+  // control lived in the expanded view — an in-memory edit with no visible way to commit or discard it.
+  const pendingCount = Object.keys(edited).length;
+  // The failure notice travels WITH the Recompute button. Rendering the control in both densities but the
+  // "it didn't save" alert in only one would recreate the silent-revert the alert exists to prevent.
+  const pendingBanner = (
+    <>
+      {pendingCount > 0 ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-violet/25 bg-violet/5 px-4 py-3">
+          <p className="text-sm text-ink-secondary">
+            {pendingCount} arc{pendingCount > 1 ? "s" : ""} edited — recompute to fold your corrections back
+            into the graph.
+          </p>
+          <button
+            type="button"
+            onClick={recompute}
+            disabled={recomputing}
+            className="btn-prism inline-flex shrink-0 items-center gap-1.5"
+          >
+            {recomputing ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
+            Recompute
+          </button>
+        </div>
+      ) : null}
+      {saveError ? (
+        <p role="alert" className="px-1 pt-2 text-sm text-rose-500">
+          {saveError}
+        </p>
+      ) : null}
+    </>
+  );
+
+  // SNAPSHOT — bounded headlines. Height stops tracking arc count, which is the whole point of the
+  // Pulse header; the full list (with editing + evidence) is one click away in the same panel.
+  if (variant === "digest" && !expanded) {
+    const { shown, hidden, total } = digest(arcs, DIGEST_ARC_LIMIT);
+    return (
+      <div className="flex flex-col gap-2">
+        {shown.map((arc) => (
+          <div key={arc.id} className="prism-card flex flex-col gap-1 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <h3 className="text-sm font-medium leading-snug text-ink">{arc.title}</h3>
+              <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${CONF[arc.confidence]}`}>
+                {arc.confidence}
+              </span>
+            </div>
+            <p className="line-clamp-2 text-[13px] leading-snug text-ink-secondary">
+              {edited[arc.id] ?? arc.summary}
+            </p>
+          </div>
+        ))}
+        {/* UNCONDITIONAL — not `hidden > 0`. This panel is mounted in exactly one place (the Pulse
+            snapshot), so gating the only route into the expanded view on "there are more than 3 arcs"
+            made summary editing, human-correction recompute, evidence trails, and the un-clamped
+            prose unreachable ANYWHERE in the product whenever the model returned ≤ 3 arcs. */}
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          aria-expanded={false}
+          className="w-fit text-xs font-medium text-violet hover:underline"
+        >
+          {hidden > 0 ? `Show all ${total} arcs →` : "View & edit arcs →"}
+        </button>
+        {pendingBanner}
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-3">
       {arcs.map((arc) => {
@@ -236,28 +315,19 @@ export function ArcsPanel({ teamSlug }: { teamSlug: string }) {
         );
       })}
 
-      {Object.keys(edited).length > 0 ? (
-        <div className="flex items-center justify-between gap-3 rounded-xl border border-violet/25 bg-violet/5 px-4 py-3">
-          <p className="text-sm text-ink-secondary">
-            {Object.keys(edited).length} arc{Object.keys(edited).length > 1 ? "s" : ""} edited — recompute to
-            fold your corrections back into the graph.
-          </p>
-          <button
-            type="button"
-            onClick={recompute}
-            disabled={recomputing}
-            className="btn-prism inline-flex shrink-0 items-center gap-1.5"
-          >
-            {recomputing ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
-            Recompute
-          </button>
-        </div>
+      {/* Reversible — an expansion you can't undo turns the snapshot into a one-way trip to the old feed. */}
+      {variant === "digest" ? (
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          aria-expanded={true}
+          className="w-fit text-xs font-medium text-violet hover:underline"
+        >
+          ← Show fewer
+        </button>
       ) : null}
-      {saveError ? (
-        <p role="alert" className="px-1 pt-2 text-sm text-rose-500">
-          {saveError}
-        </p>
-      ) : null}
+
+      {pendingBanner}
     </div>
   );
 }

--- a/docs/design/pulse-home.md
+++ b/docs/design/pulse-home.md
@@ -19,12 +19,54 @@ removed and "Home" was renamed **"Pulse"** (Brain icon).
 1. Admin pipeline-health banner (unchanged).
 2. Title "Pulse" + a **slim ask bar** (`components/dashboard/ask-bar`) — a single line that hands the
    question to the full Query chat (`/query?q=…`), replacing the old embedded query hero (`AskBrain`, removed).
-3. **HERO — Narrative arcs** (`ArcsPanel`, promoted from Learning): the story of the team right now.
-4. **Working on — per person** (`WorkingOn`): who's doing what.
+3. **SNAPSHOT — "At a glance"**: the KPI ribbon + range selector.
+4. **SNAPSHOT — two columns**: "What's happening" (`ArcsPanel variant="digest"`, 2/3 width) beside
+   "Working on" (`WorkingOn variant="roster"`, 1/3).
 5. **Timeline** disclosure (collapsed): the per-day drill-down (`TimelinePanel`, moved from Learning).
-6. **Metrics** disclosure (open for admins): KPIs, knowledge growth, usage, task funnel, decisions,
-   range selector — subordinate to the story, not deleted.
+6. **Metrics** disclosure (collapsed): knowledge growth, usage, task funnel, decisions.
 7. **Evidence trail** disclosure (collapsed): the raw events + atomic facts (from Learning).
+
+## The snapshot pass — bounding the fold
+
+The first cut of Pulse got the *order* right (story → people → metrics → evidence) but built it in the
+wrong genre: a **feed**, where every band's height is proportional to how much data exists. So the band
+answering "what's happening" was also the tallest thing on the page and sat first. Measured on prod
+(6 arcs, ~400 chars of prose each): the arcs band alone ≈1,200px, the whole page ≈2,700px — about three
+viewports, with `MAX_ARCS = 12` free to double the top band at any time.
+
+A dashboard snapshot is the opposite property: **total height is constant regardless of data volume.**
+The rule is therefore *every above-the-fold band shows "N with a link", never "all N"*:
+
+- **`lib/dashboard/pulse-digest.ts`** owns the caps (`DIGEST_ARC_LIMIT = 3`, `DIGEST_PEOPLE_LIMIT = 6`)
+  and `headlineTask` as pure, tested values — not magic numbers inside JSX.
+  `test/pulse-digest.test.ts` asserts the capped counts as **literals**, so raising a cap goes red and
+  forces a deliberate decision about the fold.
+- **`ArcsPanel variant="digest"`** renders clamped headlines and expands to the full editable list
+  *in place* — one panel, not a digest plus a duplicate list, so there is no second fetch and no way for
+  the two to disagree. Editing stays a full-view affordance (a two-line clamp is not an editing surface).
+- **`PersonWorkCard variant="row"`** is the same `PersonDay` at a second density (~56px vs ~300px); the
+  evidence tree stays in the full card, so the #358 "identical by construction" invariant still holds.
+- **Two columns** (story beside people) — the single column left ~half the width empty while pushing
+  "who's on what" a full screen down. Container widened `max-w-5xl` → `max-w-6xl`.
+- **Metrics is collapsed for everyone.** The headline numbers were promoted to the ribbon (with the
+  range selector that scopes them); what remains is ~700px of charts, i.e. drill-down. Opening it by
+  default for admins pushed the fold down for the people who use the page most.
+
+`headlineTask` ranks via **`lib/tasks/activity-policy`** rather than a local status list — the
+`activity-policy-single-source` guard caught exactly that duplication during this change, and deriving
+means a newly mapped provider status inherits the ordering. Within a tier there is no invented
+precedence; ties fall back to `groupTimeline`'s order (`evidenceCount` DESC, then title — not recency).
+
+The digest's expand affordance is rendered **unconditionally**, not only when arcs are hidden: `ArcsPanel`
+is mounted in exactly one place, so gating it on `hidden > 0` made editing, recompute, evidence trails and
+the un-clamped prose unreachable product-wide whenever synthesis returned ≤ 3 arcs. For the same reason
+the unsaved-corrections banner renders in **both** densities — the digest shows edited text, so hiding the
+only save control behind the expanded view left an in-memory edit looking applied.
+
+**"Working on" is labelled `· most recent activity`.** The band only ever covers each person's most
+recent day, so on prod it showed 2 of 9 members — which, unlabelled, reads as "the team is idle" rather
+than "2 people have activity in this window". Compressing the rows would only have sharpened the wrong
+impression.
 
 ## The "Working on ≠ Timeline" consistency fix (shipped separately in #358)
 

--- a/lib/dashboard/pulse-digest.ts
+++ b/lib/dashboard/pulse-digest.ts
@@ -1,0 +1,74 @@
+import type { PersonDay, TaskGroup } from "@/lib/dashboard/timeline-group";
+import { isActiveStatus, isOpenStatus } from "@/lib/tasks/activity-policy";
+
+/**
+ * Pulse SNAPSHOT sizing — the pure rules behind the bounded "one screen" header.
+ *
+ * The Pulse home used to be a *feed*: every band's height was proportional to how much data existed, so
+ * the band that answers "what's happening" (up to `MAX_ARCS` = 12 narrative arcs, ~400 chars of prose
+ * each) was also the tallest thing on the page and sat first. Measured on prod (6 arcs), the arcs band
+ * alone was ~1,200px and the whole page ~2,700px — roughly three viewports before you'd seen everything.
+ *
+ * A dashboard snapshot is the opposite: total height is CONSTANT regardless of data volume. Every
+ * above-the-fold band therefore shows "N with a link", never "all N". These caps are the mechanism, so
+ * they live here as pure, testable values rather than as magic numbers inside JSX — the guard in
+ * `test/pulse-digest.test.ts` is what keeps the first screen from silently growing back.
+ */
+
+/** Arcs shown in the snapshot band. 3 × ~90px ≈ 270px — the story, not the whole story. */
+export const DIGEST_ARC_LIMIT = 3;
+
+/** People shown in the snapshot roster. Bounded so a big team can't push the fold down. */
+export const DIGEST_PEOPLE_LIMIT = 6;
+
+/** A capped slice plus what it left behind, so the UI can offer "see all {total}". */
+export interface Digest<T> {
+  shown: T[];
+  hidden: number;
+  total: number;
+}
+
+/**
+ * Cap a list for a snapshot band. `limit` is clamped at 0 so a bad caller can never produce a negative
+ * `hidden` count (which would render as "see all -2"). Order is preserved — callers pass data already
+ * sorted by whatever "most relevant" means for that band.
+ */
+export function digest<T>(items: readonly T[] | null | undefined, limit: number): Digest<T> {
+  const all = items ?? [];
+  const safeLimit = Math.max(0, Math.trunc(limit));
+  return {
+    shown: all.slice(0, safeLimit),
+    hidden: Math.max(0, all.length - safeLimit),
+    total: all.length,
+  };
+}
+
+/**
+ * Rank for the ONE task a compact person-row can headline: being-worked-now, then merely-open, then
+ * everything else. Derived from `lib/tasks/activity-policy` rather than re-spelling a status list —
+ * that module is the single answer to "is this task being worked on" (a local copy is exactly the drift
+ * `test/guards/activity-policy-single-source.test.ts` fails the build over), and deriving means a newly
+ * mapped provider status inherits the ordering instead of silently falling to the bottom.
+ *
+ * Within a tier there is deliberately no further precedence — `in_progress` vs `blocked` would be a new
+ * policy distinction this module has no standing to invent, so ties fall back to the order the timeline
+ * already produced, which is `evidenceCount` DESC then title (`groupTimeline` in `timeline-group`) —
+ * i.e. the task that person put the most work into. NOT recency; don't build a caller that assumes it.
+ */
+function rankOf(status: string): number {
+  if (isActiveStatus(status)) return 0;
+  if (isOpenStatus(status)) return 1;
+  return 2;
+}
+
+/**
+ * The single task a person's snapshot row headlines — the most active one (see `rankOf`), ties broken by
+ * the order `groupTimeline` already produced: `evidenceCount` DESC then title, i.e. the task they put the
+ * most work into. NOT recency. Returns null when the person has no tasks at all, in which case the row
+ * falls back to their counts/synopsis.
+ */
+export function headlineTask(person: PersonDay): TaskGroup | null {
+  const tasks = person.tasks ?? [];
+  if (!tasks.length) return null;
+  return tasks.reduce((best, t) => (rankOf(t.status) < rankOf(best.status) ? t : best));
+}

--- a/test/pulse-digest.test.ts
+++ b/test/pulse-digest.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { digest, headlineTask, DIGEST_ARC_LIMIT, DIGEST_PEOPLE_LIMIT } from "@/lib/dashboard/pulse-digest";
+import type { PersonDay, TaskGroup } from "@/lib/dashboard/timeline-group";
+
+/**
+ * Spec: the Pulse snapshot header is BOUNDED — its height must not track data volume. These assertions
+ * are written from that product rule, not from the current constants: the expected counts below are
+ * literals, so raising a cap turns them red and forces a deliberate decision about the fold instead of
+ * letting the first screen quietly grow back into the old feed.
+ */
+
+function task(taskId: string, status: string): TaskGroup {
+  return { taskId, title: `task ${taskId}`, status, source: "linear", sources: [], evidenceCount: 0 };
+}
+
+function person(tasks: TaskGroup[]): PersonDay {
+  return { memberId: "m1", name: "Ada", handle: "ada", total: 0, tasks, other: [], unlinked: 0, signals: [] };
+}
+
+describe("digest — bounded snapshot bands", () => {
+  it("caps a full arc set to the snapshot limit and reports the remainder", () => {
+    // 12 = MAX_ARCS in lib/graph/arcs.ts — the worst case the arcs band can ever hand the snapshot.
+    const arcs = Array.from({ length: 12 }, (_, i) => `arc-${i}`);
+    const d = digest(arcs, DIGEST_ARC_LIMIT);
+    expect(d.shown).toHaveLength(3);
+    expect(d.hidden).toBe(9);
+    expect(d.total).toBe(12);
+  });
+
+  it("caps a large roster so a growing team cannot push the fold down", () => {
+    const people = Array.from({ length: 20 }, (_, i) => `p-${i}`);
+    const d = digest(people, DIGEST_PEOPLE_LIMIT);
+    expect(d.shown).toHaveLength(6);
+    expect(d.hidden).toBe(14);
+  });
+
+  it("hides nothing when the band is not full", () => {
+    const d = digest(["a", "b"], DIGEST_ARC_LIMIT);
+    expect(d.shown).toEqual(["a", "b"]);
+    expect(d.hidden).toBe(0);
+    expect(d.total).toBe(2);
+  });
+
+  it("preserves the caller's order — bands pass already-sorted data", () => {
+    expect(digest(["c", "a", "b"], 2).shown).toEqual(["c", "a"]);
+  });
+
+  it("never reports a negative remainder for a nonsense limit", () => {
+    const d = digest(["a", "b"], -5);
+    expect(d.shown).toEqual([]);
+    expect(d.hidden).toBe(2);
+  });
+
+  it("treats a missing list as empty rather than throwing", () => {
+    expect(digest(null, DIGEST_ARC_LIMIT)).toEqual({ shown: [], hidden: 0, total: 0 });
+  });
+});
+
+describe("headlineTask — the one task a compact row shows", () => {
+  it("headlines active work over finished work regardless of list order", () => {
+    const p = person([task("done-1", "done"), task("wip-1", "in_progress")]);
+    expect(headlineTask(p)?.taskId).toBe("wip-1");
+  });
+
+  it("headlines a blocked task over a merely-queued one — blocked work is underway", () => {
+    // `blocked` is ACTIVE per lib/tasks/activity-policy (underway and stuck); `ready` is only OPEN.
+    const p = person([task("ready-1", "ready"), task("blocked-1", "blocked")]);
+    expect(headlineTask(p)?.taskId).toBe("blocked-1");
+  });
+
+  it("headlines open work over backlog intake", () => {
+    const p = person([task("backlog-1", "backlog"), task("ready-1", "ready")]);
+    expect(headlineTask(p)?.taskId).toBe("ready-1");
+  });
+
+  it("keeps the incoming task order when statuses share a tier", () => {
+    // in_progress and blocked are both ACTIVE — no invented precedence between them, so the order
+    // groupTimeline already produced wins (evidenceCount DESC, then title — NOT recency).
+    const p = person([task("first", "in_progress"), task("second", "blocked")]);
+    expect(headlineTask(p)?.taskId).toBe("first");
+  });
+
+  it("falls back to null when the person has no tasks, so the row shows counts instead", () => {
+    expect(headlineTask(person([]))).toBeNull();
+  });
+
+  it("still picks something when every status is unrecognised", () => {
+    // activity-policy fails closed on unmapped statuses, so these rank last — but a row with tasks must
+    // never headline nothing.
+    const p = person([task("odd-1", "sideways")]);
+    expect(headlineTask(p)?.taskId).toBe("odd-1");
+  });
+
+  it("prefers a recognised active task over an unmapped one regardless of order", () => {
+    const p = person([task("odd-1", "sideways"), task("wip-1", "in_progress")]);
+    expect(headlineTask(p)?.taskId).toBe("wip-1");
+  });
+});


### PR DESCRIPTION
## Why

Pulse had the right **order** (story → people → metrics → evidence) but the wrong **genre**: a *feed*, where every band's height is proportional to how much data exists. So the band that answers "what's happening" was also the tallest thing on the page — and it sat first.

Measured on prod (6 arcs, avg 400-char summaries, 9 active members):

| Band | Est. height |
|---|---|
| Narrative arcs | **~1,230px** |
| Working on | ~380px |
| Metrics (`defaultOpen` for admins) | **~715px** |
| **Total (admin)** | **~2,700px ≈ 3 viewports** |

`MAX_ARCS = 12`, so the top band could silently double at any time.

## What

A dashboard snapshot has the opposite property: **height is constant regardless of data volume**. The rule is now *every above-the-fold band shows "N with a link", never "all N"*.

- **`lib/dashboard/pulse-digest.ts`** (new, pure) owns the caps — `DIGEST_ARC_LIMIT = 3`, `DIGEST_PEOPLE_LIMIT = 6` — plus `headlineTask`. Not magic numbers inside JSX.
- **`ArcsPanel variant="digest"`** — clamped headlines that expand to the full editable list **in place**. One panel, so no second fetch and no way for a digest + duplicate list to disagree.
- **`PersonWorkCard variant="row"`** — same `PersonDay` at ~56px instead of ~300px. The evidence tree stays in the full card, so **#358's "identical by construction" invariant still holds** (one component, two densities).
- **Two columns** — story beside people. `max-w-5xl` → `max-w-6xl`.
- **Metrics collapsed for everyone**; headline numbers promoted to an "At a glance" ribbon with the range selector that scopes them.
- **"Working on · most recent activity"** — the band only covers each person's most recent day; on prod it showed 2 of 9 members, which unlabelled reads as *"the team is idle"*. Accuracy-of-impression fix that the compact density would otherwise have sharpened.

## Spec-first tests

`test/pulse-digest.test.ts` (13) asserts the capped counts as **literals**, so raising a cap goes red and forces a deliberate decision about the fold. **Mutation-tested both guards non-vacuous**: cap 3→10 fails 1 test; `rankOf`→constant fails 4.

`headlineTask` ranks via **`lib/tasks/activity-policy`** rather than a local status list — the `activity-policy-single-source` guard caught exactly that duplication mid-change, and deriving means a newly mapped provider status inherits the ordering. (It also surfaced that `in_review` isn't a real `task_status` — my first draft tested a status the enum rejects.)

## Verification

✅ `npm test` 1415 pass · ✅ `tsc --noEmit` · ✅ `npm run lint` (0 errors) · ✅ `npm run build` · ✅ `npm run check:docs`
🟡 **Not visually verified in a running app** — no local DB/auth session; layout confirmed structurally only. Worth a look on deploy.

Design doc `docs/design/pulse-home.md` updated in-PR per the architecture-map loop. No routes/tables/sources touched.

## Review — Reviewed by Fable `code-reviewer` — verdict CLEAR (blocker fixed)

First pass returned **BLOCKED** on a real bug I introduced: `ArcsPanel` is mounted in exactly one place, so gating the expand affordance on `hidden > 0` made summary editing, human-correction recompute, evidence trails, and un-clamped prose **unreachable product-wide whenever synthesis returned ≤ 3 arcs**. I re-derived it against the code before fixing. Also fixed: the unsaved-corrections banner and its `saveError` alert now render in **both** densities (the digest shows edited text, so hiding the only save control behind the expanded view left an in-memory edit looking applied), corrected a mis-documented tie-break (`evidenceCount` DESC then title — *not* recency), and added `aria-expanded`. Re-review verdict: **CLEAR**.