### PR TITLE
fix(hooks): track the pre-commit guard and chain the NDA gate through core.hooksPath

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,59 @@
+# .githooks — tracked hooks + the machine-local chain convention
+
+This repo activates this directory with `core.hooksPath=.githooks` (set by the
+package.json `"prepare"` script on every `npm install`). That has one critical
+consequence: **git ignores `.git/hooks/` entirely** — any hook installed there
+(by the NDA leak-gate installers, `aios worktree install-hook`, etc.) never
+runs on its own.
+
+## The convention
+
+Two layers, one chain:
+
+| Layer | Location | Contents | Who runs it |
+|---|---|---|---|
+| **Repo policy (tracked)** | `.githooks/<hook>` | version-controlled, same for everyone: primary-commit guard, docs-drift guard, skill-sync guard | git, via `core.hooksPath` — in the primary AND every linked worktree (each worktree executes its own checked-out copy) |
+| **Machine-local (untracked)** | `$(git rev-parse --git-common-dir)/hooks/<hook>` i.e. the primary's `.git/hooks/<hook>` | per-machine, never committed: the NDA leak-gate shims (`~/.config/aios-nda/nda-leak-gate.sh`), worktree auto-hydration | **only** the tracked hook, which chains it explicitly |
+
+Every tracked hook here ends by exec'ing/running the machine-local hook of the
+same name from the **git common dir** (shared by all worktrees, so one local
+install covers every worktree). Rules baked into each tracked hook:
+
+- **Resolve via `git rev-parse --git-common-dir`, never
+  `--git-path hooks/...`** — `--git-path` honors `core.hooksPath` and resolves
+  straight back into `.githooks/` (self-recursion or a dead
+  `.githooks/<hook>.chained` target — the bug this convention fixed).
+- **Skip** a chain target that is missing, non-executable, or contains the
+  `aios-tracked-hook` marker (recursion belt-and-braces). Missing is normal for
+  contributors without the private NDA config; the NDA gate itself fails
+  closed once installed.
+- **Gate hooks chain unconditionally on the success path.** In particular the
+  pre-commit chain runs in linked worktrees *and* under
+  `AIOS_ALLOW_PRIMARY_COMMIT=1` — overriding the worktree guard never skips
+  the NDA gate. The pre-push chain runs *before* the drift/skill guards so the
+  confidentiality gate can't be masked by a drift failure.
+
+## Current hooks
+
+- `pre-commit` — blocks authored commits in the PRIMARY checkout (work belongs
+  in `aios worktree add` worktrees; override: `AIOS_ALLOW_PRIMARY_COMMIT=1`),
+  then chains the machine-local pre-commit (NDA leak gate, `staged` scan).
+- `pre-push` — chains the machine-local pre-push (NDA leak gate, `tree` scan),
+  then the docs-drift guard, then the skill-runtime-sync guard.
+- `post-checkout` — chains the machine-local post-checkout (worktree
+  auto-hydration); never blocks.
+
+Guarded by `test/guards/githooks-chain.test.ts` (fixture-repo tests: primary
+block, worktree pass-through, chain execution incl. under the override,
+ff-only merge untouched, no recursion).
+
+## Installer caveat
+
+The aios-workspace installers (`install-primary-commit-guard.sh`,
+`install-leak-gate-push-hook.sh`) resolve `core.hooksPath` and copy their hook
+INTO this tracked directory, clobbering the tracked file with an untracked
+variant whose chain resolution is broken here (see above). Until those
+installers learn to leave hooksPath repos alone (machine-local hooks belong in
+the common dir for this repo), a re-run will dirty `.githooks/pre-commit` —
+restore with `git checkout -- .githooks/pre-commit`. The tracked hooks already
+provide the guard, so the installers add nothing in this repo.

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# aios-tracked-hook: post-checkout — machine-local chain only.
+#
+# core.hooksPath=.githooks makes git ignore `.git/hooks/`, which is exactly
+# where `aios worktree install-hook` puts the worktree auto-hydration
+# post-checkout hook. Chain it so a raw `git worktree add` (without the `aios
+# worktree add` wrapper) still auto-hydrates config. Never blocks a checkout.
+# See .githooks/README.md for the chain convention.
+set -uo pipefail
+
+common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -n "$common_dir" && "$common_dir" != /* ]]; then
+  common_dir="$(cd "$common_dir" 2>/dev/null && pwd || echo "$common_dir")"
+fi
+
+local_hook="$common_dir/hooks/post-checkout"
+if [[ -n "$common_dir" && -x "$local_hook" ]] && ! grep -q "aios-tracked-hook" "$local_hook" 2>/dev/null; then
+  "$local_hook" "$@" || true
+fi
+
+exit 0

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -10,11 +10,11 @@ set -uo pipefail
 
 common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
 if [[ -n "$common_dir" && "$common_dir" != /* ]]; then
-  common_dir="$(cd "$common_dir" 2>/dev/null && pwd || echo "$common_dir")"
+  common_dir="$(cd "$common_dir" 2>/dev/null && pwd -P || echo "$common_dir")"
 fi
 
 local_hook="$common_dir/hooks/post-checkout"
-if [[ -n "$common_dir" && -x "$local_hook" ]] && ! grep -q "aios-tracked-hook" "$local_hook" 2>/dev/null; then
+if [[ -n "$common_dir" && -x "$local_hook" ]] && ! grep -q "^# aios-tracked-hook" "$local_hook" 2>/dev/null; then
   "$local_hook" "$@" || true
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -53,10 +53,13 @@ DEFAULT_BRANCH="main"
 git_dir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
 common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
 
-# Normalize the common dir to an absolute path (it can be reported relative,
-# e.g. ".git", when invoked from the primary working tree root).
+# Normalize the common dir to an absolute PHYSICAL path (it can be reported
+# relative, e.g. ".git", when invoked from the primary working tree root).
+# `pwd -P` is required: --absolute-git-dir returns the physical path, and a
+# logical `pwd` under a symlinked cwd (e.g. ~/Tessera → ~/Projects) would make
+# the two never compare equal — silently failing the guard OPEN in the primary.
 if [[ -n "$common_dir" && "$common_dir" != /* ]]; then
-  common_dir="$(cd "$common_dir" 2>/dev/null && pwd || echo "$common_dir")"
+  common_dir="$(cd "$common_dir" 2>/dev/null && pwd -P || echo "$common_dir")"
 fi
 
 is_primary=0
@@ -105,7 +108,7 @@ fi
 # Runs in linked worktrees AND in the primary under the override — the NDA
 # gate is never skippable via AIOS_ALLOW_PRIMARY_COMMIT.
 local_hook="$common_dir/hooks/pre-commit"
-if [[ -x "$local_hook" ]] && ! grep -q "aios-tracked-hook" "$local_hook" 2>/dev/null; then
+if [[ -x "$local_hook" ]] && ! grep -q "^# aios-tracked-hook" "$local_hook" 2>/dev/null; then
   exec "$local_hook" "$@"
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# aios-tracked-hook: pre-commit — primary-checkout commit guard + machine-local chain.
+#
+# This file is TRACKED and version-controlled. This repo activates it via
+# `core.hooksPath=.githooks` (set by the package.json "prepare" script on npm
+# install), so it runs in the primary checkout AND in every linked worktree —
+# each worktree executes its own checked-out copy of .githooks/.
+#
+# Because core.hooksPath makes git IGNORE `.git/hooks/` entirely, any hook
+# installed there (the machine-local NDA leak-gate shim, the worktree
+# auto-hydration hook) only runs if a tracked hook here chains it explicitly.
+# See .githooks/README.md for the chain convention.
+#
+# Two jobs, in order:
+#
+#   1. PRIMARY-COMMIT GUARD — block every authored commit made in the PRIMARY
+#      checkout, on EVERY branch including `main`. AIOS requires all work to
+#      happen in a dedicated linked worktree (`aios worktree add <branch>`);
+#      the primary should only advance via `git merge --ff-only` from origin,
+#      which moves the ref without creating a commit and so never triggers this
+#      hook. A non-ff merge in the primary IS the anti-pattern and is blocked
+#      too. NO-OP inside linked worktrees.
+#      Override for a genuinely intentional primary commit (rare hotfix or a
+#      deliberate non-ff merge on main):
+#        AIOS_ALLOW_PRIMARY_COMMIT=1 git commit ...
+#
+#   2. MACHINE-LOCAL CHAIN — after the guard passes (linked worktree, or the
+#      primary under the override), exec the machine-local hook at
+#      "$(git rev-parse --git-common-dir)/hooks/pre-commit" when present and
+#      executable. On NDA-configured machines that shim runs
+#      ~/.config/aios-nda/nda-leak-gate.sh staged — the NDA confidentiality
+#      gate. The common dir is shared by all worktrees, so one machine-local
+#      install covers every worktree. The chain runs under the override too:
+#      overriding the worktree guard NEVER skips the NDA gate.
+#      Missing/non-executable machine-local hook = skipped (contributors
+#      without the private NDA term list); the gate itself fails closed once
+#      installed.
+#
+# IMPORTANT implementation note: never resolve the chain target with
+# `git rev-parse --git-path hooks/...` — that helper honors core.hooksPath and
+# resolves straight back into .githooks/ (self-recursion / a dead target).
+# Resolve via --git-common-dir instead. As a second belt, any chain target
+# containing the "aios-tracked-hook" marker is skipped.
+
+set -euo pipefail
+
+DEFAULT_BRANCH="main"
+
+# ── Detect PRIMARY vs linked WORKTREE ──────────────────────────────────────
+# In the primary checkout, the git dir IS the common git dir.
+# In a linked worktree, the git dir is `<common>/worktrees/<name>` — different.
+git_dir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+
+# Normalize the common dir to an absolute path (it can be reported relative,
+# e.g. ".git", when invoked from the primary working tree root).
+if [[ -n "$common_dir" && "$common_dir" != /* ]]; then
+  common_dir="$(cd "$common_dir" 2>/dev/null && pwd || echo "$common_dir")"
+fi
+
+is_primary=0
+if [[ -n "$git_dir" && "$git_dir" == "$common_dir" ]]; then
+  is_primary=1
+fi
+
+if [[ "$is_primary" == "1" ]]; then
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+  if [[ "${AIOS_ALLOW_PRIMARY_COMMIT:-}" == "1" ]]; then
+    echo "[aios] AIOS_ALLOW_PRIMARY_COMMIT=1 set — allowing commit on '$branch' in the primary checkout." >&2
+  else
+    suggest_branch="$branch"
+    if [[ "$suggest_branch" == "$DEFAULT_BRANCH" || "$suggest_branch" == "HEAD" ]]; then
+      suggest_branch="feat/<short-task-name>"
+    fi
+    cat >&2 <<EOF
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  AIOS worktree guard: commit BLOCKED in the PRIMARY checkout                 │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+You are committing to branch '$branch' inside the PRIMARY checkout:
+  $(git rev-parse --show-toplevel 2>/dev/null)
+
+AIOS requires ALL work to live in a dedicated git worktree — the primary
+checkout must never carry an authored commit on ANY branch, including '$DEFAULT_BRANCH'.
+It should only ever advance via 'git merge --ff-only' from origin (which moves
+the ref without a commit and never triggers this hook). Do this instead:
+
+  aios worktree add $suggest_branch
+  cd ../$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")-worktrees/${suggest_branch//\//-}
+  # then commit there
+
+If this really is an intentional primary-checkout commit (a rare hotfix, or a
+deliberate non-ff merge on '$DEFAULT_BRANCH'), re-run:
+
+  AIOS_ALLOW_PRIMARY_COMMIT=1 git commit ...
+
+EOF
+    exit 1
+  fi
+fi
+
+# ── Chain the machine-local hook (NDA leak gate) from the git common dir ────
+# Runs in linked worktrees AND in the primary under the override — the NDA
+# gate is never skippable via AIOS_ALLOW_PRIMARY_COMMIT.
+local_hook="$common_dir/hooks/pre-commit"
+if [[ -x "$local_hook" ]] && ! grep -q "aios-tracked-hook" "$local_hook" 2>/dev/null; then
+  exec "$local_hook" "$@"
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# pre-push: block pushes that would drift the docs from the code.
+# aios-tracked-hook: pre-push — machine-local chain + docs-drift + skill-sync guards.
 #
 # Enabled via core.hooksPath=.githooks, set automatically by `npm install` (the
 # package.json "prepare" script). The brain repo is private on a free org plan, so
@@ -8,6 +8,28 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
+
+# ── Machine-local chain (see .githooks/README.md) ──────────────────────────
+# core.hooksPath points git at this tracked dir, so `.git/hooks/` is IGNORED —
+# the machine-local pre-push installed there (on NDA-configured machines: the
+# NDA leak-gate `tree` scan) only runs because we chain it here. It runs FIRST
+# so the confidentiality gate can never be masked by a drift failure. Missing/
+# non-executable = skipped (contributors without the private NDA term list).
+# Resolve via --git-common-dir, NOT --git-path (which honors core.hooksPath and
+# would resolve back into .githooks/); skip anything carrying our own marker.
+common_dir="$(git rev-parse --git-common-dir)"
+if [ "${common_dir#/}" = "$common_dir" ]; then
+  common_dir="$(cd "$common_dir" && pwd)"
+fi
+local_hook="$common_dir/hooks/pre-push"
+if [ -x "$local_hook" ] && ! grep -q "aios-tracked-hook" "$local_hook" 2>/dev/null; then
+  echo "pre-push: running machine-local hook…"
+  if ! "$local_hook" "$@"; then
+    echo "" >&2
+    echo "pre-push: BLOCKED by the machine-local hook: $local_hook" >&2
+    exit 1
+  fi
+fi
 guard="$repo_root/scripts/check-docs-drift.mjs"
 
 if [ -f "$guard" ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,10 +19,10 @@ repo_root="$(git rev-parse --show-toplevel)"
 # would resolve back into .githooks/); skip anything carrying our own marker.
 common_dir="$(git rev-parse --git-common-dir)"
 if [ "${common_dir#/}" = "$common_dir" ]; then
-  common_dir="$(cd "$common_dir" && pwd)"
+  common_dir="$(cd "$common_dir" && pwd -P)"
 fi
 local_hook="$common_dir/hooks/pre-push"
-if [ -x "$local_hook" ] && ! grep -q "aios-tracked-hook" "$local_hook" 2>/dev/null; then
+if [ -x "$local_hook" ] && ! grep -q "^# aios-tracked-hook" "$local_hook" 2>/dev/null; then
   echo "pre-push: running machine-local hook…"
   if ! "$local_hook" "$@"; then
     echo "" >&2

--- a/test/guards/githooks-chain.test.ts
+++ b/test/guards/githooks-chain.test.ts
@@ -1,0 +1,261 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * BUILD-FAILING GUARD: the tracked .githooks chain actually enforces what it claims.
+ *
+ * This repo sets `core.hooksPath=.githooks`, which makes git IGNORE `.git/hooks/` — the
+ * directory where the machine-local NDA leak-gate shims are installed. The failure this
+ * guard traces to (guard rollout fallout from AIO-578 / split program AIO-594): an
+ * untracked pre-commit guard resolved its chain with `git rev-parse --git-path
+ * hooks/pre-commit.chained`, which honors core.hooksPath and pointed at a nonexistent
+ * `.githooks/pre-commit.chained` — so the NDA gate silently never ran on any commit, in
+ * any worktree, on an NDA-gated repo.
+ *
+ * The tracked hooks now (a) block authored commits in the PRIMARY checkout, (b) no-op in
+ * linked worktrees, and (c) chain the machine-local hook from the git COMMON dir — in
+ * worktrees AND under the AIOS_ALLOW_PRIMARY_COMMIT override. These tests prove each
+ * behavior against a disposable fixture repo using the real tracked hook files.
+ *
+ * The synthetic leak term below is OBVIOUSLY fake — never put a real confidential term
+ * in a test.
+ */
+
+const REPO_ROOT = process.cwd();
+const FAKE_TERM = "TOTALLY-FAKE-NDA-CLIENT-ZZ9";
+
+/** Env for fixture git calls: identity set, hook overrides stripped. */
+const GIT_ENV: NodeJS.ProcessEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Fixture",
+  GIT_AUTHOR_EMAIL: "fixture@example.com",
+  GIT_COMMITTER_NAME: "Fixture",
+  GIT_COMMITTER_EMAIL: "fixture@example.com",
+};
+delete GIT_ENV.GIT_DIR;
+delete GIT_ENV.GIT_WORK_TREE;
+delete GIT_ENV.GIT_INDEX_FILE;
+delete GIT_ENV.AIOS_ALLOW_PRIMARY_COMMIT;
+
+function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = GIT_ENV): string {
+  return execFileSync("git", args, { cwd, env, encoding: "utf8", timeout: 20_000 });
+}
+
+/** Run git expecting failure; returns combined stdout+stderr of the failure. */
+function gitFails(cwd: string, args: string[], env: NodeJS.ProcessEnv = GIT_ENV): string {
+  try {
+    execFileSync("git", args, { cwd, env, encoding: "utf8", timeout: 20_000, stdio: "pipe" });
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; message: string };
+    return `${e.stdout ?? ""}${e.stderr ?? ""}${e.message}`;
+  }
+  throw new Error(`expected git ${args.join(" ")} to fail, but it succeeded`);
+}
+
+let root: string; // mkdtemp container
+let primary: string; // fixture primary checkout
+let sentinel: string; // file the fake machine-local hooks touch to prove they ran
+let wtCounter = 0;
+
+/** Fake machine-local NDA hook: record it ran; block if the staged/tree content leaks the fake term. */
+function installLocalHook(name: "pre-commit" | "pre-push", scan: "staged" | "tree"): void {
+  const grepSource =
+    scan === "staged"
+      ? `git diff --cached -- . | grep -F "${FAKE_TERM}"`
+      : `git grep -F "${FAKE_TERM}" -- .`;
+  writeFileSync(
+    join(primary, ".git", "hooks", name),
+    `#!/usr/bin/env bash\n` +
+      `# fixture machine-local NDA gate (fake)\n` +
+      `echo "${name}" >> "${sentinel}"\n` +
+      `if ${grepSource} > /dev/null 2>&1; then\n` +
+      `  echo "NDA-GATE: BLOCKED — forbidden term found (${scan})" >&2\n` +
+      `  exit 1\n` +
+      `fi\n` +
+      `exit 0\n`,
+  );
+  chmodSync(join(primary, ".git", "hooks", name), 0o755);
+}
+
+function addWorktree(branch: string): string {
+  const wt = join(root, `wt-${++wtCounter}`);
+  git(primary, ["worktree", "add", "-b", branch, wt, "main"]);
+  return wt;
+}
+
+function ranHooks(): string[] {
+  return existsSync(sentinel) ? readFileSync(sentinel, "utf8").trim().split("\n").filter(Boolean) : [];
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "githooks-chain-"));
+  primary = join(root, "repo");
+  sentinel = join(root, "hook-ran.log");
+  mkdirSync(primary);
+  git(primary, ["init", "-b", "main"]);
+  // Seed the fixture with the REAL tracked hooks before enabling hooksPath, so the
+  // initial commit isn't blocked by the guard under test.
+  mkdirSync(join(primary, ".githooks"));
+  for (const hook of ["pre-commit", "pre-push", "post-checkout"]) {
+    copyFileSync(join(REPO_ROOT, ".githooks", hook), join(primary, ".githooks", hook));
+    chmodSync(join(primary, ".githooks", hook), 0o755);
+  }
+  writeFileSync(join(primary, "seed.txt"), "seed\n");
+  git(primary, ["add", "-A"]);
+  git(primary, ["commit", "-m", "seed"]);
+  git(primary, ["config", "core.hooksPath", ".githooks"]);
+  installLocalHook("pre-commit", "staged");
+  installLocalHook("pre-push", "tree");
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("tracked pre-commit: primary-checkout guard", () => {
+  it("blocks an authored commit in the PRIMARY checkout, on main", () => {
+    writeFileSync(join(primary, "blocked.txt"), "clean content\n");
+    git(primary, ["add", "blocked.txt"]);
+    const out = gitFails(primary, ["commit", "-m", "should be blocked"]);
+    expect(out).toContain("PRIMARY checkout");
+    expect(out).toContain("aios worktree add");
+    git(primary, ["reset", "HEAD", "blocked.txt"]);
+    rmSync(join(primary, "blocked.txt"));
+  });
+
+  it("allows a commit in a linked worktree AND runs the machine-local (NDA) chain", () => {
+    const wt = addWorktree("feat/clean");
+    rmSync(sentinel, { force: true });
+    writeFileSync(join(wt, "feature.txt"), "clean content\n");
+    git(wt, ["add", "feature.txt"]);
+    git(wt, ["commit", "-m", "clean commit in worktree"]);
+    expect(ranHooks()).toContain("pre-commit"); // chain executed
+  });
+
+  it("NDA chain blocks a leaking commit in a linked worktree", () => {
+    const wt = addWorktree("feat/leaky");
+    writeFileSync(join(wt, "leak.txt"), `mentions ${FAKE_TERM} in prose\n`);
+    git(wt, ["add", "leak.txt"]);
+    const out = gitFails(wt, ["commit", "-m", "leaky commit"]);
+    expect(out).toContain("NDA-GATE: BLOCKED");
+  });
+
+  it("AIOS_ALLOW_PRIMARY_COMMIT=1 allows a primary commit but STILL runs the NDA chain", () => {
+    const env = { ...GIT_ENV, AIOS_ALLOW_PRIMARY_COMMIT: "1" };
+    // leaking content: override does NOT bypass the NDA gate
+    writeFileSync(join(primary, "leak.txt"), `mentions ${FAKE_TERM} in prose\n`);
+    git(primary, ["add", "leak.txt"], env);
+    const out = gitFails(primary, ["commit", "-m", "override + leak"], env);
+    expect(out).toContain("NDA-GATE: BLOCKED");
+    git(primary, ["reset", "HEAD", "leak.txt"], env);
+    rmSync(join(primary, "leak.txt"));
+    // clean content: override works, chain ran
+    rmSync(sentinel, { force: true });
+    writeFileSync(join(primary, "hotfix.txt"), "clean hotfix\n");
+    git(primary, ["add", "hotfix.txt"], env);
+    git(primary, ["commit", "-m", "intentional primary hotfix"], env);
+    expect(ranHooks()).toContain("pre-commit");
+  });
+
+  it("git merge --ff-only in the primary is unaffected", () => {
+    const wt = addWorktree("feat/ff");
+    writeFileSync(join(wt, "ff.txt"), "clean ff content\n");
+    git(wt, ["add", "ff.txt"]);
+    git(wt, ["commit", "-m", "commit to fast-forward onto main"]);
+    const before = git(primary, ["rev-parse", "HEAD"]).trim();
+    git(primary, ["merge", "--ff-only", "feat/ff"]);
+    const after = git(primary, ["rev-parse", "HEAD"]).trim();
+    expect(after).not.toBe(before);
+    expect(after).toBe(git(primary, ["rev-parse", "feat/ff"]).trim());
+  });
+
+  it("does not recurse when the machine-local hook is a copy of the tracked hook", () => {
+    // Belt-and-braces: the tracked hook skips chain targets carrying its own marker.
+    copyFileSync(join(REPO_ROOT, ".githooks", "pre-commit"), join(primary, ".git", "hooks", "pre-commit"));
+    chmodSync(join(primary, ".git", "hooks", "pre-commit"), 0o755);
+    const wt = addWorktree("feat/no-recurse");
+    writeFileSync(join(wt, "safe.txt"), "clean content\n");
+    git(wt, ["add", "safe.txt"]);
+    git(wt, ["commit", "-m", "no infinite exec loop"]); // would time out on recursion
+    installLocalHook("pre-commit", "staged"); // restore the fake NDA hook
+  });
+});
+
+describe("tracked pre-push: machine-local chain", () => {
+  it("runs the machine-local (NDA tree) hook on push, and pushes when clean", () => {
+    const remote = join(root, "remote.git");
+    git(root, ["init", "--bare", remote]);
+    git(primary, ["remote", "add", "origin", remote]);
+    rmSync(sentinel, { force: true });
+    git(primary, ["push", "origin", "main"]);
+    expect(ranHooks()).toContain("pre-push");
+  });
+
+  it("blocks the push when the machine-local hook finds a leak in the tree", () => {
+    const wt = addWorktree("feat/leaky-tree");
+    // Commit the leak with the machine-local pre-commit temporarily removed, to prove
+    // pre-push independently catches what the commit stage missed.
+    rmSync(join(primary, ".git", "hooks", "pre-commit"));
+    writeFileSync(join(wt, "tree-leak.txt"), `mentions ${FAKE_TERM} in prose\n`);
+    git(wt, ["add", "tree-leak.txt"]);
+    git(wt, ["commit", "-m", "leak slipped past commit stage"]);
+    installLocalHook("pre-commit", "staged");
+    const out = gitFails(wt, ["push", "origin", "feat/leaky-tree"]);
+    expect(out).toContain("NDA-GATE: BLOCKED");
+    expect(out).toContain("BLOCKED by the machine-local hook");
+  });
+});
+
+describe("static contract: hooks stay tracked, executable, and correctly resolved", () => {
+  it("all three tracked hooks exist and are executable", () => {
+    for (const hook of ["pre-commit", "pre-push", "post-checkout"]) {
+      const p = join(REPO_ROOT, ".githooks", hook);
+      expect(existsSync(p), `${hook} missing`).toBe(true);
+      expect(statSync(p).mode & 0o111, `${hook} not executable`).not.toBe(0);
+    }
+  });
+
+  it("no tracked hook resolves its chain via --git-path (honors hooksPath → recursion/dead target)", () => {
+    for (const hook of ["pre-commit", "pre-push", "post-checkout"]) {
+      const src = readFileSync(join(REPO_ROOT, ".githooks", hook), "utf8");
+      // Scan code only — the hooks' own header comments explain (and name) the anti-pattern.
+      const code = src
+        .split("\n")
+        .filter((line) => !line.trimStart().startsWith("#"))
+        .join("\n");
+      expect(code, `${hook} must not use --git-path hooks/…`).not.toMatch(/--git-path\s+hooks\//);
+      expect(code, `${hook} must resolve the chain via the common dir`).toContain("--git-common-dir");
+    }
+  });
+
+  it("pre-push keeps the docs-drift and skill-sync guards (never weakened)", () => {
+    const src = readFileSync(join(REPO_ROOT, ".githooks", "pre-push"), "utf8");
+    expect(src).toContain("check-docs-drift.mjs");
+    expect(src).toContain("sync-skill-runtimes.sh");
+    // The machine-local (NDA) chain must run BEFORE the drift guards.
+    expect(src.indexOf("machine-local")).toBeGreaterThan(-1);
+    expect(src.indexOf('local_hook="$common_dir/hooks/pre-push"')).toBeLessThan(
+      src.indexOf("check-docs-drift.mjs"),
+    );
+  });
+
+  it("core.hooksPath enablement is pinned in package.json prepare", () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    expect(pkg.scripts?.prepare).toContain("core.hooksPath .githooks");
+  });
+});

--- a/test/guards/githooks-chain.test.ts
+++ b/test/guards/githooks-chain.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
@@ -8,6 +8,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { existsSync } from "node:fs";
@@ -37,13 +38,20 @@ import { join } from "node:path";
 const REPO_ROOT = process.cwd();
 const FAKE_TERM = "TOTALLY-FAKE-NDA-CLIENT-ZZ9";
 
-/** Env for fixture git calls: identity set, hook overrides stripped. */
+/**
+ * Env for fixture git calls: identity set, hook overrides stripped, and config
+ * fully hermetic — a machine-global core.hooksPath / init.templateDir /
+ * commit.gpgsign would otherwise change fixture behavior and red these tests
+ * spuriously.
+ */
 const GIT_ENV: NodeJS.ProcessEnv = {
   ...process.env,
   GIT_AUTHOR_NAME: "Fixture",
   GIT_AUTHOR_EMAIL: "fixture@example.com",
   GIT_COMMITTER_NAME: "Fixture",
   GIT_COMMITTER_EMAIL: "fixture@example.com",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_NOSYSTEM: "1",
 };
 delete GIT_ENV.GIT_DIR;
 delete GIT_ENV.GIT_WORK_TREE;
@@ -125,6 +133,13 @@ afterAll(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
+// Re-install the fake machine-local hooks before every test so a mid-test failure
+// (e.g. in the recursion test, which swaps .git/hooks/pre-commit) cannot cascade.
+beforeEach(() => {
+  installLocalHook("pre-commit", "staged");
+  installLocalHook("pre-push", "tree");
+});
+
 describe("tracked pre-commit: primary-checkout guard", () => {
   it("blocks an authored commit in the PRIMARY checkout, on main", () => {
     writeFileSync(join(primary, "blocked.txt"), "clean content\n");
@@ -134,6 +149,21 @@ describe("tracked pre-commit: primary-checkout guard", () => {
     expect(out).toContain("aios worktree add");
     git(primary, ["reset", "HEAD", "blocked.txt"]);
     rmSync(join(primary, "blocked.txt"));
+  });
+
+  it("still blocks when the primary is entered through a SYMLINKED path", () => {
+    // Regression: --absolute-git-dir is physical, but a logical `pwd` keeps the
+    // inherited symlinked $PWD — without `pwd -P` normalization the comparison
+    // never matches and the guard fails OPEN (e.g. ~/Tessera → ~/Projects).
+    const link = join(root, "repo-via-symlink");
+    symlinkSync(primary, link);
+    const env = { ...GIT_ENV, PWD: link };
+    writeFileSync(join(link, "sym.txt"), "clean content\n");
+    git(link, ["add", "sym.txt"], env);
+    const out = gitFails(link, ["commit", "-m", "via symlink"], env);
+    expect(out).toContain("PRIMARY checkout");
+    git(link, ["reset", "HEAD", "sym.txt"], env);
+    rmSync(join(primary, "sym.txt"));
   });
 
   it("allows a commit in a linked worktree AND runs the machine-local (NDA) chain", () => {
@@ -246,7 +276,6 @@ describe("static contract: hooks stay tracked, executable, and correctly resolve
     expect(src).toContain("check-docs-drift.mjs");
     expect(src).toContain("sync-skill-runtimes.sh");
     // The machine-local (NDA) chain must run BEFORE the drift guards.
-    expect(src.indexOf("machine-local")).toBeGreaterThan(-1);
     expect(src.indexOf('local_hook="$common_dir/hooks/pre-push"')).toBeLessThan(
       src.indexOf("check-docs-drift.mjs"),
     );


### PR DESCRIPTION
## Problem (guard rollout fallout from AIO-578; part of the AIO-594 split program)

This repo sets `core.hooksPath=.githooks` (package.json `prepare`), which makes git ignore `.git/hooks/` entirely. Consequences, verified on the primary checkout:

- The **NDA leak-gate shims** installed at `.git/hooks/pre-commit` (staged scan) and `.git/hooks/pre-push` (tree scan) **never ran** — on any commit or push, in any worktree, on an NDA-gated repo.
- The **primary-commit guard** existed only as an **untracked** drop-in at `.githooks/pre-commit` (the aios-workspace installer resolves `core.hooksPath` and copies it there), keeping the primary perpetually dirty. Its chain line resolved via `git rev-parse --git-path hooks/pre-commit.chained`, which **honors hooksPath** and pointed at a nonexistent `.githooks/pre-commit.chained` — so even where the guard ran, the NDA chain was dead.
- The auto-hydration `post-checkout` hook in `.git/hooks/` was equally dead for raw `git worktree add`.

## Chain design chosen

**Tracked repo-policy hooks in `.githooks/` chain the machine-local hook of the same name from the git COMMON dir** (`$(git rev-parse --git-common-dir)/hooks/<hook>` — i.e. the primary's `.git/hooks/`, shared by all worktrees, exactly where the NDA installers already put their shims). Documented in `.githooks/README.md`. Key rules:

- Resolve via `--git-common-dir`, **never** `--git-path hooks/…` (honors hooksPath → self-recursion/dead target — the original bug).
- `pre-commit` = primary-commit guard (block authored commits in the primary incl. non-ff merges, no-op in linked worktrees, `AIOS_ALLOW_PRIMARY_COMMIT=1` override) **then** chain — the NDA gate runs in every worktree **and under the override**; the override never skips it.
- `pre-push` = machine-local chain **first** (confidentiality gate can't be masked by a drift failure), then the unchanged docs-drift + skill-sync guards.
- `post-checkout` = non-blocking chain (restores auto-hydration for raw `git worktree add`).
- Missing/non-executable local hook = skip (contributors without the private NDA config; the gate itself fails closed once installed). Recursion belt-and-braces: skip targets carrying the line-anchored `# aios-tracked-hook` marker.

## Tests (`test/guards/githooks-chain.test.ts`, unit tier, disposable git fixtures — 13/13 green)

- primary commit blocked (incl. via a **symlinked** path — `pwd -P` regression); linked-worktree commit allowed
- NDA chain runs in linked worktrees (synthetic marker file with the obviously-fake term `TOTALLY-FAKE-NDA-CLIENT-ZZ9` is caught) and **under the override**
- `git merge --ff-only` in the primary unaffected; pre-push chain runs and blocks on a tree leak; no recursion when the local hook is a copy of the tracked hook
- static: hooks tracked + executable, no `--git-path hooks/` in code, drift guards retained with NDA chain ordered first, `prepare` still pins `core.hooksPath .githooks`

Full verification: unit tier 1666 passed / 11 skipped; lint 0 errors; `tsc --noEmit` clean; `npm run check:docs` clean. Live: commit on this branch printed `NDA-GATE: clean (staged)`; push ran the machine-local tree scan. Counterfactual: old logical-`pwd` variant reproduces the symlink fail-open; `pwd -P` blocks.

## Review — Reviewed by Fable code-reviewer (local diff review) — verdict: OK to push

Both MEDIUM findings (symlinked-primary fail-open; non-hermetic fixture git config) fixed in 5f4e80d before push; LOWs addressed. Explicit gate-weakening check: none — strictly additive.

## Post-merge action (John / orchestrator — the primary is agent-read-only)

The primary checkout holds an **untracked** `.githooks/pre-commit` that will collide with the now-tracked file (git will refuse the fast-forward: "untracked working tree file would be overwritten"). Before fast-forwarding the primary, delete the untracked copy in `~/Projects/aios/aios-team-brain` (one-line `rm` of `.githooks/pre-commit`), then `git pull --ff-only`.

## Follow-up (aios-workspace, AIO-594 program)

`install-primary-commit-guard.sh` / `install-leak-gate-push-hook.sh` resolve `core.hooksPath` and will **clobber the tracked hooks** on their next run here (every `aios worktree add` does this), re-breaking the chain until the tracked file is restored via git checkout. They should install machine-local hooks into the common dir when a repo tracks its hooksPath hooks (or no-op on the `aios-tracked-hook` marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes commit/push enforcement and NDA confidentiality chaining; mistakes could block dev workflows or weaken gates, but behavior is heavily guarded by new tests and fixes a prior silent bypass.
> 
> **Overview**
> Fixes a **silent failure** where `core.hooksPath=.githooks` meant hooks in `.git/hooks/` (NDA leak gate, worktree hydration) never ran, and broken `--git-path` chaining pointed at dead targets.
> 
> **Tracked hooks** now implement a two-layer convention (documented in `.githooks/README.md`): repo policy in `.githooks/`, machine-local hooks chained from `$(git rev-parse --git-common-dir)/hooks/` — never via `--git-path`. New **tracked `pre-commit`** blocks authored commits in the primary checkout (override `AIOS_ALLOW_PRIMARY_COMMIT=1`), then execs the local NDA staged scan; **`post-checkout`** chains hydration without blocking. **`pre-push`** is extended to run the local NDA tree scan **before** existing docs-drift and skill-sync guards so confidentiality failures aren’t masked.
> 
> Adds **`test/guards/githooks-chain.test.ts`** (fixture repos) covering primary block (including symlinked cwd / `pwd -P`), worktree pass-through, NDA blocking, override still running NDA, ff-only merge, pre-push chain, recursion skip, and static contract checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4e80d05eb30258c21d94b27dd5abcaefed8372. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->