### PR TITLE
fix(costs): AIO-687 — spend totals are exact, not truncated by a row cap

### DIFF
--- a/lib/metrics/llm-costs.ts
+++ b/lib/metrics/llm-costs.ts
@@ -2,6 +2,13 @@ import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { scopeLlmUsage, type QueryLogViewer } from "@/lib/auth/visibility";
 import { rangeDays, type Range } from "./range";
+import {
+  getLedgerLifetimeUsdExact,
+  getSpendCallCount,
+  getSpendSlices,
+  getSpendTotalUsd,
+  type SpendSlice,
+} from "./llm-spend";
 
 /**
  * The brain's own inference-spend breakdown, read from the `llm_usage` ledger (every generation the
@@ -78,36 +85,29 @@ export interface LlmCostBreakdown {
   by_provider: CostSlice[];
 }
 
-interface UsageRow {
-  source: string;
-  provider: string;
-  model: string;
-  cost_usd: number | string;
-  input_tokens: number;
-  output_tokens: number;
-  estimated: boolean;
-}
 
 /** Group rows by a key, summing cost/tokens/calls; returns slices sorted by cost desc. */
 function slicesBy(
-  rows: UsageRow[],
-  keyOf: (r: UsageRow) => string,
+  slices: SpendSlice[],
   labelOf: (k: string) => string,
   /** Failure attempts per key, folded in AFTER the spend pass — so a key that only ever failed still
    *  gets a row (it spent money we can't see), and `estimated` is decided purely by priced rows. */
   failuresByKey?: Map<string, number>
 ): CostSlice[] {
   const map = new Map<string, CostSlice>();
-  for (const r of rows) {
-    const key = keyOf(r) || "unknown";
+  for (const r of slices) {
+    const key = r.key || "unknown";
+    // MERGE, never replace. The SQL already folds ''/NULL into one 'unknown' group, so a collision
+    // should be impossible — but `map.set` would silently DROP a slice's dollars if one ever arrived,
+    // and a breakdown that quietly loses money is the bug this whole change exists to remove.
     const cur =
       map.get(key) ??
       { key, label: labelOf(key), cost_usd: 0, input_tokens: 0, output_tokens: 0, calls: 0, failed_attempts: 0, estimated: true };
-    cur.cost_usd += Number(r.cost_usd) || 0;
-    cur.input_tokens += Number(r.input_tokens) || 0;
-    cur.output_tokens += Number(r.output_tokens) || 0;
-    cur.calls += 1;
-    // A slice is "estimated" only if EVERY row in it is — one metered row makes it real.
+    cur.cost_usd += r.cost_usd;
+    cur.input_tokens += r.input_tokens;
+    cur.output_tokens += r.output_tokens;
+    cur.calls += r.calls;
+    // "estimated" is all-rows, so merging two groups keeps it only if BOTH are estimated.
     cur.estimated = cur.estimated && r.estimated;
     map.set(key, cur);
   }
@@ -132,16 +132,17 @@ export async function getLlmCostBreakdown(
   const days = rangeDays(range);
   const windowStart = new Date(Date.now() - days * 86_400_000);
 
-  const res = await scopeLlmUsage(
-    db
-      .from("llm_usage")
-      .select("source, provider, model, cost_usd, input_tokens, output_tokens, estimated")
-      .eq("team_id", teamId)
-      .gte("created_at", windowStart.toISOString())
-      .limit(100_000),
-    viewer
-  );
-  const rows = (res.data ?? []) as UsageRow[];
+  // EXACT, aggregated in Postgres. This used to fetch up to 100,000 rows and sum them here, which
+  // silently under-reported once the window held more rows than the cap — production hit that at
+  // 128,998 rows, reporting $88.33 against a true $98.84 while Pulse's lower 50k cap said $18.62.
+  // A larger cap would only move the cliff; `SUM`/`GROUP BY` has no cliff to move.
+  const [total_usd, calls, sourceSlices, modelSlices, providerSlices] = await Promise.all([
+    getSpendTotalUsd(db, teamId, days, viewer),
+    getSpendCallCount(db, teamId, days, viewer),
+    getSpendSlices(db, teamId, days, "source", viewer),
+    getSpendSlices(db, teamId, days, "model", viewer),
+    getSpendSlices(db, teamId, days, "provider", viewer),
+  ]);
 
   // Failures live in their OWN table, fetched separately — never merged into the row set above. Sharing
   // `llm_usage` would let a storm of $0 attempt rows evict real spend rows inside this query's 100k cap
@@ -165,9 +166,12 @@ export async function getLlmCostBreakdown(
   for (const f of counted) failuresBySource.set(f.source || "unknown", (failuresBySource.get(f.source || "unknown") ?? 0) + 1);
   const failed_attempts = counted.length;
 
-  const total_usd = rows.reduce((s, r) => s + (Number(r.cost_usd) || 0), 0);
-  const calls = rows.length;
-  const hasEstimates = rows.some((r) => r.estimated);
+  // "any estimated row exists" — a slice is `estimated` only when ALL its rows are, so a slice being
+  // estimated is sufficient evidence, and a mixed slice is covered by its own rows being counted
+  // elsewhere. Cheap and exact: derived from the grouped result, not a second scan.
+  // ANY estimate in the window. `slice.estimated` is bool_and (all-rows), so it alone would miss a
+  // MIXED slice — `any_estimated` is the bool_or companion computed in the same GROUP BY.
+  const hasEstimates = sourceSlices.some((s2) => s2.any_estimated);
 
   // Earliest metered call = when this team's ledger began (i.e. when metering shipped). Team-scoped,
   // NOT role-scoped: "metering began on X" is an instance-level fact, not per-member spend, and a
@@ -192,9 +196,9 @@ export async function getLlmCostBreakdown(
     hasEstimates,
     trackingSince,
     partialWindow,
-    by_source: slicesBy(rows, (r) => r.source, (k) => SOURCE_LABEL[k] ?? k, failuresBySource),
-    by_model: slicesBy(rows, (r) => r.model, (k) => k),
-    by_provider: slicesBy(rows, (r) => r.provider, (k) => k),
+    by_source: slicesBy(sourceSlices, (k) => SOURCE_LABEL[k] ?? k, failuresBySource),
+    by_model: slicesBy(modelSlices, (k) => k),
+    by_provider: slicesBy(providerSlices, (k) => k),
   };
 }
 
@@ -210,6 +214,12 @@ export async function getLlmCostBreakdown(
  * only meaningful comparison is the whole team's ledger. The caller gates this on `isAdmin` for the
  * same reason — a member's scoped subtotal beside a whole-key total would read as a huge fake gap.
  */
+/**
+ * Retained as the historical cap this function used to fetch under. Nothing reads it any more — the
+ * sum is exact — but the constant is exported, so it is kept and marked rather than silently dropped.
+ *
+ * @deprecated The lifetime total is now an exact SQL `SUM`; there is no cap to hit.
+ */
 export const LEDGER_LIFETIME_ROW_CAP = 500_000;
 
 export async function getLedgerLifetimeUsd(
@@ -217,25 +227,9 @@ export async function getLedgerLifetimeUsd(
   teamId: string,
   provider: string
 ): Promise<number | null> {
-  try {
-    const res = await db
-      .from("llm_usage")
-      .select("cost_usd")
-      // FILTERED BY PROVIDER, and this is the whole correctness of the comparison. The figure this is
-      // measured against comes from ONE provider's billing API. Summing every provider against it
-      // dilutes the gap toward zero — an Anthropic list-price estimate is real ledger spend that
-      // OpenRouter never charged, so counting it here would "account for" money that key never saw and
-      // quietly erase the very shortfall this exists to expose.
-      .eq("provider", provider)
-      .eq("team_id", teamId)
-      .limit(LEDGER_LIFETIME_ROW_CAP);
-    const rows = (res.data ?? []) as { cost_usd: number | string }[];
-    // At the cap Postgres returns an ARBITRARY subset (no ORDER BY), so the sum would be short — and a
-    // short ledger INFLATES the unattributed figure. Refusing to answer is the only honest option;
-    // the caller then shows no reconciliation rather than a confident overstatement.
-    if (rows.length >= LEDGER_LIFETIME_ROW_CAP) return null;
-    return rows.reduce((sum, r) => sum + (Number(r.cost_usd) || 0), 0);
-  } catch {
-    return null; // can't reconcile → the caller shows nothing rather than a wrong comparison
-  }
+  // Delegates to the exact aggregate. The old implementation fetched up to 500,000 rows and returned
+  // `null` when it hit the cap rather than under-report — the right instinct, and the reason the
+  // /costs reconciliation banner stayed correct while the headline beside it drifted. With an exact
+  // `SUM` there is nothing left to refuse, so the null case now means only "the query failed".
+  return getLedgerLifetimeUsdExact(db, teamId, provider);
 }

--- a/lib/metrics/llm-spend.ts
+++ b/lib/metrics/llm-spend.ts
@@ -1,0 +1,250 @@
+import "server-only";
+import { runSql } from "@/lib/db/pg/pool";
+import type { QueryLogViewer } from "@/lib/auth/visibility";
+
+/**
+ * llm-spend — EXACT aggregates over the `llm_usage` ledger, computed in Postgres.
+ *
+ * WHY THIS MODULE EXISTS
+ *
+ * Both spend surfaces used to fetch raw rows and sum them in JavaScript under a `.limit(...)`:
+ * `lib/metrics/pulse` at 50,000 and `getLlmCostBreakdown` at 100,000. Once the table held more rows
+ * than the cap, each silently summed a subset — and the two caps differed, so the SAME window
+ * produced two different totals. Measured on production 2026-08-03: a 30-day window of 128,998 rows
+ * reported **$18.62** on Pulse and **$88.33** on /costs against a true **$98.84**.
+ *
+ * The failure mode is what makes it worth a shared module rather than two local fixes:
+ *
+ *   - It UNDER-reports, which looks reassuring, so nobody investigates.
+ *   - It has no error state. Nothing logs, nothing 500s; the number is just quietly short.
+ *   - It gets worse as the product succeeds — the gap widens with every call.
+ *
+ * Raising the caps would only move the cliff and re-arrive silently at the new number. Aggregating
+ * in SQL removes the cliff: `SUM`/`GROUP BY` is exact at any row count, transfers O(groups) instead
+ * of O(rows), and cannot be outgrown. It is also what this file's predecessor planned for —
+ * `llm-costs.ts` carried "If `llm_usage` grows large, push the group-by into SQL".
+ *
+ * DERIVATION LIVES HERE, NOT IN A SURFACE. Pulse and the costs page are two readers of one fact.
+ * Computing spend inside either would guarantee they drift again the next time one changes.
+ *
+ * SQL is written through `runSql` (the adapter's parameterized escape hatch, already used across
+ * `lib/auth`, `lib/attribution`, `lib/graph`, …). Every value is a bound parameter; no interpolation.
+ *
+ * NOTE ON THE `_db` PARAMETER: these functions take a client and ignore it — `runSql` goes to the
+ * global pool. It is kept so call sites read like every other metrics function (and so a caller
+ * cannot conclude these bypass the adapter), and underscored to say plainly that it is unused. The
+ * consequence worth knowing: a transaction-scoped client would NOT be honoured here. No caller needs
+ * that today; a future one must add explicit transaction support rather than assume it works.
+ */
+
+/**
+ * The viewer predicate for `llm_usage`, in SQL — the single definition, mirroring `scopeLlmUsage`.
+ *
+ * `llm_usage` has NO RLS backstop, so this predicate is the entire tier boundary on the table: an
+ * admin sees the team (including `member_id IS NULL` system/background rows, which is most of the
+ * graph-extraction spend), and anyone else sees only rows they initiated. A `SUM` that forgot this
+ * would hand a member the team's total spend — the aggregate rewrite is exactly the kind of change
+ * where that gets lost, so it is expressed once, here, and asserted in the data-mechanics tier.
+ *
+ * Returns a fragment to append to a WHERE clause plus the params to bind after `startAt`.
+ */
+function viewerPredicate(viewer: QueryLogViewer, nextParamIndex: number): { sql: string; params: unknown[] } {
+  if (viewer.isAdmin) return { sql: "", params: [] };
+  return { sql: ` and member_id = $${nextParamIndex}`, params: [viewer.memberId] };
+}
+
+/** `days` → the window start, matching the surfaces' existing arithmetic exactly. */
+function windowStartIso(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString();
+}
+
+/**
+ * Exact total spend for the window.
+ *
+ * `SUM()` over zero rows is SQL NULL, not 0 — coalesced in SQL so the caller can never receive a
+ * null that reads as 0 by luck and as NaN once a shape changes.
+ */
+export async function getSpendTotalUsd(
+  db: unknown,
+  teamId: string,
+  days: number,
+  viewer: QueryLogViewer
+): Promise<number> {
+  return getSpendTotalUsdBetween(db, teamId, windowStartIso(days), null, viewer);
+}
+
+/**
+ * Exact total over an explicit half-open range `[startIso, endIso)`.
+ *
+ * Pulse needs a PRIOR window (for the % delta) as well as the current one; expressing both through
+ * one function keeps the two from drifting — a delta computed against a differently-scoped total is
+ * the same class of bug as the one this module exists to remove.
+ */
+export async function getSpendTotalUsdBetween(
+  _db: unknown,
+  teamId: string,
+  startIso: string,
+  endIso: string | null,
+  viewer: QueryLogViewer
+): Promise<number> {
+  const params: unknown[] = [teamId, startIso];
+  let sql = `select coalesce(sum(cost_usd), 0) as total from llm_usage where team_id = $1 and created_at >= $2`;
+  if (endIso) {
+    params.push(endIso);
+    sql += ` and created_at < $${params.length}`;
+  }
+  const scope = viewerPredicate(viewer, params.length + 1);
+  sql += scope.sql;
+  const { rows } = await runSql<{ total: string | number }>(sql, [...params, ...scope.params]);
+  return Number(rows[0]?.total ?? 0) || 0;
+}
+
+/**
+ * Daily spend, keyed by `YYYY-MM-DD` (UTC) — the Pulse sparkline and the per-day cost series.
+ *
+ * Only days with spend are returned; the caller already maps onto its own bucket list, and emitting
+ * zero-rows for empty days would just move that work into SQL.
+ */
+export async function getSpendDailyUsd(
+  _db: unknown,
+  teamId: string,
+  startIso: string,
+  viewer: QueryLogViewer
+): Promise<Map<string, number>> {
+  const scope = viewerPredicate(viewer, 3);
+  const { rows } = await runSql<{ day: string | Date; total: string | number }>(
+    `select to_char(date_trunc('day', created_at at time zone 'UTC'), 'YYYY-MM-DD') as day,
+            coalesce(sum(cost_usd), 0) as total
+       from llm_usage
+      where team_id = $1 and created_at >= $2${scope.sql}
+      group by 1`,
+    [teamId, startIso, ...scope.params]
+  );
+  const out = new Map<string, number>();
+  for (const r of rows) out.set(String(r.day), Number(r.total) || 0);
+  return out;
+}
+
+/** One grouped slice, pre-aggregated by Postgres. */
+export interface SpendSlice {
+  key: string;
+  cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+  calls: number;
+  /** true only when EVERY row in the slice is a price-table estimate — `bool_and`, not `bool_or`. */
+  estimated: boolean;
+  /** true when ANY row in the slice is an estimate. Distinct from `estimated`: a MIXED slice is not
+   *  "estimated" (one metered row makes it real) but does contain estimates, which is what the
+   *  page-level "some figures are estimates" disclosure needs. Deriving that from `estimated` alone
+   *  would silently drop the mixed case. */
+  any_estimated: boolean;
+}
+
+/** The columns we group by. A closed set: interpolated into SQL, so it may never take user input. */
+export type SpendDimension = "source" | "model" | "provider";
+const DIMENSIONS: Record<SpendDimension, string> = {
+  source: "source",
+  model: "model",
+  provider: "provider",
+};
+
+/**
+ * Spend grouped by one dimension, exact at any row count.
+ *
+ * The dimension is looked up in `DIMENSIONS` rather than concatenated: it is the only part of these
+ * statements that is not a bound parameter, so it is constrained to a fixed allowlist and can never
+ * carry caller input into the SQL text.
+ */
+export async function getSpendSlices(
+  _db: unknown,
+  teamId: string,
+  days: number,
+  dimension: SpendDimension,
+  viewer: QueryLogViewer
+): Promise<SpendSlice[]> {
+  const column = DIMENSIONS[dimension];
+  if (!column) throw new Error(`unknown spend dimension: ${dimension}`);
+
+  const scope = viewerPredicate(viewer, 3);
+  const { rows } = await runSql<{
+    key: string | null;
+    cost_usd: string | number;
+    input_tokens: string | number;
+    output_tokens: string | number;
+    calls: string | number;
+    estimated: boolean | null;
+    any_estimated: boolean | null;
+  }>(
+    // `nullif(…, '')` matters: `model`/`source` are NOT NULL with a '' default, so a blank arrives as
+    // its own group. Folding '' and NULL to 'unknown' HERE means Postgres aggregates them into one
+    // group; doing it in JS afterwards would let a '' group and a literal 'unknown' group collide.
+    `select coalesce(nullif(${column}, ''), 'unknown') as key,
+            coalesce(sum(cost_usd), 0)      as cost_usd,
+            coalesce(sum(input_tokens), 0)  as input_tokens,
+            coalesce(sum(output_tokens), 0) as output_tokens,
+            count(*)                        as calls,
+            bool_and(coalesce(estimated, false)) as estimated,
+            bool_or(coalesce(estimated, false))  as any_estimated
+       from llm_usage
+      where team_id = $1 and created_at >= $2${scope.sql}
+      group by 1
+      order by 2 desc`,
+    [teamId, windowStartIso(days), ...scope.params]
+  );
+
+  return rows.map((r) => ({
+    key: String(r.key ?? "unknown"),
+    cost_usd: Number(r.cost_usd) || 0,
+    input_tokens: Number(r.input_tokens) || 0,
+    output_tokens: Number(r.output_tokens) || 0,
+    calls: Number(r.calls) || 0,
+    estimated: r.estimated === true,
+    any_estimated: r.any_estimated === true,
+  }));
+}
+
+/** Metered call count for the window — `count(*)`, so it never depends on how many rows we fetched. */
+export async function getSpendCallCount(
+  _db: unknown,
+  teamId: string,
+  days: number,
+  viewer: QueryLogViewer
+): Promise<number> {
+  const scope = viewerPredicate(viewer, 3);
+  const { rows } = await runSql<{ n: string | number }>(
+    `select count(*) as n from llm_usage
+      where team_id = $1 and created_at >= $2${scope.sql}`,
+    [teamId, windowStartIso(days), ...scope.params]
+  );
+  return Number(rows[0]?.n ?? 0) || 0;
+}
+
+/**
+ * Lifetime ledger total for ONE provider — the reconciliation figure.
+ *
+ * Replaces a 500,000-row fetch that returned `null` at the cap rather than under-report. That
+ * refusal was the right instinct and is why the /costs banner stayed correct while the headline
+ * beside it drifted; an exact `SUM` means there is now nothing to refuse.
+ */
+export async function getLedgerLifetimeUsdExact(
+  _db: unknown,
+  teamId: string,
+  provider: string
+): Promise<number | null> {
+  try {
+    const { rows } = await runSql<{ total: string | number }>(
+      // Provider-filtered, and that filter is the whole correctness of the comparison: the figure this
+      // is measured against comes from ONE provider's billing API. Summing every provider would count
+      // an Anthropic list-price estimate as money that key never saw, erasing the very shortfall the
+      // reconciliation exists to expose.
+      `select coalesce(sum(cost_usd), 0) as total
+         from llm_usage
+        where team_id = $1 and provider = $2`,
+      [teamId, provider]
+    );
+    return Number(rows[0]?.total ?? 0) || 0;
+  } catch {
+    return null; // can't reconcile → the caller shows nothing rather than a wrong comparison
+  }
+}

--- a/lib/metrics/pulse.ts
+++ b/lib/metrics/pulse.ts
@@ -2,9 +2,9 @@ import "server-only";
 import { isOpenStatus } from "@/lib/tasks/activity-policy";
 import type { DbClient } from "@/lib/db/types";
 import { rangeDays, type Range } from "./range";
+import { getSpendDailyUsd, getSpendTotalUsdBetween } from "./llm-spend";
 import {
   scopeQueryLog,
-  scopeLlmUsage,
   visibleItems,
   visibleTasks,
   type ViewerTier,
@@ -165,7 +165,7 @@ export async function getPulseMetrics(
 
   // Fetch each source once over the combined [prior, now] window where a delta
   // is needed, then split current vs. prior in JS.
-  const [itemsRes, queryRes, tasksRes, spendRes] = await Promise.all([
+  const [itemsRes, queryRes, tasksRes] = await Promise.all([
     // Knowledge growth reads `created_at` (first-seen), NOT `synced_at`: the scheduler bumps synced_at
     // on every 30-min tick, so windowing on it plots re-sync churn (≈all items look "new") rather than
     // real growth. created_at is set once on insert and never bumped. See postgres migration items_created_at.
@@ -198,26 +198,26 @@ export async function getPulseMetrics(
         .limit(5_000),
       tier
     ),
-    // Brain SPEND is ALL inference (Q&A + arcs + meetings + timeline + social + titles + cron), read
-    // from the `llm_usage` ledger — NOT `query_log`, which only meters the interactive Query box. The
-    // Queries KPI above still counts query_log (adoption); spend is the total cost of running the brain.
-    scopeLlmUsage(
-      db
-        .from("llm_usage")
-        .select("cost_usd, created_at")
-        .eq("team_id", teamId)
-        .gte("created_at", priorStart.toISOString())
-        .order("created_at", { ascending: false })
-        .limit(50_000),
-      viewer
-    ),
+  ]);
+
+  // Brain SPEND is ALL inference (Q&A + arcs + meetings + timeline + social + titles + cron), read
+  // from the `llm_usage` ledger — NOT `query_log`, which only meters the interactive Query box. The
+  // Queries KPI above still counts query_log (adoption); spend is the total cost of running the brain.
+  //
+  // Aggregated in Postgres via `lib/metrics/llm-spend`. This previously fetched up to 50,000 rows and
+  // summed them here, which silently under-reported once the window held more: production showed
+  // $18.62 against a true $98.84, while the /costs page's larger 100k cap showed $88.33 for the SAME
+  // window. One shared aggregate is what keeps the two surfaces from disagreeing again.
+  const [spendCurrent, spendPrior, spendByDay] = await Promise.all([
+    getSpendTotalUsdBetween(db, teamId, windowStart.toISOString(), null, viewer),
+    getSpendTotalUsdBetween(db, teamId, priorStart.toISOString(), windowStart.toISOString(), viewer),
+    getSpendDailyUsd(db, teamId, windowStart.toISOString(), viewer),
   ]);
 
   // NB: the pg adapter returns timestamptz as Date (legacy Supabase-js returned string). Normalize via toIso below.
   const itemRows = (itemsRes.data ?? []) as { kind: string; created_at: string | Date }[];
   const queryRows = (queryRes.data ?? []) as { cost_usd: number | string; created_at: string | Date }[];
   const taskRows = (tasksRes.data ?? []) as { status: string; updated_at: string | Date }[];
-  const spendRows = (spendRes.data ?? []) as { cost_usd: number | string; created_at: string | Date }[];
 
   const winStartIso = windowStart.toISOString();
   const inWindow = (iso: string) => iso >= winStartIso;
@@ -265,23 +265,13 @@ export async function getPulseMetrics(
 
   // ── brain SPEND: total inference cost per day from llm_usage (all sources, not just Q&A) ──
   const spendSpark = new Array(order.length).fill(0);
-  let spendCurrent = 0;
-  let spendPrior = 0;
-  for (const row of spendRows) {
-    const cost = Number(row.cost_usd) || 0;
-    const createdIso = toIso(row.created_at);
-    if (inWindow(createdIso)) {
-      spendCurrent += cost;
-      const i = index.get(createdIso.slice(0, 10));
-      if (i !== undefined) {
-        // Daily $ spend for the sparkline (the Sparkline normalizes, so raw dollars are fine — it
-        // shows the shape of spend under the Spend KPI).
-        spendSpark[i] += cost;
-        usage[i].cost += cost;
-      }
-    } else {
-      spendPrior += cost;
-    }
+  for (const [day, cost] of spendByDay) {
+    const i = index.get(day);
+    if (i === undefined) continue; // a day outside the rendered buckets still counts in the total
+    // Daily $ spend for the sparkline (the Sparkline normalizes, so raw dollars are fine — it
+    // shows the shape of spend under the Spend KPI).
+    spendSpark[i] += cost;
+    usage[i].cost += cost;
   }
 
   // ── tasks: funnel + in-flight KPI + activity spark ──

--- a/test/datamechanics/llm-spend-exact.datamechanics.test.ts
+++ b/test/datamechanics/llm-spend-exact.datamechanics.test.ts
@@ -1,0 +1,202 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { runSql } from "@/lib/db/pg/pool";
+import { getLlmCostBreakdown } from "@/lib/metrics/llm-costs";
+import { getSpendTotalUsd, getSpendDailyUsd } from "@/lib/metrics/llm-spend";
+import { db, seedTeam, type Seed } from "./helpers";
+
+/**
+ * Spec: a reported spend total is the EXACT sum of the window, at any row count.
+ *
+ * This is a persistence/aggregation bug, so it can only be caught here. The unit tier stubs the DB,
+ * and the row caps that cause it (`.limit(50_000)` on the Pulse KPI, `.limit(100_000)` on the costs
+ * breakdown) are invisible until the table actually holds more rows than the cap — which production
+ * now does: 128,998 rows in a 30-day window reported as $18.62 on Pulse and $88.33 on /costs, against
+ * a true $98.84.
+ *
+ * The seeded row count is a LITERAL, deliberately not derived from any production constant. Deriving
+ * it (`CAP + 1`) would mean a future cap change silently re-sizes the fixture and the test stops
+ * exercising the thing it was written for.
+ */
+
+/** Comfortably above both production caps (50k / 100k), and above any plausible near-term raise. */
+const ROWS = 120_000;
+/** Whole cents, so the expected total is exact in float: 120_000 × $0.001 = $120.00 exactly. */
+const COST_PER_ROW = 0.001;
+const EXPECTED_TOTAL = 120;
+
+const ADMIN = (seed: Seed) => ({ isAdmin: true, memberId: seed.memberId });
+const MEMBER = (seed: Seed) => ({ isAdmin: false, memberId: seed.memberId });
+
+/**
+ * Bulk-insert via generate_series — one statement, ~1s for 120k rows. Row-at-a-time through the
+ * adapter would take minutes and make this tier too slow to keep.
+ */
+async function seedUsage(
+  seed: Seed,
+  opts: { rows: number; memberId?: string | null; source?: string; model?: string; provider?: string; daysAgo?: number }
+): Promise<void> {
+  const { rows, memberId = null, source = "graph", model = "m1", provider = "openrouter", daysAgo = 1 } = opts;
+  await runSql(
+    `insert into llm_usage (id, team_id, member_id, source, provider, model, cost_usd, input_tokens, output_tokens, estimated, created_at)
+     select gen_random_uuid(), $1, $2, $3, $4, $5, $6, 10, 5, false, now() - ($7 || ' days')::interval
+     from generate_series(1, $8)`,
+    [seed.teamId, memberId, source, provider, model, COST_PER_ROW, String(daysAgo), rows]
+  );
+}
+
+describe("llm spend totals are exact, not capped (real Postgres)", () => {
+  it("sums every row in the window — not just the first N the cap allows", async () => {
+    // THE REPRODUCTION. On the pre-fix code this returns ~$50 (Pulse's 50k cap) or ~$100 (the costs
+    // page's 100k cap) instead of $120.
+    const seed = await seedTeam();
+    await seedUsage(seed, { rows: ROWS });
+
+    const total = await getSpendTotalUsd(db(), seed.teamId, 30, ADMIN(seed));
+    expect(total).toBeCloseTo(EXPECTED_TOTAL, 6);
+
+    const breakdown = await getLlmCostBreakdown(db(), seed.teamId, "30d", ADMIN(seed));
+    expect(breakdown.total_usd).toBeCloseTo(EXPECTED_TOTAL, 6);
+    expect(breakdown.calls).toBe(ROWS);
+  });
+
+  it("Pulse and the costs page agree — the same window cannot yield two totals", async () => {
+    // The user-visible symptom: $18.62 on Pulse beside $88.33 on /costs, same team, same 30 days.
+    const seed = await seedTeam();
+    await seedUsage(seed, { rows: ROWS });
+
+    const pulseTotal = await getSpendTotalUsd(db(), seed.teamId, 30, ADMIN(seed));
+    const costsTotal = (await getLlmCostBreakdown(db(), seed.teamId, "30d", ADMIN(seed))).total_usd;
+
+    expect(pulseTotal).toBeCloseTo(costsTotal, 6);
+  });
+
+  it("breakdown slices sum to the headline total", async () => {
+    // Truncation understated every bar too, not just the total, so the slices are part of the fix.
+    const seed = await seedTeam();
+    await seedUsage(seed, { rows: 60_000, source: "graph", model: "m1", provider: "openrouter" });
+    await seedUsage(seed, { rows: 60_000, source: "query", model: "m2", provider: "anthropic" });
+
+    const b = await getLlmCostBreakdown(db(), seed.teamId, "30d", ADMIN(seed));
+    const sumOf = (slices: { cost_usd: number }[]) => slices.reduce((s, x) => s + x.cost_usd, 0);
+
+    expect(b.total_usd).toBeCloseTo(EXPECTED_TOTAL, 6);
+    expect(sumOf(b.by_source)).toBeCloseTo(b.total_usd, 6);
+    expect(sumOf(b.by_model)).toBeCloseTo(b.total_usd, 6);
+    expect(sumOf(b.by_provider)).toBeCloseTo(b.total_usd, 6);
+    expect(b.by_source.map((s) => s.key).sort()).toEqual(["graph", "query"]);
+  });
+
+  it("respects the window boundary", async () => {
+    const seed = await seedTeam();
+    await seedUsage(seed, { rows: 1_000, daysAgo: 2 }); // inside 30d and 7d
+    await seedUsage(seed, { rows: 1_000, daysAgo: 20 }); // inside 30d, outside 7d
+
+    expect(await getSpendTotalUsd(db(), seed.teamId, 30, ADMIN(seed))).toBeCloseTo(2, 6);
+    expect(await getSpendTotalUsd(db(), seed.teamId, 7, ADMIN(seed))).toBeCloseTo(1, 6);
+  });
+
+  it("keeps the tier boundary: a member sees only their own rows, an admin the whole team", async () => {
+    // `llm_usage` has no RLS backstop — the viewer predicate is the ONLY thing standing between a
+    // member and the team's total spend, so moving the sum into SQL must carry it into the SQL.
+    const seed = await seedTeam();
+    await seedUsage(seed, { rows: 2_000, memberId: seed.memberId }); // $2 — theirs
+    await seedUsage(seed, { rows: 3_000, memberId: null }); // $3 — system/background rows
+
+    expect(await getSpendTotalUsd(db(), seed.teamId, 30, ADMIN(seed))).toBeCloseTo(5, 6);
+    expect(await getSpendTotalUsd(db(), seed.teamId, 30, MEMBER(seed))).toBeCloseTo(2, 6);
+
+    const asMember = await getLlmCostBreakdown(db(), seed.teamId, "30d", MEMBER(seed));
+    expect(asMember.total_usd).toBeCloseTo(2, 6);
+  });
+
+  it("never leaks another team's spend", async () => {
+    const mine = await seedTeam();
+    const theirs = await seedTeam();
+    await seedUsage(mine, { rows: 1_000 });
+    await seedUsage(theirs, { rows: 5_000 });
+
+    expect(await getSpendTotalUsd(db(), mine.teamId, 30, ADMIN(mine))).toBeCloseTo(1, 6);
+  });
+
+  it("returns 0 for a team with no rows, rather than throwing on a null SUM", async () => {
+    // `SUM()` over no rows is NULL in SQL, not 0 — an unguarded Number(null) would read as 0 by luck
+    // and as NaN if the shape ever changes.
+    const seed = await seedTeam();
+    expect(await getSpendTotalUsd(db(), seed.teamId, 30, ADMIN(seed))).toBe(0);
+  });
+
+  it("buckets the daily series by day, and the buckets sum to the total", async () => {
+    // Pulse's sparkline reads this; it was fed by the same truncated row set as the KPI.
+    const seed = await seedTeam();
+    await seedUsage(seed, { rows: 1_000, daysAgo: 1 });
+    await seedUsage(seed, { rows: 2_000, daysAgo: 3 });
+
+    const daily = await getSpendDailyUsd(db(), seed.teamId, new Date(Date.now() - 30 * 86_400_000).toISOString(), ADMIN(seed));
+    const sum = [...daily.values()].reduce((s, v) => s + v, 0);
+
+    expect(sum).toBeCloseTo(3, 6);
+    expect(daily.size).toBe(2);
+  });
+
+  it("is unaffected by unrelated rows in other teams' windows", async () => {
+    const seed = await seedTeam();
+    const other = await seedTeam();
+    await seedUsage(seed, { rows: 500, source: "query" });
+    await seedUsage(other, { rows: 500, source: "query" });
+
+    const b = await getLlmCostBreakdown(db(), seed.teamId, "30d", ADMIN(seed));
+    expect(b.total_usd).toBeCloseTo(0.5, 6);
+    expect(b.by_source).toHaveLength(1);
+  });
+
+  it("folds blank and literal-'unknown' keys into ONE slice without losing money", async () => {
+    // `model`/`source` are NOT NULL with a '' default, so a blank is its own SQL group. If '' and a
+    // literal 'unknown' both appear in a window and the fold happens in JS, one group overwrites the
+    // other and its dollars vanish from the breakdown while the headline total still counts them —
+    // the slices would stop summing to the total.
+    const seed = await seedTeam();
+    await runSql(
+      `insert into llm_usage (id, team_id, member_id, source, provider, model, cost_usd, input_tokens, output_tokens, estimated, created_at)
+       values (gen_random_uuid(), $1, null, 'query', 'p', '',        1.00, 1, 1, false, now()),
+              (gen_random_uuid(), $1, null, 'query', 'p', 'unknown', 2.00, 1, 1, false, now())`,
+      [seed.teamId]
+    );
+
+    const b = await getLlmCostBreakdown(db(), seed.teamId, "30d", ADMIN(seed));
+    const unknown = b.by_model.filter((m) => m.key === "unknown");
+    expect(unknown).toHaveLength(1); // one slice, not two colliding ones
+    expect(unknown[0].cost_usd).toBeCloseTo(3, 6); // and NEITHER dollar was dropped
+    expect(b.by_model.reduce((s2, m) => s2 + m.cost_usd, 0)).toBeCloseTo(b.total_usd, 6);
+  });
+
+  it("reports token sums per slice, not just cost", async () => {
+    const seed = await seedTeam();
+    await seedUsage(seed, { rows: 1_000 });
+
+    const b = await getLlmCostBreakdown(db(), seed.teamId, "30d", ADMIN(seed));
+    const graph = b.by_source.find((s) => s.key === "graph")!;
+    expect(graph.calls).toBe(1_000);
+    expect(graph.input_tokens).toBe(10_000); // 1000 rows × 10
+    expect(graph.output_tokens).toBe(5_000); // 1000 rows × 5
+    expect(graph.estimated).toBe(false);
+  });
+
+  it("marks a slice estimated only when EVERY row in it is an estimate", async () => {
+    const seed = await seedTeam();
+    const id = randomUUID();
+    await runSql(
+      `insert into llm_usage (id, team_id, member_id, source, provider, model, cost_usd, input_tokens, output_tokens, estimated, created_at)
+       values (gen_random_uuid(), $1, null, 'query', 'anthropic', 'est-only', 0.5, 1, 1, true, now()),
+              (gen_random_uuid(), $1, null, 'arcs', 'anthropic', 'mixed', 0.5, 1, 1, true, now()),
+              (gen_random_uuid(), $1, null, 'arcs', 'anthropic', 'mixed', 0.5, 1, 1, false, now())`,
+      [seed.teamId]
+    );
+    void id;
+
+    const b = await getLlmCostBreakdown(db(), seed.teamId, "30d", ADMIN(seed));
+    expect(b.by_source.find((s) => s.key === "query")!.estimated).toBe(true);
+    expect(b.by_source.find((s) => s.key === "arcs")!.estimated).toBe(false); // one metered row ⇒ not estimated
+    expect(b.hasEstimates).toBe(true);
+  });
+});

--- a/test/guards/ledger-reconciliation-scope.test.ts
+++ b/test/guards/ledger-reconciliation-scope.test.ts
@@ -3,25 +3,72 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
- * GUARD: the ledger sum compared against a provider's billing figure must be scoped to THAT provider.
+ * GUARD: the ledger sum compared against a provider's billing figure must be scoped to THAT provider,
+ * and must never be short.
  *
  * The provider total comes from one provider's API. Summing every provider against it dilutes the gap
  * toward zero — an Anthropic list-price estimate is real ledger spend that OpenRouter never charged,
  * so counting it "accounts for" money that key never saw and quietly erases the shortfall this whole
  * feature exists to expose. It shipped that way in review and would have been invisible the moment a
  * second provider key was added: today every row is `openrouter`, so no behavioural test can catch it.
+ *
+ * BOTH INVARIANTS SURVIVED A CHANGE OF MECHANISM, which is why this guard is now phrased against the
+ * behaviour rather than the old code shape. The lifetime total used to be a 500,000-row fetch summed
+ * in JS, which returned `null` on hitting the cap rather than report a short sum. That refusal was
+ * the right instinct — and it is precisely why this reconciliation banner stayed correct while the
+ * /costs headline beside it truncated at 100,000 rows and under-reported by $10 (AIO-687). The
+ * implementation is now an exact SQL `SUM`, so there is no cap left to refuse at: "never short" is
+ * satisfied by construction instead of by a guard clause. What must never come back is a capped fetch.
  */
-describe("guard: getLedgerLifetimeUsd is provider-scoped", () => {
-  const src = readFileSync(join(process.cwd(), "lib", "metrics", "llm-costs.ts"), "utf8");
-  const fn = src.slice(src.indexOf("export async function getLedgerLifetimeUsd"));
+const ROOT = process.cwd();
+const COSTS = readFileSync(join(ROOT, "lib", "metrics", "llm-costs.ts"), "utf8");
 
+/** Comments describe the hazard; they are not the hazard. A `.limit(` inside prose must not trip this. */
+function stripComments(src: string): string {
+  return src
+    .replace(/(^|[\s(,;=:[{])\/\*[\s\S]*?\*\//g, "$1 ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+const SPEND = stripComments(readFileSync(join(ROOT, "lib", "metrics", "llm-spend.ts"), "utf8"));
+
+/**
+ * The lifetime-sum implementation ONLY — bounded to the function, not sliced to end-of-file. An
+ * open-ended slice would silently start asserting against whatever function is appended below it.
+ */
+const implStart = SPEND.indexOf("export async function getLedgerLifetimeUsdExact");
+const implRest = SPEND.slice(implStart + 1);
+const nextExport = implRest.indexOf("\nexport ");
+const impl = nextExport === -1 ? SPEND.slice(implStart) : SPEND.slice(implStart, implStart + 1 + nextExport);
+
+describe("guard: the lifetime ledger sum is provider-scoped and never short", () => {
   it("filters llm_usage by provider", () => {
-    expect(fn).toMatch(/\.eq\("provider",\s*provider\)/);
+    // The one filter that makes the comparison meaningful at all.
+    expect(impl).toMatch(/provider = \$\d/);
+    expect(impl).toMatch(/team_id = \$\d/); // and never crosses teams
   });
 
-  it("refuses to answer at the row cap rather than returning a short sum", () => {
-    // A truncated sum understates the ledger, which INFLATES the unattributed gap — a confident
-    // overstatement is worse than showing nothing.
-    expect(fn).toMatch(/rows\.length >= LEDGER_LIFETIME_ROW_CAP.*return null/s);
+  it("computes an exact SUM rather than fetching rows", () => {
+    // Fetch-and-sum is what put a cap in the path in the first place. `SUM` has no cap to outgrow.
+    expect(impl).toMatch(/sum\(cost_usd\)/);
+    expect(impl).not.toMatch(/\.limit\(/);
+    expect(impl).not.toMatch(/\.reduce\(/);
+  });
+
+  it("cannot return a short sum — there is no row cap left in the path", () => {
+    // The original invariant restated for the new mechanism: previously "refuse at the cap", now
+    // "there is no cap". Either satisfies it; a capped fetch that sums anyway satisfies neither.
+    expect(impl).not.toMatch(/ROW_CAP/);
+  });
+
+  it("still returns null when the query fails, so the caller shows nothing rather than a wrong figure", () => {
+    // A confident overstatement is worse than showing no reconciliation at all.
+    expect(impl).toMatch(/catch\s*\{[\s\S]*return null/);
+  });
+
+  it("the public entry point delegates to that implementation", () => {
+    // Guarding the implementation is worthless if the page calls something else.
+    const entry = COSTS.slice(COSTS.indexOf("export async function getLedgerLifetimeUsd("));
+    expect(entry).toMatch(/getLedgerLifetimeUsdExact\(/);
   });
 });

--- a/test/guards/llm-usage-exact-aggregate.test.ts
+++ b/test/guards/llm-usage-exact-aggregate.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Guard: money is aggregated in SQL, never by summing a capped row fetch in JavaScript.
+ *
+ * THE BUG THIS TRACES TO. Two surfaces read `llm_usage` by fetching rows under a `.limit(...)` and
+ * summing them here — Pulse at 50,000, the /costs breakdown at 100,000. Once the table held more
+ * rows than the cap, each silently summed a subset, and because the caps differed the SAME window
+ * produced two different totals. Production, 2026-08-03: 128,998 rows reported as $18.62 on Pulse
+ * and $88.33 on /costs, against a true $98.84.
+ *
+ * Why a guard rather than trusting the fix: the failure is INVISIBLE until the table outgrows the
+ * cap, it under-reports (so it reads as good news), and nothing errors. A reviewer cannot see it in
+ * a diff — `.limit(100_000)` looks like prudence. The only durable defence is to make the pattern
+ * fail the build at the moment someone reintroduces it.
+ *
+ * KNOWN BLIND SPOT, stated rather than implied: a builder assigned to a variable with `.limit()`
+ * applied in a LATER statement is not detected — the chain scan stops at the statement boundary.
+ * Widening it to scan forward would false-positive across unrelated statements, and a guard that
+ * cries wolf gets deleted. The data-mechanics tier is the backstop for that shape.
+ *
+ * Deliberately narrow: it polices `llm_usage` (the money ledger) rather than every table. A row cap
+ * on a LIST is fine — `llm_failures` legitimately fetches `cap + 1` to detect truncation and says so
+ * in the response. What is never fine is a capped fetch feeding a dollar figure.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCAN_DIRS = ["app", "lib"];
+
+/** The one module allowed to read `llm_usage` for money — and it uses SQL aggregates, asserted below. */
+const AGGREGATE_MODULE = join("lib", "metrics", "llm-spend.ts");
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.(ts|tsx)$/.test(p)) out.push(p);
+  }
+  return out;
+}
+
+/** Strip comments — prose describing the hazard is not the hazard. Same rule the Railway policy uses. */
+function stripComments(src: string): string {
+  return src
+    .replace(/(^|[\s(,;=:[{])\/\*[\s\S]*?\*\//g, "$1 ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+/** Files that read `llm_usage` through the query builder AND put a row cap on it. */
+function cappedLlmUsageReads(): string[] {
+  const hits: string[] = [];
+  for (const d of SCAN_DIRS) {
+    for (const file of walk(join(ROOT, d))) {
+      const rel = file.slice(ROOT.length + 1);
+      const src = stripComments(readFileSync(file, "utf8"));
+      // The gate admits BOTH shapes. An earlier version gated on the builder call alone, so a file
+      // using only raw SQL was skipped entirely and the raw-SQL check below silently covered nothing.
+      // Found by probing the guard with a real offender instead of trusting that it worked.
+      if (!src.includes('from("llm_usage")') && !/from\s+llm_usage/i.test(src)) continue;
+
+      // Isolate each `.from("llm_usage")` chain and look for a `.limit(...)` on it. An INSERT chain
+      // has no limit, and the single-row `firstAt` probe is `.limit(1)` — a lookup, not an aggregate.
+      // Raw SQL too. The scan below only sees builder chains, but `llm-spend.ts` establishes
+      // `runSql` as the way to read this table — so a hand-written `select … from llm_usage … limit N`
+      // would be completely invisible to a builder-only guard.
+      for (const stmt of src.match(/`[^`]*from\s+llm_usage[^`]*`/gi) ?? []) {
+        if (/\blimit\b/i.test(stmt) && !/count\(|sum\(/i.test(stmt)) {
+          hits.push(`${rel}: raw SQL reads llm_usage with a LIMIT and no aggregate`);
+        }
+      }
+
+      const chains = src.split('from("llm_usage")').slice(1);
+      for (const chain of chains) {
+        const upToStatementEnd = chain.split(/;\s*\n/)[0];
+        // ANY argument, not just a numeric literal: `.limit(SPEND_CAP)` is the same bug wearing a
+        // constant, and the numeric-only form let it through.
+        const m = /\.limit\(\s*([^)]*)\s*\)/.exec(upToStatementEnd);
+        if (!m) continue;
+        const arg = m[1].trim();
+        if (/^1$/.test(arg)) continue; // `.limit(1)` is a single-row probe, not a truncated sum
+        hits.push(`${rel}: .limit(${arg}) on an llm_usage read`);
+      }
+    }
+  }
+  return hits.sort();
+}
+
+describe("llm_usage money reads are exact", () => {
+  it("no capped row fetch feeds a spend figure", () => {
+    const offenders = cappedLlmUsageReads();
+    expect(
+      offenders,
+      `A capped \`llm_usage\` fetch cannot produce a correct total — it silently sums a subset once the\n` +
+        `table outgrows the cap, and it fails in the reassuring direction (spend looks LOWER).\n` +
+        `Aggregate in Postgres via lib/metrics/llm-spend instead:\n${offenders.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("the aggregate module actually aggregates in SQL", () => {
+    // Without this, the guard above could be satisfied by deleting the cap and fetching EVERY row —
+    // exact, but unbounded memory, and it would regress to a JS sum.
+    const src = readFileSync(join(ROOT, AGGREGATE_MODULE), "utf8");
+    expect(src).toMatch(/sum\(cost_usd\)/);
+    expect(src).toMatch(/group by/i);
+    expect(src).not.toMatch(/\.reduce\(/); // no JS summation of fetched rows
+  });
+
+  it("the aggregate module carries the tier predicate into the SQL", () => {
+    // `llm_usage` has no RLS backstop. Moving the sum into SQL is exactly where a viewer filter gets
+    // dropped, and the result would be a member seeing the team's whole spend.
+    const src = stripComments(readFileSync(join(ROOT, AGGREGATE_MODULE), "utf8"));
+    expect(src).toMatch(/viewer\.isAdmin/);
+    expect(src).toMatch(/member_id = \$/);
+  });
+
+  it("no data value is interpolated into the SQL text", () => {
+    // Every user/caller-supplied VALUE must arrive as a bound parameter. Only three kinds of thing
+    // may be interpolated, and none of them can carry data:
+    //   column / dimension  — resolved through the closed DIMENSIONS allowlist (asserted below)
+    //   nextParamIndex / params.length — integers, used to build "$3" placeholders
+    //   scope.sql           — a constant fragment this module itself wrote
+    const SAFE = new Set(["column", "dimension", "nextParamIndex", "params.length", "scope.sql"]);
+    const src = stripComments(readFileSync(join(ROOT, AGGREGATE_MODULE), "utf8"));
+    const interpolations = [...src.matchAll(/\$\{([^}]+)\}/g)].map((m) => m[1].trim());
+
+    expect(interpolations.length).toBeGreaterThan(0); // non-vacuous: there ARE interpolations to police
+    expect(interpolations.filter((x) => !SAFE.has(x))).toEqual([]);
+  });
+
+  it("the grouped column comes from a closed allowlist, never from the caller", () => {
+    // `${column}` is the only identifier spliced into the statement, so it is the one place a caller
+    // could reach the SQL text. It must be a lookup, not the argument itself.
+    const src = stripComments(readFileSync(join(ROOT, AGGREGATE_MODULE), "utf8"));
+    expect(src).toMatch(/DIMENSIONS\[dimension\]/);
+    expect(src).toMatch(/unknown spend dimension/); // and an unknown key throws rather than splices
+  });
+});


### PR DESCRIPTION
AIOS-Work: AIO-687

Pulse's **TEAM SPEND** and the **/costs** headline disagreed for the *same team and window*, and both were wrong. The ticket was filed four days ago; the gap has widened since, which is the whole point of the bug.

| | at filing | today |
|---|---|---|
| Rows in the 30d window | 128,998 | **131,817** |
| True spend | $98.84 | **$107.93** |
| What Pulse showed | $18.62 | **$27.04** |

## Cause

Both surfaces fetched raw `llm_usage` rows and summed them **in JavaScript** under a `.limit(...)` — Pulse at 50,000, `getLlmCostBreakdown` at 100,000. Once the table held more rows than the cap, each silently summed a subset; because the caps differed, one window produced two totals. The `/costs` query had **no `ORDER BY`**, so *which* 100,000 rows it summed was arbitrary and could shift between refreshes.

Three properties made it nasty:

- It **under-reports**, which reads as good news, so nobody investigates.
- There is **no error state** — nothing logs, nothing 500s; the number is just short.
- It **worsens as the product succeeds**. The gap grew 4× while the ticket sat.

The page even contradicted itself: the reconciliation banner said *"this ledger accounts for $98.81"* — correct, because `getLedgerLifetimeUsd` used a 500k cap and **refused to answer** on hitting it — while the headline three lines above said $88.33. That refusal was the right instinct, and it's why the banner stayed honest.

## Fix

Aggregate in Postgres. `SUM`/`GROUP BY` is exact at any row count, transfers O(groups) instead of O(rows), and has no cliff to outgrow. Raising the caps would only move the cliff and re-arrive silently at the new number. It's also what the file already planned for — `llm-costs.ts` carried *"If `llm_usage` grows large, push the group-by into SQL"*.

The aggregates live in **one new module both surfaces read** (`lib/metrics/llm-spend.ts`) rather than two local fixes: Pulse and /costs are two readers of one fact, and computing it inside either guarantees they drift again.

**Tier safety got explicit attention.** `llm_usage` has no RLS backstop, so `scopeLlmUsage` is the entire boundary on that table — and moving a sum into SQL is exactly where a viewer filter gets dropped. A member would have seen the team's whole spend. The predicate is defined once, in SQL, and asserted member-vs-admin in the data-mechanics tier.

## Review — Reviewed by Fable (`code-reviewer`) — verdict CLEAR, 1 Medium + 3 Lows fixed

Fable independently verified the SQL (parameter numbering across the variable-arity range function, half-open `[priorStart, windowStart)` reproducing the old split with no boundary double-count, UTC bucketing matching `isoDay`), confirmed **no exported function misses the viewer predicate**, and confirmed the injection surface is airtight.

It also caught a **regression I introduced**: my `slicesBy` rewrite used `map.set` instead of merging, so two SQL groups normalizing to one key would **silently drop a slice's dollars** while the headline still counted them. Trigger: `model` is `NOT NULL DEFAULT ''`, so a blank arrives as its own group and collides with a literal `'unknown'`. Fixed at both ends — `coalesce(nullif(col, ''), 'unknown')` in SQL so Postgres folds them, plus a merge in `slicesBy` as belt-and-braces — with a dm test seeding exactly that shape. Reverting both loses **$2 of $3**.

Also fixed: the new guard's false negatives (`.limit(NAMED_CONST)` escaped a numeric-only regex; raw `runSql` was invisible — and while fixing that I found my own raw-SQL check sat *behind* the builder gate, so it covered nothing; found by probing the guard with a real offender rather than trusting it). Plus the ledger guard now strips comments and is bounded to its function instead of sliced to EOF.

## Verification

- **The reproduction:** a dm test seeding **120,000 rows** (above both caps) asserting the exact total. It **failed on the old code at `$100.0000000001`** — precisely the 100k cap — against a true $120. Written before the fix, not after.
- 12 dm tests: cross-surface agreement, slices summing to the headline, window boundaries, tier scoping, cross-team isolation, empty-team `SUM`-is-NULL, daily buckets, token sums, estimated-vs-mixed, and the blank/`unknown` fold.
- New guard fails the build on any capped `llm_usage` read feeding a dollar figure, and on the tier predicate going missing — **mutation-tested in both directions**, plus live probes for the named-constant and raw-SQL shapes.
- The **existing** ledger-reconciliation guard asserted the old shape ("refuses at the row cap"). Its intent — provider-scoped and never short — is preserved and restated for the new mechanism, with a new delegation assertion closing the "guard the impl but the page calls something else" hole. Fable confirmed nothing was lost.
- Full dm tier **825 passed** · unit **1762 passed** · lint ✅ (2 pre-existing warnings) · typecheck ✅ · docs-drift ✅

`test/guards/skill-runtime-sync.test.ts` has a pre-existing 5s-timeout flake that also fails on clean `main` — verified by stashing this branch.

## One deliberate subtlety

`hasEstimates` needed a `bool_or` companion to `bool_and`. A **mixed** slice is not "estimated" (one metered row makes it real) but does contain estimates — deriving the page-level disclosure from `estimated` alone would have silently dropped that case.