### PR TITLE
AIO-445: add one-click Team Brain Railway onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ revision **v1.15**.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-08-03
+
+### Added
+
+- **One-click Team Brain onboarding (AIO-445)** — the official Railway template provisions the
+  app and Postgres together, collects team and first-admin details in Railway, generates the app
+  secrets, and bootstraps a usable admin login on first start. `npm run setup` opens the stable
+  `aiosbrain.dev` deploy front door without requiring a GitHub fork or local Railway CLI.
+
+### Changed
+
+- The shared onboarding contract is v3: Create now stops for deployment approval, opens the
+  Railway template, and then resumes the same canonical-origin and `GET /api/v1/me` validation
+  used by Join. Operator-supplied admin passwords are no longer printed in deployment logs.
+
 ## [0.9.0] — 2026-08-01
 
 The Brain API contract is unchanged at **v1.15** — no member-facing route, shape,

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ curl -fsSL https://aiosbrain.dev/install.sh | sh
 ```
 
 It checks your prerequisites, fetches the repo, and hands you to an interview: run it **on this
-machine** (your own team, real install), **on Railway** (the shared server a team actually uses), or
+machine** (your own team, real install), **on Railway** (opens the official one-click template), or
 **just the demo**. It asks only what your choice needs, **proves your model key works
 before going further** — a wrong paste is caught there, not three steps later at an empty query box —
 then shows the plan before touching anything. Already cloned? `npm run setup` is the same wizard.
 
-It never uses `sudo`, never overwrites an existing install, and never deploys.
+It never uses `sudo` or overwrites an existing install. The Railway choice opens the official
+template; Railway shows the complete app + Postgres plan and asks for confirmation before deploying.
 [`install.sh`](install.sh) is short and commented — read it before you pipe it, as you should with
 any installer.
 
@@ -146,13 +147,12 @@ drive it yourself.
 | 2 | Set the environment variables | ~3 min | wizard |
 | 3 | Load the schema (`npm run pg:schema`) | ~1 min | wizard |
 | 4 | Load the vector schema (`npm run pg:schema:vector`) | ~1 min | **yours** — needs an embeddings model chosen first |
-| 5 | Create the first team + admin | ~1 min | wizard (on Railway, the `--resume` run after you connect the repo) |
+| 5 | Create the first team + admin | ~1 min | bootstrap during first start |
 | 6 | Connect one source | ~4 min | **yours** — the Admin UI is the only legal writer for tokens |
 | + | Add Neo4j + Graphiti | later, or never | **yours**, §2.8 |
 
-On the Railway path there's one more step no CLI can take for you: connecting your GitHub
-repository, which is also the deploy path. The wizard stops there and tells you exactly what to
-click.
+On the Railway path, the wizard opens **https://aiosbrain.dev/deploy/team-brain/**. The template
+deploys directly from the official repository, so a GitHub fork and `--resume` run are not required.
 
 Everything below is that sequence in dependency order, with the failure modes called out.
 

--- a/docker/bootstrap.mjs
+++ b/docker/bootstrap.mjs
@@ -18,7 +18,7 @@ import path from "node:path";
 import { randomBytes } from "node:crypto";
 import pg from "pg";
 import { shouldUseSsl } from "../scripts/pg-load-schema.mjs";
-import { credentialPlan } from "../scripts/setup/credential-plan.mjs";
+import { credentialPlan, credentialSummary } from "../scripts/setup/credential-plan.mjs";
 
 const DATABASE_URL = process.env.DATABASE_URL;
 if (!DATABASE_URL) {
@@ -206,9 +206,7 @@ async function provisionRealTeam() {
   const url = process.env.APP_URL || "http://localhost:3000";
   console.log(
     ["", "─".repeat(58), `  ${name} is ready`, "", `  URL       ${url}/t/${slug}`, `  Login     ${email}`,
-     plan.password
-       ? `  Password  ${plan.password}   ← copy it now, this is the only time it is shown`
-       : "  Password  unchanged — your existing login still works",
+     credentialSummary({ password: plan.password, supplied: Boolean(process.env.ADMIN_PASSWORD) }),
      "", "  Next: Admin → Integrations to connect Slack / GitHub / Linear.",
      "─".repeat(58), ""].join("\n")
   );

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,8 +9,26 @@ portable: plain SQL migrations, Postgres-backed rate limiting, no Vercel-only de
 > ingestion sources) are guarded against drift by `scripts/check-docs-drift.mjs` — see
 > [Docs drift guard](#docs-drift-guard).
 >
-> **Last verified against code: 2026-07-29.** If a flow here disagrees with the code, the
+> **Last verified against code: 2026-08-03.** If a flow here disagrees with the code, the
 > code wins — fix the doc (same PR).
+
+## First-install deployment flow
+
+The canonical hosted-install entry point is `https://aiosbrain.dev/deploy/team-brain/`. It resolves
+to the official Railway template described in [`RAILWAY-TEMPLATE.md`](RAILWAY-TEMPLATE.md): one app
+service from this public repository plus one Postgres service. Railway reference variables wire the
+database and public domain; template secret functions generate `AUTH_SECRET` and `SECRETS_KEY`; the
+operator supplies team and first-admin identity in Railway's form.
+
+On first start, `railway.json` runs the idempotent schema loader before release. The opt-in Railway
+startup wrapper then runs the shared bootstrap to ensure the real team and first admin from
+`TEAM_*` / `ADMIN_*`. Bootstrap runs on
+every restart but checks for an existing credential before calling the admin writer, so later
+password changes are preserved. A user-supplied `ADMIN_PASSWORD` is never rendered into logs.
+
+The local curl installer remains the Docker/self-host path. Selecting Railway in that wizard opens
+the canonical deploy page; it does not provision through an ambient Railway CLI link and does not
+pause for a GitHub fork or a post-deploy `--resume` command.
 
 ## Agent skill publication
 

--- a/docs/RAILWAY-TEMPLATE.md
+++ b/docs/RAILWAY-TEMPLATE.md
@@ -1,0 +1,46 @@
+# Official Railway template contract
+
+The stable product entry point is **https://aiosbrain.dev/deploy/team-brain/**. That page points to
+the currently published Railway template, so installers and onboarding contracts do not need to
+change when Railway rotates a template code.
+
+## Services
+
+- `aios-team-brain` — source `https://github.com/aiosbrain/aios-team-brain` on `main`, public HTTP
+  networking enabled. Repository `railway.json` runs `npm run pg:schema` before release.
+- `Postgres` — Railway Postgres template. The app references `${{Postgres.DATABASE_URL}}`.
+
+## App variables
+
+| Variable | Template behavior |
+|---|---|
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` reference |
+| `PGSSL` | fixed to `require` |
+| `APP_URL` | `https://${{RAILWAY_PUBLIC_DOMAIN}}` |
+| `AUTH_SECRET` | generated with `${{ secret(64, "0123456789abcdef") }}` |
+| `SECRETS_KEY` | `${{ secret(43, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_") }}` (32 bytes when base64url-decoded) |
+| `TEAM_NAME` | required user input |
+| `TEAM_SLUG` | required user input; lowercase letters, digits, hyphens |
+| `ADMIN_NAME` | required user input |
+| `ADMIN_EMAIL` | required user input |
+| `ADMIN_PASSWORD` | required user input; never printed by bootstrap |
+| `SEED_DEMO` | fixed to `false` |
+| `AIOS_TEMPLATE_BOOTSTRAP` | fixed to `true`; provisions the team and admin before the app starts |
+
+Optional model and mail-provider keys are configured after deployment in Admin. They are not part of
+the first-deploy form and are never encoded in a deploy URL.
+
+## Maintenance and verification
+
+The published Railway template is a derived deployment asset. For every Team Brain release:
+
+1. Confirm the template still points at the official repository and `main`.
+2. Compare its services and variables to this document and `railway.json`.
+3. Deploy it into a fresh `aios-onboarding-sandbox-<date>-<suffix>` project.
+4. Verify schema, first-admin login, API-key issuance, restart idempotency, and `/api/v1/me` through
+   an individual workspace.
+5. Record the template code, source commit, sandbox project/deployment IDs, and teardown evidence on
+   AIO-445 or its successor release issue.
+
+Do not generate the template from the production AIOS project: it contains organization-specific
+services and variables that do not belong in a public installer.

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@
 #   - Never clobbers an existing install. If the directory is already a Team Brain checkout it
 #     re-runs setup there; if it exists and is something else, it stops. An installer that
 #     re-initialises a working instance destroys its secrets — see the rotation bug this repo fixed.
-#   - Never deploys anything. The wizard's Railway path provisions only; deploys go through GitHub.
+#   - Never deploys without confirmation. The Railway choice opens the official template page.
 #
 # Overridable: AIOS_DIR (where to install), AIOS_REF (git ref to check out), AIOS_REPO.
 set -eu

--- a/lib/onboarding/agent-prompt.test.ts
+++ b/lib/onboarding/agent-prompt.test.ts
@@ -74,12 +74,24 @@ describe("buildAgentOnboardingPrompt", () => {
       teamName: "Acme",
       brainUrl: "https://brain.example.com/t/acme",
     });
-    expect(contract.version).toBe(2);
+    expect(contract.version).toBe(3);
     for (const marker of contract.requiredMarkers)
       expect(prompt).toContain(marker);
     for (const marker of contract.forbiddenMarkers)
       expect(prompt).not.toContain(marker);
     expect(prompt).toMatch(/team_id.*optional/i);
     expect(prompt).not.toMatch(/--team-id\s+acme/);
+  });
+
+  it("describes the approved Railway deploy and validated Join handoff", () => {
+    const prompt = buildAgentOnboardingPrompt({
+      teamSlug: "acme",
+      teamName: "Acme",
+      brainUrl: "https://brain.example.com",
+    });
+    expect(prompt).toMatch(/official Railway template/);
+    expect(prompt).toMatch(/stop for approval before opening the browser/);
+    expect(prompt).toMatch(/resume the Join path/);
+    expect(prompt).toMatch(/GET \/api\/v1\/me/);
   });
 });

--- a/lib/onboarding/agent-prompt.ts
+++ b/lib/onboarding/agent-prompt.ts
@@ -31,7 +31,7 @@ export function buildAgentOnboardingPrompt({
     `- For an existing workspace, repair or upgrade it instead of re-scaffolding: \`aios update --preview\` includes the safety check and shows the proposed managed-file changes. Explain the human gate, then update only with approval.`,
     `- For Join, treat ${brainUrl} as a candidate only. Normalize it to the canonical Brain origin, show the exact origin, and stop at a human gate before saving it. The person must approve; you cannot approve for them.`,
     `- The API key is authoritative for team identity; \`team_id\` is optional. Ask the person to generate AIOS_API_KEY from this dashboard's "My API keys" panel, keep it out of output/commits, and validate with GET /api/v1/me.`,
-    `- Create is guide-only: use the existing self-host guide at https://aiosbrain.dev/guides/team-brain/. Do not invent setup bundles, browser approval, join links, or auth endpoints.`,
+    `- Create deploys through the official Railway template at https://aiosbrain.dev/deploy/team-brain/. Explain that it creates the Team Brain app plus Postgres and may incur Railway charges, then stop for approval before opening the browser. After deployment, resume the Join path: ask for the Brain URL and API key, approve the canonical origin, and validate with GET /api/v1/me. If deployment is unfinished, leave the workspace unchanged and point to https://aiosbrain.dev/guides/team-brain/ so onboarding can be resumed later.`,
     `- Leave dirty workspaces/toolkits untouched. Never run \`aios push\` during onboarding. Explain every human gate before it appears.`,
     ``,
     `Finish with exactly four short sections:`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aios-team-brain",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aios-team-brain",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@aios-alpha/design": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-team-brain",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -9,7 +9,7 @@
     "start": "next start",
     "doctor": "node scripts/doctor.mjs",
     "setup": "node scripts/setup-wizard.mjs",
-    "setup:railway": "node scripts/setup.mjs",
+    "setup:railway": "node scripts/open-railway-template.mjs",
     "connectors": "npx tsx --conditions react-server scripts/connectors.ts",
     "up": "docker compose up",
     "down": "docker compose down",

--- a/railway.json
+++ b/railway.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "deploy": {
-    "preDeployCommand": "npm run pg:schema"
+    "preDeployCommand": "npm run pg:schema",
+    "startCommand": "sh scripts/railway-start.sh"
   }
 }

--- a/scripts/open-railway-template.mjs
+++ b/scripts/open-railway-template.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { RAILWAY_TEMPLATE_URL } from "./setup/railway-template.mjs";
+
+console.log(`AIOS Team Brain — Railway deploy\n\n${RAILWAY_TEMPLATE_URL}\n`);
+
+const command = process.platform === "darwin" ? ["open", [RAILWAY_TEMPLATE_URL]]
+  : process.platform === "win32" ? ["cmd", ["/c", "start", "", RAILWAY_TEMPLATE_URL]]
+    : ["xdg-open", [RAILWAY_TEMPLATE_URL]];
+const result = spawnSync(command[0], command[1], { stdio: "ignore" });
+if ((result.status ?? 1) !== 0) {
+  console.log("Could not open a browser automatically — copy the URL above.");
+}

--- a/scripts/railway-start.sh
+++ b/scripts/railway-start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+
+# Existing Railway deployments keep their current startup behavior. The public template opts in
+# so its first boot can create the requested team and admin after Postgres is reachable.
+if [ "${AIOS_TEMPLATE_BOOTSTRAP:-false}" = "true" ]; then
+  node docker/bootstrap.mjs
+fi
+
+exec npm start

--- a/scripts/setup-wizard.mjs
+++ b/scripts/setup-wizard.mjs
@@ -17,9 +17,8 @@
  *
  * 1. Invent answers. With no terminal (CI, a pipeline) it stops and prints the flag-driven form,
  *    rather than defaulting its way to a misconfigured instance and reporting success.
- * 2. Deploy. The Railway path delegates to `setup.mjs`, which classifies every command against
- *    `railway-policy.mjs` — `up`/`redeploy`/`down`/`delete` are refused there, so this file cannot
- *    reach them either.
+ * 2. Deploy without a human gate. The Railway path prints the official template URL and asks the
+ *    operating system to open it; Railway owns the reviewed resource summary and final approval.
  */
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -38,7 +37,8 @@ import {
   validateSlug,
   validateTeamName,
 } from "./setup/interview.mjs";
-import { PROBE_BAD_CREDENTIAL, PROBE_OK, dockerVerdict, probeCredential } from "./setup/probe.mjs";
+import { PROBE_OK, dockerVerdict, probeCredential } from "./setup/probe.mjs";
+import { RAILWAY_TEMPLATE_URL } from "./setup/railway-template.mjs";
 
 const ENV_FILE = ".env.local";
 
@@ -60,7 +60,7 @@ async function interview(p, out) {
   out.write("\n  Where should this brain run?\n\n");
   const target = await p.choose("", TARGETS, { def: 0 });
   const answers = { target };
-  if (target === "demo") return answers;
+  if (target === "demo" || target === "railway") return answers;
 
   const needs = new Set(questionsFor(target));
   out.write("\n  A few details, then I'll show you the plan before touching anything.\n\n");
@@ -110,16 +110,6 @@ async function preflight(answers, out) {
     // exists either way.
     const r = sh("docker", ["info"]);
     checks.push(["docker", dockerVerdict({ status: r.status ?? 1, stderr: r.stderr || r.stdout })]);
-  }
-
-  if (answers.target === "railway") {
-    const r = sh("railway", ["whoami"]);
-    checks.push([
-      "railway",
-      r.status === 0
-        ? { verdict: PROBE_OK, detail: (r.stdout || "").trim() || "authenticated" }
-        : { verdict: PROBE_BAD_CREDENTIAL, detail: "not logged in — run `railway login` (opens a browser), then re-run" },
-    ]);
   }
 
   if (answers.llmKey || answers.baseUrl) {
@@ -215,28 +205,18 @@ async function runDemo(out) {
   return streamed("docker", ["compose", "up"]);
 }
 
-async function runRailway(answers, out) {
-  out.write("\n  Provisioning on Railway. This never deploys — the GitHub connection does that.\n\n");
-  const args = [
-    "scripts/setup.mjs",
-    "--slug", answers.slug,
-    "--name", answers.teamName,
-    "--email", answers.email,
-    "--member-name", answers.memberName,
-  ];
-  // Carry whichever provider the user actually chose. Forwarding only Anthropic meant an
-  // OpenAI/OpenRouter key was validated live and then dropped, leaving an instance that could not
-  // answer anything while the wizard reported success.
-  const providerFlag = { anthropic: "--anthropic-key", openai: "--openai-key", openrouter: "--openrouter-key" }[
-    answers.provider
-  ];
-  if (providerFlag && answers.llmKey) args.push(providerFlag, answers.llmKey);
-  if (answers.baseUrl) args.push("--llm-base-url", answers.baseUrl);
-  if (answers.resendKey) args.push("--resend-key", answers.resendKey, "--resend-from", answers.resendFrom ?? "");
-  out.write("  (dry run first — nothing is written yet)\n\n");
-  const dry = await streamed("node", [...args, "--dry-run"]);
-  if (dry !== 0) return dry;
-  return streamed("node", args);
+export async function runRailway(_answers, out, { open = sh, platform = process.platform } = {}) {
+  out.write("\n  Railway will ask for your team and first-admin details, then deploy the app + Postgres.\n");
+  out.write("  No GitHub fork or local Railway CLI is required for the first deployment.\n\n");
+  out.write(`  ${RAILWAY_TEMPLATE_URL}\n\n`);
+
+  const command = platform === "darwin" ? ["open", [RAILWAY_TEMPLATE_URL]]
+    : platform === "win32" ? ["cmd", ["/c", "start", "", RAILWAY_TEMPLATE_URL]]
+      : ["xdg-open", [RAILWAY_TEMPLATE_URL]];
+  const opened = open(command[0], command[1]);
+  if ((opened.status ?? 1) === 0) out.write("  ✓ opened the deploy page in your browser\n\n");
+  else out.write("  Could not open a browser automatically — copy the URL above.\n\n");
+  return 0;
 }
 
 // ── main ────────────────────────────────────────────────────────────────────

--- a/scripts/setup/credential-plan.mjs
+++ b/scripts/setup/credential-plan.mjs
@@ -30,3 +30,13 @@ export function credentialPlan({ hasCredential, adminPassword, generate = defaul
   if (hasCredential) return { action: "skip", password: null };
   return { action: "create", password: adminPassword || generate() };
 }
+
+/**
+ * A generated local password must be shown once. A supplied deployment password must never be
+ * copied into container logs: the operator already chose it and Railway retains it as a variable.
+ */
+export function credentialSummary({ password, supplied }) {
+  if (!password) return "  Password  unchanged — your existing login still works";
+  if (supplied) return "  Password  set from ADMIN_PASSWORD — value not printed";
+  return `  Password  ${password}   ← copy it now, this is the only time it is shown`;
+}

--- a/scripts/setup/interview.mjs
+++ b/scripts/setup/interview.mjs
@@ -105,9 +105,10 @@ export function validateBaseUrl(value) {
  */
 export function questionsFor(target) {
   if (target === "demo") return ["confirm-demo"];
+  if (target === "railway") return ["railway-template"];
   const shared = ["team-slug", "team-name", "admin-email", "admin-name", "llm-provider"];
   if (target === "local") return shared;
-  return [...shared, "mail-transport"]; // Railway invites go out by email; local logs in directly
+  return shared;
 }
 
 /**
@@ -131,10 +132,10 @@ export function planFor(answers) {
     ];
   }
   return [
-    { id: "railway-project", label: `Create the Railway project aios-${answers.slug} + Postgres` },
-    { id: "railway-domain", label: "Claim a public domain and set the environment" },
-    { id: "github", label: "Hand off the GitHub connection (the deploy path — yours to click)" },
-    { id: "team", label: `Create team "${answers.slug}" and your admin login` },
+    { id: "railway-template", label: "Open the official AIOS Team Brain Railway template" },
+    { id: "railway-config", label: "Enter your team and first-admin details in Railway" },
+    { id: "railway-deploy", label: "Deploy Team Brain + Postgres and wait for the healthy public URL" },
+    { id: "railway-connect", label: "Sign in and create an API key for your individual workspace" },
   ];
 }
 

--- a/scripts/setup/railway-template.mjs
+++ b/scripts/setup/railway-template.mjs
@@ -1,0 +1,22 @@
+/** Stable product front door for the official Railway template. */
+export const RAILWAY_TEMPLATE_URL = "https://aiosbrain.dev/deploy/team-brain/";
+
+/** The Railway template owns these values; the local wizard must not collect or persist them. */
+export const RAILWAY_TEMPLATE_INPUTS = Object.freeze([
+  "TEAM_NAME",
+  "TEAM_SLUG",
+  "ADMIN_NAME",
+  "ADMIN_EMAIL",
+  "ADMIN_PASSWORD",
+]);
+
+export const RAILWAY_TEMPLATE_GENERATED = Object.freeze(["AUTH_SECRET", "SECRETS_KEY"]);
+
+export function railwayTemplatePlan() {
+  return [
+    { id: "railway-template", label: "Open the official AIOS Team Brain Railway template" },
+    { id: "railway-config", label: "Enter your team and first-admin details in Railway" },
+    { id: "railway-deploy", label: "Deploy Team Brain + Postgres and wait for the healthy public URL" },
+    { id: "railway-connect", label: "Sign in and create an API key for your individual workspace" },
+  ];
+}

--- a/test/fixtures/contract/onboarding-orchestration.json
+++ b/test/fixtures/contract/onboarding-orchestration.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "inspection": {
     "command": "aios onboard --inspect --json",
     "dependencyFree": true,
@@ -23,8 +23,17 @@
     "validationRequest": "GET /api/v1/me"
   },
   "create": {
-    "mode": "guide-only",
-    "guide": "https://aiosbrain.dev/guides/team-brain/"
+    "mode": "railway-template",
+    "provider": "railway",
+    "deployUrl": "https://aiosbrain.dev/deploy/team-brain/",
+    "guide": "https://aiosbrain.dev/guides/team-brain/",
+    "resume": {
+      "required": [
+        "brainUrl",
+        "apiKey"
+      ],
+      "validationRequest": "GET /api/v1/me"
+    }
   },
   "sharing": {
     "pushDuringOnboarding": false
@@ -40,7 +49,7 @@
     "API key is authoritative for team identity",
     "`team_id` is optional",
     "GET /api/v1/me",
-    "Create is guide-only",
+    "Create deploys through the official Railway template",
     "Never run `aios push`",
     "What AIOS now understands.",
     "What stays private.",

--- a/test/setup-wizard.test.ts
+++ b/test/setup-wizard.test.ts
@@ -16,8 +16,9 @@ import {
   probeRequestFor,
   verdictForStatus,
 } from "../scripts/setup/probe.mjs";
-import { composeEnvFor } from "../scripts/setup-wizard.mjs";
-import { credentialPlan } from "../scripts/setup/credential-plan.mjs";
+import { composeEnvFor, runRailway } from "../scripts/setup-wizard.mjs";
+import { credentialPlan, credentialSummary } from "../scripts/setup/credential-plan.mjs";
+import { RAILWAY_TEMPLATE_URL, RAILWAY_TEMPLATE_INPUTS } from "../scripts/setup/railway-template.mjs";
 import {
   LLM_PROVIDERS,
   TARGETS,
@@ -126,7 +127,7 @@ describe("the interview asks the routing question first", () => {
     // Asking for a Railway login before knowing the user wants Docker wastes their time.
     expect(questionsFor("demo")).toEqual(["confirm-demo"]);
     expect(questionsFor("local")).not.toContain("mail-transport"); // local logs in directly
-    expect(questionsFor("railway")).toContain("mail-transport"); // invites go out by email
+    expect(questionsFor("railway")).toEqual(["railway-template"]); // Railway owns its form
   });
 
   it("never asks for a secret it can generate", () => {
@@ -144,10 +145,39 @@ describe("the interview asks the routing question first", () => {
     expect(ids.indexOf("compose")).toBeLessThan(ids.indexOf("team")); // DB must exist first
   });
 
-  it("plans a Railway install that hands the deploy to GitHub rather than deploying", () => {
+  it("plans a Railway template deploy with no GitHub-fork pause", () => {
     const ids = planFor({ target: "railway", slug: "acme" }).map((s) => s.id);
-    expect(ids).toContain("github");
-    expect(ids.join(" ")).not.toMatch(/\bup\b|redeploy/); // the four forbidden verbs, never
+    expect(ids).toEqual(["railway-template", "railway-config", "railway-deploy", "railway-connect"]);
+    expect(ids).not.toContain("github");
+  });
+
+  it("opens the stable deploy front door and always prints a copyable fallback", async () => {
+    const output: string[] = [];
+    const open = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+    await runRailway({}, { write: (s: string) => output.push(s) }, { open, platform: "darwin" });
+    expect(open).toHaveBeenCalledWith("open", [RAILWAY_TEMPLATE_URL]);
+    expect(output.join("")).toContain(RAILWAY_TEMPLATE_URL);
+    expect(output.join("")).not.toMatch(/Fork aiosbrain|run `railway login`/i);
+  });
+
+  it("keeps template-owned identity inputs explicit", () => {
+    expect(RAILWAY_TEMPLATE_INPUTS).toEqual([
+      "TEAM_NAME", "TEAM_SLUG", "ADMIN_NAME", "ADMIN_EMAIL", "ADMIN_PASSWORD",
+    ]);
+  });
+
+  it("boots template installs without changing existing Railway startup behavior", () => {
+    const config = JSON.parse(
+      readFileSync(join(import.meta.dirname, "..", "railway.json"), "utf8"),
+    );
+    const start = readFileSync(
+      join(import.meta.dirname, "..", "scripts", "railway-start.sh"),
+      "utf8",
+    );
+    expect(config.deploy.startCommand).toBe("sh scripts/railway-start.sh");
+    expect(start).toContain('AIOS_TEMPLATE_BOOTSTRAP:-false');
+    expect(start).toContain("node docker/bootstrap.mjs");
+    expect(start).toContain("exec npm start");
   });
 });
 
@@ -396,6 +426,12 @@ describe("the local install keeps its login across a restart", () => {
 
   it("honours an operator-supplied password over a generated one", () => {
     expect(credentialPlan({ hasCredential: false, adminPassword: "mine" }).password).toBe("mine");
+  });
+
+  it("does not render an operator-supplied password into deployment logs", () => {
+    expect(credentialSummary({ password: "mine", supplied: true })).not.toContain("mine");
+    expect(credentialSummary({ password: "mine", supplied: true })).toMatch(/not printed/i);
+    expect(credentialSummary({ password: "generated", supplied: false })).toContain("generated");
   });
 
   it("pins WHY skipping means not running the command — admin.ts always sets a password", () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes production first-start behavior for new template deploys (bootstrap before `npm start`) and the primary hosted onboarding path, though existing Railway services are opt-in only and password logging is tightened.
> 
> **Overview**
> **One-click Railway onboarding** replaces the wizard’s old Railway CLI flow (`setup.mjs`, `railway login`, GitHub fork, `--resume`) with the stable deploy URL **`https://aiosbrain.dev/deploy/team-brain/`**, which opens in the browser while Railway owns team/admin collection and deploy approval. `npm run setup:railway` and shared `railway-template.mjs` centralize that URL and plan steps.
> 
> **Template-first boot:** `railway.json` adds `startCommand: sh scripts/railway-start.sh`, which runs `docker/bootstrap.mjs` only when **`AIOS_TEMPLATE_BOOTSTRAP=true`** (public template); existing Railway installs keep default startup. Bootstrap still idempotently creates team/admin from `TEAM_*` / `ADMIN_*` env vars.
> 
> **Onboarding contract v3:** Agent prompts and the pinned fixture now describe Create as deploy-via-template, human approval before opening the browser, then the same Join handoff (`canonical origin` + **`GET /api/v1/me`**). Operator **`ADMIN_PASSWORD`** values are no longer echoed in bootstrap logs (`credentialSummary`).
> 
> Docs/README/CHANGELOG and version **0.10.0** document the template contract (`docs/RAILWAY-TEMPLATE.md`, architecture first-install section).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483fe2f5540f12caa5b7526977577c2f214c4eff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->