### PR TITLE
fix(guards): close the .mjs blind spot in the LLM single-caller guard, and stop it flagging prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ curl -fsSL https://aiosbrain.dev/install.sh | sh
 
 It checks your prerequisites, fetches the repo, and hands you to an interview: run it **on this
 machine** (your own team, real install), **on Railway** (the shared server a team actually uses), or
-**just the demo**. It asks only what your choice needs, **validates each credential as you paste
-it** — a wrong model key is caught there, not three steps later at an empty query box — then shows
-the plan before touching anything. Already cloned? `npm run setup` is the same wizard.
+**just the demo**. It asks only what your choice needs, **proves your model key works
+before going further** — a wrong paste is caught there, not three steps later at an empty query box —
+then shows the plan before touching anything. Already cloned? `npm run setup` is the same wizard.
 
 It never uses `sudo`, never overwrites an existing install, and never deploys.
 [`install.sh`](install.sh) is short and commented — read it before you pipe it, as you should with
@@ -135,20 +135,26 @@ LLM key if you run the context engine. Self-host the model and all of it is zero
   the connectors feed the brain on their own. See
   [the quickstart](https://aiosbrain.dev/guides/quickstart).
 
-**The order, and roughly what each costs you** (~15 minutes to a first answer, excluding the
-optional context engine):
+**The order, and who does each part.** `npm run setup` (or the installer above) performs steps 1–3
+and 5; they're listed because you should know what it did to your machine, not because you have to
+type them. §2 is the same sequence by hand, for a host the wizard doesn't cover or when you'd rather
+drive it yourself.
 
-| | | |
-|---|---|---|
-| 1 | Deploy the app | ~5 min |
-| 2 | Set the environment variables | ~3 min |
-| 3 | Load the schema (`npm run pg:schema`) | ~1 min |
-| 4 | Load the vector schema (`npm run pg:schema:vector`) | ~1 min |
-| 5 | Create the first admin | ~1 min |
-| 6 | Connect one source | ~4 min |
-| + | Add Neo4j + Graphiti | later, or never |
+| | | | |
+|---|---|---|---|
+| 1 | Deploy the app | ~5 min | wizard |
+| 2 | Set the environment variables | ~3 min | wizard |
+| 3 | Load the schema (`npm run pg:schema`) | ~1 min | wizard |
+| 4 | Load the vector schema (`npm run pg:schema:vector`) | ~1 min | **yours** — needs an embeddings model chosen first |
+| 5 | Create the first team + admin | ~1 min | wizard (on Railway, the `--resume` run after you connect the repo) |
+| 6 | Connect one source | ~4 min | **yours** — the Admin UI is the only legal writer for tokens |
+| + | Add Neo4j + Graphiti | later, or never | **yours**, §2.8 |
 
-Everything below is that, in dependency order, with the failure modes called out.
+On the Railway path there's one more step no CLI can take for you: connecting your GitHub
+repository, which is also the deploy path. The wizard stops there and tells you exactly what to
+click.
+
+Everything below is that sequence in dependency order, with the failure modes called out.
 
 > **Joining a team that already runs one?** You don't need any of this — you need an invite. See
 > [Onboarding a contributor](https://aiosbrain.dev/guides/quickstart#part-2--connect-to-a-team-brain).
@@ -283,11 +289,17 @@ Kubernetes all work. Only §2.1 is Railway-specific.
 Each step explains *why*, so you can tell when something has gone wrong rather than pattern-matching
 on green output.
 
-> **Shortcut — `npm run setup` does §2.1–§2.4 for you.** On Railway, the steps below are automated
-> by `scripts/setup.mjs`: it creates the project (named `aios-<slug>`, which is what
-> `scripts/service-guard.mjs` requires), adds Postgres, **generates** `AUTH_SECRET` and
-> `SECRETS_KEY` at the right widths, claims a domain and reads `APP_URL` back from it, sets the
-> variables, and — after you connect the repo — creates your team and first admin.
+> **You probably don't need to read this section. `npm run setup` does §2.1–§2.4 for you** — it's an
+> interview, not a flag soup: it asks where to run (this machine / Railway / demo), collects only the
+> credentials that choice needs, **proves the model key works with a free metadata request** (a wrong
+> paste surfaces there, not later as an empty answer box), and shows you the plan before touching
+> anything. On Railway it creates the project (named `aios-<slug>`, which is what
+> `scripts/service-guard.mjs` requires), adds Postgres, **generates** `AUTH_SECRET` and `SECRETS_KEY`
+> at the right widths, claims a domain and reads `APP_URL` back from it, sets the variables, and —
+> after you connect the repo — creates your team and first admin.
+>
+> Read on when you're deploying somewhere the wizard doesn't cover, debugging a run that went wrong,
+> or you'd simply rather do it yourself and know why each step exists.
 > ```bash
 > railway login                                        # browser OAuth; can't be automated
 > npm run setup -- --slug acme --name "Acme Robotics" --email you@acme.com --dry-run

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,9 @@ REF="${AIOS_REF:-main}"
 DIR="${AIOS_DIR:-aios-team-brain}"
 
 say() { printf '  %s\n' "$*"; }
+# Render the target for humans. `./$DIR` is right for a relative default but produces "./tmp/x" for
+# an absolute AIOS_DIR — a path that doesn't exist and sends people looking in the wrong place.
+show_dir() { case "$1" in /*) printf '%s' "$1" ;; *) printf './%s' "$1" ;; esac; }
 die() { printf '\n  ✗ %s\n\n' "$*" >&2; exit 1; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -46,13 +49,13 @@ if [ -e "$DIR" ]; then
   # arbitrary lifecycle scripts. Require the git remote to be the repo we intended to install.
   ORIGIN="$(git -C "$DIR" remote get-url origin 2>/dev/null || echo '')"
   if [ -d "$DIR/.git" ] && [ -f "$DIR/scripts/setup-wizard.mjs" ] && [ "$ORIGIN" = "$REPO" ]; then
-    say "found an existing Team Brain checkout in ./$DIR — re-running setup there."
+    say "found an existing Team Brain checkout in $(show_dir "$DIR") — re-running setup there."
     say "(nothing fetched; your .env.local and secrets are left alone)"
   else
-    die "./$DIR already exists and is not a checkout of $REPO. Move it, or set AIOS_DIR=<other>."
+    die "$(show_dir "$DIR") already exists and is not a checkout of $REPO. Move it, or set AIOS_DIR=<other>."
   fi
 else
-  say "cloning $REF into ./$DIR"
+  say "cloning $REPO @ $REF into $(show_dir "$DIR")"
   # --depth 1: this is an install, not a contribution. Contributors clone normally.
   git clone --quiet --depth 1 --branch "$REF" "$REPO" "$DIR" ||
     die "clone failed. Check your network, or that '$REF' is a valid ref."
@@ -79,6 +82,6 @@ if [ -c /dev/tty ]; then
   exec node scripts/setup-wizard.mjs < /dev/tty
 else
   say "no terminal detected — run this from an interactive shell:"
-  say "  cd $DIR && npm run setup"
+  say "  cd $(show_dir "$DIR") && npm run setup"
   exit 1
 fi

--- a/test/guards/llm-single-caller.test.ts
+++ b/test/guards/llm-single-caller.test.ts
@@ -42,9 +42,36 @@ function walk(dir: string, out: string[] = []): string[] {
   for (const name of entries) {
     const p = join(dir, name);
     if (statSync(p).isDirectory()) walk(p, out);
-    else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
+    // `.mjs` too: `scripts/` is now mostly .mjs (setup-wizard, setup/*, doctor, bootstrap), so a
+    // TS-only walk left a growing blind spot where a raw `/chat/completions` POST would pass the
+    // build. Traces to a real class of file, not ceremony.
+    else if (/\.(ts|tsx|mjs)$/.test(p)) out.push(p);
   }
   return out;
+}
+
+/**
+ * Remove `//` line comments and block comments before matching.
+ *
+ * Not a parser, and the imprecision is bounded on purpose: it can blank a comment marker that lives
+ * inside a STRING, which loses coverage (a miss) but never invents an accusation. A miss is the safe
+ * direction for this guard — the cost is one uncaught call, not a red build someone "fixes" by
+ * deleting a comment.
+ *
+ * The block opener requires a boundary before `/*` precisely to keep that bounded: without it, a
+ * glob or cron string (`"app/*.ts"`, `"*\/5 * * * *"`) opens a phantom comment that swallows
+ * everything up to the next `*\/` anywhere in the file — including real transport code. Those
+ * strings occur by accident, not just adversarially.
+ *
+ * Still-known gaps, unchanged by this helper and pre-existing: a URL assembled from parts
+ * (`base + "/chat/" + "completions"`) never matched the raw regex either, and a protocol-relative
+ * `fetch("//host/v1/chat/completions")` has its `//` treated as a comment. Both are misses, both
+ * were misses before comment-stripping existed.
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/(^|[\s(,;=:[{])\/\*[\s\S]*?\*\//g, "$1 ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
 }
 
 function offenders(): string[] {
@@ -54,7 +81,11 @@ function offenders(): string[] {
       const rel = file.slice(ROOT.length + 1);
       if (ALLOWLIST.has(rel)) continue;
       if (rel.endsWith(".test.ts") || rel.endsWith(".test.tsx")) continue;
-      const src = readFileSync(file, "utf8");
+      // Strip comments before matching. Prose is not an invocation — the same distinction
+      // `railway-policy.mjs` draws for its forbidden verbs. Without this, a file that DOCUMENTS
+      // that it never posts to /chat/completions gets flagged for saying so, which teaches people
+      // to delete the explanation rather than keep the guard honest.
+      const src = stripComments(readFileSync(file, "utf8"));
       for (const re of RAW_TRANSPORT) {
         if (re.test(src)) hits.push(`${rel}: matches ${re}`);
       }

--- a/test/setup-wizard.test.ts
+++ b/test/setup-wizard.test.ts
@@ -317,6 +317,13 @@ describe("the curl installer's safety properties", () => {
     expect(code).toMatch(/\[ "\$ORIGIN" = "\$REPO" \]/);
   });
 
+  it("renders an absolute target directory without a bogus ./ prefix", () => {
+    // `./$DIR` with AIOS_DIR=/tmp/x printed "./tmp/x" — a path that does not exist, sending the
+    // reader to look in the wrong place.
+    expect(code).toMatch(/show_dir\(\)/);
+    expect(code).not.toMatch(/"\.\/\$DIR"/);
+  });
+
   it("fails loudly on a failed clone instead of continuing into a half-install", () => {
     expect(sh).toMatch(/clone failed/);
     expect(sh).toMatch(/^set -eu$/m);


### PR DESCRIPTION
Follow-up to #453, closing the gap that PR's review identified and left open.

## The gap

`test/guards/llm-single-caller.test.ts` walks `app/`, `lib/` and `scripts/` for raw LLM transport — but kept only `.ts`/`.tsx`. **`scripts/` is now mostly `.mjs`** (`setup-wizard`, `setup/*`, `doctor`, `bootstrap`), so a `scripts/*.mjs` POSTing to `/chat/completions` would have sailed through the build. #453 added four such files, which is what turned a theoretical hole into a real one.

## Why the one-line fix wasn't enough

Adding the extension alone makes the guard fail on **`probe.mjs`** — whose header comment contains the literal `/chat/completions` while explaining that it deliberately does *not* do that. A guard that flags a file for documenting its own compliance teaches people to delete the explanation. So the matcher strips comments first: **prose is not an invocation**, the same distinction `railway-policy.mjs` already draws for its forbidden verbs.

## Review — Reviewed by Fable (`code-reviewer`) — verdict CLEAR, 2 Mediums fixed

Fable attacked the stripper and **broke my claim that "raw transport can't hide inside a string and still execute."** It can:

```js
const glob = "app/*.ts";          // opens a phantom block comment…
const c = new Anthropic({ … });   // …which swallows this
const tail = "y*/z";              // …until here
```

Globs and cron strings (`"*/5 * * * *"`) make that open/close pair plausible **by accident**, not just adversarially — and the old TS-only guard *did* catch this case, so my change would have regressed it. Fixed by requiring a boundary before `/*`; mutation-tested with exactly the snippet above, now caught.

Also fixed: the README claimed the wizard "performs steps 1–5" while its own table three lines later marked step 4 (vector schema) as yours. Fable verified **the table is the truthful one** — nothing in the wizard chain runs `pg:schema:vector`. Prose corrected to 1–3 and 5, and step 5 now notes that on Railway the team+admin happens in the `--resume` run after you connect the repo.

Two overstatements toned down: "validates each credential" / "checks each one actually works" → the model key is genuinely probed, but the **Resend key is collected and never verified**.

Remaining stripper gaps are documented in the helper and are **pre-existing, not regressions**: a URL assembled from parts (`base + "/chat/" + "completions"`) never matched the raw regex, and a protocol-relative `fetch("//host/v1/chat/completions")` has its `//` read as a comment. Both are misses, which is the safe direction — the cost is one uncaught call, not a red build someone "fixes" by deleting a comment.

## Also here — both found by running the installer end to end

- `install.sh` printed `./$DIR` unconditionally, so `AIOS_DIR=/tmp/x` rendered as **`./tmp/x`** — a path that doesn't exist, sending the reader to look in the wrong place. Now via `show_dir`, and the clone line names the repo and ref it's using.
- The README's setup-order table presented six steps as the reader's work when five are the wizard's; §2 now opens with "you probably don't need to read this section" plus when you actually do.

## Verification

- Guard mutation-tested **both directions**: a real `new Anthropic(` / `/chat/completions` in a `scripts/**/*.mjs` is caught; a comment mentioning it is not; a glob-string opener no longer hides a real client
- `npm test` **1641 passed** · lint ✅ (2 pre-existing warnings) · docs-drift ✅ · `sh -n install.sh` ✅