### PR TITLE
docs(railway): define Graphiti and Neo4j template stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,25 +294,26 @@ on green output.
 
 > **Railway users don't need to read §2.1–§2.4.** Start at the
 > [official one-click template](https://aiosbrain.dev/deploy/team-brain/). An active Railway plan is
-> required. The template creates the app and Postgres, generates the application secrets, asks for
-> only the team and first-admin details, applies the schema, and bootstraps the login.
+> required. The template creates Team Brain, Postgres, Graphiti, and Neo4j, generates the
+> application and graph secrets, asks only for the team and first-admin details, applies the schema,
+> and bootstraps the login.
 >
 > Read on only for a non-Railway host, local development, or debugging a failed deployment.
 
 ### 2.1 — Create the services
 
-On Railway, use the [official template](https://aiosbrain.dev/deploy/team-brain/); it deploys from
-the official repository and adds Postgres without a fork, local CLI, or `--resume` step.
+On Railway, use the [official template](https://aiosbrain.dev/deploy/team-brain/); it deploys the
+four-service stack from the official repository without a fork, local CLI, or `--resume` step.
 
 On another host, deploy this repository as one web service and attach one Postgres 16 database.
 
-Add the graph services (§2.8) later, only if you want narrative arcs.
+For another host, add the graph services (§2.8) when you want narrative arcs.
 
 ### 2.2 — Set the environment variables
 
 The Railway template owns the database reference, generated secrets, and public-domain reference.
-You enter `TEAM_NAME`, `TEAM_SLUG`, `ADMIN_NAME`, `ADMIN_EMAIL`, and `ADMIN_PASSWORD` in Railway's
-reviewed form.
+You enter `TEAM_NAME`, `TEAM_SLUG`, `ADMIN_NAME`, `ADMIN_EMAIL`, and an `ADMIN_PASSWORD` of at
+least 10 characters in Railway's reviewed form.
 
 For a manual non-template deployment, set at minimum:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,10 +15,12 @@ portable: plain SQL migrations, Postgres-backed rate limiting, no Vercel-only de
 ## First-install deployment flow
 
 The canonical hosted-install entry point is `https://aiosbrain.dev/deploy/team-brain/`. It resolves
-to the official Railway template described in [`RAILWAY-TEMPLATE.md`](RAILWAY-TEMPLATE.md): one app
-service from this public repository plus one Postgres service. Railway reference variables wire the
-database and public domain; template secret functions generate `AUTH_SECRET` and `SECRETS_KEY`; the
-operator supplies team and first-admin identity in Railway's form.
+to the official Railway template described in [`RAILWAY-TEMPLATE.md`](RAILWAY-TEMPLATE.md): Team
+Brain, Postgres, Graphiti, and Neo4j. Railway reference variables keep Graphiti and Neo4j on the
+private network, wire the graph LLM proxy, and share the generated Neo4j credentials; template
+secret functions generate `AUTH_SECRET`, `SECRETS_KEY`, and `GRAPH_LLM_PROXY_SECRET`. The operator
+supplies team and first-admin identity in Railway's form, including an `ADMIN_PASSWORD` of at least
+10 characters.
 
 On first start, `railway.json` runs the idempotent schema loader before release. The opt-in Railway
 startup wrapper then runs the shared bootstrap to ensure the real team and first admin from

--- a/docs/RAILWAY-TEMPLATE.md
+++ b/docs/RAILWAY-TEMPLATE.md
@@ -16,6 +16,9 @@ that will own the deployment.
 - `aios-team-brain` — source `https://github.com/aiosbrain/aios-team-brain` on `main`, public HTTP
   networking enabled. Repository `railway.json` runs `npm run pg:schema` before release.
 - `Postgres` — Railway Postgres template. The app references `${{Postgres.DATABASE_URL}}`.
+- `neo4j` — `neo4j:5.26.2`, internal-only, with a persistent `/data` volume.
+- `graphiti` — source `https://github.com/aiosbrain/aios-team-brain` with root directory `graphiti/`,
+  internal-only on port 8000. It uses the repository's patched Dockerfile and no custom start command.
 
 ## App variables
 
@@ -25,17 +28,28 @@ that will own the deployment.
 | `PGSSL` | fixed to `require` |
 | `APP_URL` | `https://${{RAILWAY_PUBLIC_DOMAIN}}` |
 | `AUTH_SECRET` | generated with `${{ secret(64, "0123456789abcdef") }}` |
+| `GRAPH_LLM_PROXY_SECRET` | generated secret shared with Graphiti; authenticates its calls to Team Brain's internal LLM proxy |
+| `GRAPHITI_URL` | `http://${{graphiti.RAILWAY_PRIVATE_DOMAIN}}:8000` |
+| `NEO4J_URL` | `bolt://${{neo4j.RAILWAY_PRIVATE_DOMAIN}}:7687` |
+| `NEO4J_USER` | fixed to `neo4j` |
+| `NEO4J_PASSWORD` | generated secret shared with Neo4j and Graphiti |
+| `GRAPH_PROJECT_ENABLED` | fixed to `true` |
 | `SECRETS_KEY` | `${{ secret(43, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_") }}` (32 bytes when base64url-decoded) |
 | `TEAM_NAME` | required user input |
 | `TEAM_SLUG` | required user input; lowercase letters, digits, hyphens |
 | `ADMIN_NAME` | required user input |
 | `ADMIN_EMAIL` | required user input |
-| `ADMIN_PASSWORD` | required user input; never printed by bootstrap |
+| `ADMIN_PASSWORD` | required user input, minimum 10 characters; never printed by bootstrap |
 | `SEED_DEMO` | fixed to `false` |
 | `AIOS_TEMPLATE_BOOTSTRAP` | fixed to `true`; provisions the team and admin before the app starts |
 
-Optional model and mail-provider keys are configured after deployment in Admin. They are not part of
-the first-deploy form and are never encoded in a deploy URL.
+Graphiti reaches Neo4j at `bolt://${{neo4j.RAILWAY_PRIVATE_DOMAIN}}:7687` and reaches Team Brain's
+internal OpenAI-compatible proxy at
+`http://${{aios-team-brain.RAILWAY_PRIVATE_DOMAIN}}/api/internal/llm/v1`, authenticating with
+`${{aios-team-brain.GRAPH_LLM_PROXY_SECRET}}`. This keeps the provider key and extraction-model
+choice in Team Brain Admin rather than requiring Graphiti to hold a second provider key. Optional
+model and mail-provider keys are configured after deployment in Admin and are never encoded in a
+deploy URL.
 
 ## Maintenance and verification
 


### PR DESCRIPTION
## Summary
- document the four-service Railway Team Brain template: Team Brain, Postgres, Graphiti, and Neo4j
- document private graph wiring and the internal LLM proxy secret
- state the 10-character minimum for the first admin password

## Validation
- `npm test -- --run test/setup-wizard.test.ts lib/auth/password.test.ts`
- `npm run check:docs`

External model-review lane returned no content; requesting review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to deployment guides; no application or infrastructure code is modified in this PR.
> 
> **Overview**
> **Railway onboarding docs** no longer describe a two-service (app + Postgres) template. They now state that the [official one-click template](https://aiosbrain.dev/deploy/team-brain/) provisions **four services**—Team Brain, Postgres, **Graphiti**, and **Neo4j**—and that graph-related secrets are generated at deploy time.
> 
> **`docs/RAILWAY-TEMPLATE.md`** is expanded with concrete service definitions (`neo4j:5.26.2` with persistent `/data`, Graphiti from `graphiti/` on port 8000), new app env vars (`GRAPH_LLM_PROXY_SECRET`, `GRAPHITI_URL`, `NEO4J_*`, `GRAPH_PROJECT_ENABLED=true`), and a wiring section: Graphiti talks to Neo4j on the private network and to Team Brain’s **internal OpenAI-compatible LLM proxy** (so extraction keys/models stay in Admin rather than on Graphiti). **`ADMIN_PASSWORD`** is documented as **minimum 10 characters**.
> 
> **`README.md`** and **`docs/ARCHITECTURE.md`** are aligned with that story (template blurb, §2.1 four-service stack, form requirements). For non-Railway hosts, graph is still optional and pointed at §2.8 rather than “add later only on Railway.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a4e77b5ccaadef65e1d576691c6162d4eb19606. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->