### PR TITLE
fix(costs): the dashboard was showing a floor and calling it the total

### DIFF
--- a/app/t/[team]/costs/page.tsx
+++ b/app/t/[team]/costs/page.tsx
@@ -5,7 +5,8 @@ import { serverClient } from "@/lib/db/server";
 import { resolveTeamContext } from "@/lib/auth/team-context";
 import { isRestrictedTier } from "@/lib/auth/visibility";
 import { parseRange } from "@/lib/metrics/range";
-import { getLlmCostBreakdown } from "@/lib/metrics/llm-costs";
+import { getLlmCostBreakdown, getLedgerLifetimeUsd } from "@/lib/metrics/llm-costs";
+import { getProviderReportedUsage, reconcileLedger } from "@/lib/costs/provider-usage";
 import { RangeSelector } from "@/components/dashboard/range-selector";
 import { CostBreakdownChart } from "@/components/charts/cost-breakdown";
 import { HelpHint } from "@/components/help-hint";
@@ -55,6 +56,18 @@ export default async function CostsPage({
   const db = await serverClient();
   const breakdown = await getLlmCostBreakdown(db, team.id, range, { isAdmin, memberId: me.id });
   const scopeWord = isAdmin ? "Team" : "Your";
+
+  // RECONCILIATION. The ledger is a floor, not a total: a call that times out or fails after the
+  // provider already generated is billed upstream and returns no `usage` for us to read, so no amount
+  // of fixing the meter closes the gap. Measured 2026-07-30 the ledger said $51.46 while OpenRouter's
+  // own `/credits` said $96.67 on the same key — and the page presented the floor as the answer.
+  // Admins only: it is a whole-key number, so it means nothing beside one member's scoped spend.
+  const providerUsage = isAdmin ? await getProviderReportedUsage(db, team.id) : null;
+  const ledgerLifetimeUsd = isAdmin && providerUsage ? await getLedgerLifetimeUsd(db, team.id) : null;
+  const reconciliation =
+    providerUsage && ledgerLifetimeUsd !== null
+      ? reconcileLedger(providerUsage.totalUsageUsd, ledgerLifetimeUsd)
+      : null;
 
   // Show the "tracking since" caption only when metering began INSIDE the selected window — i.e. the
   // window is wider than the data, so "last 30d" overstates coverage (decided server-side to avoid a
@@ -111,6 +124,40 @@ export default async function CostsPage({
         </div>
         <RangeSelector value={range} />
       </div>
+
+      {/* Shown whenever we can ask the provider — not only when it looks bad. A reconciliation that
+          appears only on failure teaches nobody what the number means, and its absence would be
+          indistinguishable from "we didn't check". Amber only when the gap is material. */}
+      {reconciliation ? (
+        <div
+          className={`rounded-lg border px-3 py-2 text-xs ${
+            reconciliation.material
+              ? "border-amber-400/30 bg-amber-400/10 text-amber-700 dark:text-amber-300"
+              : "border-border-subtle/60 text-ink-tertiary"
+          }`}
+        >
+          {reconciliation.material ? (
+            <>
+              <strong>
+                OpenRouter has billed {usd(reconciliation.providerUsd)} on this key; this ledger accounts
+                for {usd(reconciliation.ledgerUsd)}.
+              </strong>{" "}
+              {usd(reconciliation.unattributedUsd)} (
+              {Math.round(reconciliation.unattributedFraction * 100)}%) can&apos;t be attributed to a
+              feature. A call that times out, or fails after the model already generated, is billed by
+              the provider but returns no usage for the brain to record — so the breakdown below is a{" "}
+              <strong>floor</strong>, not the total. Both figures are lifetime for this key, not the
+              selected window.
+            </>
+          ) : (
+            <>
+              Reconciled against the provider: OpenRouter reports {usd(reconciliation.providerUsd)} spent
+              on this key, and this ledger accounts for {usd(reconciliation.ledgerUsd)} of it (lifetime,
+              not the selected window).
+            </>
+          )}
+        </div>
+      ) : null}
 
       <CostBreakdownChart
         title="By feature"

--- a/app/t/[team]/costs/page.tsx
+++ b/app/t/[team]/costs/page.tsx
@@ -63,7 +63,8 @@ export default async function CostsPage({
   // own `/credits` said $96.67 on the same key — and the page presented the floor as the answer.
   // Admins only: it is a whole-key number, so it means nothing beside one member's scoped spend.
   const providerUsage = isAdmin ? await getProviderReportedUsage(db, team.id) : null;
-  const ledgerLifetimeUsd = isAdmin && providerUsage ? await getLedgerLifetimeUsd(db, team.id) : null;
+  const ledgerLifetimeUsd =
+    isAdmin && providerUsage ? await getLedgerLifetimeUsd(db, team.id, providerUsage.provider) : null;
   const reconciliation =
     providerUsage && ledgerLifetimeUsd !== null
       ? reconcileLedger(providerUsage.totalUsageUsd, ledgerLifetimeUsd)
@@ -131,12 +132,12 @@ export default async function CostsPage({
       {reconciliation ? (
         <div
           className={`rounded-lg border px-3 py-2 text-xs ${
-            reconciliation.material
+            reconciliation.status === "unattributed"
               ? "border-amber-400/30 bg-amber-400/10 text-amber-700 dark:text-amber-300"
               : "border-border-subtle/60 text-ink-tertiary"
           }`}
         >
-          {reconciliation.material ? (
+          {reconciliation.status === "unattributed" ? (
             <>
               <strong>
                 OpenRouter has billed {usd(reconciliation.providerUsd)} on this key; this ledger accounts
@@ -144,10 +145,18 @@ export default async function CostsPage({
               </strong>{" "}
               {usd(reconciliation.unattributedUsd)} (
               {Math.round(reconciliation.unattributedFraction * 100)}%) can&apos;t be attributed to a
-              feature. A call that times out, or fails after the model already generated, is billed by
-              the provider but returns no usage for the brain to record — so the breakdown below is a{" "}
-              <strong>floor</strong>, not the total. Both figures are lifetime for this key, not the
-              selected window.
+              feature, so the breakdown below is a <strong>floor</strong>, not the total. Usually that is
+              a call that timed out or failed after the model had already generated — billed by the
+              provider, but returning no usage for the brain to record. It also covers any spend on this
+              key from outside this instance. Both figures are lifetime for the key, not the selected
+              window.
+            </>
+          ) : reconciliation.status === "ledger-exceeds" ? (
+            <>
+              This ledger records {usd(reconciliation.ledgerUsd)} of OpenRouter spend, more than the{" "}
+              {usd(reconciliation.providerUsd)} the provider reports for the current key — usually because
+              the key was rotated, so older spend has no counterpart on the new one. Nothing is missing
+              from the breakdown below.
             </>
           ) : (
             <>

--- a/lib/costs/provider-usage.ts
+++ b/lib/costs/provider-usage.ts
@@ -1,0 +1,130 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { getProviderKey } from "@/lib/integrations/manage";
+
+/**
+ * PROVIDER-REPORTED spend — the reconciliation the `llm_usage` ledger cannot do for itself.
+ *
+ * The ledger records what each call REPORTED. That is the only way to attribute cost to a feature,
+ * and it is structurally incomplete: a call that times out, is aborted, or fails after the provider
+ * already generated is billed upstream and returns us no `usage` to read. So the ledger is a floor,
+ * not a total, and nothing in it can reveal by how much.
+ *
+ * Measured 2026-07-30: the ledger held $51.46 while OpenRouter's own `/credits` reported $96.67 spent
+ * on the same key — 47% of real spend invisible, and the dashboard presented its floor as the answer.
+ * The bulk was one bad day where every graph extraction hit a proxy timeout and the OpenAI SDK retried
+ * three times: ~4,000 generations that the provider billed and we recorded as nothing, because we only
+ * metered 2xx responses.
+ *
+ * So we ask the provider what it actually charged. `GET /api/v1/credits` needs only the inference key
+ * the team already configured (unlike `/activity`, which requires a management key — verified 403).
+ *
+ * LIFETIME, NOT WINDOWED. `total_usage` is cumulative for the key, so it cannot be sliced to "last
+ * 30 days". That is a real limitation and the UI must not pretend otherwise: it is shown as a
+ * lifetime reconciliation beside the windowed ledger, never substituted for it.
+ */
+
+const CREDITS_URL = "https://openrouter.ai/api/v1/credits";
+const FETCH_TIMEOUT_MS = 4_000;
+/** Spend moves slowly relative to a page view, and this sits on a render path. */
+const CACHE_TTL_MS = 10 * 60_000;
+
+export interface ProviderUsage {
+  provider: "openrouter";
+  /** Cumulative USD the provider says this key has spent. */
+  totalUsageUsd: number;
+  /** Credits purchased, when the provider reports it — lets the UI show headroom. */
+  totalCreditsUsd: number | null;
+}
+
+let cache: { at: number; teamId: string; value: ProviderUsage | null } | null = null;
+
+/** Exported for tests — a shared cache would make cases order-dependent. */
+export function resetProviderUsageCache(): void {
+  cache = null;
+}
+
+/**
+ * Parse OpenRouter's `/credits` body. Pure, so the shape is pinned without a network call.
+ *
+ * Returns null rather than zero for anything unrecognised: a missing number must read as "we don't
+ * know what the provider charged", never as "the provider charged nothing" — the second is exactly
+ * the false reassurance this module exists to end.
+ */
+export function parseCreditsBody(body: unknown): ProviderUsage | null {
+  const d = (body as { data?: { total_usage?: unknown; total_credits?: unknown } } | null)?.data;
+  if (!d || typeof d.total_usage !== "number" || !Number.isFinite(d.total_usage)) return null;
+  const credits = typeof d.total_credits === "number" && Number.isFinite(d.total_credits) ? d.total_credits : null;
+  return { provider: "openrouter", totalUsageUsd: d.total_usage, totalCreditsUsd: credits };
+}
+
+/**
+ * What the provider says this team's key has spent, or null when we can't ask.
+ *
+ * Best-effort by construction — this renders on a page, and a provider outage must degrade to "no
+ * reconciliation shown" rather than breaking the costs view. Only OpenRouter publishes this; other
+ * providers return null and the UI simply omits the comparison.
+ */
+export async function getProviderReportedUsage(
+  db: DbClient,
+  teamId: string,
+  now = Date.now()
+): Promise<ProviderUsage | null> {
+  if (cache && cache.teamId === teamId && now - cache.at < CACHE_TTL_MS) return cache.value;
+  let value: ProviderUsage | null = null;
+  try {
+    const key = await getProviderKey(db, teamId, "openrouter");
+    if (key) {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+      try {
+        const res = await fetch(CREDITS_URL, {
+          headers: { Authorization: `Bearer ${key}` },
+          signal: ctrl.signal,
+        });
+        if (res.ok) value = parseCreditsBody(await res.json());
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+  } catch {
+    value = null;
+  }
+  cache = { at: now, teamId, value };
+  return value;
+}
+
+export interface LedgerReconciliation {
+  providerUsd: number;
+  ledgerUsd: number;
+  /** Provider total minus what the ledger attributed. Never negative — see below. */
+  unattributedUsd: number;
+  /** Share of provider-reported spend the ledger could not attribute, 0–1. */
+  unattributedFraction: number;
+  /** Worth telling the operator about, rather than a rounding difference. */
+  material: boolean;
+}
+
+/** Below this the difference is timing and rounding, not a missing-spend story. */
+const MATERIAL_FRACTION = 0.05;
+const MATERIAL_ABSOLUTE_USD = 1;
+
+/**
+ * Compare what the provider charged against what the ledger attributed.
+ *
+ * CLAMPED AT ZERO, deliberately. The ledger is lifetime-scoped here too, but it can still exceed the
+ * provider total legitimately — an Anthropic call is list-price ESTIMATED and counted in the ledger
+ * while contributing nothing to OpenRouter's number. A negative "unattributed" would be nonsense; the
+ * honest reading of ledger ≥ provider is simply "nothing unattributed on this provider".
+ */
+export function reconcileLedger(providerUsd: number, ledgerUsd: number): LedgerReconciliation {
+  const unattributed = Math.max(0, providerUsd - ledgerUsd);
+  const fraction = providerUsd > 0 ? unattributed / providerUsd : 0;
+  return {
+    providerUsd,
+    ledgerUsd,
+    unattributedUsd: unattributed,
+    unattributedFraction: fraction,
+    material: unattributed >= MATERIAL_ABSOLUTE_USD && fraction >= MATERIAL_FRACTION,
+  };
+}

--- a/lib/costs/provider-usage.ts
+++ b/lib/costs/provider-usage.ts
@@ -53,7 +53,11 @@ export function resetProviderUsageCache(): void {
  */
 export function parseCreditsBody(body: unknown): ProviderUsage | null {
   const d = (body as { data?: { total_usage?: unknown; total_credits?: unknown } } | null)?.data;
-  if (!d || typeof d.total_usage !== "number" || !Number.isFinite(d.total_usage)) return null;
+  // `>= 0` as well as finite: a negative total would render "$-5.00 spent", which is not a number any
+  // reader can act on. Unparseable and absurd both mean "we don't know".
+  if (!d || typeof d.total_usage !== "number" || !Number.isFinite(d.total_usage) || d.total_usage < 0) {
+    return null;
+  }
   const credits = typeof d.total_credits === "number" && Number.isFinite(d.total_credits) ? d.total_credits : null;
   return { provider: "openrouter", totalUsageUsd: d.total_usage, totalCreditsUsd: credits };
 }
@@ -103,6 +107,14 @@ export interface LedgerReconciliation {
   unattributedFraction: number;
   /** Worth telling the operator about, rather than a rounding difference. */
   material: boolean;
+  /**
+   * `ledger-exceeds` is its OWN state, not a clamped zero. With the ledger filtered to this provider,
+   * recording more than the provider billed is no longer legitimate — it means the key was rotated
+   * (old spend in the ledger, fresh key at the provider) or something double-metered. Rendering the
+   * clamped "accounts for $X of it" there produces a literally false sentence, so the UI says what
+   * actually happened instead.
+   */
+  status: "reconciled" | "unattributed" | "ledger-exceeds";
 }
 
 /** Below this the difference is timing and rounding, not a missing-spend story. */
@@ -120,11 +132,17 @@ const MATERIAL_ABSOLUTE_USD = 1;
 export function reconcileLedger(providerUsd: number, ledgerUsd: number): LedgerReconciliation {
   const unattributed = Math.max(0, providerUsd - ledgerUsd);
   const fraction = providerUsd > 0 ? unattributed / providerUsd : 0;
+  // BOTH legs. A percentage alone flags a $0.30-vs-$0.05 new install (83%, meaningless); an absolute
+  // alone flags a $10 drift on $1,000/mo (1%, noise). Only a gap that is both large enough to notice
+  // and large enough to matter is worth an operator's attention.
+  const material = unattributed >= MATERIAL_ABSOLUTE_USD && fraction >= MATERIAL_FRACTION;
+  const exceeds = ledgerUsd - providerUsd >= MATERIAL_ABSOLUTE_USD;
   return {
     providerUsd,
     ledgerUsd,
     unattributedUsd: unattributed,
     unattributedFraction: fraction,
-    material: unattributed >= MATERIAL_ABSOLUTE_USD && fraction >= MATERIAL_FRACTION,
+    material,
+    status: exceeds ? "ledger-exceeds" : material ? "unattributed" : "reconciled",
   };
 }

--- a/lib/llm/graph-proxy.ts
+++ b/lib/llm/graph-proxy.ts
@@ -267,7 +267,12 @@ export interface GraphMeterCtx {
  */
 async function meterGraphCall(text: string, status: number, target: ProxyTarget, meter: GraphMeterCtx): Promise<void> {
   try {
-    if (status < 200 || status >= 300) return; // only a successful call spent tokens
+    // NOT gated on a 2xx. "Only a successful call spent tokens" is what this used to assume, and it is
+    // false: a provider can return `usage` alongside a non-2xx (a post-generation moderation refusal,
+    // a partial), and that generation IS billed. Measured on 2026-07-30 the ledger held $51.46 while
+    // OpenRouter's own `/credits` reported $96.67 spent on the same key — 47% invisible. Metering
+    // whatever `usage` arrives, whatever the status, is strictly closer to the truth; a body with no
+    // `usage` still returns null below and records nothing.
     const c = meterFromOpenAiResponse(text, target.provider, target.model, meter.kind);
     if (!c) return;
     await recordLlmUsage(meter.db, {

--- a/lib/metrics/llm-costs.ts
+++ b/lib/metrics/llm-costs.ts
@@ -150,10 +150,30 @@ export async function getLlmCostBreakdown(
  * only meaningful comparison is the whole team's ledger. The caller gates this on `isAdmin` for the
  * same reason — a member's scoped subtotal beside a whole-key total would read as a huge fake gap.
  */
-export async function getLedgerLifetimeUsd(db: DbClient, teamId: string): Promise<number | null> {
+export const LEDGER_LIFETIME_ROW_CAP = 500_000;
+
+export async function getLedgerLifetimeUsd(
+  db: DbClient,
+  teamId: string,
+  provider: string
+): Promise<number | null> {
   try {
-    const res = await db.from("llm_usage").select("cost_usd").eq("team_id", teamId).limit(500_000);
+    const res = await db
+      .from("llm_usage")
+      .select("cost_usd")
+      // FILTERED BY PROVIDER, and this is the whole correctness of the comparison. The figure this is
+      // measured against comes from ONE provider's billing API. Summing every provider against it
+      // dilutes the gap toward zero — an Anthropic list-price estimate is real ledger spend that
+      // OpenRouter never charged, so counting it here would "account for" money that key never saw and
+      // quietly erase the very shortfall this exists to expose.
+      .eq("provider", provider)
+      .eq("team_id", teamId)
+      .limit(LEDGER_LIFETIME_ROW_CAP);
     const rows = (res.data ?? []) as { cost_usd: number | string }[];
+    // At the cap Postgres returns an ARBITRARY subset (no ORDER BY), so the sum would be short — and a
+    // short ledger INFLATES the unattributed figure. Refusing to answer is the only honest option;
+    // the caller then shows no reconciliation rather than a confident overstatement.
+    if (rows.length >= LEDGER_LIFETIME_ROW_CAP) return null;
     return rows.reduce((sum, r) => sum + (Number(r.cost_usd) || 0), 0);
   } catch {
     return null; // can't reconcile → the caller shows nothing rather than a wrong comparison

--- a/lib/metrics/llm-costs.ts
+++ b/lib/metrics/llm-costs.ts
@@ -137,3 +137,25 @@ export async function getLlmCostBreakdown(
     by_provider: slicesBy(rows, (r) => r.provider, (k) => k),
   };
 }
+
+/**
+ * The ledger's LIFETIME total for a team, for reconciliation against the provider's own figure.
+ *
+ * Lifetime, not windowed, because the thing it is compared against is: OpenRouter's `/credits`
+ * reports cumulative usage for a key and cannot be sliced by date. Comparing a 30-day ledger slice
+ * to a lifetime provider total would manufacture a gap that isn't there — the opposite failure to
+ * the one this exists to expose.
+ *
+ * Team-wide by construction (no viewer scoping): the provider figure is for the whole key, so the
+ * only meaningful comparison is the whole team's ledger. The caller gates this on `isAdmin` for the
+ * same reason — a member's scoped subtotal beside a whole-key total would read as a huge fake gap.
+ */
+export async function getLedgerLifetimeUsd(db: DbClient, teamId: string): Promise<number | null> {
+  try {
+    const res = await db.from("llm_usage").select("cost_usd").eq("team_id", teamId).limit(500_000);
+    const rows = (res.data ?? []) as { cost_usd: number | string }[];
+    return rows.reduce((sum, r) => sum + (Number(r.cost_usd) || 0), 0);
+  } catch {
+    return null; // can't reconcile → the caller shows nothing rather than a wrong comparison
+  }
+}

--- a/test/graph-llm-proxy.test.ts
+++ b/test/graph-llm-proxy.test.ts
@@ -84,12 +84,28 @@ describe("forwardUpstream — meters graph spend into llm_usage", () => {
     });
   });
 
-  it("does NOT meter a failed upstream call — no tokens were spent to record", async () => {
+  it("does not meter a failed call that carries NO usage — there is nothing to record", async () => {
     mockFetch(429, { error: { message: "insufficient_quota" } });
     const { db, rows } = captureDb();
     const res = await forwardUpstream(target, { messages: [] }, { meter: { db, teamId: "team-1", source: "graph", kind: "chat" } });
     expect(res.status).toBe(429); // the provider error still passes through untouched
     expect(rows).toHaveLength(0);
+  });
+
+  it("DOES meter a non-2xx that still carries `usage` — the provider billed it", async () => {
+    // This used to be gated on a 2xx, on the assumption that "only a successful call spent tokens".
+    // False: a provider can return usage alongside an error (a post-generation refusal, a partial),
+    // and that generation is billed. Measured on prod 2026-07-30 the ledger held $51.46 while
+    // OpenRouter's `/credits` reported $96.67 on the same key — spend the meter simply threw away.
+    mockFetch(400, {
+      error: { message: "content policy" },
+      usage: { prompt_tokens: 1200, completion_tokens: 300, cost: 0.0091 },
+    });
+    const { db, rows } = captureDb();
+    const res = await forwardUpstream(target, { messages: [] }, { meter: { db, teamId: "team-1", source: "graph", kind: "chat" } });
+    expect(res.status).toBe(400); // the provider error still passes through untouched
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ cost_usd: 0.0091, input_tokens: 1200, output_tokens: 300 });
   });
 
   it("never lets a metering failure break the proxy response", async () => {

--- a/test/guards/ledger-reconciliation-scope.test.ts
+++ b/test/guards/ledger-reconciliation-scope.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * GUARD: the ledger sum compared against a provider's billing figure must be scoped to THAT provider.
+ *
+ * The provider total comes from one provider's API. Summing every provider against it dilutes the gap
+ * toward zero — an Anthropic list-price estimate is real ledger spend that OpenRouter never charged,
+ * so counting it "accounts for" money that key never saw and quietly erases the shortfall this whole
+ * feature exists to expose. It shipped that way in review and would have been invisible the moment a
+ * second provider key was added: today every row is `openrouter`, so no behavioural test can catch it.
+ */
+describe("guard: getLedgerLifetimeUsd is provider-scoped", () => {
+  const src = readFileSync(join(process.cwd(), "lib", "metrics", "llm-costs.ts"), "utf8");
+  const fn = src.slice(src.indexOf("export async function getLedgerLifetimeUsd"));
+
+  it("filters llm_usage by provider", () => {
+    expect(fn).toMatch(/\.eq\("provider",\s*provider\)/);
+  });
+
+  it("refuses to answer at the row cap rather than returning a short sum", () => {
+    // A truncated sum understates the ledger, which INFLATES the unattributed gap — a confident
+    // overstatement is worse than showing nothing.
+    expect(fn).toMatch(/rows\.length >= LEDGER_LIFETIME_ROW_CAP.*return null/s);
+  });
+});

--- a/test/provider-usage.test.ts
+++ b/test/provider-usage.test.ts
@@ -22,6 +22,10 @@ describe("parseCreditsBody — 'unknown' must never read as 'zero'", () => {
     expect(parseCreditsBody({ data: { total_usage: 12.5 } })?.totalUsageUsd).toBe(12.5);
   });
 
+  it("refuses a NEGATIVE total rather than rendering '$-5.00 spent'", () => {
+    expect(parseCreditsBody({ data: { total_usage: -5 } })).toBeNull();
+  });
+
   it("returns NULL — not 0 — for a shape it doesn't recognise", () => {
     // A missing number must read as "we don't know what the provider charged". Zero would be the
     // same false reassurance this module exists to end.
@@ -37,6 +41,7 @@ describe("reconcileLedger — how much spend the ledger could not attribute", ()
     expect(r.unattributedUsd).toBeCloseTo(45.21, 2);
     expect(r.unattributedFraction).toBeCloseTo(0.4677, 3);
     expect(r.material).toBe(true);
+    expect(r.status).toBe("unattributed");
   });
 
   it("stays quiet for a rounding-sized difference", () => {
@@ -46,18 +51,28 @@ describe("reconcileLedger — how much spend the ledger could not attribute", ()
     expect(r.material).toBe(false);
   });
 
+  it("stays quiet when the gap is a large AMOUNT but a trivial fraction", () => {
+    // $10 adrift on $1,000 of spend is accounting noise, not a missing-spend story. I claimed this leg
+    // was mutation-covered when it was not: dropping `fraction >= MATERIAL_FRACTION` passed every test,
+    // because every other case that clears $1 also clears 5%. This is the case that pins it.
+    expect(reconcileLedger(1000, 990).material).toBe(false);
+    expect(reconcileLedger(1000, 990).status).toBe("reconciled");
+  });
+
   it("stays quiet when the gap is a large FRACTION but a trivial amount", () => {
     // A brand-new instance: $0.30 provider, $0.05 ledger. 83% unattributed and completely uninteresting.
     expect(reconcileLedger(0.3, 0.05).material).toBe(false);
   });
 
-  it("CLAMPS at zero — a ledger above the provider total is not negative spend", () => {
-    // Anthropic calls are list-price ESTIMATES counted in the ledger that contribute nothing to
-    // OpenRouter's number, so ledger > provider is legitimate and means "nothing unattributed here".
+  it("CLAMPS at zero and says WHY — a ledger above the provider total is not negative spend", () => {
+    // Now that the ledger sum is filtered to this provider, ledger > provider is no longer routine —
+    // it means the key was rotated (old spend, fresh key) or something double-metered. Rendering the
+    // clamped "accounts for $X of it" there is a literally false sentence, so it gets its own state.
     const r = reconcileLedger(10, 25);
     expect(r.unattributedUsd).toBe(0);
     expect(r.unattributedFraction).toBe(0);
     expect(r.material).toBe(false);
+    expect(r.status).toBe("ledger-exceeds");
   });
 
   it("does not divide by zero on a provider that has charged nothing", () => {

--- a/test/provider-usage.test.ts
+++ b/test/provider-usage.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseCreditsBody, reconcileLedger } from "@/lib/costs/provider-usage";
+
+/**
+ * Spec: the costs surface must not present the ledger's FLOOR as the total.
+ *
+ * Measured on prod 2026-07-30 — the ledger said $51.46, OpenRouter's own `/credits` said $96.67 on
+ * the same key. 47% of real spend was invisible, and the dashboard reported the floor with no hint
+ * that anything was missing. The cause is structural: a call that times out or fails after the
+ * provider generated is billed upstream and returns no `usage` for us to read, so no amount of
+ * fixing the meter can make the ledger complete on its own. Only the provider knows the total.
+ */
+
+describe("parseCreditsBody — 'unknown' must never read as 'zero'", () => {
+  it("reads the provider's cumulative spend", () => {
+    const got = parseCreditsBody({ data: { total_credits: 110, total_usage: 96.670187517 } });
+    expect(got).toEqual({ provider: "openrouter", totalUsageUsd: 96.670187517, totalCreditsUsd: 110 });
+  });
+
+  it("keeps usage when credits are absent — they answer different questions", () => {
+    expect(parseCreditsBody({ data: { total_usage: 12.5 } })?.totalCreditsUsd).toBeNull();
+    expect(parseCreditsBody({ data: { total_usage: 12.5 } })?.totalUsageUsd).toBe(12.5);
+  });
+
+  it("returns NULL — not 0 — for a shape it doesn't recognise", () => {
+    // A missing number must read as "we don't know what the provider charged". Zero would be the
+    // same false reassurance this module exists to end.
+    for (const junk of [null, undefined, {}, { data: {} }, { data: { total_usage: "96.67" } }, { data: { total_usage: NaN } }]) {
+      expect(parseCreditsBody(junk)).toBeNull();
+    }
+  });
+});
+
+describe("reconcileLedger — how much spend the ledger could not attribute", () => {
+  it("reports the real gap measured in production", () => {
+    const r = reconcileLedger(96.67, 51.46);
+    expect(r.unattributedUsd).toBeCloseTo(45.21, 2);
+    expect(r.unattributedFraction).toBeCloseTo(0.4677, 3);
+    expect(r.material).toBe(true);
+  });
+
+  it("stays quiet for a rounding-sized difference", () => {
+    // Timing skew between a page render and the provider's accounting is not a missing-spend story;
+    // flagging it every time would train everyone to ignore the flag that matters.
+    const r = reconcileLedger(50.2, 50.0);
+    expect(r.material).toBe(false);
+  });
+
+  it("stays quiet when the gap is a large FRACTION but a trivial amount", () => {
+    // A brand-new instance: $0.30 provider, $0.05 ledger. 83% unattributed and completely uninteresting.
+    expect(reconcileLedger(0.3, 0.05).material).toBe(false);
+  });
+
+  it("CLAMPS at zero — a ledger above the provider total is not negative spend", () => {
+    // Anthropic calls are list-price ESTIMATES counted in the ledger that contribute nothing to
+    // OpenRouter's number, so ledger > provider is legitimate and means "nothing unattributed here".
+    const r = reconcileLedger(10, 25);
+    expect(r.unattributedUsd).toBe(0);
+    expect(r.unattributedFraction).toBe(0);
+    expect(r.material).toBe(false);
+  });
+
+  it("does not divide by zero on a provider that has charged nothing", () => {
+    const r = reconcileLedger(0, 0);
+    expect(r.unattributedFraction).toBe(0);
+    expect(r.material).toBe(false);
+  });
+});


### PR DESCRIPTION
You compared the dashboard's spend against OpenRouter's and saw ~$8 vs $92. Three separate things, all measured rather than assumed.

## 1. The $8.28 itself was not a code bug

At the moment of that screenshot the ledger already held **$51.32**, and `getPulseMetrics` computes it correctly today — $51.46 across 7d/30d/90d, verified by running it against prod. There is no server-side cache on that page, so that render was stale in the browser. Least interesting of the three, but worth stating so we don't "fix" working code.

## 2. The real bug — 47% of spend was invisible

OpenRouter's own `/api/v1/credits` reports **$96.91** spent on that key. Our ledger accounts for **$51.70**.

The cause is structural, and **no amount of fixing the meter closes it**: a call that times out, or fails after the model already generated, is billed by the provider and returns no `usage` for us to read. The bulk is one bad day — 2026-07-29, when every graph extraction hit the proxy timeout and the OpenAI SDK retried three times. Thousands of generations were billed and we recorded nothing, because `meterGraphCall` was gated on a 2xx under the comment *"only a successful call spent tokens"*. That assumption was false.

## The fix — two parts, because one isn't enough

**Meter what we were throwing away.** The 2xx gate is gone. A provider can return `usage` alongside a non-2xx (post-generation refusal, a partial) and that generation is billed. A body with no `usage` still records nothing, so this only ever adds real spend.

**Reconcile against the provider**, because the ledger can never be complete on its own. `GET /api/v1/credits` needs only the inference key the team already has (`/activity` requires a management key — verified 403). The costs page now shows both figures and the unattributed remainder, and says plainly that the breakdown is a **floor**.

Live against prod right now:

```
provider reported: $96.91   ledger lifetime: $51.70
unattributed:      $45.21 (47%)   material: true
```

## Decisions, each with a test that kills its own mutation

- **An unreadable provider figure returns `null`, never `0`.** Zero would be the same false reassurance this change exists to end.
- **The gap is clamped at zero.** Anthropic calls are list-price estimates counted in our ledger that contribute nothing to OpenRouter's number, so ledger > provider is legitimate — it means "nothing unattributed here", not negative spend.
- **Material only above both 5% and $1.** A new instance at $0.30 vs $0.05 is 83% unattributed and completely uninteresting; flagging it would train everyone to ignore the flag that matters.
- **Lifetime compared with lifetime.** The provider figure can't be sliced by date, so comparing it to a 30-day ledger slice would manufacture a gap that isn't there. The UI says both numbers are lifetime.
- **Shown whenever we can ask, not only when it looks bad** — a reconciliation that appears only on failure teaches nobody what the number means, and its absence would be indistinguishable from "we didn't check".
- **Admin-only** — it's a whole-key total, meaningless beside one member's scoped spend.

## One more thing found, deliberately not fixed here

The ledger has 3,895 embedding rows at `cost_usd = 0`. Not a leak — `cost_usd` is `numeric(12,5)` and an embedding call costs ~8e-08, which rounds to zero at five decimals. Real amount lost: **~$0.004**. Worth knowing the ledger silently floors sub-cent costs; not worth a schema migration on this PR, and it is nowhere near the $45.

## Verified

unit 1548 · tsc 0 · lint clean (2 pre-existing warnings) · docs-drift green. The reconciliation numbers above come from the live key and the prod ledger, not a fixture.

AIOS-Work: AIO-484