### PR TITLE
docs(resolver): scope the Linear-only rule to AIOS's own board (AIO-648)

### DIFF
--- a/RESOLVER.md
+++ b/RESOLVER.md
@@ -25,7 +25,7 @@ gates (AIOS hub, Tessera root) apply in addition.
 | Adding a column to an existing table | `postgres/migrations/` (alter) AND mirror into `postgres/schema.sql` (from-zero) — editing create-table alone is a prod no-op |
 | Editing any `.claude/skills/<name>/SKILL.md` | If the skill is published to other runtimes, re-run `npm run check:skills:fix` in the same change — `.agents/`, `.opencode/`, `.cursor/rules/` are generated copies (guard: `test/guards/skill-runtime-sync.test.ts` + pre-push) |
 | Writing any test | Spec-first, never characterization-first; pick the tier by failure mode (unit / data-mechanics / integration / eval — CLAUDE.md §4) |
-| Any PM/board work | `aios-linear` (global skill) — Linear only; **Plane is retired**: never register or use the `lib/pm-sync` Plane adapter (still present for historical rows; removal is a scoped migration, tracked in the resolver audit) |
+| AIOS-internal PM/board work | `aios-linear` (global skill) — Linear is the canonical board used to build AIOS; do not dual-write AIO issues to Plane. The `lib/pm-sync` Plane adapter remains a supported product integration for customer teams and must not be removed or disabled under this board-policy rule. |
 
 ## Functional Areas
 


### PR DESCRIPTION
## Summary

The RESOLVER PM row read *"Plane is retired: never register or use the `lib/pm-sync` Plane adapter"*. That conflates two separate things:

- **which board AIOS uses to build itself** — Linear, and that does not change
- **which PM tools AIOS supports as a product integration** — Plane is still one of them

`lib/pm-sync/plane.ts` is a supported connector for customer teams running Plane. The old wording invited an agent to read it as dead code and delete it, and **AIO-648** (restore and certify Plane as a supported AIOS PM connector) depends on it still existing.

This scopes the rule to AIOS-internal board work and states explicitly that the adapter must not be removed or disabled under a board-policy rule. The matching change to the hub `RESOLVER.md` goes up separately.

Docs-only, one line.

## Verification

- Single-line change to `RESOLVER.md`; no code, no tests affected.
- Pre-push NDA leak gate: clean.

Linear: AIO-648

## Review — Reviewed by Claude Opus 5 (author self-review, docs-only) — verdict pass: one-line routing-table wording change, no executable surface touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only routing-table wording; no executable code or tests changed.
> 
> **Overview**
> **Clarifies the RESOLVER “Always-On Gates” PM row** so agents do not treat `lib/pm-sync`’s Plane adapter as retired or removable.
> 
> The trigger is narrowed from generic “Any PM/board work” to **AIOS-internal PM/board work**, with Linear still canonical for building AIOS and no dual-writing AIO issues to Plane. It now states explicitly that the Plane adapter is a **supported customer product integration** and must not be removed or disabled under this board-policy rule—aligning the router with **AIO-648** and active wiring in `lib/pm-sync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae876dc3d12eeb3459d87778614a56a68a4ba7af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->