### PR TITLE
feat(costs): the measurement harness for graph-ingestion efficiency (AIO-820)

### DIFF
--- a/docs/design/graph-ingestion-efficiency.md
+++ b/docs/design/graph-ingestion-efficiency.md
@@ -219,8 +219,18 @@ Before any lever, a repeatable way to price a change against a **real payload**,
 workstream is exactly where stacked estimates go wrong:
 
 `scripts/graph-ingest-cost.mjs <since> <until>` reports **input tokens per episode**, calls per
-episode, and $/episode — derived from `llm_usage` **alone**, with `extract_nodes` (one per episode) as
-the denominator. No `graph_episodes ⋈ items` join, because that join is what made my first baseline
+episode, and $/episode — derived from `llm_usage` **alone**, with `extract_nodes` as the denominator.
+
+**What that denominator counts is attempts, not episodes**, and the distinction matters for lever 2.
+graphiti_core 0.29.3 has no reflexion loop and fires `extract_nodes` once per extraction attempt —
+but two retry layers (a MAX_RETRIES=2 pydantic-validation loop, and tenacity on
+EmptyResponse/JSONDecode) add *metered* attempts for the same episode. Rate-limited attempts carry no
+usage and never distort. So **the cross-check's SIGNED gap is the retry-rate instrument**: positive
+means retries, negative means a push the window did not bill.
+
+**Lever 2's before/after must compare the signed gap as well as the ratio.** Cutting the context
+changes prompt shape, which can change the validation-retry rate — so a token "saving" could partly
+be a retry-rate shift in either direction. Reading only the ratio would credit the lever for it. No `graph_episodes ⋈ items` join, because that join is what made my first baseline
 wrong: extraction is async, so a billing window and a projection window cover different episodes, and
 the ledger's `chunk_shas` is last-state while `projected_at` is overwritten by later pushes.
 

--- a/docs/design/graph-ingestion-efficiency.md
+++ b/docs/design/graph-ingestion-efficiency.md
@@ -1,51 +1,86 @@
-# Graph ingestion bills 40× the source text
+# Graph ingestion bills ~60× the source text
 
-**Status:** draft, for plan review · **Date:** 2026-08-06 · **Owner:** Chetan
+**Status:** revised after plan review — 1 blocker (my patch target was a no-op) + a corrected baseline
+· **Date:** 2026-08-06 · **Owner:** Chetan
 · **Task:** `PIPEFF-1` → [AIO-820](https://linear.app/je4light/issue/AIO-820)
 
-## The measurement
+## What plan review corrected, first
 
-One real batch — John's 2026-08-05 06:50 UTC workspace push, 34 items (8 Granola transcripts, 22
-work docs, 4 others), 378,129 characters of source text ≈ **94,500 tokens of content**:
+### 1. The constant I proposed patching is not the one in the path (BLOCKER)
 
+I named `EPISODE_WINDOW_LEN = 3` as the repeated-context knob. **The deployed `add_episode` path
+does not use it.** Verified against graphiti_core 0.29.3, the exact pin in `graphiti/Dockerfile`:
+
+```python
+# graphiti_core/graphiti.py:1087-1090
+previous_episodes = (
+    await self.retrieve_episodes(
+        last_n=RELEVANT_SCHEMA_LIMIT,      # ← 10, not EPISODE_WINDOW_LEN's 3
 ```
-LLM calls                912
-input tokens billed  3,827,266
-cost                     $1.40
-```
 
-**10.1 input tokens billed per source character. ~40× the content.**
+`EPISODE_WINDOW_LEN` reaches only `bulk_utils.py`, which the server never calls. So the sed I
+proposed would have built green, passed a grep gate, and **changed nothing** — the silent-no-op class
+this Dockerfile's own comments were written to prevent.
 
-Per episode of content — 2,500 chars ≈ 625 tokens — we spend **~22,800 input tokens**. The unit price
-is not the problem: extraction is already on the cheapest model that passes the quality battery, and
-$1.40 for eight meeting transcripts is still indefensible.
+Two consequences beyond the patch target:
+- **The real window is 10 previous episodes, not 3.** That is why an `extract_nodes` call averages
+  8,360 input tokens for a 625-token episode: ~6,250 of it is the ten predecessors.
+- **The patch target is the call site** (`graphiti.py:1090`, `last_n=RELEVANT_SCHEMA_LIMIT` →
+  `last_n=1`), not the constant. `RELEVANT_SCHEMA_LIMIT` is *also* the dedupe-candidate limit and the
+  query-time retrieval limit across ~20 call sites in `search_utils.py`; patching it at its
+  definition would silently narrow retrieval quality too.
 
-Where it goes (same batch):
+### 2. My baseline was measured over mismatched sets
 
-| call | calls | avg input | carried beyond the episode itself |
+I computed 10.1 tokens-per-source-char by dividing a 2-hour **billing** window by a 1-hour
+**projection** window. Extraction is async, so those cover different episodes — the window billed 109
+`extract_nodes` calls while the join counted ~169 episodes pushed. The ratio was polluted in both
+directions, and the "cannot show movement ⇒ does not ship" rule would have gated on a broken
+instrument.
+
+**The honest instrument needs no join at all.** `extract_nodes` fires once per episode, so both
+numerator and denominator come from `llm_usage` alone:
+
+| day | episodes | calls/episode | **input tokens/episode** | $/episode |
+|---|---|---|---|---|
+| 2026-08-04 (post-upgrade) | 92 | 12.0 | **37,564** | $0.0144 |
+| 2026-08-05 | 427 | 9.7 | **38,170** | $0.0140 |
+| 2026-08-06 | 3 | 8.0 | **38,572** | $0.0144 |
+
+Stable within 3% across three days and 522 episodes — that stability is what makes it a baseline.
+
+## The measurement, corrected
+
+An episode carries at most `CHUNK_CHARS` = 2,500 characters ≈ **625 tokens of content**. We bill
+**~38,000 input tokens** to ingest it.
+
+**That is ~61× the content, not the 40× I first reported** — and ~10 LLM calls per episode, not the
+5.4 I derived from the mismatched window. Cost is **~$0.014/episode**, not $0.0099.
+
+Where it goes, per call kind (2026-08-05 06:50 batch):
+
+| call | calls | avg input | what it carries beyond the episode |
 |---|---|---|---|
-| `dedupe_nodes` | 107 | **10,412** | up to 10 candidate entities + their summaries |
-| `extract_nodes` | 109 | 8,360 | **the 3 previous episodes** + entity-type prompt |
-| `extract_edges` | 109 | 8,110 | the same 3 previous episodes, again |
+| `dedupe_nodes` | 107 | **10,412** | up to 10 candidates + **the 10 previous episodes** |
+| `extract_nodes` | 109 | 8,360 | the 10 previous episodes + entity-type prompt |
+| `extract_edges` | 109 | 8,110 | the 10 previous episodes, again |
 | `dedupe_edges` | 459 | 1,060 | per edge |
 | `node_summaries_batch` | 56 | 6,998 | |
 | `edge_timestamps` | 72 | 552 | |
 
-Two structural facts, both measured rather than reasoned:
+The previous-episode window is carried by **four** call kinds (extract_nodes, extract_edges,
+dedupe_nodes, and attribute extraction) — not the two I first claimed. The same text is billed many
+times over.
 
-1. **The same text is billed 4–5 times.** `EPISODE_WINDOW_LEN = 3` (graphiti_core, hardcoded) means
-   every extract call carries the episode *plus its three predecessors*. `extract_nodes` and
-   `extract_edges` each re-send that context independently.
-2. **Cost is ~90% fixed overhead, not content.** Measured across yesterday's projections:
+Cost is also ~90% fixed overhead rather than content. Measured across yesterday's projections:
 
-   | | chars per episode | cost each |
-   |---|---|---|
-   | large docs | 2,608 | $0.0099 |
-   | commits | **189** | $0.0099 |
+| | chars per episode | cost each |
+|---|---|---|
+| large docs | 2,608 | $0.014 |
+| commits | **189** | $0.014 |
 
-   A commit is **14× less efficient per character** than a full chunk, because the prompt, the
-   previous-episode context and the candidate list dominate. **898 of 2,267 items (40%) are under 600
-   characters and each occupies a whole episode.**
+A commit is **14× less efficient per character** than a full chunk. **898 of 2,267 items (40%) are
+under 600 characters and each occupies a whole episode.**
 
 ## Why this is the scaling question, not a tuning question
 
@@ -69,7 +104,7 @@ That is the normal way documents are edited.
 **Not admission control.** An earlier framing of mine proposed deciding what "deserves" to be a graph
 episode. That is the wrong lever and it was rightly rejected: a team brain that declines to learn
 about some of your work because reading it was expensive is a worse product, and rationing coverage
-while the pipeline is 40× inefficient is fixing the symptom. **Every lever below is
+while the pipeline is ~60× inefficient is fixing the symptom. **Every lever below is
 coverage-neutral** — the same content, the same entities, fewer billed tokens.
 
 (For the record, nothing was ever at risk of being unsearchable: `items` holds every body with FTS +
@@ -96,24 +131,56 @@ today's two-case design cannot express:
 
 - boundaries *trustworthy* → delta-eligible (today: same chars, cap grew);
 - boundaries *stale AND the item owes content* → re-push (today: everything else);
-- **boundaries stale but the item is complete → leave it alone** (new): re-pushing buys nothing, and
-  the item converges the next time its body changes.
+- **boundaries stale but the item is provably complete → leave it alone** (new).
 
-That third case is the whole difference between a $0 rollout and a $51 one, and it is the part most
-likely to be got wrong — it must not become a hole through which genuinely-owed content stops being
-pushed.
+**"Complete" has to be defined precisely, because the loose definition is the hole.** It must NOT
+mean `content_sha256` matches — that is the exact bug this codebase shipped twice in review, since
+the body sha is invariant to chunking. It means:
 
-### 2. Cut the repeated context — `EPISODE_WINDOW_LEN` 3 → 1
+1. parse the **stored** `chunk_config` and re-chunk the body under **that** algorithm and parameters;
+2. require **element-wise hash equality** with the stored `chunk_shas` — not count equality;
+3. require the stored config to have **covered the whole body** (`storedChars × storedCap ≥
+   body.length`) — otherwise an item clipped at its old cap is "complete under the stored config"
+   while still owing content, and CDC would permanently re-strand exactly the population AIO-808
+   existed to un-strand (3 items today);
+4. an empty or unparseable `chunk_config` (`''` is the column default) is **never** complete.
 
-A one-line `sed` in `graphiti/Dockerfile` (the precedent exists — the same file already patches
-`DEFAULT_MAX_TOKENS` and constructs `OpenAIGenericClient`). Removes two of the three carried
-predecessor episodes from **both** extract calls, the two largest input consumers after dedupe.
+The other skip terms stay ANDed: this is a widening of the composite skip, not a new site, so
+`!tierChanged`, `!purgeBeforeRepush` and the `''` reconcile sentinel are inherited — a re-queued or
+redacted row can never sha-match and so still pushes. **One mutation test per term**, per the
+one-condition-per-fixture rule.
 
-**This one has a real quality trade and must not ship on an estimate.** Previous episodes are how the
-extractor resolves pronouns and references across chunk boundaries — "he said", "that project". The
-2026-06/07 blank-arcs incidents were extraction-quality failures, and this is an extraction-quality
-knob. Acceptance is the differential battery on the *same* 34-item batch: entity count per episode,
-people recall, and `IS_DUPLICATE_OF` share must not degrade against the window-3 baseline.
+**Cap-shrink must be decided explicitly, not inherited.** Today `chunkConfigDeltaCompatible`
+documents cap-shrink → false because "a full re-push is the honest answer". A naive third case would
+instead leave a shrunk-cap item alone, since it verifies complete under the stored, larger cap. That
+is content-safe but silently rewrites a documented decision. **Decision: leave it alone** — the
+orphan tails a shrink creates are not fixed by re-pushing the head either (nothing purges them), so
+paying to re-extract buys nothing. The `chunkConfigDeltaCompatible` comment must be updated to say
+so rather than left contradicting this.
+
+### 2. Cut the repeated context — the previous-episode window, 10 → 1
+
+**Patch the CALL SITE, not the constant:** `graphiti.py:1090`, `last_n=RELEVANT_SCHEMA_LIMIT` →
+`last_n=1`, as a `sed` in `graphiti/Dockerfile` (precedent: the same file constructs
+`OpenAIGenericClient` by sed; note the `DEFAULT_MAX_TOKENS` sed it once had is now an assert-only
+grep, so that half of the precedent no longer stands). `RELEVANT_SCHEMA_LIMIT` is *also* the
+dedupe-candidate limit and the query-time retrieval limit across ~20 sites in `search_utils.py` —
+patching its definition would silently narrow retrieval quality, which is a different feature.
+
+The window is carried by **four** call kinds (`extract_nodes`, `extract_edges`, `dedupe_nodes`,
+attribute extraction), so at ~6,250 tokens of predecessors per call this is the single largest term
+in the ~38,000.
+
+**This one has a real quality trade and must not ship on an estimate — and the trade is bigger than
+I first scoped.** Cutting 10→1 removes nine predecessors, not two. Previous episodes are how the
+extractor resolves pronouns and references across chunk boundaries ("he said", "that project"), and
+the 2026-06/07 blank-arcs incidents were extraction-quality failures. So this lever is
+coverage-neutral only **as a hypothesis the battery tests**, not by construction: entity count per
+episode, people recall, and `IS_DUPLICATE_OF` share must hold against the window-10 baseline on the
+same replayed batch. If they move, the lever is a quality regression wearing a cost saving.
+
+An intermediate (10 → 3, matching the library's own `EPISODE_WINDOW_LEN` intent) is available if 1
+degrades and 10 is wasteful, and should be measured in the same run rather than as a follow-up.
 
 ### 3. Pack small items into full episodes — coverage-neutral, 40% of items
 
@@ -124,8 +191,20 @@ survives) turns ~898 episodes into ~180.
 The constraint that makes this non-trivial: `graph_episodes` is keyed
 `(team_id, source_table, source_id)` — one ledger row per item — and episode names are `items:<id>#k`,
 which the delete/reconcile paths parse. A packed episode covers *several* item ids, so either the
-ledger grows a many-to-one shape or packing is confined to a synthetic aggregate item. **This is the
-lever with the deepest blast radius on existing invariants and should be the last of the three built.**
+ledger grows a many-to-one shape or packing is confined to a synthetic aggregate item.
+
+**Three failure modes recorded now so the design PR is reviewed against them, not surprised by them:**
+
+1. **Perpetual re-queue.** If a packed episode's name does not parse to each member's item id,
+   reconcile judges every member row "never landed" and re-pushes it forever.
+2. **Silent tier leak.** The same parse failure makes `deleteItemEpisodes` a no-op, so purge,
+   tier-reclassification and retraction deletes stop working **with no retry and no error** — the
+   B2 class this module has already paid for.
+3. **A pack may never span `access` tiers.** `episodeGroupId(teamSlug, access)` is the *sole* tier
+   enforcement in the graph (no RLS, CLAUDE.md §5), so packing must be per-group, and must also
+   handle a member item whose tier later flips alone.
+
+**Deepest blast radius of the three; built last, and its design PR gets its own plan review.**
 
 ### 4. Noted, not proposed: `use_combined_extraction`
 
@@ -139,12 +218,22 @@ Recorded so the next person does not rediscover it; out of scope here.
 Before any lever, a repeatable way to price a change against a **real payload**, because this
 workstream is exactly where stacked estimates go wrong:
 
-`scripts/graph-ingest-cost.mjs <since> <until>` — reads `llm_usage` + `graph_episodes ⋈ items` for a
-window and reports: source characters, episodes, calls, input tokens, **tokens-per-source-char**, and
-cost, broken down by `call_kind`. The 06:50 batch is the fixed baseline every lever is measured
-against (10.1 tokens/char, 5.4 calls/episode, $1.40).
+`scripts/graph-ingest-cost.mjs <since> <until>` reports **input tokens per episode**, calls per
+episode, and $/episode — derived from `llm_usage` **alone**, with `extract_nodes` (one per episode) as
+the denominator. No `graph_episodes ⋈ items` join, because that join is what made my first baseline
+wrong: extraction is async, so a billing window and a projection window cover different episodes, and
+the ledger's `chunk_shas` is last-state while `projected_at` is overwritten by later pushes.
 
-A lever that cannot show movement on that number against that batch does not ship.
+Two refusals, so the instrument cannot lie quietly:
+- **Drain check** — `source='graph'` must be quiet for N minutes before `since` and before `until`,
+  or the window is straddling a burst; report refuses rather than printing a ratio.
+- **Cross-check** — compare the `extract_nodes` count against episodes pushed in the same window from
+  `ingest_runs.meta.episodes`; on material divergence, report the divergence instead of a ratio.
+
+Baseline every lever is measured against: **~38,000 input tokens/episode, ~10 calls/episode,
+~$0.014/episode**, stable within 3% over 522 episodes across three days.
+
+A lever that cannot show movement on tokens-per-episode does not ship.
 
 ## Sequencing
 
@@ -157,15 +246,18 @@ Each is its own PR with its own before/after measurement in the body.
 
 ## How we will know it worked
 
-Tokens-per-source-char on a replayed batch of comparable shape falls from **10.1** toward **<4**, with
-entity yield, people recall and duplicate share unchanged. Cost per active-person-day becomes a number
-that survives a 10× corpus rather than one that multiplies with it.
+Input tokens per episode falls from **~38,000** toward **<12,000** (a 625-token episode billed at
+under 20× rather than ~61×), with entity yield, people recall and `IS_DUPLICATE_OF` share unchanged on
+the same replayed batch. Cost per active-person-day becomes a number that survives a 10× corpus
+rather than one that multiplies with it.
 
 ## Risks
 
 - **Lever 2 degrades extraction quality invisibly.** Mitigated by making the battery the gate, not the
   reviewer's judgement — and the dedupe-pollution alarm (AIO-693) is live as a backstop.
 - **Lever 1's lazy rollout leaves the corpus permanently mixed.** Accepted and made explicit in
-  `chunk_config`; the alternative is $51 to re-extract text we already have.
+  `chunk_config`; the alternative is $51 to re-extract text we already have. The `$47 re-extracts the
+  corpus` warnings now sitting on `CHUNK_CHARS`/`MAX_EPISODE_CHUNKS` become misleading once lazy CDC
+  lands and must be updated in that PR.
 - **Lever 3 collides with the one-row-per-item ledger.** Flagged early precisely so the design is
   reviewed before code, not after.

--- a/docs/design/graph-ingestion-efficiency.md
+++ b/docs/design/graph-ingestion-efficiency.md
@@ -1,4 +1,4 @@
-# Graph ingestion bills ~60× the source text
+# Graph ingestion bills ~64× the source text
 
 **Status:** revised after plan review — 1 blocker (my patch target was a no-op) + a corrected baseline
 · **Date:** 2026-08-06 · **Owner:** Chetan
@@ -54,8 +54,8 @@ Stable within 3% across three days and 522 episodes — that stability is what m
 An episode carries at most `CHUNK_CHARS` = 2,500 characters ≈ **625 tokens of content**. We bill
 **~38,000 input tokens** to ingest it.
 
-**That is ~61× the content, not the 40× I first reported** — and ~10 LLM calls per episode, not the
-5.4 I derived from the mismatched window. Cost is **~$0.014/episode**, not $0.0099.
+**That is ~64× the content, not the 40× I first reported** — and ~10 LLM calls per episode, not the
+5.4 I derived from the mismatched window. Cost is **$0.0147/episode**, not $0.0099.
 
 Where it goes, per call kind (2026-08-05 06:50 batch):
 
@@ -230,8 +230,18 @@ Two refusals, so the instrument cannot lie quietly:
 - **Cross-check** — compare the `extract_nodes` count against episodes pushed in the same window from
   `ingest_runs.meta.episodes`; on material divergence, report the divergence instead of a ratio.
 
-Baseline every lever is measured against: **~38,000 input tokens/episode, ~10 calls/episode,
-~$0.014/episode**, stable within 3% over 522 episodes across three days.
+**Baseline, measured by the harness on a quiet-bounded window** (2026-08-05 06:45→09:52 UTC — John's
+30-item workspace push; drain-clean at both edges, cross-check 0% apart):
+
+```
+episodes    169            calls/episode  10.3
+input tok   6,771,879      per episode    40,070
+cost        $2.48          per episode    $0.0147
+MULTIPLE    64.1x the content a full episode carries
+```
+
+Every lever is measured against this window. It also corrects the batch's cost: **$2.48, not the
+$1.40 I first reported** — that figure came from a 2-hour window that clipped the burst's tail.
 
 A lever that cannot show movement on tokens-per-episode does not ship.
 

--- a/docs/design/graph-ingestion-efficiency.md
+++ b/docs/design/graph-ingestion-efficiency.md
@@ -1,0 +1,171 @@
+# Graph ingestion bills 40× the source text
+
+**Status:** draft, for plan review · **Date:** 2026-08-06 · **Owner:** Chetan
+· **Task:** `PIPEFF-1` → [AIO-820](https://linear.app/je4light/issue/AIO-820)
+
+## The measurement
+
+One real batch — John's 2026-08-05 06:50 UTC workspace push, 34 items (8 Granola transcripts, 22
+work docs, 4 others), 378,129 characters of source text ≈ **94,500 tokens of content**:
+
+```
+LLM calls                912
+input tokens billed  3,827,266
+cost                     $1.40
+```
+
+**10.1 input tokens billed per source character. ~40× the content.**
+
+Per episode of content — 2,500 chars ≈ 625 tokens — we spend **~22,800 input tokens**. The unit price
+is not the problem: extraction is already on the cheapest model that passes the quality battery, and
+$1.40 for eight meeting transcripts is still indefensible.
+
+Where it goes (same batch):
+
+| call | calls | avg input | carried beyond the episode itself |
+|---|---|---|---|
+| `dedupe_nodes` | 107 | **10,412** | up to 10 candidate entities + their summaries |
+| `extract_nodes` | 109 | 8,360 | **the 3 previous episodes** + entity-type prompt |
+| `extract_edges` | 109 | 8,110 | the same 3 previous episodes, again |
+| `dedupe_edges` | 459 | 1,060 | per edge |
+| `node_summaries_batch` | 56 | 6,998 | |
+| `edge_timestamps` | 72 | 552 | |
+
+Two structural facts, both measured rather than reasoned:
+
+1. **The same text is billed 4–5 times.** `EPISODE_WINDOW_LEN = 3` (graphiti_core, hardcoded) means
+   every extract call carries the episode *plus its three predecessors*. `extract_nodes` and
+   `extract_edges` each re-send that context independently.
+2. **Cost is ~90% fixed overhead, not content.** Measured across yesterday's projections:
+
+   | | chars per episode | cost each |
+   |---|---|---|
+   | large docs | 2,608 | $0.0099 |
+   | commits | **189** | $0.0099 |
+
+   A commit is **14× less efficient per character** than a full chunk, because the prompt, the
+   previous-episode context and the candidate list dominate. **898 of 2,267 items (40%) are under 600
+   characters and each occupies a whole episode.**
+
+## Why this is the scaling question, not a tuning question
+
+At 5–10 actively-working people the corpus grows by megabytes a week, and two multipliers compound:
+
+**Insertion-edits re-extract everything downstream.** Chunking is byte-offset — `slice(i, i+2500)`
+stepping by 2,500 — so the chunk-delta ledger (#485) only helps for same-length edits and appends.
+Verified directly against `chunkContent`'s algorithm on a 50,000-char document:
+
+| edit | chunks re-extracted (of 20) |
+|---|---|
+| edit in place, same length | 1 |
+| append at the end | 1 |
+| **insert 33 chars near the top** | **21 — all of them** |
+
+Adding a heading, a paragraph or a bullet near the top of a document re-bills the entire rest of it.
+That is the normal way documents are edited.
+
+## What this is NOT
+
+**Not admission control.** An earlier framing of mine proposed deciding what "deserves" to be a graph
+episode. That is the wrong lever and it was rightly rejected: a team brain that declines to learn
+about some of your work because reading it was expensive is a worse product, and rationing coverage
+while the pipeline is 40× inefficient is fixing the symptom. **Every lever below is
+coverage-neutral** — the same content, the same entities, fewer billed tokens.
+
+(For the record, nothing was ever at risk of being unsearchable: `items` holds every body with FTS +
+pgvector regardless. The graph is an additional layer. But that distinction does not rescue the idea.)
+
+## The levers
+
+### 1. Content-defined chunking — kill the insertion cascade
+
+Replace byte-offset boundaries with a rolling-hash boundary (the rsync/restic/borg approach): a
+boundary falls where the content says, so an insertion shifts only the chunk it lands in.
+Expected: the 21-of-20 case becomes 1–2 of 20.
+
+**The rollout is the hard part, and it is worth $51.** Changing boundaries makes every stored
+`chunk_shas` entry meaningless, so `chunkConfigDeltaCompatible` returns false for all 2,267 items and
+the composite skip falls them all through to a full re-push: **5,166 episodes ≈ $51.14, for zero new
+information** — the same text, re-extracted under different boundaries.
+
+**So CDC must roll out LAZILY.** An item whose body has not changed keeps its existing chunking
+indefinitely; only items that actually change get re-chunked under the new algorithm. The
+`chunk_config` column already records the algorithm per row (`"2500x40"` → e.g. `"cdc1-2500"`), so a
+mixed corpus is representable and honest. This needs a third case in the compatibility helper that
+today's two-case design cannot express:
+
+- boundaries *trustworthy* → delta-eligible (today: same chars, cap grew);
+- boundaries *stale AND the item owes content* → re-push (today: everything else);
+- **boundaries stale but the item is complete → leave it alone** (new): re-pushing buys nothing, and
+  the item converges the next time its body changes.
+
+That third case is the whole difference between a $0 rollout and a $51 one, and it is the part most
+likely to be got wrong — it must not become a hole through which genuinely-owed content stops being
+pushed.
+
+### 2. Cut the repeated context — `EPISODE_WINDOW_LEN` 3 → 1
+
+A one-line `sed` in `graphiti/Dockerfile` (the precedent exists — the same file already patches
+`DEFAULT_MAX_TOKENS` and constructs `OpenAIGenericClient`). Removes two of the three carried
+predecessor episodes from **both** extract calls, the two largest input consumers after dedupe.
+
+**This one has a real quality trade and must not ship on an estimate.** Previous episodes are how the
+extractor resolves pronouns and references across chunk boundaries — "he said", "that project". The
+2026-06/07 blank-arcs incidents were extraction-quality failures, and this is an extraction-quality
+knob. Acceptance is the differential battery on the *same* 34-item batch: entity count per episode,
+people recall, and `IS_DUPLICATE_OF` share must not degrade against the window-3 baseline.
+
+### 3. Pack small items into full episodes — coverage-neutral, 40% of items
+
+898 items under 600 characters each occupy their own episode at full fixed-overhead price. Packing
+them (per source, per time bucket, preserving per-item provenance in the episode body so attribution
+survives) turns ~898 episodes into ~180.
+
+The constraint that makes this non-trivial: `graph_episodes` is keyed
+`(team_id, source_table, source_id)` — one ledger row per item — and episode names are `items:<id>#k`,
+which the delete/reconcile paths parse. A packed episode covers *several* item ids, so either the
+ledger grows a many-to-one shape or packing is confined to a synthetic aggregate item. **This is the
+lever with the deepest blast radius on existing invariants and should be the last of the three built.**
+
+### 4. Noted, not proposed: `use_combined_extraction`
+
+graphiti 0.29.3 can merge node+edge extraction into one call, which would collapse the two 8k-token
+calls into one. Per an earlier investigation it is **unreachable from the public API** (`add_episode`
+does not accept it and the sole internal caller omits it), so it would be another Dockerfile patch.
+Recorded so the next person does not rediscover it; out of scope here.
+
+## The measurement harness comes first
+
+Before any lever, a repeatable way to price a change against a **real payload**, because this
+workstream is exactly where stacked estimates go wrong:
+
+`scripts/graph-ingest-cost.mjs <since> <until>` — reads `llm_usage` + `graph_episodes ⋈ items` for a
+window and reports: source characters, episodes, calls, input tokens, **tokens-per-source-char**, and
+cost, broken down by `call_kind`. The 06:50 batch is the fixed baseline every lever is measured
+against (10.1 tokens/char, 5.4 calls/episode, $1.40).
+
+A lever that cannot show movement on that number against that batch does not ship.
+
+## Sequencing
+
+1. **Harness** (this PR) — no behaviour change, establishes the baseline.
+2. **Lever 2** (`EPISODE_WINDOW_LEN`) — biggest token win per line changed, gated on the quality battery.
+3. **Lever 1** (CDC) — the durable structural fix; needs the lazy-rollout third case.
+4. **Lever 3** (packing) — deepest blast radius, last.
+
+Each is its own PR with its own before/after measurement in the body.
+
+## How we will know it worked
+
+Tokens-per-source-char on a replayed batch of comparable shape falls from **10.1** toward **<4**, with
+entity yield, people recall and duplicate share unchanged. Cost per active-person-day becomes a number
+that survives a 10× corpus rather than one that multiplies with it.
+
+## Risks
+
+- **Lever 2 degrades extraction quality invisibly.** Mitigated by making the battery the gate, not the
+  reviewer's judgement — and the dedupe-pollution alarm (AIO-693) is live as a backstop.
+- **Lever 1's lazy rollout leaves the corpus permanently mixed.** Accepted and made explicit in
+  `chunk_config`; the alternative is $51 to re-extract text we already have.
+- **Lever 3 collides with the one-row-per-item ledger.** Flagged early precisely so the design is
+  reviewed before code, not after.

--- a/scripts/graph-ingest-cost.mjs
+++ b/scripts/graph-ingest-cost.mjs
@@ -1,0 +1,249 @@
+/**
+ * What one graph episode actually costs to ingest — the baseline every efficiency lever is measured
+ * against (PIPEFF-1 / AIO-820).
+ *
+ * WHY THIS EXISTS. Graph extraction bills ~38,000 input tokens to ingest an episode carrying at most
+ * 2,500 characters (~625 tokens) of content — roughly 60x the source text. Three levers are proposed
+ * against that (content-defined chunking, cutting the 10-episode repeated context, packing small
+ * items), and each one's claim is a percentage. Percentages multiplied together are how a cost
+ * estimate becomes a story, so no lever ships without a before/after on this script, run over a
+ * comparable window.
+ *
+ * WHY IT READS `llm_usage` ALONE. The obvious denominator — episodes pushed, from
+ * `graph_episodes ⋈ items` — produces a WRONG ratio, and did: the first baseline divided a 2-hour
+ * billing window by a 1-hour projection window and got 10.1 tokens/char, when the honest figure is
+ * ~61x. Extraction is ASYNCHRONOUS. Graphiti accepts an episode (202) and extracts it later, so a
+ * billing window and a projection window cover different episodes. Two further traps in that join:
+ * `chunk_shas` is LAST-STATE (a delta pass sends a subset the ledger never records), and
+ * `projected_at` is overwritten by later pushes, so re-querying a historical window loses rows.
+ *
+ * So the denominator is `call_kind = 'extract_nodes'`, which Graphiti fires exactly once per episode.
+ * Numerator and denominator then come from the same table, the same rows, the same window — the ratio
+ * cannot straddle a boundary even if the window does.
+ *
+ * TWO REFUSALS, so the instrument cannot lie quietly. A measurement tool that reports a plausible
+ * wrong number is worse than one that reports nothing, because the wrong number is what gets quoted:
+ *   1. DRAIN — if graph traffic is still flowing at either edge of the window, the window is
+ *      straddling a burst and the ratio mixes populations. Refuse.
+ *   2. CROSS-CHECK — compare the extract_nodes count against episodes pushed (`ingest_runs.meta.
+ *      episodes`) over the same window. They should be close; a material divergence means the window
+ *      caught one and not the other. Report the divergence instead of a ratio.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://…  node scripts/graph-ingest-cost.mjs <sinceISO> <untilISO> [--drain=10]
+ *   DATABASE_URL=…             node scripts/graph-ingest-cost.mjs --last=24h
+ *
+ * Pure node + `pg` (no tsx), so it runs anywhere the app does, including against prod read-only.
+ */
+import { Client } from "pg";
+
+/** Minutes of quiet required at each edge before a window is trustworthy. Graphiti's queue drains at
+ *  LLM speed (~1-30s per call), so a gap this size means the burst genuinely ended. */
+const DEFAULT_DRAIN_MINUTES = 10;
+/** Episode payload ceiling, from lib/graph/project.ts CHUNK_CHARS. Content tokens ≈ chars / 4. */
+const CHUNK_CHARS = 2500;
+const CHARS_PER_TOKEN = 4;
+/** Above this relative gap the two episode counts describe different populations. */
+const CROSS_CHECK_TOLERANCE = 0.15;
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const flag = (name) => args.find((a) => a.startsWith(`--${name}=`))?.split("=")[1];
+  const drainMinutes = Number(flag("drain") ?? DEFAULT_DRAIN_MINUTES);
+  const last = flag("last");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  return { since: positional[0], until: positional[1], last, drainMinutes };
+}
+
+/** `--last=24h|90m|7d` → an ISO window ending now. Convenience only; explicit bounds are preferred
+ *  because a lever's before/after must compare the SAME window shape, not "whatever the last day was". */
+export function resolveLastWindow(last, nowMs) {
+  const m = /^(\d+)([mhd])$/.exec((last ?? "").trim());
+  if (!m) return null;
+  const mult = { m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2]];
+  return { since: new Date(nowMs - Number(m[1]) * mult).toISOString(), until: new Date(nowMs).toISOString() };
+}
+
+/**
+ * Is the window safe to report on? Pure, so both refusals are testable without a database.
+ *
+ * `leadingCalls` — graph calls in the drain window immediately BEFORE `since`. Non-zero means an
+ * earlier burst was still extracting when our window opened, so its tokens land inside our numerator
+ * while its episodes do not.
+ * `trailingCalls` — graph calls in the drain window immediately before `until`. Non-zero means our
+ * own burst had not finished when the window closed, so episodes we counted are still being billed.
+ */
+export function assessWindow({ leadingCalls, trailingCalls, extractNodes, episodesPushed }) {
+  const problems = [];
+  if (leadingCalls > 0) {
+    problems.push(
+      `traffic at the LEADING edge (${leadingCalls} calls in the drain window before \`since\`) — an ` +
+        `earlier burst was still extracting, so its tokens are in this window but its episodes are not`
+    );
+  }
+  if (trailingCalls > 0) {
+    problems.push(
+      `traffic at the TRAILING edge (${trailingCalls} calls in the drain window before \`until\`) — ` +
+        `this burst had not drained, so some episodes counted here are still being billed`
+    );
+  }
+  if (extractNodes === 0) {
+    problems.push("no `extract_nodes` calls in the window — nothing was extracted, so there is no ratio");
+  }
+  // The cross-check only means something when we have both numbers; a window with no projector runs
+  // recorded (they are written at run END) simply cannot be cross-checked, which is not a failure.
+  let crossCheck = null;
+  if (extractNodes > 0 && episodesPushed !== null) {
+    const gap = Math.abs(extractNodes - episodesPushed) / Math.max(extractNodes, episodesPushed);
+    crossCheck = { extractNodes, episodesPushed, gap };
+    if (gap > CROSS_CHECK_TOLERANCE) {
+      problems.push(
+        `episode counts disagree: ${extractNodes} extract_nodes calls vs ${episodesPushed} episodes ` +
+          `pushed (${(gap * 100).toFixed(0)}% apart) — the window caught one and not the other`
+      );
+    }
+  }
+  return { trustworthy: problems.length === 0, problems, crossCheck };
+}
+
+/** The headline numbers. Pure, so the arithmetic is pinned without a database. */
+export function summarise({ rows, extractNodes }) {
+  const totals = rows.reduce(
+    (acc, r) => ({
+      calls: acc.calls + Number(r.calls),
+      inputTokens: acc.inputTokens + Number(r.input_tokens),
+      outputTokens: acc.outputTokens + Number(r.output_tokens),
+      costUsd: acc.costUsd + Number(r.cost_usd),
+    }),
+    { calls: 0, inputTokens: 0, outputTokens: 0, costUsd: 0 }
+  );
+  const per = (n) => (extractNodes > 0 ? n / extractNodes : null);
+  const contentTokens = CHUNK_CHARS / CHARS_PER_TOKEN;
+  const inputPerEpisode = per(totals.inputTokens);
+  return {
+    ...totals,
+    episodes: extractNodes,
+    callsPerEpisode: per(totals.calls),
+    inputTokensPerEpisode: inputPerEpisode,
+    usdPerEpisode: per(totals.costUsd),
+    // The number the levers move: billed input tokens per token of content in a FULL episode. A
+    // ceiling, not an average — a half-full episode reads worse, and honestly so.
+    multipleOfContent: inputPerEpisode === null ? null : inputPerEpisode / contentTokens,
+  };
+}
+
+const fmt = (n, d = 0) => (n === null || n === undefined ? "—" : Number(n).toLocaleString("en-US", { maximumFractionDigits: d, minimumFractionDigits: d }));
+
+async function main() {
+  const { since, until, last, drainMinutes } = parseArgs(process.argv);
+  const window = last ? resolveLastWindow(last, Date.now()) : { since, until };
+  if (!window?.since || !window?.until) {
+    console.error("usage: graph-ingest-cost.mjs <sinceISO> <untilISO> [--drain=10]   |   --last=24h");
+    process.exit(2);
+  }
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL is required (read-only queries only).");
+    process.exit(2);
+  }
+
+  const client = new Client({ connectionString: url, ssl: /\bsslmode=require\b/.test(url) ? { rejectUnauthorized: false } : undefined });
+  await client.connect();
+  try {
+    const drain = `${drainMinutes} minutes`;
+    // SEQUENTIAL, not Promise.all: a single `pg` Client multiplexes one connection, so concurrent
+    // .query() calls are deprecated (and will throw in pg@9). Three cheap aggregates; latency is
+    // irrelevant next to correctness here.
+    const byKind = await client.query(
+        `select coalesce(nullif(call_kind, ''), '(unlabelled)') as call_kind,
+                count(*)::int as calls,
+                sum(input_tokens)::bigint as input_tokens,
+                sum(output_tokens)::bigint as output_tokens,
+                sum(cost_usd)::numeric as cost_usd
+           from llm_usage
+          where source = 'graph' and created_at >= $1 and created_at < $2
+          group by 1 order by 5 desc nulls last`,
+      [window.since, window.until]
+    );
+    const edges = await client.query(
+        `select
+           (select count(*) from llm_usage
+             where source='graph' and created_at >= $1::timestamptz - $3::interval and created_at < $1)::int as leading_calls,
+           (select count(*) from llm_usage
+             where source='graph' and created_at >= $2::timestamptz - $3::interval and created_at < $2)::int as trailing_calls`,
+        [window.since, window.until, drain]
+    );
+    const runs = await client
+        .query(
+          // ANCHORED ON `finished_at`, not `started_at` — found by running this against prod. A
+          // projector run takes ~9 minutes and pushes its episodes as it goes, so a run that STARTED
+          // before the window can push episodes that extract entirely inside it. Anchoring on
+          // `started_at` made the cross-check report "0 episodes pushed" for a window containing 169
+          // extractions, refusing a window that was in fact clean. The push completes by
+          // `finished_at`, and extraction follows the push, so that is the edge that belongs to the
+          // same causal event as the tokens.
+          `select coalesce(sum((meta->>'episodes')::int), 0)::int as episodes, count(*)::int as runs
+             from ingest_runs
+            where source = 'graph_project' and finished_at >= $1 and finished_at < $2`,
+          [window.since, window.until]
+        )
+        .catch(() => null);
+
+    const rows = byKind.rows;
+    const extractNodes = Number(rows.find((r) => r.call_kind === "extract_nodes")?.calls ?? 0);
+    // A window with no recorded runs cannot be cross-checked (runs are written at END), which is
+    // different from a window whose runs pushed zero episodes.
+    const episodesPushed = runs && Number(runs.rows[0].runs) > 0 ? Number(runs.rows[0].episodes) : null;
+
+    const verdict = assessWindow({
+      leadingCalls: Number(edges.rows[0].leading_calls),
+      trailingCalls: Number(edges.rows[0].trailing_calls),
+      extractNodes,
+      episodesPushed,
+    });
+    const s = summarise({ rows, extractNodes });
+
+    console.log(`\nwindow      ${window.since} → ${window.until}   (drain ${drainMinutes}m)`);
+    console.log(`episodes    ${fmt(s.episodes)}   (extract_nodes calls — one per episode)`);
+    if (verdict.crossCheck) {
+      console.log(`cross-check ${fmt(verdict.crossCheck.episodesPushed)} pushed per ingest_runs · ${(verdict.crossCheck.gap * 100).toFixed(0)}% apart`);
+    }
+
+    if (!verdict.trustworthy) {
+      console.log("\nREFUSING TO REPORT A RATIO:");
+      for (const p of verdict.problems) console.log(`  · ${p}`);
+      console.log("\nPick a window that opens and closes in quiet, or widen --drain.\n");
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(`\ncalls        ${fmt(s.calls)}        ${fmt(s.callsPerEpisode, 1)} per episode`);
+    console.log(`input tok    ${fmt(s.inputTokens)}   ${fmt(s.inputTokensPerEpisode)} per episode`);
+    console.log(`output tok   ${fmt(s.outputTokens)}`);
+    console.log(`cost         $${fmt(s.costUsd, 2)}       $${fmt(s.usdPerEpisode, 4)} per episode`);
+    console.log(`\nMULTIPLE     ${fmt(s.multipleOfContent, 1)}x the content a full episode carries`);
+    console.log(`             (${CHUNK_CHARS} chars ≈ ${CHUNK_CHARS / CHARS_PER_TOKEN} tokens vs ${fmt(s.inputTokensPerEpisode)} billed)\n`);
+
+    console.log("by call kind:");
+    for (const r of rows) {
+      const calls = Number(r.calls);
+      console.log(
+        `  ${r.call_kind.padEnd(22)} ${String(calls).padStart(6)} calls  ` +
+          `${String(Math.round(Number(r.input_tokens) / calls)).padStart(7)} avg in  ` +
+          `$${Number(r.cost_usd).toFixed(3).padStart(7)}  ` +
+          `${((Number(r.cost_usd) / s.costUsd) * 100).toFixed(0).padStart(3)}%`
+      );
+    }
+    console.log("");
+  } finally {
+    await client.end();
+  }
+}
+
+// Only run when invoked directly, so the pure helpers above are importable by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/scripts/graph-ingest-cost.mjs
+++ b/scripts/graph-ingest-cost.mjs
@@ -17,9 +17,26 @@
  * `chunk_shas` is LAST-STATE (a delta pass sends a subset the ledger never records), and
  * `projected_at` is overwritten by later pushes, so re-querying a historical window loses rows.
  *
- * So the denominator is `call_kind = 'extract_nodes'`, which Graphiti fires exactly once per episode.
- * Numerator and denominator then come from the same table, the same rows, the same window — the ratio
- * cannot straddle a boundary even if the window does.
+ * So the denominator is `call_kind = 'extract_nodes'`. Numerator and denominator then come from the
+ * same table, the same rows, the same window — the ratio cannot straddle a boundary even if the
+ * window does.
+ *
+ * WHAT THE DENOMINATOR ACTUALLY COUNTS — attempts, not episodes. graphiti_core 0.29.3 fires
+ * `extract_nodes` once per extraction ATTEMPT. There is no reflexion loop (0.13.2 had one) and no
+ * per-episode fan-out, and it fires unconditionally even for content-free episodes — so the happy
+ * path is one call per episode. But two retry layers can add attempts for the SAME episode:
+ *   · `openai_base_client.py` — MAX_RETRIES=2 on pydantic validation failure. The invalid response
+ *     arrived WITH a usage block, so the proxy metered it and the retry is a second row (with a
+ *     longer prompt, since the error context is appended).
+ *   · `client.py` — tenacity on RateLimitError / EmptyResponse / JSONDecodeError. Rate-limited
+ *     attempts carry no usage and are never metered, so those don't distort; the other two do.
+ * Retries push `extract_nodes` ABOVE episodes pushed, so the cross-check's SIGNED gap is the
+ * retry-rate instrument: positive = retries, negative = the window caught a push it didn't bill.
+ * A lever that changes prompt shape can change the validation-retry rate, so a before/after must
+ * compare the signed gap as well as the ratio — otherwise a "token cut" may be a retry-rate shift.
+ *
+ * AND `llm_usage` IS LOSSY. `recordLlmUsage` is best-effort by contract, so a dropped row deflates
+ * whichever side it belonged to. Negligible against a healthy database; not zero.
  *
  * TWO REFUSALS, so the instrument cannot lie quietly. A measurement tool that reports a plausible
  * wrong number is worse than one that reports nothing, because the wrong number is what gets quoted:
@@ -40,8 +57,12 @@ import { Client } from "pg";
 /** Minutes of quiet required at each edge before a window is trustworthy. Graphiti's queue drains at
  *  LLM speed (~1-30s per call), so a gap this size means the burst genuinely ended. */
 const DEFAULT_DRAIN_MINUTES = 10;
-/** Episode payload ceiling, from lib/graph/project.ts CHUNK_CHARS. Content tokens ≈ chars / 4. */
-const CHUNK_CHARS = 2500;
+/** Episode payload ceiling, mirroring lib/graph/project.ts CHUNK_CHARS. Content tokens ≈ chars / 4.
+ *  NOTE: the projector reads `GRAPH_CHUNK_CHARS` from env, so a deployment that overrides it makes
+ *  MULTIPLE wrong here — hence the assumed size is printed in the output rather than left implicit.
+ *  Lazy CDC (`cdc1-2500`) will also mix configs across the corpus; at that point this becomes a
+ *  weighted average and the footer stops being a sufficient caveat. */
+const CHUNK_CHARS = Number(process.env.GRAPH_CHUNK_CHARS) > 0 ? Number(process.env.GRAPH_CHUNK_CHARS) : 2500;
 const CHARS_PER_TOKEN = 4;
 /** Above this relative gap the two episode counts describe different populations. */
 const CROSS_CHECK_TOLERANCE = 0.15;
@@ -49,10 +70,14 @@ const CROSS_CHECK_TOLERANCE = 0.15;
 function parseArgs(argv) {
   const args = argv.slice(2);
   const flag = (name) => args.find((a) => a.startsWith(`--${name}=`))?.split("=")[1];
-  const drainMinutes = Number(flag("drain") ?? DEFAULT_DRAIN_MINUTES);
+  const drainRaw = flag("drain");
+  const drainMinutes = drainRaw === undefined ? DEFAULT_DRAIN_MINUTES : Number(drainRaw);
   const last = flag("last");
   const positional = args.filter((a) => !a.startsWith("--"));
-  return { since: positional[0], until: positional[1], last, drainMinutes };
+  // A NaN here would reach Postgres as the literal interval 'NaN minutes' and throw a syntax error
+  // from deep inside a query, which reads as a tool bug rather than a bad flag.
+  const drainValid = Number.isFinite(drainMinutes) && drainMinutes > 0;
+  return { since: positional[0], until: positional[1], last, drainMinutes, drainValid };
 }
 
 /** `--last=24h|90m|7d` → an ISO window ending now. Convenience only; explicit bounds are preferred
@@ -73,7 +98,7 @@ export function resolveLastWindow(last, nowMs) {
  * `trailingCalls` — graph calls in the drain window immediately before `until`. Non-zero means our
  * own burst had not finished when the window closed, so episodes we counted are still being billed.
  */
-export function assessWindow({ leadingCalls, trailingCalls, extractNodes, episodesPushed }) {
+export function assessWindow({ leadingCalls, trailingCalls, forwardCalls, forwardUnknown, extractNodes, episodesPushed }) {
   const problems = [];
   if (leadingCalls > 0) {
     problems.push(
@@ -87,6 +112,22 @@ export function assessWindow({ leadingCalls, trailingCalls, extractNodes, episod
         `this burst had not drained, so some episodes counted here are still being billed`
     );
   }
+  // FORWARD drain. Both edge checks above look BACKWARD, which misses the case this deployment has
+  // actually had: a graphiti worker stalls mid-queue, goes quiet for longer than the drain, then
+  // resumes after `until`. Its episodes are counted here; its tokens are not. Silent, and it makes
+  // the pipeline look cheaper than it is — the flattering direction, which is the dangerous one.
+  if (forwardCalls > 0) {
+    problems.push(
+      `traffic AFTER the window (${forwardCalls} calls in the drain window following \`until\`) — ` +
+        `extraction spilled past the close, so episodes counted here are billed outside it`
+    );
+  }
+  if (forwardUnknown) {
+    problems.push(
+      "`until` is inside the drain window of now — the forward check cannot run yet, so a spill " +
+        "past the close would be invisible. Re-run once the window has aged past the drain."
+    );
+  }
   if (extractNodes === 0) {
     problems.push("no `extract_nodes` calls in the window — nothing was extracted, so there is no ratio");
   }
@@ -95,7 +136,9 @@ export function assessWindow({ leadingCalls, trailingCalls, extractNodes, episod
   let crossCheck = null;
   if (extractNodes > 0 && episodesPushed !== null) {
     const gap = Math.abs(extractNodes - episodesPushed) / Math.max(extractNodes, episodesPushed);
-    crossCheck = { extractNodes, episodesPushed, gap };
+    // SIGNED: positive means more extraction attempts than episodes pushed (retries); negative means
+    // the window saw a push whose extraction it did not bill. Different diagnoses, so keep the sign.
+    crossCheck = { extractNodes, episodesPushed, gap, signed: extractNodes - episodesPushed };
     if (gap > CROSS_CHECK_TOLERANCE) {
       problems.push(
         `episode counts disagree: ${extractNodes} extract_nodes calls vs ${episodesPushed} episodes ` +
@@ -135,7 +178,11 @@ export function summarise({ rows, extractNodes }) {
 const fmt = (n, d = 0) => (n === null || n === undefined ? "—" : Number(n).toLocaleString("en-US", { maximumFractionDigits: d, minimumFractionDigits: d }));
 
 async function main() {
-  const { since, until, last, drainMinutes } = parseArgs(process.argv);
+  const { since, until, last, drainMinutes, drainValid } = parseArgs(process.argv);
+  if (!drainValid) {
+    console.error("--drain must be a positive number of minutes");
+    process.exit(2);
+  }
   const window = last ? resolveLastWindow(last, Date.now()) : { since, until };
   if (!window?.since || !window?.until) {
     console.error("usage: graph-ingest-cost.mjs <sinceISO> <untilISO> [--drain=10]   |   --last=24h");
@@ -170,9 +217,13 @@ async function main() {
            (select count(*) from llm_usage
              where source='graph' and created_at >= $1::timestamptz - $3::interval and created_at < $1)::int as leading_calls,
            (select count(*) from llm_usage
-             where source='graph' and created_at >= $2::timestamptz - $3::interval and created_at < $2)::int as trailing_calls`,
+             where source='graph' and created_at >= $2::timestamptz - $3::interval and created_at < $2)::int as trailing_calls,
+           (select count(*) from llm_usage
+             where source='graph' and created_at >= $2::timestamptz and created_at < $2::timestamptz + $3::interval)::int as forward_calls,
+           (now() < $2::timestamptz + $3::interval) as forward_unknown`,
         [window.since, window.until, drain]
     );
+    let runsError = null;
     const runs = await client
         .query(
           // ANCHORED ON `finished_at`, not `started_at` — found by running this against prod. A
@@ -187,7 +238,13 @@ async function main() {
             where source = 'graph_project' and finished_at >= $1 and finished_at < $2`,
           [window.since, window.until]
         )
-        .catch(() => null);
+        // A real SQL error here (renamed table/column) would otherwise masquerade as "no runs to
+        // compare against" and silently disarm one of the two refusals — permanently, and quietly,
+        // which is the one thing this tool exists not to do. Capture it and SAY so.
+        .catch((err) => {
+          runsError = err instanceof Error ? err.message : String(err);
+          return null;
+        });
 
     const rows = byKind.rows;
     const extractNodes = Number(rows.find((r) => r.call_kind === "extract_nodes")?.calls ?? 0);
@@ -198,6 +255,8 @@ async function main() {
     const verdict = assessWindow({
       leadingCalls: Number(edges.rows[0].leading_calls),
       trailingCalls: Number(edges.rows[0].trailing_calls),
+      forwardCalls: Number(edges.rows[0].forward_calls),
+      forwardUnknown: edges.rows[0].forward_unknown === true,
       extractNodes,
       episodesPushed,
     });
@@ -206,7 +265,13 @@ async function main() {
     console.log(`\nwindow      ${window.since} → ${window.until}   (drain ${drainMinutes}m)`);
     console.log(`episodes    ${fmt(s.episodes)}   (extract_nodes calls — one per episode)`);
     if (verdict.crossCheck) {
-      console.log(`cross-check ${fmt(verdict.crossCheck.episodesPushed)} pushed per ingest_runs · ${(verdict.crossCheck.gap * 100).toFixed(0)}% apart`);
+      const sign = verdict.crossCheck.signed > 0 ? `+${verdict.crossCheck.signed} attempts over pushes (retries)` : verdict.crossCheck.signed < 0 ? `${verdict.crossCheck.signed} — pushes this window did not bill` : "exact";
+      console.log(`cross-check ${fmt(verdict.crossCheck.episodesPushed)} pushed per ingest_runs · ${(verdict.crossCheck.gap * 100).toFixed(0)}% apart · ${sign}`);
+    } else if (runsError) {
+      console.log(`cross-check UNAVAILABLE — the ingest_runs query FAILED: ${runsError}`);
+      console.log("            (one of the two refusals is disarmed; treat any ratio below with suspicion)");
+    } else {
+      console.log("cross-check unavailable — no projector runs finished inside this window");
     }
 
     if (!verdict.trustworthy) {
@@ -231,7 +296,7 @@ async function main() {
         `  ${r.call_kind.padEnd(22)} ${String(calls).padStart(6)} calls  ` +
           `${String(Math.round(Number(r.input_tokens) / calls)).padStart(7)} avg in  ` +
           `$${Number(r.cost_usd).toFixed(3).padStart(7)}  ` +
-          `${((Number(r.cost_usd) / s.costUsd) * 100).toFixed(0).padStart(3)}%`
+          `${(s.costUsd > 0 ? ((Number(r.cost_usd) / s.costUsd) * 100).toFixed(0) : "—").padStart(3)}%`
       );
     }
     console.log("");

--- a/test/graph-ingest-cost.test.ts
+++ b/test/graph-ingest-cost.test.ts
@@ -16,7 +16,14 @@ import { assessWindow, summarise, resolveLastWindow } from "../scripts/graph-ing
  * produce a ratio.
  */
 
-const clean = { leadingCalls: 0, trailingCalls: 0, extractNodes: 100, episodesPushed: 100 };
+const clean = {
+  leadingCalls: 0,
+  trailingCalls: 0,
+  forwardCalls: 0,
+  forwardUnknown: false,
+  extractNodes: 100,
+  episodesPushed: 100,
+};
 
 describe("assessWindow — refuses more than it reports", () => {
   it("trusts a window that opens and closes in quiet with agreeing counts", () => {
@@ -37,6 +44,32 @@ describe("assessWindow — refuses more than it reports", () => {
     const v = assessWindow({ ...clean, trailingCalls: 3 });
     expect(v.trustworthy).toBe(false);
     expect(v.problems.join(" ")).toMatch(/TRAILING/);
+  });
+
+  it("refuses when extraction spilled PAST the window — the flattering direction", () => {
+    // Both other edge checks look backward. A graphiti worker that stalls mid-queue, goes quiet past
+    // the drain, then resumes after `until` leaves its episodes counted here and its tokens outside —
+    // making the pipeline look cheaper than it is. Silent worker death is a recorded failure of this
+    // deployment, so this is a real window shape, not a hypothetical one.
+    const v = assessWindow({ ...clean, forwardCalls: 40 });
+    expect(v.trustworthy).toBe(false);
+    expect(v.problems.join(" ")).toMatch(/AFTER the window/);
+  });
+
+  it("refuses when the window is too recent for the forward check to have run", () => {
+    // `--last=1h` can never be forward-checked: the drain window after `until` is still in the future.
+    // Unknown must not read as clean.
+    const v = assessWindow({ ...clean, forwardUnknown: true });
+    expect(v.trustworthy).toBe(false);
+    expect(v.problems.join(" ")).toMatch(/cannot run yet/);
+  });
+
+  it("keeps the cross-check gap SIGNED, because the two directions are different diagnoses", () => {
+    // Positive = more extraction attempts than pushes (retries, which 0.29.3 meters). Negative = the
+    // window saw a push it did not bill. A lever that changes prompt shape can move the retry rate,
+    // so a before/after must read the sign, not just the magnitude.
+    expect(assessWindow({ ...clean, extractNodes: 118, episodesPushed: 100 }).crossCheck?.signed).toBe(18);
+    expect(assessWindow({ ...clean, extractNodes: 100, episodesPushed: 118 }).crossCheck?.signed).toBe(-18);
   });
 
   it("refuses a window with no extraction at all rather than dividing by zero", () => {

--- a/test/graph-ingest-cost.test.ts
+++ b/test/graph-ingest-cost.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — plain .mjs script, no types; imported for its pure helpers.
+import { assessWindow, summarise, resolveLastWindow } from "../scripts/graph-ingest-cost.mjs";
+
+/**
+ * The measurement instrument for PIPEFF-1 (AIO-820).
+ *
+ * Spec-derived, and the spec here is unusual: this tool's job is to REFUSE more often than it
+ * reports. Graph extraction is asynchronous, so a window that opens or closes mid-burst mixes one
+ * population's tokens with another's episodes — which is exactly how the first baseline came out at
+ * "10.1 tokens per source char" when the honest figure was ~61x the content. A cost instrument that
+ * emits a plausible wrong number is worse than one that emits nothing, because the wrong number is
+ * what gets quoted in a decision.
+ *
+ * So the assertions below are mostly about the refusals: each one pins a window shape that MUST NOT
+ * produce a ratio.
+ */
+
+const clean = { leadingCalls: 0, trailingCalls: 0, extractNodes: 100, episodesPushed: 100 };
+
+describe("assessWindow — refuses more than it reports", () => {
+  it("trusts a window that opens and closes in quiet with agreeing counts", () => {
+    const v = assessWindow(clean);
+    expect(v.trustworthy).toBe(true);
+    expect(v.problems).toEqual([]);
+  });
+
+  it("refuses when an earlier burst was still extracting as the window opened", () => {
+    // Its tokens land in our numerator; its episodes do not. The ratio reads too high.
+    const v = assessWindow({ ...clean, leadingCalls: 12 });
+    expect(v.trustworthy).toBe(false);
+    expect(v.problems.join(" ")).toMatch(/LEADING/);
+  });
+
+  it("refuses when our own burst had not drained as the window closed", () => {
+    // Episodes counted here are still being billed. The ratio reads too low.
+    const v = assessWindow({ ...clean, trailingCalls: 3 });
+    expect(v.trustworthy).toBe(false);
+    expect(v.problems.join(" ")).toMatch(/TRAILING/);
+  });
+
+  it("refuses a window with no extraction at all rather than dividing by zero", () => {
+    const v = assessWindow({ ...clean, extractNodes: 0 });
+    expect(v.trustworthy).toBe(false);
+    expect(v.problems.join(" ")).toMatch(/no `extract_nodes`/);
+  });
+
+  it("refuses when the two episode counts describe different populations", () => {
+    // THE failure that produced the wrong baseline: 109 extract_nodes billed against ~169 episodes
+    // pushed. Either number alone looks fine; only the comparison exposes the straddle.
+    const v = assessWindow({ ...clean, extractNodes: 109, episodesPushed: 169 });
+    expect(v.trustworthy).toBe(false);
+    expect(v.problems.join(" ")).toMatch(/episode counts disagree/);
+    expect(v.crossCheck?.gap).toBeCloseTo(0.355, 2);
+  });
+
+  it("tolerates a small disagreement — async lag is normal, not a straddle", () => {
+    expect(assessWindow({ ...clean, extractNodes: 100, episodesPushed: 108 }).trustworthy).toBe(true);
+  });
+
+  it("does not fail a window that simply has no projector runs to compare against", () => {
+    // Runs are recorded at run END, so a window can legitimately contain extraction and no run row.
+    // "Cannot cross-check" must not read as "cross-check failed".
+    const v = assessWindow({ ...clean, episodesPushed: null });
+    expect(v.trustworthy).toBe(true);
+    expect(v.crossCheck).toBeNull();
+  });
+});
+
+describe("summarise — the number the levers move", () => {
+  const rows = [
+    { call_kind: "extract_nodes", calls: 100, input_tokens: 836_000, output_tokens: 27_800, cost_usd: 0.31 },
+    { call_kind: "extract_edges", calls: 100, input_tokens: 811_000, output_tokens: 62_400, cost_usd: 0.34 },
+    { call_kind: "dedupe_nodes", calls: 100, input_tokens: 1_041_200, output_tokens: 10_500, cost_usd: 0.35 },
+  ];
+
+  it("reports per-episode figures against extract_nodes, not the row count", () => {
+    const s = summarise({ rows, extractNodes: 100 });
+    expect(s.episodes).toBe(100);
+    expect(s.callsPerEpisode).toBe(3);
+    expect(s.inputTokensPerEpisode).toBe(26_882);
+    expect(s.usdPerEpisode).toBeCloseTo(0.01, 3);
+  });
+
+  it("expresses the multiple against a FULL episode's content, the honest ceiling", () => {
+    // 2,500 chars ≈ 625 tokens. A half-full episode reads worse than this, which is correct: the
+    // fixed overhead is the same either way, and pretending otherwise would flatter the pipeline.
+    const s = summarise({ rows, extractNodes: 100 });
+    expect(s.multipleOfContent).toBeCloseTo(26_882 / 625, 2);
+  });
+
+  it("returns nulls rather than Infinity when there are no episodes", () => {
+    const s = summarise({ rows: [], extractNodes: 0 });
+    expect(s.inputTokensPerEpisode).toBeNull();
+    expect(s.multipleOfContent).toBeNull();
+  });
+});
+
+describe("resolveLastWindow", () => {
+  it("parses the convenience forms", () => {
+    const now = Date.parse("2026-08-06T12:00:00.000Z");
+    expect(resolveLastWindow("24h", now)?.since).toBe("2026-08-05T12:00:00.000Z");
+    expect(resolveLastWindow("90m", now)?.since).toBe("2026-08-06T10:30:00.000Z");
+    expect(resolveLastWindow("7d", now)?.since).toBe("2026-07-30T12:00:00.000Z");
+  });
+
+  it("returns null for anything it does not understand, rather than guessing a window", () => {
+    for (const junk of ["", "24", "h", "24w", "abc", undefined]) {
+      expect(resolveLastWindow(junk as string, Date.now())).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Why

You asked why eight meeting transcripts cost ~$2, and whether this scales to 5–10 people uploading real volume. The measured answer: **graph ingestion bills ~64× the source text** — ~40,000 input tokens to ingest an episode carrying 2,500 characters (~625 tokens).

Three levers are proposed against that (content-defined chunking, cutting the 10-episode repeated context, packing small items). Each one's claim is a percentage, and **percentages multiplied together are how a cost estimate becomes a story.** This PR is the instrument that makes each claim falsifiable — no behaviour change.

## What it measures, and what it refuses

`scripts/graph-ingest-cost.mjs <since> <until>` reports input tokens / calls / $ **per episode**, from `llm_usage` **alone** — `extract_nodes` as the denominator, so numerator and denominator come from the same rows and the ratio can't straddle a window boundary.

The `graph_episodes ⋈ items` join is deliberately absent: **that join is what produced my wrong first baseline.** Extraction is async, so I divided a 2-hour billing window by a 1-hour projection window and got "10.1 tokens per source char" when the honest figure is ~64× the content.

Three refusals, because an instrument that emits a plausible wrong number is worse than one that emits nothing:

| refusal | catches |
|---|---|
| **drain (backward)** | traffic at either edge — the window straddles a burst |
| **drain (forward)** | extraction that stalls past the drain and resumes after `until` — episodes counted, tokens outside. The *flattering* direction, and silent worker death is a recorded failure here |
| **cross-check** | `extract_nodes` vs `ingest_runs.meta.episodes` >15% apart — the window caught one and not the other |

**Validated against my own mistake:** pointed at the exact window the wrong baseline came from, all three refusals fire.

## Two bugs found by running it against prod

1. **The cross-check anchored on `ingest_runs.started_at`.** A ~9-minute projector run that *starts* before the window pushes episodes that extract inside it — so it reported "0 episodes pushed" for a window holding 169 extractions, refusing a clean window. Now anchors on `finished_at`, the edge causally adjacent to extraction.
2. **The denominator counts attempts, not episodes** (found in review). 0.29.3 has no reflexion loop, but two retry layers add *metered* attempts for the same episode. The cross-check gap is now **signed**, which makes it the retry-rate instrument — and the spec records that lever 2's before/after must compare that sign, since cutting context can move the validation-retry rate and a "token saving" could partly be a retry shift.

## The baseline every lever is now gated on

```
window      2026-08-05 06:45→09:52 UTC   (John's 30-item push; drain-clean, cross-check exact)
episodes    169            calls/episode  10.3
input tok   6,771,879      per episode    40,070
cost        $2.48          per episode    $0.0147
MULTIPLE    64.1x the content a full episode carries
```

This also corrects two figures I'd reported: that batch cost **$2.48, not $1.40**, and the multiple is **~64×, not 40×**.

## Review — Reviewed by Fable code-reviewer (subagent) — verdict CLEAR after fixes
Plan review BLOCKED the spec twice: my proposed `EPISODE_WINDOW_LEN = 3` patch would have been a **silent no-op** (the deployed path uses `RELEVANT_SCHEMA_LIMIT = 10` at `graphiti.py:1090`), and my baseline divided mismatched windows. Code review then BLOCKED on the "exactly once per episode" claim above. All fixed; both MEDIUMs (forward drain, loud cross-check-unavailable) taken in this PR rather than deferred.

## Test plan
- [x] 15 unit tests — every refusal has its own fixture, one condition each
- [x] Validated against the real wrong window (all refusals fire) and a real clean window (0% cross-check gap)
- [x] Unit **1,965** · tsc · lint (2 pre-existing) · docs-drift — green
- [ ] CI

AIOS-Work: PIPEFF-1