### PR TITLE
fix(test): replace a fixture name flagged by the confidentiality gate

### DIFF
--- a/test/dashboard-people-match.test.ts
+++ b/test/dashboard-people-match.test.ts
@@ -47,18 +47,18 @@ describe("subjectMatchesMember", () => {
  *
  * The timeline used to drop any `decided_by` that wasn't exactly one name. On prod that was 27 of 56
  * decisions — 48% — and the shape it hid was the worst possible one: the calls two people made together
- * ("John Ellison & Chetan") vanished, while solo ones stayed. Fixtures below are the real prod strings.
+ * ("John Ellison & Chetan") vanished, while solo ones stayed. Fixtures below mirror the shapes of the real prod strings (all names synthetic).
  */
 describe("decisionActors", () => {
   const roster: RosterPerson[] = [
     { memberId: "m-john", displayName: "John Ellison", handle: "john-ellison" },
     { memberId: "m-chetan", displayName: "Chetan", handle: "chetan" },
-    { memberId: "m-abe", displayName: "Abe Isleem", handle: "abe" },
+    { memberId: "m-ada", displayName: "Ada Sample", handle: "ada" },
   ];
 
   it("credits BOTH people in a joint decision", () => {
     expect(decisionActors("John Ellison & Chetan", roster)).toEqual(["m-john", "m-chetan"]);
-    expect(decisionActors("John Ellison & Abe Isleem", roster)).toEqual(["m-john", "m-abe"]);
+    expect(decisionActors("John Ellison & Ada Sample", roster)).toEqual(["m-john", "m-ada"]);
   });
 
   it("credits the decider AND the agreer in a qualified attribution", () => {

--- a/test/dashboard-people-match.test.ts
+++ b/test/dashboard-people-match.test.ts
@@ -47,7 +47,7 @@ describe("subjectMatchesMember", () => {
  *
  * The timeline used to drop any `decided_by` that wasn't exactly one name. On prod that was 27 of 56
  * decisions — 48% — and the shape it hid was the worst possible one: the calls two people made together
- * ("John Ellison & Chetan") vanished, while solo ones stayed. Fixtures below mirror the shapes of the real prod strings (all names synthetic).
+ * ("John Ellison & Chetan") vanished, while solo ones stayed. Fixtures below mirror the shapes of the real prod strings (third-party names synthetic).
  */
 describe("decisionActors", () => {
   const roster: RosterPerson[] = [


### PR DESCRIPTION
The release-gate leak scan flagged a fixture name in `test/dashboard-people-match.test.ts`; replaced with a synthetic name of the same shape (test semantics and assertions unchanged), and reworded the adjacent comment so real prod strings are not copied back into fixtures.

Verification:
- Full-tree leak-gate: `leak-gate: CLEAN — no forbidden identifiers found (baseline + term set).`
- Case-insensitive sweep across all tracked files: zero remaining instances.
- `test/dashboard-people-match.test.ts`: 12/12 passing; full suite: 223 files passed, 1715 tests passed, 11 skipped.

## Review — Reviewed by Fable code-reviewer (fresh-context subagent, diff origin/main...HEAD) — verdict clean, ship it: no P1/P2 findings; one P3 comment-accuracy nit, applied in 0799d91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezafs28cPfXAjocBnYbsMF