### PR TITLE
fix(setup): re-running the provisioner rotated both secrets — logging the team out and orphaning every token

### DIFF
--- a/.agents/skills/setup-brain/SKILL.md
+++ b/.agents/skills/setup-brain/SKILL.md
@@ -109,7 +109,12 @@ point at the dashboard or a push to `main`.
   not just create, stop and report it.
 - Never run `npm run pg:schema` by hand — it is the platform's `preDeployCommand`.
 - Never invent or accept a hand-written `AUTH_SECRET` / `SECRETS_KEY`; never echo either
-  into the transcript. The script generates them and does not print them.
+  into the transcript. The script generates them, preserves them, and prints neither.
+  **Re-running is safe:** on a project that already exists the script reads the environment
+  and keeps both secrets, generating only what is missing — rotating `AUTH_SECRET` logs the
+  team out and rotating `SECRETS_KEY` makes every stored connector token undecryptable. If it
+  reports that it could not read the environment, that abort is deliberate; diagnose the read
+  rather than working around it, and never re-set those two by hand to "unblock" a run.
 - Never paste connector tokens (Slack/GitHub/Linear) yourself — `lib/integrations/manage`
   is the single legal writer and the Admin UI encrypts and audits the write. Setting them
   up is a separate, later step, not part of standing the brain up.

--- a/.claude/skills/setup-brain/SKILL.md
+++ b/.claude/skills/setup-brain/SKILL.md
@@ -109,7 +109,12 @@ point at the dashboard or a push to `main`.
   not just create, stop and report it.
 - Never run `npm run pg:schema` by hand — it is the platform's `preDeployCommand`.
 - Never invent or accept a hand-written `AUTH_SECRET` / `SECRETS_KEY`; never echo either
-  into the transcript. The script generates them and does not print them.
+  into the transcript. The script generates them, preserves them, and prints neither.
+  **Re-running is safe:** on a project that already exists the script reads the environment
+  and keeps both secrets, generating only what is missing — rotating `AUTH_SECRET` logs the
+  team out and rotating `SECRETS_KEY` makes every stored connector token undecryptable. If it
+  reports that it could not read the environment, that abort is deliberate; diagnose the read
+  rather than working around it, and never re-set those two by hand to "unblock" a run.
 - Never paste connector tokens (Slack/GitHub/Linear) yourself — `lib/integrations/manage`
   is the single legal writer and the Admin UI encrypts and audits the write. Setting them
   up is a separate, later step, not part of standing the brain up.

--- a/.cursor/rules/setup-brain.mdc
+++ b/.cursor/rules/setup-brain.mdc
@@ -106,7 +106,12 @@ point at the dashboard or a push to `main`.
   not just create, stop and report it.
 - Never run `npm run pg:schema` by hand — it is the platform's `preDeployCommand`.
 - Never invent or accept a hand-written `AUTH_SECRET` / `SECRETS_KEY`; never echo either
-  into the transcript. The script generates them and does not print them.
+  into the transcript. The script generates them, preserves them, and prints neither.
+  **Re-running is safe:** on a project that already exists the script reads the environment
+  and keeps both secrets, generating only what is missing — rotating `AUTH_SECRET` logs the
+  team out and rotating `SECRETS_KEY` makes every stored connector token undecryptable. If it
+  reports that it could not read the environment, that abort is deliberate; diagnose the read
+  rather than working around it, and never re-set those two by hand to "unblock" a run.
 - Never paste connector tokens (Slack/GitHub/Linear) yourself — `lib/integrations/manage`
   is the single legal writer and the Admin UI encrypts and audits the write. Setting them
   up is a separate, later step, not part of standing the brain up.

--- a/.opencode/skills/setup-brain/SKILL.md
+++ b/.opencode/skills/setup-brain/SKILL.md
@@ -109,7 +109,12 @@ point at the dashboard or a push to `main`.
   not just create, stop and report it.
 - Never run `npm run pg:schema` by hand — it is the platform's `preDeployCommand`.
 - Never invent or accept a hand-written `AUTH_SECRET` / `SECRETS_KEY`; never echo either
-  into the transcript. The script generates them and does not print them.
+  into the transcript. The script generates them, preserves them, and prints neither.
+  **Re-running is safe:** on a project that already exists the script reads the environment
+  and keeps both secrets, generating only what is missing — rotating `AUTH_SECRET` logs the
+  team out and rotating `SECRETS_KEY` makes every stored connector token undecryptable. If it
+  reports that it could not read the environment, that abort is deliberate; diagnose the read
+  rather than working around it, and never re-set those two by hand to "unblock" a run.
 - Never paste connector tokens (Slack/GitHub/Linear) yourself — `lib/integrations/manage`
   is the single legal writer and the Admin UI encrypts and audits the write. Setting them
   up is a separate, later step, not part of standing the brain up.

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -22,6 +22,11 @@
  * Resumable and idempotent. Connecting the GitHub repo is a dashboard OAuth step no CLI can do,
  * so the run stops there, tells you exactly what to click, and picks up where it left off.
  *
+ * Idempotent INCLUDES the secrets: a re-run reads the project's environment and preserves an
+ * existing AUTH_SECRET / SECRETS_KEY rather than generating fresh ones (see `resolveSecrets`).
+ * Rotating them would log the whole team out and make every encrypted connector token
+ * undecryptable, so if the environment can't be read, the run aborts instead of guessing.
+ *
  *   node scripts/setup.mjs --slug acme --name "Acme Robotics" --email you@acme.com
  *   node scripts/setup.mjs --dry-run     # print the plan, touch nothing
  */
@@ -29,6 +34,7 @@ import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { parseArgs } from "node:util";
 import {
+  READONLY_VERBS,
   assertPinnedTarget,
   classifyRailwayCommand,
   isSanctionedProjectName,
@@ -72,6 +78,71 @@ export function generateSecrets() {
   };
 }
 
+/**
+ * Keep the secrets an instance already has; generate only what is missing.
+ *
+ * Regenerating these is destructive, not merely wasteful: AUTH_SECRET invalidates every
+ * session, and SECRETS_KEY is the AES-256-GCM key connector tokens are encrypted at rest
+ * with — rotate it and every stored Slack/GitHub/Linear token becomes undecryptable. This
+ * script advertises itself as resumable and the skill tells you to re-run after fixing a
+ * failure, so a second run reaches this code on a live instance by design. `compose.yml`
+ * already persists both generated secrets for exactly this reason.
+ *
+ * A malformed existing value is preserved, not repaired: replacing a wrong-width SECRETS_KEY
+ * would "fix" the width by destroying the data it protects. The caller warns instead.
+ */
+export function resolveSecrets(existing, generated) {
+  const kept = (v) => (typeof v === "string" && v.trim().length > 0 ? v : null);
+  const authSecret = kept(existing?.AUTH_SECRET);
+  const secretsKey = kept(existing?.SECRETS_KEY);
+  return {
+    authSecret: authSecret ?? generated.authSecret,
+    secretsKey: secretsKey ?? generated.secretsKey,
+    reused: [authSecret && "AUTH_SECRET", secretsKey && "SECRETS_KEY"].filter(Boolean),
+  };
+}
+
+/** null when fine, else the reason — a base64 SECRETS_KEY that isn't exactly 32 bytes. */
+export function secretsKeyComplaint(value) {
+  if (typeof value !== "string" || !value.trim()) return null;
+  // No try/catch: `Buffer.from(junk, "base64")` never throws, it yields a short buffer — so
+  // garbage reports "decodes to 0 bytes", which is the actionable message anyway.
+  const width = Buffer.from(value, "base64").length;
+  if (width === 32) return null;
+  return `SECRETS_KEY decodes to ${width} bytes, not 32 — connector saves will fail (\`npm run doctor\` explains the fix)`;
+}
+
+/**
+ * Does this invocation only read? `variables` is a provisioning (write) verb in the policy, but
+ * `variables --json` with no `--set` is a read — the one verb whose direction depends on flags.
+ */
+export function isReadOnly(args) {
+  const verb = args[0];
+  if (verb === "variables") return !args.includes("--set") && !args.includes("--set-from-stdin");
+  return READONLY_VERBS.includes(verb);
+}
+
+/** The environment read must be a JSON OBJECT. `[]` and `"ok"` are truthy and parse fine, and
+ * treating either as "no secrets present" would fall through to generating fresh ones — the
+ * precise failure the abort exists to prevent. */
+export function isEnvironmentMap(parsed) {
+  return !!parsed && typeof parsed === "object" && !Array.isArray(parsed);
+}
+
+/**
+ * Render a command for the dry-run plan with secret VALUES masked.
+ *
+ * The plan is printed to a terminal and read by agents, and each line is a paste-ready
+ * `railway variables --set …`. Echoing a real AUTH_SECRET/SECRETS_KEY there hands someone a
+ * copyable command that performs exactly the rotation this script now prevents.
+ */
+export function redactSecretsForPlan(rendered) {
+  return String(rendered).replace(
+    /(--set (?:AUTH_SECRET|SECRETS_KEY)=)\S+/g,
+    (_m, prefix) => `${prefix}<generated-or-preserved>`
+  );
+}
+
 /** Where a run should resume from, given what already exists. */
 export function nextPhase(state) {
   if (!state.projectExists) return "create";
@@ -95,18 +166,25 @@ function defaultExec(cmd, args, opts = {}) {
  * run, not to what a comment claims we run. A forbidden verb throws before reaching the CLI.
  */
 export function makeRailway(io, { dryRun = false } = {}) {
-  return function railway(args, { write = false, pin = null, status = null } = {}) {
+  // `verify` pin-checks a READ. Reading the environment back is not a mutation, but its result
+  // is written straight back out — so a read from a drifted link would copy another project's
+  // secrets into this one. Same proof, same reason.
+  return function railway(args, { write = false, verify = false, pin = null, status = null } = {}) {
     const rendered = `railway ${args.join(" ")}`;
     const verdict = classifyRailwayCommand(rendered);
     if (verdict.decision === "block") {
       throw new Error(`setup.mjs refused its own command: ${verdict.reason}`);
     }
-    if (write) {
-      if (!pin) throw new Error(`internal: write \`${rendered}\` attempted with no pinned target`);
+    if (write || verify) {
+      if (!pin) throw new Error(`internal: \`${rendered}\` attempted with no pinned target`);
       assertPinnedTarget(status, pin); // throws on drift
     }
-    if (dryRun) {
-      io.log(`  [dry-run] ${rendered}`);
+    // `--dry-run` suppresses WRITES, not reads. Faking the reads too made the plan blind: it
+    // could not see whether the project already existed (so it showed a secret rotation a real
+    // run would not perform), and it could not detect the link drift that a real run aborts on.
+    // A read mutates nothing, so running it for real is what makes the plan predictive.
+    if (dryRun && !isReadOnly(args)) {
+      io.log(`  [dry-run] ${redactSecretsForPlan(rendered)}`);
       return { status: 0, stdout: "", stderr: "" };
     }
     return io.exec("railway", args);
@@ -189,8 +267,34 @@ export async function runSetup(opts, io = { exec: defaultExec, log: console.log 
   io.log(`✓ domain ${appUrl}`);
 
   // 7. Variables — secrets generated here, never prompted for and never echoed.
+  //
+  // On a project that already existed, read the environment FIRST. A re-run must not rotate
+  // AUTH_SECRET (logs the team out) or SECRETS_KEY (orphans every encrypted connector token).
+  // No read for a project this run just created: there is nothing to preserve.
+  // Runs in dry-run too — it is a read, and it is what lets the plan say truthfully whether a
+  // real run would preserve or generate.
+  let existingVars = {};
+  if (existingName) {
+    // Deliberately the same service targeting as the write below — an asymmetric read could
+    // preserve one service's secrets while overwriting another's. Nothing between this read
+    // and the write below can relink the CLI, so the two cannot resolve differently.
+    const read = railway(["variables", "--json"], { verify: true, pin: project, status: pinned });
+    const parsed = read.status === 0 ? parseJson(read.stdout) : null;
+    if (!isEnvironmentMap(parsed)) {
+      throw new Error(
+        `could not read the existing environment of "${project}" — refusing to continue, because ` +
+          `overwriting AUTH_SECRET/SECRETS_KEY unseen would log the team out and make every stored ` +
+          `connector token undecryptable. Fix the read (\`railway variables\`) and re-run.`
+      );
+    }
+    existingVars = parsed;
+  }
+
   io.log("▶ setting environment variables…");
-  const { authSecret, secretsKey } = generateSecrets();
+  const { authSecret, secretsKey, reused } = resolveSecrets(existingVars, generateSecrets());
+  if (reused.length) io.log(`  ↺ preserving existing ${reused.join(" + ")} (rotating them is destructive)`);
+  const complaint = secretsKeyComplaint(existingVars.SECRETS_KEY);
+  if (complaint) io.log(`  ⚠ ${complaint}`);
   const vars = buildVariables({ appUrl, authSecret, secretsKey, anthropicKey, resendKey, resendFrom });
   const setv = railway(["variables", ...toVariableArgs(vars)], { write: true, pin: project, status: pinned });
   if (setv.status !== 0) throw new Error(`setting variables failed: ${setv.stderr.trim()}`);
@@ -285,7 +389,9 @@ async function main() {
         "  --anthropic-key <k>    answering model (or configure per-team in Admin later)",
         "  --resend-key <k> --resend-from <addr>   magic-link email",
         "  --resume               continue after connecting the GitHub repo",
-        "  --dry-run              print the plan, touch nothing",
+        "  --dry-run              print the plan and write nothing. Reads DO run (so the plan can",
+        "                         tell you whether secrets would be preserved, and can catch link",
+        "                         drift) — so it needs an authenticated `railway login`.",
       ].join("\n")
     );
     process.exit(values.help ? 0 : 1);

--- a/test/setup-provisioner.test.ts
+++ b/test/setup-provisioner.test.ts
@@ -8,13 +8,23 @@ import {
   generateSecrets,
   makeRailway,
   nextPhase,
+  redactSecretsForPlan,
   runSetup,
   toVariableArgs,
 } from "../scripts/setup.mjs";
 import { FORBIDDEN_VERBS } from "../scripts/railway-policy.mjs";
 
 /** A fake Railway CLI that records every invocation and answers plausibly. */
-function fakeRailway({ linkedTo = null }: { linkedTo?: string | null } = {}) {
+function fakeRailway({
+  linkedTo = null,
+  existingVars = null,
+  varsReadFails = false,
+}: {
+  linkedTo?: string | null;
+  /** What `railway variables --json` reports — i.e. the environment already on the project. */
+  existingVars?: Record<string, string> | null;
+  varsReadFails?: boolean;
+} = {}) {
   const calls: string[][] = [];
   let project = linkedTo;
   const exec = vi.fn((cmd: string, args: string[]) => {
@@ -30,6 +40,11 @@ function fakeRailway({ linkedTo = null }: { linkedTo?: string | null } = {}) {
       project = args[args.indexOf("--name") + 1];
       return { status: 0, stdout: `created ${project}`, stderr: "" };
     }
+    // A read: `variables --json` with no --set. Distinct from the write below.
+    if (verb === "variables" && args.includes("--json") && !args.includes("--set")) {
+      if (varsReadFails) return { status: 1, stdout: "", stderr: "no service found" };
+      return { status: 0, stdout: JSON.stringify(existingVars ?? {}), stderr: "" };
+    }
     if (verb === "domain") return { status: 0, stdout: "https://aios-acme.up.railway.app", stderr: "" };
     if (verb === "run") {
       return { status: 0, stdout: "✓ member you@acme.com\n✓ password set (copy now, shown once): s3cret-pw-x", stderr: "" };
@@ -37,6 +52,19 @@ function fakeRailway({ linkedTo = null }: { linkedTo?: string | null } = {}) {
     return { status: 0, stdout: "", stderr: "" };
   });
   return { exec, calls, log: vi.fn() };
+}
+
+/** The `K=V` pairs of the `variables --set` write, as a map. */
+function varsWritten(calls: string[][]): Record<string, string> {
+  const call = calls.find((a) => a[0] === "variables" && a.includes("--set"));
+  if (!call) return {};
+  const out: Record<string, string> = {};
+  for (let i = 0; i < call.length; i++) {
+    if (call[i] !== "--set") continue;
+    const eq = call[i + 1].indexOf("=");
+    out[call[i + 1].slice(0, eq)] = call[i + 1].slice(eq + 1);
+  }
+  return out;
 }
 
 const OPTS = { slug: "acme", displayName: "Acme Robotics", email: "you@acme.com", memberName: "You" };
@@ -153,6 +181,136 @@ describe("generated secrets satisfy the checks that would otherwise fail later",
     const varsArg = io.calls.find((a) => a[0] === "variables")!.join(" ");
     const secret = /AUTH_SECRET=(\w+)/.exec(varsArg)![1];
     expect(logged).not.toContain(secret);
+  });
+});
+
+// Spec: the script calls itself "resumable and idempotent", and the skill tells you to re-run
+// after fixing a failure. So a second run must not be destructive. Rotating these two is exactly
+// that: AUTH_SECRET invalidates every session, and SECRETS_KEY orphans every connector token,
+// which is encrypted at rest with it (README §5). compose.yml already persists both for this
+// reason — the Railway path has to hold the same line.
+describe("re-provisioning preserves secrets that already exist", () => {
+  const EXISTING = {
+    AUTH_SECRET: "existing-auth-secret-do-not-rotate",
+    SECRETS_KEY: Buffer.alloc(32, 7).toString("base64"),
+  };
+
+  it("reuses both secrets rather than generating new ones", async () => {
+    const io = fakeRailway({ linkedTo: "aios-acme", existingVars: EXISTING });
+    await runSetup(OPTS, io);
+    const written = varsWritten(io.calls);
+    expect(written.AUTH_SECRET).toBe(EXISTING.AUTH_SECRET);
+    expect(written.SECRETS_KEY).toBe(EXISTING.SECRETS_KEY);
+  });
+
+  it("still generates both for a brand-new project, where there is nothing to preserve", async () => {
+    const io = fakeRailway(); // nothing linked → the run creates the project
+    await runSetup(OPTS, io);
+    const written = varsWritten(io.calls);
+    expect(written.AUTH_SECRET).toMatch(/^[0-9a-f]{64}$/);
+    expect(Buffer.from(written.SECRETS_KEY, "base64")).toHaveLength(32);
+  });
+
+  it("generates only the half that is missing", async () => {
+    const io = fakeRailway({ linkedTo: "aios-acme", existingVars: { AUTH_SECRET: EXISTING.AUTH_SECRET } });
+    await runSetup(OPTS, io);
+    const written = varsWritten(io.calls);
+    expect(written.AUTH_SECRET).toBe(EXISTING.AUTH_SECRET);
+    expect(Buffer.from(written.SECRETS_KEY, "base64")).toHaveLength(32); // absent → generated
+  });
+
+  it("aborts rather than overwriting secrets it could not read", async () => {
+    // Fail closed. A transient read failure that fell through to "generate" would silently
+    // destroy a live instance's tokens — the worst possible outcome of a retry.
+    const io = fakeRailway({ linkedTo: "aios-acme", varsReadFails: true });
+    await expect(runSetup(OPTS, io)).rejects.toThrow(/could not read the existing environment/i);
+    expect(io.calls.filter((a) => a[0] === "variables" && a.includes("--set"))).toHaveLength(0);
+  });
+
+  it("preserves a malformed existing SECRETS_KEY and warns, instead of silently replacing it", async () => {
+    // Replacing it would "fix" the width by orphaning every token encrypted under it. Naming
+    // the problem is correct; deciding to destroy data on the user's behalf is not.
+    const io = fakeRailway({
+      linkedTo: "aios-acme",
+      existingVars: { ...EXISTING, SECRETS_KEY: Buffer.alloc(35, 1).toString("base64") },
+    });
+    await runSetup(OPTS, io);
+    expect(varsWritten(io.calls).SECRETS_KEY).toBe(Buffer.alloc(35, 1).toString("base64"));
+    // Names the key AND the required width — not a bare mention of "doctor", which any future
+    // log line could satisfy.
+    expect(io.log.mock.calls.flat().join("\n")).toMatch(/SECRETS_KEY[^\n]*35 bytes, not 32/i);
+  });
+
+  it("aborts when the read succeeds but does not yield an environment map", async () => {
+    // `[]` and `"ok"` are truthy and parse fine. Treating either as "no secrets present" would
+    // fall straight through to generating fresh ones — the exact outcome the abort exists for.
+    for (const stdout of ["[]", '"ok"', "42", "null"]) {
+      const io = fakeRailway({ linkedTo: "aios-acme" });
+      io.exec.mockImplementation((_c: string, args: string[]) => {
+        io.calls.push(args);
+        if (args[0] === "whoami") return { status: 0, stdout: "you@example.com", stderr: "" };
+        if (args[0] === "status") return { status: 0, stdout: JSON.stringify({ name: "aios-acme" }), stderr: "" };
+        if (args[0] === "variables" && args.includes("--json")) return { status: 0, stdout, stderr: "" };
+        if (args[0] === "domain") return { status: 0, stdout: "https://aios-acme.up.railway.app", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      });
+      await expect(runSetup(OPTS, io)).rejects.toThrow(/could not read the existing environment/i);
+      expect(io.calls.filter((a) => a[0] === "variables" && a.includes("--set"))).toHaveLength(0);
+    }
+  });
+
+  it("accepts an empty environment — a created-but-unconfigured project generates both", async () => {
+    const io = fakeRailway({ linkedTo: "aios-acme", existingVars: {} });
+    await runSetup(OPTS, io);
+    const written = varsWritten(io.calls);
+    expect(written.AUTH_SECRET).toMatch(/^[0-9a-f]{64}$/);
+    expect(Buffer.from(written.SECRETS_KEY, "base64")).toHaveLength(32);
+  });
+});
+
+describe("the dry-run plan neither leaks nor misrepresents", () => {
+  it("masks secret values, so no plan line is a paste-ready rotation command", () => {
+    const plan = redactSecretsForPlan(
+      "railway variables --set AUTH_SECRET=deadbeefcafe --set SECRETS_KEY=aGVsbG8= --set PGSSL=require"
+    );
+    expect(plan).not.toContain("deadbeefcafe");
+    expect(plan).not.toContain("aGVsbG8=");
+    expect(plan).toContain("PGSSL=require"); // non-secrets stay legible
+    expect(plan).toContain("AUTH_SECRET=<generated-or-preserved>");
+  });
+
+  it("predicts preservation truthfully, because the reads are real", async () => {
+    // The plan must not show a rotation a real run would not perform.
+    const io = fakeRailway({
+      linkedTo: "aios-acme",
+      existingVars: { AUTH_SECRET: "live", SECRETS_KEY: Buffer.alloc(32, 3).toString("base64") },
+    });
+    await runSetup({ ...OPTS, dryRun: true }, io);
+    const logged = io.log.mock.calls.flat().join("\n");
+    expect(logged).toMatch(/preserving existing AUTH_SECRET \+ SECRETS_KEY/i);
+    expect(logged).not.toContain("live"); // and still never echoes the value
+  });
+
+  it("performs the reads but none of the writes", async () => {
+    const io = fakeRailway({ linkedTo: "aios-acme", existingVars: {} });
+    await runSetup({ ...OPTS, dryRun: true }, io);
+    const verbs = io.calls.map((a) => a[0]);
+    expect(verbs).toContain("status"); // read → really ran
+    expect(io.calls.filter((a) => a[0] === "variables" && a.includes("--set"))).toHaveLength(0);
+    for (const write of ["init", "add", "domain", "run"]) expect(verbs).not.toContain(write);
+  });
+
+  it("a dry run now catches the link drift a real run aborts on", async () => {
+    // Previously the faked `status` read made every dry run look clean from a drifted directory.
+    const io = fakeRailway({ linkedTo: "kula" });
+    await expect(runSetup({ ...OPTS, dryRun: true }, io)).rejects.toThrow(/already linked.*kula/is);
+  });
+
+  it("does not read the environment at all for a brand-new project", async () => {
+    // There is nothing to preserve, and the read would target a service that does not exist yet.
+    const io = fakeRailway();
+    await runSetup(OPTS, io);
+    expect(io.calls.filter((a) => a[0] === "variables" && a.includes("--json"))).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Found while scoping the setup wizard. `scripts/setup.mjs` called `generateSecrets()` unconditionally and wrote the result to Railway, **never reading what was already there** — so a second run against an existing project silently replaced `AUTH_SECRET` and `SECRETS_KEY`.

That's destructive, not wasteful:

- **`AUTH_SECRET`** is the session signing key. Rotating it logs the whole team out.
- **`SECRETS_KEY`** is the AES-256-GCM key connector tokens are encrypted at rest with. Rotating it makes every stored Slack / GitHub / Linear token **undecryptable** (README §5).

It was reachable by following the documented flow: the file header advertises "resumable and idempotent" and `/setup-brain` tells you to re-run after fixing a `doctor` failure. `compose.yml` already persists both generated secrets and explains exactly why — the Railway path just didn't hold the same line.

Proven before the fix by driving the real `runSetup` twice through its injectable io:

```
run 1 AUTH_SECRET: 4859f250b9ad1e8f   SECRETS_KEY: JyS3ZAbQbBoZ
run 2 AUTH_SECRET: 5890990e4ae2a4a8   SECRETS_KEY: TUOEQR5bYzqK   ← both rotated
```

and after it, three consecutive re-runs against a live instance write back the identical live values.

## The three judgement calls

- **Fail closed.** If the environment can't be read, abort. Falling through to "generate" would turn a transient read failure into destroyed tokens — the worst possible outcome of a retry.
- **No read for a brand-new project.** Nothing to preserve.
- **A malformed existing `SECRETS_KEY` is preserved and *warned about*, not repaired.** Replacing a wrong-width key would "fix" the width by destroying the data it protects. Naming the problem is right; deciding to lose data on the user's behalf is not.

Reads that feed a write are pin-checked too (`verify`), since a read from a drifted link would copy another project's secrets into this one.

## `--dry-run` now suppresses writes, not reads

Fable's review surfaced that dry-run faked the *reads* as well, which made the plan blind in two ways: it couldn't see whether the project already existed (so it printed a **paste-ready `railway variables --set AUTH_SECRET=…`** line showing the very rotation this PR prevents), and it couldn't detect the link drift a real run aborts on — every dry run from a drifted directory looked clean.

Now reads really run (they mutate nothing), writes are simulated, and secret values are masked in the plan. Cost: `--dry-run` needs an authenticated `railway login`, noted in `--help`.

## Review — Reviewed by Fable (`code-reviewer`) — verdict CLEAR, 2 Mediums + 3 Lows fixed

Fable confirmed the fix is complete (step 7 is the only writer; `finishSetup` never touches these), verified the empty-environment case generates rather than aborts, and independently re-derived the service-targeting question I was least sure about: read and write both omit `--service` and **nothing between them can relink the CLI**, so they cannot resolve differently — the fix is correct-or-safe under every resolution.

Both Mediums fixed: the fail-closed check tested truthiness, so a read returning `[]` or `"ok"` parsed fine and fell through to generating fresh secrets (now `isEnvironmentMap`); and the dry-run leak above. Lows fixed: a dead `try/catch` (`Buffer.from(junk, "base64")` never throws), a half-true comment, and a weak warn-assertion regex that a bare "doctor" anywhere in the log would satisfy.

**One advisory Fable raised that I did not fix here** (pre-existing, and it predates this PR): the app service doesn't exist until the GitHub connection, so where the *whole* variables step lands pre-connect is ambiguous — it may be writing to the Postgres service. Worth a one-time check against a real project; it's the next thing I'd look at, and it doesn't change this fix's correctness.

## Verification

- `test/setup-provisioner.test.ts` **32 passed** (was 26; +6 for the bug, +4 for dry-run/shape)
- The 4 tests describing the bug were **red before the fix**; each new guard mutation-tested: reverting the shape check → 1 red, dropping the redaction → 1 red, re-faking dry-run reads → 3 red
- `npm test` **1551 passed** · lint ✅ (2 pre-existing warnings) · docs-drift ✅ · skill mirrors in sync ✅