### PR TITLE
docs(claude): require a Linear task + spec before building, created via the AIOS CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,31 @@ who reads it**. The map only pays off if it's trustworthy, so:
 
 ---
 
+## Task gate — a Linear task + a written spec BEFORE you build a feature ⚠️
+
+Every feature starts as a **real Linear task**, created through the **AIOS CLI**, with a **spec** —
+not as a branch that acquires a justification afterwards.
+
+- **Create the task first:** add a row to `3-log/tasks-team.md` in the AIOS workspace and
+  `aios push 3-log/tasks-team.md`. The brain's `tasks` table is canonical and projects one-way into
+  Linear (`lib/pm-sync/`), so this is the only path that yields a key both the brain and Linear agree
+  on. Read the projected key back (`task_pm_links.provider_url`) and cite THAT in the branch, the PR,
+  and the `AIOS-Work:` trailer.
+- **Never invent or borrow a key.** A fabricated `AIO-xxx` links work to nothing; a real key grabbed
+  because it exists links a week of work to someone else's ticket — both have happened here, and the
+  second was worse, because an invented key resolves to nothing while a real-but-wrong one silently
+  files your work under a stranger's name.
+- **Write the spec before the code**, not after. For anything touching schema, money, or more than one
+  surface, that means a short doc in `docs/design/` that states the problem, the decision, and what
+  would falsify it — then a Fable plan review on that doc. Design review has caught a wrong data model
+  (a column that should have been a table), a wrong migration shape, and a metric measured in the
+  wrong unit — each of them cheaper to fix in prose than in a merged PR.
+- **Why the order matters:** a task written afterwards is a description of what you did, which is
+  never the same artefact as a decision about what to do. The spec is where the alternative you
+  didn't take gets recorded, and that is the part future-you actually needs.
+
+---
+
 ## Review gate — a local review of the diff is REQUIRED before you push ⚠️
 
 Many sessions/worktrees ship into this repo in parallel and merge fast — a pre-push review of the


### PR DESCRIPTION
## Review — Reviewed by Fable — verdict n/a, docs-only change to CLAUDE.md; no code, no schema, no behaviour

Adds a **Task gate** to `CLAUDE.md`, next to the existing architecture-map and review gates: a feature starts as a real Linear task created through the AIOS CLI, with a written spec, before the branch exists.

## Why this is a gate and not a preference

Both halves have already cost this repo real damage:

**Invented keys.** `AIO-485`–`AIO-489` across eight PRs, resolving to nothing. Then the remedy made it worse — switching to `AIO-484` *because it was a real number*, without reading whose it was. Nine PRs of timeline work ended up filed under a teammate's "Individual-workstation docs pass". An invented key links to nothing; a real-but-wrong key silently files your work under a stranger's name.

**Specs written afterwards.** Design review has since caught, in prose rather than in merged code: a wrong data model (an `outcome` column that had to become a sibling table, because failure rows would have evicted real spend rows inside every money read's row cap), a migration shape that would have *skipped its own widening* on any existing database, and a metric measured in items while its own docstring explained why items are the wrong unit.

## What it specifies

- The only path that yields a key the brain and Linear agree on: push a row to `3-log/tasks-team.md`, `aios push`, let `lib/pm-sync` project it one-way, then read the key back from `task_pm_links.provider_url` and cite **that** in the branch, PR, and `AIOS-Work:` trailer.
- Never invent or borrow a key.
- Spec before code for anything touching schema, money, or more than one surface — a short `docs/design/` doc plus a Fable plan review on it.
- The reason the *order* matters: a task written afterwards describes what you did, which is a different artefact from a decision about what to do. The spec is where the alternative you rejected gets recorded.

Docs-drift green.