### PR TITLE
feat(costs): spec + measurement scaffolding for the episode-window lever (AIO-821)

### DIFF
--- a/docs/design/graph-episode-window.md
+++ b/docs/design/graph-episode-window.md
@@ -1,0 +1,342 @@
+# Lever 2 — stop paying for predecessor episodes that carry nothing
+
+**Status:** spec, revised after plan review — 2 blockers + 1 HIGH that inverted a finding of mine
+· **Date:** 2026-08-06 · **Owner:** Chetan
+· **Task:** `PIPEFF-2` → [AIO-821](https://linear.app/je4light/issue/AIO-821)
+· **Parent:** `PIPEFF-1` / [AIO-820](https://linear.app/je4light/issue/AIO-820) —
+  [`graph-ingestion-efficiency.md`](./graph-ingestion-efficiency.md)
+· **Depends on:** the measurement harness (`scripts/graph-ingest-cost.mjs`, merged as `efdda1b`)
+
+## The problem, in one number
+
+Every `add_episode` retrieves **ten previous episodes** and carries their full content into **four
+metered LLM calls**. At ~625 tokens each that is **~6,250 tokens of predecessor context per call** —
+the single largest term in the ~40,070 input tokens per episode the harness measured.
+
+## What the window actually is — re-derived, and it is not what the parent spec assumed
+
+Read from `graphiti_core==0.29.3` (the exact pin in `graphiti/Dockerfile`) and from
+`/app/graph_service` inside the built image `aios-graphiti:0293-pinned`.
+
+### 1. One call site, one occurrence
+
+```python
+# graphiti_core/graphiti.py:1087-1093   (`name` is in scope — add_episode's first parameter)
+previous_episodes = (
+    await self.retrieve_episodes(
+        reference_time,
+        last_n=RELEVANT_SCHEMA_LIMIT,      # ← 10
+        group_ids=[group_id],
+        source=source,
+    )
+    if previous_episode_uuids is None
+    else await EpisodicNode.get_by_uuids(self.driver, previous_episode_uuids)
+)
+```
+
+`grep -rn 'last_n=RELEVANT_SCHEMA_LIMIT' graphiti_core/` returns **exactly one line**. The constant
+itself is defined in `search/search_utils.py` and appears there **15 times** (1 definition + 14 uses)
+as the dedupe-candidate limit and the query-time retrieval limit — so patching the *constant* would
+silently narrow search quality, a different feature. **Patch the call site.** (Both this spec's
+earlier draft and the parent spec said "~20 sites"; the number is 15, and the parent spec is
+corrected in the same PR.)
+
+### 2. The server can never take the other branch
+
+`graph_service/routers/ingest.py:57` calls `add_episode(uuid, group_id, name, episode_body,
+reference_time, source, source_description)` — **no `previous_episode_uuids`**. The REST surface the
+brain uses always takes the `retrieve_episodes` branch.
+
+### 3. The window is same-**group**, not same-**document**
+
+```cypher
+MATCH (e:Episodic) WHERE e.valid_at <= $reference_time
+AND e.group_id IN $group_ids AND e.source = $source
+ORDER BY e.valid_at DESC LIMIT $num_episodes
+```
+
+Predecessors are the ten episodes in the same group (`<teamSlug>_team` / `_external`) with the
+nearest earlier `valid_at`, regardless of which item they came from.
+
+### 4. …but for a multi-chunk item, its own prior chunks are *guaranteed* to be selected
+
+**This corrects the previous draft of this spec, which claimed the opposite and built its prediction
+on it.** The derivation the reviewer supplied, which I re-checked:
+
+- The graph service runs a **single sequential FIFO worker** (`routers/ingest.py`), so chunks
+  `0..k-1` are persisted before chunk `k` is processed.
+- `lib/graph/project.ts:toEpisodes` stamps every chunk with one `pickEpisodeTimestamp(item)`, so all
+  of an item's chunks share `valid_at` — and that value **equals** `reference_time`, which is the
+  *maximum* value the `valid_at <= reference_time` filter admits.
+- `ORDER BY valid_at DESC` therefore ranks every equal-max row **above** every strictly-earlier row.
+
+So chunk `k` receives all of its own prior chunks (up to 10). What is genuinely unpinned is only
+(a) their **order** within the prompt and (b) which rows survive `LIMIT 10` if the tie pool exceeds
+ten — either because the item has more than 11 chunks, or because another item carries a
+byte-identical `valid_at` (possible where `pickEpisodeTimestamp` resolves to a date-granular
+`worked_at`; **Phase A measures how often that happens**).
+
+**The consequence, and it reshapes the lever:**
+
+| item shape | what the 10 predecessors carry | verdict |
+|---|---|---|
+| **single-chunk** (40% of items are under 600 chars) | ten **unrelated** items | pure cost, nothing to resolve |
+| **multi-chunk** | its own prior chunks first, unrelated items only as filler | the coreference mechanism, working |
+
+The waste and the value are cleanly separable by item. So the right lever is **not** a smaller
+number — it is *"carry the document's own predecessors and nothing else."*
+
+## The lever: a same-item filter, with `last_n=1` as the blunt fallback
+
+Episode names are `items:<id>` (single chunk) or `items:<id>#k` (`lib/graph/episode-name.ts`), and
+`name` is in scope at the call site. So the filter is a post-retrieval predicate on the name's
+pre-`#` prefix — the Cypher query is unchanged (retrieval is not an LLM call and costs nothing worth
+optimising); only what reaches the four prompts changes.
+
+- **single-chunk item** → **zero** predecessors (better than `last_n=1`, and provably lossless: no
+  predecessor could have been the same document)
+- **multi-chunk item** → all of its own prior chunks, up to 10 (the mechanism preserved intact)
+
+`last_n=1` — the parent spec's proposal — remains in the battery as the **blunt floor**: it is a
+smaller patch, and if the same-item filter fails to cut enough tokens (a corpus dominated by long
+documents), `last_n=1` is the fallback whose quality cost we will then have measured rather than
+guessed.
+
+## Phase A — measure what the ten predecessors actually contain, before any A/B
+
+One local run at the **current** window (10) with request bodies captured. **Capture mechanism,
+decided here rather than at build time:** a thin local forwarder sits between graphiti and the local
+brain, appends each request body to a JSONL, and forwards unchanged — so metering still traverses the
+production path (`graph-proxy` → `classifyGraphCall` → `recordLlmUsage`) and nothing about the cost
+shape is simulated. Nothing in the proxy or `llm_usage` stores prompts, and this spec is not going to
+add prompt storage to a production path to run an experiment.
+
+Measured **across all four metered carriers** — `extract_nodes`, `extract_edges`, `dedupe_nodes` and
+`node_summaries_batch`:
+
+| measured | why it decides the design |
+|---|---|
+| predecessor tokens per call, **per call kind** | sizes the prize; the parent's ~6,250 is derived, not observed, and measuring only `extract_nodes` would understate it |
+| **same-item share**, split single-chunk vs multi-chunk | the prediction from §4 is ~0% and ~100% respectively; a blended number would hide both |
+| **tie-pool contamination** — how often a *different* item shares an episode's exact `valid_at` | the one way §4's guarantee can break; if it is common, the same-item filter is worth more, not less |
+
+> `node_attributes` is **not** a fourth carrier on this install: with no custom entity types,
+> `_extract_entity_attributes` returns `{}` with no LLM call (`node_operations.py:783-791`). The
+> fourth metered carrier is `node_summaries_batch`, which embeds full predecessor content
+> (`node_operations.py:948-963`). The parent spec names the wrong one.
+
+Phase A's numbers are written into this doc **before** Phase B runs, so the prediction is on the
+record before the result exists.
+
+## Phase B — the battery
+
+Three arms, each replaying the **same corpus in the same order into a fresh, empty Neo4j**, at the
+same model and temperature as prod:
+
+| arm | patch |
+|---|---|
+| **W10** | incumbent — unpatched |
+| **SAME** | same-item filter (the designed fix) |
+| **W1** | `last_n=1` (blunt floor) |
+
+`last_n` is not env-configurable, so each arm is a **locally built image variant** off
+`graphiti/Dockerfile`. Local topology per arm: neo4j + that graphiti variant + the capture tap +
+`next start` (the brain) + the `db:test:up` Postgres — **on its own container/ports**, because a
+shared test Postgres has previously made concurrent runs look like product bugs.
+
+### The corpus is this install's own content, pulled at run time
+
+Never a checked-in fixture. `EXMODEL-1` failed exactly there: the repo is public, so the fixture had
+to be synthetic, and two synthetic attempts scored the *negative control* — the model that actually
+polluted the graph — as a pass and the good model as a fail. A fixture iterated until it agrees with
+the conclusion is the failure this workstream exists to prevent.
+
+The battery copies the selected `items` rows, the `members` rows (Q2 needs them) and the `teams` row
+from prod (read-only) into the local Postgres. Content stays local; nothing is committed.
+
+**Selection rule, fixed in advance, buckets disjoint by construction, `access = 'team'` only:**
+
+| bucket | rule | ≈episodes |
+|---|---|---|
+| A | the **5** most recent items of **≥ 8 chunks** | ~50 |
+| B | the **20** most recent items of **exactly 1 chunk and < 600 chars** | 20 |
+| C | the **8** most recent items of **2–7 chunks** | ~30 |
+
+≈100 episodes per rep. The `access='team'` restriction is what makes this land in **one group** — by
+selection, not by bypassing the projector (see below). The selected item ids are **pinned in the
+report** so a later run is comparable rather than merely similar.
+
+**Q2 power extension, deterministic:** if the corpus yields fewer than **15** literal member-name
+occurrences, extend bucket C by the next most-recent qualifying items, up to **+10**, until it does.
+If it still does not, Q2 is **UNDERPOWERED**, which counts as a FAIL (see the decision function —
+the conservative default is the point).
+
+### The push is the real projector run path
+
+**The battery drives `runGraphProjection`** against the local Postgres with `GRAPHITI_URL` pointed at
+the arm's graphiti. Not a bespoke loop over `chunkContent` + REST. This is a blocker-level
+correction, and the reason is specific:
+
+`scripts/graph-ingest-cost.mjs` cross-checks `extract_nodes` calls against `ingest_runs.meta.
+episodes`, which **only the projector run path writes** (`lib/graph/projection-run.ts:21-31`). With a
+bespoke pusher there is no such row, `episodesPushed` is `null`, and the harness prints
+"cross-check unavailable" **and reports the ratios anyway** (`graph-ingest-cost.mjs:137, 253` — a
+null is not a refusal). Q5 would then be silently unmeasurable, and C1 would lose its guard: the
+denominator counts **attempts**, so a patch-induced rise in validation retries inflates it and
+manufactures a token-per-episode "saving" — C1 stays green through the exact failure Q5 exists to
+catch.
+
+**So: cross-check unavailable ⇒ the run is INVALID, not "report with suspicion."** Same for any
+harness refusal (drain, zero episodes).
+
+### Metrics and pass bands — pre-registered
+
+Every band is relative to the **W10 arm measured in the same session**. No stored answer key, no
+absolute target except where noted: the question is *"is this worse than what we have"*, asked
+against this install's own content.
+
+| # | metric | derived from | band |
+|---|---|---|---|
+| Q1 | **entity yield** | `Entity` nodes per episode | ≥ **90%** of W10 |
+| Q2 | **people recall** | member names appearing literally in a chunk's text, found as an `Entity` in that group | ≥ **95%** of W10 **and** at most **1** person lost outright |
+| Q3 | **duplicate pollution** | `IS_DUPLICATE_OF` share of edges, via **`lib/graph/extraction-health.ts`'s own Cypher predicate** (pinned by `test/guards/dedupe-predicate-pinned.test.ts`) | ≤ W10 **+ 5 pp** |
+| Q4 | **cross-chunk entity continuity** | bucket A + C items only: share of an item's entities appearing in ≥ 2 of its chunks | ≥ **85%** of W10 |
+| Q5 | **signed retry gap** | `(extract_nodes − episodesPushed) / episodesPushed`, in pp — the harness's `signed`, normalised | must not rise by more than **2 pp** vs W10 |
+| C1 | **input tokens per episode** | the harness | must fall by ≥ **25%** vs W10 |
+
+**Q4 is the metric that tests the actual mechanism** — Q1–Q3 would all stay green while cross-chunk
+references silently stopped resolving. Q2's two clauses are both floors and the stricter binds; at
+realistic n the 95% clause is usually the operative one, and the "1 person" clause only bites on a
+small denominator.
+
+### The decision function — total, and fixed before any number exists
+
+The previous draft pre-registered bands *and* a noise rule, and never said what happens when a metric
+lands below its band but within noise. That gap is a joint that gets chosen after the numbers exist —
+EXMODEL-1's failure re-entering through analysis flexibility instead of through the fixture. So:
+
+**Aggregation.** Each arm runs **2 reps** on the same corpus into a fresh database. An arm's value
+for a metric is the **mean of its two reps**. Ratios use the mean of W10's two reps as denominator.
+W10's own **spread** — `|rep1 − rep2|`, expressed in the same units as the band — is the noise
+estimate.
+
+**Per metric, exactly one of:**
+
+- **PASS** — the arm's mean meets the band.
+- **FAIL** — the arm's mean misses the band by **more than** W10's spread.
+- **INCONCLUSIVE** — the arm's mean misses the band by **no more than** W10's spread.
+
+**INCONCLUSIVE counts as FAIL for shipping.** The burden of proof is on the change: a metric we
+cannot distinguish from a regression is not evidence that there is none. Deciding this now is what
+stops it from being decided later, in the direction I want.
+
+**Arm order and outcome:**
+
+1. Evaluate **SAME**. All of Q1–Q5 and C1 PASS → **SAME ships**.
+2. Else evaluate **W1** on the identical rule → **W1 ships**.
+3. Else **the lever does not ship**, and the negative result is committed to this doc. Cutting the
+   context is then off the table until the `previous_episode_uuids` alternative is spec'd (below).
+
+C1's ≥25% applies identically to every candidate arm: a quality-clean arm that barely moves tokens
+does not justify a deploy of this service (see *Rollout*).
+
+**Rerun policy.** "Most recent" re-draws the corpus each session, so nothing structurally binds me to
+the first result. Therefore: **every started session's outcome is appended to this doc**, pass or
+fail, with its pinned item ids. A session may be marked *invalidated* only for a pre-defined infra
+reason — a harness refusal, an unavailable cross-check, or an arm that failed to complete every
+episode — never for its numbers.
+
+**Estimated spend: ≈$5–8** on the OpenRouter key (3 arms × 2 reps × ~100 episodes, cheaper per
+episode as the window shrinks). Direct-to-provider from a local brain: the `llm_usage` **rows** land
+in the local test database (which is what the harness reads), while the **dollars** land on the
+provider bill and never in our ledger or the Costs page.
+
+### Prod parity
+
+The local team row mirrors the prod team's `extraction_provider`/`extraction_model` **and its
+small-extraction backend** — `resolveGraphChatTargets`/`selectSmallExtractionBackend` returns
+`small: null` when unconfigured, and every small-marked call then silently lands on the strong model,
+so an unmirrored small setting measures a cost shape prod does not have. **Both resolved targets are
+printed in the battery's report.**
+
+## Phase C — the patch, only if Phase B clears
+
+A `sed` in `graphiti/Dockerfile` in that file's established style: a `grep` asserting the pre-state
+(and its uniqueness), a `grep` + `ast.parse` asserting the post-state, so a base-image change that
+moves the line **fails the build** rather than silently no-op'ing. That silent no-op is the class the
+Dockerfile's own comments exist to prevent, and is exactly what the parent spec's original
+`EPISODE_WINDOW_LEN = 3` proposal would have been.
+
+**Placement is load-bearing:** the RUN must come **after** the `pip install` RUN, or pip overwrites
+the edit and every gate still passes against the pre-install file — the precedent is patch 2's own
+comment at `graphiti/Dockerfile:102`. A final assertion RUN after **all** installs re-greps the
+post-state, so ordering cannot silently regress.
+
+```
+F=/app/.venv/lib/python3.12/site-packages/graphiti_core/graphiti.py
+test "$(grep -c 'last_n=RELEVANT_SCHEMA_LIMIT,' "$F")" = "1"          # pre-state + uniqueness
+sed -i '<the arm that won>' "$F"
+grep -q '<post-state marker, incl. a PIPEFF-2 comment>' "$F"
+python -c "import ast; ast.parse(open('$F').read())"
+# the constant's own uses are untouched — hardcoded, not "unchanged":
+test "$(grep -c RELEVANT_SCHEMA_LIMIT .../search/search_utils.py)" = "15"
+```
+
+### Rollout and rollback
+
+Deploying the `graphiti` service is not routine: **restarting or var-touching it has previously
+rebuilt a broken image**, and recovery is a **dashboard rollback to a recorded deployment ID** —
+never `railway up` / `redeploy` (denied by `.claude/settings.json` and a PreToolUse hook).
+
+1. Record the current deployment ID **before** the change.
+2. Confirm the service still has **no custom start command** — a start command re-syncs the venv at
+   boot and silently reverts every patch in the image (the ⚠️ precondition in the Dockerfile).
+3. Merge → Railway builds from `graphiti/`. **`docs/ARCHITECTURE.md` is updated in the same PR**
+   (CLAUDE.md §1).
+4. **Verify in the ledger, not the logs:** input tokens/episode on the same harness, over a
+   drain-clean prod window after the deploy, against the pre-deploy baseline — and read the signed
+   cross-check, not only the ratio.
+5. Watch Q3 in prod via the **dedupe-pollution alarm (AIO-693)**, live, which emails admins on the
+   ok→polluted edge. That alarm is the backstop for a quality regression the battery missed.
+
+Rollback is data-safe in the same sense the 0.29.3 upgrade was — same labels, same embedder, same
+indices — but Graphiti's worker queue is **in-memory**, so episodes accepted (202) and unprocessed at
+rollback are lost; confirm the brain's reconcile re-pushed them.
+
+## Alternatives considered
+
+- **Patch the constant `RELEVANT_SCHEMA_LIMIT`.** Rejected: 14 further uses in `search_utils.py` make
+  it a silent search-quality change.
+- **Pass `previous_episode_uuids` from the brain.** The most explicit version of the same idea, and
+  it lives in *our* code rather than a sed into a vendored library, so it survives image bumps. It
+  needs a patch to `graph_service/routers/ingest.py` **and** a new field on the brain's `/messages`
+  payload — two surfaces, and the brain would have to track chunk uuids it does not track today.
+  **Recorded as the follow-up if Phase B kills both arms**; it gets its own task key when triggered.
+- **`use_combined_extraction`** (merge node+edge extraction into one call). Unreachable from the
+  public API; noted in the parent spec, out of scope here.
+
+## How we will know it worked
+
+Input tokens per episode falls from **~40,070** by ≥25% on the harness, over a drain-clean prod
+window after the deploy, with Q1–Q5 unmoved on the battery — and the AIO-693 alarm quiet for a week.
+
+## Risks
+
+- **The battery passes and prod still degrades**, because ~100 episodes of this install's content is
+  not every shape of content. Mitigated by the AIO-693 alarm as the live backstop and by the recorded
+  rollback path — not by claiming the battery is exhaustive.
+- **Two reps is a thin noise estimate.** It bounds noise crudely; it cannot prove a small regression
+  absent. The INCONCLUSIVE-counts-as-FAIL rule is what makes a thin estimate safe rather than
+  convenient: thin noise makes shipping *harder*, not easier.
+- **The same-item filter changes behaviour for non-`items:` episodes** (e.g. `correction:<arc_id>`
+  writeback episodes), which would get zero predecessors. That is the intended semantics — a
+  correction episode has no document to be a chunk of — but it must be stated, and the Phase C PR
+  needs a test that pins it rather than discovering it.
+
+## Session log
+
+_(every started session appended here, pass or fail — see Rerun policy)_
+
+| session | corpus item ids | Phase A result | arm outcomes | verdict |
+|---|---|---|---|---|
+| — | — | not yet run | — | — |

--- a/docs/design/graph-episode-window.md
+++ b/docs/design/graph-episode-window.md
@@ -178,6 +178,12 @@ The heavy displacement (2.3 of 10 slots kept) is confined to small Linear items 
 with a 40-episode batch, which had little own-context to lose. So §4's guarantee is sound in
 practice for the case it matters for.
 
+**Which graph state this applies to.** These are **prod steady-state** numbers: they assume every
+episode finds a full ten-slot window. A Phase A/B run starts from an **empty Neo4j**, so the first
+~10 episodes have fewer predecessors available and carry less filler than the model says. That is
+~55 of 1,080 slots — it moves no verdict, but the comparison must be made against the same state, so
+the runner reports the warm-up episodes separately rather than blending them in.
+
 **The prediction this puts on the record, before Phase B runs:** the `SAME` filter removes **57.1% of
 all predecessor slots** as carrying nothing, and makes the remaining 43% *deterministic* rather than
 95% deterministic. Since the predecessor block is the largest term in the ~40,070 input tokens, C1's
@@ -291,7 +297,7 @@ against this install's own content.
 | # | metric | derived from | band |
 |---|---|---|---|
 | Q1 | **entity yield, TWO-SIDED** | `Entity` nodes per episode | within **± 10%** of W10 — an *increase* is as disqualifying as a fall |
-| Q2 | **people recall** | member names appearing literally in a chunk's text, found as an `Entity` in that group | ≥ **95%** of W10 **and** at most **1** person lost outright |
+| Q2 | **people recall** | member names appearing literally in a chunk's text, found as an `Entity` in that group | ≥ **95%** of W10 **and** at most **1** person lost outright — the count clause is **noise-free** (see below) |
 | Q3 | **duplicate pollution, TWO-SIDED** | `IS_DUPLICATE_OF` share of edges, via **`lib/graph/extraction-health.ts`'s own Cypher predicate** (pinned by `test/guards/dedupe-predicate-pinned.test.ts`) | within **± 5 pp** of W10 — a *fall* is as disqualifying as a rise |
 | Q4 | **cross-chunk entity continuity** | buckets A + C only: share of an item's entities appearing in ≥ 2 of its chunks | ≥ **85%** of W10 |
 | Q5 | **signed retry gap** | `(extract_nodes − episodesPushed) / episodesPushed`, in pp — the harness's `signed`, normalised | must not rise by more than **3 pp** vs W10 |
@@ -317,6 +323,13 @@ own, but it must be *auditable* rather than invisible, so the per-name counts go
 
 Q2's two clauses are both floors and the stricter binds; at realistic n the 95% clause is usually the
 operative one, and the "1 person" clause only bites on a small denominator.
+
+**The count clause takes no tolerance and yields no INCONCLUSIVE**, unlike every other gate. Applying
+a spread to an integer count of people would swallow the clause whole — any spread ≥ 1 makes "lost 2"
+and "lost 0" indistinguishable — which deletes the floor it exists to be. Losing two known people
+outright is not a statistical question. Both clauses are executable in
+`scripts/graph-window-battery/decision.mjs`, and it **refuses to judge Q2 at all** if the count was
+never measured, so the clause cannot be satisfied by omitting its input.
 
 **Q4's per-chunk attribution is real, not assumed:** 0.29.3 persists `(:Episodic)-[:MENTIONS]->(:Entity)`
 per episode (`models/edges/edge_db_queries.py:22`), built in `_process_episode_data` over the

--- a/docs/design/graph-episode-window.md
+++ b/docs/design/graph-episode-window.md
@@ -36,10 +36,11 @@ previous_episodes = (
 
 `grep -rn 'last_n=RELEVANT_SCHEMA_LIMIT' graphiti_core/` returns **exactly one line**. The constant
 itself is defined in `search/search_utils.py` and appears there **15 times** (1 definition + 14 uses)
-as the dedupe-candidate limit and the query-time retrieval limit — so patching the *constant* would
-silently narrow search quality, a different feature. **Patch the call site.** (Both this spec's
-earlier draft and the parent spec said "~20 sites"; the number is 15, and the parent spec is
-corrected in the same PR.)
+as the **query-time retrieval limit** — so patching the *constant* would silently narrow search
+quality, a different feature. **Patch the call site.** (Both this spec's earlier draft and the parent
+spec said "~20 sites"; the number is 15. Both also called it the dedupe-candidate limit — it isn't:
+that cap is `NODE_DEDUP_CANDIDATE_LIMIT = 15` at `node_operations.py:64`. Immaterial to the
+don't-patch-the-constant decision, but the parent spec is corrected in the same PR.)
 
 ### 2. The server can never take the other branch
 
@@ -93,9 +94,38 @@ Episode names are `items:<id>` (single chunk) or `items:<id>#k` (`lib/graph/epis
 pre-`#` prefix — the Cypher query is unchanged (retrieval is not an LLM call and costs nothing worth
 optimising); only what reaches the four prompts changes.
 
-- **single-chunk item** → **zero** predecessors (better than `last_n=1`, and provably lossless: no
-  predecessor could have been the same document)
+- **single-chunk item** → **zero** predecessors (better than `last_n=1`, and **provably loses no
+  same-document context**: no predecessor could have been the same document)
 - **multi-chunk item** → all of its own prior chunks, up to 10 (the mechanism preserved intact)
+
+### What the filter *can* still cost — and why the first draft's gates were blind to it
+
+An earlier draft called the single-chunk case "provably lossless". That overclaims, and the failure
+it hides is this repo's own documented incident class. Unrelated predecessors do two real jobs:
+
+1. **Name canonicalization at extraction** — a chunk saying "John" extracts the canonical "John Smith"
+   when a predecessor named him in full; without one it extracts "John".
+2. **Dedupe judgment context** — `_resolve_with_llm` embeds full predecessor content into the
+   `dedupe_nodes` prompt (`node_operations.py:539-548`) precisely so the model can decide whether
+   extracted-"John" *is* candidate-"John Smith". With no context, the safe answer is **don't merge**.
+
+(Candidate *retrieval* is unaffected — candidates come from embedding similarity capped at
+`NODE_DEDUP_CANDIDATE_LIMIT`, `node_operations.py:418-452`. It is the *judgment* that loses context.)
+
+The resulting failure is **cross-item entity fragmentation**: one person or project as several
+parallel nodes. Check that against the direction of each band in the first draft and every one of
+them passes:
+
+| gate | what fragmentation does to it |
+|---|---|
+| entity yield ≥ 90% | fragmentation **raises** node count → PASS |
+| people recall | conditioned on the full name appearing literally, so the partial-name case is excluded from the denominator by construction → blind |
+| dupe share ≤ W10 + 5pp | a failure-to-merge emits **no** `IS_DUPLICATE_OF` edge, so the share **falls** → PASS |
+| cross-chunk continuity | within-item only; SAME preserves own-chunk context → PASS |
+
+So the first draft's battery would have cleared an arm that fragmented the graph's identity layer —
+the AIO-693 class. It applies to the `W1` arm too (1 unrelated predecessor instead of 10), so it is a
+battery gap, not a SAME-specific one. **Q3 becomes two-sided and Q6 is added below.**
 
 `last_n=1` — the parent spec's proposal — remains in the battery as the **blunt floor**: it is a
 smaller patch, and if the same-item filter fails to cut enough tokens (a corpus dominated by long
@@ -151,25 +181,46 @@ to be synthetic, and two synthetic attempts scored the *negative control* — th
 polluted the graph — as a pass and the good model as a fail. A fixture iterated until it agrees with
 the conclusion is the failure this workstream exists to prevent.
 
-The battery copies the selected `items` rows, the `members` rows (Q2 needs them) and the `teams` row
+The battery copies the selected `items` rows, the `members` rows (Q2/Q6 need them) and the `teams` row
 from prod (read-only) into the local Postgres. Content stays local; nothing is committed.
+
+**Three things beyond rows are required before a single call can flow**, named here because omitting
+one produces a stack that boots and then does nothing:
+
+1. the team's **`integrations` row copied verbatim, still encrypted**, plus `SECRETS_KEY` read from
+   Railway — so the provider key is never materialised into a file at any point;
+2. **`GRAPH_LLM_PROXY_SECRET`** set identically on the brain, the capture tap and graphiti
+   (`authorizeGraphProxy` fails **closed** when it is unset — by design);
+3. **`GRAPH_LLM_TEAM`** = the seeded team's slug, or `resolveGraphProxyTeamId` refuses rather than
+   guessing.
 
 **Selection rule, fixed in advance, buckets disjoint by construction, `access = 'team'` only:**
 
 | bucket | rule | ≈episodes |
 |---|---|---|
 | A | the **5** most recent items of **≥ 8 chunks** | ~50 |
-| B | the **20** most recent items of **exactly 1 chunk and < 600 chars** | 20 |
+| B1 | the **15** most recent items of **exactly 1 chunk, < 600 chars** | 15 |
+| B2 | the **5** most recent items of **exactly 1 chunk, ≥ 600 chars** | 5 |
 | C | the **8** most recent items of **2–7 chunks** | ~30 |
 
-≈100 episodes per rep. The `access='team'` restriction is what makes this land in **one group** — by
-selection, not by bypassing the projector (see below). The selected item ids are **pinned in the
-report** so a later run is comparable rather than merely similar.
+The four buckets **partition** the corpus by chunk count — an earlier draft's "1 chunk *and* <600
+chars" against "2–7 chunks" left a 1-chunk-but-large item in no bucket at all, the same class of hole
+as the 4–7-chunk gap before it.
 
-**Q2 power extension, deterministic:** if the corpus yields fewer than **15** literal member-name
-occurrences, extend bucket C by the next most-recent qualifying items, up to **+10**, until it does.
-If it still does not, Q2 is **UNDERPOWERED**, which counts as a FAIL (see the decision function —
-the conservative default is the point).
+≈100 episodes per rep, of which ~20% are single-chunk-item episodes — against **~17% in prod**
+(898 of 5,166). That match is what makes the blended C1 transferable, and C1 is corpus-mix-sensitive,
+so it is stated rather than left implicit.
+
+The `access='team'` restriction is what makes this land in **one group** — by selection, not by
+bypassing the projector (see below). The selected item ids are **pinned in the report** so a later
+run is comparable rather than merely similar.
+
+**Q2/Q6 power extension, deterministic:** if the corpus yields fewer than **15** literal member-name
+occurrences (Q2), or fewer than **5** member names present in ≥2 distinct items (Q6), extend bucket C
+by the next most-recent qualifying items, up to **+10**, until it does. If it still does not, that
+metric is **UNDERPOWERED**, which **invalidates the session** — it does not count as a FAIL. A corpus
+that cannot produce enough names is a power failure, not evidence of a regression, and the spec
+already draws that distinction for harness refusals.
 
 ### The push is the real projector run path
 
@@ -199,15 +250,30 @@ against this install's own content.
 |---|---|---|---|
 | Q1 | **entity yield** | `Entity` nodes per episode | ≥ **90%** of W10 |
 | Q2 | **people recall** | member names appearing literally in a chunk's text, found as an `Entity` in that group | ≥ **95%** of W10 **and** at most **1** person lost outright |
-| Q3 | **duplicate pollution** | `IS_DUPLICATE_OF` share of edges, via **`lib/graph/extraction-health.ts`'s own Cypher predicate** (pinned by `test/guards/dedupe-predicate-pinned.test.ts`) | ≤ W10 **+ 5 pp** |
-| Q4 | **cross-chunk entity continuity** | bucket A + C items only: share of an item's entities appearing in ≥ 2 of its chunks | ≥ **85%** of W10 |
+| Q3 | **duplicate pollution, TWO-SIDED** | `IS_DUPLICATE_OF` share of edges, via **`lib/graph/extraction-health.ts`'s own Cypher predicate** (pinned by `test/guards/dedupe-predicate-pinned.test.ts`) | within **± 5 pp** of W10 — a *fall* is as disqualifying as a rise |
+| Q4 | **cross-chunk entity continuity** | buckets A + C only: share of an item's entities appearing in ≥ 2 of its chunks | ≥ **85%** of W10 |
 | Q5 | **signed retry gap** | `(extract_nodes − episodesPushed) / episodesPushed`, in pp — the harness's `signed`, normalised | must not rise by more than **2 pp** vs W10 |
+| Q6 | **cross-item entity convergence** | over member names appearing literally in chunks of **≥ 2 distinct items**: distinct `Entity` nodes carrying that name ÷ distinct names matched | ≤ **105%** of W10 |
 | C1 | **input tokens per episode** | the harness | must fall by ≥ **25%** vs W10 |
 
-**Q4 is the metric that tests the actual mechanism** — Q1–Q3 would all stay green while cross-chunk
-references silently stopped resolving. Q2's two clauses are both floors and the stricter binds; at
-realistic n the 95% clause is usually the operative one, and the "1 person" clause only bites on a
-small denominator.
+**Q4 and Q6 are the two metrics that test mechanisms rather than symptoms.** Q4 catches the loss of
+*within-document* context — Q1–Q3 would all stay green while cross-chunk references stopped
+resolving. Q6 catches the loss of *cross-item* dedupe judgment described above, which is the only
+gate whose direction is right for fragmentation; it deliberately reuses Q2's member-name machinery
+rather than inventing a second identity notion.
+
+**Q3's lower bound is not symmetry for its own sake.** `extraction-health.ts` already treats an
+anomalously *low* duplicate share as suspect, and failure-to-merge is exactly how the share falls
+while the graph gets worse.
+
+Q2's two clauses are both floors and the stricter binds; at realistic n the 95% clause is usually the
+operative one, and the "1 person" clause only bites on a small denominator.
+
+**Q4's per-chunk attribution is real, not assumed:** 0.29.3 persists `(:Episodic)-[:MENTIONS]->(:Entity)`
+per episode (`models/edges/edge_db_queries.py:22`), built in `_process_episode_data` over the
+**resolved** (post-dedupe, canonical) nodes — so Q4 measures whether resolution converged across
+chunks, which is what it is for. The item id must be parsed with `itemIdFromEpisodeName`'s exact
+logic, **never** `STARTS WITH 'items:<id>'`, which would swallow `items:123` into `items:12`.
 
 ### The decision function — total, and fixed before any number exists
 
@@ -220,19 +286,30 @@ for a metric is the **mean of its two reps**. Ratios use the mean of W10's two r
 W10's own **spread** — `|rep1 − rep2|`, expressed in the same units as the band — is the noise
 estimate.
 
-**Per metric, exactly one of:**
+**Per metric, exactly one of — and the rule is SYMMETRIC about the band:**
 
-- **PASS** — the arm's mean meets the band.
+- **PASS** — the arm's mean beats the band by **more than** W10's spread.
 - **FAIL** — the arm's mean misses the band by **more than** W10's spread.
-- **INCONCLUSIVE** — the arm's mean misses the band by **no more than** W10's spread.
+- **INCONCLUSIVE** — the arm's mean lands **within ± spread** of the band.
 
 **INCONCLUSIVE counts as FAIL for shipping.** The burden of proof is on the change: a metric we
-cannot distinguish from a regression is not evidence that there is none. Deciding this now is what
-stops it from being decided later, in the direction I want.
+cannot distinguish from a regression is not evidence that there is none.
+
+**Why the PASS side has to carry the spread too.** An earlier draft required only "the mean meets the
+band", which made the noise estimate irrelevant to every above-band outcome — and since the bands are
+*multiplicative in W10's mean*, that let noise work in the shipping direction. Worked example: true
+W10 entity yield 10.0/episode, SAME's true value 8.5 (a real 15% regression that should fail the 90%
+band). W10's reps come in at 10.2 and 6.0 — one rep quietly degraded by a provider brownout that
+completes every episode and so trips none of the invalidation conditions. W10 mean 8.1 → band 7.29 →
+SAME's 8.5 **passes**. More noise, easier shipping — the exact opposite of what the Risks section
+claims. Under the symmetric rule the band is 7.29 + 4.2 = 11.5 and SAME correctly fails.
+
+**Belt and braces:** if W10's spread on any metric exceeds **25% of its own mean**, the session is
+**INVALID** — that is not a result, it is a broken instrument.
 
 **Arm order and outcome:**
 
-1. Evaluate **SAME**. All of Q1–Q5 and C1 PASS → **SAME ships**.
+1. Evaluate **SAME**. All of Q1–Q6 and C1 PASS → **SAME ships**.
 2. Else evaluate **W1** on the identical rule → **W1 ships**.
 3. Else **the lever does not ship**, and the negative result is committed to this doc. Cutting the
    context is then off the table until the `previous_episode_uuids` alternative is spec'd (below).
@@ -240,11 +317,18 @@ stops it from being decided later, in the direction I want.
 C1's ≥25% applies identically to every candidate arm: a quality-clean arm that barely moves tokens
 does not justify a deploy of this service (see *Rollout*).
 
-**Rerun policy.** "Most recent" re-draws the corpus each session, so nothing structurally binds me to
-the first result. Therefore: **every started session's outcome is appended to this doc**, pass or
-fail, with its pinned item ids. A session may be marked *invalidated* only for a pre-defined infra
-reason — a harness refusal, an unavailable cross-check, or an arm that failed to complete every
-episode — never for its numbers.
+**Rerun policy — and which session BINDS.** "Most recent" re-draws the corpus each session, so
+logging reruns makes multiplicity *visible* without closing it: running sessions until one passes and
+shipping on the passer would still be legal under a log-everything rule. So:
+
+- **every started session's outcome is appended to this doc**, pass or fail, with its pinned item ids;
+- **the first valid session's verdict binds.** A further session may only follow a **committed
+  amendment to this spec** stating what is being changed and why;
+- shipping requires the latest valid session to pass **and** no prior valid session to have failed the
+  same arm without that amendment on the record;
+- a session is *invalidated* only for a **pre-defined** reason — a harness refusal, an unavailable
+  cross-check, an arm that failed to complete every episode, an UNDERPOWERED Q2/Q6, or a W10 spread
+  above 25% of its mean — **never for its numbers**.
 
 **Estimated spend: ≈$5–8** on the OpenRouter key (3 arms × 2 reps × ~100 episodes, cheaper per
 episode as the window shrinks). Direct-to-provider from a local brain: the `llm_usage` **rows** land
@@ -272,10 +356,15 @@ the edit and every gate still passes against the pre-install file — the preced
 comment at `graphiti/Dockerfile:102`. A final assertion RUN after **all** installs re-greps the
 post-state, so ordering cannot silently regress.
 
+**The sed that ships is the sed that was measured, byte for byte** — lifted from the arm's image and
+recorded in the session log, not re-derived at ship time. This matters more for `SAME` than for `W1`:
+`W1` is a one-argument swap, while `SAME` is a multi-line Python insertion, and a "cleaned up"
+re-derivation is precisely how a measured result gets attached to an unmeasured patch.
+
 ```
 F=/app/.venv/lib/python3.12/site-packages/graphiti_core/graphiti.py
 test "$(grep -c 'last_n=RELEVANT_SCHEMA_LIMIT,' "$F")" = "1"          # pre-state + uniqueness
-sed -i '<the arm that won>' "$F"
+sed -i '<the winning arm's sed, VERBATIM from the image the battery ran>' "$F"
 grep -q '<post-state marker, incl. a PIPEFF-2 comment>' "$F"
 python -c "import ast; ast.parse(open('$F').read())"
 # the constant's own uses are untouched — hardcoded, not "unchanged":
@@ -326,8 +415,13 @@ window after the deploy, with Q1–Q5 unmoved on the battery — and the AIO-693
   not every shape of content. Mitigated by the AIO-693 alarm as the live backstop and by the recorded
   rollback path — not by claiming the battery is exhaustive.
 - **Two reps is a thin noise estimate.** It bounds noise crudely; it cannot prove a small regression
-  absent. The INCONCLUSIVE-counts-as-FAIL rule is what makes a thin estimate safe rather than
-  convenient: thin noise makes shipping *harder*, not easier.
+  absent. The **symmetric** PASS/FAIL/INCONCLUSIVE rule is what makes a thin estimate safe rather than
+  convenient: because the spread widens the band on *both* sides, more noise is strictly anti-ship.
+  (The asymmetric version in the first draft made this sentence false — bands are multiplicative in
+  W10's mean, so a degraded W10 rep *lowered* the bar. That is why the rule is symmetric.)
+- **A metric can still be blind to a failure nobody enumerated.** Q6 exists because the first draft's
+  five gates all pointed the wrong way for entity fragmentation. There is no argument that Q1–Q6 are
+  exhaustive — only that each named failure mode now has a gate whose direction is right for it.
 - **The same-item filter changes behaviour for non-`items:` episodes** (e.g. `correction:<arc_id>`
   writeback episodes), which would get zero predecessors. That is the intended semantics — a
   correction episode has no document to be a chunk of — but it must be stated, and the Phase C PR

--- a/docs/design/graph-episode-window.md
+++ b/docs/design/graph-episode-window.md
@@ -158,6 +158,36 @@ Measured **across all four metered carriers** — `extract_nodes`, `extract_edge
 Phase A's numbers are written into this doc **before** Phase B runs, so the prediction is on the
 record before the result exists.
 
+### Phase A, part 1 — the structural half, measured 2026-08-06 at **zero LLM cost**
+
+Two of Phase A's three questions turned out not to need a run at all. Given the tie-rank guarantee
+(§4), the same-item share is **derivable** from the corpus shape, and tie-pool contamination is a
+**SQL query against prod**. Both were computed over the pinned 108-episode corpus:
+
+| | result |
+|---|---|
+| predecessor slots that are **unrelated items** | **617 of 1,080 — 57.1%**, pure billed waste |
+| same-item share, **single-chunk** items | **0%** (200 slots, all filler — nothing to be a chunk of) |
+| same-item share, **multi-chunk** items | **52.6%** (the rest is filler because chunk *k* has only *k* predecessors of its own to offer, and *k* < 10 for most chunks) |
+| tie-pool contamination | **every** corpus item has a rival sharing its exact `work_at`; worst is 40 rival episodes |
+| own-chunk slots the guarantee actually delivers | **95.1%** (440 of 463) |
+
+**The contamination is real but lands where it costs least.** The multi-chunk *documents* — the
+population Q4 measures — carry **1 rival episode each** and keep 95–100% of their own-chunk slots.
+The heavy displacement (2.3 of 10 slots kept) is confined to small Linear items sharing a `work_at`
+with a 40-episode batch, which had little own-context to lose. So §4's guarantee is sound in
+practice for the case it matters for.
+
+**The prediction this puts on the record, before Phase B runs:** the `SAME` filter removes **57.1% of
+all predecessor slots** as carrying nothing, and makes the remaining 43% *deterministic* rather than
+95% deterministic. Since the predecessor block is the largest term in the ~40,070 input tokens, C1's
+25% band should be cleared comfortably — and if it is not, the token accounting is wrong somewhere
+and that is itself the finding.
+
+**What still needs the stack:** the *size* of the predecessor block per call kind — the parent spec's
+~6,250 tokens is derived, not observed — across all four metered carriers. That is the only part of
+Phase A that spends money.
+
 ## Phase B — the battery
 
 Three arms, each replaying the **same corpus in the same order into a fresh, empty Neo4j**, at the

--- a/docs/design/graph-episode-window.md
+++ b/docs/design/graph-episode-window.md
@@ -196,20 +196,32 @@ one produces a stack that boots and then does nothing:
 
 **Selection rule, fixed in advance, buckets disjoint by construction, `access = 'team'` only:**
 
-| bucket | rule | ≈episodes |
+| bucket | rule | episodes (measured) |
 |---|---|---|
-| A | the **5** most recent items of **≥ 8 chunks** | ~50 |
+| A | the **3** most recent items of **≥ 8 chunks** | 57 |
 | B1 | the **15** most recent items of **exactly 1 chunk, < 600 chars** | 15 |
 | B2 | the **5** most recent items of **exactly 1 chunk, ≥ 600 chars** | 5 |
-| C | the **8** most recent items of **2–7 chunks** | ~30 |
+| C | the **8** most recent items of **2–7 chunks** | 31 |
+
+> **Amendment, 2026-08-06, before any session ran — bucket A: 5 → 3.** Run against this install, `A: 5`
+> selected 9, 8, 40, 23 and 22-chunk items: **102 episodes in bucket A alone, 153 in total**, against
+> the ~100 this spec assumed. That is not just a cost overrun — **Q5's band is derived from the corpus
+> size.** At ~100 episodes one validation retry moves the signed gap by ~1 pp, which is the entire
+> reason the band is 3 pp and its ceiling 1.5 pp. At 153 episodes one retry is 0.65 pp, so the same
+> pre-registered ceiling would silently tolerate **2.3 retries instead of one** — the number unchanged,
+> its meaning changed. Fixing the corpus size preserves the coupling; re-deriving the band after
+> seeing a corpus would not. `A: 3` measures **108 episodes**, one retry ≈ 0.93 pp, and the
+> single-chunk episode share moves from 13.1% to **18.5%** — *closer* to prod's ~17%, which matters
+> because C1 is corpus-mix-sensitive. `selectCorpus` now refuses outside **90–120 episodes**
+> (`EPISODE_BUDGET`), so a future draw cannot break the coupling quietly.
 
 The four buckets **partition** the corpus by chunk count — an earlier draft's "1 chunk *and* <600
 chars" against "2–7 chunks" left a 1-chunk-but-large item in no bucket at all, the same class of hole
 as the 4–7-chunk gap before it.
 
-≈100 episodes per rep, of which ~20% are single-chunk-item episodes — against **~17% in prod**
-(898 of 5,166). That match is what makes the blended C1 transferable, and C1 is corpus-mix-sensitive,
-so it is stated rather than left implicit.
+**108 episodes per rep, of which 18.5% are single-chunk-item episodes** — against **~17% in prod**
+(898 of 5,166). Both numbers are measured, not estimated. That match is what makes the blended C1
+transferable, and C1 is corpus-mix-sensitive, so it is stated rather than left implicit.
 
 The `access='team'` restriction is what makes this land in **one group** — by selection, not by
 bypassing the projector (see below). The selected item ids are **pinned in the report** so a later
@@ -419,8 +431,9 @@ needs no amendment. So the redraw joint is closed on the invalid side too:
 > future edit ever softens "the first valid session binds", *consecutive* silently becomes a real
 > hole and must become a total count in the same change.
 
-**Estimated spend: ≈$5–8** on the OpenRouter key (3 arms × 2 reps × ~100 episodes, cheaper per
-episode as the window shrinks). Direct-to-provider from a local brain: the `llm_usage` **rows** land
+**Estimated spend: ≤ $9.53** on the OpenRouter key — 3 arms × 2 reps × 108 episodes at the incumbent's
+measured $0.0147/episode, and that is an upper bound because the two candidate arms carry less context
+and so cost less per episode. Direct-to-provider from a local brain: the `llm_usage` **rows** land
 in the local test database (which is what the harness reads), while the **dollars** land on the
 provider bill and never in our ledger or the Costs page.
 

--- a/docs/design/graph-episode-window.md
+++ b/docs/design/graph-episode-window.md
@@ -248,12 +248,12 @@ against this install's own content.
 
 | # | metric | derived from | band |
 |---|---|---|---|
-| Q1 | **entity yield** | `Entity` nodes per episode | ≥ **90%** of W10 |
+| Q1 | **entity yield, TWO-SIDED** | `Entity` nodes per episode | within **± 10%** of W10 — an *increase* is as disqualifying as a fall |
 | Q2 | **people recall** | member names appearing literally in a chunk's text, found as an `Entity` in that group | ≥ **95%** of W10 **and** at most **1** person lost outright |
 | Q3 | **duplicate pollution, TWO-SIDED** | `IS_DUPLICATE_OF` share of edges, via **`lib/graph/extraction-health.ts`'s own Cypher predicate** (pinned by `test/guards/dedupe-predicate-pinned.test.ts`) | within **± 5 pp** of W10 — a *fall* is as disqualifying as a rise |
 | Q4 | **cross-chunk entity continuity** | buckets A + C only: share of an item's entities appearing in ≥ 2 of its chunks | ≥ **85%** of W10 |
-| Q5 | **signed retry gap** | `(extract_nodes − episodesPushed) / episodesPushed`, in pp — the harness's `signed`, normalised | must not rise by more than **2 pp** vs W10 |
-| Q6 | **cross-item entity convergence** | over member names appearing literally in chunks of **≥ 2 distinct items**: distinct `Entity` nodes carrying that name ÷ distinct names matched | ≤ **105%** of W10 |
+| Q5 | **signed retry gap** | `(extract_nodes − episodesPushed) / episodesPushed`, in pp — the harness's `signed`, normalised | must not rise by more than **3 pp** vs W10 |
+| Q6 | **cross-item entity convergence** | over member names appearing literally in chunks of **≥ 2 distinct items**: distinct `Entity` nodes carrying that name ÷ distinct names matched, **case-normalised on both sides** | ≤ **105%** of W10 |
 | C1 | **input tokens per episode** | the harness | must fall by ≥ **25%** vs W10 |
 
 **Q4 and Q6 are the two metrics that test mechanisms rather than symptoms.** Q4 catches the loss of
@@ -262,9 +262,16 @@ resolving. Q6 catches the loss of *cross-item* dedupe judgment described above, 
 gate whose direction is right for fragmentation; it deliberately reuses Q2's member-name machinery
 rather than inventing a second identity notion.
 
-**Q3's lower bound is not symmetry for its own sake.** `extraction-health.ts` already treats an
-anomalously *low* duplicate share as suspect, and failure-to-merge is exactly how the share falls
-while the graph gets worse.
+**Q1's and Q3's upper/lower bounds are not symmetry for its own sake.** `extraction-health.ts` already
+treats an anomalously *low* duplicate share as suspect, and failure-to-merge is exactly how the share
+falls while the graph gets worse. Q1's new **upper** bound is the catch-all for the fragmentation
+Q6 cannot see: the canonicalization failure above yields a node named `"John"`, which carries no
+member name at all and so never enters Q6's denominator — but it does inflate node count. A one-sided
+Q1 would have waved it through.
+
+**Q6 reports a per-name breakdown, not only the ratio.** The aggregate can stay flat while the arm
+fragments name A and W10 happens to fragment name B. That case is rare and not disqualifying on its
+own, but it must be *auditable* rather than invisible, so the per-name counts go in the report.
 
 Q2's two clauses are both floors and the stricter binds; at realistic n the 95% clause is usually the
 operative one, and the "1 person" clause only bites on a small denominator.
@@ -304,8 +311,43 @@ completes every episode and so trips none of the invalidation conditions. W10 me
 SAME's 8.5 **passes**. More noise, easier shipping — the exact opposite of what the Risks section
 claims. Under the symmetric rule the band is 7.29 + 4.2 = 11.5 and SAME correctly fails.
 
-**Belt and braces:** if W10's spread on any metric exceeds **25% of its own mean**, the session is
-**INVALID** — that is not a result, it is a broken instrument.
+**The validity ceiling is expressed in BAND units, not as a fraction of the mean.** An earlier draft
+said "spread > 25% of W10's mean ⇒ INVALID", which is degenerate in both directions:
+
+- **Too tight where the healthy mean is ~0.** Q5's healthy W10 value is ≈ 0 (the prod baseline
+  cross-checked *exact*), so 25%-of-mean ≈ 0 and **a single validation retry in one W10 rep**
+  invalidates the session. The battery could plausibly never complete a valid session.
+- **Too loose where the band is tight.** At a healthy W10 dupe share of 30%, the ceiling permits a
+  spread of 7.5 pp — but Q3's band is ± 5 pp, and PASS requires sitting more than `spread` inside
+  *both* edges, so the PASS window is **empty**. A session would be valid with a metric no arm could
+  ever pass.
+
+A decision procedure that can deadlock mid-experiment is the failure this spec exists to prevent,
+because a deadlock is what gets rewritten under pressure. So, per metric:
+
+> **W10's spread must be ≤ half that metric's band margin**, with an absolute floor where the healthy
+> mean sits near zero. Otherwise the session is **INVALID** — not a result, a broken instrument.
+
+| metric | band margin | max W10 spread |
+|---|---|---|
+| Q1 | ± 10% of W10 | 5% of W10's mean |
+| Q2 | 5% | 2.5% |
+| Q3 | ± 5 pp | 2.5 pp |
+| Q4 | 15% | 7.5% |
+| Q5 | 3 pp | **1.5 pp** (floor: at ~100 episodes one retry ≈ 1 pp, so one retry of rep-to-rep difference is tolerated and two is not — which is why Q5's band is 3 pp rather than 2) |
+| Q6 | 5% | 2.5% |
+| C1 | 25% | 12.5% |
+
+**This construction also guarantees every PASS window is non-empty in a valid session**: PASS needs
+the arm to beat the band by more than `spread`, and `spread ≤ ½ margin` always leaves room. That is
+the property the old ceiling lacked, and it is why the ceiling is derived from the band rather than
+chosen.
+
+**One further sanity gate, borrowed from the module that already owns the question:** if W10's own
+duplicate share falls outside **15–45%**, the session is INVALID. `extraction-health.ts` measures a
+healthy share on this graph at **~26–35%** and treats a literal zero as evidence the *predicate* is
+broken rather than the graph clean; ~70% was the degraded model. A W10 arm outside that range is not
+a baseline worth comparing against.
 
 **Arm order and outcome:**
 
@@ -327,8 +369,20 @@ shipping on the passer would still be legal under a log-everything rule. So:
 - shipping requires the latest valid session to pass **and** no prior valid session to have failed the
   same arm without that amendment on the record;
 - a session is *invalidated* only for a **pre-defined** reason — a harness refusal, an unavailable
-  cross-check, an arm that failed to complete every episode, an UNDERPOWERED Q2/Q6, or a W10 spread
-  above 25% of its mean — **never for its numbers**.
+  cross-check, an arm that failed to complete every episode, an UNDERPOWERED Q2/Q6, a W10 spread over
+  its per-metric ceiling, or a W10 duplicate share outside 15–45% — **never for its numbers**.
+
+**Invalidation is a free retry, so it is capped.** The amendment gate binds only *valid* sessions, and
+it has to — an infra failure must not deadlock the battery. But one trigger is operator-inducible:
+killing a container mid-arm invalidates a session that was trending badly, and next week's redraw then
+needs no amendment. So the redraw joint is closed on the invalid side too:
+
+- an invalidated session still has its **partial metrics computed and appended** to the session log,
+  with the invalidation cause attached — so a run that was going badly leaves the same trace as one
+  that was going well;
+- **more than two consecutive invalidations** without an intervening committed amendment **block
+  further sessions**. If the battery cannot complete twice running, the instrument is what needs
+  fixing, and that fix belongs in this doc before more money is spent.
 
 **Estimated spend: ≈$5–8** on the OpenRouter key (3 arms × 2 reps × ~100 episodes, cheaper per
 episode as the window shrinks). Direct-to-provider from a local brain: the `llm_usage` **rows** land
@@ -407,7 +461,7 @@ rollback are lost; confirm the brain's reconcile re-pushed them.
 ## How we will know it worked
 
 Input tokens per episode falls from **~40,070** by ≥25% on the harness, over a drain-clean prod
-window after the deploy, with Q1–Q5 unmoved on the battery — and the AIO-693 alarm quiet for a week.
+window after the deploy, with Q1–Q6 unmoved on the battery — and the AIO-693 alarm quiet for a week.
 
 ## Risks
 

--- a/docs/design/graph-episode-window.md
+++ b/docs/design/graph-episode-window.md
@@ -1,7 +1,7 @@
 # Lever 2 — stop paying for predecessor episodes that carry nothing
 
-**Status:** spec, revised after plan review — 2 blockers + 1 HIGH that inverted a finding of mine
-· **Date:** 2026-08-06 · **Owner:** Chetan
+**Status:** **CLEAR** after four plan-review rounds — 3 blockers + 2 HIGHs, one of which inverted a
+finding of mine and reshaped the lever · **Date:** 2026-08-06 · **Owner:** Chetan
 · **Task:** `PIPEFF-2` → [AIO-821](https://linear.app/je4light/issue/AIO-821)
 · **Parent:** `PIPEFF-1` / [AIO-820](https://linear.app/je4light/issue/AIO-820) —
   [`graph-ingestion-efficiency.md`](./graph-ingestion-efficiency.md)
@@ -335,19 +335,46 @@ because a deadlock is what gets rewritten under pressure. So, per metric:
 | Q3 | ± 5 pp | 2.5 pp |
 | Q4 | 15% | 7.5% |
 | Q5 | 3 pp | **1.5 pp** (floor: at ~100 episodes one retry ≈ 1 pp, so one retry of rep-to-rep difference is tolerated and two is not — which is why Q5's band is 3 pp rather than 2) |
+
 | Q6 | 5% | 2.5% |
 | C1 | 25% | 12.5% |
 
-**This construction also guarantees every PASS window is non-empty in a valid session**: PASS needs
-the arm to beat the band by more than `spread`, and `spread ≤ ½ margin` always leaves room. That is
-the property the old ceiling lacked, and it is why the ceiling is derived from the band rather than
-chosen.
+**This construction also guarantees every PASS window is non-empty in a valid session.** For the
+two-sided bands that is the whole point: Q3's window is `(W10−5+s, W10+5−s)`, non-empty iff
+`s < 5 pp`, and the ceiling is 2.5. Q1's band is two-sided *and multiplicative* — edges `0.9M` and
+`1.1M`, window non-empty iff `s < 0.1M` — and its ceiling is `0.05M`, which scales with the **same
+`M`** as the edges, so the inequality holds identically for every `M > 0`. That is structurally
+unlike the old rule, which used the mean as a *universal* scale including for Q5, whose mean is
+legitimately ≈0 and has nothing to do with its band width; here the scale is the band, and the two
+metrics with dangerous means (Q3, Q5) carry absolute-pp ceilings. (For the one-sided bands the PASS
+region is a half-line and is non-empty for any spread — there the ceiling is doing a different job,
+namely stopping the same two reps from setting both the bar and the noise gate too coarsely.)
+
+**Why Q5's band is 3 pp and why widening it did not cost the guard its teeth.** A validation retry
+adds one attempt to C1's denominator and one metered `extract_nodes` call — ~8,400 input tokens,
+well under the ~40,000/attempt baseline — to its numerator, so retries drag tokens-per-episode
+*down*. At 100 episodes with the full 3-retry allowance:
+`(100 × 40,070 + 3 × 8,400) / 103 ≈ 39,148` — a **−2.3% artifact against a band that demands −25%**,
+about a tenth of the required movement, and the symmetric rule already requires beating 25% by more
+than W10's C1 spread on top of that. The bound is conservative in the right direction, too: retry
+prompts are *longer* than the originals (the error context is appended), which raises the added
+numerator and shrinks the artifact further.
 
 **One further sanity gate, borrowed from the module that already owns the question:** if W10's own
-duplicate share falls outside **15–45%**, the session is INVALID. `extraction-health.ts` measures a
-healthy share on this graph at **~26–35%** and treats a literal zero as evidence the *predicate* is
-broken rather than the graph clean; ~70% was the degraded model. A W10 arm outside that range is not
-a baseline worth comparing against.
+duplicate share falls outside **15–45%**, the session is INVALID — a baseline outside that range is
+not worth comparing against.
+
+- The **45%** is not padding: it is `DEDUPE_ABSOLUTE_FLOOR = 0.45` (`extraction-health.ts:284`), the
+  module's own constant, sitting above every healthy reading on record (~26–35%) and below the
+  degraded model's ~70%.
+- The **15%** has no module counterpart, and the reason it is below prod's healthy range is
+  structural rather than arbitrary: **the battery runs into a fresh, empty Neo4j**, so early episodes
+  have no existing candidates to duplicate against and the blended share over ~100 episodes sits
+  below prod's steady state by construction. If a first valid W10 arm still lands under 15%, that is
+  an **amendment case** — the number gets re-derived on the record, not silently re-padded.
+- The module also refuses to judge the share below `MIN_EDGES_FOR_DEDUPE_SIGNAL = 200` edges
+  (`:272`). **The battery adopts the same minimum-sample refusal for Q3 and Q6**; ~100 episodes
+  should clear it comfortably at prod's edge rates, so it is a cheap tripwire rather than a burden.
 
 **Arm order and outcome:**
 
@@ -383,6 +410,14 @@ needs no amendment. So the redraw joint is closed on the invalid side too:
 - **more than two consecutive invalidations** without an intervening committed amendment **block
   further sessions**. If the battery cannot complete twice running, the instrument is what needs
   fixing, and that fix belongs in this doc before more money is spent.
+
+> **These two rules are load-bearing on each other and must not be edited independently.**
+> *Consecutive* is a safe counter **only because a valid session binds**: resetting the counter
+> requires completing a valid session, and a valid session is never neutral — a valid FAIL binds
+> against the arm, a valid PASS ends the experiment. So interleaving a "sacrificial" valid run to
+> reset the count is self-defeating, and before the first valid session *consecutive* ≡ *total*. If a
+> future edit ever softens "the first valid session binds", *consecutive* silently becomes a real
+> hole and must become a total count in the same change.
 
 **Estimated spend: ≈$5–8** on the OpenRouter key (3 arms × 2 reps × ~100 episodes, cheaper per
 episode as the window shrinks). Direct-to-provider from a local brain: the `llm_usage` **rows** land

--- a/docs/design/graph-episode-window.md
+++ b/docs/design/graph-episode-window.md
@@ -533,6 +533,16 @@ rollback are lost; confirm the brain's reconcile re-pushed them.
   needs a patch to `graph_service/routers/ingest.py` **and** a new field on the brain's `/messages`
   payload — two surfaces, and the brain would have to track chunk uuids it does not track today.
   **Recorded as the follow-up if Phase B kills both arms**; it gets its own task key when triggered.
+- **A hybrid: same-item, falling back to *N* unrelated predecessors when the item has none of its
+  own.** Phase A's structural result makes this the *specific* successor if `SAME` fails, so it is
+  named now rather than improvised at readout time. The reasoning: the two risks are not evenly
+  spread. Multi-chunk items keep their own chunks under `SAME` and lose nothing — they actually gain
+  determinism, since rival displacement disappears. **All** the fragmentation risk sits on the
+  single-chunk population, whose predecessor slots are 100% unrelated today and 0% under `SAME`. A
+  hybrid would keep a small dedupe-judgment context exactly there while still killing the 47% filler
+  that multi-chunk items carry. **Trigger: `SAME` fails on Q1-high or Q6 (the fragmentation
+  direction) but passes Q4 and C1.** It gets its own task key and its own battery session under an
+  amendment — it does not get bolted onto a running experiment.
 - **`use_combined_extraction`** (merge node+edge extraction into one call). Unreachable from the
   public API; noted in the parent spec, out of scope here.
 

--- a/docs/design/graph-ingestion-efficiency.md
+++ b/docs/design/graph-ingestion-efficiency.md
@@ -26,7 +26,7 @@ Two consequences beyond the patch target:
 - **The real window is 10 previous episodes, not 3.** That is why an `extract_nodes` call averages
   8,360 input tokens for a 625-token episode: ~6,250 of it is the ten predecessors.
 - **The patch target is the call site** (`graphiti.py:1090`, `last_n=RELEVANT_SCHEMA_LIMIT` →
-  `last_n=1`), not the constant. `RELEVANT_SCHEMA_LIMIT` is *also* the dedupe-candidate limit and the
+  `last_n=1`), not the constant. `RELEVANT_SCHEMA_LIMIT` is *also* the
   query-time retrieval limit across **15 lines** in `search_utils.py` (1 definition + 14 uses);
   patching it at its definition would silently narrow retrieval quality too. (Corrected from "~20
   call sites" — counted, not estimated, in PIPEFF-2.)
@@ -176,8 +176,9 @@ so rather than left contradicting this.
 `last_n=1`, as a `sed` in `graphiti/Dockerfile` (precedent: the same file constructs
 `OpenAIGenericClient` by sed; note the `DEFAULT_MAX_TOKENS` sed it once had is now an assert-only
 grep, so that half of the precedent no longer stands). `RELEVANT_SCHEMA_LIMIT` is *also* the
-dedupe-candidate limit and the query-time retrieval limit across **15 lines** in `search_utils.py` —
-patching its definition would silently narrow retrieval quality, which is a different feature.
+query-time retrieval limit across **15 lines** in `search_utils.py` — patching its definition would
+silently narrow retrieval quality, which is a different feature. (It is NOT the dedupe-candidate
+limit; that is `NODE_DEDUP_CANDIDATE_LIMIT = 15`. Corrected in PIPEFF-2.)
 
 The window is carried by **four** call kinds (`extract_nodes`, `extract_edges`, `dedupe_nodes` and
 `node_summaries_batch` — **not** attribute extraction, see the correction above), so at ~6,250 tokens

--- a/docs/design/graph-ingestion-efficiency.md
+++ b/docs/design/graph-ingestion-efficiency.md
@@ -27,8 +27,9 @@ Two consequences beyond the patch target:
   8,360 input tokens for a 625-token episode: ~6,250 of it is the ten predecessors.
 - **The patch target is the call site** (`graphiti.py:1090`, `last_n=RELEVANT_SCHEMA_LIMIT` →
   `last_n=1`), not the constant. `RELEVANT_SCHEMA_LIMIT` is *also* the dedupe-candidate limit and the
-  query-time retrieval limit across ~20 call sites in `search_utils.py`; patching it at its
-  definition would silently narrow retrieval quality too.
+  query-time retrieval limit across **15 lines** in `search_utils.py` (1 definition + 14 uses);
+  patching it at its definition would silently narrow retrieval quality too. (Corrected from "~20
+  call sites" — counted, not estimated, in PIPEFF-2.)
 
 ### 2. My baseline was measured over mismatched sets
 
@@ -68,9 +69,11 @@ Where it goes, per call kind (2026-08-05 06:50 batch):
 | `node_summaries_batch` | 56 | 6,998 | |
 | `edge_timestamps` | 72 | 552 | |
 
-The previous-episode window is carried by **four** call kinds (extract_nodes, extract_edges,
-dedupe_nodes, and attribute extraction) — not the two I first claimed. The same text is billed many
-times over.
+The previous-episode window is carried by **four** call kinds — not the two I first claimed. The same
+text is billed many times over. (Which four was also wrong: `node_attributes` does **not** fire on
+this install — with no custom entity types `_extract_entity_attributes` returns `{}` with no LLM call
+— so the fourth carrier is `node_summaries_batch`, which embeds full predecessor content. Corrected
+in PIPEFF-2.)
 
 Cost is also ~90% fixed overhead rather than content. Measured across yesterday's projections:
 
@@ -158,18 +161,27 @@ orphan tails a shrink creates are not fixed by re-pushing the head either (nothi
 paying to re-extract buys nothing. The `chunkConfigDeltaCompatible` comment must be updated to say
 so rather than left contradicting this.
 
-### 2. Cut the repeated context — the previous-episode window, 10 → 1
+### 2. Cut the repeated context — the previous-episode window
+
+> **Superseded in detail by [`graph-episode-window.md`](./graph-episode-window.md) (PIPEFF-2 /
+> AIO-821).** Re-deriving the window against the deployed image showed the waste and the value are
+> separable *by item shape*: a single-chunk item's ten predecessors are all unrelated items (pure
+> cost), while a multi-chunk item's own prior chunks are **guaranteed** to be selected (they share
+> `valid_at` with the episode, which is the maximum value the filter admits, so they rank above every
+> strictly-earlier row). So the lever became **"carry the document's own predecessors and nothing
+> else"**, with `last_n=1` demoted to the blunt fallback arm. The paragraphs below are kept as the
+> original framing.
 
 **Patch the CALL SITE, not the constant:** `graphiti.py:1090`, `last_n=RELEVANT_SCHEMA_LIMIT` →
 `last_n=1`, as a `sed` in `graphiti/Dockerfile` (precedent: the same file constructs
 `OpenAIGenericClient` by sed; note the `DEFAULT_MAX_TOKENS` sed it once had is now an assert-only
 grep, so that half of the precedent no longer stands). `RELEVANT_SCHEMA_LIMIT` is *also* the
-dedupe-candidate limit and the query-time retrieval limit across ~20 sites in `search_utils.py` —
+dedupe-candidate limit and the query-time retrieval limit across **15 lines** in `search_utils.py` —
 patching its definition would silently narrow retrieval quality, which is a different feature.
 
-The window is carried by **four** call kinds (`extract_nodes`, `extract_edges`, `dedupe_nodes`,
-attribute extraction), so at ~6,250 tokens of predecessors per call this is the single largest term
-in the ~38,000.
+The window is carried by **four** call kinds (`extract_nodes`, `extract_edges`, `dedupe_nodes` and
+`node_summaries_batch` — **not** attribute extraction, see the correction above), so at ~6,250 tokens
+of predecessors per call this is the single largest term in the ~38,000.
 
 **This one has a real quality trade and must not ship on an estimate — and the trade is bigger than
 I first scoped.** Cutting 10→1 removes nine predecessors, not two. Previous episodes are how the

--- a/scripts/graph-window-battery/RUNBOOK.md
+++ b/scripts/graph-window-battery/RUNBOOK.md
@@ -1,0 +1,174 @@
+# Running the episode-window battery (PIPEFF-2 / AIO-821)
+
+The spec is [`docs/design/graph-episode-window.md`](../../docs/design/graph-episode-window.md). This
+is the operational sequence. Read the spec's **decision function** and **rerun policy** first — the
+numbers this produces bind, and a second session needs a committed amendment.
+
+**Everything up to step 5 costs nothing.** Step 5 is the only step that spends.
+
+---
+
+## What the topology is, and why each piece is there
+
+```
+  projector (local brain)  ──push episodes──►  graphiti (arm variant)  ──►  neo4j (fresh per rep)
+                                                     │
+                                            OPENAI_BASE_URL
+                                                     ▼
+                                              capture tap  ──►  brain /api/internal/llm/v1/*
+                                                (JSONL)              │
+                                                                     ▼
+                                                            llm_usage in the battery Postgres
+                                                                     │
+                                                                     ▼
+                                                        scripts/graph-ingest-cost.mjs
+```
+
+The tap forwards **byte-for-byte**. Metering has to traverse the production path
+(`graph-proxy` → `classifyGraphCall` → `recordLlmUsage`) so the `llm_usage` rows the cost harness
+reads are the real ones — a tap that normalised anything would measure a pipeline that does not
+exist, and the harness would then be reading a second, divergent cost model.
+
+The arms differ in **exactly one file**, bind-mounted over the image's copy:
+
+| arm | file | patch |
+|---|---|---|
+| `W10` | `graphiti.w10.py` | none — the incumbent |
+| `SAME` | `graphiti.same.py` | +17 lines, 0 removed: carry only the same item's prior chunks |
+| `W1` | `graphiti.w1.py` | `last_n=RELEVANT_SCHEMA_LIMIT` → `last_n=1` |
+
+Bind-mounting rather than building three images is deliberate: it makes "the arms differ in one
+file" checkable with `diff` rather than a claim about three Dockerfiles. **Before Phase C, assert the
+shipped Dockerfile produces a byte-identical `graphiti.py` to the arm that won** — the spec requires
+the sed that ships to be the sed that was measured.
+
+---
+
+## 1. Secrets and env (free)
+
+```bash
+railway status                     # MUST print Project: AIOS before anything else
+export SECRETS_KEY=$(railway variables -s aios-team-brain --json | python3 -c "import sys,json;print(json.load(sys.stdin)['SECRETS_KEY'])")
+export GRAPH_LLM_PROXY_SECRET=$(openssl rand -hex 24)   # local only; any ≥ MIN_SECRET_LEN value
+export GRAPH_LLM_TEAM=aios
+export PROD_URL=$(railway variables -s Postgres --json | python3 -c "import sys,json;print(json.load(sys.stdin)['DATABASE_PUBLIC_URL'])")
+```
+
+`SECRETS_KEY` is needed because the provider key is copied **still encrypted** — the battery never
+decrypts it, the local brain does, in-process, exactly as prod does. Without the other two the stack
+boots and quietly extracts nothing: `authorizeGraphProxy` fails **closed** on an unset secret, and
+`resolveGraphProxyTeamId` refuses rather than guessing.
+
+## 2. Battery Postgres — its own container (free)
+
+```bash
+docker rm -f gwb-pg 2>/dev/null
+docker run -d --name gwb-pg -e POSTGRES_USER=app -e POSTGRES_PASSWORD=app -e POSTGRES_DB=battery \
+  -p 0:5432 --tmpfs /var/lib/postgresql/data postgres:16
+export BATTERY_URL="postgres://app:app@localhost:$(docker port gwb-pg 5432/tcp | head -1 | sed 's/.*://')/battery"
+DATABASE_URL="$BATTERY_URL" npm run pg:schema
+```
+
+**Its own container, on an ephemeral port.** The shared test Postgres has previously made concurrent
+runs look like product bugs, and a battery run is long enough to collide with anything else.
+
+## 3. Seed from prod, read-only (free)
+
+```bash
+SOURCE_DATABASE_URL="$PROD_URL" TARGET_DATABASE_URL="$BATTERY_URL" \
+  node scripts/graph-window-battery/seed-local.mjs
+```
+
+Record the **pinned item ids** it prints — the spec requires them in the session log, and they are
+what makes a later session comparable rather than merely similar.
+
+Check its three outputs before continuing: `episode budget: within range` (outside 90–120, Q5's band
+is not valid and needs a committed amendment first), any `divergent` items, and the extraction target
+the arms must match.
+
+## 4. Phase A, part 1 — structural, free
+
+```bash
+DATABASE_URL="$PROD_URL" node scripts/graph-window-battery/phase-a-structural.mjs
+```
+
+Already run 2026-08-06; its numbers are in the spec. Re-run if the corpus is re-drawn.
+
+## 5. Per arm × 2 reps — **this is the step that spends**
+
+For `ARM` in `W10`, `SAME`, `W1`, and `REP` in `1`, `2` — always a **fresh Neo4j**, since a
+carried-over graph makes the second rep measure a different question:
+
+```bash
+# 5a. fresh graph + the arm's single patched file
+docker compose -p gwb-$ARM-$REP -f graphiti/docker-compose.yml down -v
+docker run ... neo4j:5.26.2 ...
+docker run ... aios-graphiti:0293-pinned \
+  -v $PWD/graphiti.$ARM.py:/app/.venv/lib/python3.12/site-packages/graphiti_core/graphiti.py:ro \
+  -e OPENAI_BASE_URL=http://host.docker.internal:3099/v1 \
+  -e OPENAI_API_KEY=$GRAPH_LLM_PROXY_SECRET
+
+# 5b. the tap
+ARM=$ARM CAPTURE_FILE=/tmp/gwb/capture-$ARM-$REP.jsonl BRAIN_URL=http://localhost:3000 \
+  node scripts/graph-window-battery/capture-tap.mjs &
+
+# 5c. the brain, against the battery Postgres
+DATABASE_URL="$BATTERY_URL" GRAPHITI_URL=http://localhost:8001 \
+  GRAPH_LLM_PROXY_SECRET=$GRAPH_LLM_PROXY_SECRET GRAPH_LLM_TEAM=$GRAPH_LLM_TEAM SECRETS_KEY=$SECRETS_KEY \
+  npm run build && npm start &
+
+# 5d. drive the REAL projector run path — not a bespoke pusher
+#     (this is what writes ingest_runs.meta.episodes, without which Q5 is unmeasurable
+#      and C1 loses its guard against a retry-rate shift masquerading as a token saving)
+curl -X POST localhost:3000/api/v1/integrations/graph/project   # or the Admin "Project to graph" button
+```
+
+Then **wait for the queue to drain** — Graphiti returns 202 and extracts later, so measuring early
+measures a partial graph. Watch `llm_usage` go quiet for the harness's drain window.
+
+## 6. Read out (free)
+
+```bash
+# cost — the same instrument, the same refusals, as the prod baseline
+DATABASE_URL="$BATTERY_URL" node scripts/graph-ingest-cost.mjs <since> <until>
+
+# predecessor block size (Phase A part 2)
+npx tsx --conditions react-server scripts/graph-window-battery/phase-a-predecessors.ts /tmp/gwb/capture-W10-1.jsonl
+
+# quality — Q1/Q2/Q3/Q4/Q6 out of Neo4j + the seeded Postgres
+NEO4J_URL=bolt://localhost:7688 NEO4J_PASSWORD=... DATABASE_URL="$BATTERY_URL" \
+  npx tsx --conditions react-server scripts/graph-window-battery/measure.ts
+```
+
+**If the harness refuses, or the cross-check is unavailable, the session is INVALID.** Not "report
+with suspicion" — a null cross-check is not a refusal *in the harness*, which is exactly why
+`assessSession` makes it one here.
+
+## 7. Judge — never by reading the table
+
+```js
+import { assessSession, decide } from "./decision.mjs";
+decide({ session: assessSession({...}), incumbent, arms: [{name:"SAME",...}, {name:"W1",...}] })
+```
+
+`decision.mjs` is the decision function. Reading the numbers and forming a view is the failure this
+whole workstream exists to prevent — the procedure is code so the readout cannot be reinterpreted
+after the numbers exist. It throws rather than defaulting when a safety input is missing, so a
+readout that runs at all is one where every gate was actually measured.
+
+Append the outcome to the spec's **session log** — pass, fail *or invalid*, with the pinned item ids
+and the cause. The first valid session's verdict **binds**.
+
+---
+
+## What to do with the result
+
+- **SHIP** → Phase C in the spec: the sed into `graphiti/Dockerfile` (after the pip install RUN, with
+  a post-all-installs assertion), the recorded deployment id, the empty-start-command precondition,
+  `docs/ARCHITECTURE.md` in the same PR, and verification **in the ledger, not the logs**.
+- **NO_SHIP** → commit the negative result to the spec. If `SAME` failed on Q1-high or Q6 (the
+  fragmentation direction) but passed Q4 and C1, the spec already names the successor: a hybrid that
+  keeps a small dedupe context only for items with no predecessors of their own. It gets its own task
+  and its own session under an amendment — it does not get bolted onto this one.
+- **INVALID** → fix the instrument, not the rules. More than two consecutive invalidations without a
+  committed amendment blocks further sessions.

--- a/scripts/graph-window-battery/capture-tap.mjs
+++ b/scripts/graph-window-battery/capture-tap.mjs
@@ -1,0 +1,107 @@
+/**
+ * The battery's capture tap (PIPEFF-2 / AIO-821).
+ *
+ * Phase A has to measure the SIZE of the predecessor block that every extraction call carries — the
+ * parent spec's ~6,250 tokens is derived, not observed. Nothing stores prompts: neither
+ * `lib/llm/graph-proxy` nor `llm_usage` keeps a request body, and this spec is not going to add
+ * prompt storage to a production path in order to run an experiment.
+ *
+ * So the tap sits BETWEEN graphiti and the local brain:
+ *
+ *     graphiti  ──►  this tap  ──►  brain /api/internal/llm/v1/*  ──►  provider
+ *                      │
+ *                      └── appends each request body to a JSONL
+ *
+ * It forwards **byte-for-byte** and changes nothing — no header rewriting, no body reshaping, no
+ * retries of its own. That matters: metering must still traverse the production path
+ * (`graph-proxy` → `classifyGraphCall` → `recordLlmUsage`), so the `llm_usage` rows the cost harness
+ * reads are the real ones, produced by the real code. A tap that "helpfully" normalised anything
+ * would measure a pipeline that does not exist.
+ *
+ * It is also fail-loud rather than fail-open: if the capture file cannot be written, the tap exits
+ * instead of quietly forwarding unrecorded traffic, because a Phase A run that silently captured
+ * nothing looks exactly like one that captured a clean zero.
+ *
+ * Usage:
+ *   TAP_PORT=3099 BRAIN_URL=http://localhost:3000 CAPTURE_FILE=/tmp/gwb/capture-w10.jsonl \
+ *   node scripts/graph-window-battery/capture-tap.mjs
+ *
+ * Then point graphiti at it:  OPENAI_BASE_URL=http://host.docker.internal:3099/v1
+ */
+import { createServer } from "node:http";
+import { appendFileSync, openSync, closeSync } from "node:fs";
+
+const PORT = Number(process.env.TAP_PORT ?? 3099);
+const BRAIN_URL = (process.env.BRAIN_URL ?? "http://localhost:3000").replace(/\/$/, "");
+const CAPTURE_FILE = process.env.CAPTURE_FILE;
+const ARM = process.env.ARM ?? "unknown";
+
+if (!CAPTURE_FILE) {
+  console.error("CAPTURE_FILE is required — a tap that captures nothing is worse than no tap");
+  process.exit(1);
+}
+// Prove writability NOW. Discovering it at the first request means the run is already burning money.
+try {
+  closeSync(openSync(CAPTURE_FILE, "a"));
+} catch (err) {
+  console.error(`cannot write ${CAPTURE_FILE}: ${err.message}`);
+  process.exit(1);
+}
+
+let captured = 0;
+let forwarded = 0;
+let failed = 0;
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on("data", (c) => chunks.push(c));
+  req.on("end", async () => {
+    const raw = Buffer.concat(chunks);
+
+    // `/v1/chat/completions` from the OpenAI SDK → the brain's internal proxy at the same suffix.
+    const target = `${BRAIN_URL}/api/internal/llm/v1${req.url.replace(/^\/v1/, "")}`;
+
+    // Capture BEFORE forwarding, so a call that errors downstream is still in the record. A capture
+    // that only holds successful calls would understate exactly the population Q5 exists to watch.
+    try {
+      appendFileSync(
+        CAPTURE_FILE,
+        JSON.stringify({ arm: ARM, at: new Date().toISOString(), path: req.url, body: JSON.parse(raw.toString("utf8") || "{}") }) + "\n"
+      );
+      captured++;
+    } catch {
+      // Deliberately fatal — see the header.
+      console.error("capture write failed; exiting rather than forwarding unrecorded traffic");
+      process.exit(1);
+    }
+
+    try {
+      const headers = { ...req.headers };
+      delete headers.host; // the only rewrite, and it is a transport necessity
+      delete headers["content-length"];
+      const upstream = await fetch(target, { method: req.method, headers, body: raw.length ? raw : undefined });
+      const buf = Buffer.from(await upstream.arrayBuffer());
+      res.writeHead(upstream.status, { "content-type": upstream.headers.get("content-type") ?? "application/json" });
+      res.end(buf);
+      forwarded++;
+    } catch (err) {
+      failed++;
+      res.writeHead(502, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { message: `tap could not reach the brain: ${err.message}` } }));
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`tap [${ARM}] :${PORT} → ${BRAIN_URL}/api/internal/llm/v1  ·  capturing to ${CAPTURE_FILE}`);
+});
+
+const report = () => console.log(`\ntap [${ARM}]: ${captured} captured · ${forwarded} forwarded · ${failed} failed`);
+process.on("SIGINT", () => {
+  report();
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  report();
+  process.exit(0);
+});

--- a/scripts/graph-window-battery/corpus.mjs
+++ b/scripts/graph-window-battery/corpus.mjs
@@ -26,10 +26,28 @@
  * Hence `bucketOf` is total over every chunk count ≥ 1, and a unit test asserts that directly.
  */
 
+/**
+ * A byte-for-byte replica of `resolvePositiveInt` from `lib/util/env`, which the projector uses for
+ * these same two knobs. A .mjs script cannot import the TypeScript, so the logic is duplicated — and
+ * a unit test pins the two against each other across the cases where a loose parse diverges
+ * (`"0.5"`, `"Infinity"`, `""`, `"abc"`, `"-5"`).
+ *
+ * The loose version this replaced (`Number(x) > 0 ? Number(x) : d`) disagreed on exactly those:
+ * `GRAPH_CHUNK_CHARS=0.5` would have had the battery chunk at 0.5 chars while the projector chunked
+ * at 2,500 — a silent, total mis-count of the corpus.
+ */
+function resolvePositiveInt(raw, fallback) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  const floored = Math.floor(n);
+  return floored > 0 ? floored : fallback;
+}
+
 /** Mirrors lib/graph/project.ts. A divergence here silently mis-buckets the whole corpus, so the
- *  battery prints both values in its report rather than trusting them. */
-export const CHUNK_CHARS = Number(process.env.GRAPH_CHUNK_CHARS) > 0 ? Number(process.env.GRAPH_CHUNK_CHARS) : 2500;
-export const MAX_EPISODE_CHUNKS = Number(process.env.GRAPH_MAX_EPISODE_CHUNKS) > 0 ? Number(process.env.GRAPH_MAX_EPISODE_CHUNKS) : 40;
+ *  runner must print both values in its report rather than leaving them implicit. */
+export const CHUNK_CHARS = resolvePositiveInt(process.env.GRAPH_CHUNK_CHARS, 2500);
+export const MAX_EPISODE_CHUNKS = resolvePositiveInt(process.env.GRAPH_MAX_EPISODE_CHUNKS, 40);
+export { resolvePositiveInt };
 
 /** The small-item threshold. 898 of 2,267 items (40%) sit under this and each occupies a whole
  *  episode at full fixed-overhead price — the population B1 exists to represent. */
@@ -133,10 +151,20 @@ export function selectCorpus(rows, targets = BUCKET_TARGETS) {
  * The SQL the battery runs against a read-only prod connection. Kept here beside the rule so the two
  * cannot drift; `length(body)` rather than `body` so selection never pulls content it does not need.
  */
+/**
+ * "This body yields no episodes", in SQL, matching `chunkContent`'s `!text.trim()`.
+ *
+ * NOT `btrim(body) = ''`: Postgres `btrim/1` strips **spaces only**, so `btrim(E'  \n\t  ')` is
+ * `E'\n\t'`, not `''` — verified on the test database. A newline/tab-only body would have been
+ * counted as a 1-episode item the projector then emits ZERO episodes for, diverging the counted and
+ * pushed totals, wasting a B1 slot, and skewing the single-chunk share.
+ */
+export const blankBodySql = (alias = "body") => `${alias} ~ '^\\s*$'`;
+
 export const CANDIDATE_SQL = `
   select id, path, kind, work_at,
          length(body) as chars,
-         (btrim(body) = '') as blank
+         (${blankBodySql()}) as blank
     from items
    where team_id = $1
      and access = 'team'
@@ -144,3 +172,46 @@ export const CANDIDATE_SQL = `
    order by work_at desc, id
    limit 2000
 `;
+
+/** The projectable kinds, mirrored from lib/graph/project.ts PROJECTABLE_KINDS (pinned by test). */
+export const PROJECTABLE_KINDS = ["transcript", "deliverable", "decision", "task", "artifact"];
+
+/**
+ * Recompute the SELECTED corpus's episode counts with the projector's REAL `chunkContent`.
+ *
+ * `chunkCount` estimates from Postgres `length(body)`, which counts CHARACTERS while `chunkContent`
+ * slices by JS string index, i.e. UTF-16 units — `length('👍👍')` is 2 in Postgres and 4 in JS. A body
+ * with astral characters near a chunk boundary therefore estimates low, which would mis-bucket at
+ * the A/C and B2/C edges and, worse, run the `EPISODE_BUDGET` check (the thing keeping Q5's band
+ * meaningful) on an undercount.
+ *
+ * The estimate is still right for SELECTION — it runs over ~2,000 rows and a boundary item landing
+ * in the neighbouring bucket is a minor sampling effect. But the ~31 selected items are few enough
+ * to chunk for real, so the number that actually matters is exact rather than derived.
+ *
+ * `chunkFn` is injected so the caller passes the projector's own `chunkContent` rather than this
+ * module re-deriving it a second time.
+ */
+export function verifyCorpus(selection, bodyById, chunkFn) {
+  const items = selection.items.map((it) => {
+    const body = bodyById.get(it.id);
+    if (body === undefined) throw new Error(`verifyCorpus: no body supplied for ${it.id}`);
+    return { ...it, estimatedChunks: it.chunks, chunks: chunkFn(body).length };
+  });
+  const episodes = items.reduce((s, i) => s + i.chunks, 0);
+  const single = items.filter((i) => i.chunks === 1).length;
+  const divergent = items.filter((i) => i.chunks !== i.estimatedChunks);
+  return {
+    ...selection,
+    items,
+    episodes,
+    singleChunkEpisodeShare: episodes > 0 ? single / episodes : 0,
+    // Surfaced, never swallowed: a divergence means the SQL estimate and the projector disagree, and
+    // the runner should say so rather than quietly using whichever number it holds.
+    divergent: divergent.map((i) => ({ id: i.id, estimated: i.estimatedChunks, actual: i.chunks })),
+    episodeBudgetBreach:
+      episodes < EPISODE_BUDGET.min || episodes > EPISODE_BUDGET.max
+        ? `${episodes} episodes is outside the ${EPISODE_BUDGET.min}-${EPISODE_BUDGET.max} range Q5's band was derived at — re-derive it in a committed amendment first`
+        : null,
+  };
+}

--- a/scripts/graph-window-battery/corpus.mjs
+++ b/scripts/graph-window-battery/corpus.mjs
@@ -72,6 +72,14 @@ export function chunkCount(chars, blank = false) {
  * A zero-chunk (whitespace-only) item is `null`: the projector skips it upstream, so it is not a
  * hole in the partition, it is not an item the graph ever sees.
  */
+/**
+ * Episode count for a body already in memory, using the JS string length — which is what
+ * `chunkContent` slices by, and is exactly the number Postgres `length()` cannot give (it counts
+ * characters, not UTF-16 units). For plain-node callers that cannot import the TypeScript.
+ * Equivalent to `chunkContent(body).length`, pinned by unit test.
+ */
+export const countFromBody = (body) => chunkCount((body ?? "").length, !(body ?? "").trim());
+
 export function bucketOf(chunks, chars) {
   if (chunks <= 0) return null;
   if (chunks >= 8) return "A"; // multi-chunk: the coreference case the lever must not break
@@ -190,14 +198,15 @@ export const PROJECTABLE_KINDS = ["transcript", "deliverable", "decision", "task
  * in the neighbouring bucket is a minor sampling effect. But the ~31 selected items are few enough
  * to chunk for real, so the number that actually matters is exact rather than derived.
  *
- * `chunkFn` is injected so the caller passes the projector's own `chunkContent` rather than this
- * module re-deriving it a second time.
+ * `countFn` is injected rather than hardcoded. Callers that can load the TypeScript (the tests) pass
+ * the projector's own `chunkContent` directly; a plain-node caller passes `countFromBody` below,
+ * which is the same algorithm over the same input and is pinned against `chunkContent` by unit test.
  */
-export function verifyCorpus(selection, bodyById, chunkFn) {
+export function verifyCorpus(selection, bodyById, countFn) {
   const items = selection.items.map((it) => {
     const body = bodyById.get(it.id);
     if (body === undefined) throw new Error(`verifyCorpus: no body supplied for ${it.id}`);
-    const chunks = chunkFn(body).length;
+    const chunks = countFn(body);
     // Re-bucket on the TRUE count too. Returning verified `items` beside an estimated `byBucket`
     // would hand a reader stale numbers while looking verified — and Q4's population is spec'd as
     // "buckets A + C", so a truly-2-chunk item estimated at 1 would sit in B2 and be silently

--- a/scripts/graph-window-battery/corpus.mjs
+++ b/scripts/graph-window-battery/corpus.mjs
@@ -27,7 +27,8 @@
  */
 
 /**
- * A byte-for-byte replica of `resolvePositiveInt` from `lib/util/env`, which the projector uses for
+ * An extensionally-equivalent replica of `resolvePositiveInt` from `lib/util/env` — pinned by test,
+ * not by assertion, which the projector uses for
  * these same two knobs. A .mjs script cannot import the TypeScript, so the logic is duplicated — and
  * a unit test pins the two against each other across the cases where a loose parse diverges
  * (`"0.5"`, `"Infinity"`, `""`, `"abc"`, `"-5"`).
@@ -196,14 +197,26 @@ export function verifyCorpus(selection, bodyById, chunkFn) {
   const items = selection.items.map((it) => {
     const body = bodyById.get(it.id);
     if (body === undefined) throw new Error(`verifyCorpus: no body supplied for ${it.id}`);
-    return { ...it, estimatedChunks: it.chunks, chunks: chunkFn(body).length };
+    const chunks = chunkFn(body).length;
+    // Re-bucket on the TRUE count too. Returning verified `items` beside an estimated `byBucket`
+    // would hand a reader stale numbers while looking verified — and Q4's population is spec'd as
+    // "buckets A + C", so a truly-2-chunk item estimated at 1 would sit in B2 and be silently
+    // excluded from the very metric that measures cross-chunk continuity.
+    return { ...it, estimatedChunks: it.chunks, chunks, bucket: bucketOf(chunks, it.chars) ?? it.bucket };
   });
   const episodes = items.reduce((s, i) => s + i.chunks, 0);
   const single = items.filter((i) => i.chunks === 1).length;
   const divergent = items.filter((i) => i.chunks !== i.estimatedChunks);
+  const byBucket = { A: [], B1: [], B2: [], C: [] };
+  for (const it of items) if (byBucket[it.bucket]) byBucket[it.bucket].push(it);
+
   return {
     ...selection,
     items,
+    byBucket,
+    shortfall: Object.entries(BUCKET_TARGETS)
+      .filter(([b, want]) => byBucket[b].length < want)
+      .map(([b, want]) => `${b}: wanted ${want}, found ${byBucket[b].length}`),
     episodes,
     singleChunkEpisodeShare: episodes > 0 ? single / episodes : 0,
     // Surfaced, never swallowed: a divergence means the SQL estimate and the projector disagree, and

--- a/scripts/graph-window-battery/corpus.mjs
+++ b/scripts/graph-window-battery/corpus.mjs
@@ -1,0 +1,146 @@
+/**
+ * The battery's corpus selection (PIPEFF-2 / AIO-821).
+ *
+ * WHY THE RULE IS FIXED IN ADVANCE AND THE CONTENT IS NOT CHECKED IN.
+ *
+ * EXMODEL-1 failed exactly here. This repo is public, so a checked-in fixture had to be synthetic —
+ * and two synthetic attempts scored the NEGATIVE CONTROL (the model that actually polluted the
+ * graph) as a pass, and the good model as a fail. Wrong in both directions. A third iteration would
+ * have been tuning the fixture until it agreed with the conclusion.
+ *
+ * So there is no fixture. The battery reads this install's own `items` at run time and chunks them
+ * with the projector's own algorithm. What IS fixed in advance — here, in code, before any run — is
+ * the SELECTION RULE, so the corpus cannot be hand-picked toward a result. The chosen item ids are
+ * pinned in the report so a later session is comparable rather than merely similar.
+ *
+ * ── THE BUCKETS PARTITION BY CHUNK COUNT ─────────────────────────────────────────────────────────
+ *
+ * Not a taste decision: the lever's whole thesis is that the ten predecessors behave differently by
+ * item shape (a single-chunk item's are all unrelated; a multi-chunk item's are its own document),
+ * so the corpus has to represent both, in a mix close to prod's.
+ *
+ * Two drafts of the spec left a HOLE here, and each hole was found by review rather than by running:
+ *   · draft 1: buckets "≥8 chunks" / "<600 chars" / "1-3 chunks" — 4-7-chunk items fell in none;
+ *   · draft 2: "≥8" / "1 chunk AND <600 chars" / "2-7" — a 1-chunk item of 600-2,500 chars fell in
+ *     none.
+ * Hence `bucketOf` is total over every chunk count ≥ 1, and a unit test asserts that directly.
+ */
+
+/** Mirrors lib/graph/project.ts. A divergence here silently mis-buckets the whole corpus, so the
+ *  battery prints both values in its report rather than trusting them. */
+export const CHUNK_CHARS = Number(process.env.GRAPH_CHUNK_CHARS) > 0 ? Number(process.env.GRAPH_CHUNK_CHARS) : 2500;
+export const MAX_EPISODE_CHUNKS = Number(process.env.GRAPH_MAX_EPISODE_CHUNKS) > 0 ? Number(process.env.GRAPH_MAX_EPISODE_CHUNKS) : 40;
+
+/** The small-item threshold. 898 of 2,267 items (40%) sit under this and each occupies a whole
+ *  episode at full fixed-overhead price — the population B1 exists to represent. */
+export const SMALL_ITEM_CHARS = 600;
+
+/**
+ * How many episodes an item becomes, by the projector's own rule: whitespace-only → none, otherwise
+ * ceil(chars / CHUNK_CHARS) capped at MAX_EPISODE_CHUNKS.
+ *
+ * Derived from `chunkContent`'s algorithm rather than by calling it, because the battery selects
+ * from a SQL projection of `length(body)` over thousands of rows and never needs the bodies to
+ * count. The equivalence is unit-tested against `chunkContent` itself.
+ */
+export function chunkCount(chars, blank = false) {
+  if (blank || chars <= 0) return 0;
+  return Math.min(Math.ceil(chars / CHUNK_CHARS), MAX_EPISODE_CHUNKS);
+}
+
+/**
+ * Which bucket an item belongs to. TOTAL over every chunk count ≥ 1 — see the header.
+ * A zero-chunk (whitespace-only) item is `null`: the projector skips it upstream, so it is not a
+ * hole in the partition, it is not an item the graph ever sees.
+ */
+export function bucketOf(chunks, chars) {
+  if (chunks <= 0) return null;
+  if (chunks >= 8) return "A"; // multi-chunk: the coreference case the lever must not break
+  if (chunks === 1) return chars < SMALL_ITEM_CHARS ? "B1" : "B2"; // the 40% tail, and the rest of the single-chunk population
+  return "C"; // 2-7 chunks
+}
+
+/**
+ * How many items of each bucket the corpus takes, most recent first.
+ *
+ * ── WHY `A` IS 3 AND NOT 5 — a pre-registration amendment, recorded before any session ran ───────
+ *
+ * The spec sized the corpus at ~100 episodes and DERIVED Q5's band from that: at ~100 episodes one
+ * validation retry moves the signed gap by ~1pp, so a 1.5pp validity ceiling tolerates exactly one
+ * retry of rep-to-rep difference and not two. That derivation is the only reason Q5's band is 3pp.
+ *
+ * Run against this install, `A: 5` selected 9, 8, 40, 23 and 22-chunk items — 102 episodes in bucket
+ * A alone, 153 in total. At 153 episodes one retry is 0.65pp, so the SAME pre-registered 1.5pp
+ * ceiling would silently tolerate 2.3 retries. The number would not have changed; what it MEANT
+ * would have. That is the quiet kind of drift this whole workstream is about.
+ *
+ * So the corpus size is fixed to keep the coupling, rather than the band re-derived after seeing a
+ * corpus: `A: 3` yields 57 + 15 + 5 + 31 = 108 episodes, where one retry is 0.93pp. It also moves the
+ * single-chunk episode share from 13.1% to ~18.5%, CLOSER to prod's ~17% — which matters because C1
+ * is corpus-mix-sensitive.
+ *
+ * If a future draw lands materially outside ~100-120 episodes, Q5's band must be re-derived in a
+ * committed amendment BEFORE that session runs. `selectCorpus` reports `episodes` so this is
+ * checkable rather than assumed.
+ */
+export const BUCKET_TARGETS = Object.freeze({ A: 3, B1: 15, B2: 5, C: 8 });
+
+/** The episode range Q5's pre-registered band was derived at. Outside it, the band is not valid. */
+export const EPISODE_BUDGET = Object.freeze({ min: 90, max: 120 });
+
+/**
+ * Pick the corpus from candidate rows, newest first within each bucket.
+ *
+ * `rows` must already be ordered newest-first and restricted to `access='team'` and the projectable
+ * kinds — the tier restriction is what makes the whole corpus land in ONE Graphiti group by
+ * SELECTION rather than by bypassing the projector, which is how the spec avoids a bespoke pusher.
+ *
+ * Pure and deterministic given `rows`: same input, same corpus. That is what makes "pinned item ids"
+ * a meaningful claim rather than a hopeful one.
+ */
+export function selectCorpus(rows, targets = BUCKET_TARGETS) {
+  const picked = { A: [], B1: [], B2: [], C: [] };
+  for (const r of rows) {
+    const n = chunkCount(r.chars, r.blank);
+    const b = bucketOf(n, r.chars);
+    if (!b) continue;
+    if (picked[b].length >= targets[b]) continue;
+    picked[b].push({ ...r, chunks: n, bucket: b });
+  }
+  const items = [...picked.A, ...picked.B1, ...picked.B2, ...picked.C];
+  const episodes = items.reduce((s, i) => s + i.chunks, 0);
+  const singleChunkEpisodes = items.filter((i) => i.chunks === 1).length;
+  return {
+    items,
+    byBucket: picked,
+    episodes,
+    // Reported because C1 is corpus-mix-sensitive: prod's single-chunk share is ~17% (898 of 5,166
+    // episodes), and a blended tokens-per-episode figure only transfers if the mix is close.
+    singleChunkEpisodeShare: episodes > 0 ? singleChunkEpisodes / episodes : 0,
+    shortfall: Object.entries(targets)
+      .filter(([b, want]) => picked[b].length < want)
+      .map(([b, want]) => `${b}: wanted ${want}, found ${picked[b].length}`),
+    // Q5's band was derived at ~100 episodes (one retry ≈ 1pp). Outside this range the band's
+    // MEANING changes without its number changing, so the runner must refuse rather than proceed.
+    episodeBudgetBreach:
+      episodes < EPISODE_BUDGET.min || episodes > EPISODE_BUDGET.max
+        ? `${episodes} episodes is outside the ${EPISODE_BUDGET.min}-${EPISODE_BUDGET.max} range Q5's band was derived at — re-derive it in a committed amendment first`
+        : null,
+  };
+}
+
+/**
+ * The SQL the battery runs against a read-only prod connection. Kept here beside the rule so the two
+ * cannot drift; `length(body)` rather than `body` so selection never pulls content it does not need.
+ */
+export const CANDIDATE_SQL = `
+  select id, path, kind, work_at,
+         length(body) as chars,
+         (btrim(body) = '') as blank
+    from items
+   where team_id = $1
+     and access = 'team'
+     and kind = any($2)
+   order by work_at desc, id
+   limit 2000
+`;

--- a/scripts/graph-window-battery/decision.mjs
+++ b/scripts/graph-window-battery/decision.mjs
@@ -1,0 +1,236 @@
+/**
+ * The battery's decision procedure, as code (PIPEFF-2 / AIO-821).
+ *
+ * WHY THIS IS CODE AND NOT PROSE. The failure this whole workstream exists to prevent is a readout
+ * that gets *interpreted* after the numbers exist. It already happened once: on EXMODEL-1 a synthetic
+ * fixture was iterated twice, and a third iteration would have been tuning it until it agreed with
+ * the conclusion. The fixture was the visible joint. The invisible one is analysis flexibility — a
+ * band, a noise rule and a kill rule that do not compose into a total function, so the metric that
+ * lands in the gap gets read whichever way suits.
+ *
+ * So the rules from `docs/design/graph-episode-window.md` live here, executable and unit-pinned,
+ * and the runner calls this rather than a human reading a table. Changing a band means editing a
+ * constant that a test asserts, in a commit, before the run — which is the whole point.
+ *
+ * ── THE PROCEDURE ────────────────────────────────────────────────────────────────────────────────
+ *
+ * Each arm runs TWICE on the same corpus into a fresh database. An arm's value for a metric is the
+ * MEAN of its two reps; the incumbent's own |rep1 - rep2| is the noise estimate (`spread`).
+ *
+ * Per metric, exactly one of — and the rule is SYMMETRIC about the band:
+ *   PASS         the arm beats the band by MORE than the incumbent's spread
+ *   FAIL         the arm misses the band by MORE than the incumbent's spread
+ *   INCONCLUSIVE the arm lands WITHIN ±spread of the band
+ *
+ * INCONCLUSIVE counts as FAIL for shipping. The burden of proof is on the change: a metric we cannot
+ * distinguish from a regression is not evidence there is none.
+ *
+ * WHY THE PASS SIDE CARRIES THE SPREAD TOO. An earlier draft required only "the mean meets the band",
+ * which made the noise estimate irrelevant to every above-band outcome — while the bands are
+ * MULTIPLICATIVE in the incumbent's mean. A degraded incumbent rep therefore LOWERED the bar: true
+ * W10 yield 10.0, reps 10.2 and 6.0, mean 8.1, band 7.29, and an arm whose true value is 8.5 (a real
+ * 15% regression) passes. More noise, easier shipping. Symmetric, that arm fails.
+ *
+ * ── SESSION VALIDITY ─────────────────────────────────────────────────────────────────────────────
+ *
+ * The ceiling on the incumbent's spread is expressed in BAND UNITS, not as a fraction of the mean.
+ * "Spread > 25% of the mean" was degenerate in both directions: Q5's healthy mean is ~0, so a single
+ * validation retry in one incumbent rep would invalidate every session; and at a healthy 30% dupe
+ * share it permitted a 7.5pp spread against a ±5pp band, making Q3's PASS window EMPTY — a session
+ * valid by the rules with a metric no arm could ever pass. A procedure that can deadlock mid
+ * experiment is one that gets rewritten under pressure.
+ *
+ * So: the incumbent's spread must be at most HALF that metric's band margin. That also GUARANTEES a
+ * non-empty PASS window in any valid session, which is the property the old ceiling lacked.
+ */
+
+/**
+ * The gated metrics. `margin` is the distance from the incumbent's own value to the band edge, in
+ * the band's units; `maxSpread` is half of it (the validity ceiling), except where a near-zero
+ * healthy mean needs an absolute floor.
+ *
+ * `kind`:
+ *   ratio-lower   the arm's value ÷ incumbent's must be at least `1 - margin`
+ *   ratio-both    …and at most `1 + margin` (an INCREASE is disqualifying too)
+ *   ratio-upper   the arm's value ÷ incumbent's must be at most `1 + margin`
+ *   pp-both       |arm - incumbent| in percentage points must stay within `margin`
+ *   pp-upper      arm - incumbent in percentage points must stay at or below `margin`
+ *   ratio-fall    the arm's value must be at most `1 - margin` of the incumbent's (a REQUIRED fall)
+ */
+export const METRICS = Object.freeze({
+  // Two-sided: fragmentation RAISES node count, and a one-sided floor waved that through. It is also
+  // the catch-all for the variant-form inflation Q6 cannot see — a node named "John" carries no
+  // member name, so it never enters Q6's denominator, but it does inflate this.
+  Q1: { label: "entity yield / episode", kind: "ratio-both", margin: 0.1, maxSpreadRatio: 0.05 },
+  Q2: { label: "people recall", kind: "ratio-lower", margin: 0.05, maxSpreadRatio: 0.025 },
+  // Two-sided in PERCENTAGE POINTS: a failure-to-merge emits no IS_DUPLICATE_OF edge at all, so
+  // fragmentation makes this share FALL. extraction-health.ts already treats an anomalously low
+  // share as evidence the predicate is broken rather than the graph clean.
+  Q3: { label: "IS_DUPLICATE_OF share", kind: "pp-both", margin: 0.05, maxSpreadPp: 0.025 },
+  Q4: { label: "cross-chunk continuity", kind: "ratio-lower", margin: 0.15, maxSpreadRatio: 0.075 },
+  // 3pp, not 2: at ~100 episodes one retry ≈ 1pp, so a 1.5pp ceiling tolerates exactly one retry of
+  // rep-to-rep difference and not two. The widening does not cost the guard its teeth — a retry adds
+  // ~8,400 input tokens against a ~40,000/attempt baseline, so the full 3-retry allowance is a -2.3%
+  // artifact on C1, against a band demanding -25%.
+  Q5: { label: "signed retry gap", kind: "pp-upper", margin: 0.03, maxSpreadPp: 0.015 },
+  Q6: { label: "cross-item entity convergence", kind: "ratio-upper", margin: 0.05, maxSpreadRatio: 0.025 },
+  // The lever must EARN its deploy: this service's redeploy history is not free (see the spec's
+  // Rollout). A quality-clean arm that barely moves tokens does not ship.
+  C1: { label: "input tokens / episode", kind: "ratio-fall", margin: 0.25, maxSpreadRatio: 0.125 },
+});
+
+export const VERDICT = Object.freeze({ PASS: "PASS", FAIL: "FAIL", INCONCLUSIVE: "INCONCLUSIVE" });
+
+const mean = (a, b) => (a + b) / 2;
+const spread = (a, b) => Math.abs(a - b);
+
+/**
+ * Judge ONE metric for ONE arm against the incumbent.
+ *
+ * `arm` and `incumbent` are each `[rep1, rep2]` in the metric's natural unit — a rate for the ratio
+ * kinds, a FRACTION (0.30, not 30) for the pp kinds.
+ *
+ * Returns the verdict plus the numbers behind it, because a verdict without its inputs is exactly
+ * the kind of claim this file exists to stop.
+ */
+export function judgeMetric(key, arm, incumbent) {
+  const m = METRICS[key];
+  if (!m) throw new Error(`unknown metric ${key}`);
+  if (!Array.isArray(arm) || arm.length !== 2 || !Array.isArray(incumbent) || incumbent.length !== 2) {
+    throw new Error(`${key}: both arms need exactly 2 reps — the spread IS the second rep`);
+  }
+  const armMean = mean(arm[0], arm[1]);
+  const baseMean = mean(incumbent[0], incumbent[1]);
+  const baseSpread = spread(incumbent[0], incumbent[1]);
+
+  // Reduce every kind to: a `value`, one or two `edges`, and which side of each edge is "good".
+  // Working in the metric's own units keeps the ceiling and the band commensurable — the bug in the
+  // rule this replaced was exactly a units mismatch.
+  let value, edges;
+  switch (m.kind) {
+    case "ratio-lower":
+      value = armMean / baseMean;
+      edges = [{ at: 1 - m.margin, good: "above" }];
+      break;
+    case "ratio-upper":
+      value = armMean / baseMean;
+      edges = [{ at: 1 + m.margin, good: "below" }];
+      break;
+    case "ratio-both":
+      value = armMean / baseMean;
+      edges = [
+        { at: 1 - m.margin, good: "above" },
+        { at: 1 + m.margin, good: "below" },
+      ];
+      break;
+    case "ratio-fall":
+      value = armMean / baseMean;
+      edges = [{ at: 1 - m.margin, good: "below" }];
+      break;
+    case "pp-both":
+      value = armMean - baseMean;
+      edges = [
+        { at: -m.margin, good: "above" },
+        { at: m.margin, good: "below" },
+      ];
+      break;
+    case "pp-upper":
+      value = armMean - baseMean;
+      edges = [{ at: m.margin, good: "below" }];
+      break;
+    default:
+      throw new Error(`${key}: unknown kind ${m.kind}`);
+  }
+
+  // The spread has to be expressed in the same units as `value`. For the ratio kinds `value` is a
+  // ratio against the incumbent's mean, so the spread divides by that mean too; for the pp kinds
+  // both are already differences in fractions.
+  const tol = m.kind.startsWith("ratio") ? baseSpread / baseMean : baseSpread;
+
+  // Symmetric: PASS must clear EVERY edge by more than the tolerance; FAIL means at least one edge
+  // is missed by more than it; anything else is within the noise of an edge.
+  const clears = edges.every((e) => (e.good === "above" ? value > e.at + tol : value < e.at - tol));
+  const misses = edges.some((e) => (e.good === "above" ? value < e.at - tol : value > e.at + tol));
+  const verdict = clears ? VERDICT.PASS : misses ? VERDICT.FAIL : VERDICT.INCONCLUSIVE;
+
+  return { key, label: m.label, verdict, value, armMean, baseMean, baseSpread, tolerance: tol, edges };
+}
+
+/**
+ * Is the SESSION itself trustworthy? Returns the reasons it is not, so an invalid session is
+ * reported as broken rather than as a result.
+ *
+ * Every trigger here is pre-defined and none of them is "the numbers came out wrong" — that
+ * distinction is the difference between a rule and an excuse.
+ */
+export function assessSession({ incumbent, dupeShare, dupeEdges, underpowered = [], armsCompleted = true, harnessRefused = false, crossCheckAvailable = true }) {
+  const problems = [];
+
+  if (harnessRefused) problems.push("the cost harness refused the window — drain or cross-check");
+  // A null cross-check is NOT a refusal in the harness (it prints "unavailable" and reports ratios
+  // anyway), which is precisely why it has to be one here: without ingest_runs.meta.episodes, Q5 is
+  // unmeasurable and C1 loses its guard against a retry-rate shift masquerading as a token saving.
+  if (!crossCheckAvailable) problems.push("no cross-check: ingest_runs recorded no finished projector run in the window");
+  if (!armsCompleted) problems.push("an arm did not complete every episode");
+  for (const u of underpowered) problems.push(`${u} is UNDERPOWERED — a corpus too thin to measure is not evidence of a regression`);
+
+  // The incumbent's spread ceiling, per metric, in band units.
+  for (const [key, reps] of Object.entries(incumbent ?? {})) {
+    const m = METRICS[key];
+    if (!m || !Array.isArray(reps) || reps.length !== 2) continue;
+    const s = spread(reps[0], reps[1]);
+    if (m.maxSpreadRatio !== undefined) {
+      const baseMean = mean(reps[0], reps[1]);
+      // A near-zero incumbent mean is itself a broken instrument, and the ceiling collapsing with it
+      // is the correct behaviour rather than a degeneracy.
+      const ceiling = m.maxSpreadRatio * baseMean;
+      if (s > ceiling) problems.push(`${key} incumbent spread ${s.toFixed(4)} exceeds ${ceiling.toFixed(4)} (${m.maxSpreadRatio * 100}% of its mean)`);
+    } else if (m.maxSpreadPp !== undefined) {
+      if (s > m.maxSpreadPp) problems.push(`${key} incumbent spread ${(s * 100).toFixed(2)}pp exceeds ${(m.maxSpreadPp * 100).toFixed(2)}pp`);
+    }
+  }
+
+  // The incumbent has to be a graph worth comparing against. 0.45 is extraction-health.ts's own
+  // DEDUPE_ABSOLUTE_FLOOR; the 0.15 floor is below prod's healthy ~26-35% on purpose, because the
+  // battery runs into an EMPTY Neo4j where early episodes have nothing to duplicate against.
+  if (dupeShare !== undefined && dupeShare !== null && (dupeShare < DUPE_SANE_MIN || dupeShare > DUPE_SANE_MAX)) {
+    problems.push(`incumbent duplicate share ${(dupeShare * 100).toFixed(1)}% outside the sane ${DUPE_SANE_MIN * 100}-${DUPE_SANE_MAX * 100}% range`);
+  }
+  // extraction-health.ts refuses to judge the share below this many edges; so does this.
+  if (dupeEdges !== undefined && dupeEdges !== null && dupeEdges < MIN_EDGES_FOR_SHARE) {
+    problems.push(`only ${dupeEdges} edges — below the ${MIN_EDGES_FOR_SHARE}-edge minimum for a share signal`);
+  }
+
+  return { valid: problems.length === 0, problems };
+}
+
+/** Mirrors extraction-health.ts's DEDUPE_ABSOLUTE_FLOOR; see assessSession. */
+export const DUPE_SANE_MAX = 0.45;
+/** Below prod's healthy ~26-35% on purpose — the battery's Neo4j starts empty. */
+export const DUPE_SANE_MIN = 0.15;
+/** Mirrors extraction-health.ts's MIN_EDGES_FOR_DEDUPE_SIGNAL. */
+export const MIN_EDGES_FOR_SHARE = 200;
+
+/**
+ * The whole readout: which arm ships, if any.
+ *
+ * `arms` is ordered — SAME before W1 — and the FIRST arm to pass every gate wins. An arm ships only
+ * if every metric PASSes; INCONCLUSIVE blocks exactly as FAIL does.
+ */
+export function decide({ session, incumbent, arms }) {
+  if (!session.valid) {
+    return { outcome: "INVALID", reasons: session.problems, arms: [] };
+  }
+  const judged = arms.map(({ name, metrics }) => {
+    const results = Object.keys(METRICS).map((key) => judgeMetric(key, metrics[key], incumbent[key]));
+    const blocking = results.filter((r) => r.verdict !== VERDICT.PASS);
+    return { name, results, ships: blocking.length === 0, blocking };
+  });
+  const winner = judged.find((a) => a.ships);
+  return {
+    outcome: winner ? "SHIP" : "NO_SHIP",
+    winner: winner?.name ?? null,
+    arms: judged,
+    reasons: winner ? [] : ["no arm cleared every gate — the negative result is committed to the spec"],
+  };
+}

--- a/scripts/graph-window-battery/decision.mjs
+++ b/scripts/graph-window-battery/decision.mjs
@@ -62,7 +62,21 @@ export const METRICS = Object.freeze({
   // the catch-all for the variant-form inflation Q6 cannot see — a node named "John" carries no
   // member name, so it never enters Q6's denominator, but it does inflate this.
   Q1: { label: "entity yield / episode", kind: "ratio-both", margin: 0.1, maxSpreadRatio: 0.05 },
-  Q2: { label: "people recall", kind: "ratio-lower", margin: 0.05, maxSpreadRatio: 0.025 },
+  // TWO clauses, both floors, and the stricter binds. The ratio is the noisy one; `absolute` is the
+  // one that bites at small n, which is exactly where the ratio is weakest — at 12 names, "95%"
+  // rounds to "lose none", so without this clause a 2-person loss on a thin corpus would ship.
+  //
+  // The count clause is deliberately NOISE-FREE: no tolerance, no INCONCLUSIVE. A spread on an
+  // integer count of people would swallow the clause whole (any spread ≥ 1 makes "lost 2" and "lost
+  // 0" indistinguishable), which would delete the floor it exists to be. Losing two known people
+  // outright is not a statistical question.
+  Q2: {
+    label: "people recall",
+    kind: "ratio-lower",
+    margin: 0.05,
+    maxSpreadRatio: 0.025,
+    absolute: { input: "personsLost", max: 1, describe: (v) => `${v} people lost outright (max 1)` },
+  },
   // Two-sided in PERCENTAGE POINTS: a failure-to-merge emits no IS_DUPLICATE_OF edge at all, so
   // fragmentation makes this share FALL. extraction-health.ts already treats an anomalously low
   // share as evidence the predicate is broken rather than the graph clean.
@@ -85,6 +99,17 @@ const mean = (a, b) => (a + b) / 2;
 const spread = (a, b) => Math.abs(a - b);
 
 /**
+ * "Strictly over the ceiling", tolerant of float representation.
+ *
+ * The spec says the incumbent's spread must be **at most** half the band margin, so a spread sitting
+ * exactly on the ceiling is VALID. Written as a bare `>` that fails: `0.3125 - 0.2875` evaluates to
+ * 0.025000000000000022, which is "over" a 0.025 ceiling by 2e-17 and invalidates a session on
+ * nothing. The relative epsilon is ~1e-9 — twelve orders of magnitude below any measurement this
+ * battery takes, so it can only ever absorb representation error, never a real breach.
+ */
+const over = (value, ceiling) => value > ceiling * (1 + 1e-9) + Number.EPSILON;
+
+/**
  * Judge ONE metric for ONE arm against the incumbent.
  *
  * `arm` and `incumbent` are each `[rep1, rep2]` in the metric's natural unit — a rate for the ratio
@@ -93,11 +118,17 @@ const spread = (a, b) => Math.abs(a - b);
  * Returns the verdict plus the numbers behind it, because a verdict without its inputs is exactly
  * the kind of claim this file exists to stop.
  */
-export function judgeMetric(key, arm, incumbent) {
+export function judgeMetric(key, arm, incumbent, extras = {}) {
   const m = METRICS[key];
   if (!m) throw new Error(`unknown metric ${key}`);
   if (!Array.isArray(arm) || arm.length !== 2 || !Array.isArray(incumbent) || incumbent.length !== 2) {
     throw new Error(`${key}: both arms need exactly 2 reps — the spread IS the second rep`);
+  }
+  // An absolute clause whose input was simply not supplied must NOT read as satisfied. Omission
+  // defaulting to "fine" is the class of fake this repo has already been burned by, and it would be
+  // worst here — a gate that disappears when the runner forgets to measure it.
+  if (m.absolute && extras[m.absolute.input] === undefined) {
+    throw new Error(`${key}: needs \`${m.absolute.input}\` — the clause cannot be satisfied by omitting its input`);
   }
   const armMean = mean(arm[0], arm[1]);
   const baseMean = mean(incumbent[0], incumbent[1]);
@@ -151,9 +182,17 @@ export function judgeMetric(key, arm, incumbent) {
   // is missed by more than it; anything else is within the noise of an edge.
   const clears = edges.every((e) => (e.good === "above" ? value > e.at + tol : value < e.at - tol));
   const misses = edges.some((e) => (e.good === "above" ? value < e.at - tol : value > e.at + tol));
-  const verdict = clears ? VERDICT.PASS : misses ? VERDICT.FAIL : VERDICT.INCONCLUSIVE;
+  let verdict = clears ? VERDICT.PASS : misses ? VERDICT.FAIL : VERDICT.INCONCLUSIVE;
 
-  return { key, label: m.label, verdict, value, armMean, baseMean, baseSpread, tolerance: tol, edges };
+  // The absolute clause is a hard floor and overrides a passing band — never the other way round.
+  // Both clauses are floors and the stricter binds, which is what the spec says of Q2.
+  let absoluteBreach = null;
+  if (m.absolute && extras[m.absolute.input] > m.absolute.max) {
+    absoluteBreach = m.absolute.describe(extras[m.absolute.input]);
+    verdict = VERDICT.FAIL;
+  }
+
+  return { key, label: m.label, verdict, value, armMean, baseMean, baseSpread, tolerance: tol, edges, absoluteBreach };
 }
 
 /**
@@ -163,7 +202,14 @@ export function judgeMetric(key, arm, incumbent) {
  * Every trigger here is pre-defined and none of them is "the numbers came out wrong" — that
  * distinction is the difference between a rule and an excuse.
  */
-export function assessSession({ incumbent, dupeShare, dupeEdges, underpowered = [], armsCompleted = true, harnessRefused = false, crossCheckAvailable = true }) {
+export function assessSession({ incumbent, dupeShare, dupeEdges, underpowered = [], armsCompleted, harnessRefused, crossCheckAvailable }) {
+  // REQUIRED, not defaulted-permissive. A default of `armsCompleted = true` means a runner that
+  // forgets to pass it silently disarms that validity trigger — the same "omission canonicalized as
+  // fine" class as the absolute clause above, in the one file whose job is that the readout cannot
+  // be quietly softened. Throw instead: a missing safety input is a bug, not a pass.
+  for (const [k, v] of Object.entries({ dupeShare, dupeEdges, armsCompleted, harnessRefused, crossCheckAvailable })) {
+    if (v === undefined || v === null) throw new Error(`assessSession: \`${k}\` is required — omitting it must not read as valid`);
+  }
   const problems = [];
 
   if (harnessRefused) problems.push("the cost harness refused the window — drain or cross-check");
@@ -184,20 +230,20 @@ export function assessSession({ incumbent, dupeShare, dupeEdges, underpowered = 
       // A near-zero incumbent mean is itself a broken instrument, and the ceiling collapsing with it
       // is the correct behaviour rather than a degeneracy.
       const ceiling = m.maxSpreadRatio * baseMean;
-      if (s > ceiling) problems.push(`${key} incumbent spread ${s.toFixed(4)} exceeds ${ceiling.toFixed(4)} (${m.maxSpreadRatio * 100}% of its mean)`);
+      if (over(s, ceiling)) problems.push(`${key} incumbent spread ${s.toFixed(4)} exceeds ${ceiling.toFixed(4)} (${m.maxSpreadRatio * 100}% of its mean)`);
     } else if (m.maxSpreadPp !== undefined) {
-      if (s > m.maxSpreadPp) problems.push(`${key} incumbent spread ${(s * 100).toFixed(2)}pp exceeds ${(m.maxSpreadPp * 100).toFixed(2)}pp`);
+      if (over(s, m.maxSpreadPp)) problems.push(`${key} incumbent spread ${(s * 100).toFixed(2)}pp exceeds ${(m.maxSpreadPp * 100).toFixed(2)}pp`);
     }
   }
 
   // The incumbent has to be a graph worth comparing against. 0.45 is extraction-health.ts's own
   // DEDUPE_ABSOLUTE_FLOOR; the 0.15 floor is below prod's healthy ~26-35% on purpose, because the
   // battery runs into an EMPTY Neo4j where early episodes have nothing to duplicate against.
-  if (dupeShare !== undefined && dupeShare !== null && (dupeShare < DUPE_SANE_MIN || dupeShare > DUPE_SANE_MAX)) {
+  if (dupeShare < DUPE_SANE_MIN || dupeShare > DUPE_SANE_MAX) {
     problems.push(`incumbent duplicate share ${(dupeShare * 100).toFixed(1)}% outside the sane ${DUPE_SANE_MIN * 100}-${DUPE_SANE_MAX * 100}% range`);
   }
   // extraction-health.ts refuses to judge the share below this many edges; so does this.
-  if (dupeEdges !== undefined && dupeEdges !== null && dupeEdges < MIN_EDGES_FOR_SHARE) {
+  if (dupeEdges < MIN_EDGES_FOR_SHARE) {
     problems.push(`only ${dupeEdges} edges — below the ${MIN_EDGES_FOR_SHARE}-edge minimum for a share signal`);
   }
 
@@ -221,8 +267,8 @@ export function decide({ session, incumbent, arms }) {
   if (!session.valid) {
     return { outcome: "INVALID", reasons: session.problems, arms: [] };
   }
-  const judged = arms.map(({ name, metrics }) => {
-    const results = Object.keys(METRICS).map((key) => judgeMetric(key, metrics[key], incumbent[key]));
+  const judged = arms.map(({ name, metrics, extras = {} }) => {
+    const results = Object.keys(METRICS).map((key) => judgeMetric(key, metrics[key], incumbent[key], extras));
     const blocking = results.filter((r) => r.verdict !== VERDICT.PASS);
     return { name, results, ships: blocking.length === 0, blocking };
   });

--- a/scripts/graph-window-battery/decision.mjs
+++ b/scripts/graph-window-battery/decision.mjs
@@ -124,11 +124,18 @@ export function judgeMetric(key, arm, incumbent, extras = {}) {
   if (!Array.isArray(arm) || arm.length !== 2 || !Array.isArray(incumbent) || incumbent.length !== 2) {
     throw new Error(`${key}: both arms need exactly 2 reps — the spread IS the second rep`);
   }
-  // An absolute clause whose input was simply not supplied must NOT read as satisfied. Omission
-  // defaulting to "fine" is the class of fake this repo has already been burned by, and it would be
-  // worst here — a gate that disappears when the runner forgets to measure it.
-  if (m.absolute && extras[m.absolute.input] === undefined) {
-    throw new Error(`${key}: needs \`${m.absolute.input}\` — the clause cannot be satisfied by omitting its input`);
+  // An absolute clause's input must be a real measurement. Checking only `=== undefined` was not
+  // enough: `null > 1` and `NaN > 1` are both FALSE, so a failed query coercing to null — the exact
+  // omission-shaped value the guard exists to refuse — sailed through as a pass. The clause must be
+  // impossible to satisfy by not measuring it, in every shape "not measured" can take.
+  if (m.absolute) {
+    const v = extras[m.absolute.input];
+    if (!Number.isInteger(v) || v < 0) {
+      throw new Error(
+        `${key}: \`${m.absolute.input}\` must be a non-negative integer, got ${JSON.stringify(v)} — ` +
+          `the clause cannot be satisfied by failing to measure it`
+      );
+    }
   }
   const armMean = mean(arm[0], arm[1]);
   const baseMean = mean(incumbent[0], incumbent[1]);
@@ -202,14 +209,21 @@ export function judgeMetric(key, arm, incumbent, extras = {}) {
  * Every trigger here is pre-defined and none of them is "the numbers came out wrong" — that
  * distinction is the difference between a rule and an excuse.
  */
-export function assessSession({ incumbent, dupeShare, dupeEdges, underpowered = [], armsCompleted, harnessRefused, crossCheckAvailable }) {
+export function assessSession({ incumbent, dupeShare, dupeEdges, underpowered, armsCompleted, harnessRefused, crossCheckAvailable }) {
   // REQUIRED, not defaulted-permissive. A default of `armsCompleted = true` means a runner that
   // forgets to pass it silently disarms that validity trigger — the same "omission canonicalized as
   // fine" class as the absolute clause above, in the one file whose job is that the readout cannot
   // be quietly softened. Throw instead: a missing safety input is a bug, not a pass.
-  for (const [k, v] of Object.entries({ dupeShare, dupeEdges, armsCompleted, harnessRefused, crossCheckAvailable })) {
+  for (const [k, v] of Object.entries({ dupeShare, dupeEdges, underpowered, armsCompleted, harnessRefused, crossCheckAvailable })) {
     if (v === undefined || v === null) throw new Error(`assessSession: \`${k}\` is required — omitting it must not read as valid`);
   }
+  // NaN is the other shape of "not measured", and it slipped BOTH dupe gates: `NaN < 0.15` and
+  // `NaN > 0.45` are each false, so a broken query produced a clean bill of health. Same reason the
+  // absolute clause above rejects it.
+  for (const [k, v] of Object.entries({ dupeShare, dupeEdges })) {
+    if (!Number.isFinite(v)) throw new Error(`assessSession: \`${k}\` must be a finite number, got ${JSON.stringify(v)}`);
+  }
+  if (!Array.isArray(underpowered)) throw new Error("assessSession: `underpowered` must be an array — defaulting it to [] reads as \"every metric is powered\"");
   const problems = [];
 
   if (harnessRefused) problems.push("the cost harness refused the window — drain or cross-check");

--- a/scripts/graph-window-battery/measure.ts
+++ b/scripts/graph-window-battery/measure.ts
@@ -1,0 +1,179 @@
+/**
+ * The battery's quality measurements, read out of Neo4j and Postgres (PIPEFF-2 / AIO-821).
+ *
+ * Produces the five quality numbers an arm is judged on. It does NOT judge — `decision.mjs` owns
+ * that, so the readout stays a function of the numbers rather than of whoever is reading them.
+ *
+ * WHAT EACH ONE IS FOR, since three of the five exist only because review found the others blind:
+ *
+ *   Q1  entity yield          two-sided. Fragmentation RAISES node count, so a floor alone waved it
+ *                             through — and it is the only gate that sees variant-form inflation
+ *                             ("John" as a separate node from "John Smith"), which Q6 cannot,
+ *                             because such a node carries no member name at all.
+ *   Q2  people recall         member names literally present in a chunk, found as an Entity.
+ *   Q3  duplicate share       TWO-SIDED, using `extraction-health.ts`'s own predicate. A
+ *                             failure-to-merge emits NO IS_DUPLICATE_OF edge, so fragmentation makes
+ *                             this FALL — an upper bound alone pointed the wrong way.
+ *   Q4  cross-chunk continuity the within-document mechanism the window exists for.
+ *   Q6  cross-item convergence the cross-item dedupe judgment the window also feeds. Fragmentation's
+ *                             most direct signal.
+ *
+ * TIER NOTE (CLAUDE.md §5): every query is scoped to ONE `group_id`. The corpus is selected
+ * `access='team'` precisely so the whole battery lives in one group — the graph has no other tier
+ * enforcement, so a query that spanned groups would silently mix tiers.
+ */
+import { runRead } from "@/lib/graph/neo4j";
+import { itemIdFromEpisodeName } from "@/lib/graph/episode-name";
+
+export type Metrics = {
+  Q1: number;
+  Q2: number;
+  Q3: number;
+  Q4: number;
+  Q6: number;
+  personsLost: number;
+  dupeEdges: number;
+  episodes: number;
+};
+
+/** Case-normalised, so "john smith" and "John Smith" are not silently two people. */
+const norm = (s: string) => s.trim().toLowerCase();
+
+/** Q1 — Entity nodes per episode. */
+export async function entityYield(groupId: string, episodes: number): Promise<number> {
+  const rows = await runRead<{ n: number }>("MATCH (n:Entity {group_id: $g}) RETURN count(n) AS n", { g: groupId });
+  return episodes > 0 ? Number(rows[0]?.n ?? 0) / episodes : 0;
+}
+
+/**
+ * Q3 — the IS_DUPLICATE_OF share of RELATES_TO edges.
+ *
+ * The predicate is deliberately identical to `lib/graph/extraction-health.ts`'s, which is pinned by
+ * `test/guards/dedupe-predicate-pinned.test.ts` against what the deployed image actually writes. If a
+ * Graphiti upgrade renames the relation, that guard fails the build rather than this quietly reading
+ * zero — and a zero here would look like a *clean* graph while meaning the opposite.
+ */
+export async function dupeShare(groupId: string): Promise<{ share: number; total: number }> {
+  const rows = await runRead<{ total: number; dupe: number }>(
+    `MATCH (a:Entity {group_id: $g})-[r:RELATES_TO]->(b:Entity {group_id: $g})
+     RETURN count(r) AS total, count(CASE WHEN r.name = 'IS_DUPLICATE_OF' THEN 1 END) AS dupe`,
+    { g: groupId }
+  );
+  const total = Number(rows[0]?.total ?? 0);
+  const dupe = Number(rows[0]?.dupe ?? 0);
+  return { share: total > 0 ? dupe / total : 0, total };
+}
+
+/**
+ * Q4 — for multi-chunk items, the share of an item's entities that appear in ≥2 of its chunks.
+ *
+ * The join is `(:Episodic)-[:MENTIONS]->(:Entity)`, built in `_process_episode_data` over the
+ * RESOLVED (post-dedupe, canonical) nodes — so this measures whether resolution converged across
+ * chunks, which is what it is for.
+ *
+ * The item id comes from `itemIdFromEpisodeName`, never a `STARTS WITH 'items:<id>'` prefix match,
+ * which would swallow `items:123` into `items:12`.
+ */
+export async function crossChunkContinuity(groupId: string, multiChunkItemIds: Set<string>): Promise<number> {
+  const rows = await runRead<{ episode: string; entity: string }>(
+    `MATCH (e:Episodic {group_id: $g})-[:MENTIONS]->(n:Entity {group_id: $g})
+     RETURN e.name AS episode, n.uuid AS entity`,
+    { g: groupId }
+  );
+  return continuityFrom(rows, multiChunkItemIds);
+}
+
+/** The aggregation half of Q4, split out so it is testable without a graph. Pure. */
+export function continuityFrom(rows: { episode: string; entity: string }[], multiChunkItemIds: Set<string>): number {
+  // item id -> entity uuid -> the set of chunk episodes that mention it
+  const perItem = new Map<string, Map<string, Set<string>>>();
+  for (const r of rows) {
+    const itemId = itemIdFromEpisodeName(r.episode);
+    if (!itemId || !multiChunkItemIds.has(itemId)) continue;
+    const forItem = perItem.get(itemId) ?? new Map<string, Set<string>>();
+    const chunks = forItem.get(r.entity) ?? new Set<string>();
+    chunks.add(r.episode);
+    forItem.set(r.entity, chunks);
+    perItem.set(itemId, forItem);
+  }
+
+  let shared = 0;
+  let total = 0;
+  for (const forItem of perItem.values()) {
+    for (const chunks of forItem.values()) {
+      total++;
+      if (chunks.size >= 2) shared++;
+    }
+  }
+  return total > 0 ? shared / total : 0;
+}
+
+/**
+ * Q2 and Q6 together, because both are computed over the same member-name evidence and running them
+ * apart would let the two disagree about who counts as present.
+ *
+ * `presence` maps a normalised member name to the set of item ids whose text literally contains it —
+ * derived from the seeded Postgres by the caller, so this stays a pure Neo4j read plus set algebra.
+ *
+ *   Q2 = names present anywhere and found as an Entity, over names present anywhere.
+ *   Q6 = distinct Entity nodes carrying a name, over names present in ≥2 DISTINCT items.
+ *        Restricted that way because cross-ITEM convergence is the thing the unrelated predecessors
+ *        were feeding; a name confined to one item cannot demonstrate it.
+ *
+ * `personsLost` is Q2's second, noise-free clause: names present in the source and absent from the
+ * graph entirely.
+ */
+export async function peopleMetrics(
+  groupId: string,
+  presence: Map<string, Set<string>>
+): Promise<{ recall: number; convergence: number; personsLost: number; convergenceNames: number }> {
+  const rows = await runRead<{ name: string }>("MATCH (n:Entity {group_id: $g}) RETURN n.name AS name", { g: groupId });
+  return peopleFrom(rows.map((r) => r.name), presence);
+}
+
+/** The aggregation half of Q2/Q6, split out so it is testable without a graph. Pure. */
+export function peopleFrom(
+  entityNames: string[],
+  presence: Map<string, Set<string>>
+): { recall: number; convergence: number; personsLost: number; convergenceNames: number } {
+  const rows = entityNames.map((name) => ({ name }));
+  const nodesByName = new Map<string, number>();
+  for (const r of rows) {
+    const n = norm(r.name ?? "");
+    if (!n) continue;
+    nodesByName.set(n, (nodesByName.get(n) ?? 0) + 1);
+  }
+
+  const present = [...presence.keys()];
+  const found = present.filter((n) => (nodesByName.get(n) ?? 0) > 0);
+  const recall = present.length > 0 ? found.length / present.length : 0;
+
+  const multiItem = present.filter((n) => (presence.get(n)?.size ?? 0) >= 2);
+  const nodesForMultiItem = multiItem.reduce((s, n) => s + (nodesByName.get(n) ?? 0), 0);
+  const convergence = multiItem.length > 0 ? nodesForMultiItem / multiItem.length : 0;
+
+  return { recall, convergence, personsLost: present.length - found.length, convergenceNames: multiItem.length };
+}
+
+/**
+ * Which member names literally appear in which items' text.
+ *
+ * Literal presence is the point: it is the only definition that needs no answer key, which is what
+ * keeps the whole battery self-calibrating against this install rather than against a fixture.
+ */
+export function memberPresence(members: { display_name: string }[], items: { id: string; body: string }[]): Map<string, Set<string>> {
+  const presence = new Map<string, Set<string>>();
+  for (const m of members) {
+    const name = (m.display_name ?? "").trim();
+    // A one-word handle would match far too much prose to mean anything.
+    if (name.length < 4 || !name.includes(" ")) continue;
+    const needle = name.toLowerCase();
+    for (const it of items) {
+      if (!(it.body ?? "").toLowerCase().includes(needle)) continue;
+      const set = presence.get(norm(name)) ?? new Set<string>();
+      set.add(it.id);
+      presence.set(norm(name), set);
+    }
+  }
+  return presence;
+}

--- a/scripts/graph-window-battery/phase-a-predecessors.ts
+++ b/scripts/graph-window-battery/phase-a-predecessors.ts
@@ -1,0 +1,130 @@
+/**
+ * Phase A, part 2 — the SIZE of the predecessor block each call carries (PIPEFF-2 / AIO-821).
+ *
+ * Part 1 (`phase-a-structural.mjs`) answered two of Phase A's three questions at zero cost: how much
+ * of the window is same-item (57.1% is not), and how often a tie-pool rival displaces an item's own
+ * chunks (4.9%). This is the third, and the only one that needs a run: the parent spec's ~6,250
+ * tokens per call is DERIVED (625 tokens × 10 predecessors), never observed.
+ *
+ * It reads the tap's JSONL — the real request bodies, byte-for-byte as graphiti sent them — and for
+ * each one reports how much of the prompt is predecessor content rather than the episode being
+ * extracted.
+ *
+ * WHY THIS IS TypeScript AND THE REST OF THE BATTERY IS .mjs: so it can import the brain's own
+ * `classifyGraphCall`. That call-kind table is derived from the runtime call graph and has already
+ * been wrong once in a way that labelled ~80% of production spend `unknown`; a second copy here
+ * would drift from it silently. `npx tsx` is how this repo already runs its TS scripts.
+ *
+ * Usage:
+ *   npx tsx --conditions react-server scripts/graph-window-battery/phase-a-predecessors.ts <capture.jsonl>
+ */
+import { readFileSync } from "node:fs";
+import { classifyGraphCall, UNKNOWN_GRAPH_CALL } from "@/lib/llm/graph-call-kind";
+
+/** Rough but consistent: the same chars/4 the cost harness uses, so the two agree by construction. */
+const CHARS_PER_TOKEN = 4;
+const tokens = (s: string) => Math.round(s.length / CHARS_PER_TOKEN);
+
+type Row = { arm: string; at: string; path: string; body: { messages?: { role: string; content: string }[] } };
+
+/**
+ * The section tag graphiti wraps the previous episodes in.
+ *
+ * TWO SPELLINGS, because graphiti_core 0.29.3 is not internally consistent: `extract_nodes` and
+ * `dedupe_nodes` emit `<PREVIOUS MESSAGES>` (space) while `extract_edges` emits `<PREVIOUS_MESSAGES>`
+ * (underscore). Verified by generating the prompts inside the deployed image, not by reading docs.
+ */
+export const PREV_TAGS = ["PREVIOUS MESSAGES", "PREVIOUS_MESSAGES"] as const;
+
+/**
+ * Split a prompt into predecessor content and everything else.
+ *
+ * AN UNMATCHED PROMPT IS REPORTED, NEVER ASSUMED TO CARRY NOTHING. The first version of this looked
+ * for a JSON key `"previous_episodes"`, which these prompts do not contain — and it dutifully
+ * reported **0% predecessors** on prompts that were ~75% predecessors. Against a paid session that
+ * would have "measured" the ten-episode window as free and killed the lever on its own bug, with a
+ * plausible number and no error. Hence `parsed`, surfaced per call kind rather than folded into a
+ * zero that looks like a measurement.
+ */
+export function splitPrompt(content: string): { predecessors: number; episode: number; total: number; parsed: boolean } {
+  const total = tokens(content);
+  for (const tag of PREV_TAGS) {
+    const open = content.indexOf(`<${tag}>`);
+    if (open === -1) continue;
+    const close = content.indexOf(`</${tag}>`, open);
+    if (close === -1) continue;
+    const predecessors = tokens(content.slice(open, close + tag.length + 3));
+    return { predecessors, episode: total - predecessors, total, parsed: true };
+  }
+  return { predecessors: 0, episode: total, total, parsed: false };
+}
+
+type Agg = { calls: number; total: number; predecessors: number; unparsed: number };
+
+/** Aggregate a capture file by call kind. Pure; exported so the report and its test share one path. */
+export function summarise(rows: Row[]): Map<string, Agg> {
+  const byKind = new Map<string, Agg>();
+  for (const r of rows) {
+    const kind = classifyGraphCall(r.body);
+    const content = (r.body.messages ?? []).map((m) => m.content ?? "").join("\n");
+    const { predecessors, total, parsed } = splitPrompt(content);
+    const a = byKind.get(kind) ?? { calls: 0, total: 0, predecessors: 0, unparsed: 0 };
+    a.calls++;
+    a.total += total;
+    a.predecessors += predecessors;
+    if (!parsed) a.unparsed++;
+    byKind.set(kind, a);
+  }
+  return byKind;
+}
+
+function main(): void {
+  const file = process.argv[2];
+  if (!file) {
+    console.error("usage: phase-a-predecessors.ts <capture.jsonl>");
+    process.exit(1);
+  }
+
+  const rows: Row[] = readFileSync(file, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+
+  if (rows.length === 0) {
+    // A silent zero here is indistinguishable from a clean measurement, so it refuses.
+    console.error(`${file} holds no captured calls — the tap was not in the path, or the run never started`);
+    process.exit(1);
+  }
+
+  const byKind = summarise(rows);
+  console.log(`\nPHASE A part 2 — predecessor block size, arm ${rows[0].arm}, ${rows.length} captured calls\n`);
+  console.log("call kind               calls   avg input   avg predecessors   predecessor share");
+
+  let totalIn = 0;
+  let totalPred = 0;
+  for (const [kind, a] of [...byKind.entries()].sort((x, y) => y[1].total - x[1].total)) {
+    const share = a.total > 0 ? (a.predecessors / a.total) * 100 : 0;
+    totalIn += a.total;
+    totalPred += a.predecessors;
+    const warn = a.unparsed > 0 ? `  ⚠ ${a.unparsed} unparsed` : "";
+    console.log(
+      `${kind.padEnd(22)}${String(a.calls).padStart(6)}${String(Math.round(a.total / a.calls)).padStart(12)}` +
+        `${String(Math.round(a.predecessors / a.calls)).padStart(19)}${(share.toFixed(1) + "%").padStart(20)}${warn}`
+    );
+  }
+
+  console.log(`\n  total input tokens        ${totalIn.toLocaleString()}`);
+  console.log(`  of which predecessors     ${totalPred.toLocaleString()}  (${((totalPred / totalIn) * 100).toFixed(1)}%)`);
+  console.log(`\n  The parent spec DERIVED ~6,250 predecessor tokens per extract call. The figure above is`);
+  console.log(`  observed, and it is what the SAME arm's saving is measured against.`);
+
+  // A rising `unknown` share means the deployed prompts have moved away from lib/llm/graph-call-kind —
+  // the designed failure mode of that table, and a reason to distrust every row above.
+  const unknown = byKind.get(UNKNOWN_GRAPH_CALL);
+  if (unknown) {
+    console.log(`\n  ⚠ ${unknown.calls} call(s) classified '${UNKNOWN_GRAPH_CALL}' — the prompt table has drifted from what is deployed.`);
+  }
+}
+
+// Only when invoked as a script, so the parser above is unit-testable without producing a report.
+if (process.argv[1]?.includes("phase-a-predecessors")) main();

--- a/scripts/graph-window-battery/phase-a-structural.mjs
+++ b/scripts/graph-window-battery/phase-a-structural.mjs
@@ -20,13 +20,17 @@
  *   DATABASE_URL=<prod public URL> node scripts/graph-window-battery/phase-a-structural.mjs
  */
 import { Client } from "pg";
-import { selectCorpus, CANDIDATE_SQL, CHUNK_CHARS, MAX_EPISODE_CHUNKS } from "./corpus.mjs";
+import { selectCorpus, CANDIDATE_SQL, CHUNK_CHARS, MAX_EPISODE_CHUNKS, blankBodySql, PROJECTABLE_KINDS } from "./corpus.mjs";
 
-const KINDS = ["transcript", "deliverable", "decision", "task", "artifact"];
-const c = new Client({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+const KINDS = PROJECTABLE_KINDS;
+// Gate SSL the way the sibling scripts do, so this also runs against a plain local Postgres.
+const url = process.env.DATABASE_URL ?? "";
+const needsSsl = /\bsslmode=require\b/.test(url) || /\.rlwy\.net|proxy\.rlwy\.net|railway/.test(url);
+const c = new Client({ connectionString: url, ...(needsSsl ? { ssl: { rejectUnauthorized: false } } : {}) });
 await c.connect();
 
-const t = await c.query("select id, slug from teams limit 1");
+// Deterministic: `limit 1` with no ORDER BY picks an arbitrary row on a multi-team install.
+const t = await c.query("select id, slug from teams order by created_at, id limit 1");
 const teamId = t.rows[0].id;
 const { rows } = await c.query(CANDIDATE_SQL, [teamId, KINDS]);
 const got = selectCorpus(rows.map((r) => ({ ...r, chars: Number(r.chars) })));
@@ -60,7 +64,7 @@ const rival = await c.query(
      from items i
      left join items o
        on o.team_id = i.team_id and o.access = i.access and o.work_at = i.work_at
-      and o.id <> i.id and o.kind = any($3) and btrim(o.body) <> ''
+      and o.id <> i.id and o.kind = any($3) and not (${blankBodySql('o.body')})
     where i.id = any($1) and i.team_id = $2
     group by i.id, i.path
     order by rival_eps desc`,

--- a/scripts/graph-window-battery/phase-a-structural.mjs
+++ b/scripts/graph-window-battery/phase-a-structural.mjs
@@ -1,0 +1,92 @@
+/**
+ * Phase A, part 1 — what the ten predecessors actually contain, WITHOUT spending anything
+ * (PIPEFF-2 / AIO-821).
+ *
+ * Two of Phase A's three questions do not need an LLM run:
+ *
+ *   · SAME-ITEM SHARE is derivable. Given the tie-rank guarantee (an item's own chunks share
+ *     `valid_at` with the episode being extracted, which is the MAXIMUM the `valid_at <=
+ *     reference_time` filter admits, so they outrank every strictly-earlier row), chunk k of an item
+ *     receives exactly min(k, 10) of its own prior chunks and 10 - min(k, 10) unrelated fillers.
+ *   · TIE-POOL CONTAMINATION is a SQL query: another item with a byte-identical `work_at` competes
+ *     for the same ten slots, and it competes with one row PER CHUNK, so the honest unit is rival
+ *     EPISODES rather than rival items.
+ *
+ * Only the third question — the token SIZE of the predecessor block per call kind — needs the stack
+ * and the money. Running this first means the expensive half is entered with a prediction already on
+ * the record, which is the whole point of Phase A.
+ *
+ * Read-only against prod. Usage:
+ *   DATABASE_URL=<prod public URL> node scripts/graph-window-battery/phase-a-structural.mjs
+ */
+import { Client } from "pg";
+import { selectCorpus, CANDIDATE_SQL, CHUNK_CHARS, MAX_EPISODE_CHUNKS } from "./corpus.mjs";
+
+const KINDS = ["transcript", "deliverable", "decision", "task", "artifact"];
+const c = new Client({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+await c.connect();
+
+const t = await c.query("select id, slug from teams limit 1");
+const teamId = t.rows[0].id;
+const { rows } = await c.query(CANDIDATE_SQL, [teamId, KINDS]);
+const got = selectCorpus(rows.map((r) => ({ ...r, chars: Number(r.chars) })));
+
+// ANALYTIC same-item share. For chunk k (0-based) of an item, the window holds min(k,10) of that
+// item's own prior chunks and 10-min(k,10) unrelated fillers — guaranteed by the valid_at tie rank
+// (own chunks sit AT reference_time, the maximum the filter admits, so they outrank every earlier
+// row). No LLM call needed to know this; the only empirical unknowns are contamination and size.
+let own = 0, filler = 0, ownMulti = 0, fillerMulti = 0, singleSlots = 0;
+for (const it of got.items) {
+  for (let k = 0; k < it.chunks; k++) {
+    const o = Math.min(k, 10);
+    const f = 10 - o;
+    own += o;
+    filler += f;
+    if (it.chunks > 1) { ownMulti += o; fillerMulti += f; } else { singleSlots += f; }
+  }
+}
+const pct = (a, b) => (a + b === 0 ? "n/a" : ((a / (a + b)) * 100).toFixed(1) + "%");
+
+console.log("PREDECESSOR SLOTS across the corpus (analytic, from the tie-rank guarantee)");
+console.log(`  overall       same-item ${pct(own, filler)}   (${own} own / ${filler} unrelated slots)`);
+console.log(`  multi-chunk   same-item ${pct(ownMulti, fillerMulti)}`);
+console.log(`  single-chunk  same-item 0.0%   (${singleSlots} slots, all unrelated — nothing to be a chunk of)`);
+
+// TIE-POOL CONTAMINATION — the one way the guarantee breaks: another item in the same group with a
+// byte-identical `work_at` competes for the same ten slots. It competes with one row PER CHUNK, so
+// the honest unit is rival EPISODES; counting rival ITEMS understates a 40-chunk rival 40-fold.
+const rival = await c.query(
+  `select i.id, i.path, coalesce(sum(least(ceil(length(o.body)::numeric / $4), $5)), 0)::int as rival_eps
+     from items i
+     left join items o
+       on o.team_id = i.team_id and o.access = i.access and o.work_at = i.work_at
+      and o.id <> i.id and o.kind = any($3) and btrim(o.body) <> ''
+    where i.id = any($1) and i.team_id = $2
+    group by i.id, i.path
+    order by rival_eps desc`,
+  [got.items.map((i) => i.id), teamId, KINDS, CHUNK_CHARS, MAX_EPISODE_CHUNKS]
+);
+const byId = new Map(rival.rows.map((r) => [r.id, r.rival_eps]));
+
+// For chunk k with R rival episodes at the same rank, the tie pool is k + R for 10 slots. When the
+// pool overflows, the own chunks expected to survive are ~10 * k/(k+R) — Cypher does not define the
+// order among ties, so this is the expectation rather than a bound.
+let promised = 0;
+let expected = 0;
+for (const it of got.items) {
+  const R = byId.get(it.id) ?? 0;
+  for (let k = 0; k < it.chunks; k++) {
+    const ideal = Math.min(k, 10);
+    promised += ideal;
+    expected += k + R <= 10 ? ideal : (10 * k) / (k + R);
+  }
+}
+const contaminated = rival.rows.filter((r) => r.rival_eps > 0);
+console.log("\nTIE-POOL CONTAMINATION (rival EPISODES sharing an exact work_at)");
+console.log(`  corpus items with any rival: ${contaminated.length} of ${rival.rows.length}`);
+console.log(`  worst single item:           ${Math.max(0, ...rival.rows.map((r) => r.rival_eps))} rival episodes`);
+console.log(`  own-chunk slots promised:    ${promised}`);
+console.log(`  expected to survive:         ${expected.toFixed(1)} (${((expected / promised) * 100).toFixed(1)}%)`);
+console.log("\n  The SAME filter removes rival displacement entirely — own chunks are the only candidates.");
+
+await c.end();

--- a/scripts/graph-window-battery/seed-local.mjs
+++ b/scripts/graph-window-battery/seed-local.mjs
@@ -1,0 +1,121 @@
+/**
+ * Seed the battery's local Postgres from prod, read-only on the source (PIPEFF-2 / AIO-821).
+ *
+ * WHY A COPY AND NOT A FIXTURE. The corpus has to be this install's own content — see `corpus.mjs`
+ * for why a synthetic fixture is the failure this workstream exists to prevent. The repo is public,
+ * so that content can never be committed; it is copied into a throwaway local database at run time
+ * and dies with the container.
+ *
+ * WHAT GETS COPIED, AND WHY EACH ONE IS LOAD-BEARING:
+ *   · `teams`         — the projector and the LLM proxy both resolve the team; the row also carries
+ *                       `extraction_provider`/`extraction_model`, which the arms must match or they
+ *                       measure a cost shape prod does not have.
+ *   · `projects`      — `items.project_id` is NOT NULL with an FK, so the corpus cannot land without it.
+ *   · `members`       — Q2 (people recall) and Q6 (entity convergence) are both computed over member
+ *                       names. Without these two metrics have no denominator at all.
+ *   · `items`         — the pinned corpus, bodies included. The only table whose content is sensitive.
+ *   · `integrations`  — copied **still encrypted**. The battery never decrypts, never prints and never
+ *                       writes the provider key anywhere; the local brain decrypts it in-process with
+ *                       the same `SECRETS_KEY`, exactly as prod does. That is the whole reason to copy
+ *                       the ciphertext rather than resolve the key and pass it along.
+ *
+ * The three things beyond rows that the stack needs — `SECRETS_KEY`, `GRAPH_LLM_PROXY_SECRET` and
+ * `GRAPH_LLM_TEAM` — are asserted here rather than discovered later, because without them the stack
+ * boots and then quietly does nothing: `authorizeGraphProxy` fails CLOSED on an unset secret, and
+ * `resolveGraphProxyTeamId` refuses rather than guessing.
+ *
+ * Usage:
+ *   SOURCE_DATABASE_URL=<prod public URL>  TARGET_DATABASE_URL=<local test DB>  \
+ *   node scripts/graph-window-battery/seed-local.mjs
+ */
+import { Client } from "pg";
+import { selectCorpus, verifyCorpus, countFromBody, CANDIDATE_SQL, PROJECTABLE_KINDS } from "./corpus.mjs";
+
+/** SSL only where the URL says so, so this runs against a plain local Postgres too. */
+const connect = async (url, label) => {
+  if (!url) throw new Error(`${label} is required`);
+  const needsSsl = /\bsslmode=require\b/.test(url) || /rlwy\.net|railway/.test(url);
+  const c = new Client({ connectionString: url, ...(needsSsl ? { ssl: { rejectUnauthorized: false } } : {}) });
+  await c.connect();
+  return c;
+};
+
+/**
+ * Copy whole rows without naming every column, so a schema change cannot silently drop one.
+ *
+ * `nulled` blanks specific columns on the way across. Used for exactly one thing today —
+ * `members.auth_user_id` — and that is a decision rather than a workaround: the FK points at
+ * `auth_users`, which the battery has no reason to copy because **nothing ever logs in**. Nulling it
+ * is also strictly safer than satisfying it: no authentication identity is duplicated into a
+ * throwaway database to run a cost experiment.
+ */
+async function copyRows(src, dst, table, where, params, nulled = []) {
+  const { rows } = await src.query(`select * from ${table} where ${where}`, params);
+  if (rows.length === 0) return 0;
+  const cols = Object.keys(rows[0]).filter((c) => c !== "search"); // generated column — Postgres refuses a write
+  const colList = cols.map((c) => `"${c}"`).join(", ");
+  for (const r of rows) {
+    const vals = cols.map((c) => (nulled.includes(c) ? null : r[c]));
+    const ph = cols.map((_, i) => `$${i + 1}`).join(", ");
+    await dst.query(`insert into ${table} (${colList}) values (${ph}) on conflict (id) do nothing`, vals);
+  }
+  return rows.length;
+}
+
+const src = await connect(process.env.SOURCE_DATABASE_URL, "SOURCE_DATABASE_URL");
+const dst = await connect(process.env.TARGET_DATABASE_URL, "TARGET_DATABASE_URL");
+
+// Refuse to run the two at the same place. Seeding writes; the source must never be written to.
+const same = process.env.SOURCE_DATABASE_URL === process.env.TARGET_DATABASE_URL;
+if (same) throw new Error("SOURCE and TARGET are the same database — this script WRITES to the target");
+
+const team = (await src.query("select * from teams order by created_at, id limit 1")).rows[0];
+if (!team) throw new Error("no team in the source database");
+
+const { rows: candidates } = await src.query(CANDIDATE_SQL, [team.id, PROJECTABLE_KINDS]);
+const selection = selectCorpus(candidates.map((r) => ({ ...r, chars: Number(r.chars) })));
+if (selection.shortfall.length) console.log(`  shortfall: ${selection.shortfall.join(" · ")}`);
+
+const ids = selection.items.map((i) => i.id);
+const { rows: bodies } = await src.query("select id, body from items where id = any($1)", [ids]);
+const bodyById = new Map(bodies.map((r) => [r.id, r.body]));
+
+// Chunk the selected bodies with the projector's REAL algorithm — the SQL estimate counts Postgres
+// characters, not JS UTF-16 units, and this number gates Q5's band via EPISODE_BUDGET.
+const verified = verifyCorpus(selection, bodyById, countFromBody);
+if (verified.divergent?.length) {
+  console.log(`  ⚠ ${verified.divergent.length} item(s) where the SQL estimate and the projector disagree:`);
+  for (const d of verified.divergent) console.log(`      ${d.id}: estimated ${d.estimated}, actual ${d.actual}`);
+}
+
+await dst.query("begin");
+const counts = {
+  teams: await copyRows(src, dst, "teams", "id = $1", [team.id], ["created_by"]),
+  projects: await copyRows(src, dst, "projects", "team_id = $1", [team.id]),
+  members: await copyRows(src, dst, "members", "team_id = $1", [team.id], ["auth_user_id"]),
+  items: await copyRows(src, dst, "items", "id = any($1)", [ids]),
+  // Encrypted. Never decrypted here — the local brain does that in-process with the same SECRETS_KEY.
+  integrations: await copyRows(src, dst, "integrations", "team_id = $1", [team.id]),
+};
+await dst.query("commit");
+
+console.log(`\nseeded into the local database (team ${team.slug}):`);
+for (const [t, n] of Object.entries(counts)) console.log(`  ${String(n).padStart(5)} ${t}`);
+console.log(`\ncorpus: ${verified.items.length} items · ${verified.episodes} episodes`);
+console.log(`  single-chunk episode share ${(verified.singleChunkEpisodeShare * 100).toFixed(1)}% (prod ~17%)`);
+console.log(`  episode budget: ${verified.episodeBudgetBreach ?? "within range"}`);
+console.log(`\nextraction target the arms must match: ${team.extraction_provider ?? "(unset)"} / ${team.extraction_model ?? "(unset)"}`);
+
+// Named here rather than discovered when the stack silently does nothing.
+const missing = ["SECRETS_KEY", "GRAPH_LLM_PROXY_SECRET", "GRAPH_LLM_TEAM"].filter((k) => !process.env[k]);
+if (missing.length) {
+  console.log(`\n⚠ still needed before a single LLM call can flow: ${missing.join(", ")}`);
+  console.log("  authorizeGraphProxy fails CLOSED on an unset secret, and resolveGraphProxyTeamId refuses");
+  console.log("  rather than guessing — so the stack would boot and quietly extract nothing.");
+}
+
+// The pinned corpus, for the session log. Ids only; no content leaves the local database.
+console.log(`\npinned item ids (for the session log):\n${verified.items.map((i) => `${i.bucket} ${i.chunks}ch ${i.id}`).join("\n")}`);
+
+await src.end();
+await dst.end();

--- a/test/datamechanics/graph-window-battery-blank-predicate.datamechanics.test.ts
+++ b/test/datamechanics/graph-window-battery-blank-predicate.datamechanics.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { runSql } from "@/lib/db/pg/pool";
+import { chunkContent } from "@/lib/graph/project";
+// @ts-expect-error — plain .mjs script, no types.
+import { blankBodySql } from "../../scripts/graph-window-battery/corpus.mjs";
+
+/**
+ * Spec: the battery's "this body yields no episodes" SQL predicate must agree with `chunkContent`,
+ * which decides it with JS `.trim()` (PIPEFF-2 / AIO-821).
+ *
+ * THIS BELONGS IN THE REAL-POSTGRES TIER AND NOWHERE ELSE. The whole subtlety is Postgres string
+ * semantics: `btrim/1` strips **spaces only**, so `btrim(E'  \n\t  ')` is `E'\n\t'`, not `''`. The
+ * first version of the battery used `btrim(body) = ''` and would therefore have counted a
+ * newline-or-tab-only body as a one-episode item that the projector then emits ZERO episodes for.
+ *
+ * That divergence is not cosmetic: the counted and pushed episode totals drift apart, which can trip
+ * the `armsCompleted` validity check and invalidate a paid session over an instrument bug, and it
+ * skews the single-chunk share that makes C1 transferable to prod.
+ *
+ * A unit test cannot catch any of this — it would hand-feed a `blank` boolean the SQL would never
+ * have produced, which is exactly how the original whitespace test passed while the bug was live.
+ */
+describe("blankBodySql agrees with chunkContent about which bodies yield no episodes", () => {
+  // Each case is one whitespace shape. Plain spaces are the case both predicates get right; the
+  // others are the ones only the regex gets right.
+  const blankCases = ["", " ", "   ", "\n", "\t", "  \n\t  ", "\r\n", ""];
+  const nonBlankCases = ["a", " a ", "\n#\n", "0"];
+
+  it("marks every whitespace-only body blank, matching chunkContent's empty output", async () => {
+    for (const body of blankCases) {
+      const { rows } = await runSql<{ blank: boolean }>(`select (${blankBodySql("$1::text")}) as blank`, [body]);
+      expect(chunkContent(body), `chunkContent for ${JSON.stringify(body)}`).toEqual([]);
+      expect(rows[0].blank, `SQL predicate for ${JSON.stringify(body)}`).toBe(true);
+    }
+  });
+
+  it("marks every content-bearing body non-blank, matching chunkContent's non-empty output", async () => {
+    for (const body of nonBlankCases) {
+      const { rows } = await runSql<{ blank: boolean }>(`select (${blankBodySql("$1::text")}) as blank`, [body]);
+      expect(chunkContent(body).length, `chunkContent for ${JSON.stringify(body)}`).toBeGreaterThan(0);
+      expect(rows[0].blank, `SQL predicate for ${JSON.stringify(body)}`).toBe(false);
+    }
+  });
+
+  it("proves the predicate this replaced was WRONG — btrim strips spaces only", async () => {
+    // Non-vacuity: if this ever starts agreeing, the case above stopped discriminating and the two
+    // tests together no longer prove the fix.
+    const { rows } = await runSql<{ old_says_blank: boolean; js_says_blank: boolean }>(
+      `select (btrim($1::text) = '') as old_says_blank, true as js_says_blank`,
+      ["  \n\t  "]
+    );
+    expect(rows[0].old_says_blank).toBe(false);
+    expect(chunkContent("  \n\t  ")).toEqual([]);
+  });
+});

--- a/test/datamechanics/graph-window-battery-blank-predicate.datamechanics.test.ts
+++ b/test/datamechanics/graph-window-battery-blank-predicate.datamechanics.test.ts
@@ -23,7 +23,7 @@ import { blankBodySql } from "../../scripts/graph-window-battery/corpus.mjs";
 describe("blankBodySql agrees with chunkContent about which bodies yield no episodes", () => {
   // Each case is one whitespace shape. Plain spaces are the case both predicates get right; the
   // others are the ones only the regex gets right.
-  const blankCases = ["", " ", "   ", "\n", "\t", "  \n\t  ", "\r\n", ""];
+  const blankCases = ["", " ", "   ", "\n", "\t", "  \n\t  ", "\r\n", "\v\f"];
   const nonBlankCases = ["a", " a ", "\n#\n", "0"];
 
   it("marks every whitespace-only body blank, matching chunkContent's empty output", async () => {
@@ -42,14 +42,19 @@ describe("blankBodySql agrees with chunkContent about which bodies yield no epis
     }
   });
 
-  it("proves the predicate this replaced was WRONG — btrim strips spaces only", async () => {
-    // Non-vacuity: if this ever starts agreeing, the case above stopped discriminating and the two
-    // tests together no longer prove the fix.
-    const { rows } = await runSql<{ old_says_blank: boolean; js_says_blank: boolean }>(
-      `select (btrim($1::text) = '') as old_says_blank, true as js_says_blank`,
-      ["  \n\t  "]
-    );
-    expect(rows[0].old_says_blank).toBe(false);
-    expect(chunkContent("  \n\t  ")).toEqual([]);
+  it("keeps at least one SHARED case that separates the new predicate from the old one", async () => {
+    // Non-vacuity, bound to the fixture above rather than to its own literal. An earlier version
+    // hardcoded "  \n\t  " here, so pruning every discriminating shape out of `blankCases` would
+    // have left this green while the suite stopped proving anything — which is exactly what it
+    // claims to prevent.
+    const discriminating: string[] = [];
+    for (const body of blankCases) {
+      const { rows } = await runSql<{ old_blank: boolean }>(`select (btrim($1::text) = '') as old_blank`, [body]);
+      if (!rows[0].old_blank) discriminating.push(body);
+    }
+    expect(discriminating.length, "no shared case separates btrim from the regex any more").toBeGreaterThan(0);
+    // …and every one of them is genuinely blank to the projector, so the disagreement is the old
+    // predicate's fault rather than the fixture's.
+    for (const body of discriminating) expect(chunkContent(body)).toEqual([]);
   });
 });

--- a/test/graph-window-battery-corpus.test.ts
+++ b/test/graph-window-battery-corpus.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — plain .mjs script, no types; imported for its pure selection rule.
+import { bucketOf, chunkCount, selectCorpus, BUCKET_TARGETS, SMALL_ITEM_CHARS, MAX_EPISODE_CHUNKS, EPISODE_BUDGET } from "../scripts/graph-window-battery/corpus.mjs";
+import { chunkContent } from "../lib/graph/project";
+
+/**
+ * The battery's corpus selection for PIPEFF-2 (AIO-821).
+ *
+ * Spec-derived. Two properties carry the weight, and both are here because review caught them
+ * missing rather than because a run failed:
+ *
+ *   1. THE BUCKETS PARTITION. Two successive drafts of the spec left an item shape in no bucket at
+ *      all — first 4-7-chunk items, then 1-chunk-but-large items. A hole is silent: the item is just
+ *      never selected, the corpus quietly misrepresents prod, and C1 (which is corpus-mix-sensitive)
+ *      transfers wrongly. So totality is asserted directly over the whole domain, not sampled.
+ *   2. `chunkCount` AGREES WITH `chunkContent`. The battery counts episodes from `length(body)` in
+ *      SQL rather than chunking thousands of bodies, which is a re-derivation of the projector's
+ *      algorithm — exactly the kind of parallel implementation that drifts. Pinned against the real
+ *      function, including the cap and the whitespace case.
+ */
+
+describe("the buckets partition every item the graph can see", () => {
+  it("assigns a bucket to EVERY chunk count from 1 to the cap — no shape falls through", () => {
+    const unbucketed: number[] = [];
+    for (let n = 1; n <= MAX_EPISODE_CHUNKS; n++) {
+      // Probe both sides of the small-item threshold, since bucketing at n=1 depends on chars too.
+      for (const chars of [1, SMALL_ITEM_CHARS - 1, SMALL_ITEM_CHARS, 2500, 100_000]) {
+        if (bucketOf(n, chars) === null) unbucketed.push(n);
+      }
+    }
+    expect(unbucketed).toEqual([]);
+  });
+
+  it("puts a 1-chunk item of 600-2,500 chars in B2 — the hole the second draft opened", () => {
+    expect(bucketOf(1, 1200)).toBe("B2");
+  });
+
+  it("puts a 4-7-chunk item in C — the hole the first draft opened", () => {
+    expect(bucketOf(4, 9000)).toBe("C");
+    expect(bucketOf(7, 17_000)).toBe("C");
+  });
+
+  it("separates the small tail (B1) from the rest of the single-chunk population (B2)", () => {
+    expect(bucketOf(1, SMALL_ITEM_CHARS - 1)).toBe("B1");
+    expect(bucketOf(1, SMALL_ITEM_CHARS)).toBe("B2");
+  });
+
+  it("sends 8-or-more chunks to A — the coreference case the lever must not break", () => {
+    expect(bucketOf(8, 20_000)).toBe("A");
+    expect(bucketOf(40, 100_000)).toBe("A");
+  });
+
+  it("returns null for a whitespace-only item — the projector skips it, so it is not a hole", () => {
+    expect(bucketOf(chunkCount(500, true), 500)).toBeNull();
+    expect(bucketOf(0, 0)).toBeNull();
+  });
+});
+
+describe("chunkCount is the projector's algorithm, not a paraphrase of it", () => {
+  const cases = [1, 100, 2499, 2500, 2501, 5000, 7501, 99_000, 250_000];
+
+  it.each(cases)("agrees with chunkContent for a %i-char body", (chars) => {
+    expect(chunkCount(chars)).toBe(chunkContent("x".repeat(chars)).length);
+  });
+
+  it("agrees on the cap — a body past CHUNK_CHARS * MAX_EPISODE_CHUNKS is clipped, not extrapolated", () => {
+    const huge = 2500 * (MAX_EPISODE_CHUNKS + 12);
+    expect(chunkCount(huge)).toBe(MAX_EPISODE_CHUNKS);
+    expect(chunkContent("x".repeat(huge))).toHaveLength(MAX_EPISODE_CHUNKS);
+  });
+
+  it("agrees that a whitespace-only body yields no episodes at all", () => {
+    expect(chunkContent("   \n\t ")).toEqual([]);
+    expect(chunkCount(6, true)).toBe(0);
+  });
+});
+
+describe("selectCorpus — deterministic, newest-first, capped per bucket", () => {
+  // Newest first, as the SQL orders them. Deliberately interleaved so "takes the newest N of each
+  // bucket" is a real claim rather than an artefact of grouped input.
+  const rows = [
+    { id: "a1", chars: 30_000 }, // A  (12 chunks)
+    { id: "s1", chars: 200 }, // B1
+    { id: "c1", chars: 6000 }, // C  (3 chunks)
+    { id: "a2", chars: 25_000 }, // A  (10 chunks)
+    { id: "m1", chars: 1500 }, // B2
+    { id: "s2", chars: 100 }, // B1
+    { id: "a3", chars: 21_000 }, // A  (9 chunks)
+    { id: "s3", chars: 550 }, // B1
+    { id: "c2", chars: 12_000 }, // C  (5 chunks)
+    { id: "m2", chars: 900 }, // B2
+  ];
+
+  it("caps each bucket at its target and keeps the newest", () => {
+    const got = selectCorpus(rows, { A: 2, B1: 2, B2: 1, C: 1 });
+    expect(got.byBucket.A.map((i: { id: string }) => i.id)).toEqual(["a1", "a2"]);
+    expect(got.byBucket.B1.map((i: { id: string }) => i.id)).toEqual(["s1", "s2"]);
+    expect(got.byBucket.B2.map((i: { id: string }) => i.id)).toEqual(["m1"]);
+    expect(got.byBucket.C.map((i: { id: string }) => i.id)).toEqual(["c1"]);
+  });
+
+  it("is deterministic — the same rows give the same corpus, which is what 'pinned item ids' means", () => {
+    const a = selectCorpus(rows);
+    const b = selectCorpus(rows);
+    expect(a.items.map((i: { id: string }) => i.id)).toEqual(b.items.map((i: { id: string }) => i.id));
+  });
+
+  it("counts episodes, not items — the unit every band is expressed in", () => {
+    const got = selectCorpus(rows, { A: 1, B1: 1, B2: 0, C: 0 });
+    expect(got.episodes).toBe(12 + 1);
+  });
+
+  it("reports a shortfall rather than silently returning a thin corpus", () => {
+    const got = selectCorpus(rows.slice(0, 3), BUCKET_TARGETS);
+    // Reads the target rather than restating it: a test that hardcodes the constant it is checking
+    // goes red for a deliberate retarget and green for a typo, which is backwards.
+    expect(got.shortfall.join(" ")).toMatch(new RegExp(`A: wanted ${BUCKET_TARGETS.A}, found 1`));
+  });
+
+  it("skips whitespace-only items entirely", () => {
+    const got = selectCorpus([{ id: "blank", chars: 800, blank: true }], { A: 5, B1: 5, B2: 5, C: 5 });
+    expect(got.items).toEqual([]);
+    expect(got.episodes).toBe(0);
+  });
+
+  it("reports the single-chunk episode share, because C1 is corpus-mix-sensitive", () => {
+    // Prod's is ~17% (898 of 5,166). A corpus far from that makes a blended tokens/episode figure
+    // untransferable, so the number has to be visible rather than assumed.
+    const got = selectCorpus(rows, BUCKET_TARGETS);
+    const single = got.items.filter((i: { chunks: number }) => i.chunks === 1).length;
+    expect(got.singleChunkEpisodeShare).toBeCloseTo(single / got.episodes, 10);
+  });
+});
+
+describe("the episode budget guards Q5's band, whose number means nothing without a corpus size", () => {
+  /**
+   * Q5's 3pp band and 1.5pp ceiling were derived at ~100 episodes, where one validation retry moves
+   * the signed gap by ~1pp. At 153 episodes one retry is 0.65pp and the SAME ceiling silently
+   * tolerates 2.3 retries — the number unchanged, its meaning changed. This is the guard that makes
+   * that visible instead of quiet.
+   */
+  const big = Array.from({ length: 60 }, (_, i) => ({ id: `a${i}`, chars: 100_000 })); // 40 chunks each
+
+  it("breaches when the corpus is far larger than the band was derived at", () => {
+    const got = selectCorpus(big, { A: 5, B1: 0, B2: 0, C: 0 });
+    expect(got.episodes).toBe(200);
+    expect(got.episodeBudgetBreach).toMatch(/outside the 90-120 range/);
+  });
+
+  it("breaches when it is far smaller, too — a thin corpus makes one retry huge", () => {
+    const got = selectCorpus([{ id: "s", chars: 100 }], { A: 0, B1: 1, B2: 0, C: 0 });
+    expect(got.episodeBudgetBreach).toMatch(/outside the 90-120 range/);
+  });
+
+  it("passes inside the range", () => {
+    const rows = Array.from({ length: 100 }, (_, i) => ({ id: `s${i}`, chars: 100 }));
+    const got = selectCorpus(rows, { A: 0, B1: 100, B2: 0, C: 0 });
+    expect(got.episodes).toBe(100);
+    expect(got.episodeBudgetBreach).toBeNull();
+  });
+});

--- a/test/graph-window-battery-corpus.test.ts
+++ b/test/graph-window-battery-corpus.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from "vitest";
 // @ts-expect-error — plain .mjs script, no types; imported for its pure selection rule.
-import { bucketOf, chunkCount, selectCorpus, BUCKET_TARGETS, SMALL_ITEM_CHARS, MAX_EPISODE_CHUNKS, EPISODE_BUDGET } from "../scripts/graph-window-battery/corpus.mjs";
-import { chunkContent } from "../lib/graph/project";
+import {
+  bucketOf,
+  chunkCount,
+  selectCorpus,
+  verifyCorpus,
+  resolvePositiveInt,
+  BUCKET_TARGETS,
+  SMALL_ITEM_CHARS,
+  MAX_EPISODE_CHUNKS,
+  EPISODE_BUDGET,
+  PROJECTABLE_KINDS,
+} from "../scripts/graph-window-battery/corpus.mjs";
+import { chunkContent, PROJECTABLE_KINDS as REAL_PROJECTABLE_KINDS } from "../lib/graph/project";
+import { resolvePositiveInt as realResolvePositiveInt } from "../lib/util/env";
 
 /**
  * The battery's corpus selection for PIPEFF-2 (AIO-821).
@@ -160,5 +172,69 @@ describe("the episode budget guards Q5's band, whose number means nothing withou
     const got = selectCorpus(rows, { A: 0, B1: 100, B2: 0, C: 0 });
     expect(got.episodes).toBe(100);
     expect(got.episodeBudgetBreach).toBeNull();
+  });
+});
+
+describe("verifyCorpus — the number that matters is computed by the real function, not estimated", () => {
+  /**
+   * `chunkCount` estimates from Postgres `length(body)`, which counts CHARACTERS, while
+   * `chunkContent` slices by JS string index — UTF-16 units. `length('👍👍')` is 2 in Postgres and 4
+   * in JS (both verified). The estimate is fine for SELECTION over ~2,000 rows, but the selected ~31
+   * items feed `EPISODE_BUDGET`, which is the check keeping Q5's band meaningful — so that number is
+   * recomputed with the projector's own function rather than trusted.
+   */
+  const bodies = (m: Record<string, string>) => new Map(Object.entries(m));
+
+  it("replaces the estimate with the real chunk count and reports the divergence", () => {
+    // 1,251 astral chars = 2,502 UTF-16 units → 2 real chunks, but Postgres counts 1,251 → 1 chunk.
+    const astral = "👍".repeat(1251);
+    const selection = selectCorpus([{ id: "e", chars: astral.length / 2 }], { A: 0, B1: 0, B2: 1, C: 0 });
+    expect(selection.items[0].chunks).toBe(1); // the estimate
+    const verified = verifyCorpus(selection, bodies({ e: astral }), chunkContent);
+    expect(verified.items[0].chunks).toBe(2); // the truth
+    expect(verified.items[0].estimatedChunks).toBe(1);
+    expect(verified.divergent).toEqual([{ id: "e", estimated: 1, actual: 2 }]);
+    expect(verified.episodes).toBe(2);
+  });
+
+  it("reports NO divergence for ASCII, so the field means something when it is non-empty", () => {
+    const selection = selectCorpus([{ id: "a", chars: 6000 }], { A: 0, B1: 0, B2: 0, C: 1 });
+    const verified = verifyCorpus(selection, bodies({ a: "x".repeat(6000) }), chunkContent);
+    expect(verified.divergent).toEqual([]);
+    expect(verified.episodes).toBe(selection.episodes);
+  });
+
+  it("re-runs the episode budget on the TRUE count, not the estimate", () => {
+    const rows = Array.from({ length: 89 }, (_, i) => ({ id: `s${i}`, chars: 100 }));
+    const selection = selectCorpus(rows, { A: 0, B1: 89, B2: 0, C: 0 });
+    expect(selection.episodeBudgetBreach).toMatch(/outside/); // 89 estimated, under the floor
+    const map = new Map(rows.map((r) => [r.id, "x".repeat(100)]));
+    expect(verifyCorpus(selection, map, chunkContent).episodeBudgetBreach).toMatch(/outside/);
+  });
+
+  it("refuses when a body was not supplied rather than silently skipping the item", () => {
+    const selection = selectCorpus([{ id: "a", chars: 6000 }], { A: 0, B1: 0, B2: 0, C: 1 });
+    expect(() => verifyCorpus(selection, bodies({}), chunkContent)).toThrow(/no body supplied/);
+  });
+});
+
+describe("the env parse mirrors the projector's, including where a loose parse diverges", () => {
+  /**
+   * A .mjs script cannot import the TypeScript, so `resolvePositiveInt` is duplicated. The version
+   * this replaced (`Number(x) > 0 ? Number(x) : d`) disagreed on fractional and infinite values:
+   * `GRAPH_CHUNK_CHARS=0.5` would have had the battery chunk at 0.5 chars while the projector chunked
+   * at 2,500 — a silent, total mis-count. Pinned against the real function, not described.
+   */
+  it.each([["0.5"], ["Infinity"], ["-Infinity"], [""], ["abc"], ["-5"], ["0"], ["2500"], ["7.9"], [undefined], [null]])(
+    "agrees with lib/util/env for %s",
+    (raw) => {
+      expect(resolvePositiveInt(raw as string, 2500)).toBe(realResolvePositiveInt(raw as string, 2500));
+    }
+  );
+});
+
+describe("the projectable kinds mirror lib/graph/project.ts", () => {
+  it("matches PROJECTABLE_KINDS exactly — a drift here silently changes which items the battery can see", () => {
+    expect([...PROJECTABLE_KINDS]).toEqual([...REAL_PROJECTABLE_KINDS]);
   });
 });

--- a/test/graph-window-battery-corpus.test.ts
+++ b/test/graph-window-battery-corpus.test.ts
@@ -11,6 +11,7 @@ import {
   MAX_EPISODE_CHUNKS,
   EPISODE_BUDGET,
   PROJECTABLE_KINDS,
+  countFromBody,
 } from "../scripts/graph-window-battery/corpus.mjs";
 import { chunkContent, PROJECTABLE_KINDS as REAL_PROJECTABLE_KINDS } from "../lib/graph/project";
 import { resolvePositiveInt as realResolvePositiveInt } from "../lib/util/env";
@@ -184,13 +185,15 @@ describe("verifyCorpus — the number that matters is computed by the real funct
    * recomputed with the projector's own function rather than trusted.
    */
   const bodies = (m: Record<string, string>) => new Map(Object.entries(m));
+  // The REAL projector function, so verifyCorpus is exercised against the thing it claims to use.
+  const realCount = (b: string) => chunkContent(b).length;
 
   it("replaces the estimate with the real chunk count and reports the divergence", () => {
     // 1,251 astral chars = 2,502 UTF-16 units → 2 real chunks, but Postgres counts 1,251 → 1 chunk.
     const astral = "👍".repeat(1251);
     const selection = selectCorpus([{ id: "e", chars: astral.length / 2 }], { A: 0, B1: 0, B2: 1, C: 0 });
     expect(selection.items[0].chunks).toBe(1); // the estimate
-    const verified = verifyCorpus(selection, bodies({ e: astral }), chunkContent);
+    const verified = verifyCorpus(selection, bodies({ e: astral }), realCount);
     expect(verified.items[0].chunks).toBe(2); // the truth
     expect(verified.items[0].estimatedChunks).toBe(1);
     expect(verified.divergent).toEqual([{ id: "e", estimated: 1, actual: 2 }]);
@@ -199,7 +202,7 @@ describe("verifyCorpus — the number that matters is computed by the real funct
 
   it("reports NO divergence for ASCII, so the field means something when it is non-empty", () => {
     const selection = selectCorpus([{ id: "a", chars: 6000 }], { A: 0, B1: 0, B2: 0, C: 1 });
-    const verified = verifyCorpus(selection, bodies({ a: "x".repeat(6000) }), chunkContent);
+    const verified = verifyCorpus(selection, bodies({ a: "x".repeat(6000) }), realCount);
     expect(verified.divergent).toEqual([]);
     expect(verified.episodes).toBe(selection.episodes);
   });
@@ -209,12 +212,12 @@ describe("verifyCorpus — the number that matters is computed by the real funct
     const selection = selectCorpus(rows, { A: 0, B1: 89, B2: 0, C: 0 });
     expect(selection.episodeBudgetBreach).toMatch(/outside/); // 89 estimated, under the floor
     const map = new Map(rows.map((r) => [r.id, "x".repeat(100)]));
-    expect(verifyCorpus(selection, map, chunkContent).episodeBudgetBreach).toMatch(/outside/);
+    expect(verifyCorpus(selection, map, realCount).episodeBudgetBreach).toMatch(/outside/);
   });
 
   it("refuses when a body was not supplied rather than silently skipping the item", () => {
     const selection = selectCorpus([{ id: "a", chars: 6000 }], { A: 0, B1: 0, B2: 0, C: 1 });
-    expect(() => verifyCorpus(selection, bodies({}), chunkContent)).toThrow(/no body supplied/);
+    expect(() => verifyCorpus(selection, bodies({}), realCount)).toThrow(/no body supplied/);
   });
 });
 
@@ -236,5 +239,26 @@ describe("the env parse mirrors the projector's, including where a loose parse d
 describe("the projectable kinds mirror lib/graph/project.ts", () => {
   it("matches PROJECTABLE_KINDS exactly — a drift here silently changes which items the battery can see", () => {
     expect([...PROJECTABLE_KINDS]).toEqual([...REAL_PROJECTABLE_KINDS]);
+  });
+});
+
+
+describe("countFromBody is chunkContent's count, for callers that cannot load the TypeScript", () => {
+  /**
+   * `seed-local.mjs` runs under plain node and cannot import `lib/graph/project.ts`. Rather than
+   * duplicate `chunkContent` there — the parallel-implementation drift this suite already guards
+   * against once — it passes `countFromBody`, pinned here against the real function including the
+   * astral case that motivated the whole verification step.
+   */
+  it.each([
+    ["ascii", "x".repeat(6000)],
+    ["astral", "\u{1F44D}".repeat(1251)],
+    ["mixed", "a\u{1F44D}".repeat(900)],
+    ["whitespace only", "  \n\t "],
+    ["empty", ""],
+    ["single char", "x"],
+    ["past the cap", "x".repeat(2500 * (MAX_EPISODE_CHUNKS + 5))],
+  ])("agrees with chunkContent for %s", (_label, body) => {
+    expect(countFromBody(body)).toBe(chunkContent(body).length);
   });
 });

--- a/test/graph-window-battery-corpus.test.ts
+++ b/test/graph-window-battery-corpus.test.ts
@@ -140,16 +140,19 @@ describe("the episode budget guards Q5's band, whose number means nothing withou
    * that visible instead of quiet.
    */
   const big = Array.from({ length: 60 }, (_, i) => ({ id: `a${i}`, chars: 100_000 })); // 40 chunks each
+  // Read the budget rather than restate it: a test that hardcodes the constant it checks goes red
+  // for a deliberate retarget and green for a typo, which is backwards.
+  const rangeRe = new RegExp(`outside the ${EPISODE_BUDGET.min}-${EPISODE_BUDGET.max} range`);
 
   it("breaches when the corpus is far larger than the band was derived at", () => {
     const got = selectCorpus(big, { A: 5, B1: 0, B2: 0, C: 0 });
     expect(got.episodes).toBe(200);
-    expect(got.episodeBudgetBreach).toMatch(/outside the 90-120 range/);
+    expect(got.episodeBudgetBreach).toMatch(rangeRe);
   });
 
   it("breaches when it is far smaller, too — a thin corpus makes one retry huge", () => {
     const got = selectCorpus([{ id: "s", chars: 100 }], { A: 0, B1: 1, B2: 0, C: 0 });
-    expect(got.episodeBudgetBreach).toMatch(/outside the 90-120 range/);
+    expect(got.episodeBudgetBreach).toMatch(rangeRe);
   });
 
   it("passes inside the range", () => {

--- a/test/graph-window-battery-decision.test.ts
+++ b/test/graph-window-battery-decision.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — plain .mjs script, no types; imported for its pure decision procedure.
+import { judgeMetric, assessSession, decide, VERDICT, METRICS } from "../scripts/graph-window-battery/decision.mjs";
+
+/**
+ * The battery's decision procedure for PIPEFF-2 (AIO-821).
+ *
+ * Spec-derived from `docs/design/graph-episode-window.md`, and the spec here is a rulebook rather
+ * than a feature: its job is to make the readout a FUNCTION of the numbers, so no metric can be
+ * reinterpreted once the numbers exist. Four plan-review rounds found three ways it wasn't one, and
+ * every one of those is a test below — they are regressions against real holes, not hypotheticals:
+ *
+ *   · a metric landing below its band but within noise had NO defined outcome;
+ *   · the PASS side ignored the spread, so a degraded incumbent rep LOWERED the bar (bands are
+ *     multiplicative in the incumbent's mean) — more noise, easier shipping;
+ *   · one-sided Q1/Q3 pointed the wrong way for entity fragmentation, so an arm could fragment the
+ *     graph's identity layer and clear every gate.
+ *
+ * One condition per fixture: each test mutates exactly ONE field of `clean`, so a failure names its
+ * own cause. `clean` itself is asserted to SHIP, or every mutation below would prove nothing.
+ */
+
+// Two reps per arm; the incumbent's own |rep1 - rep2| is the noise estimate.
+const incumbent = {
+  Q1: [10.0, 10.1], // entity yield / episode
+  Q2: [0.9, 0.91], // people recall
+  Q3: [0.3, 0.31], // IS_DUPLICATE_OF share (a fraction, not pp)
+  Q4: [0.8, 0.81], // cross-chunk continuity
+  Q5: [0.0, 0.01], // signed retry gap
+  Q6: [1.0, 1.02], // entity nodes per member name
+  C1: [40000, 40100], // input tokens / episode
+};
+
+const cleanArm = {
+  Q1: [10.0, 10.0],
+  Q2: [0.9, 0.9],
+  Q3: [0.3, 0.3],
+  Q4: [0.8, 0.8],
+  Q5: [0.0, 0.0],
+  Q6: [1.0, 1.0],
+  C1: [24000, 24000], // a 40% fall, comfortably past the 25% C1 demands
+};
+
+const session = { incumbent, dupeShare: 0.305, dupeEdges: 900 };
+
+const run = (over: Record<string, unknown> = {}, armOver: Record<string, number[]> = {}) =>
+  decide({
+    session: assessSession({ ...session, ...over }),
+    incumbent,
+    arms: [{ name: "SAME", metrics: { ...cleanArm, ...armOver } }],
+  });
+
+describe("the baseline is non-vacuous", () => {
+  it("ships an arm that beats every band by more than the incumbent's own spread", () => {
+    const d = run();
+    expect(d.outcome).toBe("SHIP");
+    expect(d.winner).toBe("SAME");
+  });
+
+  it("gates on every metric the spec names — a metric silently dropped from METRICS is a gate that stops existing", () => {
+    expect(Object.keys(METRICS).sort()).toEqual(["C1", "Q1", "Q2", "Q3", "Q4", "Q5", "Q6"]);
+    expect(run().arms[0].results).toHaveLength(7);
+  });
+});
+
+describe("the fragmentation direction — the hole that made Q1 and Q3 two-sided", () => {
+  /**
+   * Stripping unrelated predecessors removes the context `_resolve_with_llm` uses to decide whether
+   * extracted-"John" IS candidate-"John Smith", so the model stops merging. The result is the same
+   * person as several parallel nodes — the AIO-693 class. Under the one-sided bands of the first
+   * draft it cleared every gate, because it moves each metric in the PASSING direction.
+   */
+  it("FAILS an arm whose entity yield RISES — one-sided Q1 called this a pass", () => {
+    const d = run({}, { Q1: [11.5, 11.5] }); // +14% against a ±10% band
+    expect(d.outcome).toBe("NO_SHIP");
+    expect(d.arms[0].blocking.map((b: { key: string }) => b.key)).toEqual(["Q1"]);
+    expect(d.arms[0].results.find((r: { key: string }) => r.key === "Q1").verdict).toBe(VERDICT.FAIL);
+  });
+
+  it("FAILS an arm whose duplicate share FALLS — a failure-to-merge emits no IS_DUPLICATE_OF edge at all", () => {
+    const d = run({}, { Q3: [0.23, 0.23] }); // -7.5pp against a ±5pp band
+    expect(d.arms[0].results.find((r: { key: string }) => r.key === "Q3").verdict).toBe(VERDICT.FAIL);
+    expect(d.outcome).toBe("NO_SHIP");
+  });
+
+  it("FAILS an arm that fragments a member name across more nodes (Q6)", () => {
+    const d = run({}, { Q6: [1.2, 1.2] }); // +18% against a ≤105% band
+    expect(d.arms[0].results.find((r: { key: string }) => r.key === "Q6").verdict).toBe(VERDICT.FAIL);
+  });
+});
+
+describe("INCONCLUSIVE blocks exactly as FAIL does", () => {
+  it("does not ship a metric that misses its band by less than the incumbent's spread", () => {
+    // Q4's band is 85% of the incumbent; the incumbent's spread here is ~1.2% of its mean, so a value
+    // just under the edge lands inside the noise and must NOT be read as a pass.
+    const d = run({}, { Q4: [0.6825, 0.6825] }); // ratio ≈ 0.8478, band 0.85, tolerance ≈ 0.0124
+    const q4 = d.arms[0].results.find((r: { key: string }) => r.key === "Q4");
+    expect(q4.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(d.outcome).toBe("NO_SHIP");
+  });
+
+  it("does not ship a metric that BEATS its band by less than the spread either — the symmetric half", () => {
+    // Just above the edge. The asymmetric rule this replaced called it PASS.
+    const d = run({}, { Q4: [0.688, 0.688] }); // ratio ≈ 0.8547, band 0.85, tolerance ≈ 0.0124
+    const q4 = d.arms[0].results.find((r: { key: string }) => r.key === "Q4");
+    expect(q4.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(d.outcome).toBe("NO_SHIP");
+  });
+});
+
+describe("noise is strictly ANTI-ship — the review's worked counterexample", () => {
+  /**
+   * True incumbent yield 10.0, true arm value 8.5 — a real 15% regression that must fail a 90% band.
+   * One incumbent rep is quietly degraded (a provider brownout that still completes every episode,
+   * so it trips no completion check). Mean falls to 8.1, and because the band is MULTIPLICATIVE in
+   * that mean, the bar falls with it to 7.29 — and 8.5 clears it. That is how the asymmetric rule let
+   * noise work in the shipping direction.
+   */
+  const degraded = { ...incumbent, Q1: [10.2, 6.0] };
+
+  it("invalidates the session before the arm is even judged — the spread ceiling catches it first", () => {
+    const s = assessSession({ ...session, incumbent: degraded });
+    expect(s.valid).toBe(false);
+    expect(s.problems.join(" ")).toMatch(/Q1 incumbent spread/);
+  });
+
+  it("and if the ceiling were removed, the symmetric band still refuses to call it a PASS", () => {
+    // Judged directly, bypassing session validity: 8.5 against a lowered 7.29 bar, with a spread of
+    // 4.2 (52% of the mean) as the tolerance. The asymmetric rule shipped this.
+    const q1 = judgeMetric("Q1", [8.5, 8.5], degraded.Q1);
+    expect(q1.verdict).not.toBe(VERDICT.PASS);
+  });
+});
+
+describe("the C1 gate — a quality-clean arm that barely moves tokens does not ship", () => {
+  it("FAILS a token fall short of the 25% the deploy has to earn", () => {
+    const d = run({}, { C1: [36000, 36000] }); // a 10% fall
+    expect(d.arms[0].results.find((r: { key: string }) => r.key === "C1").verdict).toBe(VERDICT.FAIL);
+    expect(d.outcome).toBe("NO_SHIP");
+  });
+
+  it("FAILS a retry-gap rise beyond 3pp, since retries inflate C1's attempt denominator", () => {
+    const d = run({}, { Q5: [0.05, 0.05] }); // +4.5pp against a +3pp band
+    expect(d.arms[0].results.find((r: { key: string }) => r.key === "Q5").verdict).toBe(VERDICT.FAIL);
+  });
+});
+
+describe("session validity — every trigger is pre-defined, and none of them is 'the numbers came out wrong'", () => {
+  it("INVALID when the cross-check is unavailable — the harness prints a ratio anyway, which is why this refuses", () => {
+    const d = run({ crossCheckAvailable: false });
+    expect(d.outcome).toBe("INVALID");
+    expect(d.reasons.join(" ")).toMatch(/cross-check/);
+  });
+
+  it("INVALID when a metric is UNDERPOWERED — a corpus too thin to measure is not evidence of a regression", () => {
+    const d = run({ underpowered: ["Q6"] });
+    expect(d.outcome).toBe("INVALID");
+    expect(d.reasons.join(" ")).toMatch(/UNDERPOWERED/);
+  });
+
+  it("INVALID when an arm did not complete every episode", () => {
+    expect(run({ armsCompleted: false }).outcome).toBe("INVALID");
+  });
+
+  it("INVALID when the harness itself refused the window", () => {
+    expect(run({ harnessRefused: true }).outcome).toBe("INVALID");
+  });
+
+  it("INVALID when the incumbent's duplicate share is above extraction-health's own DEDUPE_ABSOLUTE_FLOOR", () => {
+    const d = run({ dupeShare: 0.7 }); // the degraded model's reading
+    expect(d.outcome).toBe("INVALID");
+    expect(d.reasons.join(" ")).toMatch(/duplicate share/);
+  });
+
+  it("INVALID when the incumbent's duplicate share is near zero — that means the PREDICATE is broken, not the graph clean", () => {
+    expect(run({ dupeShare: 0.01 }).outcome).toBe("INVALID");
+  });
+
+  it("INVALID below the 200-edge minimum the health module also refuses to judge under", () => {
+    const d = run({ dupeEdges: 150 });
+    expect(d.outcome).toBe("INVALID");
+    expect(d.reasons.join(" ")).toMatch(/200-edge/);
+  });
+
+  it("an INVALID session yields no arm verdicts at all — a broken instrument reports no result", () => {
+    expect(run({ crossCheckAvailable: false }).arms).toEqual([]);
+  });
+});
+
+describe("the spread ceiling is per-metric and in BAND units, not a fraction of the mean", () => {
+  /**
+   * "Spread > 25% of the mean" was degenerate at both ends. Q5's healthy mean is ~0, so 25% of it is
+   * ~0 and a single retry in one incumbent rep would have invalidated every session — the battery
+   * could never have completed a valid run.
+   */
+  it("tolerates one retry of rep-to-rep difference on Q5, whose healthy mean is ~0", () => {
+    const s = assessSession({ ...session, incumbent: { ...incumbent, Q5: [0.0, 0.01] } });
+    expect(s.valid).toBe(true);
+  });
+
+  it("but not two — 1.5pp is half of Q5's 3pp band", () => {
+    const s = assessSession({ ...session, incumbent: { ...incumbent, Q5: [0.0, 0.02] } });
+    expect(s.valid).toBe(false);
+    expect(s.problems.join(" ")).toMatch(/Q5 incumbent spread/);
+  });
+
+  it("refuses a Q3 spread that would leave its two-sided PASS window EMPTY", () => {
+    // The old ceiling allowed 7.5pp against a ±5pp band: valid by the rules, unpassable by any arm.
+    const s = assessSession({ ...session, incumbent: { ...incumbent, Q3: [0.27, 0.345] } }); // 7.5pp
+    expect(s.valid).toBe(false);
+  });
+
+  it("GUARANTEES a non-empty PASS window at the ceiling — for every gated metric", () => {
+    // The structural property the old ceiling lacked. At exactly half the band margin there must
+    // still exist an arm value that PASSes, or the procedure can deadlock mid-experiment.
+    for (const key of Object.keys(METRICS)) {
+      const m = METRICS[key as keyof typeof METRICS] as { kind: string; margin: number };
+      const base = incumbent[key as keyof typeof incumbent] as number[];
+      const baseMean = (base[0] + base[1]) / 2;
+      // Sit the arm exactly on the incumbent's own value: the most favourable value there is.
+      const armAt = m.kind === "ratio-fall" ? [baseMean * (1 - m.margin) * 0.5, baseMean * (1 - m.margin) * 0.5] : [baseMean, baseMean];
+      expect(judgeMetric(key, armAt, base).verdict, `${key} has no passable value at its ceiling`).toBe(VERDICT.PASS);
+    }
+  });
+});
+
+describe("arm order — SAME is evaluated before the blunt W1 fallback", () => {
+  it("ships W1 when SAME fails, and names W1 as the winner", () => {
+    const d = decide({
+      session: assessSession(session),
+      incumbent,
+      arms: [
+        { name: "SAME", metrics: { ...cleanArm, Q4: [0.5, 0.5] } },
+        { name: "W1", metrics: cleanArm },
+      ],
+    });
+    expect(d.outcome).toBe("SHIP");
+    expect(d.winner).toBe("W1");
+  });
+
+  it("ships SAME when BOTH pass — the first arm wins, never the better-looking one", () => {
+    const d = decide({
+      session: assessSession(session),
+      incumbent,
+      arms: [
+        { name: "SAME", metrics: cleanArm },
+        { name: "W1", metrics: { ...cleanArm, C1: [10000, 10000] } }, // a far bigger token cut
+      ],
+    });
+    expect(d.winner).toBe("SAME");
+  });
+
+  it("NO_SHIP when neither arm clears, and says the negative result gets committed", () => {
+    const d = decide({
+      session: assessSession(session),
+      incumbent,
+      arms: [
+        { name: "SAME", metrics: { ...cleanArm, Q4: [0.5, 0.5] } },
+        { name: "W1", metrics: { ...cleanArm, Q2: [0.5, 0.5] } },
+      ],
+    });
+    expect(d.outcome).toBe("NO_SHIP");
+    expect(d.winner).toBeNull();
+    expect(d.reasons.join(" ")).toMatch(/negative result/);
+  });
+});
+
+describe("the two-rep requirement is structural, not stylistic", () => {
+  it("refuses a single-rep arm — the second rep IS the noise estimate", () => {
+    expect(() => judgeMetric("Q1", [10.0], incumbent.Q1)).toThrow(/2 reps/);
+  });
+
+  it("refuses a single-rep incumbent for the same reason", () => {
+    expect(() => judgeMetric("Q1", [10.0, 10.0], [10.0])).toThrow(/2 reps/);
+  });
+});

--- a/test/graph-window-battery-decision.test.ts
+++ b/test/graph-window-battery-decision.test.ts
@@ -41,13 +41,13 @@ const cleanArm = {
   C1: [24000, 24000], // a 40% fall, comfortably past the 25% C1 demands
 };
 
-const session = { incumbent, dupeShare: 0.305, dupeEdges: 900 };
+const session = { incumbent, dupeShare: 0.305, dupeEdges: 900, armsCompleted: true, harnessRefused: false, crossCheckAvailable: true };
 
 const run = (over: Record<string, unknown> = {}, armOver: Record<string, number[]> = {}) =>
   decide({
     session: assessSession({ ...session, ...over }),
     incumbent,
-    arms: [{ name: "SAME", metrics: { ...cleanArm, ...armOver } }],
+    arms: [{ name: "SAME", metrics: { ...cleanArm, ...armOver }, extras: { personsLost: 0 } }],
   });
 
 describe("the baseline is non-vacuous", () => {
@@ -127,7 +127,7 @@ describe("noise is strictly ANTI-ship — the review's worked counterexample", (
   it("and if the ceiling were removed, the symmetric band still refuses to call it a PASS", () => {
     // Judged directly, bypassing session validity: 8.5 against a lowered 7.29 bar, with a spread of
     // 4.2 (52% of the mean) as the tolerance. The asymmetric rule shipped this.
-    const q1 = judgeMetric("Q1", [8.5, 8.5], degraded.Q1);
+    const q1 = judgeMetric("Q1", [8.5, 8.5], degraded.Q1, {});
     expect(q1.verdict).not.toBe(VERDICT.PASS);
   });
 });
@@ -210,16 +210,41 @@ describe("the spread ceiling is per-metric and in BAND units, not a fraction of 
     expect(s.valid).toBe(false);
   });
 
-  it("GUARANTEES a non-empty PASS window at the ceiling — for every gated metric", () => {
-    // The structural property the old ceiling lacked. At exactly half the band margin there must
-    // still exist an arm value that PASSes, or the procedure can deadlock mid-experiment.
+  it("GUARANTEES a non-empty PASS window AT the ceiling — for every gated metric", () => {
+    // The structural property the old ceiling lacked, tested where it actually binds. An earlier
+    // version of this test used the shared fixture, whose spreads sit ~1/50th of the ceiling — so it
+    // would have stayed green if a future edit raised a maxSpread constant above margin/2 and
+    // re-opened the deadlock. Here each incumbent is built so its spread EQUALS the ceiling.
     for (const key of Object.keys(METRICS)) {
-      const m = METRICS[key as keyof typeof METRICS] as { kind: string; margin: number };
-      const base = incumbent[key as keyof typeof incumbent] as number[];
-      const baseMean = (base[0] + base[1]) / 2;
-      // Sit the arm exactly on the incumbent's own value: the most favourable value there is.
-      const armAt = m.kind === "ratio-fall" ? [baseMean * (1 - m.margin) * 0.5, baseMean * (1 - m.margin) * 0.5] : [baseMean, baseMean];
-      expect(judgeMetric(key, armAt, base).verdict, `${key} has no passable value at its ceiling`).toBe(VERDICT.PASS);
+      const m = METRICS[key as keyof typeof METRICS] as {
+        kind: string;
+        margin: number;
+        maxSpreadRatio?: number;
+        maxSpreadPp?: number;
+        absolute?: { input: string };
+      };
+      const mean = m.kind.startsWith("pp") ? 0.3 : 10;
+      const ceiling = m.maxSpreadRatio !== undefined ? m.maxSpreadRatio * mean : (m.maxSpreadPp as number);
+      const base = [mean - ceiling / 2, mean + ceiling / 2];
+      // The most favourable arm there is: the incumbent's own value, except for C1, where the band
+      // demands a fall rather than tolerating drift.
+      const best = m.kind === "ratio-fall" ? mean * (1 - m.margin) * 0.5 : mean;
+      const extras = m.absolute ? { [m.absolute.input]: 0 } : {};
+
+      // Precondition: this incumbent is exactly at — not over — the validity ceiling.
+      const sess = assessSession({
+        incumbent: { [key]: base },
+        dupeShare: 0.305,
+        dupeEdges: 900,
+        armsCompleted: true,
+        harnessRefused: false,
+        crossCheckAvailable: true,
+      });
+      expect(sess.problems.join(" "), `${key} fixture should sit at the ceiling, not over it`).not.toMatch(key);
+
+      expect(judgeMetric(key, [best, best], base, extras).verdict, `${key} has no passable value at its ceiling`).toBe(
+        VERDICT.PASS
+      );
     }
   });
 });
@@ -230,8 +255,8 @@ describe("arm order — SAME is evaluated before the blunt W1 fallback", () => {
       session: assessSession(session),
       incumbent,
       arms: [
-        { name: "SAME", metrics: { ...cleanArm, Q4: [0.5, 0.5] } },
-        { name: "W1", metrics: cleanArm },
+        { name: "SAME", metrics: { ...cleanArm, Q4: [0.5, 0.5] }, extras: { personsLost: 0 } },
+        { name: "W1", metrics: cleanArm, extras: { personsLost: 0 } },
       ],
     });
     expect(d.outcome).toBe("SHIP");
@@ -243,8 +268,8 @@ describe("arm order — SAME is evaluated before the blunt W1 fallback", () => {
       session: assessSession(session),
       incumbent,
       arms: [
-        { name: "SAME", metrics: cleanArm },
-        { name: "W1", metrics: { ...cleanArm, C1: [10000, 10000] } }, // a far bigger token cut
+        { name: "SAME", metrics: cleanArm, extras: { personsLost: 0 } },
+        { name: "W1", metrics: { ...cleanArm, C1: [10000, 10000] }, extras: { personsLost: 0 } }, // a far bigger token cut
       ],
     });
     expect(d.winner).toBe("SAME");
@@ -255,8 +280,8 @@ describe("arm order — SAME is evaluated before the blunt W1 fallback", () => {
       session: assessSession(session),
       incumbent,
       arms: [
-        { name: "SAME", metrics: { ...cleanArm, Q4: [0.5, 0.5] } },
-        { name: "W1", metrics: { ...cleanArm, Q2: [0.5, 0.5] } },
+        { name: "SAME", metrics: { ...cleanArm, Q4: [0.5, 0.5] }, extras: { personsLost: 0 } },
+        { name: "W1", metrics: { ...cleanArm, Q2: [0.5, 0.5] }, extras: { personsLost: 0 } },
       ],
     });
     expect(d.outcome).toBe("NO_SHIP");
@@ -273,4 +298,61 @@ describe("the two-rep requirement is structural, not stylistic", () => {
   it("refuses a single-rep incumbent for the same reason", () => {
     expect(() => judgeMetric("Q1", [10.0, 10.0], [10.0])).toThrow(/2 reps/);
   });
+});
+
+describe("Q2's second clause — the one that bites where the ratio is weakest", () => {
+  /**
+   * The spec gates Q2 on TWO floors: "≥ 95% of W10 AND at most 1 person lost outright". The first
+   * version of this file implemented only the ratio, so at small n — where "95%" of 12 names rounds
+   * to "lose none" — an arm losing two known people outright would have shipped. A gate clause left
+   * outside the executable procedure is the interpretive joint this file exists to close.
+   */
+  it("FAILS an arm that loses 2 people outright even when the recall RATIO passes", () => {
+    const d = decide({
+      session: assessSession(session),
+      incumbent,
+      arms: [{ name: "SAME", metrics: cleanArm, extras: { personsLost: 2 } }],
+    });
+    const q2 = d.arms[0].results.find((r: { key: string }) => r.key === "Q2");
+    expect(q2.verdict).toBe(VERDICT.FAIL);
+    expect(q2.absoluteBreach).toMatch(/2 people lost outright/);
+    expect(d.outcome).toBe("NO_SHIP");
+  });
+
+  it("allows exactly 1 — the clause is 'at most 1', not 'none'", () => {
+    const d = decide({
+      session: assessSession(session),
+      incumbent,
+      arms: [{ name: "SAME", metrics: cleanArm, extras: { personsLost: 1 } }],
+    });
+    expect(d.outcome).toBe("SHIP");
+  });
+
+  it("REFUSES to judge when the count was never measured — omission must not read as satisfied", () => {
+    expect(() => judgeMetric("Q2", cleanArm.Q2, incumbent.Q2, {})).toThrow(/personsLost/);
+  });
+
+  it("is noise-free: a huge incumbent spread cannot rescue a 2-person loss", () => {
+    // Deliberate: any tolerance on an integer count would make "lost 2" and "lost 0" indistinguishable
+    // and delete the floor. Losing two known people is not a statistical question.
+    const q2 = judgeMetric("Q2", cleanArm.Q2, [0.9, 0.2], { personsLost: 2 });
+    expect(q2.verdict).toBe(VERDICT.FAIL);
+  });
+});
+
+describe("assessSession refuses to run on missing safety inputs", () => {
+  /**
+   * These used to default permissive (`armsCompleted = true`, `crossCheckAvailable = true`), so a
+   * runner that forgot to pass one silently disarmed that validity trigger. Same class as the
+   * absolute-clause omission above, in the file whose whole job is that the readout cannot be
+   * quietly softened.
+   */
+  it.each(["dupeShare", "dupeEdges", "armsCompleted", "harnessRefused", "crossCheckAvailable"])(
+    "throws when %s is omitted rather than treating it as fine",
+    (field) => {
+      const full = { incumbent, dupeShare: 0.305, dupeEdges: 900, armsCompleted: true, harnessRefused: false, crossCheckAvailable: true };
+      const { [field as keyof typeof full]: _omitted, ...rest } = full;
+      expect(() => assessSession(rest)).toThrow(new RegExp(field));
+    }
+  );
 });

--- a/test/graph-window-battery-decision.test.ts
+++ b/test/graph-window-battery-decision.test.ts
@@ -41,7 +41,7 @@ const cleanArm = {
   C1: [24000, 24000], // a 40% fall, comfortably past the 25% C1 demands
 };
 
-const session = { incumbent, dupeShare: 0.305, dupeEdges: 900, armsCompleted: true, harnessRefused: false, crossCheckAvailable: true };
+const session = { incumbent, dupeShare: 0.305, dupeEdges: 900, underpowered: [], armsCompleted: true, harnessRefused: false, crossCheckAvailable: true };
 
 const run = (over: Record<string, unknown> = {}, armOver: Record<string, number[]> = {}) =>
   decide({
@@ -236,6 +236,7 @@ describe("the spread ceiling is per-metric and in BAND units, not a fraction of 
         incumbent: { [key]: base },
         dupeShare: 0.305,
         dupeEdges: 900,
+        underpowered: [],
         armsCompleted: true,
         harnessRefused: false,
         crossCheckAvailable: true,
@@ -347,12 +348,34 @@ describe("assessSession refuses to run on missing safety inputs", () => {
    * absolute-clause omission above, in the file whose whole job is that the readout cannot be
    * quietly softened.
    */
-  it.each(["dupeShare", "dupeEdges", "armsCompleted", "harnessRefused", "crossCheckAvailable"])(
+  it.each(["dupeShare", "dupeEdges", "underpowered", "armsCompleted", "harnessRefused", "crossCheckAvailable"])(
     "throws when %s is omitted rather than treating it as fine",
     (field) => {
-      const full = { incumbent, dupeShare: 0.305, dupeEdges: 900, armsCompleted: true, harnessRefused: false, crossCheckAvailable: true };
+      const full = { incumbent, dupeShare: 0.305, dupeEdges: 900, underpowered: [], armsCompleted: true, harnessRefused: false, crossCheckAvailable: true };
       const { [field as keyof typeof full]: _omitted, ...rest } = full;
       expect(() => assessSession(rest)).toThrow(new RegExp(field));
     }
   );
+});
+
+
+describe("\"not measured\" has more shapes than undefined, and none of them may pass", () => {
+  /**
+   * The first version of these guards checked only `=== undefined`. But `null > 1` and `NaN > 1` are
+   * both FALSE, so a failed query coercing to null — the exact omission-shaped value the guard exists
+   * to refuse — sailed through as a clean pass. Probed and confirmed before this fix.
+   */
+  it.each([[null], [NaN], [1.5], [-1], ["2"], [undefined]])("refuses personsLost=%s", (bad) => {
+    expect(() => judgeMetric("Q2", cleanArm.Q2, incumbent.Q2, { personsLost: bad })).toThrow(/personsLost/);
+  });
+
+  it.each([["dupeShare"], ["dupeEdges"]])("refuses a NaN %s, which slipped BOTH sanity gates", (field) => {
+    const full = { incumbent, dupeShare: 0.305, dupeEdges: 900, underpowered: [], armsCompleted: true, harnessRefused: false, crossCheckAvailable: true };
+    expect(() => assessSession({ ...full, [field]: NaN })).toThrow(/finite/);
+  });
+
+  it("refuses a non-array underpowered — defaulting it to [] read as 'every metric is powered'", () => {
+    const full = { incumbent, dupeShare: 0.305, dupeEdges: 900, underpowered: [], armsCompleted: true, harnessRefused: false, crossCheckAvailable: true };
+    expect(() => assessSession({ ...full, underpowered: "Q6" })).toThrow(/underpowered/);
+  });
 });

--- a/test/graph-window-battery-measure.test.ts
+++ b/test/graph-window-battery-measure.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { continuityFrom, peopleFrom, memberPresence } from "../scripts/graph-window-battery/measure";
+
+/**
+ * The battery's quality measurements for PIPEFF-2 (AIO-821).
+ *
+ * Spec-derived. The property that matters most is DIRECTION: three of these metrics exist only
+ * because plan review found the original five all pointed the wrong way for entity fragmentation —
+ * an arm could split one person into several nodes and every gate would have read it as healthy.
+ * So each test below states which way the number must move when the graph gets worse, not merely
+ * that it computes something.
+ */
+
+describe("Q4 — cross-chunk continuity measures within-DOCUMENT convergence", () => {
+  const multi = new Set(["item-a"]);
+
+  it("scores 1 when every entity of a multi-chunk item appears in two of its chunks", () => {
+    const rows = [
+      { episode: "items:item-a#0", entity: "e1" },
+      { episode: "items:item-a#1", entity: "e1" },
+      { episode: "items:item-a#0", entity: "e2" },
+      { episode: "items:item-a#2", entity: "e2" },
+    ];
+    expect(continuityFrom(rows, multi)).toBe(1);
+  });
+
+  it("FALLS when resolution stops converging — the direction that matters", () => {
+    // The same document, but each chunk now yields its own node for the same thing. That is exactly
+    // what losing the predecessor context looks like, and Q4 is the gate that has to see it.
+    const rows = [
+      { episode: "items:item-a#0", entity: "e1" },
+      { episode: "items:item-a#1", entity: "e1-dup" },
+      { episode: "items:item-a#2", entity: "e1-dup2" },
+    ];
+    expect(continuityFrom(rows, multi)).toBe(0);
+  });
+
+  it("ignores single-chunk items, which cannot demonstrate continuity by construction", () => {
+    const rows = [
+      { episode: "items:item-b", entity: "e1" },
+      { episode: "items:item-a#0", entity: "e2" },
+      { episode: "items:item-a#1", entity: "e2" },
+    ];
+    expect(continuityFrom(rows, multi)).toBe(1); // item-b contributes nothing either way
+  });
+
+  it("parses the item id exactly — `items:12` must not swallow `items:123`", () => {
+    // A `STARTS WITH 'items:12'` prefix match would fold the two documents together and inflate the
+    // score. This is the nit review raised, pinned.
+    const rows = [
+      { episode: "items:12#0", entity: "e1" },
+      { episode: "items:123#0", entity: "e1" },
+    ];
+    // Only `items:12` is in the multi-chunk set, so the shared entity must NOT count as continuous.
+    expect(continuityFrom(rows, new Set(["12"]))).toBe(0);
+  });
+
+  it("returns 0 rather than NaN when nothing qualifies", () => {
+    expect(continuityFrom([], multi)).toBe(0);
+  });
+});
+
+describe("Q2/Q6 — recall and cross-ITEM convergence", () => {
+  const presence = new Map([
+    ["john ellison", new Set(["i1", "i2"])], // present in TWO items → counts toward Q6
+    ["chetan nandakumar", new Set(["i1"])], // one item only → Q2 but not Q6
+  ]);
+
+  it("scores full recall when every present name is an entity", () => {
+    const got = peopleFrom(["John Ellison", "Chetan Nandakumar"], presence);
+    expect(got.recall).toBe(1);
+    expect(got.personsLost).toBe(0);
+  });
+
+  it("counts a name absent from the graph as a person LOST — Q2's noise-free clause", () => {
+    const got = peopleFrom(["John Ellison"], presence);
+    expect(got.personsLost).toBe(1);
+    expect(got.recall).toBe(0.5);
+  });
+
+  it("is case-insensitive — Cypher equality is not, and would silently split a person in two", () => {
+    const got = peopleFrom(["john ELLISON", "chetan nandakumar"], presence);
+    expect(got.recall).toBe(1);
+  });
+
+  it("Q6 RISES when one person becomes several nodes — the fragmentation direction", () => {
+    const clean = peopleFrom(["John Ellison", "Chetan Nandakumar"], presence);
+    const fragmented = peopleFrom(["John Ellison", "John Ellison", "John Ellison", "Chetan Nandakumar"], presence);
+    expect(clean.convergence).toBe(1);
+    expect(fragmented.convergence).toBe(3);
+    expect(fragmented.convergence).toBeGreaterThan(clean.convergence);
+  });
+
+  it("Q6 counts only names present in ≥2 DISTINCT items", () => {
+    // A name confined to one item cannot demonstrate cross-item convergence, so fragmenting it must
+    // not move Q6 — that case belongs to Q4 and Q1.
+    const got = peopleFrom(["John Ellison", "Chetan Nandakumar", "Chetan Nandakumar"], presence);
+    expect(got.convergenceNames).toBe(1);
+    expect(got.convergence).toBe(1);
+  });
+
+  it("returns 0 rather than NaN on an empty presence map", () => {
+    const got = peopleFrom(["Anyone"], new Map());
+    expect(got.recall).toBe(0);
+    expect(got.convergence).toBe(0);
+  });
+});
+
+describe("memberPresence — literal presence, which is what needs no answer key", () => {
+  const members = [{ display_name: "John Ellison" }, { display_name: "Chetan Nandakumar" }, { display_name: "Bo" }];
+
+  it("maps each name to the items whose text contains it", () => {
+    const got = memberPresence(members, [
+      { id: "i1", body: "John Ellison reviewed the spec." },
+      { id: "i2", body: "Chetan Nandakumar and John Ellison paired." },
+      { id: "i3", body: "nobody named here" },
+    ]);
+    expect([...(got.get("john ellison") ?? [])].sort()).toEqual(["i1", "i2"]);
+    expect([...(got.get("chetan nandakumar") ?? [])]).toEqual(["i2"]);
+  });
+
+  it("is case-insensitive on the body side too", () => {
+    const got = memberPresence(members, [{ id: "i1", body: "JOHN ELLISON shipped it" }]);
+    expect(got.has("john ellison")).toBe(true);
+  });
+
+  it("skips single-word and very short names, which would match ordinary prose", () => {
+    // "Bo" would hit "Bob", "about", "border" — a denominator built from that measures nothing.
+    const got = memberPresence(members, [{ id: "i1", body: "we talked about the border" }]);
+    expect(got.has("bo")).toBe(false);
+  });
+
+  it("omits a name that appears nowhere rather than mapping it to an empty set", () => {
+    const got = memberPresence(members, [{ id: "i1", body: "no names at all" }]);
+    expect(got.size).toBe(0);
+  });
+});
+
+describe("Q3's predicate stays tied to the one the health module pins", () => {
+  it("uses the relation and property Graphiti actually writes", () => {
+    // `test/guards/dedupe-predicate-pinned.test.ts` pins extraction-health.ts against the deployed
+    // image. This asserts the battery did not quietly diverge from it — a mismatch here would make
+    // Q3 read zero, which looks like a CLEAN graph while meaning the relation is gone.
+    const src = readFileSync(join(process.cwd(), "scripts/graph-window-battery/measure.ts"), "utf8");
+    expect(src).toContain("[r:RELATES_TO]");
+    expect(src).toContain("r.name = 'IS_DUPLICATE_OF'");
+  });
+
+  it("scopes every read to a single group_id — the graph's only tier enforcement", () => {
+    // CLAUDE.md §5: no RLS, and `episodeGroupId(teamSlug, access)` is the sole tier boundary. A query
+    // that forgot the scope would silently mix tiers into a measurement.
+    const src = readFileSync(join(process.cwd(), "scripts/graph-window-battery/measure.ts"), "utf8");
+    const matches = src.match(/MATCH \([^)]*\{ ?group_id: \$g ?\}/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(4);
+    // …and no MATCH on a labelled node without it.
+    expect(src).not.toMatch(/MATCH \(n:Entity\)(?!.*group_id)/);
+  });
+});

--- a/test/graph-window-battery-predecessors.test.ts
+++ b/test/graph-window-battery-predecessors.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { splitPrompt, PREV_TAGS } from "../scripts/graph-window-battery/phase-a-predecessors";
+
+/**
+ * The predecessor-block parser for Phase A (PIPEFF-2 / AIO-821).
+ *
+ * THIS TEST EXISTS BECAUSE THE FIRST PARSER WAS CONFIDENTLY WRONG AND SILENT ABOUT IT. It looked for
+ * a JSON key `"previous_episodes"`, which graphiti_core 0.29.3's prompts do not contain — they use
+ * XML-ish section tags. So it reported **0% predecessors** on prompts that were ~75% predecessors.
+ * Had that run against a paid session it would have "measured" the ten-episode window as free and
+ * killed the lever on its own bug, with a plausible number and no error.
+ *
+ * A dry run against prompts generated inside the deployed image caught it — which is the procedure
+ * worth keeping, because this test can only pin what the parser does with a KNOWN format, never that
+ * the format is still what the image emits. Re-run the generator before trusting a Phase A number:
+ *
+ *   docker exec <graphiti> /app/.venv/bin/python -c "from graphiti_core.prompts import prompt_library; ..."
+ *
+ * The two spellings below are not a style choice — graphiti 0.29.3 genuinely emits both, `extract_nodes`
+ * and `dedupe_nodes` with a space and `extract_edges` with an underscore.
+ */
+
+const predecessorBlock = (tag: string, filler: string) => `<${tag}>\n[{"content": "${filler}"}]\n</${tag}>`;
+
+describe("splitPrompt finds the predecessor block in both spellings graphiti emits", () => {
+  it.each([...PREV_TAGS])("parses <%s>", (tag) => {
+    const filler = "predecessor text. ".repeat(200);
+    const content = `preamble\n${predecessorBlock(tag, filler)}\n<CURRENT MESSAGE>\nthe episode\n</CURRENT MESSAGE>`;
+    const got = splitPrompt(content);
+    expect(got.parsed).toBe(true);
+    expect(got.predecessors).toBeGreaterThan(0);
+    // The block is the bulk of this prompt, so the share must be large — a parser that matched the
+    // tag but measured the wrong span would still pass a bare `> 0`.
+    expect(got.predecessors / got.total).toBeGreaterThan(0.8);
+  });
+
+  it("covers both tag spellings — dropping one is how extract_edges would silently read as zero", () => {
+    expect([...PREV_TAGS]).toEqual(["PREVIOUS MESSAGES", "PREVIOUS_MESSAGES"]);
+  });
+
+  // The `it.each` above iterates PREV_TAGS, so it follows the constant and cannot catch a WRONG one —
+  // it would simply test whatever tag is configured. These two fixtures are literals taken from the
+  // shapes the deployed image actually emits, so a changed constant reddens a behaviour test rather
+  // than only an equality assertion.
+  it("parses a literal extract_nodes-shaped prompt (space spelling)", () => {
+    const got = splitPrompt(`<ENTITY TYPES>\n[]\n</ENTITY TYPES>\n<PREVIOUS MESSAGES>\n[{"content": "${"p".repeat(4000)}"}]\n</PREVIOUS MESSAGES>\n<CURRENT MESSAGE>\nepisode\n</CURRENT MESSAGE>`);
+    expect(got.parsed).toBe(true);
+    expect(got.predecessors / got.total).toBeGreaterThan(0.8);
+  });
+
+  it("parses a literal extract_edges-shaped prompt (underscore spelling)", () => {
+    const got = splitPrompt(`<PREVIOUS_MESSAGES>\n[{"content": "${"p".repeat(4000)}"}]\n</PREVIOUS_MESSAGES>\n<CURRENT_MESSAGE>\nepisode\n</CURRENT_MESSAGE>\n<ENTITIES>\n[]\n</ENTITIES>`);
+    expect(got.parsed).toBe(true);
+    expect(got.predecessors / got.total).toBeGreaterThan(0.8);
+  });
+});
+
+describe("an unrecognised prompt is REPORTED, never assumed to carry nothing", () => {
+  it("marks a prompt with no predecessor tag unparsed rather than 0% and moving on", () => {
+    const got = splitPrompt("a prompt in some future format with no predecessor section at all");
+    expect(got.parsed).toBe(false);
+    // The distinction that matters: `parsed: false` is what the report surfaces per call kind. A
+    // parser that returned {predecessors: 0, parsed: true} would be indistinguishable from a genuine
+    // measurement of a window that carries nothing — which is exactly the claim the lever rests on.
+    expect(got.predecessors).toBe(0);
+  });
+
+  it("marks an unclosed tag unparsed rather than swallowing the rest of the prompt", () => {
+    const got = splitPrompt(`<PREVIOUS MESSAGES>\n[{"content": "truncated`);
+    expect(got.parsed).toBe(false);
+  });
+
+  it("does not match a tag that only appears in the closing form", () => {
+    expect(splitPrompt("</PREVIOUS MESSAGES>\nstray").parsed).toBe(false);
+  });
+});
+
+describe("the split is exhaustive — episode plus predecessors accounts for the whole prompt", () => {
+  it("assigns every token to exactly one side", () => {
+    const content = `head\n${predecessorBlock("PREVIOUS MESSAGES", "x".repeat(4000))}\ntail`;
+    const got = splitPrompt(content);
+    expect(got.predecessors + got.episode).toBe(got.total);
+  });
+
+  it("reports the whole prompt as episode when there is no predecessor block", () => {
+    const got = splitPrompt("just the episode, nothing else");
+    expect(got.episode).toBe(got.total);
+  });
+});


### PR DESCRIPTION
## Why

You asked why eight transcripts cost ~$2, and whether this scales to 5–10 people. The measured answer was **~64× the source text**, and the largest single term in it is the **ten previous episodes** every `add_episode` retrieves and carries into **four metered LLM calls**.

This PR is the spec and the measurement scaffolding for cutting that. **The lever itself is not built yet, and no product behaviour changes here.**

## What re-deriving the deployed system changed

Read from `graphiti_core==0.29.3` (the exact pin) and the server inside `aios-graphiti:0293-pinned`, rather than from the parent spec:

- `last_n=RELEVANT_SCHEMA_LIMIT` appears **exactly once** in the package (`graphiti.py:1090`), and the server can never take the `previous_episode_uuids` branch.
- **The window is same-group, not same-document** — for the 40% of items that are a single chunk, all ten predecessors are unrelated items.
- But for a multi-chunk item, its own prior chunks are **guaranteed** to be selected: they share `valid_at` with the episode, which is the maximum the filter admits, so they outrank every earlier row.

So the waste and the value separate **by item shape**, and the lever stopped being "a smaller number". It is now **carry the document's own predecessors and nothing else** — a post-retrieval filter on the episode name's pre-`#` prefix. `last_n=1`, the parent spec's proposal, is demoted to the blunt fallback arm.

## Phase A's structural half — measured at zero LLM cost

Two of Phase A's three questions didn't need a run: given the tie-rank guarantee the same-item share is derivable, and contamination is a SQL query.

| | over the pinned 108-episode corpus |
|---|---|
| predecessor slots that are **unrelated items** | **617 of 1,080 — 57.1%**, pure billed waste |
| single-chunk items | **0% same-item** (200 slots, all filler) |
| own-chunk slots the guarantee delivers | **95.1%** |

**The prediction, on the record before Phase B runs:** `SAME` removes 57.1% of all predecessor slots and makes the rest deterministic. If C1's 25% band is not cleared comfortably, the token accounting is wrong somewhere and that is itself the finding.

## The decision procedure is code, not prose

`scripts/graph-window-battery/decision.mjs` — because the failure this workstream exists to prevent is a readout *interpreted* after the numbers exist. Bands, the noise rule, session validity and arm ordering are one total function, unit-pinned. Changing a band means editing a constant a test asserts, in a commit, before the run.

## Test plan

- [x] **89 unit tests** across the decision procedure and corpus rule, plus a **data-mechanics** test for the SQL blank predicate (the only tier that can judge Postgres string semantics)
- [x] **Every fix mutation-proven** by putting the bug back and checking the *intended* test reddens
- [x] Unit **2,065** · dm tier · tsc · lint (2 pre-existing warnings) · docs-drift — green
- [ ] Phase A's paid half, then the battery (**≤ $9.53** measured), then the patch — this PR stays draft until there is a verdict

## Review — Reviewed by Fable (plan review ×4 rounds, then code-reviewer ×2 rounds) — verdict CLEAR after fixes
Plan review returned BLOCKED three times. It inverted one of my own findings (the tie-rank guarantee, which reshaped the lever); caught that the battery would have **passed an arm that fragments the graph's identity layer**, since fragmentation *raises* entity yield and makes the duplicate share *fall* — all five original gates pointed the wrong way; and caught that my decision rule made noise work in the *shipping* direction, then that my fix for it could deadlock the battery outright. Code review then returned BLOCKED on a gate that had quietly stopped existing (Q2's second clause was in the spec, not in the code) plus five MEDIUMs, and the delta pass found two residual cracks in those fixes — `personsLost: null` and `NaN` both passed the gate built to refuse omission. All closed.

AIOS-Work: PIPEFF-2
