### PR TITLE
fix(pulse): make the "Working on" roster readable — synopsis first, not task first

### DIFF
--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -223,8 +223,10 @@ export default async function TeamHome({
 
       {/* Story beside people, not above them — the single column was leaving ~half the width empty while
           pushing "who's on what" a full screen down. */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <section className="flex flex-col gap-3 lg:col-span-2">
+      {/* 60/40, and `items-start` so the roster sizes to its content — stretching it to match a taller
+          arcs column produced a card that was mostly void while its text was being clipped. */}
+      <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-5">
+        <section className="flex flex-col gap-3 lg:col-span-3">
           <BandHeading title="What's happening" />
           <ArcsPanel teamSlug={teamSlug} variant="digest" />
         </section>
@@ -232,7 +234,9 @@ export default async function TeamHome({
         {/* Who's doing what — reads the SAME work-timeline layer as the Timeline below (shared card), so
             they agree by construction. The consistency fix (#358) lives inside this component, which
             renders its own "Working on" heading. */}
-        <WorkingOn teamSlug={teamSlug} variant="roster" timelineHref="#timeline" />
+        <div className="lg:col-span-2">
+          <WorkingOn teamSlug={teamSlug} variant="roster" timelineHref="#timeline" />
+        </div>
       </div>
 
       {/* Timeline — the per-day drill-down (absorbed from the old Learning tab), collapsed by default. */}

--- a/components/dashboard/person-work-card.tsx
+++ b/components/dashboard/person-work-card.tsx
@@ -6,7 +6,7 @@ import { GitBranch, Gavel } from "lucide-react";
 import { MemberAvatar } from "@/components/people/member-avatar";
 import { SourceIcon, sourceLabel } from "@/components/icons/source-icon";
 import type { PersonDay, SignalGroup, SourceGroup, TaskGroup } from "@/lib/dashboard/timeline-group";
-import { headlineTask } from "@/lib/dashboard/pulse-digest";
+import { headlineTask, sourceCounts } from "@/lib/dashboard/pulse-digest";
 
 /**
  * One person's work card — the shared presentational unit behind BOTH the Pulse Timeline panel
@@ -126,33 +126,83 @@ function TaskCard({ task }: { task: TaskGroup }) {
   );
 }
 
+/** How many source chips a snapshot row shows before collapsing the rest into "+N". */
+const ROW_SOURCE_CHIPS = 2;
+
 /**
- * The SNAPSHOT row — one person in ~56px instead of the full card's ~300px. Shows who, their counts, and
- * the single task they're most active on (`headlineTask`); the evidence tree stays in the full card. Both
- * variants render the same `PersonDay`, so the Pulse roster and the Timeline still agree by construction
- * (the #358 invariant) — this is the same data at a second density, not a second implementation.
+ * The SNAPSHOT row — one person at reading density, not the full card's evidence tree.
+ *
+ * The first cut of this was task-centric (headline task + status pill, summary as a one-line
+ * `truncate` fallback) and it was wrong about the data: on prod EVERY person had `tasks: 0`, so the
+ * task line never rendered and the row always fell through to a 190-char synopsis clipped to ~45
+ * characters — in a column that had ~250px of unused vertical space. Compressing vertically in the one
+ * place with room to spare, while destroying the only informative field, is the opposite of the trade
+ * that was wanted.
+ *
+ * So the synopsis is now PRIMARY and gets four lines; the task line is the optional extra shown when
+ * linking actually resolves one. Both variants still render the same `PersonDay` (the #358 invariant) —
+ * one component, two densities, not a second implementation.
  */
 function PersonWorkRow({ person }: { person: PersonDay }) {
   const p = person;
   const lead = headlineTask(p);
+  const sources = sourceCounts(p);
+  const chips = sources.slice(0, ROW_SOURCE_CHIPS);
+  const restChips = sources.length - chips.length;
   return (
-    <div className="flex items-center gap-2.5 rounded-md border border-border-subtle/60 px-3 py-2">
+    <div className="flex gap-2.5 rounded-md border border-border-subtle/60 px-3 py-2.5">
       <MemberAvatar person={{ displayName: p.name, avatarUrl: p.avatarUrl }} size={24} />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-baseline justify-between gap-2">
           <p className="truncate text-sm font-medium text-ink">{p.name}</p>
-          <p className="shrink-0 text-[11px] text-ink-tertiary">{personSummary(p)}</p>
+          {/* Where the work happened — the cheap signal that survives when no task resolves. */}
+          <div className="flex shrink-0 items-center gap-1.5">
+            {chips.map((s) => (
+              // The brand glyphs are aria-hidden, so without a label the chip announces as a bare
+              // number ("10"). Matches the sr-only precedent on the TaskCard assignee avatar.
+              <span
+                key={s.source}
+                className="flex items-center gap-1 text-[11px] text-ink-tertiary"
+                title={`${sourceLabel(s.source)}: ${s.count}`}
+                aria-label={`${sourceLabel(s.source)}: ${s.count} items`}
+              >
+                <SourceIcon source={s.source} className="size-3" />
+                {s.count}
+              </span>
+            ))}
+            {/* Counts SOURCES, while its siblings count items — "+1" beside "github 10" otherwise reads
+                as one more item. */}
+            {restChips > 0 ? (
+              <span
+                className="text-[11px] text-ink-tertiary"
+                title={`${restChips} more source${restChips > 1 ? "s" : ""}`}
+                aria-label={`${restChips} more source${restChips > 1 ? "s" : ""}`}
+              >
+                +{restChips}
+              </span>
+            ) : null}
+          </div>
         </div>
+
         {lead ? (
-          <div className="mt-0.5 flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5">
             <SourceIcon source={lead.source} className="size-3 shrink-0" />
             <span className="min-w-0 flex-1 truncate text-[12px] text-ink-secondary">{lead.title}</span>
+            <StatusPill status={lead.status} />
           </div>
-        ) : p.summary ? (
-          <p className="mt-0.5 truncate text-[12px] text-ink-secondary">{p.summary}</p>
+        ) : null}
+
+        {/* The LLM synopsis — the actual answer to "what is this person doing". Clamped, not truncated.
+            Four lines, not three: measured against the real payload at this column's width (~40% of
+            max-w-6xl), prod's longest summary (190 chars) needs four lines and was still losing its last
+            clause at three. The synopsis is 1–3 sentences by construction, so this fits essentially all
+            of them; the clamp stays as the backstop against one long outlier, not as the normal case. */}
+        {p.summary ? (
+          <p className="line-clamp-4 text-[13px] leading-snug text-ink-secondary">{p.summary}</p>
+        ) : !lead ? (
+          <p className="text-[12px] text-ink-tertiary">{personSummary(p)}</p>
         ) : null}
       </div>
-      {lead ? <StatusPill status={lead.status} /> : null}
     </div>
   );
 }

--- a/components/dashboard/working-on.tsx
+++ b/components/dashboard/working-on.tsx
@@ -48,7 +48,7 @@ export function WorkingOn({
   const view = isRoster ? digest(people ?? [], DIGEST_PEOPLE_LIMIT) : null;
 
   return (
-    <section className="prism-card flex h-full flex-col px-5 py-4">
+    <section className="prism-card flex flex-col px-5 py-4">
       <h2 className="mb-3 flex flex-wrap items-center gap-x-2 text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
         <span className="flex items-center gap-2">
           <Users className="size-3.5 text-violet" /> Working on

--- a/docs/design/pulse-home.md
+++ b/docs/design/pulse-home.md
@@ -44,8 +44,8 @@ The rule is therefore *every above-the-fold band shows "N with a link", never "a
 - **`ArcsPanel variant="digest"`** renders clamped headlines and expands to the full editable list
   *in place* — one panel, not a digest plus a duplicate list, so there is no second fetch and no way for
   the two to disagree. Editing stays a full-view affordance (a two-line clamp is not an editing surface).
-- **`PersonWorkCard variant="row"`** is the same `PersonDay` at a second density (~56px vs ~300px); the
-  evidence tree stays in the full card, so the #358 "identical by construction" invariant still holds.
+- **`PersonWorkCard variant="row"`** is the same `PersonDay` at a second density; the evidence tree stays
+  in the full card, so the #358 "identical by construction" invariant still holds.
 - **Two columns** (story beside people) — the single column left ~half the width empty while pushing
   "who's on what" a full screen down. Container widened `max-w-5xl` → `max-w-6xl`.
 - **Metrics is collapsed for everyone.** The headline numbers were promoted to the ribbon (with the
@@ -62,6 +62,32 @@ is mounted in exactly one place, so gating it on `hidden > 0` made editing, reco
 the un-clamped prose unreachable product-wide whenever synthesis returned ≤ 3 arcs. For the same reason
 the unsaved-corrections banner renders in **both** densities — the digest shows edited text, so hiding the
 only save control behind the expanded view left an in-memory edit looking applied.
+
+### The roster correction — synopsis first, not task first
+
+The first roster shipped **task-centric**: headline task + status pill, with the person's synopsis as a
+one-line `truncate` fallback. That was wrong about the data. On prod, **every person had `tasks: 0`** —
+task linking resolves only a small fraction of items, so the task line never rendered and the row always
+fell through to the fallback, clipping a 190-character synopsis to about 45 characters. It did that
+inside a column with ~250px of *unused vertical space*: compressing vertically where there was room to
+spare, while destroying the one informative field.
+
+So the row is now:
+
+- **synopsis primary**, `line-clamp-4` (not `truncate`). Four lines is measured, not guessed — at this
+  column's width prod's longest summary (190 chars) needs four and still lost its last clause at three.
+  The synopsis is 1–3 sentences by construction, so the clamp is a backstop for an outlier, not the
+  normal case.
+- **`sourceCounts(person)`** chips (`github 10`) — evidence rolled up per source across **both** the
+  task lane and the unlinked `other` lane, busiest first. Counting `other` is the whole point: with
+  linking as sparse as it is, a rollup reading only `tasks` reports nothing for the actual data.
+- **task line + status pill** kept, but as the optional extra shown when linking *does* resolve one.
+- grid is **60/40** (`lg:grid-cols-5`, 3+2) with `items-start`, so the roster sizes to its content
+  instead of stretching into a void beside a taller arcs column.
+
+Verified visually by server-rendering the real component against the real prod payload
+(`.context/render-roster.tsx`, gitignored) — including the task/`+N`-chip branches that current prod
+data never reaches.
 
 **"Working on" is labelled `· most recent activity`.** The band only ever covers each person's most
 recent day, so on prod it showed 2 of 9 members — which, unlabelled, reads as "the team is idle" rather

--- a/lib/dashboard/pulse-digest.ts
+++ b/lib/dashboard/pulse-digest.ts
@@ -72,3 +72,28 @@ export function headlineTask(person: PersonDay): TaskGroup | null {
   if (!tasks.length) return null;
   return tasks.reduce((best, t) => (rankOf(t.status) < rankOf(best.status) ? t : best));
 }
+
+/** One source and how much of a person's day came through it. */
+export interface SourceCount {
+  source: string;
+  count: number;
+}
+
+/**
+ * Where a person's work actually happened — evidence counts rolled up per source across BOTH the
+ * task-linked lane and the unlinked `other` lane, busiest first (ties alphabetical, so the order is
+ * stable between renders).
+ *
+ * Both lanes are counted because on real data almost everything is in `other`: task linking currently
+ * resolves a small fraction of items, so a rollup that only read `tasks` would report nothing for most
+ * people. This is the cheap "what kind of work was it" signal that survives when `headlineTask` is null.
+ */
+export function sourceCounts(person: PersonDay): SourceCount[] {
+  const totals = new Map<string, number>();
+  const add = (source: string, count: number) => totals.set(source, (totals.get(source) ?? 0) + count);
+  for (const t of person.tasks ?? []) for (const g of t.sources ?? []) add(g.source, g.count);
+  for (const g of person.other ?? []) add(g.source, g.count);
+  return [...totals.entries()]
+    .map(([source, count]) => ({ source, count }))
+    .sort((a, b) => b.count - a.count || (a.source < b.source ? -1 : 1));
+}

--- a/test/pulse-digest.test.ts
+++ b/test/pulse-digest.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { digest, headlineTask, DIGEST_ARC_LIMIT, DIGEST_PEOPLE_LIMIT } from "@/lib/dashboard/pulse-digest";
-import type { PersonDay, TaskGroup } from "@/lib/dashboard/timeline-group";
+import { digest, headlineTask, sourceCounts, DIGEST_ARC_LIMIT, DIGEST_PEOPLE_LIMIT } from "@/lib/dashboard/pulse-digest";
+import type { PersonDay, SourceGroup, TaskGroup } from "@/lib/dashboard/timeline-group";
 
 /**
  * Spec: the Pulse snapshot header is BOUNDED — its height must not track data volume. These assertions
@@ -13,8 +13,12 @@ function task(taskId: string, status: string): TaskGroup {
   return { taskId, title: `task ${taskId}`, status, source: "linear", sources: [], evidenceCount: 0 };
 }
 
-function person(tasks: TaskGroup[]): PersonDay {
-  return { memberId: "m1", name: "Ada", handle: "ada", total: 0, tasks, other: [], unlinked: 0, signals: [] };
+function person(tasks: TaskGroup[], other: SourceGroup[] = []): PersonDay {
+  return { memberId: "m1", name: "Ada", handle: "ada", total: 0, tasks, other, unlinked: 0, signals: [] };
+}
+
+function group(source: string, count: number): SourceGroup {
+  return { source, count, items: [] };
 }
 
 describe("digest — bounded snapshot bands", () => {
@@ -94,5 +98,47 @@ describe("headlineTask — the one task a compact row shows", () => {
   it("prefers a recognised active task over an unmapped one regardless of order", () => {
     const p = person([task("odd-1", "sideways"), task("wip-1", "in_progress")]);
     expect(headlineTask(p)?.taskId).toBe("wip-1");
+  });
+});
+
+describe("sourceCounts — where the work happened", () => {
+  it("counts the UNLINKED lane, which is where nearly all real work sits", () => {
+    // The case that motivated this: prod's most recent day had tasks:0 for every person and all 10/1
+    // items in `other`. A rollup that only read `tasks` reports nothing for exactly the real data.
+    const p = person([], [group("github", 10)]);
+    expect(sourceCounts(p)).toEqual([{ source: "github", count: 10 }]);
+  });
+
+  it("merges the same source across the task and unlinked lanes", () => {
+    const t: TaskGroup = { ...task("t1", "in_progress"), sources: [group("github", 3)] };
+    expect(sourceCounts(person([t], [group("github", 4)]))).toEqual([{ source: "github", count: 7 }]);
+  });
+
+  it("orders busiest first so the chips lead with the dominant source", () => {
+    const p = person([], [group("slack", 2), group("github", 9)]);
+    expect(sourceCounts(p).map((s) => s.source)).toEqual(["github", "slack"]);
+  });
+
+  it("breaks count ties alphabetically so the order is stable between renders", () => {
+    const p = person([], [group("notion", 5), group("github", 5)]);
+    expect(sourceCounts(p).map((s) => s.source)).toEqual(["github", "notion"]);
+  });
+
+  it("returns nothing for a person with no evidence at all", () => {
+    expect(sourceCounts(person([]))).toEqual([]);
+  });
+
+  it("sums to the person's work total — the chips can never out-count the header", () => {
+    // groupTimeline puts each evidence item in EXACTLY ONE of `tasks` / `other` and sets `total` to the
+    // work it showed, so Σ chips must equal `total`. Pins the cross-layer agreement: a chip row that
+    // adds up to more than the "N items" line is how a summary stops being trusted. `signals` are
+    // present and must NOT be counted — decisions are context, never work.
+    const t: TaskGroup = { ...task("t1", "in_progress"), sources: [group("github", 6)], evidenceCount: 6 };
+    const p: PersonDay = {
+      ...person([t], [group("notion", 5), group("slack", 3)]),
+      total: 14,
+      signals: [{ kind: "decision", count: 2, items: [] }],
+    };
+    expect(sourceCounts(p).reduce((n, s) => n + s.count, 0)).toBe(p.total);
   });
 });


### PR DESCRIPTION
Follow-up to #440, from your screenshot.

## The bug was in my design, not the styling

The roster I shipped was **task-centric**: headline task + status pill, with the person's LLM synopsis as a one-line `truncate` fallback. On real prod data that inverts:

```
name          | tasks | total | summary_len | sources
Chetan        |   0   |  10   |    190      | github
John Ellison  |   0   |   1   |     77      | slack
```

**Every person has `tasks: 0`** — task linking resolves only a small fraction of items — so the task line never rendered, and the row *always* fell through to the fallback, clipping 190 chars to ~45:

> Fixed the cost graph to display accurate dat…

And it did that inside a column with **~250px of unused vertical space**. I compressed vertically in the one place that had room to spare, while destroying the only informative field.

## What changed

- **Synopsis is primary**, `line-clamp-4` (not `truncate`). Four lines is *measured*: at this column's width prod's longest summary needs four and still lost its last clause at three. The synopsis is 1–3 sentences by construction, so the clamp is a backstop for an outlier, not the normal case.
- **New pure `sourceCounts()`** → per-source evidence chips (`github 10`), rolled up across **both** the task lane and the unlinked `other` lane. Counting `other` is the whole point: a rollup reading only `tasks` reports nothing for the actual data.
- **Task line + status pill kept**, as the optional extra shown when linking *does* resolve one.
- **Grid 60/40** (`lg:grid-cols-5`, 3+2) with `items-start` — the roster now sizes to its content instead of stretching into a void beside a taller arcs column.

## Verification — actually looked at it this time ✅

Last PR shipped with "🟡 not visually verified". Fixed that: `.context/render-roster.tsx` (gitignored) server-renders the **real component** against the **real prod payload** with the app's compiled CSS, so the row can be eyeballed with no DB or auth session. Confirmed at the true 40% column width:

- Chetan — full 190-char synopsis, no ellipsis, `github 10` chip
- John — full synopsis, `slack 1`
- Synthetic third person — exercises the branches prod data never reaches: resolved task line + `Blocked` pill, and `github 6 · notion 5 · +1` chip overflow

✅ `npm test` 1421 · ✅ `tsc` · ✅ lint (0 errors) · ✅ `build` · ✅ `check:docs`

## Tests

Pin the cross-layer invariant that **chips sum to `PersonDay.total`** — a chip row adding up to more than the "N items" header is how a summary stops being trusted — and that **`signals` are never counted as work**. Mutation-tested: dropping the `other` lane fails 5 tests.

## Review — Reviewed by Fable `code-reviewer` — verdict CLEAR

Independently verified the double-counting question against `groupTimeline`: each evidence item lands in exactly one of `tasks`/`other` (strict if/else), and `sources[].count` partitions a task's items, so Σ`sourceCounts` = `PersonDay.total` = `personSummary`'s item total — no over-reporting, and it agrees with the established convention. Applied all three Low findings before push: `aria-label` on the chips (brand SVGs are `aria-hidden`, so they announced as bare numbers), a title on `+N` (it counts *sources* while siblings count *items*), and one stale "three lines" comment. Also added the reviewer's suggested sum-agreement test.