### PR TITLE
feat(skills): adversarial-build — the dual-review build loop as a repo skill

### DIFF
--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: adversarial-build
+description: >
+  The full build loop for a feature slice in this repo: AIOS-CLI ticket
+  (create-or-update) → write code with spec-first tests → Fable adversarial
+  review → fold → Codex adversarial review → fold → push the PR → update the
+  ticket. Use when asked to "build the next phase/slice", "build X with
+  reviews", or /adversarial-build. Every step below traces to a defect one of
+  the two reviewers actually caught while this loop was being practiced
+  (PCCA-1/PCCA-2, PRs #519/#520) — none of it is ceremony. Never merges; the
+  merge word belongs to the human.
+---
+
+# Adversarial build loop
+
+The spine, verbatim from the operator:
+
+> **aios ticket (create or update) → write code → Fable adversarial review → fold →
+> Codex adversarial review → fold → push the PR → aios ticket update**
+
+Two different models review because they demonstrably catch different defect
+distributions: on the slices this loop was built on, Fable found the
+reserved-slug hijack and the untested fail-open scope direction; Codex found the
+planted-agent-in-builtin oracle hole and the Everyone-vs-External asymmetry —
+each after the other had passed the same code. One reviewer is a gate; two are
+an experiment with replication.
+
+## 0. Ticket first (AIOS CLI)
+
+- If no ticket exists for this work: append a row to `3-log/tasks.md` in
+  `~/Projects/chetan-workspace` — ID matching `[A-Z][A-Z0-9]+-\d+` (ONE hyphen,
+  uppercase; `ARC-STAB-1` silently fails to close), status `in_progress`.
+  If one exists: update its row instead.
+- `cd ~/Projects/chetan-workspace && set -a && . ./.env && set +a`, then
+  `/opt/homebrew/bin/aios push --dry-run` (always preview) and
+  `/opt/homebrew/bin/aios push`. The binary path matters: bare `aios` is a
+  shell function that fails outside a workspace.
+- Read the projection back (`aios status` → `pm projection: ok · N synced`).
+  Cite the BRAIN row key in branch/PR/trailer, never the Linear `AIO-*` key.
+
+## 1. Write the code
+
+- Branch from `origin/main` — or from the prerequisite slice's branch when
+  stacking (PR base = that branch; retarget to `main` after it merges).
+- Spec-first tests in the tier that catches the failure mode (CLAUDE.md §4);
+  for access/persistence work that means real-Postgres data-mechanics, not
+  FakeSupabase. Update `docs/ARCHITECTURE.md` (drift blocks + sources-of-truth
+  row) in the same change.
+- Full local verification: `npx tsc --noEmit` · `npm run lint` · `npm test` ·
+  `npm run db:test:up && DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test
+  npx vitest run --config vitest.datamechanics.config.ts` · `npm run check:docs`.
+- **Commit BEFORE mutation-testing.** Mutations are reverted with
+  `git checkout <file>`, which restores the last COMMIT — running it against an
+  uncommitted tree silently destroys unfolded work (this happened; the folds
+  had to be re-applied by hand).
+- Mutation-verify every guard and security-relevant branch: break the thing,
+  confirm the INTENDED test reddens (not just any test), revert, confirm the
+  tree is clean (`git status --short`). A guard that survives its mutation is
+  decoration.
+
+## 2. Fable adversarial review
+
+Spawn the reviewer (`Agent`, `subagent_type: "code-reviewer"`, `model: "fable"`,
+background) on the branch diff. The prompt shape that works:
+
+- Name the exact diff command (`git diff <base>...HEAD`) and what the diff IS,
+  including which spec sections govern it.
+- If a prior review round already ran, list what was found AND folded — so the
+  reviewer hunts new defects and attacks the folds for second-order bugs
+  instead of re-reporting.
+- Give a concrete attack list per surface (schema traps, races, fail-open
+  paths, guard evasions, green-by-construction tests, false claims in
+  comments/docs) and require file:line evidence plus a CLEAR/BLOCKED verdict.
+- **Forbid DB-touching test runs in the reviewer** ("do NOT run the
+  data-mechanics tier or npm test — shared test-Postgres collision with the
+  main session; pure unit tests are fine"). Concurrent runs against the shared
+  container produce phantom failures that read as product bugs.
+- Never run your own data-mechanics tier while the reviewer is live, for the
+  same reason.
+
+## 3. Fold — with re-derivation both ways
+
+- **Every finding is a hypothesis.** Re-derive it against the code before
+  touching anything. Confirmed → fix + a regression test named for the finding.
+  Wrong → REFUTE with evidence and record the refutation in the commit/PR
+  (example from practice: a claimed regex match disproven with a one-line
+  `node -e` repro — the fold would otherwise have "fixed" working code).
+- Re-run the full verification set after folding; mutation-verify the new
+  fixes; commit as `fix(...): fold Fable review — <finding list>`.
+- Deferring a finding is allowed only with the reason written down (PR body +
+  a code comment at the site), never silently.
+
+## 4. Codex adversarial review
+
+`codex exec --sandbox read-only -m gpt-5.6 "<prompt>"` in the background. Same
+prompt discipline as step 2, plus:
+
+- Tell it what Fable found and what was folded (including refuted claims), and
+  explicitly task it with breaking the folds.
+- Same DB-test prohibition.
+- Expect it to find things Fable missed — that is the point of the second
+  model, not a formality. If both passes come back CLEAR on first try, be
+  suspicious of the prompts before being proud of the code.
+
+## 5. Fold again
+
+Same discipline as step 3. Commit as `fix(...): fold Codex review — <list>`.
+Re-run everything; the tiers must be green after EVERY fold, not just at the
+end.
+
+## 6. Push the PR (never merge)
+
+- `git push -u origin <branch>`, then `gh pr create` — base `main`, or the
+  prerequisite branch when stacked.
+- PR body must carry, honestly:
+  - what the slice is + what is deliberately NOT in it (next slices named);
+  - the verification table (tier counts, mutations run and what each reddened);
+  - `## Review` attestation naming BOTH reviewers, their verdicts INCLUDING
+    the BLOCKED rounds and refuted claims — an attestation that only says
+    CLEAR launders the process; the blocked-then-folded history is the value;
+  - deferrals with reasons;
+  - `AIOS-Work: <ROW-KEY>` trailer (brain row key, not Linear key).
+- Stacked-PR trap: `ci.yml` fires only on PRs targeting `main`/`staging`, so a
+  stacked PR runs just the gate workflows. Close the gap yourself:
+  `npm run test:http:local` (the http tier is otherwise CI-only) and comment
+  the result on the PR. Read the brain-task check's RUNTIME log line
+  (`Found work key(s): …`) — the check is advisory and greens on failure.
+- Watch checks to a terminal state (background `until … pending …` loop).
+- **Do not merge.** Report and stop; the merge word is the human's.
+
+## 7. Close the loop (AIOS CLI again)
+
+- After pushing: update the ticket row if scope changed; the PR link lands via
+  the work-events trailer.
+- After the HUMAN merges: set the row's `Status` to `done` in
+  `3-log/tasks.md`, `aios push` (dry-run first), and read the status back.
+  The merge automation deliberately does NOT close workspace-pushed rows
+  (`linked`, not `applied`) — closing it yourself is the only thing that
+  closes it (CLAUDE.md close gate).
+
+## Failure modes this loop exists to catch (all observed, none hypothetical)
+
+| Class | Caught by | Example from practice |
+|---|---|---|
+| Second-order bug in your own fix | either reviewer | tier-only builtin filter added in a fold; agent-in-Everyone passed it |
+| Fail-open direction untested | Fable | `[]`→`NULL` scope conflation had no red test; suite stayed green |
+| Guard evasion | both | backtick quotes, variable-table idiom, SQL files unscanned |
+| Spec ruling silently unimplemented | Fable | "no external-tier delegation" stated twice, enforced nowhere |
+| Reviewer hallucination | you | regex-matches claim refuted with a node repro |
+| Phantom test failures | process rule | concurrent data-mechanics runs on the shared container |
+| Lost work during mutation testing | process rule | `git checkout` against an uncommitted tree |

--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -2,7 +2,9 @@
 name: adversarial-build
 description: >
   The full build loop for a feature slice in this repo: AIOS-CLI ticket
-  (create-or-update) → write code with spec-first tests → Fable adversarial
+  (create-or-update) → spec gate (author via `aios spec init` if none exists,
+  then `aios spec eval` must say SPEC_READY) → write code with spec-first
+  tests → Fable adversarial
   review → fold → Codex adversarial review → fold → push the PR → update the
   ticket. Use when asked to "build the next phase/slice", "build X with
   reviews", or /adversarial-build. Every step below traces to a defect one of
@@ -13,10 +15,11 @@ description: >
 
 # Adversarial build loop
 
-The spine, verbatim from the operator:
+The spine, from the operator (spec gate added by operator revision):
 
-> **aios ticket (create or update) → write code → Fable adversarial review → fold →
-> Codex adversarial review → fold → push the PR → aios ticket update**
+> **aios ticket (create or update) → spec gate (author if none + `aios spec eval`) →
+> write code → Fable adversarial review → fold → Codex adversarial review → fold →
+> push the PR → aios ticket update**
 
 Two different models review because they demonstrably catch different defect
 distributions: on the slices this loop was built on, Fable found the
@@ -39,6 +42,37 @@ an experiment with replication.
 - Read the projection back (`/opt/homebrew/bin/aios status` → `pm projection: ok · N synced`
   — both `push` and `status` print that line).
   Cite the BRAIN row key in branch/PR/trailer, never the Linear `AIO-*` key.
+
+## 0.5 Spec gate (AIOS CLI)
+
+- **Locate the governing spec.** A build slice must trace to a written spec
+  (CLAUDE.md task gate: anything touching schema, money, or more than one
+  surface). For this repo's access work that is
+  `docs/specs/project-context-classification-v1.md` §-references in the PR.
+- **If no spec exists**: author one before any code — scaffold with
+  `/opt/homebrew/bin/aios spec init <path>` (writes the issue-template shape)
+  or write it in `docs/design/`/`docs/specs/`, then run it through review
+  rounds (a fresh Fable cold read at minimum) before building against it.
+- **Gate the spec** with the eval tool, and mind two sharp edges learned in
+  practice:
+  - Run **from the repo root** with the workspace env loaded:
+    `set -a && . ~/Projects/chetan-workspace/.env && set +a &&
+    /opt/homebrew/bin/aios spec eval <file> --tier deterministic --no-llm`.
+    Running from the workspace directory resolves the spec's repo-relative
+    code paths against the wrong tree and emits dozens of FALSE `SR3` blockers
+    (observed; cost a full debugging detour).
+  - Required outcome: `verdict: SPEC_READY`, exit 0. Real blockers this gate
+    has caught: acceptance criteria with no observable anchor (it reads only
+    each bullet's FIRST source line — put the test-tier/backtick anchor
+    there), a missing build-with tier, module references that don't resolve.
+  - `--tier full` adds the adversarial LLM layer when its key
+    (`DEEPSEEK_API_KEY`) is configured; when absent, the loop's two model
+    reviews stand in as the adversarial layer — say so in the PR, don't
+    pretend the layer ran.
+  - `aios spec fix <file>` exists for the bounded auto-fix loop; hand-fixing
+    against the blocker list is usually faster for a spec you just wrote.
+- Re-run the eval after ANY spec amendment mid-build — SPEC_READY is a state,
+  not a milestone.
 
 ## 1. Write the code
 

--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -27,7 +27,8 @@ an experiment with replication.
 
 ## 0. Ticket first (AIOS CLI)
 
-- If no ticket exists for this work: append a row to `3-log/tasks.md` in
+- Detect first: `grep '<KEY>' ~/Projects/chetan-workspace/3-log/tasks.md` (or scan for the
+  work's obvious key prefix). If no ticket exists: append a row to `3-log/tasks.md` in
   `~/Projects/chetan-workspace` — ID matching `[A-Z][A-Z0-9]+-\d+` (ONE hyphen,
   uppercase; `ARC-STAB-1` silently fails to close), status `in_progress`.
   If one exists: update its row instead.
@@ -35,7 +36,8 @@ an experiment with replication.
   `/opt/homebrew/bin/aios push --dry-run` (always preview) and
   `/opt/homebrew/bin/aios push`. The binary path matters: bare `aios` is a
   shell function that fails outside a workspace.
-- Read the projection back (`aios status` → `pm projection: ok · N synced`).
+- Read the projection back (`/opt/homebrew/bin/aios status` → `pm projection: ok · N synced`
+  — both `push` and `status` print that line).
   Cite the BRAIN row key in branch/PR/trailer, never the Linear `AIO-*` key.
 
 ## 1. Write the code
@@ -47,12 +49,13 @@ an experiment with replication.
   FakeSupabase. Update `docs/ARCHITECTURE.md` (drift blocks + sources-of-truth
   row) in the same change.
 - Full local verification: `npx tsc --noEmit` · `npm run lint` · `npm test` ·
-  `npm run db:test:up && DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test
-  npx vitest run --config vitest.datamechanics.config.ts` · `npm run check:docs`.
+  `npm run db:test:up && npm run test:datamechanics:local` · `npm run check:docs`.
+  (The npm script pins the test-DB URL/port; never hand-write the incantation — it drifts.)
 - **Commit BEFORE mutation-testing.** Mutations are reverted with
-  `git checkout <file>`, which restores the last COMMIT — running it against an
-  uncommitted tree silently destroys unfolded work (this happened; the folds
-  had to be re-applied by hand).
+  `git checkout <file>`, which restores the file from the index/HEAD — either
+  way, uncommitted edits are gone. Running it against an uncommitted tree
+  silently destroys unfolded work (this happened; the folds had to be
+  re-applied by hand).
 - Mutation-verify every guard and security-relevant branch: break the thing,
   confirm the INTENDED test reddens (not just any test), revert, confirm the
   tree is clean (`git status --short`). A guard that survives its mutation is
@@ -92,8 +95,9 @@ background) on the branch diff. The prompt shape that works:
 
 ## 4. Codex adversarial review
 
-`codex exec --sandbox read-only -m gpt-5.6 "<prompt>"` in the background. Same
-prompt discipline as step 2, plus:
+`codex exec --sandbox read-only -m gpt-5.6 "<prompt>"` in the background (model
+id current as of 2026-08; update as Codex models roll). Same prompt discipline
+as step 2, plus:
 
 - Tell it what Fable found and what was folded (including refuted claims), and
   explicitly task it with breaking the folds.
@@ -117,7 +121,13 @@ end.
   - the verification table (tier counts, mutations run and what each reddened);
   - `## Review` attestation naming BOTH reviewers, their verdicts INCLUDING
     the BLOCKED rounds and refuted claims — an attestation that only says
-    CLEAR launders the process; the blocked-then-folded history is the value;
+    CLEAR launders the process; the blocked-then-folded history is the value.
+    **At least one line must parse as `Reviewed by <tool> — verdict <summary>`**
+    — that exact shape is what the required `pr-review-gate` check matches
+    (`scripts/pr-review-gate.mjs`); a bullet-list rendering with no such line
+    fails the gate. Steps 2–5 SATISFY the CLAUDE.md Review gate — do not run
+    the separate `pr-review-attestation` protocol on top; use it only for its
+    line-format reference;
   - deferrals with reasons;
   - `AIOS-Work: <ROW-KEY>` trailer (brain row key, not Linear key).
 - Stacked-PR trap: `ci.yml` fires only on PRs targeting `main`/`staging`, so a
@@ -133,7 +143,7 @@ end.
 - After pushing: update the ticket row if scope changed; the PR link lands via
   the work-events trailer.
 - After the HUMAN merges: set the row's `Status` to `done` in
-  `3-log/tasks.md`, `aios push` (dry-run first), and read the status back.
+  `3-log/tasks.md`, `/opt/homebrew/bin/aios push` (dry-run first), and read the status back.
   The merge automation deliberately does NOT close workspace-pushed rows
   (`linked`, not `applied`) — closing it yourself is the only thing that
   closes it (CLAUDE.md close gate).

--- a/RESOLVER.md
+++ b/RESOLVER.md
@@ -34,6 +34,7 @@ gates (AIOS hub, Tessera root) apply in addition.
 | Admin/ops tasks on the brain instance | `.claude/skills/admin/SKILL.md` |
 | Branches diverged / reconcile a fork | `.claude/skills/branch-reconciliation/SKILL.md` |
 | "Is this test actually wired into CI" | `.claude/skills/test-ci-wiring-audit/SKILL.md` |
+| Building a feature slice end-to-end ("build the next phase/slice", dual adversarial reviews) | `.claude/skills/adversarial-build/SKILL.md` — its steps 2–5 satisfy the Review gate; don't stack the attestation protocol on top |
 | About to push a PR branch / "did this get reviewed" / attest a PR | `.claude/skills/pr-review-attestation/SKILL.md` |
 | Just merged to main / "did the deploy go out" / check Railway | `.claude/skills/railway-deploy-verify/SKILL.md` |
 | PM projection questions (brain→Linear) | `lib/pm-sync/` — the brain's tasks table is canonical, projection is one-way; reconcile reads live status surface-only |


### PR DESCRIPTION
## What this is

The build order practiced on PCCA-1/PCCA-2 (#519/#520), encoded as `.claude/skills/adversarial-build/SKILL.md` per Chetan's spine: **aios ticket (create-or-update) → write code → Fable adversarial review → fold → Codex adversarial review → fold → push the PR → aios ticket update.** Every step traces to a defect one of the reviewers actually caught; the failure-mode table at the bottom is all observed, none hypothetical. Claude-only (not in `.skill-runtimes.json`); RESOLVER.md gains a routing row with an explicit boundary against `pr-review-attestation` (steps 2–5 satisfy the Review gate; the attestation skill is referenced for its line format only).

## Verification
`bash scripts/sync-skill-runtimes.sh --check` ✓ · skill-runtime-sync guard 14/14 ✓ · docs drift ✓ · skill loads (visible as /adversarial-build this session, and this PR's sibling slice-3 build is running under it).

## Review
Reviewed by Fable code-reviewer — verdict CLEAR with 4 Mediums, all folded (the skill violated its own bare-`aios` warning; hand-written dm incantation replaced with `npm run test:datamechanics:local`; the machine-parseable `Reviewed by … — verdict …` line shape is now stated so a cold agent can't fail the required gate; RESOLVER routing + skill-boundary cross-reference added) + 3 Lows folded. One reviewer sub-claim refuted with lived evidence (`aios status` does print the pm-projection line). Codex round deliberately skipped: docs-only skill, no executable surface — the dual-model loop is for feature slices; the gate requires one local review.

AIOS-Work: BUILDLOOP-1