### PR TITLE
docs(spec): V2 — project partitioning and permissioning (review rounds)

### DIFF
--- a/docs/specs/project-context-classification-v1.md
+++ b/docs/specs/project-context-classification-v1.md
@@ -3,14 +3,729 @@ eval_tier: full
 spec_gate: block
 ---
 
-# Project context classification and curation V1
+# Project partitioning and permissioning — V2
+
+> Filename note: this file keeps its V1 path (`project-context-classification-v1.md`) so existing
+> links survive; the document it contains is the V2 parent specification. V1's classification and
+> curation machinery is retained in Part II as the tagging engine; where V2 contradicts V1, V2 wins,
+> and every such flip is listed explicitly in §2.
 
 ## Status
 
-Proposed parent specification. This document defines the target architecture and an incremental
-delivery sequence; it is not a claim that every phase belongs in one pull request. Each phase below
-must be implemented as its own reviewed, deployable increment with the stated migration and test
-gates.
+Draft for review round 1 — spec only, no implementation. This revision reorients the V1 spec around
+the two primitives the vision brief names: **project partitioning** and **permissioning**. It is a
+re-architecture, not a feature: it touches the data model, ingestion, all three retrieval modalities,
+the graph layer, the API contract, the agent surface, and the UI, and it makes the graph a required
+dependency. Content ingested under a model that cannot express access must be reclassified later by
+hand — permission models are load-bearing from the first row, which is why this document front-loads
+the schema and enforcement decisions and defers everything decorative.
+
+Process: the vision brief mandates phased delivery with stop-and-check-in gates. This document is the
+Phase 0 audit plus the full target design; the build phases at the end each end at a checkpoint.
+
+---
+
+# Part I — the access architecture
+
+## 1. Phase 0 audit — the briefing, verified line by line
+
+The vision brief says "assume parts of the next section are wrong; your first job is to find out
+which parts." Verified against `origin/main` (commit `1693d9e`):
+
+| Briefing claim | Verdict | Evidence |
+|---|---|---|
+| ~75 tables, 56 migrations, ~600 commits, two contributors | ✅ almost exact | 75 `create table` in `postgres/schema.sql`; **55** migrations; 610 commits; 2 human contributors + dependabot |
+| ~27 `/api/v1/*` routes, brain-api v1.17 | ✅ | **26** route files under `app/api/v1/`; v1.17 in `lib/api/schemas.ts:55` |
+| API keys `aios_<key_id>_<secret>`, Bearer + `X-AIOS-Team` | ✅ | `lib/api/auth.ts:40,76` |
+| Only access model is two-tier `team`/`external`, `admin` → 422, app-code only, no RLS | ✅ | `lib/graph/group.ts:8`, `app/api/v1/items/route.ts:54-60`, CLAUDE.md §5 |
+| Projects partition nothing — not an access or retrieval boundary | ✅ (with nuance) | `projects` = `slug/name/last_synced_at` only. Nuance: `retrieve(..., projectSlug)` already narrows to one ingestion project (`lib/query/retrieve.ts:496,667`) — a *scope*, not an access boundary |
+| Single audited write path, zod, SHA-dedupe, versions, diff-sync, audit log | ✅ | `lib/ingest/index.ts`, `lib/api/audit.ts` |
+| Scheduler is in-process `setInterval`, single-instance, ingest ~30m, graph ~60m | ✅ | `instrumentation.ts` → `lib/ingest/scheduler.ts:24` (`INGEST_POLL_MINUTES ?? 30`) |
+| Retrieval: FTS + optional pgvector HNSW cosine + RRF + graph expansion + optional cross-encoder rerank; SSE, citations, abstain | ✅ | `lib/query/{fts-search,dense-search,retrieve}.ts`; HNSW cosine at `postgres/optional/pgvector.sql:42`; reranker at `lib/query/retrieve.ts:45-47` |
+| Graphiti 0.29.3 over Neo4j 5.26.2, optional; tier in `group_id` as `<teamSlug>_team/_external`; direct bolt reads | ✅ | `docs/ARCHITECTURE.md:768`, `docs/RAILWAY-TEMPLATE.md:19`, `lib/graph/group.ts:20`, `lib/graph/neo4j.ts` |
+| Derived/cached: `graph_entities`, `graph_relationships`, `arc_cache`, `work_timeline_cache`, `item_chunks` | ✅ | `schema.sql:1301,1316`; plus `graph_episodes` (`schema.sql:2211`) — the item→episode ledger that matters most for provenance, absent from the briefing |
+| Policy engine exists (engine + schema, no UI, no enforcement) | ✅ mostly | `lib/actions/` (engine, handlers, sandbox), `policies` (`schema.sql:1348`), `gateway_*` (`schema.sql:400+`). Partially wrong: the gateway identity path has live DB-level preflight enforcement (`gateway_service_identity_legacy_preflight` trigger) |
+| Retrieval quality CI-gated, 6/9 keyword-only → 9/9 with graph | ✅ | `test/query-recall.test.ts` + live eval in `scripts/e2e.sh` step 9 |
+| MCP read-only stdio server in `aios-workspace` | ✅ | `aios-workspace/scripts/brain-mcp.mjs` |
+| Postgres 16 required | ✅ | `compose.test.yml`, `pgvector/pgvector:pg16` |
+
+**Corrections that change the design:**
+
+1. **`graph_episodes` already is the extraction cache the brief asks for.** It maps
+   `(team, group_id, item, content)` → episode UUID with dedupe (the dedupe-pollution alarm of
+   AIO-693 guards it). Per-project extraction reuses this table with a widened key rather than
+   inventing a cache.
+2. **Identity infrastructure exists and is deterministic** — `member_emails` (`schema.sql:218`),
+   `member_identities` (`schema.sql:234`, provider user-ids for slack/linear/plane), and
+   `members.github_login`, consumed by `lib/attribution/resolve-authors.ts` and
+   `lib/attribution/contributor-credit.ts`. It was built for *attribution*, where an error mislabels
+   a timeline row. V2 makes it compute *access*, where an error is a vulnerability. The gap is not
+   resolution capability; it is audit, confidence, and fail-closed handling (§8).
+3. **A FalkorDB-vs-Neo4j evaluation already ran** (2026-08, under global-graph assumptions) and
+   recommended **no**: the win was RAM, not LLM spend; the cost was a server swap plus rewriting the
+   app's direct bolt reads; SSPL was noted. Per-project graphs and the single-container self-host
+   requirement reopen the question with different weights (§7).
+4. **The graph cost catastrophe is already fixed and measured** — 0.29.3 killed a 198× amplification
+   (27.2 LLM calls / 123,809 billed input tokens per 2,500-char episode on 0.13.2, one
+   `extract_attributes_from_node` call per resolved entity). Every cost number in §6 builds on the
+   post-fix baseline, metered per call in `llm_usage` (`source=graph`) with failures in
+   `llm_failures` (`docs/ARCHITECTURE.md:933`).
+5. **The recall eval has two layers**, not one: a deterministic FTS baseline in
+   `test/query-recall.test.ts` and the live 9/9 graph eval in `scripts/e2e.sh` step 9. The principal
+   axis (§12) must extend both.
+
+## 2. What V2 changes about V1 — the explicit flip list
+
+V1 was built on "membership is metadata, not a visibility grant." V2 inverts that posture. Every
+flip, stated once so no one discovers them mid-build:
+
+| V1 said | V2 says | Why |
+|---|---|---|
+| Invariant 2: "A membership never widens visibility"; membership is metadata over an item whose `access` tier is authoritative | Membership **is** the visibility path: person → group → project → content. The two-tier `access` flag survives only as a migration input and a legacy API compat shim | The access chain is the product |
+| Non-goal: "Making project context available to external-tier viewers… project taxonomy is team-tier metadata" | Projects/groups ARE the access model for every principal, external included. The `external` tier becomes a built-in group with visibility into designated projects | One access model, not two |
+| `projects.audience access_tier` column (V1 §model changes) | **Dropped.** Project visibility is the `project_groups` join, not a scalar | A scalar can't express 1+ groups |
+| Graphiti "optional derived consumer, never the owner" | Graph **required**; still never the owner of assignments/rules — but per-project graphs are the enforcement mechanism for derived knowledge | An optional graph means two permission implementations, and the second is the one nobody tests |
+| Tier safety via `visibleItems`/tier checks per surface | One visibility oracle (§5.4) + Postgres RLS as backstop (§9) | Agents are now in the loop; app-layer-only was the accepted risk being retired |
+| Auto-classification gated by `classification_mode` for *quality* | Additionally gated by the **no-widening invariant** (§5.6): an automatic tag may never increase the set of principals who can see content | An LLM mis-tag was noise in V1; in V2 it is a leak |
+
+**What survives from V1 intact** (Part II): context units and their merge contract, meeting topic
+segments, memberships/events/feedback tables, the rule AST and evaluator, the staged
+deterministic→embedding→LLM classifier, suggestions/review, curation semantics
+(force-include/exclude, return-to-auto), the initiative profile, and the amended duplicate-meeting
+merge handling. V1's machinery becomes the **tagging engine** that populates the access model.
+
+## 3. The access chain — target model
+
+```
+Person ──► Identity bindings ──► { Slack ID, GitHub login, email, Linear ID, … }
+   │
+   ├──► Group          (person ∈ 1+ groups; "Everyone" is built-in)
+            │
+            └──► Project    (project visible to 1+ groups, via project_groups)
+                     │
+                     └──► Content   (content tagged into 1+ projects, via memberships)
+```
+
+**One rule:** a person can see content iff they are in a group that can see a project that the
+content is effectively tagged into. No additional hops. Two candidate extra hops were considered and
+rejected to protect the rule's simplicity:
+
+- *Roles on groups* (viewer/editor per group-project edge): deferred. Curation authority stays on
+  the existing `members.role` (admin/lead/member) exactly as today (`lib/auth/guard.ts`); the
+  group-project edge answers only "can see."
+- *Per-item ACL exceptions*: rejected outright. An item needing different visibility from every
+  project it is in belongs in a different project. Exceptions are what made every enterprise
+  permission model unauditable.
+
+### Units of content — containers and atoms
+
+| Container | Atom(s) | Existing representation |
+|---|---|---|
+| Slack channel | thread item | `items` at `slack/<channelId>/<ts>.md`, channel id in `frontmatter` (`lib/ingest/sources/slack-normalize.ts`) |
+| GitHub repo | PR / commit / file item | `github`/`github-files` connectors, repo in path/frontmatter |
+| Meeting series | meeting note; topic segment (Part II) | `meeting_notes` + transcript item; segments are V1 units |
+| Linear/Plane team | issue (task row), update | materialized `tasks` rows via diff-sync |
+| Docs (Notion/Drive/local) | whole item | `items` by path |
+
+Containers carry **default tags**; atoms inherit and may override, and tagging is many-to-many at
+both levels. This maps onto V1 machinery directly: a container default is a **system-authored
+source-association rule** (V1 already stores Settings associations as high-priority rule versions,
+and the rule AST already has fields for Slack channel id/name, repository, path prefix — Part II
+§rules). An atom override is an ordinary membership with `mode='force_include'|'force_exclude'`.
+No new mechanism is required — this is the strongest continuity between V1 and V2.
+
+## 4. Data model — DDL
+
+All new tables are additive (`postgres/schema.sql` + timestamped migration, replay-tested per the
+`migrations-numbering` and schema-replay guards). Every table carries `team_id` and follows the
+single-writer rule (CLAUDE.md §2) with a named owner module.
+
+```sql
+-- Groups of people. "Everyone" and "External" are built-in rows (is_builtin), created per team by
+-- migration; built-ins cannot be deleted, only have membership edited.
+create table if not exists groups (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  slug text not null,
+  name text not null,
+  is_builtin boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (team_id, slug)
+);
+
+create table if not exists group_members (
+  team_id uuid not null references teams(id) on delete cascade,
+  group_id uuid not null references groups(id) on delete cascade,
+  member_id uuid not null references members(id) on delete cascade,
+  added_by uuid references members(id) on delete set null,
+  created_at timestamptz not null default now(),
+  primary key (group_id, member_id)
+);
+create index if not exists group_members_member_idx on group_members (team_id, member_id);
+
+-- Which groups can see a project. THE access edge.
+create table if not exists project_groups (
+  team_id uuid not null references teams(id) on delete cascade,
+  project_id uuid not null references projects(id) on delete cascade,
+  group_id uuid not null references groups(id) on delete cascade,
+  added_by uuid references members(id) on delete set null,
+  created_at timestamptz not null default now(),
+  primary key (project_id, group_id)
+);
+create index if not exists project_groups_group_idx on project_groups (team_id, group_id);
+```
+
+Content↔project is **`project_context_memberships`** exactly as specified in Part II (V1), now
+access-bearing. `context_unit_id` remains the grain (whole item, task/decision row, meeting
+segment), which is what lets a Slack channel be visible to Everyone while one thread in it is
+force-excluded into a restricted project only.
+
+Identity hardening (§8) adds columns to `member_identities` / `member_emails` rather than new
+tables: `verified_by uuid`, `verified_at`, `confidence text check (confidence in
+('deterministic','confirmed','suggested'))`, `evidence jsonb`. Delegation adds `agent_tokens` (§10).
+Signal seams add `intent_records` (§13, design-only).
+
+**Effective visibility is a pure function**, computed in one place (§5.4):
+
+```
+visibleProjects(principal) =
+  { p | ∃ g : (principal.member ∈ g) ∧ ((p,g) ∈ project_groups) }
+  ∩ attenuation(principal)            -- token project-scope, §10; identity fail-closed, §8
+canSee(principal, unit) =
+  ∃ m current effective include membership of unit into some p ∈ visibleProjects(principal)
+```
+
+## 5. Enforcement — every read path, one oracle
+
+### 5.1 The oracle
+
+One module — proposed `lib/access/oracle.ts`, superseding ad-hoc tier checks the way
+`lib/auth/visibility.ts` centralized dashboard reads — computes `visibleProjectIds(principal)` once
+per request and hands an immutable set to every downstream read. No surface re-derives it (guard
+test, mirroring `test/guards/dashboard-tier-filter.test.ts`). The existing two-tier world maps onto
+the oracle during migration: tier `team` ≙ membership of built-in Everyone; tier `external` ≙
+membership of built-in External only (§11).
+
+### 5.2 Postgres FTS
+
+Straightforward, as the brief presumes — confirmed: `lib/query/fts-search.ts` queries `items.search`
+scoped by `team_id` + tier. V2: join through current effective memberships against the oracle's
+project set (`exists (select 1 from project_context_memberships m where m.context_unit_id … and
+m.project_id = any($projects) and m.decision='include' and m.valid_to is null)`). Index support:
+memberships already carry `(team_id, project_id, context_unit_id)` uniqueness (Part II); add a
+covering index on `(context_unit_id) where valid_to is null`.
+
+### 5.3 pgvector — the hard case, priced
+
+Post-filtering leaks through counts and can return empty pages; naive pre-filtering degrades HNSW
+recall badly when the filter is selective — and one project inside a company corpus is exactly a
+selective filter. Options, priced:
+
+1. **Iterative index scans** (`hnsw.iterative_scan = relaxed_order`, pgvector ≥ 0.8.0): the index
+   keeps scanning until enough rows pass the WHERE clause. Preferred mechanism. **Unverified
+   assumption to close before build:** the deployed pgvector version on Railway and in
+   `pgvector/pgvector:pg16` (tag floats). Gate: `pg:schema:vector` fails loudly below 0.8.0.
+2. **Over-fetch + filter fallback** (works on any version): fetch `k × max(4, 40/selectivity%)`
+   candidates, filter by membership, degrade to FTS-only for that partition if starved — never an
+   empty page with a "results exist" shape (that is the §5.7 disclosure rule).
+3. **Per-partition indexes** (partial index per project): recall-perfect but priced out at realistic
+   counts — 40 projects × HNSW build memory × write amplification on every item update; rejected as
+   the default, reserved for a future hot-project optimization behind measurement.
+
+Dense search currently joins `items.project_id` → slug (`lib/query/dense-search.ts:70-74`); V2 joins
+memberships instead — same join point, different edge.
+
+### 5.4–5.5 Graph: structural isolation + the bolt exception list
+
+Per-project graphs (§6) make traversal isolation structural — a query fanning out inside
+`group_id = team_<teamId>_p_<projectId>` cannot reach another project's subgraph, which is the
+answer to "filtering a path is not filtering a result set." **The residual risk is the app's direct
+bolt reads** (`lib/graph/neo4j.ts` consumers: arcs fact reads in `lib/graph/arcs.ts`/`learning.ts`,
+reconcile, health probes). Ruling: every bolt query must take `group_ids` from the oracle as a
+required parameter — enforced by a guard test that scans `lib/graph/` for cypher strings lacking a
+`group_id` predicate (same discovery-based pattern as `test/guards/llm-single-caller.test.ts`), plus
+a datamechanics leak test (§14) that plants a fact in project B and proves an A-scoped principal
+cannot retrieve it through any read, including bolt.
+
+### 5.6 The tagging engine under access semantics
+
+The no-widening invariant, stated once and guarded: **an automatic process may create or settle a
+membership only when doing so does not increase the set of principals who can see the content.**
+Formally: auto-tag of unit u into project p is allowed iff `audience(p) ⊆ audience_now(u)` where
+`audience(p)` = union of members of p's groups. Any widening tag — including container-default
+inheritance into a broader project — enters the review queue and requires a human with curation
+rights over the destination project. This subsumes V1's quality gating (`classification_mode`,
+Part II) and is enforced in the membership single writer, not in each classifier.
+
+### 5.7 Citations, abstention, counts
+
+- **Citations are the same filter, not a second pass:** citation candidates are drawn from the
+  already-oracle-filtered hit set (`lib/query/retrieve.ts` builds citations from merged hits;
+  the merge is where the filter lives). A citation to an invisible source is a leak even when the
+  prose is clean — pinned by an http-tier test.
+- **Abstention does not disclose existence.** "No results" is byte-identical whether content is
+  absent or invisible; result counts, pagination totals, and the SSE abstain path never reflect
+  filtered-out rows. Defense: existence disclosure is a real product need ("something is in flight
+  here") but it is the *signal layer's* job (§13), where it is opt-in, coarse, rate-limited, and
+  audited — not an ambient side channel of search.
+
+### 5.8 Derived and cached surfaces
+
+Every cache keyed today by team or tier gets a project/visibility axis or dies:
+`arc_cache.group_key` (already tier-scoped) becomes per-project (§6); `work_timeline_cache` gains a
+visibility variant keyed by **sorted visible-project-set hash** (bounded by distinct group
+combinations, not by principal count — 2 people with identical groups share a cache row);
+`item_chunks` carries no access data (content only) and is filtered at query time. The permission
+inspector (§15.6) is the runtime check that a cached surface never leaked: it recomputes the access
+path live.
+
+## 6. Per-project graphs and the extraction cost model
+
+### group_id scheme
+
+`lib/graph/group.ts` becomes the single authority (it already validates charset
+`[A-Za-z0-9_-]`): `g_<teamId>_p_<projectId>` with UUIDs stripped of hyphens if length limits bite —
+verified against Graphiti's group-id charset gotcha (memory: charset constraint is real). Tier
+suffixes disappear; the External group + project edges express what `_external` did.
+
+### Projection
+
+`graph_episodes` (schema.sql:2211) widens its identity to `(team_id, group_id, item, content_sha)`
+— i.e. **the (content_hash, project_id) extraction cache the brief asks for already exists modulo
+the key**. Projection fans an item's episode into each project the item is effectively tagged into.
+Re-tagging into a project that already saw this content SHA is a cache hit: zero LLM calls.
+
+### Cost model — with numbers
+
+Post-0.29.3 measured baseline (ARCHITECTURE:768+, `llm_usage source=graph`): extraction is batched,
+node-attribute amplification is gone, small-call routing sends `node_attributes`/`dedupe_edges` to
+`teams.extraction_small_model`. Let E = episodes/day (~50–150 on the live team), P̄ = mean projects
+per item. Naive cost multiplier = P̄. Mitigations, in force order:
+
+1. **Content-hash cache** (above): re-tags and re-syncs of unchanged content are free.
+2. **Laziness for cold projects:** extraction into a project graph is deferred until the project has
+   a reader (first query/view arms it; `classification_mode='off'` projects never extract). A tag
+   into a cold project records a pending projection row, not an LLM call.
+3. **Batching:** the projector already batches per tick; per-project queues share the tick budget.
+4. **The structural fact:** most content will live in exactly one project + General. The
+   no-widening invariant means auto-tagging doesn't proliferate copies; P̄ stays near 1–2 unless
+   humans deliberately fan content out. Model: cost ≈ baseline × (1 + share_multi × (P̄multi − 1)).
+5. **Visibility:** per-project spend surfaces in the existing cost dashboard by extending
+   `llm_usage` metering with `meta.group_id` (the proxy already tags calls; `lib/llm/graph-proxy.ts`)
+   — the dashboard's graph row gains a per-project breakdown. Budget ceiling: the existing graph
+   proxy ceiling applies per team; a per-project soft cap is configuration.
+
+**General-project ruling:** the General partition (everything, Everyone-visible) is the one graph
+that would double all extraction if naively separate. Ruling: General IS the migration target graph
+(the current single team graph, renamed), and content tagged into a specific project is extracted
+*additionally* into that project's graph. Cross-project synthesis is never computed (the
+permission-laundering answer); General-partition synthesis is computed over General-visible content
+only — which is exactly today's behavior, so the eval baseline survives.
+
+## 7. FalkorDB vs Neo4j — recommendation
+
+Prior evaluation (2026-08, global-graph assumptions): **no** — a server swap plus rewriting the
+app's direct bolt reads, for RAM savings that don't touch the real cost (LLM extraction), plus SSPL
+licensing to weigh. What V2 changes: (a) per-project graphs make **multi-graph** a first-class need
+— FalkorDB treats many graphs in one process as native and cheap, while Neo4j community expresses
+them as group_id partitions inside one database (workable — Graphiti group_ids — but logical, not
+physical); (b) **graph becomes required**, so the JVM footprint now sits inside the minimum
+self-host, and the single-container distribution story ends with mandatory Neo4j.
+
+**Recommendation:** keep Neo4j through the alpha (isolation via disjoint group_ids + the §14 leak
+suite proving it), and run a **time-boxed FalkorDB spike as the exit gate of Phase C** with three
+decision facts to produce: (1) Graphiti 0.29.x FalkorDB-driver parity for the calls we use, (2) a
+port cost for the ~5 bolt-read modules (they'd move to the driver or an equivalent), (3) memory/
+latency at 50 project-graphs on a 2 GB container. If all three pass, FalkorDB becomes the default
+self-host backend and Neo4j stays a supported alternative; SSPL is acceptable for a
+user-pulled-image dependency (same posture as Neo4j's GPL community edition — we distribute neither).
+This honors "answer it early" with the honest caveat that the deciding facts are empirical, and the
+alpha is not blocked on them.
+
+## 8. Identity resolution as a security surface
+
+Today: deterministic provider-ID bindings (`member_identities`), email/git aliases
+(`member_emails`), GitHub login on `members` — consumed by `lib/attribution/resolve-authors.ts` at
+ingest and `lib/attribution/contributor-credit.ts` (the single attribution oracle). Assessment: the
+*mechanism* is already deterministic-first and never infers from message prose; what's missing for a
+security bar is provenance and ceremony, not capability.
+
+Required changes:
+
+1. **Every binding carries evidence and an author**: `confidence
+   ('deterministic'|'confirmed'|'suggested')`, `verified_by/at`, `evidence jsonb` (e.g. "Slack
+   profile email matched member email", "admin bound manually"). Every create/update/delete audits
+   through `lib/api/audit.ts`.
+2. **Fail closed:** an unresolved or `suggested` identity grants **nothing** — a principal's
+   visible-project set is computed only from `deterministic`/`confirmed` bindings. Suggested
+   bindings queue for human confirmation in the identity manager (§15.2) and affect attribution
+   display at most, never access.
+3. **Identity is never inferred from content.** A name in a message body is not an identity claim —
+   invariant + guard test asserting no access-path code imports content-derived attribution.
+4. **Unbinding cascades** are read-time: access is recomputed per request from live bindings via the
+   oracle, so revoking a binding takes effect on the next request with no cache to chase (caches key
+   on group-set, which changes when membership does — §5.8).
+
+## 9. RLS — the backstop and its pooling trap
+
+Design (defence-in-depth under the oracle, not a replacement):
+
+- **Roles:** the app connects as a dedicated `aios_app` role with RLS enforced (no `BYPASSRLS`);
+  `npm run pg:schema` / migrations run as the owner role. Today the app uses a single privileged
+  connection (`lib/db/pg/pool.ts`) — this split is the enabling migration.
+- **Session mechanism:** every request executes inside a transaction that first runs
+  `select set_config('aios.team_id', $1, true), set_config('aios.member_id', $2, true)` —
+  `set_config(..., true)` is **transaction-local** (`SET LOCAL` semantics), which is the entire
+  answer to the pooling trap: pool checkout order cannot leak one principal into another because the
+  variables die at COMMIT/ROLLBACK. Session-level `SET` is forbidden by a guard grep. `runSql` and
+  the query-builder adapter gain a `withPrincipal(tx)` entry so a bare pool query without principal
+  context hits policies that see NULL and return nothing — fail closed. (If external pooling is ever
+  added, transaction mode is required; statement mode would break `SET LOCAL` — documented in
+  `docs/OPS.md`.)
+- **Policies:** phase one covers the content-bearing tables (`items`, `item_versions`,
+  `item_chunks`, `tasks`, `decisions`, `meeting_notes`, `project_context_*`), expressed as
+  membership-join policies mirroring the oracle. Derived caches (`arc_cache`,
+  `work_timeline_cache`) are covered by their key discipline (§5.8) plus team_id policies.
+- **The backstop is tested as a backstop:** a datamechanics test deliberately calls the data layer
+  *wrongly* (no principal context / forged member id) and asserts the database returns zero rows —
+  i.e. RLS catches an application bug by construction (§14).
+
+Perf note (honest): membership-join policies on every row-read add a join per table; the phase gate
+includes a before/after latency measurement on the three hottest reads (timeline, retrieve, items
+list) with a stated budget (+15% p95 ceiling) before RLS graduates from staging to default.
+
+## 10. Principals, delegation, and the QM slice
+
+- **Principal model:** `member` (today's API key → member binding, unchanged) or `agent_token`.
+  New table `agent_tokens`: `id, team_id, member_id (the launching principal), on_behalf_of
+  (member_id, nullable = self), project_scope uuid[] (attenuation set), expires_at, revoked_at,
+  created_by, last_used_at`, hashed secret, audited on mint/use/revoke.
+- **Attenuation, never expansion, enforced at the token layer:**
+  `effective = visibleProjects(on_behalf_of ?? member) ∩ project_scope` — computed in
+  `lib/api/auth.ts` where the Bearer key already resolves (`auth.ts:40`), so every route and the
+  oracle see only the attenuated set. A token whose `project_scope` names a project its principal
+  cannot see contributes nothing (intersection, not union) — expansion is structurally impossible,
+  not policy-forbidden.
+- **Agents never read out-of-scope content — no summaries, no gist:** agent context assembly draws
+  exclusively from oracle-filtered reads; the MCP server (`aios-workspace/scripts/brain-mcp.mjs`)
+  authenticates with a key/token and inherits the same attenuation because it speaks the same API.
+- **v1.17 compatibility:** existing `aios_*` member keys behave identically (full principal, no
+  attenuation). `agent_tokens` ship as additive brain-api v1.18; the CLI needs no change until it
+  wants delegation.
+- **QM unblock slice** (minimum, shippable first): principal resolution + `on_behalf_of` +
+  project-scope intersection in `lib/api/auth.ts`, the `agent_tokens` table, and mint/revoke admin
+  actions — **before** any UI or graph work. Alpha restriction: read-only routes
+  (`GET /api/v1/items`, `query`) for delegated tokens, single team, no external-tier delegation.
+
+## 11. Migration of live production data
+
+Ruling and its direction, argued:
+
+1. **Built-ins:** per team, migration creates group `everyone` (all active members), group
+   `external` (members with `tier='external'`), project `general` (kind `system`), project
+   `external-shared` (kind `system`); `project_groups`: general↔everyone, external-shared↔external
+   **and** external-shared↔everyone (external content is team-visible today — verified:
+   `visibleItems` lets team-tier read external rows, not vice versa).
+2. **Backfill:** every existing item's unit gets a membership into `general` if `access='team'`,
+   into `external-shared` if `access='external'` — batched, online (the backfill is a scheduler job
+   writing through the membership single writer, resumable by fingerprint, exactly the Part II
+   reconciler pattern). Result: **byte-identical visibility to today** for every principal. The
+   recall eval must pass unchanged after backfill — that is the migration's acceptance test.
+3. **Why fail-open-to-today rather than fail-closed-to-invisible:** "unclassifiable" content is
+   today *visible to the whole team by contract* — the current product promise. Making it invisible
+   would break every existing customer query on migration day and would be indistinguishable from
+   data loss. The fail-closed posture V2 adds applies to *new* restriction claims (unresolved
+   identity grants nothing; RLS default-deny without principal context), not to retroactively
+   un-sharing what teams already shared. A team that wants restriction-by-default flips a team
+   setting: new content with no container rule then lands in a `triage` project visible to admins
+   only.
+4. **Graph:** the existing `<teamSlug>_team` graph is renamed/aliased as General's graph (no
+   re-extraction); `_external` becomes external-shared's. New per-project graphs build lazily (§6).
+   Nothing is re-extracted during migration — cost ≈ 0.
+5. **Ordering:** three additive migrations (groups/edges, identity columns, agent_tokens) appended
+   after the current 55, plus the backfill job; replay-tested from zero AND from a populated
+   pre-V2 database per the schema-phase gates (the #251/#495 replay lessons are the reason this is
+   stated).
+
+## 12. The recall eval gains a principal axis
+
+Both eval layers (§1 correction 5) become matrices over principals:
+
+- `test/query-recall.test.ts` (deterministic): fixtures gain a restricted principal whose
+  visible-project set excludes planted content; assertions per principal: unrestricted keeps the
+  existing baseline (regression gate), restricted must (a) never retrieve planted out-of-scope
+  content — a leak probe, not a recall score — and (b) meet a stated floor on in-scope recall so
+  enforcement cost is measured, not assumed.
+- `scripts/e2e.sh` step 9 (live 9/9): runs twice, unrestricted (must stay 9/9) and restricted
+  (expected N/9 where N counts in-scope answers; the delta is *documented recall cost of
+  restriction*, reported not hidden).
+- The seed dataset (§15) is the fixture source, so CI and the demo exercise the same shapes.
+
+## 13. The signal layer — seams only, not built
+
+`intent_records` (design-only DDL): `id, team_id, actor_member_id, project_id, coarse_scope text
+(e.g. path prefix or component label), status, created_at, expires_at` — plus its own access
+semantics: `intent_visibility` edges naming which groups may see *existence* (default: none;
+opt-in per project; the interesting case — visible existence with invisible content — is expressed
+by granting a group intent-visibility on a project it cannot see, which is legal precisely because
+intent rows carry no content). Rate-limited reads, every read audited, coarse_scope validated
+against an allowlist of granularities so it cannot become a filename side channel. Nothing else in
+V2 depends on this table existing.
+
+## 14. Adversarial leak test suite — first-class deliverable
+
+Tiered per CLAUDE.md §4; every test plants content a principal must NOT see and asserts absence
+through the *outcome*, not the code path:
+
+| Path | Tier | Probe |
+|---|---|---|
+| FTS | datamechanics | planted term in project B; A-principal search returns nothing, count = 0 |
+| Dense | datamechanics (vector compose) | same, via embedding similarity; also empty-filter starvation ≠ error shape |
+| Graph traversal | datamechanics (neo4j compose) | fact in B's graph; A-scoped group_ids can't reach it, including via `lib/graph/neo4j.ts` direct read |
+| Citations | http | answer citing B-content never reaches an A-principal — citation ids checked, not just prose |
+| Abstention/counts | http | byte-identical "no results" for absent vs invisible; pagination totals equal |
+| Arcs / timeline / caches | datamechanics | B-only evidence never appears in A's arc evidence or timeline payloads; cache keyed per §5.8 |
+| Re-tag cascade | datamechanics | untag from B → B's graph facts revised (§Part II cascade), B-principal loses retrieval of the derived fact |
+| Delegation | http | token with `project_scope=[B]` for an A-only principal reads nothing (intersection), and cannot mint wider |
+| Unresolved identity | datamechanics | `suggested` binding grants no project; oracle returns builtin-Everyone only if the member row itself is confirmed |
+| RLS backstop | datamechanics | deliberate data-layer misuse (no principal context) returns zero rows — the app-bypass test |
+| MCP / agent context | http | tool responses for an attenuated token contain no out-of-scope item ids |
+
+Probing tests are explicitly adversarial: timing-insensitive, but shape-sensitive (result counts,
+empty-page shapes, citation numbering gaps) — the places post-filtering leaks.
+
+## 15. GUI — verification instrument, in scope
+
+Eight screens; each states the invariant it makes visible. All reuse the admin surface conventions
+under `app/t/[team]/admin/*` and the guard that pages read through the oracle.
+
+1. **People, groups & projects admin** — CRUD + membership matrices. *Invariant visible:* the whole
+   access model on one screen; if a human can't read it, it isn't trustworthy.
+2. **Identity manager** — bindings with confidence, evidence, audit trail, confirm/unbind. Designed
+   as a security surface (destructive-action ceremony, audit inline), not a settings page.
+3. **Content tagging** — the Part II curation UI (chips, bulk, review queue) + **cascade preview**:
+   before an untag commits, show what derived knowledge will be revised in the losing project
+   (counts of facts/arcs affected, from the provenance ledger) and progress while the cascade runs.
+4. **Per-person brain view** — the existing brain, oracle-scoped. *The demo that proves the model:*
+   two people, same team, different brains.
+5. **View-as** — admin impersonation of any principal: gated admin-only, every session audited
+   (`audit` action `access.view_as`), visually unmistakable (persistent banner + distinct chrome),
+   read-only while active. The single most valuable permission-testing tool.
+6. **Permission inspector — "why can I see this?"** — for any item/unit: person → group → project →
+   membership chain, with each edge's provenance (who added, when, which rule). Agreed: highest
+   value per effort — it is also the support tool for every future access bug report, and it doubles
+   as the runtime cache-leak check (§5.8). Build early, not last.
+7. **Agent launcher** — scope (project set) shown explicitly pre-launch; launching mints the
+   attenuated token (§10).
+8. **Signal view** — placeholder rendering `intent_records` at the viewer's disclosure level; ships
+   dark until §13 is built.
+
+**Seed dataset:** extend `scripts/seed-demo.ts` (Northwind Robotics) with: 5 people, 3 groups
+(Everyone, Firmware, Leadership), 4 projects (general, firmware-x, supplier-negotiation ← Leadership
+only, external-shared), overlapping content including one meeting whose segments split across
+firmware-x and supplier-negotiation — the two-brains demo and every §14 fixture come from this.
+
+## 16. Runtime assessment — does this force a job runner?
+
+Honest answer: **not for the alpha, yes before broad per-project backfill.** The in-process
+scheduler (`instrumentation.ts` → `lib/ingest/scheduler.ts`, single-instance, single-flight
+in-process) already runs bounded per-tick work (doc-task-infer batching is the template). Per-
+project extraction with the §6 cache and laziness stays within that envelope at alpha scale (≤ ~10
+active projects). It breaks when: cascade recomputation of a large project, historical rule
+backfills, and cold-project arming collide in one tick — the tick either overruns or starves legs.
+Graduation path (named now, built then): a Postgres-backed queue (graphile-worker or pg-boss) in the
+same container — no new infrastructure, self-host story intact — with the scheduler ticks becoming
+enqueuers. Trigger to build it: sustained tick overrun or the first >50k-item backfill, whichever
+comes first; measured via the existing `ingest_runs` duration metadata.
+
+## 17. Phasing — two engineers, checkpoints, QM early
+
+Each phase ends at a **stop-and-review checkpoint** (spec round, then build). Ships in this order
+precisely so the access chain exists before anything depends on it:
+
+- **A — Principals & access skeleton** *(unblocks QM)*: groups/edges DDL + built-ins, oracle,
+  `agent_tokens` + attenuation in auth, migration §11 (backfill + built-ins), identity columns +
+  fail-closed rule. Alpha restriction: delegated tokens read-only, single team. Eval: unchanged
+  baseline must pass post-backfill.
+- **B — Enforced reads**: FTS/dense/timeline/arcs through the oracle; citation/abstention rules;
+  RLS on content tables + the backstop test; permission inspector + admin screens 1–2; leak suite
+  paths 1–2, 4–6, 9–10.
+- **C — Per-project graphs**: group_id scheme, projector fan-out + cache, per-project arcs, bolt
+  guard, cost surfacing; FalkorDB spike = exit gate; leak suite graph paths; eval principal axis.
+- **D — Tagging at scale** (Part II engine under V2 invariants): container defaults, review queue,
+  rules UI, cascade + provenance ledger + cascade preview; view-as; seed dataset; remaining screens.
+- **E — Signal layer** (deferred; seams already in place).
+
+Explicitly out of reach for two engineers in this horizon, stated per the brief's instruction:
+Slack topic segmentation (Part II defers it), per-partition HNSW indexes, the full policy-engine UI
+(`lib/actions` stays as-is), FalkorDB migration execution (spike only).
+
+## 18. Open questions, ranked
+
+1. **pgvector version in deployment** (gates §5.3 mechanism) — resolve by checking
+   `select extversion from pg_extension` on Railway + pinning the compose image; one hour.
+2. **Graphiti 0.29.3 revision semantics on episode removal** (gates cascade §Part II) — resolve by
+   a datamechanics-style probe against the test Neo4j: remove an episode, observe edge invalidation
+   vs dangling; half a day. The provenance ledger is designed to not depend on the answer, but
+   incremental-vs-rebuild cost does.
+3. **FalkorDB spike facts** (§7) — Phase C gate.
+4. **RLS latency budget** (§9) — measured at Phase B on the three hottest reads.
+5. **Cache-key cardinality** for visibility-keyed caches (§5.8) — bounded by distinct group
+   combinations; verify the bound holds on real team shapes before Phase B ships.
+
+---
+
+# Part II — provenance, cascade, and the tagging engine
+
+Part II carries the machinery that assigns content to projects — V1's classification and curation
+design, revised where V2's access semantics touch it. Sections here are normative and self-contained;
+"unchanged from V1" always means the amended V1 (merge contract, classification_mode gating, row
+heal paths — merged in #502).
+
+## 19. Provenance and cascade — the highest-leverage schema decision
+
+The brief asks to be convinced this is or isn't the highest-leverage decision. **It is — with one
+sharpening.** The schema is small; the leverage is in (a) the *revision* semantics — facts are
+revised, never merely deleted — and (b) a structural consequence of "never synthesise across
+projects": a derived fact exists in exactly **one** project's graph, so provenance rows never span
+partitions and a cascade never crosses an access boundary. That single property is what keeps
+cascade tractable AND what makes it impossible for revision to become a laundering channel.
+
+### What already exists (verified)
+
+- `graph_episodes` (`schema.sql:2211`) — the item→episode ledger per `(team, group_id)`, deduped by
+  content (AIO-693's pollution alarm guards it). This is the anchor: which items produced which
+  episodes is already durable, per partition.
+- Arcs carry per-evidence provenance (`NarrativeArc.evidence[].itemId`,
+  `lib/graph/arc-continuity.ts`) — the arc side of the cascade is already reconciliation-based.
+- Graphiti's temporal model invalidates edges (`valid_at`/`invalid_at`) rather than deleting them.
+  **Marked inference (open question 2):** that 0.29.3's episode-removal path invalidates derived
+  edges cleanly for our usage; resolved by a half-day probe against the test Neo4j before Phase C.
+
+### The ledger
+
+```sql
+create table if not exists graph_provenance (
+  team_id uuid not null references teams(id) on delete cascade,
+  group_id text not null,                    -- the partition; never spans projects
+  target_kind text not null check (target_kind in ('fact','entity')),
+  target_uuid text not null,                 -- Graphiti uuid
+  source_item_id uuid not null references items(id) on delete cascade,
+  added_at timestamptz not null default now(),
+  removed_at timestamptz,
+  primary key (group_id, target_kind, target_uuid, source_item_id)
+);
+create index if not exists graph_provenance_item_idx on graph_provenance (team_id, source_item_id)
+  where removed_at is null;
+```
+
+Sole writer: the graph projector (`lib/graph/project.ts` extended), which learns each fact's source
+episodes from the extraction round-trip it already performs. Arcs need no new rows — their evidence
+IS the ledger.
+
+### Revision semantics
+
+On **untag** of item i from project P (membership closed):
+
+1. Resolve i's episodes in P's `group_id` via `graph_episodes`.
+2. Facts whose ONLY live provenance is those episodes → **invalidate** (Graphiti temporal
+   invalidation; ledger rows get `removed_at`). Last-source removal is therefore invalidation plus a
+   tombstoned ledger row — the fact's history remains inspectable, its content stops being served
+   (same posture as `lib/ingest/forget-bodies.ts`: ids stay, prose goes).
+3. Facts with remaining sources → **recompute from the remainder**: re-run extraction over the
+   remaining source episodes only (bounded, incremental). If recomputation changes a fact's meaning,
+   that is a NEW fact uuid with fresh provenance; the old one is invalidated — never mutated in
+   place, so the ledger never lies about what produced what.
+4. Arcs: no synchronous work. The next synthesis reads only live facts; arc identity survives via
+   evidence-overlap reconciliation (`reconcileArcIdentity`), and a force-included arc whose evidence
+   died goes to review rather than silently vanishing (Part II curation rules).
+5. Entities: orphaned entities (no live facts) are swept by the existing reconcile pass.
+
+**Incremental vs rebuild:** incremental by default with cost
+`O(episodes(i,P) + facts_citing × re-extract)` — for the live team, episodes(i,P) is almost always
+1 and facts-per-episode averages single digits (measurable from `graph_entities` counts; the Phase C
+gate records the constant before enabling cascade at scale). Full project rebuild is the correctness
+escape hatch: an explicit admin action costing `items(P) × per-episode extraction` at the
+post-0.29.3 rate, surfaced with a cost estimate in the cascade-preview UI (§15.3) before it runs.
+**Retag into P** is the cheap direction by construction: `graph_episodes`' content-hash key makes
+previously-seen content a cache hit (§6).
+
+## 20. The tagging engine — retained V1 design under V2 invariants
+
+The remainder of Part II is the V1 specification (as amended in #502) with the V2 deltas applied
+INLINE — the full normative text follows in §20.2, so this document is self-contained; §20.1 is the
+ledger of every delta so reviewers of V1 can see exactly what moved.
+
+### 20.1 Deltas to V1 sections
+
+- **V1 "Why" / "Product outcome" / "Goals":** stand, with one reframe — the outcome is no longer
+  only "a continuously maintained context space" but *the access boundary itself*. Goal 8 ("preserve
+  app-code tier isolation") is superseded by Part I §5/§9 (oracle + RLS).
+- **V1 "Non-goals":** two removed — "Making project context available to external-tier viewers"
+  (superseded: the access chain covers every principal) and the implication that project metadata is
+  team-tier-only (project *existence* visibility follows `project_groups`; a principal never sees
+  the name of a project no group of theirs can see — this now matters because project names leak
+  strategy). The rest stand, including "no second competing project table" and "no arbitrary model-
+  minted projects."
+- **V1 "Non-negotiable invariants":** invariant 2 is REPLACED by Part I §5.6's no-widening invariant
+  plus the oracle rule; invariant 6 gains teeth — a model cannot mint a project id *and* a model
+  suggestion can never confer visibility (only settle within it). Invariants 1, 3, 4, 5, 7, 8 stand
+  verbatim.
+- **V1 "Existing project model changes":** the `audience access_tier` column is **dropped** from the
+  proposal (replaced by `project_groups`, Part I §4). `project_kind` gains no new values; built-ins
+  from Part I §11 use kind `system`. Everything else (kind, description, aliases, lifecycle,
+  activity window, classification_mode, context_version, updated_at, conservative migration rules)
+  stands.
+- **V1 "Persistence contracts"** (`project_context_units`, `memberships`, `events`, `suggestions`,
+  `rules` + versions, `feedback`): stand in full, including the meeting-note anchoring, the
+  exactly-one-source check, the merge contract, and single writers — with one addition:
+  `project_context_memberships` writes now pass through the no-widening check (Part I §5.6) inside
+  the single writer, and every effective-membership change emits an access-relevant audit action
+  (`project_context.access_widened` when a human approves a widening tag).
+- **V1 "Context unit reconciliation"** (whole items + structured rows, meeting segments, merge):
+  stands in full as amended.
+- **V1 "Initiative profile and normalized features," "Automatic classification pipeline," "Learning
+  and editable rule proposals":** stand, with the classification_mode contract now COMPOSED with
+  no-widening: configuration-backed settlement (source associations, enabled rules) still settles in
+  `suggest` mode *only when non-widening*; a widening rule outcome queues for review even in `auto`.
+  Container default tags (Part I §3) are exactly these source-association rules, extended with
+  channel/repo/series/PM-team granularity the rule AST already carries.
+- **V1 "Read model and GUI":** stands as the tagging surfaces; composes with Part I §15 (screens
+  1–3, 6). The Context tab's project chips become access-aware: a chip for a project the viewer
+  cannot see renders as a count placeholder, never a name (see non-goal delta above).
+- **V1 "Project timeline":** stands; the timeline read joins the oracle's project set.
+- **V1 "Project-scoped retrieval":** stands, with `RetrievalScope.contextProjectSlug` now REQUIRED
+  to be within the oracle's visible set (403 semantics identical to today's team mismatch in
+  `lib/api/auth.ts:76`), and the Graphiti-expansion carve-out replaced by Part I §6 per-project
+  graphs (the V1 leak it guarded against is now structurally impossible).
+- **V1 "Source-specific behavior," "Failure handling," "Observability":** stand; observability adds
+  the per-project spend breakdown (Part I §6) and cascade-run metadata (`ingest_runs.source =
+  'graph_cascade'`).
+- **V1 "Tier safety and deletion":** superseded by Part I §5/§8/§9 EXCEPT the purge and heal
+  contracts, which stand as amended (purge covers units/memberships/suggestions/embeddings;
+  row-audience heal points; stored audience as index hint) — with `audience`'s meaning updated: it
+  is the *legacy tier* hint used during migration and for the two built-in projects, not the access
+  authority.
+- **V1 "Delivery sequence" (Phases 0–5):** REPLACED by Part I §17 (A–E). Mapping: V1 Phase 0→A,
+  1→B/D, 2→D, 3→D, 4→D, 5→C/D. Nothing from V1's sequence is lost; it is re-ordered so access
+  exists before tagging ships.
+- **V1 "Test strategy" and "Acceptance criteria":** stand, plus the Part I §14 leak suite and these
+  V2 acceptance criteria:
+  - Two principals in the seed dataset open the same brain and see different, correct content on
+    every surface (timeline, arcs, search, citations, projects list).
+  - A delegated token can never read beyond `visibleProjects(principal) ∩ scope`.
+  - The migration backfill produces byte-identical visibility to pre-migration behavior, proven by
+    the unchanged recall eval and a before/after visibility diff on the seed team.
+  - An untag cascade removes derived knowledge from the losing project's graph within one projector
+    cycle, and the permission inspector shows the revised state.
+- **V1 "Existing modules" / "Proposed modules":** stand, plus: `lib/access/oracle.ts` (visibility
+  oracle, single reader), `lib/access/groups.ts` (groups/edges single writer), extensions to
+  `lib/api/auth.ts` (principal + attenuation), `lib/graph/group.ts` (per-project group ids),
+  `lib/graph/provenance.ts` (ledger single writer), `agent_tokens` admin actions, and the Part I
+  §15 screens.
+
+### 20.2 Normative tagging-engine specification (V1 as amended, V2 edits inline)
 
 ## Why
 
@@ -66,7 +781,8 @@ An active initiative has a continuously maintained context space containing:
 6. Use deterministic metadata and existing embeddings before paying for an LLM.
 7. Keep Postgres canonical. Graphiti is an optional derived consumer, never the owner of assignments,
    rules, segments, or corrections.
-8. Preserve app-code tier isolation and source deletion guarantees on every read and write.
+8. *(Superseded in V2 — Part I §5/§9)* Enforcement is the oracle + RLS backstop; source deletion
+   guarantees stand unchanged.
 
 ## Non-goals
 
@@ -76,8 +792,9 @@ An active initiative has a continuously maintained context space containing:
 - Building a general-purpose policy language or exposing raw SQL/JSON rule editing in the UI.
 - Segmenting every source in V1. Whole-item units plus meeting topic segments are sufficient for the
   first complete product.
-- Making project context available to external-tier viewers in V1. Project taxonomy and curation are
-  team-tier metadata, matching `app/api/v1/projects/route.ts` today.
+- *(Removed in V2)* — the access chain covers every principal, external included; and project
+  EXISTENCE visibility follows `project_groups` (a principal never sees the name of a project no
+  group of theirs can see — project names leak strategy).
 - Re-embedding unchanged items or reclassifying the whole corpus on every scheduler tick.
 
 ## Terminology
@@ -95,8 +812,11 @@ An active initiative has a continuously maintained context space containing:
 ## Non-negotiable invariants
 
 1. `items.project_id` remains the ingestion owner. Context operations never mutate it.
-2. A membership never widens visibility. The source item's live `access` is authoritative; every
-   materialized unit also inherits `audience` and is healed by the existing reclassification path.
+2. *(Replaced in V2 — Part I §5.6)* Visibility is the access chain (person → group → project →
+   membership), computed only by the oracle. An automatic process may never create or settle a
+   membership that increases the set of principals who can see the content; only a human with
+   curation rights on the destination project widens. The stored unit `audience` is a legacy-tier
+   index hint (Part II §20.1), never the authority.
 3. Manual include/exclude decisions are never overwritten by an automatic run. A user must choose
    `Return to automatic` before automation can decide that pair again.
 4. Automatic runs are idempotent on content fingerprint plus project-profile, ruleset, classifier,
@@ -104,7 +824,8 @@ An active initiative has a continuously maintained context space containing:
 5. Source removal or retraction removes served segment text and effective memberships. Audit rows may
    retain ids and action metadata, never deleted source prose.
 6. A model can suggest membership only among existing active initiatives supplied in the prompt. It
-   cannot mint a project id, member id, rule, or access tier.
+   cannot mint a project id, member id, rule, or access tier — and a model suggestion can never
+   confer visibility: settlement happens strictly within the no-widening rule above.
 7. Every effective automatic assignment has an inspectable explanation and its exact rule/classifier
    version.
 8. Project-scoped retrieval returns the selected segment text for a segmented meeting, not unrelated
@@ -147,7 +868,6 @@ Extend `projects` additively in `postgres/schema.sql` and a timestamped migratio
 | `description` | Human-owned classifier and UI description, bounded text |
 | `aliases` | Normalized text array of names, abbreviations, product/system names, and issue prefixes |
 | `lifecycle` | `proposed`, `active`, `paused`, `completed`, or `archived` |
-| `audience` | `access_tier`, V1 initiative default `team` |
 | `starts_at`, `ends_at` | Optional activity window used as a classifier signal, not a hard visibility filter |
 | `classification_mode` | `off`, `suggest`, or `auto`; new initiatives start in `suggest` |
 | `context_version` | Monotonic integer bumped by the project-profile single writer whenever classifier inputs change |
@@ -462,8 +1182,11 @@ the phase plan coherent:
 - `auto`: additionally, high-confidence embedding/LLM results may settle automatically.
 
 Configuration-backed stages settle in both `suggest` and `auto` because a human explicitly authored
-the association or enabled the rule; that authority is the same kind as a manual decision, only
-forward-looking. Conflicts and medium-confidence results go to review in every mode.
+the association or enabled the rule. Conflicts and medium-confidence results go to review in every
+mode. **V2 composition (Part I §5.6):** every automatic settlement — configuration-backed included —
+additionally passes the no-widening check inside the membership writer; a widening outcome queues
+for review even in `auto`, and only a human approval commits it (audited as
+`project_context.access_widened`).
 
 Threshold calibration requires a held-out set from human feedback. Confidence displayed to users is
 method-specific and must not imply that a rule match and an LLM score are statistically equivalent.
@@ -592,9 +1315,10 @@ Keep the old ingestion scope until all callers migrate. The new context scope:
 - returns selected segment text and source offsets for meeting citations;
 - includes effective project tasks/decisions only through their context units or explicit initiative
   link, not merely their ingestion project;
-- leaves Graphiti global expansion out of context-scoped queries until graph facts can be filtered by
-  settled membership provenance. Including the current tier-only Graphiti search would leak unrelated
-  projects into a project answer.
+- *(Superseded in V2 — Part I §6)* uses the project's own graph partition for expansion; the V1
+  carve-out existed because tier-only Graphiti search would leak unrelated projects, which per-project
+  `group_id` isolation makes structurally impossible. The context scope must lie within the oracle's
+  visible set (403 otherwise, matching `lib/api/auth.ts:76` team-mismatch semantics).
 
 Proposed adapters:
 
@@ -644,9 +1368,11 @@ Its deletion contract is stricter because a thread is re-rendered source-owned c
 classification preserves the existing `retainSupersededBodies: false` behavior in
 `lib/ingest/source-rules.ts`.
 
-## Tier safety and deletion
+## Tier safety and deletion *(V2: enforcement superseded by Part I §5/§8/§9 — purge and heal
+contracts below remain normative)*
 
-There is no RLS backstop, so all new raw-SQL and query-builder reads must be visibly tier-scoped.
+V2 adds RLS as a backstop (Part I §9); until it lands, and beneath it after, all new raw-SQL and
+query-builder reads must be visibly oracle-scoped.
 
 - `project_context_units.audience` inherits `items.access` and is not user/model writable.
 - `lib/ingest/reclassify.ts` must cascade audience narrowing to ITEM-anchored context units before
@@ -708,63 +1434,6 @@ Project health UI should show unassigned rate, review backlog, correction rate b
 precision/coverage from feedback, median classification age, and classification cost per settled unit.
 The success metric is not raw auto-coverage: it is high accepted auto-coverage with a falling
 correction rate and bounded cost.
-
-## Delivery sequence
-
-### Phase 0 - project taxonomy and contracts
-
-- additive `projects` fields and conservative migration;
-- strict enums/Zod types and project profile single writer;
-- initiative/source/system filters in the existing project list;
-- architecture documentation and schema replay tests.
-
-### Phase 1 - whole-item and structured-row units, manual curation
-
-- context units, memberships, events, feedback, and single writers;
-- asynchronous reconciler for whole items AND materialized task/decision rows — both grains from day
-  one, so the item-suppression rule for materialized sources never has an interim state to migrate;
-- the duplicate-meeting merge contract for whole-item units (retract the replaced item's unit,
-  transfer memberships to the note's current item);
-- project Context tab, item membership editor, bulk actions, history, and audit;
-- source deletion and access-reclassification integration;
-- no automatic LLM classification yet.
-
-This phase proves the cardinality, UI, and authority semantics with humans before automation learns
-from them.
-
-### Phase 2 - deterministic rules and project timeline
-
-- rule AST, versions, pure evaluator, visual builder, preview, and future-only application;
-- explicit source/reference matching;
-- `project_context_suggestions` persistence (rule conflicts and deterministic outcomes need a landing
-  zone before the Phase 3 review UI exists: a Phase 2 conflict is stored `pending`, surfaced as a
-  count on the Overview tab, and held unresolved — never silently defaulted);
-- project-first timeline and overview metrics;
-- targeted cache invalidation if measurement shows it is needed.
-
-### Phase 3 - semantic and LLM suggestions
-
-- profile embeddings and segment-ready optional vector schema;
-- fingerprinted classifier queue, batched ambiguity-only model pass, and the review UI over the
-  Phase 2 suggestions table;
-- confidence calibration, usage metering, run health, and held-out evaluation;
-- high-confidence CLASSIFIER auto-settlement behind the initiative's `classification_mode='auto'`
-  after review precision qualifies; every initiative starts in `suggest` mode
-  (configuration-backed deterministic/rule settlement is mode-independent — see the
-  `classification_mode` contract in the classification pipeline section).
-
-### Phase 4 - meeting topic segments
-
-- strict segmentation parser, lineage reconciler, segment FTS/embeddings;
-- meeting Projects tab, split/merge/boundary controls, ambiguous-lineage review;
-- segment-aware timeline and retrieval citations.
-
-### Phase 5 - project-scoped retrieval and learned rule proposals
-
-- explicit context retrieval scope and query UI;
-- deterministic feedback clustering and proposed-rule workflow;
-- historical backfill jobs with preview/progress;
-- optional settled-membership projection to Graphiti only after provenance filtering is proven.
 
 ## Test strategy
 
@@ -911,45 +1580,31 @@ components/meetings/
   meeting-project-segments.tsx
 ```
 
-## Documentation and verification gates
+---
 
-Each phase updates `docs/ARCHITECTURE.md`, `docs/context-management-system.md`, schema/table/source
-drift blocks, and the affected API documentation. Any new `llm_usage` source and `ingest_runs.source`
-must be enumerated wherever those unions are closed.
+## 21. Documentation and verification gates
 
-Minimum verification for every implementation phase:
+Unchanged from V1 (typecheck, lint, unit, check:docs, check:skills, db:test:up, datamechanics,
+http, build — all verified to exist in `package.json`), plus per phase: the §14 leak-suite subset
+for that phase's paths, the §12 eval matrix, and for schema phases the replay-from-populated gate.
+Every phase updates `docs/ARCHITECTURE.md` sources-of-truth rows for the new tables and the
+`drift:tables` block, and enumerates any new `llm_usage` source / `ingest_runs.source` where those
+unions are closed.
 
-```bash
-npm run typecheck
-npm run lint
-npm test
-npm run check:docs
-npm run check:skills
-npm run db:test:up
-npm run test:datamechanics
-npm run test:http
-npm run build
-```
+## 22. Decisions carried by this revision
 
-Schema phases additionally prove fresh schema load, migration from a populated pre-feature database,
-and a second idempotent application. Retrieval phases run the existing grounding/RRF tests plus new
-cross-project and segment-isolation cases. UI phases require desktop and mobile Playwright screenshots
-for the project workspace, review queue, rule builder, and meeting segment editor, including long names,
-empty states, loading/error states, and bulk-selection layouts.
-
-## Decisions carried by this spec
-
-1. Existing `projects` stays canonical, gains an explicit kind, and separates initiatives from
-   ingestion/system containers without a second competing project table.
-2. `items.project_id` remains provenance; project context is a separate many-to-many layer.
-3. Context units are semantic assignment grains, not aliases for retrieval chunks.
-4. Postgres owns effective state and human corrections; Graphiti is derived and optional.
-5. Manual authority is reversible through `Return to automatic`, avoiding the current attribution
-   lock's documented one-way-door limitation.
-6. Rules are proposed from repeated feedback and require human activation.
-7. Classification is deterministic-first, embedding-second, ambiguity-only LLM, fingerprinted, and
-   metered.
-8. Meeting segmentation is source-grounded and lineage-aware; ambiguous edits never silently inherit
-   a human decision.
-9. Project-scoped retrieval is an explicit new scope and does not silently redefine the existing
-   ingestion-project slug filter.
+1. Partitioning and permissioning are the primitives; the access chain is four hops and stays four.
+2. The V1 tagging machinery is the mechanism that populates the access model — retained, not
+   rebuilt.
+3. Automatic tagging can never widen visibility; only humans widen.
+4. The graph is required; derived knowledge is computed per project and never across; a fact lives
+   in exactly one partition, which is what makes both cascade and enforcement tractable.
+5. Provenance is a small ledger plus revision-not-deletion semantics; incremental cascade by
+   default, rebuild as an explicit priced escape hatch.
+6. RLS is a transaction-scoped backstop beneath one application oracle — tested by deliberate
+   bypass, not assumed.
+7. Delegation is intersection, structurally incapable of expansion; v1.17 clients are untouched.
+8. Migration preserves today's visibility exactly (built-in Everyone/General), and fail-closed
+   applies to new restriction claims, not to retroactive un-sharing.
+9. Neo4j through alpha; FalkorDB decided by a priced spike at the Phase C gate.
+10. The signal layer gets seams (own access semantics for existence), not an implementation.

--- a/docs/specs/project-context-classification-v1.md
+++ b/docs/specs/project-context-classification-v1.md
@@ -20,8 +20,12 @@ dependency. Content ingested under a model that cannot express access must be re
 hand — permission models are load-bearing from the first row, which is why this document front-loads
 the schema and enforcement decisions and defers everything decorative.
 
-Process: the vision brief mandates phased delivery with stop-and-check-in gates. This document is the
-Phase 0 audit plus the full target design; the build phases at the end each end at a checkpoint.
+Process honesty: the brief mandates producing the specification itself in phases with
+stop-and-check-in gates ("do not produce the entire specification in one pass"). This round
+deliberately collapses spec-production into one artifact because the review loop (fresh cold review
+per round, findings applied, human reads each round) supplies the adversarial checkpoints the
+phasing was for — but that is a substitution, not compliance, and it is flagged rather than
+laundered. The BUILD phases (§17) retain hard stop-and-review gates.
 
 ---
 
@@ -34,7 +38,7 @@ which parts." Verified against `origin/main` (commit `1693d9e`):
 
 | Briefing claim | Verdict | Evidence |
 |---|---|---|
-| ~75 tables, 56 migrations, ~600 commits, two contributors | ✅ almost exact | 75 `create table` in `postgres/schema.sql`; **55** migrations; 610 commits; 2 human contributors + dependabot |
+| ~75 tables, 56 migrations, ~600 commits, two contributors | ✅ almost exact | 76 `create table` in `postgres/schema.sql` (75 `if not exists` + 1 plain); **55** migrations; 610 commits; 2 human contributors + dependabot |
 | ~27 `/api/v1/*` routes, brain-api v1.17 | ✅ | **26** route files under `app/api/v1/`; v1.17 in `lib/api/schemas.ts:55` |
 | API keys `aios_<key_id>_<secret>`, Bearer + `X-AIOS-Team` | ✅ | `lib/api/auth.ts:40,76` |
 | Only access model is two-tier `team`/`external`, `admin` → 422, app-code only, no RLS | ✅ | `lib/graph/group.ts:8`, `app/api/v1/items/route.ts:54-60`, CLAUDE.md §5 |
@@ -51,10 +55,13 @@ which parts." Verified against `origin/main` (commit `1693d9e`):
 
 **Corrections that change the design:**
 
-1. **`graph_episodes` already is the extraction cache the brief asks for.** It maps
-   `(team, group_id, item, content)` → episode UUID with dedupe (the dedupe-pollution alarm of
-   AIO-693 guards it). Per-project extraction reuses this table with a widened key rather than
-   inventing a cache.
+1. **`graph_episodes` already is the extraction cache the brief asks for — modulo a real rework.**
+   It maps an item to its episode UUID with content-SHA dedupe (the AIO-693 pollution alarm guards
+   it), but its unique key is `(team_id, source_table, source_id)` with a SINGLE `group_id` column,
+   and the reconcile/tier-cleanup and chunk-ledger state hanging off it (`pending_delete_group_id`,
+   `chunk_shas`) are single-group by construction. Per-project extraction is a widening of this
+   table to one row per `(item, group_id)` — a redesign of that machinery, scoped in Phase C, not a
+   key tweak.
 2. **Identity infrastructure exists and is deterministic** — `member_emails` (`schema.sql:218`),
    `member_identities` (`schema.sql:234`, provider user-ids for slack/linear/plane), and
    `members.github_login`, consumed by `lib/attribution/resolve-authors.ts` and
@@ -85,7 +92,7 @@ flip, stated once so no one discovers them mid-build:
 | Non-goal: "Making project context available to external-tier viewers… project taxonomy is team-tier metadata" | Projects/groups ARE the access model for every principal, external included. The `external` tier becomes a built-in group with visibility into designated projects | One access model, not two |
 | `projects.audience access_tier` column (V1 §model changes) | **Dropped.** Project visibility is the `project_groups` join, not a scalar | A scalar can't express 1+ groups |
 | Graphiti "optional derived consumer, never the owner" | Graph **required**; still never the owner of assignments/rules — but per-project graphs are the enforcement mechanism for derived knowledge | An optional graph means two permission implementations, and the second is the one nobody tests |
-| Tier safety via `visibleItems`/tier checks per surface | One visibility oracle (§5.4) + Postgres RLS as backstop (§9) | Agents are now in the loop; app-layer-only was the accepted risk being retired |
+| Tier safety via `visibleItems`/tier checks per surface | One visibility oracle (§5.1) + Postgres RLS as backstop (§9) | Agents are now in the loop; app-layer-only was the accepted risk being retired |
 | Auto-classification gated by `classification_mode` for *quality* | Additionally gated by the **no-widening invariant** (§5.6): an automatic tag may never increase the set of principals who can see content | An LLM mis-tag was noise in V1; in V2 it is a leak |
 
 **What survives from V1 intact** (Part II): context units and their merge contract, meeting topic
@@ -181,12 +188,16 @@ access-bearing. `context_unit_id` remains the grain (whole item, task/decision r
 segment), which is what lets a Slack channel be visible to Everyone while one thread in it is
 force-excluded into a restricted project only.
 
+Built-in maintenance: `lib/access/groups.ts` (the groups single writer) keeps Everyone's membership
+equal to active members — hooked on member activation/deactivation, never edited by hand; built-in
+rows are undeletable and their group membership is the only editable thing about them.
+
 Identity hardening (§8) adds columns to `member_identities` / `member_emails` rather than new
 tables: `verified_by uuid`, `verified_at`, `confidence text check (confidence in
 ('deterministic','confirmed','suggested'))`, `evidence jsonb`. Delegation adds `agent_tokens` (§10).
 Signal seams add `intent_records` (§13, design-only).
 
-**Effective visibility is a pure function**, computed in one place (§5.4):
+**Effective visibility is a pure function**, computed in one place (§5.1):
 
 ```
 visibleProjects(principal) =
@@ -223,8 +234,13 @@ recall badly when the filter is selective — and one project inside a company c
 selective filter. Options, priced:
 
 1. **Iterative index scans** (`hnsw.iterative_scan = relaxed_order`, pgvector ≥ 0.8.0): the index
-   keeps scanning until enough rows pass the WHERE clause. Preferred mechanism. **Unverified
-   assumption to close before build:** the deployed pgvector version on Railway and in
+   keeps scanning until enough rows pass the WHERE clause. Preferred mechanism. Cost profile:
+   recall is preserved (the scan continues rather than truncating); latency grows roughly with
+   1/selectivity and is bounded by `hnsw.max_scan_tuples` (default 20k) — worst case is a ~20k-tuple
+   walk, tens of ms on this corpus, hit only when a very selective project filter meets a large
+   index. `strict_order` trades a stricter ordering for more work; `relaxed_order` + RRF downstream
+   is the right pairing since RRF re-ranks anyway. Measured at the Phase B gate on the seed corpus.
+   **Unverified assumption to close before build:** the deployed pgvector version on Railway and in
    `pgvector/pgvector:pg16` (tag floats). Gate: `pg:schema:vector` fails loudly below 0.8.0.
 2. **Over-fetch + filter fallback** (works on any version): fetch `k × max(4, 40/selectivity%)`
    candidates, filter by membership, degrade to FTS-only for that partition if starved — never an
@@ -239,7 +255,7 @@ memberships instead — same join point, different edge.
 ### 5.4–5.5 Graph: structural isolation + the bolt exception list
 
 Per-project graphs (§6) make traversal isolation structural — a query fanning out inside
-`group_id = team_<teamId>_p_<projectId>` cannot reach another project's subgraph, which is the
+`group_id = g_<teamId>_p_<projectId>` cannot reach another project's subgraph, which is the
 answer to "filtering a path is not filtering a result set." **The residual risk is the app's direct
 bolt reads** (`lib/graph/neo4j.ts` consumers: arcs fact reads in `lib/graph/arcs.ts`/`learning.ts`,
 reconcile, health probes). Ruling: every bolt query must take `group_ids` from the oracle as a
@@ -255,8 +271,9 @@ membership only when doing so does not increase the set of principals who can se
 Formally: auto-tag of unit u into project p is allowed iff `audience(p) ⊆ audience_now(u)` where
 `audience(p)` = union of members of p's groups. Any widening tag — including container-default
 inheritance into a broader project — enters the review queue and requires a human with curation
-rights over the destination project. This subsumes V1's quality gating (`classification_mode`,
-Part II) and is enforced in the membership single writer, not in each classifier.
+rights over the destination project. This COMPOSES with V1's quality gating (`classification_mode`, Part II §20.2) — the mode gate
+remains fully normative for classifier-originated settlement — and is enforced in the membership
+single writer, not in each classifier.
 
 ### 5.7 Citations, abstention, counts
 
@@ -280,6 +297,41 @@ combinations, not by principal count — 2 people with identical groups share a 
 inspector (§15.6) is the runtime check that a cached surface never leaked: it recomputes the access
 path live.
 
+### 5.9 Query fan-out for multi-project principals (hard problem 4)
+
+Partitions are the storage and security unit; **fan-out is the query unit** — validated, with one
+correction to the brief's framing: two of the three modalities never fan out at all.
+
+- **FTS and dense are single queries, O(1) in project count.** Both are one SQL statement whose
+  membership join takes the oracle's whole visible set as an array parameter (§5.2–5.3) — a
+  40-project principal costs the same query shape as a 2-project one; only row selectivity changes.
+  No fan-out, no fusion, no cap needed. This is worth stating because it confines the hard problem
+  to the graph modality alone.
+- **Graph search fans out inside one call.** `POST /search` already accepts a `group_ids` array
+  (`lib/graph/graphiti-client.ts:174` — `search(query, groupIds, maxFacts)`), so N partitions are
+  one HTTP round-trip; Graphiti's hybrid search cost scales with candidate facts across the named
+  groups, not with N itself. The expansion stage (graph terms driving a second FTS pass) then feeds
+  the existing RRF fusion in `lib/query/retrieve.ts` unchanged — partition provenance rides the fact,
+  and fused ranking is exactly what RRF is for.
+- **Arcs/Pulse fuse at read time:** per-partition arc sets (each bounded by `MAX_ARCS`) merge by
+  rank with a per-partition cap of 3 on the Pulse surface; the project workspace shows its own
+  partition uncapped.
+
+**The cap, and the 40-project principal.** Unbounded graph expansion over 40 partitions is the case
+that breaks latency AND answer focus. Ruling: an **expansion budget** — the graph stage covers the
+top-K visible partitions (K = 8 default, configuration not constant), selected by a cheap router:
+initiative-profile-embedding similarity to the query (the Part II profile embeddings, reused) plus a
+recency prior, with General always included. FTS/dense remain complete over the full visible set, so
+**correctness never depends on the router** — beyond-cap partitions lose only graph-flavored recall,
+and the answer footer discloses scope ("graph expansion covered 8 of your 37 projects") — a
+deliberate exception to §5.7's non-disclosure because it describes the principal's OWN scope, not
+others' content.
+
+**Latency model:** `T ≈ T_fts + T_dense + T_graph(K) + T_rerank`, with `T_graph(K)` the only term
+that grows — sublinearly, since one call spans K groups and fact candidates are budget-capped
+(`maxFacts`). Ceiling: p95 end-to-end ≤ 2× today's single-scope query, measured on the seed dataset
+at K ∈ {1, 8, 16} as a Phase C gate; the K default moves only on that evidence.
+
 ## 6. Per-project graphs and the extraction cost model
 
 ### group_id scheme
@@ -300,8 +352,18 @@ Re-tagging into a project that already saw this content SHA is a cache hit: zero
 
 Post-0.29.3 measured baseline (ARCHITECTURE:768+, `llm_usage source=graph`): extraction is batched,
 node-attribute amplification is gone, small-call routing sends `node_attributes`/`dedupe_edges` to
-`teams.extraction_small_model`. Let E = episodes/day (~50–150 on the live team), P̄ = mean projects
-per item. Naive cost multiplier = P̄. Mitigations, in force order:
+`teams.extraction_small_model`. **Measured on prod, trailing 7 days (2026-08-07):** 59,087 graph LLM
+calls over 583 newly projected episodes — **$87.97/week, $0.151 and ~101 calls per episode** at
+~448k input tokens/episode. Caveat stated rather than smoothed: this window includes the AIO-798
+priced repo-import backfill and the denominator is `projected_at`-based, so the steady-state
+per-episode constant is likely lower; the Phase C gate re-reads it from `llm_usage` over a quiet
+window before any multiplier decision. Worked example at the measured rate: E ≈ 83/day →
+**≈ $380/month at P̄ = 1**; every +1.0 of P̄ adds the same again. That is what makes rules 1–3 of the
+General ruling above worth real money: restriction-moves-not-copies and no-widening are the
+mechanisms that hold P̄ near 1.
+
+Let E = episodes/day, P̄ = mean partitions per item (General counts). Naive cost multiplier = P̄.
+Mitigations, in force order:
 
 1. **Content-hash cache** (above): re-tags and re-syncs of unchanged content are free.
 2. **Laziness for cold projects:** extraction into a project graph is deferred until the project has
@@ -316,12 +378,27 @@ per item. Naive cost multiplier = P̄. Mitigations, in force order:
    — the dashboard's graph row gains a per-project breakdown. Budget ceiling: the existing graph
    proxy ceiling applies per team; a per-project soft cap is configuration.
 
-**General-project ruling:** the General partition (everything, Everyone-visible) is the one graph
-that would double all extraction if naively separate. Ruling: General IS the migration target graph
-(the current single team graph, renamed), and content tagged into a specific project is extracted
-*additionally* into that project's graph. Cross-project synthesis is never computed (the
-permission-laundering answer); General-partition synthesis is computed over General-visible content
-only — which is exactly today's behavior, so the eval baseline survives.
+**General-project ruling — what General is, and when content leaves it.** General is **the content
+Everyone may see**, not "everything":
+
+1. **New content defaults** to General plus whatever container rules assign — the default-mode rule
+   that preserves today's promise. A container rule may be marked **`exclusive`**, which suppresses
+   the General default: that is the restricted-Slack-channel flow, and it is how restricted content
+   is restricted *from ingest onward*, never retroactively.
+2. **Restricting existing content MOVES it out of General** (close the General membership, open the
+   restricted one — the V1 move semantics). Restriction never copies, so restricted content is
+   extracted once, in its restricted partition only, and can never sit in an Everyone-visible graph.
+   The seed dataset's `supplier-negotiation` content is NOT in General — that is the leak-by-
+   construction this rule exists to prevent.
+3. **Deliberate wide+specific tagging** (content in General AND project P) is allowed, costs 2×
+   extraction for that item, and is counted honestly in P̄ — it is the only source of multiplication,
+   and the no-widening invariant keeps automation from creating it.
+4. **Migration:** General's graph is today's team graph (nothing re-extracted); the eval baseline
+   survives migration byte-for-byte. It then *drifts by design* as teams restrict content out of
+   General — which is exactly what §12's restricted-principal eval axis exists to keep honest.
+
+Cross-project synthesis is never computed (the permission-laundering answer); each partition's
+synthesis reads only its own content.
 
 ## 7. FalkorDB vs Neo4j — recommendation
 
@@ -363,7 +440,11 @@ Required changes:
    display at most, never access.
 3. **Identity is never inferred from content.** A name in a message body is not an identity claim —
    invariant + guard test asserting no access-path code imports content-derived attribution.
-4. **Unbinding cascades** are read-time: access is recomputed per request from live bindings via the
+4. **Scope honesty:** today NO access path consumes identity bindings — principals authenticate as
+   members via keys/tokens, and bindings feed attribution only. The fail-closed rule above pre-arms
+   the first surface that will consume them (a Slack-initiated agent claiming "asking as @chetan"):
+   that claim resolves through `deterministic`/`confirmed` bindings or not at all.
+5. **Unbinding cascades** are read-time: access is recomputed per request from live bindings via the
    oracle, so revoking a binding takes effect on the next request with no cache to chase (caches key
    on group-set, which changes when membership does — §5.8).
 
@@ -391,6 +472,13 @@ Design (defence-in-depth under the oracle, not a replacement):
   *wrongly* (no principal context / forged member id) and asserts the database returns zero rows —
   i.e. RLS catches an application bug by construction (§14).
 
+- **Writes are covered, not just reads** — the brief's original accepted risk was specifically that
+  *machine sync writes* had no DB backstop. An API-key write runs with the principal context of the
+  key's member (`lib/api/auth.ts` already resolves it); INSERT/UPDATE policies on content tables
+  require `team_id = current_setting('aios.team_id')::uuid` and a non-null principal, so a forged or
+  cross-team write dies in the database even if a route bug lets it past the app layer. Single-writer
+  modules are unaffected — they run as the same app role with principal context set.
+
 Perf note (honest): membership-join policies on every row-read add a join per table; the phase gate
 includes a before/after latency measurement on the three hottest reads (timeline, retrieve, items
 list) with a stated budget (+15% p95 ceiling) before RLS graduates from staging to default.
@@ -398,6 +486,10 @@ list) with a stated budget (+15% p95 ceiling) before RLS graduates from staging 
 ## 10. Principals, delegation, and the QM slice
 
 - **Principal model:** `member` (today's API key → member binding, unchanged) or `agent_token`.
+  Wire format: `aiosd_<token_id>_<secret>` — a distinct prefix so no parser can confuse a delegated
+  token with a member key (`aios_…`, `lib/api/auth.ts:40`); same hashed-secret storage discipline as
+  `api_keys`. An old server rejects the unknown prefix with today's 401 — additive compatibility
+  needs no version negotiation.
   New table `agent_tokens`: `id, team_id, member_id (the launching principal), on_behalf_of
   (member_id, nullable = self), project_scope uuid[] (attenuation set), expires_at, revoked_at,
   created_by, last_used_at`, hashed secret, audited on mint/use/revoke.
@@ -440,9 +532,12 @@ Ruling and its direction, argued:
    un-sharing what teams already shared. A team that wants restriction-by-default flips a team
    setting: new content with no container rule then lands in a `triage` project visible to admins
    only.
-4. **Graph:** the existing `<teamSlug>_team` graph is renamed/aliased as General's graph (no
-   re-extraction); `_external` becomes external-shared's. New per-project graphs build lazily (§6).
-   Nothing is re-extracted during migration — cost ≈ 0.
+4. **Graph:** Graphiti has no rename operation, so nothing is renamed: `projects` gains a
+   `graph_group_id` column, and General records the legacy `<teamSlug>_team` id while
+   external-shared records `<teamSlug>_external` — the existing graphs become those projects'
+   partitions by pointer, not by rewrite. New projects mint `g_<teamId>_p_<projectId>` ids; the
+   scheme therefore has exactly two grandfathered exceptions per team, stored not inferred. Nothing
+   is re-extracted during migration — cost ≈ 0.
 5. **Ordering:** three additive migrations (groups/edges, identity columns, agent_tokens) appended
    after the current 55, plus the backfill job; replay-tested from zero AND from a populated
    pre-V2 database per the schema-phase gates (the #251/#495 replay lessons are the reason this is
@@ -488,7 +583,7 @@ through the *outcome*, not the code path:
 | Arcs / timeline / caches | datamechanics | B-only evidence never appears in A's arc evidence or timeline payloads; cache keyed per §5.8 |
 | Re-tag cascade | datamechanics | untag from B → B's graph facts revised (§Part II cascade), B-principal loses retrieval of the derived fact |
 | Delegation | http | token with `project_scope=[B]` for an A-only principal reads nothing (intersection), and cannot mint wider |
-| Unresolved identity | datamechanics | `suggested` binding grants no project; oracle returns builtin-Everyone only if the member row itself is confirmed |
+| Unresolved identity | datamechanics | a `suggested` binding contributes nothing to principal resolution — a connector-actor claim backed only by suggested evidence resolves to NO principal (fail closed), never to the suggested member |
 | RLS backstop | datamechanics | deliberate data-layer misuse (no principal context) returns zero rows — the app-bypass test |
 | MCP / agent context | http | tool responses for an attenuated token contain no out-of-scope item ids |
 
@@ -545,15 +640,20 @@ Each phase ends at a **stop-and-review checkpoint** (spec round, then build). Sh
 precisely so the access chain exists before anything depends on it:
 
 - **A — Principals & access skeleton** *(unblocks QM)*: groups/edges DDL + built-ins, oracle,
-  `agent_tokens` + attenuation in auth, migration §11 (backfill + built-ins), identity columns +
-  fail-closed rule. Alpha restriction: delegated tokens read-only, single team. Eval: unchanged
-  baseline must pass post-backfill.
+  `agent_tokens` + attenuation in auth, identity columns + fail-closed rule — **plus the minimal
+  context substrate the migration requires**: the `project_context_units` and
+  `project_context_memberships` tables (Part II contracts) with an item-grain-only reconciler and
+  the membership single writer. No classifier, no segments, no curation UI — just enough for §11's
+  backfill to have something to write and the oracle's `canSee` to have something to read. Stated
+  here because a Phase A that pretends it doesn't need this discovers it in week one. Then the §11
+  migration (backfill + built-ins). Alpha restriction: delegated tokens read-only, single team.
+  Eval: unchanged baseline must pass post-backfill.
 - **B — Enforced reads**: FTS/dense/timeline/arcs through the oracle; citation/abstention rules;
   RLS on content tables + the backstop test; permission inspector + admin screens 1–2; leak suite
   paths 1–2, 4–6, 9–10.
 - **C — Per-project graphs**: group_id scheme, projector fan-out + cache, per-project arcs, bolt
   guard, cost surfacing; FalkorDB spike = exit gate; leak suite graph paths; eval principal axis.
-- **D — Tagging at scale** (Part II engine under V2 invariants): container defaults, review queue,
+- **D — Tagging at scale** (Part II engine on the Phase A substrate): container defaults, review queue,
   rules UI, cascade + provenance ledger + cascade preview; view-as; seed dataset; remaining screens.
 - **E — Signal layer** (deferred; seams already in place).
 
@@ -620,9 +720,30 @@ create index if not exists graph_provenance_item_idx on graph_provenance (team_i
   where removed_at is null;
 ```
 
-Sole writer: the graph projector (`lib/graph/project.ts` extended), which learns each fact's source
-episodes from the extraction round-trip it already performs. Arcs need no new rows — their evidence
-IS the ledger.
+Sole writer: the graph projector (`lib/graph/project.ts` extended). **How rows are produced — the
+mechanism, not a hand-wave:** `POST /messages` is async fire-and-forget (202, returns neither uuid
+nor name — `lib/graph/graphiti-client.ts:7-11`), so there is NO extraction round-trip to read facts
+from. The ledger is populated by a **post-extraction harvest** in the projector's reconcile leg:
+
+1. Resolve our stable episode names (`items:<id>`) to Graphiti uuids via `GET /episodes/{group}` —
+   the client already does exactly this for the same fire-and-forget reason (client doc, same file).
+2. Per group, a bolt query walks edges/facts referencing episodes newer than a per-group harvest
+   cursor (`MATCH (f)-[:MENTIONS|…]->(e:Episodic) WHERE …`) and upserts `graph_provenance` rows.
+3. The cursor advances only on a complete sweep, so the ledger is **eventually complete with lag ≤
+   one projector cadence (60 min)** — a stated property, not an accident.
+
+**Cascade under lag:** an untag does episode-level removal immediately (`DELETE /episode/{uuid}` —
+the client's existing tier-cleanup endpoint), which stops the removed source being served regardless
+of ledger state; fact-level revision (steps 2–3 below) runs on harvested provenance and is completed
+by the next sweep. So the security property (removed content stops serving) never waits on the
+ledger; only the fidelity property (recompute-from-remainder) does.
+
+**Option B, considered and deferred:** we control the graph-service image (`graphiti/Dockerfile`),
+so `/messages` could be extended to return extraction results synchronously. Rejected for now — it
+forks the upstream API surface and couples ingest latency to extraction latency; the harvest gets
+the same data with one moving part we already run. Revisit only if harvest lag proves harmful.
+
+Arcs need no new rows — their evidence IS the ledger.
 
 ### Revision semantics
 
@@ -779,8 +900,9 @@ An active initiative has a continuously maintained context space containing:
 5. Learn from corrections by proposing editable rules, never by silently turning one correction into
    an active rule.
 6. Use deterministic metadata and existing embeddings before paying for an LLM.
-7. Keep Postgres canonical. Graphiti is an optional derived consumer, never the owner of assignments,
-   rules, segments, or corrections.
+7. *(Amended in V2 — Part I §2 flip 4)* Keep Postgres canonical. Graphiti is a REQUIRED derived
+   consumer — still never the owner of assignments, rules, segments, or corrections — and its
+   per-project partitions are the enforcement mechanism for derived knowledge.
 8. *(Superseded in V2 — Part I §5/§9)* Enforcement is the oracle + RLS backstop; source deletion
    guarantees stand unchanged.
 
@@ -849,7 +971,7 @@ flowchart LR
   Q --> R
   L --> T["Project timeline and context UI"]
   L --> C["Project-scoped retrieval"]
-  L -. "optional derived facts" .-> G["Graphiti"]
+  L -- "derived facts (required, per-project partitions)" --> G["Graphiti"]
 ```
 
 The write path is asynchronous. `lib/ingest/index.ts` remains responsible only for canonical item
@@ -1278,8 +1400,9 @@ The module reuses:
 - `lib/attribution/contributor-credit.ts` as the single attribution oracle for whole items;
 - `task_evidence` for task grouping/link explanation;
 - existing source URLs and item detail routes;
-- `lib/auth/visibility.ts` tier rules even though V1 project context is team-only, so the read remains
-  fail-closed if audience support expands later.
+- *(Amended in V2)* the access oracle (Part I §5.1) — the timeline read joins the principal's
+  visible-project set; `lib/auth/visibility.ts` tier rules remain only as the legacy-tier index-hint
+  layer beneath it.
 
 Meeting segments are context signals, not duplicated work credit for every attendee. They appear once
 at meeting time with attendees and submitters as metadata. Whole items retain the existing work/signal
@@ -1390,13 +1513,16 @@ query-builder reads must be visibly oracle-scoped.
   from the live canonical source (`items.access`, `tasks.audience`, `decisions.audience`), exactly as
   invariant 2 requires — so a missed heal can cost filter freshness, never a leak. A guard test pins
   that no project-context read trusts stored unit audience without the live-source join.
-- Effective membership is metadata, not a visibility grant. Reads join the live item and apply
-  `visibleItems`/`isRestrictedTier` semantics.
+- *(Inverted in V2 — Part I §2 flip 1)* Effective membership IS the visibility path, computed only
+  by the oracle (Part I §5.1); reads join the oracle's project set. The live item's legacy `access`
+  tier remains a migration input and index hint, never the authority.
 - `lib/ingest/purge.ts` must include context units, suggestions, memberships, and embeddings in its
   source-removal contract. Foreign-key cascades should perform deletion; the purge tests prove no
   served context remains.
 - Retracted segment content is cleared before any background classifier can read it again.
-- Project descriptions, aliases, rules, feedback, and review queues are team-tier only in V1.
+- *(Amended in V2)* Project descriptions, aliases, rules, feedback, and review queues are visible
+  exactly to principals with visibility on the project (`project_groups`) — and a principal never
+  sees the existence or name of a project no group of theirs can see.
 - Add guard tests ensuring every project-context dashboard read uses the visibility/domain read
   module and every table has one sanctioned writer.
 

--- a/docs/specs/project-context-classification-v1.md
+++ b/docs/specs/project-context-classification-v1.md
@@ -38,7 +38,7 @@ which parts." Verified against `origin/main` (commit `1693d9e`):
 
 | Briefing claim | Verdict | Evidence |
 |---|---|---|
-| ~75 tables, 56 migrations, ~600 commits, two contributors | ✅ almost exact | 76 `create table` in `postgres/schema.sql` (75 `if not exists` + 1 plain); **55** migrations; 610 commits; 2 human contributors + dependabot |
+| ~75 tables, 56 migrations, ~600 commits, two contributors | ✅ almost exact | 75 `create table if not exists` in `postgres/schema.sql` (a naive `create table` grep counts 76 — the extra hit is the comment at `schema.sql:13`); **55** migrations; 610 commits; 2 human contributors + dependabot |
 | ~27 `/api/v1/*` routes, brain-api v1.17 | ✅ | **26** route files under `app/api/v1/`; v1.17 in `lib/api/schemas.ts:55` |
 | API keys `aios_<key_id>_<secret>`, Bearer + `X-AIOS-Team` | ✅ | `lib/api/auth.ts:40,76` |
 | Only access model is two-tier `team`/`external`, `admin` → 422, app-code only, no RLS | ✅ | `lib/graph/group.ts:8`, `app/api/v1/items/route.ts:54-60`, CLAUDE.md §5 |
@@ -321,7 +321,9 @@ correction to the brief's framing: two of the three modalities never fan out at 
 that breaks latency AND answer focus. Ruling: an **expansion budget** — the graph stage covers the
 top-K visible partitions (K = 8 default, configuration not constant), selected by a cheap router:
 initiative-profile-embedding similarity to the query (the Part II profile embeddings, reused) plus a
-recency prior, with General always included. FTS/dense remain complete over the full visible set, so
+recency prior, with General always included. Phase dependency stated: profile embeddings are a
+Phase D artifact while fan-out ships in Phase C — the router runs recency-only until profiles
+exist, which is safe precisely because correctness never depends on the router (below). FTS/dense remain complete over the full visible set, so
 **correctness never depends on the router** — beyond-cap partitions lose only graph-flavored recall,
 and the answer footer discloses scope ("graph expansion covered 8 of your 37 projects") — a
 deliberate exception to §5.7's non-disclosure because it describes the principal's OWN scope, not
@@ -390,9 +392,16 @@ Everyone may see**, not "everything":
    extracted once, in its restricted partition only, and can never sit in an Everyone-visible graph.
    The seed dataset's `supplier-negotiation` content is NOT in General — that is the leak-by-
    construction this rule exists to prevent.
-3. **Deliberate wide+specific tagging** (content in General AND project P) is allowed, costs 2×
-   extraction for that item, and is counted honestly in P̄ — it is the only source of multiplication,
-   and the no-widening invariant keeps automation from creating it.
+3. **Wide+specific tagging** (content in General AND project P) costs 2× extraction for that item
+   and is counted honestly in P̄. Be precise about who creates it: auto-tagging Everyone-visible
+   content into a NARROWER initiative is non-widening, therefore permitted — it is the tagging
+   engine's core use case — so automation legitimately produces General+P dual membership. The
+   no-widening invariant prevents the opposite direction only (restricted → wider). **Expected
+   steady state, stated rather than implied:** P̄ ≈ 1 + (share of content classified into an
+   initiative) — approaching ~2 (≈ $760/month at the measured rate) if the whole corpus classifies.
+   The levers that hold real spend below that ceiling: `exclusive` container rules (restricted
+   content is extracted once, not twice), cold-project laziness (§6 mitigation 2 — an initiative
+   nobody reads never extracts), and the small-model routing already in force.
 4. **Migration:** General's graph is today's team graph (nothing re-extracted); the eval baseline
    survives migration byte-for-byte. It then *drifts by design* as teams restrict content out of
    General — which is exactly what §12's restricted-principal eval axis exists to keep honest.
@@ -477,7 +486,11 @@ Design (defence-in-depth under the oracle, not a replacement):
   key's member (`lib/api/auth.ts` already resolves it); INSERT/UPDATE policies on content tables
   require `team_id = current_setting('aios.team_id')::uuid` and a non-null principal, so a forged or
   cross-team write dies in the database even if a route bug lets it past the app layer. Single-writer
-  modules are unaffected — they run as the same app role with principal context set.
+  modules are unaffected — they run as the same app role with principal context set. Scheduler and
+  background runs have no member: they set a per-team SYSTEM principal
+  (`set_config('aios.member_id', 'system', …)` with `aios.team_id` real), which write policies accept
+  and read policies treat as full-team — the non-null-principal rule therefore never blocks a tick,
+  and a background job that forgets to set context still fails closed.
 
 Perf note (honest): membership-join policies on every row-read add a join per table; the phase gate
 includes a before/after latency measurement on the three hottest reads (timeline, retrieve, items

--- a/docs/specs/project-context-classification-v1.md
+++ b/docs/specs/project-context-classification-v1.md
@@ -595,6 +595,12 @@ empty-page shapes, citation numbering gaps) — the places post-filtering leaks.
 Eight screens; each states the invariant it makes visible. All reuse the admin surface conventions
 under `app/t/[team]/admin/*` and the guard that pages read through the oracle.
 
+> **Stated gap for round 2:** the brief demands "information architecture, states, empty and error
+> states" per screen. This round delivers the screen list, each screen's invariant, and the seed
+> dataset; the full IA/state specification is a dedicated round-2 pass over all eight screens at
+> once (they share state machinery — loading/empty/error/permission-denied — that should be specified
+> once, not eight times). Flagged rather than silently thinned.
+
 1. **People, groups & projects admin** — CRUD + membership matrices. *Invariant visible:* the whole
    access model on one screen; if a human can't read it, it isn't trustworthy.
 2. **Identity manager** — bindings with confidence, evidence, audit trail, confirm/unbind. Designed


### PR DESCRIPTION
**Draft — spec review rounds. Round 1 COMPLETE at `8605982`. No implementation.**

Full V2 revision of `docs/specs/project-context-classification-v1.md` (1,755 lines) per the context-engine re-architecture brief: the access chain (person → group → project → content), one visibility oracle + RLS backstop (transaction-local `set_config`, write policies, system principal for background runs), per-project graphs with a harvest-based provenance ledger and revision-not-deletion cascade, query fan-out confined to the graph modality with a K-budget router, structural delegation attenuation (`aiosd_` tokens, intersection semantics), a visibility-preserving migration (General = what Everyone may see; `exclusive` container rules restrict from ingest; restriction moves, never copies), measured cost model ($0.151/episode prod; steady-state P̄ ceiling stated at ≈$760/mo with its levers), the principal axis on the recall eval, the adversarial leak suite, eight GUI verification screens (IA/states flagged for a dedicated round-2 pass), and two-engineer phasing with the QM slice first.

Part II retains V1's classification machinery as the tagging engine — spliced in full, every V2 delta inline and ledgered in §20.1.

**Round 1 review:** fresh cold Fable session, adversarial, against the brief's own bad-spec criteria. Verdict after fixes: 11 hard problems — 9 solved, 2 partial→resolved in-round; 19 findings + 4 verification follow-ups all closed, including one Critical (fan-out section was missing) and one false code claim of mine (the provenance "round-trip" — `/messages` is fire-and-forget; replaced with the harvest design).

Round 2 candidates: dedicated GUI IA/states pass; open questions §18 (pgvector version, Graphiti removal semantics probe, FalkorDB spike criteria).

## Review — Reviewed by code-reviewer (fable), fresh cold session + verification round — verdict resolved substantively, ready for round-2 human review: 11 hard problems covered (9 solved, 2 partial resolved in-round), 19 findings + 4 verification follow-ups closed incl. 1 Critical (missing fan-out section) and 2 false claims of the author's own; Codex CLI review running post-merge for round 2
