### PR TITLE
fix(ci): pin release scan dependencies (AIO-697)

### DIFF
--- a/.github/scripts/brain-scanner-requirements.txt
+++ b/.github/scripts/brain-scanner-requirements.txt
@@ -1,0 +1,27 @@
+# Runtime-only dependency lock for the in-repository Team Brain codebase scanner.
+# Keep this list hash-locked and binary-only in scan-on-merge.yml. The scanner source itself is
+# used via PYTHONPATH, avoiding an editable build and build-isolation dependency resolution.
+annotated-types==0.8.0 \
+    --hash=sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0
+anyio==4.14.2 \
+    --hash=sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
+click==8.2.1 \
+    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+h11==0.16.0 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+httpcore==1.0.9 \
+    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55
+httpx==0.28.1 \
+    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+idna==3.18 \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+pydantic==2.11.7 \
+    --hash=sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b
+pydantic-core==2.33.2 \
+    --hash=sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+typing-inspection==0.4.2 \
+    --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7

--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -20,6 +20,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 # One scan at a time; newer pushes supersede in-flight ones.
 concurrency:
   group: scan-on-merge
@@ -31,21 +34,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'aiosbrain/aios-team-brain'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # full history — the scanner reads the commit window
+          persist-credentials: false
 
       # Produce coverage/coverage-summary.json (lib/** lines pct) for the scanner to read.
       # `|| true`: this is a metrics source, not a gate — never block the scan on coverage.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
           cache: "npm"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - name: Generate coverage report (metrics source for the scanner)
         run: npm run coverage || true
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -22,6 +22,8 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 # One scan at a time; newer pushes supersede in-flight ones.
 concurrency:

--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -47,16 +47,22 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-      - run: npm ci --ignore-scripts
       - name: Generate coverage report (metrics source for the scanner)
-        run: npm run coverage || true
+        run: |
+          if npm ci --ignore-scripts; then
+            npm run coverage || true
+          else
+            echo "dependency install failed — continuing without a coverage report."
+          fi
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install the ingestion scanner
-        run: pip install -e ingestion
+        run: >-
+          python -m pip install --only-binary=:all: --require-hashes
+          -r .github/scripts/brain-scanner-requirements.txt
 
       - name: Scan this repo into the brain
         env:
@@ -64,9 +70,11 @@ jobs:
           AIOS_TEAM: ${{ secrets.AIOS_TEAM }}
           AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONPATH: ingestion
         run: |
           if [ -z "$AIOS_API_KEY" ] || [ -z "$BRAIN_URL" ] || [ -z "$AIOS_TEAM" ]; then
             echo "scan secrets not configured (BRAIN_URL/AIOS_TEAM/AIOS_API_KEY) — skipping."
             exit 0
           fi
-          aios-ingest scan --path . --slug aios-team-brain --full-name "$GITHUB_REPOSITORY"
+          python -m aios_ingest.cli scan \
+            --path . --slug aios-team-brain --full-name "$GITHUB_REPOSITORY"

--- a/test/guards/scan-on-merge-security.test.ts
+++ b/test/guards/scan-on-merge-security.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  join(process.cwd(), ".github", "workflows", "scan-on-merge.yml"),
+  "utf8",
+);
+const requirements = readFileSync(
+  join(process.cwd(), ".github", "scripts", "brain-scanner-requirements.txt"),
+  "utf8",
+);
+
+describe("guard: scan-on-merge dependency and coverage isolation", () => {
+  it("keeps optional coverage installation fail-open", () => {
+    expect(workflow).toMatch(
+      /if npm ci --ignore-scripts; then[\s\S]*?npm run coverage \|\| true/,
+    );
+    expect(workflow).toMatch(
+      /else\n\s+echo "dependency install failed — continuing without a coverage report\."/,
+    );
+  });
+
+  it("uses only hash-locked binary scanner dependencies without a package build", () => {
+    expect(workflow).toMatch(
+      /python -m pip install --only-binary=:all: --require-hashes/,
+    );
+    expect(workflow).toMatch(/PYTHONPATH: ingestion/);
+    expect(workflow).toMatch(/python -m aios_ingest\.cli scan/);
+    expect(workflow).not.toMatch(/pip install -e|pip install ingestion/);
+    const pinned = requirements.split("\n").filter((line) => /^[a-z]/.test(line));
+    expect(pinned.length).toBeGreaterThan(0);
+    for (const line of pinned) expect(line).toMatch(/^[a-z][a-z0-9-]*==[^ ]+ \\$/);
+    expect(requirements.match(/--hash=sha256:[0-9a-f]{64}/g)?.length).toBe(pinned.length);
+  });
+});


### PR DESCRIPTION
## Summary

- pin checkout, Node, and Python Actions to reviewed immutable SHAs
- discard checkout credentials
- declare read-only repository permissions
- disable lifecycle scripts during dependency installation

Brain credentials remain scoped only to the final scan step.

## Verification

- `npm run check:docs`
- contract conformance: 9 passed

Linear: AIO-697

## Review — Reviewed by Codex adversarial diff review — verdict no blockers
