### PR TITLE
docs(brain): align constitution with API v1.16 (AIO-703)

### DIFF
--- a/docs/ENGINEERING-CONSTITUTION.md
+++ b/docs/ENGINEERING-CONSTITUTION.md
@@ -13,7 +13,7 @@ governed by the sync contract and the tier model — there is no side channel.
 
 ## 2. The sync contract is law
 
-`aios-workspace/docs/brain-api.md` (currently v1.8, major `/api/v1`) is the single
+`aios-workspace/docs/brain-api.md` (currently v1.16, major `/api/v1`) is the single
 pinned contract. Any protocol change is a versioned change in that file first, with
 matching changes on both sides. Clients must ignore unknown item kinds
 (forward-compat); the brain must never silently change response shapes.
@@ -51,7 +51,7 @@ and update it in the same commit as any principle change.
 <!-- agent-digest:start -->
 - The brain is the ONE shared hub: workspaces push to it; it never reaches into a
   workspace; no side channels around the sync contract.
-- `brain-api.md` (v1.8, `/api/v1`) is law: protocol changes are versioned there
+- `brain-api.md` (v1.16, `/api/v1`) is law: protocol changes are versioned there
   FIRST with matching changes on both sides; never silently change a response
   shape; ignore-unknown-kinds stays intact.
 - Tier enforcement is a hard boundary: `admin`-tier content → 422 at the API


### PR DESCRIPTION
## Summary

- update the Team Brain engineering constitution’s pinned Brain API revision from v1.8 to v1.16
- keep the human-readable principle and machine-read agent digest consistent
- align with the v1.16 contract documentation landed in AIO-718
- make no API, route, schema, or Brain contract changes

## Verification

- `npm run check:docs`
- `npm run typecheck`
- `npm test` (1782 passed, 11 skipped)
- pre-push NDA, docs-drift, and skill-runtime gates

## Review — Reviewed by Codex adversarial sub-agent — verdict no findings at exact head f67e22d867692e7a155f274ed7c32c7363abf003

Linear: AIO-703
Dependency landed: AIO-718