### PR TITLE
fix(admin): the small-model card's help and status text rendered invisible

### DIFF
--- a/components/admin/integrations-manager.tsx
+++ b/components/admin/integrations-manager.tsx
@@ -602,51 +602,55 @@ export function IntegrationsManager({
           fallback={answering.extraction.usedFallback}
         />
 
-        {/* The cheap model for the two calls Graphiti itself marks simple. Deliberately a bare input
-            rather than a RolePicker: there is no provider to choose — it rides the extraction
-            backend's provider and key. */}
-        <div className="rounded-lg border border-line/60 p-3">
-          <div className="text-sm font-medium">Cheap model for simple graph calls (optional)</div>
-          <p className="mt-1 text-xs text-muted">
-            Graphiti asks for a cheaper model on two of its five calls — filling in entity attributes, and
-            picking between duplicate facts. Both only refine work the extraction model already did, so a
-            weak model here can’t reduce what the graph knows about. Measured on the Costs page, those two
-            calls are most of the graph bill. Runs on the extraction model’s provider and key; blank = use
-            the extraction model for everything, exactly as before. Requires an extraction model to be set.
+        {/* The cheap model for the calls Graphiti itself marks simple. Deliberately not a RolePicker:
+            there is no provider to choose — it rides the extraction backend's provider and key.
+            Markup mirrors RolePicker's tokens EXACTLY. The first version invented `text-muted`,
+            `bg-surface` and `border-line`, none of which is a token in `app/globals.css` (which
+            defines `--color-ink-secondary`, `--color-border-subtle`, …). Tailwind emits no rule for
+            an undefined token, so the help paragraph, both status lines and the card border rendered
+            INVISIBLE — title, blank gap, input, as a screenshot of the live page showed.
+            (The inert-state warning used `text-amber`, which IS a real token, so that one line would
+            have rendered. An earlier version of this comment claimed otherwise.) */}
+        <div className="flex flex-col gap-1.5 border-t border-border-subtle pt-3">
+          <p className="text-xs font-medium text-ink">Cheap model for simple graph calls (optional)</p>
+          <p className="text-xs text-ink-secondary">
+            Graphiti asks for a cheaper model on some of its calls — filling in entity attributes or
+            summaries, picking between duplicate facts, and dating them. Each only refines work the
+            extraction model already did, so a weak model here can’t reduce what the graph knows about.
+            Runs on the extraction model’s provider and key; blank = the extraction model serves every
+            call. Requires an extraction model above.
           </p>
-          <div className="mt-2 flex gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <input
-              className="min-w-0 flex-1 rounded-md border border-line bg-surface px-2 py-1 text-sm"
-              placeholder="e.g. mistralai/mistral-small-3.2-24b-instruct"
               value={extSmallModel}
               onChange={(e) => setExtSmallModel(e.target.value)}
+              placeholder="model id, e.g. mistralai/mistral-small-3.2-24b-instruct"
+              disabled={pending}
+              className="min-w-0 flex-1 rounded-md border border-ink/15 bg-transparent px-2.5 py-1.5 font-mono text-xs text-ink outline-none focus:border-ink/30 disabled:opacity-50"
             />
             <button
               type="button"
-              className="rounded-md border border-line px-3 py-1 text-sm disabled:opacity-50"
               onClick={saveExtractionSmall}
               disabled={pending}
+              className="btn-prism shrink-0 text-xs disabled:opacity-50"
             >
               Save
             </button>
           </div>
-          <p className="mt-1 text-xs">
-            {answering.extraction.smallEnabled ? (
-              <span className="text-muted">
-                In effect — serving the simple graph calls.
-              </span>
-            ) : answering.extraction.smallInert ? (
-              /* The whole reason this indicator exists: a cost setting that reverted unnoticed is a
-                 surprise bill. Same class as the extraction picker's fallback warning. */
-              <span className="text-amber">
-                Saved but NOT in effect — every call is still served by the extraction model. Set an
-                extraction model above, and make sure its provider is configured (a fallback switches
-                this off deliberately).
-              </span>
-            ) : (
-              <span className="text-muted">Not set — the extraction model serves every graph call.</span>
-            )}
-          </p>
+          {answering.extraction.smallEnabled ? (
+            <p className="text-xs text-ink-secondary">
+              Effective: <span className="font-medium text-violet">{answering.extraction.smallModel}</span>
+              <span className="ml-1">· serving the simple graph calls</span>
+            </p>
+          ) : answering.extraction.smallInert ? (
+            <p className="text-xs text-amber-700">
+              Saved but NOT in effect — every call is still served by the extraction model. Set an
+              extraction model above, and make sure its provider is configured (a fallback switches this
+              off deliberately).
+            </p>
+          ) : (
+            <p className="text-xs text-ink-secondary">Not set — the extraction model serves every graph call.</p>
+          )}
         </div>
       </div>
 

--- a/test/guards/design-tokens-exist.test.ts
+++ b/test/guards/design-tokens-exist.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * A colour class that names an UNDEFINED design token renders nothing — silently.
+ *
+ * The failure this exists for: the admin "cheap model for simple graph calls" card shipped using
+ * `text-muted`, `bg-surface` and `border-line/60`. None is a token in `app/globals.css`, Tailwind
+ * emits no rule for them, TypeScript can't see them, and no test rendered the component — so the
+ * card's help paragraph, both of its status lines and its border were **invisible in production**.
+ * The user saw a title, a blank gap and an input.
+ *
+ * Precisely (an earlier draft of this file got it wrong): the inert-state warning used `text-amber`,
+ * which IS a defined token, so that line would have rendered. What vanished was the muted text.
+ *
+ * SCOPE IS DELIBERATELY NARROW. It checks the files this bug touched — the admin integrations
+ * surface — rather than the whole app, because a repo-wide sweep surfaces pre-existing undefined
+ * tokens (`text-ink-subtle`, `bg-surface-sunken`) in several other components. Those are real and
+ * worth fixing, but silently widening this guard would turn one bug's lesson into an unrelated
+ * red build. Widen the file list deliberately, with the fixes.
+ */
+
+const TOKENS = (() => {
+  const css = readFileSync(join(process.cwd(), "app/globals.css"), "utf8");
+  return new Set([...css.matchAll(/--color-([a-z0-9-]+)\s*:/g)].map((m) => m[1]));
+})();
+
+/** Tailwind's built-in palette families and non-colour values that share the prefixes. */
+const BUILT_IN = new Set([
+  "white", "black", "transparent", "current", "inherit",
+  "slate", "gray", "zinc", "neutral", "stone", "red", "orange", "amber", "yellow", "lime",
+  "green", "emerald", "teal", "cyan", "sky", "blue", "indigo", "violet", "purple", "fuchsia",
+  "pink", "rose",
+]);
+/**
+ * `text-xs`, `border-t`, `bg-gradient-prism` (an explicit `.class` in globals.css), etc.
+ *
+ * FULLY ANCHORED, and that is not tidiness. An earlier version left these prefix-matched, so the
+ * single-letter `l` (from `border-l`) matched the START of `line` — and `border-line/60`, the actual
+ * class from the bug this guard exists for, sailed through green. A guard that cannot catch its own
+ * originating bug is decoration.
+ */
+const NON_COLOUR = new Set([
+  "xs", "sm", "base", "lg", "xl", "2xl", "3xl", "4xl", "5xl", "6xl", "7xl",
+  "left", "right", "center", "justify", "start", "end", "top", "bottom",
+  "balance", "pretty", "nowrap", "wrap", "clip", "ellipsis",
+  "mono", "sans", "serif", "thin", "light", "normal", "medium", "semibold", "bold",
+  "solid", "dashed", "dotted", "hidden", "none", "auto", "full", "screen", "fit", "min", "max",
+  "px", "b", "t", "l", "r", "x", "y", "gradient-prism",
+]);
+const isNonColour = (base: string) =>
+  NON_COLOUR.has(base) ||
+  /^\d+$/.test(base) ||
+  base.startsWith("[") ||
+  // `border-t-0`, `border-x-2` — a side plus a width, not a colour at all.
+  /^(?:b|t|l|r|x|y|s|e)-\d+$/.test(base);
+
+const FILES = ["components/admin/integrations-manager.tsx"];
+
+describe("design tokens referenced by the admin integrations surface actually exist", () => {
+  it("globals.css yields a non-trivial token set (guard is not vacuous)", () => {
+    expect(TOKENS.size).toBeGreaterThan(10);
+    for (const t of ["ink", "ink-secondary", "border-subtle", "violet"]) expect(TOKENS.has(t)).toBe(true);
+    // The tokens the bug invented must NOT be present — otherwise this guard proves nothing.
+    for (const t of ["muted", "surface", "line"]) expect(TOKENS.has(t)).toBe(false);
+  });
+
+  for (const rel of FILES) {
+    it(`${rel} uses only defined colour tokens`, () => {
+      const src = readFileSync(join(process.cwd(), rel), "utf8");
+      const bad: string[] = [];
+      // Only look inside className="..." so prose in comments/strings can't trip it.
+      // Both quoted and template-literal classNames — the file uses each, and a bug hiding in a
+      // template literal is no less invisible than one in a quoted string.
+      const chunks = [...src.matchAll(/className=(?:"([^"]+)"|\{`([^`]+)`\})/g)].map((m) => m[1] ?? m[2]);
+      for (const chunk of chunks) {
+        for (const raw of chunk.split(/\s+/)) {
+          // Strip variant prefixes (`focus:`, `dark:`, `hover:md:`…) — a bad token behind one is
+          // just as dead as a bare one.
+          const cls = raw.replace(/^(?:[a-z-]+:)+/, "");
+          // …and allow an opacity modifier. Without this the guard misses `border-line/60`, which is
+          // the ACTUAL class from the bug it was written for — the reason to mutate with the real
+          // shape rather than a convenient one.
+          const hit = /^(?:text|bg|border)-([a-z][a-z0-9-]*)(?:\/[0-9.]+)?$/.exec(cls);
+          if (!hit) continue;
+          const base = hit[1];
+          if (TOKENS.has(base) || BUILT_IN.has(base.split("-")[0]) || isNonColour(base)) continue;
+          bad.push(cls);
+        }
+      }
+      expect(bad, `undefined design tokens (they render as nothing): ${bad.join(", ")}`).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Review — Reviewed by Fable `code-reviewer` — verdict BLOCKED on an overstatement in my own commit message; corrected, plus two real gaps in the guard it found

`AIOS-Work: GRAPHCOST-7` · follow-up to [#488](https://github.com/aiosbrain/aios-team-brain/pull/488)

## What you reported vs what was actually wrong

Two separate things, and only one is a code bug.

**The crash is not a code bug.** Railway logs show `Failed to find Server Action "60b2a23…" — This request might be from an older or newer deployment.` A deploy landed at 16:50 SGT; the screenshots are 19:11 SGT, so the tab predated it and posted an action ID the new build doesn't have. **A hard reload fixes it.** I traced the clear path end to end (`setExtractionSmallModel("")` → `extraction_small_model: null` → `smallModelWarning` early-return → `selectSmallExtractionBackend` → `describeSmallExtraction` → page read) and there is no server-side throw for `null`/`''`. Fable independently confirmed.

**The real bug is mine, from #488.** The card used `text-muted`, `bg-surface` and `border-line/60` — none is a token in `app/globals.css`, which defines `--color-ink-secondary`, `--color-border-subtle` and friends. Tailwind emits no rule for an undefined token, TypeScript can't see it, and no test renders the component, so the **help paragraph, both status lines and the card border were invisible in production** — exactly the "title, blank gap, input" in your screenshot.

The markup now mirrors `RolePicker`'s tokens, the idiom the rest of the file already uses.

## The correction Fable forced

My first commit message claimed the *inert-state warning* was invisible and "failed silently at the one job it exists for". **That was false** — it used `text-amber`, which is a real token (`globals.css:29`), so it would have rendered. What actually vanished was the muted text, including the "Not set" line you were looking at. I'd written that claim into three places. Corrected in all three.

## A guard, and three passes to make it non-vacuous

It reads the `--color-*` set from `globals.css` and fails the build on a colour class naming a token that doesn't exist. Each miss is recorded in the file because each is instructive:

1. It matched only `className="…"` — a bad token in a **template literal** passed.
2. It rejected only bare classes — **`border-line/60`, the actual class from the bug it was written for**, passed.
3. Its skip-list was prefix-matched, so the single letter `l` (from `border-l`) matched the start of `line` and let that same class through *again*.

All three now redden, mutation-verified with the real shapes rather than convenient ones. Also fixed a false positive it introduced (`border-t-0`).

Scoped to the admin integrations surface **on purpose**: a repo-wide sweep also flags `text-ink-subtle` and `bg-surface-sunken` in the maturity pages, `person-work-card`, `attribution-correction-box`, `attribution-health-view` and `member-drilldown` — real pre-existing instances of the same bug, but widening the guard silently would turn one bug's lesson into an unrelated red build.

## Filed, not fixed here — [AIO-796](https://linear.app/je4light/issue/AIO-796)

`run()` in this component has no `catch`, so **any** rejected server action — including the stale-deployment ID that prompted this report — takes down the whole Admin tab via the error boundary instead of showing "reload and retry". Every deploy invalidates every open admin tab, so this will recur. Ticket also covers the five other files with undefined tokens.

Verification: unit **1844** · tsc clean · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)