### PR TITLE
docs(costs): defer the per-day provider reconciliation, and record why

### DIFF
--- a/docs/design/failed-call-ledger.md
+++ b/docs/design/failed-call-ledger.md
@@ -31,8 +31,18 @@ storm's aborted calls cost ~$10, not ~$46.
 
 **The larger block is 2026-07-28, and it is not failures at all.** Graph metering's first row is
 `2026-07-29 03:25 UTC`, but the proxy went live the day before — so 59 episodes were extracted on 07-28
-through OpenRouter with **no meter in existence**. The ledger holds $0.05 for that day. That is not a
-call that died; it is a call nobody was counting.
+through OpenRouter with **no meter in existence**. That is not a call that died; it is a call nobody was
+counting.
+
+Full reconciliation, from the provider's own per-day chart:
+
+| UTC day | OpenRouter billed | Ledger | Unattributed | Why |
+|---|---|---|---|---|
+| 2026-07-28 | **$29.30** | $0.05 | **$29.25** | proxy live, graph meter not yet shipped |
+| 2026-07-29 | **$58.70** | $48.24 | **$10.46** | the timeout storm's aborted calls |
+| | | | **$39.71 of $46.23 — 86%** | |
+
+So the gap is **63% never-metered, 23% failed, 14% tail**. The failure ledger addresses the 23%.
 
 Which means: the reconciliation gap is dominated by "metering did not exist yet", a one-time historical
 fact that no code can retroactively fix — and both of its causes are now closed (graph metering since

--- a/docs/design/failed-call-ledger.md
+++ b/docs/design/failed-call-ledger.md
@@ -17,10 +17,27 @@ The gap is structural, not a bug in the meter. Three cases:
 | **no readable body at all** — timeout, abort, connection drop | ❌ **impossible** — the provider billed for tokens it generated and there is nothing to read |
 | **any body with no `usage` field** | ❌ silently dropped by `meterFromOpenAiResponse` returning null |
 
-The third case is what produced most of the $46: on 2026-07-29 a 120s proxy ceiling aborted extraction
-calls after the model had already generated, and the OpenAI SDK retried each three times. Measured:
-the ledger holds $48.24 for that day; the provider's lifetime figure implies roughly as much again
-unrecorded.
+The third case is real but is NOT most of the $46 — **corrected 2026-07-31 by reading OpenRouter's own
+per-day chart**, which is what the deferred `provider-daily-truth.md` was going to be built to do:
+
+| 2026-07-29 | |
+|---|---|
+| OpenRouter billed | **$58.70** (`qwen3.7-max` $58.60) |
+| Ledger recorded | **$48.24** |
+| Unrecorded | **$10.46 — 18%** |
+
+I had inferred "roughly as much again unrecorded ≈ a 50% abort rate". Wrong by a factor of four. The
+storm's aborted calls cost ~$10, not ~$46.
+
+**The larger block is 2026-07-28, and it is not failures at all.** Graph metering's first row is
+`2026-07-29 03:25 UTC`, but the proxy went live the day before — so 59 episodes were extracted on 07-28
+through OpenRouter with **no meter in existence**. The ledger holds $0.05 for that day. That is not a
+call that died; it is a call nobody was counting.
+
+Which means: the reconciliation gap is dominated by "metering did not exist yet", a one-time historical
+fact that no code can retroactively fix — and both of its causes are now closed (graph metering since
+07-29, the timeout since #438). The gap should stop growing. This ledger addresses the genuine but
+smaller slice.
 
 **No meter fix closes it** — you cannot read a `usage` block off a connection that died. What we CAN
 do is stop losing the *fact* of the call.

--- a/docs/design/provider-daily-truth.md
+++ b/docs/design/provider-daily-truth.md
@@ -1,0 +1,172 @@
+# Per-day provider truth (OpenRouter `/activity`)
+
+**Status:** **DEFERRED** after design review — the question this was built to answer needs no code
+· **Date:** 2026-07-31 · **Owner:** Chetan
+
+> ## Why this is deferred
+>
+> The $46 question is answerable **today, in a browser**, at `openrouter.ai/activity` — per day, per
+> model, no schema change. And the 30-day window expires ~**2026-08-28** regardless of how long a build
+> takes, so shipping a feature to read it could easily miss the data it was built for.
+>
+> The forward-looking half is already solved: `llm_failures` (#458) records billed-but-unmeterable
+> attempts **with feature attribution**, which `/activity` structurally cannot provide (its rows are
+> per-day/per-model, not per-call). What a permanent per-day table adds is narrow: an alarm for spend
+> that escapes *both* the meter and `llm_failures`.
+>
+> **Evidence bar for reopening:** the lifetime `/credits` reconciliation already on the Costs page shows
+> the gap **growing again** after #458. That would prove a blind spot #458 doesn't cover, and would
+> justify the build with data instead of with a hunch.
+>
+> **The corrected design is below** — it changed materially in review, so if this is reopened, start
+> from the corrections, not from the original plan.
+
+## The problem
+
+The Costs page reconciles the ledger against the provider **once, lifetime**: *"OpenRouter has billed
+$101.74; this ledger accounts for $55.51."* That is honest but un-sliceable — it cannot say **which day**
+or **which model** the missing $46 belongs to, so it can name a total and nothing else.
+
+`llm_failures` (#458) fixed the forward-looking half: from now on a billed-but-unmeterable attempt is
+recorded with a feature and a reason. It cannot explain the **existing** $46, because it only records
+from the day it shipped.
+
+## What unlocks it
+
+`GET /api/v1/activity` returns, per day and per model:
+
+```json
+{ "date": "2026-07-29", "model": "qwen/qwen3.7-max", "provider_name": "Alibaba",
+  "requests": 5, "prompt_tokens": 50, "completion_tokens": 125, "reasoning_tokens": 25,
+  "usage": 0.015, "byok_usage_inference": 0.012 }
+```
+
+Three things matter here beyond the daily split:
+
+- **`usage` is dollars**, so it reconciles directly against `llm_usage.cost_usd`.
+- **`reasoning_tokens` is a first-class field.** The chain-of-thought waste that took a live-proxy probe
+  to measure was in the provider's own data the whole time.
+- **`api_key_hash`** filters to one key, so other spend on the account can't contaminate the comparison.
+
+**It requires a management key.** Verified from the API reference's own error list: `403 — "Only
+management keys can perform this operation"`. The inference key cannot read it, and a management key
+cannot make completions (they are disjoint by design). Created at
+`openrouter.ai/settings/provisioning-keys`.
+
+**30-day window.** `date` filters "a single UTC date in the last 30 days", so the 2026-07-29 storm is
+recoverable until roughly 2026-08-28 and then permanently gone.
+
+## Where the key lives
+
+**Admin → Integrations, encrypted at rest like every other key.** Not an env var: a second place a key
+lives, invisible to the console, is exactly the failure that killed graph extraction for hours on
+2026-07-28 (Graphiti's own `OPENAI_API_KEY`), and this repo spent a week removing it.
+
+**As a nullable `integrations.management_secret_ciphertext` column on the EXISTING `openrouter` row** —
+NOT a new integration type. My first draft proposed `openrouter_admin`, and review was right that it
+jumped from "not a second row of the same type" straight to "therefore a new type", skipping the option
+that dominates both:
+
+- **No CHECK widening**, so the whole incident-#251 hazard below evaporates. `add column if not exists`
+  is the benign migration shape.
+- **No leak points.** No `INTEGRATION_TYPES` entry, no zod config schema, no connectors-filter exclusion,
+  no `GET /api/v1/integrations` surface, no delete-cascade question. The "each is a filter, so each is a
+  place someone forgets" problem set becomes empty.
+- **It models the domain correctly.** A management key is a second credential *of the same account*, not
+  a different integration — and deleting the OpenRouter integration should take it along, which the
+  separate type would not do (it would strand a live admin key).
+- **It generalizes.** Anthropic has admin keys too; a generic management-secret column serves every
+  provider with no further CHECK widenings, where `openrouter_admin` starts a `*_admin` type family that
+  repeats this whole exercise each time.
+
+A dedicated typed reader (`getManagementKey`) rather than widening `ProviderIntegrationType` — that
+narrow union is itself what keeps the key away from every answering/embedding resolver.
+
+### Why a second row of the same type is still ruled out
+
+ `getProviderSettings` resolves a provider key with
+
+```ts
+.eq("type", type).eq("status", "enabled").limit(1).maybeSingle()   // no ORDER BY
+```
+
+so a second row of the same type is picked **nondeterministically**. Since a management key cannot call
+completions, roughly half of all inference — answering, extraction, embeddings — would authenticate with
+a key that physically cannot serve it. Intermittent, total, and indistinguishable from a provider outage.
+
+### The migration hazard the column design avoids (recorded because my plan for it was WRONG twice over)
+
+Had this gone the new-type route, it would widen `integrations_type_check` — the constraint behind
+incident #251. My original prescription was wrong in both shape and scope, and it is worth writing down:
+
+- **Shape:** I wrote "a conname-guarded DO block". That block adds the constraint *only when the name is
+  absent* — so on any existing database the narrow constraint is already there, the widening is
+  **skipped entirely**, and the first insert of the new type fails at runtime. The proven pattern is two
+  plain idempotent statements: `drop constraint if exists` then `add constraint`.
+- **Scope:** I wrote "the migration", singular. **Four** existing migrations re-add this constraint
+  (`20260624120000`, `20260710140000`, `20260711160000`, `20260725160000`) and `pg:schema` replays all of
+  them on every deploy with no applied-tracking. Widening only a new one means the next deploy replays an
+  older, narrower re-add against a row that now violates it — byte-for-byte the #251 failure.
+- I also proposed guard discipline the repo **already automates**:
+  `test/guards/integrations-type-check-replay.test.ts` and `test/guards/enum-check-replay.test.ts` pin
+  every definition of the set against `schema.sql`. They would have caught my plan in CI.
+
+### Three places the new type must NOT leak
+
+1. **`PROVIDER_INTEGRATION_TYPES`** — that set means "an LLM provider key the answer path may resolve".
+   A management key is not one. Adding it there would make it selectable as an answering backend.
+2. **The connectors list** in `components/admin/integrations-manager.tsx`, which renders every
+   integration that isn't github/openrouter/a provider type. Left alone, the management key would appear
+   as a knowledge **source** to sync.
+3. **The embeddings/answering pickers**, for the same reason as (1).
+
+Each is a filter, so each is a place someone forgets. A guard asserts the type is absent from the
+provider sets.
+
+## The read
+
+`getProviderDailyUsage(db, teamId)` in `lib/costs/provider-usage.ts` — beside the existing `/credits`
+call, same best-effort contract (a provider outage degrades to "no per-day view", never a broken page),
+same 10-minute cache, same 4s timeout. Parsing is a pure function so the shape is pinned without a
+network call, mirroring `parseCreditsBody`.
+
+**READ-ONLY, and this is a security statement, not a style note.** A management key can create and delete
+API keys on the account — a materially larger blast radius than an inference key. This code path issues
+exactly one request, `GET /activity`, and a guard fails the build if the management key is ever passed
+to a different URL.
+
+## The surface
+
+A per-day table under the existing lifetime banner, shown only when a management key is configured:
+
+| Day | Provider billed | Ledger attributed | Unattributed |
+|---|---|---|---|
+
+Reusing `reconcileLedger`'s existing semantics per row (clamped at zero, `ledger-exceeds` as its own
+state, materiality on both a fraction and an absolute).
+
+**Both numbers must be built from the same window and the same provider**, or the comparison invents a
+gap. The ledger side filters `provider='openrouter'` (as `getLedgerLifetimeUsd` already does) and buckets
+by UTC date to match `activity`'s `date`, which is UTC.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| The `date` parameter is documented as a single-date filter; whether omitting it returns the full 30 days is **unverified** | Parse defensively and treat a single-day response as a single day. Verify against the live API the moment a key exists, before trusting the table. |
+| Timezone skew between `activity`'s UTC `date` and ledger bucketing | Bucket the ledger in UTC explicitly, not in server-local time |
+| A rotated inference key makes ledger and provider disagree by construction | `api_key_hash` filtering, if the current key's hash is derivable; otherwise state the caveat |
+| The key leaks | Encrypted at rest (AES-256-GCM under `SECRETS_KEY`), never returned to the client, read-only usage, guarded |
+
+## Out of scope
+
+- Backfilling `llm_usage` from `/activity`. The provider's rows are per-day/per-model, not per-call, so
+  they cannot be attributed to a **feature** — which is what the ledger is for. Mixing them would make
+  `source` slices lie.
+- Any write operation with the management key.
+
+## How we will know it worked
+
+The 2026-07-29 storm gets a line: provider $X on `qwen/qwen3.7-max`, ledger $48.24, remainder named. If
+the remainder concentrates on that one day, the timeout diagnosis is confirmed from the provider's own
+books rather than from my inference.


### PR DESCRIPTION
You asked me to build the `openrouter_admin` type + panel field + per-day reconciliation. **I stopped and did not build it**, because the design review's verdict was "this doesn't need to exist" and I think it's right. This PR records the decision and the corrected design, so the next person starts from the fix rather than my plan.

## Review — Reviewed by Fable (design review) — verdict: don't build; 1 BLOCKER + 2 HIGH in the plan itself

## Why not build it

- **The $46 question is answerable today, in a browser.** `openrouter.ai/activity` shows per-day, per-model spend with no schema change, no integration type, no render-path dependency.
- **The 30-day window expires ~2026-08-28 regardless of what we ship.** A feature built to read that data could plausibly land after the data is gone. The manual read is urgent; the build is not.
- **#458 already solved the forward-looking half, better.** `llm_failures` records billed-but-unmeterable attempts *with feature attribution* — which `/activity` structurally cannot do, since its rows are per-day/per-model, not per-call. What a permanent table adds is narrow: an alarm for spend escaping *both* the meter and `llm_failures`.

**Evidence bar for reopening** (recorded in the doc): the lifetime reconciliation already on the Costs page shows the gap **growing again** post-#458. That would prove a blind spot exists instead of assuming one.

## Two corrections to my own plan, recorded because they were wrong

**Storage.** I went from "not a second row of the same type" straight to "therefore a new integration type", skipping the option that dominates: a nullable `management_secret_ciphertext` column on the existing `openrouter` row. No CHECK widening, no leak points, and it models the domain correctly — deleting the OpenRouter integration takes its admin key along, where a separate type would strand a live one. It also generalizes to other providers without repeating the exercise.

**Migration — wrong twice over.** I prescribed a "conname-guarded DO block". That adds the constraint only when the name is *absent*, so on any existing database the widening is **skipped entirely** and the first insert fails at runtime. And I wrote "the migration", singular, when **four** existing migrations re-add `integrations_type_check` and `pg:schema` replays all of them every deploy — widening only a new one reproduces incident #251 byte-for-byte. I also proposed guard discipline the repo **already automates**: `integrations-type-check-replay` and `enum-check-replay` would have failed my plan in CI.

Both claims verified independently before recording them (`grep -rln integrations_type_check postgres/migrations/` → four files; both guards present).

## What I did verify about the API, for whenever this is reopened

- `date` is an **optional filter**, so omitting it returns the window rather than forcing 30 calls.
- `api_key_hash` accepts a SHA-256 hash "as returned by the keys API" — and `/api/v1/keys` is exactly what a management key can call. So the "other spend on the account contaminates the comparison" caveat is closeable, not permanent.
- `403 — "Only management keys can perform this operation"` is the documented error, which is what confirms the key type is genuinely required.

Doc-only change. No code, no schema, no migration.

## Review — Reviewed by code-reviewer (fable), fresh diff review vs current main — verdict CLEAR, safe to merge as-is: every falsifiable claim re-verified against today’s code (query shape, the 4 type-check migrations, both replay guards, llm_failures live, the reconciliation arithmetic); branch merges clean
