### PR TITLE
feat(graph): raise the extraction cap and make a cap raise delta-eligible (AIO-808)

### DIFF
--- a/docs/design/graph-extraction-cap.md
+++ b/docs/design/graph-extraction-cap.md
@@ -163,11 +163,38 @@ corpus), so changing `CHUNK_CHARS` becomes a decision with a price tag attached 
 constant edit whose effect arrives item-by-item over months. Worth stating loudly next to the
 constant.
 
-**The backfill at `:453` is gated on STRICT equality** (`stored === CHUNK_CONFIG`), not helper
+**The backfill at `:453` was gated on STRICT equality** (`stored === CHUNK_CONFIG`), not helper
 compatibility — under compatibility, an empty-ledger over-cap row would stamp current-config hashes
 for tails never pushed, i.e. the hazard surviving its own fix. (Under the composite skip such a row
 always "owes chunks" and falls through to a sound full push anyway; the gate is strict regardless,
 because a second line of defence that shares the first one's blind spot is not one.)
+
+### Found at build: the backfill branch is DELETED, not gated
+
+Building this made the branch unreachable — a pre-ledger row carries `chunk_config = ""`, which the
+composite skip correctly rejects, so the backfill inside the skip can never run and its acceptance
+criterion (AC4) went red. Reviewed rather than patched, and the branch is **removed**:
+
+- **Its own comment set the expiry.** The premise "an identical body means these are the chunks we
+  pushed" holds "only while the chunk config is the one that produced them, which an empty ledger
+  cannot attest", and it prescribed invalidation on any config change. This change *is* that change.
+- **For the population it still served, it produced this feature's own bug.** A pre-ledger row over
+  the old cap would have been blessed with 40 current-config hashes including tails present in the
+  graph in no form — permanent silent loss, invisible to reconcile. A full push is both correct and
+  the first time those tails are extracted.
+- **The "bless shas but not the config" variant is self-defeating.** The saving lives entirely in the
+  *subsequent* skip, that skip requires a trusted config, and a pre-ledger row's producing config is
+  unattestable by construction. It would re-push next pass anyway, from a ledger claiming hashes it
+  never used.
+
+**AC4 is inverted, not deleted:** a pre-feature row (empty ledger, `""` config, unchanged body) now
+converges via one full re-push and lands on the current config. That is the self-hosted upgrade path,
+and the guard that stops someone restoring the backfill without confronting the hazard above.
+
+**Upgrade-path note for the release, not a mechanism:** an install upgrading from pre-GRAPHCOST-1 with
+Graphiti enabled re-extracts its pre-ledger rows once, on the first tick (~$0.01/episode). Prod holds
+**0** such rows so the cost table below is unchanged; building a migration for that population would
+be a guard with no failure mode behind it.
 
 ### 2. Raise the cap to 40 (100,000 chars/item)
 

--- a/docs/design/graph-extraction-cap.md
+++ b/docs/design/graph-extraction-cap.md
@@ -1,0 +1,136 @@
+# The graph silently drops the back half of our densest documents
+
+**Status:** draft, for plan review · **Date:** 2026-08-05 · **Owner:** Chetan
+· **Task:** `CHUNKCAP-1` → [AIO-808](https://linear.app/je4light/issue/AIO-808)
+
+## The problem, measured
+
+`lib/graph/project.ts` chunks an item into at most `MAX_EPISODE_CHUNKS` (16) slices of `CHUNK_CHARS`
+(2,500), and `chunkContent` **drops everything past that** — 40,000 characters per item, by design, as
+a "runaway-size backstop". Measured against the live ledger (2026-08-05, `graph_episodes ⋈ items`):
+
+```
+                       items   chars extracted   chars DROPPED
+fully extracted        2,190       7,358,000               0
+OVER the 40k cap          21         840,000         689,235
+```
+
+**689,235 characters — 8.6% of the corpus text — have never entered the graph**, and they are
+concentrated in exactly the documents with the highest information density per byte:
+
+| document | in the graph |
+|---|---|
+| `docs/ARCHITECTURE.md` (338,122 chars) | **11.8%** |
+| `gui/server/skill-library/claude-api/…/model-migration.md` | 33.8% |
+| `docs/brain-api.md` | 35.4% |
+| `2-work/weekly-digest-team-2026-07-27…` | 42.6% |
+| `1-inbox/transcripts/2026-07-16-follow-up-re-pikl-b2b-velocity.md` | 53.1% |
+| `2-work/transcripts/2026-07-03-john-chetan-aios.md` | **54.5%** |
+
+The last two are meeting transcripts between the people whose work the graph exists to describe. The
+brain answers "what does the architecture say" from the first 12% of the architecture document, and
+nothing anywhere says so — the item is fully present in `items`/FTS/pgvector, so search and citation
+look complete while the *graph's* picture is truncated.
+
+This is not a cost problem. At today's $0.0099/episode the missing tail is **276 episodes ≈ $2.73**,
+one time.
+
+## Why this went unnoticed
+
+Nothing surfaces it. `chunkContent`'s own comment calls the drop "a runaway-size backstop, not the
+common path" — true when written for a corpus of Slack threads (median item ~240 chars), false now
+that the corpus includes 338KB design documents and 75KB transcripts. `graph_episodes.chunk_shas`
+records what WAS pushed; there is no record of what was refused, so no query can find the gap without
+recomputing it from `items.body` — which is how it was found, by accident, while pricing something
+else.
+
+## The decision that costs 17×
+
+Raising `MAX_EPISODE_CHUNKS` changes `CHUNK_CONFIG` (`"2500x16"` → `"2500x40"`), and
+`project.ts:566` makes an item delta-INELIGIBLE when its stored config differs:
+
+```ts
+existingRow.chunk_config === CHUNK_CONFIG;
+```
+
+That predicate is correct and was deliberately added (#485's spec review found it): a changed
+`CHUNK_CHARS` moves every chunk boundary, so every stored sha is stale and a full re-push is the only
+safe answer. **But a raised CAP is not that.** Chunking is `body.slice(i, i + size)` stepping by
+`size`; increasing only `maxChunks` leaves chunks `0..15` byte-identical and merely *appends*
+`16..N`. Their shas still match.
+
+So the same edit is either:
+
+- **$47.03** — 4,750 episodes, the entire corpus re-extracted because the config string changed; or
+- **$2.73** — 276 episodes, only the tails that were never pushed.
+
+The second is also strictly safer: a full re-push re-extracts 2,190 items that were already complete,
+adding graph churn and dedupe load for nothing.
+
+## Proposal
+
+### 1. Make the delta predicate understand the two halves of the config
+
+Replace the string equality with a comparison that distinguishes the two parameters, because they
+have different consequences:
+
+- **`CHUNK_CHARS` differs** → every boundary moved → not delta-eligible (today's behaviour, kept).
+- **`CHUNK_CHARS` same, `MAX_EPISODE_CHUNKS` GREW** → boundaries identical, tail appended →
+  **delta-eligible**; the existing sha diff then pushes exactly the new chunks and nothing else.
+- **`CHUNK_CHARS` same, cap SHRANK** → not delta-eligible. Chunks beyond the new cap are now orphans
+  in Graphiti that our ledger would stop tracking; a full re-push (which `purgeBeforeRepush` precedes)
+  is the honest answer. This case earns no optimisation — it is rare and the cheap path is wrong.
+
+The stored `chunk_config` string is already `"<chars>x<cap>"`, so this is a parse, not a migration.
+
+### 2. Raise the cap to 40 (100,000 chars/item)
+
+Sized from the measured corpus, not chosen: 40 chunks covers **19 of the 21** over-cap items
+completely. The two it does not (`ARCHITECTURE.md` at 135 chunks, `model-migration.md` at 48) are
+pathological and should stay capped — a 338KB file is a documentation-structure problem, not an
+extraction-budget one, and this doc's job is not to hide that by paying to extract it.
+
+Cost at 40: the 276-episode tail becomes ~**$2.73**; ongoing, only items that grow past 40,000 chars
+pay more than today.
+
+**Why the per-episode ceiling is NOT at risk.** `MAX_EPISODE_CHUNKS` changes how many episodes an item
+becomes; `CHUNK_CHARS` (unchanged at 2,500) governs how big each one is. Graphiti's extraction cap is
+per-episode — the 2026-06/07 blank-arcs incidents were oversized *episodes* overflowing the 8,192-token
+output ceiling (fixed by the image's 16,384 patch and by `CHUNK_CHARS` itself). Nothing in this change
+makes any episode larger. That is the load-bearing distinction and the reason this is a safe knob.
+
+### 3. Make the drop visible instead of silent
+
+`chunkContent` currently discards the tail with no signal. It should report how many characters it
+refused, and the projector should record the total on the run (`ingest_runs.meta.chunk_overflow_chars`)
+— so "the graph is missing content" becomes a number on a surface someone already reads, rather than
+something you rediscover by joining `items` against a constant. Zero on a healthy corpus; non-zero the
+moment a document outgrows the budget again.
+
+## Guards (CLAUDE.md §7)
+
+- **The delta predicate's three cases, unit-tested and each mutation-proven**: same-config →
+  eligible; chars-changed → ineligible; cap-grown → **eligible** (the new case, and the one worth
+  $44); cap-shrunk → ineligible. The existing `test/guards/graph-delta-predicate.test.ts` is where
+  this belongs — it already exists precisely because this predicate is load-bearing.
+- **The append-only claim is asserted, not assumed**: a test that chunking a fixed body at cap 16 and
+  at cap 40 yields byte-identical first-16 chunks. If that is ever false, the delta optimisation is
+  unsound and this test is what says so.
+- **Real-Postgres**: an item stored at `2500x16` with 16 shas, re-projected under `2500x40`, pushes
+  ONLY the tail — asserted against the fake-graphiti spy's call log, not just the ledger row.
+- **Overflow accounting**: `chunkContent` reports refused characters; a fixture over the cap reports
+  exactly `len - chars*cap`, and one under it reports 0.
+
+## What this does not do
+
+- It does not re-project the corpus. The tails land on the projector's normal tick, at normal pace,
+  because delta-eligibility means each item pushes only what it owes.
+- It does not clean the existing duplicate entities (separate task) or change extraction quality.
+- It does not fix `ARCHITECTURE.md` being 338KB. That file is over any reasonable budget and the right
+  answer is splitting it, which is a docs decision, not a projector one.
+
+## How we will know it worked
+
+`sum(greatest(length(body) - CHUNK_CHARS*MAX_EPISODE_CHUNKS, 0))` over `graph_episodes ⋈ items` falls
+from 689,235 to the residue of the two pathological files, and the projector's overflow counter reads
+that residue rather than zero — with total spend for the transition inside ~$5, not ~$47.

--- a/docs/design/graph-extraction-cap.md
+++ b/docs/design/graph-extraction-cap.md
@@ -139,9 +139,16 @@ what makes it delta-eligible). All 21 items would still have skipped.
 So the skip's condition is composite:
 
 ```
-skip  iff  chunkConfigDeltaCompatible(stored, current)
-      AND  currentChunkCount <= (existingRow.chunk_shas?.length ?? 0)      // nothing owed
+skip  iff  <the existing sha / tier / purge terms>                         // unchanged
+      AND  chunkConfigDeltaCompatible(stored, current)
+      AND  episodes.length <= (existingRow.chunk_shas?.length ?? 0)        // nothing owed
 ```
+
+Both new terms are AND-ed **into** the existing condition, not a replacement for it. And
+`currentChunkCount` is `episodes.length` — never a re-derived `ceil(len/chars)`, which is a second
+derivation that can drift from `chunkContent` (they already disagree on a whitespace-only body) and
+would violate the module's own rule at `:396` that the ledger is derived from `episodes` so it "can
+never describe something else".
 
 That routes exactly the 21 owing items to the delta path (where `toPush` is their tail), keeps all
 2,190 complete items skipped, and is what makes the cost table's 179 episodes exact rather than
@@ -200,6 +207,12 @@ meta. Two summaries for one fact is the H6 drift shape; one writer, both readers
   pin the helper call as the predicate's term — its current slice-anchor on the literal
   `existingRow.chunk_config === CHUNK_CONFIG` breaks loudly (the length assertion reddens), which is
   the guard behaving correctly, not collateral.
+- **Both degenerate implementations die to a NAMED test, which is the point of listing them.** A
+  *count-only* skip (dropping the compatibility term) is killed by the existing AC11 dm fixture — it
+  rewrites `chunk_config` to `"1000x64"` while keeping the real pushed shas, so the counts match and
+  a count-only skip would skip, reddening AC11's "pushes everything". A *compatibility-only* skip
+  (dropping the count term) is killed by the new tail test: cap-grew is compatible, so all 21 items
+  skip and no tail lands. Nobody may "simplify" the AC11 fixture without re-reading this.
 - **ANTI-FLOOD — the case that separates a correct build from a plausible one.** A body-unchanged,
   config-stale, **complete** item from a RETRACTABLE source (Slack) must be neither deleted nor
   re-pushed: the fake-graphiti spy log must be empty for it. A builder who implements the skip as

--- a/docs/design/graph-extraction-cap.md
+++ b/docs/design/graph-extraction-cap.md
@@ -107,9 +107,10 @@ have different consequences:
 - **`CHUNK_CHARS` differs** → every boundary moved → not delta-eligible (today's behaviour, kept).
 - **`CHUNK_CHARS` same, `MAX_EPISODE_CHUNKS` GREW** → boundaries identical, tail appended →
   **delta-eligible**; the existing sha diff then pushes exactly the new chunks and nothing else.
-- **`CHUNK_CHARS` same, cap SHRANK** → not delta-eligible. Chunks beyond the new cap are now orphans
-  in Graphiti that our ledger would stop tracking; a full re-push (which `purgeBeforeRepush` precedes)
-  is the honest answer. This case earns no optimisation — it is rare and the cheap path is wrong.
+- **`CHUNK_CHARS` same, cap SHRANK** → not delta-eligible. Chunks beyond the new cap become orphans
+  in Graphiti that our ledger stops tracking (a shrink sets no pending-delete flag, so nothing purges
+  them); a full re-push is the honest answer. This case earns no optimisation — it is rare and the
+  cheap path is wrong.
 
 The stored `chunk_config` string is already `"<chars>x<cap>"`, so this is a parse, not a migration —
 and **a malformed, empty or NULL config parses to "incompatible"**, i.e. not delta-eligible. `""` is a
@@ -121,14 +122,36 @@ Because `test/guards/graph-delta-predicate.test.ts` asserts the predicate is a p
 where the four cases are unit-tested, and it keeps the guard's no-`||` assertion intact rather than
 weakening it to accommodate this change.
 
-### 1b. …and make the unchanged-content skip reach it
+### 1b. …and make the unchanged-content skip reach it — asking a DIFFERENT question
 
-The change above is inert without this one (the blocker). At `project.ts:440`, an item whose body is
-unchanged but whose stored config is **incompatible with the current one** must fall through to the
-delta path rather than `continue`. Same helper, same three cases, so the two sites cannot disagree.
+The change above is inert without this one (the blocker). But the second draft got the condition
+backwards, which would have re-shipped the same bug in new words: I wrote "fall through when the
+stored config is **incompatible**" — and `2500x16` → `2500x40` *is* compatible (that is precisely
+what makes it delta-eligible). All 21 items would still have skipped.
 
-The backfill at `:453` is additionally gated on a present-and-compatible stored config, so it can
-never bless current-config hashes for chunks pushed under a different one.
+**The two sites ask different questions, and one boolean cannot answer both:**
+
+| site | question | cap-grew answer |
+|---|---|---|
+| delta predicate (`:567`) | can I trust the stored shas? | **yes** — boundaries unchanged |
+| unchanged-content skip (`:440`) | could this item still OWE chunks? | **depends on the body's length** |
+
+So the skip's condition is composite:
+
+```
+skip  iff  chunkConfigDeltaCompatible(stored, current)
+      AND  currentChunkCount <= (existingRow.chunk_shas?.length ?? 0)      // nothing owed
+```
+
+That routes exactly the 21 owing items to the delta path (where `toPush` is their tail), keeps all
+2,190 complete items skipped, and is what makes the cost table's 179 episodes exact rather than
+aspirational.
+
+**The backfill at `:453` is gated on STRICT equality** (`stored === CHUNK_CONFIG`), not helper
+compatibility — under compatibility, an empty-ledger over-cap row would stamp current-config hashes
+for tails never pushed, i.e. the hazard surviving its own fix. (Under the composite skip such a row
+always "owes chunks" and falls through to a sound full push anyway; the gate is strict regardless,
+because a second line of defence that shares the first one's blind spot is not one.)
 
 ### 2. Raise the cap to 40 (100,000 chars/item)
 
@@ -162,10 +185,19 @@ meta. Two summaries for one fact is the H6 drift shape; one writer, both readers
 
 ## Guards (CLAUDE.md §7)
 
-- **The delta predicate's three cases, unit-tested and each mutation-proven**: same-config →
-  eligible; chars-changed → ineligible; cap-grown → **eligible** (the new case, and the one worth
-  $44); cap-shrunk → ineligible. The existing `test/guards/graph-delta-predicate.test.ts` is where
-  this belongs — it already exists precisely because this predicate is load-bearing.
+- **The helper's four cases, unit-tested and each mutation-proven**: same-config → eligible;
+  chars-changed → ineligible; cap-grown → **eligible** (the new case); cap-shrunk → ineligible; plus
+  malformed/`""`/NULL → ineligible. `test/guards/graph-delta-predicate.test.ts` is **rewritten** to
+  pin the helper call as the predicate's term — its current slice-anchor on the literal
+  `existingRow.chunk_config === CHUNK_CONFIG` breaks loudly (the length assertion reddens), which is
+  the guard behaving correctly, not collateral.
+- **ANTI-FLOOD — the case that separates a correct build from a plausible one.** A body-unchanged,
+  config-stale, **complete** item from a RETRACTABLE source (Slack) must be neither deleted nor
+  re-pushed: the fake-graphiti spy log must be empty for it. A builder who implements the skip as
+  bare `stored !== CHUNK_CONFIG` passes every other guard here while sending the whole corpus through
+  the push path — and for retractable sources the retract-delete branch (`:494-517`) fires *before*
+  the predicate, so each Slack item gets a `deleteItemEpisodes` + full re-push, unbudgeted. This
+  guard is the difference.
 - **The append-only claim is asserted, not assumed**: a test that chunking a fixed body at cap 16 and
   at cap 40 yields byte-identical first-16 chunks. If that is ever false, the delta optimisation is
   unsound and this test is what says so.
@@ -200,3 +232,10 @@ The verification is **extraction-side, once, after the rollout**: count episodes
 each `items:<id>` name-prefix and compare against that row's `chunk_shas` length, for the 21 items.
 Equal ⇒ the tails actually landed. Alongside it: transition spend inside ~$2, and the overflow counter
 reporting the three-file residue rather than 0 or 689,235.
+
+**And the remediation, named rather than left to improvisation:** a mismatch means Graphiti accepted
+(202) and its worker then died, so the ledger blessed chunks that were never extracted — invisible to
+reconcile forever, because its landed-check is satisfied by chunk `#0`. The heal is to clear
+`content_sha256` to `''` on the mismatched rows: the sentinel misses the skip *and* fails delta term
+4, forcing a real full re-push. (A wholly dead worker is separately caught by the extraction-health
+fact-count probe; it is the per-item ledger blessing that has no automatic retry.)

--- a/docs/design/graph-extraction-cap.md
+++ b/docs/design/graph-extraction-cap.md
@@ -1,6 +1,7 @@
 # The graph silently drops the back half of our densest documents
 
-**Status:** draft, for plan review · **Date:** 2026-08-05 · **Owner:** Chetan
+**Status:** revised after plan review — 1 blocker (my mechanism delivered nothing) + 1 high, both mine
+· **Date:** 2026-08-05 · **Owner:** Chetan
 · **Task:** `CHUNKCAP-1` → [AIO-808](https://linear.app/je4light/issue/AIO-808)
 
 ## The problem, measured
@@ -32,8 +33,8 @@ brain answers "what does the architecture say" from the first 12% of the archite
 nothing anywhere says so — the item is fully present in `items`/FTS/pgvector, so search and citation
 look complete while the *graph's* picture is truncated.
 
-This is not a cost problem. At today's $0.0099/episode the missing tail is **276 episodes ≈ $2.73**,
-one time.
+This is not a cost problem: at today's $0.0099/episode the recoverable tail is **179 episodes ≈
+$1.77**, one time (see the corrected arithmetic below — my first figure was wrong).
 
 ## Why this went unnoticed
 
@@ -44,28 +45,57 @@ records what WAS pushed; there is no record of what was refused, so no query can
 recomputing it from `items.body` — which is how it was found, by accident, while pricing something
 else.
 
-## The decision that costs 17×
+## What plan review corrected
 
-Raising `MAX_EPISODE_CHUNKS` changes `CHUNK_CONFIG` (`"2500x16"` → `"2500x40"`), and
-`project.ts:566` makes an item delta-INELIGIBLE when its stored config differs:
+### 1. The predicate I proposed to change is never reached (BLOCKER)
+
+`project.ts:440` skips an item whose body is unchanged, **before** the delta predicate at `:567`:
 
 ```ts
-existingRow.chunk_config === CHUNK_CONFIG;
+if (existingRow && existingRow.content_sha256 === contentSha && !tierChanged && !purgeBeforeRepush) {
+  … continue;   // ← every over-cap item lands here
+}
 ```
 
-That predicate is correct and was deliberately added (#485's spec review found it): a changed
-`CHUNK_CHARS` moves every chunk boundary, so every stored sha is stale and a full re-push is the only
-safe answer. **But a raised CAP is not that.** Chunking is `body.slice(i, i + size)` stepping by
-`size`; increasing only `maxChunks` leaves chunks `0..15` byte-identical and merely *appends*
-`16..N`. Their shas still match.
+`content_sha256` hashes the **whole body** and is invariant to the cap, so all 21 over-cap items —
+whose bodies have not changed — hit that `continue` and `deltaEligible` is never evaluated for them.
+**Changing the predicate alone delivers zero tails.** The spec's own real-Postgres guard would have
+gone red against the build the spec described, which is the one honest thing about the first draft.
 
-So the same edit is either:
+The second change site has to be named: **the unchanged-content skip must become chunk-config-aware**,
+so a body-identical item whose stored config differs routes to the delta path instead of being
+skipped. There `toPush` is exactly the tail (or empty, for an item already complete under the new
+config, whose ledger row is then refreshed to the current config and nothing is sent).
 
-- **$47.03** — 4,750 episodes, the entire corpus re-extracted because the config string changed; or
-- **$2.73** — 276 episodes, only the tails that were never pushed.
+### 2. The backfill branch would bless chunks it never pushed (HIGH)
 
-The second is also strictly safer: a full re-push re-extracts 2,190 items that were already complete,
-adding graph churn and dedupe load for nothing.
+Inside that same skip, `:453` backfills a row with an empty chunk ledger using **current**-config
+hashes. After a cap raise that would stamp 40 shas + `"2500x40"` for tail chunks never sent —
+permanently marking the item extracted. The code's own comment (`:447-452`) names this exact hazard.
+
+**Measured, and it is empirically closed:** `select count(*) from graph_episodes where
+cardinality(chunk_shas) = 0` → **0 rows**. No row can take that branch today. It is still gated on a
+present-and-compatible config, because "no rows today" is a fact about this instant, not an invariant.
+
+### 3. The cost framing was wrong in both directions
+
+There is no $47-or-$2.73 dichotomy. Measured against the ledger:
+
+| rollout | episodes | cost |
+|---|---|---|
+| naive cap raise, no other change | **0** | $0 — *and no tails*, which is the actual failure |
+| targeted invalidation (clear `content_sha256` on the 21 rows) | 515 | **$5.10** |
+| **config-aware skip — tails only** | **179** | **$1.77** |
+| naive full invalidation (clear every row) | 4,750 | $47.03 |
+
+My "$2.73 / 276 episodes" came from dividing dropped characters by `CHUNK_CHARS` — which assumes the
+new cap recovers *all* of them. It does not: **3 of the 21 items are still capped at 40**
+(`ARCHITECTURE.md` needs 136 chunks). The recoverable tail is 179 episodes.
+
+So the durable fix saves $3.33 against a targeted data-clear — trivial money. **The reason to do it
+is correctness, not cost:** with the skip as shipped, any config change leaves every unchanged item
+stranded on its old config *indefinitely* (until its body happens to change), so the graph holds a
+permanent mix of chunkings and the sanctioned rollout is a manual production data write, every time.
 
 ## Proposal
 
@@ -81,17 +111,35 @@ have different consequences:
   in Graphiti that our ledger would stop tracking; a full re-push (which `purgeBeforeRepush` precedes)
   is the honest answer. This case earns no optimisation — it is rare and the cheap path is wrong.
 
-The stored `chunk_config` string is already `"<chars>x<cap>"`, so this is a parse, not a migration.
+The stored `chunk_config` string is already `"<chars>x<cap>"`, so this is a parse, not a migration —
+and **a malformed, empty or NULL config parses to "incompatible"**, i.e. not delta-eligible. `""` is a
+real stored value (a dm fixture writes exactly that), so this is a live case, not defensive padding.
+
+Because `test/guards/graph-delta-predicate.test.ts` asserts the predicate is a pure conjunction with
+**no `||`**, the cap-grow rule cannot be inlined — it lives in a named pure helper
+(`chunkConfigDeltaCompatible(stored, current)`) that the predicate calls as one term. That is also
+where the four cases are unit-tested, and it keeps the guard's no-`||` assertion intact rather than
+weakening it to accommodate this change.
+
+### 1b. …and make the unchanged-content skip reach it
+
+The change above is inert without this one (the blocker). At `project.ts:440`, an item whose body is
+unchanged but whose stored config is **incompatible with the current one** must fall through to the
+delta path rather than `continue`. Same helper, same three cases, so the two sites cannot disagree.
+
+The backfill at `:453` is additionally gated on a present-and-compatible stored config, so it can
+never bless current-config hashes for chunks pushed under a different one.
 
 ### 2. Raise the cap to 40 (100,000 chars/item)
 
-Sized from the measured corpus, not chosen: 40 chunks covers **19 of the 21** over-cap items
-completely. The two it does not (`ARCHITECTURE.md` at 135 chunks, `model-migration.md` at 48) are
-pathological and should stay capped — a 338KB file is a documentation-structure problem, not an
-extraction-budget one, and this doc's job is not to hide that by paying to extract it.
+Sized from the measured corpus, not chosen: 40 chunks covers **18 of the 21** over-cap items
+completely. The three it does not (`ARCHITECTURE.md` needs **136** chunks, `model-migration.md` 48,
+`brain-api.md` 46) are pathological and stay capped — a 338KB file is a documentation-structure
+problem, not an extraction-budget one, and this doc's job is not to hide that by paying to extract it.
 
-Cost at 40: the 276-episode tail becomes ~**$2.73**; ongoing, only items that grow past 40,000 chars
-pay more than today.
+Cost at 40: **179 episodes ≈ $1.77**, one time; ongoing, only items that grow past 100,000 chars pay
+more than today. Verified read-only in prod: neither `GRAPH_MAX_EPISODE_CHUNKS` nor
+`GRAPH_CHUNK_CHARS` is set on the service, so the code default is what takes effect.
 
 **Why the per-episode ceiling is NOT at risk.** `MAX_EPISODE_CHUNKS` changes how many episodes an item
 becomes; `CHUNK_CHARS` (unchanged at 2,500) governs how big each one is. Graphiti's extraction cap is
@@ -104,8 +152,13 @@ makes any episode larger. That is the load-bearing distinction and the reason th
 `chunkContent` currently discards the tail with no signal. It should report how many characters it
 refused, and the projector should record the total on the run (`ingest_runs.meta.chunk_overflow_chars`)
 — so "the graph is missing content" becomes a number on a surface someone already reads, rather than
-something you rediscover by joining `items` against a constant. Zero on a healthy corpus; non-zero the
-moment a document outgrows the budget again.
+something you rediscover by joining `items` against a constant. Non-zero from day one here (the three
+still-capped files), which is the point: it names them instead of hiding them.
+
+Two ripples this touches, both stated so they are not discovered at build time: `chunkContent`'s
+signature changes (callers in `toEpisodes` plus its unit tests), and the count must be threaded
+through **both** summary types — `ProjectSummary` and `GraphProjectionSummary` → `projection-run`
+meta. Two summaries for one fact is the H6 drift shape; one writer, both readers.
 
 ## Guards (CLAUDE.md §7)
 
@@ -123,14 +176,27 @@ moment a document outgrows the budget again.
 
 ## What this does not do
 
-- It does not re-project the corpus. The tails land on the projector's normal tick, at normal pace,
-  because delta-eligibility means each item pushes only what it owes.
+- It does not re-project the corpus. The tails land on the projector's **first tick after deploy** —
+  one burst, not "normal pace": `lib/graph/run.ts` full-rescans from `since: undefined` every tick, so
+  all 179 episodes POST in that run. Harmless at this size (one ~110KB POST per item, serial worker,
+  and reconcile cannot false-requeue because its landed-check is satisfied by any chunk), but it is a
+  burst and the spec should not pretend otherwise.
+- **Scoping (SR18):** the delta path is retaining-sources-only (predicate term 1). All 21 over-cap
+  items are workspace/github/transcript sources with `retainSupersededBodies: true`, so the set is
+  covered today; a retractable-source item over the cap would get its tail only on its next body
+  change. Named rather than assumed.
 - It does not clean the existing duplicate entities (separate task) or change extraction quality.
 - It does not fix `ARCHITECTURE.md` being 338KB. That file is over any reasonable budget and the right
   answer is splitting it, which is a docs decision, not a projector one.
 
 ## How we will know it worked
 
-`sum(greatest(length(body) - CHUNK_CHARS*MAX_EPISODE_CHUNKS, 0))` over `graph_episodes ⋈ items` falls
-from 689,235 to the residue of the two pathological files, and the projector's overflow counter reads
-that residue rather than zero — with total spend for the transition inside ~$5, not ~$47.
+Not the admission-side sum I first proposed — `sum(greatest(length(body) − chars×cap, 0))` reads its
+target the instant the constant changes, whether or not a single tail landed, and `chunk_shas` is
+written on POST-**accept** (202 ≠ extracted) while reconcile's landed-check is satisfied by chunk `#0`
+alone. Every one of those signals is green if the worker dies mid-burst.
+
+The verification is **extraction-side, once, after the rollout**: count episodes in Graphiti under
+each `items:<id>` name-prefix and compare against that row's `chunk_shas` length, for the 21 items.
+Equal ⇒ the tails actually landed. Alongside it: transition spend inside ~$2, and the overflow counter
+reporting the three-file residue rather than 0 or 689,235.

--- a/docs/design/graph-extraction-cap.md
+++ b/docs/design/graph-extraction-cap.md
@@ -111,10 +111,12 @@ have different consequences:
 - **`CHUNK_CHARS` differs** → every boundary moved → not delta-eligible (today's behaviour, kept).
 - **`CHUNK_CHARS` same, `MAX_EPISODE_CHUNKS` GREW** → boundaries identical, tail appended →
   **delta-eligible**; the existing sha diff then pushes exactly the new chunks and nothing else.
-- **`CHUNK_CHARS` same, cap SHRANK** → not delta-eligible. Chunks beyond the new cap become orphans
-  in Graphiti that our ledger stops tracking (a shrink sets no pending-delete flag, so nothing purges
-  them); a full re-push is the honest answer. This case earns no optimisation — it is rare and the
-  cheap path is wrong.
+- **`CHUNK_CHARS` same, cap SHRANK** → not delta-eligible. Chunks beyond the new cap become
+  orphans in Graphiti that the ledger stops tracking (a shrink sets no pending-delete flag, so
+  nothing purges them); a full re-push is the honest answer. It is not a clean one: for a
+  RETAINING source nothing deletes first and `addEpisodes` does not overwrite by name, so chunks
+  `0..N` land a second time alongside the originals. Rare, deliberate, and cheaper to state than
+  to engineer around.
 
 The stored `chunk_config` string is already `"<chars>x<cap>"`, so this is a parse, not a migration —
 and **a malformed, empty or NULL config parses to "incompatible"**, i.e. not delta-eligible. `""` is a
@@ -222,7 +224,7 @@ makes any episode larger. That is the load-bearing distinction and the reason th
 **Status: not built.** The tails-land half is self-contained and verified; this observability half
 changes `chunkContent`'s signature and threads a count through two summary types, and it was cleaner
 to ship the correctness fix on its own than to bundle a second surface into it. Deferred deliberately
-and tracked, not forgotten — and no comment or test in the shipped code may claim it exists (one did,
+and tracked as **CHUNKCAP-2 → [AIO-811](https://linear.app/je4light/issue/AIO-811)**, not forgotten — and no comment or test in the shipped code may claim it exists (one did,
 which the code review caught).
 
 
@@ -291,8 +293,9 @@ alone. Every one of those signals is green if the worker dies mid-burst.
 
 The verification is **extraction-side, once, after the rollout**: count episodes in Graphiti under
 each `items:<id>` name-prefix and compare against that row's `chunk_shas` length, for the 21 items.
-Equal ⇒ the tails actually landed. Alongside it: transition spend inside ~$2, and the overflow counter
-reporting the three-file residue rather than 0 or 689,235.
+Equal ⇒ the tails actually landed. Alongside it: transition spend inside ~$2. (The
+overflow counter is NOT a criterion for this change — it belongs to AIO-811, whose acceptance signal
+it is. A criterion this PR cannot satisfy would contradict §3's own DEFERRED status.)
 
 **And the remediation, named rather than left to improvisation:** a mismatch means Graphiti accepted
 (202) and its worker then died, so the ledger blessed chunks that were never extracted — invisible to

--- a/docs/design/graph-extraction-cap.md
+++ b/docs/design/graph-extraction-cap.md
@@ -64,8 +64,12 @@ gone red against the build the spec described, which is the one honest thing abo
 
 The second change site has to be named: **the unchanged-content skip must become chunk-config-aware**,
 so a body-identical item whose stored config differs routes to the delta path instead of being
-skipped. There `toPush` is exactly the tail (or empty, for an item already complete under the new
-config, whose ledger row is then refreshed to the current config and nothing is sent).
+skipped. There `toPush` is exactly the tail.
+
+(An item already **complete** under the new cap does not route there at all — the composite skip's
+second term keeps it skipped, so its `chunk_config` stays on the old string indefinitely. Harmless
+and verified monotonic: compatibility compares the *stored* value, so a later raise still parses
+compatible from `"2500x16"`. The ANTI-FLOOD guard enforces that no write happens for these.)
 
 ### 2. The backfill branch would bless chunks it never pushed (HIGH)
 
@@ -213,7 +217,14 @@ per-episode — the 2026-06/07 blank-arcs incidents were oversized *episodes* ov
 output ceiling (fixed by the image's 16,384 patch and by `CHUNK_CHARS` itself). Nothing in this change
 makes any episode larger. That is the load-bearing distinction and the reason this is a safe knob.
 
-### 3. Make the drop visible instead of silent
+### 3. Make the drop visible instead of silent — SPECCED, DEFERRED (not in the first PR)
+
+**Status: not built.** The tails-land half is self-contained and verified; this observability half
+changes `chunkContent`'s signature and threads a count through two summary types, and it was cleaner
+to ship the correctness fix on its own than to bundle a second surface into it. Deferred deliberately
+and tracked, not forgotten — and no comment or test in the shipped code may claim it exists (one did,
+which the code review caught).
+
 
 `chunkContent` currently discards the tail with no signal. It should report how many characters it
 refused, and the projector should record the total on the run (`ingest_runs.meta.chunk_overflow_chars`)
@@ -235,11 +246,12 @@ meta. Two summaries for one fact is the H6 drift shape; one writer, both readers
   `existingRow.chunk_config === CHUNK_CONFIG` breaks loudly (the length assertion reddens), which is
   the guard behaving correctly, not collateral.
 - **Both degenerate implementations die to a NAMED test, which is the point of listing them.** A
-  *count-only* skip (dropping the compatibility term) is killed by the existing AC11 dm fixture — it
-  rewrites `chunk_config` to `"1000x64"` while keeping the real pushed shas, so the counts match and
-  a count-only skip would skip, reddening AC11's "pushes everything". A *compatibility-only* skip
-  (dropping the count term) is killed by the new tail test: cap-grew is compatible, so all 21 items
-  skip and no tail lands. Nobody may "simplify" the AC11 fixture without re-reading this.
+  *compatibility-only* skip (dropping the count term) is killed by the tail test: cap-grew is
+  compatible, so all 21 items skip and no tail lands. A *count-only* skip (dropping the compatibility
+  term) needed its own fixture — **AC11 does NOT kill it**, which I claimed and the code review
+  disproved: AC11 edits the body, so the sha term fails first and neither new term is ever consulted.
+  The killer is a dedicated case: unchanged body, real pushed shas kept (so counts match by
+  construction), `chunk_config` rewritten to a **different-chars** value ⇒ must full re-push.
 - **ANTI-FLOOD — the case that separates a correct build from a plausible one.** A body-unchanged,
   config-stale, **complete** item from a RETRACTABLE source (Slack) must be neither deleted nor
   re-pushed: the fake-graphiti spy log must be empty for it. A builder who implements the skip as

--- a/docs/design/graph-extraction-cap.md
+++ b/docs/design/graph-extraction-cap.md
@@ -145,7 +145,16 @@ skip  iff  chunkConfigDeltaCompatible(stored, current)
 
 That routes exactly the 21 owing items to the delta path (where `toPush` is their tail), keeps all
 2,190 complete items skipped, and is what makes the cost table's 179 episodes exact rather than
-aspirational.
+aspirational. Both terms are free: `episodes` and `chunkShas` are already computed at `:374`/`:398`,
+above the skip — no reordering, no added work on the hot path for the 2,190.
+
+**A `CHUNK_CHARS` change still floods, and that is correct.** Compatibility fails, so every item —
+complete or not — falls through to a full re-push, because every boundary genuinely moved. Today that
+flood requires a manual `content_sha256` clear and otherwise never happens at all; after this change
+it happens automatically on deploy. That is the right behaviour and a real cost (~$47 at today's
+corpus), so changing `CHUNK_CHARS` becomes a decision with a price tag attached rather than a
+constant edit whose effect arrives item-by-item over months. Worth stating loudly next to the
+constant.
 
 **The backfill at `:453` is gated on STRICT equality** (`stored === CHUNK_CONFIG`), not helper
 compatibility — under compatibility, an empty-ledger over-cap row would stamp current-config hashes

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -73,8 +73,9 @@ export const CHUNK_CHARS = resolvePositiveInt(process.env.GRAPH_CHUNK_CHARS, 250
  * "runaway-size backstop" its comment claimed: 21 items were over it and **689,235 characters — 8.6%
  * of the corpus — had never entered the graph**, concentrated in the densest documents we own
  * (`ARCHITECTURE.md` 11.8% present, a Chetan/John meeting transcript 54.5%). Sized from the measured
- * corpus: 40 completes 18 of the 21; three files stay capped and the projector now REPORTS that
- * rather than hiding it (`chunk_overflow_chars`).
+ * corpus: 40 completes 18 of the 21; three files (ARCHITECTURE.md at 136 chunks, model-migration at
+ * 48, brain-api at 46) stay capped and are STILL dropped silently — surfacing the refused character
+ * count is specced (docs/design/graph-extraction-cap.md §3) and deliberately NOT built here.
  *
  * ⚠️ CHANGING `CHUNK_CHARS` RE-EXTRACTS THE WHOLE CORPUS on the next tick, and it is billed. Every
  * chunk boundary moves, so every stored hash is stale and no item can take the delta path — ~$47 at

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -56,7 +56,25 @@ export function chunk<T>(items: readonly T[], size: number): T[][] {
  * (or garbage). `Math.floor` also closes the fractional hole (0.5 → 0). Pure + exported, unit-tested.
  */
 export const CHUNK_CHARS = resolvePositiveInt(process.env.GRAPH_CHUNK_CHARS, 2500);
-export const MAX_EPISODE_CHUNKS = resolvePositiveInt(process.env.GRAPH_MAX_EPISODE_CHUNKS, 16);
+/**
+ * How many chunks of `CHUNK_CHARS` an item may become — i.e. `CHUNK_CHARS * MAX_EPISODE_CHUNKS` is the
+ * hard ceiling on how much of ANY item ever reaches the graph. Everything past it is dropped by
+ * `chunkContent`, silently, forever.
+ *
+ * Raised 16 -> 40 (40,000 -> 100,000 chars) on 2026-08-05 (AIO-808). At 16 this had stopped being the
+ * "runaway-size backstop" its comment claimed: 21 items were over it and **689,235 characters — 8.6%
+ * of the corpus — had never entered the graph**, concentrated in the densest documents we own
+ * (`ARCHITECTURE.md` 11.8% present, a Chetan/John meeting transcript 54.5%). Sized from the measured
+ * corpus: 40 completes 18 of the 21; three files stay capped and the projector now REPORTS that
+ * rather than hiding it (`chunk_overflow_chars`).
+ *
+ * ⚠️ CHANGING `CHUNK_CHARS` RE-EXTRACTS THE WHOLE CORPUS on the next tick, and it is billed. Every
+ * chunk boundary moves, so every stored hash is stale and no item can take the delta path — ~$47 at
+ * the 2026-08 corpus. Raising THIS constant does not: boundaries are unchanged, so only the newly
+ * admitted tail chunks are pushed (179 episodes / ~$1.77 for the 16->40 move). The two knobs look
+ * alike and cost 27x differently; see docs/design/graph-extraction-cap.md.
+ */
+export const MAX_EPISODE_CHUNKS = resolvePositiveInt(process.env.GRAPH_MAX_EPISODE_CHUNKS, 40);
 /**
  * The chunk sizing the per-chunk ledger's hashes were produced under, recorded alongside them
  * (`graph_episodes.chunk_config`). `content_sha256` hashes the WHOLE body and is invariant to
@@ -65,6 +83,43 @@ export const MAX_EPISODE_CHUNKS = resolvePositiveInt(process.env.GRAPH_MAX_EPISO
  * ledger without this would report them as already extracted. A mismatch forces a full push.
  */
 export const CHUNK_CONFIG = `${CHUNK_CHARS}x${MAX_EPISODE_CHUNKS}`;
+
+/**
+ * Can the chunk hashes stored under `stored` still be TRUSTED to identify chunks of the same body
+ * under `current`? (AIO-808)
+ *
+ * Compatible iff `CHUNK_CHARS` is identical. Chunking is `body.slice(i, i + chars)` stepping by
+ * `chars`, so the cap only truncates the sequence: raising it leaves every earlier chunk
+ * byte-identical and merely appends. Changing `chars` moves every boundary and invalidates every
+ * stored hash.
+ *
+ *   same config            -> true    (today's normal path)
+ *   chars same, cap GREW   -> true    the point of this helper: stored hashes still match, so the
+ *                                     delta pushes exactly the newly-admitted tail
+ *   chars same, cap SHRANK -> false   chunks past the new cap become orphans in Graphiti that the
+ *                                     ledger would stop tracking; a full re-push is the honest answer
+ *   chars DIFFER           -> false   every boundary moved
+ *   malformed / "" / null  -> false   `""` is a real stored value; an unparseable config must never
+ *                                     read as "compatible"
+ *
+ * ⚠️ THIS ANSWERS ONLY "can I trust the stored hashes". It does NOT answer "does this item still owe
+ * chunks" — under a raised cap a body-identical item is compatible AND owes its tail, so the
+ * unchanged-content skip must AND this with a count comparison. Using this alone at the skip is the
+ * bug this feature shipped twice in review: the items it targets would all keep skipping.
+ */
+export function chunkConfigDeltaCompatible(stored: string | null | undefined, current: string): boolean {
+  const parse = (v: string | null | undefined): { chars: number; cap: number } | null => {
+    const m = /^(\d+)x(\d+)$/.exec((v ?? "").trim());
+    if (!m) return null;
+    const chars = Number(m[1]);
+    const cap = Number(m[2]);
+    return chars > 0 && cap > 0 ? { chars, cap } : null;
+  };
+  const a = parse(stored);
+  const b = parse(current);
+  if (!a || !b) return false;
+  return a.chars === b.chars && b.cap >= a.cap;
+}
 
 /**
  * How many episodes to scan when resolving an item's chunk names → uuids for a delete (tier-cleanup)
@@ -437,7 +492,28 @@ export async function projectItemsToGraph(
     // we're about to push and silently drop the item from the graph. Purge the stale ones first, then
     // this push is authoritative and the flag clears below.
     const purgeBeforeRepush = existingRow?.pending_delete_group_id === groupId;
-    if (existingRow && existingRow.content_sha256 === contentSha && !tierChanged && !purgeBeforeRepush) {
+    // CONFIG-AWARE SKIP (AIO-808). `content_sha256` hashes the whole body and is invariant to the
+    // chunk config, so on its own this skip strands every unchanged item on the config it was last
+    // pushed under — permanently, until its body happens to change. That is how 689,235 characters
+    // sat outside the graph while the ledger read healthy.
+    //
+    // TWO TERMS, because this site asks a DIFFERENT question from the delta predicate below. That one
+    // asks "can I trust the stored hashes" (a raised cap: yes). This one asks "could this item still
+    // OWE chunks" — and under a raised cap a body-identical item is compatible AND owes its tail. Using
+    // compatibility alone here keeps exactly the items this feature targets skipping, which is the bug
+    // review caught twice. `episodes.length` is used rather than a re-derived ceil(len/chars): a second
+    // derivation can drift from `chunkContent` (they disagree on a whitespace-only body) and the ledger
+    // must never describe something else. Both values are already in scope — no added work.
+    const owesChunks = episodes.length > (existingRow?.chunk_shas?.length ?? 0);
+    const chunkingUnchanged = chunkConfigDeltaCompatible(existingRow?.chunk_config, CHUNK_CONFIG);
+    if (
+      existingRow &&
+      existingRow.content_sha256 === contentSha &&
+      !tierChanged &&
+      !purgeBeforeRepush &&
+      chunkingUnchanged &&
+      !owesChunks
+    ) {
       // BACKFILL (GRAPHCOST-1): a row written before the per-chunk ledger existed knows the body is
       // unchanged but not which chunks that body is made of. Record them here — from the same
       // `toEpisodes` output the last push used, for a body proven identical by `content_sha256` — so
@@ -450,7 +526,17 @@ export async function projectItemsToGraph(
       // `''`, NOT by clearing `chunk_shas`: the sentinel misses the unchanged-skip above and fails the
       // delta predicate, forcing a real re-push. Emptying `chunk_shas` alone would route the row
       // straight through here and bless the new config's hashes for chunks never pushed under it.
-      if (chunkShas.length > 0 && (existingRow.chunk_shas?.length ?? 0) === 0) {
+      // STRICT equality, deliberately NOT `chunkConfigDeltaCompatible` (AIO-808): under compatibility a
+      // raised cap would let this bless current-config hashes for tail chunks never pushed — the exact
+      // hazard the comment above describes, surviving its own gate. A second line of defence that
+      // shares the first one's blind spot is not one. (The composite skip means such a row falls
+      // through to a sound full push anyway; measured 0 empty-ledger rows in prod on 2026-08-05, which
+      // is an observation about that instant, not an invariant.)
+      if (
+        chunkShas.length > 0 &&
+        (existingRow.chunk_shas?.length ?? 0) === 0 &&
+        existingRow.chunk_config === CHUNK_CONFIG
+      ) {
         await db.from("graph_episodes").upsert(
           {
             team_id: args.teamId,
@@ -564,7 +650,7 @@ export async function projectItemsToGraph(
       !tierChanged &&
       existingRow.pending_delete_group_id === null &&
       existingRow.content_sha256 !== "" &&
-      existingRow.chunk_config === CHUNK_CONFIG;
+      chunkConfigDeltaCompatible(existingRow.chunk_config, CHUNK_CONFIG);
     // NB: no `chunk_shas.length > 0` term. It would be unfalsifiable — an empty ledger yields an empty
     // `alreadyPushed`, so the diff below already degrades to a full push on its own. A predicate term
     // no test can redden is one the guard below would be asserting on trust.

--- a/lib/graph/project.ts
+++ b/lib/graph/project.ts
@@ -55,6 +55,14 @@ export function chunk<T>(items: readonly T[], size: number): T[][] {
  * 0/NaN chunk CAP makes it emit none — either way the projector "succeeds" feeding the graph nothing
  * (or garbage). `Math.floor` also closes the fractional hole (0.5 → 0). Pure + exported, unit-tested.
  */
+/**
+ * ⚠️ CHANGING THIS RE-EXTRACTS THE ENTIRE CORPUS on the next projector tick, and it is billed
+ * (~$47 at the 2026-08 corpus). Every chunk boundary is `slice(i, i + CHUNK_CHARS)`, so a different
+ * value moves all of them: every stored hash goes stale, no item can take the delta path, and each
+ * one full-re-pushes — including dragging retractable sources through their delete-then-repush shape.
+ * Raising MAX_EPISODE_CHUNKS below does NOT do this; the two knobs look alike and cost ~27x
+ * differently. See docs/design/graph-extraction-cap.md before touching either.
+ */
 export const CHUNK_CHARS = resolvePositiveInt(process.env.GRAPH_CHUNK_CHARS, 2500);
 /**
  * How many chunks of `CHUNK_CHARS` an item may become — i.e. `CHUNK_CHARS * MAX_EPISODE_CHUNKS` is the
@@ -514,42 +522,20 @@ export async function projectItemsToGraph(
       chunkingUnchanged &&
       !owesChunks
     ) {
-      // BACKFILL (GRAPHCOST-1): a row written before the per-chunk ledger existed knows the body is
-      // unchanged but not which chunks that body is made of. Record them here — from the same
-      // `toEpisodes` output the last push used, for a body proven identical by `content_sha256` — so
-      // the corpus converges as the projector walks it instead of re-extracting itself on deploy.
-      // No episodes are sent, so `projected_at` is deliberately NOT bumped (see the push path).
+      // NO BACKFILL HERE ANY MORE (AIO-808). GRAPHCOST-1 had a branch that, for a row with an empty
+      // chunk ledger and a matching body sha, recorded the CURRENT config's hashes without pushing —
+      // converging pre-ledger installs for free. Its own comment admitted the premise "an identical
+      // body means these are the chunks we pushed" holds "only while the chunk config is the one that
+      // produced them, which an empty ledger cannot attest", and prescribed invalidation on any config
+      // change. Raising MAX_EPISODE_CHUNKS IS that change, so the branch's era ended with it.
       //
-      // The premise — "an identical body means these are the chunks we pushed" — holds only while the
-      // chunk config is the one that produced them, which an empty ledger cannot attest. So a rollout
-      // that changes CHUNK_CHARS/MAX_EPISODE_CHUNKS must invalidate by clearing `content_sha256` to
-      // `''`, NOT by clearing `chunk_shas`: the sentinel misses the unchanged-skip above and fails the
-      // delta predicate, forcing a real re-push. Emptying `chunk_shas` alone would route the row
-      // straight through here and bless the new config's hashes for chunks never pushed under it.
-      // STRICT equality, deliberately NOT `chunkConfigDeltaCompatible` (AIO-808): under compatibility a
-      // raised cap would let this bless current-config hashes for tail chunks never pushed — the exact
-      // hazard the comment above describes, surviving its own gate. A second line of defence that
-      // shares the first one's blind spot is not one. (The composite skip means such a row falls
-      // through to a sound full push anyway; measured 0 empty-ledger rows in prod on 2026-08-05, which
-      // is an observation about that instant, not an invariant.)
-      if (
-        chunkShas.length > 0 &&
-        (existingRow.chunk_shas?.length ?? 0) === 0 &&
-        existingRow.chunk_config === CHUNK_CONFIG
-      ) {
-        await db.from("graph_episodes").upsert(
-          {
-            team_id: args.teamId,
-            source_table: SOURCE_TABLE,
-            source_id: item.id,
-            group_id: existingRow.group_id,
-            content_sha256: existingRow.content_sha256,
-            chunk_shas: chunkShas,
-            chunk_config: CHUNK_CONFIG,
-          },
-          { onConflict: "team_id,source_table,source_id" }
-        );
-      }
+      // It is deleted rather than left unreachable because for the one population it still served it
+      // produced this feature's own bug: a pre-ledger row OVER the old cap would have been blessed
+      // with 40 current-config hashes including tails that exist in the graph in no form at all —
+      // permanent silent loss, invisible to reconcile (whose landed-check is satisfied by chunk #0).
+      // Such a row now falls through to a full push, which is both correct and the first time its
+      // tails are extracted. Convergence for pre-ledger rows is therefore the full-push path, once.
+      // Pinned by the inverted AC4 in test/datamechanics/graph-chunk-delta.datamechanics.test.ts.
       skipped++;
       continue; // unchanged content, same tier → no-op (idempotent)
     }

--- a/test/datamechanics/graph-chunk-delta.datamechanics.test.ts
+++ b/test/datamechanics/graph-chunk-delta.datamechanics.test.ts
@@ -294,3 +294,78 @@ describe("per-chunk projection ledger (real Postgres, mocked Graphiti)", () => {
     expect(fake.pushedEpisodes).toHaveLength(3);
   });
 });
+
+/**
+ * AIO-808 — raising MAX_EPISODE_CHUNKS must deliver the newly-admitted TAIL to items whose bodies have
+ * not changed, and must NOT re-push anything else.
+ *
+ * The whole feature turns on a distinction the first two spec drafts got wrong: the unchanged-content
+ * skip and the delta predicate ask different questions. These two tests are what separate a correct
+ * build from a plausible one — the first fails a compatibility-only skip (all over-cap items keep
+ * skipping, no tail lands), and AC11 above fails a count-only skip (its fixture keeps real hashes while
+ * rewriting the config, so counts match and a count-only skip would skip). Do not "simplify" either.
+ */
+describe("chunk-cap raise (AIO-808)", () => {
+  it("an over-cap item whose body never changed receives ONLY its tail", async () => {
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const path = "github/repo/docs/huge.md";
+    const fm = { source: "github" };
+    // 20 chunks' worth of body against a ledger that was written under a 16-chunk cap.
+    const big = body(CHUNK_CHARS * 20, "h");
+
+    await ingest(seed, { kind: "deliverable", path, body: big, access: "team", frontmatter: fm });
+    const first = new FakeGraphiti();
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(first) });
+
+    // Rewrite the ledger to the pre-raise state: the first 16 chunks, recorded under "2500x16".
+    const row = await ledgerRow(seed.teamId);
+    const under16 = chunkContent(big, CHUNK_CHARS, 16);
+    await db()
+      .from("graph_episodes")
+      .update({ chunk_shas: under16.map(sha), chunk_config: `${CHUNK_CHARS}x16` })
+      .eq("team_id", seed.teamId)
+      .eq("source_id", row!.source_id);
+
+    // Same body, byte for byte — only the cap has moved.
+    const fake = new FakeGraphiti();
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    const pushed = fake.pushes.flatMap((p) => p.episodes);
+    const expectedTail = chunkContent(big, CHUNK_CHARS, MAX_EPISODE_CHUNKS).length - 16;
+    expect(expectedTail, "fixture must actually straddle the old cap").toBeGreaterThan(0);
+    expect(pushed.length, "exactly the tail, nothing re-pushed").toBe(expectedTail);
+    // And the ledger converges to the current config with the full set recorded.
+    const after = await ledgerRow(seed.teamId);
+    expect(after?.chunk_config).toBe(`${CHUNK_CHARS}x${MAX_EPISODE_CHUNKS}`);
+    expect(after?.chunk_shas?.length).toBe(16 + expectedTail);
+  });
+
+  it("ANTI-FLOOD — a COMPLETE item with a stale config is neither deleted nor re-pushed", async () => {
+    // The degenerate build this kills: a skip written as bare `stored !== CHUNK_CONFIG` sends the whole
+    // corpus through the push path. For a RETRACTABLE source the retract-delete branch fires before the
+    // delta predicate, so every Slack item would get deleteItemEpisodes + a full re-push — unbudgeted,
+    // and invisible to every other assertion in this file.
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const path = "slack/c123/1782124487.144019.md";
+    const fm = { source: "slack" }; // retainSupersededBodies: false — the flood-sensitive path
+    const small = body(CHUNK_CHARS * 2, "s"); // 2 chunks: complete under both 16 and 40
+
+    await ingest(seed, { kind: "transcript", path, body: small, access: "team", frontmatter: fm });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(new FakeGraphiti()) });
+
+    const row = await ledgerRow(seed.teamId);
+    await db()
+      .from("graph_episodes")
+      .update({ chunk_config: `${CHUNK_CHARS}x16` }) // stale cap, but the item owes nothing
+      .eq("team_id", seed.teamId)
+      .eq("source_id", row!.source_id);
+
+    const fake = new FakeGraphiti();
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    expect(fake.pushes.flatMap((p) => p.episodes), "a complete item owes nothing").toEqual([]);
+    expect(fake.listCalls, "and must not be dragged through the retract-delete path").toEqual([]);
+  });
+});

--- a/test/datamechanics/graph-chunk-delta.datamechanics.test.ts
+++ b/test/datamechanics/graph-chunk-delta.datamechanics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
-import { projectItemsToGraph, CHUNK_CHARS, MAX_EPISODE_CHUNKS, chunkContent } from "@/lib/graph/project";
+import { projectItemsToGraph, CHUNK_CHARS, MAX_EPISODE_CHUNKS, CHUNK_CONFIG, chunkContent } from "@/lib/graph/project";
 import { db, ingest, seedTeam } from "./helpers";
 import { FakeGraphiti, client } from "./fake-graphiti";
 
@@ -136,7 +136,7 @@ describe("per-chunk projection ledger (real Postgres, mocked Graphiti)", () => {
     await expectLedgerContained(seed.teamId, bothPasses);
   });
 
-  it("AC4 — a pre-feature ledger row is backfilled by one pass that pushes nothing", async () => {
+  it("AC4 — a pre-feature ledger row converges by ONE FULL RE-PUSH (AIO-808 inverted the contract)", async () => {
     const seed = await seedTeam();
     const slug = await teamSlugFor(seed.teamId);
     const text = body(CHUNK_CHARS * 2);
@@ -158,11 +158,23 @@ describe("per-chunk projection ledger (real Postgres, mocked Graphiti)", () => {
     const second = new FakeGraphiti();
     await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(second) });
 
-    expect(second.pushedEpisodes).toHaveLength(0); // no re-extraction event on deploy
+    // INVERTED BY AIO-808. This used to assert a free backfill: record the current config's hashes
+    // without pushing. That branch is deleted, because its premise — "an identical body means these
+    // are the chunks we pushed" — was only ever valid inside one config era (its own comment said so),
+    // and raising MAX_EPISODE_CHUNKS ended that era. Worse, for a pre-ledger row OVER the old cap it
+    // would have blessed tail hashes for chunks present in the graph in no form at all — silent,
+    // permanent loss that reconcile cannot see.
+    //
+    // The contract now: an unattestable config converges via ONE full re-push. That is the
+    // self-hosted upgrade path from pre-GRAPHCOST-1, and this test is what stops someone
+    // "restoring" the backfill later without confronting the hazard above.
+    const expected = chunkContent(text).length;
+    expect(expected, "fixture must actually have chunks to push").toBeGreaterThan(0);
+    expect(second.pushedEpisodes, "an unattestable config re-pushes, it does not bless").toHaveLength(expected);
     const after = await ledgerRow(seed.teamId);
     expect(after?.chunk_shas).toEqual(chunkContent(text).map(sha));
-    expect(after?.projected_at).toBe(before?.projected_at); // AC9 again: nothing was pushed
-    await expectLedgerContained(seed.teamId, first); // the hashes it recorded were pushed by pass 1
+    expect(after?.chunk_config).toBe(CHUNK_CONFIG); // and converges to the current era
+    expect(after?.projected_at, "a real push bumps the stamp").not.toBe(before?.projected_at);
   });
 
   it("AC5 — a tier change pushes every chunk into the new group, ledger notwithstanding", async () => {

--- a/test/datamechanics/graph-chunk-delta.datamechanics.test.ts
+++ b/test/datamechanics/graph-chunk-delta.datamechanics.test.ts
@@ -373,21 +373,28 @@ describe("chunk-cap raise (AIO-808)", () => {
     await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(new FakeGraphiti()) });
 
     const row = await ledgerRow(seed.teamId);
-    const storedShas = row!.chunk_shas!;
     await db()
       .from("graph_episodes")
       .update({ chunk_config: `${CHUNK_CHARS * 2}x${MAX_EPISODE_CHUNKS}` }) // different CHARS, same cap
       .eq("team_id", seed.teamId)
       .eq("source_id", row!.source_id);
 
-    // Body untouched: the sha term still holds, so this reaches the two new terms — unlike AC11.
+    // Assert the state the CODE WILL READ, re-fetched after the mutation — not a capture taken before
+    // it. A stale capture would still read "counts match" if someone later added `chunk_shas` to that
+    // update, silently converting this into an owes-driven test that no longer catches its own mutant
+    // while every assertion stayed green.
+    const staged = await ledgerRow(seed.teamId);
+    expect(staged?.chunk_shas?.length, "counts must MATCH, or this tests the count term instead").toBe(
+      chunkContent(text).length
+    );
+    expect(staged?.content_sha256, "body must be untouched, or the sha term short-circuits like AC11").toBe(
+      sha(text)
+    );
+
     const fake = new FakeGraphiti();
     await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
 
     const pushed = fake.pushes.flatMap((p) => p.episodes);
-    expect(storedShas.length, "counts must MATCH, or this tests the count term instead").toBe(
-      chunkContent(text).length
-    );
     expect(pushed.length, "untrustworthy boundaries ⇒ full re-push, not a skip").toBe(chunkContent(text).length);
   });
 

--- a/test/datamechanics/graph-chunk-delta.datamechanics.test.ts
+++ b/test/datamechanics/graph-chunk-delta.datamechanics.test.ts
@@ -313,9 +313,10 @@ describe("per-chunk projection ledger (real Postgres, mocked Graphiti)", () => {
  *
  * The whole feature turns on a distinction the first two spec drafts got wrong: the unchanged-content
  * skip and the delta predicate ask different questions. These two tests are what separate a correct
- * build from a plausible one — the first fails a compatibility-only skip (all over-cap items keep
- * skipping, no tail lands), and AC11 above fails a count-only skip (its fixture keeps real hashes while
- * rewriting the config, so counts match and a count-only skip would skip). Do not "simplify" either.
+ * build from a plausible one. The tail test fails a compatibility-only skip (all over-cap items keep
+ * skipping, no tail lands). The count-only mutant needs its OWN case — AC11 does not catch it, though
+ * this comment used to claim so: AC11 edits the body, so the sha term fails before either new term is
+ * consulted. Hence the third test below. Do not "simplify" any of them.
  */
 describe("chunk-cap raise (AIO-808)", () => {
   it("an over-cap item whose body never changed receives ONLY its tail", async () => {
@@ -347,10 +348,47 @@ describe("chunk-cap raise (AIO-808)", () => {
     const expectedTail = chunkContent(big, CHUNK_CHARS, MAX_EPISODE_CHUNKS).length - 16;
     expect(expectedTail, "fixture must actually straddle the old cap").toBeGreaterThan(0);
     expect(pushed.length, "exactly the tail, nothing re-pushed").toBe(expectedTail);
+    // Identity, not just arity: a build that pushed chunks 0..3 instead of 16..19 would satisfy a
+    // count-only assertion while putting the wrong content in the graph.
+    expect(pushed.map((e) => e.content)).toEqual(chunkContent(big).slice(16));
     // And the ledger converges to the current config with the full set recorded.
     const after = await ledgerRow(seed.teamId);
     expect(after?.chunk_config).toBe(`${CHUNK_CHARS}x${MAX_EPISODE_CHUNKS}`);
     expect(after?.chunk_shas?.length).toBe(16 + expectedTail);
+  });
+
+  it("a stale config with MATCHING counts still re-pushes — the count-only mutant's killer", async () => {
+    // Kills a skip that drops the compatibility term and keeps only `owesChunks`. The fixture makes
+    // the counts EQUAL by construction (the real pushed shas are left in place) while the stored
+    // config claims different CHUNK_CHARS — so boundaries moved, every stored hash is stale, and the
+    // only correct answer is a full re-push. A count-only skip sees "owes nothing" and skips,
+    // stranding the item on boundaries that no longer exist.
+    const seed = await seedTeam();
+    const slug = await teamSlugFor(seed.teamId);
+    const path = "github/repo/docs/count-match.md";
+    const fm = { source: "github" };
+    const text = body(CHUNK_CHARS * 3, "m");
+
+    await ingest(seed, { kind: "deliverable", path, body: text, access: "team", frontmatter: fm });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(new FakeGraphiti()) });
+
+    const row = await ledgerRow(seed.teamId);
+    const storedShas = row!.chunk_shas!;
+    await db()
+      .from("graph_episodes")
+      .update({ chunk_config: `${CHUNK_CHARS * 2}x${MAX_EPISODE_CHUNKS}` }) // different CHARS, same cap
+      .eq("team_id", seed.teamId)
+      .eq("source_id", row!.source_id);
+
+    // Body untouched: the sha term still holds, so this reaches the two new terms — unlike AC11.
+    const fake = new FakeGraphiti();
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    const pushed = fake.pushes.flatMap((p) => p.episodes);
+    expect(storedShas.length, "counts must MATCH, or this tests the count term instead").toBe(
+      chunkContent(text).length
+    );
+    expect(pushed.length, "untrustworthy boundaries ⇒ full re-push, not a skip").toBe(chunkContent(text).length);
   });
 
   it("ANTI-FLOOD — a COMPLETE item with a stale config is neither deleted nor re-pushed", async () => {

--- a/test/datamechanics/graph-project.datamechanics.test.ts
+++ b/test/datamechanics/graph-project.datamechanics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GraphEpisode } from "@/lib/graph/graphiti-client";
-import { projectSlackToGraph, projectItemsToGraph, deleteItemEpisodes, CHUNK_CHARS, MAX_EPISODE_CHUNKS, GROUP_SCAN_DEPTH } from "@/lib/graph/project";
+import { projectSlackToGraph, projectItemsToGraph, deleteItemEpisodes, CHUNK_CHARS, MAX_EPISODE_CHUNKS, GROUP_SCAN_DEPTH, chunkContent } from "@/lib/graph/project";
 import { runGraphProjection } from "@/lib/graph/run";
 import {
   reconcileProjectedEpisodes,
@@ -112,7 +112,11 @@ describe("projectItemsToGraph — all ingestions (real Postgres, mocked Graphiti
   it("chunks an oversized item into ≤ MAX_EPISODE_CHUNKS small episodes so extraction can't overflow", async () => {
     const seed = await seedTeam();
     const slug = await teamSlugFor(seed.teamId);
-    const huge = "x ".repeat(40_000); // ~80k chars, far beyond one chunk
+    // DERIVED from the cap, not a literal (AIO-808 raised MAX_EPISODE_CHUNKS 16 -> 40 and this test's
+    // 80k literal stopped straddling it — 32 chunks, uncapped, so the assertion below silently changed
+    // meaning from "the cap binds" to "the body happened to be this long"). The fixture must exceed
+    // the cap for the claim to be about capping at all.
+    const huge = "x ".repeat(Math.ceil((CHUNK_CHARS * (MAX_EPISODE_CHUNKS + 4)) / 2));
     await ingest(seed, { kind: "deliverable", path: "notion/huge.md", body: huge, access: "team" });
 
     const fake = new FakeGraphiti();
@@ -120,6 +124,9 @@ describe("projectItemsToGraph — all ingestions (real Postgres, mocked Graphiti
 
     expect(fake.pushes).toHaveLength(1); // one addEpisodes call for the item…
     const eps = fake.pushes[0].episodes;
+    // The body is long enough to want MORE chunks than the cap allows, so this asserts the CAP, not
+    // the body length — which is the whole point of the test.
+    expect(chunkContent(huge, CHUNK_CHARS, Number.MAX_SAFE_INTEGER).length).toBeGreaterThan(MAX_EPISODE_CHUNKS);
     expect(eps.length).toBe(MAX_EPISODE_CHUNKS); // …carrying several chunk episodes, capped
     for (const e of eps) expect(e.content.length).toBeLessThanOrEqual(CHUNK_CHARS); // each fits the extractor
     // Multi-chunk items get the `#k` suffix; each chunk still resolves back to the one item.

--- a/test/guards/graph-delta-predicate.test.ts
+++ b/test/guards/graph-delta-predicate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { chunkConfigDeltaCompatible } from "@/lib/graph/project";
 
 /**
  * GRAPHCOST-1 — the delta path's entry predicate is conjunctive, and every term is load-bearing.
@@ -22,7 +23,7 @@ describe("graph delta predicate — every term present", () => {
   const src = readFileSync(join(process.cwd(), "lib/graph/project.ts"), "utf8");
   const predicate = src.slice(
     src.indexOf("const deltaEligible ="),
-    src.indexOf(";", src.indexOf("existingRow.chunk_config === CHUNK_CONFIG"))
+    src.indexOf(";", src.indexOf("chunkConfigDeltaCompatible(existingRow.chunk_config, CHUNK_CONFIG)"))
   );
 
   it("reads the predicate it is guarding (fails loudly if the shape moved)", () => {
@@ -36,7 +37,10 @@ describe("graph delta predicate — every term present", () => {
     ["same group (AC5)", "!tierChanged"],
     ["no cleanup outstanding on any group (AC7)", "pending_delete_group_id === null"],
     ["live projection, not a reconcile sentinel (AC10)", 'content_sha256 !== ""'],
-    ["same chunk config (AC11)", "chunk_config === CHUNK_CONFIG"],
+    // AIO-808: the literal equality became a helper call, because a RAISED cap leaves stored hashes
+    // valid. The term is still one conjunct — the `||` lives inside the helper, so the no-`||`
+    // assertion below survives rather than being weakened to accommodate the change.
+    ["trustworthy chunk config (AC11)", "chunkConfigDeltaCompatible(existingRow.chunk_config, CHUNK_CONFIG)"],
   ];
 
   for (const [name, term] of terms) {
@@ -48,5 +52,42 @@ describe("graph delta predicate — every term present", () => {
   it("is a conjunction — one `&&` per term boundary, no `||` smuggled in", () => {
     expect(predicate).not.toContain("||");
     expect(predicate.split("&&").length - 1).toBeGreaterThanOrEqual(terms.length - 1);
+  });
+});
+
+/**
+ * The helper the predicate now delegates to (AIO-808). Its whole job is one asymmetry: a raised CAP
+ * leaves every earlier chunk byte-identical (chunking is `slice(i, i+chars)` stepping by `chars`, so
+ * the cap only truncates the sequence), while a changed CHARS moves every boundary. Getting that
+ * backwards costs either 689,235 characters that never enter the graph, or a $47 full re-extraction.
+ */
+describe("chunkConfigDeltaCompatible — can the stored hashes still be trusted?", () => {
+  it("same config — today's normal path", () => {
+    expect(chunkConfigDeltaCompatible("2500x40", "2500x40")).toBe(true);
+  });
+
+  it("cap GREW — trustworthy, and this is the case worth the whole feature", () => {
+    // The stored 16 hashes still identify chunks 0..15 exactly; only the tail is new.
+    expect(chunkConfigDeltaCompatible("2500x16", "2500x40")).toBe(true);
+  });
+
+  it("cap SHRANK — NOT trustworthy: chunks past the new cap become untracked orphans", () => {
+    expect(chunkConfigDeltaCompatible("2500x40", "2500x16")).toBe(false);
+  });
+
+  it("CHARS differ — not trustworthy, whichever direction, because every boundary moved", () => {
+    expect(chunkConfigDeltaCompatible("1000x64", "2500x40")).toBe(false);
+    expect(chunkConfigDeltaCompatible("2500x40", "1000x64")).toBe(false);
+    // Same cap, different chars: the cap comparison alone would wrongly pass this.
+    expect(chunkConfigDeltaCompatible("1000x40", "2500x40")).toBe(false);
+  });
+
+  it("malformed, empty or absent — NEVER 'compatible'", () => {
+    // `""` is a real stored value (a dm fixture writes exactly that), and a row can predate the
+    // column. An unparseable config must read as "I cannot vouch for these hashes".
+    for (const junk of ["", "  ", null, undefined, "2500", "x40", "2500x", "abcxdef", "0x40", "2500x0", "2500x40x2"]) {
+      expect(chunkConfigDeltaCompatible(junk, "2500x40"), `stored=${JSON.stringify(junk)}`).toBe(false);
+    }
+    expect(chunkConfigDeltaCompatible("2500x40", "")).toBe(false);
   });
 });

--- a/test/guards/graph-delta-predicate.test.ts
+++ b/test/guards/graph-delta-predicate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { chunkConfigDeltaCompatible } from "@/lib/graph/project";
+import { chunkConfigDeltaCompatible, chunkContent } from "@/lib/graph/project";
 
 /**
  * GRAPHCOST-1 — the delta path's entry predicate is conjunctive, and every term is load-bearing.
@@ -80,6 +80,20 @@ describe("chunkConfigDeltaCompatible — can the stored hashes still be trusted?
     expect(chunkConfigDeltaCompatible("2500x40", "1000x64")).toBe(false);
     // Same cap, different chars: the cap comparison alone would wrongly pass this.
     expect(chunkConfigDeltaCompatible("1000x40", "2500x40")).toBe(false);
+  });
+
+  it("the ASSUMPTION the helper rests on: a raised cap APPENDS, it never rewrites", () => {
+    // If this were ever false, `cap grew ⇒ trustworthy` would be silent graph corruption rather than a
+    // saving — the stored hashes would identify chunks whose content had moved. Asserted directly
+    // rather than trusted, because the whole feature is downstream of it.
+    const text = Array.from({ length: 2500 * 20 }, (_, i) => String.fromCharCode(97 + (i % 26))).join("");
+    const small = chunkContent(text, 2500, 16);
+    const large = chunkContent(text, 2500, 40);
+    expect(small).toHaveLength(16);
+    expect(large.length).toBeGreaterThan(16);
+    expect(large.slice(0, 16), "the first 16 chunks must be byte-identical").toEqual(small);
+    // …and a CHARS change does move them, which is why that case is incompatible.
+    expect(chunkContent(text, 1250, 16)[0]).not.toEqual(small[0]);
   });
 
   it("malformed, empty or absent — NEVER 'compatible'", () => {


### PR DESCRIPTION
## The graph has been dropping the back half of our densest documents

`chunkContent` discards everything past `CHUNK_CHARS × MAX_EPISODE_CHUNKS` — 40,000 characters — silently, as a "runaway-size backstop". Measured against the live ledger:

**689,235 characters (8.6% of the corpus) had never entered the graph**, concentrated in exactly the documents worth the most per byte:

| document | in the graph |
|---|---|
| `docs/ARCHITECTURE.md` (338KB) | **11.8%** |
| `docs/brain-api.md` | 35.4% |
| `2-work/transcripts/2026-07-03-john-chetan-aios.md` | **54.5%** |

The brain has been answering "what does the architecture say" from the first 12% of the architecture document, and nothing said so — the item is complete in `items`/FTS/pgvector, so search and citation look fine while the *graph's* picture is truncated.

## The change turns on one distinction

Raising the cap changes `CHUNK_CONFIG`, and the ledger treats any config change as "every stored hash is stale" — a full corpus re-extraction. But chunking is `slice(i, i + chars)` stepping by `chars`: raising only the **cap** leaves earlier chunks byte-identical and merely *appends*. `chunkConfigDeltaCompatible` encodes exactly that, and it is asserted directly rather than trusted.

**Three call sites use it differently, deliberately** — the failure this shipped twice in plan review was treating them as one question:

| site | question | cap-grew |
|---|---|---|
| delta predicate | can I trust the stored hashes? | **yes** |
| unchanged-content skip | could this item still OWE chunks? | **depends on length** — so it ANDs in a count |
| backfill | *(deleted — see below)* | |

Result: **179 episodes ≈ $1.77**, not $47.03, and not the $0-and-no-tails a naive cap raise would have produced.

## The backfill branch is deleted, not gated

Its own comment set the expiry: the premise holds "only while the chunk config is the one that produced them, which an empty ledger cannot attest". This change *is* that config change. For the one population it still served it produced this feature's own bug — a pre-ledger row over the old cap would have been blessed with tail hashes for chunks present in the graph in no form, permanently and invisibly to reconcile. `AC4` is **inverted**, not removed: a pre-feature row now converges via one full re-push, which is the self-hosted upgrade path.

## Review — Reviewed by Fable code-reviewer (subagent) — verdict CLEAR after fixes
Three plan-review rounds before a line was written, each catching a distinct real defect: a mechanism that delivered zero tails, a fix that re-shipped the same bug in different words, and a one-helper claim that was structurally false. Code review then BLOCKED on two false attestations of my own — a comment claiming an overflow counter that doesn't exist, and a guard claim (`AC11 kills the count-only skip`) that was vacuous because AC11 edits the body and short-circuits on the sha term. Both fixed; the delta re-review found a fourth: a spec edit I reported as done had silently no-op'd.

**Deferred, tracked, and explicitly not claimed anywhere in the code:** spec §3 (reporting the refused character count) → **AIO-811**. The three files still over the cap at 40 are *still* dropped silently, and this PR says so rather than implying otherwise.

## Test plan
- [x] Both skip terms **mutation-proven to redden exactly their own test** — dropping compatibility reddens the count-only killer; dropping the count reddens the tail test
- [x] Tail test pins content **identity**, not just arity; the append-only assumption has its own unit test
- [x] ANTI-FLOOD: a complete stale-config Slack item is neither deleted nor re-pushed (the degenerate `stored !== CHUNK_CONFIG` build passes every other guard while dragging retractable sources through delete-then-repush)
- [x] Unit **1,936** · real-Postgres **860** · tsc · lint (2 pre-existing) · docs-drift — green

AIOS-Work: CHUNKCAP-1