### PR TITLE
feat(admin): warn at save time when a model can't do graph extraction

### DIFF
--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -26,6 +26,10 @@ import { checkSlackChannels, privateChannelRejection } from "@/lib/integrations/
 import { RepoFormatError } from "@/lib/integrations/github-repos";
 import { validateOpenrouterKey, saveOpenrouterSettings } from "@/lib/integrations/openrouter";
 import { MEETING_TASK_STATUSES, type MeetingTaskStatus } from "@/lib/meetings/target-status";
+import {
+  checkStructuredOutputSupport,
+  structuredOutputWarning,
+} from "@/lib/llm/structured-output-support";
 import { setMeetingTaskStatus as setMeetingTaskStatusDb } from "@/lib/meetings/target-status-db";
 import {
   IntegrationConfigError,
@@ -466,7 +470,7 @@ export async function setAnsweringModel(
   teamSlug: string,
   provider: AnsweringProvider,
   model: string
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ ok: boolean; error?: string; warning?: string }> {
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
   const allowed: AnsweringProvider[] = ["anthropic", "openai", "openrouter", "local"];
@@ -493,7 +497,19 @@ export async function setAnsweringModel(
     return { ok: false, error: e instanceof Error ? e.message : "could not save answering model" };
   }
   revalidatePath(`/t/${teamSlug}/admin/integrations`);
-  return { ok: true };
+  // The save SUCCEEDED — this is advisory. Since the graph proxy made this picker also drive
+  // Graphiti's extraction, a model without structured-output support silently empties the graph:
+  // Graphiti keeps returning 202, arcs go blank, and the next signal is the stall detector six hours
+  // later. Surfacing it here turns that into a sentence at the moment of the choice. Best-effort —
+  // an unreachable catalogue or an unlisted model yields no warning rather than a false accusation.
+  let warning: string | undefined;
+  try {
+    warning =
+      structuredOutputWarning(await checkStructuredOutputSupport(provider, model.trim())) ?? undefined;
+  } catch {
+    warning = undefined;
+  }
+  return warning ? { ok: true, warning } : { ok: true };
 }
 
 /**

--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -319,6 +319,8 @@ export function IntegrationsManager({
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  /** A save that SUCCEEDED but has a consequence worth naming — rendered amber, never emerald. */
+  const [warning, setWarning] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
   const SYNCABLE: Partial<Record<IntegrationType, (slug: string) => Promise<{ ok: boolean; error?: string; message?: string }>>> = {
@@ -339,6 +341,7 @@ export function IntegrationsManager({
     if (!fn) return;
     setError(null);
     setNotice(null);
+    setWarning(null);
     startTransition(async () => {
       const res = await fn(teamSlug);
       if (!res.ok) setError(res.error ?? "sync failed");
@@ -365,6 +368,7 @@ export function IntegrationsManager({
   function projectToGraph() {
     setError(null);
     setNotice(null);
+    setWarning(null);
     startTransition(async () => {
       const res = await projectToGraphNow(teamSlug);
       if (!res.ok) setError(res.error ?? "projection failed");
@@ -375,12 +379,22 @@ export function IntegrationsManager({
     });
   }
 
-  function run(fn: () => Promise<{ ok: boolean; error?: string }>) {
+  function run(fn: () => Promise<{ ok: boolean; error?: string; warning?: string }>) {
     setError(null);
+    setNotice(null);
+    setWarning(null);
     startTransition(async () => {
       const res = await fn();
       if (!res.ok) setError(res.error ?? "something went wrong");
-      else router.refresh();
+      else {
+        // A SUCCESSFUL save can still carry a warning — currently "this model can't do structured
+        // outputs, so graph extraction will stop producing facts". Shown here, at the moment of the
+        // choice: the alternative is discovering it as blank narrative arcs hours later. Kept OUT of
+        // `notice`, which renders emerald — a caution styled as success reads as "all good" and would
+        // defeat the point of surfacing it at all.
+        setWarning(res.warning ?? null);
+        router.refresh();
+      }
     });
   }
 
@@ -763,6 +777,12 @@ export function IntegrationsManager({
       {notice ? (
         <p className="rounded-lg border border-emerald/30 bg-emerald/5 px-3 py-2 text-sm text-emerald-700">
           {notice}
+        </p>
+      ) : null}
+
+      {warning ? (
+        <p className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
+          {warning}
         </p>
       ) : null}
 

--- a/lib/llm/structured-output-support.ts
+++ b/lib/llm/structured-output-support.ts
@@ -1,0 +1,124 @@
+import "server-only";
+
+/**
+ * Does the selected model support STRUCTURED OUTPUTS — and therefore graph extraction?
+ *
+ * Graphiti extracts entities and edges via `client.beta.chat.completions.parse`: an OpenAI call
+ * carrying a JSON schema that the model must adhere to. A model that cannot do that returns prose or
+ * loosely-shaped JSON, Graphiti fails to parse it, and — because it keeps returning `202` — the
+ * symptom is an empty graph and blank narrative arcs. Indistinguishable from a quota outage, and it
+ * took log forensics across two services to attribute the last one.
+ *
+ * Since the graph proxy made the Admin answering-model picker also drive extraction, that failure is
+ * now one dropdown away. `qwen3.7-flash` is exactly the shape: it advertises `response_format` but
+ * NOT `structured_outputs`, and it is the cheap one, so it is the one people reach for.
+ *
+ * The two flags are not interchangeable, and only the second decides this:
+ *   • `response_format`    — can mean merely "will emit valid JSON" (`json_object` mode).
+ *   • `structured_outputs` — adheres to a supplied JSON *schema*. This is what `.parse()` needs.
+ *
+ * Advisory, never blocking: this is a save-time WARNING, so an unreachable capability list, an
+ * unlisted model, or a local endpoint must all read as "can't tell" and let the save proceed. Telling
+ * someone their model is broken on no evidence is the failure mode of the work-key check, and this
+ * file exists downstream of that lesson.
+ */
+
+/** OpenRouter publishes per-model capabilities here. No key required — it is a public catalogue. */
+const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+const FETCH_TIMEOUT_MS = 4_000;
+/** One process-wide cache. The catalogue changes on the order of days; a save is rare. */
+const CACHE_TTL_MS = 60 * 60_000;
+
+export type StructuredOutputVerdict =
+  | { status: "supported" }
+  | { status: "unsupported"; model: string }
+  | { status: "unknown"; reason: string };
+
+interface CatalogueEntry {
+  supportsStructuredOutputs: boolean;
+}
+
+let cache: { at: number; models: Map<string, CatalogueEntry> } | null = null;
+
+/** Exported for tests — a stale cache between cases would make them order-dependent. */
+export function resetStructuredOutputCache(): void {
+  cache = null;
+}
+
+/**
+ * Parse OpenRouter's catalogue into "model id → does it adhere to a JSON schema".
+ *
+ * Pure, so the capability rule is testable without a network. Keyed on `structured_outputs`
+ * specifically; a model listing only `response_format` counts as UNSUPPORTED, which is the whole
+ * distinction that makes this check worth having.
+ */
+export function parseModelCatalogue(body: unknown): Map<string, CatalogueEntry> {
+  const out = new Map<string, CatalogueEntry>();
+  const rows = (body as { data?: unknown } | null)?.data;
+  if (!Array.isArray(rows)) return out;
+  for (const row of rows as { id?: unknown; supported_parameters?: unknown }[]) {
+    if (typeof row?.id !== "string") continue;
+    const params = Array.isArray(row.supported_parameters) ? row.supported_parameters : [];
+    out.set(row.id, { supportsStructuredOutputs: params.includes("structured_outputs") });
+  }
+  return out;
+}
+
+/** Decide from an already-fetched catalogue. Pure — the network half is `checkStructuredOutputSupport`. */
+export function verdictFor(model: string, models: Map<string, CatalogueEntry>): StructuredOutputVerdict {
+  if (!models.size) return { status: "unknown", reason: "the model catalogue could not be read" };
+  const entry = models.get(model);
+  // An unlisted model is NOT a broken one — OpenRouter adds models continually, and a stale catalogue
+  // must never accuse. "Couldn't verify" is its own outcome.
+  if (!entry) return { status: "unknown", reason: `${model} is not listed in the model catalogue` };
+  return entry.supportsStructuredOutputs ? { status: "supported" } : { status: "unsupported", model };
+}
+
+async function loadCatalogue(now: number): Promise<Map<string, CatalogueEntry>> {
+  if (cache && now - cache.at < CACHE_TTL_MS) return cache.models;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(OPENROUTER_MODELS_URL, { signal: ctrl.signal });
+    if (!res.ok) return new Map();
+    const models = parseModelCatalogue(await res.json());
+    if (models.size) cache = { at: now, models };
+    return models;
+  } catch {
+    return new Map(); // → "unknown", never a false accusation
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Does this provider+model support the structured outputs graph extraction needs?
+ *
+ * Only OpenRouter can be answered: it publishes a capability catalogue. For every other provider this
+ * returns `unknown` rather than guessing — Anthropic is refused by the proxy for a different reason
+ * anyway, OpenAI's own models all support it, and a local endpoint is unknowable from here.
+ */
+export async function checkStructuredOutputSupport(
+  provider: string,
+  model: string,
+  now = Date.now()
+): Promise<StructuredOutputVerdict> {
+  if (provider !== "openrouter") {
+    return { status: "unknown", reason: `capability data is only published for OpenRouter models` };
+  }
+  if (!model.trim()) return { status: "unknown", reason: "no model selected" };
+  return verdictFor(model.trim(), await loadCatalogue(now));
+}
+
+/**
+ * The sentence an admin sees. Returned alongside a SUCCESSFUL save — the model is theirs to choose,
+ * and the brain's own answering path works fine without structured outputs. Only the graph breaks.
+ */
+export function structuredOutputWarning(v: StructuredOutputVerdict): string | null {
+  if (v.status !== "unsupported") return null;
+  return (
+    `Saved — but ${v.model} does not support structured outputs, which graph extraction requires. ` +
+    `Narrative arcs and the learning panel will stop gaining new facts (the query box, timeline and ` +
+    `search are unaffected). Pick a model listing "structured_outputs" if you use the context engine.`
+  );
+}

--- a/test/guards/model-warning-surfaced.test.ts
+++ b/test/guards/model-warning-surfaced.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * GUARD: a save-time warning must actually reach the admin, and must not be styled as success.
+ *
+ * The whole value of `structuredOutputWarning` is that it appears at the MOMENT the model is chosen —
+ * a warning computed and dropped is worth exactly nothing, and one rendered emerald reads as "all
+ * good", which is worse than silence. Both are one careless edit away, and neither would fail any
+ * behavioural test, so they are pinned here.
+ */
+describe("guard: the structured-output warning is surfaced, in amber", () => {
+  const ui = readFileSync(join(process.cwd(), "components", "admin", "integrations-manager.tsx"), "utf8");
+  const action = readFileSync(
+    join(process.cwd(), "app", "t", "[team]", "admin", "integrations", "actions.ts"),
+    "utf8"
+  );
+
+  it("the save action computes it", () => {
+    expect(action).toContain("structuredOutputWarning");
+    expect(action).toContain("checkStructuredOutputSupport");
+  });
+
+  it("the UI consumes `res.warning` rather than dropping it", () => {
+    expect(ui).toMatch(/setWarning\(res\.warning/);
+  });
+
+  it("it renders amber, NOT the emerald success style", () => {
+    const block = ui.slice(ui.indexOf("{warning ?"), ui.indexOf("{warning ?") + 400);
+    expect(block, "a caution styled as success defeats the point").toContain("amber");
+    expect(block).not.toContain("emerald");
+  });
+});

--- a/test/structured-output-support.test.ts
+++ b/test/structured-output-support.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseModelCatalogue,
+  verdictFor,
+  structuredOutputWarning,
+} from "@/lib/llm/structured-output-support";
+
+/**
+ * Spec: picking a model that can't do structured outputs must warn AT SAVE TIME.
+ *
+ * Since the graph proxy made the Admin answering-model picker also drive Graphiti's extraction, a
+ * model without structured-output support silently empties the graph — Graphiti keeps returning 202,
+ * arcs go blank, and the only other signal is the stall detector six hours later. This turns that
+ * into a sentence in the console at the moment of the choice.
+ *
+ * The shape of the data is taken from OpenRouter's live catalogue, checked 2026-07-29:
+ * `qwen3.7-max` and `qwen3.7-plus` list `structured_outputs`; `qwen3.7-flash` lists only
+ * `response_format`. That last one is the trap — it is the cheap variant.
+ */
+
+const CATALOGUE = {
+  data: [
+    { id: "qwen/qwen3.7-max", supported_parameters: ["response_format", "structured_outputs", "tools"] },
+    { id: "qwen/qwen3.7-plus", supported_parameters: ["response_format", "structured_outputs"] },
+    { id: "qwen/qwen3.7-flash", supported_parameters: ["response_format"] },
+    { id: "openai/gpt-4o", supported_parameters: ["response_format", "structured_outputs"] },
+  ],
+};
+
+describe("parseModelCatalogue — only `structured_outputs` counts", () => {
+  it("distinguishes schema adherence from mere JSON mode", () => {
+    // THE distinction. `response_format` can mean only "emits valid JSON" (`json_object`), which is
+    // not enough for `.parse()` — it needs adherence to a supplied schema. Conflating the two is
+    // exactly how a model that looks capable empties the graph.
+    const m = parseModelCatalogue(CATALOGUE);
+    expect(m.get("qwen/qwen3.7-max")?.supportsStructuredOutputs).toBe(true);
+    expect(m.get("qwen/qwen3.7-flash")?.supportsStructuredOutputs).toBe(false);
+  });
+
+  it("survives a shape it doesn't recognise rather than throwing", () => {
+    for (const junk of [null, undefined, {}, { data: "nope" }, { data: [{ id: 1 }] }]) {
+      expect(parseModelCatalogue(junk).size).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("verdictFor — 'couldn't verify' is its own outcome", () => {
+  const models = parseModelCatalogue(CATALOGUE);
+
+  it("flags a model that cannot do structured outputs", () => {
+    expect(verdictFor("qwen/qwen3.7-flash", models)).toEqual({
+      status: "unsupported",
+      model: "qwen/qwen3.7-flash",
+    });
+  });
+
+  it("passes a model that can", () => {
+    expect(verdictFor("qwen/qwen3.7-max", models).status).toBe("supported");
+  });
+
+  it("says UNKNOWN for an unlisted model — a stale catalogue must never accuse", () => {
+    // OpenRouter adds models continually. Treating "not in my list" as "broken" is the cry-wolf
+    // failure that made the work-key check worthless, and this file exists downstream of that.
+    expect(verdictFor("some/brand-new-model", models).status).toBe("unknown");
+  });
+
+  it("says UNKNOWN when the catalogue could not be read at all", () => {
+    expect(verdictFor("qwen/qwen3.7-flash", new Map()).status).toBe("unknown");
+  });
+});
+
+describe("structuredOutputWarning — warns without blocking", () => {
+  it("names the model and what specifically breaks", () => {
+    const msg = structuredOutputWarning({ status: "unsupported", model: "qwen/qwen3.7-flash" });
+    expect(msg).toContain("qwen/qwen3.7-flash");
+    expect(msg).toMatch(/Saved/); // the save SUCCEEDS — the model is the admin's choice
+    expect(msg).toMatch(/arcs|learning/i);
+    // …and it must say what is NOT affected, or an admin reads it as "the brain is broken".
+    expect(msg).toMatch(/query box|search|timeline/i);
+  });
+
+  it("is silent for supported and unknown — no warning without evidence", () => {
+    expect(structuredOutputWarning({ status: "supported" })).toBeNull();
+    expect(structuredOutputWarning({ status: "unknown", reason: "x" })).toBeNull();
+  });
+});


### PR DESCRIPTION
The graph proxy made the answering-model picker also drive Graphiti's extraction. That's the right architecture, and it created a new trap: **pick a model that can't honour a JSON schema and the graph silently stops gaining facts.** Graphiti keeps returning `202`, narrative arcs go blank, and the next signal is the stall detector six hours later — indistinguishable, from the console, from the quota outage that started all of this.

`qwen3.7-flash` is exactly that shape, and it's the *cheap* variant, so it's the one someone reaches for.

## The distinction that matters

Verified against OpenRouter's live catalogue rather than from memory:

| Model | `response_format` | `structured_outputs` |
|---|---|---|
| `qwen/qwen3.7-max` | ✅ | ✅ |
| `qwen/qwen3.7-plus` | ✅ | ✅ |
| **`qwen/qwen3.7-flash`** | ✅ | ❌ |

**Only the second flag decides this.** `response_format` can mean merely "emits valid JSON" (`json_object` mode); `structured_outputs` means adherence to a supplied *schema*, which is what `beta.chat.completions.parse` requires. Conflating them is precisely how a model that looks capable empties the graph.

## What it does

The save checks OpenRouter's public capability catalogue — no key needed, 4s timeout, cached an hour — and returns a warning **alongside a successful save**. The model is the admin's choice, and the brain's own answering path works fine without structured outputs; only the graph breaks. The message says that explicitly rather than implying the brain is broken.

**Advisory, never blocking.** An unreachable catalogue, an unlisted model, a non-OpenRouter provider and a local endpoint all read as *"can't tell"* and produce no warning. Accusing on no evidence is the failure that made the work-key check worthless — this file sits downstream of that lesson and repeats it in a comment so the next person doesn't tighten it into a false positive.

Rendered **amber**, and deliberately not through `notice`, which is emerald: a caution styled as success reads as "all good" and would defeat the point. Guarded — dropping `res.warning`, or restyling it emerald, each turn a test red.

## Verified

unit 1427 · tsc 0 · lint clean (2 pre-existing warnings) · docs-drift green. The test fixture was checked against OpenRouter's live catalogue, not written from memory.

AIOS-Work: AIO-484