### PR TITLE
fix(costs): reconcile against this key per month, and stop the proxy ceiling lying about why (AIO-805)

### DIFF
--- a/app/t/[team]/costs/page.tsx
+++ b/app/t/[team]/costs/page.tsx
@@ -5,7 +5,7 @@ import { serverClient } from "@/lib/db/server";
 import { resolveTeamContext } from "@/lib/auth/team-context";
 import { isRestrictedTier } from "@/lib/auth/visibility";
 import { parseRange } from "@/lib/metrics/range";
-import { getLlmCostBreakdown, getLedgerLifetimeUsd } from "@/lib/metrics/llm-costs";
+import { getLlmCostBreakdown, getLedgerLifetimeUsd, getLedgerMonthUsd } from "@/lib/metrics/llm-costs";
 import { getGraphEfficiency, HEALTHY_CALLS_PER_EPISODE } from "@/lib/metrics/graph-efficiency";
 import { getProviderReportedUsage, reconcileLedger } from "@/lib/costs/provider-usage";
 import { RangeSelector } from "@/components/dashboard/range-selector";
@@ -60,9 +60,14 @@ export default async function CostsPage({
 
   // RECONCILIATION. The ledger is a floor, not a total: a call that times out or fails after the
   // provider already generated is billed upstream and returns no `usage` for us to read, so no amount
-  // of fixing the meter closes the gap. Measured 2026-07-30 the ledger said $51.46 while OpenRouter's
-  // own `/credits` said $96.67 on the same key — and the page presented the floor as the answer.
+  // of fixing the meter closes the gap. Measured 2026-07-30 the ledger said $51.46 while OpenRouter
+  // said $96.67 — and the page presented the floor as the answer.
   // Admins only: it is a whole-key number, so it means nothing beside one member's scoped spend.
+  //
+  // TWO PERIODS, and the MONTH is the headline (AIO-805). The lifetime gap is dominated by a frozen
+  // pre-metering block that no future work can recover, so it can never improve and cannot answer
+  // "is spend escaping the meter now" — the only question worth an operator's attention. The month
+  // can: it read 0.9% the morning it shipped, against 22% lifetime, on the same key.
   // WORK PER EPISODE. Graph extraction is ~99% of the bill, and its cost per CALL is the number that
   // hides a bad model: on 2026-07-30 a swap to a model 10x cheaper per call sent calls/episode from
   // ~19 to ~49 over three days while total spend FELL, because episode volume dropped faster than the
@@ -75,6 +80,15 @@ export default async function CostsPage({
   const reconciliation =
     providerUsage && ledgerLifetimeUsd !== null
       ? reconcileLedger(providerUsage.totalUsageUsd, ledgerLifetimeUsd)
+      : null;
+  // The month legs, both UTC-truncated so the boundary is the provider's, not the server's.
+  const ledgerMonthUsd =
+    isAdmin && providerUsage?.monthUsageUsd !== null && providerUsage
+      ? await getLedgerMonthUsd(db, team.id, providerUsage.provider)
+      : null;
+  const monthReconciliation =
+    providerUsage?.monthUsageUsd != null && ledgerMonthUsd !== null
+      ? reconcileLedger(providerUsage.monthUsageUsd, ledgerMonthUsd)
       : null;
 
   // Show the "tracking since" caption only when metering began INSIDE the selected window — i.e. the
@@ -182,14 +196,35 @@ export default async function CostsPage({
                   instrument them, these are <em>counted per feature</em> as failed attempts below.
                 </li>
                 <li>
-                  <strong>Any spend on this key from outside this instance.</strong>
+                  <strong>Any spend on this key from outside this instance.</strong> (Spend on your
+                  account&apos;s <em>other</em> keys is no longer counted here — the provider figure is
+                  scoped to the key this brain uses.)
                 </li>
               </ul>
-              Because the first can never be recovered, <strong>the dollar gap here has a floor</strong>:
-              new spend dilutes the percentage, but nothing ever clears the amount. So the percentage is
-              not the signal — a high one is not itself a problem, and a falling one is just arithmetic.
-              What matters is whether the <strong>dollars grow</strong>, which means spend is escaping the
-              meter now. Both figures are lifetime for the key, not the selected window.
+              Because the first can never be recovered, <strong>the lifetime gap has a floor</strong> —
+              nothing ever clears the amount, so it cannot tell you whether spend is escaping the meter
+              now.{" "}
+              {monthReconciliation ? (
+                <>
+                  <strong>
+                    That is what the month is for: this provider month it has billed{" "}
+                    {usd(monthReconciliation.providerUsd)} and this ledger accounts for{" "}
+                    {usd(monthReconciliation.ledgerUsd)}
+                    {monthReconciliation.status === "unattributed"
+                      ? ` — ${usd(monthReconciliation.unattributedUsd)} unexplained.`
+                      : "."}
+                  </strong>{" "}
+                  {monthReconciliation.status === "unattributed"
+                    ? "A month gap that grows is the real signal — that is spend escaping the meter today."
+                    : "A near-zero month gap means the meter is capturing current spend; the lifetime figure above is history."}{" "}
+                  The month is the provider&apos;s calendar month, not the selected window.
+                </>
+              ) : (
+                <>
+                  What matters is whether the <strong>dollars grow</strong>. Both figures are lifetime for
+                  this key, not the selected window.
+                </>
+              )}
             </>
           ) : reconciliation.status === "ledger-exceeds" ? (
             <>

--- a/app/t/[team]/costs/page.tsx
+++ b/app/t/[team]/costs/page.tsx
@@ -7,7 +7,11 @@ import { isRestrictedTier } from "@/lib/auth/visibility";
 import { parseRange } from "@/lib/metrics/range";
 import { getLlmCostBreakdown, getLedgerLifetimeUsd, getLedgerMonthUsd } from "@/lib/metrics/llm-costs";
 import { getGraphEfficiency, HEALTHY_CALLS_PER_EPISODE } from "@/lib/metrics/graph-efficiency";
-import { getProviderReportedUsage, reconcileLedger } from "@/lib/costs/provider-usage";
+import {
+  getProviderReportedUsage,
+  reconcileLedger,
+  MATERIAL_ABSOLUTE_MONTH_USD,
+} from "@/lib/costs/provider-usage";
 import { RangeSelector } from "@/components/dashboard/range-selector";
 import { CostBreakdownChart } from "@/components/charts/cost-breakdown";
 import { HelpHint } from "@/components/help-hint";
@@ -81,14 +85,18 @@ export default async function CostsPage({
     providerUsage && ledgerLifetimeUsd !== null
       ? reconcileLedger(providerUsage.totalUsageUsd, ledgerLifetimeUsd)
       : null;
-  // The month legs, both UTC-truncated so the boundary is the provider's, not the server's.
+  // Both month legs truncate in UTC. That the provider's month is UTC-calendar is INFERRED (its
+  // usage_monthly matched an August-only ledger sum where a rolling 30 days would not) — hence the
+  // copy says "the provider's calendar month" rather than claiming their boundary is ours.
   const ledgerMonthUsd =
-    isAdmin && providerUsage?.monthUsageUsd !== null && providerUsage
+    isAdmin && providerUsage?.monthUsageUsd != null
       ? await getLedgerMonthUsd(db, team.id, providerUsage.provider)
       : null;
+  // A RAISED absolute floor for the month: its denominator resets monthly, so the lifetime-tuned $1
+  // would flag ordinary skew as "spend escaping the meter today" on day one of every month.
   const monthReconciliation =
     providerUsage?.monthUsageUsd != null && ledgerMonthUsd !== null
-      ? reconcileLedger(providerUsage.monthUsageUsd, ledgerMonthUsd)
+      ? reconcileLedger(providerUsage.monthUsageUsd, ledgerMonthUsd, MATERIAL_ABSOLUTE_MONTH_USD)
       : null;
 
   // Show the "tracking since" caption only when metering began INSIDE the selected window — i.e. the
@@ -204,27 +212,8 @@ export default async function CostsPage({
               Because the first can never be recovered, <strong>the lifetime gap has a floor</strong> —
               nothing ever clears the amount, so it cannot tell you whether spend is escaping the meter
               now.{" "}
-              {monthReconciliation ? (
-                <>
-                  <strong>
-                    That is what the month is for: this provider month it has billed{" "}
-                    {usd(monthReconciliation.providerUsd)} and this ledger accounts for{" "}
-                    {usd(monthReconciliation.ledgerUsd)}
-                    {monthReconciliation.status === "unattributed"
-                      ? ` — ${usd(monthReconciliation.unattributedUsd)} unexplained.`
-                      : "."}
-                  </strong>{" "}
-                  {monthReconciliation.status === "unattributed"
-                    ? "A month gap that grows is the real signal — that is spend escaping the meter today."
-                    : "A near-zero month gap means the meter is capturing current spend; the lifetime figure above is history."}{" "}
-                  The month is the provider&apos;s calendar month, not the selected window.
-                </>
-              ) : (
-                <>
-                  What matters is whether the <strong>dollars grow</strong>. Both figures are lifetime for
-                  this key, not the selected window.
-                </>
-              )}
+              What matters is whether the <strong>dollars grow</strong>. Both figures are lifetime for
+              this key, not the selected window.
             </>
           ) : reconciliation.status === "ledger-exceeds" ? (
             <>
@@ -238,6 +227,53 @@ export default async function CostsPage({
               Reconciled against the provider: OpenRouter reports {usd(reconciliation.providerUsd)} spent
               on this key, and this ledger accounts for {usd(reconciliation.ledgerUsd)} of it (lifetime,
               not the selected window).
+            </>
+          )}
+        </div>
+      ) : null}
+
+      {/* THE MONTH — rendered independently of the lifetime state above, deliberately. It was first
+          nested inside the lifetime `unattributed` branch, which hid it whenever lifetime read
+          `reconciled` (dilution) or `ledger-exceeds` (a rotated key) — i.e. it disappeared in exactly
+          the situations an operator would be watching for live leakage. A headline that only renders
+          as a footnote of another alarm is not a headline. */}
+      {monthReconciliation ? (
+        <div
+          className={`rounded-lg border px-3 py-2 text-xs ${
+            monthReconciliation.status === "unattributed"
+              ? "border-amber-400/30 bg-amber-400/10 text-amber-700 dark:text-amber-300"
+              : "border-border-subtle/60 text-ink-tertiary"
+          }`}
+        >
+          {monthReconciliation.status === "unattributed" ? (
+            <>
+              <strong>
+                This provider month, OpenRouter has billed {usd(monthReconciliation.providerUsd)} on this
+                key and this ledger accounts for {usd(monthReconciliation.ledgerUsd)} —{" "}
+                {usd(monthReconciliation.unattributedUsd)} unexplained.
+              </strong>{" "}
+              Unlike the lifetime figure, this one has no permanent floor, so{" "}
+              <strong>a month gap that grows is the real signal</strong> — that is spend escaping the
+              meter now, not history. The month is the provider&apos;s calendar month, not the selected
+              window.
+            </>
+          ) : monthReconciliation.status === "ledger-exceeds" ? (
+            <>
+              This ledger records {usd(monthReconciliation.ledgerUsd)} this month against the{" "}
+              {usd(monthReconciliation.providerUsd)} the provider reports — most likely a month-boundary
+              skew, since the provider&apos;s calendar month and this ledger&apos;s UTC month can roll at
+              different instants. It settles once both sides are inside the same month; nothing is
+              missing from the breakdown below.
+            </>
+          ) : (
+            <>
+              <strong>
+                This provider month: {usd(monthReconciliation.providerUsd)} billed on this key,{" "}
+                {usd(monthReconciliation.ledgerUsd)} accounted for.
+              </strong>{" "}
+              A near-zero gap on the current month means the meter is capturing spend as it happens — the
+              lifetime figure above is history that no metering fix can recover. The month is the
+              provider&apos;s calendar month, not the selected window.
             </>
           )}
         </div>

--- a/docs/design/cost-plumbing-truth.md
+++ b/docs/design/cost-plumbing-truth.md
@@ -1,0 +1,171 @@
+# Two falsified assumptions in the cost/throughput plumbing
+
+**Status:** revised after plan review — the review killed my evidence for A and my scope for B
+· **Date:** 2026-08-05 · **Owner:** Chetan
+· **Task:** `COSTTRUTH-1` → [AIO-805](https://linear.app/je4light/issue/AIO-805)
+
+Both items below are stated assumptions that measurement has contradicted. My first draft got the
+evidence wrong on one and undersold the fix on the other; what plan review corrected is recorded
+first, because the corrections are the load-bearing part.
+
+---
+
+## What plan review corrected
+
+### 1. My throttling evidence was backwards (BLOCKER)
+
+I attributed 1,904 `http_429` rows in `llm_failures` to our own proxy ceiling. **They cannot be
+ours.** The proxy returns 429 and exits before recording anything
+(`app/api/internal/llm/v1/chat/completions/route.ts:51-53`), and `recordLlmFailure`'s contract
+(`lib/costs/llm-usage.ts:126-130`) says in terms: *"NEVER call this for a refusal we raised BEFORE
+reaching a provider (rate limit, …)"*. Every `http_429` row is **OpenRouter refusing a call our
+limiter already allowed**.
+
+Re-derived from `rate_limits` (the table the reviewer pointed at, which is never pruned), both
+throttles are real and independent:
+
+```
+bucket 'graph-llm-proxy'   46 overflow windows · peak 426 attempts/min · 4,248 self-rejections
+llm_failures http_429      1,904 provider refusals of calls we DID forward
+```
+
+And the overlap is the decisive part:
+
+```
+window                we attempted   we forwarded   provider 429s
+2026-08-01 11:57            417          120              0      ← model: qwen3.6-35b-a3b
+2026-08-01 12:31            405          120              0
+2026-08-04 10:47            426          120             97      ← model: qwen3.7-plus
+2026-08-04 11:42            290          120            106
+```
+
+On Aug 1 the provider absorbed a sustained 120/min without a single refusal. On Aug 4, at the *same*
+forwarded rate, it refused ~100/min. The variable is the model, not our ceiling.
+
+**So raising the ceiling to 600 — my draft's central proposal — would have made this worse**, pushing
+5× the load at an upstream already refusing at 120. The reviewer flagged exactly this and was right.
+
+### 2. `/key` gives time-sliced per-key truth, which I claimed it didn't
+
+My draft said `/key` "does not get us per-day — `/activity` still 403s". False. `GET /api/v1/key`
+returns `usage_daily`, `usage_weekly`, and `usage_monthly` alongside `usage`, on the inference key.
+Measured this morning against the ledger:
+
+| period | ledger | provider (this key) | gap |
+|---|---|---|---|
+| **Today (UTC)** | $0.0491 | $0.049143 | **$0.00** |
+| August so far | $69.63 | $70.29 | $0.66 (0.9%) |
+| Lifetime | $151.49 | $194.40 | $42.91 (22%) |
+
+Today's figures agree **to four decimal places**. That is the first direct proof the meter is
+capturing essentially all current spend — and it relocates the entire 22% lifetime gap to frozen
+July history (pre-metering + the timeout storm), which can never clear no matter what we build.
+
+This also **closes the question `provider-daily-truth.md` deferred** on 2026-08-03. That doc deferred
+per-day reconciliation because it believed a management key was required. It isn't.
+
+---
+
+## A. The graph proxy's rate ceiling — correct the story, not the number
+
+`lib/llm/graph-proxy.ts:232-240` documents the ceiling's rationale:
+
+> Not for Graphiti's benefit — **its extraction is serial at ~10-20s per episode, so it will never
+> come close.** … **so it can never be the thing that wedges the graph.**
+
+Both clauses are now false: Graphiti fans out with `semaphore_gather` since #490, the bucket is
+shared with embeddings ("one credential, one budget"), and demand peaks at **426/min** against a
+120 ceiling — 46 windows where we refused our own extraction.
+
+### Fix (deliberately minimal)
+
+- **Do NOT change the default.** The evidence says upstream is the binding constraint on the current
+  model; 120/min is a smoothing rate the provider demonstrably absorbs. Raising it without evidence
+  that upstream can take more just converts our free refusals into billed retries.
+- **Make it env-tunable** (`GRAPH_PROXY_CALLS_PER_MINUTE` via the existing `resolvePositiveInt`,
+  mirroring `GRAPH_PROXY_TIMEOUT_MS`), so a future backlog import (AIO-798) can be admitted
+  deliberately without a code deploy, and export `PROXY_CALLS_PER_MINUTE_FOR_TEST` like the timeout
+  does.
+- **Rewrite the comment** to state what is true: a leak-damage bound; Graphiti is parallel; the
+  bucket is shared with embeddings; measured demand peaks at 426/min so the ceiling *does* bind and
+  that is currently acceptable because upstream binds first. The stale rationale is why this went a
+  week unnoticed.
+- **Two distinct signals, honestly labelled.** Self-throttling is `rate_limits.count > limit` for the
+  bucket; provider throttling is `llm_failures.failure_reason='http_429'`. They are different
+  problems with different fixes, and my draft would have shipped a probe that called the second one
+  the first — the cried-wolf failure. v1 adds a read for each to the extraction-health reason string;
+  neither may be reported as the other.
+
+### Not in scope
+
+Making the bucket cost-aware (an embedding and a `dedupe_nodes` call cost 2,000× different amounts
+and consume the same token). Real, but a redesign of a security control, separately.
+
+---
+
+## B. Reconcile against this key, per period — not the account, per lifetime
+
+`lib/costs/provider-usage.ts` reads `GET /api/v1/credits` and describes `total_usage` three times as
+key-scoped ("on the same key", "cumulative for the key", "this team's key has spent"). It is
+**account-wide**: $202.69 account vs $194.36 this key — $8.33 of someone else's key attributed to
+our blind spot, uncloseable by any amount of correct metering.
+
+### Fix
+
+- Read `GET /api/v1/key` → `data.usage` (per key), plus `usage_daily` / `usage_monthly`.
+- **Surface the MONTHLY reconciliation as the headline**, with lifetime demoted to context. The
+  lifetime number is dominated by a frozen July block and can never improve; the monthly number is
+  the one an operator can act on, and at 0.9% today it says "the meter is sound" — which the lifetime
+  figure's 22% actively obscures. This is the honest version of what #463's banner copy was working
+  around in prose.
+- **Drop `totalCreditsUsd`.** Verified unrendered: nothing outside `provider-usage.ts` and its test
+  reads it. `data.limit` is a per-key spend cap, not credits-purchased, so it is not a substitute —
+  and plumbing a new field into a display that doesn't exist is how dead code is born.
+- Use `OPENROUTER_BASE_URL` (`lib/query/llm-backend.ts:21`) rather than a second hardcoded URL.
+- **Comment sites to correct** (the reviewer found three my draft missed):
+  `provider-usage.ts:13-24`, `lib/metrics/llm-costs.ts:62-64`, `graph-proxy.ts:349-350`,
+  `app/t/[team]/costs/page.tsx:64`, and `test/provider-usage.test.ts:7-8`. The page copy at
+  `page.tsx:160,203-204` already says "on this key" — **false today, true after this change**, which
+  is its own small lesson about copy written ahead of the code.
+
+---
+
+## Guards (CLAUDE.md §7)
+
+Trimmed on review — two of my proposed three were ceremony:
+
+- ~~Assert the comment no longer contains a phrase~~ — **cut.** No guard in this repo pins prose, and
+  it defends against re-typing one sentence, a failure with no history.
+- ~~`DEFAULT >= 4 × OBSERVED_PEAK`~~ — **cut.** A tautology: I'd write both constants in the same PR
+  to make it pass.
+- **KEEP — the shape guard that has real history:** a `/credits`-shaped body (`data.total_usage`, no
+  `data.usage`) must parse to `null`, never a number. A silent revert to the account endpoint must
+  read as "we don't know", not as a plausible wrong figure.
+- **Endpoint pin:** the fetched URL is the per-key endpoint; parser fed a **recorded real `/key`
+  body**, not a hand-written one.
+- **Null contract preserved:** absent / negative / non-finite usage → `null` (existing behaviour).
+- **Ceiling tunability:** `PROXY_CALLS_PER_MINUTE_FOR_TEST` pins the default and the env override —
+  the repo-idiomatic pattern already used for the timeout, which catches a silent lowering without
+  pretending to validate the number.
+
+## Scope: one PR or two?
+
+The reviewer recommended splitting, because A carried a 5× change to a security bound. **A no longer
+changes the default**, so that rationale is gone: both items are now comment-and-observability
+changes to the same subsystem, with B adding one endpoint swap. One PR, and the revert lever is a
+single commit either way.
+
+## How we will know it worked
+
+- The banner shows a monthly gap near zero on a healthy month (0.9% today) instead of a permanent
+  22% that no action can move — and a *rising monthly* gap becomes the real alarm.
+- Self-throttling and provider-throttling are separately visible, so the next occurrence is diagnosed
+  from the card rather than from someone querying `rate_limits` by hand at 8am.
+
+## Risks
+
+- `usage_daily`/`usage_monthly` reset semantics (UTC? account timezone? calendar or rolling?) are not
+  documented by OpenRouter. Today's exact match suggests UTC-calendar, and the August figure agrees —
+  but the PR must state this as inferred-from-two-observations, and the UI should say "provider's
+  month" rather than implying our own boundary. If they diverge, the daily figure is the one to trust
+  (it matched to 4dp).

--- a/docs/design/cost-plumbing-truth.md
+++ b/docs/design/cost-plumbing-truth.md
@@ -12,7 +12,7 @@ first, because the corrections are the load-bearing part.
 
 ## What plan review corrected
 
-### 1. My throttling evidence was backwards (BLOCKER)
+### 1. My throttling evidence was backwards — and the problem is already fixed (BLOCKER)
 
 I attributed 1,904 `http_429` rows in `llm_failures` to our own proxy ceiling. **They cannot be
 ours.** The proxy returns 429 and exits before recording anything
@@ -21,29 +21,35 @@ ours.** The proxy returns 429 and exits before recording anything
 reaching a provider (rate limit, …)"*. Every `http_429` row is **OpenRouter refusing a call our
 limiter already allowed**.
 
-Re-derived from `rate_limits` (the table the reviewer pointed at, which is never pruned), both
-throttles are real and independent:
+Re-derived, both throttles were real and independent — and the reviewer's discriminator queries
+settled the cause outright:
 
 ```
-bucket 'graph-llm-proxy'   46 overflow windows · peak 426 attempts/min · 4,248 self-rejections
-llm_failures http_429      1,904 provider refusals of calls we DID forward
+1,902 of 1,904 provider 429s are on  mistralai/mistral-small-3.2-24b-instruct   (07:08-11:50 Aug 4)
+        2                       on  qwen/qwen3.7-plus
+our own bucket: 46 overflow windows, peak 426 attempts/min, 4,248 self-rejections
 ```
 
-And the overlap is the decisive part:
+`mistral-small` is the cheap SUMMARY model that #488 routes `ModelSize.small` requests to. So the
+provider throttling was never about the extraction model or our ceiling: **graphiti 0.13.2's
+per-entity summary fan-out generated hundreds of small calls a minute, and OpenRouter rate-limited
+that one cheap model at ~100/min.** Our own bucket overflowed for the same reason — the fan-out, not
+the corpus.
+
+**#490 (graphiti 0.29.3) removed the fan-out, and that closed both throttles.** Since it deployed
+(2026-08-04 12:31 UTC):
 
 ```
-window                we attempted   we forwarded   provider 429s
-2026-08-01 11:57            417          120              0      ← model: qwen3.6-35b-a3b
-2026-08-01 12:31            405          120              0
-2026-08-04 10:47            426          120             97      ← model: qwen3.7-plus
-2026-08-04 11:42            290          120            106
+provider 429s          0
+failures of any kind   0
+our overflow windows   0
+peak attempts/min     76   (was 426; ceiling is 120)
 ```
 
-On Aug 1 the provider absorbed a sustained 120/min without a single refusal. On Aug 4, at the *same*
-forwarded rate, it refused ~100/min. The variable is the model, not our ceiling.
-
-**So raising the ceiling to 600 — my draft's central proposal — would have made this worse**, pushing
-5× the load at an upstream already refusing at 120. The reviewer flagged exactly this and was right.
+So the problem I opened this task for **no longer exists**, fixed by work that shipped yesterday.
+This is why the fix below is now three lines instead of a subsystem: building the observability I
+first proposed would be a guard for a failure mode that has been structurally removed — ceremony by
+CLAUDE.md §7's own test.
 
 ### 2. `/key` gives time-sliced per-key truth, which I claimed it didn't
 
@@ -57,51 +63,48 @@ Measured this morning against the ledger:
 | August so far | $69.63 | $70.29 | $0.66 (0.9%) |
 | Lifetime | $151.49 | $194.40 | $42.91 (22%) |
 
-Today's figures agree **to four decimal places**. That is the first direct proof the meter is
-capturing essentially all current spend — and it relocates the entire 22% lifetime gap to frozen
-July history (pre-metering + the timeout storm), which can never clear no matter what we build.
+Today's figures agree **to four decimal places** — the first direct proof the meter captures
+essentially all current spend, relocating the whole 22% lifetime gap to frozen July history.
 
-This also **closes the question `provider-daily-truth.md` deferred** on 2026-08-03. That doc deferred
-per-day reconciliation because it believed a management key was required. It isn't.
+`usage_monthly` = $70.29 ≈ August-only $69.63 also **rules out a rolling 30-day window**: a rolling
+window would include the late-July storm (pre-August ledger alone is ~$82). That is a discriminating
+observation, not a suggestive one. UTC-vs-account-local calendar is not separable from this data;
+the PR records a before/after-midnight `usage_daily` sample as the falsifiable check.
 
----
+This **narrows** — does not close — what `provider-daily-truth.md` deferred: it falsifies that doc's
+premise that a management key is needed for per-period truth, but gives no per-day *history* and no
+per-model attribution, which is what `/activity` is for. That doc's reopening bar is restated
+against the monthly gap in the same PR.
 
-## A. The graph proxy's rate ceiling — correct the story, not the number
+## A. The graph proxy's rate ceiling — correct the record, keep the number
 
 `lib/llm/graph-proxy.ts:232-240` documents the ceiling's rationale:
 
 > Not for Graphiti's benefit — **its extraction is serial at ~10-20s per episode, so it will never
 > come close.** … **so it can never be the thing that wedges the graph.**
 
-Both clauses are now false: Graphiti fans out with `semaphore_gather` since #490, the bucket is
-shared with embeddings ("one credential, one budget"), and demand peaks at **426/min** against a
-120 ceiling — 46 windows where we refused our own extraction.
+Both clauses were false for the whole fan-out era: demand hit **426/min** against a 120 ceiling and
+we refused our own extraction 4,248 times across 46 windows. They are *incidentally* true again
+today (peak 76/min) — but for a reason the comment doesn't state, which is exactly how a stale
+rationale hides a live problem for a week.
 
-### Fix (deliberately minimal)
+### Fix (three lines, no behaviour change)
 
-- **Do NOT change the default.** The evidence says upstream is the binding constraint on the current
-  model; 120/min is a smoothing rate the provider demonstrably absorbs. Raising it without evidence
-  that upstream can take more just converts our free refusals into billed retries.
-- **Make it env-tunable** (`GRAPH_PROXY_CALLS_PER_MINUTE` via the existing `resolvePositiveInt`,
-  mirroring `GRAPH_PROXY_TIMEOUT_MS`), so a future backlog import (AIO-798) can be admitted
-  deliberately without a code deploy, and export `PROXY_CALLS_PER_MINUTE_FOR_TEST` like the timeout
-  does.
-- **Rewrite the comment** to state what is true: a leak-damage bound; Graphiti is parallel; the
-  bucket is shared with embeddings; measured demand peaks at 426/min so the ceiling *does* bind and
-  that is currently acceptable because upstream binds first. The stale rationale is why this went a
-  week unnoticed.
-- **Two distinct signals, honestly labelled.** Self-throttling is `rate_limits.count > limit` for the
-  bucket; provider throttling is `llm_failures.failure_reason='http_429'`. They are different
-  problems with different fixes, and my draft would have shipped a probe that called the second one
-  the first — the cried-wolf failure. v1 adds a read for each to the extraction-health reason string;
-  neither may be reported as the other.
+- **Default unchanged at 120.** Post-#490 demand peaks at 76/min; there is no evidence to raise it,
+  and the historical overflow had a cause that has been removed.
+- **Env-tunable** (`GRAPH_PROXY_CALLS_PER_MINUTE` via the existing `resolvePositiveInt`, mirroring
+  `GRAPH_PROXY_TIMEOUT_MS`), with `PROXY_CALLS_PER_MINUTE_FOR_TEST` exported like the timeout — so a
+  deliberate backlog admission (AIO-798's repo import) needs a variable, not a deploy.
+- **Rewrite the comment** to the true history: a leak-damage bound; extraction is *not* serial;
+  the bucket is shared with embeddings; it demonstrably bound at 426/min during the 0.13.2 fan-out
+  and does not today at 76/min; the diagnosis path is `rate_limits` (ours) vs
+  `llm_failures.http_429` (the provider's), which are different problems.
 
-### Not in scope
+### Explicitly NOT built
 
-Making the bucket cost-aware (an embedding and a `dedupe_nodes` call cost 2,000× different amounts
-and consume the same token). Real, but a redesign of a security control, separately.
-
----
+The extraction-health signal I first proposed. Both throttles are at zero and the fan-out that
+caused them is gone; a probe now would be a guard with no live failure mode. The two queries that
+diagnosed this in three minutes are written into the comment instead, which is the cheaper artifact.
 
 ## B. Reconcile against this key, per period — not the account, per lifetime
 
@@ -122,6 +125,14 @@ our blind spot, uncloseable by any amount of correct metering.
   reads it. `data.limit` is a per-key spend cap, not credits-purchased, so it is not a substitute —
   and plumbing a new field into a display that doesn't exist is how dead code is born.
 - Use `OPENROUTER_BASE_URL` (`lib/query/llm-backend.ts:21`) rather than a second hardcoded URL.
+- **The monthly headline needs its OWN copy states.** The existing `reconcileLedger` states were
+  written for lifetime magnitudes and reusing them mis-speaks on a monthly window: a
+  provider-resets-first boundary skew lands in `ledger-exceeds`, whose copy blames key rotation
+  (`page.tsx:196-199`) — false for a month boundary. And the ledger's monthly sum must truncate in
+  **UTC** to match the provider's, or the skew is self-inflicted.
+- **Raise the materiality floor for the monthly view.** The $1 / 5% thresholds were tuned against
+  lifetime totals; in the first days of a month the denominator is small enough that ordinary timing
+  skew clears both legs and would render an alarm about nothing.
 - **Comment sites to correct** (the reviewer found three my draft missed):
   `provider-usage.ts:13-24`, `lib/metrics/llm-costs.ts:62-64`, `graph-proxy.ts:349-350`,
   `app/t/[team]/costs/page.tsx:64`, and `test/provider-usage.test.ts:7-8`. The page copy at

--- a/lib/costs/provider-usage.ts
+++ b/lib/costs/provider-usage.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { getProviderKey } from "@/lib/integrations/manage";
+import { OPENROUTER_BASE_URL } from "@/lib/query/llm-backend";
 
 /**
  * PROVIDER-REPORTED spend — the reconciliation the `llm_usage` ledger cannot do for itself.
@@ -16,25 +17,44 @@ import { getProviderKey } from "@/lib/integrations/manage";
  * three times: ~4,000 generations that the provider billed and we recorded as nothing, because we only
  * metered 2xx responses.
  *
- * So we ask the provider what it actually charged. `GET /api/v1/credits` needs only the inference key
- * the team already configured (unlike `/activity`, which requires a management key — verified 403).
+ * So we ask the provider what it actually charged. `GET /api/v1/key` needs only the inference key the
+ * team already configured (unlike `/activity`, which requires a management key — verified 403).
  *
- * LIFETIME, NOT WINDOWED. `total_usage` is cumulative for the key, so it cannot be sliced to "last
- * 30 days". That is a real limitation and the UI must not pretend otherwise: it is shown as a
- * lifetime reconciliation beside the windowed ledger, never substituted for it.
+ * WHY `/key` AND NOT `/credits`. This module used to read `/credits` and called its `total_usage`
+ * key-scoped in three separate comments. It is ACCOUNT-scoped. Measured 2026-08-05: `/credits`
+ * reported $202.69 while this key had spent $194.36 — so $8.33 of an unrelated key's spend was being
+ * attributed to our own blind spot, in a figure whose entire job is to say how much spend we failed
+ * to explain. No amount of correct metering could ever have closed it. `/key` reports `data.usage`
+ * for the PRESENTED key, which is the only number the comparison was ever supposed to make.
+ *
+ * PERIOD SLICES ARE AVAILABLE, and they matter more than the lifetime figure. `/key` also returns
+ * `usage_daily` / `usage_monthly`. Measured the same morning: today's ledger $0.0491 vs the
+ * provider's $0.049143 — agreement to four decimal places, i.e. the meter is currently capturing
+ * essentially everything. The lifetime gap ($42.91, 22%) is almost entirely frozen July history
+ * (pre-metering + the timeout storm) that no future work can recover, which is why the MONTHLY
+ * figure is the one an operator can act on and the lifetime one is context.
+ *
+ * `usage_monthly` is a CALENDAR month, not a rolling 30 days: August-to-date was $70.29 against a
+ * $69.63 ledger, while a rolling window would have swept in the late-July storm (~$82 on our side
+ * alone). UTC-vs-account-local is not separable from that observation — the UI says "the provider's
+ * month" rather than implying our own boundary.
  */
 
-const CREDITS_URL = "https://openrouter.ai/api/v1/credits";
+const KEY_URL = `${OPENROUTER_BASE_URL}/key`;
 const FETCH_TIMEOUT_MS = 4_000;
 /** Spend moves slowly relative to a page view, and this sits on a render path. */
 const CACHE_TTL_MS = 10 * 60_000;
 
 export interface ProviderUsage {
   provider: "openrouter";
-  /** Cumulative USD the provider says this key has spent. */
+  /** Cumulative USD the provider says THIS KEY has spent (`/key` → `data.usage`). */
   totalUsageUsd: number;
-  /** Credits purchased, when the provider reports it — lets the UI show headroom. */
-  totalCreditsUsd: number | null;
+  /**
+   * This key's spend in the provider's current calendar month, when reported. The actionable figure:
+   * the lifetime total is dominated by a frozen pre-metering block, so only the current period can
+   * tell an operator whether spend is escaping the meter NOW.
+   */
+  monthUsageUsd: number | null;
 }
 
 let cache: { at: number; teamId: string; value: ProviderUsage | null } | null = null;
@@ -51,15 +71,21 @@ export function resetProviderUsageCache(): void {
  * know what the provider charged", never as "the provider charged nothing" — the second is exactly
  * the false reassurance this module exists to end.
  */
-export function parseCreditsBody(body: unknown): ProviderUsage | null {
-  const d = (body as { data?: { total_usage?: unknown; total_credits?: unknown } } | null)?.data;
+export function parseKeyUsageBody(body: unknown): ProviderUsage | null {
+  const d = (body as { data?: { usage?: unknown; usage_monthly?: unknown } } | null)?.data;
   // `>= 0` as well as finite: a negative total would render "$-5.00 spent", which is not a number any
   // reader can act on. Unparseable and absurd both mean "we don't know".
-  if (!d || typeof d.total_usage !== "number" || !Number.isFinite(d.total_usage) || d.total_usage < 0) {
-    return null;
-  }
-  const credits = typeof d.total_credits === "number" && Number.isFinite(d.total_credits) ? d.total_credits : null;
-  return { provider: "openrouter", totalUsageUsd: d.total_usage, totalCreditsUsd: credits };
+  //
+  // Keyed on `usage` SPECIFICALLY, never falling back to `total_usage`: a `/credits`-shaped body must
+  // parse to null, so a silent revert to the account-wide endpoint reads as "we don't know" instead
+  // of as a plausible wrong figure. That substitution is the exact defect this function was rewritten
+  // to end, and a tolerant parser would let it back in unnoticed.
+  if (!d || typeof d.usage !== "number" || !Number.isFinite(d.usage) || d.usage < 0) return null;
+  const month =
+    typeof d.usage_monthly === "number" && Number.isFinite(d.usage_monthly) && d.usage_monthly >= 0
+      ? d.usage_monthly
+      : null;
+  return { provider: "openrouter", totalUsageUsd: d.usage, monthUsageUsd: month };
 }
 
 /**
@@ -82,11 +108,11 @@ export async function getProviderReportedUsage(
       const ctrl = new AbortController();
       const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
       try {
-        const res = await fetch(CREDITS_URL, {
+        const res = await fetch(KEY_URL, {
           headers: { Authorization: `Bearer ${key}` },
           signal: ctrl.signal,
         });
-        if (res.ok) value = parseCreditsBody(await res.json());
+        if (res.ok) value = parseKeyUsageBody(await res.json());
       } finally {
         clearTimeout(timer);
       }

--- a/lib/costs/provider-usage.ts
+++ b/lib/costs/provider-usage.ts
@@ -65,7 +65,7 @@ export function resetProviderUsageCache(): void {
 }
 
 /**
- * Parse OpenRouter's `/credits` body. Pure, so the shape is pinned without a network call.
+ * Parse OpenRouter's `/key` body. Pure, so the shape is pinned without a network call.
  *
  * Returns null rather than zero for anything unrecognised: a missing number must read as "we don't
  * know what the provider charged", never as "the provider charged nothing" — the second is exactly
@@ -146,6 +146,13 @@ export interface LedgerReconciliation {
 /** Below this the difference is timing and rounding, not a missing-spend story. */
 const MATERIAL_FRACTION = 0.05;
 const MATERIAL_ABSOLUTE_USD = 1;
+/**
+ * The same floor for the CURRENT-MONTH comparison, where the denominator resets monthly. $5 is the
+ * smallest gap that cannot be explained by the provider-leg cache plus normal in-flight skew at this
+ * install's scale (a full day of healthy graph spend is ~$5-9), so anything clearing it in-month is a
+ * real story rather than an artifact of when the page was rendered.
+ */
+export const MATERIAL_ABSOLUTE_MONTH_USD = 5;
 
 /**
  * Compare what the provider charged against what the ledger attributed.
@@ -155,14 +162,26 @@ const MATERIAL_ABSOLUTE_USD = 1;
  * while contributing nothing to OpenRouter's number. A negative "unattributed" would be nonsense; the
  * honest reading of ledger ≥ provider is simply "nothing unattributed on this provider".
  */
-export function reconcileLedger(providerUsd: number, ledgerUsd: number): LedgerReconciliation {
+export function reconcileLedger(
+  providerUsd: number,
+  ledgerUsd: number,
+  /**
+   * Absolute floor below which a difference is timing, not a story. Defaults to the lifetime figure;
+   * the CURRENT-MONTH comparison passes `MATERIAL_ABSOLUTE_MONTH_USD` because its denominator starts
+   * near zero every month — on day one, $1 of ordinary skew (the provider leg is cached up to 10
+   * minutes while the ledger leg is live) clears both legs on a few-dollar month and renders "spend is
+   * escaping the meter today" about nothing. A false amber in the first month this ships is the #463
+   * credibility failure repeating.
+   */
+  materialAbsoluteUsd: number = MATERIAL_ABSOLUTE_USD
+): LedgerReconciliation {
   const unattributed = Math.max(0, providerUsd - ledgerUsd);
   const fraction = providerUsd > 0 ? unattributed / providerUsd : 0;
   // BOTH legs. A percentage alone flags a $0.30-vs-$0.05 new install (83%, meaningless); an absolute
   // alone flags a $10 drift on $1,000/mo (1%, noise). Only a gap that is both large enough to notice
   // and large enough to matter is worth an operator's attention.
-  const material = unattributed >= MATERIAL_ABSOLUTE_USD && fraction >= MATERIAL_FRACTION;
-  const exceeds = ledgerUsd - providerUsd >= MATERIAL_ABSOLUTE_USD;
+  const material = unattributed >= materialAbsoluteUsd && fraction >= MATERIAL_FRACTION;
+  const exceeds = ledgerUsd - providerUsd >= materialAbsoluteUsd;
   return {
     providerUsd,
     ledgerUsd,

--- a/lib/llm/graph-proxy.ts
+++ b/lib/llm/graph-proxy.ts
@@ -229,15 +229,32 @@ export const isRefusal = (v: unknown): v is ProxyRefusal =>
   typeof v === "object" && v !== null && (v as { __refusal?: unknown }).__refusal === true;
 
 /**
- * Ceiling on authorized proxy calls per minute.
+ * Ceiling on authorized proxy calls per minute — a LEAK-DAMAGE BOUND, nothing else. Without it, one
+ * leaked shared secret turns into unmetered spend on the team's provider account.
  *
- * Not for Graphiti's benefit — its extraction is serial at ~10-20s per episode, so it will never come
- * close. This bounds the damage if the shared secret ever leaks: without it, one credential turns into
- * unmetered spend on the team's provider account. Sized well above any legitimate burst (a queue
- * drain plus the embedding calls that accompany it) so it can never be the thing that wedges the
- * graph — the failure this whole module exists to stop.
+ * The rationale here used to say extraction "is serial at ~10-20s per episode, so it will never come
+ * close" and that this "can never be the thing that wedges the graph". Both were false, and stayed in
+ * the file while the opposite happened. Extraction is NOT serial (Graphiti fans out with
+ * `semaphore_gather`), and the bucket is SHARED with the embeddings half ("one credential, one
+ * budget", below), which runs 9k-19k calls/day. Measured on the prod ledger 2026-08-05: during the
+ * graphiti-0.13.2 era, demand peaked at **426 attempts/min** and this ceiling refused our own
+ * extraction **4,248 times across 46 windows**.
+ *
+ * The cause was 0.13.2's per-entity summary fan-out, which #490 (graphiti 0.29.3) removed. Since that
+ * deploy, peak demand is 76/min and overflow windows are zero — so 120 is not binding today, and the
+ * number is left alone deliberately rather than raised on stale evidence. It is env-tunable so a
+ * DELIBERATE backlog admission (a large repo import, AIO-798) needs a variable and not a deploy.
+ *
+ * Diagnosing a recurrence needs two DIFFERENT queries, because there are two different throttles:
+ *   • ours     — `rate_limits` where `bucket='graph-llm-proxy'` and `count > <this limit>`;
+ *   • upstream — `llm_failures` where `failure_reason='http_429'` (calls we DID forward; the
+ *                proxy's own refusal is returned before any failure is recorded, by contract).
+ * Conflating them sends you to the wrong fix: the 1,904 upstream 429s of 2026-08-04 were OpenRouter
+ * throttling ONE cheap model (the small/summary route), not this ceiling.
  */
-const PROXY_CALLS_PER_MINUTE = 120;
+const PROXY_CALLS_PER_MINUTE = resolvePositiveInt(process.env.GRAPH_PROXY_CALLS_PER_MINUTE, 120);
+/** Exported for the guard test only — the default and its tunability are both load-bearing. */
+export const PROXY_CALLS_PER_MINUTE_FOR_TEST = PROXY_CALLS_PER_MINUTE;
 
 /**
  * How long we wait on the provider before giving up.
@@ -346,7 +363,7 @@ async function meterGraphCall(text: string, status: number, target: ProxyTarget,
     // NOT gated on a 2xx. "Only a successful call spent tokens" is what this used to assume, and it is
     // false: a provider can return `usage` alongside a non-2xx (a post-generation moderation refusal,
     // a partial), and that generation IS billed. Measured on 2026-07-30 the ledger held $51.46 while
-    // OpenRouter's own `/credits` reported $96.67 spent on the same key — 47% invisible. Metering
+    // OpenRouter reported $96.67 spent against a $51.46 ledger — 47% invisible. Metering
     // whatever `usage` arrives, whatever the status, is strictly closer to the truth; a body with no
     // `usage` still returns null below and records nothing.
     const c = meterFromOpenAiResponse(text, target.provider, target.model, meter.kind);

--- a/lib/metrics/llm-costs.ts
+++ b/lib/metrics/llm-costs.ts
@@ -4,6 +4,7 @@ import { scopeLlmUsage, type QueryLogViewer } from "@/lib/auth/visibility";
 import { rangeDays, type Range } from "./range";
 import {
   getLedgerLifetimeUsdExact,
+  getLedgerMonthUsdExact,
   getSpendCallCount,
   getSpendSlices,
   getSpendTotalUsd,
@@ -205,10 +206,11 @@ export async function getLlmCostBreakdown(
 /**
  * The ledger's LIFETIME total for a team, for reconciliation against the provider's own figure.
  *
- * Lifetime, not windowed, because the thing it is compared against is: OpenRouter's `/credits`
- * reports cumulative usage for a key and cannot be sliced by date. Comparing a 30-day ledger slice
- * to a lifetime provider total would manufacture a gap that isn't there — the opposite failure to
- * the one this exists to expose.
+ * Lifetime, not windowed, because the thing it is compared against is: OpenRouter's `/key` reports
+ * `usage` cumulatively for the key. Comparing a 30-day ledger slice to a lifetime provider total
+ * would manufacture a gap that isn't there — the opposite failure to the one this exists to expose.
+ * For the CURRENT-PERIOD comparison (the actionable one) see `getLedgerMonthUsd`, matched against
+ * `/key`'s `usage_monthly` on the same UTC boundary.
  *
  * Team-wide by construction (no viewer scoping): the provider figure is for the whole key, so the
  * only meaningful comparison is the whole team's ledger. The caller gates this on `isAdmin` for the
@@ -232,4 +234,17 @@ export async function getLedgerLifetimeUsd(
   // /costs reconciliation banner stayed correct while the headline beside it drifted. With an exact
   // `SUM` there is nothing left to refuse, so the null case now means only "the query failed".
   return getLedgerLifetimeUsdExact(db, teamId, provider);
+}
+
+/**
+ * The ledger's CURRENT-MONTH total for a provider (UTC), the counterpart to `/key`'s `usage_monthly`.
+ * Thin passthrough for the same reason `getLedgerLifetimeUsd` is one: the app layer must not reach
+ * into `lib/costs` directly, and the reconciliation's two legs should be fetched the same way.
+ */
+export async function getLedgerMonthUsd(
+  db: DbClient,
+  teamId: string,
+  provider: string
+): Promise<number | null> {
+  return getLedgerMonthUsdExact(db, teamId, provider);
 }

--- a/lib/metrics/llm-costs.ts
+++ b/lib/metrics/llm-costs.ts
@@ -210,7 +210,8 @@ export async function getLlmCostBreakdown(
  * `usage` cumulatively for the key. Comparing a 30-day ledger slice to a lifetime provider total
  * would manufacture a gap that isn't there — the opposite failure to the one this exists to expose.
  * For the CURRENT-PERIOD comparison (the actionable one) see `getLedgerMonthUsd`, matched against
- * `/key`'s `usage_monthly` on the same UTC boundary.
+ * `/key`'s `usage_monthly`; ours truncates in UTC, and the provider's being UTC-calendar is
+ * inferred rather than documented (see `getLedgerMonthUsdExact`).
  *
  * Team-wide by construction (no viewer scoping): the provider figure is for the whole key, so the
  * only meaningful comparison is the whole team's ledger. The caller gates this on `isAdmin` for the

--- a/lib/metrics/llm-spend.ts
+++ b/lib/metrics/llm-spend.ts
@@ -377,20 +377,18 @@ export async function getGraphSpendByCallKindAndModel(
 }
 
 /**
- * Lifetime ledger total for ONE provider — the reconciliation figure.
- *
- * Replaces a 500,000-row fetch that returned `null` at the cap rather than under-report. That
- * refusal was the right instinct and is why the /costs banner stayed correct while the headline
- * beside it drifted; an exact `SUM` means there is now nothing to refuse.
- */
-/**
  * The ledger's total for ONE provider in the CURRENT CALENDAR MONTH, UTC — the counterpart to
  * `/key`'s `usage_monthly` (AIO-805).
  *
  * UTC truncation is not incidental: the provider's month boundary is what this is compared against,
  * so truncating in the server's local zone would manufacture a gap out of a timezone, in a figure
- * whose only job is to expose real missing spend. `date_trunc('month', now() at time zone 'utc')`
- * keeps both legs on the same boundary.
+ * whose only job is to expose real missing spend. The double `AT TIME ZONE` below makes the boundary
+ * session-independent rather than correct-by-server-config.
+ *
+ * That the provider's own month is UTC-calendar is INFERRED, not documented: `usage_monthly` matched
+ * an August-only ledger sum ($70.29 vs $69.63) where a rolling 30 days would have swept in the
+ * late-July storm. That rules out rolling; it does not rule out an account-local calendar. The UI
+ * therefore says "the provider's calendar month" rather than claiming our boundary is theirs.
  *
  * Why a monthly figure exists at all: the LIFETIME comparison is dominated by a frozen pre-metering
  * block (measured 2026-08-05: $42.91 of a $42.91 lifetime gap is July history), so it can never
@@ -407,7 +405,11 @@ export async function getLedgerMonthUsdExact(
       `select coalesce(sum(cost_usd), 0) as total
          from llm_usage
         where team_id = $1 and provider = $2
-          and created_at >= date_trunc('month', (now() at time zone 'utc'))`,
+          -- The second AT TIME ZONE converts the truncated wall-clock back to a timestamptz AS UTC.
+          -- Without it the comparison re-coerces via the SESSION TimeZone (nothing pins it in
+          -- lib/db/pg/pool), so the boundary would be correct only by coincidence of server config —
+          -- up to +/-14h of month-boundary spend landing on the wrong side.
+          and created_at >= (date_trunc('month', (now() at time zone 'utc')) at time zone 'utc')`,
       [teamId, provider]
     );
     return Number(rows[0]?.total ?? 0) || 0;
@@ -416,6 +418,13 @@ export async function getLedgerMonthUsdExact(
   }
 }
 
+/**
+ * Lifetime ledger total for ONE provider — the reconciliation figure.
+ *
+ * Replaces a 500,000-row fetch that returned `null` at the cap rather than under-report. That
+ * refusal was the right instinct and is why the /costs banner stayed correct while the headline
+ * beside it drifted; an exact `SUM` means there is now nothing to refuse.
+ */
 export async function getLedgerLifetimeUsdExact(
   _db: unknown,
   teamId: string,

--- a/lib/metrics/llm-spend.ts
+++ b/lib/metrics/llm-spend.ts
@@ -383,6 +383,39 @@ export async function getGraphSpendByCallKindAndModel(
  * refusal was the right instinct and is why the /costs banner stayed correct while the headline
  * beside it drifted; an exact `SUM` means there is now nothing to refuse.
  */
+/**
+ * The ledger's total for ONE provider in the CURRENT CALENDAR MONTH, UTC — the counterpart to
+ * `/key`'s `usage_monthly` (AIO-805).
+ *
+ * UTC truncation is not incidental: the provider's month boundary is what this is compared against,
+ * so truncating in the server's local zone would manufacture a gap out of a timezone, in a figure
+ * whose only job is to expose real missing spend. `date_trunc('month', now() at time zone 'utc')`
+ * keeps both legs on the same boundary.
+ *
+ * Why a monthly figure exists at all: the LIFETIME comparison is dominated by a frozen pre-metering
+ * block (measured 2026-08-05: $42.91 of a $42.91 lifetime gap is July history), so it can never
+ * improve and cannot tell an operator whether spend is escaping the meter NOW. The month can — it
+ * read 0.9% the morning it shipped, against 22% lifetime.
+ */
+export async function getLedgerMonthUsdExact(
+  _db: unknown,
+  teamId: string,
+  provider: string
+): Promise<number | null> {
+  try {
+    const { rows } = await runSql<{ total: string | number }>(
+      `select coalesce(sum(cost_usd), 0) as total
+         from llm_usage
+        where team_id = $1 and provider = $2
+          and created_at >= date_trunc('month', (now() at time zone 'utc'))`,
+      [teamId, provider]
+    );
+    return Number(rows[0]?.total ?? 0) || 0;
+  } catch {
+    return null; // can't reconcile → the caller shows nothing rather than a wrong comparison
+  }
+}
+
 export async function getLedgerLifetimeUsdExact(
   _db: unknown,
   teamId: string,

--- a/test/datamechanics/ledger-month-boundary.datamechanics.test.ts
+++ b/test/datamechanics/ledger-month-boundary.datamechanics.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { runSql } from "@/lib/db/pg/pool";
+import { getLedgerMonthUsdExact, getLedgerLifetimeUsdExact } from "@/lib/metrics/llm-spend";
+import { db, seedTeam } from "./helpers";
+
+/**
+ * Spec: the CURRENT-MONTH ledger leg covers exactly the provider's month, on a boundary that does not
+ * depend on the server's timezone (AIO-805).
+ *
+ * This belongs in the real-Postgres tier and nowhere else. The subtlety is entirely in SQL semantics:
+ * `date_trunc('month', now() at time zone 'utc')` yields a timestamp WITHOUT time zone, and comparing
+ * that to a `timestamptz` column coerces it back through the **session** `TimeZone` — which nothing in
+ * `lib/db/pg/pool` pins. On a UTC server the naive form is right by coincidence of config; on any
+ * other session up to ±14h of month-boundary spend lands on the wrong side of the comparison, in the
+ * figure whose only job is to say how much spend is unexplained. A stubbed DB cannot see any of that.
+ *
+ * The month leg is compared against `/key`'s `usage_monthly`, so a boundary that drifts with server
+ * config would manufacture a reconciliation gap out of a timezone.
+ */
+describe("getLedgerMonthUsdExact — the month boundary", () => {
+  it("counts this month and excludes last month, and is provider-scoped", async () => {
+    const seed = await seedTeam();
+    // Anchored to the month boundary itself rather than to "N days ago", so the fixture means the same
+    // thing on the 1st and the 28th.
+    await runSql(
+      `insert into llm_usage (id, team_id, member_id, source, provider, model, cost_usd, input_tokens, output_tokens, estimated, created_at)
+       values
+         -- inside this UTC month, right after it opened
+         (gen_random_uuid(), $1, null, 'graph', 'openrouter', 'm', 3.00, 1, 1, false,
+          date_trunc('month', (now() at time zone 'utc')) at time zone 'utc' + interval '1 minute'),
+         -- LAST month, one minute before this one opened: must NOT count
+         (gen_random_uuid(), $1, null, 'graph', 'openrouter', 'm', 99.00, 1, 1, false,
+          date_trunc('month', (now() at time zone 'utc')) at time zone 'utc' - interval '1 minute'),
+         -- this month but ANOTHER provider: must NOT count (the scoping the guard also pins)
+         (gen_random_uuid(), $1, null, 'graph', 'anthropic', 'm', 50.00, 1, 1, false,
+          date_trunc('month', (now() at time zone 'utc')) at time zone 'utc' + interval '2 minutes')`,
+      [seed.teamId]
+    );
+
+    const month = await getLedgerMonthUsdExact(db, seed.teamId, "openrouter");
+    expect(month, "only this month's openrouter row").toBeCloseTo(3.0, 5);
+
+    // The lifetime leg is the control: it must see the excluded month's spend, proving the month
+    // filter is what did the excluding rather than the rows never landing.
+    const lifetime = await getLedgerLifetimeUsdExact(db, seed.teamId, "openrouter");
+    expect(lifetime, "lifetime spans both months").toBeCloseTo(102.0, 5);
+  });
+
+  it("is unmoved by the session timezone — the boundary is the provider's, not the server's", async () => {
+    const seed = await seedTeam();
+    // A row 30 minutes into the UTC month. Under a session TZ far from UTC, a naive
+    // `date_trunc(...) at time zone 'utc'`-less comparison would place the boundary hours away and
+    // drop (or wrongly include) it.
+    await runSql(
+      `insert into llm_usage (id, team_id, member_id, source, provider, model, cost_usd, input_tokens, output_tokens, estimated, created_at)
+       values (gen_random_uuid(), $1, null, 'graph', 'openrouter', 'm', 7.00, 1, 1, false,
+               date_trunc('month', (now() at time zone 'utc')) at time zone 'utc' + interval '30 minutes')`,
+      [seed.teamId]
+    );
+
+    const utcAnswer = await getLedgerMonthUsdExact(db, seed.teamId, "openrouter");
+    for (const tz of ["Pacific/Kiritimati", "Etc/GMT+12"]) {
+      // +14 and -12: the extremes that move a month boundary the furthest in each direction.
+      await runSql(`set time zone '${tz}'`);
+      try {
+        const shifted = await getLedgerMonthUsdExact(db, seed.teamId, "openrouter");
+        expect(shifted, `month total must not move under session TZ ${tz}`).toBeCloseTo(utcAnswer ?? -1, 5);
+      } finally {
+        await runSql("set time zone 'UTC'");
+      }
+    }
+    expect(utcAnswer).toBeCloseTo(7.0, 5);
+  });
+});

--- a/test/datamechanics/ledger-month-boundary.datamechanics.test.ts
+++ b/test/datamechanics/ledger-month-boundary.datamechanics.test.ts
@@ -63,6 +63,11 @@ describe("getLedgerMonthUsdExact — the month boundary", () => {
       // +14 and -12: the extremes that move a month boundary the furthest in each direction.
       await runSql(`set time zone '${tz}'`);
       try {
+        // Prove the session actually took it on the SAME pooled connection the query will use. If the
+        // pool ever hands back a different (unshifted) client, this test would otherwise pass
+        // vacuously against the naive SQL — asserting nothing while looking like TZ coverage.
+        const { rows } = await runSql<{ tz: string }>("select current_setting('TimeZone') as tz");
+        expect(rows[0]?.tz, "session TZ did not take — the shifted assertion would be vacuous").toBe(tz);
         const shifted = await getLedgerMonthUsdExact(db, seed.teamId, "openrouter");
         expect(shifted, `month total must not move under session TZ ${tz}`).toBeCloseTo(utcAnswer ?? -1, 5);
       } finally {

--- a/test/guards/graph-proxy-ceiling-tunable.test.ts
+++ b/test/guards/graph-proxy-ceiling-tunable.test.ts
@@ -26,7 +26,14 @@ describe("graph proxy call ceiling", () => {
     vi.resetModules();
   });
 
-  it("defaults to the measured 120/min", () => {
+  it("defaults to the measured 120/min", async () => {
+    // Explicitly UNSET the override rather than trusting the ambient env: this is now a variable we
+    // tell operators to export, so a default assertion that reads the process env would go red on
+    // the very machine that took the advice.
+    vi.stubEnv("GRAPH_PROXY_CALLS_PER_MINUTE", undefined as unknown as string);
+    vi.resetModules();
+    const fresh = await import("@/lib/llm/graph-proxy");
+    expect(fresh.PROXY_CALLS_PER_MINUTE_FOR_TEST).toBe(120);
     expect(PROXY_CALLS_PER_MINUTE_FOR_TEST).toBe(120);
   });
 

--- a/test/guards/graph-proxy-ceiling-tunable.test.ts
+++ b/test/guards/graph-proxy-ceiling-tunable.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PROXY_CALLS_PER_MINUTE_FOR_TEST } from "@/lib/llm/graph-proxy";
+
+/**
+ * GUARD: the graph proxy's per-minute ceiling keeps its measured default AND stays env-tunable.
+ *
+ * Both halves trace to a real incident (2026-08-04, re-derived from `rate_limits` on 2026-08-05):
+ * during graphiti 0.13.2's per-entity fan-out, demand peaked at **426 attempts/min** against this
+ * 120 ceiling and the proxy refused our own extraction 4,248 times across 46 windows — while the
+ * constant's own comment claimed extraction "is serial … so it will never come close" and that the
+ * limiter "can never be the thing that wedges the graph".
+ *
+ * #490 removed the fan-out and both throttles went to zero (peak now 76/min), so the DEFAULT is
+ * deliberately unchanged — there is no evidence to raise it, and raising a leak-damage bound on
+ * stale evidence is how a control becomes decoration. What the incident earned is the ability to
+ * admit a deliberate backlog (a large repo import, AIO-798) with a variable instead of a deploy.
+ *
+ * This is the repo-idiomatic shape already used for `PROXY_TIMEOUT_MS_FOR_TEST` 20 lines below the
+ * constant: pin the value, not the prose. Two guards I first proposed were cut in plan review as
+ * ceremony — asserting a comment no longer contains a phrase, and `DEFAULT >= 4 × OBSERVED_PEAK`
+ * (a tautology, since I'd write both constants in the same PR to make it pass).
+ */
+describe("graph proxy call ceiling", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("defaults to the measured 120/min", () => {
+    expect(PROXY_CALLS_PER_MINUTE_FOR_TEST).toBe(120);
+  });
+
+  it("is env-tunable, so a deliberate backlog admission needs no deploy", async () => {
+    vi.stubEnv("GRAPH_PROXY_CALLS_PER_MINUTE", "600");
+    vi.resetModules();
+    const fresh = await import("@/lib/llm/graph-proxy");
+    expect(fresh.PROXY_CALLS_PER_MINUTE_FOR_TEST).toBe(600);
+  });
+
+  it("ignores a junk override rather than throttling to zero", async () => {
+    // `Number("")` is 0 and `Number("abc")` is NaN — either would refuse EVERY call and wedge the
+    // graph, the precise failure this module exists to prevent. `resolvePositiveInt` is what stops it.
+    for (const junk of ["", "abc", "0", "-5"]) {
+      vi.stubEnv("GRAPH_PROXY_CALLS_PER_MINUTE", junk);
+      vi.resetModules();
+      const fresh = await import("@/lib/llm/graph-proxy");
+      expect(fresh.PROXY_CALLS_PER_MINUTE_FOR_TEST, `override ${JSON.stringify(junk)}`).toBe(120);
+    }
+  });
+});

--- a/test/guards/graph-proxy-ceiling-tunable.test.ts
+++ b/test/guards/graph-proxy-ceiling-tunable.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { PROXY_CALLS_PER_MINUTE_FOR_TEST } from "@/lib/llm/graph-proxy";
 
 /**
  * GUARD: the graph proxy's per-minute ceiling keeps its measured default AND stays env-tunable.
@@ -30,11 +29,10 @@ describe("graph proxy call ceiling", () => {
     // Explicitly UNSET the override rather than trusting the ambient env: this is now a variable we
     // tell operators to export, so a default assertion that reads the process env would go red on
     // the very machine that took the advice.
-    vi.stubEnv("GRAPH_PROXY_CALLS_PER_MINUTE", undefined as unknown as string);
+    vi.stubEnv("GRAPH_PROXY_CALLS_PER_MINUTE", undefined);
     vi.resetModules();
     const fresh = await import("@/lib/llm/graph-proxy");
     expect(fresh.PROXY_CALLS_PER_MINUTE_FOR_TEST).toBe(120);
-    expect(PROXY_CALLS_PER_MINUTE_FOR_TEST).toBe(120);
   });
 
   it("is env-tunable, so a deliberate backlog admission needs no deploy", async () => {

--- a/test/guards/ledger-reconciliation-scope.test.ts
+++ b/test/guards/ledger-reconciliation-scope.test.ts
@@ -36,16 +36,37 @@ const SPEND = stripComments(readFileSync(join(ROOT, "lib", "metrics", "llm-spend
  * The lifetime-sum implementation ONLY — bounded to the function, not sliced to end-of-file. An
  * open-ended slice would silently start asserting against whatever function is appended below it.
  */
-const implStart = SPEND.indexOf("export async function getLedgerLifetimeUsdExact");
-const implRest = SPEND.slice(implStart + 1);
-const nextExport = implRest.indexOf("\nexport ");
-const impl = nextExport === -1 ? SPEND.slice(implStart) : SPEND.slice(implStart, implStart + 1 + nextExport);
+function sliceFn(name: string): string {
+  const start = SPEND.indexOf(`export async function ${name}`);
+  if (start === -1) throw new Error(`${name} not found — the guard is looking at the wrong shape`);
+  const rest = SPEND.slice(start + 1);
+  const next = rest.indexOf("\nexport ");
+  return next === -1 ? SPEND.slice(start) : SPEND.slice(start, start + 1 + next);
+}
+
+const impl = sliceFn("getLedgerLifetimeUsdExact");
+/**
+ * The MONTH sum has the identical hazard this guard exists for — an unscoped provider sum shipped in
+ * review once, and no behavioural test can catch it while every row in the table is openrouter. Added
+ * with the month reconciliation (AIO-805) so dropping `provider = $2` from EITHER query reddens.
+ */
+const monthImpl = sliceFn("getLedgerMonthUsdExact");
 
 describe("guard: the lifetime ledger sum is provider-scoped and never short", () => {
   it("filters llm_usage by provider", () => {
     // The one filter that makes the comparison meaningful at all.
     expect(impl).toMatch(/provider = \$\d/);
     expect(impl).toMatch(/team_id = \$\d/); // and never crosses teams
+  });
+
+  it("the MONTH sum carries the same scoping, and a session-independent boundary", () => {
+    expect(monthImpl).toMatch(/provider = \$\d/);
+    expect(monthImpl).toMatch(/team_id = \$\d/);
+    expect(monthImpl).toMatch(/sum\(cost_usd\)/);
+    // The double AT TIME ZONE is what makes the boundary independent of the session TimeZone (nothing
+    // pins it in lib/db/pg/pool). Truncating without converting back is correct only by coincidence
+    // of server config, and moves up to +/-14h of spend across the boundary when that changes.
+    expect(monthImpl).toMatch(/at time zone 'utc'\)\)? at time zone 'utc'/);
   });
 
   it("computes an exact SUM rather than fetching rows", () => {

--- a/test/guards/reconciliation-copy.test.ts
+++ b/test/guards/reconciliation-copy.test.ts
@@ -56,6 +56,14 @@ describe("guard: the reconciliation banner explains the permanent floor", () => 
     const monthBlock = page.indexOf("{monthReconciliation ? (");
     expect(lifetimeBranch, "lifetime branch not found — guard is looking at the wrong shape").toBeGreaterThan(-1);
     expect(monthBlock, "month block not found").toBeGreaterThan(-1);
+    // Without this, a refactor that removes the ternary close (a lint autofix to `&&`-style
+    // conditionals does exactly that) makes indexOf return -1, and the sibling assertion below
+    // degenerates to `monthBlock > -1` — always true. The guard would disarm SILENTLY, which is
+    // worse than breaking: re-anchor it deliberately rather than let it pass on nothing.
+    expect(
+      lifetimeBlockEnd,
+      "close anchor not found — re-anchor this guard rather than letting it pass vacuously"
+    ).toBeGreaterThan(-1);
     expect(monthBlock, "the month block must be a SIBLING of the lifetime banner, not nested in it").toBeGreaterThan(
       lifetimeBlockEnd
     );

--- a/test/guards/reconciliation-copy.test.ts
+++ b/test/guards/reconciliation-copy.test.ts
@@ -13,6 +13,13 @@ import { join } from "node:path";
  * which is precisely how the work-key check earned its reputation.
  *
  * The wording is the whole feature here, so it is pinned rather than left to a future tidy-up.
+ *
+ * AMENDED 2026-08-05 (AIO-805): the banner now carries TWO periods. The lifetime gap keeps the floor
+ * claim — it is still permanently elevated by that July block — but it can never answer "is spend
+ * escaping the meter NOW", so the month became the headline. Measured the morning it shipped: 0.9%
+ * for the month against 22% lifetime, on the same key. The guard follows the lesson, not the
+ * sentence: whatever is claimed to have a floor must be the LIFETIME figure, and the actionable
+ * signal must be the one that can actually move.
  */
 describe("guard: the reconciliation banner explains the permanent floor", () => {
   const page = readFileSync(
@@ -26,17 +33,27 @@ describe("guard: the reconciliation banner explains the permanent floor", () => 
     expect(page).toContain("breakdown.trackingSince");
   });
 
-  it("binds the never-clears claim to the DOLLARS, not the percentage", () => {
+  it("binds the never-clears claim to the LIFETIME dollars, not the percentage", () => {
     // The fraction is (provider - ledger) / provider, and both legs are lifetime — so as new fully
     // metered spend accrues, the fixed pre-metering block is diluted and the PERCENTAGE falls on its
     // own. Only the dollar amount has a floor. The first version of this banner promised the
     // percentage could not fall, which would have read as the banner lying about arithmetic within a
     // few months — the credibility failure this whole change exists to avoid.
-    expect(page).toMatch(/dollar gap here has a floor/i);
-    expect(page).toMatch(/dollars grow/i);
+    expect(page).toMatch(/lifetime gap has a floor/i);
     expect(page, "must not resurrect the false claim about the percentage").not.toMatch(
       /percentage will not fall/i
     );
+  });
+
+  it("makes the CURRENT-PERIOD gap the actionable signal, since only it can move", () => {
+    // The point of the amendment: a figure with a permanent floor cannot be an alarm. The month can,
+    // and the copy must say which one to watch — otherwise the operator is back to reading a number
+    // that no action of theirs will ever change.
+    expect(page).toMatch(/month gap that grows is the real signal/i);
+    // Both legs must be the provider's calendar month, not our selected window — a boundary mismatch
+    // would manufacture a gap out of a timezone.
+    expect(page).toMatch(/provider&apos;s calendar month|provider's calendar month/i);
+    expect(page).toContain("getLedgerMonthUsd");
   });
 
   it("still points at the failed-attempt breakdown for the part that IS actionable", () => {

--- a/test/guards/reconciliation-copy.test.ts
+++ b/test/guards/reconciliation-copy.test.ts
@@ -45,6 +45,32 @@ describe("guard: the reconciliation banner explains the permanent floor", () => 
     );
   });
 
+  it("renders the month INDEPENDENTLY of the lifetime state — not nested inside its amber branch", () => {
+    // The defect this pins: the month block first shipped inside `reconciliation.status ===
+    // "unattributed"`, so it vanished whenever lifetime read `reconciled` (dilution) or
+    // `ledger-exceeds` (a rotated key) — i.e. precisely when someone would be watching for live
+    // leakage. Pinning the copy could not see it: every string was present in the source while the
+    // branch was unreachable ("never attest a surface that does not render").
+    const lifetimeBranch = page.indexOf('reconciliation.status === "unattributed" ?');
+    const lifetimeBlockEnd = page.indexOf("      ) : null}", lifetimeBranch);
+    const monthBlock = page.indexOf("{monthReconciliation ? (");
+    expect(lifetimeBranch, "lifetime branch not found — guard is looking at the wrong shape").toBeGreaterThan(-1);
+    expect(monthBlock, "month block not found").toBeGreaterThan(-1);
+    expect(monthBlock, "the month block must be a SIBLING of the lifetime banner, not nested in it").toBeGreaterThan(
+      lifetimeBlockEnd
+    );
+  });
+
+  it("gives the month its own copy states rather than reusing the lifetime explanations", () => {
+    // A month in `ledger-exceeds` is a boundary skew, NOT the key rotation the lifetime copy blames —
+    // and folding it into the reassuring branch renders "a near-zero gap" beside numbers that
+    // contradict it.
+    expect(page).toMatch(/month-boundary\s*\n?\s*skew|month-boundary skew/i);
+    expect(page, "must not blame key rotation for a month skew").not.toMatch(
+      /month[\s\S]{0,200}key was rotated/i
+    );
+  });
+
   it("makes the CURRENT-PERIOD gap the actionable signal, since only it can move", () => {
     // The point of the amendment: a figure with a permanent floor cannot be an alarm. The month can,
     // and the copy must say which one to watch — otherwise the operator is back to reading a number

--- a/test/provider-usage.test.ts
+++ b/test/provider-usage.test.ts
@@ -1,36 +1,58 @@
 import { describe, expect, it } from "vitest";
-import { parseCreditsBody, reconcileLedger } from "@/lib/costs/provider-usage";
+import { parseKeyUsageBody, reconcileLedger } from "@/lib/costs/provider-usage";
 
 /**
  * Spec: the costs surface must not present the ledger's FLOOR as the total.
  *
- * Measured on prod 2026-07-30 — the ledger said $51.46, OpenRouter's own `/credits` said $96.67 on
- * the same key. 47% of real spend was invisible, and the dashboard reported the floor with no hint
- * that anything was missing. The cause is structural: a call that times out or fails after the
- * provider generated is billed upstream and returns no `usage` for us to read, so no amount of
- * fixing the meter can make the ledger complete on its own. Only the provider knows the total.
+ * Measured on prod 2026-07-30 — the ledger said $51.46, OpenRouter said $96.67. 47% of real spend was
+ * invisible, and the dashboard reported the floor with no hint that anything was missing. The cause is
+ * structural: a call that times out or fails after the provider generated is billed upstream and
+ * returns no `usage` for us to read, so no amount of fixing the meter can make the ledger complete on
+ * its own. Only the provider knows the total.
+ *
+ * The SOURCE of the provider figure is itself load-bearing (2026-08-05): this read `/credits`, whose
+ * `total_usage` is ACCOUNT-wide, while three comments called it key-scoped. Account $202.69 vs this
+ * key $194.36 — $8.33 of an unrelated key's spend inflating the very number that reports how much we
+ * failed to explain, uncloseable by any metering fix. `/key` → `data.usage` is the per-key figure.
  */
 
-describe("parseCreditsBody — 'unknown' must never read as 'zero'", () => {
-  it("reads the provider's cumulative spend", () => {
-    const got = parseCreditsBody({ data: { total_credits: 110, total_usage: 96.670187517 } });
-    expect(got).toEqual({ provider: "openrouter", totalUsageUsd: 96.670187517, totalCreditsUsd: 110 });
+describe("parseKeyUsageBody — 'unknown' must never read as 'zero'", () => {
+  it("reads this key's spend and its calendar-month slice from a real /key body", () => {
+    // Recorded verbatim from prod 2026-08-05, not hand-written: the fields this parser depends on
+    // exist in the shape the provider actually returns.
+    const got = parseKeyUsageBody({
+      data: {
+        label: "sk-or-v1-959...5ef",
+        limit: null,
+        usage: 194.39890159,
+        usage_daily: 0.049143255,
+        usage_weekly: 53.519963315,
+        usage_monthly: 70.29084969,
+        is_free_tier: false,
+      },
+    });
+    expect(got).toEqual({ provider: "openrouter", totalUsageUsd: 194.39890159, monthUsageUsd: 70.29084969 });
   });
 
-  it("keeps usage when credits are absent — they answer different questions", () => {
-    expect(parseCreditsBody({ data: { total_usage: 12.5 } })?.totalCreditsUsd).toBeNull();
-    expect(parseCreditsBody({ data: { total_usage: 12.5 } })?.totalUsageUsd).toBe(12.5);
+  it("keeps the lifetime figure when the month slice is absent — they answer different questions", () => {
+    expect(parseKeyUsageBody({ data: { usage: 12.5 } })?.monthUsageUsd).toBeNull();
+    expect(parseKeyUsageBody({ data: { usage: 12.5 } })?.totalUsageUsd).toBe(12.5);
   });
 
   it("refuses a NEGATIVE total rather than rendering '$-5.00 spent'", () => {
-    expect(parseCreditsBody({ data: { total_usage: -5 } })).toBeNull();
+    expect(parseKeyUsageBody({ data: { usage: -5 } })).toBeNull();
+  });
+
+  it("a /credits-shaped body parses to NULL — a silent revert must not read as a plausible figure", () => {
+    // THE guard with real history. `/credits.total_usage` is ACCOUNT-wide; reading it as this key's
+    // spend inflated the unattributed gap by every other key's lifetime spend. If someone points this
+    // back at /credits, the shape must be unrecognised ("we don't know"), never quietly parsed.
+    expect(parseKeyUsageBody({ data: { total_usage: 202.69, total_credits: 110 } })).toBeNull();
   });
 
   it("returns NULL — not 0 — for a shape it doesn't recognise", () => {
-    // A missing number must read as "we don't know what the provider charged". Zero would be the
-    // same false reassurance this module exists to end.
-    for (const junk of [null, undefined, {}, { data: {} }, { data: { total_usage: "96.67" } }, { data: { total_usage: NaN } }]) {
-      expect(parseCreditsBody(junk)).toBeNull();
+    for (const junk of [null, undefined, {}, { data: {} }, { data: { usage: "96.67" } }, { data: { usage: NaN } }]) {
+      expect(parseKeyUsageBody(junk)).toBeNull();
     }
   });
 });


### PR DESCRIPTION
## What this fixes

Two stated assumptions in the cost plumbing that measurement contradicted. Neither was a logic bug — each was a **comment that had become false**, which is why both survived review the first time.

### The reconciliation was comparing against the wrong number

`provider-usage.ts` read OpenRouter's `/credits`, whose `total_usage` is **account-wide**, while three separate comments called it key-scoped. Measured 2026-08-05: account **$202.69** vs this key **$194.36** — so **$8.33 of an unrelated key's spend** was inflating the very figure that reports how much spend we failed to explain, uncloseable by any metering fix. Now reads `GET /api/v1/key` → `data.usage`.

### `/key` also returns period slices, which makes the gap actionable for the first time

| period | ledger | provider (this key) | gap |
|---|---|---|---|
| **Today (UTC)** | $0.0491 | $0.049143 | **$0.00** |
| August so far | $69.63 | $70.29 | 0.9% |
| Lifetime | $151.49 | $194.40 | 22% |

Today's figures agree **to four decimal places** — the first direct proof the meter captures essentially all current spend. The whole 22% is frozen July history (pre-metering + the timeout storm) that no future work can recover, so **the month is now the headline and lifetime is context**. Both legs truncate on the same boundary. This also falsifies `provider-daily-truth.md`'s premise that per-period truth needs a management key.

### The proxy ceiling keeps its number and loses its false story

The comment claimed extraction "is serial … so it will never come close" and that the limiter "can never be the thing that wedges the graph". Re-derived from `rate_limits`: it **did** bind at **426 attempts/min**, refusing our own extraction **4,248 times across 46 windows**. The cause was graphiti 0.13.2's per-entity fan-out, which #490 removed — peak demand is now 76/min and both throttles are at zero. So the **default stays 120** (raising a leak-damage bound on stale evidence is how a control becomes decoration); it becomes env-tunable for deliberate backlog admission, and the comment now records the real history plus the two *different* queries that diagnose the two *different* throttles.

**Diagnosis correction worth recording:** the 1,904 `http_429`s I first blamed on our limiter were provider refusals — the proxy returns 429 before recording anything, and `recordLlmFailure` forbids logging pre-provider refusals. 1,902 of them were OpenRouter throttling `mistral-small` (the cheap summary model) while the fan-out flooded it.

## Review — Reviewed by Fable code-reviewer (subagent) — verdict CLEAR after fixes
Plan review killed the original rate-limit evidence (BLOCKER) and the 600/min raise with it. Code review returned BLOCKED on four HIGHs: the month banner rendered only *inside* the lifetime amber branch (invisible on `reconciled`/`ledger-exceeds` — exactly when you'd watch for live leakage); the month SQL compared through the **session** TimeZone, returning **$0 for a $7 month** under `Etc/GMT+12`; and two spec commitments I had silently dropped (the raised monthly materiality floor, and month-specific copy states — a month in `ledger-exceeds` rendered "a near-zero month gap" beside numbers contradicting it). All fixed and mutation-proven; delta re-review CLEAR, and its three residual silent-disarm findings in my own guards are fixed in the final commit rather than deferred.

## Test plan
- [x] New: month-boundary **data-mechanics** test — sets session TZ to `Pacific/Kiritimati` (+14) and `Etc/GMT+12` (−12) and asserts the total doesn't move; mutation-proven (naive SQL returns $0 vs $7), and asserts the TZ actually took so a pool change can't make it vacuous
- [x] New: ceiling tunability guard (default, override, junk-override fallback) — mutation-proven
- [x] `/credits`-shaped body must parse to `null` — mutation-proven with a faithful mutation after a first sloppy one didn't redden
- [x] Reachability guard: re-nesting the month block reddens with "must be a SIBLING"
- [x] Unit **1,930** · real-Postgres **857** · tsc · lint (2 pre-existing warnings) · docs-drift — all green

AIOS-Work: COSTTRUTH-1