### PR TITLE
release: v0.9.0 candidate (AIO-594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,63 @@ revision **v1.15**.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-01
+
+The Brain API contract is unchanged at **v1.15** — no member-facing route, shape,
+or semantics changed after the 1.15 revision landed (#456).
+
 ### Added
 
-- **Workspace-governance health ingest (brain-api 1.15, AIO-609)** —
+- **Workspace-governance health ingest (brain-api 1.15, AIO-609, #456)** —
   `POST /api/v1/codebases` accepts an optional, provenance-only
   `metrics.codebase_health` object (scored scanner-side, persisted verbatim on
   `code_metrics.codebase_health`, never recomputed; sparse or malformed pushes
   are rejected 422). The codebase detail view surfaces the latest snapshot
-  (score, status, measured_at).
+  (score, status, measured_at). Deployed to production and live-verified; this
+  is the same scanner-ingest endpoint that serves the workspace repo's
+  scan-on-merge CI push (an anonymous-checkout, team-tier-key consumer).
+- **Setup front door** — `npm run setup` is a real interview (#453), backed by a
+  one-command local stack + `npm run doctor` preflight (#444) and agent-driven,
+  provisioning-scoped Railway setup (#445). Connectors gained terminal status,
+  forced verify, and a `/connect` skill (#447).
+- **Cost visibility** — graph extraction + embeddings are metered (#437), the
+  spend the ledger can't see is named instead of reported as an anonymous
+  percentage (#450, #458, #463), and the cost window no longer fakes 30 days.
+- **Meetings on push** — the meeting note is created when a transcript is
+  pushed, not up to 30 minutes later on the next tick (#454), with
+  push-triggered backfills traced to `ingest_runs` (#457).
+- **Model administration** — a separate, save-time-validated model for graph
+  extraction so the graph stops billing the answer model (#442, #452); the
+  graph's LLM key lives only in the admin console (#425).
+- **Plain-English timeline** — headline-first day summaries with no machine
+  tokens (#435), and a one-screen Pulse snapshot (#440, #441).
+
+### Changed
+
+- **Review gate enforced** — the pre-push diff review attestation
+  (`Reviewed by … — verdict …`) is now a required CI check
+  (`pr-review-gate.yml`), not a remembered convention (#460, #462).
+- Phantom connectors retired (sidecar GitHub, Drive watch, `wise`, Granola);
+  README rewritten from the code — hosted-first setup order, per-step timings,
+  and the Team Brain schematic (#421, #424, #431, #436, #448).
+
+### Fixed
+
+- **NDA hook chain (#459)** — the pre-commit guard is tracked in `.githooks/`
+  and the NDA leak gate chains through `core.hooksPath`, so the policy hooks
+  can no longer be silently clobbered or skipped.
+- Re-running the provisioner rotated both secrets, logging the team out and
+  orphaning every token (#451); `SECRETS_KEY` is warned about at boot and
+  `doctor` accepts valid hex keys (#449).
+- Graph extraction: the 120s proxy timeout killed long extractions (#438), and
+  monitoring now detects extraction that *stopped*, not just extraction that
+  never started (#423).
+- Cache-backed routes report the row's real age, and degraded state has its own
+  column instead of overloading `computed_at` (#426, #432).
+- The LLM single-caller guard covers `.mjs` and stops flagging prose (#455);
+  Notion/Drive/Confluence `fetch()` is proven without an account, fixing the
+  TypeError it found (#439); personal Slack OAuth scopes aligned (#443); the
+  ingest-health banner no longer cries wolf on a healthy 12h job (#434).
 
 ## [0.8.0] — 2026-07-28
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aios-team-brain",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aios-team-brain",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@aios-alpha/design": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-team-brain",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## What & Why

v0.9.0 release candidate: bump `package.json` + lockfile 0.8.0 → 0.9.0 and cut the CHANGELOG from the 42 commits since the `v0.8.0` tag. Candidate only — do not merge until release sign-off.

**Verified highlights** (each traced to the commit range `v0.8.0..main`):

- **brain-api 1.15 `codebase_health` ingest** (#456, AIO-609) — `POST /api/v1/codebases` accepts the optional, provenance-only `metrics.codebase_health` object; sparse/malformed pushes 422. Deployed to prod (latest Railway deploy 2026-07-31 SUCCESS postdates the merge) and live-verified per AIO-594/609. This is the same scanner-ingest endpoint that serves the workspace repo's scan-on-merge CI push (anonymous-checkout, team-tier-key consumer).
- **NDA hook chain repair** (#459) — pre-commit guard tracked in `.githooks/`, NDA leak gate chained through `core.hooksPath`.
- **Review gate enforced in CI** (#460, #462), setup front door (#444/#445/#447/#453), cost visibility (#437/#450/#458/#463), meetings-on-push (#454/#457), model administration (#425/#442/#452), plain-English timeline + Pulse (#435/#440/#441), plus the fixes listed in the CHANGELOG.

**Contract check:** the Brain API stays at **1.15** — `git log 7063ff4..main -- app/api/v1 test/fixtures/contract lib/codebases` is empty, `docs/ARCHITECTURE.md` and the workspace's `docs/brain-api.md` (document revision 1.15) agree; no undocumented contract change found.

## Work item

AIOS-Work: AIO-594

## Checklist

- [x] `node scripts/check-docs-drift.mjs` passes locally (no routes/tables/sources changed)
- [x] Unit tests pass: `npm test` (223 files, 1715 passed)
- [x] Datamechanics: n/a — no persistence change (version + changelog only)
- [x] Ingestion: n/a — no Python change
- [x] `brain-api.md` unchanged — sync protocol untouched, stays 1.15
- [x] No secrets or admin-tier content in diff
- [x] Local diff review recorded below

## Review summary

Reviewed by Fable code-reviewer (local pre-push diff review) — verdict no blockers; 2 LOW cosmetic notes, both addressed or noted (Unreleased stub restored; prod-deploy claim corroborated via read-only `railway deployment list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezafs28cPfXAjocBnYbsMF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only diff with no routes, schema, or application logic changes.
> 
> **Overview**
> **Release packaging only:** `package.json` and `package-lock.json` move **0.8.0 → 0.9.0**, and `CHANGELOG.md` gains a dated **[0.9.0] — 2026-08-01** section with an empty **[Unreleased]** stub restored above it.
> 
> The new changelog text **documents** the prior release window (setup/doctor/Railway, cost metering, meetings-on-push, graph model admin, Pulse/timeline copy, CI review gate, NDA hooks, and assorted fixes) and states Brain API stays at **v1.15** — it does **not** implement those changes; they are already on `main` per linked PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dcca01645f0a9a0c192db22281345784e62ade8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->