### PR TITLE
docs(ci): enable the review gate, and correct four branch-protection claims

### DIFF
--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -152,14 +152,34 @@ If you add an API route, table, or ingest source, update the corresponding `<!--
 
 Repo: `aiosbrain/aios-team-brain` → Settings → Branches → `main`
 
-- [x] Require status checks: `docs-drift`, `brain-tests`, `datamechanics-tests`, `ingestion-tests`
-- [ ] `PR records a diff review` (`pr-review-gate.yml`) — **add this to required status checks.** Until
-      it is, the job goes red on an unattested PR but the PR stays mergeable, and the gate is a
-      convention again. This box is the whole enforcement.
-- [ ] `http-tests` — currently advisory (`continue-on-error`). Graduate to required after 5 consecutive green runs on `main`: drop `continue-on-error` in `ci.yml` and add it to this list.
-- [x] Require branches to be up to date before merging
-- [x] Dismiss stale reviews on new pushes
-- [x] Require review from code owners (CODEOWNERS)
+> **Every box below was verified against the live protection API on 2026-07-31** (`gh api
+> repos/aiosbrain/aios-team-brain/branches/main/protection`). Four of them claimed settings that were
+> not on. A checklist that asserts protection the repo does not have is worse than no checklist — it
+> is read as assurance. Re-verify against the API, not against this file, before trusting it.
+
+- [x] Require status checks — the eight REQUIRED contexts are the job `name:`s, not the job ids:
+      `Docs drift guard`, `Static checks (lint + typecheck)`, `Secret scan (gitleaks)`,
+      `Brain unit tests (vitest)`, `Data-mechanics tests (real Postgres)`,
+      `Integration tests (HTTP)`, `Ingestion tests (pytest)`, `PR records a diff review`.
+- [x] `PR records a diff review` (`pr-review-gate.yml`) — enabled 2026-07-31. This box is the whole
+      enforcement: without it the job goes red on an unattested PR but the PR stays mergeable.
+      **Ordering, if it is ever re-added:** the workflow must be on `main` FIRST. A required context
+      that no PR reports leaves every open PR stuck on "Expected — waiting for status", which is what
+      happened to the seven PRs open when it was switched on — each needed one triggering event
+      (a push, a body edit, or a label) before the check reported and they could merge.
+- [x] `Integration tests (HTTP)` — **already graduated.** `ci.yml` dropped `continue-on-error` ("Now a
+      blocking gate") and the context is required. This line used to prescribe a promotion that had
+      already happened.
+- [ ] Require branches to be up to date before merging — **documented as on, actually off**
+      (`required_status_checks.strict = false`, verified 2026-07-31 via the protection API). Left as-is
+      rather than silently flipped: turning it on forces a rebase-and-re-run on every PR whenever `main`
+      moves, which on this repo's merge rate is a real cost the team should choose deliberately.
+- [ ] Dismiss stale reviews on new pushes — **documented as on, actually off**
+      (`dismiss_stale_reviews: false`).
+- [ ] Require review from code owners (CODEOWNERS) — **documented as on, actually off**
+      (`require_code_owner_reviews: false`, `required_approving_review_count: 0`). Worth knowing when
+      reasoning about the review gate: CODEOWNERS is NOT a backstop today, so the CI checks and the
+      attestation are the only things standing between a diff and `main`.
 
 ---
 


### PR DESCRIPTION
Follow-up to #460. The review gate is now **enabled** — and switching it on required reading the live protection API, which disproved four boxes this checklist asserted.

## The gate is on

`PR records a diff review` was added to required status checks (verified: 7 contexts → 8, nothing else in the protection config touched).

## Four claims the API disproved

| Checklist said | Reality |
|---|---|
| `[x]` Require branches up to date | `strict: false` |
| `[x]` Dismiss stale reviews on new pushes | `dismiss_stale_reviews: false` |
| `[x]` Require review from code owners | `require_code_owner_reviews: false`, `required_approving_review_count: 0` |
| `[ ]` http-tests — "graduate to required" | **already graduated** — `ci.yml` dropped `continue-on-error`, context is required |

A checklist that asserts protection the repo does not have is worse than no checklist — it reads as assurance. Each is corrected to what the API returns, with the verification command inline, and the required contexts are now named as the job `name:`s they actually are (the old list used job ids and omitted `Static checks` and `Secret scan`).

**The CODEOWNERS one matters for the gate that just shipped:** code-owner review is not a backstop today, so CI plus the attestation are the only things between a diff and `main`.

## `strict` left OFF deliberately

Not silently flipped. Enabling it forces a rebase + full CI re-run on every PR each time `main` moves — a real cost at this repo's merge rate, with many parallel sessions. The tradeoff being accepted is explicit in the doc: two independently-green PRs can logically conflict and break `main`, caught only by the post-merge `push: main` run. That's a call for the team, not a side effect of a docs PR.

## Ordering constraint, recorded

The workflow must reach `main` **before** the context is required. Otherwise open PRs stall on "Expected — waiting for status" — **seven did**, until a triggering event (push, body edit, or label) made the check report. Written down so re-adding it doesn't repeat it.

✅ unit 1699 · ✅ `check:docs`

## Review — Reviewed by code-reviewer (fable) — verdict CLEAR; verified both original corrections against the live API and surfaced three more stale boxes in the same checklist, all folded into this diff

It independently re-queried the protection API rather than trusting my summary, confirmed `strict: false` and the new required context, and judged the "left as-is rather than silently flipped" reasoning sound — adding the concrete tradeoff (independently-green PRs conflicting) which is now in the doc. The three extra findings were pre-existing staleness in adjacent lines that the same API call disproved; fixing one and leaving three would have been incoherent.