### PR TITLE
feat(AIO-785): materialize durable codebase finding lifecycle

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,6 +215,16 @@ evidence completeness, fail-closed quality/automation admission, per-dimension e
 and redacted stable findings in the existing provenance-only `code_metrics.codebase_health`
 JSONB column. It does not grant Team Brain repository-write or remediation authority.
 
+AIO-785 materializes those redacted v2 findings into `codebase_findings` (one current row per
+team/codebase/fingerprint) and append-only `codebase_finding_events`. The only writer remains
+`lib/codebases/ingest`, which calls the atomic `reconcile_codebase_findings` Postgres function
+after the metrics point is persisted. Replaying one metrics point is idempotent; reconciliation
+is serialized per codebase; an older analysis cannot replace active state (a previously unseen
+historical fingerprint is retained as `stale_analysis`); and only a complete, current v2 snapshot
+may resolve an absent open finding.
+`lib/metrics/codebases.getCodebaseDetail` is the sole team-tier read and returns current state
+plus lifecycle history. The ledger stores no path, symbol, source text, or diagnostic prose.
+
 Two principals, one tier model:
 
 - **Humans** — invite-only, two sign-in mechanisms:
@@ -839,7 +849,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 `gateway_executions` · `gateway_approvals` · `gateway_audit_log` · `gateway_rate_limits` · `rate_limits` ·
 `projects` · `items` · `item_versions` · `tasks` · `decisions` · `extracted_facts` · `stakeholder_mentions` · `graph_entities` ·
 `graph_relationships` · `query_log` · `policies` · `approval_requests` · `actions` ·
-`codebases` · `code_metrics` · `code_contributions` · `github_issues` · `member_emails` ·
+`codebases` · `code_metrics` · `codebase_findings` · `codebase_finding_events` · `code_contributions` · `github_issues` · `member_emails` ·
 `member_identities` · `member_secrets` · `member_profiles` · `member_time_off` · `member_goals` · `member_provisioning` · `integrations` ·
 `agentic_maturity_snapshots` · `task_pm_links` · `task_evidence` · `work_events` · `usage_costs` · `llm_usage` · `llm_failures` · `subscriptions` · `graph_episodes` · `arc_cache` · `arc_corrections` · `work_timeline_cache` · `doc_task_inference` ·
 `conversations` · `chat_messages` · `ingest_runs` · `social_jobs` · `brand_profiles` · `brand_assets` · `social_opportunities` · `content_plans` · `content_variants` · `media_assets` · `social_image_usage` · `social_settings` · `content_approvals` · `social_publications` · `publication_analytics` ·

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -245,6 +245,17 @@ railway run -s Postgres bash -lc \
   are idempotent by design (`create table if not exists`, `alter table … add column if not
 exists` — see `postgres/migrations/README.md`), so re-running it after a restore is always safe.
 
+### Codebase finding-ledger rollback
+
+Migration `20260804120000_codebase_finding_ledger.sql` adds only derived, redacted lifecycle
+state. The authoritative scan snapshots remain in `code_metrics.codebase_health`. If the ledger
+must be removed before a dependent Phase 1 release, first take and verify a backup, stop scan
+ingest, deploy code that no longer calls `reconcile_codebase_findings`, drop that function, then
+drop `codebase_finding_events` before `codebase_findings`. Dropping either table destroys lifecycle
+history and is therefore a human-approved rollback, never an automatic migration step. Re-running
+`npm run pg:schema` recreates the empty tables and function; the current migration does not
+backfill old snapshots or guess historical transitions.
+
 ---
 
 ## 6. API-key rotation — `scripts/admin.ts`

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -273,16 +273,27 @@ export const githubIssueSchema = z.object({
   closed_at: z.string().nullable().optional(),
 });
 
-export const codebaseScanPayloadSchema = z.object({
-  codebase: codebaseRecordSchema,
-  metrics: codeMetricsSchema,
-  contributions: z
-    .array(codeContributionSchema)
-    .max(5000)
-    .optional()
-    .default([]),
-  issues: z.array(githubIssueSchema).max(5000).optional().default([]),
-});
+export const codebaseScanPayloadSchema = z
+  .object({
+    codebase: codebaseRecordSchema,
+    metrics: codeMetricsSchema,
+    contributions: z
+      .array(codeContributionSchema)
+      .max(5000)
+      .optional()
+      .default([]),
+    issues: z.array(githubIssueSchema).max(5000).optional().default([]),
+  })
+  .superRefine((payload, context) => {
+    const health = payload.metrics.codebase_health;
+    if (health?.schema_version === "2" && health.head_sha !== payload.metrics.head_sha) {
+      context.addIssue({
+        code: "custom",
+        path: ["metrics", "codebase_health", "head_sha"],
+        message: "codebase health head_sha must match metrics head_sha",
+      });
+    }
+  });
 export type CodebaseScanPayload = z.infer<typeof codebaseScanPayloadSchema>;
 
 // AEM individual-scope maturity signals (ratios + counts; the entire privacy

--- a/lib/codebases/finding-ledger.ts
+++ b/lib/codebases/finding-ledger.ts
@@ -1,0 +1,103 @@
+import type { CodebaseHealth } from "@/lib/api/schemas";
+import type { DbClient } from "@/lib/db/types";
+
+export type FindingStatus =
+  | "open"
+  | "accepted"
+  | "resolved"
+  | "reopened"
+  | "false_positive"
+  | "risk_accepted"
+  | "superseded"
+  | "stale_analysis";
+
+export type FindingEventType =
+  | "detected"
+  | "observed"
+  | "resolved"
+  | "reopened"
+  | "stale_analysis";
+
+export type FindingTransition = {
+  status: FindingStatus;
+  event: FindingEventType;
+  mutatesCurrent: boolean;
+};
+
+type EvidenceStatus = "complete" | "partial" | "missing" | "stale" | "error";
+
+/**
+ * Pure mirror of the database lifecycle rules. The SQL function is the atomic writer;
+ * this helper keeps the fail-closed transition contract executable in fast unit tests.
+ */
+export function decideFindingTransition(input: {
+  currentStatus: FindingStatus | null;
+  present: boolean;
+  evidenceStatus: EvidenceStatus;
+  olderThanCurrent?: boolean;
+}): FindingTransition | null {
+  const { currentStatus, present, evidenceStatus, olderThanCurrent = false } = input;
+
+  if (olderThanCurrent) {
+    if (currentStatus) {
+      return { status: currentStatus, event: "stale_analysis", mutatesCurrent: false };
+    }
+    return present
+      ? { status: "stale_analysis", event: "stale_analysis", mutatesCurrent: false }
+      : null;
+  }
+
+  if (present) {
+    if (!currentStatus) return { status: "open", event: "detected", mutatesCurrent: true };
+    if (currentStatus === "resolved" || currentStatus === "stale_analysis") {
+      return { status: "reopened", event: "reopened", mutatesCurrent: true };
+    }
+    return { status: currentStatus, event: "observed", mutatesCurrent: true };
+  }
+
+  if (
+    evidenceStatus === "complete" &&
+    (currentStatus === "open" || currentStatus === "reopened")
+  ) {
+    return { status: "resolved", event: "resolved", mutatesCurrent: true };
+  }
+  return null;
+}
+
+export interface FindingReconcileResult {
+  detected: number;
+  observed: number;
+  resolved: number;
+  reopened: number;
+  stale: number;
+}
+
+const EMPTY_RESULT: FindingReconcileResult = {
+  detected: 0,
+  observed: 0,
+  resolved: 0,
+  reopened: 0,
+  stale: 0,
+};
+
+/** Atomically project one validated v2 snapshot into current state + append-only history. */
+export async function reconcileCodebaseFindings(
+  db: DbClient,
+  input: {
+    teamId: string;
+    codebaseId: string;
+    metricsId: string;
+    health: CodebaseHealth | undefined;
+  }
+): Promise<FindingReconcileResult> {
+  if (!input.health || input.health.schema_version !== "2") return EMPTY_RESULT;
+
+  const { data, error } = await db.rpc("reconcile_codebase_findings", {
+    p_team_id: input.teamId,
+    p_codebase_id: input.codebaseId,
+    p_metrics_id: input.metricsId,
+    p_health: input.health,
+  });
+  if (error) throw new Error(`finding reconciliation failed: ${error.message}`);
+  return { ...EMPTY_RESULT, ...(data as Partial<FindingReconcileResult>) };
+}

--- a/lib/codebases/ingest.ts
+++ b/lib/codebases/ingest.ts
@@ -5,6 +5,7 @@ import { computeScores } from "@/lib/codebases/score";
 import { buildIdentityMap, resolveMember } from "@/lib/identity/resolve";
 import { projectCommitsToItems, type ScanCommit } from "@/lib/codebases/commits-to-items";
 import { audit } from "@/lib/api/audit";
+import { reconcileCodebaseFindings } from "@/lib/codebases/finding-ledger";
 
 /**
  * The ONLY write path for codebase analytics tables (single-writer guarded). Runs
@@ -12,6 +13,7 @@ import { audit } from "@/lib/api/audit";
  * there is one scoring implementation. Idempotency:
  *   • codebases       — upsert (team_id, slug)
  *   • code_metrics    — upsert (codebase_id, head_sha): same commit = no new point
+ *   • finding ledger  — atomic reconcile by stable fingerprint + metrics point
  *   • contributions   — recompute + upsert (codebase_id, author_key, day)
  *   • github_issues   — upsert (codebase_id, number)
  */
@@ -114,7 +116,17 @@ export async function ingestCodebaseScan(
     .single();
   if (mErr || !metrics) throw new Error(`code_metrics upsert failed: ${mErr?.message}`);
 
-  // 4. contributions + commits — map author → member, then write aggregates and searchable items.
+  // 4. project validated v2 findings into durable current state + append-only history.
+  // Historical v1/v1.0 snapshots remain metrics-only. The DB function is atomic and
+  // idempotent for the same metrics point; incomplete evidence can never resolve absence.
+  const findingLedger = await reconcileCodebaseFindings(db, {
+    teamId: auth.teamId,
+    codebaseId: codebase.id,
+    metricsId: metrics.id,
+    health: m.codebase_health,
+  });
+
+  // 5. contributions + commits — map author → member, then write aggregates and searchable items.
   const recentCommits = (m.recent_commits ?? []) as ScanCommit[];
   let contribCount = 0;
   let commitItemCount = 0;
@@ -151,7 +163,7 @@ export async function ingestCodebaseScan(
     commitItemCount = await projectCommitsToItems(db, auth, c.slug, recentCommits, identityMap);
   }
 
-  // 5. issues — upsert by number
+  // 6. issues — upsert by number
   let issueCount = 0;
   for (const iss of payload.issues) {
     const { error } = await db.from("github_issues").upsert(
@@ -194,6 +206,7 @@ export async function ingestCodebaseScan(
       contributions: contribCount,
       commit_items: commitItemCount,
       issues: issueCount,
+      finding_ledger: findingLedger,
     },
   });
 

--- a/lib/db/pg/client.ts
+++ b/lib/db/pg/client.ts
@@ -25,6 +25,18 @@ export class PgClient {
         );
         return { data: rows[0]?.result ?? 0, error: null };
       }
+      if (fn === "reconcile_codebase_findings") {
+        const { rows } = await runSql<{ result: Record<string, number> }>(
+          `SELECT reconcile_codebase_findings($1, $2, $3, $4::jsonb) AS result`,
+          [
+            args.p_team_id,
+            args.p_codebase_id,
+            args.p_metrics_id,
+            JSON.stringify(args.p_health),
+          ]
+        );
+        return { data: rows[0]?.result ?? {}, error: null };
+      }
       throw new Error(`pg-adapter: unsupported rpc "${fn}"`);
     } catch (err) {
       const message = err instanceof Error ? err.message : "rpc failed";

--- a/lib/metrics/codebases.ts
+++ b/lib/metrics/codebases.ts
@@ -5,6 +5,7 @@ import type { Kpi } from "./pulse";
 import { rangeDays, type Range } from "./range";
 import { canSeeCodebases, type ViewerTier } from "@/lib/codebases/visibility";
 import { num, numOrNull, round } from "@/lib/num";
+import type { FindingStatus } from "@/lib/codebases/finding-ledger";
 
 /**
  * The ONLY read path for codebase analytics tables — pages must go through here,
@@ -348,6 +349,35 @@ export interface CommitVolumePoint {
   human: number;
 }
 
+export interface CodebaseFindingEvent {
+  id: string;
+  event_type: string;
+  from_status: FindingStatus | null;
+  to_status: FindingStatus;
+  head_sha: string;
+  observed_at: string;
+  details: Record<string, unknown>;
+}
+
+export interface CodebaseFinding {
+  id: string;
+  fingerprint: string;
+  status: FindingStatus;
+  check_id: string;
+  axis: string;
+  kind: "quality_issue" | "evidence_gap";
+  severity: "low" | "medium" | "high" | "critical";
+  evidence_status: "complete" | "partial" | "missing" | "stale" | "error";
+  remediation_tier: number;
+  first_seen_sha: string;
+  last_seen_sha: string;
+  first_seen_at: string;
+  last_seen_at: string;
+  resolved_at: string | null;
+  occurrence_count: number;
+  events: CodebaseFindingEvent[];
+}
+
 export interface CodebaseDetail {
   id: string;
   slug: string;
@@ -368,6 +398,7 @@ export interface CodebaseDetail {
   commitVolume: CommitVolumePoint[];
   contributors: ContributorRow[];
   issues: IssueRow[];
+  findings: CodebaseFinding[];
 }
 
 export async function getCodebaseDetail(
@@ -399,7 +430,15 @@ export async function getCodebaseDetail(
     "test_coverage_functions_pct, test_coverage_branches_pct, recent_commits, " +
     "readiness_level, readiness_pct, readiness_pillars, codebase_health";
 
-  const [metricsRes, contribRes, issuesRes, membersRes, profilesRes] = await Promise.all([
+  const [
+    metricsRes,
+    contribRes,
+    issuesRes,
+    membersRes,
+    profilesRes,
+    findingsRes,
+    findingEventsRes,
+  ] = await Promise.all([
     // NOT windowed: the breakdown/headline reflect the LAST scan even if it predates the range
     // (a stale detail page keeps its last-known values). The trend windows this series in JS below.
     db
@@ -424,6 +463,24 @@ export async function getCodebaseDetail(
     db.from("members").select("id, display_name, github_login, avatar_url").eq("team_id", teamId),
     // Uploaded avatars live on member_profiles (1:1, separate table) — sibling query, merged in JS.
     db.from("member_profiles").select("member_id, avatar_data_url").eq("team_id", teamId),
+    db
+      .from("codebase_findings")
+      .select(
+        "id, fingerprint, status, check_id, axis, kind, severity, evidence_status, remediation_tier, occurrence_count, first_seen_sha, last_seen_sha, first_seen_at, last_seen_at, resolved_at"
+      )
+      .eq("team_id", teamId)
+      .eq("codebase_id", codebaseId)
+      .order("last_seen_at", { ascending: false })
+      .limit(500),
+    db
+      .from("codebase_finding_events")
+      .select(
+        "id, finding_id, event_type, from_status, to_status, head_sha, observed_at, details"
+      )
+      .eq("team_id", teamId)
+      .eq("codebase_id", codebaseId)
+      .order("observed_at", { ascending: false })
+      .limit(5_000),
   ]);
 
   type MemberMeta = { display_name: string | null; github_login: string | null; avatar_url: string | null };
@@ -555,6 +612,43 @@ export async function getCodebaseDetail(
     labels: Array.isArray(i.labels) ? i.labels : [],
   }));
 
+  type FindingEventRow = Omit<CodebaseFindingEvent, "observed_at"> & {
+    finding_id: string;
+    observed_at: string | Date;
+  };
+  const findingEventsById = new Map<string, CodebaseFindingEvent[]>();
+  for (const row of (findingEventsRes.data ?? []) as FindingEventRow[]) {
+    const events = findingEventsById.get(row.finding_id) ?? [];
+    events.push({
+      id: row.id,
+      event_type: row.event_type,
+      from_status: row.from_status,
+      to_status: row.to_status,
+      head_sha: row.head_sha,
+      observed_at: new Date(row.observed_at).toISOString(),
+      details: row.details ?? {},
+    });
+    findingEventsById.set(row.finding_id, events);
+  }
+
+  type FindingRow = Omit<CodebaseFinding, "first_seen_at" | "last_seen_at" | "resolved_at" | "events"> & {
+    first_seen_at: string | Date;
+    last_seen_at: string | Date;
+    resolved_at: string | Date | null;
+  };
+  const findings: CodebaseFinding[] = ((findingsRes.data ?? []) as FindingRow[]).map((row) => {
+    const events = findingEventsById.get(row.id) ?? [];
+    return {
+      ...row,
+      remediation_tier: num(row.remediation_tier),
+      occurrence_count: num(row.occurrence_count),
+      first_seen_at: new Date(row.first_seen_at).toISOString(),
+      last_seen_at: new Date(row.last_seen_at).toISOString(),
+      resolved_at: row.resolved_at == null ? null : new Date(row.resolved_at).toISOString(),
+      events,
+    };
+  });
+
   const c = cb as Record<string, unknown>;
   return {
     id: codebaseId,
@@ -578,6 +672,7 @@ export async function getCodebaseDetail(
     commitVolume,
     contributors,
     issues,
+    findings,
   };
 }
 

--- a/postgres/migrations/20260804120000_codebase_finding_ledger.sql
+++ b/postgres/migrations/20260804120000_codebase_finding_ledger.sql
@@ -1,0 +1,319 @@
+-- AIO-785 — durable lifecycle materialization for redacted codebase_health v2 findings.
+-- Additive and idempotent. Rollback, if required before any dependent Phase 1 release:
+--   drop function if exists reconcile_codebase_findings(uuid, uuid, uuid, jsonb);
+--   drop table if exists codebase_finding_events;
+--   drop table if exists codebase_findings;
+-- Take a verified backup first; rollback discards lifecycle history, not scan snapshots.
+
+create table if not exists codebase_findings (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  codebase_id uuid not null references codebases(id) on delete cascade,
+  fingerprint text not null check (fingerprint ~ '^[0-9a-f]{64}$'),
+  status text not null default 'open' check (status in (
+    'open', 'accepted', 'resolved', 'reopened', 'false_positive',
+    'risk_accepted', 'superseded', 'stale_analysis'
+  )),
+  check_id text not null,
+  axis text not null,
+  kind text not null check (kind in ('quality_issue', 'evidence_gap')),
+  severity text not null check (severity in ('low', 'medium', 'high', 'critical')),
+  evidence_status text not null check (evidence_status in (
+    'complete', 'partial', 'missing', 'stale', 'error'
+  )),
+  remediation_tier integer not null check (remediation_tier between 0 and 3),
+  occurrence_count integer not null default 1 check (occurrence_count >= 1),
+  first_seen_sha text not null,
+  last_seen_sha text not null,
+  first_seen_at timestamptz not null,
+  last_seen_at timestamptz not null,
+  resolved_at timestamptz,
+  latest_metrics_id uuid references code_metrics(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (team_id, codebase_id, fingerprint)
+);
+
+alter table codebase_findings
+  add column if not exists occurrence_count integer not null default 1;
+
+create index if not exists codebase_findings_active_idx
+  on codebase_findings (team_id, codebase_id, status, last_seen_at desc);
+
+create table if not exists codebase_finding_events (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  codebase_id uuid not null references codebases(id) on delete cascade,
+  finding_id uuid not null references codebase_findings(id) on delete cascade,
+  metrics_id uuid not null references code_metrics(id) on delete cascade,
+  event_type text not null check (event_type in (
+    'detected', 'observed', 'resolved', 'reopened', 'stale_analysis',
+    'accepted', 'risk_accepted', 'false_positive', 'expired', 'superseded'
+  )),
+  from_status text,
+  to_status text not null,
+  head_sha text not null,
+  observed_at timestamptz not null,
+  details jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  unique (finding_id, metrics_id, event_type)
+);
+
+create index if not exists codebase_finding_events_history_idx
+  on codebase_finding_events (team_id, codebase_id, finding_id, observed_at desc);
+
+create or replace function reconcile_codebase_findings(
+  p_team_id uuid,
+  p_codebase_id uuid,
+  p_metrics_id uuid,
+  p_health jsonb
+) returns jsonb
+language plpgsql
+as $$
+declare
+  v_schema_version text := coalesce(p_health->>'schema_version', '');
+  v_evidence_status text;
+  v_head_sha text;
+  v_observed_at timestamptz;
+  v_latest_observed_at timestamptz;
+  v_snapshot_is_stale boolean := false;
+  v_finding jsonb;
+  v_row codebase_findings%rowtype;
+  v_previous_status text;
+  v_event_type text;
+  v_new_status text;
+  v_detected integer := 0;
+  v_observed integer := 0;
+  v_resolved integer := 0;
+  v_reopened integer := 0;
+  v_stale integer := 0;
+begin
+  if v_schema_version <> '2' then
+    return jsonb_build_object(
+      'detected', 0, 'observed', 0, 'resolved', 0, 'reopened', 0, 'stale', 0
+    );
+  end if;
+
+  v_evidence_status := p_health->>'evidence_status';
+  v_head_sha := p_health->>'head_sha';
+  v_observed_at := (p_health->>'measured_at')::timestamptz;
+
+  if not exists (
+    select 1
+    from code_metrics
+    where id = p_metrics_id
+      and team_id = p_team_id
+      and codebase_id = p_codebase_id
+      and head_sha = v_head_sha
+      and codebase_health = p_health
+  ) then
+    raise exception 'finding reconciliation metrics identity mismatch';
+  end if;
+
+  -- Serialize lifecycle projection per codebase. Metrics writes happen before this
+  -- function, so whichever reconciliation wins the lock can see every committed v2
+  -- measurement and classify an out-of-order snapshot deterministically.
+  perform pg_advisory_xact_lock(
+    hashtextextended(p_team_id::text || ':' || p_codebase_id::text, 0)
+  );
+  select coalesce(
+    max((codebase_health->>'measured_at')::timestamptz),
+    v_observed_at
+  )
+  into v_latest_observed_at
+  from code_metrics
+  where team_id = p_team_id
+    and codebase_id = p_codebase_id
+    and codebase_health->>'schema_version' = '2';
+  v_snapshot_is_stale := v_observed_at < v_latest_observed_at;
+
+  for v_finding in
+    select value from jsonb_array_elements(coalesce(p_health->'findings', '[]'::jsonb))
+  loop
+    select *
+    into v_row
+    from codebase_findings
+    where team_id = p_team_id
+      and codebase_id = p_codebase_id
+      and fingerprint = v_finding->>'fingerprint'
+    for update;
+
+    if not found then
+      v_new_status := case when v_snapshot_is_stale then 'stale_analysis' else 'open' end;
+      v_event_type := case when v_snapshot_is_stale then 'stale_analysis' else 'detected' end;
+      insert into codebase_findings (
+        team_id, codebase_id, fingerprint, status, check_id, axis, kind, severity,
+        evidence_status, remediation_tier, first_seen_sha, last_seen_sha,
+        first_seen_at, last_seen_at, latest_metrics_id
+      ) values (
+        p_team_id,
+        p_codebase_id,
+        v_finding->>'fingerprint',
+        v_new_status,
+        v_finding->>'check_id',
+        v_finding->>'axis',
+        v_finding->>'kind',
+        v_finding->>'severity',
+        v_finding->>'evidence_status',
+        (v_finding->>'remediation_tier')::integer,
+        v_head_sha,
+        v_head_sha,
+        v_observed_at,
+        v_observed_at,
+        p_metrics_id
+      )
+      on conflict (team_id, codebase_id, fingerprint) do nothing
+      returning * into v_row;
+
+      if found then
+        insert into codebase_finding_events (
+          team_id, codebase_id, finding_id, metrics_id, event_type,
+          from_status, to_status, head_sha, observed_at, details
+        ) values (
+          p_team_id, p_codebase_id, v_row.id, p_metrics_id, v_event_type,
+          null, v_new_status, v_head_sha, v_observed_at,
+          jsonb_build_object(
+            'rubric_version', p_health->>'rubric_version',
+            'profile_id', p_health->>'profile_id',
+            'profile_version', p_health->>'profile_version',
+            'evidence_status', v_evidence_status
+          )
+        )
+        on conflict (finding_id, metrics_id, event_type) do nothing;
+        if v_snapshot_is_stale then
+          v_stale := v_stale + 1;
+        else
+          v_detected := v_detected + 1;
+        end if;
+        continue;
+      end if;
+
+      select *
+      into v_row
+      from codebase_findings
+      where team_id = p_team_id
+        and codebase_id = p_codebase_id
+        and fingerprint = v_finding->>'fingerprint'
+      for update;
+    end if;
+
+    if exists (
+      select 1 from codebase_finding_events
+      where finding_id = v_row.id and metrics_id = p_metrics_id
+    ) then
+      continue;
+    end if;
+
+    if v_snapshot_is_stale or v_observed_at < greatest(
+      v_row.last_seen_at,
+      coalesce(v_row.resolved_at, '-infinity'::timestamptz)
+    ) then
+      insert into codebase_finding_events (
+        team_id, codebase_id, finding_id, metrics_id, event_type,
+        from_status, to_status, head_sha, observed_at, details
+      ) values (
+        p_team_id, p_codebase_id, v_row.id, p_metrics_id, 'stale_analysis',
+        v_row.status, v_row.status, v_head_sha, v_observed_at,
+        jsonb_build_object(
+          'rubric_version', p_health->>'rubric_version',
+          'profile_id', p_health->>'profile_id',
+          'profile_version', p_health->>'profile_version',
+          'evidence_status', v_evidence_status
+        )
+      )
+      on conflict (finding_id, metrics_id, event_type) do nothing;
+      v_stale := v_stale + 1;
+      continue;
+    end if;
+
+    v_previous_status := v_row.status;
+    if v_previous_status in ('resolved', 'stale_analysis') then
+      v_event_type := 'reopened';
+      v_row.status := 'reopened';
+      v_reopened := v_reopened + 1;
+    else
+      v_event_type := 'observed';
+      v_observed := v_observed + 1;
+    end if;
+
+    update codebase_findings
+    set status = v_row.status,
+        check_id = v_finding->>'check_id',
+        axis = v_finding->>'axis',
+        kind = v_finding->>'kind',
+        severity = v_finding->>'severity',
+        evidence_status = v_finding->>'evidence_status',
+        remediation_tier = (v_finding->>'remediation_tier')::integer,
+        occurrence_count = occurrence_count + 1,
+        last_seen_sha = v_head_sha,
+        last_seen_at = v_observed_at,
+        resolved_at = case when v_row.status = 'reopened' then null else resolved_at end,
+        latest_metrics_id = p_metrics_id,
+        updated_at = now()
+    where id = v_row.id and team_id = p_team_id;
+
+    insert into codebase_finding_events (
+      team_id, codebase_id, finding_id, metrics_id, event_type,
+      from_status, to_status, head_sha, observed_at, details
+    ) values (
+      p_team_id, p_codebase_id, v_row.id, p_metrics_id, v_event_type,
+      v_previous_status, v_row.status, v_head_sha, v_observed_at,
+      jsonb_build_object(
+        'rubric_version', p_health->>'rubric_version',
+        'profile_id', p_health->>'profile_id',
+        'profile_version', p_health->>'profile_version',
+        'evidence_status', v_evidence_status
+      )
+    )
+    on conflict (finding_id, metrics_id, event_type) do nothing;
+  end loop;
+
+  if v_evidence_status = 'complete' and not v_snapshot_is_stale then
+    for v_row in
+      select *
+      from codebase_findings f
+      where f.team_id = p_team_id
+        and f.codebase_id = p_codebase_id
+        and f.status in ('open', 'reopened')
+        and f.last_seen_at <= v_observed_at
+        and not exists (
+          select 1
+          from jsonb_array_elements(coalesce(p_health->'findings', '[]'::jsonb)) current_finding
+          where current_finding->>'fingerprint' = f.fingerprint
+        )
+      for update
+    loop
+      update codebase_findings
+      set status = 'resolved',
+          resolved_at = v_observed_at,
+          latest_metrics_id = p_metrics_id,
+          updated_at = now()
+      where id = v_row.id and team_id = p_team_id;
+
+      insert into codebase_finding_events (
+        team_id, codebase_id, finding_id, metrics_id, event_type,
+        from_status, to_status, head_sha, observed_at, details
+      ) values (
+        p_team_id, p_codebase_id, v_row.id, p_metrics_id, 'resolved',
+        v_row.status, 'resolved', v_head_sha, v_observed_at,
+        jsonb_build_object(
+          'rubric_version', p_health->>'rubric_version',
+          'profile_id', p_health->>'profile_id',
+          'profile_version', p_health->>'profile_version',
+          'evidence_status', v_evidence_status
+        )
+      )
+      on conflict (finding_id, metrics_id, event_type) do nothing;
+      v_resolved := v_resolved + 1;
+    end loop;
+  end if;
+
+  return jsonb_build_object(
+    'detected', v_detected,
+    'observed', v_observed,
+    'resolved', v_resolved,
+    'reopened', v_reopened,
+    'stale', v_stale
+  );
+end;
+$$;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1474,6 +1474,320 @@ create table if not exists code_metrics (
   created_at timestamptz not null default now(),
   unique (codebase_id, head_sha)
 );
+
+-- Durable, redacted finding state derived from codebase_health v2 snapshots (AIO-785).
+-- The scanner remains the evidence authority; Team Brain owns lifecycle materialization.
+-- No path, symbol, source text, or diagnostic prose is stored here.
+create table if not exists codebase_findings (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  codebase_id uuid not null references codebases(id) on delete cascade,
+  fingerprint text not null check (fingerprint ~ '^[0-9a-f]{64}$'),
+  status text not null default 'open' check (status in (
+    'open', 'accepted', 'resolved', 'reopened', 'false_positive',
+    'risk_accepted', 'superseded', 'stale_analysis'
+  )),
+  check_id text not null,
+  axis text not null,
+  kind text not null check (kind in ('quality_issue', 'evidence_gap')),
+  severity text not null check (severity in ('low', 'medium', 'high', 'critical')),
+  evidence_status text not null check (evidence_status in (
+    'complete', 'partial', 'missing', 'stale', 'error'
+  )),
+  remediation_tier integer not null check (remediation_tier between 0 and 3),
+  occurrence_count integer not null default 1 check (occurrence_count >= 1),
+  first_seen_sha text not null,
+  last_seen_sha text not null,
+  first_seen_at timestamptz not null,
+  last_seen_at timestamptz not null,
+  resolved_at timestamptz,
+  latest_metrics_id uuid references code_metrics(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (team_id, codebase_id, fingerprint)
+);
+alter table codebase_findings
+  add column if not exists occurrence_count integer not null default 1;
+create index if not exists codebase_findings_active_idx
+  on codebase_findings (team_id, codebase_id, status, last_seen_at desc);
+
+-- Append-only lifecycle/observation history. Replaying one metrics point is idempotent.
+create table if not exists codebase_finding_events (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  codebase_id uuid not null references codebases(id) on delete cascade,
+  finding_id uuid not null references codebase_findings(id) on delete cascade,
+  metrics_id uuid not null references code_metrics(id) on delete cascade,
+  event_type text not null check (event_type in (
+    'detected', 'observed', 'resolved', 'reopened', 'stale_analysis',
+    'accepted', 'risk_accepted', 'false_positive', 'expired', 'superseded'
+  )),
+  from_status text,
+  to_status text not null,
+  head_sha text not null,
+  observed_at timestamptz not null,
+  details jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  unique (finding_id, metrics_id, event_type)
+);
+create index if not exists codebase_finding_events_history_idx
+  on codebase_finding_events (team_id, codebase_id, finding_id, observed_at desc);
+
+create or replace function reconcile_codebase_findings(
+  p_team_id uuid,
+  p_codebase_id uuid,
+  p_metrics_id uuid,
+  p_health jsonb
+) returns jsonb
+language plpgsql
+as $$
+declare
+  v_schema_version text := coalesce(p_health->>'schema_version', '');
+  v_evidence_status text;
+  v_head_sha text;
+  v_observed_at timestamptz;
+  v_latest_observed_at timestamptz;
+  v_snapshot_is_stale boolean := false;
+  v_finding jsonb;
+  v_row codebase_findings%rowtype;
+  v_previous_status text;
+  v_event_type text;
+  v_new_status text;
+  v_detected integer := 0;
+  v_observed integer := 0;
+  v_resolved integer := 0;
+  v_reopened integer := 0;
+  v_stale integer := 0;
+begin
+  if v_schema_version <> '2' then
+    return jsonb_build_object(
+      'detected', 0, 'observed', 0, 'resolved', 0, 'reopened', 0, 'stale', 0
+    );
+  end if;
+
+  v_evidence_status := p_health->>'evidence_status';
+  v_head_sha := p_health->>'head_sha';
+  v_observed_at := (p_health->>'measured_at')::timestamptz;
+
+  if not exists (
+    select 1
+    from code_metrics
+    where id = p_metrics_id
+      and team_id = p_team_id
+      and codebase_id = p_codebase_id
+      and head_sha = v_head_sha
+      and codebase_health = p_health
+  ) then
+    raise exception 'finding reconciliation metrics identity mismatch';
+  end if;
+
+  -- Serialize lifecycle projection per codebase. Metrics writes happen before this
+  -- function, so whichever reconciliation wins the lock can see every committed v2
+  -- measurement and classify an out-of-order snapshot deterministically.
+  perform pg_advisory_xact_lock(
+    hashtextextended(p_team_id::text || ':' || p_codebase_id::text, 0)
+  );
+  select coalesce(
+    max((codebase_health->>'measured_at')::timestamptz),
+    v_observed_at
+  )
+  into v_latest_observed_at
+  from code_metrics
+  where team_id = p_team_id
+    and codebase_id = p_codebase_id
+    and codebase_health->>'schema_version' = '2';
+  v_snapshot_is_stale := v_observed_at < v_latest_observed_at;
+
+  for v_finding in
+    select value from jsonb_array_elements(coalesce(p_health->'findings', '[]'::jsonb))
+  loop
+    select *
+    into v_row
+    from codebase_findings
+    where team_id = p_team_id
+      and codebase_id = p_codebase_id
+      and fingerprint = v_finding->>'fingerprint'
+    for update;
+
+    if not found then
+      v_new_status := case when v_snapshot_is_stale then 'stale_analysis' else 'open' end;
+      v_event_type := case when v_snapshot_is_stale then 'stale_analysis' else 'detected' end;
+      insert into codebase_findings (
+        team_id, codebase_id, fingerprint, status, check_id, axis, kind, severity,
+        evidence_status, remediation_tier, first_seen_sha, last_seen_sha,
+        first_seen_at, last_seen_at, latest_metrics_id
+      ) values (
+        p_team_id,
+        p_codebase_id,
+        v_finding->>'fingerprint',
+        v_new_status,
+        v_finding->>'check_id',
+        v_finding->>'axis',
+        v_finding->>'kind',
+        v_finding->>'severity',
+        v_finding->>'evidence_status',
+        (v_finding->>'remediation_tier')::integer,
+        v_head_sha,
+        v_head_sha,
+        v_observed_at,
+        v_observed_at,
+        p_metrics_id
+      )
+      on conflict (team_id, codebase_id, fingerprint) do nothing
+      returning * into v_row;
+
+      if found then
+        insert into codebase_finding_events (
+          team_id, codebase_id, finding_id, metrics_id, event_type,
+          from_status, to_status, head_sha, observed_at, details
+        ) values (
+          p_team_id, p_codebase_id, v_row.id, p_metrics_id, v_event_type,
+          null, v_new_status, v_head_sha, v_observed_at,
+          jsonb_build_object(
+            'rubric_version', p_health->>'rubric_version',
+            'profile_id', p_health->>'profile_id',
+            'profile_version', p_health->>'profile_version',
+            'evidence_status', v_evidence_status
+          )
+        )
+        on conflict (finding_id, metrics_id, event_type) do nothing;
+        if v_snapshot_is_stale then
+          v_stale := v_stale + 1;
+        else
+          v_detected := v_detected + 1;
+        end if;
+        continue;
+      end if;
+
+      select *
+      into v_row
+      from codebase_findings
+      where team_id = p_team_id
+        and codebase_id = p_codebase_id
+        and fingerprint = v_finding->>'fingerprint'
+      for update;
+    end if;
+
+    if exists (
+      select 1 from codebase_finding_events
+      where finding_id = v_row.id and metrics_id = p_metrics_id
+    ) then
+      continue;
+    end if;
+
+    if v_snapshot_is_stale or v_observed_at < greatest(
+      v_row.last_seen_at,
+      coalesce(v_row.resolved_at, '-infinity'::timestamptz)
+    ) then
+      insert into codebase_finding_events (
+        team_id, codebase_id, finding_id, metrics_id, event_type,
+        from_status, to_status, head_sha, observed_at, details
+      ) values (
+        p_team_id, p_codebase_id, v_row.id, p_metrics_id, 'stale_analysis',
+        v_row.status, v_row.status, v_head_sha, v_observed_at,
+        jsonb_build_object(
+          'rubric_version', p_health->>'rubric_version',
+          'profile_id', p_health->>'profile_id',
+          'profile_version', p_health->>'profile_version',
+          'evidence_status', v_evidence_status
+        )
+      )
+      on conflict (finding_id, metrics_id, event_type) do nothing;
+      v_stale := v_stale + 1;
+      continue;
+    end if;
+
+    v_previous_status := v_row.status;
+    if v_previous_status in ('resolved', 'stale_analysis') then
+      v_event_type := 'reopened';
+      v_row.status := 'reopened';
+      v_reopened := v_reopened + 1;
+    else
+      v_event_type := 'observed';
+      v_observed := v_observed + 1;
+    end if;
+
+    update codebase_findings
+    set status = v_row.status,
+        check_id = v_finding->>'check_id',
+        axis = v_finding->>'axis',
+        kind = v_finding->>'kind',
+        severity = v_finding->>'severity',
+        evidence_status = v_finding->>'evidence_status',
+        remediation_tier = (v_finding->>'remediation_tier')::integer,
+        occurrence_count = occurrence_count + 1,
+        last_seen_sha = v_head_sha,
+        last_seen_at = v_observed_at,
+        resolved_at = case when v_row.status = 'reopened' then null else resolved_at end,
+        latest_metrics_id = p_metrics_id,
+        updated_at = now()
+    where id = v_row.id and team_id = p_team_id;
+
+    insert into codebase_finding_events (
+      team_id, codebase_id, finding_id, metrics_id, event_type,
+      from_status, to_status, head_sha, observed_at, details
+    ) values (
+      p_team_id, p_codebase_id, v_row.id, p_metrics_id, v_event_type,
+      v_previous_status, v_row.status, v_head_sha, v_observed_at,
+      jsonb_build_object(
+        'rubric_version', p_health->>'rubric_version',
+        'profile_id', p_health->>'profile_id',
+        'profile_version', p_health->>'profile_version',
+        'evidence_status', v_evidence_status
+      )
+    )
+    on conflict (finding_id, metrics_id, event_type) do nothing;
+  end loop;
+
+  if v_evidence_status = 'complete' and not v_snapshot_is_stale then
+    for v_row in
+      select *
+      from codebase_findings f
+      where f.team_id = p_team_id
+        and f.codebase_id = p_codebase_id
+        and f.status in ('open', 'reopened')
+        and f.last_seen_at <= v_observed_at
+        and not exists (
+          select 1
+          from jsonb_array_elements(coalesce(p_health->'findings', '[]'::jsonb)) current_finding
+          where current_finding->>'fingerprint' = f.fingerprint
+        )
+      for update
+    loop
+      update codebase_findings
+      set status = 'resolved',
+          resolved_at = v_observed_at,
+          latest_metrics_id = p_metrics_id,
+          updated_at = now()
+      where id = v_row.id and team_id = p_team_id;
+
+      insert into codebase_finding_events (
+        team_id, codebase_id, finding_id, metrics_id, event_type,
+        from_status, to_status, head_sha, observed_at, details
+      ) values (
+        p_team_id, p_codebase_id, v_row.id, p_metrics_id, 'resolved',
+        v_row.status, 'resolved', v_head_sha, v_observed_at,
+        jsonb_build_object(
+          'rubric_version', p_health->>'rubric_version',
+          'profile_id', p_health->>'profile_id',
+          'profile_version', p_health->>'profile_version',
+          'evidence_status', v_evidence_status
+        )
+      )
+      on conflict (finding_id, metrics_id, event_type) do nothing;
+      v_resolved := v_resolved + 1;
+    end loop;
+  end if;
+
+  return jsonb_build_object(
+    'detected', v_detected,
+    'observed', v_observed,
+    'resolved', v_resolved,
+    'reopened', v_reopened,
+    'stale', v_stale
+  );
+end;
+$$;
 create index if not exists code_metrics_codebase_time_idx on code_metrics (codebase_id, scanned_at desc);
 create index if not exists code_metrics_team_time_idx on code_metrics (team_id, scanned_at desc);
 -- AEM agent-readiness columns — added via alter so an already-deployed code_metrics

--- a/test/codebase-finding-ledger.test.ts
+++ b/test/codebase-finding-ledger.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { decideFindingTransition } from "@/lib/codebases/finding-ledger";
+
+describe("codebase finding lifecycle", () => {
+  it("detects a new finding", () => {
+    expect(
+      decideFindingTransition({
+        currentStatus: null,
+        present: true,
+        evidenceStatus: "complete",
+      })
+    ).toEqual({ status: "open", event: "detected", mutatesCurrent: true });
+  });
+
+  it.each(["partial", "missing", "stale", "error"] as const)(
+    "does not resolve absence from %s evidence",
+    (evidenceStatus) => {
+      expect(
+        decideFindingTransition({ currentStatus: "open", present: false, evidenceStatus })
+      ).toBeNull();
+    }
+  );
+
+  it("resolves absence only from complete evidence", () => {
+    expect(
+      decideFindingTransition({
+        currentStatus: "reopened",
+        present: false,
+        evidenceStatus: "complete",
+      })
+    ).toEqual({ status: "resolved", event: "resolved", mutatesCurrent: true });
+  });
+
+  it("reopens a resolved fingerprint when it returns", () => {
+    expect(
+      decideFindingTransition({
+        currentStatus: "resolved",
+        present: true,
+        evidenceStatus: "complete",
+      })
+    ).toEqual({ status: "reopened", event: "reopened", mutatesCurrent: true });
+  });
+
+  it("preserves future decision states when a finding is observed", () => {
+    expect(
+      decideFindingTransition({
+        currentStatus: "risk_accepted",
+        present: true,
+        evidenceStatus: "complete",
+      })
+    ).toEqual({ status: "risk_accepted", event: "observed", mutatesCurrent: true });
+  });
+
+  it("records older analysis without mutating current state", () => {
+    expect(
+      decideFindingTransition({
+        currentStatus: "open",
+        present: true,
+        evidenceStatus: "complete",
+        olderThanCurrent: true,
+      })
+    ).toEqual({ status: "open", event: "stale_analysis", mutatesCurrent: false });
+  });
+
+  it("retains a previously unseen historical fingerprint without making it active", () => {
+    expect(
+      decideFindingTransition({
+        currentStatus: null,
+        present: true,
+        evidenceStatus: "complete",
+        olderThanCurrent: true,
+      })
+    ).toEqual({ status: "stale_analysis", event: "stale_analysis", mutatesCurrent: false });
+  });
+});

--- a/test/datamechanics/codebase-health.datamechanics.test.ts
+++ b/test/datamechanics/codebase-health.datamechanics.test.ts
@@ -32,6 +32,66 @@ function fixture(bucket: "valid" | "invalid", prefix: string): Fixture["payload"
   return structuredClone(f.payload);
 }
 
+type V2Finding = {
+  fingerprint: string;
+  check_id: string;
+  axis: string;
+  kind: "quality_issue" | "evidence_gap";
+  severity: "low" | "medium" | "high" | "critical";
+  evidence_status: "complete" | "partial" | "missing" | "stale" | "error";
+  remediation_tier: number;
+};
+
+function v2Payload(input: {
+  slug: string;
+  head: string;
+  measuredAt: string;
+  findings?: V2Finding[];
+  evidenceStatus?: "complete" | "partial" | "missing" | "stale" | "error";
+}) {
+  const body = fixture("valid", "valid-without-health");
+  const findings = input.findings ?? [];
+  const evidenceStatus = input.evidenceStatus ?? "complete";
+  const complete = evidenceStatus === "complete";
+  body.codebase.slug = input.slug;
+  body.metrics.head_sha = input.head;
+  body.metrics.scanned_at = input.measuredAt;
+  body.metrics.codebase_health = {
+    schema_version: "2",
+    rubric_version: "1.1.0",
+    profile_id: "aios.team-brain",
+    profile_version: "1.0.0",
+    head_sha: input.head,
+    score_pct: complete && findings.length === 0 ? 100 : 70,
+    status: complete ? (findings.length === 0 ? "pass" : "fail") : "warn",
+    evidence_status: evidenceStatus,
+    quality_gate: complete ? (findings.length === 0 ? "pass" : "fail") : "unknown",
+    automation_eligible: complete && findings.length === 0,
+    dimensions: {
+      test_rigor: {
+        passed: complete && findings.length === 0 ? 1 : 0,
+        total: complete ? 1 : 0,
+        band: complete ? (findings.length === 0 ? 4 : 0) : null,
+        evidence_status: evidenceStatus,
+      },
+    },
+    failed_invariant_ids: findings.map((finding) => finding.check_id),
+    measured_at: input.measuredAt,
+    findings,
+  };
+  return body;
+}
+
+const FINDING_A: V2Finding = {
+  fingerprint: "a".repeat(64),
+  check_id: "coverage_lines_pct",
+  axis: "test_rigor",
+  kind: "quality_issue",
+  severity: "high",
+  evidence_status: "complete",
+  remediation_tier: 0,
+};
+
 /** Issue a key for the seeded team member (tier=team) or a fresh external member. */
 async function issueKeyFor(seed: Seed, tier: "team" | "external") {
   let memberId = seed.memberId;
@@ -100,6 +160,179 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
     expect(detail?.breakdown).not.toBeNull();
     expect(detail?.breakdown?.codebase_health).toBeNull();
+    expect(detail?.findings).toEqual([]);
+  });
+
+  it("v2 round-trips and materializes deduplicated resolve/reopen history fail closed", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+    const slug = `ledger-${randomUUID().slice(0, 6)}`;
+    const first = v2Payload({
+      slug,
+      head: "1".repeat(40),
+      measuredAt: "2026-08-04T01:00:00Z",
+      findings: [FINDING_A],
+    });
+
+    expect((await post(key, seed.teamSlug, first)).status).toBe(201);
+    let detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    expect(detail?.breakdown?.codebase_health).toEqual(first.metrics.codebase_health);
+    expect(detail?.findings).toHaveLength(1);
+    expect(detail?.findings[0]).toMatchObject({
+      fingerprint: FINDING_A.fingerprint,
+      status: "open",
+      occurrence_count: 1,
+    });
+    expect(detail?.findings[0].events.map((event) => event.event_type)).toEqual(["detected"]);
+
+    // Same exact metrics point is idempotent: no duplicate row and no duplicate event.
+    expect((await post(key, seed.teamSlug, structuredClone(first))).status).toBe(201);
+    detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    expect(detail?.findings[0].events).toHaveLength(1);
+
+    // Unknown/partial absence cannot resolve the finding.
+    const partial = v2Payload({
+      slug,
+      head: "2".repeat(40),
+      measuredAt: "2026-08-04T02:00:00Z",
+      evidenceStatus: "partial",
+    });
+    expect((await post(key, seed.teamSlug, partial)).status).toBe(201);
+    detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    expect(detail?.findings[0].status).toBe("open");
+
+    // Complete absence resolves; a later recurrence reopens with history intact.
+    const resolved = v2Payload({
+      slug,
+      head: "3".repeat(40),
+      measuredAt: "2026-08-04T03:00:00Z",
+    });
+    expect((await post(key, seed.teamSlug, resolved)).status).toBe(201);
+
+    // An observation older than the resolving snapshot is history-only. Comparing only
+    // last_seen_at would incorrectly reopen this because resolution does not mean "seen".
+    const staleBeforeReopen = v2Payload({
+      slug,
+      head: "5".repeat(40),
+      measuredAt: "2026-08-04T02:30:00Z",
+      findings: [FINDING_A],
+    });
+    expect((await post(key, seed.teamSlug, staleBeforeReopen)).status).toBe(201);
+    detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    expect(detail?.findings[0]).toMatchObject({ status: "resolved", occurrence_count: 1 });
+
+    const reopened = v2Payload({
+      slug,
+      head: "4".repeat(40),
+      measuredAt: "2026-08-04T04:00:00Z",
+      findings: [FINDING_A],
+    });
+    expect((await post(key, seed.teamSlug, reopened)).status).toBe(201);
+
+    detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    expect(detail?.findings[0]).toMatchObject({ status: "reopened", occurrence_count: 2 });
+    expect(detail?.findings[0].events.map((event) => event.event_type).sort()).toEqual([
+      "detected",
+      "reopened",
+      "resolved",
+      "stale_analysis",
+    ]);
+
+    // An older analysis is history only; it cannot overwrite the reopened current state.
+    const stale = v2Payload({
+      slug,
+      head: "6".repeat(40),
+      measuredAt: "2026-08-04T03:30:00Z",
+      findings: [FINDING_A],
+    });
+    expect((await post(key, seed.teamSlug, stale)).status).toBe(201);
+    detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    expect(detail?.findings[0]).toMatchObject({
+      status: "reopened",
+      last_seen_sha: "4".repeat(40),
+      occurrence_count: 2,
+    });
+    expect(detail?.findings[0].events.some((event) => event.event_type === "stale_analysis")).toBe(
+      true
+    );
+  });
+
+  it("v2 ledger rows remain isolated between teams for the same repository slug", async () => {
+    const one = await seedTeam();
+    const two = await seedTeam();
+    const oneKey = await issueKeyFor(one, "team");
+    const twoKey = await issueKeyFor(two, "team");
+    const slug = `shared-${randomUUID().slice(0, 6)}`;
+    const findingB = { ...FINDING_A, fingerprint: "b".repeat(64), check_id: "eslint_warning_count" };
+
+    expect(
+      (
+        await post(
+          oneKey.key,
+          one.teamSlug,
+          v2Payload({
+            slug,
+            head: "6".repeat(40),
+            measuredAt: "2026-08-04T05:00:00Z",
+            findings: [FINDING_A],
+          })
+        )
+      ).status
+    ).toBe(201);
+    expect(
+      (
+        await post(
+          twoKey.key,
+          two.teamSlug,
+          v2Payload({
+            slug,
+            head: "7".repeat(40),
+            measuredAt: "2026-08-04T05:00:00Z",
+            findings: [findingB],
+          })
+        )
+      ).status
+    ).toBe(201);
+
+    const oneDetail = await getCodebaseDetail(db(), one.teamId, slug, "90d", "team");
+    const twoDetail = await getCodebaseDetail(db(), two.teamId, slug, "90d", "team");
+    expect(oneDetail?.findings.map((finding) => finding.fingerprint)).toEqual([
+      FINDING_A.fingerprint,
+    ]);
+    expect(twoDetail?.findings.map((finding) => finding.fingerprint)).toEqual([
+      findingB.fingerprint,
+    ]);
+  });
+
+  it("retains a previously unseen older fingerprint as history, never as active debt", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+    const slug = `stale-new-${randomUUID().slice(0, 6)}`;
+    const latestClean = v2Payload({
+      slug,
+      head: "a".repeat(40),
+      measuredAt: "2026-08-04T08:00:00Z",
+    });
+    expect((await post(key, seed.teamSlug, latestClean)).status).toBe(201);
+
+    const olderDirty = v2Payload({
+      slug,
+      head: "b".repeat(40),
+      measuredAt: "2026-08-04T07:00:00Z",
+      findings: [FINDING_A],
+    });
+    expect((await post(key, seed.teamSlug, olderDirty)).status).toBe(201);
+
+    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    expect(detail?.findings).toHaveLength(1);
+    expect(detail?.findings[0]).toMatchObject({
+      fingerprint: FINDING_A.fingerprint,
+      status: "stale_analysis",
+      occurrence_count: 1,
+    });
+    expect(detail?.findings[0].events.map((event) => event.event_type)).toEqual([
+      "stale_analysis",
+    ]);
   });
 
   it("422 sparse: health without the full raw-metrics block is rejected, nothing persisted", async () => {
@@ -126,6 +359,24 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     const res = await post(key, seed.teamSlug, body);
     expect(res.status).toBe(422);
     expect((await res.json()).error.code).toBe("invalid_payload");
+  });
+
+  it("422 mismatched v2 head: lifecycle evidence cannot target a different metrics head", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+    const slug = `head-mismatch-${randomUUID().slice(0, 6)}`;
+    const body = v2Payload({
+      slug,
+      head: "8".repeat(40),
+      measuredAt: "2026-08-04T06:00:00Z",
+      findings: [FINDING_A],
+    });
+    (body.metrics.codebase_health as { head_sha: string }).head_sha = "9".repeat(40);
+
+    const res = await post(key, seed.teamSlug, body);
+    expect(res.status).toBe(422);
+    expect((await res.json()).error.code).toBe("invalid_payload");
+    expect(await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team")).toBeNull();
   });
 
   it("422 smuggled key: a health object carrying a file path is rejected, not stripped", async () => {

--- a/test/datamechanics/setup.ts
+++ b/test/datamechanics/setup.ts
@@ -5,6 +5,8 @@ import { Client } from "pg";
 // before each test. One dedicated connection (separate from the app's pool) so
 // truncation can't deadlock against in-flight adapter queries.
 const DATA_TABLES = [
+  "codebase_finding_events",
+  "codebase_findings",
   "gateway_audit_log",
   "gateway_service_credentials",
   "gateway_approvals",
@@ -25,6 +27,10 @@ const DATA_TABLES = [
   "brand_profiles",
   "social_jobs",
   "integrations",
+  "github_issues",
+  "code_contributions",
+  "code_metrics",
+  "codebases",
   "actions",
   "approval_requests",
   "policies",

--- a/test/guards/codebases-tier-filter.test.ts
+++ b/test/guards/codebases-tier-filter.test.ts
@@ -16,7 +16,8 @@ import { join } from "node:path";
 const ROOT = join(import.meta.dirname, "..", "..");
 const PAGES_DIR = join(ROOT, "app", "t");
 const HELPER = join(ROOT, "lib", "metrics", "codebases.ts");
-const TABLES = /from\(\s*["'](codebases|code_metrics|code_contributions|github_issues)["']\s*\)/;
+const TABLES =
+  /from\(\s*["'](codebases|code_metrics|codebase_findings|codebase_finding_events|code_contributions|github_issues)["']\s*\)/;
 
 function walk(dir: string, out: string[] = []): string[] {
   let entries: string[];

--- a/test/guards/single-writer-codebases.test.ts
+++ b/test/guards/single-writer-codebases.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 
 /**
  * Single-writer guard for codebase analytics (CLAUDE.md §2). `codebases`,
- * `code_metrics`, `code_contributions`, and `github_issues` are written ONLY by the
+ * `code_metrics`, `codebase_findings`, `codebase_finding_events`,
+ * `code_contributions`, and `github_issues` are written ONLY by the
  * sanctioned, audited paths: `lib/codebases/*` (ingest, behind POST /api/v1/codebases)
  * and `lib/admin/aliases.ts` (the audited alias remap, which sets
  * `code_contributions.member_id` and is itself guarded by the data-mechanics
@@ -16,7 +17,8 @@ const ROOT = join(import.meta.dirname, "..", "..");
 const SCAN_DIRS = ["app", "lib", "scripts"];
 // Sanctioned writers (audited): the ingest path + the alias remap.
 const OWNERS = [join("lib", "codebases"), join("lib", "admin", "aliases.ts")];
-const TABLES = "codebases|code_metrics|code_contributions|github_issues";
+const TABLES =
+  "codebases|code_metrics|codebase_findings|codebase_finding_events|code_contributions|github_issues";
 const WRITE_RE = new RegExp(
   `from\\(\\s*["'](${TABLES})["']\\s*\\)\\s*\\.\\s*(insert|update|upsert|delete)\\b`,
   "g"
@@ -66,6 +68,8 @@ describe("single-writer: codebase analytics tables", () => {
     expect(WRITE_RE.test('db.from("code_metrics").upsert(')).toBe(true);
     WRITE_RE.lastIndex = 0;
     expect(WRITE_RE.test('db.from("code_metrics").select(')).toBe(false);
+    WRITE_RE.lastIndex = 0;
+    expect(WRITE_RE.test('db.from("codebase_findings").update(')).toBe(true);
     WRITE_RE.lastIndex = 0;
   });
 });


### PR DESCRIPTION
## What & Why

Materializes validated `codebase_health` v2 findings into a durable, redacted lifecycle ledger. Stable fingerprints now deduplicate across scans, complete current scans resolve absent active findings, recurrence reopens resolved findings, and out-of-order analyses are retained without corrupting current state. The existing v1/v1.0 wire remains compatible and the Brain API stays at 1.17.

## Work item

AIOS-Work: AIO-785

## Implementation

- Adds `codebase_findings` current state, append-only `codebase_finding_events`, and an idempotent Postgres reconciliation function.
- Serializes reconciliation per codebase and classifies globally older snapshots from persisted v2 measurement time.
- Stores atomic occurrence counts for Phase 1 ranking without reconstructing them from a capped event window.
- Rejects a v2 health head that does not match the metrics head.
- Exposes team-tier current state and history through `getCodebaseDetail`; external tier remains fail-closed at the existing read choke point.
- Documents architecture, schema inventory, and the human-approved rollback order.

## Verification

- [x] `npm run check:docs` — routes 61, tables 75, sources 8 in sync
- [x] `npm run coverage` — 1,852 passed, 11 skipped; 40.24% lines
- [x] focused unit/guard tests — 16/16
- [x] focused real-route, real-Postgres codebase-health tests — 12/12
- [x] canonical full data-mechanics suite — 849 passed, 4 skipped
- [x] `npm run typecheck`
- [x] `npm run lint` — no errors; two pre-existing warnings tracked in AIO-794
- [x] `npm run check:errors`
- [x] `npm run check:skills`
- [x] `npm run build` — success; pre-existing optional E2B warning tracked in AIO-795
- [x] schema replayed idempotently; schema/migration function bodies match
- [x] gitleaks — no leaks
- [x] Brain API conformance — shipped routes documented and version anchors all 1.17

## Rollout and rollback

The Railway pre-deploy schema hook applies the additive migration before application rollout. Rollback requires stopping ingest, deploying code that no longer calls the function, taking a verified backup, dropping the function, then dropping events before current findings. Authoritative snapshots remain in `code_metrics.codebase_health`; lifecycle history is intentionally not guessed or backfilled.

## Checklist

- [x] `node scripts/check-docs-drift.mjs` passes locally
- [x] Unit tests pass
- [x] Data-mechanics tests pass against isolated real Postgres
- [x] No Brain API version bump required: no wire change
- [x] No secrets, paths, symbols, source text, or diagnostic prose stored in the ledger
- [x] Local diff review completed and recorded below

## Review — Reviewed by AI code-review skill — verdict no blockers; pull-request CI pending

Review artifact: `code-review-2026-08-04.md` (local handoff artifact, intentionally not committed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New derived persistence and complex lifecycle SQL on the sole codebase ingest path; behavior is heavily tested but wrong reconciliation could skew finding state without touching authoritative `code_metrics` snapshots.
> 
> **Overview**
> **Durable finding ledger for `codebase_health` v2** — redacted v2 findings are projected from scan ingest into `codebase_findings` (one row per team/codebase/fingerprint) and append-only `codebase_finding_events`, driven by the atomic `reconcile_codebase_findings` Postgres function with per-codebase advisory locking and idempotent replay per metrics point.
> 
> **Ingest and validation** — `ingestCodebaseScan` reconciles the ledger immediately after `code_metrics` upsert and records counts in audit metadata. `codebaseScanPayloadSchema` now rejects v2 health when `head_sha` does not match `metrics.head_sha`. The pg adapter wires the new RPC.
> 
> **Reads** — `getCodebaseDetail` returns current findings plus lifecycle events (team tier only); v1 snapshots stay metrics-only with empty findings.
> 
> **Ops/docs** — Architecture and schema inventory document the writer/read paths; OPS describes human-approved rollback order (no automatic backfill).
> 
> Guards and datamechanics tests cover single-writer rules, tier isolation, detect/resolve/reopen/stale ordering, and team isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374fc4d013207f880b639a1a277a8721b8827335. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->