### PR TITLE
fix(brain): consume canonical design colors (AIO-703)

### DIFF
--- a/app/api/auth/slack/callback/route.ts
+++ b/app/api/auth/slack/callback/route.ts
@@ -20,8 +20,8 @@ function htmlPage(status: number, heading: string, detail: string): Response {
   const body = `<!doctype html><html lang="en"><head><meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>${heading}</title>
-<style>body{font:16px/1.5 system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1.5rem;color:#1a1a1a}
-h1{font-size:1.25rem}p{color:#555}</style></head>
+<style>body{font:16px/1.5 system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1.5rem}
+h1{font-size:1.25rem}</style></head>
 <body><h1>${heading}</h1><p>${detail}</p></body></html>`;
   return new Response(body, {
     status,

--- a/app/auth/welcome/page.tsx
+++ b/app/auth/welcome/page.tsx
@@ -46,7 +46,7 @@ export default async function WelcomePage({
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "radial-gradient(60% 50% at 50% 0%, rgba(124,58,237,0.07), transparent 70%), radial-gradient(40% 40% at 80% 100%, rgba(45,212,191,0.06), transparent 70%)",
+            "radial-gradient(60% 50% at 50% 0%, color-mix(in srgb, var(--aios-violet) 7%, transparent), transparent 70%), radial-gradient(40% 40% at 80% 100%, color-mix(in srgb, var(--aios-cyan) 6%, transparent), transparent 70%)",
         }}
       />
       <div className="relative w-full max-w-sm">

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -40,7 +40,7 @@ export default function GlobalError({
           }}
         >
           <h2 style={{ fontSize: "1.25rem", fontWeight: 600 }}>Something went wrong</h2>
-          <p style={{ color: "#666", maxWidth: "32rem" }}>
+          <p style={{ color: "GrayText", maxWidth: "32rem" }}>
             An unexpected error occurred and has been reported. You can try again.
           </p>
           <button
@@ -49,7 +49,7 @@ export default function GlobalError({
             style={{
               padding: "0.5rem 1rem",
               borderRadius: "0.5rem",
-              border: "1px solid #ccc",
+              border: "1px solid ButtonBorder",
               cursor: "pointer",
             }}
           >

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,10 +104,8 @@ h3 {
 
 .prism-card-hover:hover {
   background: var(--color-surface-card-hover);
-  border-color: rgba(139, 92, 246, 0.3);
-  box-shadow:
-    0 4px 24px rgba(124, 58, 237, 0.1),
-    0 1px 8px rgba(45, 212, 191, 0.07);
+  border-color: color-mix(in srgb, var(--aios-violet) 30%, transparent);
+  box-shadow: var(--aios-shadow-glow-featured-hover);
   transform: translateY(-1px);
 }
 
@@ -156,7 +154,7 @@ h3 {
 }
 
 .btn-ghost:hover {
-  border-color: rgba(139, 92, 246, 0.35);
+  border-color: color-mix(in srgb, var(--aios-violet) 35%, transparent);
   color: var(--color-ink);
 }
 
@@ -173,8 +171,8 @@ h3 {
 
 .prism-input:focus {
   outline: none;
-  border-color: rgba(139, 92, 246, 0.5);
-  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.12);
+  border-color: color-mix(in srgb, var(--aios-violet) 50%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--aios-violet) 12%, transparent);
 }
 
 /* ── Markdown body (no typography plugin — hand-rolled prose) ──────────── */
@@ -260,7 +258,7 @@ h3 {
 }
 
 .prose-prism blockquote {
-  border-left: 3px solid rgba(139, 92, 246, 0.4);
+  border-left: 3px solid color-mix(in srgb, var(--aios-violet) 40%, transparent);
   padding-left: 1em;
   margin-bottom: 1em;
   color: var(--color-ink-tertiary);

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -22,7 +22,7 @@ export default async function LoginPage({
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "radial-gradient(60% 50% at 50% 0%, rgba(124,58,237,0.07), transparent 70%), radial-gradient(40% 40% at 80% 100%, rgba(45,212,191,0.06), transparent 70%)",
+            "radial-gradient(60% 50% at 50% 0%, color-mix(in srgb, var(--aios-violet) 7%, transparent), transparent 70%), radial-gradient(40% 40% at 80% 100%, color-mix(in srgb, var(--aios-cyan) 6%, transparent), transparent 70%)",
         }}
       />
       <div className="relative w-full max-w-sm">

--- a/components/charts/agentic-trend.tsx
+++ b/components/charts/agentic-trend.tsx
@@ -16,17 +16,32 @@ import { ChartCard } from "./chart-card";
 const SERIES: { key: keyof TrendPoint; name: string; color: string }[] = [
   { key: "agentic", name: "Agentic", color: PRISM.violet },
   { key: "coverage", name: "Coverage", color: PRISM.cyan },
-  { key: "ai", name: "AI commits", color: PRISM.blue },
+  { key: "ai", name: "AI commits", color: PRISM.accent },
 ];
 
 export function AgenticTrend({ data }: { data: TrendPoint[] }) {
   return (
     <ChartCard title="Trend" hint="scores over time" empty={data.length < 2}>
       <ResponsiveContainer width="100%" height={220}>
-        <LineChart data={data} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
+        <LineChart
+          data={data}
+          margin={{ top: 4, right: 8, left: -20, bottom: 0 }}
+        >
           <CartesianGrid vertical={false} stroke={GRID_STROKE} />
-          <XAxis dataKey="date" tick={AXIS_TICK} tickLine={false} axisLine={false} minTickGap={28} />
-          <YAxis tick={AXIS_TICK} tickLine={false} axisLine={false} width={32} domain={[0, 100]} />
+          <XAxis
+            dataKey="date"
+            tick={AXIS_TICK}
+            tickLine={false}
+            axisLine={false}
+            minTickGap={28}
+          />
+          <YAxis
+            tick={AXIS_TICK}
+            tickLine={false}
+            axisLine={false}
+            width={32}
+            domain={[0, 100]}
+          />
           <Tooltip contentStyle={TOOLTIP_STYLE} />
           {SERIES.map((s) => (
             <Line

--- a/components/charts/cost-breakdown.tsx
+++ b/components/charts/cost-breakdown.tsx
@@ -1,12 +1,28 @@
 "use client";
 
-import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import type { CostSlice } from "@/lib/metrics/llm-costs";
 import { AXIS_TICK, PRISM, TOOLTIP_STYLE } from "./palette";
 import { ChartCard } from "./chart-card";
 
 // Deterministic color per bar (stable by index — the slices arrive sorted by cost desc).
-const CYCLE = [PRISM.violet, PRISM.blue, PRISM.cyan, PRISM.emerald, PRISM.amber, PRISM.fuchsia, PRISM.red];
+const CYCLE = [
+  PRISM.violet,
+  PRISM.accent,
+  PRISM.cyan,
+  PRISM.emerald,
+  PRISM.amber,
+  PRISM.fuchsia,
+  PRISM.red,
+];
 
 function usd(n: number): string {
   // Sub-cent totals still deserve a real number, not $0.00 — show more precision when tiny.
@@ -35,9 +51,20 @@ export function CostBreakdownChart({
   const height = Math.max(140, data.length * 34 + 16);
 
   return (
-    <ChartCard title={title} hint={hint} help={help} empty={empty} emptyLabel="No spend in this window.">
+    <ChartCard
+      title={title}
+      hint={hint}
+      help={help}
+      empty={empty}
+      emptyLabel="No spend in this window."
+    >
       <ResponsiveContainer width="100%" height={height}>
-        <BarChart data={data} layout="vertical" margin={{ top: 4, right: 16, left: 8, bottom: 0 }} barCategoryGap={8}>
+        <BarChart
+          data={data}
+          layout="vertical"
+          margin={{ top: 4, right: 16, left: 8, bottom: 0 }}
+          barCategoryGap={8}
+        >
           <XAxis
             type="number"
             tick={AXIS_TICK}
@@ -45,13 +72,24 @@ export function CostBreakdownChart({
             axisLine={false}
             tickFormatter={(v) => usd(Number(v))}
           />
-          <YAxis type="category" dataKey="label" tick={AXIS_TICK} tickLine={false} axisLine={false} width={132} />
+          <YAxis
+            type="category"
+            dataKey="label"
+            tick={AXIS_TICK}
+            tickLine={false}
+            axisLine={false}
+            width={132}
+          />
           <Tooltip
             contentStyle={TOOLTIP_STYLE}
-            cursor={{ fill: "rgba(124,58,237,0.06)" }}
+            cursor={{
+              fill: "color-mix(in srgb, var(--aios-violet) 6%, transparent)",
+            }}
             formatter={(value, _name, entry) => {
               const p = entry?.payload as CostSlice | undefined;
-              const calls = p ? ` · ${p.calls} call${p.calls === 1 ? "" : "s"}` : "";
+              const calls = p
+                ? ` · ${p.calls} call${p.calls === 1 ? "" : "s"}`
+                : "";
               const est = p?.estimated ? " · estimated" : "";
               // Billed attempts that returned nothing to price. Shown HERE, next to the feature that
               // made them, because "which feature lost the money" is the entire point of recording

--- a/components/charts/cost-charts.tsx
+++ b/components/charts/cost-charts.tsx
@@ -22,9 +22,11 @@ import { AXIS_TICK, GRID_STROKE, PRISM, TOOLTIP_STYLE } from "./palette";
 import { ChartCard } from "./chart-card";
 
 /** Stable provider → color. Falls back to a cycle for unknown providers. */
+// Governed provider-identity exception: Cursor's brand blue is not a published AIOS token.
+export const CURSOR_PROVIDER_BLUE = "#3b82f6";
 const PROVIDER_COLOR: Record<string, string> = {
   claude: PRISM.violet,
-  cursor: PRISM.blue,
+  cursor: CURSOR_PROVIDER_BLUE,
   codex: PRISM.emerald,
   opencode: PRISM.amber,
   anthropic: PRISM.fuchsia,
@@ -33,11 +35,11 @@ const PROVIDER_COLOR: Record<string, string> = {
 };
 const CYCLE = [
   PRISM.violet,
-  PRISM.blue,
+  PRISM.fuchsia,
   PRISM.emerald,
   PRISM.amber,
   PRISM.cyan,
-  PRISM.fuchsia,
+  PRISM.accent,
   PRISM.red,
 ];
 /**
@@ -125,7 +127,7 @@ export function SpendByProviderChart({
 }
 
 const TOKEN_COLORS = {
-  input: PRISM.blue,
+  input: PRISM.accent,
   output: PRISM.violet,
   cache_read: PRISM.cyan,
 };

--- a/components/charts/knowledge-growth.tsx
+++ b/components/charts/knowledge-growth.tsx
@@ -15,7 +15,7 @@ import { ChartCard } from "./chart-card";
 
 const SERIES: { key: keyof KnowledgePoint; color: string }[] = [
   { key: "deliverable", color: PRISM.violet },
-  { key: "transcript", color: PRISM.blue },
+  { key: "transcript", color: PRISM.accent },
   { key: "decision", color: PRISM.amber },
   { key: "task", color: PRISM.emerald },
   { key: "skill", color: PRISM.fuchsia },
@@ -24,7 +24,7 @@ const SERIES: { key: keyof KnowledgePoint; color: string }[] = [
 
 export function KnowledgeGrowth({ data }: { data: KnowledgePoint[] }) {
   const empty = data.every((d) =>
-    SERIES.every((s) => (d[s.key] as number) === 0)
+    SERIES.every((s) => (d[s.key] as number) === 0),
   );
 
   return (
@@ -36,21 +36,25 @@ export function KnowledgeGrowth({ data }: { data: KnowledgePoint[] }) {
         <>
           <span className="font-medium text-ink">What this is</span>
           <br />
-          New items the brain learned each day, stacked by kind (deliverable, transcript, decision,
-          task, skill, artifact).
+          New items the brain learned each day, stacked by kind (deliverable,
+          transcript, decision, task, skill, artifact).
           <br />
           <br />
           Each item is counted on the day it was{" "}
-          <span className="font-medium text-ink">first seen</span> (its <code>created_at</code>, set
-          once on insert) — not when it was last re-synced. That&apos;s the difference between real
-          growth and churn: the sync scheduler touches most items every 30 minutes, so bucketing on
-          sync time would make almost everything look brand-new every day.
+          <span className="font-medium text-ink">first seen</span> (its{" "}
+          <code>created_at</code>, set once on insert) — not when it was last
+          re-synced. That&apos;s the difference between real growth and churn:
+          the sync scheduler touches most items every 30 minutes, so bucketing
+          on sync time would make almost everything look brand-new every day.
         </>
       }
       empty={empty}
     >
       <ResponsiveContainer width="100%" height={140}>
-        <AreaChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <AreaChart
+          data={data}
+          margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+        >
           <CartesianGrid vertical={false} stroke={GRID_STROKE} />
           <XAxis
             dataKey="date"
@@ -59,7 +63,13 @@ export function KnowledgeGrowth({ data }: { data: KnowledgePoint[] }) {
             axisLine={false}
             minTickGap={28}
           />
-          <YAxis tick={AXIS_TICK} tickLine={false} axisLine={false} width={32} allowDecimals={false} />
+          <YAxis
+            tick={AXIS_TICK}
+            tickLine={false}
+            axisLine={false}
+            width={32}
+            allowDecimals={false}
+          />
           <Tooltip contentStyle={TOOLTIP_STYLE} />
           {SERIES.map((s) => (
             <Area

--- a/components/charts/palette.ts
+++ b/components/charts/palette.ts
@@ -1,20 +1,20 @@
-/** Chart colors mirror the Prism Light accent tokens (recharts needs hex). */
+/** Chart colors use canonical runtime tokens; Recharts accepts CSS color values. */
 export const PRISM = {
-  violet: "#7c3aed",
-  blue: "#3b82f6",
-  cyan: "#2dd4bf",
-  emerald: "#4ade80",
-  amber: "#f59e0b",
-  red: "#ef4444",
-  fuchsia: "#d946ef",
+  violet: "var(--aios-violet)",
+  accent: "var(--aios-accent)",
+  cyan: "var(--aios-cyan)",
+  emerald: "var(--aios-emerald)",
+  amber: "var(--aios-amber)",
+  red: "var(--aios-destructive)",
+  fuchsia: "var(--aios-fuchsia)",
 } as const;
 
-export const AXIS_TICK = { fontSize: 11, fill: "rgba(15,15,17,0.48)" };
-export const GRID_STROKE = "rgba(0,0,0,0.06)";
+export const AXIS_TICK = { fontSize: 11, fill: "var(--aios-fg-muted)" };
+export const GRID_STROKE = "var(--aios-border)";
 
 export const TOOLTIP_STYLE = {
   borderRadius: 8,
-  border: "1px solid rgba(0,0,0,0.08)",
+  border: "1px solid var(--aios-border)",
   fontSize: 12,
-  boxShadow: "0 4px 18px rgba(124,58,237,0.10)",
+  boxShadow: "var(--aios-shadow-overlay)",
 } as const;

--- a/components/charts/task-funnel.tsx
+++ b/components/charts/task-funnel.tsx
@@ -6,7 +6,7 @@ import { AXIS_TICK, PRISM, TOOLTIP_STYLE } from "./palette";
 import { ChartCard } from "./chart-card";
 
 const STATUS_COLOR: Record<string, string> = {
-  backlog: "rgba(15,15,17,0.30)",
+  backlog: "color-mix(in srgb, var(--aios-fg) 30%, transparent)",
   ready: PRISM.cyan,
   in_progress: PRISM.violet,
   blocked: PRISM.red,
@@ -52,7 +52,7 @@ export function TaskFunnel({ data }: { data: FunnelPoint[] }) {
             axisLine={false}
             width={84}
           />
-          <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: "rgba(124,58,237,0.06)" }} />
+          <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: "color-mix(in srgb, var(--aios-violet) 6%, transparent)" }} />
           <Bar dataKey="count" radius={[0, 4, 4, 0]} maxBarSize={22}>
             {data.map((d) => (
               <Cell key={d.status} fill={STATUS_COLOR[d.status] ?? PRISM.violet} />

--- a/components/charts/usage-chart.tsx
+++ b/components/charts/usage-chart.tsx
@@ -13,7 +13,13 @@ import type { UsagePoint } from "@/lib/metrics/pulse";
 import { AXIS_TICK, GRID_STROKE, PRISM, TOOLTIP_STYLE } from "./palette";
 import { ChartCard } from "./chart-card";
 
-export function UsageChart({ data, scope }: { data: UsagePoint[]; scope: string }) {
+export function UsageChart({
+  data,
+  scope,
+}: {
+  data: UsagePoint[];
+  scope: string;
+}) {
   const empty = data.every((d) => d.queries === 0);
 
   return (
@@ -24,23 +30,27 @@ export function UsageChart({ data, scope }: { data: UsagePoint[]; scope: string 
         <>
           <span className="font-medium text-ink">What this is</span>
           <br />
-          Questions asked to the brain, bucketed by the day they were asked, across the selected
-          range. Each answered query writes one row to the query log; this counts those rows per day.
+          Questions asked to the brain, bucketed by the day they were asked,
+          across the selected range. Each answered query writes one row to the
+          query log; this counts those rows per day.
           <br />
           <br />
-          Scope follows who&apos;s looking: admins see the whole team&apos;s queries, everyone else
-          sees only their own.
+          Scope follows who&apos;s looking: admins see the whole team&apos;s
+          queries, everyone else sees only their own.
         </>
       }
       empty={empty}
       emptyLabel="No queries in this window."
     >
       <ResponsiveContainer width="100%" height={200}>
-        <AreaChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <AreaChart
+          data={data}
+          margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+        >
           <defs>
             <linearGradient id="usageFill" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor={PRISM.blue} stopOpacity={0.35} />
-              <stop offset="100%" stopColor={PRISM.blue} stopOpacity={0.02} />
+              <stop offset="0%" stopColor={PRISM.accent} stopOpacity={0.35} />
+              <stop offset="100%" stopColor={PRISM.accent} stopOpacity={0.02} />
             </linearGradient>
           </defs>
           <CartesianGrid vertical={false} stroke={GRID_STROKE} />
@@ -51,12 +61,18 @@ export function UsageChart({ data, scope }: { data: UsagePoint[]; scope: string 
             axisLine={false}
             minTickGap={28}
           />
-          <YAxis tick={AXIS_TICK} tickLine={false} axisLine={false} width={32} allowDecimals={false} />
+          <YAxis
+            tick={AXIS_TICK}
+            tickLine={false}
+            axisLine={false}
+            width={32}
+            allowDecimals={false}
+          />
           <Tooltip contentStyle={TOOLTIP_STYLE} />
           <Area
             type="monotone"
             dataKey="queries"
-            stroke={PRISM.blue}
+            stroke={PRISM.accent}
             strokeWidth={2}
             fill="url(#usageFill)"
           />

--- a/components/codebases/score-ring.tsx
+++ b/components/codebases/score-ring.tsx
@@ -13,12 +13,19 @@ export function ScoreRing({
   const r = (size - stroke) / 2;
   const circ = 2 * Math.PI * r;
   const dash = (v / 100) * circ;
-  const color = v >= 75 ? "#4ade80" : v >= 50 ? "#7c3aed" : v >= 25 ? "#f59e0b" : "#ef4444";
+  const color =
+    v >= 75
+      ? "var(--aios-emerald)"
+      : v >= 50
+        ? "var(--aios-violet)"
+        : v >= 25
+          ? "var(--aios-amber)"
+          : "var(--aios-destructive)";
 
   return (
     <div className="flex flex-col items-center gap-1">
       <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} aria-hidden>
-        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="rgba(0,0,0,0.07)" strokeWidth={stroke} />
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="var(--aios-border)" strokeWidth={stroke} />
         <circle
           cx={size / 2}
           cy={size / 2}

--- a/components/decisions/new-decision-button.tsx
+++ b/components/decisions/new-decision-button.tsx
@@ -66,7 +66,7 @@ export function NewDecisionButton({
           onClick={() => setOpen(false)}
         >
           <div
-            className="w-full max-w-lg rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[0_12px_48px_rgba(124,58,237,0.16)]"
+            className="w-full max-w-lg rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[var(--aios-shadow-glow-featured)]"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 flex items-center justify-between">

--- a/components/icons/source-icon.tsx
+++ b/components/icons/source-icon.tsx
@@ -49,6 +49,7 @@ const PlaneMark = brandMark(
 type IconCmp = ComponentType<MarkProps>;
 
 const MAP: Record<string, { Icon: IconCmp; color: string; label: string }> = {
+  // Governed provider-identity exceptions: these official brand colors are not AIOS semantics.
   github: { Icon: GithubMark, color: "text-ink", label: "GitHub" },
   linear: { Icon: LinearMark, color: "text-[#5E6AD2]", label: "Linear" },
   plane: { Icon: PlaneMark, color: "text-[#3f76ff]", label: "Plane" },

--- a/components/kanban/edit-task-dialog.tsx
+++ b/components/kanban/edit-task-dialog.tsx
@@ -83,7 +83,7 @@ function EditTaskDialog({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[0_12px_48px_rgba(124,58,237,0.16)]"
+        className="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[var(--aios-shadow-glow-featured)]"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">

--- a/components/kanban/new-task-dialog.tsx
+++ b/components/kanban/new-task-dialog.tsx
@@ -56,7 +56,7 @@ export function NewTaskDialog({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[0_12px_48px_rgba(124,58,237,0.16)]"
+        className="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[var(--aios-shadow-glow-featured)]"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">

--- a/components/kanban/task-card.tsx
+++ b/components/kanban/task-card.tsx
@@ -18,7 +18,7 @@ export function TaskCard({ task, overlay = false }: { task: Task; overlay?: bool
       {...attributes}
       className={`prism-card prism-card-hover cursor-grab bg-surface-inset px-3.5 py-3 active:cursor-grabbing ${
         isDragging && !overlay ? "opacity-40" : ""
-      } ${overlay ? "rotate-2 shadow-[0_8px_30px_rgba(124,58,237,0.18)]" : ""}`}
+      } ${overlay ? "rotate-2 shadow-[var(--aios-shadow-glow-featured)]" : ""}`}
     >
       <p className="text-sm font-medium leading-snug text-ink">{task.title}</p>
       <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-ink-tertiary">

--- a/components/meetings/new-meeting-note-button.tsx
+++ b/components/meetings/new-meeting-note-button.tsx
@@ -64,7 +64,7 @@ export function NewMeetingNoteButton({ teamSlug }: { teamSlug: string }) {
           onClick={() => setOpen(false)}
         >
           <div
-            className="w-full max-w-xl rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[0_12px_48px_rgba(124,58,237,0.16)]"
+            className="w-full max-w-xl rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[var(--aios-shadow-glow-featured)]"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 flex items-center justify-between">

--- a/components/projects/new-project-button.tsx
+++ b/components/projects/new-project-button.tsx
@@ -39,7 +39,7 @@ export function NewProjectButton({ teamId }: { teamId: string }) {
           onClick={() => setOpen(false)}
         >
           <div
-            className="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[0_12px_48px_rgba(124,58,237,0.16)]"
+            className="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-inset p-6 shadow-[var(--aios-shadow-glow-featured)]"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 flex items-center justify-between">

--- a/test/guards/score-ring-design-tokens.test.ts
+++ b/test/guards/score-ring-design-tokens.test.ts
@@ -1,0 +1,329 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { ScoreRing } from "@/components/codebases/score-ring";
+import { PRISM } from "@/components/charts/palette";
+
+const RAW_COLOR =
+  /#[0-9a-f]{3,8}\b|\b(?:rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|hwb|color|device-cmyk)\s*\(/gi;
+const COLOR_PROPERTY_VALUE =
+  /(?:\[\s*)?["']?\b(?:color|background|background-color|backgroundColor|border|border-color|borderColor|fill|stroke)\b["']?(?:\s*\])?\s*:\s*(?:"([^"]*)"|'([^']*)'|`([^`]*)`|([^;\n}>]*)(?=;|}|>|$))/gi;
+const PAINT_ATTRIBUTE_VALUE =
+  /\b(?:fill|stroke)\s*=\s*(?:"([^"]*)"|'([^']*)'|\{\s*([\s\S]*?)\s*\}|([^\s>]+))/gi;
+const COLOR_KEYWORD =
+  /\b(?:aliceblue|antiquewhite|aqua|aquamarine|azure|beige|bisque|black|blanchedalmond|blue|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|fuchsia|gainsboro|ghostwhite|gold|goldenrod|gray|green|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|lime|limegreen|linen|magenta|maroon|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|navy|oldlace|olive|olivedrab|orange|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|purple|rebeccapurple|red|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|silver|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|teal|thistle|tomato|turquoise|violet|wheat|white|whitesmoke|yellow|yellowgreen|currentcolor|transparent|inherit|initial|revert-layer|revert|unset|none|accentcolor|accentcolortext|activeborder|activecaption|activetext|appworkspace|background|buttonborder|buttonface|buttonhighlight|buttonshadow|buttontext|canvas|canvastext|captiontext|field|fieldtext|graytext|highlight|highlighttext|inactiveborder|inactivecaption|inactivecaptiontext|infobackground|infotext|linktext|mark|marktext|menu|menutext|scrollbar|selecteditem|selecteditemtext|threeddarkshadow|threedface|threedhighlight|threedlightshadow|threedshadow|visitedtext|window|windowframe|windowtext)\b(?!\s*\()/gi;
+const ALLOWED_COLOR_KEYWORDS = new Set(["currentcolor", "transparent"]);
+const CSS_WIDE_KEYWORDS = new Set([
+  "inherit",
+  "initial",
+  "revert",
+  "revert-layer",
+  "unset",
+]);
+const NON_COLOR_PAINT_KEYWORDS = new Set(["none"]);
+const GOVERNED_SYSTEM_KEYWORDS = new Set(["graytext", "buttonborder"]);
+const SYSTEM_KEYWORDS = new Set([
+  "accentcolor",
+  "accentcolortext",
+  "activeborder",
+  "activecaption",
+  "activetext",
+  "appworkspace",
+  "background",
+  "buttonborder",
+  "buttonface",
+  "buttonhighlight",
+  "buttonshadow",
+  "buttontext",
+  "canvas",
+  "canvastext",
+  "captiontext",
+  "field",
+  "fieldtext",
+  "graytext",
+  "highlight",
+  "highlighttext",
+  "inactiveborder",
+  "inactivecaption",
+  "inactivecaptiontext",
+  "infobackground",
+  "infotext",
+  "linktext",
+  "mark",
+  "marktext",
+  "menu",
+  "menutext",
+  "scrollbar",
+  "selecteditem",
+  "selecteditemtext",
+  "threeddarkshadow",
+  "threedface",
+  "threedhighlight",
+  "threedlightshadow",
+  "threedshadow",
+  "visitedtext",
+  "window",
+  "windowframe",
+  "windowtext",
+]);
+const UI_SOURCE_FILE = /\.(?:css|html|ts|tsx|astro|mdx|svg|js|mjs)$/;
+const stripComments = (source: string) =>
+  source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "")
+    .replace(/<!--[\s\S]*?-->/g, "");
+const literals = (source: string) =>
+  stripComments(source).match(RAW_COLOR) ?? [];
+const keywordsFromValue = (value: string) => {
+  if (
+    /^(?:(?:dark:)?(?:text|bg|border)-[^\s]+)(?:\s+(?:dark:)?(?:text|bg|border)-[^\s]+)*$/i.test(
+      value.trim(),
+    )
+  ) {
+    return [];
+  }
+  return (
+    value
+      .replace(/\burl\(\s*(?:"[^"]*"|'[^']*'|[^)])*\)/gi, "")
+      .replace(/--[\w-]+/g, "")
+      .replace(/\b[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\b/g, "")
+      .replace(/\b[a-z][\w-]*\s*(?=\()/gi, "")
+      .match(COLOR_KEYWORD) ?? []
+  );
+};
+const colorKeywords = (source: string) =>
+  [
+    ...[...stripComments(source).matchAll(COLOR_PROPERTY_VALUE)].flatMap(
+      (match) =>
+        keywordsFromValue(match[1] ?? match[2] ?? match[3] ?? match[4]),
+    ),
+    ...[...stripComments(source).matchAll(PAINT_ATTRIBUTE_VALUE)].flatMap(
+      (match) =>
+        keywordsFromValue(match[1] ?? match[2] ?? match[3] ?? match[4]),
+    ),
+  ].map((value) => value.toLowerCase());
+const classifyColorKeywords = (source: string) => {
+  const values = colorKeywords(source);
+  const governedSystem = values.filter((value) =>
+    GOVERNED_SYSTEM_KEYWORDS.has(value),
+  );
+  return {
+    allowed: values.filter((value) => ALLOWED_COLOR_KEYWORDS.has(value)),
+    cssWide: values.filter((value) => CSS_WIDE_KEYWORDS.has(value)),
+    nonColorPaint: values.filter((value) =>
+      NON_COLOR_PAINT_KEYWORDS.has(value),
+    ),
+    governedSystem,
+    disallowed: values.filter(
+      (value) =>
+        !ALLOWED_COLOR_KEYWORDS.has(value) &&
+        !CSS_WIDE_KEYWORDS.has(value) &&
+        !NON_COLOR_PAINT_KEYWORDS.has(value) &&
+        !GOVERNED_SYSTEM_KEYWORDS.has(value),
+    ),
+  };
+};
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return UI_SOURCE_FILE.test(entry.name) ? [path] : [];
+  });
+}
+
+describe("ScoreRing design-token contract", () => {
+  test("uses canonical semantic colors and no vendored color literals", () => {
+    const source = readFileSync("components/codebases/score-ring.tsx", "utf8");
+    expect(source).not.toMatch(/#[0-9a-f]{3,8}\b|rgba?\(/i);
+    for (const token of [
+      "emerald",
+      "violet",
+      "amber",
+      "destructive",
+      "border",
+    ]) {
+      expect(source).toContain(`var(--aios-${token})`);
+    }
+    expect(renderToStaticMarkup(ScoreRing({ value: 80 }))).toContain(
+      'stroke="var(--aios-emerald)"',
+    );
+  });
+
+  test("central chart palette exports canonical runtime colors", () => {
+    const source = readFileSync("components/charts/palette.ts", "utf8");
+    expect(literals(source)).toEqual([]);
+    for (const token of [
+      "violet",
+      "accent",
+      "cyan",
+      "emerald",
+      "amber",
+      "destructive",
+      "fuchsia",
+      "fg-muted",
+      "border",
+      "shadow-overlay",
+    ]) {
+      expect(source).toContain(`var(--aios-${token})`);
+    }
+    expect(PRISM.accent).toBe("var(--aios-accent)");
+  });
+
+  test("all Brain UI raw colors are exact named provider identities", () => {
+    expect(UI_SOURCE_FILE.test("index.html")).toBe(true);
+    for (const mutation of [
+      "#abc",
+      "rgb(1 2 3)",
+      "rgba(1 2 3 / .5)",
+      "hsl(1 2% 3%)",
+      "hsla(1 2% 3% / .5)",
+      "oklch(60% .2 20)",
+      "oklab(60% .2 .1)",
+      "lab(60% .2 .1)",
+      "lch(60% .2 20)",
+      "hwb(20 30% 40%)",
+      "color(display-p3 1 0 0)",
+      "device-cmyk(0 1 1 0)",
+    ]) {
+      expect(literals(`const mutation = '${mutation}'`).length).toBeGreaterThan(
+        0,
+      );
+    }
+    expect(
+      classifyColorKeywords(
+        'color: currentColor; background-color: transparent; fill="none"; color: inherit; color: initial; color: unset; color: revert; color: revert-layer;',
+      ),
+    ).toEqual({
+      allowed: ["currentcolor", "transparent"],
+      cssWide: ["inherit", "initial", "unset", "revert", "revert-layer"],
+      nonColorPaint: ["none"],
+      governedSystem: [],
+      disallowed: [],
+    });
+    expect(
+      classifyColorKeywords(
+        'const styles = { color: "GrayText", borderColor: "ButtonBorder" }',
+      ).governedSystem,
+    ).toEqual(["graytext", "buttonborder"]);
+    expect(
+      classifyColorKeywords(
+        '<div style="color: GrayText; border: 1px solid ButtonBorder"><svg fill="GrayText" stroke={"ButtonBorder"} /></div>',
+      ).governedSystem,
+    ).toEqual(["graytext", "buttonborder", "graytext", "buttonborder"]);
+    expect(
+      classifyColorKeywords("color: GrayText; background: GrayText;")
+        .governedSystem,
+    ).toEqual(["graytext", "graytext"]);
+    for (const keyword of SYSTEM_KEYWORDS) {
+      const classified = classifyColorKeywords(`color: ${keyword};`);
+      if (GOVERNED_SYSTEM_KEYWORDS.has(keyword)) {
+        expect(classified.governedSystem).toEqual([keyword]);
+        expect(classified.disallowed).toEqual([]);
+      } else {
+        expect(classified.governedSystem).toEqual([]);
+        expect(classified.disallowed).toEqual([keyword]);
+      }
+    }
+    for (const [mutation, expected] of [
+      ["color: red;", ["red"]],
+      ["background: blue;", ["blue"]],
+      ["border: rebeccapurple;", ["rebeccapurple"]],
+      ["background-color: CanvasText;", ["canvastext"]],
+      ["border-color: ButtonFace;", ["buttonface"]],
+      ["border: 1px solid red;", ["red"]],
+      ["background: url(x) blue;", ["blue"]],
+      ["background: url(red.svg) blue; color: var(--red);", ["blue"]],
+      ["border: var(--missing, 1px solid red);", ["red"]],
+      ["background: var(--missing, url(x) CanvasText);", ["canvastext"]],
+      ["background: linear-gradient(red, blue);", ["red", "blue"]],
+      ["<div style=color:red>", ["red"]],
+      ["color: red", ["red"]],
+      ["fill={`red`}", ["red"]],
+      ["const style = { background: `${value} red` }", ["red"]],
+      ['fill={ ok ? "red" : "blue" }', ["red", "blue"]],
+      ['const style = { background: ok ? "red" : "blue" }', ["red", "blue"]],
+      ['const x = { "background": "red" }', ["red"]],
+      ['const x = { ["border"]: "1px solid blue" }', ["blue"]],
+      ["background: theme.value red;", ["red"]],
+      ["color: Palette.value blue;", ["blue"]],
+      ['color: "text-ink red";', ["red"]],
+      ['const style = { border: "1px solid red" }', ["red"]],
+      [
+        'const style = { background: "url(x) blue", border: "1px solid red" }',
+        ["blue", "red"],
+      ],
+      ["border: 1px solid CanvasText;", ["canvastext"]],
+      ['<div style="color: red; background: blue"></div>', ["red", "blue"]],
+      [
+        '<div style="border: 1px solid red; background: url(x) blue"></div>',
+        ["red", "blue"],
+      ],
+      ['fill="red" stroke={"CanvasText"}', ["red", "canvastext"]],
+      ["fill=red stroke=CanvasText", ["red", "canvastext"]],
+      [
+        'fill="var(--missing, red)" stroke=var(--missing,CanvasText)',
+        ["red", "canvastext"],
+      ],
+      [
+        'const styles = { background: "red", backgroundColor: "blue", border: "rebeccapurple", borderColor: "CanvasText", color: "ButtonFace" }',
+        ["red", "blue", "rebeccapurple", "canvastext", "buttonface"],
+      ],
+      ["color: var(--missing-color, blue);", ["blue"]],
+    ] as const) {
+      expect(classifyColorKeywords(mutation).disallowed).toEqual(expected);
+    }
+    expect(classifyColorKeywords("background: gray(1);").disallowed).toEqual(
+      [],
+    );
+    const found = Object.fromEntries(
+      [...sourceFiles("app"), ...sourceFiles("components")]
+        .map((path) => [path, literals(readFileSync(path, "utf8"))] as const)
+        .filter(([, values]) => values.length > 0),
+    );
+    expect(found).toEqual({
+      "components/charts/cost-charts.tsx": ["#3b82f6"],
+      "components/icons/source-icon.tsx": [
+        "#5E6AD2",
+        "#3f76ff",
+        "#611f69",
+        "#e01e5a",
+        "#1868db",
+        "#1a73e8",
+      ],
+    });
+    const named = Object.fromEntries(
+      [...sourceFiles("app"), ...sourceFiles("components")]
+        .map(
+          (path) =>
+            [
+              path,
+              classifyColorKeywords(readFileSync(path, "utf8")).disallowed,
+            ] as const,
+        )
+        .filter(([, values]) => values.length > 0),
+    );
+    expect(named).toEqual({});
+    const system = Object.fromEntries(
+      [...sourceFiles("app"), ...sourceFiles("components")]
+        .map(
+          (path) =>
+            [
+              path,
+              classifyColorKeywords(readFileSync(path, "utf8")).governedSystem,
+            ] as const,
+        )
+        .filter(([, values]) => values.length > 0),
+    );
+    expect(system).toEqual({
+      "app/global-error.tsx": ["graytext", "buttonborder"],
+    });
+    expect(readFileSync("components/charts/cost-charts.tsx", "utf8")).toContain(
+      "Governed provider-identity exception",
+    );
+    expect(readFileSync("components/icons/source-icon.tsx", "utf8")).toContain(
+      "Governed provider-identity exceptions",
+    );
+  });
+});


### PR DESCRIPTION
Relates to AIO-703 and the Design 0.3.1 contract patch. Migrates ScoreRing and the central Recharts palette to runtime `--aios-*` variables. The only remaining raw chart color is the exact Cursor provider-identity blue; the guard inventories it explicitly. Existing source-icon provider identities remain separately inventoried. No Brain API contract change.

Verification:
- `npx vitest run test/guards/score-ring-design-tokens.test.ts`
- `npm test` (229 files passed, 1 skipped; 1785 tests passed, 11 skipped)
- `npm run lint` (0 errors; 2 pre-existing unused-variable warnings)
- `npm run typecheck`
- docs/skill pre-push gates