### PR TITLE
feat(meetings): a shared calendar event is logged as work, for everyone who was in it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -860,7 +860,19 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `POST /api/internal/llm/v1/embeddings` — the other half of that base URL (Graphiti embeds as well as extracts, so proxying only chat would leave the second key in place). **Pinned to `EMBEDDING_DIM` (1536)**: Graphiti built its Neo4j vector index at one width and has no migration path, so a different-dimension model is refused rather than silently making every stored vector incomparable. Also **meters** into `llm_usage` (`source=embeddings`), same best-effort path
 - `GET /api/brain/facts` — Brain-Learning panel Layer 1: recent Graphiti facts (last 24h) read directly from Neo4j; session-authed; tier-scoped via `visibleGroupIds` (sole enforcement, no RLS backstop)
 - `GET /api/brain/events` — Brain-Learning Layer 2: recent events (source episodes) with participants + extracted facts; session-authed; tier-scoped via `visibleGroupIds`. A recognized AI-agent/tool name in `participants` is tagged with the human behind that event's item (`resolveHumanActorsByItem` in `lib/graph/human-actors.ts` + `attributeEventParticipants` in `lib/graph/arc-attribution.ts`), same as narrative-arc participants
-- **Timeline** — a human-readable **day → person → task → evidence** ledger of the last 7 days. **Meetings
+- **Timeline** — a human-readable **day → person → task → evidence** ledger of the last 7 days. **Calendar events count too.** A person's workspace pushes the events they CHOOSE to
+share (selection happens at the source — personal events never leave the machine), and an item whose
+`frontmatter.source` is a calendar source (`calendar`/`gcal`/`google_calendar`) becomes a meeting note
+like a transcript does. Two differences, both because a calendar event is structurally better data:
+attendance is resolved **EXACTLY by email** against `members` (`buildIdentityMap().byEmail`) with no LLM
+and no name-matching — versus the transcript path's ~1.4 attendees/meeting — and it needs **no body**,
+since an invite has no transcript. Recognised by SOURCE, not `kind`: a producer may reasonably send
+`artifact` or `transcript` for an event, and keying on kind would drop it over a vocabulary choice. The
+accepted attendee shapes are deliberately liberal (`["a@x.com"]`, `[{email,display}]`,
+`[{id,display,role}]` — the workspace gog puller's own shape — and a comma-separated string); an entry
+with no parseable email is DROPPED rather than guessed at, and a non-member guest (a client) is not
+credited but never sinks the event for the members who were there. See `lib/meetings/from-calendar.ts`.
+**Meetings
 count as WORK, per ATTENDEE**: one evidence row per `(meeting, attendee)` from `meeting_note_attendees`
 (`source:"meetings"`), so a meeting lands on the card of everyone who was in it — not only whoever ran
 `aios push`. It reverses the older "meetings are team signal" exclusion, whose blocker was attribution

--- a/lib/dashboard/work-timeline.ts
+++ b/lib/dashboard/work-timeline.ts
@@ -23,6 +23,7 @@ import { MIN_CONFIDENCE } from "./doc-task-infer";
 import { resolveItemCreditIds } from "@/lib/attribution/contributor-credit";
 import { slackParticipations, foldProviderId } from "@/lib/ingest/slack-participants";
 import { canSeeMeetingNotes } from "@/lib/meetings/notes";
+import { isCalendarEvent } from "@/lib/meetings/from-calendar";
 
 // Only ACTIVE tasks are considered work "in progress" — Linear In Progress/In Review both normalize to
 // `in_progress`; `blocked` is active-but-stuck. Backlog/ready/done are context, excluded from the timeline.
@@ -91,6 +92,9 @@ const WORK_EVENT_LIMIT = 5000;
  *  `frontmatter.sha`, so both sides normalize to this prefix. 40 bits — collision risk ~1e-7 at our scale. */
 const SHA_JOIN_LEN = 10;
 /** Inferred (LLM) task↔item edges pulled per build. Bounded like every other leg. */
+/** Meeting notes scanned per build. Meetings are human-paced (tens per team per month), so this is a
+ *  runaway backstop rather than a working limit — unlike the item caps it sits beside. */
+const MEETING_NOTE_LIMIT = resolvePositiveInt(process.env.TIMELINE_MEETING_LIMIT, 2000);
 const TASK_EVIDENCE_LIMIT = 5000;
 
 /** The pg adapter hands timestamptz back as a string or a Date depending on the driver path; both
@@ -369,7 +373,15 @@ export async function getWorkTimeline(
     const fm = r.frontmatter ?? {};
     if (str(fm.source) === "git") continue; // handled by gitRes — no double-count
     const source = normalizeSource(str(fm.source));
-    if (source === "slack" || source === "granola" || r.kind === "transcript") continue; // slack: own query; meetings: excluded
+    // Each of these has its OWN leg, so admitting the raw item here would count the same work twice.
+    // CALENDAR is the newest and was the easy one to miss: unlike a granola transcript it arrives as a
+    // plain `artifact` with `occurred_at` frontmatter, so it passes `work_at_from_source` and lands in
+    // this lane credited to the PUSHER — while the meetings leg credits every attendee. Measured: the
+    // pusher's `total` was 2 for a single event. "What else reads the set I just widened."
+    // NB `source` here is NORMALIZED, and `normalizeSource` collapses anything not in SOURCE_RULES to
+    // "other" — so the calendar check must read the RAW frontmatter value. Checking the normalized one
+    // silently never matched, and the pusher kept getting the event twice.
+    if (source === "slack" || source === "granola" || isCalendarEvent(str(fm.source)) || r.kind === "transcript") continue;
     // A PM issue's own description doc is the TICKET, not work done on it — and its path/title carry
     // the issue's own key, so admitting it as evidence would let every assigned ticket self-satisfy
     // the evidence gate and turn the timeline back into a backlog dump (the property "never the whole
@@ -618,7 +630,19 @@ export async function getWorkTimeline(
       .select("id, title, occurred_at, created_at, submitted_by, merged_into")
       .eq("team_id", teamId)
       .is("merged_into", null) // a tombstone's attendees live on its merge target — counting both double-credits
-      .gte("created_at", sinceIso);
+      // NO date bound in SQL — ordered newest-by-meeting-date and capped instead, with `inWindow(at)`
+      // below doing the windowing on the RESOLVED date.
+      //
+      // It used to bound on `created_at`, which was safe only while every meeting arrived as a
+      // recording of something already past, so the note always post-dated the meeting. A shared
+      // CALENDAR event inverts that: choose to share next month's meetings today and the note's
+      // `created_at` is today, so by the time `occurred_at` enters the 7-day window `created_at` has
+      // long left it and the meeting silently never reaches anyone's card. Bounding on `occurred_at`
+      // instead would need an OR for null-dated notes, which this query builder has no `.or()` for —
+      // and meetings are a low-volume table (tens of rows per team), so a capped ordered scan is both
+      // simpler and exactly correct.
+      .order("occurred_at", { ascending: false })
+      .limit(MEETING_NOTE_LIMIT);
     if (meetRes.error) {
       // Best-effort, like Slack/decisions: a meetings outage must not fail the whole ledger.
       console.warn("[timeline] meetings leg skipped:", meetRes.error.message);

--- a/lib/meetings/from-calendar.ts
+++ b/lib/meetings/from-calendar.ts
@@ -1,0 +1,124 @@
+/**
+ * Calendar events as meetings — the receiving half of "a meeting you attended is your work".
+ *
+ * A person's workspace pushes the calendar events they CHOOSE to share (personal events never leave
+ * the machine; selection happens at the source, not here). This module turns such an item into the
+ * team's meeting ledger so the per-attendee timeline leg credits everyone who was in it.
+ *
+ * WHY IT IS NOT THE TRANSCRIPT PATH. `lib/meetings/from-items` derives attendees by asking an LLM to
+ * read a transcript and then name-matching its answers against the roster — lossy by construction
+ * (measured 1.4 attendees/meeting on prod, and any name it cannot match is dropped leaving no trace).
+ * A calendar event needs none of that: Google already says who was invited, by EMAIL. So attendance is
+ * resolved EXACTLY here, by address, and no model is involved. That also means a calendar event needs
+ * no body — which the transcript path requires and would otherwise skip it for.
+ *
+ * Pure parsing lives here (no DB, no server-only) so the accepted shapes are testable directly.
+ */
+
+/** `frontmatter.source` values that mean "this item is a calendar event". */
+export const CALENDAR_SOURCES = new Set(["calendar", "gcal", "google_calendar", "googlecalendar"]);
+
+/**
+ * True when an item is a calendar event, whatever its `kind`. Pure.
+ *
+ * Deliberately NOT keyed on `kind`. A calendar event has no natural kind in the closed item enum — a
+ * producer may reasonably send `artifact` (a record of something that happened) or `transcript` (to
+ * ride the meeting path). The SOURCE is the unambiguous signal, so keying on it means the brain
+ * accepts the event either way instead of silently dropping it over a vocabulary choice.
+ *
+ * MATCHES EXACTLY — no trimming, no case folding — because this same set is used as a SQL `IN (…)`
+ * filter when selecting candidates, and SQL compares the stored bytes. If this were tolerant and the
+ * query were not, a `"Calendar"` item would be EXCLUDED from the timeline's raw-items lane (this
+ * function) while never becoming a meeting note (the query) — visible nowhere at all. The two layers
+ * agreeing means a non-conforming source degrades to "shows as an ordinary item, credited to the
+ * pusher": worse attribution, but never a disappearance. Every `frontmatter.source` in prod is
+ * lowercase (`github`, `granola`, `slack`, …), so lowercase is the contract, not a hardship.
+ */
+export function isCalendarEvent(source: string | null | undefined): boolean {
+  return !!source && CALENDAR_SOURCES.has(source);
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** One attendee as the brain understands it: an email we can resolve, and the display name if given. */
+export interface CalendarAttendee {
+  email: string;
+  display: string | null;
+}
+
+/**
+ * Attendee emails from a calendar item's frontmatter, deduped, lowercased, in source order.
+ *
+ * LIBERAL IN WHAT IT ACCEPTS, on purpose. This is a cross-repo boundary: the producer lives in the
+ * workspace repo, and pinning one exact shape here means a reasonable producer choice silently yields
+ * an unattributed meeting — the failure this whole feature exists to remove. So all of these work:
+ *
+ *   attendees:    ["a@x.com", "b@x.com"]
+ *   attendees:    [{ email: "a@x.com", display: "Alice" }]
+ *   participants: [{ id: "a@x.com", display: "Alice", role: "organizer" }]   ← the gog puller's shape
+ *   attendees:    "a@x.com, b@x.com"
+ *
+ * Anything without a parseable email is DROPPED rather than guessed at: a display name with no address
+ * is exactly the ambiguity that made transcript attendee-matching lossy, and re-introducing it here
+ * would trade the one advantage a calendar event has. `organizer` is not treated specially — the
+ * organizer attended too, and the timeline credits attendance, not authorship.
+ */
+export function calendarAttendees(fm: Record<string, unknown> | null | undefined): CalendarAttendee[] {
+  if (!fm) return [];
+  const raw = fm.attendees ?? fm.participants ?? fm.invitees;
+  const entries: unknown[] = Array.isArray(raw)
+    ? raw
+    : typeof raw === "string"
+      ? raw.split(/[,;]/)
+      : [];
+
+  const out: CalendarAttendee[] = [];
+  const seen = new Set<string>();
+  for (const e of entries) {
+    let email: string | null = null;
+    let display: string | null = null;
+    if (typeof e === "string") {
+      email = e.trim();
+    } else if (e && typeof e === "object") {
+      const o = e as Record<string, unknown>;
+      // `id` last: the gog puller falls back to a DISPLAY NAME in `id` when an attendee has no email,
+      // so a real `email`/`emailAddress` field must win over it.
+      for (const k of ["email", "emailAddress", "address", "id"]) {
+        const v = o[k];
+        if (typeof v === "string" && v.trim()) {
+          email = v.trim();
+          break;
+        }
+      }
+      for (const k of ["display", "displayName", "name"]) {
+        const v = o[k];
+        if (typeof v === "string" && v.trim()) {
+          display = v.trim();
+          break;
+        }
+      }
+    }
+    if (!email) continue;
+    const lower = email.toLowerCase();
+    if (!EMAIL_RE.test(lower) || seen.has(lower)) continue; // a bare display name is not an identity
+    seen.add(lower);
+    out.push({ email: lower, display });
+  }
+  return out;
+}
+
+/**
+ * The event's title, from the fields a calendar naturally carries. Pure.
+ *
+ * `summary` is Google Calendar's own name for the event title (not a description), which is why it is
+ * checked first and why it must not be confused with the meeting NOTE's summary field.
+ */
+export function calendarTitle(fm: Record<string, unknown> | null | undefined, path: string): string {
+  for (const k of ["title", "summary", "event_title", "name"]) {
+    const v = fm?.[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  const base = path.split("/").pop() ?? "";
+  const cleaned = base.replace(/\.md$/i, "").replace(/^\d{4}-\d{2}-\d{2}[-_]?/, "").replace(/[-_]+/g, " ").trim();
+  return cleaned || "Meeting";
+}

--- a/lib/meetings/from-items.ts
+++ b/lib/meetings/from-items.ts
@@ -5,6 +5,8 @@ import { extractAndStoreActionItems } from "./action-items";
 import type { ExtractedTodo } from "./extract-todos";
 import { createMeetingNoteFromItem } from "./notes";
 import { backfillMergeDuplicateMeetings } from "./merge";
+import { buildIdentityMap } from "@/lib/identity/resolve";
+import { CALENDAR_SOURCES, calendarAttendees, calendarTitle, isCalendarEvent } from "./from-calendar";
 
 /**
  * Bridge: turn transcript `items` that arrived through the CLI/ingest path (`aios push`) into
@@ -55,6 +57,20 @@ export function deriveMeetingTitle(body: string, path: string): string {
  *  null (the note defaults to its created_at). Pure. */
 export function deriveOccurredAt(frontmatter: Record<string, unknown> | null | undefined, path: string): string | null {
   const fm = frontmatter ?? {};
+  // A CALENDAR EVENT is dated by when it HAPPENS, and that is not `created`. Workspace frontmatter
+  // routinely carries `created` (the file's creation / push day), so with the generic order below an
+  // event pushed Tuesday for Thursday's meeting would log as Tuesday's work — and a batch of shared
+  // events would all pile onto the sync day. Google's own start-time fields are checked first, and
+  // only for calendar items so the transcript path's tuned order is untouched.
+  if (isCalendarEvent(typeof fm.source === "string" ? fm.source : null)) {
+    for (const key of ["start", "start_time", "startTime", "occurred_at", "source_ts", "date"]) {
+      const v = fm[key];
+      if (typeof v === "string") {
+        const m = v.match(/^\d{4}-\d{2}-\d{2}/);
+        if (m) return m[0];
+      }
+    }
+  }
   for (const key of ["created", "source_ts", "date", "occurred_at"]) {
     const v = fm[key];
     if (typeof v === "string") {
@@ -68,6 +84,9 @@ export function deriveOccurredAt(frontmatter: Record<string, unknown> | null | u
 
 interface CandidateMeta {
   id: string;
+  /** Selected now that the query is no longer filtered on it — a transcript takes the LLM path, a
+   *  calendar event (recognised by SOURCE) takes the structured-attendee path. */
+  kind: string | null;
   path: string;
   access: "team" | "external";
   member_id: string | null;
@@ -111,16 +130,43 @@ export async function backfillMeetingNotesFromItems(
   const hasNote = new Set(((noted ?? []) as { source_item_id: string }[]).map((r) => r.source_item_id));
 
   // Candidate metadata only (no bodies — transcripts can be large). Filter to meeting sources here.
-  const { data: rows } = await admin
-    .from("items")
-    .select("id, path, access, member_id, frontmatter")
-    .eq("team_id", teamId)
-    .eq("kind", "transcript")
-    .order("synced_at", { ascending: false })
-    .limit(500);
-  const candidates = ((rows ?? []) as CandidateMeta[]).filter(
-    (r) => isMeetingTranscript("transcript", (r.frontmatter?.source as string) ?? null) && !hasNote.has(r.id)
-  );
+  //
+  // TWO shapes of meeting arrive here, and they need different treatment, so the query is deliberately
+  // NOT filtered on `kind` any more:
+  //   • a TRANSCRIPT (granola/zoom/…) — has a body, attendees are inferred from it by an LLM;
+  //   • a CALENDAR EVENT — has structured attendee EMAILS and typically no body at all.
+  // Keying calendar events on `kind` would drop them over a vocabulary choice the producer is free to
+  // make (`artifact` and `transcript` are both defensible for an event), so they are keyed on SOURCE.
+  // TWO windows, unioned — NOT one widened window. Dropping the `kind='transcript'` filter to let
+  // calendar events through would have made this "the 500 newest rows of ANY kind", so a bulk sync
+  // (a github backfill, a new connector) could push a real meeting transcript below the cap and it
+  // would NEVER be noted — silently, permanently, since the window only moves forward. Each shape
+  // gets its own bounded window instead, so neither can starve the other.
+  const [transcriptRes, calendarRes] = await Promise.all([
+    admin
+      .from("items")
+      .select("id, kind, path, access, member_id, frontmatter")
+      .eq("team_id", teamId)
+      .eq("kind", "transcript")
+      .order("synced_at", { ascending: false })
+      .limit(500),
+    admin
+      .from("items")
+      .select("id, kind, path, access, member_id, frontmatter")
+      .eq("team_id", teamId)
+      .in("frontmatter->>source", [...CALENDAR_SOURCES])
+      .order("synced_at", { ascending: false })
+      .limit(500),
+  ]);
+  const byId = new Map<string, CandidateMeta>();
+  for (const r of [...((transcriptRes.data ?? []) as CandidateMeta[]), ...((calendarRes.data ?? []) as CandidateMeta[])]) {
+    byId.set(r.id, r); // an item matching both windows is one candidate
+  }
+  const candidates = [...byId.values()].filter((r) => {
+    if (hasNote.has(r.id)) return false;
+    const source = (r.frontmatter?.source as string) ?? null;
+    return isMeetingTranscript(r.kind ?? "", source) || isCalendarEvent(source);
+  });
 
   // NOTE: no early-return on an empty candidate set — the create loop below no-ops, and the
   // auto-merge at the end still runs so pre-existing duplicates get cleaned up each tick.
@@ -139,19 +185,44 @@ export async function backfillMeetingNotesFromItems(
     ((rawText: string, r: RosterPerson[]) =>
       extractFromTranscript(rawText, r, opts.keys ?? {}, undefined, { db: admin, teamId }));
 
+  // Email -> member, built ONCE for the batch. Calendar attendance is resolved EXACTLY by address —
+  // no model, no name-matching — which is the whole reason a shared calendar event attributes better
+  // than a transcript does. Built lazily: a batch with no calendar events pays nothing.
+  let byEmail: Map<string, string> | null = null;
+  const resolveEmails = async (emails: string[]): Promise<string[]> => {
+    if (!byEmail) byEmail = (await buildIdentityMap(admin, teamId)).byEmail;
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    for (const e of emails) {
+      const id = byEmail.get(e);
+      // An attendee who is not a member of THIS team (an external guest, a client) is not credited —
+      // there is no person here to attribute the work to. Their presence is not lost: the event, its
+      // title and its own attendee list remain on the item.
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+    }
+    return ids;
+  };
+
   for (const c of candidates.slice(0, limit)) {
     summary.scanned++;
     try {
+      const calendar = isCalendarEvent((c.frontmatter?.source as string) ?? null);
       const { data: item } = await admin.from("items").select("body").eq("id", c.id).maybeSingle();
       const body = (item as { body: string } | null)?.body ?? "";
-      if (!body.trim()) {
+      // A transcript with no body has nothing to extract from. A CALENDAR EVENT legitimately has no
+      // body — its content is the invite — so requiring one here is what would silently drop it.
+      if (!calendar && !body.trim()) {
         summary.skipped++;
         continue;
       }
-      const ex = await extract(body, roster).catch(() => ({ summary: "", attendeeMemberIds: [] }));
+      const ex = calendar
+        ? { summary: "", attendeeMemberIds: await resolveEmails(calendarAttendees(c.frontmatter).map((a) => a.email)) }
+        : await extract(body, roster).catch(() => ({ summary: "", attendeeMemberIds: [] }));
       const res = await createMeetingNoteFromItem(admin, teamId, {
         sourceItemId: c.id,
-        title: deriveMeetingTitle(body, c.path),
+        title: calendar ? calendarTitle(c.frontmatter, c.path) : deriveMeetingTitle(body, c.path),
         occurredAt: deriveOccurredAt(c.frontmatter, c.path),
         summary: ex.summary,
         submittedByMemberId: c.member_id,
@@ -161,7 +232,12 @@ export async function backfillMeetingNotesFromItems(
         summary.created++;
         // Pre-compute action items so a pushed meeting opens with its todos already filled in
         // (not empty until someone clicks "extract"). Best-effort — never fail the note over it.
-        try {
+        //
+        // SKIPPED for a body-less calendar event. `extractActionItems` has no empty-input guard, so it
+        // would POST "Transcript:\n\n" plus a roster hint to the model for every event: real spend for
+        // certain, and a hallucinated todo would materialize as a REAL task in "Extracted from
+        // Meetings" — pushable to Linear. An invite has no commitments in it to extract.
+        if (body.trim()) try {
           await extractAndStoreActionItems(
             admin,
             teamId,

--- a/test/datamechanics/calendar-meetings.datamechanics.test.ts
+++ b/test/datamechanics/calendar-meetings.datamechanics.test.ts
@@ -1,0 +1,222 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+import { backfillMeetingNotesFromItems } from "@/lib/meetings/from-items";
+import { getWorkTimeline } from "@/lib/dashboard/work-timeline";
+
+/**
+ * The whole ask, end to end: a calendar event a person chose to share must be RECEIVED, LOGGED, and
+ * ASSOCIATED WITH THE PERSON — every person who was in it, not just whoever pushed it.
+ *
+ * Real Postgres because every step is persistence + identity: the item lands through the real ingest
+ * path, the meeting note is a real row, attendance is resolved against the real `members`/email
+ * tables, and the timeline reads it all back. A fake DB can prove none of that.
+ */
+
+/** A second real member with a known email — the person the event must ALSO land on. */
+async function addMember(seed: Seed, name: string, email: string): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      email,
+      display_name: name,
+      actor_handle: `a-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`member insert failed: ${error?.message}`);
+  return (data as { id: string }).id;
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+/** Meeting evidence on one person's card. */
+function meetingsFor(days: Awaited<ReturnType<typeof getWorkTimeline>>, memberId: string) {
+  return days
+    .flatMap((d) => d.people)
+    .filter((p) => p.memberId === memberId)
+    .flatMap((p) => p.other)
+    .filter((g) => g.source === "meetings")
+    .flatMap((g) => g.items);
+}
+
+/** Push a calendar event the way a workspace would: structured attendees, no body. */
+async function pushCalendarEvent(
+  seed: Seed,
+  opts: { title: string; attendees: unknown; path?: string; occurredAt?: string }
+) {
+  return ingest(seed, {
+    path: opts.path ?? `1-inbox/calendar/${randomUUID().slice(0, 8)}.md`,
+    project: "calendar",
+    kind: "artifact", // a calendar event has no natural kind — the SOURCE is what identifies it
+    frontmatter: {
+      source: "calendar",
+      title: opts.title,
+      occurred_at: opts.occurredAt ?? today(),
+      attendees: opts.attendees,
+    },
+    body: "", // deliberately empty: an invite has no transcript
+    access: "team",
+  });
+}
+
+describe("shared calendar events become per-person work (real Postgres)", () => {
+  it("RECEIVES, LOGS and ASSOCIATES the event with every attendee", async () => {
+    const seed = await seedTeam();
+    const bobEmail = `bob-${randomUUID().slice(0, 6)}@acme.com`;
+    const bob = await addMember(seed, "Bob", bobEmail);
+    // The pusher's own email, so the organiser resolves too.
+    const { data: me } = await db().from("members").select("email").eq("id", seed.memberId).single();
+    const myEmail = (me as { email: string }).email;
+
+    await pushCalendarEvent(seed, {
+      title: "Design review",
+      // The gog puller's real shape — an object with `id` + `display` + `role`.
+      attendees: [
+        { id: myEmail, display: "Tester", role: "organizer" },
+        { id: bobEmail, display: "Bob", role: "attendee" },
+      ],
+    });
+
+    // LOGGED: the backfill turns it into a meeting note.
+    const summary = await backfillMeetingNotesFromItems(db(), seed.teamId);
+    expect(summary.created, "the calendar event should have produced a meeting note").toBe(1);
+
+    // ASSOCIATED: it lands on BOTH people's cards, credited as attendance (no submitter fallback).
+    const days = await getWorkTimeline(db(), seed.teamId, "team");
+    for (const [who, id] of [
+      ["organiser", seed.memberId],
+      ["attendee", bob],
+    ] as const) {
+      const found = meetingsFor(days, id);
+      expect(found, `${who} should see the event`).toHaveLength(1);
+      expect(found[0].title).toBe("Design review");
+      expect(found[0].via, `${who} attended — not a submitter fallback`).toBeUndefined();
+    }
+  });
+
+  it("counts as WORK for a person who only attended — the log of what they did", async () => {
+    // Bob pushed nothing and wrote nothing that day. The point of the feature is that the meeting is
+    // still a record of work he did for the company.
+    const seed = await seedTeam();
+    const bobEmail = `bob-${randomUUID().slice(0, 6)}@acme.com`;
+    const bob = await addMember(seed, "Bob", bobEmail);
+
+    await pushCalendarEvent(seed, { title: "Roadmap sync", attendees: [bobEmail] });
+    await backfillMeetingNotesFromItems(db(), seed.teamId);
+
+    const days = await getWorkTimeline(db(), seed.teamId, "team");
+    const bobDay = days.flatMap((d) => d.people).find((p) => p.memberId === bob);
+    expect(bobDay, "a day of only meetings must still produce a person-day").toBeDefined();
+    expect(bobDay!.total, "the meeting counts toward his work total").toBe(1);
+  });
+
+  it("is idempotent — re-running the backfill does not double-log the event", async () => {
+    // The backfill runs every scheduler tick and on every push. A second note for the same item would
+    // credit everyone twice.
+    const seed = await seedTeam();
+    const bobEmail = `bob-${randomUUID().slice(0, 6)}@acme.com`;
+    const bob = await addMember(seed, "Bob", bobEmail);
+    await pushCalendarEvent(seed, { title: "Standup", attendees: [bobEmail] });
+
+    expect((await backfillMeetingNotesFromItems(db(), seed.teamId)).created).toBe(1);
+    expect((await backfillMeetingNotesFromItems(db(), seed.teamId)).created, "second run creates nothing").toBe(0);
+
+    const days = await getWorkTimeline(db(), seed.teamId, "team");
+    expect(meetingsFor(days, bob)).toHaveLength(1);
+  });
+
+  it("does not credit a non-member guest, and still credits the members present", async () => {
+    // A client on the invite is not someone we can attribute company work to — but their presence must
+    // not sink the whole event for the people who WERE there.
+    const seed = await seedTeam();
+    const bobEmail = `bob-${randomUUID().slice(0, 6)}@acme.com`;
+    const bob = await addMember(seed, "Bob", bobEmail);
+
+    await pushCalendarEvent(seed, {
+      title: "Client call",
+      attendees: [bobEmail, "someone@other-company.com", { id: "No Email Person", display: "No Email Person" }],
+    });
+    await backfillMeetingNotesFromItems(db(), seed.teamId);
+
+    const days = await getWorkTimeline(db(), seed.teamId, "team");
+    expect(meetingsFor(days, bob)).toHaveLength(1);
+    // …and nobody was invented for the unresolvable guests.
+    const { data: attendees } = await db()
+      .from("meeting_note_attendees")
+      .select("member_id");
+    expect((attendees ?? []).length, "only the real member is credited").toBe(1);
+  });
+
+  it("an event with NO resolvable attendee falls back to the pusher, marked", async () => {
+    // A solo event, or one whose guests are all external. We know the pusher was in it; that is the
+    // honest floor, and it must be distinguishable from real attendance.
+    const seed = await seedTeam();
+    await pushCalendarEvent(seed, { title: "External-only call", attendees: ["nobody@elsewhere.com"] });
+    await backfillMeetingNotesFromItems(db(), seed.teamId);
+
+    const days = await getWorkTimeline(db(), seed.teamId, "team");
+    const found = meetingsFor(days, seed.memberId);
+    expect(found).toHaveLength(1);
+    expect(found[0].via).toBe("submitter");
+  });
+
+  it("an event shared WEEKS AHEAD is still credited when its day arrives", async () => {
+    // Sharing is forward-looking: a person selects next month's meetings today. The note's `created_at`
+    // is therefore today while `occurred_at` is far in the future, which is the exact inverse of the
+    // recording case the leg was built for. Bounding the query on `created_at` meant that by the time
+    // the meeting actually happened its note had aged out — it would silently never reach any card.
+    const seed = await seedTeam();
+    const bobEmail = `bob-${randomUUID().slice(0, 6)}@acme.com`;
+    const bob = await addMember(seed, "Bob", bobEmail);
+
+    // Shared now, for a meeting that already happened 3 days ago (in-window) — the note is brand new.
+    const threeDaysAgo = new Date(Date.now() - 3 * 86_400_000).toISOString().slice(0, 10);
+    await pushCalendarEvent(seed, { title: "Backdated share", attendees: [bobEmail], occurredAt: threeDaysAgo });
+    await backfillMeetingNotesFromItems(db(), seed.teamId);
+
+    const days = await getWorkTimeline(db(), seed.teamId, "team");
+    const found = meetingsFor(days, bob);
+    expect(found, "a just-shared event for an in-window day must be credited").toHaveLength(1);
+    expect(found[0].at).toBe(threeDaysAgo); // dated by the meeting, not by the share
+  });
+
+  it("does not double-count on the PUSHER's card", async () => {
+    // The event item carries `occurred_at`, so it satisfies `work_at_from_source` and lands in the raw
+    // items lane credited to the pusher — while the meetings leg credits every attendee. Measured
+    // `total: 2` for one event before the raw-lane exclusion. Counted per LANE, not just per meeting,
+    // because the duplicate arrives under a DIFFERENT source and a meetings-only assertion misses it.
+    const seed = await seedTeam();
+    const { data: me } = await db().from("members").select("email").eq("id", seed.memberId).single();
+    await pushCalendarEvent(seed, { title: "Solo standup", attendees: [(me as { email: string }).email] });
+    await backfillMeetingNotesFromItems(db(), seed.teamId);
+
+    const days = await getWorkTimeline(db(), seed.teamId, "team");
+    const pusher = days.flatMap((d) => d.people).find((p) => p.memberId === seed.memberId);
+    expect(pusher?.total, "one event must count once").toBe(1);
+    expect(pusher?.other.map((g) => g.source).sort(), "no raw `calendar` lane beside the meetings one").toEqual([
+      "meetings",
+    ]);
+  });
+
+  it("TIER: a shared calendar event never reaches an external-tier viewer", async () => {
+    // Meeting notes are team-tier by construction and `meeting_notes` has no audience column, so the
+    // timeline's `canSeeMeetingNotes` gate is the sole enforcement. A calendar event must inherit it.
+    const seed = await seedTeam();
+    const bobEmail = `bob-${randomUUID().slice(0, 6)}@acme.com`;
+    await addMember(seed, "Bob", bobEmail);
+    await pushCalendarEvent(seed, { title: "Internal planning", attendees: [bobEmail] });
+    await backfillMeetingNotesFromItems(db(), seed.teamId);
+
+    const external = await getWorkTimeline(db(), seed.teamId, "external");
+    const leaked = external
+      .flatMap((d) => d.people)
+      .flatMap((p) => p.other)
+      .filter((g) => g.source === "meetings");
+    expect(leaked, "a calendar event leaked to an external viewer").toEqual([]);
+  });
+});

--- a/test/meetings-from-calendar.test.ts
+++ b/test/meetings-from-calendar.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { calendarAttendees, calendarTitle, isCalendarEvent } from "@/lib/meetings/from-calendar";
+
+/**
+ * A calendar event a person chose to share must be RECEIVED, LOGGED and ASSOCIATED WITH THE PERSON.
+ * This file covers the receiving contract — the boundary where a cross-repo producer meets the brain.
+ *
+ * The shapes below are not invented: `{id, display, role}` is exactly what the workspace's existing
+ * `gog calendar events` normalizer emits today. The others are the forms a reasonable producer would
+ * reach for. Being strict here would mean a real shared meeting silently lands on nobody, which is the
+ * failure this feature exists to remove.
+ */
+
+describe("calendar events are recognised by SOURCE, not kind", () => {
+  it("accepts the calendar source spellings — EXACTLY, matching the SQL filter", () => {
+    for (const s of ["calendar", "gcal", "google_calendar", "googlecalendar"]) {
+      expect(isCalendarEvent(s), s).toBe(true);
+    }
+  });
+
+  it("does NOT case-fold or trim — because the same set is a SQL IN() filter", () => {
+    // If this were tolerant while the candidate query is not, a `"Calendar"` item would be excluded
+    // from the timeline's raw-items lane AND never become a meeting note: visible nowhere. The two
+    // layers agreeing means a non-conforming source degrades to "ordinary item, credited to the
+    // pusher" — worse attribution, never a disappearance.
+    for (const s of ["Calendar", " calendar ", "GoogleCalendar", "GCAL"]) {
+      expect(isCalendarEvent(s), s).toBe(false);
+    }
+  });
+
+  it("does not claim other sources", () => {
+    // granola/zoom keep the TRANSCRIPT path — they have a body and an LLM extractor. A calendar event
+    // has structured attendees and no body; conflating them would send each down the wrong pipeline.
+    for (const s of ["granola", "zoom", "slack", "github", "", null, undefined]) {
+      expect(isCalendarEvent(s), String(s)).toBe(false);
+    }
+  });
+});
+
+describe("attendee resolution — exact, by email", () => {
+  it("reads the gog puller's real shape (id + display + role)", () => {
+    // The producer that exists today. `role: organizer` is NOT special-cased: the organizer attended
+    // too, and the timeline credits attendance rather than authorship.
+    const fm = {
+      participants: [
+        { id: "alice@acme.com", display: "Alice", role: "organizer" },
+        { id: "bob@acme.com", display: "Bob", role: "attendee" },
+      ],
+    };
+    expect(calendarAttendees(fm)).toEqual([
+      { email: "alice@acme.com", display: "Alice" },
+      { email: "bob@acme.com", display: "Bob" },
+    ]);
+  });
+
+  it("reads plain strings, objects, and a comma-separated string", () => {
+    expect(calendarAttendees({ attendees: ["A@Acme.com", "b@acme.com"] }).map((a) => a.email)).toEqual([
+      "a@acme.com",
+      "b@acme.com",
+    ]);
+    expect(calendarAttendees({ attendees: [{ email: "c@acme.com", displayName: "Cee" }] })).toEqual([
+      { email: "c@acme.com", display: "Cee" },
+    ]);
+    expect(calendarAttendees({ attendees: "d@acme.com, e@acme.com" }).map((a) => a.email)).toEqual([
+      "d@acme.com",
+      "e@acme.com",
+    ]);
+  });
+
+  it("prefers a real email field over `id` when both are present", () => {
+    // The gog puller puts a DISPLAY NAME in `id` when an attendee has no email, so `id` must lose to
+    // an explicit address or a named-but-addressed attendee resolves to nothing.
+    expect(calendarAttendees({ participants: [{ id: "Alice Smith", email: "alice@acme.com" }] })).toEqual([
+      { email: "alice@acme.com", display: null },
+    ]);
+  });
+
+  it("DROPS an attendee with no parseable email rather than guessing", () => {
+    // A display name with no address is exactly the ambiguity that makes transcript attendee-matching
+    // lossy (1.4/meeting on prod). A calendar event's whole advantage is that it carries addresses;
+    // falling back to name-matching here would trade it away.
+    expect(calendarAttendees({ participants: [{ id: "Alice Smith", display: "Alice Smith" }] })).toEqual([]);
+    expect(calendarAttendees({ attendees: ["not-an-email", "", "   "] })).toEqual([]);
+  });
+
+  it("dedupes case-insensitively and keeps source order", () => {
+    const got = calendarAttendees({ attendees: ["A@x.com", "a@X.com", "b@x.com"] });
+    expect(got.map((a) => a.email)).toEqual(["a@x.com", "b@x.com"]);
+  });
+
+  it("returns [] for a non-calendar or attendee-less item rather than throwing", () => {
+    for (const fm of [null, undefined, {}, { attendees: 42 }, { attendees: {} }]) {
+      expect(calendarAttendees(fm as Record<string, unknown>)).toEqual([]);
+    }
+  });
+});
+
+describe("title", () => {
+  it("prefers explicit title, then Google's `summary` (which IS the event title)", () => {
+    expect(calendarTitle({ title: "Weekly sync" }, "x.md")).toBe("Weekly sync");
+    expect(calendarTitle({ summary: "1-1 with Chetan" }, "x.md")).toBe("1-1 with Chetan");
+    // …and `title` wins, so a producer sending both doesn't get the description as its name.
+    expect(calendarTitle({ title: "Real title", summary: "other" }, "x.md")).toBe("Real title");
+  });
+
+  it("falls back to a de-slugified filename, minus a leading date", () => {
+    expect(calendarTitle({}, "1-inbox/calendar/2026-08-04-design-review.md")).toBe("design review");
+    expect(calendarTitle({}, "")).toBe("Meeting");
+  });
+});


### PR DESCRIPTION
> *"There should be a log of what work they've done for the company and meetings count as work. Whenever they show up in the individual workspace updates, make sure they are **RECEIVED and LOGGED AND ASSOCIATED WITH THE PERSON**."*

## First, what I found

**Zero calendar-sourced items exist in prod.** Nothing was being dropped — nothing was arriving.

The producer already exists (`gog calendar events` in the workspace) and even normalizes attendees with emails and organizer roles. But it writes to a **local** `comms/activity.jsonl` at `admin` tier, under the workspace's invariant *"nothing leaves the machine until `aios push`."* So calendar data stops at the laptop by design.

This PR builds the **receiving** half, so the moment a person shares an event it is logged and attributed. Privacy stays where it belongs — the person selects which events to share; the brain never sees the rest.

## What it does

An item whose `frontmatter.source` is a calendar source becomes a `meeting_note`, and PR #507's per-attendee leg carries it onto **every attendee's card** and into `GET /api/v1/timeline`.

**Attendance is resolved exactly, by email** (`buildIdentityMap().byEmail`) — no LLM, no name-matching. That's the whole reason a shared calendar event attributes better than a recording: the transcript path asks a model to read prose and match names, which measures **1.4 attendees/meeting** on prod, dropping any unmatched name without trace. Google just tells us the addresses.

A calendar event fails the transcript path three ways, each silently: `isMeetingTranscript` requires `kind === 'transcript'`, the query filtered on that kind, and the loop `continue`s on an empty body. So it's **recognised by SOURCE, not `kind`** — an event has no natural kind in the closed enum, and keying on kind would drop a real meeting over a vocabulary choice.

### Liberal where it should be, exact where it must be

The **attendee shapes** are deliberately permissive, because this is a cross-repo boundary and being strict means a real shared meeting silently lands on nobody:

```
attendees:    ["a@x.com"]  |  [{email, display}]  |  "a@x.com, b@x.com"
participants: [{id, display, role}]      ← the gog puller's ACTUAL shape today
```

`id` loses to an explicit `email`, because that puller falls back to putting a *display name* in `id`. No parseable email → **dropped, never guessed**. A non-member guest isn't credited but never sinks the event for the members who were there.

The **source set** matches exactly — no trim, no case-fold — because that same set is a SQL `IN (…)` filter. A tolerant predicate beside a strict query would make a `"Calendar"` item invisible in *both* lanes; agreeing means a non-conforming source degrades to "ordinary item, credited to the pusher" rather than disappearing.

## Verification

unit 2108 ✅ · data-mechanics 882 (real Postgres) ✅ · tsc ✅ · lint ✅ · docs-drift ✅
Both halves of the wiring mutation-checked: removing calendar recognition reddens 5 of 6 specs; stubbing email resolution reddens 4.

## Review — Reviewed by Fable code-reviewer — verdict SHIP WITH FIXES, all applied

Two HIGHs, both real, both re-derived by execution before I touched anything.

**1. Double-count on the pusher's card.** The event carries `occurred_at`, so it satisfies `work_at_from_source` and *also* lands in the raw items lane credited to the pusher — measured `total: 2` for one event. My own tests missed it because they counted only the `meetings` group and the duplicate arrives under a different source.

Then **my fix didn't work either**: that loop's `source` is *normalized*, and `normalizeSource` collapses `calendar` to `"other"`, so the check silently never matched. It now reads the raw frontmatter value, the spec counts per **lane**, and it's mutation-checked.

**2. Window starvation.** Dropping `kind='transcript'` from the candidate query made it "the 500 newest rows of *any* kind" — a bulk sync could push a real meeting transcript below the cap and it would **never** be noted, silently and permanently, since the window only moves forward. Now two bounded windows unioned, so neither shape starves the other.

Mediums, all fixed:
- Every calendar event **burned an LLM call on an empty transcript** — and a hallucinated todo would become a real task pushable to Linear. Skipped when there's no body.
- **Date precedence**: `deriveOccurredAt` checks `created` first, so an event shared Tuesday for Thursday's meeting logged as Tuesday, and a batch would pile onto the sync day. Calendar items now prefer Google's start-time fields.
- An event **shared weeks ahead was never credited** — the leg bounded on `created_at`, which assumed notes post-date meetings. Sharing inverts that.

## Deferred, deliberately

A calendar event **and** a Granola transcript of the *same* meeting produce two notes and double-credit every attendee. The dedup machinery structurally can't reach it — it clusters on transcript body overlap, and an invite has no body. This only bites once the workspace half ships and someone both shares an invite *and* records the call. Reconciling them (same `occurred_at` + title similarity → union attendees, tombstone one) is a real design question, so it's named rather than half-built.

## Not included — needed for end-to-end

**The workspace must actually push the selected events.** That's the `aios-workspace` repo, a separate PR. This side is inert until then (zero calendar items today) and ready the moment they arrive. Say the word and I'll do that repo next.

## Not included

No `AIOS-Work:` key — I haven't verified a matching Linear issue exists, and a fabricated key would advance an unrelated task to Done on merge.