### PR TITLE
feat(codebases): explain durable debt priority (AIO-786)

### DIFF
--- a/app/t/[team]/codebases/[slug]/actions.ts
+++ b/app/t/[team]/codebases/[slug]/actions.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { audit } from "@/lib/api/audit";
+import { currentMember } from "@/lib/auth/guard";
+import {
+  decideCodebaseFinding,
+  findingDecisionSchema,
+  type FindingDecision,
+} from "@/lib/codebases/finding-ledger";
+import { adminClient } from "@/lib/db/admin";
+import { serverClient } from "@/lib/db/server";
+import { getCodebaseIdentity } from "@/lib/metrics/codebases";
+
+export async function recordFindingDecision(
+  teamSlug: string,
+  codebaseSlug: string,
+  input: FindingDecision,
+): Promise<{ ok: boolean; error?: string }> {
+  const parsed = findingDecisionSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: parsed.error.issues[0]?.message ?? "invalid decision",
+    };
+  }
+
+  const db = await serverClient();
+  const { data: team } = await db
+    .from("teams")
+    .select("id")
+    .eq("slug", teamSlug)
+    .maybeSingle();
+  if (!team) return { ok: false, error: "team not found" };
+
+  const me = await currentMember((team as { id: string }).id);
+  if (
+    !me ||
+    me.tier !== "team" ||
+    (me.role !== "admin" && me.role !== "lead")
+  ) {
+    return { ok: false, error: "team leads or admins only" };
+  }
+
+  const codebase = await getCodebaseIdentity(
+    db,
+    team.id,
+    codebaseSlug,
+    me.tier,
+  );
+  if (!codebase) return { ok: false, error: "codebase not found" };
+
+  const writeDb = adminClient();
+  try {
+    const result = await decideCodebaseFinding(writeDb, {
+      ...parsed.data,
+      teamId: team.id,
+      codebaseId: codebase.id,
+      actorMemberId: me.id,
+    });
+    await audit(writeDb, {
+      team_id: team.id,
+      actor_kind: "member",
+      member_id: me.id,
+      action: "codebase_finding.decision",
+      target_type: "codebase_finding",
+      target_id: result.findingId,
+      meta: {
+        status: result.status,
+        owner_member_id: parsed.data.ownerMemberId,
+        expires_at: parsed.data.expiresAt,
+      },
+    });
+    revalidatePath(`/t/${teamSlug}/codebases/${codebaseSlug}`);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "could not record finding decision",
+    };
+  }
+}

--- a/app/t/[team]/codebases/[slug]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { ContributorTable } from "@/components/codebases/contributor-table";
 import { IssuesList } from "@/components/codebases/issues-list";
 import { AgenticTrend } from "@/components/charts/agentic-trend";
 import { ContributionsTrend } from "@/components/charts/contributions-trend";
+import { DebtPatrol } from "@/components/codebases/debt-patrol";
 
 export const metadata: Metadata = { title: "Codebase" };
 
@@ -128,6 +129,16 @@ export default async function CodebaseDetailPage({
           <AgenticScoreCard b={cb.breakdown} />
         )
       ) : null}
+
+      <DebtPatrol
+        patrol={cb.debtPatrol}
+        findings={cb.findings}
+        decisionOwners={cb.decisionOwners}
+        teamSlug={teamSlug}
+        codebaseSlug={cb.slug}
+        currentMemberId={me.id}
+        canDecide={me.tier === "team" && (me.role === "admin" || me.role === "lead")}
+      />
 
       <ContributionsTrend data={cb.commitVolume} />
 

--- a/components/codebases/debt-patrol.tsx
+++ b/components/codebases/debt-patrol.tsx
@@ -1,0 +1,462 @@
+import { ChevronRight } from "lucide-react";
+import type {
+  CodebaseFinding,
+  FindingDecisionOwner,
+} from "@/lib/metrics/codebases";
+import type {
+  DebtFactor,
+  DebtPatrol as DebtPatrolModel,
+} from "@/lib/codebases/debt-ranking";
+import { FindingDecisionControl } from "@/components/codebases/finding-decision-control";
+
+const DECISION_STATUSES = new Set([
+  "accepted",
+  "risk_accepted",
+  "false_positive",
+]);
+const DISPLAY_LIMIT = 100;
+
+function shortDate(value: string | null): string {
+  if (!value) return "unknown";
+  return new Date(value).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function severityClass(severity: CodebaseFinding["severity"]): string {
+  if (severity === "critical")
+    return "border-red-400/40 bg-red-400/10 text-red-700 dark:text-red-300";
+  if (severity === "high")
+    return "border-amber-400/40 bg-amber-400/10 text-amber-700 dark:text-amber-300";
+  return "border-border-subtle bg-surface-raised text-ink-secondary";
+}
+
+function statusLabel(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function FactorRow({ factor }: { factor: DebtFactor }) {
+  return (
+    <tr className="border-t border-border-subtle align-top">
+      <th
+        scope="row"
+        className="px-2 py-2 text-left font-medium text-ink-secondary"
+      >
+        {factor.label}
+        <span className="ml-1 font-normal text-ink-tertiary">
+          · {factor.group}
+        </span>
+      </th>
+      <td className="px-2 py-2 font-mono text-ink-secondary">
+        {factor.state === "unknown" ? (
+          <span className="rounded border border-amber-400/40 px-1.5 py-0.5 text-amber-700 dark:text-amber-300">
+            unknown
+          </span>
+        ) : (
+          `${factor.points}/${factor.weight}`
+        )}
+      </td>
+      <td className="px-2 py-2 text-ink-secondary">
+        <span className="font-medium text-ink">{factor.value}</span>
+        <span className="mt-0.5 block text-ink-tertiary">
+          {factor.explanation}
+        </span>
+      </td>
+      <td className="px-2 py-2 text-ink-tertiary">
+        {factor.provenance}
+        <span className="block font-mono text-[10px]">
+          {factor.verifierClass}
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+function DecisionSummary({ finding }: { finding: CodebaseFinding }) {
+  if (!DECISION_STATUSES.has(finding.status)) return null;
+  return (
+    <div className="border-l-2 border-amber-400 px-3 py-1.5 text-xs text-ink-secondary">
+      <p>
+        <span className="font-medium text-ink">
+          {statusLabel(finding.status)}
+        </span>{" "}
+        by {finding.decision_by_member_name ?? "former member"}; owned by{" "}
+        {finding.decision_owner_name ?? "former member"}; expires{" "}
+        {shortDate(finding.decision_expires_at)}.
+      </p>
+      {finding.decision_reason ? (
+        <p className="mt-1 text-ink-tertiary">{finding.decision_reason}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export function DebtPatrol({
+  patrol,
+  findings,
+  decisionOwners,
+  teamSlug,
+  codebaseSlug,
+  currentMemberId,
+  canDecide,
+}: {
+  patrol: DebtPatrolModel;
+  findings: CodebaseFinding[];
+  decisionOwners: FindingDecisionOwner[];
+  teamSlug: string;
+  codebaseSlug: string;
+  currentMemberId: string;
+  canDecide: boolean;
+}) {
+  const byId = new Map(findings.map((finding) => [finding.id, finding]));
+  const visibleRanked = patrol.ranked.slice(0, DISPLAY_LIMIT);
+  const suppressedAll = findings.filter(
+    (finding) =>
+      DECISION_STATUSES.has(finding.status) &&
+      !patrol.ranked.some((ranking) => ranking.findingId === finding.id),
+  );
+  const suppressed = suppressedAll.slice(0, DISPLAY_LIMIT);
+
+  return (
+    <section
+      aria-labelledby="debt-patrol-heading"
+      className="overflow-hidden rounded-lg border border-border-subtle"
+    >
+      <div className="border-b border-border-subtle px-4 py-4 sm:px-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-ink-tertiary">
+              Repository patrol · report only
+            </p>
+            <h2
+              id="debt-patrol-heading"
+              className="mt-1 font-display text-xl text-ink"
+            >
+              Explainable debt priority
+            </h2>
+            <p className="mt-1 max-w-3xl text-xs text-ink-secondary">
+              Deterministic ranking of durable scanner findings. Unknown inputs
+              remain unknown; this surface never writes source code, pull
+              requests, or Linear issues.
+            </p>
+          </div>
+          <span className="rounded-full border border-border-subtle px-2 py-1 font-mono text-[10px] text-ink-tertiary">
+            method v{patrol.methodologyVersion}
+          </span>
+        </div>
+
+        <dl className="mt-4 grid grid-cols-2 divide-x divide-border-subtle border-y border-border-subtle sm:grid-cols-4">
+          {[
+            ["Active", patrol.rollups.active],
+            ["Recurring", patrol.rollups.recurring],
+            ["Suppressed", patrol.rollups.suppressed],
+            [
+              "Score coverage",
+              patrol.rollups.admission.meanCoveragePct == null
+                ? "n/a"
+                : `${patrol.rollups.admission.meanCoveragePct}%`,
+            ],
+          ].map(([label, value]) => (
+            <div key={label} className="px-3 py-2 first:pl-0 sm:first:pl-3">
+              <dt className="text-[10px] font-medium uppercase tracking-wide text-ink-tertiary">
+                {label}
+              </dt>
+              <dd className="mt-0.5 font-mono text-lg text-ink">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      {patrol.ranked.length === 0 ? (
+        <div className="px-5 py-8 text-center text-sm text-ink-secondary">
+          No active durable findings in the latest admitted ledger state.
+        </div>
+      ) : (
+        <ol className="divide-y divide-border-subtle">
+          {visibleRanked.map((ranking) => {
+            const finding = byId.get(ranking.findingId);
+            if (!finding) return null;
+            return (
+              <li key={finding.id} className="px-4 py-4 sm:px-5">
+                <article aria-labelledby={`finding-${finding.id}`}>
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-xs text-ink-tertiary">
+                          #{ranking.rank}
+                        </span>
+                        <span
+                          className={`rounded border px-1.5 py-0.5 text-[10px] font-medium uppercase ${severityClass(finding.severity)}`}
+                        >
+                          {finding.severity}
+                        </span>
+                        <span className="rounded border border-border-subtle px-1.5 py-0.5 text-[10px] text-ink-tertiary">
+                          {statusLabel(ranking.effectiveStatus)}
+                        </span>
+                        {ranking.decisionExpired ? (
+                          <span className="rounded border border-amber-400/40 px-1.5 py-0.5 text-[10px] text-amber-700 dark:text-amber-300">
+                            decision expired · re-entered
+                          </span>
+                        ) : null}
+                      </div>
+                      <h3
+                        id={`finding-${finding.id}`}
+                        className="mt-2 font-mono text-sm font-medium text-ink"
+                      >
+                        {finding.check_id}
+                      </h3>
+                      <p className="mt-0.5 text-xs text-ink-tertiary">
+                        {finding.axis} · {statusLabel(finding.kind)} · observed{" "}
+                        {finding.occurrence_count}× · first seen{" "}
+                        {shortDate(finding.first_seen_at)}
+                      </p>
+                    </div>
+                    <div className="grid grid-cols-3 gap-x-4 text-right">
+                      <div>
+                        <p className="text-[10px] uppercase tracking-wide text-ink-tertiary">
+                          Priority
+                        </p>
+                        <p className="font-mono text-xl text-ink">
+                          {ranking.priorityScore}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-[10px] uppercase tracking-wide text-ink-tertiary">
+                          Principal
+                        </p>
+                        <p className="font-mono text-sm text-ink-secondary">
+                          {ranking.principalScore}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-[10px] uppercase tracking-wide text-ink-tertiary">
+                          Interest
+                        </p>
+                        <p className="font-mono text-sm text-ink-secondary">
+                          {ranking.interestScore}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <p className="mt-2 font-mono text-[10px] text-ink-tertiary">
+                    fingerprint {finding.fingerprint} · score admission{" "}
+                    {ranking.scoreCoveragePct}%
+                  </p>
+                  <DecisionSummary finding={finding} />
+
+                  <details className="group/rank mt-3">
+                    <summary className="flex cursor-pointer list-none items-center gap-1 text-xs font-medium text-ink-secondary hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50">
+                      <ChevronRight className="size-3 transition-transform group-open/rank:rotate-90" />
+                      Why this rank
+                    </summary>
+                    <div className="mt-2 overflow-x-auto">
+                      <table className="min-w-[720px] w-full text-xs">
+                        <thead className="text-left text-[10px] uppercase tracking-wide text-ink-tertiary">
+                          <tr>
+                            <th className="px-2 py-1 font-medium">Factor</th>
+                            <th className="px-2 py-1 font-medium">Points</th>
+                            <th className="px-2 py-1 font-medium">
+                              Interpretation
+                            </th>
+                            <th className="px-2 py-1 font-medium">
+                              Provenance
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {ranking.factors.map((factor) => (
+                            <FactorRow key={factor.key} factor={factor} />
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </details>
+
+                  <details className="group/history mt-3">
+                    <summary className="flex cursor-pointer list-none items-center gap-1 text-xs text-ink-secondary hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50">
+                      <ChevronRight className="size-3 transition-transform group-open/history:rotate-90" />
+                      Lifecycle history ({finding.events.length})
+                    </summary>
+                    <ol className="mt-2 border-l border-border-subtle pl-3 text-xs">
+                      {finding.events.map((event) => (
+                        <li
+                          key={event.id}
+                          className="py-1.5 text-ink-secondary"
+                        >
+                          <span className="font-medium text-ink">
+                            {statusLabel(event.event_type)}
+                          </span>{" "}
+                          <span className="text-ink-tertiary">
+                            {shortDate(event.observed_at)} ·{" "}
+                            {event.from_status
+                              ? `${statusLabel(event.from_status)} → `
+                              : ""}
+                            {statusLabel(event.to_status)} · head{" "}
+                            {event.head_sha.slice(0, 8)}
+                          </span>
+                          {typeof event.details.reason === "string" ? (
+                            <span className="mt-0.5 block text-ink-tertiary">
+                              {event.details.reason}
+                            </span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ol>
+                  </details>
+
+                  {canDecide ? (
+                    <div className="mt-3">
+                      <FindingDecisionControl
+                        teamSlug={teamSlug}
+                        codebaseSlug={codebaseSlug}
+                        findingId={finding.id}
+                        owners={decisionOwners}
+                        currentMemberId={currentMemberId}
+                        existingOwnerId={finding.decision_owner_member_id}
+                      />
+                    </div>
+                  ) : null}
+                </article>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      {patrol.ranked.length > visibleRanked.length ? (
+        <p className="border-t border-border-subtle px-5 py-3 text-xs text-ink-tertiary">
+          Showing the top {visibleRanked.length} of {patrol.ranked.length}{" "}
+          active findings; all findings remain included in rollups.
+        </p>
+      ) : null}
+
+      {suppressedAll.length > 0 ? (
+        <details className="group/suppressed border-t border-border-subtle px-4 py-3 sm:px-5">
+          <summary className="flex cursor-pointer list-none items-center gap-1 text-xs font-medium text-ink-secondary hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50">
+            <ChevronRight className="size-3 transition-transform group-open/suppressed:rotate-90" />
+            Current operator decisions ({suppressedAll.length})
+          </summary>
+          <div className="mt-3 grid gap-3">
+            {suppressed.map((finding) => (
+              <div
+                key={finding.id}
+                className="grid gap-2 border-t border-border-subtle pt-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+              >
+                <div>
+                  <p className="font-mono text-xs text-ink">
+                    {finding.check_id}
+                  </p>
+                  <DecisionSummary finding={finding} />
+                </div>
+                {canDecide ? (
+                  <FindingDecisionControl
+                    teamSlug={teamSlug}
+                    codebaseSlug={codebaseSlug}
+                    findingId={finding.id}
+                    owners={decisionOwners}
+                    currentMemberId={currentMemberId}
+                    existingOwnerId={finding.decision_owner_member_id}
+                  />
+                ) : null}
+              </div>
+            ))}
+            {suppressedAll.length > suppressed.length ? (
+              <p className="text-xs text-ink-tertiary">
+                Showing {suppressed.length} of {suppressedAll.length} current
+                decisions.
+              </p>
+            ) : null}
+          </div>
+        </details>
+      ) : null}
+
+      <details className="group/northstar border-t border-border-subtle px-4 py-3 sm:px-5">
+        <summary className="flex cursor-pointer list-none items-center gap-1 text-xs font-medium text-ink-secondary hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50">
+          <ChevronRight className="size-3 transition-transform group-open/northstar:rotate-90" />
+          North Star reconciliation and admission gaps
+        </summary>
+        <div className="mt-3 grid gap-4 lg:grid-cols-2">
+          <dl className="divide-y divide-border-subtle border-y border-border-subtle">
+            {patrol.rollups.northStar.map((metric) => (
+              <div
+                key={metric.key}
+                className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 py-2 text-xs"
+              >
+                <div>
+                  <dt className="font-medium text-ink">{metric.label}</dt>
+                  <dd className="text-ink-tertiary">{metric.explanation}</dd>
+                </div>
+                <dd className="text-right font-mono text-ink-secondary">
+                  {metric.value ?? "unknown"}
+                  <span className="block text-[10px] text-ink-tertiary">
+                    {metric.unit}
+                  </span>
+                </dd>
+              </div>
+            ))}
+          </dl>
+          <div className="text-xs text-ink-secondary">
+            <p className="font-medium text-ink">Operational rollups</p>
+            <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-2">
+              {[
+                ["Recurring", patrol.rollups.recurring],
+                ["Evidence incomplete", patrol.rollups.evidenceUnknown],
+                ["Expired decisions", patrol.rollups.expired],
+                ["Age 0–7d", patrol.rollups.age.fresh],
+                ["Age 8–30d", patrol.rollups.age.established],
+                ["Age 31–90d", patrol.rollups.age.aging],
+                ["Age 90d+", patrol.rollups.age.entrenched],
+              ].map(([label, value]) => (
+                <div
+                  key={label}
+                  className="flex justify-between border-b border-border-subtle pb-1"
+                >
+                  <dt>{label}</dt>
+                  <dd className="font-mono">{value}</dd>
+                </div>
+              ))}
+            </dl>
+            <p className="mt-4 font-medium text-ink">Stored lifecycle</p>
+            <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-2">
+              {Object.entries(patrol.rollups.lifecycle)
+                .filter(([, count]) => count > 0)
+                .map(([status, count]) => (
+                  <div
+                    key={status}
+                    className="flex justify-between border-b border-border-subtle pb-1"
+                  >
+                    <dt>{statusLabel(status)}</dt>
+                    <dd className="font-mono">{count}</dd>
+                  </div>
+                ))}
+            </dl>
+            <p className="mt-4 font-medium text-ink">
+              Unknown factor admission
+            </p>
+            <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-2">
+              {Object.entries(patrol.rollups.admission.unknownFactors).map(
+                ([key, count]) => (
+                  <div
+                    key={key}
+                    className="flex justify-between border-b border-border-subtle pb-1"
+                  >
+                    <dt>{statusLabel(key)}</dt>
+                    <dd className="font-mono">{count}</dd>
+                  </div>
+                ),
+              )}
+            </dl>
+            <p className="mt-3 text-ink-tertiary">
+              The verified hardening-efficacy and cost report remains in the
+              engineering harness; these repository rollups do not replace it.
+            </p>
+          </div>
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/components/codebases/finding-decision-control.tsx
+++ b/components/codebases/finding-decision-control.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useMemo, useState, useTransition, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { recordFindingDecision } from "@/app/t/[team]/codebases/[slug]/actions";
+import type { FindingDecisionOwner } from "@/lib/metrics/codebases";
+
+type DecisionStatus = "accepted" | "risk_accepted" | "false_positive";
+
+function defaultExpiryDate(): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + 30);
+  return date.toISOString().slice(0, 10);
+}
+
+export function FindingDecisionControl({
+  teamSlug,
+  codebaseSlug,
+  findingId,
+  owners,
+  currentMemberId,
+  existingOwnerId,
+}: {
+  teamSlug: string;
+  codebaseSlug: string;
+  findingId: string;
+  owners: FindingDecisionOwner[];
+  currentMemberId: string;
+  existingOwnerId: string | null;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<DecisionStatus>("risk_accepted");
+  const [ownerMemberId, setOwnerMemberId] = useState(
+    existingOwnerId ??
+      (owners.some((owner) => owner.id === currentMemberId)
+        ? currentMemberId
+        : (owners[0]?.id ?? "")),
+  );
+  const [reason, setReason] = useState("");
+  const [expiresOn, setExpiresOn] = useState(defaultExpiryDate);
+  const [message, setMessage] = useState<{
+    tone: "error" | "success";
+    text: string;
+  } | null>(null);
+  const minimumExpiry = useMemo(
+    () => new Date().toISOString().slice(0, 10),
+    [],
+  );
+  const prefix = `finding-decision-${findingId}`;
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setMessage(null);
+    const expiresAt = new Date(`${expiresOn}T23:59:59.000Z`).toISOString();
+    startTransition(async () => {
+      const result = await recordFindingDecision(teamSlug, codebaseSlug, {
+        findingId,
+        ownerMemberId,
+        status,
+        reason,
+        expiresAt,
+      });
+      if (!result.ok) {
+        setMessage({
+          tone: "error",
+          text: result.error ?? "could not record decision",
+        });
+        return;
+      }
+      setReason("");
+      setMessage({
+        tone: "success",
+        text: "Decision recorded in finding history.",
+      });
+      router.refresh();
+    });
+  }
+
+  return (
+    <details className="group/decision border-t border-border-subtle pt-3">
+      <summary className="cursor-pointer list-none text-xs font-medium text-ink-secondary hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50">
+        Record operator decision
+      </summary>
+      <form
+        onSubmit={submit}
+        className="mt-3 grid gap-3 rounded-md bg-surface-overlay p-3 sm:grid-cols-2"
+      >
+        <label className="grid gap-1 text-[11px] font-medium uppercase tracking-wide text-ink-tertiary">
+          Decision
+          <select
+            id={`${prefix}-status`}
+            value={status}
+            onChange={(event) =>
+              setStatus(event.target.value as DecisionStatus)
+            }
+            disabled={pending}
+            className="min-h-9 rounded-md border border-border-subtle bg-surface px-2 text-sm normal-case tracking-normal text-ink outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
+          >
+            <option value="accepted">Accepted</option>
+            <option value="risk_accepted">Risk accepted</option>
+            <option value="false_positive">False positive</option>
+          </select>
+        </label>
+        <label className="grid gap-1 text-[11px] font-medium uppercase tracking-wide text-ink-tertiary">
+          Owner
+          <select
+            id={`${prefix}-owner`}
+            value={ownerMemberId}
+            onChange={(event) => setOwnerMemberId(event.target.value)}
+            disabled={pending || owners.length === 0}
+            required
+            className="min-h-9 rounded-md border border-border-subtle bg-surface px-2 text-sm normal-case tracking-normal text-ink outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
+          >
+            {owners.map((owner) => (
+              <option key={owner.id} value={owner.id}>
+                {owner.display_name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="grid gap-1 text-[11px] font-medium uppercase tracking-wide text-ink-tertiary">
+          Expires on
+          <input
+            id={`${prefix}-expiry`}
+            type="date"
+            min={minimumExpiry}
+            value={expiresOn}
+            onChange={(event) => setExpiresOn(event.target.value)}
+            disabled={pending}
+            required
+            className="min-h-9 rounded-md border border-border-subtle bg-surface px-2 text-sm normal-case tracking-normal text-ink outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
+          />
+        </label>
+        <label className="grid gap-1 text-[11px] font-medium uppercase tracking-wide text-ink-tertiary sm:col-span-2">
+          Reason
+          <textarea
+            id={`${prefix}-reason`}
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            disabled={pending}
+            minLength={10}
+            maxLength={500}
+            required
+            rows={3}
+            placeholder="Why is this decision appropriate, and what should the next operator know?"
+            className="rounded-md border border-border-subtle bg-surface px-2 py-2 text-sm normal-case tracking-normal text-ink outline-none placeholder:text-ink-tertiary focus-visible:ring-2 focus-visible:ring-amber-500/50"
+          />
+        </label>
+        <div className="flex flex-wrap items-center gap-3 sm:col-span-2">
+          <button
+            type="submit"
+            disabled={pending || !ownerMemberId}
+            className="min-h-9 rounded-md bg-ink px-3 text-xs font-medium text-surface-base disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {pending ? "Recording…" : "Record decision"}
+          </button>
+          <span className="text-[11px] text-ink-tertiary">
+            Reason, owner, expiry, and actor are audited.
+          </span>
+        </div>
+        {message ? (
+          <p
+            role="status"
+            className={`text-xs sm:col-span-2 ${message.tone === "error" ? "text-red-600 dark:text-red-300" : "text-emerald-700 dark:text-emerald-300"}`}
+          >
+            {message.text}
+          </p>
+        ) : null}
+      </form>
+    </details>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -626,7 +626,34 @@ erDiagram
   actions ||--o| approval_requests : may_link
   teams ||--o{ audit_log : records
   teams ||--o{ query_log : meters
+  teams ||--o{ codebases : scans
+  codebases ||--o{ codebase_findings : projects_current_state
+  codebase_findings ||--o{ codebase_finding_events : retains_history
 ```
+
+### Durable-debt patrol
+
+`code_metrics.codebase_health` remains the authoritative, versioned scanner snapshot.
+`reconcile_codebase_findings` projects admitted v2 findings into team/codebase/fingerprint-scoped
+current state plus append-only `codebase_finding_events`; it does not persist source paths,
+symbols, diagnostic prose, or source text. `lib/metrics/codebases.getCodebaseDetail` is the only
+read path and builds the report-only patrol with `lib/codebases/debt-ranking`.
+
+Ranking method v1 is deterministic. Principal (severity plus explicitly unknown reachability) is
+reported separately from interest (recurrence, age, repository change pressure, and explicitly
+unknown agent friction). Evidence confidence and remediation affordability are disclosed as
+separate factors. The score normalizes over known factor weight and always publishes admission
+coverage; unknown reachability, friction, or review cost is never converted to a measured zero.
+North Star rollups are labelled `proxy` or `unknown`. The independently verified efficacy/cost
+report stays in the engineering harness and is not redefined by this dashboard.
+
+Active team leads/admins may call `decide_codebase_finding` through the codebase server action.
+The database re-checks actor role, tenant/codebase/finding identity, active same-team ownership,
+reason length, and a bounded future expiry before atomically updating current status and appending
+an operator event. `accepted`, `risk_accepted`, and `false_positive` decisions require reason,
+owner, actor, and expiry. An expired decision re-enters the report through an effective
+`open`/`reopened` status while the stored decision and history remain intact. The action also emits
+a best-effort `audit_log` entry; the finding event is the atomic audit record.
 
 ## Module map
 

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -256,6 +256,23 @@ history and is therefore a human-approved rollback, never an automatic migration
 `npm run pg:schema` recreates the empty tables and function; the current migration does not
 backfill old snapshots or guess historical transitions.
 
+### Explainable-debt decision rollback
+
+Migration `20260804160000_explainable_debt_decisions.sql` is additive. The preferred application
+rollback is to deploy code that does not call `decide_codebase_finding` and retain the decision
+columns/events: old application builds ignore them, and operator history remains recoverable.
+Do not set `codebase_finding_events.metrics_id` back to `NOT NULL` while operator events exist;
+decision events intentionally use a null metrics id so repeated human decisions cannot collide
+with scan-replay idempotency.
+
+A physical rollback is destructive to audit history and requires a verified backup plus human
+approval. In order: disable the decision action, drop `decide_codebase_finding`, export the
+operator events (`event_type in ('accepted','risk_accepted','false_positive')`), delete those null-
+metrics events only after the export is verified, restore the metrics-id constraint, then drop the
+decision-expiry index, decision metadata constraint, and five decision columns. The scanner
+snapshot and original finding ledger remain authoritative throughout; never drop either ledger
+table for a Phase 1 UI rollback.
+
 ---
 
 ## 6. API-key rotation — `scripts/admin.ts`

--- a/lib/codebases/debt-ranking.ts
+++ b/lib/codebases/debt-ranking.ts
@@ -1,0 +1,538 @@
+import type { FindingStatus } from "@/lib/codebases/finding-ledger";
+
+export type DebtFactorGroup = "principal" | "interest" | "confidence" | "cost";
+export type DebtFactorState = "known" | "unknown";
+
+export interface DebtFactor {
+  key:
+    | "severity"
+    | "reachability"
+    | "recurrence"
+    | "age"
+    | "change_pressure"
+    | "agent_friction"
+    | "evidence_confidence"
+    | "remediation_cost"
+    | "review_cost";
+  label: string;
+  group: DebtFactorGroup;
+  state: DebtFactorState;
+  points: number | null;
+  weight: number;
+  value: string;
+  explanation: string;
+  provenance: string;
+  verifierClass: "scanner" | "ledger" | "repository" | "unavailable";
+}
+
+export interface DebtFindingInput {
+  id: string;
+  fingerprint: string;
+  status: FindingStatus;
+  check_id: string;
+  axis: string;
+  kind: "quality_issue" | "evidence_gap";
+  severity: "low" | "medium" | "high" | "critical";
+  evidence_status: "complete" | "partial" | "missing" | "stale" | "error";
+  remediation_tier: number;
+  occurrence_count: number;
+  first_seen_at: string;
+  last_seen_at: string;
+  decision_expires_at?: string | null;
+}
+
+export interface DebtRankingContext {
+  commitsWindow: number | null;
+  windowDays: number | null;
+  now: string;
+}
+
+export interface RankedDebtFinding {
+  findingId: string;
+  rank: number;
+  priorityScore: number;
+  scoreCoveragePct: number;
+  principalScore: number;
+  principalCoveragePct: number;
+  interestScore: number;
+  interestCoveragePct: number;
+  effectiveStatus: FindingStatus;
+  decisionExpired: boolean;
+  active: boolean;
+  factors: DebtFactor[];
+}
+
+export interface DebtPatrolRollups {
+  lifecycle: Record<FindingStatus, number>;
+  active: number;
+  suppressed: number;
+  expired: number;
+  recurring: number;
+  evidenceUnknown: number;
+  age: {
+    fresh: number;
+    established: number;
+    aging: number;
+    entrenched: number;
+  };
+  admission: {
+    scored: number;
+    meanCoveragePct: number | null;
+    unknownFactors: Record<string, number>;
+  };
+  northStar: Array<{
+    key:
+      | "change_risk"
+      | "agent_rework"
+      | "reviewer_effort"
+      | "future_development_cost";
+    label: string;
+    state: "proxy" | "unknown";
+    value: number | null;
+    unit: string;
+    explanation: string;
+  }>;
+}
+
+export interface DebtPatrol {
+  ranked: RankedDebtFinding[];
+  rollups: DebtPatrolRollups;
+  generatedAt: string;
+  methodologyVersion: "1";
+}
+
+const DECISION_STATUSES = new Set<FindingStatus>([
+  "accepted",
+  "risk_accepted",
+  "false_positive",
+]);
+
+const LIFECYCLE_ZERO: Record<FindingStatus, number> = {
+  open: 0,
+  accepted: 0,
+  resolved: 0,
+  reopened: 0,
+  false_positive: 0,
+  risk_accepted: 0,
+  superseded: 0,
+  stale_analysis: 0,
+};
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function knownFactor(
+  factor: Omit<DebtFactor, "state" | "points"> & { points: number },
+): DebtFactor {
+  return {
+    ...factor,
+    state: "known",
+    points: clamp(factor.points, 0, factor.weight),
+  };
+}
+
+function unknownFactor(
+  factor: Omit<DebtFactor, "state" | "points" | "value" | "verifierClass"> & {
+    value?: string;
+  },
+): DebtFactor {
+  return {
+    ...factor,
+    state: "unknown",
+    points: null,
+    value: factor.value ?? "unknown",
+    verifierClass: "unavailable",
+  };
+}
+
+function severityPoints(severity: DebtFindingInput["severity"]): number {
+  return { low: 5, medium: 12, high: 22, critical: 30 }[severity];
+}
+
+function recurrencePoints(occurrences: number): number {
+  if (occurrences <= 1) return 0;
+  if (occurrences === 2) return 5;
+  if (occurrences <= 4) return 10;
+  return 15;
+}
+
+function ageDays(firstSeenAt: string, now: string): number {
+  const first = Date.parse(firstSeenAt);
+  const current = Date.parse(now);
+  if (!Number.isFinite(first) || !Number.isFinite(current)) return 0;
+  return Math.max(0, Math.floor((current - first) / 86_400_000));
+}
+
+function agePoints(days: number): number {
+  if (days <= 7) return 0;
+  if (days <= 30) return 3;
+  if (days <= 90) return 7;
+  return 10;
+}
+
+function changePressure(
+  input: DebtRankingContext,
+): { points: number; value: string } | null {
+  if (
+    input.commitsWindow == null ||
+    input.windowDays == null ||
+    input.windowDays <= 0 ||
+    input.commitsWindow < 0
+  ) {
+    return null;
+  }
+  const commitsPer30Days = (input.commitsWindow / input.windowDays) * 30;
+  const points =
+    commitsPer30Days === 0
+      ? 0
+      : commitsPer30Days <= 10
+        ? 4
+        : commitsPer30Days <= 40
+          ? 9
+          : 15;
+  return { points, value: `${round(commitsPer30Days)} commits / 30d` };
+}
+
+function confidencePoints(status: DebtFindingInput["evidence_status"]): number {
+  return { complete: 10, partial: 6, stale: 3, missing: 0, error: 0 }[status];
+}
+
+function remediationPoints(tier: number): number {
+  return { 0: 3, 1: 2, 2: 1, 3: 0 }[clamp(Math.round(tier), 0, 3)] ?? 0;
+}
+
+function factorScore(
+  factors: DebtFactor[],
+  group?: DebtFactorGroup,
+): {
+  score: number;
+  coveragePct: number;
+  knownPoints: number;
+  knownWeight: number;
+} {
+  const selected = group
+    ? factors.filter((factor) => factor.group === group)
+    : factors;
+  const known = selected.filter((factor) => factor.state === "known");
+  const knownPoints = known.reduce(
+    (total, factor) => total + (factor.points ?? 0),
+    0,
+  );
+  const knownWeight = known.reduce((total, factor) => total + factor.weight, 0);
+  const totalWeight = selected.reduce(
+    (total, factor) => total + factor.weight,
+    0,
+  );
+  return {
+    score: knownWeight === 0 ? 0 : round((knownPoints / knownWeight) * 100),
+    coveragePct:
+      totalWeight === 0 ? 0 : round((knownWeight / totalWeight) * 100),
+    knownPoints,
+    knownWeight,
+  };
+}
+
+function effectiveLifecycle(
+  finding: DebtFindingInput,
+  now: string,
+): {
+  status: FindingStatus;
+  decisionExpired: boolean;
+  active: boolean;
+} {
+  const decisionExpired =
+    DECISION_STATUSES.has(finding.status) &&
+    finding.decision_expires_at != null &&
+    Date.parse(finding.decision_expires_at) <= Date.parse(now);
+  const status = decisionExpired
+    ? finding.occurrence_count > 1
+      ? "reopened"
+      : "open"
+    : finding.status;
+  return {
+    status,
+    decisionExpired,
+    active: status === "open" || status === "reopened",
+  };
+}
+
+export function rankDebtFinding(
+  finding: DebtFindingInput,
+  context: DebtRankingContext,
+): RankedDebtFinding {
+  const days = ageDays(finding.first_seen_at, context.now);
+  const pressure = changePressure(context);
+  const factors: DebtFactor[] = [
+    knownFactor({
+      key: "severity",
+      label: "Severity",
+      group: "principal",
+      weight: 30,
+      points: severityPoints(finding.severity),
+      value: finding.severity,
+      explanation: "Inherent impact reported by the versioned scanner rubric.",
+      provenance: `finding ${finding.check_id}`,
+      verifierClass: "scanner",
+    }),
+    unknownFactor({
+      key: "reachability",
+      label: "Reachability",
+      group: "principal",
+      weight: 10,
+      explanation:
+        "Source paths and symbols are intentionally not stored in Team Brain.",
+      provenance: "not admitted by the ledger contract",
+    }),
+    knownFactor({
+      key: "recurrence",
+      label: "Recurrence",
+      group: "interest",
+      weight: 15,
+      points: recurrencePoints(finding.occurrence_count),
+      value: `${finding.occurrence_count} observation${finding.occurrence_count === 1 ? "" : "s"}`,
+      explanation: "Repeated observations increase the expected rework burden.",
+      provenance: "durable finding ledger",
+      verifierClass: "ledger",
+    }),
+    knownFactor({
+      key: "age",
+      label: "Age",
+      group: "interest",
+      weight: 10,
+      points: agePoints(days),
+      value: `${days}d`,
+      explanation:
+        "Unresolved debt accumulates interest as it survives more change cycles.",
+      provenance: "first_seen_at",
+      verifierClass: "ledger",
+    }),
+    pressure
+      ? knownFactor({
+          key: "change_pressure",
+          label: "Change pressure",
+          group: "interest",
+          weight: 15,
+          points: pressure.points,
+          value: pressure.value,
+          explanation:
+            "Repository-level commit cadence raises the chance that active debt is touched.",
+          provenance: "latest code_metrics commits_window/window_days",
+          verifierClass: "repository",
+        })
+      : unknownFactor({
+          key: "change_pressure",
+          label: "Change pressure",
+          group: "interest",
+          weight: 15,
+          explanation:
+            "The latest scan did not contain a usable commit window.",
+          provenance: "latest code_metrics unavailable",
+        }),
+    unknownFactor({
+      key: "agent_friction",
+      label: "Agent friction",
+      group: "interest",
+      weight: 5,
+      explanation:
+        "No finding-level rework or retry signal is admitted by the current contract.",
+      provenance: "not yet measured",
+    }),
+    knownFactor({
+      key: "evidence_confidence",
+      label: "Evidence confidence",
+      group: "confidence",
+      weight: 10,
+      points: confidencePoints(finding.evidence_status),
+      value: finding.evidence_status,
+      explanation:
+        "Incomplete evidence reduces confidence without pretending the risk is absent.",
+      provenance: "scanner evidence_status",
+      verifierClass: "scanner",
+    }),
+    knownFactor({
+      key: "remediation_cost",
+      label: "Remediation affordability",
+      group: "cost",
+      weight: 3,
+      points: remediationPoints(finding.remediation_tier),
+      value: `tier ${finding.remediation_tier}`,
+      explanation:
+        "Lower remediation tiers receive a small priority lift; this is not a cost estimate.",
+      provenance: "scanner remediation_tier",
+      verifierClass: "scanner",
+    }),
+    unknownFactor({
+      key: "review_cost",
+      label: "Review cost",
+      group: "cost",
+      weight: 2,
+      explanation:
+        "No independently verified review-effort estimate exists for this finding.",
+      provenance: "not yet measured",
+    }),
+  ];
+  const total = factorScore(factors);
+  const principal = factorScore(factors, "principal");
+  const interest = factorScore(factors, "interest");
+  const lifecycle = effectiveLifecycle(finding, context.now);
+  return {
+    findingId: finding.id,
+    rank: 0,
+    priorityScore: total.score,
+    scoreCoveragePct: total.coveragePct,
+    principalScore: principal.score,
+    principalCoveragePct: principal.coveragePct,
+    interestScore: interest.score,
+    interestCoveragePct: interest.coveragePct,
+    effectiveStatus: lifecycle.status,
+    decisionExpired: lifecycle.decisionExpired,
+    active: lifecycle.active,
+    factors,
+  };
+}
+
+function rankingComparator(
+  findings: Map<string, DebtFindingInput>,
+  left: RankedDebtFinding,
+  right: RankedDebtFinding,
+): number {
+  const a = findings.get(left.findingId)!;
+  const b = findings.get(right.findingId)!;
+  return (
+    right.priorityScore - left.priorityScore ||
+    severityPoints(b.severity) - severityPoints(a.severity) ||
+    b.occurrence_count - a.occurrence_count ||
+    Date.parse(a.first_seen_at) - Date.parse(b.first_seen_at) ||
+    a.fingerprint.localeCompare(b.fingerprint)
+  );
+}
+
+function ageBucket(days: number): keyof DebtPatrolRollups["age"] {
+  if (days <= 7) return "fresh";
+  if (days <= 30) return "established";
+  if (days <= 90) return "aging";
+  return "entrenched";
+}
+
+export function buildDebtPatrol(
+  findings: DebtFindingInput[],
+  context: DebtRankingContext,
+): DebtPatrol {
+  const byId = new Map(findings.map((finding) => [finding.id, finding]));
+  const allRankings = findings.map((finding) =>
+    rankDebtFinding(finding, context),
+  );
+  const ranked = allRankings
+    .filter((finding) => finding.active)
+    .sort((a, b) => rankingComparator(byId, a, b))
+    .map((finding, index) => ({ ...finding, rank: index + 1 }));
+
+  const lifecycle = { ...LIFECYCLE_ZERO };
+  const age: DebtPatrolRollups["age"] = {
+    fresh: 0,
+    established: 0,
+    aging: 0,
+    entrenched: 0,
+  };
+  const unknownFactors: Record<string, number> = {};
+  for (const finding of findings) lifecycle[finding.status] += 1;
+  for (const ranking of ranked) {
+    const finding = byId.get(ranking.findingId)!;
+    age[ageBucket(ageDays(finding.first_seen_at, context.now))] += 1;
+    for (const factor of ranking.factors) {
+      if (factor.state === "unknown")
+        unknownFactors[factor.key] = (unknownFactors[factor.key] ?? 0) + 1;
+    }
+  }
+
+  const meanCoveragePct =
+    ranked.length === 0
+      ? null
+      : round(
+          ranked.reduce(
+            (total, finding) => total + finding.scoreCoveragePct,
+            0,
+          ) / ranked.length,
+        );
+  const highRisk = ranked.filter((ranking) => {
+    const severity = byId.get(ranking.findingId)!.severity;
+    return severity === "high" || severity === "critical";
+  }).length;
+  const meanInterest =
+    ranked.length === 0
+      ? null
+      : round(
+          ranked.reduce((total, finding) => total + finding.interestScore, 0) /
+            ranked.length,
+        );
+
+  return {
+    ranked,
+    generatedAt: context.now,
+    methodologyVersion: "1",
+    rollups: {
+      lifecycle,
+      active: ranked.length,
+      suppressed: findings.filter(
+        (finding) =>
+          DECISION_STATUSES.has(finding.status) &&
+          !effectiveLifecycle(finding, context.now).decisionExpired,
+      ).length,
+      expired: allRankings.filter((finding) => finding.decisionExpired).length,
+      recurring: ranked.filter(
+        (ranking) => byId.get(ranking.findingId)!.occurrence_count > 1,
+      ).length,
+      evidenceUnknown: ranked.filter((ranking) => {
+        const status = byId.get(ranking.findingId)!.evidence_status;
+        return status !== "complete";
+      }).length,
+      age,
+      admission: { scored: ranked.length, meanCoveragePct, unknownFactors },
+      northStar: [
+        {
+          key: "change_risk",
+          label: "Change risk",
+          state: "proxy",
+          value: highRisk,
+          unit: "high/critical active findings",
+          explanation:
+            "A patrol proxy, not an independently verified outcome metric.",
+        },
+        {
+          key: "agent_rework",
+          label: "Agent rework",
+          state: "unknown",
+          value: null,
+          unit: "unknown",
+          explanation:
+            "Retry and rework telemetry is not present in the ledger contract.",
+        },
+        {
+          key: "reviewer_effort",
+          label: "Reviewer effort",
+          state: "unknown",
+          value: null,
+          unit: "unknown",
+          explanation:
+            "Verified review-time evidence remains in the engineering harness, not Team Brain.",
+        },
+        {
+          key: "future_development_cost",
+          label: "Future development cost",
+          state: meanInterest == null ? "unknown" : "proxy",
+          value: meanInterest,
+          unit: meanInterest == null ? "unknown" : "mean interest index",
+          explanation:
+            meanInterest == null
+              ? "No active admitted findings are available for an interest proxy."
+              : "Age, recurrence, and repository change pressure only; not a currency estimate.",
+        },
+      ],
+    },
+  };
+}

--- a/lib/codebases/finding-ledger.ts
+++ b/lib/codebases/finding-ledger.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { CodebaseHealth } from "@/lib/api/schemas";
 import type { DbClient } from "@/lib/db/types";
 
@@ -16,7 +17,22 @@ export type FindingEventType =
   | "observed"
   | "resolved"
   | "reopened"
-  | "stale_analysis";
+  | "stale_analysis"
+  | "accepted"
+  | "risk_accepted"
+  | "false_positive"
+  | "expired"
+  | "superseded";
+
+export const findingDecisionSchema = z.object({
+  findingId: z.string().uuid(),
+  ownerMemberId: z.string().uuid(),
+  status: z.enum(["accepted", "risk_accepted", "false_positive"]),
+  reason: z.string().trim().min(10).max(500),
+  expiresAt: z.string().datetime({ offset: true }),
+});
+
+export type FindingDecision = z.infer<typeof findingDecisionSchema>;
 
 export type FindingTransition = {
   status: FindingStatus;
@@ -25,6 +41,19 @@ export type FindingTransition = {
 };
 
 type EvidenceStatus = "complete" | "partial" | "missing" | "stale" | "error";
+
+const RESOLVABLE_STATUSES = new Set<FindingStatus>([
+  "open",
+  "reopened",
+  "accepted",
+  "risk_accepted",
+  "false_positive",
+]);
+const DECISION_STATUSES = new Set<FindingStatus>([
+  "accepted",
+  "risk_accepted",
+  "false_positive",
+]);
 
 /**
  * Pure mirror of the database lifecycle rules. The SQL function is the atomic writer;
@@ -35,8 +64,15 @@ export function decideFindingTransition(input: {
   present: boolean;
   evidenceStatus: EvidenceStatus;
   olderThanCurrent?: boolean;
+  decisionNewerThanEvidence?: boolean;
 }): FindingTransition | null {
-  const { currentStatus, present, evidenceStatus, olderThanCurrent = false } = input;
+  const {
+    currentStatus,
+    present,
+    evidenceStatus,
+    olderThanCurrent = false,
+    decisionNewerThanEvidence = false,
+  } = input;
 
   if (olderThanCurrent) {
     if (currentStatus) {
@@ -57,7 +93,9 @@ export function decideFindingTransition(input: {
 
   if (
     evidenceStatus === "complete" &&
-    (currentStatus === "open" || currentStatus === "reopened")
+    currentStatus != null &&
+    RESOLVABLE_STATUSES.has(currentStatus) &&
+    !(DECISION_STATUSES.has(currentStatus) && decisionNewerThanEvidence)
   ) {
     return { status: "resolved", event: "resolved", mutatesCurrent: true };
   }
@@ -100,4 +138,31 @@ export async function reconcileCodebaseFindings(
   });
   if (error) throw new Error(`finding reconciliation failed: ${error.message}`);
   return { ...EMPTY_RESULT, ...(data as Partial<FindingReconcileResult>) };
+}
+
+/** Record an operator decision atomically with its append-only finding event. */
+export async function decideCodebaseFinding(
+  db: DbClient,
+  input: FindingDecision & {
+    teamId: string;
+    codebaseId: string;
+    actorMemberId: string;
+  }
+): Promise<{ findingId: string; status: FindingDecision["status"] }> {
+  const decision = findingDecisionSchema.parse(input);
+  const { data, error } = await db.rpc("decide_codebase_finding", {
+    p_team_id: input.teamId,
+    p_codebase_id: input.codebaseId,
+    p_finding_id: decision.findingId,
+    p_actor_member_id: input.actorMemberId,
+    p_owner_member_id: decision.ownerMemberId,
+    p_decision_status: decision.status,
+    p_reason: decision.reason,
+    p_expires_at: decision.expiresAt,
+  });
+  if (error) throw new Error(`finding decision failed: ${error.message}`);
+  return {
+    findingId: (data as { finding_id: string }).finding_id,
+    status: (data as { status: FindingDecision["status"] }).status,
+  };
 }

--- a/lib/db/pg/client.ts
+++ b/lib/db/pg/client.ts
@@ -37,6 +37,22 @@ export class PgClient {
         );
         return { data: rows[0]?.result ?? {}, error: null };
       }
+      if (fn === "decide_codebase_finding") {
+        const { rows } = await runSql<{ result: { finding_id: string; status: string } }>(
+          `SELECT decide_codebase_finding($1, $2, $3, $4, $5, $6, $7, $8) AS result`,
+          [
+            args.p_team_id,
+            args.p_codebase_id,
+            args.p_finding_id,
+            args.p_actor_member_id,
+            args.p_owner_member_id,
+            args.p_decision_status,
+            args.p_reason,
+            args.p_expires_at,
+          ]
+        );
+        return { data: rows[0]?.result ?? {}, error: null };
+      }
       throw new Error(`pg-adapter: unsupported rpc "${fn}"`);
     } catch (err) {
       const message = err instanceof Error ? err.message : "rpc failed";

--- a/lib/metrics/codebases.ts
+++ b/lib/metrics/codebases.ts
@@ -6,6 +6,7 @@ import { rangeDays, type Range } from "./range";
 import { canSeeCodebases, type ViewerTier } from "@/lib/codebases/visibility";
 import { num, numOrNull, round } from "@/lib/num";
 import type { FindingStatus } from "@/lib/codebases/finding-ledger";
+import { buildDebtPatrol, type DebtPatrol } from "@/lib/codebases/debt-ranking";
 
 /**
  * The ONLY read path for codebase analytics tables — pages must go through here,
@@ -375,7 +376,19 @@ export interface CodebaseFinding {
   last_seen_at: string;
   resolved_at: string | null;
   occurrence_count: number;
+  decision_reason: string | null;
+  decision_owner_member_id: string | null;
+  decision_owner_name: string | null;
+  decision_by_member_id: string | null;
+  decision_by_member_name: string | null;
+  decision_at: string | null;
+  decision_expires_at: string | null;
   events: CodebaseFindingEvent[];
+}
+
+export interface FindingDecisionOwner {
+  id: string;
+  display_name: string;
 }
 
 export interface CodebaseDetail {
@@ -399,6 +412,24 @@ export interface CodebaseDetail {
   contributors: ContributorRow[];
   issues: IssueRow[];
   findings: CodebaseFinding[];
+  decisionOwners: FindingDecisionOwner[];
+  debtPatrol: DebtPatrol;
+}
+
+export async function getCodebaseIdentity(
+  db: DbClient,
+  teamId: string,
+  slug: string,
+  tier: ViewerTier
+): Promise<{ id: string } | null> {
+  if (!canSeeCodebases(tier)) return null;
+  const { data } = await db
+    .from("codebases")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("slug", slug)
+    .maybeSingle();
+  return data ? { id: (data as { id: string }).id } : null;
 }
 
 export async function getCodebaseDetail(
@@ -424,7 +455,7 @@ export async function getCodebaseDetail(
   const windowStart = new Date(Date.now() - rangeDays(range) * 86_400_000).toISOString();
 
   const METRIC_COLS =
-    "scanned_at, agentic_score, health_score, ai_commit_ratio, test_coverage_score, " +
+    "scanned_at, window_days, commits_window, agentic_score, health_score, ai_commit_ratio, test_coverage_score, " +
     "scaffolding_score, skill_breadth_score, cadence_score, issue_health, has_claude_md, " +
     "has_agents_md, agents_md_count, skills_count, commands_count, test_coverage_pct, " +
     "test_coverage_functions_pct, test_coverage_branches_pct, recent_commits, " +
@@ -460,13 +491,16 @@ export async function getCodebaseDetail(
       .eq("codebase_id", codebaseId)
       .order("updated_at", { ascending: false })
       .limit(200),
-    db.from("members").select("id, display_name, github_login, avatar_url").eq("team_id", teamId),
+    db
+      .from("members")
+      .select("id, display_name, github_login, avatar_url, tier, status")
+      .eq("team_id", teamId),
     // Uploaded avatars live on member_profiles (1:1, separate table) — sibling query, merged in JS.
     db.from("member_profiles").select("member_id, avatar_data_url").eq("team_id", teamId),
     db
       .from("codebase_findings")
       .select(
-        "id, fingerprint, status, check_id, axis, kind, severity, evidence_status, remediation_tier, occurrence_count, first_seen_sha, last_seen_sha, first_seen_at, last_seen_at, resolved_at"
+        "id, fingerprint, status, check_id, axis, kind, severity, evidence_status, remediation_tier, occurrence_count, first_seen_sha, last_seen_sha, first_seen_at, last_seen_at, resolved_at, decision_reason, decision_owner_member_id, decision_by_member_id, decision_at, decision_expires_at"
       )
       .eq("team_id", teamId)
       .eq("codebase_id", codebaseId)
@@ -494,6 +528,15 @@ export async function getCodebaseDetail(
   for (const m of (membersRes.data ?? []) as ({ id: string } & MemberMeta)[]) {
     members.set(m.id, { display_name: m.display_name, github_login: m.github_login, avatar_url: m.avatar_url });
   }
+  const decisionOwners = ((membersRes.data ?? []) as Array<
+    { id: string; tier: string; status: string } & MemberMeta
+  >)
+    .filter((member) => member.tier === "team" && member.status === "active")
+    .map((member) => ({
+      id: member.id,
+      display_name: member.display_name ?? member.github_login ?? "Unnamed member",
+    }))
+    .sort((a, b) => a.display_name.localeCompare(b.display_name));
 
   // newest-first from the query. `latest` is the true last scan (unwindowed) so the breakdown
   // never blanks; the trend is windowed with a fallback to the most recent points.
@@ -631,10 +674,22 @@ export async function getCodebaseDetail(
     findingEventsById.set(row.finding_id, events);
   }
 
-  type FindingRow = Omit<CodebaseFinding, "first_seen_at" | "last_seen_at" | "resolved_at" | "events"> & {
+  type FindingRow = Omit<
+    CodebaseFinding,
+    | "first_seen_at"
+    | "last_seen_at"
+    | "resolved_at"
+    | "decision_at"
+    | "decision_expires_at"
+    | "decision_owner_name"
+    | "decision_by_member_name"
+    | "events"
+  > & {
     first_seen_at: string | Date;
     last_seen_at: string | Date;
     resolved_at: string | Date | null;
+    decision_at: string | Date | null;
+    decision_expires_at: string | Date | null;
   };
   const findings: CodebaseFinding[] = ((findingsRes.data ?? []) as FindingRow[]).map((row) => {
     const events = findingEventsById.get(row.id) ?? [];
@@ -645,8 +700,26 @@ export async function getCodebaseDetail(
       first_seen_at: new Date(row.first_seen_at).toISOString(),
       last_seen_at: new Date(row.last_seen_at).toISOString(),
       resolved_at: row.resolved_at == null ? null : new Date(row.resolved_at).toISOString(),
+      decision_owner_name:
+        row.decision_owner_member_id == null
+          ? null
+          : (members.get(row.decision_owner_member_id)?.display_name ?? "Former member"),
+      decision_by_member_name:
+        row.decision_by_member_id == null
+          ? null
+          : (members.get(row.decision_by_member_id)?.display_name ?? "Former member"),
+      decision_at: row.decision_at == null ? null : new Date(row.decision_at).toISOString(),
+      decision_expires_at:
+        row.decision_expires_at == null ? null : new Date(row.decision_expires_at).toISOString(),
       events,
     };
+  });
+
+  const patrolGeneratedAt = new Date().toISOString();
+  const debtPatrol = buildDebtPatrol(findings, {
+    commitsWindow: latest?.commits_window == null ? null : num(latest.commits_window as number),
+    windowDays: latest?.window_days == null ? null : num(latest.window_days as number),
+    now: patrolGeneratedAt,
   });
 
   const c = cb as Record<string, unknown>;
@@ -673,6 +746,8 @@ export async function getCodebaseDetail(
     contributors,
     issues,
     findings,
+    decisionOwners,
+    debtPatrol,
   };
 }
 

--- a/postgres/migrations/20260804160000_explainable_debt_decisions.sql
+++ b/postgres/migrations/20260804160000_explainable_debt_decisions.sql
@@ -1,0 +1,403 @@
+-- AIO-786: audited, expiring operator decisions for the durable finding ledger.
+alter table codebase_findings
+  add column if not exists decision_reason text,
+  add column if not exists decision_owner_member_id uuid references members(id) on delete set null,
+  add column if not exists decision_by_member_id uuid references members(id) on delete set null,
+  add column if not exists decision_at timestamptz,
+  add column if not exists decision_expires_at timestamptz;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'codebase_findings_decision_metadata'
+      and conrelid = 'codebase_findings'::regclass
+  ) then
+    alter table codebase_findings
+      add constraint codebase_findings_decision_metadata check (
+        (
+          status = any (array['accepted', 'risk_accepted', 'false_positive']::text[])
+          and decision_reason is not null
+          and char_length(decision_reason) between 10 and 500
+          and decision_at is not null
+          and decision_expires_at > decision_at
+        )
+        or
+        (
+          status <> all (array['accepted', 'risk_accepted', 'false_positive']::text[])
+          and decision_reason is null
+          and decision_owner_member_id is null
+          and decision_by_member_id is null
+          and decision_at is null
+          and decision_expires_at is null
+        )
+      );
+  end if;
+end;
+$$;
+
+alter table codebase_finding_events alter column metrics_id drop not null;
+
+create index if not exists codebase_findings_decision_expiry_idx
+  on codebase_findings (team_id, codebase_id, decision_expires_at)
+  where status in ('accepted', 'risk_accepted', 'false_positive');
+
+-- Re-project a complete absence through decided states as resolved. Decision
+-- metadata is cleared from current state; append-only operator events remain.
+create or replace function reconcile_codebase_findings(
+  p_team_id uuid,
+  p_codebase_id uuid,
+  p_metrics_id uuid,
+  p_health jsonb
+) returns jsonb
+language plpgsql
+as $$
+declare
+  v_schema_version text := coalesce(p_health->>'schema_version', '');
+  v_evidence_status text;
+  v_head_sha text;
+  v_observed_at timestamptz;
+  v_latest_observed_at timestamptz;
+  v_snapshot_is_stale boolean := false;
+  v_finding jsonb;
+  v_row codebase_findings%rowtype;
+  v_previous_status text;
+  v_event_type text;
+  v_new_status text;
+  v_detected integer := 0;
+  v_observed integer := 0;
+  v_resolved integer := 0;
+  v_reopened integer := 0;
+  v_stale integer := 0;
+begin
+  if v_schema_version <> '2' then
+    return jsonb_build_object(
+      'detected', 0, 'observed', 0, 'resolved', 0, 'reopened', 0, 'stale', 0
+    );
+  end if;
+
+  v_evidence_status := p_health->>'evidence_status';
+  v_head_sha := p_health->>'head_sha';
+  v_observed_at := (p_health->>'measured_at')::timestamptz;
+
+  if not exists (
+    select 1
+    from code_metrics
+    where id = p_metrics_id
+      and team_id = p_team_id
+      and codebase_id = p_codebase_id
+      and head_sha = v_head_sha
+      and codebase_health = p_health
+  ) then
+    raise exception 'finding reconciliation metrics identity mismatch';
+  end if;
+
+  -- Serialize lifecycle projection per codebase. Metrics writes happen before this
+  -- function, so whichever reconciliation wins the lock can see every committed v2
+  -- measurement and classify an out-of-order snapshot deterministically.
+  perform pg_advisory_xact_lock(
+    hashtextextended(p_team_id::text || ':' || p_codebase_id::text, 0)
+  );
+  select coalesce(
+    max((codebase_health->>'measured_at')::timestamptz),
+    v_observed_at
+  )
+  into v_latest_observed_at
+  from code_metrics
+  where team_id = p_team_id
+    and codebase_id = p_codebase_id
+    and codebase_health->>'schema_version' = '2';
+  v_snapshot_is_stale := v_observed_at < v_latest_observed_at;
+
+  for v_finding in
+    select value from jsonb_array_elements(coalesce(p_health->'findings', '[]'::jsonb))
+  loop
+    select *
+    into v_row
+    from codebase_findings
+    where team_id = p_team_id
+      and codebase_id = p_codebase_id
+      and fingerprint = v_finding->>'fingerprint'
+    for update;
+
+    if not found then
+      v_new_status := case when v_snapshot_is_stale then 'stale_analysis' else 'open' end;
+      v_event_type := case when v_snapshot_is_stale then 'stale_analysis' else 'detected' end;
+      insert into codebase_findings (
+        team_id, codebase_id, fingerprint, status, check_id, axis, kind, severity,
+        evidence_status, remediation_tier, first_seen_sha, last_seen_sha,
+        first_seen_at, last_seen_at, latest_metrics_id
+      ) values (
+        p_team_id,
+        p_codebase_id,
+        v_finding->>'fingerprint',
+        v_new_status,
+        v_finding->>'check_id',
+        v_finding->>'axis',
+        v_finding->>'kind',
+        v_finding->>'severity',
+        v_finding->>'evidence_status',
+        (v_finding->>'remediation_tier')::integer,
+        v_head_sha,
+        v_head_sha,
+        v_observed_at,
+        v_observed_at,
+        p_metrics_id
+      )
+      on conflict (team_id, codebase_id, fingerprint) do nothing
+      returning * into v_row;
+
+      if found then
+        insert into codebase_finding_events (
+          team_id, codebase_id, finding_id, metrics_id, event_type,
+          from_status, to_status, head_sha, observed_at, details
+        ) values (
+          p_team_id, p_codebase_id, v_row.id, p_metrics_id, v_event_type,
+          null, v_new_status, v_head_sha, v_observed_at,
+          jsonb_build_object(
+            'rubric_version', p_health->>'rubric_version',
+            'profile_id', p_health->>'profile_id',
+            'profile_version', p_health->>'profile_version',
+            'evidence_status', v_evidence_status
+          )
+        )
+        on conflict (finding_id, metrics_id, event_type) do nothing;
+        if v_snapshot_is_stale then
+          v_stale := v_stale + 1;
+        else
+          v_detected := v_detected + 1;
+        end if;
+        continue;
+      end if;
+
+      select *
+      into v_row
+      from codebase_findings
+      where team_id = p_team_id
+        and codebase_id = p_codebase_id
+        and fingerprint = v_finding->>'fingerprint'
+      for update;
+    end if;
+
+    if exists (
+      select 1 from codebase_finding_events
+      where finding_id = v_row.id and metrics_id = p_metrics_id
+    ) then
+      continue;
+    end if;
+
+    if v_snapshot_is_stale or v_observed_at < greatest(
+      v_row.last_seen_at,
+      coalesce(v_row.resolved_at, '-infinity'::timestamptz)
+    ) then
+      insert into codebase_finding_events (
+        team_id, codebase_id, finding_id, metrics_id, event_type,
+        from_status, to_status, head_sha, observed_at, details
+      ) values (
+        p_team_id, p_codebase_id, v_row.id, p_metrics_id, 'stale_analysis',
+        v_row.status, v_row.status, v_head_sha, v_observed_at,
+        jsonb_build_object(
+          'rubric_version', p_health->>'rubric_version',
+          'profile_id', p_health->>'profile_id',
+          'profile_version', p_health->>'profile_version',
+          'evidence_status', v_evidence_status
+        )
+      )
+      on conflict (finding_id, metrics_id, event_type) do nothing;
+      v_stale := v_stale + 1;
+      continue;
+    end if;
+
+    v_previous_status := v_row.status;
+    if v_previous_status in ('resolved', 'stale_analysis') then
+      v_event_type := 'reopened';
+      v_row.status := 'reopened';
+      v_reopened := v_reopened + 1;
+    else
+      v_event_type := 'observed';
+      v_observed := v_observed + 1;
+    end if;
+
+    update codebase_findings
+    set status = v_row.status,
+        check_id = v_finding->>'check_id',
+        axis = v_finding->>'axis',
+        kind = v_finding->>'kind',
+        severity = v_finding->>'severity',
+        evidence_status = v_finding->>'evidence_status',
+        remediation_tier = (v_finding->>'remediation_tier')::integer,
+        occurrence_count = occurrence_count + 1,
+        last_seen_sha = v_head_sha,
+        last_seen_at = v_observed_at,
+        resolved_at = case when v_row.status = 'reopened' then null else resolved_at end,
+        latest_metrics_id = p_metrics_id,
+        updated_at = now()
+    where id = v_row.id and team_id = p_team_id;
+
+    insert into codebase_finding_events (
+      team_id, codebase_id, finding_id, metrics_id, event_type,
+      from_status, to_status, head_sha, observed_at, details
+    ) values (
+      p_team_id, p_codebase_id, v_row.id, p_metrics_id, v_event_type,
+      v_previous_status, v_row.status, v_head_sha, v_observed_at,
+      jsonb_build_object(
+        'rubric_version', p_health->>'rubric_version',
+        'profile_id', p_health->>'profile_id',
+        'profile_version', p_health->>'profile_version',
+        'evidence_status', v_evidence_status
+      )
+    )
+    on conflict (finding_id, metrics_id, event_type) do nothing;
+  end loop;
+
+  if v_evidence_status = 'complete' and not v_snapshot_is_stale then
+    for v_row in
+      select *
+      from codebase_findings f
+      where f.team_id = p_team_id
+        and f.codebase_id = p_codebase_id
+        and (
+          f.status in ('open', 'reopened')
+          or (
+            f.status in ('accepted', 'risk_accepted', 'false_positive')
+            and f.decision_at <= v_observed_at
+          )
+        )
+        and f.last_seen_at <= v_observed_at
+        and not exists (
+          select 1
+          from jsonb_array_elements(coalesce(p_health->'findings', '[]'::jsonb)) current_finding
+          where current_finding->>'fingerprint' = f.fingerprint
+        )
+      for update
+    loop
+      update codebase_findings
+      set status = 'resolved',
+          resolved_at = v_observed_at,
+          decision_reason = null,
+          decision_owner_member_id = null,
+          decision_by_member_id = null,
+          decision_at = null,
+          decision_expires_at = null,
+          latest_metrics_id = p_metrics_id,
+          updated_at = now()
+      where id = v_row.id and team_id = p_team_id;
+
+      insert into codebase_finding_events (
+        team_id, codebase_id, finding_id, metrics_id, event_type,
+        from_status, to_status, head_sha, observed_at, details
+      ) values (
+        p_team_id, p_codebase_id, v_row.id, p_metrics_id, 'resolved',
+        v_row.status, 'resolved', v_head_sha, v_observed_at,
+        jsonb_build_object(
+          'rubric_version', p_health->>'rubric_version',
+          'profile_id', p_health->>'profile_id',
+          'profile_version', p_health->>'profile_version',
+          'evidence_status', v_evidence_status
+        )
+      )
+      on conflict (finding_id, metrics_id, event_type) do nothing;
+      v_resolved := v_resolved + 1;
+    end loop;
+  end if;
+
+  return jsonb_build_object(
+    'detected', v_detected,
+    'observed', v_observed,
+    'resolved', v_resolved,
+    'reopened', v_reopened,
+    'stale', v_stale
+  );
+end;
+$$;
+
+create or replace function decide_codebase_finding(
+  p_team_id uuid,
+  p_codebase_id uuid,
+  p_finding_id uuid,
+  p_actor_member_id uuid,
+  p_owner_member_id uuid,
+  p_decision_status text,
+  p_reason text,
+  p_expires_at timestamptz
+) returns jsonb
+language plpgsql
+as $$
+declare
+  v_now timestamptz := now();
+  v_reason text := btrim(coalesce(p_reason, ''));
+  v_finding codebase_findings%rowtype;
+begin
+  if p_decision_status not in ('accepted', 'risk_accepted', 'false_positive') then
+    raise exception 'invalid finding decision status';
+  end if;
+  if char_length(v_reason) not between 10 and 500 then
+    raise exception 'finding decision reason must be between 10 and 500 characters';
+  end if;
+  if p_expires_at <= v_now or p_expires_at > v_now + interval '366 days' then
+    raise exception 'finding decision expiry must be in the next 366 days';
+  end if;
+  if not exists (
+    select 1 from members
+    where id = p_actor_member_id
+      and team_id = p_team_id
+      and status = 'active'
+      and tier = 'team'
+      and role in ('admin', 'lead')
+  ) then
+    raise exception 'finding decisions require an active team lead or admin';
+  end if;
+  if not exists (
+    select 1 from members
+    where id = p_owner_member_id
+      and team_id = p_team_id
+      and status = 'active'
+      and tier = 'team'
+  ) then
+    raise exception 'finding decision owner must be an active team member';
+  end if;
+
+  select * into v_finding
+  from codebase_findings
+  where id = p_finding_id
+    and team_id = p_team_id
+    and codebase_id = p_codebase_id
+  for update;
+  if not found then
+    raise exception 'finding not found';
+  end if;
+  if v_finding.status not in (
+    'open', 'reopened', 'accepted', 'risk_accepted', 'false_positive'
+  ) then
+    raise exception 'finding status cannot receive an operator decision';
+  end if;
+
+  update codebase_findings
+  set status = p_decision_status,
+      decision_reason = v_reason,
+      decision_owner_member_id = p_owner_member_id,
+      decision_by_member_id = p_actor_member_id,
+      decision_at = v_now,
+      decision_expires_at = p_expires_at,
+      updated_at = v_now
+  where id = p_finding_id
+    and team_id = p_team_id
+    and codebase_id = p_codebase_id;
+
+  insert into codebase_finding_events (
+    team_id, codebase_id, finding_id, metrics_id, event_type,
+    from_status, to_status, head_sha, observed_at, details
+  ) values (
+    p_team_id, p_codebase_id, p_finding_id, null, p_decision_status,
+    v_finding.status, p_decision_status, v_finding.last_seen_sha, v_now,
+    jsonb_build_object(
+      'reason', v_reason,
+      'owner_member_id', p_owner_member_id,
+      'actor_member_id', p_actor_member_id,
+      'expires_at', p_expires_at
+    )
+  );
+
+  return jsonb_build_object('finding_id', p_finding_id, 'status', p_decision_status);
+end;
+$$;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1501,15 +1501,41 @@ create table if not exists codebase_findings (
   first_seen_at timestamptz not null,
   last_seen_at timestamptz not null,
   resolved_at timestamptz,
+  decision_reason text,
+  decision_owner_member_id uuid references members(id) on delete set null,
+  decision_by_member_id uuid references members(id) on delete set null,
+  decision_at timestamptz,
+  decision_expires_at timestamptz,
   latest_metrics_id uuid references code_metrics(id) on delete set null,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
+  constraint codebase_findings_decision_metadata check (
+    (
+      status = any (array['accepted', 'risk_accepted', 'false_positive']::text[])
+      and decision_reason is not null
+      and char_length(decision_reason) between 10 and 500
+      and decision_at is not null
+      and decision_expires_at > decision_at
+    )
+    or
+    (
+      status <> all (array['accepted', 'risk_accepted', 'false_positive']::text[])
+      and decision_reason is null
+      and decision_owner_member_id is null
+      and decision_by_member_id is null
+      and decision_at is null
+      and decision_expires_at is null
+    )
+  ),
   unique (team_id, codebase_id, fingerprint)
 );
 alter table codebase_findings
   add column if not exists occurrence_count integer not null default 1;
 create index if not exists codebase_findings_active_idx
   on codebase_findings (team_id, codebase_id, status, last_seen_at desc);
+create index if not exists codebase_findings_decision_expiry_idx
+  on codebase_findings (team_id, codebase_id, decision_expires_at)
+  where status in ('accepted', 'risk_accepted', 'false_positive');
 
 -- Append-only lifecycle/observation history. Replaying one metrics point is idempotent.
 create table if not exists codebase_finding_events (
@@ -1517,7 +1543,9 @@ create table if not exists codebase_finding_events (
   team_id uuid not null references teams(id) on delete cascade,
   codebase_id uuid not null references codebases(id) on delete cascade,
   finding_id uuid not null references codebase_findings(id) on delete cascade,
-  metrics_id uuid not null references code_metrics(id) on delete cascade,
+  -- Scan lifecycle events carry metrics_id. Operator decisions are durable audit
+  -- events with metrics_id null so repeated decisions never collide with ingest idempotency.
+  metrics_id uuid references code_metrics(id) on delete cascade,
   event_type text not null check (event_type in (
     'detected', 'observed', 'resolved', 'reopened', 'stale_analysis',
     'accepted', 'risk_accepted', 'false_positive', 'expired', 'superseded'
@@ -1745,7 +1773,13 @@ begin
       from codebase_findings f
       where f.team_id = p_team_id
         and f.codebase_id = p_codebase_id
-        and f.status in ('open', 'reopened')
+        and (
+          f.status in ('open', 'reopened')
+          or (
+            f.status in ('accepted', 'risk_accepted', 'false_positive')
+            and f.decision_at <= v_observed_at
+          )
+        )
         and f.last_seen_at <= v_observed_at
         and not exists (
           select 1
@@ -1757,6 +1791,11 @@ begin
       update codebase_findings
       set status = 'resolved',
           resolved_at = v_observed_at,
+          decision_reason = null,
+          decision_owner_member_id = null,
+          decision_by_member_id = null,
+          decision_at = null,
+          decision_expires_at = null,
           latest_metrics_id = p_metrics_id,
           updated_at = now()
       where id = v_row.id and team_id = p_team_id;
@@ -1786,6 +1825,97 @@ begin
     'reopened', v_reopened,
     'stale', v_stale
   );
+end;
+$$;
+
+create or replace function decide_codebase_finding(
+  p_team_id uuid,
+  p_codebase_id uuid,
+  p_finding_id uuid,
+  p_actor_member_id uuid,
+  p_owner_member_id uuid,
+  p_decision_status text,
+  p_reason text,
+  p_expires_at timestamptz
+) returns jsonb
+language plpgsql
+as $$
+declare
+  v_now timestamptz := now();
+  v_reason text := btrim(coalesce(p_reason, ''));
+  v_finding codebase_findings%rowtype;
+begin
+  if p_decision_status not in ('accepted', 'risk_accepted', 'false_positive') then
+    raise exception 'invalid finding decision status';
+  end if;
+  if char_length(v_reason) not between 10 and 500 then
+    raise exception 'finding decision reason must be between 10 and 500 characters';
+  end if;
+  if p_expires_at <= v_now or p_expires_at > v_now + interval '366 days' then
+    raise exception 'finding decision expiry must be in the next 366 days';
+  end if;
+  if not exists (
+    select 1 from members
+    where id = p_actor_member_id
+      and team_id = p_team_id
+      and status = 'active'
+      and tier = 'team'
+      and role in ('admin', 'lead')
+  ) then
+    raise exception 'finding decisions require an active team lead or admin';
+  end if;
+  if not exists (
+    select 1 from members
+    where id = p_owner_member_id
+      and team_id = p_team_id
+      and status = 'active'
+      and tier = 'team'
+  ) then
+    raise exception 'finding decision owner must be an active team member';
+  end if;
+
+  select * into v_finding
+  from codebase_findings
+  where id = p_finding_id
+    and team_id = p_team_id
+    and codebase_id = p_codebase_id
+  for update;
+  if not found then
+    raise exception 'finding not found';
+  end if;
+  if v_finding.status not in (
+    'open', 'reopened', 'accepted', 'risk_accepted', 'false_positive'
+  ) then
+    raise exception 'finding status cannot receive an operator decision';
+  end if;
+
+  update codebase_findings
+  set status = p_decision_status,
+      decision_reason = v_reason,
+      decision_owner_member_id = p_owner_member_id,
+      decision_by_member_id = p_actor_member_id,
+      decision_at = v_now,
+      decision_expires_at = p_expires_at,
+      updated_at = v_now
+  where id = p_finding_id
+    and team_id = p_team_id
+    and codebase_id = p_codebase_id;
+
+  insert into codebase_finding_events (
+    team_id, codebase_id, finding_id, metrics_id, event_type,
+    from_status, to_status, head_sha, observed_at, details
+  ) values (
+    p_team_id, p_codebase_id, p_finding_id, null, p_decision_status,
+    v_finding.status, p_decision_status, v_finding.last_seen_sha, v_now,
+    jsonb_build_object(
+      'reason', v_reason,
+      'owner_member_id', p_owner_member_id,
+      'actor_member_id', p_actor_member_id,
+      'expires_at', p_expires_at
+    )
+  );
+
+  return jsonb_build_object('finding_id', p_finding_id, 'status', p_decision_status);
 end;
 $$;
 create index if not exists code_metrics_codebase_time_idx on code_metrics (codebase_id, scanned_at desc);

--- a/test/codebase-debt-ranking.test.ts
+++ b/test/codebase-debt-ranking.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDebtPatrol,
+  rankDebtFinding,
+  type DebtFindingInput,
+} from "@/lib/codebases/debt-ranking";
+
+const NOW = "2026-08-04T12:00:00.000Z";
+
+function finding(overrides: Partial<DebtFindingInput> = {}): DebtFindingInput {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    fingerprint: "a".repeat(64),
+    status: "open",
+    check_id: "coverage_lines_pct",
+    axis: "test_rigor",
+    kind: "quality_issue",
+    severity: "high",
+    evidence_status: "complete",
+    remediation_tier: 1,
+    occurrence_count: 2,
+    first_seen_at: "2026-05-01T12:00:00.000Z",
+    last_seen_at: "2026-08-04T10:00:00.000Z",
+    decision_expires_at: null,
+    ...overrides,
+  };
+}
+
+const CONTEXT = { commitsWindow: 90, windowDays: 90, now: NOW };
+
+describe("explainable debt ranking", () => {
+  it("separates principal from interest and normalizes only over known evidence", () => {
+    const ranked = rankDebtFinding(finding(), CONTEXT);
+
+    expect(ranked).toMatchObject({
+      priorityScore: 69.9,
+      scoreCoveragePct: 83,
+      principalScore: 73.3,
+      principalCoveragePct: 75,
+      interestScore: 60,
+      interestCoveragePct: 88.9,
+      active: true,
+    });
+    expect(
+      ranked.factors
+        .filter((factor) => factor.state === "unknown")
+        .map((factor) => factor.key),
+    ).toEqual(["reachability", "agent_friction", "review_cost"]);
+    expect(
+      ranked.factors.find((factor) => factor.key === "reachability"),
+    ).toMatchObject({
+      points: null,
+      value: "unknown",
+    });
+  });
+
+  it("keeps a measured zero distinct from an unknown input", () => {
+    const ranked = rankDebtFinding(
+      finding({
+        occurrence_count: 1,
+        first_seen_at: "2026-08-03T12:00:00.000Z",
+      }),
+      { commitsWindow: 0, windowDays: 90, now: NOW },
+    );
+
+    expect(
+      ranked.factors.find((factor) => factor.key === "recurrence"),
+    ).toMatchObject({
+      state: "known",
+      points: 0,
+    });
+    expect(
+      ranked.factors.find((factor) => factor.key === "change_pressure"),
+    ).toMatchObject({
+      state: "known",
+      points: 0,
+      value: "0 commits / 30d",
+    });
+    expect(
+      ranked.factors.find((factor) => factor.key === "review_cost"),
+    ).toMatchObject({
+      state: "unknown",
+      points: null,
+    });
+  });
+
+  it("orders ties deterministically by the stable fingerprint", () => {
+    const second = finding({
+      id: "00000000-0000-4000-8000-000000000002",
+      fingerprint: "b".repeat(64),
+    });
+    const patrol = buildDebtPatrol([second, finding()], CONTEXT);
+
+    expect(patrol.ranked.map((ranking) => ranking.findingId)).toEqual([
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ]);
+    expect(patrol.ranked.map((ranking) => ranking.rank)).toEqual([1, 2]);
+  });
+
+  it("suppresses a current decision and re-enters it after expiry without erasing status", () => {
+    const current = finding({
+      status: "risk_accepted",
+      decision_expires_at: "2026-08-05T12:00:00.000Z",
+    });
+    const expired = finding({
+      id: "00000000-0000-4000-8000-000000000002",
+      fingerprint: "b".repeat(64),
+      status: "accepted",
+      decision_expires_at: "2026-08-03T12:00:00.000Z",
+    });
+    const patrol = buildDebtPatrol([current, expired], CONTEXT);
+
+    expect(patrol.rollups).toMatchObject({
+      active: 1,
+      suppressed: 1,
+      expired: 1,
+    });
+    expect(patrol.ranked[0]).toMatchObject({
+      findingId: expired.id,
+      effectiveStatus: "reopened",
+      decisionExpired: true,
+      active: true,
+    });
+    expect(patrol.rollups.lifecycle).toMatchObject({
+      risk_accepted: 1,
+      accepted: 1,
+    });
+  });
+
+  it("labels North Star values as patrol proxies or unknowns, never verified outcomes", () => {
+    const patrol = buildDebtPatrol([finding()], CONTEXT);
+    const states = Object.fromEntries(
+      patrol.rollups.northStar.map((metric) => [metric.key, metric.state]),
+    );
+
+    expect(states).toEqual({
+      change_risk: "proxy",
+      agent_rework: "unknown",
+      reviewer_effort: "unknown",
+      future_development_cost: "proxy",
+    });
+  });
+
+  it("reports no-data rollups as unavailable rather than measured zero", () => {
+    const patrol = buildDebtPatrol([], CONTEXT);
+    const futureCost = patrol.rollups.northStar.find(
+      (metric) => metric.key === "future_development_cost",
+    );
+
+    expect(patrol.rollups.admission).toMatchObject({
+      scored: 0,
+      meanCoveragePct: null,
+    });
+    expect(futureCost).toMatchObject({
+      state: "unknown",
+      value: null,
+      unit: "unknown",
+    });
+  });
+});

--- a/test/codebase-finding-ledger.test.ts
+++ b/test/codebase-finding-ledger.test.ts
@@ -51,6 +51,27 @@ describe("codebase finding lifecycle", () => {
     ).toEqual({ status: "risk_accepted", event: "observed", mutatesCurrent: true });
   });
 
+  it("resolves a decided finding when complete evidence proves it absent", () => {
+    expect(
+      decideFindingTransition({
+        currentStatus: "risk_accepted",
+        present: false,
+        evidenceStatus: "complete",
+      })
+    ).toEqual({ status: "resolved", event: "resolved", mutatesCurrent: true });
+  });
+
+  it("does not let evidence older than the operator decision resolve it", () => {
+    expect(
+      decideFindingTransition({
+        currentStatus: "risk_accepted",
+        present: false,
+        evidenceStatus: "complete",
+        decisionNewerThanEvidence: true,
+      })
+    ).toBeNull();
+  });
+
   it("records older analysis without mutating current state", () => {
     expect(
       decideFindingTransition({

--- a/test/datamechanics/codebase-debt-decisions.datamechanics.test.ts
+++ b/test/datamechanics/codebase-debt-decisions.datamechanics.test.ts
@@ -1,0 +1,349 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { CodebaseHealth } from "@/lib/api/schemas";
+import {
+  decideCodebaseFinding,
+  reconcileCodebaseFindings,
+} from "@/lib/codebases/finding-ledger";
+import { getCodebaseDetail } from "@/lib/metrics/codebases";
+import { db, seedTeam, type Seed } from "./helpers";
+
+async function seedFinding(seed: Seed, fingerprint = "d".repeat(64)) {
+  const { data: codebase, error: codebaseError } = await db()
+    .from("codebases")
+    .insert({ team_id: seed.teamId, slug: `debt-${randomUUID().slice(0, 8)}` })
+    .select("id, slug")
+    .single();
+  if (codebaseError || !codebase)
+    throw new Error(`codebase seed failed: ${codebaseError?.message}`);
+
+  const observedAt = new Date(Date.now() - 10 * 86_400_000).toISOString();
+  const { data: finding, error: findingError } = await db()
+    .from("codebase_findings")
+    .insert({
+      team_id: seed.teamId,
+      codebase_id: codebase.id,
+      fingerprint,
+      status: "open",
+      check_id: "coverage_lines_pct",
+      axis: "test_rigor",
+      kind: "quality_issue",
+      severity: "high",
+      evidence_status: "complete",
+      remediation_tier: 1,
+      occurrence_count: 2,
+      first_seen_sha: "1".repeat(40),
+      last_seen_sha: "2".repeat(40),
+      first_seen_at: observedAt,
+      last_seen_at: observedAt,
+    })
+    .select("id")
+    .single();
+  if (findingError || !finding)
+    throw new Error(`finding seed failed: ${findingError?.message}`);
+  return {
+    codebaseId: codebase.id as string,
+    codebaseSlug: codebase.slug as string,
+    findingId: finding.id as string,
+  };
+}
+
+async function seedOwner(seed: Seed): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      email: `${randomUUID()}@test.local`,
+      display_name: "Finding Owner",
+      actor_handle: `owner-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`owner seed failed: ${error?.message}`);
+  return data.id as string;
+}
+
+function futureExpiry(days = 30): string {
+  return new Date(Date.now() + days * 86_400_000).toISOString();
+}
+
+describe("codebase finding decisions (real Postgres)", () => {
+  it("requires a lead/admin actor and an active same-team owner", async () => {
+    const seed = await seedTeam();
+    const target = await seedFinding(seed);
+    const ownerId = await seedOwner(seed);
+    const input = {
+      teamId: seed.teamId,
+      codebaseId: target.codebaseId,
+      findingId: target.findingId,
+      actorMemberId: seed.memberId,
+      ownerMemberId: ownerId,
+      status: "risk_accepted" as const,
+      reason: "The owner will revisit this after the coverage migration lands.",
+      expiresAt: futureExpiry(),
+    };
+
+    await expect(decideCodebaseFinding(db(), input)).rejects.toThrow(
+      "lead or admin",
+    );
+
+    await db().from("members").update({ role: "lead" }).eq("id", seed.memberId);
+    const otherTeam = await seedTeam();
+    await expect(
+      decideCodebaseFinding(db(), {
+        ...input,
+        ownerMemberId: otherTeam.memberId,
+      }),
+    ).rejects.toThrow("active team member");
+  });
+
+  it("persists the decision and appends every operator audit event", async () => {
+    const seed = await seedTeam();
+    await db().from("members").update({ role: "lead" }).eq("id", seed.memberId);
+    const target = await seedFinding(seed);
+    const ownerId = await seedOwner(seed);
+    const base = {
+      teamId: seed.teamId,
+      codebaseId: target.codebaseId,
+      findingId: target.findingId,
+      actorMemberId: seed.memberId,
+      ownerMemberId: ownerId,
+      reason: "The owner will revisit this after the coverage migration lands.",
+      expiresAt: futureExpiry(),
+    };
+
+    await decideCodebaseFinding(db(), { ...base, status: "risk_accepted" });
+    await decideCodebaseFinding(db(), {
+      ...base,
+      status: "accepted",
+      reason:
+        "Accepted into the next hardening cycle with the same accountable owner.",
+    });
+
+    const { data: finding } = await db()
+      .from("codebase_findings")
+      .select(
+        "status, decision_reason, decision_owner_member_id, decision_by_member_id, decision_expires_at",
+      )
+      .eq("id", target.findingId)
+      .single();
+    expect(finding).toMatchObject({
+      status: "accepted",
+      decision_owner_member_id: ownerId,
+      decision_by_member_id: seed.memberId,
+    });
+    expect(
+      new Date(finding.decision_expires_at as string).getTime(),
+    ).toBeGreaterThan(Date.now());
+
+    const { data: events } = await db()
+      .from("codebase_finding_events")
+      .select("event_type, metrics_id, details")
+      .eq("finding_id", target.findingId)
+      .order("observed_at", { ascending: true });
+    expect(events).toHaveLength(2);
+    expect(events?.map((event) => event.event_type)).toEqual([
+      "risk_accepted",
+      "accepted",
+    ]);
+    expect(events?.every((event) => event.metrics_id == null)).toBe(true);
+    expect(events?.[1].details).toMatchObject({
+      owner_member_id: ownerId,
+      actor_member_id: seed.memberId,
+    });
+  });
+
+  it("keeps tenant boundaries and re-enters an expired decision in the report", async () => {
+    const one = await seedTeam();
+    const two = await seedTeam();
+    await db().from("members").update({ role: "lead" }).eq("id", one.memberId);
+    await db().from("members").update({ role: "lead" }).eq("id", two.memberId);
+    const target = await seedFinding(one);
+    const ownerId = await seedOwner(one);
+
+    await expect(
+      decideCodebaseFinding(db(), {
+        teamId: two.teamId,
+        codebaseId: target.codebaseId,
+        findingId: target.findingId,
+        actorMemberId: two.memberId,
+        ownerMemberId: two.memberId,
+        status: "accepted",
+        reason: "A different tenant must never be able to decide this finding.",
+        expiresAt: futureExpiry(),
+      }),
+    ).rejects.toThrow("finding not found");
+
+    await decideCodebaseFinding(db(), {
+      teamId: one.teamId,
+      codebaseId: target.codebaseId,
+      findingId: target.findingId,
+      actorMemberId: one.memberId,
+      ownerMemberId: ownerId,
+      status: "risk_accepted",
+      reason:
+        "Temporary acceptance while the migration is actively owned and reviewed.",
+      expiresAt: futureExpiry(),
+    });
+    await db()
+      .from("codebase_findings")
+      .update({
+        decision_at: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+        decision_expires_at: new Date(Date.now() - 86_400_000).toISOString(),
+      })
+      .eq("id", target.findingId);
+
+    const detail = await getCodebaseDetail(
+      db(),
+      one.teamId,
+      target.codebaseSlug,
+      "90d",
+      "team",
+    );
+    expect(detail?.findings[0]).toMatchObject({ status: "risk_accepted" });
+    expect(detail?.debtPatrol).toMatchObject({
+      rollups: { active: 1, suppressed: 0, expired: 1 },
+    });
+    expect(detail?.debtPatrol.ranked[0]).toMatchObject({
+      findingId: target.findingId,
+      effectiveStatus: "reopened",
+      decisionExpired: true,
+    });
+  });
+
+  it("resolves a decided finding when a later complete scan proves it absent", async () => {
+    const seed = await seedTeam();
+    await db().from("members").update({ role: "lead" }).eq("id", seed.memberId);
+    const target = await seedFinding(seed);
+    const ownerId = await seedOwner(seed);
+    await decideCodebaseFinding(db(), {
+      teamId: seed.teamId,
+      codebaseId: target.codebaseId,
+      findingId: target.findingId,
+      actorMemberId: seed.memberId,
+      ownerMemberId: ownerId,
+      status: "risk_accepted",
+      reason:
+        "Temporary acceptance while the coverage migration is still in progress.",
+      expiresAt: futureExpiry(),
+    });
+
+    const headSha = "9".repeat(40);
+    const measuredAt = new Date().toISOString();
+    const health = {
+      schema_version: "2",
+      head_sha: headSha,
+      measured_at: measuredAt,
+      evidence_status: "complete",
+      findings: [],
+    } as unknown as CodebaseHealth;
+    const { data: metrics, error } = await db()
+      .from("code_metrics")
+      .insert({
+        team_id: seed.teamId,
+        codebase_id: target.codebaseId,
+        head_sha: headSha,
+        scanned_at: measuredAt,
+        codebase_health: health,
+      })
+      .select("id")
+      .single();
+    if (error || !metrics)
+      throw new Error(`metrics seed failed: ${error?.message}`);
+
+    await reconcileCodebaseFindings(db(), {
+      teamId: seed.teamId,
+      codebaseId: target.codebaseId,
+      metricsId: metrics.id as string,
+      health,
+    });
+
+    const { data: findingRow } = await db()
+      .from("codebase_findings")
+      .select(
+        "status, resolved_at, decision_reason, decision_owner_member_id, decision_expires_at",
+      )
+      .eq("id", target.findingId)
+      .single();
+    expect(findingRow).toMatchObject({
+      status: "resolved",
+      decision_reason: null,
+      decision_owner_member_id: null,
+      decision_expires_at: null,
+    });
+    const { data: events } = await db()
+      .from("codebase_finding_events")
+      .select("event_type")
+      .eq("finding_id", target.findingId)
+      .order("observed_at", { ascending: true });
+    expect(events?.map((event) => event.event_type)).toEqual([
+      "risk_accepted",
+      "resolved",
+    ]);
+  });
+
+  it("does not let an older clean measurement erase a newer operator decision", async () => {
+    const seed = await seedTeam();
+    await db().from("members").update({ role: "lead" }).eq("id", seed.memberId);
+    const target = await seedFinding(seed);
+    const ownerId = await seedOwner(seed);
+    const headSha = "8".repeat(40);
+    const measuredAt = new Date(Date.now() - 60 * 60_000).toISOString();
+    const health = {
+      schema_version: "2",
+      head_sha: headSha,
+      measured_at: measuredAt,
+      evidence_status: "complete",
+      findings: [],
+    } as unknown as CodebaseHealth;
+    const { data: metrics, error } = await db()
+      .from("code_metrics")
+      .insert({
+        team_id: seed.teamId,
+        codebase_id: target.codebaseId,
+        head_sha: headSha,
+        scanned_at: measuredAt,
+        codebase_health: health,
+      })
+      .select("id")
+      .single();
+    if (error || !metrics)
+      throw new Error(`metrics seed failed: ${error?.message}`);
+
+    await decideCodebaseFinding(db(), {
+      teamId: seed.teamId,
+      codebaseId: target.codebaseId,
+      findingId: target.findingId,
+      actorMemberId: seed.memberId,
+      ownerMemberId: ownerId,
+      status: "risk_accepted",
+      reason:
+        "This decision is newer than the queued scan and must remain authoritative.",
+      expiresAt: futureExpiry(),
+    });
+    await reconcileCodebaseFindings(db(), {
+      teamId: seed.teamId,
+      codebaseId: target.codebaseId,
+      metricsId: metrics.id as string,
+      health,
+    });
+
+    const { data: findingRow } = await db()
+      .from("codebase_findings")
+      .select("status, decision_reason, decision_owner_member_id")
+      .eq("id", target.findingId)
+      .single();
+    expect(findingRow).toMatchObject({
+      status: "risk_accepted",
+      decision_owner_member_id: ownerId,
+    });
+    const { data: events } = await db()
+      .from("codebase_finding_events")
+      .select("event_type")
+      .eq("finding_id", target.findingId);
+    expect(events?.map((event) => event.event_type)).toEqual(["risk_accepted"]);
+  });
+});

--- a/test/guards/debt-patrol-ui.test.ts
+++ b/test/guards/debt-patrol-ui.test.ts
@@ -1,0 +1,72 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { DebtPatrol } from "@/components/codebases/debt-patrol";
+import { buildDebtPatrol } from "@/lib/codebases/debt-ranking";
+import type { CodebaseFinding } from "@/lib/metrics/codebases";
+
+const finding: CodebaseFinding = {
+  id: "00000000-0000-4000-8000-000000000001",
+  fingerprint: "a".repeat(64),
+  status: "open",
+  check_id: "coverage_lines_pct",
+  axis: "test_rigor",
+  kind: "quality_issue",
+  severity: "high",
+  evidence_status: "complete",
+  remediation_tier: 1,
+  first_seen_sha: "1".repeat(40),
+  last_seen_sha: "2".repeat(40),
+  first_seen_at: "2026-07-01T00:00:00.000Z",
+  last_seen_at: "2026-08-04T00:00:00.000Z",
+  resolved_at: null,
+  occurrence_count: 2,
+  decision_reason: null,
+  decision_owner_member_id: null,
+  decision_owner_name: null,
+  decision_by_member_id: null,
+  decision_by_member_name: null,
+  decision_at: null,
+  decision_expires_at: null,
+  events: [
+    {
+      id: "00000000-0000-4000-8000-000000000002",
+      event_type: "detected",
+      from_status: null,
+      to_status: "open",
+      head_sha: "1".repeat(40),
+      observed_at: "2026-07-01T00:00:00.000Z",
+      details: {},
+    },
+  ],
+};
+
+describe("debt patrol accessibility guard", () => {
+  it("renders an accessible, explainable, report-only ranking without hiding unknowns", () => {
+    const patrol = buildDebtPatrol([finding], {
+      commitsWindow: 30,
+      windowDays: 90,
+      now: "2026-08-04T12:00:00.000Z",
+    });
+    const html = renderToStaticMarkup(
+      DebtPatrol({
+        patrol,
+        findings: [finding],
+        decisionOwners: [],
+        teamSlug: "test-team",
+        codebaseSlug: "test-codebase",
+        currentMemberId: "00000000-0000-4000-8000-000000000003",
+        canDecide: false,
+      }),
+    );
+
+    expect(html).toContain('aria-labelledby="debt-patrol-heading"');
+    expect(html).toContain("Repository patrol · report only");
+    expect(html).toContain("Principal");
+    expect(html).toContain("Interest");
+    expect(html).toContain("Why this rank");
+    expect(html).toContain("unknown");
+    expect(html).toContain("North Star reconciliation and admission gaps");
+    expect(html).toContain('<th scope="row"');
+    expect(html).not.toContain("Record operator decision");
+  });
+});


### PR DESCRIPTION
## What & Why

Turns the AIO-785 durable finding ledger into a deterministic, report-only repository debt patrol. Operators can see principal risk separately from accumulating interest, inspect every factor's provenance and verifier class, and record expiring accepted / risk-accepted / false-positive decisions without writing source code, pull requests, or Linear issues.

This PR is intentionally stacked on #491 and must not merge before AIO-785 lands.

## Work item

AIOS-Work: AIO-786

## Implementation

- Adds ranking method v1 across severity, recurrence, age, repository change pressure, evidence confidence, and remediation affordability.
- Keeps reachability, finding-level agent friction, and review cost explicitly unknown; scores normalize only over admitted evidence and publish coverage.
- Reconciles lifecycle, age, recurrence, evidence, admission, and North Star rollups without redefining the engineering-harness efficacy/cost report.
- Adds a responsive, keyboard-accessible patrol to the existing codebase detail page with factor provenance, lifecycle history, and stored-vs-effective status.
- Adds audited, expiring operator decisions with lead/admin and tenant enforcement at both the server action and atomic Postgres writer.
- Prevents older queued scan evidence from erasing a newer decision; complete evidence at or after the decision can still resolve it.
- Documents architecture and fail-safe rollback. No `/api/v1` wire or Brain API version changes.

## Verification

- [x] `npm test` — 1,861 passed, 11 skipped
- [x] `npm run test:datamechanics:local` — 855 passed, 4 skipped against real Postgres
- [x] `npm run coverage` — 1,861 passed, 11 skipped; 40.66% lines
- [x] `npm run typecheck`
- [x] `npm run lint` — no errors; two pre-existing warnings tracked in AIO-794
- [x] `npm run check:docs` — routes 61, tables 75, sources 8 in sync
- [x] `npm run check:errors`
- [x] `npm run check:skills`
- [x] `npm run build` — success; pre-existing optional E2B warning tracked in AIO-795
- [x] clean schema install plus idempotent replay
- [x] schema/migration bodies match for both finding functions
- [x] `gitleaks dir --no-banner .` — no leaks
- [x] `git diff --check`
- [x] static accessibility/render guard for the patrol surface

## Rollout and rollback

The additive migration may remain in place during an application rollback so operator history stays recoverable. A physical rollback requires a verified backup and human approval: disable the action, export decision events, remove only null-metrics operator events, restore the metrics-id constraint, then remove decision-only schema. The authoritative scanner snapshots and original ledger remain intact.

After #491 merges, rebase this branch onto Team Brain main, retarget this PR to main, and rerun all gates before merge.

## Checklist

- [x] Report-only ranking makes no source, PR, or Linear writes
- [x] Unknown evidence is never represented as measured zero
- [x] Principal and interest are separate
- [x] Decision reason, owner, actor, expiry, and append-only history are enforced
- [x] Team-tier and tenant isolation are fail-closed
- [x] No dependency or lockfile changes
- [x] No Brain API version bump required
- [x] Local diff review completed and recorded below

## Review — Reviewed by AI code-review skill — verdict no blockers; stacked base and pull-request CI pending

Review artifact: `code-review-2026-08-04.md` (local handoff artifact, intentionally not committed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches finding lifecycle, authorization (lead/admin), and atomic Postgres writes with tenant checks; scope is additive and well-tested but mistakes could affect suppression/resolution of security findings.
> 
> **Overview**
> Adds a **report-only “Debt Patrol”** on the codebase detail page: deterministic ranking of durable scanner findings with separate **principal** vs **interest** scores, per-factor provenance, lifecycle history, and rollups (including explicit **unknown** factors and score admission coverage).
> 
> Introduces **method v1** in `lib/codebases/debt-ranking` and wires it through `getCodebaseDetail` (`debtPatrol`, decision metadata, active team members as decision owners).
> 
> **Operator decisions** (accepted / risk accepted / false positive) for team leads and admins: server action `recordFindingDecision`, client `FindingDecisionControl`, Postgres `decide_codebase_finding`, decision columns on `codebase_findings`, nullable `metrics_id` on operator events, and updated `reconcile_codebase_findings` (resolve decided findings when absent on complete scans; respect decisions newer than stale evidence). Expired decisions **re-enter** the active ranking without erasing stored history.
> 
> Docs (`ARCHITECTURE`, `OPS`) and unit/datamechanics/UI guard tests cover ranking, auth, tenancy, and rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7fa166a64af9b490d0a8a68ae08bea9a8f9a8bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->