### PR TITLE
feat(graph): alarm on extraction degradation — dedupe pollution detected, and actually delivered (AIO-693)

### DIFF
--- a/components/admin/retrieval-health-card.tsx
+++ b/components/admin/retrieval-health-card.tsx
@@ -54,16 +54,22 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
     health.graphEpisodes != null
       ? `${health.graphEpisodes} episodes${health.graphLastProjectedAt ? ` · last projected ${timeAgo(health.graphLastProjectedAt)}` : " · none projected yet"}`
       : undefined;
+  // Extraction failing the OTHER way (AIO-693): episodes become facts, but the duplicate-entity rate
+  // is over this graph's own baseline — the extractor is resolving identity badly. A stall outranks
+  // it in the copy below, same priority as the server's reason string: no facts is worse than bad facts.
+  const graphDedupePolluted = health.graphDedupePolluted;
   const graphDetail =
     health.graph === "off"
       ? "not configured"
       : graphExtractionStalled
         ? `accepting episodes but extracting 0 facts — ${graphFreshness}`
-        : graphStalled
-          ? `projector stalled — ${graphFreshness}`
-          : health.graph === "degraded"
-            ? "configured but unreachable"
-            : graphFreshness;
+        : graphDedupePolluted
+          ? `extracting duplicate entities at an abnormal rate — ${graphFreshness}`
+          : graphStalled
+            ? `projector stalled — ${graphFreshness}`
+            : health.graph === "degraded"
+              ? "configured but unreachable"
+              : graphFreshness;
   // A configured-but-unreachable OR stalled-projector graph is a real failure — flag it loudly (red),
   // like a degraded semantic leg.
   const graphDegraded = health.graph === "degraded";
@@ -129,6 +135,15 @@ export function RetrievalHealthCard({ health }: { health: RetrievalHealth }) {
               output-token cap (<code>Output length exceeded max tokens</code>). New activity isn&apos;t
               becoming graph facts, so narrative arcs can&apos;t update. Check the Graphiti service logs.
               Keyword and semantic search are unaffected.
+            </>
+          ) : graphDedupePolluted ? (
+            <>
+              The graph&apos;s extraction model is <strong>producing duplicate entities at an abnormal
+              rate</strong> — it resolves entity identity badly, so the same person or thing accumulates
+              as separate nodes with split facts, and retrieval quietly degrades. This is the failure no
+              save-time model check can see. Check the <strong>Extraction model</strong> in
+              Admin&nbsp;→&nbsp;Integrations and consider reverting a recent change; admins were emailed
+              when this tripped.
             </>
           ) : graphStalled ? (
             <>

--- a/docs/design/extraction-degradation-alarm.md
+++ b/docs/design/extraction-degradation-alarm.md
@@ -1,0 +1,144 @@
+# Alarm on extraction degradation
+
+**Status:** revised after plan review — 2 blockers, both mine · **Date:** 2026-08-03 · **Owner:** Chetan
+· **Task:** AIO-693 (`COST3`)
+
+## The problem
+
+On 2026-07-30 the extraction model was changed to one 10x cheaper per call. It passed the only
+save-time check we have (`checkStructuredOutputSupport`, #442) because it genuinely does support
+structured outputs — it just resolves entity identity badly. Work per episode climbed while **total
+spend fell** (episode volume dropped faster), so every headline number moved the right way.
+
+Nobody was told for four days. It was found because someone asked why the bill looked odd.
+
+Prod's extraction model is now cleared (`teams.extraction_model IS NULL` → answering, `qwen3.7-max`,
+reasoning off), verified live through the proxy on 2026-08-03. So this is about the next time.
+
+## What plan review corrected (both were load-bearing, both were mine)
+
+### 1. The probe I planned to extend is NOT scheduled
+
+I wrote that extraction-health "already runs on a schedule". It does not. `getGraphExtractionHealth`
+has exactly two callers and both are **page renders** (`lib/ingest/pipeline-health.ts:158` →
+the dashboard home and the admin integrations page). The file's own header says it must not break
+"a page render".
+
+So the design as written delivered exactly as poorly as the Costs-page panel I dismissed as "a *pull*
+surface — it waits for a human to visit". It would have reproduced the incident verbatim: four days of
+nobody opening the page.
+
+**The repo already has the right mechanism and I didn't know it.** `lib/query/retrieval-alert.ts` sends
+an **edge-triggered, debounced admin email** — fires only on the ok→degraded transition, with a
+symmetric recovery mail — driven from the scheduler tick (`lib/ingest/scheduler.ts:52-81`). That is
+what makes "nobody was told" impossible, and it is the shape this must copy.
+
+### 2. "Non-zero duplicate facts is suspicious" was already disproven, in this codebase
+
+I proposed alarming on the presence of `IS_DUPLICATE_OF` edges. `lib/graph/learning.ts:24-36` —
+written **2026-07-20, ten days before the bad model** — measured **~26% of the graph** as exactly those
+edges on a healthy extractor, and filters them out of every read as "bookkeeping, never knowledge".
+
+My own sampling (35% before the switch → 70% after) corroborates that baseline rather than
+contradicting it. Which means the number I reported as a discovery was documented in the repo the whole
+time, and one grep would have found it. Same failure as [[grep-before-claiming-every-other]], in the
+spec written to prevent a different failure.
+
+**Consequence for the design:** an absolute threshold is unusable. Graphiti emits these edges as normal
+dedupe bookkeeping. Only a **rate change against a rolling baseline** is signal.
+
+## Proposal (Signal 1 cut — see below)
+
+One signal, delivered on the scheduler tick.
+
+### The predicate
+
+Dedupe-edge share of recent extraction output:
+
+```cypher
+MATCH ()-[r:RELATES_TO]->()
+WHERE r.created_at >= $since
+RETURN count(r) AS total,
+       count(CASE WHEN r.name = 'IS_DUPLICATE_OF' THEN 1 END) AS dedupe
+```
+
+`r.created_at` is extraction time, deliberately distinct from the backdated `valid_at`
+(`extraction-health.ts:107-117`), so a time-bounded slice means "what the extractor did recently".
+
+**Cost:** one aggregate over `RELATES_TO`, the same query class as the two full-edge scans
+`getGraphExtractionHealth` already runs concurrently per admin render. Tens of milliseconds at ~31k
+facts. (My first draft cited a `LIMIT` as the mitigation — that is a no-op on an aggregate, which
+returns one row regardless.)
+
+### The threshold, measured not guessed
+
+Fire when the recent dedupe share exceeds the **trailing baseline** by a margin, with a floor:
+
+- **Baseline:** the same ratio over an older window, so the comparison is self-calibrating per install.
+  A team whose corpus naturally produces more dedupe edges is not permanently accused.
+- **Minimum denominator**, mirroring `MIN_EPISODES_FOR_EXTRACTION_SIGNAL = 25` — 1 dedupe edge out of 3
+  on a fresh install is 33% and means nothing.
+- Measured reference points: ~26% (healthy, 2026-07-20, from `learning.ts`), ~35% (my sample,
+  pre-07-30), ~70% (during the bad model). The margin is set from those and its provenance goes in a
+  comment beside the constant.
+
+### Delivery
+
+Scheduler tick → edge-triggered admin email, copying `alertDenseDegraded`'s debounce exactly (fire on
+the transition only, never on every tick), plus the reason on the existing admin card.
+
+### Signal 1 (calls-per-episode) is CUT from this task
+
+It was going to reuse `getGraphEfficiency` from #471. Review found the reuse is not "one import":
+
+- It returns `EMPTY` unless `viewer.isAdmin`, and a probe has no viewer — using it means fabricating an
+  admin, deliberately bypassing a gate whose stated purpose is that no caller decides it.
+- `degrading` is `!truncated && …`, and truncation binds first **in exactly the degraded regime the
+  alarm exists to catch**. Reused as an alarm that inverts: maximum damage → silence.
+- It only exists on the unmerged `feat/calls-per-episode` branch.
+
+It adds little over the dedupe signal, which is cheaper, more specific, and fires on the same incident.
+Separate task if wanted, after #471 merges.
+
+## Contract change, named because it spans two consumers
+
+`GraphExtractionHealth` is `{stalled, reason}` and pipeline-health synthesizes ONE failing leg keyed on
+`extraction?.stalled` (`pipeline-health.ts:188-196`), while `retrieval-health.ts` re-assembles from the
+pure fns with a single `extractionStalled` boolean. A second degraded cause touches the interface and
+both assemblies — the probe's own header warns that two assemblies of one number is how surfaces drift.
+
+## What this deliberately does NOT do
+
+- **No auto-revert.** It tells; the human decides.
+- **No save-time block.** Entity-resolution quality is a property of the model's judgment on *your*
+  corpus; no catalogue exposes it and a curated allowlist would be false confidence on someone else's
+  corpus.
+- **No cleanup.** Removing existing duplicates needs the re-projection tool `project.ts:96-100` says was
+  never built, and the naive shortcut re-pushes duplicates under the same names. Separate task.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Threshold cries wolf and the alarm gets ignored | Relative to a trailing baseline, not absolute; minimum denominator; provenance comment |
+| Multi-team instance misattributes | The model is per-team (`teams.extraction_model`) but every Neo4j count is global — a bad pick by team A degrades team B's card. Stated, matching the probe's existing documented scope asymmetry |
+| Graphiti renames the relation | Pin `IS_DUPLICATE_OF` and real prod fact strings in a unit test — otherwise a version bump silently zeroes the count and the signal dies quietly |
+| Neo4j unreachable | Unknown reads as unknown, never degraded — matches the existing contract |
+| Email fatigue | Edge-debounced like `alertDenseDegraded`; one mail per transition |
+
+## How we will know it worked
+
+The damage from 07-30→08-02 is still in prod. **Date-pin the acceptance run to that `created_at`
+range** — otherwise, once those edges age out of the recency window, the test passes by never being
+runnable.
+
+## Guards worth building (CLAUDE.md §7)
+
+1. The predicate pinned against **real prod fact strings and the real `r.name`** — a Graphiti bump that
+   renames the relation must fail the build, not silently disarm the alarm.
+2. Unknown / empty-graph / below-floor cases assert **not degraded** — the cry-wolf contract.
+3. If the email ships: a debounce test (one mail per transition).
+
+Skipped as ceremony: a drift guard over the measured threshold (unmachineable; a provenance comment is
+the honest artefact), and a CI fixture replaying the damage window seeded from the threshold constant —
+that is the mutation-testing trap this repo has already recorded.

--- a/docs/design/extraction-model-qualification.md
+++ b/docs/design/extraction-model-qualification.md
@@ -180,9 +180,49 @@ checked-in fixture must reproduce the discrimination the real episodes produced 
 
 If it cannot separate those eight, it is not a qualification probe and this does not ship on it.
 
-Episodes in the fixture are **synthetic but structurally matched** to the four real ones (the repo is
-public). The Linear-spec shape is mandatory: it is the only episode type on which several models
-collapse.
+### The acceptance run FAILED. Twice. This design is blocked on it.
+
+Episodes and dedupe candidates had to be **synthetic** (the repo is public). They were built
+structurally matched to the real ones — Linear-spec shape, full-name → bare-first-name merge,
+descriptive-label → named-entity merge, a false-merge trap.
+
+**Attempt 1** (one dedupe scenario, the direct synthetic analogue of the real one):
+`qwen3.6-35b-a3b` — the negative control, the model that actually polluted the graph — scored
+**3/3 correct**. The fixture cannot see the failure it exists to catch.
+
+**Attempt 2** (three harder scenarios, all must be correct):
+
+```
+qwen/qwen3.7-max        PASS   (correct on all three)
+qwen/qwen3.6-35b-a3b    PASS   ← the negative control passes. Still blind.
+qwen/qwen3.7-plus       FAIL   ← a model that is 3/3 on real content. FALSE NEGATIVE.
+openai/gpt-4o-mini      FAIL
+z-ai/glm-4.7-flash      FAIL
+```
+
+So the synthetic fixture is wrong in **both** directions: it passes the model we know damages the
+graph and rejects one we measured as good. Tuning it further would be fitting the fixture until it
+agrees with the conclusion — the precise failure this whole feature exists to prevent, and the one
+that produced the retraction above. **Stopping here is the criterion working, not the criterion
+failing.**
+
+The discrimination lived in the real corpus's entity names, not in the structure I could copy.
+
+### The design this points at instead: a DIFFERENTIAL probe, no fixture at all
+
+Do not ship an answer key. At save time, run the candidate model and the **incumbent** model over the
+same payload built from **this install's own recent `items`**, and flag when they disagree on identity
+resolution. That removes every problem above at once:
+
+- no synthetic fixture, so nothing to fit and nothing to drift;
+- no answer key, so no labelling of a corpus we cannot label;
+- self-calibrating per install, which is the same conclusion AIO-693's plan review reached about
+  thresholds (relative to this graph's own baseline, never an absolute);
+- it asks the question that actually matters — *is this worse than what we have* — rather than
+  *is this good in the abstract*.
+
+Cost roughly doubles (both models run) and it needs a definition of "disagree" that tolerates
+harmless variation. That is the next spec, and it should be written before any code.
 
 ## Schema drift — guarded, not hoped
 

--- a/docs/design/extraction-model-qualification.md
+++ b/docs/design/extraction-model-qualification.md
@@ -1,0 +1,230 @@
+# Qualify an extraction model before it governs the graph
+
+**Status:** revised after plan review — 2 blockers, both mine, plus a measurement I had to retract
+· **Date:** 2026-08-03 · **Owner:** Chetan
+· **Task:** `EXMODEL-1` → [AIO-705](https://linear.app/je4light/issue/AIO-705)
+
+## The problem
+
+The only save-time check on the extraction model reads a **catalogue flag**
+(`checkStructuredOutputSupport`, #442: does OpenRouter list `structured_outputs`?). On 2026-07-30 a
+model that passes that flag was chosen, and it degraded the graph for four days: duplicate entities,
+`IS_DUPLICATE_OF` share roughly doubled, work per episode climbed 7.5 → 49 while total spend *fell*.
+
+The flag is not weak — it is **blind to the failure that occurs**. Every model below advertises
+`structured_outputs: true`, and five of them break the graph.
+
+## What plan review corrected, and what the deployed image then corrected in me
+
+### 1. My first measurement was against a payload we do not send (retracted)
+
+I measured with graphiti-core **0.29.3**'s prompts, its raw `model_json_schema()` without `strict`,
+and an episode body of `user(): …`. Prod runs `zepai/graphiti@sha256:76d14f30…`
+(`graphiti/Dockerfile:21`), which contains graphiti-core **0.13.2**, calls
+`client.beta.chat.completions.parse` (`llm_client/openai_client.py:72`) — so the SDK sends
+`strict: true` with `additionalProperties: false` throughout — and builds the body as `(user): …`
+(`graph_service/routers/ingest.py:61`). 0.13.2's dedupe schema is also a different question:
+`duplicate_idx` over `idx` candidates, not 0.29.3's `duplicate_candidate_id` over `candidate_id`.
+
+On that wrong payload I reported **`openai/gpt-4.1-mini`: all 12 calls HTTP 400 — unusable**. That
+was my schema's fault (`additionalProperties is required to be supplied and to be false` — which
+`.parse()` supplies). **Retracted: `gpt-4.1-mini` passes everything.** This is the third time on this
+workstream that a fixture of my own making produced a confident wrong verdict, and it is the reason
+the probe below is generated *from the deployed image* rather than written by hand.
+
+### 2. "Advisory, never blocking" contradicted the feature's own success criterion
+
+I wrote that success is "rejected at the picker" and, four paragraphs earlier, that the save always
+proceeds. As specced the feature could not achieve its stated goal — it re-created the incident's
+shape with a better warning. Resolved below: a **completed** probe that failed is evidence, and
+refusing on evidence is not the work-key failure (which was accusing on *none*).
+
+### 3. `graphModelWarning` does not cover every path that changes the graph's model
+
+I claimed the probe "inherits that correctness". It inherits the holes too:
+`setAnsweringProvider` (`actions.ts:439-461`, the "Auto" choice) and `saveProviderModel`
+(`actions.ts:415-431`) both change which model governs the graph and call no check at all. Auto
+precedence can land on Anthropic, which `graphChatTarget` 501s — the silent-stall case, reachable
+with zero warning. v1 closes both.
+
+## The measurement
+
+Request bodies generated **inside the deployed image** by `gen.py` — graphiti 0.13.2's real
+`extract_nodes.extract_message` and `dedupe_nodes.nodes`, and the OpenAI SDK's own
+`type_to_response_format_param`, the function `.parse()` calls. Nothing reconstructed. Four real prod
+episodes × 3 runs + one dedupe scenario × 3 runs, built from duplicate pairs observed in the live
+graph. `max_tokens: 16384` (our Dockerfile's patched cap), `temperature: 0`, plus the two flags the
+proxy adds on the OpenRouter leg.
+
+```
+model                        in $/M  extract  people  dedupe   entities/episode (median)   $/ep est
+                                                               sync sum slack linear-spec
+qwen/qwen3.7-max  ← today     1.475    12/12   21/21     3/3     13  15   14      16       0.0238
+qwen/qwen3.7-plus             0.320    12/12   21/21     3/3     37  24   15      22       0.0087
+openai/gpt-4.1-mini           0.400    12/12   20/21     3/3     22  19   12      21       0.0077
+qwen/qwen3.6-27b              0.300    12/12   21/21     2/3     25  25   14      10       0.0082
+qwen/qwen3.6-35b-a3b          0.140    12/12   21/21   * 0/3 *   20  17   14      22       0.0036
+openai/gpt-4o-mini            0.150    12/12   18/21     0/3      6  20   13       7       0.0019
+z-ai/glm-4.7-flash            0.060    12/12   21/21     0/3     24  17   14      35       0.0018
+google/gemini-2.5-flash-lite  0.100     8/12    6/12     1/3     41  12   12       2       —
+qwen/qwen3.6-flash            0.188     0/12       —     3/3      HTTP 400 on every extract call
+```
+
+`qwen/qwen3.6-35b-a3b` is the **negative control**: it degraded the live graph, so a battery that
+does not flag it proves nothing. It fails **0/3 on dedupe** — and the specific failure is the one that
+polluted the graph: it refuses to resolve `Chetan Nandakumar` onto the existing `Chetan`, creating a
+second person node.
+
+**The dedupe probe separates the field cleanly.** Every model that is known or observed to damage the
+graph fails it; every model that does not, passes 3/3. Entity count, people recall and error rate all
+add information, but none of them alone splits the list — `35b-a3b` and `glm-4.7-flash` score 21/21 on
+people while failing dedupe 0/3.
+
+Two failures are real and survive the correction:
+
+- **`qwen/qwen3.6-flash` 400s on every extraction call** while passing dedupe 3/3 — the provider
+  downgrades `json_schema` to `json_object` and then rejects the request for not containing the word
+  "json". Extraction stops entirely; the symptom is an empty graph. Schema-specific, so a probe that
+  tests only one of the two calls would miss it.
+- **`qwen/qwen3.6-27b` returned a bare JSON array where the schema says object**, despite
+  `strict: true`. graphiti does `llm_response.get('entity_resolutions', [])`
+  (`node_operations.py:296`), so that response raises `AttributeError` inside the dedupe path.
+
+### The cost model, validated against production
+
+`(2 × extract input + entities × 700) × $in + outputs × $out`, where the 700-token term is the
+per-node summary call — the ~600-input-token band that ran 1,675 calls/day on the healthy model and
+4,240–5,672/day on the cheap one. It predicts **$0.0238/episode** for `qwen3.7-max` against
+**$0.0267/episode measured in production today**: 11% agreement.
+
+**Known bias: it flatters the models that fail**, because it does not model the extra calls duplicate
+pollution creates (it under-predicts `35b-a3b` by ~2.3× versus its measured production cost). A floor
+is the safe direction for a gate, and the wrong direction for a purchase decision — so this table
+ranks safety, not price.
+
+## Proposal
+
+### `lib/graph/extraction-qualify.ts` — a live probe of the backend that will govern the graph
+
+Four calls, issued **concurrently**, against a checked-in fixture:
+
+1. **One extraction call** — graphiti's `ExtractedEntities` schema. Fails on: non-2xx, unparseable
+   body, entity count below the fixture's floor, or a named person missing.
+2. **Three dedupe calls** — graphiti's `NodeResolutions` schema over a candidate set with an
+   unambiguous answer key including a **false-merge trap** (an unrelated pair that must resolve to
+   `-1`). **All three must be exactly correct.** Fails on: non-2xx, unparseable, a non-object
+   response, or any wrong resolution.
+
+`n=3` on dedupe is not decoration: the two marginal models in the battery scored 2/3 and 1/3, so a
+single run would pass them roughly half the time. It is still a **filter, not a proof** — it catches
+the 0/3 models with certainty and the marginal ones with probability. Say so in the help text.
+
+Verdict: `ok` · `degraded` (calls succeed, answers wrong) · `unusable` (calls fail) · `unknown`.
+
+**Budget: 45s wall clock, all four calls in flight at once.** Observed latencies in the battery:
+1.0–30.4s per call. A save that takes up to 45 seconds is a deliberate UX choice for an action that
+changes what every graph write costs; the picker shows a "qualifying…" state.
+
+### Refuse on evidence, proceed on doubt
+
+| Verdict | Behaviour |
+|---|---|
+| `ok` | save stands, silent |
+| `degraded` / `unusable` | **the write is reverted** and the evidence is returned — "resolved 2 of 5 identities correctly; `Chetan Nandakumar` was not matched to the existing `Chetan`". An explicit **Save anyway** re-submits with `force: true` and is audited as a forced save. |
+| `unknown` (timeout, network, no key) | save stands, **silently** — the work-key lesson: never accuse on no evidence |
+
+The probe runs **after** the write, because `graphModelWarning` already resolves the backend that
+governs the graph *after* it — the ordering hole #452 closed. Reverting is a second write; two admins
+racing the same picker inside 45s could interleave. Named, not solved: this panel has one writer in
+practice, and the alternative (re-deriving the post-write backend before writing) reintroduces the
+exact bug #452 fixed.
+
+### Cover the paths that were never checked
+
+`graphModelWarning` is added to `setAnsweringProvider` and `saveProviderModel`. Both change the
+graph's model today with no check of any kind.
+
+### Metering
+
+Probe calls record to `llm_usage` under a **distinct source** (`graph-probe`), never `graph`. Sharing
+the source would put probe calls in the numerator of calls-per-episode (#471) with nothing in the
+denominator — the same defect Fable caught in that PR's manual "Project to graph" button.
+`llm_usage.source` has no DB CHECK, so this is the TS union in `lib/costs/llm-usage.ts` plus a
+`SOURCE_LABEL` entry (`lib/metrics/llm-costs.ts` falls back to the raw key, so a missing label
+degrades visibly rather than silently).
+
+Cost: ~$0.02–0.09 per save, four calls. With extraction unset, **every answering-model save now
+spends this too** — stated because it is a real change to a previously free action.
+
+### A CLI that tests a model WITHOUT changing production
+
+`npm run qualify:extraction -- <provider> <model>`. Today the only way to evaluate a candidate is to
+point the live setting at it, because the proxy overrides the model — so "try three models" means
+three production config writes on a running graph. It resolves the key exactly as the app does
+(`resolveAnsweringKeys` against `DATABASE_URL`), meters under `graph-probe` like the save path, and
+shares the scoring module, so CLI and picker cannot disagree.
+
+## The fixture, and why it is not a fixture of my own making
+
+`test/fixtures/extraction-probe/` holds the request bodies **emitted by `gen.py` inside the pinned
+image**, with the digest and `graphiti_core` version in the header. Not hand-written, because
+hand-written is what produced the retraction above.
+
+**Acceptance criterion, run once at build time (~$0.20) and recorded in the fixture header:** the
+checked-in fixture must reproduce the discrimination the real episodes produced —
+
+- pass: `qwen3.7-max`, `qwen3.7-plus`, `gpt-4.1-mini`
+- fail: `qwen3.6-35b-a3b` (the negative control), `gpt-4o-mini`, `glm-4.7-flash`,
+  `gemini-2.5-flash-lite`
+- `unusable`: `qwen3.6-flash`
+
+If it cannot separate those eight, it is not a qualification probe and this does not ship on it.
+
+Episodes in the fixture are **synthetic but structurally matched** to the four real ones (the repo is
+public). The Linear-spec shape is mandatory: it is the only episode type on which several models
+collapse.
+
+## Schema drift — guarded, not hoped
+
+The fixture is graphiti 0.13.2's shape. If the service image moves, the probe validates a payload the
+service no longer sends and goes quietly vacuous — the "guard must cover the level that changed"
+failure. **Guard:** a unit test asserts the digest recorded in the fixture header equals the digest in
+`graphiti/Dockerfile`. Changing the image without regenerating the fixture fails the build. It does
+not verify the *contents* match — only that nobody moved the image and left the fixture behind.
+
+## Guards (CLAUDE.md §7)
+
+- **Scoring** against **recorded real responses** from the battery — the `35b-a3b` mis-resolution, the
+  bare-array schema violation, the `qwen3.6-flash` 400 body. Not hand-written JSON.
+- **Call site:** deleting the qualification call from `graphModelWarning` turns a test red
+  (`pin-the-call-site-not-just-the-function`).
+- **Request shape:** the probe posts the fixture body verbatim through the proxy's own
+  `forwardBody`, and a guard asserts the posted body still carries `strict: true` and
+  `additionalProperties: false`. Rebuilding the schema by hand — the exact mistake this doc retracts —
+  turns it red.
+- **Digest drift:** fixture header digest == `graphiti/Dockerfile` digest.
+- **`unknown` never blocks and never warns** — pinned, mutation: make `unknown` return an error → red.
+- **Source:** the probe's `llm_usage.source` is not `graph`; mutation → red.
+
+## What this does not do
+
+- It does not re-qualify a model after adoption. Post-adoption degradation is AIO-693's alarm.
+- It does not judge Q&A answer quality — extraction and dedupe have right answers, "was that a good
+  answer" does not.
+
+## Out of scope, deliberately
+
+Entity-resolution efficiency (type gating, cosine short-circuits, top-K candidate retrieval). That is
+the structural cost fix, it lives in Graphiti's resolution path, and it is a separate task.
+
+## How we will know it worked
+
+The next extraction model that would have degraded the graph is refused **at the picker**, naming the
+identity it failed to resolve — instead of four days later, from the bill.
+
+## The separate decision this measurement unblocks
+
+Not part of this build; the operator's call. On the corrected battery, **`qwen/qwen3.7-plus`**
+(21/21 people, 3/3 dedupe, 12/12 calls, already trusted in this stack for narrative arcs) is
+**~2.7× cheaper per episode** than today's `qwen3.7-max` — roughly $115/month against $310/month at
+current volume. `openai/gpt-4.1-mini` is marginally cheaper again but scored 20/21 on people.

--- a/lib/graph/extraction-alert.ts
+++ b/lib/graph/extraction-alert.ts
@@ -1,0 +1,129 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { sendOpsAlert, mailerConfigured } from "@/lib/auth/mailer";
+import { dedupeSignals, deriveDedupePollution, type DedupePollution } from "@/lib/graph/extraction-health";
+import { recordIngestRun } from "@/lib/ingest/runs";
+
+/**
+ * Email admins when graph extraction TRANSITIONS into/out of dedupe pollution — the delivery half of
+ * the AIO-693 alarm, copying `lib/query/retrieval-alert`'s shape (the one alert path in this repo
+ * that has actually reached a human).
+ *
+ * WHY DELIVERY IS THE FEATURE, not the detector: the 2026-07-30 incident was DETECTED on every tier
+ * that existed — cost per episode rose, calls per episode rose, the Costs page would have shown both —
+ * and still ran for four days, because every surface was a page render waiting for a visit. The plan
+ * review's blocking finding on this design was exactly that `getGraphExtractionHealth` had no
+ * scheduled caller. This module is that caller, driven from the ingest scheduler tick.
+ *
+ * STATE LIVES IN `ingest_runs` (`source: "graph_health"`), like the dense leg's — no new table, and
+ * the Admin panel's run list doubles as the alarm's audit trail. Rows are written ONLY on a
+ * transition, so a four-day incident is two rows (degraded, recovered), not 384 tick rows drowning
+ * the panel.
+ *
+ * The debounce contract, shared with retrieval-alert: one mail on ok→polluted, one on polluted→ok,
+ * silence in between. `unknown` (Neo4j unreadable, sample too small) changes NOTHING — it neither
+ * fires nor clears, because an alarm that recovers during an outage teaches people to ignore the
+ * recovery mail too.
+ */
+
+/** The run-ledger source this alarm records its transitions under. */
+export const GRAPH_HEALTH_SOURCE = "graph_health";
+
+export type DedupeAlertAction = "alert" | "recover" | "none";
+
+/**
+ * The edge detector, pure: prior state (was the last recorded transition a failure?) + this tick's
+ * verdict → what to do. `judgeable` is false when the pollution verdict came from an unreadable or
+ * too-small sample — those ticks are a no-op in BOTH directions.
+ */
+export function decideDedupeAlert(
+  priorPolluted: boolean,
+  pollution: Pick<DedupePollution, "polluted" | "recentShare" | "baselineShare">
+): DedupeAlertAction {
+  const judgeable = pollution.recentShare !== null && pollution.baselineShare !== null;
+  if (!judgeable) return "none";
+  if (pollution.polluted && !priorPolluted) return "alert";
+  if (!pollution.polluted && priorPolluted) return "recover";
+  return "none";
+}
+
+/** Was the most recent recorded graph-health transition a failure? (false when there are none.) */
+export async function lastGraphHealthFailed(db: DbClient): Promise<boolean> {
+  const { data } = await db
+    .from("ingest_runs")
+    .select("ok")
+    .eq("source", GRAPH_HEALTH_SOURCE)
+    .order("finished_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return !!data && (data as { ok: boolean }).ok === false;
+}
+
+async function activeAdminEmails(db: DbClient): Promise<string[]> {
+  const { data } = await db
+    .from("members")
+    .select("email")
+    .eq("role", "admin")
+    .eq("status", "active");
+  const emails = (data ?? [])
+    .map((m) => (m as { email: string | null }).email)
+    .filter((e): e is string => !!e && e.includes("@"));
+  return [...new Set(emails.map((e) => e.toLowerCase()))];
+}
+
+const pct = (n: number | null) => (n === null ? "?" : `${Math.round(n * 100)}%`);
+
+/**
+ * One scheduler-tick evaluation: read the graph's dedupe signals, compare against the recorded prior
+ * state, and on a transition record the run row + email every active admin. Best-effort throughout —
+ * nothing here may fail the ingest tick. Returns the action taken, for the tick's log line.
+ */
+export async function runDedupePollutionCheck(db: DbClient, nowMs = Date.now()): Promise<DedupeAlertAction> {
+  try {
+    const startedAt = Date.now();
+    const pollution = deriveDedupePollution(await dedupeSignals(nowMs));
+    const priorPolluted = await lastGraphHealthFailed(db).catch(() => false);
+    const action = decideDedupeAlert(priorPolluted, pollution);
+    if (action === "none") return "none";
+
+    const shares = { recentShare: pollution.recentShare, baselineShare: pollution.baselineShare };
+    await recordIngestRun(db, {
+      source: GRAPH_HEALTH_SOURCE,
+      trigger: "scheduler",
+      ok: action === "recover",
+      errors: action === "alert" && pollution.reason ? [pollution.reason] : [],
+      meta: shares,
+      startedAt,
+    });
+
+    if (!mailerConfigured()) return action; // transition is still recorded — state must not depend on mail
+    const admins = await activeAdminEmails(db);
+    if (admins.length === 0) return action;
+    const where = process.env.APP_URL
+      ? `${process.env.APP_URL.replace(/\/$/, "")} → Admin → Integrations`
+      : "Admin → Integrations";
+
+    if (action === "alert") {
+      const text =
+        `The graph extraction model is producing duplicate entities: ${pct(pollution.recentShare)} of the ` +
+        `last 24h of graph edges are duplicate-of records, against ${pct(pollution.baselineShare)} for this ` +
+        `graph's own baseline.\n\nThat is the signature of an extraction model resolving entity identity ` +
+        `badly — the same failure that silently degraded the graph for four days on 2026-07-30. It passes ` +
+        `every static model check, so this rate alarm is the only thing that catches it.\n\n` +
+        `Likely cause: the Extraction model (or the answering model, if no extraction model is set) was ` +
+        `recently changed. Check Admin → Integrations and consider reverting the pick.\n\n` +
+        `See the pipeline banner at ${where}. You'll get one more email when it recovers.`;
+      for (const to of admins) await sendOpsAlert(to, "⚠️ AIOS Team Brain — graph extraction degraded", text);
+    } else {
+      const text =
+        `Graph extraction has recovered: duplicate-entity records are back to ${pct(pollution.recentShare)} ` +
+        `of recent edges (baseline ${pct(pollution.baselineShare)}). No action needed.\n\n` +
+        `Note: entities created while it was degraded may remain duplicated in the graph until a cleanup ` +
+        `re-projection.`;
+      for (const to of admins) await sendOpsAlert(to, "✅ AIOS Team Brain — graph extraction recovered", text);
+    }
+    return action;
+  } catch {
+    return "none"; // best-effort — the ingest tick must never pay for the alarm
+  }
+}

--- a/lib/graph/extraction-alert.ts
+++ b/lib/graph/extraction-alert.ts
@@ -1,7 +1,12 @@
 import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { sendOpsAlert, mailerConfigured } from "@/lib/auth/mailer";
-import { dedupeSignals, deriveDedupePollution, type DedupePollution } from "@/lib/graph/extraction-health";
+import {
+  dedupeSignals,
+  deriveDedupePollution,
+  GRAPH_HEALTH_SOURCE,
+  type DedupePollution,
+} from "@/lib/graph/extraction-health";
 import { recordIngestRun } from "@/lib/ingest/runs";
 
 /**
@@ -26,22 +31,22 @@ import { recordIngestRun } from "@/lib/ingest/runs";
  * recovery mail too.
  */
 
-/** The run-ledger source this alarm records its transitions under. */
-export const GRAPH_HEALTH_SOURCE = "graph_health";
+export { GRAPH_HEALTH_SOURCE };
 
 export type DedupeAlertAction = "alert" | "recover" | "none";
 
 /**
  * The edge detector, pure: prior state (was the last recorded transition a failure?) + this tick's
- * verdict → what to do. `judgeable` is false when the pollution verdict came from an unreadable or
- * too-small sample — those ticks are a no-op in BOTH directions.
+ * verdict → what to do. Keyed on the detector's OWN `judgeable` verdict, never re-derived from the
+ * shares: a below-minimum sample carries non-null shares but no verdict, and treating it as judged
+ * would turn one quiet Saturday during a sustained incident into a false "recovered" mail (review
+ * finding on the first cut of this file). Unjudgeable ticks are a no-op in BOTH directions.
  */
 export function decideDedupeAlert(
   priorPolluted: boolean,
-  pollution: Pick<DedupePollution, "polluted" | "recentShare" | "baselineShare">
+  pollution: Pick<DedupePollution, "polluted" | "judgeable">
 ): DedupeAlertAction {
-  const judgeable = pollution.recentShare !== null && pollution.baselineShare !== null;
-  if (!judgeable) return "none";
+  if (!pollution.judgeable) return "none";
   if (pollution.polluted && !priorPolluted) return "alert";
   if (!pollution.polluted && priorPolluted) return "recover";
   return "none";

--- a/lib/graph/extraction-health.ts
+++ b/lib/graph/extraction-health.ts
@@ -332,12 +332,13 @@ export function deriveDedupePollution(s: DedupeSignals): DedupePollution {
   if (recentShare === null || baselineShare === null) return out(false, false);
   if ((s.recentTotal ?? 0) < MIN_EDGES_FOR_DEDUPE_SIGNAL) return out(false, false);
   if ((s.baselineTotal ?? 0) < MIN_EDGES_FOR_DEDUPE_SIGNAL) return out(false, false);
-  // Predicate self-check: a healthy baseline on this graph is ~26–35% dupe edges — a LITERAL ZERO
-  // over ≥200 edges means the relation this probe greps for no longer exists as written (a Graphiti
-  // upgrade renaming `IS_DUPLICATE_OF` / moving it off `RELATES_TO`), not that extraction got
-  // perfect. Judging on it would let a rename silently disarm the alarm — or worse, mail "recovered"
-  // during an active incident. Unjudgeable, in both directions.
-  if (s.baselineDupe === 0) return out(false, false);
+  // Predicate self-check: a healthy share on this graph is ~26–35% dupe edges — a LITERAL ZERO over
+  // ≥200 edges (~0.7^200 naturally) means the relation this probe greps for no longer exists as
+  // written (a Graphiti upgrade renaming `IS_DUPLICATE_OF` / moving it off `RELATES_TO`), not that
+  // extraction got perfect. Both windows are checked: a zero BASELINE would let a rename silently
+  // disarm the alarm, and a zero RECENT window during an active incident would mail "recovered"
+  // mid-incident while the baseline still carried pre-rename dupes (review finding). Unjudgeable.
+  if (s.baselineDupe === 0 || s.recentDupe === 0) return out(false, false);
   if (recentShare < DEDUPE_ABSOLUTE_FLOOR) return out(false, true);
   if (recentShare < baselineShare * DEDUPE_MARGIN) return out(false, true);
   const pct = (n: number) => `${Math.round(n * 100)}%`;

--- a/lib/graph/extraction-health.ts
+++ b/lib/graph/extraction-health.ts
@@ -255,6 +255,13 @@ export async function getGraphExtractionHealth(teamId: string): Promise<GraphExt
  * regression it doesn't have.
  * ──────────────────────────────────────────────────────────────────────────────────────────────── */
 
+/**
+ * The `ingest_runs.source` under which the alarm's delivery half (`lib/graph/extraction-alert`)
+ * records its transitions. Defined HERE, not there, so `lib/ingest/pipeline-health` can exclude the
+ * ledger from its legs without importing the mailer into every dashboard render.
+ */
+export const GRAPH_HEALTH_SOURCE = "graph_health";
+
 /** Recent window whose dedupe share is judged. */
 export const DEDUPE_RECENT_MS = 24 * 3_600_000;
 /** Trailing window it is judged AGAINST — long enough that one bad day can't move the baseline it is
@@ -287,6 +294,15 @@ export interface DedupeSignals {
 
 export interface DedupePollution {
   polluted: boolean;
+  /**
+   * Could the detector actually JUDGE this tick, or did it refuse (Neo4j unreadable, either window
+   * under the minimum sample, or a predicate-suspect zero-dupe baseline)? Consumers that act on
+   * transitions — the alarm's edge state machine — MUST key on this and not on `polluted`, because a
+   * refusal also reads `polluted: false`: during a sustained incident, one quiet Saturday whose
+   * recent window is 80 edges would otherwise look like a judged recovery and send a "recovered"
+   * mail while the graph is still at 70% duplicates.
+   */
+  judgeable: boolean;
   recentShare: number | null;
   baselineShare: number | null;
   reason: string | null;
@@ -305,20 +321,28 @@ const share = (dupe: number | null, total: number | null): number | null =>
 export function deriveDedupePollution(s: DedupeSignals): DedupePollution {
   const recentShare = share(s.recentDupe, s.recentTotal);
   const baselineShare = share(s.baselineDupe, s.baselineTotal);
-  const out = (polluted: boolean, reason: string | null = null): DedupePollution => ({
+  const out = (polluted: boolean, judgeable: boolean, reason: string | null = null): DedupePollution => ({
     polluted,
+    judgeable,
     recentShare,
     baselineShare,
     reason,
   });
   // Unreadable graph, too small a sample, or no baseline to compare against: all "can't tell".
-  if (recentShare === null || baselineShare === null) return out(false);
-  if ((s.recentTotal ?? 0) < MIN_EDGES_FOR_DEDUPE_SIGNAL) return out(false);
-  if ((s.baselineTotal ?? 0) < MIN_EDGES_FOR_DEDUPE_SIGNAL) return out(false);
-  if (recentShare < DEDUPE_ABSOLUTE_FLOOR) return out(false);
-  if (recentShare < baselineShare * DEDUPE_MARGIN) return out(false);
+  if (recentShare === null || baselineShare === null) return out(false, false);
+  if ((s.recentTotal ?? 0) < MIN_EDGES_FOR_DEDUPE_SIGNAL) return out(false, false);
+  if ((s.baselineTotal ?? 0) < MIN_EDGES_FOR_DEDUPE_SIGNAL) return out(false, false);
+  // Predicate self-check: a healthy baseline on this graph is ~26–35% dupe edges — a LITERAL ZERO
+  // over ≥200 edges means the relation this probe greps for no longer exists as written (a Graphiti
+  // upgrade renaming `IS_DUPLICATE_OF` / moving it off `RELATES_TO`), not that extraction got
+  // perfect. Judging on it would let a rename silently disarm the alarm — or worse, mail "recovered"
+  // during an active incident. Unjudgeable, in both directions.
+  if (s.baselineDupe === 0) return out(false, false);
+  if (recentShare < DEDUPE_ABSOLUTE_FLOOR) return out(false, true);
+  if (recentShare < baselineShare * DEDUPE_MARGIN) return out(false, true);
   const pct = (n: number) => `${Math.round(n * 100)}%`;
   return out(
+    true,
     true,
     `Extraction is producing duplicate entities: ${pct(recentShare)} of the last 24h of graph edges ` +
       `are duplicate-of records, against ${pct(baselineShare)} for this graph's own baseline. That is ` +

--- a/lib/graph/extraction-health.ts
+++ b/lib/graph/extraction-health.ts
@@ -60,7 +60,12 @@ export interface GraphExtractionHealth {
   episodes: number | null; // projected episodes for this team (Postgres ledger)
   facts: number | null; // extracted RELATES_TO facts in Neo4j (null = Neo4j unreadable)
   stalled: boolean; // episodes are landing but not becoming facts → extractor failing
-  reason: string | null; // human-facing cause when stalled
+  /** The extractor is producing duplicate entities well above this graph's own baseline — a DIFFERENT
+   *  failure from `stalled`: extraction is working, and producing bad knowledge. Kept as its own flag
+   *  rather than folded into `stalled` because the two send an operator to different places (service
+   *  logs vs the Extraction model picker). */
+  dedupePolluted: boolean;
+  reason: string | null; // human-facing cause when stalled OR polluted
 }
 
 export interface ExtractionSignals {
@@ -184,14 +189,22 @@ async function countProjectedEpisodes(teamId: string): Promise<number | null> {
 }
 
 export async function getGraphExtractionHealth(teamId: string): Promise<GraphExtractionHealth> {
-  const empty: GraphExtractionHealth = { episodes: null, facts: null, stalled: false, reason: null };
+  const empty: GraphExtractionHealth = {
+    episodes: null,
+    facts: null,
+    stalled: false,
+    dedupePolluted: false,
+    reason: null,
+  };
   if (!neo4jConfigured()) return empty;
-  const [episodes, facts, newestEpisode, newestFact] = await Promise.all([
+  const [episodes, facts, newestEpisode, newestFact, dedupe] = await Promise.all([
     countProjectedEpisodes(teamId),
     countGraphFacts(),
     newestEpisodeAtMs(teamId),
     newestFactAtMs(),
+    dedupeSignals(),
   ]);
+  const pollution = deriveDedupePollution(dedupe);
   const signals: ExtractionSignals = {
     episodes,
     facts,
@@ -208,13 +221,152 @@ export async function getGraphExtractionHealth(teamId: string): Promise<GraphExt
     episodes,
     facts,
     stalled,
+    dedupePolluted: pollution.polluted,
     // Two distinct causes deserve two distinct sentences — "it never worked" and "it stopped" send an
     // operator to different places. Both name the graphiti service logs, which is where the actual
     // error string lives (a token cap, a 429 `insufficient_quota`, an invalid group_id).
+    // A STALL outranks pollution: no facts at all is worse news than bad facts, and stacking two
+    // paragraphs into one banner buries both.
     reason: !stalled
-      ? null
+      ? pollution.reason
       : neverExtracted
         ? `${episodes} episodes were projected but the graph has 0 extracted facts — Graphiti is accepting episodes (202) yet its entity-extraction worker is failing on every job (commonly the LLM output-token cap, e.g. "Output length exceeded max tokens"). New activity isn't becoming graph facts, so narrative arcs can't update. Check the graphiti service logs.`
         : `Graph extraction has STOPPED: episodes are still being projected, but no new fact has been extracted for about ${lagHours}h (the graph holds ${facts} facts from before). Graphiti keeps returning 202 while its extraction worker fails every job — most often the extraction LLM key is out of quota (a 429 \`insufficient_quota\`), or its output-token cap is being exceeded. Narrative arcs and the Learning panel are running on stale facts. Check the graphiti service logs.`,
   };
+}
+
+/* ────────────────────────────────────────────────────────────────────────────────────────────────
+ * DEDUPE POLLUTION — the extractor confusing entity identity, which no static check can predict.
+ *
+ * On 2026-07-30 a cheaper extraction model was selected. It passed the save-time structured-output
+ * check (#442) because it genuinely supports structured outputs; it just resolves identity badly. For
+ * four days it filled the graph with duplicate entities, and every headline number moved the RIGHT
+ * way — total spend fell, because episode volume dropped faster than work per episode rose. It was
+ * found by hand.
+ *
+ * WHY THE THRESHOLD IS RELATIVE, NOT ABSOLUTE. Graphiti records entity dedup as a `RELATES_TO` edge
+ * named `IS_DUPLICATE_OF` — normal bookkeeping, emitted by every model. `lib/graph/learning.ts`
+ * measured ~26% of this graph as those edges on 2026-07-20, ten days BEFORE the bad model, and filters
+ * them out of every read. So "any duplicate edges" is the healthy steady state: an absolute threshold
+ * would be permanently on, which is the cry-wolf failure this repo has already paid for twice.
+ *
+ * Only a RATE CHANGE against the graph's own trailing baseline is signal. That also makes it
+ * self-calibrating: a corpus that naturally produces more dedupe edges is never accused of a
+ * regression it doesn't have.
+ * ──────────────────────────────────────────────────────────────────────────────────────────────── */
+
+/** Recent window whose dedupe share is judged. */
+export const DEDUPE_RECENT_MS = 24 * 3_600_000;
+/** Trailing window it is judged AGAINST — long enough that one bad day can't move the baseline it is
+ *  compared to, which is what stops the alarm normalising a regression as it happens. */
+export const DEDUPE_BASELINE_MS = 14 * 86_400_000;
+/** Below this many recent edges the share is noise — 1 of 3 is 33% and means nothing. Mirrors
+ *  MIN_EPISODES_FOR_EXTRACTION_SIGNAL's role: refuse to judge a sample too small to carry a verdict. */
+export const MIN_EDGES_FOR_DEDUPE_SIGNAL = 200;
+/**
+ * How far above its own baseline the recent share must sit. MEASURED, not chosen: healthy observations
+ * are ~26% (learning.ts, 2026-07-20) and ~35% (sampled 2026-08-03 over pre-07-30 edges); the bad model
+ * ran ~70%. 1.4x over a ~30% baseline fires at ~42% — above every healthy reading, well below the
+ * degraded one.
+ */
+export const DEDUPE_MARGIN = 1.4;
+/**
+ * …AND an absolute floor, because a relative margin alone fires on noise when the baseline is tiny
+ * (2% → 3% is +50%). 45% sits above every healthy observation on record and below the degraded one.
+ */
+export const DEDUPE_ABSOLUTE_FLOOR = 0.45;
+
+export interface DedupeSignals {
+  /** Edges extracted in the recent window; null = Neo4j unreadable. */
+  recentTotal: number | null;
+  recentDupe: number | null;
+  /** Edges extracted in the trailing baseline window, EXCLUDING the recent one. */
+  baselineTotal: number | null;
+  baselineDupe: number | null;
+}
+
+export interface DedupePollution {
+  polluted: boolean;
+  recentShare: number | null;
+  baselineShare: number | null;
+  reason: string | null;
+}
+
+const share = (dupe: number | null, total: number | null): number | null =>
+  typeof dupe === "number" && typeof total === "number" && total > 0 ? dupe / total : null;
+
+/**
+ * Is the extractor producing duplicate entities at a rate its own history doesn't justify?
+ *
+ * Pure so every refusal-to-judge is testable without Neo4j. Every uncertain case returns
+ * `polluted: false` — unknown must never read as degraded, or an outage teaches people to ignore the
+ * banner (the same contract `deriveGraphExtractionStalled` keeps).
+ */
+export function deriveDedupePollution(s: DedupeSignals): DedupePollution {
+  const recentShare = share(s.recentDupe, s.recentTotal);
+  const baselineShare = share(s.baselineDupe, s.baselineTotal);
+  const out = (polluted: boolean, reason: string | null = null): DedupePollution => ({
+    polluted,
+    recentShare,
+    baselineShare,
+    reason,
+  });
+  // Unreadable graph, too small a sample, or no baseline to compare against: all "can't tell".
+  if (recentShare === null || baselineShare === null) return out(false);
+  if ((s.recentTotal ?? 0) < MIN_EDGES_FOR_DEDUPE_SIGNAL) return out(false);
+  if ((s.baselineTotal ?? 0) < MIN_EDGES_FOR_DEDUPE_SIGNAL) return out(false);
+  if (recentShare < DEDUPE_ABSOLUTE_FLOOR) return out(false);
+  if (recentShare < baselineShare * DEDUPE_MARGIN) return out(false);
+  const pct = (n: number) => `${Math.round(n * 100)}%`;
+  return out(
+    true,
+    `Extraction is producing duplicate entities: ${pct(recentShare)} of the last 24h of graph edges ` +
+      `are duplicate-of records, against ${pct(baselineShare)} for this graph's own baseline. That is ` +
+      `the signature of an extraction model resolving entity identity badly — check the Extraction ` +
+      `model in Admin → Integrations.`
+  );
+}
+
+/**
+ * Read both windows in ONE aggregate. Same query class as `countGraphFacts` — an aggregate returns one
+ * row, so this scans `RELATES_TO` once and costs what the probe's existing full-edge scans cost
+ * (tens of ms at ~31k edges). A `LIMIT` would do nothing here: it applies after aggregation.
+ *
+ * `r.created_at` is EXTRACTION time, deliberately not `valid_at`, which Graphiti backdates to the
+ * episode's work time — ranking a health probe by that reports on a backfill's content age instead of
+ * on what the extractor just did.
+ */
+export async function dedupeSignals(nowMs = Date.now()): Promise<DedupeSignals> {
+  const unknown: DedupeSignals = { recentTotal: null, recentDupe: null, baselineTotal: null, baselineDupe: null };
+  if (!neo4jConfigured()) return unknown;
+  try {
+    const recentSince = new Date(nowMs - DEDUPE_RECENT_MS).toISOString();
+    const baselineSince = new Date(nowMs - DEDUPE_BASELINE_MS).toISOString();
+    const rows = await runRead<{
+      recentTotal: number;
+      recentDupe: number;
+      baselineTotal: number;
+      baselineDupe: number;
+    }>(
+      `MATCH ()-[r:RELATES_TO]->()
+       WHERE r.created_at >= datetime($baselineSince)
+       RETURN
+         count(CASE WHEN r.created_at >= datetime($recentSince) THEN 1 END) AS recentTotal,
+         count(CASE WHEN r.created_at >= datetime($recentSince) AND r.name = 'IS_DUPLICATE_OF' THEN 1 END) AS recentDupe,
+         count(CASE WHEN r.created_at < datetime($recentSince) THEN 1 END) AS baselineTotal,
+         count(CASE WHEN r.created_at < datetime($recentSince) AND r.name = 'IS_DUPLICATE_OF' THEN 1 END) AS baselineDupe`,
+      { recentSince, baselineSince }
+    );
+    const r = rows[0];
+    return r
+      ? {
+          recentTotal: Number(r.recentTotal) || 0,
+          recentDupe: Number(r.recentDupe) || 0,
+          baselineTotal: Number(r.baselineTotal) || 0,
+          baselineDupe: Number(r.baselineDupe) || 0,
+        }
+      : unknown;
+  } catch {
+    return unknown; // unreadable → unknown, never degraded
+  }
 }

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
-import { getGraphExtractionHealth } from "@/lib/graph/extraction-health";
+import { getGraphExtractionHealth, GRAPH_HEALTH_SOURCE } from "@/lib/graph/extraction-health";
 
 /**
  * Aggregate ingestion-pipeline health for a LOUD admin surface. Every pipeline leg (slack/plane/
@@ -176,7 +176,13 @@ export async function getPipelineHealth(teamId: string): Promise<PipelineHealth>
     const beatAt: Map<string, string> | null = beats
       ? new Map(beats.rows.map((r) => [r.source, iso(r.finished_at)]))
       : null;
-    const legs: PipelineLeg[] = res.rows.map((r) => {
+    // The dedupe-pollution alarm's transition LEDGER (lib/graph/extraction-alert) is not a leg: it
+    // writes a row only when the alarm flips (weeks apart), so any age-based read of it is
+    // meaningless — an ok=true recovery row would go "stale" 3h later and redden the banner on a
+    // healthy graph forever (review finding). Its live state already surfaces through the synthetic
+    // `graph_extract` leg below, fed by the same detector; the ledger rows remain visible in the
+    // Recent-runs panel as the alarm's audit trail.
+    const legs: PipelineLeg[] = res.rows.filter((r) => r.source !== GRAPH_HEALTH_SOURCE).map((r) => {
       const at = iso(r.finished_at);
       // Stale only past THIS source's own cadence — a 24h job isn't stale at 3h (would cry wolf).
       const threshold = staleThresholdMs(r.source);

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -192,7 +192,10 @@ export async function getPipelineHealth(teamId: string): Promise<PipelineHealth>
     // graph_project=OK on a 202, but Graphiti then fails entity extraction asynchronously, so
     // episodes are accepted while zero facts are created. Append it as a failing leg so the loud
     // banner names it just like a real broken poller.
-    if (extraction?.stalled) {
+    // Either extraction failure earns the leg: a stall (no facts) or dedupe pollution (bad facts).
+    // Keyed on both so a model that extracts confidently-wrong knowledge is as loud as one that
+    // extracts nothing — the 2026-07-30 incident was the second kind and nothing announced it.
+    if (extraction?.stalled || extraction?.dedupePolluted) {
       legs.push({
         source: "graph_extract",
         ok: false,

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -87,6 +87,16 @@ export function startIngestScheduler(): void {
         await alertDenseDegraded(db, priorFailed, { failed: 0, scanned: 0, errorSample: msg });
       }
     }
+
+    // Graph dedupe-pollution alarm (AIO-693): the scheduled caller extraction health never had. The
+    // 2026-07-30 bad-model incident was visible on every page that anyone didn't open for four days;
+    // this pushes the transition to admins instead. One cheap Neo4j aggregate per tick; best-effort,
+    // edge-debounced, and an unreadable graph changes nothing (see lib/graph/extraction-alert).
+    {
+      const { runDedupePollutionCheck } = await import("@/lib/graph/extraction-alert");
+      const action = await runDedupePollutionCheck(db);
+      if (action !== "none") console.warn(`[ingest] graph_health: dedupe pollution ${action}`);
+    }
   };
 
   // Inbound PM-sync step (brain-api v1.4): apply Linear board edits to brain tasks + adopt

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -108,7 +108,8 @@ export function isGraphStale(lastProjectedAtMs: number | null, nowMs: number): b
  *   • not configured (no/malformed GRAPHITI_URL)             → "off"
  *   • configured BUT /healthcheck failed (down/unreachable)   → "degraded"
  *   • reachable BUT projector hasn't written in > GRAPH_STALE_MS (writes failing) → "degraded"
- *   • reachable + writing BUT the extractor makes no facts from projected episodes → "degraded"
+ *   • reachable + writing BUT extraction is failing — no facts from projected episodes, or facts
+ *     polluted by abnormal duplicate-entity rates (both arrive via `extractionStalled`) → "degraded"
  *   • reachable AND recently projected (or nothing to project yet) → "on"
  */
 export function deriveGraphState(input: {

--- a/lib/query/retrieval-health.ts
+++ b/lib/query/retrieval-health.ts
@@ -6,6 +6,8 @@ import { getLlmHealth, type LlmHealth } from "@/lib/query/llm-health";
 import { resolveGraphChatTarget, resolveGraphEmbeddingTarget, isRefusal } from "@/lib/llm/graph-proxy";
 import {
   countGraphFacts,
+  dedupeSignals,
+  deriveDedupePollution,
   deriveGraphExtractionStalled,
   newestEpisodeAtMs,
   newestFactAtMs,
@@ -50,6 +52,7 @@ export interface RetrievalHealth {
   graphLastProjectedAt: string | null; // most recent successful projection (null = never)
   graphStalled: boolean; // degraded specifically because the projector stopped writing (vs unreachable)
   graphExtractionStalled: boolean; // episodes are reaching Graphiti (202) but its extractor makes no facts
+  graphDedupePolluted: boolean; // extraction runs, but duplicate-entity rate is over the graph's own baseline (AIO-693)
   /** A CONFIG refusal from the graph LLM proxy — Anthropic selected, embeddings unset or the wrong
    *  width, ambiguous team. Resolved from settings only (no upstream call, no spend), so it is free
    *  to check on every render and lands here INSTANTLY. Without it a misconfiguration is
@@ -163,6 +166,7 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
     graphFacts,
     graphNewestFactAt,
     graphNewestEpisodeAt,
+    graphDedupe,
     graphProxyRefusal,
     llm,
   ] =
@@ -173,6 +177,9 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
     graphConfiguredNow ? countGraphFacts() : Promise.resolve(null),
     graphConfiguredNow ? newestFactAtMs() : Promise.resolve(null),
     graphConfiguredNow ? newestEpisodeAtMs(teamId) : Promise.resolve(null),
+    graphConfiguredNow
+      ? dedupeSignals()
+      : Promise.resolve({ recentTotal: null, recentDupe: null, baselineTotal: null, baselineDupe: null }),
     // Config-only resolution: no upstream call, nothing spent. Best-effort — a broken probe must
     // never fail the admin page.
     graphConfiguredNow
@@ -212,11 +219,17 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
       newestEpisodeAtMs: graphNewestEpisodeAt,
       newestFactAtMs: graphNewestFactAt,
     });
+  // The OTHER extraction failure: episodes become facts, but the facts are confidently wrong —
+  // duplicate entities from a model resolving identity badly (AIO-693, the 2026-07-30 incident).
+  // Same detector as the pipeline banner + the admin email alarm, so all three surfaces flip on the
+  // same evidence and can't drift apart.
+  const graphDedupePolluted = graphReachable && deriveDedupePollution(graphDedupe).polluted;
   const graph = deriveGraphState({
     configured: graphConfiguredNow,
     reachable: graphReachable,
     lastProjectedAtMs,
-    extractionStalled: graphExtractionStalled,
+    // Either extraction failure degrades the leg — no facts, or wrong facts.
+    extractionStalled: graphExtractionStalled || graphDedupePolluted,
     nowMs,
   });
   // Degraded specifically because the projector went quiet (reachable, but a stale write path) — the
@@ -230,6 +243,7 @@ export async function getRetrievalHealth(teamId: string): Promise<RetrievalHealt
     graphLastProjectedAt: graphFresh.lastProjectedAt,
     graphStalled,
     graphExtractionStalled,
+    graphDedupePolluted,
     graphProxyRefusal,
     graphFacts,
     rerank,

--- a/test/dedupe-pollution.test.ts
+++ b/test/dedupe-pollution.test.ts
@@ -50,17 +50,21 @@ describe("deriveDedupePollution — the real incident", () => {
 });
 
 describe("deriveDedupePollution — refuses to judge what it cannot", () => {
-  it("unknown (Neo4j unreadable) is NOT degraded", () => {
-    expect(
-      deriveDedupePollution({ recentDupe: null, recentTotal: null, baselineDupe: null, baselineTotal: null })
-        .polluted
-    ).toBe(false);
+  it("unknown (Neo4j unreadable) is NOT degraded — and says so via `judgeable`", () => {
+    const out = deriveDedupePollution({ recentDupe: null, recentTotal: null, baselineDupe: null, baselineTotal: null });
+    expect(out.polluted).toBe(false);
+    expect(out.judgeable, "a refusal must be distinguishable from a judged 'healthy'").toBe(false);
   });
 
   it("a sample below the floor cannot carry a verdict", () => {
     // 100% recent duplicates — but over 3 edges. A fresh install, not a regression.
     const tiny = deriveDedupePollution(sig(3, 3, 100, 1000));
     expect(tiny.polluted).toBe(false);
+    // The refusal is explicit: shares are computed (they exist for display) but carry no verdict.
+    // The alarm's edge machine keys on THIS — a quiet day during a sustained incident must not
+    // read as a judged recovery (review finding on the delivery half).
+    expect(tiny.judgeable).toBe(false);
+    expect(tiny.recentShare).not.toBeNull();
     // …and the same ratio over a real sample DOES flag, so the floor is what's doing the work.
     expect(deriveDedupePollution(sig(MIN_EDGES_FOR_DEDUPE_SIGNAL, MIN_EDGES_FOR_DEDUPE_SIGNAL, 100, 1000)).polluted).toBe(true);
   });
@@ -83,10 +87,12 @@ describe("deriveDedupePollution — both conditions are load-bearing", () => {
     expect(out.polluted, "a relative margin alone fires on noise").toBe(false);
   });
 
-  it("a high share that is NOT a rise does not fire", () => {
+  it("a high share that is NOT a rise does not fire — but IS a judged verdict", () => {
     const out = deriveDedupePollution(sig(500, 1000, 480, 1000));
     expect(out.recentShare!).toBeGreaterThan(DEDUPE_ABSOLUTE_FLOOR);
     expect(out.polluted, "high-but-flat is the model's nature, not a regression").toBe(false);
+    // Judged-healthy, not refused: this CAN clear an active alarm, where a refusal cannot.
+    expect(out.judgeable).toBe(true);
   });
 
   it("needs BOTH: above the floor AND above the baseline by the margin", () => {

--- a/test/dedupe-pollution.test.ts
+++ b/test/dedupe-pollution.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveDedupePollution,
+  DEDUPE_ABSOLUTE_FLOOR,
+  DEDUPE_MARGIN,
+  MIN_EDGES_FOR_DEDUPE_SIGNAL,
+} from "@/lib/graph/extraction-health";
+
+/**
+ * Spec: catch an extraction model that resolves entity identity badly — the failure no static check
+ * can predict, because no catalogue exposes it.
+ *
+ * The numbers here are real. `lib/graph/learning.ts` measured ~26% of this graph as `IS_DUPLICATE_OF`
+ * edges on 2026-07-20, on a HEALTHY extractor, and filters them from every read as bookkeeping.
+ * Sampling on 2026-08-03 put pre-07-30 edges at ~35% and the bad model's at ~70%. So "any duplicate
+ * edges" is the healthy steady state, and only a rate change against the graph's own history is signal.
+ *
+ * Every uncertain case must return NOT polluted. An alarm that fires on an outage, a fresh install, or
+ * a quiet week is one people learn to dismiss — which this repo has paid for twice already.
+ */
+
+const sig = (recentDupe: number, recentTotal: number, baselineDupe: number, baselineTotal: number) => ({
+  recentDupe,
+  recentTotal,
+  baselineDupe,
+  baselineTotal,
+});
+
+describe("deriveDedupePollution — the real incident", () => {
+  it("flags the 2026-07-30 shape: ~35% baseline, ~70% recent", () => {
+    const out = deriveDedupePollution(sig(700, 1000, 350, 1000));
+    expect(out.polluted).toBe(true);
+    expect(out.recentShare).toBeCloseTo(0.7, 3);
+    expect(out.baselineShare).toBeCloseTo(0.35, 3);
+    expect(out.reason).toMatch(/duplicate entities/i);
+    // The message must name the action, not just the observation.
+    expect(out.reason).toMatch(/Extraction model/i);
+  });
+
+  it("does NOT flag the healthy steady state, however high it looks in absolute terms", () => {
+    // ~26% is what a GOOD extractor produces here. An absolute threshold would fire forever.
+    const out = deriveDedupePollution(sig(260, 1000, 260, 1000));
+    expect(out.polluted, "the healthy baseline must never be an alarm").toBe(false);
+  });
+
+  it("does not flag a graph that has always run hot — self-calibrating, not absolute", () => {
+    // 60% recent would trip any fixed threshold, but this graph has always been at 60%.
+    expect(deriveDedupePollution(sig(600, 1000, 600, 1000)).polluted).toBe(false);
+  });
+});
+
+describe("deriveDedupePollution — refuses to judge what it cannot", () => {
+  it("unknown (Neo4j unreadable) is NOT degraded", () => {
+    expect(
+      deriveDedupePollution({ recentDupe: null, recentTotal: null, baselineDupe: null, baselineTotal: null })
+        .polluted
+    ).toBe(false);
+  });
+
+  it("a sample below the floor cannot carry a verdict", () => {
+    // 100% recent duplicates — but over 3 edges. A fresh install, not a regression.
+    const tiny = deriveDedupePollution(sig(3, 3, 100, 1000));
+    expect(tiny.polluted).toBe(false);
+    // …and the same ratio over a real sample DOES flag, so the floor is what's doing the work.
+    expect(deriveDedupePollution(sig(MIN_EDGES_FOR_DEDUPE_SIGNAL, MIN_EDGES_FOR_DEDUPE_SIGNAL, 100, 1000)).polluted).toBe(true);
+  });
+
+  it("no baseline to compare against is NOT degraded", () => {
+    // A graph younger than the baseline window has no history to be judged against.
+    expect(deriveDedupePollution(sig(900, 1000, 2, 5)).polluted).toBe(false);
+  });
+
+  it("an empty recent window is not a verdict either", () => {
+    expect(deriveDedupePollution(sig(0, 0, 300, 1000)).polluted).toBe(false);
+  });
+});
+
+describe("deriveDedupePollution — both conditions are load-bearing", () => {
+  it("a big RELATIVE rise off a tiny baseline does not fire", () => {
+    // 2% → 6% is a 3x rise and completely meaningless. The absolute floor is what stops it.
+    const out = deriveDedupePollution(sig(60, 1000, 20, 1000));
+    expect(out.recentShare! / out.baselineShare!).toBeGreaterThan(DEDUPE_MARGIN);
+    expect(out.polluted, "a relative margin alone fires on noise").toBe(false);
+  });
+
+  it("a high share that is NOT a rise does not fire", () => {
+    const out = deriveDedupePollution(sig(500, 1000, 480, 1000));
+    expect(out.recentShare!).toBeGreaterThan(DEDUPE_ABSOLUTE_FLOOR);
+    expect(out.polluted, "high-but-flat is the model's nature, not a regression").toBe(false);
+  });
+
+  it("needs BOTH: above the floor AND above the baseline by the margin", () => {
+    expect(deriveDedupePollution(sig(500, 1000, 300, 1000)).polluted).toBe(true); // 50% vs 30% = 1.67x
+    expect(deriveDedupePollution(sig(440, 1000, 300, 1000)).polluted).toBe(false); // 44% — under the floor
+    expect(deriveDedupePollution(sig(500, 1000, 400, 1000)).polluted).toBe(false); // 1.25x — under the margin
+  });
+});

--- a/test/extraction-alert.test.ts
+++ b/test/extraction-alert.test.ts
@@ -11,10 +11,11 @@ import { decideDedupeAlert } from "@/lib/graph/extraction-alert";
  * space, so flipping any comparison in `decideDedupeAlert` reddens at least one.
  */
 
-const judged = (polluted: boolean) => ({ polluted, recentShare: 0.5, baselineShare: 0.3 });
-// The detector can only emit `polluted: false` for an unjudgeable sample (its own contract), so the
-// unjudgeable rows below never pair `polluted: true` with null shares.
-const unjudgeable = { polluted: false, recentShare: null, baselineShare: null };
+const judged = (polluted: boolean) => ({ polluted, judgeable: true });
+// A refusal always reads `polluted: false, judgeable: false` — the detector's contract. Note a
+// refused tick can still CARRY shares (a below-minimum sample computes them); `judgeable` is the
+// only field that says whether they mean anything, which is why the machine keys on it alone.
+const unjudgeable = { polluted: false, judgeable: false };
 
 describe("decideDedupeAlert", () => {
   it("fires exactly on the ok→polluted edge", () => {
@@ -41,7 +42,9 @@ describe("decideDedupeAlert", () => {
     expect(decideDedupeAlert(true, unjudgeable)).toBe("none");
   });
 
-  it("a partially readable sample (one window null) is unjudgeable, not half-judged", () => {
-    expect(decideDedupeAlert(true, { polluted: false, recentShare: 0.2, baselineShare: null })).toBe("none");
+  it("a below-minimum sample during an active alarm is not a recovery — quiet Saturday, still polluted", () => {
+    // The first cut re-derived judgeability from shares-non-null; a small sample carries shares, so
+    // one quiet day inside a sustained incident sent a false "recovered" mail (review finding).
+    expect(decideDedupeAlert(true, { polluted: false, judgeable: false })).toBe("none");
   });
 });

--- a/test/extraction-alert.test.ts
+++ b/test/extraction-alert.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { decideDedupeAlert } from "@/lib/graph/extraction-alert";
+
+/**
+ * The edge state machine that decides when the dedupe-pollution alarm mails an admin (AIO-693).
+ *
+ * Spec-first, from the alarm's contract: one mail on the ok→polluted edge, one on polluted→ok,
+ * silence in between — and an UNJUDGEABLE tick (Neo4j unreadable / sample too small) moves the
+ * machine in neither direction, because an alarm that "recovers" during an outage teaches admins to
+ * ignore the recovery mail. Each row pins one transition; together they cover the full 2×2×judgeable
+ * space, so flipping any comparison in `decideDedupeAlert` reddens at least one.
+ */
+
+const judged = (polluted: boolean) => ({ polluted, recentShare: 0.5, baselineShare: 0.3 });
+// The detector can only emit `polluted: false` for an unjudgeable sample (its own contract), so the
+// unjudgeable rows below never pair `polluted: true` with null shares.
+const unjudgeable = { polluted: false, recentShare: null, baselineShare: null };
+
+describe("decideDedupeAlert", () => {
+  it("fires exactly on the ok→polluted edge", () => {
+    expect(decideDedupeAlert(false, judged(true))).toBe("alert");
+  });
+
+  it("stays silent while pollution persists (no mail per tick)", () => {
+    expect(decideDedupeAlert(true, judged(true))).toBe("none");
+  });
+
+  it("recovers exactly on the polluted→ok edge", () => {
+    expect(decideDedupeAlert(true, judged(false))).toBe("recover");
+  });
+
+  it("stays silent while healthy", () => {
+    expect(decideDedupeAlert(false, judged(false))).toBe("none");
+  });
+
+  it("an unjudgeable tick never fires", () => {
+    expect(decideDedupeAlert(false, unjudgeable)).toBe("none");
+  });
+
+  it("an unjudgeable tick never clears an active alarm either — an outage is not a recovery", () => {
+    expect(decideDedupeAlert(true, unjudgeable)).toBe("none");
+  });
+
+  it("a partially readable sample (one window null) is unjudgeable, not half-judged", () => {
+    expect(decideDedupeAlert(true, { polluted: false, recentShare: 0.2, baselineShare: null })).toBe("none");
+  });
+});

--- a/test/guards/dedupe-predicate-pinned.test.ts
+++ b/test/guards/dedupe-predicate-pinned.test.ts
@@ -45,4 +45,18 @@ describe("dedupe predicate pinning", () => {
     expect(out.judgeable).toBe(false);
     expect(out.polluted).toBe(false);
   });
+
+  it("a zero-dupe RECENT window is equally predicate-suspect — a rename mid-incident is not a recovery", () => {
+    // A Graphiti bump that renames the relation zeroes the recent window IMMEDIATELY while the
+    // baseline still carries pre-rename dupes for up to 14 days. Judging that as healthy would mail
+    // "recovered" during an active incident, then go permanently silent once the baseline drains.
+    const out = deriveDedupePollution({
+      recentTotal: MIN_EDGES_FOR_DEDUPE_SIGNAL * 4,
+      recentDupe: 0,
+      baselineTotal: MIN_EDGES_FOR_DEDUPE_SIGNAL * 4,
+      baselineDupe: MIN_EDGES_FOR_DEDUPE_SIGNAL, // 25% — a normal healthy baseline
+    });
+    expect(out.judgeable).toBe(false);
+    expect(out.polluted).toBe(false);
+  });
 });

--- a/test/guards/dedupe-predicate-pinned.test.ts
+++ b/test/guards/dedupe-predicate-pinned.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  deriveDedupePollution,
+  MIN_EDGES_FOR_DEDUPE_SIGNAL,
+} from "@/lib/graph/extraction-health";
+
+/**
+ * GUARD: the dedupe-pollution alarm's Cypher predicate must stay pinned to what Graphiti actually
+ * writes (AIO-693 spec, guard #1).
+ *
+ * The failure mode: a Graphiti upgrade renames `IS_DUPLICATE_OF` (or moves it off `RELATES_TO`), the
+ * query silently matches nothing, shares fall to zero, and the alarm dies without a sound — worse, an
+ * ACTIVE alarm would mail "recovered" mid-incident. Two layers, because neither alone covers both
+ * sides:
+ *
+ *  1. OUR side (this file): the query text in `dedupeSignals` must still say what the deployed image
+ *     (zepai/graphiti@76d14f30, graphiti_core 0.13.2 — verified 2026-08-03) actually writes. A
+ *     refactor that rewords the predicate fails the build.
+ *  2. GRAPHITI's side (runtime, `deriveDedupePollution`): a zero-dupe baseline over a ≥MIN-edge
+ *     window is treated as predicate-suspect and UNJUDGEABLE — this graph's measured healthy
+ *     baseline is ~26–35%, so a literal zero means the relation is gone, not that extraction became
+ *     perfect. That check is asserted here so it can't be simplified away.
+ */
+describe("dedupe predicate pinning", () => {
+  const src = readFileSync(join(process.cwd(), "lib/graph/extraction-health.ts"), "utf8");
+
+  it("the signal query still greps the relation Graphiti actually writes", () => {
+    expect(src).toContain("MATCH ()-[r:RELATES_TO]->()");
+    expect(src).toContain("r.name = 'IS_DUPLICATE_OF'");
+    // Extraction time, not `valid_at` — Graphiti backdates valid_at to the episode's WORK time, so a
+    // backfill would otherwise be judged by its content's age instead of what the extractor just did.
+    expect(src).toContain("r.created_at");
+    expect(src.includes("r.valid_at")).toBe(false);
+  });
+
+  it("a zero-dupe baseline over a real sample is unjudgeable, not perfectly healthy", () => {
+    const out = deriveDedupePollution({
+      recentTotal: MIN_EDGES_FOR_DEDUPE_SIGNAL * 4,
+      recentDupe: MIN_EDGES_FOR_DEDUPE_SIGNAL * 2, // 50% recent — would alarm against any real baseline
+      baselineTotal: MIN_EDGES_FOR_DEDUPE_SIGNAL * 4,
+      baselineDupe: 0, // ...but a literal-zero baseline means the predicate matched nothing
+    });
+    expect(out.judgeable).toBe(false);
+    expect(out.polluted).toBe(false);
+  });
+});

--- a/test/guards/extraction-alert-wired.test.ts
+++ b/test/guards/extraction-alert-wired.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * GUARD: the dedupe-pollution alarm must have a SCHEDULED caller (AIO-693).
+ *
+ * The failure this traces to: the 2026-07-30 bad-extraction-model incident was detectable on every
+ * surface that existed and still ran for four days, because every surface was a page render waiting
+ * for a visit. The plan review's blocking finding on the alarm design was exactly that
+ * `getGraphExtractionHealth` had no scheduled caller — so DELIVERY, not detection, is the feature.
+ *
+ * This pins the wiring, not the module: `runDedupePollutionCheck` has its own unit tests, all of
+ * which stay green if the one line calling it from the ingest tick is deleted — the
+ * "14 tests over the selector, none over the argument that wires it" failure this repo has already
+ * shipped once (#452's review catch, recorded as a standing lesson). Deleting the scheduler call
+ * turns THIS red.
+ */
+describe("dedupe-pollution alarm wiring", () => {
+  const scheduler = readFileSync(join(process.cwd(), "lib/ingest/scheduler.ts"), "utf8");
+
+  it("the ingest scheduler tick invokes the dedupe-pollution check", () => {
+    expect(scheduler).toMatch(/runDedupePollutionCheck\s*\(/);
+    expect(scheduler).toContain("@/lib/graph/extraction-alert");
+  });
+});


### PR DESCRIPTION
## What

The 2026-07-30 bad-extraction-model incident ran for four days while being detectable on every surface that existed — because every surface was a page render waiting for a visit. This ships the AIO-693 alarm end to end:

- **Detector** (`lib/graph/extraction-health.ts`): share of recent graph edges named `IS_DUPLICATE_OF`, judged against this graph's own 14-day trailing baseline — never an absolute threshold (`learning.ts` measured ~26% as the healthy steady state ten days before the incident). Fires only above an absolute floor (45%) AND 1.4× the baseline. Every uncertain case — unreadable Neo4j, sample under 200 edges, a literal-zero window (predicate-suspect: a Graphiti rename, not perfection) — returns an explicit `judgeable: false`, which can neither fire nor clear the alarm.
- **Delivery** (`lib/graph/extraction-alert.ts`, wired into the ingest scheduler tick): edge-debounced admin email on the ok→polluted transition, symmetric recovery mail, state in `ingest_runs` (`source: graph_health`, rows only on transitions — a four-day incident is two rows, not 384).
- **Surfaces**: the pipeline "broken legs" banner and the retrieval-health card both key on the same detector, so all three surfaces flip on one piece of evidence.
- Also carries the AIO-693/AIO-705 design docs, including the recorded negative result (the synthetic qualification fixture failed its own acceptance test in both directions — documented, not tuned).

## Review — Reviewed by Fable code-reviewer (subagent) — verdict CLEAR after fixes: initial pass BLOCKED (stale-ledger leg would redden the banner forever post-recovery; judgeability re-derived from shares sent a false "recovered" during a quiet day mid-incident; second display surface unwired; relation-name unpinned); all four fixed and delta-verified closed, plus the reviewer's residual (zero RECENT window mid-rename) taken in the final commit. Two LOWs noted by the reviewer accepted as-is: the `RELATES_TO` guard assertion is individually vacuous (the `IS_DUPLICATE_OF` pin carries it), and one extra Neo4j aggregate per admin card render (established cost class).

## Test plan
- [x] 21 alarm-specific unit tests (detector thresholds, refusal semantics, edge state machine, both guards)
- [x] Wiring guard mutation-proven: deleting the scheduler call turns it red
- [x] Full unit tier 1893 green · tsc clean · lint clean (2 pre-existing warnings) · docs-drift green
- [ ] CI data-mechanics + http tiers

AIOS-Work: COST3