### PR TITLE
chore(conductor): shared workspace settings + concurrency-safe compose ports

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,53 @@
+# Conductor workspace settings — shared, for anyone who develops this repo in Conductor
+# (https://conductor.build). Each Conductor workspace is a git worktree on its own branch, which
+# is the layout CONTRIBUTING.md already requires. Inert if you don't use Conductor.
+#
+# Conductor only picks up changes to THIS file once they are merged to the default branch on the
+# remote — editing it on a feature branch does nothing for that workspace.
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+# Share the primary checkout's node_modules instead of installing per workspace. This is
+# CONTRIBUTING.md's documented convention, and next.config.ts contains a Turbopack workaround
+# written specifically for it (a node_modules symlink pointing outside the project root makes
+# Turbopack panic, so the root is widened to the common ancestor). It also matters at this scale:
+# node_modules is ~826 MB, so installing per workspace would cost tens of GB across the ~20
+# workspaces this repo typically has open.
+#
+# Falls back to `npm ci` when there's no root install to borrow (a fresh clone, or a cloud
+# workspace). If a branch changes package.json, run `npm install` in the workspace to break off
+# its own copy — shared deps are stale by definition then.
+setup = 'if [ -d "$CONDUCTOR_ROOT_PATH/node_modules" ]; then ln -sfn "$CONDUCTOR_ROOT_PATH/node_modules" node_modules && echo "linked shared node_modules"; else npm ci; fi'
+
+# Safe to run several workspaces at once: every run script below is parameterised on
+# CONDUCTOR_PORT, and the compose stack additionally gets a per-workspace project name so its
+# containers, volumes and generated secrets never collide with another workspace's.
+run_mode = "concurrent"
+
+# The default, because it is the only one that works in a fresh workspace with no configuration:
+# the stack brings its own Postgres, loads the schema, seeds the demo team and prints a login.
+# `.env.local` is gitignored and absent from the repo, so `next dev` alone has no database.
+#
+# COMPOSE_PROJECT_NAME isolates containers/volumes per workspace; APP_PORT and PG_PORT keep the
+# published ports inside this workspace's allocated range (CONDUCTOR_PORT … +9).
+#
+# The workspace name is lowercased and stripped: Compose rejects a project name containing
+# uppercase or anything outside [a-z0-9_-], and workspace names are free-form (a capital or a
+# space in one would otherwise fail the run with "invalid project name").
+[scripts.run.up]
+command = 'COMPOSE_PROJECT_NAME="aios-$(printf %s "$CONDUCTOR_WORKSPACE_NAME" | tr "[:upper:]" "[:lower:]" | tr -cs "a-z0-9_-" "-")" APP_PORT="$CONDUCTOR_PORT" PG_PORT="$((CONDUCTOR_PORT + 1))" docker compose up'
+default = true
+icon = "database"
+
+# For iterating on the app itself against a database you already have configured
+# (DATABASE_URL exported, or a .env.local you copied in).
+[scripts.run.dev]
+command = 'npm run dev -- --port "$CONDUCTOR_PORT"'
+icon = "play"
+
+# Unit tier in watch mode. The data-mechanics tier is deliberately not a run script: it binds
+# compose.test.yml's fixed port 5434, so it cannot run concurrently — use `npm run db:test:up`
+# and `npm run test:datamechanics:local` by hand.
+[scripts.run.test]
+command = "npx vitest"
+icon = "test-tube"

--- a/compose.yml
+++ b/compose.yml
@@ -22,7 +22,11 @@ services:
       POSTGRES_DB: app
     # 5435, not 5432/5433/5434: leaves a host Postgres, another project's dev DB, and the
     # data-mechanics tier in compose.test.yml all free to run at the same time.
-    ports: ["5435:5432"]
+    # Override to run several workspaces at once — the app reaches Postgres over the compose
+    # network at postgres:5432 regardless, so this port is only for reaching it from the host
+    # (`psql`). Pair it with COMPOSE_PROJECT_NAME so each stack gets its own containers/volumes:
+    #   COMPOSE_PROJECT_NAME=aios-mine APP_PORT=3100 PG_PORT=5436 docker compose up
+    ports: ["${PG_PORT:-5435}:5432"]
     volumes: ["pgdata:/var/lib/postgresql/data"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U app -d app"]


### PR DESCRIPTION
CONTRIBUTING already requires working in a git worktree — which is exactly what a Conductor workspace is — but the repo shipped no Conductor config. A new workspace started with **no dependencies, no Run button, and no database**.

Shared (`.conductor/settings.toml`, committed) rather than personal, matching the existing precedent of committing `.claude` / `.agents` / `.opencode` / `.cursor`. **Inert for anyone not using Conductor.**

## What it does

| Setting | Why |
|---|---|
| `setup` links the root's `node_modules` | CONTRIBUTING's documented convention; `next.config.ts` has a Turbopack workaround written *specifically* for that symlink. `node_modules` is ~826 MB, so per-workspace installs would cost tens of GB across the ~20 workspaces this repo typically has open. Falls back to `npm ci` when there's no root install to borrow. |
| `up` (compose) is the **default** run script | The only one that works in a fresh workspace — `.env.local` is gitignored and absent, so `next dev` alone has no database. The compose stack brings its own Postgres, schema, seed and printed login. |
| `dev` + `test` run scripts | The other two loops. The data-mechanics tier is deliberately **not** a run script: it binds `compose.test.yml`'s fixed 5434 and can't run concurrently. |

## One line in `compose.yml`

Postgres' host port is now `${PG_PORT:-5435}`. The app reaches Postgres over the compose network regardless, so that port exists only for host `psql` — hardcoding it was the single thing forcing `run_mode = "nonconcurrent"`. **Default behaviour is unchanged.**

## `run_mode = "concurrent"` is justified by test, not assertion

Brought **two stacks up simultaneously** (`3200/5436` and `3210/5437`): both served `/login` **200**, and their generated dev secrets **differ** — confirming `COMPOSE_PROJECT_NAME` really gives each workspace its own containers and volumes.

## A bug found by verifying instead of assuming

Compose **rejects** a project name containing uppercase or anything outside `[a-z0-9_-]`, and workspace names are free-form — so `COMPOSE_PROJECT_NAME=aios-$CONDUCTOR_WORKSPACE_NAME` would have failed outright for anyone whose workspace had a capital or a space. The name is now lowercased and stripped; checked against `wsA`, `Krakow`, `los-angeles`, `My Feature 2`, `feat/thing`, `UPPER_Case`.

## Note on rollout

Conductor only picks up shared settings **once merged to the default branch** — this PR can't demonstrate itself in its own workspace.

Verified: `check:docs` congruent · doctor tests 26 pass · `docker compose config` valid with and without overrides · both test stacks torn down.