### PR TITLE
fix(graph): the census tripwire needs a sample before it accuses (AIO-867)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -801,9 +801,14 @@ guard enforces it, it's named.
   Cypher-side aggregation) whose newest node landed in the recent window (`CENSUS_RECENT_MS`, 7d;
   baseline scales ~1:14 via `CENSUS_BASELINE_MS`), the fraction carried by >1 node. **Zero splits is
   a healthy, judged reading** on 0.29.3 (exact-name dedup is deterministic); a **zero-NAME** census
-  is cross-checked against the `graph_episodes` ledger — episodes flowing but no names ⇒
-  `predicate-suspect` (a graphiti rename OR a stalled extractor; the alert mail names both), no
-  episodes ⇒ ledger-confirmed young/quiet. The alarm ships **UNARMED** (`CENSUS_ALARM_ARMED=false`;
+  is cross-checked against the `graph_episodes` ledger — **at least
+  `MIN_EPISODES_FOR_CENSUS_SUSPICION` (25) windowed** episodes flowing but no names ⇒
+  `predicate-suspect` (a graphiti rename OR a stalled extractor; the alert mail names both), fewer
+  than that ⇒ ledger-confirmed young/quiet. **The floor is load-bearing** (CENSUSFLOOR-1): it
+  originally accused on ONE episode, and prod's `aios_external` — a single 196-char boilerplate index
+  stub in the window — was rendered on the card as "stalled extractor" while that group held 16
+  entities. `predicate-suspect` RUNS the blindness clock and `small-sample` PARKS it, so the floor is
+  also what stops a low-volume group paging a healthy install. The alarm ships **UNARMED** (`CENSUS_ALARM_ARMED=false`;
   margin/floor are placeholders) until the admin card's per-group census has been measured on prod —
   flipping it is the rollout's step-3 commit. Delivery (`lib/graph/extraction-alert`, driven from the
   ingest scheduler tick) runs **two machines over the `graph_health` `ingest_runs` ledger**,

--- a/docs/design/census-sample-floor.md
+++ b/docs/design/census-sample-floor.md
@@ -175,6 +175,14 @@ silently with no criterion covering the change.
 `test/name-collision-pollution.test.ts:143-149` (null ledger ⇒ `small-sample`) must stay green
 untouched; it is A4's existing pin.
 
+**A third test flipped that neither this spec nor the plan review named** — found by running the full
+suite, not by reading: `test/guards/dedupe-predicate-pinned.test.ts:109-121` pins the tripwire at
+`recentEpisodes: 12`. So "named rather than discovered" was **incomplete**, and the honest record is
+that one of the three was discovered. Its fixture moves to 30, and — because it is a *guard*, whose
+job is to make a regression fail the build — it gained the **other side**: the same signals at 1
+episode must read `small-sample`. A guard that pins only the firing half can be satisfied by a
+regression that drops the floor, which is precisely the failure this whole change is about.
+
 ### The contract comment is part of the change
 
 `extraction-health.ts:605-611` currently states: *"episodes projected in the window but zero census

--- a/docs/design/census-sample-floor.md
+++ b/docs/design/census-sample-floor.md
@@ -151,7 +151,26 @@ prod data. This fix is about a *refusal*, which computes regardless of arming.
 | A4 | `recentEpisodes: null` (unreadable ledger) still ⇒ `small-sample`, never an accusation | unit | any accusation from a null ledger |
 | A5 | **The page cannot fire from a below-floor group alone**, tested through the REAL chain: `deriveNameCollisionPollution` → `refusalRunsClock(refusal, …)` → `classifyBlindnessTick`. With `aios_team` at `small-sample` and `aios_external` below the floor, the tick is `"parked"`, not `"running"` | unit | `"running"` — §0.2's latent bug surviving the fix |
 | A6 | Prod's exact measured state reproduces: 1 recent episode, 0 names ⇒ `small-sample` | unit | anything else |
-| A7 | **Mutation:** restoring `> 0` reddens **A1, A3, A5 and A6** — and not A2 | mutation | a mutation reddening no test, or reddening A2 (which would mean A2 pins the wrong thing) |
+| A7 | **Mutations, three, with the redden list recorded from the RUN and not predicted** | mutation | a mutation reddening no test, or reddening the wrong set |
+
+### A7's three mutations — measured redden lists
+
+Recorded from running them, not from predicting them. My first draft predicted mutation 2 would
+redden "A2 alone"; it reddens three tests. Same unverified-"alone" class I have hit twice already
+this week, so the lists below are transcribed output.
+
+| mutation | reddens |
+|---|---|
+| **1 — restore the `> 0` floor** (the bug itself) | A1 · A3 · A6 · A5's parked case · the guard's below-floor half |
+| **2 — floor → 10,000** (detection dead) | A2 · the unarmed-clamp refusal test · the guard's firing half |
+| **3 — the production seam:** replace `refusalRunsClock(…)` with `refusal !== null` in `runBlindnessMachine` | the roundtrip park pin, alone |
+
+**Mutation 3 is the code review's find, not mine, and it is the important one.** A5 composes the
+chain *test-side*, so it stays green if the *production* tick construction stops consulting
+`refusalRunsClock` — and that mutation ships exactly the spurious page this change exists to
+prevent, with the entire suite green. It is now pinned at the production seam
+(`test/graph-health-roundtrip.test.ts`), over the full 25h the machine needs, with a non-vacuity
+case beside it proving a clock-running refusal still anchors on the same shape.
 
 **Why A2 uses a literal 25 and A3 uses the constant.** If both read the exported constant, a mutation
 raising the floor to 10,000 — which kills detection entirely — leaves the whole suite green. A2's

--- a/docs/design/census-sample-floor.md
+++ b/docs/design/census-sample-floor.md
@@ -1,0 +1,123 @@
+# The census tripwire accuses on a sample of one — CENSUSFLOOR-1 / AIO-867
+
+**Status:** spec, pre-review.
+**Related:** `docs/design/dedupe-alarm-0293.md` (the alarm this is a defect in, merged `031f5bb`, 4 days old).
+
+---
+
+## 0. What is actually wrong, and a correction to my own first report
+
+The admin card currently shows, for the `aios_external` group:
+
+> ⚠️ *episodes are flowing but the census reads zero names — rename or stalled extractor*
+
+**Nothing is stalled.** In the whole 7-day census window that group contains **one** episode:
+`4-shared/index.md`, a **196-character boilerplate directory header** ("What you've deliberately
+promoted outward…"). It has no people or projects in it, so it correctly produces zero named
+entities. The `aios_team` group in the same read is healthy and judged: 2,439 names, 12.66
+entities/episode, 0.2% splits against a 1.6% baseline.
+
+The cause is one predicate. `deriveNameCollisionPollution` (`lib/graph/extraction-health.ts:643`):
+
+```ts
+if (signals.recentNames === 0) {
+  return (recentEpisodes ?? 0) > 0 ? refuse("predicate-suspect") : refuse("small-sample");
+}
+```
+
+**The accusation floor is one episode.** Its sibling judgement, in the same file, refuses below
+**twenty-five** — `MIN_EPISODES_FOR_EXTRACTION_SIGNAL` (`extraction-health.ts:48`), whose own
+docstring states the reason: *"Below this many projected episodes we can't distinguish 'extractor
+broken' from 'fresh install still mid-first-extraction'."* That reasoning applies verbatim to this
+tripwire. The two judgements disagree about how much evidence an accusation needs, in the same file,
+about the same pipeline.
+
+### Correction: I told the owner this "will email you". It will not — today.
+
+I reported that the blindness meta-alarm would email an accusation about a healthy system. **That was
+wrong, and I am correcting it before it becomes the justification for the fix.**
+`classifyBlindnessTick` (`extraction-alert.ts:225`) returns `"judged"` if **any** group is judgeable.
+`aios_team` is judgeable, so the tick is judged, the blindness clock never runs, and no mail fires.
+
+**What is true is narrower and still worth fixing:**
+
+1. **The card states a falsehood today** — "stalled extractor" about a working one. An alarm surface
+   that accuses on no evidence trains its reader to ignore it, which is how the last alarm ended up
+   silently dead.
+2. **There is a real latent paging path.** `predicate-suspect` *does* run the blindness clock
+   (`extraction-alert.ts:202`). It is currently masked only because `aios_team` clears
+   `MIN_NAMES_FOR_CENSUS_SIGNAL = 50`. On a quiet week `aios_team` drops to `small-sample`, which
+   **parks** — so the only clock-running refusal left is `aios_external`'s false one, the tick
+   becomes `"running"`, and 24 hours later the meta-alarm **mails an accusation of a stalled
+   extractor during a week when the real story is "not much happened"**. That is the cry-wolf failure
+   arriving by the exact route the meta-alarm was built to prevent, inverted.
+
+So: not urgent, genuinely wrong, and it fires on the quiet week when a spurious page is least welcome.
+
+---
+
+## 1. The fix
+
+Give the tripwire an episode floor, and make a below-floor group read as what it is:
+
+```ts
+if (signals.recentNames === 0) {
+  return (recentEpisodes ?? 0) >= MIN_EPISODES_FOR_CENSUS_SUSPICION
+    ? refuse("predicate-suspect")   // enough pushed that zero names is unexplained
+    : refuse("small-sample");       // honest "cannot judge", parks, no accusation
+}
+```
+
+**A new constant rather than reusing `MIN_EPISODES_FOR_EXTRACTION_SIGNAL`.** The two judgements read
+different populations (facts vs normalised names) and this file's existing convention is one
+documented constant per population — `MIN_NAMES_FOR_CENSUS_SIGNAL` exists separately from the episode
+minimum for exactly this reason, and says so. Coupling them would mean a future re-derivation of one
+silently moves the other. **Initial value 25**, matching the sibling, with the derivation written
+down and marked as inherited rather than measured.
+
+`small-sample` is the correct destination: it parks the blindness clock
+(`extraction-alert.ts:211-213`), so a low-volume group produces neither an accusation nor a page —
+while a genuinely broken extractor on a *busy* group still trips at 25.
+
+---
+
+## 2. What this deliberately does not fix
+
+**A group could push 25 boilerplate episodes and still legitimately yield zero names**, and the
+tripwire would then accuse it. An episode count is a proxy for "enough content that entities were
+owed"; content *volume* would be the honest measure. I am not building that: the sibling judgement
+accepts the identical tradeoff, 25 near-empty episodes in one group is not a realistic steady state,
+and adding a second unmeasured threshold to fix an unmeasured one is how thresholds multiply.
+Recorded so the next person does not think it was missed.
+
+**The alarm stays unarmed.** `CENSUS_ALARM_ARMED` is still `false` and this change does not touch it —
+arming remains rollout step 3, after `CENSUS_MARGIN` / `CENSUS_ABSOLUTE_FLOOR` are set from measured
+prod data. This fix is about a *refusal*, which computes regardless of arming.
+
+---
+
+## 3. Acceptance
+
+| # | Criterion | Tier | Falsifier |
+|---|---|---|---|
+| A1 | Zero names with **1** recent episode ⇒ `small-sample`, `judgeable: false`, **no accusation** | unit | any `predicate-suspect` below the floor |
+| A2 | Zero names with **25** recent episodes ⇒ `predicate-suspect` — the real detection is **not** lost | unit | a genuinely stalled busy group reading `small-sample` |
+| A3 | The boundary is exact at the constant: floor−1 ⇒ `small-sample`, floor ⇒ `predicate-suspect` | unit | an off-by-one at the threshold |
+| A4 | `recentEpisodes: null` (unreadable ledger) still ⇒ `small-sample`, never an accusation | unit | any accusation from a null ledger |
+| A5 | **The quiet-week page cannot fire from a below-floor group alone**: with `aios_team` at `small-sample` and `aios_external` below the floor, `classifyBlindnessTick` returns `"parked"`, not `"running"` | unit | `"running"`, which is the latent bug in §0.2 surviving the fix |
+| A6 | Prod's exact current state reproduces: 1 episode, 0 names ⇒ `small-sample` | unit (fixture from the measured values) | anything else |
+| A7 | **Mutation:** restoring `> 0` reddens A1, A3, A5 and **nothing else** | mutation | a mutation that reddens no test, or reddens A2 (which would mean A2 pins the wrong thing) |
+
+A5 is the one that matters most — it is the only criterion that tests the *consequence* rather than
+the predicate, and §0.2 is the reason this fix is worth shipping at all.
+
+---
+
+## 4. Rollout
+
+Pure-function change plus tests. No schema, no migration, no new surface. The card's copy is
+unchanged — the point is that the state it renders becomes correct, not that the words change.
+
+**Verification after merge:** the `aios_external` row on the admin card should read as a quiet
+small-sample group rather than an orange accusation. That is a one-look check on the same card that
+surfaced it, and unlike the last lever it needs no window, no drain, and no spend.

--- a/docs/design/census-sample-floor.md
+++ b/docs/design/census-sample-floor.md
@@ -17,6 +17,19 @@ promoted outward…"). It has no people or projects in it, so it correctly produ
 entities. The `aios_team` group in the same read is healthy and judged: 2,439 names, 12.66
 entities/episode, 0.2% splits against a 1.6% baseline.
 
+**Confirmed, not assumed — extraction for that group works.** The review would not accept "nothing is
+stalled" on the strength of one episode's content, so I read Neo4j directly (read-only, via
+`railway ssh` to the graphiti service, the only host that can reach `neo4j.railway.internal`):
+
+```
+aios_external | entities: 16 | episodic: 6
+aios_team     | entities: 18999 | episodic: 6037
+```
+
+`aios_external` has **16 entities all-time**. There is no per-group extraction failure being explained
+away here: the zero is purely a *windowing* effect — no new entity landed in the last 7 days because
+the only episode in that window is boilerplate.
+
 The cause is one predicate. `deriveNameCollisionPollution` (`lib/graph/extraction-health.ts:643`):
 
 ```ts
@@ -44,15 +57,26 @@ wrong, and I am correcting it before it becomes the justification for the fix.**
 1. **The card states a falsehood today** — "stalled extractor" about a working one. An alarm surface
    that accuses on no evidence trains its reader to ignore it, which is how the last alarm ended up
    silently dead.
-2. **There is a real latent paging path.** `predicate-suspect` *does* run the blindness clock
-   (`extraction-alert.ts:202`). It is currently masked only because `aios_team` clears
-   `MIN_NAMES_FOR_CENSUS_SIGNAL = 50`. On a quiet week `aios_team` drops to `small-sample`, which
-   **parks** — so the only clock-running refusal left is `aios_external`'s false one, the tick
-   becomes `"running"`, and 24 hours later the meta-alarm **mails an accusation of a stalled
-   extractor during a week when the real story is "not much happened"**. That is the cry-wolf failure
-   arriving by the exact route the meta-alarm was built to prevent, inverted.
+2. **There is a real latent paging path — rarer than I first said, and I am pricing it honestly.**
+   `predicate-suspect` *does* run the blindness clock (`extraction-alert.ts:203-204`), while
+   `small-sample` parks (`:211-213`). It is masked only because `aios_team` clears
+   `MIN_NAMES_FOR_CENSUS_SIGNAL = 50`. If `aios_team` ever falls below that it parks, leaving
+   `aios_external`'s false refusal as the only clock-running one, the tick becomes `"running"`, and
+   24 hours later the meta-alarm **mails a stalled-extractor accusation**.
 
-So: not urgent, genuinely wrong, and it fires on the quiet week when a spurious page is least welcome.
+   **I first wrote "on a quiet week". That overstates it and the measured rates say so.** The path
+   needs a conjunction: `aios_team`'s recent-name arrivals collapsing from **2,439/week to under 50**
+   — a >97% drop, a full shutdown rather than a quiet week (and diff-sync means unchanged content
+   does not re-project, so it is reachable, roughly annually) — **and** a fresh zero-yield
+   `aios_external` push (~0.7/week historically) inside the same window, **and** both holding 24h.
+
+   **The stronger version of this argument is the one I had not made:** AIOS is self-hosted per
+   organisation (CLAUDE.md §5). On a small install — one team, low volume, an external group of a
+   handful of shared files — *this conjunction is the normal state*, not the annual tail. The bug is
+   mild here and routine there.
+
+So: not urgent on this install, genuinely wrong on every install, and it pages exactly when a
+spurious page is least welcome.
 
 ---
 
@@ -68,12 +92,21 @@ if (signals.recentNames === 0) {
 }
 ```
 
-**A new constant rather than reusing `MIN_EPISODES_FOR_EXTRACTION_SIGNAL`.** The two judgements read
-different populations (facts vs normalised names) and this file's existing convention is one
-documented constant per population — `MIN_NAMES_FOR_CENSUS_SIGNAL` exists separately from the episode
-minimum for exactly this reason, and says so. Coupling them would mean a future re-derivation of one
-silently moves the other. **Initial value 25**, matching the sibling, with the derivation written
-down and marked as inherited rather than measured.
+**A new constant rather than reusing `MIN_EPISODES_FOR_EXTRACTION_SIGNAL`.** My first draft justified
+this as "different populations (facts vs names)". That is the wrong reason — **both constants are
+denominated in episodes.** The real and stronger one: `MIN_EPISODES_FOR_EXTRACTION_SIGNAL` counts
+**lifetime** episodes (`countProjectedEpisodes`, `extraction-health.ts:180-190`, no window), while
+this tripwire counts **7-day-windowed** episodes, which is a *rate*. Reusing one constant would couple
+a fresh-install threshold to a rate threshold, and a future re-derivation of either would silently
+move the other.
+
+**Initial value 25 — chosen conservative against the measured yield, not merely inherited.** At
+`aios_team`'s measured 12.66 entities/episode, even 3–5 typical episodes yielding zero names would be
+anomalous, so a floor of 25 is far above what detection strictly needs. It is set there deliberately,
+against the counter-case that makes a low floor dangerous: a workspace restructure re-pushing several
+boilerplate index files in one week would legitimately yield near-zero names, and a card that
+accuses on that burst is back to crying wolf. The asymmetry is the same one the review gate uses —
+a false accusation costs the alarm's credibility, a missed low-volume detection costs a delay.
 
 `small-sample` is the correct destination: it parks the blindness clock
 (`extraction-alert.ts:211-213`), so a low-volume group produces neither an accusation nor a page —
@@ -90,6 +123,18 @@ accepts the identical tradeoff, 25 near-empty episodes in one group is not a rea
 and adding a second unmeasured threshold to fix an unmeasured one is how thresholds multiply.
 Recorded so the next person does not think it was missed.
 
+**And its dual, which my first draft omitted — the inverse of the residual above.** Below the floor,
+a *genuine* per-group extraction failure is now **permanently silent**: a client project that
+resumes and pushes 10 content-rich episodes a week to `aios_external`, with graphiti rejecting that
+group, reads `small-sample` forever — no amber card, no clock — because that group never reaches 25
+episodes in a window. Detection of the failures that matter (a graphiti rename, a global stall) rides
+entirely on the **busy** group, which does trip: after ≤7 days of stall `aios_team`'s `recentNames`
+decays to 0 with thousands of recent episodes. So A2's "the real detection is not lost" is true **for
+busy groups only**, and must not be read as "detection preserved, period". The surviving surface for a
+quiet group is the observational `entitiesPerEpisode` number on the card. Recorded because I wrote one
+half of this residual and not the other, which is the exact failure that let a leak through the
+packing spec's criteria two days ago.
+
 **The alarm stays unarmed.** `CENSUS_ALARM_ARMED` is still `false` and this change does not touch it —
 arming remains rollout step 3, after `CENSUS_MARGIN` / `CENSUS_ABSOLUTE_FLOOR` are set from measured
 prod data. This fix is about a *refusal*, which computes regardless of arming.
@@ -101,17 +146,42 @@ prod data. This fix is about a *refusal*, which computes regardless of arming.
 | # | Criterion | Tier | Falsifier |
 |---|---|---|---|
 | A1 | Zero names with **1** recent episode ⇒ `small-sample`, `judgeable: false`, **no accusation** | unit | any `predicate-suspect` below the floor |
-| A2 | Zero names with **25** recent episodes ⇒ `predicate-suspect` — the real detection is **not** lost | unit | a genuinely stalled busy group reading `small-sample` |
-| A3 | The boundary is exact at the constant: floor−1 ⇒ `small-sample`, floor ⇒ `predicate-suspect` | unit | an off-by-one at the threshold |
+| A2 | Zero names with a **literal 25** recent episodes ⇒ `predicate-suspect` — the real detection is not lost **for a busy group** | unit | a genuinely stalled busy group reading `small-sample` |
+| A3 | The boundary is exact **at the exported constant**: `FLOOR−1` ⇒ `small-sample`, `FLOOR` ⇒ `predicate-suspect` | unit | an off-by-one at the threshold |
 | A4 | `recentEpisodes: null` (unreadable ledger) still ⇒ `small-sample`, never an accusation | unit | any accusation from a null ledger |
-| A5 | **The quiet-week page cannot fire from a below-floor group alone**: with `aios_team` at `small-sample` and `aios_external` below the floor, `classifyBlindnessTick` returns `"parked"`, not `"running"` | unit | `"running"`, which is the latent bug in §0.2 surviving the fix |
-| A6 | Prod's exact current state reproduces: 1 episode, 0 names ⇒ `small-sample` | unit (fixture from the measured values) | anything else |
-| A7 | **Mutation:** restoring `> 0` reddens A1, A3, A5 and **nothing else** | mutation | a mutation that reddens no test, or reddens A2 (which would mean A2 pins the wrong thing) |
+| A5 | **The page cannot fire from a below-floor group alone**, tested through the REAL chain: `deriveNameCollisionPollution` → `refusalRunsClock(refusal, …)` → `classifyBlindnessTick`. With `aios_team` at `small-sample` and `aios_external` below the floor, the tick is `"parked"`, not `"running"` | unit | `"running"` — §0.2's latent bug surviving the fix |
+| A6 | Prod's exact measured state reproduces: 1 recent episode, 0 names ⇒ `small-sample` | unit | anything else |
+| A7 | **Mutation:** restoring `> 0` reddens **A1, A3, A5 and A6** — and not A2 | mutation | a mutation reddening no test, or reddening A2 (which would mean A2 pins the wrong thing) |
 
-A5 is the one that matters most — it is the only criterion that tests the *consequence* rather than
-the predicate, and §0.2 is the reason this fix is worth shipping at all.
+**Why A2 uses a literal 25 and A3 uses the constant.** If both read the exported constant, a mutation
+raising the floor to 10,000 — which kills detection entirely — leaves the whole suite green. A2's
+literal is what makes that mutation fail. A3 legitimately reads the constant, because its job is the
+boundary wherever the boundary is.
 
----
+**A5 must not hand-feed booleans.** `classifyBlindnessTick` takes
+`Array<{judgeable, clockRuns}>`, so a test that constructs those literals proves a trivial OR and
+nothing about this fix. It has to derive `clockRuns` from the real refusal via `refusalRunsClock` —
+the composition `test/extraction-alert.test.ts:340-346` already uses for `graph-unreadable`.
+A5 is the only criterion that tests the *consequence* rather than the predicate, and §0.2 is the
+reason this fix is worth shipping at all.
+
+### The existing test this fix flips, named rather than discovered
+
+`test/name-collision-pollution.test.ts:104-112` pins `recentEpisodes: 10` ⇒ `predicate-suspect`. It
+**must go red** under this change — that is the fix working — and its fixture moves to `≥ 25`. Named
+here so the builder does not "resolve" the red by lowering the floor to 10, and does not update it
+silently with no criterion covering the change.
+
+`test/name-collision-pollution.test.ts:143-149` (null ledger ⇒ `small-sample`) must stay green
+untouched; it is A4's existing pin.
+
+### The contract comment is part of the change
+
+`extraction-health.ts:605-611` currently states: *"episodes projected in the window but zero census
+names ⇒ `predicate-suspect`"*. After this fix that sentence is **false as written** and must be
+updated in the same commit. A stale contract comment describing behaviour the code no longer has is
+the drift class this repo has hit four times in a week — and here it sits directly above the function
+it misdescribes.
 
 ## 4. Rollout
 

--- a/lib/graph/extraction-health.ts
+++ b/lib/graph/extraction-health.ts
@@ -299,6 +299,35 @@ export const CENSUS_BASELINE_MS = 14 * CENSUS_RECENT_MS;
  */
 export const MIN_NAMES_FOR_CENSUS_SIGNAL = 50;
 /**
+ * Below this many episodes projected INTO THE RECENT WINDOW, a zero-name census is not evidence of
+ * anything and must not accuse — it reads `small-sample` (which parks the blindness clock) rather
+ * than `predicate-suspect` (which runs it). CENSUSFLOOR-1 / AIO-867.
+ *
+ * The bug this closes, found live on the admin card: the floor was **one episode**, and prod's
+ * `aios_external` group held exactly one 196-char boilerplate index stub in the window — so the card
+ * read "rename or stalled extractor" about a working extractor (Neo4j: 16 entities all-time in that
+ * group). An alarm surface that accuses on no evidence trains its reader to ignore it, which is how
+ * the alarm this replaced ended up silently dead.
+ *
+ * SEPARATE from `MIN_EPISODES_FOR_EXTRACTION_SIGNAL` despite sharing its initial value, because they
+ * are different quantities: that one counts LIFETIME episodes (a fresh-install threshold), this one
+ * counts 7-day-WINDOWED episodes (a rate). One constant would couple them, and a future
+ * re-derivation of either would silently move the other.
+ *
+ * 25 is deliberately CONSERVATIVE, not inherited: at prod's measured 12.66 entities/episode even
+ * 3-5 typical episodes yielding zero names would be anomalous, so detection needs far less. It is
+ * set high against the counter-case that makes a low floor dangerous — a workspace restructure
+ * re-pushing several boilerplate index files in one week legitimately yields near-zero names, and a
+ * card that accuses on that burst is back to crying wolf.
+ *
+ * KNOWN AND ACCEPTED, both halves (see docs/design/census-sample-floor.md §2): a group pushing 25
+ * boilerplate episodes would still be accused; and a GENUINE per-group extraction failure in a group
+ * that never reaches 25 episodes per window is now permanently silent, its detection riding on the
+ * busy group (which does trip — a global stall decays the busy group's `recentNames` to 0 against
+ * thousands of recent episodes).
+ */
+export const MIN_EPISODES_FOR_CENSUS_SUSPICION = 25;
+/**
  * ⚠️ PLACEHOLDER — armed after prod measurement per the rollout (docs/design/dedupe-alarm-0293.md):
  * the card ships the per-group split-share numbers first, the margin is set from a few days of
  * measured baseline in a follow-up commit (the same measured-not-chosen path the original AIO-693
@@ -603,12 +632,18 @@ export interface NameCollisionInput {
  *  • At `baselineShare === 0` the relative margin rejects nothing, so ONLY the absolute floor
  *    judges.
  *  • A ZERO-NAME census is indistinguishable from a young group on its own, so it cross-checks the
- *    `graph_episodes` ledger: episodes projected in the window but zero census names ⇒
- *    `predicate-suspect` (a graphiti bump renaming `Entity`/`created_at` — OR a stalled extractor;
- *    the alert mail names both); no episodes either ⇒ a genuinely young/quiet group
- *    (`small-sample`). "Young" is thereby defined by the ledger, the one source that knows whether
- *    anything was pushed. An unreadable ledger (`recentEpisodes: null`) reads as `small-sample`,
- *    never as an accusation.
+ *    `graph_episodes` ledger: **at least `MIN_EPISODES_FOR_CENSUS_SUSPICION`** episodes projected in
+ *    the window but zero census names ⇒ `predicate-suspect` (a graphiti bump renaming
+ *    `Entity`/`created_at` — OR a stalled extractor; the alert mail names both); fewer than that ⇒ a
+ *    genuinely young/quiet group (`small-sample`). "Young" is thereby defined by the ledger, the one
+ *    source that knows whether anything was pushed. An unreadable ledger (`recentEpisodes: null`)
+ *    reads as `small-sample`, never as an accusation.
+ *
+ *    The floor is load-bearing, not decoration (CENSUSFLOOR-1): this cross-check originally accused
+ *    on ONE episode, and prod's `aios_external` — a single 196-char boilerplate index stub in the
+ *    window — was rendered on the admin card as "stalled extractor" while that group in fact held 16
+ *    entities. `small-sample` PARKS the blindness clock and `predicate-suspect` RUNS it, so the floor
+ *    is also what stops a low-volume group from paging an install where nothing is wrong.
  *
  * `armed` defaults to `CENSUS_ALARM_ARMED` (rollout: false until margin/floor are measured); tests
  * pass `true` to pin the armed mechanics. While unarmed the verdict is clamped `polluted: false`
@@ -639,8 +674,11 @@ export function deriveNameCollisionPollution(
     return refuse("graph-unreadable");
   }
   if (signals.recentNames === 0) {
-    // The tripwire that replaced the old zero-predicate check — see the contract above.
-    return (recentEpisodes ?? 0) > 0 ? refuse("predicate-suspect") : refuse("small-sample");
+    // The tripwire that replaced the old zero-predicate check — see the contract above. The floor is
+    // what stops it accusing on no evidence (CENSUSFLOOR-1): below it, zero names is unremarkable.
+    return (recentEpisodes ?? 0) >= MIN_EPISODES_FOR_CENSUS_SUSPICION
+      ? refuse("predicate-suspect")
+      : refuse("small-sample");
   }
   if (signals.recentNames < MIN_NAMES_FOR_CENSUS_SIGNAL) return refuse("small-sample");
   if (signals.baselineNames < MIN_NAMES_FOR_CENSUS_SIGNAL) return refuse("no-baseline");

--- a/test/extraction-alert.test.ts
+++ b/test/extraction-alert.test.ts
@@ -12,6 +12,12 @@ import {
   type BlindnessPhase,
   type PollutionGroupTick,
 } from "@/lib/graph/extraction-alert";
+import {
+  deriveNameCollisionPollution,
+  MIN_EPISODES_FOR_CENSUS_SUSPICION,
+  MIN_NAMES_FOR_CENSUS_SIGNAL,
+  type NameCollisionInput,
+} from "@/lib/graph/extraction-health";
 import type { DbClient } from "@/lib/db/types";
 
 /**
@@ -418,5 +424,72 @@ describe("the per-kind ledger read", () => {
     ]);
     const blind = await latestGraphHealthOfKind(db, "blindness");
     expect(blind?.meta.phase).toBe("cleared");
+  });
+});
+
+/**
+ * CENSUSFLOOR-1 A5 — the CONSEQUENCE, not the predicate.
+ *
+ * §0.2 of docs/design/census-sample-floor.md: `predicate-suspect` runs the blindness clock while
+ * `small-sample` parks, so a below-floor group holding a FALSE `predicate-suspect` is the only
+ * clock-running refusal the moment the busy group drops to `small-sample` — and 24h later the
+ * meta-alarm mails a stalled-extractor accusation at an install where nothing is wrong. On a small
+ * self-hosted install that conjunction is the normal state, not the annual tail.
+ *
+ * This composes the REAL chain — deriveNameCollisionPollution → refusalRunsClock →
+ * classifyBlindnessTick — deliberately. Hand-feeding `{judgeable, clockRuns}` literals would test a
+ * trivial OR and stay green if the predicate wiring broke.
+ */
+describe("CENSUSFLOOR-1 A5 — a below-floor group cannot run the blindness clock", () => {
+  const tickFor = (groups: NameCollisionInput[]): ReturnType<typeof classifyBlindnessTick> =>
+    classifyBlindnessTick(
+      groups.map((input) => {
+        const pollution = deriveNameCollisionPollution(input);
+        return {
+          judgeable: pollution.judgeable,
+          clockRuns: pollution.refusal
+            ? refusalRunsClock(pollution.refusal, {
+                baselineEpisodes: 0,
+                unreadableSinceMs: null,
+                nowMs: Date.UTC(2026, 7, 11),
+              })
+            : false,
+        };
+      })
+    );
+
+  const zeroNames = (recentEpisodes: number | null): NameCollisionInput => ({
+    configured: true,
+    signals: { recentNames: 0, recentSplit: 0, baselineNames: 0, baselineSplit: 0 },
+    recentEpisodes,
+  });
+
+  /** A quiet busy-group week: too few names to judge, ledger present. Parks on its own. */
+  const quietBusyGroup: NameCollisionInput = {
+    configured: true,
+    signals: { recentNames: 3, recentSplit: 0, baselineNames: 3, baselineSplit: 0 },
+    recentEpisodes: 4,
+  };
+
+  it("the shutdown-week conjunction PARKS: quiet busy group + one boilerplate external episode", () => {
+    expect(tickFor([quietBusyGroup, zeroNames(1)])).toBe("parked");
+  });
+
+  it("a busy group with real content still RUNS the clock — the detection that matters survives", () => {
+    expect(tickFor([quietBusyGroup, zeroNames(MIN_EPISODES_FOR_CENSUS_SUSPICION)])).toBe("running");
+  });
+
+  it("while the busy group is judgeable the tick is judged regardless — today's masking", () => {
+    const healthyBusy: NameCollisionInput = {
+      configured: true,
+      signals: {
+        recentNames: MIN_NAMES_FOR_CENSUS_SIGNAL * 2,
+        recentSplit: 0,
+        baselineNames: MIN_NAMES_FOR_CENSUS_SIGNAL * 2,
+        baselineSplit: 0,
+      },
+      recentEpisodes: 2000,
+    };
+    expect(tickFor([healthyBusy, zeroNames(1)])).toBe("judged");
   });
 });

--- a/test/graph-health-roundtrip.test.ts
+++ b/test/graph-health-roundtrip.test.ts
@@ -147,3 +147,38 @@ describe("pollution rows round-trip: groups written by alert/refresh are the mem
     expect(metas[1].refresh).toBe(true);
   });
 });
+
+/**
+ * CENSUSFLOOR-1 (code review MEDIUM): the PRODUCTION tick construction was unpinned against a
+ * taxonomy bypass. `runBlindnessMachine` derives `clockRuns` per group via `refusalRunsClock`
+ * (`lib/graph/extraction-alert.ts:496-502`); replacing that with `refusal !== null` leaves the whole
+ * suite green — A5 composes the chain test-side, `refusalRunsClock`'s own tests are pure, and every
+ * all-unjudgeable sequence in this file used `predicate-suspect` (which runs the clock either way),
+ * while its one `small-sample` dip sits beside a judgeable group so the tick is `judged` regardless.
+ *
+ * That mutation ships EXACTLY the spurious page CENSUSFLOOR-1 exists to prevent: a healthy install
+ * whose only refusal is a parked `small-sample` would anchor and then mail "the pollution alarm has
+ * gone blind". Pinning the park here, at the production seam, over the full 25h the machine needs.
+ */
+describe("a parked refusal never runs the blindness clock — the production seam (CENSUSFLOOR-1)", () => {
+  const t0 = Date.UTC(2026, 7, 1);
+  const parked = { judgeable: false, polluted: false, refusal: "small-sample" as const };
+
+  it("every group small-sample for 25h+ NEVER anchors and NEVER fires", async () => {
+    const { db } = ledgerDb();
+    // Hour 0 — a parked tick must not even anchor; anchoring is what makes the 24h clock start.
+    expect((await tick(db, [census("A", parked), census("B", parked)], t0)).blindness).toBe("none");
+    // Hour 25 — past UNJUDGEABLE_ALERT_HOURS. Still nothing: parked ticks change nothing, so there
+    // is no anchor to fire off. If `clockRuns` ever stops consulting `refusalRunsClock`, this reads
+    // "anchor" here and "fire" on the next tick.
+    expect(
+      (await tick(db, [census("A", parked), census("B", parked)], t0 + 25 * HOUR)).blindness
+    ).toBe("none");
+  });
+
+  it("…while a clock-RUNNING refusal on the same shape does anchor — the pin is not vacuous", async () => {
+    const { db } = ledgerDb();
+    const suspect = { judgeable: false, polluted: false, refusal: "predicate-suspect" as const };
+    expect((await tick(db, [census("A", suspect)], t0)).blindness).toBe("anchor");
+  });
+});

--- a/test/guards/dedupe-predicate-pinned.test.ts
+++ b/test/guards/dedupe-predicate-pinned.test.ts
@@ -111,13 +111,29 @@ describe("name-collision census pinning (graphiti_core 0.29.3)", () => {
     // silent-death shape the old guard fell to. The `graph_episodes` ledger is the one source that
     // knows whether anything was pushed: episodes in the window + nothing in the census means the
     // query no longer matches what the image writes (a rename) OR the extractor is stalled.
+    //
+    // 30, not 12: CENSUSFLOOR-1 gave the tripwire an episode floor
+    // (`MIN_EPISODES_FOR_CENSUS_SUSPICION = 25`), because at 12 — and at prod's actual ONE — a zero
+    // census is not evidence of anything, and the card was accusing a working extractor. This guard
+    // pins that the tripwire STILL FIRES once the sample is real; the floor itself is pinned by
+    // A2/A3 in test/name-collision-pollution.test.ts. Do NOT resolve a failure here by lowering the
+    // floor — that reinstates the false accusation this guard's own subject was corrected for.
     const out = deriveNameCollisionPollution({
       configured: true,
       signals: { recentNames: 0, recentSplit: 0, baselineNames: 0, baselineSplit: 0 },
-      recentEpisodes: 12,
+      recentEpisodes: 30,
     });
     expect(out.judgeable).toBe(false);
     expect(out.refusal).toBe("predicate-suspect");
+
+    // …and below the floor the SAME signals must not accuse — the guard covers both sides, so a
+    // regression that drops the floor cannot pass by satisfying only the firing half.
+    const belowFloor = deriveNameCollisionPollution({
+      configured: true,
+      signals: { recentNames: 0, recentSplit: 0, baselineNames: 0, baselineSplit: 0 },
+      recentEpisodes: 1,
+    });
+    expect(belowFloor.refusal).toBe("small-sample");
   });
 
   it("…and NO episodes either ⇒ a ledger-confirmed young/quiet group (small-sample), never an accusation", () => {

--- a/test/guards/dedupe-predicate-pinned.test.ts
+++ b/test/guards/dedupe-predicate-pinned.test.ts
@@ -125,14 +125,18 @@ describe("name-collision census pinning (graphiti_core 0.29.3)", () => {
     });
     expect(out.judgeable).toBe(false);
     expect(out.refusal).toBe("predicate-suspect");
+  });
 
-    // …and below the floor the SAME signals must not accuse — the guard covers both sides, so a
-    // regression that drops the floor cannot pass by satisfying only the firing half.
+  it("…and below the floor the SAME signals must NOT accuse — the other half of the same guard", () => {
+    // Its own `it`, not a second expect in the one above: under a floor-raising mutation the firing
+    // expect fails first and a packed assertion never executes, so it would prove nothing about the
+    // half it exists for (one-condition-per-fixture).
     const belowFloor = deriveNameCollisionPollution({
       configured: true,
       signals: { recentNames: 0, recentSplit: 0, baselineNames: 0, baselineSplit: 0 },
       recentEpisodes: 1,
     });
+    expect(belowFloor.judgeable).toBe(false);
     expect(belowFloor.refusal).toBe("small-sample");
   });
 

--- a/test/name-collision-pollution.test.ts
+++ b/test/name-collision-pollution.test.ts
@@ -3,6 +3,7 @@ import {
   deriveNameCollisionPollution,
   CENSUS_ABSOLUTE_FLOOR,
   MIN_NAMES_FOR_CENSUS_SIGNAL,
+  MIN_EPISODES_FOR_CENSUS_SUSPICION,
   type NameCollisionInput,
 } from "@/lib/graph/extraction-health";
 
@@ -103,10 +104,14 @@ describe("deriveNameCollisionPollution — the unarmed clamp (rollout step 1)", 
 
   it("…but judgeable and refusal still compute — the blindness meta-alarm needs them", () => {
     expect(deriveNameCollisionPollution(hot()).judgeable).toBe(true);
+    // 30, not 10: CENSUSFLOOR-1 gave the accusation an episode floor
+    // (`MIN_EPISODES_FOR_CENSUS_SUSPICION`), so 10 now reads `small-sample`. This test is about
+    // refusals still computing while unarmed, so it needs a fixture that genuinely reaches the
+    // tripwire — the floor is pinned separately by A2/A3, and must NOT be lowered to keep this green.
     const suspect = deriveNameCollisionPollution({
       configured: true,
       signals: { recentNames: 0, recentSplit: 0, baselineNames: 0, baselineSplit: 0 },
-      recentEpisodes: 10,
+      recentEpisodes: 30,
     });
     expect(suspect.refusal).toBe("predicate-suspect");
   });
@@ -158,5 +163,55 @@ describe("the configured flag is checked before the signals", () => {
       recentEpisodes: 0,
     });
     expect(out.refusal).toBe("graph-unconfigured");
+  });
+});
+
+/**
+ * CENSUSFLOOR-1 (docs/design/census-sample-floor.md): the zero-name tripwire accused on a sample of
+ * ONE episode, while its sibling judgement in the same file refuses below 25
+ * (`MIN_EPISODES_FOR_EXTRACTION_SIGNAL`) with the reason in its own docstring. Found live: prod's
+ * `aios_external` group held exactly one 196-char boilerplate index stub in the 7-day window and the
+ * admin card read "rename or stalled extractor". Neo4j confirmed 16 entities all-time in that group —
+ * extraction was fine; the zero was windowing.
+ */
+describe("deriveNameCollisionPollution — the accusation needs a sample (CENSUSFLOOR-1)", () => {
+  const zeroNames = (recentEpisodes: number | null): NameCollisionInput => ({
+    configured: true,
+    signals: { recentNames: 0, recentSplit: 0, baselineNames: 0, baselineSplit: 0 },
+    recentEpisodes,
+  });
+
+  // A1 — prod's exact shape must not accuse.
+  it("A1: zero names with ONE recent episode reads small-sample, never an accusation", () => {
+    const out = deriveNameCollisionPollution(zeroNames(1));
+    expect(out.refusal).toBe("small-sample");
+    expect(out.judgeable).toBe(false);
+    expect(out.polluted).toBe(false);
+  });
+
+  // A2 — LITERAL 25, not the constant: if every test read the constant, a mutation raising the
+  // floor to 10_000 (killing detection outright) would leave the whole suite green.
+  it("A2: zero names with a literal 25 recent episodes still trips predicate-suspect", () => {
+    expect(deriveNameCollisionPollution(zeroNames(25)).refusal).toBe("predicate-suspect");
+  });
+
+  // A3 — the boundary, wherever the constant sits.
+  it("A3: the boundary is exact at the exported constant", () => {
+    expect(deriveNameCollisionPollution(zeroNames(MIN_EPISODES_FOR_CENSUS_SUSPICION - 1)).refusal).toBe(
+      "small-sample"
+    );
+    expect(deriveNameCollisionPollution(zeroNames(MIN_EPISODES_FOR_CENSUS_SUSPICION)).refusal).toBe(
+      "predicate-suspect"
+    );
+  });
+
+  // A6 — prod's measured state, as a fixture.
+  it("A6: prod's measured aios_external state (1 episode, 0 names) reads small-sample", () => {
+    expect(deriveNameCollisionPollution(zeroNames(1)).refusal).toBe("small-sample");
+  });
+
+  // A4's null case already pinned above; re-asserted here against the new predicate's `??`.
+  it("A4: an unreadable ledger still reads small-sample under the floor comparison", () => {
+    expect(deriveNameCollisionPollution(zeroNames(null)).refusal).toBe("small-sample");
   });
 });


### PR DESCRIPTION
Fixes an alarm that was telling you a working extractor was stalled. **Found by the day-0 sanity read** that `graph-episode-window-phase-c.md` required before any quality number — the check that exists precisely because a number matching nothing looks exactly like a real measurement.

## The bug

`deriveNameCollisionPollution` accused on **one episode**. Its sibling in the same file refuses below **25** (`MIN_EPISODES_FOR_EXTRACTION_SIGNAL`), with the reason in its own docstring: below that you can't distinguish "extractor broken" from "still starting up".

Prod's `aios_external` held exactly one 196-char boilerplate index stub in the 7-day window, so the admin card read *"rename or stalled extractor"*. **Neo4j says that group holds 16 entities all-time** — read directly via `railway ssh`, because the plan review would not accept "nothing is stalled" on one episode's content. Extraction is fine; the zero was windowing.

## Why it matters beyond the card

`predicate-suspect` **runs** the blindness clock; `small-sample` **parks** it. Today the busy group is judgeable so no mail fires — *I told the owner it would, and that was wrong; corrected in the spec.* But once the busy group drops below `MIN_NAMES_FOR_CENSUS_SIGNAL`, the false refusal is the only clock-runner left and it pages 24h later. **On a small self-hosted install that conjunction is the normal state, not the tail.**

## What review caught that I'd have shipped

| | |
|---|---|
| **Plan review, condition 5** | I asserted "nothing is stalled" having checked only the *one recent* episode. Three older rows were unexamined, and per-group extraction failure is a real class here. If that group had zero entities all-time, my "fix" would have **parked a real alarm forever**. Settled with the Neo4j read. |
| **Plan review, condition 4** | My residual list had a missing half **again** — I recorded that 25 boilerplate episodes would still false-accuse, not that a genuine below-floor failure is now permanently silent. |
| **Code review, HIGH** | `ARCHITECTURE.md` still stated the old predicate. Fifth false comment this week, in the one doc CLAUDE.md requires you to reason *from*. |
| **Code review, MEDIUM** | The reviewer **constructed the wiring break my own A5 misses**: replace `refusalRunsClock(…)` with `refusal !== null` in `runBlindnessMachine` and the entire suite stays green while shipping the exact spurious page this PR prevents. Now pinned at the production seam. |

## Mutation proof

Three mutations, redden lists **transcribed from the run, not predicted** (my first claim of "reddens A2 alone" was wrong — it reddens three):

- **restore `> 0`** → A1, A3, A6, A5's parked case, the guard's below-floor half
- **floor → 10,000** (detection dead) → A2, the unarmed-clamp test, the guard's firing half
- **the production seam** → the roundtrip park pin, alone

A2 deliberately uses a **literal 25** rather than the constant, so the floor-raising mutation can't leave the suite green.

Unit **2,257** green · tsc clean · docs guard clean. No schema, no migration, alarm stays unarmed.

**Verification after merge:** the `aios_external` row on the admin card reads as a quiet small-sample group instead of an orange accusation. One look, no window, no spend.

## Review — Reviewed by Fable — verdict CLEAR-WITH-NITS after fixes: floor correct and wired to the real windowed count, all three mutations reproduced with transcribed redden lists, A5 non-vacuous, guard strengthened not weakened, downstream refusal readers verified unaffected; the HIGH (stale ARCHITECTURE.md predicate) and the MEDIUM (unpinned production tick seam) are both closed in-PR.

AIOS-Work: CENSUSFLOOR-1
