### PR TITLE
fix(codebases): a missing coverage report is null, not a measured 0%

### DIFF
--- a/components/codebases/agentic-breakdown.tsx
+++ b/components/codebases/agentic-breakdown.tsx
@@ -53,17 +53,27 @@ export function AgenticScoreCard({ b }: { b: Breakdown }) {
 
       <div className="flex flex-col gap-3">
         {BARS.map((row) => {
-          const value = b[row.score] as number;
+          const value = b[row.score] as number | null;
           const weight = AGENTIC_WEIGHTS[row.key];
+          // A null sub-score means "not measured" and is excluded from the composite, so it
+          // must not render as an empty bar sitting at 0 — that reads as a measured failure.
+          const reported = value != null;
           return (
             <div key={row.key} className="flex flex-col gap-1">
               <div className="flex items-baseline justify-between text-xs">
                 <span className="text-ink-secondary">{row.label}</span>
                 <span className="text-ink-tertiary">
-                  {value} <span className="opacity-60">· {Math.round(weight * 100)}%</span>
+                  {reported ? value : <span className="italic">no report</span>}{" "}
+                  <span className="opacity-60">
+                    · {reported ? `${Math.round(weight * 100)}%` : "excluded"}
+                  </span>
                 </span>
               </div>
-              <Bar value={value} />
+              {reported ? (
+                <Bar value={value} />
+              ) : (
+                <div className="h-2 w-full rounded-full border border-dashed border-border-subtle" />
+              )}
             </div>
           );
         })}

--- a/lib/codebases/score.test.ts
+++ b/lib/codebases/score.test.ts
@@ -30,8 +30,10 @@ const FULLY_AGENTIC: ScanInputs = {
 };
 
 describe("sub-scores", () => {
-  it("coverage: null report → 0; 80% → 100; 40% → 50", () => {
-    expect(coverageScore({ ...FULLY_AGENTIC, test_coverage_pct: null })).toBe(0);
+  it("coverage: no report → null; 0% → 0; 80% → 100; 40% → 50", () => {
+    // null and 0 are different facts: "never measured" vs "measured, covers nothing".
+    expect(coverageScore({ ...FULLY_AGENTIC, test_coverage_pct: null })).toBeNull();
+    expect(coverageScore({ ...FULLY_AGENTIC, test_coverage_pct: 0 })).toBe(0);
     expect(coverageScore({ ...FULLY_AGENTIC, test_coverage_pct: 80 })).toBe(100);
     expect(coverageScore({ ...FULLY_AGENTIC, test_coverage_pct: 40 })).toBe(50);
   });
@@ -76,13 +78,41 @@ describe("composite scores (weights locked)", () => {
     expect(s.health_score).toBe(100);
   });
 
-  it("dropping the coverage report lowers both scores (coverage carries weight)", () => {
+  it("a MEASURED 0% coverage lowers both scores (coverage carries weight)", () => {
     const withCov = computeScores(FULLY_AGENTIC);
-    const noCov = computeScores({ ...FULLY_AGENTIC, test_coverage_pct: null });
+    const zeroCov = computeScores({ ...FULLY_AGENTIC, test_coverage_pct: 0 });
     // agentic loses 0.25*100 = 25; health loses 0.4*100 = 40
-    expect(noCov.agentic_score).toBe(withCov.agentic_score - 25);
-    expect(noCov.health_score).toBe(withCov.health_score - 40);
-    expect(noCov.test_coverage_score).toBe(0);
+    expect(zeroCov.agentic_score).toBe(withCov.agentic_score - 25);
+    expect(zeroCov.health_score).toBe(withCov.health_score - 40);
+    expect(zeroCov.test_coverage_score).toBe(0);
+  });
+
+  it("NO coverage report is excluded from the composites, not scored as zero", () => {
+    // The regression that lets this recur: a repo that never filed a report used to score
+    // identically to a repo measured at 0%. Coverage is 40% of health, so every scaffolded
+    // workspace — a content repo with no suite, and `coverage/` gitignored so no clone can
+    // ever supply one — sat at a permanent 40-point penalty and showed as a false 0%.
+    const noCov = computeScores({ ...FULLY_AGENTIC, test_coverage_pct: null });
+    const zeroCov = computeScores({ ...FULLY_AGENTIC, test_coverage_pct: 0 });
+
+    expect(noCov.test_coverage_score).toBeNull();
+    expect(noCov.agentic_score).not.toBe(zeroCov.agentic_score);
+    expect(noCov.health_score).not.toBe(zeroCov.health_score);
+
+    // Renormalized over the components that DID report: the other four agentic weights total
+    // 0.75, and this fixture scores 100 on all of them except ai_commit_ratio (90).
+    // (0.15*90 + 0.25*100 + 0.20*100 + 0.15*100) / 0.75 = 98
+    expect(noCov.agentic_score).toBe(98);
+    // health: cadence + issue_health both 100, renormalized over 0.6 → 100
+    expect(noCov.health_score).toBe(100);
+  });
+
+  it("an unmeasured signal never drags a composite below its measured peers", () => {
+    // The invariant behind the fix, stated independently of the fixture's numbers.
+    const noCov = computeScores({ ...FULLY_AGENTIC, test_coverage_pct: null });
+    const zeroCov = computeScores({ ...FULLY_AGENTIC, test_coverage_pct: 0 });
+    expect(noCov.health_score).toBeGreaterThan(zeroCov.health_score);
+    expect(noCov.agentic_score).toBeGreaterThan(zeroCov.agentic_score);
   });
 
   it("the AI-commit trailer is a low-weight signal, not the backbone", () => {

--- a/lib/codebases/score.ts
+++ b/lib/codebases/score.ts
@@ -54,7 +54,8 @@ export interface ComputedScores {
   agentic_score: number;
   health_score: number;
   ai_commit_ratio: number;
-  test_coverage_score: number;
+  /** null = the repo filed no coverage report; NOT the same as a measured 0%. */
+  test_coverage_score: number | null;
   scaffolding_score: number;
   skill_breadth_score: number;
   cadence_score: number;
@@ -66,10 +67,40 @@ export function aiCommitRatio(i: ScanInputs): number {
   return clamp((100 * i.ai_commits_window) / Math.max(i.commits_window, 1));
 }
 
-/** Coverage normalized so 80% → 100 (null report → 0, surfaced as "no report" in UI). */
-export function coverageScore(i: ScanInputs): number {
-  if (i.test_coverage_pct == null) return 0;
+/**
+ * Coverage normalized so 80% → 100. Returns **null** when the repo filed no coverage report.
+ *
+ * It previously returned 0 for null, with a comment promising it was "surfaced as 'no report'
+ * in UI". That held for the aggregate tile, but not for the composites: a repo that has never
+ * reported coverage scored identically to a repo measured at 0%, and since coverage carries
+ * 40% of health_score and 25% of agentic_score, "we don't know" cost up to 40 points of health.
+ *
+ * That is not a hypothetical. A scaffolded workspace is a content repo with no test suite, and
+ * `coverage/` is gitignored so no clone can ever supply one — so EVERY workspace sat at a
+ * permanent 40-point health penalty for a test suite it was never supposed to have.
+ *
+ * Null now propagates, and `computeScores` renormalizes over the components that actually
+ * reported. Absence of evidence is not evidence of zero.
+ */
+export function coverageScore(i: ScanInputs): number | null {
+  if (i.test_coverage_pct == null) return null;
   return clamp((i.test_coverage_pct / 80) * 100);
+}
+
+/**
+ * Weighted mean over the components that reported, renormalized by their weights. A null
+ * component is EXCLUDED, not counted as zero — so dropping an unmeasurable signal leaves the
+ * remaining ones at full relative strength rather than silently capping the total.
+ */
+export function weightedScore(parts: Array<{ weight: number; value: number | null }>): number {
+  let weighted = 0;
+  let totalWeight = 0;
+  for (const { weight, value } of parts) {
+    if (value == null) continue;
+    weighted += weight * value;
+    totalWeight += weight;
+  }
+  return totalWeight === 0 ? 0 : weighted / totalWeight;
 }
 
 /** Presence of agent-native scaffolding (CLAUDE.md / AGENTS.md). */
@@ -107,23 +138,28 @@ export function computeScores(i: ScanInputs): ComputedScores {
   const cadence_score = cadenceScore(i);
   const issue_health = issueHealth(i);
 
-  const agentic_score =
-    AGENTIC_WEIGHTS.ai_commit_ratio * ai_commit_ratio +
-    AGENTIC_WEIGHTS.test_coverage_score * test_coverage_score +
-    AGENTIC_WEIGHTS.scaffolding_score * scaffolding_score +
-    AGENTIC_WEIGHTS.skill_breadth_score * skill_breadth_score +
-    AGENTIC_WEIGHTS.cadence_score * cadence_score;
+  // Renormalized over reported components — an unmeasured signal is dropped from the mean,
+  // never folded in as a zero. With coverage present both formulas are arithmetically
+  // identical to the previous straight weighted sum (the weights each total 1.0).
+  const agentic_score = weightedScore([
+    { weight: AGENTIC_WEIGHTS.ai_commit_ratio, value: ai_commit_ratio },
+    { weight: AGENTIC_WEIGHTS.test_coverage_score, value: test_coverage_score },
+    { weight: AGENTIC_WEIGHTS.scaffolding_score, value: scaffolding_score },
+    { weight: AGENTIC_WEIGHTS.skill_breadth_score, value: skill_breadth_score },
+    { weight: AGENTIC_WEIGHTS.cadence_score, value: cadence_score },
+  ]);
 
-  const health_score =
-    HEALTH_WEIGHTS.test_coverage_score * test_coverage_score +
-    HEALTH_WEIGHTS.cadence_score * cadence_score +
-    HEALTH_WEIGHTS.issue_health * issue_health;
+  const health_score = weightedScore([
+    { weight: HEALTH_WEIGHTS.test_coverage_score, value: test_coverage_score },
+    { weight: HEALTH_WEIGHTS.cadence_score, value: cadence_score },
+    { weight: HEALTH_WEIGHTS.issue_health, value: issue_health },
+  ]);
 
   return {
     agentic_score: round(agentic_score),
     health_score: round(health_score),
     ai_commit_ratio: round(ai_commit_ratio),
-    test_coverage_score: round(test_coverage_score),
+    test_coverage_score: test_coverage_score == null ? null : round(test_coverage_score),
     scaffolding_score: round(scaffolding_score),
     skill_breadth_score: round(skill_breadth_score),
     cadence_score: round(cadence_score),

--- a/lib/metrics/codebases.ts
+++ b/lib/metrics/codebases.ts
@@ -4,7 +4,7 @@ import type { DbClient } from "@/lib/db/types";
 import type { Kpi } from "./pulse";
 import { rangeDays, type Range } from "./range";
 import { canSeeCodebases, type ViewerTier } from "@/lib/codebases/visibility";
-import { num, round } from "@/lib/num";
+import { num, numOrNull, round } from "@/lib/num";
 
 /**
  * The ONLY read path for codebase analytics tables — pages must go through here,
@@ -288,7 +288,8 @@ export interface AgenticBreakdown {
   agentic_score: number;
   health_score: number;
   ai_commit_ratio: number;
-  test_coverage_score: number;
+  /** null = no coverage report; NOT a measured 0%. */
+  test_coverage_score: number | null;
   scaffolding_score: number;
   skill_breadth_score: number;
   cadence_score: number;
@@ -453,7 +454,7 @@ export async function getCodebaseDetail(
         agentic_score: num(latest.agentic_score as number),
         health_score: num(latest.health_score as number),
         ai_commit_ratio: num(latest.ai_commit_ratio as number),
-        test_coverage_score: num(latest.test_coverage_score as number),
+        test_coverage_score: numOrNull(latest.test_coverage_score as number | null),
         scaffolding_score: num(latest.scaffolding_score as number),
         skill_breadth_score: num(latest.skill_breadth_score as number),
         cadence_score: num(latest.cadence_score as number),

--- a/lib/num.ts
+++ b/lib/num.ts
@@ -13,3 +13,15 @@ export const round = (n: number, dp = 2): number => {
  * strings) to a number; null/undefined/NaN → 0. */
 export const num = (v: number | string | null | undefined): number =>
   v == null ? 0 : Number(v) || 0;
+
+/**
+ * Like `num`, but PRESERVES null instead of collapsing it to 0. Use this for any metric where
+ * "not measured" is a real, distinct state — `num()` silently turns an unknown into a zero,
+ * which for a score is a claim you did not measure (a repo that never filed a coverage report
+ * reading as a repo measured at 0%). NaN still degrades to null rather than leaking through.
+ */
+export const numOrNull = (v: number | string | null | undefined): number | null => {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};

--- a/postgres/migrations/20260802120000_code_metrics_nullable_coverage_score.sql
+++ b/postgres/migrations/20260802120000_code_metrics_nullable_coverage_score.sql
@@ -1,0 +1,21 @@
+-- test_coverage_score: "no coverage report" is null, not 0.
+--
+-- The column was `not null default 0`, so a repo that never filed a coverage report was stored
+-- as a measured 0% — indistinguishable from a repo whose suite genuinely covers nothing. Since
+-- coverage carries 40% of health_score and 25% of agentic_score, "we don't know" cost up to 40
+-- points of health.
+--
+-- That hit every scaffolded workspace: they are content repos with no test suite, and
+-- `coverage/` is gitignored so no clone can supply an artifact. `test_coverage_pct` alongside it
+-- has always been nullable with exactly this meaning; the derived score simply failed to follow.
+--
+-- lib/codebases/score.ts now returns null and renormalizes the composites over the components
+-- that actually reported.
+--
+-- Existing rows are deliberately NOT backfilled to null: a stored 0 is ambiguous (it could be a
+-- real 0%), and the next scan rewrites the row anyway — the upsert replaces on
+-- (codebase_id, head_sha). Guessing history would be worse than letting it age out.
+
+alter table code_metrics
+  alter column test_coverage_score drop not null,
+  alter column test_coverage_score drop default;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1451,7 +1451,7 @@ create table if not exists code_metrics (
   agentic_score numeric(5,2) not null default 0,
   health_score numeric(5,2) not null default 0,
   ai_commit_ratio numeric(5,2) not null default 0,
-  test_coverage_score numeric(5,2) not null default 0,
+  test_coverage_score numeric(5,2),               -- null = no coverage report (NOT a measured 0%)
   scaffolding_score numeric(5,2) not null default 0,
   skill_breadth_score numeric(5,2) not null default 0,
   cadence_score numeric(5,2) not null default 0,


### PR DESCRIPTION
## Summary

**This is the false 0% on the Codebases dashboard.**

`lib/codebases/score.ts` returned `0` when a repo filed no coverage report:

```ts
/** Coverage normalized so 80% → 100 (null report → 0, surfaced as "no report" in UI). */
export function coverageScore(i: ScanInputs): number {
  if (i.test_coverage_pct == null) return 0;
```

The docstring's promise held for the aggregate tile (`lib/metrics/codebases.ts:194` correctly renders `—`), but **not for the composites**: a repo that had never reported coverage scored identically to one measured at 0%.

Coverage carries **40% of `health_score`** and 25% of `agentic_score`, so *"we don't know"* cost up to **40 points of health**.

Not hypothetical. A scaffolded workspace is a content repo with no test suite, and `coverage/` is gitignored so no clone can ever supply an artifact — so **every AIOS workspace sat at a permanent 40-point penalty and displayed a false 0%** for a suite it was never meant to have.

## Changes

- `coverageScore` returns `number | null`; null propagates instead of collapsing.
- `computeScores` uses a new `weightedScore()` that **renormalizes over the components that actually reported**. With coverage present the result is arithmetically identical to the old straight weighted sum (each weight set totals 1.0) — **no existing score moves**.
- `lib/num.ts` gains `numOrNull`. `num()` coerces null → 0, which is the same bug one layer down in the read path.
- `code_metrics.test_coverage_score` drops `NOT NULL`/default (migration + `schema.sql` mirrored per CLAUDE.md). `test_coverage_pct` beside it has always been nullable with exactly this meaning; the derived score just failed to follow. Existing rows are **not** backfilled — a stored 0 is ambiguous, and the next scan replaces the row on `(codebase_id, head_sha)`.
- The breakdown bar renders `no report · excluded` with a dashed track, instead of a full-width empty bar at 0 that reads as a measured failure.

## On the tests that changed

Two existing tests **encoded the bug as intended behaviour** — including one literally asserting `expect(noCov.test_coverage_score).toBe(0)`. They are replaced by tests that pin the distinction:

- a **measured** 0% still costs the full weight (unchanged)
- an **absent** report is excluded from the composite
- the two must not produce equal composites — this is the assertion that stops it recurring

## Verification

- `npm run typecheck` — clean.
- `npx vitest run` — **1719 passed**, 11 skipped, 0 failed.
- `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files).
- Renormalization arithmetic checked explicitly in the tests: with coverage absent, agentic = `(0.15*90 + 0.25*100 + 0.20*100 + 0.15*100) / 0.75 = 98`, health = 100.

Pairs with the producer-side work in aiosbrain/aios-workspace#519 and #520 — this PR is what makes "no coverage" read honestly for repos that legitimately have none.

Linear: AIO-594

## Review — Reviewed by Claude Opus 5 (manual review + replaced regression tests) — verdict pass: composite arithmetic verified unchanged when coverage is present; the migration is additive-nullable with a documented no-backfill decision; the two superseded tests asserted the defect and were replaced deliberately, not deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scoring semantics and DB nullability for a heavily weighted metric; behavior is well-tested and unchanged when coverage is reported, but existing stored 0s stay ambiguous until rescanned.
> 
> **Overview**
> Fixes **false 0% coverage** on Codebases: repos with no coverage report used to get `test_coverage_score` **0**, which dragged **agentic** and **health** composites as if coverage were measured at zero (up to a **40-point health** hit for workspaces that legitimately have no suite).
> 
> **`coverageScore`** now returns **`null`** when `test_coverage_pct` is missing; **`computeScores`** uses new **`weightedScore()`** to **renormalize** over sub-scores that actually reported (unchanged math when coverage is present). **`test_coverage_score`** is **`number | null`** end-to-end; reads use **`numOrNull`** instead of **`num()`**. **`code_metrics.test_coverage_score`** is nullable in schema + migration (no backfill of historical 0s).
> 
> The agentic breakdown UI shows **no report · excluded** and a dashed bar instead of a zero-width bar at 0. Tests now lock **absent report ≠ measured 0%**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3360d0e97fca6ed7ecea0dc095ec015bce9aa0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->