### PR TITLE
docs(design): decline the small-item packing lever on evidence (PIPEFF-4/AIO-845)

### DIFF
--- a/docs/design/graph-episode-packing.md
+++ b/docs/design/graph-episode-packing.md
@@ -89,10 +89,26 @@ multi-chunk episodes that *do* carry a predecessor block. Commit episodes sit fa
 507 eliminated commit episodes at the fleet average — which §1 of the original draft did — **credits
 this lever with a saving PIPEFF-2 already banked yesterday.**
 
-I have **not** measured the marginal cost of a commit episode. It is measurable (a drain-clean,
-commits-only window through `scripts/graph-ingest-cost.mjs`) and it has not been done. What is
-certain is the direction and that it is large: the honest ceiling is well under the $5.60/month the
-first draft claimed.
+I have **not** measured the marginal cost of a commit episode, and this section's central claim is
+therefore an **inference** — from the zero-predecessor rule plus a ~50-token body — not a
+measurement. It is labelled as one deliberately, because it is the load-bearing fact of the decline.
+
+**I tried to measure it and it is not obtainable from existing data.** Querying every projection hour
+since the PIPEFF-2 deploy (2026-08-07 07:08:24Z) for an hour whose episodes were *all* commits
+returns **nothing** — post-deploy volume is 24 episodes across 6 hours, every one of them mixed:
+
+```
+07:00 → 3 eps (1 commit)   08:00 → 7 (2)   09:00 → 7 (0)
+10:00 → 1 (0)              16:00 → 3 (1)   00:00 → 3 (1)
+```
+
+So the number needs a **deliberately constructed** commits-only drain-clean window, not a lucky one.
+That is cheap and it has not been done. Until it exists, treat every figure in this section as a
+ceiling.
+
+What is not in doubt is the *direction*: a commit episode carries zero predecessors and ~50 tokens of
+content, while the $0.0110 fleet average is dominated by multi-chunk episodes that do carry a
+predecessor block. The honest ceiling is well under the $5.60/month the first draft claimed.
 
 ### And accretion halves the episode count too
 

--- a/docs/design/graph-episode-packing.md
+++ b/docs/design/graph-episode-packing.md
@@ -1,317 +1,271 @@
 # Packing small items into shared graph episodes — PIPEFF-4 / AIO-845
 
-**Status:** spec, pre-review. No code written.
+**Status: DECLINED, on evidence, after plan review. Not built.**
+This document is the record of why, and of what would have to change for the answer to flip.
+
 **Parent:** `docs/design/graph-ingestion-efficiency.md` §3 ("lever 3 — deepest blast radius, built last").
-**Siblings shipped:** PIPEFF-2 (predecessor filter, −25.5% measured) · PIPEFF-3 (content-defined chunking).
+**Siblings shipped:** PIPEFF-2 (predecessor filter, −25.5% verified in prod) · PIPEFF-3 (content-defined chunking).
 
 ---
 
-## 0. The finding that should decide this before anything else
+## 0. The verdict, and the two things that produced it
 
-The parent spec proposed this lever from a count: *"898 items under 600 characters each occupy their
-own episode at full fixed-overhead price."* I measured the actual payload before designing against
-it, and two numbers arrived that the parent never had.
+I specified this lever in full, then Fable plan-reviewed it. The review returned **BLOCKED**, and the
+decisive findings were not defects in the design — they were **two facts about the payload that make
+the lever much smaller than the parent spec assumed, and one that makes it more dangerous.**
 
-**Measured on prod, 2026-08-08, items synced in the last 30 days:**
+1. **The saving is a fraction of what §1 first priced**, because PIPEFF-2 — which we shipped
+   *yesterday* — already made these exact episodes the cheapest in the fleet.
+2. **The design as I wrote it specified an indefinite tier leak**, and the fix for it erodes the
+   saving further.
 
-| source | items | est. episodes | of which are small (<600 chars) |
+Both are below, measured. The lever is declined in favour of `use_combined_extraction`, with that
+alternative re-costed honestly rather than inherited from the parent spec's optimistic note.
+
+---
+
+## 1. What the payload actually is (measured, prod, 2026-08-08)
+
+Items synced in the last 30 days, estimated episodes:
+
+| source | items | est. episodes | of which small (<600 chars) |
 |---|---|---|---|
 | `github/` | 674 | 2,298 | 50 |
 | `linear/` | 593 | 975 | 109 |
 | `2-work/` | 148 | 778 | 4 |
 | **`commits/`** | **570** | **570** | **570 — 100%** |
 | everything else | ~130 | ~550 | ~50 |
-| **total** | | **~5,170** | |
+| **total** | | **~5,170** (ledger: 5,068) | |
 
-**The lever is a commits lever.** 570 of ~5,170 episodes — **11.0%** — are commit items, every one of
-them under 600 chars, averaging **197 characters**, each paying the same ~30,000-token extraction
-overhead as a full 2,500-char chunk. Nothing else in the corpus has this shape: the other sources'
-small items are a rounding error against their own episode counts.
+**The lever is a commits lever.** 570 of ~5,170 episodes — 11.0% — are commit items, every one under
+600 chars, averaging **198**. Nothing else in the corpus has this shape.
 
-They also pack cleanly. Small commit artifacts concentrate on **two humans** (John Ellison 338,
-Chetan Nandakumar 314) across ~37 active days each, so a same-author same-day pack averages **~9
-commits**. Packing commits alone: 570 → ~63 episodes, **a ~9.8% cut in total episodes.**
+**Author distribution, corrected.** My first pass reported John 338 / Chetan 314 — from *git-author
+frontmatter*. Those sum to 652 against a population of 570, which should have stopped me and didn't.
+Resolved through `items.member_id`, the resolver arc credit actually uses:
 
-### And the number that cuts the other way
+| who | commits (30d) |
+|---|---|
+| John Ellison | 296 |
+| Chetan | 257 |
+| (null `member_id`) | 17 |
+| | **570** ✓ |
 
-Arc evidence citations, all arcs currently in `arc_cache`, by the source of the cited item:
+**That the two resolvers disagree is itself a finding** — see §4.3.
+
+### Arc evidence: heavily used, but I over-read the rank
+
+Citations across all arcs currently in `arc_cache`, by source of the cited item:
 
 | source | citations | distinct items |
 |---|---|---|
-| **`commits/`** | **16** | **15** |
+| `commits/` | 16 | 15 |
 | `github/` | 10 | 10 |
 | `linear/` | 6 | 2 |
 | `2-work/` | 2 | 2 |
 | `slack/` | 1 | 1 |
 
-**Commits are the single most-cited arc evidence source — 16 of 35 citations, 46%.** The entire
-saving and the most-used evidence channel are *the same items*. That is not a coincidence to design
-around; it is the lever's defining property, and the parent spec did not know it.
+I originally wrote "**the single most-cited** arc evidence source". That is not supportable: this is
+**one `arc_cache` row, 6 arcs, one snapshot day, n=35 clustered citations**. 16-vs-10 is p≈0.16 by
+sign test. The supportable claim — and all the argument needs — is that **commits are a heavily-used
+evidence channel, cited by 5 of the 6 current arcs** (spread 4/4/4/2/2/0, so not one arc's artifact).
 
-### What that means, stated plainly before any design
-
-The episode **name** is the only structured per-item provenance that reaches the graph
-(`graphiti-client.ts:168` sends `role: null` — authorship never enters the payload). So
-`episodeUuid → ONE itemId` (`learning.ts:156`) is the hinge the entire arc chain hangs off:
-`actorOfFact` takes the first human (`arcs.ts:766`), `ArcEvidence.itemId` links a citation to its
-library page (`arcs.ts:352`), arc *identity* is item-set overlap (`arc-continuity.ts:38`), and
-eligibility keeps a fact if **any** of its items is eligible (`arcs.ts:817`).
-
-Pack nine commits into one episode and, with no further change, an arc citation that today points at
-*the commit that actually motivated it* points instead at an arbitrary one of nine. **That is a
-functionality regression on the surface this lever's own savings come from**, and the standing
-instruction on this workstream is that cost may not be bought with graph quality or functionality.
-
-So this spec's first job is not the packing algorithm. It is to answer: **is the saving worth what it
-costs, and can the cost be designed to zero?**
+This is the second time this week I have ranked on a sample too small to rank. Recorded here rather
+than quietly softened.
 
 ---
 
-## 1. What the saving is actually worth
+## 2. Why the saving is smaller than it looks — the PIPEFF-2 interaction
 
-Measured, not estimated, using PIPEFF-2's verified post-deploy cost:
+§1's episode count is real. Pricing it at the fleet average is not.
 
-```
-~5,170 episodes / 30 days  ×  $0.0110 per episode   =   ~$57 / month   (current total)
-~507 episodes eliminated   ×  $0.0110               =   ~$5.6 / month  (this lever)
-```
+**PIPEFF-2's patch gives a single-chunk item ZERO predecessors** — `graphiti/patch-same-item.py:12`,
+verbatim: *"A single-chunk item gets ZERO predecessors; a multi-chunk item keeps all of…"*. Every
+commit is single-chunk by definition (198 chars against a 1,250-char minimum). So **commit episodes
+already carry no predecessor block at all**, and their bodies are ~50 tokens.
 
-**~$5.60 per month at today's volume.** That is the honest size. It scales with headcount and commit
-volume — at 5–10 active engineers it is $15–30/month — but the decision has to be taken on what is
-true now plus a stated growth assumption, not on the growth assumption alone.
+The fleet average of **$0.0110/episode** (PIPEFF-2's verified post-deploy figure) is dominated by
+multi-chunk episodes that *do* carry a predecessor block. Commit episodes sit far below it. Pricing
+507 eliminated commit episodes at the fleet average — which §1 of the original draft did — **credits
+this lever with a saving PIPEFF-2 already banked yesterday.**
 
-Against that: this lever touches the **sole tier-isolation boundary** (`episodeGroupId`, no RLS
-backstop), the **arc evidence surface**, **reconcile**, the **`entitiesPerEpisode` sensor shipped
-yesterday**, and requires a **new table**. Every other lever in this workstream was cheap to build
-and impossible to get catastrophically wrong. This one is the inverse.
+I have **not** measured the marginal cost of a commit episode. It is measurable (a drain-clean,
+commits-only window through `scripts/graph-ingest-cost.mjs`) and it has not been done. What is
+certain is the direction and that it is large: the honest ceiling is well under the $5.60/month the
+first draft claimed.
 
-**I am specifying it fully anyway**, because "it's only $5.60" is an argument that must survive
-review rather than a conclusion I take alone — and because the design below turns the attribution
-cost to zero rather than accepting it. But §7 records the conditions under which the right answer is
-to decline, and I want the reviewer to rule on that first.
+### And accretion halves the episode count too
 
----
+A pack must be re-pushed as its day accretes. Measured: a `(member, work-day)`'s commits arrive
+across **4.47 distinct sync hours on average (median 3, max 16)**, and the projector runs hourly
+(`project.ts:233`). So under the replace semantics §4.2 shows are mandatory, each author-day pack is
+deleted and re-pushed **3–5 times**:
 
-## 2. Constraints the terrain imposes (all verified, with call sites)
+- episodes pushed per author-day ≈ **3–5, not 1** → the ~9.8% episode cut becomes **~5%**
+- each re-push **re-extracts the whole accumulated pack** — repeated extraction of identical text,
+  which is pressure on the dedupe-pollution alarm re-armed two days ago
+- every delete+re-add **churns episode UUIDs** that cached arcs' `episodeUuids` still reference,
+  blanking evidence resolution mid-day
 
-| # | Constraint | Where | Failure if violated |
-|---|---|---|---|
-| C1 | `group_id` is derived **per item** from `item.access` and is the only tier enforcement — no RLS | `project.ts:612`, `group.ts:20-26`, CLAUDE.md §5 | A mixed-tier pack is a **permanent, unrecoverable external leak**. Graphiti `/search` returns everything in a group; there is no post-hoc filter anywhere. |
-| C2 | The ledger is keyed `unique (team_id, source_table, source_id)` — **one row per item** | `schema.sql:2231` | A packed episode covers N items; either the ledger grows a many-to-one shape or packing hides inside a synthetic item. |
-| C3 | `itemIdFromEpisodeName` is **pure and single-valued** (`string \| undefined`) | `episode-name.ts:21-26` | Every consumer is typed on a scalar. A multi-item episode has no representation. |
-| C4 | `deleteItemEpisodes` deletes every episode whose parsed id matches — **silently** | `project.ts:527-541` | Deleting one item would delete its pack-mates' content. Purge, retraction and tier-flip all route through it. |
-| C5 | Reconcile confirms a row if **any** chunk landed | `reconcile.ts:270-278` | One landed packed episode confirms **every** member, including members whose text never arrived. |
-| C6 | `toPush` filters by **positional index** into one item's chunk array | `project.ts:842` | A pack's chunk shas span several items; positional delta is meaningless across a pack. |
-| C7 | The PIPEFF-2 graphiti patch groups predecessor context by `name.split('#')[0]` | `graphiti/patch-same-item.py:21,25` | "Same document" silently becomes "same **pack**" — a behaviour change to a shipped, sha-pinned patch. |
-| C8 | `entitiesPerEpisode` divides entities by **episodes** | `extraction-health.ts:561-571` | Packing changes the denominator's meaning; the sensor shipped yesterday would step-change for a non-quality reason. |
-| C9 | Eligibility keeps a fact if **any** of its items is eligible | `arcs.ts:817-822` | An ineligible item rides along on an eligible pack-mate. |
-| C10 | Arc identity is item-set overlap, `MIN_SHARED_ITEMS = 2` | `arc-continuity.ts:29,38` | Changing which items a fact resolves to perturbs day-to-day arc identity. |
+**Combined: roughly half the episode saving, on episodes that were already the cheapest.** The honest
+figure is low single-digit dollars per month at today's volume, and I decline to state it more
+precisely than that without the commits-only cost window.
 
 ---
 
-## 3. The design
+## 3. The design as specified contained a leak
 
-### 3.1 The pack key — bounded so C1, C9 and attribution cannot bite
+The original §3.4 said: *"**Never** delete the pack episode while other members remain"* and *"delete
+the pack episode only when its last member leaves."*
 
-An item is packable only if it is **small** (`length(body) < PACK_MAX_ITEM_CHARS`, 600) and it joins a
-pack whose key matches on **all five** of:
+**`addEpisodes` does not overwrite by name** — `project.ts:752`, verbatim: *"`addEpisodes` does not
+overwrite by name — Graphiti keeps the old episode and the facts extracted from it."*
 
-```
-(group_id, kind, source, author, day)
-```
+So "re-push the pack without the removed member" **adds a second episode**. The old one — containing
+a reclassified or purged member's text *and its extracted facts* — stays readable in the old group
+until the last member leaves, i.e. for a 9-commit day pack, effectively forever.
 
-- **`group_id`** — closes C1 by construction, not by check. Two items of different `access` can never
-  share a key, because `group_id` *is* part of the key.
-- **`author`** — this is what makes the attribution cost zero rather than bounded. Every fact from a
-  pack has exactly one human behind it, so `actorOfFact` returning "the first human" is **correct**,
-  not approximately correct.
-- **`kind` + `source`** — closes C9: pack-mates are the same class of thing, so eligibility is
-  uniform across the pack.
-- **`day`** — the natural bucket for commits and what makes a pack legible as a unit of evidence.
+That is:
+- the falsifier of my own A2 (tier-flip exposure), verbatim;
+- a violation of the `lib/ingest/purge` contract — a purged commit's text stays extracted;
+- **covered by no acceptance criterion I wrote.** A3 asserted survivors keep their content; nothing
+  asserted the removed member's content is *gone*. The criterion set had a hole exactly where the
+  danger was.
 
-An item with no resolvable author is **never packed**. Not "packed into a `(none)` bucket" — never
-packed. An unattributed pack is exactly the failure this key exists to prevent.
-
-**Expected effect at today's payload:** commits pack ~9:1; `linear/`, `plane/` and `slack/` smalls
-(109 + 33 + 13) pack far more weakly because they spread across more authors and days. The spec
-targets commits and takes the rest as whatever falls out — it does **not** widen the key to chase
-them.
-
-### 3.2 Episode identity — a `pack:` grammar and a join table
-
-`itemIdFromEpisodeName` stays pure and unchanged for `items:` names (C3). Packed episodes take a new
-prefix:
-
-```
-pack:<packId>          or   pack:<packId>#k   for a multi-chunk pack
-```
-
-`packId` is the deterministic sha of the pack key, so it is reproducible from the inputs and carries
-no ordering.
-
-The episode → items relation becomes **data, in a new table**, rather than something parsed out of a
-string:
-
-```sql
-create table if not exists graph_episode_items (
-  team_id     uuid not null references teams(id) on delete cascade,
-  episode_name text not null,
-  item_id     uuid not null,
-  ordinal     int  not null,
-  primary key (team_id, episode_name, item_id)
-);
-```
-
-This is deliberate and follows the standing design principle: **attribution belongs at the lowest
-shared layer**, readable identically by arcs, the timeline, the dashboard and any future surface —
-not re-derived by each of them from a name. A name-encoded list (`items:<id1>+<id2>+…`) was rejected:
-nine UUIDs is a 340-character episode name, and it would put a variable-length parse in the hot path
-of ten call sites.
-
-`resolveEpisodeItems` (`learning.ts:137-168`) becomes the single reader of that table, returning
-`itemIds: string[]` where it returns a scalar today. **It is the one choke point**, which is why the
-table is worth its cost: every downstream consumer keeps reading `epToItem` and gets the right answer
-without knowing packs exist.
-
-### 3.3 The ledger — C2 without changing its key
-
-`graph_episodes` keeps `unique (team_id, source_table, source_id)`. Each packed item keeps **its own
-row**, and gains:
-
-- `pack_name text not null default ''` — the `pack:<id>` episode this item's text was pushed inside,
-  `''` for unpacked items.
-- `chunk_shas` stores the sha of **this item's own slice** of the packed body, not the packed
-  episode's chunks. That keeps the delta predicate per-item and closes C6: an edit to one member
-  invalidates that member, and re-packing the day re-pushes the pack.
-
-**Consequence, recorded as accepted:** editing one commit in a nine-commit pack re-extracts the whole
-pack. For commits — immutable once pushed — this is close to never. If a source with mutable small
-items is added to the pack set later, this cost must be re-derived, not inherited.
-
-### 3.4 Deletion, purge, tier flip — C4
-
-`deleteItemEpisodes(client, groupId, itemId)` currently deletes by parsed name. For a packed item it
-must instead:
-
-1. Look up the item's `pack_name`.
-2. **Never delete the pack episode** while other members remain — that would silently destroy their
-   content, which is C4's failure exactly.
-3. Remove the item's row from `graph_episode_items`, mark the item's ledger row for re-pack, and
-   **re-push the pack without the removed member** on the next projection pass.
-4. Delete the pack episode only when its last member leaves.
-
-Tier reclassification of one member is the sharp case: the item must leave the pack (its `group_id`
-changed, so it can no longer satisfy the pack key) **and** the pack must be re-pushed without it, in
-the same pass. Until the re-push lands, the removed item's text is still inside an episode in the old
-group. **That is a real, time-bounded tier exposure**, and it is the single most dangerous property of
-this design. §5's acceptance criteria treat it as a blocking requirement, not a caveat.
-
-### 3.5 Reconcile — C5, and it fixes RECONCILE-1's class for packs
-
-The landed-check must confirm a packed item only when **its pack episode is present**, and must not
-let one pack episode confirm members that were dropped from it. Concretely: build the map from
-`graph_episode_items` rather than from parsed names, and require the member row to appear there.
-`RECONCILE-1` (AIO-824) is the general form of this bug for chunks; this spec fixes it only for
-packs, and says so rather than claiming the ticket.
-
-### 3.6 The sensors — C7, C8
-
-- **C8:** `entitiesPerEpisode` will step-change downward when packs land, for a purely structural
-  reason. The sensor must record the discontinuity — an annotation at the deploy instant — or its
-  "week-over-week move > 25% ⇒ investigate" falsifier will fire on this change and teach everyone to
-  ignore it. **A sensor that cries wolf once gets switched off**, and this one is two days old.
-- **C7:** `name.split('#')[0]` makes a pack its own predecessor group, which is the *correct*
-  analogue of "the document's own chunks". It must be **verified, not assumed** — the patch is
-  sha-pinned by `test/guards/graphiti-patch-same-item.test.ts`, and a `pack:` name must be added to
-  that test's cases.
+**The fix is replace semantics** — delete the old pack episode(s) by name, *then* push the remainder,
+in that order (safe precisely because the survivors are re-pushed). That requires the two-phase
+projector §8 Q3 suspected, because the per-item loop at `project.ts:607` cannot assemble a pack body.
+With it, the residual window is the same class as today's per-item tier flip — no new exposure class.
+But the price is that **every membership change becomes "delete 9, re-extract 8"**, which is the
+accretion cost in §2.
 
 ---
 
-## 4. What this spec explicitly does not do
+## 4. The central claim did not survive: attribution loss is bounded, not zero
 
-- **It does not widen packing beyond the measured shape.** No packing of `linear/`, `github/` or
-  `slack/` smalls as a goal; they fall out of the same rule or they don't.
-- **It does not change `ArcEvidence`'s rendering.** With the author bound into the pack key, a
-  citation still resolves to a correct human and a correct set of items. Whether the UI should say
-  "9 commits by John on Aug 3" instead of linking one of them is a **product** question, filed
-  separately, not smuggled in as a cost change.
-- **It does not touch the chunker.** Packs are chunked by the same CDC path as any other body.
-- **It does not claim RECONCILE-1.** See §3.5.
+The design's justification was that binding `author` into the pack key makes attribution loss **zero**
+rather than bounded. Three live paths say otherwise.
 
----
+**4.1 Pack-time binding vs live credit resolution.** The pack key freezes `author` at pack time.
+`resolveItemCredit` (`lib/attribution/contributor-credit.ts`) resolves **live** — from
+`items.member_id`, `member_id_locked` admin corrections, `item_versions`, and `member_identities`
+remaps. An identity remap or an admin correction on one of nine members *after* the pack is pushed
+makes the pack retroactively mixed-credit, and **nothing re-packs on a credit change** (the delta is
+content-sha keyed; `member_id` is not in it). `actorOfFact` (`arcs.ts:802`) then assigns "the first
+item that resolves a human" to *every* fact from the pack, and `attributedFactTexts`
+(`arc-attribution.ts:118-135`) unions humans across the pack's item set. Per-item episodes stay
+correct through exactly the same correction today.
 
-## 5. Acceptance — what must be true, and what would falsify it
+**4.2 The pack-key author resolver was never specified** — and §1 shows the two candidate resolvers
+disagree *today* (frontmatter 338/314 vs `member_id` 296/257/17-null). If the pack key uses one and
+arc credit uses the other, mixed-credit packs exist from day one, no drift required. My A4 test, with
+a clean fixture where both resolvers agree, would have been **green by construction** against both
+this and 4.1.
 
-Every criterion below is a test, not a judgement. The tier ones are data-mechanics (real Postgres);
-the arithmetic ones are unit.
-
-| # | Criterion | Tier | Falsifier |
-|---|---|---|---|
-| A1 | **No pack ever spans two `group_id`s.** Mutation: force two tiers into one key; the guard must redden. | data-mechanics | any pack whose members disagree on `access` |
-| A2 | **A tier flip of one member removes it from the pack AND re-pushes the pack without it, in the same projection pass.** Assert on the *episode body*, not on a ledger flag. | data-mechanics | the removed member's text still readable in the old group after the pass |
-| A3 | **Deleting/purging one member never deletes another member's content.** | data-mechanics | any surviving member's text absent after a co-member purge |
-| A4 | **Every fact from a pack attributes to exactly one human**, and it is the pack's author. | data-mechanics | any pack-derived fact resolving to ≥2 humans, or to the wrong one |
-| A5 | **Arc evidence for a packed item resolves to a real, eligible item of the same author.** | data-mechanics | evidence resolving to an item outside the pack, or to an ineligible one (C9) |
-| A6 | **Reconcile confirms a packed member only if it is in `graph_episode_items` for a present episode.** Mutation: drop one member; only that member must re-queue. | data-mechanics | a dropped member reading as confirmed (C5) |
-| A7 | **Episode count on a replayed real commit day falls ≥ 5×**, measured by arithmetic on the real projector, no LLM call. | unit | a fall under 5× — the lever isn't paying for its blast radius |
-| A8 | **No item is ever in two packs, and no item's text is pushed twice in one pass.** | data-mechanics | duplicate `graph_episode_items` rows, or duplicate content across episodes |
-| A9 | **An item with no resolvable author is never packed.** | unit | any pack containing an author-less item |
-| A10 | **`itemIdFromEpisodeName` still returns `undefined` for a `pack:` name**, and every one of the ten call sites in §2 either reads the table or is proven not to need to. | unit + guard | any consumer silently reading a scalar and getting `undefined` where it used to get an id |
-| A11 | **The `pack:` name behaves in `patch-same-item.py`** — a pack's own chunks are its predecessors and nothing else's are. | unit (runs the real Python) | a pack chunk receiving another pack's episodes |
-
-**The falsifier for the whole lever:** if A7's measured fall on real commit days is under 5×, or if
-A2 cannot be made to hold without a window in which a reclassified item's text is readable in the
-wrong group, **this lever does not ship.** Those are the two conditions under which the saving stops
-covering the risk.
+**4.3 Item-level provenance loss is attribution loss on this codebase's own terms.**
+`ArcEvidence.itemId` (`arcs.ts:38`) becomes arbitrary-of-nine. I filed that as "a product question".
+That undercounts it: item ids are also the only channel by which graph payoff can be priced at all,
+and the anchor of arc identity (§5).
 
 ---
 
-## 6. Rollout
+## 5. Two functionality regressions the criteria never covered
 
-Packing is **forward-only and lazy**, exactly as CDC was. Already-projected items keep their existing
-per-item episodes forever; only items projected *after* the change are eligible to pack. A
-backfill would re-extract the entire commit history for zero new information — the $76 mistake
-PIPEFF-3 explicitly avoided.
+**5.1 Arc identity (C10 had no design answer and no criterion).** With `resolveEpisodeItems` returning
+`itemIds: string[]`, either:
+- fact→item collapses to one representative (`actorOfFact` first-match), shrinking a commit-heavy
+  arc's evidence anchors from ~9/day to 1 and starving `MIN_SHARED_ITEMS = 2`
+  (`arc-continuity.ts:29`) — **arcs on this evidence source get reborn daily**, the exact churn
+  `arc-continuity` exists to stop; or
+- evidence fans out to all nine, and two unrelated arcs each citing one fact from the same pack now
+  share ≥2 items, `isSameArc` binds them, and one is absorbed into the other.
 
-**Consequence, stated rather than discovered:** the saving arrives at the rate new commits arrive,
-not at deploy. The measured ~9.8% is a steady-state figure reached over weeks. Any post-deploy
-verification must be windowed on new content only, or it will read as a no-op and be misdiagnosed as
-a broken patch — the failure PIPEFF-2's verification table exists to prevent.
+The spec specified neither. Either is a functionality loss.
 
----
-
-## 7. The case for declining, stated so the reviewer can rule on it
-
-I want this ruled on before build, not discovered at review of the diff:
-
-1. **The saving is ~$5.60/month today.** The build is a schema change, a new table, a rewrite of the
-   episode→item resolution that the entire arc chain depends on, and changes to purge, reclassification
-   and reconcile.
-2. **It is the only lever in this workstream that can cause an unrecoverable failure.** A mixed-tier
-   pack cannot be cleaned up after the fact — the content has already been extracted into a group an
-   external principal can read.
-3. **§3.4's tier-flip window is a genuine exposure**, not a theoretical one, and A2 is the criterion I
-   am least confident can be met without a projector restructure.
-4. **The cheaper alternative exists and is unbuilt:** `use_combined_extraction` (parent spec §4)
-   collapses `extract_nodes` + `extract_edges` into one call — an estimated ~15%, *larger* than this
-   lever, as a vendored patch of the shape we have now shipped twice, with no schema change, no
-   attribution surface and no tier surface.
-
-**My recommendation to the reviewer:** attack §3.4 and A2 first. If the tier-flip window cannot be
-closed, this lever should be declined in favour of `use_combined_extraction`, and this document should
-stand as the record of why — which is worth more than the $5.60.
+**5.2 Prompt representation collapse.** All facts from a pack resolve to one item for balancing
+(`itemOfFact` → same first item), so `PER_ITEM_CAP = 20` (`arcs.ts:86`, applied `arcs.ts:863`) caps an
+author's **entire commit day** as one item, where today it is ~9 items each with their own cap.
+Commit work's share of the synthesis prompt shrinks. This is the narrative-arcs representation-skew
+class — the failure the per-contributor round-robin fix was built for — reintroduced through a
+different door. No criterion covered it.
 
 ---
 
-## 8. Open questions for plan review
+## 6. Corrections to my own analysis, recorded
 
-1. Is the five-part pack key sufficient to make attribution loss **zero** rather than bounded, or is
-   there a path by which a fact from a pack resolves to a human who did not write it?
-2. Does `graph_episode_items` belong in the ledger table as an array column instead? I chose a table
-   because the relation is many-to-many-ish over time (an item leaves a pack) and an array makes
-   "which items are in this episode" unqueryable from the episode side.
-3. Is A2 satisfiable within the current projector's per-item loop (`project.ts:607`), or does it need
-   a two-phase pass (plan packs, then push)? I suspect the latter and have not specified it.
-4. Is C8's discontinuity annotation enough, or should packed episodes be excluded from the
-   `entitiesPerEpisode` denominator entirely?
-5. Given §7, should this be built at all right now?
+| what I wrote | what is true |
+|---|---|
+| "the single most-cited arc evidence source" | heavily cited (5 of 6 arcs); n=35 from one snapshot is too small to rank |
+| authors 338 / 314 | 296 / 257 / 17-null via `items.member_id`; my figures came from frontmatter and summed to more than the population |
+| "~$5.60/month" | priced at the fleet average; commit episodes carry **zero** predecessors post-PIPEFF-2 and are the cheapest in the fleet. Low single digits, and unmeasured |
+| "~9.8% episode cut" | ~5% after accretion re-pushes (4.47 sync-hours/author-day, hourly projector) |
+| "attribution cost is zero" | **bounded**, not zero — §4 |
+| `entitiesPerEpisode` "steps downward" | steps **up** (fewer episodes, ~constant entities); direction is genuinely ambiguous once accretion re-pushes are counted, which is itself the point — I stated a hypothesis as a prediction |
+| anchors `arcs.ts:766 / 352 / 817` | `802` (`actorOfFact`) / `38` (`ArcEvidence`) / `849-856` (eligibility). Taken from a subagent's map and not read |
+
+**On the sensor (C8), the review's ruling stands and I accept it:** an annotation is sufficient;
+excluding packs from the `entitiesPerEpisode` denominator would blind it to pack-extraction failures.
+Do not exclude.
+
+---
+
+## 7. What to do instead — `use_combined_extraction`, re-costed honestly
+
+Verified in the actual `graphiti_core` 0.29.3 wheel rather than trusted from the parent spec:
+
+- It **exists** — `utils/maintenance/combined_extraction.py`, referenced at `utils/bulk_utils.py:271`.
+- The parent's "unreachable from the public API" note is **accurate**: it lives only on the
+  `add_episode_bulk` path, and even there the sole internal caller (`graphiti.py:798`) does not pass
+  it, so it defaults `False`. The single-episode `add_episode` path the REST server uses calls
+  `extract_nodes` (`graphiti.py:617`) and `extract_edges` (`graphiti.py:656`) separately.
+
+**Correction to my own §7.4 in the first draft:** I called it "a patch of the shape we have shipped
+twice". It is not. `extract_nodes_and_edges` is single-episode-shaped and returns exactly the
+`(nodes, edges, index_map)` the pipeline needs, but installing it means **rerouting control flow
+across `_extract_and_resolve_nodes` / `_extract_and_resolve_edges`** — materially deeper than
+patch-same-item's 17-line filter insert. And it **changes the extraction prompt**, so it needs its own
+quality battery (~4 reps, given the measured ~7% run-to-run noise at temperature 0).
+
+In its favour: upstream's own docstring claims combined extraction *"produces better results… reducing
+orphaned nodes"*, so the quality risk is at least not adverse — unlike this lever, where every risk
+pointed one way.
+
+**It is still the better next lever**: larger (~15% vs ~5%), no schema change, no new table, no
+attribution surface, and **no tier surface** — which is the one that matters, because packing is the
+only lever in this workstream with an unrecoverable failure mode.
+
+---
+
+## 8. What would flip this decision
+
+Not "more conviction" — these, specifically:
+
+1. **Volume.** At 5–10 active engineers the commit tail multiplies while the blast radius does not.
+   Revisit when commit episodes exceed ~25% of the fleet, or when the measured commits-only cost
+   window shows the marginal saving above ~$25/month.
+2. **A measured marginal price for a commit episode.** Until that exists, every number here is a
+   ceiling. It is a free measurement and it is the first thing to do if anyone reopens this.
+3. **A two-phase projector**, if one is built for another reason. §3's replace semantics need it, and
+   it is most of the build cost.
+4. **Per-item provenance inside the graph payload.** The root constraint is that authorship never
+   reaches Graphiti (`graphiti-client.ts` sends `role: null`) so the episode *name* is the only
+   structured provenance. If that ever changes, §4 and §5 mostly dissolve.
+
+---
+
+## 9. What this cost, and what it bought
+
+Two prod measurement passes and one plan review; **no code, no LLM spend, nothing deployed.**
+
+What it bought beyond the decline:
+
+- **PIPEFF-2 already banked most of this lever's saving** — single-chunk items get zero predecessors,
+  so the small-item tail is no longer the expensive thing the parent spec described. **The parent
+  spec's §3 is now stale and should say so.**
+- **The commits-only marginal cost is unmeasured**, and it is the number any future small-item work
+  starts from.
+- **`use_combined_extraction` is real and reachable via a deeper patch** — verified in the wheel, no
+  longer a note anyone has to re-derive.
+- **An acceptance-criteria hole worth remembering:** I wrote A1–A11 against the constraints I had
+  listed, and still missed the criterion for "the removed member's content is gone" — the *inverse*
+  of the one I did write. When a criterion asserts something survives, ask what must not.

--- a/docs/design/graph-episode-packing.md
+++ b/docs/design/graph-episode-packing.md
@@ -10,17 +10,33 @@ This document is the record of why, and of what would have to change for the ans
 
 ## 0. The verdict, and the two things that produced it
 
-I specified this lever in full, then Fable plan-reviewed it. The review returned **BLOCKED**, and the
-decisive findings were not defects in the design — they were **two facts about the payload that make
-the lever much smaller than the parent spec assumed, and one that makes it more dangerous.**
+I specified this lever in full, then Fable plan-reviewed it. The review returned **BLOCKED** on two
+counts: **a fact about the payload that makes the lever smaller than the parent spec assumed**, and
+**a defect in my design that makes it more dangerous** — I originally wrote that the findings "were
+not defects in the design", which is self-flattering and wrong: §3 is a defect, and it is mine.
 
-1. **The saving is a fraction of what §1 first priced**, because PIPEFF-2 — which we shipped
-   *yesterday* — already made these exact episodes the cheapest in the fleet.
+1. **The saving is smaller than §1 first priced**, because PIPEFF-2 — which we shipped *yesterday* —
+   removed the predecessor block, which is proportionally the largest cost of exactly these episodes.
+   **How much smaller is an inference, not a measurement** (§2), and it is labelled as one throughout.
 2. **The design as I wrote it specified an indefinite tier leak**, and the fix for it erodes the
    saving further.
 
-Both are below, measured. The lever is declined in favour of `use_combined_extraction`, with that
-alternative re-costed honestly rather than inherited from the parent spec's optimistic note.
+**The decline does not hinge on that inference, and this is the point to check before reading further.**
+Three findings carry it on their own, every one of them measured or quoted from code:
+
+- **accretion** halves the episode cut (§2, measured: 4.47 sync-hours/author-day against an hourly
+  projector);
+- **the §3 leak**, quoted verbatim from `project.ts:752`;
+- **the §4/§5 quality regressions**, which are volume-independent and arguably worsen as commit share
+  grows.
+
+Even if a commit episode cost the **full** fleet average, those three still decline the lever. The
+pricing inference makes it more obviously not worth building; it is not what makes it not worth
+building. I state that explicitly because I have an incentive to make the case airtight, and the
+reviewer said so.
+
+The lever is declined in favour of `use_combined_extraction`, with that alternative re-costed rather
+than inherited from the parent spec's note.
 
 ---
 
@@ -85,9 +101,10 @@ commit is single-chunk by definition (198 chars against a 1,250-char minimum). S
 already carry no predecessor block at all**, and their bodies are ~50 tokens.
 
 The fleet average of **$0.0110/episode** (PIPEFF-2's verified post-deploy figure) is dominated by
-multi-chunk episodes that *do* carry a predecessor block. Commit episodes sit far below it. Pricing
-507 eliminated commit episodes at the fleet average — which §1 of the original draft did — **credits
-this lever with a saving PIPEFF-2 already banked yesterday.**
+multi-chunk episodes that *do* carry a predecessor block. Commit episodes therefore sit **below** it —
+by how much is the open question of this section. Pricing 507 eliminated commit episodes at the fleet
+average — which §1 of the original draft did — **credits this lever with some of the saving PIPEFF-2
+banked yesterday.**
 
 I have **not** measured the marginal cost of a commit episode, and this section's central claim is
 therefore an **inference** — from the zero-predecessor rule plus a ~50-token body — not a
@@ -106,15 +123,22 @@ So the number needs a **deliberately constructed** commits-only drain-clean wind
 That is cheap and it has not been done. Until it exists, treat every figure in this section as a
 ceiling.
 
-What is not in doubt is the *direction*: a commit episode carries zero predecessors and ~50 tokens of
-content, while the $0.0110 fleet average is dominated by multi-chunk episodes that do carry a
-predecessor block. The honest ceiling is well under the $5.60/month the first draft claimed.
+What is not in doubt is the *direction*, and it can be **bounded** without guessing at magnitude: the
+marginal saving per eliminated episode sits between a floor (the fixed prompt boilerplate a commit
+episode still pays across its ~4–10 calls, plus its **output** tokens, which the predecessor cut never
+touched) and a ceiling (the $0.0110 fleet average). So the pre-accretion saving is **≤ $5.60/month by
+construction**, and accretion halves whatever it actually is.
+
+I deliberately do not say "the cut is large". A commit episode plausibly still costs one-third to
+two-thirds of fleet average — at two-thirds, PIPEFF-2 banked about a third of this lever's saving, not
+most of it. **The bound is what the decline uses; the magnitude is unmeasured and stays unmeasured in
+this document.**
 
 ### And accretion halves the episode count too
 
 A pack must be re-pushed as its day accretes. Measured: a `(member, work-day)`'s commits arrive
 across **4.47 distinct sync hours on average (median 3, max 16)**, and the projector runs hourly
-(`project.ts:233`). So under the replace semantics §4.2 shows are mandatory, each author-day pack is
+(`project.ts:233`). So under the replace semantics §3 shows are mandatory, each author-day pack is
 deleted and re-pushed **3–5 times**:
 
 - episodes pushed per author-day ≈ **3–5, not 1** → the ~9.8% episode cut becomes **~5%**
@@ -123,7 +147,8 @@ deleted and re-pushed **3–5 times**:
 - every delete+re-add **churns episode UUIDs** that cached arcs' `episodeUuids` still reference,
   blanking evidence resolution mid-day
 
-**Combined: roughly half the episode saving, on episodes that were already the cheapest.** The honest
+**Combined: roughly half the episode saving, on episodes that were already cheaper than average by
+an unmeasured margin.** The honest
 figure is low single-digit dollars per month at today's volume, and I decline to state it more
 precisely than that without the commits-only cost window.
 
@@ -246,7 +271,11 @@ In its favour: upstream's own docstring claims combined extraction *"produces be
 orphaned nodes"*, so the quality risk is at least not adverse — unlike this lever, where every risk
 pointed one way.
 
-**It is still the better next lever**: larger (~15% vs ~5%), no schema change, no new table, no
+**Its ~15% is the parent spec's estimate and is itself unmeasured** — flagged here because this
+document exists to stop unmeasured parent numbers travelling, and carrying one through unhedged while
+correcting the other would be exactly that failure.
+
+**It is still the better next lever**: larger (~15% estimated vs ~5% measured), no schema change, no new table, no
 attribution surface, and **no tier surface** — which is the one that matters, because packing is the
 only lever in this workstream with an unrecoverable failure mode.
 
@@ -256,9 +285,14 @@ only lever in this workstream with an unrecoverable failure mode.
 
 Not "more conviction" — these, specifically:
 
-1. **Volume.** At 5–10 active engineers the commit tail multiplies while the blast radius does not.
-   Revisit when commit episodes exceed ~25% of the fleet, or when the measured commits-only cost
-   window shows the marginal saving above ~$25/month.
+1. **Volume — but with no numeric trigger, and never on its own.** An earlier draft of this section
+   said "revisit when commit episodes exceed ~25% of the fleet, or the marginal saving exceeds
+   ~$25/month". **Both numbers were invented** — round figures with no derivation anywhere in this
+   document. Worse, a dollar trigger contradicts the constraint that governs this whole workstream:
+   §4's attribution paths and §5's arc-identity and representation regressions are
+   **volume-independent** — arc-identity churn arguably *worsens* as commit share grows — and cost may
+   not be bought with quality at any price. **So no saving figure alone can flip this.** Revisit on
+   volume only *in combination with* item 4 below, or with a design that actually resolves §4 and §5.
 2. **A measured marginal price for a commit episode.** Until that exists, every number here is a
    ceiling. It is a free measurement and it is the first thing to do if anyone reopens this.
 3. **A two-phase projector**, if one is built for another reason. §3's replace semantics need it, and
@@ -275,7 +309,9 @@ Two prod measurement passes and one plan review; **no code, no LLM spend, nothin
 
 What it bought beyond the decline:
 
-- **PIPEFF-2 already banked most of this lever's saving** — single-chunk items get zero predecessors,
+- **PIPEFF-2 already banked a material — but unmeasured — fraction of this lever's saving** (the
+  predecessor block, proportionally largest for exactly these episodes; *not* established as "most")
+  — single-chunk items get zero predecessors,
   so the small-item tail is no longer the expensive thing the parent spec described. **The parent
   spec's §3 is now stale and should say so.**
 - **The commits-only marginal cost is unmeasured**, and it is the number any future small-item work
@@ -285,3 +321,46 @@ What it bought beyond the decline:
 - **An acceptance-criteria hole worth remembering:** I wrote A1–A11 against the constraints I had
   listed, and still missed the criterion for "the removed member's content is gone" — the *inverse*
   of the one I did write. When a criterion asserts something survives, ask what must not.
+
+---
+
+## Appendix — what survives the decline
+
+Restored at the reviewer's insistence: the rewrite deleted both of these, and they are the most
+durable things this work produced. Anyone touching graph projection for **any** reason starts
+here rather than re-deriving it.
+
+### A.1 Terrain facts C1–C10 (verified against the working tree; true independent of packing)
+
+| # | Constraint | Where | Failure if violated |
+|---|---|---|---|
+| C1 | `group_id` is derived **per item** from `item.access` and is the only tier enforcement — no RLS | `project.ts:612`, `group.ts:20-26`, CLAUDE.md §5 | A mixed-tier pack is a **permanent, unrecoverable external leak**. Graphiti `/search` returns everything in a group; there is no post-hoc filter anywhere. |
+| C2 | The ledger is keyed `unique (team_id, source_table, source_id)` — **one row per item** | `schema.sql:2231` | A packed episode covers N items; either the ledger grows a many-to-one shape or packing hides inside a synthetic item. |
+| C3 | `itemIdFromEpisodeName` is **pure and single-valued** (`string \| undefined`) | `episode-name.ts:21-26` | Every consumer is typed on a scalar. A multi-item episode has no representation. |
+| C4 | `deleteItemEpisodes` deletes every episode whose parsed id matches — **silently** | `project.ts:527-541` | Deleting one item would delete its pack-mates' content. Purge, retraction and tier-flip all route through it. |
+| C5 | Reconcile confirms a row if **any** chunk landed | `reconcile.ts:270-278` | One landed packed episode confirms **every** member, including members whose text never arrived. |
+| C6 | `toPush` filters by **positional index** into one item's chunk array | `project.ts:842` | A pack's chunk shas span several items; positional delta is meaningless across a pack. |
+| C7 | The PIPEFF-2 graphiti patch groups predecessor context by `name.split('#')[0]` | `graphiti/patch-same-item.py:21,25` | "Same document" silently becomes "same **pack**" — a behaviour change to a shipped, sha-pinned patch. |
+| C8 | `entitiesPerEpisode` divides entities by **episodes** | `extraction-health.ts:561-571` | Packing changes the denominator's meaning; the sensor shipped yesterday would step-change for a non-quality reason. |
+| C9 | Eligibility keeps a fact if **any** of its items is eligible | `arcs.ts:849-856` | An ineligible item rides along on an eligible pack-mate. |
+| C10 | Arc identity is item-set overlap, `MIN_SHARED_ITEMS = 2` | `arc-continuity.ts:29,39` | Changing which items a fact resolves to perturbs day-to-day arc identity. |
+
+
+### A.2 Design fragments the review upheld
+
+The lever is declined; these parts of it were judged **correct** and should be reused, not rebuilt, if
+anyone reopens this or designs anything adjacent:
+
+- **`group_id` inside the pack key.** This closes C1 *by construction* rather than by check — two
+  items of different `access` cannot share a key because the key contains the group. For the one
+  invariant with no RLS backstop, "impossible by construction" beats any guard.
+- **Never pack an author-less item.** Not "pack into a `(none)` bucket" — never. Measured population:
+  17 of 570 commits (3%), immaterial to the saving and material to correctness.
+- **A join table, not an array column.** Reconcile's fixed landed-check needs the *episode-side*
+  question ("which members does `pack:<id>` claim"), which an array on member rows cannot answer
+  without a scan; and membership changing over time makes the array a mutation-in-place shape.
+- **Replace semantics as the deletion primitive** — delete the old pack episode(s) by name, *then*
+  push the remainder, in that order. This is the correct fix for §3's leak, and it is safe precisely
+  because the survivors are re-pushed. It needs a two-phase projector (§8.3).
+- **`entitiesPerEpisode` keeps packs in its denominator.** Excluding them would blind the sensor to
+  pack-extraction failures. Annotate the discontinuity instead.

--- a/docs/design/graph-episode-packing.md
+++ b/docs/design/graph-episode-packing.md
@@ -1,0 +1,317 @@
+# Packing small items into shared graph episodes — PIPEFF-4 / AIO-845
+
+**Status:** spec, pre-review. No code written.
+**Parent:** `docs/design/graph-ingestion-efficiency.md` §3 ("lever 3 — deepest blast radius, built last").
+**Siblings shipped:** PIPEFF-2 (predecessor filter, −25.5% measured) · PIPEFF-3 (content-defined chunking).
+
+---
+
+## 0. The finding that should decide this before anything else
+
+The parent spec proposed this lever from a count: *"898 items under 600 characters each occupy their
+own episode at full fixed-overhead price."* I measured the actual payload before designing against
+it, and two numbers arrived that the parent never had.
+
+**Measured on prod, 2026-08-08, items synced in the last 30 days:**
+
+| source | items | est. episodes | of which are small (<600 chars) |
+|---|---|---|---|
+| `github/` | 674 | 2,298 | 50 |
+| `linear/` | 593 | 975 | 109 |
+| `2-work/` | 148 | 778 | 4 |
+| **`commits/`** | **570** | **570** | **570 — 100%** |
+| everything else | ~130 | ~550 | ~50 |
+| **total** | | **~5,170** | |
+
+**The lever is a commits lever.** 570 of ~5,170 episodes — **11.0%** — are commit items, every one of
+them under 600 chars, averaging **197 characters**, each paying the same ~30,000-token extraction
+overhead as a full 2,500-char chunk. Nothing else in the corpus has this shape: the other sources'
+small items are a rounding error against their own episode counts.
+
+They also pack cleanly. Small commit artifacts concentrate on **two humans** (John Ellison 338,
+Chetan Nandakumar 314) across ~37 active days each, so a same-author same-day pack averages **~9
+commits**. Packing commits alone: 570 → ~63 episodes, **a ~9.8% cut in total episodes.**
+
+### And the number that cuts the other way
+
+Arc evidence citations, all arcs currently in `arc_cache`, by the source of the cited item:
+
+| source | citations | distinct items |
+|---|---|---|
+| **`commits/`** | **16** | **15** |
+| `github/` | 10 | 10 |
+| `linear/` | 6 | 2 |
+| `2-work/` | 2 | 2 |
+| `slack/` | 1 | 1 |
+
+**Commits are the single most-cited arc evidence source — 16 of 35 citations, 46%.** The entire
+saving and the most-used evidence channel are *the same items*. That is not a coincidence to design
+around; it is the lever's defining property, and the parent spec did not know it.
+
+### What that means, stated plainly before any design
+
+The episode **name** is the only structured per-item provenance that reaches the graph
+(`graphiti-client.ts:168` sends `role: null` — authorship never enters the payload). So
+`episodeUuid → ONE itemId` (`learning.ts:156`) is the hinge the entire arc chain hangs off:
+`actorOfFact` takes the first human (`arcs.ts:766`), `ArcEvidence.itemId` links a citation to its
+library page (`arcs.ts:352`), arc *identity* is item-set overlap (`arc-continuity.ts:38`), and
+eligibility keeps a fact if **any** of its items is eligible (`arcs.ts:817`).
+
+Pack nine commits into one episode and, with no further change, an arc citation that today points at
+*the commit that actually motivated it* points instead at an arbitrary one of nine. **That is a
+functionality regression on the surface this lever's own savings come from**, and the standing
+instruction on this workstream is that cost may not be bought with graph quality or functionality.
+
+So this spec's first job is not the packing algorithm. It is to answer: **is the saving worth what it
+costs, and can the cost be designed to zero?**
+
+---
+
+## 1. What the saving is actually worth
+
+Measured, not estimated, using PIPEFF-2's verified post-deploy cost:
+
+```
+~5,170 episodes / 30 days  ×  $0.0110 per episode   =   ~$57 / month   (current total)
+~507 episodes eliminated   ×  $0.0110               =   ~$5.6 / month  (this lever)
+```
+
+**~$5.60 per month at today's volume.** That is the honest size. It scales with headcount and commit
+volume — at 5–10 active engineers it is $15–30/month — but the decision has to be taken on what is
+true now plus a stated growth assumption, not on the growth assumption alone.
+
+Against that: this lever touches the **sole tier-isolation boundary** (`episodeGroupId`, no RLS
+backstop), the **arc evidence surface**, **reconcile**, the **`entitiesPerEpisode` sensor shipped
+yesterday**, and requires a **new table**. Every other lever in this workstream was cheap to build
+and impossible to get catastrophically wrong. This one is the inverse.
+
+**I am specifying it fully anyway**, because "it's only $5.60" is an argument that must survive
+review rather than a conclusion I take alone — and because the design below turns the attribution
+cost to zero rather than accepting it. But §7 records the conditions under which the right answer is
+to decline, and I want the reviewer to rule on that first.
+
+---
+
+## 2. Constraints the terrain imposes (all verified, with call sites)
+
+| # | Constraint | Where | Failure if violated |
+|---|---|---|---|
+| C1 | `group_id` is derived **per item** from `item.access` and is the only tier enforcement — no RLS | `project.ts:612`, `group.ts:20-26`, CLAUDE.md §5 | A mixed-tier pack is a **permanent, unrecoverable external leak**. Graphiti `/search` returns everything in a group; there is no post-hoc filter anywhere. |
+| C2 | The ledger is keyed `unique (team_id, source_table, source_id)` — **one row per item** | `schema.sql:2231` | A packed episode covers N items; either the ledger grows a many-to-one shape or packing hides inside a synthetic item. |
+| C3 | `itemIdFromEpisodeName` is **pure and single-valued** (`string \| undefined`) | `episode-name.ts:21-26` | Every consumer is typed on a scalar. A multi-item episode has no representation. |
+| C4 | `deleteItemEpisodes` deletes every episode whose parsed id matches — **silently** | `project.ts:527-541` | Deleting one item would delete its pack-mates' content. Purge, retraction and tier-flip all route through it. |
+| C5 | Reconcile confirms a row if **any** chunk landed | `reconcile.ts:270-278` | One landed packed episode confirms **every** member, including members whose text never arrived. |
+| C6 | `toPush` filters by **positional index** into one item's chunk array | `project.ts:842` | A pack's chunk shas span several items; positional delta is meaningless across a pack. |
+| C7 | The PIPEFF-2 graphiti patch groups predecessor context by `name.split('#')[0]` | `graphiti/patch-same-item.py:21,25` | "Same document" silently becomes "same **pack**" — a behaviour change to a shipped, sha-pinned patch. |
+| C8 | `entitiesPerEpisode` divides entities by **episodes** | `extraction-health.ts:561-571` | Packing changes the denominator's meaning; the sensor shipped yesterday would step-change for a non-quality reason. |
+| C9 | Eligibility keeps a fact if **any** of its items is eligible | `arcs.ts:817-822` | An ineligible item rides along on an eligible pack-mate. |
+| C10 | Arc identity is item-set overlap, `MIN_SHARED_ITEMS = 2` | `arc-continuity.ts:29,38` | Changing which items a fact resolves to perturbs day-to-day arc identity. |
+
+---
+
+## 3. The design
+
+### 3.1 The pack key — bounded so C1, C9 and attribution cannot bite
+
+An item is packable only if it is **small** (`length(body) < PACK_MAX_ITEM_CHARS`, 600) and it joins a
+pack whose key matches on **all five** of:
+
+```
+(group_id, kind, source, author, day)
+```
+
+- **`group_id`** — closes C1 by construction, not by check. Two items of different `access` can never
+  share a key, because `group_id` *is* part of the key.
+- **`author`** — this is what makes the attribution cost zero rather than bounded. Every fact from a
+  pack has exactly one human behind it, so `actorOfFact` returning "the first human" is **correct**,
+  not approximately correct.
+- **`kind` + `source`** — closes C9: pack-mates are the same class of thing, so eligibility is
+  uniform across the pack.
+- **`day`** — the natural bucket for commits and what makes a pack legible as a unit of evidence.
+
+An item with no resolvable author is **never packed**. Not "packed into a `(none)` bucket" — never
+packed. An unattributed pack is exactly the failure this key exists to prevent.
+
+**Expected effect at today's payload:** commits pack ~9:1; `linear/`, `plane/` and `slack/` smalls
+(109 + 33 + 13) pack far more weakly because they spread across more authors and days. The spec
+targets commits and takes the rest as whatever falls out — it does **not** widen the key to chase
+them.
+
+### 3.2 Episode identity — a `pack:` grammar and a join table
+
+`itemIdFromEpisodeName` stays pure and unchanged for `items:` names (C3). Packed episodes take a new
+prefix:
+
+```
+pack:<packId>          or   pack:<packId>#k   for a multi-chunk pack
+```
+
+`packId` is the deterministic sha of the pack key, so it is reproducible from the inputs and carries
+no ordering.
+
+The episode → items relation becomes **data, in a new table**, rather than something parsed out of a
+string:
+
+```sql
+create table if not exists graph_episode_items (
+  team_id     uuid not null references teams(id) on delete cascade,
+  episode_name text not null,
+  item_id     uuid not null,
+  ordinal     int  not null,
+  primary key (team_id, episode_name, item_id)
+);
+```
+
+This is deliberate and follows the standing design principle: **attribution belongs at the lowest
+shared layer**, readable identically by arcs, the timeline, the dashboard and any future surface —
+not re-derived by each of them from a name. A name-encoded list (`items:<id1>+<id2>+…`) was rejected:
+nine UUIDs is a 340-character episode name, and it would put a variable-length parse in the hot path
+of ten call sites.
+
+`resolveEpisodeItems` (`learning.ts:137-168`) becomes the single reader of that table, returning
+`itemIds: string[]` where it returns a scalar today. **It is the one choke point**, which is why the
+table is worth its cost: every downstream consumer keeps reading `epToItem` and gets the right answer
+without knowing packs exist.
+
+### 3.3 The ledger — C2 without changing its key
+
+`graph_episodes` keeps `unique (team_id, source_table, source_id)`. Each packed item keeps **its own
+row**, and gains:
+
+- `pack_name text not null default ''` — the `pack:<id>` episode this item's text was pushed inside,
+  `''` for unpacked items.
+- `chunk_shas` stores the sha of **this item's own slice** of the packed body, not the packed
+  episode's chunks. That keeps the delta predicate per-item and closes C6: an edit to one member
+  invalidates that member, and re-packing the day re-pushes the pack.
+
+**Consequence, recorded as accepted:** editing one commit in a nine-commit pack re-extracts the whole
+pack. For commits — immutable once pushed — this is close to never. If a source with mutable small
+items is added to the pack set later, this cost must be re-derived, not inherited.
+
+### 3.4 Deletion, purge, tier flip — C4
+
+`deleteItemEpisodes(client, groupId, itemId)` currently deletes by parsed name. For a packed item it
+must instead:
+
+1. Look up the item's `pack_name`.
+2. **Never delete the pack episode** while other members remain — that would silently destroy their
+   content, which is C4's failure exactly.
+3. Remove the item's row from `graph_episode_items`, mark the item's ledger row for re-pack, and
+   **re-push the pack without the removed member** on the next projection pass.
+4. Delete the pack episode only when its last member leaves.
+
+Tier reclassification of one member is the sharp case: the item must leave the pack (its `group_id`
+changed, so it can no longer satisfy the pack key) **and** the pack must be re-pushed without it, in
+the same pass. Until the re-push lands, the removed item's text is still inside an episode in the old
+group. **That is a real, time-bounded tier exposure**, and it is the single most dangerous property of
+this design. §5's acceptance criteria treat it as a blocking requirement, not a caveat.
+
+### 3.5 Reconcile — C5, and it fixes RECONCILE-1's class for packs
+
+The landed-check must confirm a packed item only when **its pack episode is present**, and must not
+let one pack episode confirm members that were dropped from it. Concretely: build the map from
+`graph_episode_items` rather than from parsed names, and require the member row to appear there.
+`RECONCILE-1` (AIO-824) is the general form of this bug for chunks; this spec fixes it only for
+packs, and says so rather than claiming the ticket.
+
+### 3.6 The sensors — C7, C8
+
+- **C8:** `entitiesPerEpisode` will step-change downward when packs land, for a purely structural
+  reason. The sensor must record the discontinuity — an annotation at the deploy instant — or its
+  "week-over-week move > 25% ⇒ investigate" falsifier will fire on this change and teach everyone to
+  ignore it. **A sensor that cries wolf once gets switched off**, and this one is two days old.
+- **C7:** `name.split('#')[0]` makes a pack its own predecessor group, which is the *correct*
+  analogue of "the document's own chunks". It must be **verified, not assumed** — the patch is
+  sha-pinned by `test/guards/graphiti-patch-same-item.test.ts`, and a `pack:` name must be added to
+  that test's cases.
+
+---
+
+## 4. What this spec explicitly does not do
+
+- **It does not widen packing beyond the measured shape.** No packing of `linear/`, `github/` or
+  `slack/` smalls as a goal; they fall out of the same rule or they don't.
+- **It does not change `ArcEvidence`'s rendering.** With the author bound into the pack key, a
+  citation still resolves to a correct human and a correct set of items. Whether the UI should say
+  "9 commits by John on Aug 3" instead of linking one of them is a **product** question, filed
+  separately, not smuggled in as a cost change.
+- **It does not touch the chunker.** Packs are chunked by the same CDC path as any other body.
+- **It does not claim RECONCILE-1.** See §3.5.
+
+---
+
+## 5. Acceptance — what must be true, and what would falsify it
+
+Every criterion below is a test, not a judgement. The tier ones are data-mechanics (real Postgres);
+the arithmetic ones are unit.
+
+| # | Criterion | Tier | Falsifier |
+|---|---|---|---|
+| A1 | **No pack ever spans two `group_id`s.** Mutation: force two tiers into one key; the guard must redden. | data-mechanics | any pack whose members disagree on `access` |
+| A2 | **A tier flip of one member removes it from the pack AND re-pushes the pack without it, in the same projection pass.** Assert on the *episode body*, not on a ledger flag. | data-mechanics | the removed member's text still readable in the old group after the pass |
+| A3 | **Deleting/purging one member never deletes another member's content.** | data-mechanics | any surviving member's text absent after a co-member purge |
+| A4 | **Every fact from a pack attributes to exactly one human**, and it is the pack's author. | data-mechanics | any pack-derived fact resolving to ≥2 humans, or to the wrong one |
+| A5 | **Arc evidence for a packed item resolves to a real, eligible item of the same author.** | data-mechanics | evidence resolving to an item outside the pack, or to an ineligible one (C9) |
+| A6 | **Reconcile confirms a packed member only if it is in `graph_episode_items` for a present episode.** Mutation: drop one member; only that member must re-queue. | data-mechanics | a dropped member reading as confirmed (C5) |
+| A7 | **Episode count on a replayed real commit day falls ≥ 5×**, measured by arithmetic on the real projector, no LLM call. | unit | a fall under 5× — the lever isn't paying for its blast radius |
+| A8 | **No item is ever in two packs, and no item's text is pushed twice in one pass.** | data-mechanics | duplicate `graph_episode_items` rows, or duplicate content across episodes |
+| A9 | **An item with no resolvable author is never packed.** | unit | any pack containing an author-less item |
+| A10 | **`itemIdFromEpisodeName` still returns `undefined` for a `pack:` name**, and every one of the ten call sites in §2 either reads the table or is proven not to need to. | unit + guard | any consumer silently reading a scalar and getting `undefined` where it used to get an id |
+| A11 | **The `pack:` name behaves in `patch-same-item.py`** — a pack's own chunks are its predecessors and nothing else's are. | unit (runs the real Python) | a pack chunk receiving another pack's episodes |
+
+**The falsifier for the whole lever:** if A7's measured fall on real commit days is under 5×, or if
+A2 cannot be made to hold without a window in which a reclassified item's text is readable in the
+wrong group, **this lever does not ship.** Those are the two conditions under which the saving stops
+covering the risk.
+
+---
+
+## 6. Rollout
+
+Packing is **forward-only and lazy**, exactly as CDC was. Already-projected items keep their existing
+per-item episodes forever; only items projected *after* the change are eligible to pack. A
+backfill would re-extract the entire commit history for zero new information — the $76 mistake
+PIPEFF-3 explicitly avoided.
+
+**Consequence, stated rather than discovered:** the saving arrives at the rate new commits arrive,
+not at deploy. The measured ~9.8% is a steady-state figure reached over weeks. Any post-deploy
+verification must be windowed on new content only, or it will read as a no-op and be misdiagnosed as
+a broken patch — the failure PIPEFF-2's verification table exists to prevent.
+
+---
+
+## 7. The case for declining, stated so the reviewer can rule on it
+
+I want this ruled on before build, not discovered at review of the diff:
+
+1. **The saving is ~$5.60/month today.** The build is a schema change, a new table, a rewrite of the
+   episode→item resolution that the entire arc chain depends on, and changes to purge, reclassification
+   and reconcile.
+2. **It is the only lever in this workstream that can cause an unrecoverable failure.** A mixed-tier
+   pack cannot be cleaned up after the fact — the content has already been extracted into a group an
+   external principal can read.
+3. **§3.4's tier-flip window is a genuine exposure**, not a theoretical one, and A2 is the criterion I
+   am least confident can be met without a projector restructure.
+4. **The cheaper alternative exists and is unbuilt:** `use_combined_extraction` (parent spec §4)
+   collapses `extract_nodes` + `extract_edges` into one call — an estimated ~15%, *larger* than this
+   lever, as a vendored patch of the shape we have now shipped twice, with no schema change, no
+   attribution surface and no tier surface.
+
+**My recommendation to the reviewer:** attack §3.4 and A2 first. If the tier-flip window cannot be
+closed, this lever should be declined in favour of `use_combined_extraction`, and this document should
+stand as the record of why — which is worth more than the $5.60.
+
+---
+
+## 8. Open questions for plan review
+
+1. Is the five-part pack key sufficient to make attribution loss **zero** rather than bounded, or is
+   there a path by which a fact from a pack resolves to a human who did not write it?
+2. Does `graph_episode_items` belong in the ledger table as an array column instead? I chose a table
+   because the relation is many-to-many-ish over time (an item leaves a pack) and an array makes
+   "which items are in this episode" unqueryable from the episode side.
+3. Is A2 satisfiable within the current projector's per-item loop (`project.ts:607`), or does it need
+   a two-phase pass (plan packs, then push)? I suspect the latter and have not specified it.
+4. Is C8's discontinuity annotation enough, or should packed episodes be excluded from the
+   `entitiesPerEpisode` denominator entirely?
+5. Given §7, should this be built at all right now?

--- a/docs/design/graph-ingestion-efficiency.md
+++ b/docs/design/graph-ingestion-efficiency.md
@@ -200,12 +200,21 @@ degrades and 10 is wasteful, and should be measured in the same run rather than 
 > **⛔ SUPERSEDED — DECLINED on evidence, 2026-08-08. See `docs/design/graph-episode-packing.md`
 > (PIPEFF-4 / AIO-845).** The section below is preserved as written, but its premise no longer holds:
 > it prices small items at full fixed overhead, and **PIPEFF-2 has since given every single-chunk item
-> ZERO predecessors** (`graphiti/patch-same-item.py:12`). Every small item is single-chunk, so this
-> tail is now the *cheapest* part of the fleet, not the most wasteful — most of this lever's saving
-> was banked by lever 2. Measured remainder after pack-accretion re-pushes: **~5% of episodes**, on
-> the cheapest episodes, against the only unrecoverable failure mode in this workstream (a mixed-tier
-> pack cannot be cleaned up). The next lever is `use_combined_extraction` (§4), which is larger and
-> has no tier or attribution surface.
+> ZERO predecessors** (`graphiti/patch-same-item.py:12`). Every small item is single-chunk, so lever 2
+> already banked **a material but unmeasured fraction** of this lever's saving — the predecessor block,
+> proportionally largest for exactly these episodes. *How much* is explicitly not established: the
+> commits-only marginal price has never been measured, and the decline record labels that an inference
+> rather than a fact.
+>
+> **What is measured** is the rest, and it is what decides: after pack-accretion re-pushes the episode
+> cut is **~5%** (4.47 sync-hours per author-day against an hourly projector), the design needs
+> delete-then-repush semantics or it leaks a reclassified item's text into the old tier group
+> indefinitely, and it carries two volume-independent quality regressions (arc identity, prompt
+> representation). Those hold **even if a small episode cost the full fleet average**. Packing is also
+> the only lever here with an unrecoverable failure mode — a mixed-tier pack cannot be cleaned up.
+>
+> The next lever is `use_combined_extraction` (§4): larger on the parent's own **unmeasured** ~15%
+> estimate, and with no tier or attribution surface.
 
 898 items under 600 characters each occupy their own episode at full fixed-overhead price. Packing
 them (per source, per time bucket, preserving per-item provenance in the episode body so attribution

--- a/docs/design/graph-ingestion-efficiency.md
+++ b/docs/design/graph-ingestion-efficiency.md
@@ -197,6 +197,16 @@ degrades and 10 is wasteful, and should be measured in the same run rather than 
 
 ### 3. Pack small items into full episodes — coverage-neutral, 40% of items
 
+> **⛔ SUPERSEDED — DECLINED on evidence, 2026-08-08. See `docs/design/graph-episode-packing.md`
+> (PIPEFF-4 / AIO-845).** The section below is preserved as written, but its premise no longer holds:
+> it prices small items at full fixed overhead, and **PIPEFF-2 has since given every single-chunk item
+> ZERO predecessors** (`graphiti/patch-same-item.py:12`). Every small item is single-chunk, so this
+> tail is now the *cheapest* part of the fleet, not the most wasteful — most of this lever's saving
+> was banked by lever 2. Measured remainder after pack-accretion re-pushes: **~5% of episodes**, on
+> the cheapest episodes, against the only unrecoverable failure mode in this workstream (a mixed-tier
+> pack cannot be cleaned up). The next lever is `use_combined_extraction` (§4), which is larger and
+> has no tier or attribution surface.
+
 898 items under 600 characters each occupy their own episode at full fixed-overhead price. Packing
 them (per source, per time bucket, preserving per-item provenance in the episode body so attribution
 survives) turns ~898 episodes into ~180.
@@ -273,7 +283,9 @@ A lever that cannot show movement on tokens-per-episode does not ship.
 1. **Harness** (this PR) — no behaviour change, establishes the baseline.
 2. **Lever 2** (`EPISODE_WINDOW_LEN`) — biggest token win per line changed, gated on the quality battery.
 3. **Lever 1** (CDC) — the durable structural fix; needs the lazy-rollout third case.
-4. **Lever 3** (packing) — deepest blast radius, last.
+4. ~~**Lever 3** (packing) — deepest blast radius, last.~~ **DECLINED 2026-08-08** — see §3's notice
+   and `docs/design/graph-episode-packing.md`. The next lever is **§4 `use_combined_extraction`**,
+   which this document recorded as "noted, not proposed" and which is now the largest remaining one.
 
 Each is its own PR with its own before/after measurement in the body.
 


### PR DESCRIPTION
**Declines** the small-item packing lever (lever 3 of `graph-ingestion-efficiency`) on evidence, and records why. **No code. No LLM spend. Nothing deployed.**

## Why

The parent spec proposed this from a count — *898 items under 600 chars each paying full fixed overhead*. Measuring prod first turned it into a **commits lever**: 570 of ~5,170 episodes in 30 days, all under 600 chars, averaging 198.

Three findings decline it, and **none of them depends on the pricing inference**:

| finding | basis |
|---|---|
| **Accretion halves the cut.** A `(member, day)`'s commits arrive across **4.47 sync-hours** against an hourly projector, so each pack is rebuilt 3–5 times. ~9.8% → **~5%**, each re-push re-extracting the whole pack | measured |
| **The design I wrote specified a leak.** `addEpisodes` does not overwrite by name (`project.ts:752`), so "re-push without the removed member" *adds* an episode — a reclassified or purged item's text stays readable in the old tier group indefinitely. My own A2 falsifier, and **no criterion I wrote covered it** | quoted from code |
| **Two functionality regressions.** Arc identity (`MIN_SHARED_ITEMS` starves, or unrelated arcs bind) and prompt representation (`PER_ITEM_CAP` caps a whole commit day as one item) | volume-independent |

Separately: **PIPEFF-2 already banked a material fraction of this saving** — single-chunk items get zero predecessors, and every commit is single-chunk. *How much* is explicitly **not** established; §2 bounds it rather than characterising it, and records that I tried to measure it and it is not obtainable from existing data.

## Corrections to my own analysis, on the record

- "**Single most-cited** evidence source" → n=35 from one `arc_cache` snapshot, p≈0.16. Not rankable. Second time this week.
- Author counts **338/314** came from the wrong resolver and summed to **652 against a population of 570**.
- "Attribution cost is **zero**" → **bounded**. Credit resolves live; nothing re-packs on a correction.
- `entitiesPerEpisode` steps **up**, not down.
- An **invented** reopen trigger (~25% of fleet / ~$25/month) with no derivation — replaced, and quoted so the correction is legible.

## What survives

An appendix keeps the **C1–C10 terrain table** (verified call sites, true independent of packing) and the **five design fragments the review judged correct**, so a future reopener doesn't start from zero.

Parent spec §3 and its sequencing line are marked **SUPERSEDED** rather than left as live guidance.

## Next lever

`use_combined_extraction` — verified directly in the 0.29.3 wheel: real, defaults `False`, sole caller omits it. Larger on the parent's **unmeasured** ~15%, no schema, no attribution surface, **no tier surface**. Deeper than the two patches shipped so far and it changes the extraction prompt, so it needs its own battery.

## Review — Reviewed by Fable — verdict CLEAR: decline record verified against code and prod (all anchors exact, ~5% accretion arithmetic reproduced); plan review BLOCKED the build, delta CLEAR-WITH-CONDITIONS and all four conditions applied — invented §8 trigger replaced, unmeasured "most/cheapest" claims re-hedged, C1–C10 terrain table restored, parent ~15% marked as an estimate.

AIOS-Work: PIPEFF-4
