### PR TITLE
docs(graphiti): AIO-806 — the deploy docs could silently undo the graph cost fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,37 +542,52 @@ NEO4J_PASSWORD=<choose one>
 
 **2.8b. Use the patched image — never the upstream one.**
 
-`graphiti/Dockerfile` builds from a **digest-pinned** `zepai/graphiti` and patches one constant:
+`graphiti/Dockerfile` builds from a **digest-pinned** `zepai/graphiti`, installs
+**`graphiti-core==0.29.3`** into the image's venv (transitively pinned by `constraints.txt`), patches
+the server to construct the `/chat/completions` client at `temperature=0` with small-model routing,
+and starts uvicorn **from the venv directly**. Read that file before changing anything here — every
+step carries the failure it exists to prevent.
+
+> ⚠️ **The graphiti service's Custom Start Command must be EMPTY.** This is the one deploy setting
+> that can silently undo the whole thing. A start command **overrides the image's `CMD`**, and the
+> base image's own command is `uv run uvicorn …` — and **`uv run` re-syncs the venv against
+> `/app/uv.lock` at boot**, which pins `graphiti-core` **0.13.2**. So the image builds green, every
+> gate in the Dockerfile passes, and the server then imports 0.13.2 anyway: the per-entity summary
+> fan-out comes back — 27.2 LLM calls per episode, of which `node_attributes` alone was 65.6% of
+> graph spend (both measured from `llm_usage`; the upgraded image runs in single digits) — and
+> nothing in the image can detect it. Observed directly — `Uninstalled 2 packages / Installed 2
+> packages` in the boot log.
+>
+> Earlier revisions of this file said the opposite ("if you have a Custom Start Command set, leave it
+> alone"), because the command that used to be prescribed here wrapped the ingest worker so it
+> survived a failed extraction. That advice predates the 0.29.3 image and is now **wrong** — the
+> command must go. To check whether yours has one, see §5. Also confirm the service still targets
+> **port 8000** (the image's `CMD` binds it, as the base image did).
+>
+> The trap the old start command also fixed — the image declares a non-root `USER app` but the base
+> `CMD` launches `uv` from `/root/.local/bin/uv`, which `app` cannot execute — is fixed by the image
+> itself now: the `CMD` invokes `/app/.venv/bin/uvicorn`, no `uv` involved.
+
+**Why the extraction-output ceiling still matters.** Graphiti extracts entities and edges with its
+own LLM, and that call's *output* is capped at `DEFAULT_MAX_TOKENS`. A dense episode whose extraction
+overflows raises inside the worker — and getzep's worker loop catches only `CancelledError`, so **any
+other exception kills the worker for the whole process.** The HTTP API keeps returning `202`.
+Episodes are accepted, nothing is extracted, and narrative arcs quietly go blank. That failure hit
+production three times.
+
+**0.29.3 ships the raised ceiling (16384) natively, so the old `sed` that patched
+`DEFAULT_MAX_TOKENS = 8192 → 16384` is gone.** In its place the Dockerfile *asserts* the value:
 
 ```dockerfile
-RUN CONFIG=/app/.venv/.../graphiti_core/llm_client/config.py \
- && grep -q 'DEFAULT_MAX_TOKENS = 8192' "$CONFIG" \
- && sed -i 's/DEFAULT_MAX_TOKENS = 8192/DEFAULT_MAX_TOKENS = 16384/' "$CONFIG"
+RUN grep -q 'DEFAULT_MAX_TOKENS = 16384' /app/.venv/.../graphiti_core/llm_client/config.py
 ```
 
-**Why this matters.** Graphiti extracts entities and edges with its own LLM, and that call's *output*
-is hard-capped at `DEFAULT_MAX_TOKENS`, which is 8192 in every published image. A dense episode whose
-extraction overflows raises inside the worker — and getzep's worker loop catches only
-`CancelledError`, so **any other exception kills the worker for the whole process.** The HTTP API
-keeps returning `202`. Episodes are accepted, nothing is extracted, and narrative arcs quietly go
-blank. That failure hit production three times. There is no env var to raise the cap; 16384 exists
-only on unreleased upstream `main`.
+Same discipline, one layer up: a future base image that regresses the ceiling **fails the build**
+rather than silently shipping an unpatched one. (If you are reading an older note that prescribes the
+`sed`, it will now fail its own `grep -q` gate — that gate working as designed.)
 
-The `grep -q` before the `sed` is a build gate: if a future base image renames the constant the build
-**fails loudly** rather than silently shipping an unpatched image.
-
-The digest pin is also deliberate — it guarantees the Neo4j schema our Cypher depends on and the REST
-API our projector uses are byte-identical to what's been running; only the token ceiling moves.
-
-> ⚠️ **If your graphiti service has a Custom Start Command set, leave it alone.** Older docs in this
-> repo prescribe one that wraps the ingest worker so it survives a failed extraction instead of dying
-> silently. It is complementary to the Dockerfile patch, not a replacement — the `sed` above modifies
-> a file *inside the image*, so it applies no matter how the process is launched. To check whether
-> yours has one, see §5.
->
-> A start command is also the documented fix for a separate trap: the image declares a non-root
-> `USER app` but its default CMD launches via `uv` at `/root/.local/bin/uv`, which `app` cannot
-> execute once the platform runs the container as the declared user. That broke a production restart.
+The digest pin is deliberate — it guarantees the Neo4j schema our Cypher depends on and the REST API
+our projector uses are byte-identical to what's been running.
 
 **2.8c. Point the app at it.** These go in the *brain's* environment, not the graphiti service's:
 
@@ -594,7 +609,7 @@ NEO4J_PASSWORD=<same as above>
 
 So 40,000 characters per item maximum; beyond that content is dropped as a runaway backstop (the full
 text still lives in `items`, FTS, and pgvector — only the graph projection is bounded). Chunking keeps
-each extraction well under the patched 16384-token ceiling.
+each extraction well under the 16384-token ceiling.
 
 > If you have seen `MAX_EPISODE_CHARS` (4000, or 6000, or 2000) referenced anywhere — in older notes
 > or docs — **it no longer exists.** It was deleted and replaced by chunking. Don't set it.
@@ -825,8 +840,14 @@ Causes, in the order they actually occur:
 1. **The extraction LLM key is out of quota.** Look for `insufficient_quota` / `RateLimitError:
    Error code: 429`. Graphiti's `OPENAI_API_KEY` is **separate from the app's** and is easy to forget
    when you top one up. Every episode fails extraction while the HTTP API keeps returning `202`.
-2. **Unpatched image.** If `DEFAULT_MAX_TOKENS` is still 8192, look for `Output length exceeded max
-   tokens`. Rebuild from `graphiti/Dockerfile`; don't deploy `zepai/graphiti` directly.
+2. **Unpatched image, or a Custom Start Command that reverted it.** If `DEFAULT_MAX_TOKENS` is still
+   8192, look for `Output length exceeded max tokens`. Rebuild from `graphiti/Dockerfile`; don't
+   deploy `zepai/graphiti` directly. **Check the service has no Custom Start Command** — one that
+   runs `uv run …` re-syncs the venv to `graphiti-core` 0.13.2 at boot and undoes the image (§2.8b).
+   Confirm what's actually running: `railway logs -s graphiti | grep -i "installed .* packages"`
+   should print **nothing** — any `Uninstalled N packages / Installed N packages` at boot means the
+   venv is being re-resolved out from under the image. (Nothing prints the library version at boot;
+   the definitive check is the service settings screen.)
 3. **`OPENAI_BASE_URL=""`.** An empty string reads as *set* and breaks every LLM call, hanging the
    queue with no error at all. Comment it out instead of blanking it.
 4. **Invalid `group_id`.** Anything outside `[A-Za-z0-9_-]` raises inside the worker.
@@ -842,23 +863,32 @@ railway logs -s graphiti | grep -c "Got a job"    # jobs picked up
 railway logs -s graphiti | grep -c "Traceback"    # jobs that failed
 ```
 
-Upstream's worker catches only `CancelledError`, so an **unpatched** worker dies on the first
-non-cancelled exception — you'd see one traceback and then silence. If `Got a job` keeps appearing
-*after* tracebacks and the queue drains to 0, a Custom Start Command wrapping the worker loop is in
-effect and doing its job. That is also how to answer "is a Custom Start Command set on this service?"
-without a settings screen — though the definitive check is your host's service settings (Railway:
-service → **Settings → Deploy → Custom Start Command**).
+Upstream's worker catches only `CancelledError`, so it dies on the first non-cancelled exception —
+you'd see one traceback and then silence. **The image no longer ships a wrapper around that loop**
+(§2.8b: the Custom Start Command that used to provide one must now be empty, or it reverts the whole
+image), so treat one traceback followed by silence as "the worker is dead". Restart it **from the
+Railway dashboard**, and if it doesn't come back healthy roll back to the last-good deployment rather
+than iterating on a live service (see below) — never `railway up`/`redeploy`. Keep the episodes/facts
+probe on Admin → Integrations as the detector, since the HTTP API will
+keep answering `202` either way.
+
+To answer "is a Custom Start Command set on this service?": the definitive check is your host's
+service settings (Railway: service → **Settings → Deploy → Custom Start Command**). From the logs,
+`Uninstalled N packages / Installed N packages` at boot is the giveaway that one is running `uv run`
+and re-resolving the venv.
 
 **Recovery:** the graph is fully regenerable from Postgres — clear `graph_episodes` and let the
 projector re-run.
 
 ### Graphiti won't come up after a restart or redeploy
 
-Two known traps. The image declares a non-root `USER app` but its default CMD launches via `uv` at
-`/root/.local/bin/uv`, which `app` can't execute once the platform runs the container as the declared
-user — this broke a production restart. And a redeploy that rebuilds from the wrong source
-reintroduces the unpatched 8192 cap. If it doesn't come healthy, roll back to the last-good deployment
-in the dashboard rather than iterating on a live service.
+Two known traps. The **base** image declares a non-root `USER app` while its default CMD launches
+`uv` from `/root/.local/bin/uv`, which `app` can't execute once the platform runs the container as
+the declared user — this broke a production restart, and is why `graphiti/Dockerfile` now starts
+`/app/.venv/bin/uvicorn` directly. A **`uv`-based** Custom Start Command reintroduces it. And a redeploy that
+rebuilds from the wrong source drops back to upstream `graphiti-core` (0.13.2, 8192-token ceiling and
+the per-entity summary fan-out). If it doesn't come healthy, roll back to the last-good deployment in
+the dashboard rather than iterating on a live service.
 
 ### Semantic search returns nothing / "degraded"
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -760,19 +760,24 @@ guard enforces it, it's named.
   projected + zero extracted ⇒ **degraded**, surfaced on the Admin retrieval-health card (Graph memory
   leg) **and** the loud pipeline-health banner (synthetic `graph_extract` leg) on Home + Integrations.
   **Root fix — raise the cap (not shrink episodes).** The extractor's output cap is graphiti_core's
-  `DEFAULT_MAX_TOKENS`, which is **8192 in every published `zepai/graphiti` image** (verified 2026-07-17
-  through v0.22.0) and is **not** settable by env (getzep's `graph_service/config.py` exposes only
-  api_key/base_url/model_name/embedding; the 16384 default lives only on unreleased `main`). So we run a
-  **patched image** — `graphiti/Dockerfile` builds FROM the exact prod-pinned digest and bumps only that
-  constant to 16384 (gpt-4o's max output). No version jump ⇒ the Neo4j schema our `lib/graph/learning`
-  Cypher reads and the REST API the projector uses stay byte-identical; only the token ceiling moves.
-  Large items are **chunked** (`GRAPH_CHUNK_CHARS` default 2500 × `GRAPH_MAX_EPISODE_CHUNKS` default 16)
-  into one episode per chunk, so each chunk's extraction output stays under the 16384 ceiling without
-  truncating/losing content (chunking replaced the old single-episode `MAX_EPISODE_CHARS` cap; a
-  malformed size/cap env falls back to the default rather than emitting empty/garbage episodes).
-  Deploying the patched image is a `graphiti`-service rebuild (roll back to deployment `6208aed5`
-  if unhealthy). _Guards:_ `test/graph-extraction-health.test.ts` + the `deriveGraphState` extraction-stall
-  case in `test/retrieval-health.test.ts`.
+  `DEFAULT_MAX_TOKENS`, **8192 in every published `zepai/graphiti` image** (verified 2026-07-17 through
+  v0.22.0) and **not** settable by env (getzep's `graph_service/config.py` exposes only
+  api_key/base_url/model_name/embedding). It was raised by a `sed` in `graphiti/Dockerfile` until
+  **#490 (AIO-755)** replaced that with a version jump: the image now installs **`graphiti-core==0.29.3`**
+  into the venv (transitively pinned by `constraints.txt`), which ships **16384 natively** — so the sed is
+  gone and the build **asserts** the constant instead. The same jump is what removed the per-entity
+  summary fan-out (`extract_attributes_from_node`, one LLM call per resolved entity, 65.6% of graph
+  spend). Rollback is a **dashboard rollback to the last-good deployment**, recorded before the
+  deploy — never `railway up`/`redeploy`; it is data-safe (same labels/relationships/embedder) but
+  Graphiti's queue is in-memory, so 202-accepted-but-unprocessed episodes are lost and must come back
+  via reconcile. ⚠️ **The service's Custom Start Command must be EMPTY** — it overrides the image `CMD`,
+  and any `uv run` variant re-syncs the venv back to 0.13.2 at boot, silently restoring both the 8192
+  ceiling and the fan-out (README §2.8b). Large items are **chunked** (`GRAPH_CHUNK_CHARS` default 2500 ×
+  `GRAPH_MAX_EPISODE_CHUNKS` default 16) into one episode per chunk, so each chunk's extraction output
+  stays under the 16384 ceiling without truncating/losing content (chunking replaced the old
+  single-episode `MAX_EPISODE_CHARS` cap; a malformed size/cap env falls back to the default rather than
+  emitting empty/garbage episodes). _Guards:_ `test/graph-extraction-health.test.ts` + the
+  `deriveGraphState` extraction-stall case in `test/retrieval-health.test.ts`.
 
 ## Changing X? read this
 

--- a/docs/design/brain-learning-panel.md
+++ b/docs/design/brain-learning-panel.md
@@ -257,8 +257,22 @@ on that), so the fire-and-forget promise is not at risk of serverless request-te
   (superseded the old single-episode truncation cap in #305 — chunking preserves all content instead of
   losing it), so each chunk's extraction output stays under the limit; full item text still lives in
   `items`/pgvector/FTS. Median item ~240 chars = a single chunk. If the worker
-  ever wedges anyway, restart graphiti (it's an image-based service; the Custom Start Command below persists).
-- **Graphiti start command (Railway)** — the `zepai/graphiti:latest` image declares a non-root `USER app`
+  ever wedges anyway, restart graphiti **from the Railway dashboard** and roll back to the last-good
+  deployment if it doesn't come up healthy (see the superseded start-command note below — the
+  boot-time worker patch it describes is no longer in effect).
+- **Graphiti start command (Railway)** — ⚠️ **SUPERSEDED (AIO-806, 2026-08-05). This is the "older
+  doc" the README warns about: the Custom Start Command must now be EMPTY.** A start command overrides
+  the image's `CMD`, and any variant built on `uv run` re-syncs the venv back to `graphiti-core`
+  0.13.2 at boot — silently undoing the 0.29.3 image (AIO-755) and restoring the per-entity LLM
+  fan-out. Of the two problems this bullet solved, only one moves into the image: the non-root
+  `USER app` / `uv` exec trap is fixed by `graphiti/Dockerfile`'s `CMD ["/app/.venv/bin/uvicorn", …]`.
+  The **worker-resilience wrapper is deliberately NOT carried over** — it cannot coexist with an empty
+  start command. What replaces it is narrower and honest: the overflow that triggered the wedge is
+  mitigated (16384 native + chunking) and a dead worker is *detected* by
+  `lib/graph/extraction-health.ts` (episodes vs facts), not survived. See README §5.
+  Left below as the point-in-time record.
+
+  — the `zepai/graphiti:latest` image declares a non-root `USER app`
   but its default CMD launches via `uv` at `/root/.local/bin/uv`, which `app` can't exec once Railway
   runs the container as the declared user (it broke on a 2026-07-03 restart). Fix = a **Custom Start
   Command** on the graphiti service that (a) base64-injects an `except Exception: continue` into the

--- a/graphiti/README.md
+++ b/graphiti/README.md
@@ -36,7 +36,8 @@ unless `GRAPHITI_URL` is set. Tune with `GRAPH_PROJECT_MINUTES` (default 60), `G
 (default 500 items/run), `GRAPH_PROJECT_ENABLED=false` to disable, and the episode-sizing knobs
 `GRAPH_CHUNK_CHARS` (default 2500) / `GRAPH_MAX_EPISODE_CHUNKS` (default 16). A large item is split into
 ≤16 chunks of ≤2500 chars, each projected as its own episode (`items:<id>#k`), so every chunk's
-extraction output stays under Graphiti's ceiling (16384 on the patched image — see `Dockerfile` + the
+extraction output stays under Graphiti's ceiling (16384, native in graphiti-core 0.29.3 and asserted
+by the build — see `Dockerfile`, whose ⚠️ start-command note is a deploy precondition, + the
 "202 ≠ extracted" gotcha in `docs/ARCHITECTURE.md`). Chunking replaced the old single-episode char cap:
 truncating to fit LOSES content, whereas chunking preserves all of it. A malformed value
 (empty/non-numeric/≤0/fractional) falls back to the default rather than emitting empty/garbage episodes.

--- a/graphiti/docker-compose.yml
+++ b/graphiti/docker-compose.yml
@@ -10,12 +10,16 @@ name: aios-graphiti
 # depends on structured-output support — start with a strong cloud model, swap later via env.
 services:
   graph:
-    # Built from ./Dockerfile = the digest verified running in prod on 2026-07-06 (audit M5 — an
-    # unpinned `latest` tag is a reproducibility/supply-chain risk) + ONE surgical patch: raise the
-    # LLM extraction output cap 8192 → 16384 (graphiti_core `DEFAULT_MAX_TOKENS`), because every
-    # published image caps at 8192 and the server exposes no env for it. The base digest stays pinned
-    # inside the Dockerfile, so reproducibility holds; only the token ceiling changes. Bump the base
-    # digest deliberately and re-check against prod before/after. See ./Dockerfile for the full why.
+    # Built from ./Dockerfile = a pinned base digest (audit M5 — an unpinned `latest` tag is a
+    # reproducibility/supply-chain risk) with graphiti-core pinned to 0.29.3 on top, because EVERY
+    # published zepai/graphiti image — including the one tagged 0.22.0 — serves 0.13.2 from
+    # /app/.venv, and 0.13.2 makes one LLM call PER RESOLVED ENTITY per episode (AIO-755: ~65% of the
+    # graph bill). The image also patches the server onto the /chat/completions client at
+    # temperature=0 with small-model routing, and starts uvicorn from the venv directly — never
+    # `uv run`, which would re-sync the venv back to 0.13.2 at boot. The 8192 → 16384 output-cap sed
+    # is GONE: 0.29.3 ships 16384 and the build now asserts it. Bump the base digest deliberately and
+    # re-check against prod before/after. See ./Dockerfile for the full why, incl. the ⚠️ deploy
+    # precondition that the platform's custom start command must be EMPTY.
     build:
       context: .
       dockerfile: Dockerfile

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -38,8 +38,8 @@ export function chunk<T>(items: readonly T[], size: number): T[][] {
 
 /**
  * Graphiti extracts entities/edges from each episode with its OWN LLM, and that call's OUTPUT is
- * hard-capped (graphiti_core `DEFAULT_MAX_TOKENS`; 16384 on the patched image — gpt-4o's ceiling, can't
- * go higher). A dense episode whose extraction output overflows that cap raises `Output length exceeded
+ * hard-capped (graphiti_core `DEFAULT_MAX_TOKENS`; 16384 — native in the 0.29.3 image and asserted by
+ * the build, no longer a patched constant). A dense episode whose extraction output overflows that cap raises `Output length exceeded
  * max tokens` in `resolve_extracted_nodes`, so it's accepted (202) but never becomes facts — the item's
  * work then never appears in the graph or narrative arcs (prod 2026-06/07). Truncating to fit LOSES
  * content, so instead we CHUNK: a large item is projected as several small episodes (`items:<id>#0`,


### PR DESCRIPTION
**AIOS-Work: GRAPHDOC-1** · [AIO-806](https://linear.app/je4light/issue/AIO-806) · guards [AIO-755](https://linear.app/je4light/issue/AIO-755) (#490)

## The contradiction

`README.md` said:

> ⚠️ **If your graphiti service has a Custom Start Command set, leave it alone.**

`graphiti/Dockerfile:32-37` says it must be **EMPTY** — a start command overrides the image's `CMD`, and the base image's own command is `uv run uvicorn …`, which **re-syncs the venv against `/app/uv.lock` at boot** and pins `graphiti-core` back to **0.13.2**. Follow the README and #490's image builds green, passes every gate in the Dockerfile, and then serves 0.13.2 anyway: the per-entity summary fan-out returns (27.2 calls/episode, `node_attributes` alone 65.6% of graph spend) and **nothing in the image can detect it**.

**Prod is currently fine** — the ledger shows `node_attributes` stopping and the 0.29-only `node_summaries_batch` starting at the 2026-08-04 12:00 UTC hour — so this is a rollback / second-install footgun, not a live regression.

## Also corrected (same class: docs describing a build step that no longer exists)

| where | was | now |
|---|---|---|
| README §2.8b | prescribed the `DEFAULT_MAX_TOKENS 8192 → 16384` sed as the live patch | 0.29.3 ships 16384; the build **asserts** it (the old sed would fail its own `grep -q` gate) |
| README §5 worker check | "if `Got a job` keeps appearing after tracebacks, the start command is doing its job" | the wrapper is gone — one traceback then silence means the worker is dead |
| README §5 restart trap | "a Custom Start Command reintroduces it" | scoped to a **`uv`-based** one; the `USER app`/`uv` trap is fixed by the image's `CMD` |
| `docs/ARCHITECTURE.md` | "no version jump ⇒ only the token ceiling moves", rollback to `6208aed5` | the 0.29.3 jump, the assert, and dashboard-rollback-never-`railway up` |
| `graphiti/docker-compose.yml` | "ONE surgical patch: raise the cap" | the actual image: 0.29.3 + client patches + direct-venv `CMD` |
| `graphiti/README.md`, `lib/graph/project.ts` | "16384 on the patched image" | 16384, native and asserted |
| `docs/design/brain-learning-panel.md` | **the doc that prescribed the start command** | flagged superseded in place, per the point-in-time convention |

## Deliberately not carried over

The wrapper that made the ingest worker survive a failed extraction (`except Exception: continue`, injected at boot). It cannot coexist with an empty start command. What replaces it is narrower and stated as such: the overflow that triggered the wedge is mitigated (16384 native + chunking), and a dead worker is **detected** by `lib/graph/extraction-health.ts` (episodes vs facts) rather than survived.

Docs only — no behaviour change; the one code edit is a stale comment in `lib/graph/project.ts`. Verified: unit 1922 ✅ · `tsc --noEmit` ✅ · docs drift ✅

## Review — Reviewed by Fable `code-reviewer` — verdict approve-with-changes: 3 HIGH (a contradicting parenthetical left alive one line above my own SUPERSEDED marker; a "both problems are now fixed in the image" sentence that was false — only one is; `docs/ARCHITECTURE.md` still telling the sed-era story while this diff routed readers to it) + 3 MEDIUM (an unverifiable boot-log claim, an unsourced "~8 calls" figure now replaced with the measured 27.2/65.6% pair, and redeploy wording that fought the repo's own never-`railway up` rule) + 2 LOW — all fixed before push.