### PR TITLE
fix(costs): the unattributed % is a permanent floor, not a live alarm — say so

### DIFF
--- a/app/t/[team]/costs/page.tsx
+++ b/app/t/[team]/costs/page.tsx
@@ -155,11 +155,27 @@ export default async function CostsPage({
               </strong>{" "}
               {usd(reconciliation.unattributedUsd)} (
               {Math.round(reconciliation.unattributedFraction * 100)}%) can&apos;t be attributed to a
-              feature, so the breakdown below is a <strong>floor</strong>, not the total. Usually that is
-              a call that timed out or failed after the model had already generated — billed by the
-              provider, but returning no usage for the brain to record. It also covers any spend on this
-              key from outside this instance. Both figures are lifetime for the key, not the selected
-              window.
+              feature, so the breakdown below is a <strong>floor</strong>, not the total. Three things
+              land here:
+              <ul className="mt-1.5 list-disc space-y-1 pl-5">
+                <li>
+                  <strong>Spend from before metering existed.</strong>
+                  {breakdown.trackingSince ? ` This ledger starts ${fmtDay(breakdown.trackingSince)}; ` : " "}
+                  anything the provider billed earlier is in its lifetime total and can never enter ours.
+                </li>
+                <li>
+                  <strong>Calls billed after the model generated but returning no usage</strong> — a
+                  timeout, a dropped connection. Nothing to price, so nothing to record; these are counted
+                  per feature as <em>failed attempts</em> below.
+                </li>
+                <li>
+                  <strong>Any spend on this key from outside this instance.</strong>
+                </li>
+              </ul>
+              Because the first can never be recovered, <strong>this percentage will not fall as things
+              improve</strong> — a high number is not itself a problem. What matters is whether it{" "}
+              <strong>grows</strong>: that means spend is escaping the meter now. Both figures are lifetime
+              for the key, not the selected window.
             </>
           ) : reconciliation.status === "ledger-exceeds" ? (
             <>

--- a/app/t/[team]/costs/page.tsx
+++ b/app/t/[team]/costs/page.tsx
@@ -159,23 +159,30 @@ export default async function CostsPage({
               land here:
               <ul className="mt-1.5 list-disc space-y-1 pl-5">
                 <li>
-                  <strong>Spend from before metering existed.</strong>
-                  {breakdown.trackingSince ? ` This ledger starts ${fmtDay(breakdown.trackingSince)}; ` : " "}
-                  anything the provider billed earlier is in its lifetime total and can never enter ours.
+                  <strong>Spend from before metering existed.</strong> Anything the provider billed before
+                  this ledger&apos;s first metered call
+                  {/* The ledger's earliest row across ALL providers, while the comparison above is scoped
+                      to this one — so on a team whose first metered calls were another provider's, this
+                      date is earlier than OpenRouter coverage actually began. Phrased as "the ledger's
+                      first call" rather than "coverage of this key started here", which stays true either
+                      way; tightening it would cost a provider-scoped query for a one-word gain. */}
+                  {breakdown.trackingSince ? ` (${fmtDay(breakdown.trackingSince)})` : ""} is in its
+                  lifetime total and can never enter ours.
                 </li>
                 <li>
                   <strong>Calls billed after the model generated but returning no usage</strong> — a
-                  timeout, a dropped connection. Nothing to price, so nothing to record; these are counted
-                  per feature as <em>failed attempts</em> below.
+                  timeout, a dropped connection. Nothing to price, so nothing to record. Where we
+                  instrument them, these are <em>counted per feature</em> as failed attempts below.
                 </li>
                 <li>
                   <strong>Any spend on this key from outside this instance.</strong>
                 </li>
               </ul>
-              Because the first can never be recovered, <strong>this percentage will not fall as things
-              improve</strong> — a high number is not itself a problem. What matters is whether it{" "}
-              <strong>grows</strong>: that means spend is escaping the meter now. Both figures are lifetime
-              for the key, not the selected window.
+              Because the first can never be recovered, <strong>the dollar gap here has a floor</strong>:
+              new spend dilutes the percentage, but nothing ever clears the amount. So the percentage is
+              not the signal — a high one is not itself a problem, and a falling one is just arithmetic.
+              What matters is whether the <strong>dollars grow</strong>, which means spend is escaping the
+              meter now. Both figures are lifetime for the key, not the selected window.
             </>
           ) : reconciliation.status === "ledger-exceeds" ? (
             <>

--- a/test/guards/reconciliation-copy.test.ts
+++ b/test/guards/reconciliation-copy.test.ts
@@ -26,12 +26,23 @@ describe("guard: the reconciliation banner explains the permanent floor", () => 
     expect(page).toContain("breakdown.trackingSince");
   });
 
-  it("says the number will not fall, and to watch whether it grows", () => {
-    expect(page).toMatch(/will not fall/i);
-    expect(page).toMatch(/grows/i);
+  it("binds the never-clears claim to the DOLLARS, not the percentage", () => {
+    // The fraction is (provider - ledger) / provider, and both legs are lifetime — so as new fully
+    // metered spend accrues, the fixed pre-metering block is diluted and the PERCENTAGE falls on its
+    // own. Only the dollar amount has a floor. The first version of this banner promised the
+    // percentage could not fall, which would have read as the banner lying about arithmetic within a
+    // few months — the credibility failure this whole change exists to avoid.
+    expect(page).toMatch(/dollar gap here has a floor/i);
+    expect(page).toMatch(/dollars grow/i);
+    expect(page, "must not resurrect the false claim about the percentage").not.toMatch(
+      /percentage will not fall/i
+    );
   });
 
   it("still points at the failed-attempt breakdown for the part that IS actionable", () => {
-    expect(page).toMatch(/failed attempts/i);
+    // Anchored on wording unique to the BANNER. "failed attempts" alone also appears in the By-feature
+    // help text, so this assertion passed even with the banner's bullet deleted — vacuous against the
+    // one thing it was written to protect.
+    expect(page).toMatch(/counted per feature<\/em> as failed attempts below/i);
   });
 });

--- a/test/guards/reconciliation-copy.test.ts
+++ b/test/guards/reconciliation-copy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * GUARD: the reconciliation banner must name the cause it can never fix, and must tell the operator to
+ * read the TREND rather than the level.
+ *
+ * Measured 2026-07-31 against OpenRouter's own per-day figures: of a $46.23 gap, $29.25 was spend from
+ * 2026-07-28 — the graph proxy was live, the graph meter was not yet — and only $10.46 was failed calls.
+ * That first block can never enter this ledger, so the percentage is permanently elevated with nothing
+ * wrong. A banner that reads as a live alarm and can never be cleared trains the reader to ignore it,
+ * which is precisely how the work-key check earned its reputation.
+ *
+ * The wording is the whole feature here, so it is pinned rather than left to a future tidy-up.
+ */
+describe("guard: the reconciliation banner explains the permanent floor", () => {
+  const page = readFileSync(
+    join(import.meta.dirname, "..", "..", "app", "t", "[team]", "costs", "page.tsx"),
+    "utf8"
+  );
+
+  it("names pre-metering spend as a cause", () => {
+    expect(page).toMatch(/before metering existed/i);
+    // Dated from the ledger's own first row, never hardcoded — a wrong date is worse than none.
+    expect(page).toContain("breakdown.trackingSince");
+  });
+
+  it("says the number will not fall, and to watch whether it grows", () => {
+    expect(page).toMatch(/will not fall/i);
+    expect(page).toMatch(/grows/i);
+  });
+
+  it("still points at the failed-attempt breakdown for the part that IS actionable", () => {
+    expect(page).toMatch(/failed attempts/i);
+  });
+});


### PR DESCRIPTION
## Review — Reviewed by Fable — verdict HIGH, fixed before merge: the banner's central maths claim was false (the percentage dilutes; only the dollars have a floor) and one guard assertion was vacuous. Both corrected in `4c4a0e1`.

## What we learned

I read OpenRouter's per-day chart rather than inferring from the lifetime total, and the composition of the $46.23 gap is not what the banner implied:

| UTC day | OpenRouter billed | Ledger | Unattributed | Why |
|---|---|---|---|---|
| **2026-07-28** | $29.30 | $0.05 | **$29.25** | graph proxy live, graph meter not yet shipped |
| **2026-07-29** | $58.70 | $48.24 | **$10.46** | the timeout storm's aborted calls |
| | | | **$39.71 of $46.23 — 86%** | |

**63% never metered · 23% failed calls · 14% tail.**

I had told the team the whole $46 was the storm — a ~50% abort rate. It was $10.46 on $58.70, an 18% loss. Wrong by about 4×, and wrong because I reasoned from "pre-Jul-24 spend must be small" without noticing that **2026-07-28 sat in a gap of its own**: graph metering's first row is `2026-07-29 03:25 UTC`, but the proxy went live the day before. 59 episodes extracted, $0.05 recorded.

## Why the copy had to change

That $29.25 can **never** enter this ledger. So the percentage is permanently elevated with nothing wrong — and the old wording explained it as *"usually a call that timed out or failed after the model had already generated"*, which reads as a live, fixable problem. It isn't, and it will never clear.

A warning that cannot be cleared is one the reader learns to ignore. This repo already has that lesson written down from the work-key check, which accused a real ticket of not existing and taught us that an advisory which cries wolf is worse than none.

## The change

The banner now lists all three causes, dates the pre-metering one from the ledger's own first row (`breakdown.trackingSince`, never a hardcoded date — a wrong date is worse than none), and states the actionable reading outright:

> Because the first can never be recovered, **this percentage will not fall as things improve** — a high number is not itself a problem. What matters is whether it **grows**: that means spend is escaping the meter now.

That reframe is the point. The level is noise; the trend is the signal.

## Verified

unit **1702** (3 new) · tsc clean · lint clean (2 pre-existing warnings). The copy is the entire feature, so it's pinned by a guard rather than left to a future tidy-up — reverting to a single-cause wording turns it red (mutation-checked).

No schema, no data change, no new dependency.

## Correction made during review

The first version of this banner said *"this percentage will not fall as things improve."* That is false — the fraction is `(provider − ledger) / provider`, both legs lifetime, so new metered spend **dilutes** the fixed pre-metering block and the percentage drops on its own (~45% today becomes ~17% at ~$300 lifetime with clean metering). Only the dollar amount has a floor.

Worse, it pointed the reader at the wrong number: a percentage can *fall* while new spend is escaping the meter. The banner now says the **dollar gap** has a floor, that a falling percentage is just arithmetic, and that **growing dollars** are the signal.

The guard's third assertion was also vacuous — `/failed attempts/i` matches the By-feature help text further down the page, so deleting the banner bullet it was written to protect left it green. Re-anchored; both mutations now go red.

Also softened two overclaims: failures are counted per feature only **where instrumented** (not streaming Q&A, chat titles, or app-side embeddings), and the date is described as the ledger's first metered call rather than as when coverage of this key began — `trackingSince` spans all providers while the comparison is provider-scoped.
