### PR TITLE
fix(schema): prod deploys are failing — mirror AIO-786's decision columns into schema.sql (replay order)

### DIFF
--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1531,6 +1531,18 @@ create table if not exists codebase_findings (
 );
 alter table codebase_findings
   add column if not exists occurrence_count integer not null default 1;
+-- AIO-786 decision columns, mirrored from 20260804160000_explainable_debt_decisions.sql. REQUIRED
+-- here, not just in the migration: schema.sql loads BEFORE migrations, and the standalone
+-- decision-expiry index below references decision_expires_at — on a live DB whose table predates the
+-- migration, the guarded create-table above is a no-op, so without these alters the index statement
+-- aborts the whole load and the migration that would have added the column never runs (every deploy
+-- fails; broke prod 2026-08-04, the #251 replay class).
+alter table codebase_findings
+  add column if not exists decision_reason text,
+  add column if not exists decision_owner_member_id uuid references members(id) on delete set null,
+  add column if not exists decision_by_member_id uuid references members(id) on delete set null,
+  add column if not exists decision_at timestamptz,
+  add column if not exists decision_expires_at timestamptz;
 create index if not exists codebase_findings_active_idx
   on codebase_findings (team_id, codebase_id, status, last_seen_at desc);
 create index if not exists codebase_findings_decision_expiry_idx

--- a/test/guards/schema-index-column-replay.test.ts
+++ b/test/guards/schema-index-column-replay.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * GUARD: a standalone index in schema.sql may not reference a migration-added column unless
+ * schema.sql ALSO carries the mirrored `add column if not exists`.
+ *
+ * The failure this traces to (2026-08-04, prod deploys blocked): #492 added decision columns to
+ * `codebase_findings` via migration AND the create-table body, then created a standalone partial
+ * index on `decision_expires_at` in schema.sql. On a live DB the table already existed, so
+ * `create table if not exists` was a no-op, the index statement aborted the load with
+ * `column "decision_expires_at" does not exist` — and because schema.sql loads BEFORE migrations
+ * (scripts/pg-load-schema.mjs), the migration that would have added the column never ran. Every
+ * deploy failed until the alter was mirrored into schema.sql (the same pattern the adjacent
+ * `occurrence_count` alter already followed). Same replay class as incident #251.
+ *
+ * The rule encoded: for every (table, column) pair that any migration adds via
+ * `add column if not exists`, if schema.sql's standalone `create index` statements reference that
+ * column on that table, schema.sql must contain its own `alter table <table> add column if not
+ * exists <column>`. From-zero stays correct either way; this is about the live-DB replay order.
+ */
+
+const ROOT = process.cwd();
+const schema = readFileSync(join(ROOT, "postgres/schema.sql"), "utf8");
+const migDir = join(ROOT, "postgres/migrations");
+
+/**
+ * (table, column) → offset of the `alter table … add column if not exists` that adds it. The offset
+ * matters: statements execute top-to-bottom, so a mirrored alter placed AFTER the index it exists to
+ * protect still aborts the live load — the guard must reject that, not just require presence.
+ */
+function addedColumns(sql: string): Map<string, number> {
+  const out = new Map<string, number>();
+  // An ALTER can carry several comma-separated add-column clauses; scan statement-wise.
+  const alterRe = /alter\s+table\s+(?:if\s+exists\s+)?([a-z0-9_]+)\s+((?:.|\n)*?);/gi;
+  for (const m of sql.matchAll(alterRe)) {
+    const table = m[1].toLowerCase();
+    for (const col of m[2].matchAll(/add\s+column\s+if\s+not\s+exists\s+([a-z0-9_]+)/gi)) {
+      const key = `${table}.${col[1].toLowerCase()}`;
+      if (!out.has(key)) out.set(key, m.index ?? 0);
+    }
+  }
+  return out;
+}
+
+/** Standalone `create index` statements in schema.sql: table, referenced-column text, and offset. */
+function indexStatements(sql: string): { table: string; body: string; at: number }[] {
+  const out: { table: string; body: string; at: number }[] = [];
+  const re = /create\s+(?:unique\s+)?index\s+(?:if\s+not\s+exists\s+)?[a-z0-9_]+\s+on\s+([a-z0-9_]+)\s*((?:.|\n)*?);/gi;
+  for (const m of sql.matchAll(re)) out.push({ table: m[1].toLowerCase(), body: m[2].toLowerCase(), at: m.index ?? 0 });
+  return out;
+}
+
+describe("schema.sql standalone indexes vs migration-added columns", () => {
+  it("every migration-added column referenced by a standalone schema.sql index is also altered-in by schema.sql", () => {
+    const migrationAdded = new Set<string>();
+    for (const f of readdirSync(migDir).filter((f) => f.endsWith(".sql"))) {
+      for (const pair of addedColumns(readFileSync(join(migDir, f), "utf8")).keys()) migrationAdded.add(pair);
+    }
+    const schemaAdded = addedColumns(schema);
+    const violations: string[] = [];
+    for (const { table, body, at } of indexStatements(schema)) {
+      for (const pair of migrationAdded) {
+        const [t, col] = pair.split(".");
+        if (t !== table) continue;
+        // Word-boundary match keeps `decision_at` from matching inside `decision_expires_at`.
+        if (!new RegExp(`\\b${col}\\b`).test(body)) continue;
+        const alterAt = schemaAdded.get(pair);
+        // Present AND above the index — statements run top-to-bottom, so a mirror placed below the
+        // index it protects is the same broken load with a green guard (review finding).
+        if (alterAt === undefined || alterAt > at) {
+          violations.push(
+            `schema.sql index on "${table}" references "${col}", which only a migration adds — ` +
+              `mirror \`alter table ${table} add column if not exists ${col}\` into schema.sql ` +
+              `BEFORE the index, or the load aborts on any live DB that predates the migration.`
+          );
+        }
+      }
+    }
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("is non-vacuous: the incident's own pair is seen by both sides", () => {
+    // If either parser goes blind (a regex refactor), the guard silently passes on everything —
+    // so pin the exact pair from the 2026-08-04 incident on both sides of the rule.
+    const migAdded = addedColumns(
+      readFileSync(join(migDir, "20260804160000_explainable_debt_decisions.sql"), "utf8")
+    );
+    expect(migAdded.has("codebase_findings.decision_expires_at")).toBe(true);
+    expect(addedColumns(schema).has("codebase_findings.decision_expires_at")).toBe(true);
+    const idx = indexStatements(schema).filter(
+      (s) => s.table === "codebase_findings" && /\bdecision_expires_at\b/.test(s.body)
+    );
+    expect(idx.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

**Prod deploys are currently blocked** — two consecutive FAILED deployments (`1248f844`, `18fdae49`), pre-deploy schema load aborting with `column "decision_expires_at" does not exist`. Prod is stuck on the 20:31 build; #492 and #494 are merged but not live.

Root cause (the #251 replay class, index variant): #492 added the decision columns to `codebase_findings` in the migration **and** the create-table body, then created a standalone partial index on `decision_expires_at` in schema.sql. schema.sql loads BEFORE migrations (`pg-load-schema.mjs`), the live table predates the migration so create-table no-ops, the index statement aborts the entire load — and the migration that would have added the column never gets to run. Every deploy fails until the alter is mirrored into schema.sql, which is exactly the pattern the adjacent `occurrence_count` alter already followed.

Fix: the migration's five `add column if not exists` lines mirrored into schema.sql **above** the index, token-identical to the migration's.

## Proven, not assumed

On ephemeral Postgres: reproduced the exact prod failure by loading the pre-#492 schema state and running the current loader (same error, byte-for-byte) → with the fix, that DB **loads**, re-runs **idempotently**, and a from-zero DB **replays clean**, with the column present in both.

Guarded: `test/guards/schema-index-column-replay.test.ts` encodes the rule — a standalone schema.sql index may not reference a migration-added column unless schema.sql carries the mirrored alter **above** the index (ordering enforced per review). Mutation-proven both ways: deleting the alter reddens it, moving it below the index reddens it. Non-vacuity pinned on this incident's own pair.

## Review — Reviewed by Fable code-reviewer (subagent) — verdict CLEAR: mirror token-identical to the migration, placement safe (DO-block constraint validated against the pre-#492 writer set — no decided statuses existed, so the #251 constraint-violation variant can't fire), fix complete for the blocked deploy (no other same-day statement fails on that shape). Reviewer's Medium (guard accepted a mirrored alter placed below the index) fixed in this PR; two LOWs consciously deferred: the guard doesn't strip SQL comments/`$$` bodies, and covers only the `create index` class — both trace to no real bug yet (CLAUDE.md §7).

## Test plan
- [x] Live-shape replay, idempotent re-run, from-zero replay — all green on ephemeral Postgres
- [x] Guard mutation-proven (delete → red, misplace → red)
- [x] Unit tier 1895 green · docs-drift green
- [ ] CI

AIOS-Work: SCHEMAFIX-1