### PR TITLE
fix(gateway): AIO-407 conformance — resume fingerprint excludes credential fields

### DIFF
--- a/lib/gateway/persistence.ts
+++ b/lib/gateway/persistence.ts
@@ -533,6 +533,8 @@ export async function resumeClaimGatewayExecution<T>(input: {
       state: string;
       resume_fingerprint: string | null;
       claim_idempotency_key: string | null;
+      claimed_credential_public_id: string | null;
+      claimed_credential_version: number | null;
       approval_id: string;
       approval_status: string;
       approval_expires_at: string;
@@ -560,6 +562,8 @@ export async function resumeClaimGatewayExecution<T>(input: {
               e.connection_id,e.toolkit,e.tool,e.request_hash,e.encrypted_request_envelope,
               e.request_envelope_hash,e.actor_snapshot,e.role_snapshot,e.tier_snapshot,
               e.policy_resource,e.state,e.resume_fingerprint,e.claim_idempotency_key,
+              cc.credential_id claimed_credential_public_id,
+              cc.version claimed_credential_version,
               a.id approval_id,a.status approval_status,a.expires_at approval_expires_at,
               (a.expires_at<=now()) approval_expired,
               b.executor_tenant_id,b.executor_subject_id,b.revoked_at binding_revoked_at,
@@ -583,6 +587,8 @@ export async function resumeClaimGatewayExecution<T>(input: {
          join gateway_service_identities s on s.id=e.service_identity_id and s.team_id=e.team_id
          join gateway_service_credentials gc
            on gc.id=$5 and gc.service_identity_id=e.service_identity_id and gc.team_id=e.team_id
+         left join gateway_service_credentials cc
+           on cc.id=e.claimed_credential_id and cc.team_id=e.team_id
         where e.id=$1 and e.service_identity_id=$2
           and b.executor_tenant_id=$3 and b.executor_subject_id=$4
         for update of e,a,gc`,
@@ -600,10 +606,15 @@ export async function resumeClaimGatewayExecution<T>(input: {
       inTransaction = false;
       throw new GatewayPersistenceError("gateway_not_found");
     }
+    // Internal gateway 1.10 fingerprint amendment (AIO-407, 2026-07-19): the
+    // idempotency fingerprint deliberately EXCLUDES the authenticating
+    // credential's credentialId/credentialVersion, so an identical retry
+    // authenticated by an active sibling credential of the same service
+    // identity (credential-rotation overlap) resolves to already_claimed
+    // instead of being permanently 409'd. Credential identity is still
+    // revalidated at claim time and recorded on the audit row.
     const fingerprint = sha256(
       canonicalize({
-        credentialId: input.service.credentialId,
-        credentialVersion: input.service.credentialVersion,
         executionId: input.executionId,
         executorSubjectId: input.executorSubjectId,
         executorTenantId: input.executorTenantId,
@@ -616,8 +627,36 @@ export async function resumeClaimGatewayExecution<T>(input: {
       }),
     );
     if (["claimed", "succeeded", "failed"].includes(row.state)) {
+      // Back-compat for rows claimed before the amendment: their stored
+      // fingerprint included the CLAIMING credential's credentialId/version.
+      // Recompute that legacy form from the recorded claiming credential
+      // (never the authenticating one). A legacy match proves every amended
+      // fingerprint field is byte-identical, so this acceptance is strictly
+      // narrower than the amended fingerprint — it can never widen it.
+      const legacyFingerprint =
+        row.resume_fingerprint === fingerprint ||
+        row.claimed_credential_public_id === null ||
+        row.claimed_credential_version === null
+          ? null
+          : sha256(
+              canonicalize({
+                credentialId: row.claimed_credential_public_id,
+                credentialVersion: row.claimed_credential_version,
+                executionId: input.executionId,
+                executorSubjectId: input.executorSubjectId,
+                executorTenantId: input.executorTenantId,
+                memberId: row.member_id,
+                requestHash: input.requestHash,
+                serviceIdentityId: input.service.id,
+                teamId: row.team_id,
+                tool: input.tool,
+                toolkit: input.toolkit,
+              }),
+            );
       if (
-        row.resume_fingerprint !== fingerprint ||
+        (row.resume_fingerprint !== fingerprint &&
+          (legacyFingerprint === null ||
+            row.resume_fingerprint !== legacyFingerprint)) ||
         row.claim_idempotency_key !== input.idempotencyKey
       ) {
         await client.query("ROLLBACK");

--- a/test/datamechanics/gateway-approval.datamechanics.test.ts
+++ b/test/datamechanics/gateway-approval.datamechanics.test.ts
@@ -1,6 +1,7 @@
-import { randomBytes, randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { getPool } from "@/lib/db/pg/pool";
+import { canonicalize } from "@/lib/gateway/canonical";
 import {
   authorizeGatewayAdmin,
   createGatewayAdminPolicy,
@@ -398,6 +399,142 @@ describe("gateway durable approval and resume", () => {
     oldAuth.secretBytes.fill(0);
     newAuth.secretBytes.fill(0);
     stillActive.secretBytes.fill(0);
+    service.secretBytes.fill(0);
+  });
+
+  it("resolves an identical retry after credential rotation instead of 409ing (AIO-407 amendment)", async () => {
+    const { seed, ctx, service, executionId } = await approvedExecution();
+    const idempotencyKey = randomUUID();
+    let payloads = 0;
+    const winner = await resumeClaimGatewayExecution(
+      claimInput(seed, executionId, service, idempotencyKey, () => payloads++),
+    );
+    expect(winner.status).toBe("claimed");
+    expect(payloads).toBe(1);
+    const credentialId = randomBytes(16).toString("base64url");
+    const secret = randomBytes(32).toString("base64url");
+    await rotateGatewayCredential(ctx, seed.serviceIdentityId, {
+      credentialId,
+      secret,
+      replacesCredentialId: seed.credentialId,
+      correlationId: randomUUID(),
+    });
+    const rotatedAuth = await authenticateGatewayServiceCredential(
+      `Bearer aios_gw_${credentialId}_${secret}`,
+    );
+    expect(rotatedAuth.id).toBe(service.id);
+    expect(rotatedAuth.credentialRowId).not.toBe(service.credentialRowId);
+    // The defect: with credentialId/credentialVersion in the fingerprint this
+    // identical retry was permanently 409'd after rotation.
+    const retry = await resumeClaimGatewayExecution(
+      claimInput(seed, executionId, rotatedAuth, idempotencyKey, () => payloads++),
+    );
+    expect(retry).toEqual({
+      status: "already_claimed",
+      executionId,
+      state: "claimed",
+    });
+    expect(payloads).toBe(1);
+    // A change in any OTHER fingerprint field must still conflict.
+    await expect(
+      resumeClaimGatewayExecution({
+        ...claimInput(seed, executionId, rotatedAuth, idempotencyKey, () => payloads++),
+        requestHash: "a".repeat(64),
+      }),
+    ).rejects.toMatchObject({ code: "gateway_idempotency_conflict" });
+    expect(payloads).toBe(1);
+    rotatedAuth.secretBytes.fill(0);
+    service.secretBytes.fill(0);
+  });
+
+  it("resolves legacy pre-amendment stored fingerprints without widening acceptance", async () => {
+    const { seed, ctx, service, executionId } = await approvedExecution();
+    const idempotencyKey = randomUUID();
+    let payloads = 0;
+    await resumeClaimGatewayExecution(
+      claimInput(seed, executionId, service, idempotencyKey, () => payloads++),
+    );
+    // Rewrite the stored fingerprint to the pre-amendment (legacy) form that
+    // included the claiming credential's credentialId/credentialVersion —
+    // exactly what a row claimed before this fix carries in production.
+    const claimedRow = await getPool().query(
+      `select e.member_id, cc.credential_id, cc.version
+         from gateway_executions e
+         join gateway_service_credentials cc on cc.id=e.claimed_credential_id
+        where e.id=$1`,
+      [executionId],
+    );
+    const legacyFingerprint = createHash("sha256")
+      .update(
+        canonicalize({
+          credentialId: claimedRow.rows[0].credential_id,
+          credentialVersion: claimedRow.rows[0].version,
+          executionId,
+          executorSubjectId: seed.executorSubjectId,
+          executorTenantId: seed.executorTenantId,
+          memberId: claimedRow.rows[0].member_id,
+          requestHash: REQUEST_HASH,
+          serviceIdentityId: seed.serviceIdentityId,
+          teamId: seed.teamId,
+          tool: "github.repository.get",
+          toolkit: "aios-github-readonly",
+        }),
+        "utf8",
+      )
+      .digest("hex");
+    // resume_fingerprint is write-once (gateway_executions_protect), so plant
+    // the legacy value the way pre-fix code wrote it: toggle the trigger
+    // inside one transaction (ALTER TABLE is transactional, so the guard is
+    // never observably disabled outside it). Values are inlined because a
+    // multi-statement simple query cannot take bind parameters.
+    await getPool().query(`
+      begin;
+      alter table gateway_executions disable trigger gateway_executions_protect;
+      update gateway_executions set resume_fingerprint='${legacyFingerprint}'
+        where id='${executionId}';
+      alter table gateway_executions enable trigger gateway_executions_protect;
+      commit;
+    `);
+    // Identical retry with the same credential resolves via the legacy match.
+    const sameCredential = await resumeClaimGatewayExecution(
+      claimInput(seed, executionId, service, idempotencyKey, () => payloads++),
+    );
+    expect(sameCredential).toEqual({
+      status: "already_claimed",
+      executionId,
+      state: "claimed",
+    });
+    // Identical retry with a rotated sibling credential resolves too: the
+    // legacy fallback recomputes from the RECORDED claiming credential, not
+    // the authenticating one — legacy rows get the amended semantics.
+    const credentialId = randomBytes(16).toString("base64url");
+    const secret = randomBytes(32).toString("base64url");
+    await rotateGatewayCredential(ctx, seed.serviceIdentityId, {
+      credentialId,
+      secret,
+      replacesCredentialId: seed.credentialId,
+      correlationId: randomUUID(),
+    });
+    const rotatedAuth = await authenticateGatewayServiceCredential(
+      `Bearer aios_gw_${credentialId}_${secret}`,
+    );
+    const rotated = await resumeClaimGatewayExecution(
+      claimInput(seed, executionId, rotatedAuth, idempotencyKey, () => payloads++),
+    );
+    expect(rotated).toEqual({
+      status: "already_claimed",
+      executionId,
+      state: "claimed",
+    });
+    // A different fingerprint field never matches the legacy form either.
+    await expect(
+      resumeClaimGatewayExecution({
+        ...claimInput(seed, executionId, rotatedAuth, idempotencyKey, () => payloads++),
+        requestHash: "a".repeat(64),
+      }),
+    ).rejects.toMatchObject({ code: "gateway_idempotency_conflict" });
+    expect(payloads).toBe(1);
+    rotatedAuth.secretBytes.fill(0);
     service.secretBytes.fill(0);
   });
 

--- a/test/fixtures/contract/gateway-approval-v1.10.json
+++ b/test/fixtures/contract/gateway-approval-v1.10.json
@@ -524,8 +524,6 @@
   "vectors": {
     "resumeFingerprint": {
       "fields": [
-        "credentialId",
-        "credentialVersion",
         "executionId",
         "executorSubjectId",
         "executorTenantId",
@@ -536,9 +534,9 @@
         "tool",
         "toolkit"
       ],
+      "excludedFields": ["credentialId", "credentialVersion"],
+      "excludedFieldsRationale": "credential-rotation-overlap-must-not-invalidate-resume-idempotency; credential identity is revalidated (authenticating-credential-active, stable-service-identity) and recorded on the audit row, never fingerprinted",
       "value": {
-        "credentialId": "ICEiIyQlJicoKSorLC0uLw",
-        "credentialVersion": 2,
         "executionId": "22222222-2222-4222-8222-222222222222",
         "executorSubjectId": "executor-user-42",
         "executorTenantId": "executor-tenant-7",
@@ -549,8 +547,8 @@
         "tool": "github.repository.get",
         "toolkit": "aios-github-readonly"
       },
-      "jcs": "{\"credentialId\":\"ICEiIyQlJicoKSorLC0uLw\",\"credentialVersion\":2,\"executionId\":\"22222222-2222-4222-8222-222222222222\",\"executorSubjectId\":\"executor-user-42\",\"executorTenantId\":\"executor-tenant-7\",\"memberId\":\"44444444-4444-4444-8444-444444444444\",\"requestHash\":\"4b18a1b9c0f093f7e46b4410e245fd88f011e6d820b34ef9446296ff9386f310\",\"serviceIdentityId\":\"11111111-1111-4111-8111-111111111111\",\"teamId\":\"33333333-3333-4333-8333-333333333333\",\"tool\":\"github.repository.get\",\"toolkit\":\"aios-github-readonly\"}",
-      "sha256": "0f0369a66660d1030e4104cfd394e001a16d90e0df6511698c6642ea92f7ee45"
+      "jcs": "{\"executionId\":\"22222222-2222-4222-8222-222222222222\",\"executorSubjectId\":\"executor-user-42\",\"executorTenantId\":\"executor-tenant-7\",\"memberId\":\"44444444-4444-4444-8444-444444444444\",\"requestHash\":\"4b18a1b9c0f093f7e46b4410e245fd88f011e6d820b34ef9446296ff9386f310\",\"serviceIdentityId\":\"11111111-1111-4111-8111-111111111111\",\"teamId\":\"33333333-3333-4333-8333-333333333333\",\"tool\":\"github.repository.get\",\"toolkit\":\"aios-github-readonly\"}",
+      "sha256": "93bd21487ca4f8bbbd0aa38d32735753141bec16abf9814d0e0fd3c043510472"
     },
     "requestEnvelope": {
       "algorithm": "AES-256-GCM",

--- a/test/gateway/gateway-approval-contracts.test.ts
+++ b/test/gateway/gateway-approval-contracts.test.ts
@@ -21,8 +21,10 @@ const fixture = JSON.parse(bytes.toString("utf8"));
 
 describe("gateway approval v1.10 vendored contract", () => {
   it("is the reviewed Workspace fixture and pins the AIO-401 base", () => {
+    // Amended fixture (AIO-407, 2026-07-19): the pinned SHA-256 published in
+    // Workspace docs/brain-api.md for the in-place fingerprint amendment.
     expect(createHash("sha256").update(bytes).digest("hex")).toBe(
-      "b1bed83fbdd4e6cfff2200a4cefa828a2d770c66f898e9e7d704511935cc5e62",
+      "49156f5f1025c7408350d6bc97bd8769bf0fc54b90ffc6c78639597c4f12d02d",
     );
     expect(fixture.baseContract.sha256).toBe(
       "4ddd6495fa505b76118080865d60255bfba94a9ccda249defe428babb3d0c205",
@@ -87,6 +89,13 @@ describe("gateway approval v1.10 vendored contract", () => {
 
   it("matches the resume fingerprint vector", () => {
     const vector = fixture.vectors.resumeFingerprint;
+    // AIO-407 amendment: the fingerprint must never bind the authenticating
+    // credential, or a supported credential-rotation overlap permanently
+    // 409s an identical resume retry.
+    expect(vector.excludedFields).toEqual(["credentialId", "credentialVersion"]);
+    expect(vector.fields).not.toContain("credentialId");
+    expect(vector.fields).not.toContain("credentialVersion");
+    expect(Object.keys(vector.value).sort()).toEqual(vector.fields);
     expect(canonicalize(vector.value)).toBe(vector.jcs);
     expect(createHash("sha256").update(vector.jcs).digest("hex")).toBe(
       vector.sha256,


### PR DESCRIPTION
## What & Why

**v0.9.0 release-gate finding (contract conformance):** the workspace contract (`docs/brain-api.md` rev **1.15**, internal gateway **1.10** — workspace SHA `108adadd`) carries the 2026-07-19 **AIO-407 fingerprint amendment**: the durable resume-claim idempotency fingerprint must **exclude** the authenticating credential's `credentialId`/`credentialVersion`, binding only execution, Executor tenant/subject, member, team, service identity, toolkit, tool, and request hash. The brain's implementation (`lib/gateway/persistence.ts` `canonicalize()` in `resumeClaimGatewayExecution`) and its vendored fixture (`test/fixtures/contract/gateway-approval-v1.10.json`) predated the amendment and still included both fields — reintroducing the defect the amendment fixed: an Executor that claimed, lost the response, rotated its credential (an explicitly supported overlap flow), and retried the identical resume was **permanently `409 gateway_idempotency_conflict`** and could never learn the claim state.

Changes:
- `canonicalize()` no longer includes `credentialId`/`credentialVersion`. Credential identity is still fully revalidated at claim time (active-credential lock + stable service identity) and recorded on the audit row (`claimed_credential_id`) — it is just never fingerprinted, exactly per the amendment.
- Fixture **byte-copied** from the workspace: SHA-256 `49156f5f1025c7408350d6bc97bd8769bf0fc54b90ffc6c78639597c4f12d02d` — identical to the value pinned in `brain-api.md`. Contract test SHA pin updated and hardened (asserts `excludedFields`, and that the vector fields never contain the credential pair).
- **No version bump**: this is conformance to the *existing* pinned contract (doc rev 1.15 / gateway 1.10), not a protocol change. The workspace-side amendment (workspace PR #352, `57fad62`) was contract-only; this PR is the brain's matching implementation.

## Migration / back-compat analysis

`resume_fingerprint` is persisted **once**, at winning claim time (`state → claimed`; the column is write-once, enforced by the `gateway_executions_protect` trigger), and compared on every later retry of a `claimed|succeeded|failed` row. So any row claimed **before** this fix stores a legacy fingerprint that includes the claiming credential — after the fix, an identical retry would recompute the amended form, mismatch, and 409: the fix itself would strand pre-fix rows.

**Implemented narrow dual-match back-compat** rather than assuming prod is empty (`AIOS_GATEWAY_INTERNAL_ENABLED` is default-off, but that's an env fact I can't verify from the repo): when the stored fingerprint doesn't match the amended computation, the legacy form is recomputed using the **recorded claiming credential** (`claimed_credential_id → gateway_service_credentials.credential_id/version` via a `left join`), never the authenticating one. Properties:

- A legacy match implies every amended fingerprint field is byte-identical (the legacy form is a strict superset of the amended fields), so acceptance is **strictly narrower** than the amended fingerprint — the fallback can never widen it.
- Because the legacy form is rebuilt from the *claiming* credential, a pre-fix row retried under a **rotated sibling credential** also resolves `already_claimed` — legacy rows get the amended semantics, not just pre-fix parity.
- Rows claimed post-fix store the amended fingerprint and never enter the fallback path (it is only computed on amended mismatch).

## Test evidence (all local, worktree `gateway-110`, head `5cc2291`)

- New regression: *"resolves an identical retry after credential rotation instead of 409ing (AIO-407 amendment)"* — claim, rotate, identical retry under the new credential → `already_claimed`, payload callback still fired exactly once; a change in any **other** fingerprint field (`requestHash`) still `409`s.
- New back-compat: *"resolves legacy pre-amendment stored fingerprints without widening acceptance"* — plants the pre-fix fingerprint (trigger toggled inside one transaction, mirroring how pre-fix code wrote it), then: identical retry same credential → `already_claimed`; identical retry rotated credential → `already_claimed`; different `requestHash` → `409`.
- `npm test`: **223 files passed / 1 skipped, 1715 tests passed / 11 skipped**
- `npm run test:datamechanics:local` (full): **163 files passed / 2 skipped, 803 passed / 4 skipped** (gateway-approval file: 17/17, incl. the 2 new)
- Gateway HTTP (built app, flag on): enabled suite 2/2 passed, disabled-flag file correctly skipped
- `npm run lint`: 0 errors (2 pre-existing warnings in unrelated `me-slack-token` test)
- `node scripts/check-docs-drift.mjs`: routes/tables/sources all in sync

## Work item

AIOS-Work: AIO-407

## Checklist

- [x] `node scripts/check-docs-drift.mjs` passes locally (or no routes/tables/sources changed)
- [x] Unit tests pass: `npm test`
- [x] Datamechanics tests pass if persistence changed: `npm run test:datamechanics:local`
- [ ] Ingestion tests pass if Python changed: `cd ingestion && pytest -q` (no Python changed)
- [x] `brain-api.md` version bumped if sync protocol changed (n/a — conformance to the existing pinned 1.10 contract, no protocol change)
- [x] No secrets or admin-tier content in diff
- [x] Local diff review recorded below

## Review summary

Reviewed by Fable — verdict no blockers, back-compat fallback verified strictly narrower than the amended fingerprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezafs28cPfXAjocBnYbsMF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway resume-claim idempotency in `lib/gateway/persistence.ts`, a security-sensitive path; the dual fingerprint match is intentionally narrow but still alters conflict resolution for in-flight claims.
> 
> **Overview**
> Aligns **internal gateway 1.10** resume-claim idempotency with the **AIO-407** contract amendment: the `resume_fingerprint` in `resumeClaimGatewayExecution` no longer includes the authenticating credential’s `credentialId` / `credentialVersion`, so an identical retry after **credential rotation overlap** returns `already_claimed` instead of a permanent **`409 gateway_idempotency_conflict`**. Claim-time credential checks and audit recording are unchanged.
> 
> For rows already claimed with the old fingerprint, a **narrow legacy fallback** recomputes the pre-amendment hash from the **recorded claiming credential** (via `left join` on `claimed_credential_id`), so existing executions are not stranded while acceptance cannot widen beyond the amended fingerprint.
> 
> The vendored **`gateway-approval-v1.10.json`** fixture, SHA pin, and JCS/SHA vector are updated; contract and datamechanics tests cover rotation retries, legacy fingerprints, and unchanged conflict behavior when other fingerprint fields differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc229102c6b6da6301c9c079c976a62a0bc557b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->