### PR TITLE
ci(review-gate): make the pre-push diff review required, and enforce it

### DIFF
--- a/.agents/skills/pr-review-attestation/SKILL.md
+++ b/.agents/skills/pr-review-attestation/SKILL.md
@@ -23,9 +23,13 @@ single reviewer pass to raise a false-positive HIGH finding that triggers
 unnecessary rework. This skill packages the gate exactly as documented and adds
 a second, independent check before treating any HIGH finding as real.
 
-This gate is **flexible and never blocks a push** — it complements CI and
-label-gated CodeRabbit; only required CI checks actually block a merge. Never
-refuse to push because of an unresolved MEDIUM/LOW finding.
+This gate is **tool-flexible but REQUIRED** — any equivalent local diff review
+counts, skipping it does not. `.github/workflows/pr-review-gate.yml` fails a
+non-draft PR carrying neither an attestation line nor the `ready-for-review`
+label, so the attestation is now a merge-blocking check rather than a habit.
+It complements CI and label-gated CodeRabbit rather than replacing either.
+Still never refuse to push over an unresolved MEDIUM/LOW finding — record it
+and move on; only blocker/HIGH findings hold a push.
 
 ## When this runs
 
@@ -125,9 +129,12 @@ genuinely done.
 
 ## Boundaries
 
-- Never treat this as a merge blocker — CLAUDE.md is explicit that the gate
-  never blocks a push. Report unresolved MEDIUM/LOW findings; don't refuse to
-  proceed over them.
+- The gate IS merge-blocking (`pr-review-gate.yml`), but the blocker is the
+  missing *attestation*, not an unresolved MEDIUM/LOW finding. Report those and
+  proceed; don't refuse to push over them.
+- Satisfy it honestly or take the labelled path. Adding `ready-for-review`
+  because no reviewer was available is sanctioned; adding it to silence a red
+  check after skipping a review you could have run is not.
 - Never write the `## Review — Reviewed by …` line without a review subagent
   actually having run against the current diff in this session.
 - Adversarial verification is per-finding — never batch-refute a whole review

--- a/.agents/skills/pr-review-attestation/evals/rubric.md
+++ b/.agents/skills/pr-review-attestation/evals/rubric.md
@@ -26,8 +26,10 @@ calls should not guess "pass".
    refutation, not a rubber-stamp downgrade.
 4. **No unnecessary work from a refuted finding.** In case 3, the finding
    being wrong means no code should change because of it.
-5. **The gate never blocks.** The transcript should not claim the push cannot
-   proceed because of an unresolved MEDIUM/LOW.
+5. **The blocker is the missing attestation, not a finding.** The gate IS
+   merge-blocking (`pr-review-gate.yml`), but the transcript should not claim a
+   push cannot proceed because of an unresolved MEDIUM/LOW — those get recorded
+   and deferred with a reason.
 6. **The diff is fresh.** `git fetch origin main` (or an equivalent refresh)
    precedes `git diff origin/main...HEAD`, so findings can't be raised against
    someone else's already-merged commits.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -55,7 +55,7 @@ You are the AIOS Team Brain Code Reviewer. The team is small and uses different 
 - A local diff review (Local Bugbot or Fable, whichever the author has) over
   `git diff origin/main...HEAD` should be recorded in the PR body. If none ran, the
   `ready-for-review` label should be on the PR (CodeRabbit reviews instead). Flag a PR with
-  neither — but this is advisory; only CI blocks a merge.
+  neither — a PR with neither FAILS the required `pr-review-gate.yml` check.
 - Local review evidence is scoped to the branch head it reviewed. Treat it as stale after a fix
   commit or base movement.
 - CodeRabbit auto-review fires only on PRs labeled `ready-for-review`. Only substantive comments

--- a/.claude/skills/pr-review-attestation/SKILL.md
+++ b/.claude/skills/pr-review-attestation/SKILL.md
@@ -23,9 +23,13 @@ single reviewer pass to raise a false-positive HIGH finding that triggers
 unnecessary rework. This skill packages the gate exactly as documented and adds
 a second, independent check before treating any HIGH finding as real.
 
-This gate is **flexible and never blocks a push** — it complements CI and
-label-gated CodeRabbit; only required CI checks actually block a merge. Never
-refuse to push because of an unresolved MEDIUM/LOW finding.
+This gate is **tool-flexible but REQUIRED** — any equivalent local diff review
+counts, skipping it does not. `.github/workflows/pr-review-gate.yml` fails a
+non-draft PR carrying neither an attestation line nor the `ready-for-review`
+label, so the attestation is now a merge-blocking check rather than a habit.
+It complements CI and label-gated CodeRabbit rather than replacing either.
+Still never refuse to push over an unresolved MEDIUM/LOW finding — record it
+and move on; only blocker/HIGH findings hold a push.
 
 ## When this runs
 
@@ -125,9 +129,12 @@ genuinely done.
 
 ## Boundaries
 
-- Never treat this as a merge blocker — CLAUDE.md is explicit that the gate
-  never blocks a push. Report unresolved MEDIUM/LOW findings; don't refuse to
-  proceed over them.
+- The gate IS merge-blocking (`pr-review-gate.yml`), but the blocker is the
+  missing *attestation*, not an unresolved MEDIUM/LOW finding. Report those and
+  proceed; don't refuse to push over them.
+- Satisfy it honestly or take the labelled path. Adding `ready-for-review`
+  because no reviewer was available is sanctioned; adding it to silence a red
+  check after skipping a review you could have run is not.
 - Never write the `## Review — Reviewed by …` line without a review subagent
   actually having run against the current diff in this session.
 - Adversarial verification is per-finding — never batch-refute a whole review

--- a/.claude/skills/pr-review-attestation/evals/rubric.md
+++ b/.claude/skills/pr-review-attestation/evals/rubric.md
@@ -26,8 +26,10 @@ calls should not guess "pass".
    refutation, not a rubber-stamp downgrade.
 4. **No unnecessary work from a refuted finding.** In case 3, the finding
    being wrong means no code should change because of it.
-5. **The gate never blocks.** The transcript should not claim the push cannot
-   proceed because of an unresolved MEDIUM/LOW.
+5. **The blocker is the missing attestation, not a finding.** The gate IS
+   merge-blocking (`pr-review-gate.yml`), but the transcript should not claim a
+   push cannot proceed because of an unresolved MEDIUM/LOW — those get recorded
+   and deferred with a reason.
 6. **The diff is fresh.** `git fetch origin main` (or an equivalent refresh)
    precedes `git diff origin/main...HEAD`, so findings can't be raised against
    someone else's already-merged commits.

--- a/.cursor/rules/pr-review-attestation.mdc
+++ b/.cursor/rules/pr-review-attestation.mdc
@@ -18,9 +18,13 @@ single reviewer pass to raise a false-positive HIGH finding that triggers
 unnecessary rework. This skill packages the gate exactly as documented and adds
 a second, independent check before treating any HIGH finding as real.
 
-This gate is **flexible and never blocks a push** — it complements CI and
-label-gated CodeRabbit; only required CI checks actually block a merge. Never
-refuse to push because of an unresolved MEDIUM/LOW finding.
+This gate is **tool-flexible but REQUIRED** — any equivalent local diff review
+counts, skipping it does not. `.github/workflows/pr-review-gate.yml` fails a
+non-draft PR carrying neither an attestation line nor the `ready-for-review`
+label, so the attestation is now a merge-blocking check rather than a habit.
+It complements CI and label-gated CodeRabbit rather than replacing either.
+Still never refuse to push over an unresolved MEDIUM/LOW finding — record it
+and move on; only blocker/HIGH findings hold a push.
 
 ## When this runs
 
@@ -120,9 +124,12 @@ genuinely done.
 
 ## Boundaries
 
-- Never treat this as a merge blocker — CLAUDE.md is explicit that the gate
-  never blocks a push. Report unresolved MEDIUM/LOW findings; don't refuse to
-  proceed over them.
+- The gate IS merge-blocking (`pr-review-gate.yml`), but the blocker is the
+  missing *attestation*, not an unresolved MEDIUM/LOW finding. Report those and
+  proceed; don't refuse to push over them.
+- Satisfy it honestly or take the labelled path. Adding `ready-for-review`
+  because no reviewer was available is sanctioned; adding it to silence a red
+  check after skipping a review you could have run is not.
 - Never write the `## Review — Reviewed by …` line without a review subagent
   actually having run against the current diff in this session.
 - Adversarial verification is per-finding — never batch-refute a whole review

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,8 @@ AIOS-Work: <!-- e.g. AIO-72 -->
 
 ## Review summary
 
-<!-- One line: Reviewed by <Local Bugbot|Fable|CodeRabbit> — verdict …
+<!-- REQUIRED (pr-review-gate.yml). Replace this comment with one line, e.g.
+       Reviewed by Fable — verdict no blockers, 1 LOW deferred
+     Keep the `Reviewed by … — verdict …` shape; fill in BOTH sides.
      No local reviewer available? Apply the `ready-for-review` label (triggers CodeRabbit).
      After a fix push, refresh CodeRabbit with `@coderabbitai review` (incremental review is off). -->

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -1,0 +1,76 @@
+name: PR review gate
+
+# Enforces CLAUDE.md §"Review gate": every PR must record WHAT reviewed its diff, as a
+#   ## Review — Reviewed by <tool> — verdict <one-line summary>
+# line in the body — or hand the review to CodeRabbit with the `ready-for-review` label.
+#
+# Why a check and not a convention: the convention existed and was honoured only when someone
+# remembered. CLAUDE.md §2 — "a single writer + a build-failing guard > discipline you have to
+# remember." Drafts are skipped (you push a draft before reviewing it) and the job re-runs on
+# `ready_for_review`, so nothing merges unattested.
+#
+# The matcher lives in `scripts/pr-review-gate.mjs` and is unit-tested. Inline heredoc logic is how
+# `pr-task-link.yml` shipped a parser that read a response shape the API never returns — a gate that is
+# itself unverified either blocks honest PRs or waves everything through, and nobody finds out which.
+#
+# ⛔ STAYS ON `pull_request`. NEVER `pull_request_target`.
+# Be accurate about what this executes: on `pull_request`, `actions/checkout` gives us the PR's MERGE
+# commit, so the `scripts/pr-review-gate.mjs` that runs IS the PR's copy. A PR can therefore edit the
+# matcher (or this workflow) to pass itself — inherent to every `pull_request`-triggered check, the same
+# way a PR can edit its own tests. It is acceptable here because the job takes NO secrets, has only a
+# `contents: read` token, and makes no network calls, so there is nothing to steal; the change is
+# visible in the diff and CODEOWNERS review is the backstop. Do NOT "fix" this by reaching for
+# `pull_request_target` — that hands a fork's script the base repo's token and secrets, the textbook
+# pwn-request spelled out in pr-task-link.yml.
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+      - converted_to_draft
+
+permissions:
+  contents: read
+
+jobs:
+  review-attested:
+    name: PR records a diff review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for a review attestation
+        run: |
+          node <<'NODE'
+          (async () => {
+            const fs = require("node:fs");
+            const { evaluatePr, FAIL_MESSAGE } = await import("./scripts/pr-review-gate.mjs");
+            const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+            const verdict = evaluatePr(ev.pull_request || {});
+
+            if (verdict.status === "skip") {
+              console.log("Draft PR — review gate deferred until it is marked ready for review.");
+              return;
+            }
+            if (verdict.status === "pass") {
+              if (verdict.reason === "coderabbit-label") {
+                console.log("No local review recorded, but `ready-for-review` is set — CodeRabbit reviews this PR.");
+              } else {
+                console.log(`Diff reviewed by: ${verdict.tool}\nVerdict: ${verdict.verdict}`);
+              }
+              return;
+            }
+            // Fail LOUD and actionable. A gate whose message doesn't say how to satisfy it just gets
+            // bypassed by relabelling.
+            console.log(`::error title=No diff review recorded::${FAIL_MESSAGE[verdict.reason]}`);
+            process.exitCode = 1;
+          })().catch((err) => {
+            // An error in the GATE must not silently pass the PR it was meant to check.
+            console.log(`::error title=Review gate errored::${err && err.message}`);
+            process.exitCode = 1;
+          });
+          NODE

--- a/.opencode/skills/pr-review-attestation/SKILL.md
+++ b/.opencode/skills/pr-review-attestation/SKILL.md
@@ -23,9 +23,13 @@ single reviewer pass to raise a false-positive HIGH finding that triggers
 unnecessary rework. This skill packages the gate exactly as documented and adds
 a second, independent check before treating any HIGH finding as real.
 
-This gate is **flexible and never blocks a push** — it complements CI and
-label-gated CodeRabbit; only required CI checks actually block a merge. Never
-refuse to push because of an unresolved MEDIUM/LOW finding.
+This gate is **tool-flexible but REQUIRED** — any equivalent local diff review
+counts, skipping it does not. `.github/workflows/pr-review-gate.yml` fails a
+non-draft PR carrying neither an attestation line nor the `ready-for-review`
+label, so the attestation is now a merge-blocking check rather than a habit.
+It complements CI and label-gated CodeRabbit rather than replacing either.
+Still never refuse to push over an unresolved MEDIUM/LOW finding — record it
+and move on; only blocker/HIGH findings hold a push.
 
 ## When this runs
 
@@ -125,9 +129,12 @@ genuinely done.
 
 ## Boundaries
 
-- Never treat this as a merge blocker — CLAUDE.md is explicit that the gate
-  never blocks a push. Report unresolved MEDIUM/LOW findings; don't refuse to
-  proceed over them.
+- The gate IS merge-blocking (`pr-review-gate.yml`), but the blocker is the
+  missing *attestation*, not an unresolved MEDIUM/LOW finding. Report those and
+  proceed; don't refuse to push over them.
+- Satisfy it honestly or take the labelled path. Adding `ready-for-review`
+  because no reviewer was available is sanctioned; adding it to silence a red
+  check after skipping a review you could have run is not.
 - Never write the `## Review — Reviewed by …` line without a review subagent
   actually having run against the current diff in this session.
 - Adversarial verification is per-finding — never batch-refute a whole review

--- a/.opencode/skills/pr-review-attestation/evals/rubric.md
+++ b/.opencode/skills/pr-review-attestation/evals/rubric.md
@@ -26,8 +26,10 @@ calls should not guess "pass".
    refutation, not a rubber-stamp downgrade.
 4. **No unnecessary work from a refuted finding.** In case 3, the finding
    being wrong means no code should change because of it.
-5. **The gate never blocks.** The transcript should not claim the push cannot
-   proceed because of an unresolved MEDIUM/LOW.
+5. **The blocker is the missing attestation, not a finding.** The gate IS
+   merge-blocking (`pr-review-gate.yml`), but the transcript should not claim a
+   push cannot proceed because of an unresolved MEDIUM/LOW — those get recorded
+   and deferred with a reason.
 6. **The diff is fresh.** `git fetch origin main` (or an equivalent refresh)
    precedes `git diff origin/main...HEAD`, so findings can't be raised against
    someone else's already-merged commits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,23 +26,32 @@ who reads it**. The map only pays off if it's trustworthy, so:
 
 ---
 
-## Review gate — local review before pushing a PR (flexible, non-blocking)
+## Review gate — a local review of the diff is REQUIRED before you push ⚠️
 
 Many sessions/worktrees ship into this repo in parallel and merge fast — a pre-push review of the
-branch diff catches tier leaks, sync-contract drift, and correctness bugs before they land. We are
-a small team on different local tools, so the gate is **tool-flexible and never blocks a push**:
+branch diff catches tier leaks, sync-contract drift, and correctness bugs before they land. It keeps
+catching the class of defect the author structurally cannot see: the **second-order bug introduced by
+their own fix**, and the **call site that nothing pins** (a helper with a dozen green tests whose
+wiring could be deleted with every one of them still passing). So this is not advisory:
 
-- **Before you `git push` a PR branch:** review `git diff origin/main...HEAD` with whichever local
-  reviewer you have — **Local Bugbot** (John, via Cursor) or a **Fable `code-reviewer` run**
-  (Chetan — `Agent(subagent_type: "code-reviewer", model: "fable")`). Any equivalent local diff
-  review counts; use what's available.
+- **Before you `git push` a PR branch:** review `git diff origin/main...HEAD` with a local reviewer —
+  **Fable `code-reviewer`** (Chetan — `Agent(subagent_type: "code-reviewer", model: "fable")`) or
+  **Local Bugbot** (John, via Cursor). The gate is **tool-flexible but not optional**: any equivalent
+  local diff review counts, skipping it does not.
 - **Address blocker/HIGH findings before pushing**; fix or consciously defer MEDIUM/LOW with a
-  one-line reason.
-- **Record what reviewed the diff in the PR body** — one `## Review — Reviewed by <tool> — verdict …`
-  line so it's auditable. If no local reviewer was available, say so and apply the
-  `ready-for-review` label so CodeRabbit reviews the PR instead.
-- The local review examines the **diff you're about to ship**, not the bots' comments. It
-  complements CI and label-gated CodeRabbit; only the required CI checks block a merge.
+  one-line reason in the PR body.
+- **Record what reviewed the diff in the PR body** — exactly one line:
+  `## Review — Reviewed by <tool> — verdict <one-line summary>`. **Never write that line for a review
+  that didn't run** — a fabricated attestation is worse than an absent one, because it launders the
+  gap. The `pr-review-attestation` skill walks the whole flow.
+- **If no local reviewer is available:** say so, and apply the **`ready-for-review`** label so
+  CodeRabbit reviews the PR instead. That is the sanctioned alternative — silence is not.
+- **Enforced in CI.** `.github/workflows/pr-review-gate.yml` fails a non-draft PR that records neither
+  an attestation nor the `ready-for-review` label (matcher: `scripts/pr-review-gate.mjs`, unit-tested;
+  an unedited `<tool>` placeholder is rejected, because shape alone is not a check). Drafts are
+  skipped — push a draft freely; the gate re-runs when you mark it ready.
+- The local review examines the **diff you're about to ship**, not the bots' comments; it complements
+  CI and label-gated CodeRabbit rather than replacing either.
 
 ---
 

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -66,6 +66,16 @@ flowchart TD
 
 The four required jobs (`docs-drift`, `brain-tests`, `datamechanics-tests`, `ingestion-tests`) must pass for a PR to merge (enforced via branch protection). `http-tests` runs `continue-on-error` (advisory) until it proves stable — see Branch Protection below.
 
+### `pr-review-gate.yml` — the review gate (REQUIRED)
+
+Fails a non-draft PR whose body records no `Reviewed by … — verdict …` line and which carries no
+`ready-for-review` label. Drafts are skipped and it re-runs on `ready_for_review`, so a draft can be
+pushed freely. The matcher is `scripts/pr-review-gate.mjs` (unit-tested in `test/pr-review-gate.test.ts`)
+— deliberately permissive about FORM (heading level, emphasis, bare line, any dash, NBSP, CRLF) and
+strict only about SUBSTANCE, because a gate that rejects honest attestations gets switched off. Text
+inside fenced blocks and HTML comments is ignored, so quoting the template neither satisfies nor poisons
+the check. Reads only the event payload — no secrets, no network. See CLAUDE.md §"Review gate".
+
 ### `aios-work-sync.yml` — fires on merge to `main`
 
 Extracts work keys from the PR **title, body and branch ref** and POSTs a merge event to `/api/v1/work-events`. This closes the matching issue in the team's primary PM tool automatically — currently **Linear** (the brain projects the merge event to whichever provider `teams.primary_pm_provider` names; the sync path itself is provider-neutral).
@@ -91,8 +101,9 @@ The team is small and members use different local reviewers — **John runs Loca
 **Chetan runs Fable** (`Agent(subagent_type: "code-reviewer", model: "fable")` from the
 `aios-workspace` ship tooling). Whichever ran is the local evidence, recorded as one line in the
 PR body. Local review evidence is scoped to the branch head it reviewed — treat it as stale after
-a fix commit or base movement. **None of this blocks a push or merge; only the required CI checks
-do.**
+a fix commit or base movement. **Recording it is required**: `pr-review-gate.yml` fails a non-draft
+PR that carries neither an attestation line nor the `ready-for-review` label. Which reviewer ran is
+flexible; recording one is not.
 
 CodeRabbit runs outside GitHub Actions and posts to the PR conversation. `.coderabbit.yaml` keeps
 `auto_review.enabled: true` but restricts it with `labels: [ready-for-review]` — auto-review fires
@@ -142,6 +153,9 @@ If you add an API route, table, or ingest source, update the corresponding `<!--
 Repo: `aiosbrain/aios-team-brain` → Settings → Branches → `main`
 
 - [x] Require status checks: `docs-drift`, `brain-tests`, `datamechanics-tests`, `ingestion-tests`
+- [ ] `PR records a diff review` (`pr-review-gate.yml`) — **add this to required status checks.** Until
+      it is, the job goes red on an unattested PR but the PR stays mergeable, and the gate is a
+      convention again. This box is the whole enforcement.
 - [ ] `http-tests` — currently advisory (`continue-on-error`). Graduate to required after 5 consecutive green runs on `main`: drop `continue-on-error` in `ci.yml` and add it to this list.
 - [x] Require branches to be up to date before merging
 - [x] Dismiss stale reviews on new pushes

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -98,7 +98,8 @@ must stay `true`). Result: CodeRabbit auto-reviews only PRs carrying the label.
    ```
 
 2. Apply it when no local reviewer (Local Bugbot / Fable) was available for the PR, or whenever an
-   extra automated pass is wanted. It never blocks — only the required CI checks gate a merge.
+   extra automated pass is wanted. This label is also the sanctioned way to satisfy the required
+   review gate (`pr-review-gate.yml`) when no local reviewer could run — see CLAUDE.md §"Review gate".
 3. After any later push, comment `@coderabbitai review`; the label does not trigger incremental
    reviews while `auto_incremental_review: false`.
 4. Prefer substantive comments/reviews created at or after the latest PR commit as evidence. A

--- a/scripts/pr-review-gate.mjs
+++ b/scripts/pr-review-gate.mjs
@@ -1,0 +1,131 @@
+/**
+ * The pre-push review gate, as a check (CLAUDE.md §"Review gate").
+ *
+ * The convention — every PR records WHAT reviewed its diff — existed for a while and was honoured only
+ * when someone remembered. That is the failure mode CLAUDE.md §2 names: "a single writer + a
+ * build-failing guard > discipline you have to remember."
+ *
+ * Pure and unit-tested ON PURPOSE. `pr-task-link.yml` documents what happens otherwise: its response
+ * parser "shipped reading the tasks response in a shape it never returns … because it lived in a YAML
+ * heredoc that no tier could reach". A gate that is itself unverified either blocks honest PRs or waves
+ * everything through, and nobody finds out which.
+ *
+ * ── The asymmetry that shapes this file ─────────────────────────────────────────────────────────────
+ * A FALSE NEGATIVE (rejecting a real attestation) is much worse than a false positive. It blocks honest
+ * work with a message accusing the author of skipping a review they did — and the response to a gate
+ * that cries wolf is to switch it off. A false positive costs one un-gated PR. So the matcher is
+ * deliberately PERMISSIVE about form and strict only about substance:
+ *   - `## Review — Reviewed by X — verdict Y` (CLAUDE.md's canonical line) and a bare
+ *     `Reviewed by X — verdict Y` (what `.github/pull_request_template.md` asks for) both pass.
+ *   - emphasis, heading level, blockquote, NBSP, CRLF, `verdict:`, and every unicode dash all pass.
+ * Rather than one baroque regex, the body is NORMALIZED and then matched — each step is separately
+ * testable, and adding tolerance can't silently break another case.
+ *
+ * SHAPE ALONE IS NOT A CHECK — the lesson the work-key check learned when every PR in one session cited
+ * an invented `AIO-48x` that matched the pattern and existed nowhere. The skill hands authors a template
+ * containing literal `<tool>` / `<one-line summary>` slots; pasting it unedited must FAIL, or the gate
+ * certifies a review that never happened.
+ */
+
+/** Fenced code and HTML comments are QUOTED text, not claims. Stripping them first is what stops the
+ *  instructions (which contain the template) from either poisoning or satisfying the check — the same
+ *  reason `pr-work-keys.mjs` refuses to count a work-key written inside backticks. */
+function stripQuotedRegions(body) {
+  return String(body ?? "")
+    .replace(/```[\s\S]*?```/g, "\n")
+    .replace(/~~~[\s\S]*?~~~/g, "\n")
+    .replace(/<!--[\s\S]*?-->/g, "\n");
+}
+
+/** One line, reduced to the form the matcher cares about. */
+function normalizeLine(line) {
+  return line
+    .replace(/ /g, " ") // NBSP — routine when pasting from rendered markdown
+    .replace(/[*_`]/g, "") // emphasis / inline code around any part of the line
+    // Leading markdown furniture: blockquote, heading hashes, a list marker (`-`, `+`, `1.`, `1)`)
+    // and a task-list checkbox. This repo's prose style is bullets, so an attestation written as a
+    // list item is a LIKELY form, not an exotic one — and before this `* Reviewed by …` passed while
+    // `- Reviewed by …` was rejected, purely because the emphasis strip above ate the asterisk.
+    // Being accused of skipping a review you ran, based on which bullet you typed, is exactly the
+    // false negative this file exists to avoid.
+    .replace(/^[\s>#]*(?:[-+]|\d+[.)])?\s*(?:\[[ xX]\])?\s*/, "")
+    .replace(/[‐-―−]/g, "-") // every unicode dash/minus → ASCII hyphen
+    .trim();
+}
+
+// After normalization: an optional `Review -` label, then the claim. `.+?` for the tool is bounded by
+// the ` - verdict` separator; the verdict runs to end of line.
+const CLAIM_RE = /^(?:review\s*-+\s*)?reviewed by\s+(.+?)\s*-+\s*verdict\b\s*:?\s*(.+)$/i;
+
+/** An unedited template slot. Anchored to the WHOLE value: a verdict may legitimately contain angle
+ *  brackets (`fixed <Button> null deref`, `Map<string,int>`) and rejecting those told honest authors
+ *  they had pasted a template. Only a value that IS a slot counts. */
+function isPlaceholder(value) {
+  const v = (value ?? "").trim();
+  if (!v) return true;
+  return /^<[^>]*>$/.test(v);
+}
+
+/**
+ * Does this PR body carry a REAL attestation? Scans EVERY candidate line and accepts if any one is
+ * genuine — a single `.exec` meant that quoting the template (or this check's own error message, which
+ * prints it) above a real attestation rejected the PR.
+ *
+ * Returns the parsed parts so the caller can echo what it accepted; an opaque pass is how a broken
+ * matcher hides.
+ */
+export function readAttestation(body) {
+  let sawPlaceholder = false;
+  for (const raw of stripQuotedRegions(body).split(/\r?\n/)) {
+    // Cheap pre-filter, and it is what keeps `CLAIM_RE` off pathological input: its `(.+?)\s*-+\s*`
+    // backtracks quadratically on a long run of hyphens (65k chars ≈ 7s). Only a line that actually
+    // claims a review reaches the regex, and a line far longer than any real attestation is skipped.
+    if (raw.length > 2000 || !/reviewed by/i.test(raw)) continue;
+    const m = CLAIM_RE.exec(normalizeLine(raw));
+    if (!m) continue;
+    const [, tool, verdict] = m;
+    if (isPlaceholder(tool) || isPlaceholder(verdict)) {
+      sawPlaceholder = true;
+      continue;
+    }
+    return { ok: true, tool: tool.trim(), verdict: verdict.trim() };
+  }
+  return { ok: false, reason: sawPlaceholder ? "placeholder" : "missing" };
+}
+
+/** The sanctioned alternative when no local reviewer was available: hand the diff to CodeRabbit. */
+export const CODERABBIT_LABEL = "ready-for-review";
+
+export function hasCodeRabbitLabel(labels) {
+  return (labels ?? []).some((l) => String(l?.name ?? l).trim().toLowerCase() === CODERABBIT_LABEL);
+}
+
+/**
+ * The gate's verdict for one PR.
+ *
+ * `pass` — attested, or handed to CodeRabbit via the label.
+ * `skip` — a draft. You legitimately push a draft BEFORE reviewing it; blocking there would only teach
+ *          people to write the line early, which is the fabrication this is meant to prevent. The gate
+ *          re-runs on `ready_for_review`, so nothing merges unattested.
+ * `fail` — everything else.
+ */
+export function evaluatePr(pr) {
+  if (pr?.draft) return { status: "skip", reason: "draft" };
+  if (hasCodeRabbitLabel(pr?.labels)) return { status: "pass", reason: "coderabbit-label" };
+  const att = readAttestation(pr?.body);
+  if (att.ok) return { status: "pass", reason: "attested", tool: att.tool, verdict: att.verdict };
+  return { status: "fail", reason: att.reason };
+}
+
+// The template is shown INSIDE a fenced block, which `stripQuotedRegions` removes — so an author who
+// pastes this whole message into the PR body while fixing it doesn't lock themselves out.
+export const FAIL_MESSAGE = {
+  missing:
+    "This PR records no diff review. Per CLAUDE.md, review `git diff origin/main...HEAD` with a local " +
+    "reviewer (Fable `code-reviewer`, Local Bugbot, or equivalent), then add ONE line to the PR body:\n" +
+    "```\n## Review — Reviewed by <the reviewer you ran> — verdict <what it found>\n```\n" +
+    `If no local reviewer was available, say so and add the \`${CODERABBIT_LABEL}\` label so CodeRabbit reviews it instead.`,
+  placeholder:
+    "The review line still has the template's `<...>` slots unfilled. Name the reviewer you actually " +
+    "ran and what it found — a pasted template certifies a review that never happened.",
+};

--- a/test/pr-review-gate.test.ts
+++ b/test/pr-review-gate.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error — plain .mjs shared with the GitHub workflow (same pattern as pr-work-keys).
+import { readAttestation, evaluatePr, hasCodeRabbitLabel, CODERABBIT_LABEL } from "../scripts/pr-review-gate.mjs";
+
+/**
+ * Spec: the gate must accept a real attestation, reject a missing or PASTED-TEMPLATE one, and never
+ * block a draft. Written from the rule in CLAUDE.md §"Review gate", not from the regex.
+ *
+ * The check itself is the thing most likely to be wrong here — `pr-task-link.yml` shipped a parser that
+ * read a response shape the API never returns, because it lived in a YAML heredoc no test could reach.
+ * So the matcher lives in a script and every branch of it is pinned.
+ */
+
+const REAL = "## Review — Reviewed by code-reviewer (fable) — verdict CLEAR, 1 LOW deferred";
+
+function pr(over: Record<string, unknown> = {}) {
+  return { draft: false, labels: [], body: REAL, ...over };
+}
+
+describe("readAttestation — what counts as a recorded review", () => {
+  it("accepts the canonical line and reports what it accepted", () => {
+    const a = readAttestation(REAL);
+    expect(a.ok).toBe(true);
+    expect(a.tool).toBe("code-reviewer (fable)");
+    expect(a.verdict).toBe("CLEAR, 1 LOW deferred");
+  });
+
+  it("finds the line anywhere in a long body", () => {
+    expect(readAttestation(`## What\n\nsome prose\n\n${REAL}\n\n## Test plan\n- [ ] x`).ok).toBe(true);
+  });
+
+  it("accepts Local Bugbot — the gate is tool-flexible, not Fable-only", () => {
+    expect(readAttestation("## Review — Reviewed by Local Bugbot — verdict no blockers").ok).toBe(true);
+  });
+
+  it("accepts plain hyphens — editors and authors rewrite em-dashes", () => {
+    expect(readAttestation("## Review - Reviewed by Fable - verdict clean").ok).toBe(true);
+  });
+
+  it("REJECTS the unedited template — a pasted placeholder certifies a review that never happened", () => {
+    const a = readAttestation("## Review — Reviewed by <tool> — verdict <one-line summary>");
+    expect(a.ok).toBe(false);
+    expect(a.reason).toBe("placeholder");
+  });
+
+  it("rejects a half-filled template", () => {
+    expect(readAttestation("## Review — Reviewed by Fable — verdict <one-line summary>").ok).toBe(false);
+  });
+
+  it("rejects a body with no review line", () => {
+    expect(readAttestation("## What\nfixed a bug\n## Test plan\n- [ ] ran it").reason).toBe("missing");
+  });
+
+  it("rejects prose that merely mentions a review", () => {
+    expect(readAttestation("I reviewed this myself and it looks fine.").ok).toBe(false);
+  });
+
+  it("rejects an empty or absent body", () => {
+    expect(readAttestation("").ok).toBe(false);
+    expect(readAttestation(null).ok).toBe(false);
+  });
+});
+
+/**
+ * Every case below is a FALSE NEGATIVE found by review — an honest attestation the first matcher
+ * rejected. These matter more than false positives: blocking real work with a message accusing the
+ * author of skipping a review they ran is how a gate gets switched off.
+ */
+describe("readAttestation — forms that must NOT be rejected", () => {
+  it("accepts the bare line the PR template asks for (no `## Review —` prefix)", () => {
+    // .github/pull_request_template.md says: "One line: Reviewed by <…> — verdict …"
+    expect(readAttestation("## Review summary\n\nReviewed by Fable — verdict no blockers")).toMatchObject({
+      ok: true,
+      tool: "Fable",
+      verdict: "no blockers",
+    });
+  });
+
+  it("accepts a real attestation even when the TEMPLATE is quoted above it", () => {
+    // The gate's own failure message prints the template; pasting it in while fixing must not lock
+    // the author out. A single `.exec` matched the placeholder first and rejected the PR.
+    const body = "## Review — Reviewed by <tool> — verdict <one-line summary>\n\n## Review — Reviewed by Fable — verdict CLEAR";
+    expect(readAttestation(body)).toMatchObject({ ok: true, tool: "Fable", verdict: "CLEAR" });
+  });
+
+  it("accepts a verdict containing angle brackets", () => {
+    // `<Button>` / `Map<string,int>` are ordinary things to name in a verdict — not a pasted template.
+    expect(readAttestation("## Review — Reviewed by Fable — verdict fixed <Button> null deref")).toMatchObject({
+      ok: true,
+      verdict: "fixed <Button> null deref",
+    });
+  });
+
+  it("accepts emphasis, blockquotes and CRLF", () => {
+    expect(readAttestation("**## Review — Reviewed by Fable — verdict clean**").ok).toBe(true);
+    expect(readAttestation("> Reviewed by Local Bugbot — verdict clean").ok).toBe(true);
+    expect(readAttestation("## Review — Reviewed by Fable — verdict clean\r\n").ok).toBe(true);
+  });
+
+  it("accepts a non-breaking space and `verdict:`", () => {
+    expect(readAttestation("Reviewed by\u00a0Fable — verdict:\u00a0clean").ok).toBe(true);
+  });
+
+  it("accepts every list-marker form — this repo writes prose in bullets", () => {
+    // `* …` used to pass while `- …` was rejected, purely because the emphasis strip ate the asterisk.
+    // Accusing someone of skipping a review based on which bullet they typed is the worst kind of
+    // false negative: arbitrary, and it teaches people the gate is noise.
+    for (const marker of ["-", "+", "*", "1.", "1)", "- [x]", "- [ ]"]) {
+      expect(readAttestation(`${marker} Reviewed by Fable — verdict clean`).ok, marker).toBe(true);
+    }
+  });
+
+  it("accepts unicode minus and horizontal bar as separators", () => {
+    expect(readAttestation("Reviewed by Fable − verdict clean").ok).toBe(true);
+    expect(readAttestation("Reviewed by Fable ― verdict clean").ok).toBe(true);
+  });
+});
+
+describe("readAttestation — quoted regions are not claims", () => {
+  it("ignores an attestation inside a fenced code block", () => {
+    // Otherwise a filled EXAMPLE in a template would auto-pass every PR that kept the template.
+    expect(readAttestation("```\n## Review — Reviewed by Fable — verdict clean\n```").ok).toBe(false);
+  });
+
+  it("ignores an attestation inside an HTML comment", () => {
+    expect(readAttestation("<!--\nReviewed by Fable — verdict clean\n-->").ok).toBe(false);
+  });
+
+  it("still finds a real line outside the fence", () => {
+    expect(readAttestation("```\nexample: Reviewed by <tool> — verdict <x>\n```\nReviewed by Fable — verdict clean").ok).toBe(true);
+  });
+});
+
+describe("readAttestation — pathological input", () => {
+  it("does not hang on a long hyphen run (the matcher backtracks quadratically)", () => {
+    // 65k is GitHub's PR-body cap; unguarded this took ~7s. Self-inflicted only, but a gate that can
+    // be stalled by its own input is a gate people learn to ignore.
+    const started = Date.now();
+    expect(readAttestation(`Reviewed by ${"-".repeat(65_000)} verdict x`).ok).toBe(false);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  it("still reads a normal attestation in a very long body", () => {
+    const filler = "lorem ipsum dolor sit amet\n".repeat(2_000);
+    expect(readAttestation(`${filler}Reviewed by Fable — verdict clean\n${filler}`).ok).toBe(true);
+  });
+});
+
+describe("evaluatePr — the gate's verdict", () => {
+  it("passes an attested PR", () => {
+    expect(evaluatePr(pr())).toMatchObject({ status: "pass", reason: "attested" });
+  });
+
+  it("passes an unattested PR that handed the review to CodeRabbit", () => {
+    expect(evaluatePr(pr({ body: "no review line", labels: [{ name: CODERABBIT_LABEL }] }))).toMatchObject({
+      status: "pass",
+      reason: "coderabbit-label",
+    });
+  });
+
+  it("skips a draft — you push a draft BEFORE reviewing it", () => {
+    // Blocking here would teach people to write the attestation early, which is the fabrication the
+    // gate exists to prevent. It re-runs on ready_for_review.
+    expect(evaluatePr(pr({ draft: true, body: "wip" }))).toMatchObject({ status: "skip" });
+  });
+
+  it("FAILS an unattested, unlabelled, non-draft PR", () => {
+    expect(evaluatePr(pr({ body: "## What\njust a small change" }))).toMatchObject({
+      status: "fail",
+      reason: "missing",
+    });
+  });
+
+  it("FAILS a PR carrying only the pasted template", () => {
+    expect(evaluatePr(pr({ body: "## Review — Reviewed by <tool> — verdict <one-line summary>" }))).toMatchObject({
+      status: "fail",
+      reason: "placeholder",
+    });
+  });
+});
+
+describe("hasCodeRabbitLabel", () => {
+  it("matches case-insensitively and tolerates bare strings", () => {
+    expect(hasCodeRabbitLabel([{ name: "Ready-For-Review" }])).toBe(true);
+    expect(hasCodeRabbitLabel([CODERABBIT_LABEL])).toBe(true);
+  });
+
+  it("does not match an unrelated label", () => {
+    expect(hasCodeRabbitLabel([{ name: "bug" }])).toBe(false);
+    expect(hasCodeRabbitLabel([])).toBe(false);
+  });
+});


### PR DESCRIPTION
Both halves of the ask: restore the rule in CLAUDE.md, and build the GitHub gate that enforces it.

## What

- **CLAUDE.md §"Review gate" is now REQUIRED**, not "flexible, non-blocking". Still tool-flexible — Fable `code-reviewer` (Chetan) or Local Bugbot (John) — but *recording which reviewer ran* is not optional.
- **New `.github/workflows/pr-review-gate.yml`** fails a non-draft PR that records neither a `Reviewed by … — verdict …` line nor the `ready-for-review` label. Drafts are skipped and it re-runs on `ready_for_review`, so drafts push freely.
- **Matcher in `scripts/pr-review-gate.mjs` + 28 unit tests**, not inline YAML. `pr-task-link.yml` documents why: its parser shipped reading a response shape the API never returns, *because it lived in a heredoc no tier could reach*.

## The design constraint that shaped it

A **false negative — rejecting an attestation someone actually earned — is far worse than a false positive.** It accuses an honest author and teaches the team the gate is noise, and a gate people distrust gets switched off. So the matcher is permissive about **form** and strict only about **substance**.

Review found five such bugs before this shipped. All fixed, all pinned:

| Bug | Effect |
|---|---|
| The repo's **own PR template** shape was rejected | Following the shipped template blocked you |
| Quoting the template above a real line rejected the PR | The gate's own error message prints that template |
| `verdict fixed <Button> null deref` flagged as a template | Any verdict naming a component/generic |
| `* …` passed but `- …` was rejected | Purely which bullet character you typed |
| 65k hyphen run backtracked ~7s | Self-inflicted stall |

Fenced blocks and HTML comments are stripped first, so quoting the template neither satisfies nor poisons the check.

Also corrected **four places that still told future agents "the gate never blocks"** — `docs/CI-ARCHITECTURE.md` (§Review evidence + a new workflow section), `.claude/agents/code-reviewer.md`, and the skill's `evals/rubric.md` (+ `.agents`/`.opencode`/`.cursor` mirrors). A stale instruction contradicting the new rule would have quietly defeated it.

## ⚠️ This does not block a merge yet — one manual step, and the order matters

The job goes red, but a red check only blocks if it's in **branch protection**. Current required contexts:

```
Docs drift guard · Static checks · Secret scan · Brain unit tests
Data-mechanics tests · Integration tests · Ingestion tests
```

The one to add is **`PR records a diff review`**, tracked as an unchecked box in `docs/CI-ARCHITECTURE.md`.

**It must be added AFTER this merges.** Reverse the order and every open PR blocks forever waiting for a context that never reports. ("Require branches to be up to date" is already on, so stale branches pick the workflow up when they update.)

## Deferred, with reason

- **Odd stray ` ``` ` in prose** can pair with a later real fence and swallow an attestation between them. Rare, and the failure message is actionable.
- **An attestation whose only occurrence is inside a fenced block** is rejected — deliberate ("quoted ≠ claim"), covered by a test so it's a chosen behaviour, not a surprise.

✅ unit 1676 · ✅ `tsc` · ✅ lint (0 errors) · ✅ `check:docs` · ✅ `check:skills` in sync · ✅ workflow YAML parses

**This PR is the gate's own first live test** — the workflow runs on the PR that introduces it.

## Review — Reviewed by code-reviewer (fable) — verdict CLEAR to push; two rounds, first BLOCKED on five false-negative bugs in the matcher (all fixed + pinned), second CLEAR with the bullet-marker gap fixed in-diff

Round 1 returned **BLOCKED** — correctly: the gate would have rejected honest work, including the repo's own PR template format. Round 2 re-verified every fix *by executing the matcher* rather than reading it, and found the bullet-marker inconsistency, which I fixed here (mutation-verified: reverting the strip fails that test). The ReDoS guard came from the same round. Remaining Lows are the two deferred items above.