### PR TITLE
fix(arcs): size the reasoning token budget from the measurement, not a hedge (ARCHEAD-1)

### DIFF
--- a/lib/llm/complete.ts
+++ b/lib/llm/complete.ts
@@ -32,7 +32,34 @@ const LLM_MODEL = process.env.LLM_MODEL;
  * work. Override with LLM_REASONING_HEADROOM_TOKENS. (The Anthropic path uses a separate thinking
  * budget and isn't affected.)
  */
-const REASONING_HEADROOM_TOKENS = Number(process.env.LLM_REASONING_HEADROOM_TOKENS ?? 6000);
+/** A garbage env value must not become `NaN`: `maxTokens + NaN` serializes to `max_tokens: null`, which
+ *  the provider reads as "no limit" — the opposite of a budget. Fall back to the default instead. */
+const envTokens = (raw: string | undefined, fallback: number): number => {
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+};
+
+const REASONING_HEADROOM_TOKENS = envTokens(process.env.LLM_REASONING_HEADROOM_TOKENS, 6000);
+
+/**
+ * Headroom for a call that is ACTUALLY routed to a reasoning model (`role:"reasoning"` with a distinct
+ * `teams.reasoning_model` set). The flat 6000 above is sized for "some model here might reason"; this is
+ * sized for "this model definitely will, over a large input".
+ *
+ * MEASURED, not guessed (ARCHEAD-1). Arc synthesis asks for 4096, so the old ceiling was 10,096 for
+ * reasoning + answer together. Across 19 prod runs on `qwen/qwen3.7-plus`: successful runs generated
+ * 3,892–9,870 output tokens, and ALL THREE failures sat at 10,096/10,098 — every failure is the cap, and
+ * the best success cleared it by 226 tokens. 30% of arc runs died there, each billing ~1.5¢ for a blank.
+ *
+ * Deliberately NOT a bump to the global default: that would lift `max_tokens` on every OpenRouter call,
+ * including the small-model paths whose ceiling then trips the token-limit retry below on every request.
+ * Billing is per token GENERATED, so a bigger cap adds no PER-TOKEN cost to runs that already fit — it
+ * only lets the runs that were being thrown away finish. Not literally free, though: OpenRouter filters
+ * candidate providers by whether they can serve the requested `max_tokens` and pre-authorizes against
+ * the worst case, so a larger ask can route to a different (pricier or slower) provider, or be refused
+ * outright on a low-credit account. The ladder below is what keeps that refusal from becoming a blank.
+ */
+const REASONING_ROLE_HEADROOM_TOKENS = envTokens(process.env.LLM_REASONING_ROLE_HEADROOM_TOKENS, 16000);
 
 export interface CompleteArgs {
   system: string;
@@ -170,17 +197,29 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
       // starve the answer to empty). If the headroom pushes max_tokens past a SMALL model's ceiling
       // (400), retry once with just the answer budget — mirrors the streaming path (lib/query/claude);
       // without this, every non-streaming task 400s on a small local backend while Query still works.
-      let res = await doPost(maxTokens + REASONING_HEADROOM_TOKENS);
+      // A LADDER, not a cliff. On a token-limit refusal we step DOWN one rung at a time instead of
+      // dropping straight to the bare answer budget. That mattered the moment the reasoning rung got
+      // bigger: a provider whose output ceiling sits between the two rungs would refuse the top ask and
+      // land the retry on `maxTokens` alone — 4096 for arcs, combined with reasoning still ON, which is
+      // BELOW the 3,892 minimum a successful run has ever needed. The old 30%-of-runs failure would have
+      // become ~100%. Verified once against prod that `qwen/qwen3.7-plus` accepts the top rung (HTTP 200,
+      // finish=stop), so this is insurance for the next model rather than a live bug — but it is the
+      // difference between degrading and falling over.
+      const rungs = [...new Set([
+        maxTokens + (reasoningActive(opts.role, keys) ? REASONING_ROLE_HEADROOM_TOKENS : REASONING_HEADROOM_TOKENS),
+        maxTokens + REASONING_HEADROOM_TOKENS, // the budget prod ran on for months — known-accepted
+        maxTokens,
+      ])].sort((a, b) => b - a);
+      let res = await doPost(rungs[0]);
+      for (let i = 1; i < rungs.length && !res.ok; i++) {
+        const errBody = await res.text().catch(() => "");
+        // Only a TOKEN-LIMIT refusal is worth retrying smaller; anything else is a real error and must
+        // surface immediately rather than being re-sent two more times.
+        if (!looksLikeTokenLimit(res.status, errBody)) throw httpError(backend, res.status, errBody);
+        res = await doPost(rungs[i]);
+      }
       if (!res.ok) {
-        const firstErrBody = await res.text().catch(() => "");
-        if (looksLikeTokenLimit(res.status, firstErrBody)) {
-          res = await doPost(maxTokens);
-          if (!res.ok) {
-            throw httpError(backend, res.status, await res.text().catch(() => ""));
-          }
-        } else {
-          throw httpError(backend, res.status, firstErrBody);
-        }
+        throw httpError(backend, res.status, await res.text().catch(() => ""));
       }
       const j = (await res.json()) as {
         choices?: { message?: { content?: string }; finish_reason?: string }[];
@@ -293,7 +332,9 @@ export async function completeText(args: CompleteArgs, opts: CompleteOptions = {
     });
     // File the billed-but-unmeterable attempt so the Costs page can name which feature lost the money.
     // ONE row per logical call here, unlike the graph proxy where each SDK retry is its own request —
-    // this function's only retry is the token-limit re-ask, so a two-attempt call under-counts by one.
+    // this function's only retries are the token-limit LADDER's re-asks (up to two step-downs), so a
+    // laddered call under-counts by however many rungs were refused. Those refusals are pre-generation
+    // 400s that billed nothing, so the money under-count is ~zero — it is the ATTEMPT count that is low.
     // Stated rather than fixed: over-counting a spend gap is worse than under-counting it.
     // A failure that never reached a provider spent nothing, so it must not enter a ledger whose only
     // job is explaining money — the Anthropic SDK throws at CONSTRUCTION when no key resolves, and a

--- a/test/llm-complete-reasoning.test.ts
+++ b/test/llm-complete-reasoning.test.ts
@@ -62,3 +62,116 @@ describe("completeText reasoning control", () => {
     expect(body.model).toBe("qwen/qwen3.7-plus"); // the reasoning model, not the query model
   });
 });
+
+/**
+ * TOKEN BUDGET (ARCHEAD-1). `max_tokens` caps hidden reasoning + visible answer TOGETHER, so a
+ * reasoning-role call needs far more headroom than a "this model might reason" hedge.
+ *
+ * Measured on prod before this change: arc synthesis asks for 4096, the flat 6000 headroom capped it at
+ * 10,096, and across 19 runs every single failure sat AT that cap (10,096/10,098) while the best success
+ * cleared it by 226 tokens — 30% of runs billed ~1.5¢ to return nothing.
+ */
+describe("completeText token budget by role", () => {
+  const budgetOf = (m: ReturnType<typeof mock>) =>
+    JSON.parse(String((m.mock.calls[0] as [string, RequestInit])[1].body)).max_tokens as number;
+
+  it("a REASONING-role call gets the large headroom — enough to clear the ceiling that was eating arcs", async () => {
+    const fetchMock = mock('{"arcs":[]}');
+    await completeText(
+      { system: "s", prompt: "p" },
+      {
+        role: "reasoning",
+        maxTokens: 4096, // what arc synthesis asks for
+        keys: { openrouterKey: "or", openrouterModel: "openai/gpt-4o-mini", reasoningModel: "qwen/qwen3.7-plus", activeProvider: "openrouter" },
+      }
+    );
+    // 4096 + 16000. The specific number matters less than the property: comfortably past the 10,098
+    // the model actually reached, with room for a heavier fact set.
+    expect(budgetOf(fetchMock)).toBe(20096);
+    expect(budgetOf(fetchMock)).toBeGreaterThan(10098);
+  });
+
+  it("a NON-reasoning call keeps the small headroom — the blast radius stays off every other path", async () => {
+    // The control. Raising the global default instead would have lifted max_tokens on every OpenRouter
+    // call, including small models whose ceiling then trips the token-limit retry on every request.
+    const fetchMock = mock('{"ok":true}');
+    await completeText(
+      { system: "s", prompt: "p" },
+      { maxTokens: 4096, keys: { openrouterKey: "or", openrouterModel: "qwen/qwen3.7-max", activeProvider: "openrouter" } }
+    );
+    expect(budgetOf(fetchMock)).toBe(10096); // 4096 + 6000, unchanged
+  });
+
+  it("the reasoning role WITHOUT a distinct reasoning model does not get the large headroom", async () => {
+    // `reasoningActive` is false here (no `reasoningModel`), so the call fell back to the query model and
+    // reasoning is turned OFF — giving it the big budget would be sizing for reasoning that won't happen.
+    const fetchMock = mock('{"ok":true}');
+    await completeText(
+      { system: "s", prompt: "p" },
+      { role: "reasoning", maxTokens: 4096, keys: { openrouterKey: "or", openrouterModel: "qwen/qwen3.7-max", activeProvider: "openrouter" } }
+    );
+    expect(budgetOf(fetchMock)).toBe(10096);
+  });
+});
+
+/**
+ * THE LADDER (ARCHEAD-1, Fable HIGH). A token-limit refusal must step DOWN one rung, not fall to the
+ * bare answer budget. With the reasoning rung at 20,096, a provider whose ceiling sits between the rungs
+ * would refuse the top ask and land the retry on 4,096 — with reasoning still ON, that is BELOW the 3,892
+ * minimum any successful arc run has ever needed, so a 30% failure rate would become ~100%.
+ */
+describe("completeText token-limit ladder", () => {
+  const REFUSAL = { status: 400, body: JSON.stringify({ error: { message: "max_tokens exceeds the model's limit" } }) };
+
+  /** Refuse the first `refuseCount` requests with a token-limit 400, then succeed. */
+  function laddered(refuseCount: number) {
+    let n = 0;
+    const fetchMock = vi.fn(async () => {
+      if (n++ < refuseCount) return new Response(REFUSAL.body, { status: REFUSAL.status });
+      return new Response(JSON.stringify({ choices: [{ message: { content: '{"arcs":[]}' }, finish_reason: "stop" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+  const budgets = (m: ReturnType<typeof laddered>) =>
+    m.mock.calls.map((c) => JSON.parse(String((c as [string, RequestInit])[1].body)).max_tokens as number);
+
+  const reasoningOpts = {
+    role: "reasoning" as const,
+    maxTokens: 4096,
+    keys: { openrouterKey: "or", openrouterModel: "openai/gpt-4o-mini", reasoningModel: "qwen/qwen3.7-plus", activeProvider: "openrouter" as const },
+  };
+
+  it("steps DOWN to the known-accepted rung instead of collapsing to the bare answer budget", async () => {
+    const fetchMock = laddered(1);
+    await completeText({ system: "s", prompt: "p" }, reasoningOpts);
+    // 20,096 refused → retry at 10,096 (what prod ran on for months), NOT 4,096.
+    expect(budgets(fetchMock)).toEqual([20096, 10096]);
+  });
+
+  it("only reaches the bare budget after the middle rung is ALSO refused", async () => {
+    const fetchMock = laddered(2);
+    await completeText({ system: "s", prompt: "p" }, reasoningOpts);
+    expect(budgets(fetchMock)).toEqual([20096, 10096, 4096]);
+  });
+
+  it("does NOT retry a non-token-limit error — a real fault must surface, not be re-sent", async () => {
+    // The control: without this, a 500 or an auth failure would be hammered three times.
+    const fetchMock = vi.fn(async () => new Response("upstream exploded", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(completeText({ system: "s", prompt: "p" }, reasoningOpts)).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a NON-reasoning call has no duplicate rung — it starts at 10,096 and drops to the budget", async () => {
+    const fetchMock = laddered(1);
+    await completeText(
+      { system: "s", prompt: "p" },
+      { maxTokens: 4096, keys: { openrouterKey: "or", openrouterModel: "qwen/qwen3.7-max", activeProvider: "openrouter" } }
+    );
+    expect(budgets(fetchMock)).toEqual([10096, 4096]); // deduped — no pointless repeat of 10,096
+  });
+});

--- a/test/llm-complete.test.ts
+++ b/test/llm-complete.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock the backend resolver so we exercise the OpenAI-compatible/OpenRouter path deterministically.
-vi.mock("@/lib/query/llm-backend", () => ({
+// Stub ONLY the backend selection; everything else stays real. `completeText` also calls
+// `reasoningActive` to size the token budget, and a bare object mock silently dropped that export —
+// which went unnoticed only because the other call site short-circuits on `backend.kind` before
+// reaching it. Spreading the real module keeps the budget logic honest instead of mock-shaped.
+vi.mock("@/lib/query/llm-backend", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/query/llm-backend")>()),
   selectLlmBackend: () => ({
     kind: "openai-compatible" as const,
     provider: "openai" as const,


### PR DESCRIPTION
## The problem, measured

`max_tokens` caps **hidden reasoning and the visible answer together**. `completeText` adds a flat 6,000-token headroom, so arc synthesis (asks 4,096) ran with a **10,096 ceiling**.

Across **19 prod runs** on `qwen/qwen3.7-plus`:

| | |
|---|---|
| Successful runs generated | 3,892 – **9,870** output tokens |
| All three failures (08-05, 08-06, 08-10) | pinned at **10,096 / 10,098** |
| Best success cleared the cap by | **226 tokens** |
| Arc runs failing this way | **30%**, each billing ~1.5¢ for a blank ($0.0453 wasted) |

Every failure *is* the cap. This was never model flakiness — the budget was simply too tight for a reasoning model over ~200 facts.

## The fix

A call **actually routed to a reasoning model** (`role:"reasoning"` + a distinct `teams.reasoning_model`) gets its own headroom — default **16,000 → 20,096 total**, ~2× observed demand, env-tunable. Everything else keeps 6,000.

Deliberately **not** a global bump: that lifts `max_tokens` on every OpenRouter call, including small-model paths whose ceiling then trips the token-limit retry on every request.

**Plus a ladder, not a cliff.** The retry now steps down `20,096 → 10,096 → 4,096` on token-limit refusals (deduped, descending) instead of dropping straight to the bare budget. That mattered the moment the top rung grew: a provider ceiling between the rungs would have landed the retry on 4,096 *with reasoning still on* — below the 3,892 minimum any successful run has needed — turning 30% failure into ~100%.

## Test plan
- [x] Budget-by-role tests + 4 ladder tests, **all mutation-verified**: cliff-collapse, retry-everything, always-big-headroom, and dedupe-removal each redden exactly their own tests
- [x] Controls are load-bearing — a non-reasoning call and a `role:"reasoning"` call *without* a distinct model both stay at 10,096
- [x] Fixed a mock that had gone quietly wrong: `test/llm-complete.test.ts` stubbed `llm-backend` with a bare object, dropping `reasoningActive`. It only passed because the other call site short-circuits on `backend.kind` first
- [x] 2253 unit · tsc · eslint · docs-drift green

## Known, deliberate
- **Inline cold-miss may now time out instead of blanking.** A run needing >10k tokens will likely exceed the 110s inline abort and succeed via the 280s background refresh instead. Strictly better (the cache fills), but the payoff lands mostly on the BG path.
- **`finish_reason=length` with non-empty truncated content still reads healthy** — filed as `TRUNCARC-1` (AIO-871), not widened into this PR.

## Review — Reviewed by Fable (`code-reviewer`, 2 rounds) — verdict CLEAR
Round 1 **BLOCKED** on the retry cliff above. Discharged twice: I verified empirically against prod that `qwen/qwen3.7-plus` accepts `max_tokens=20096` (one real request — HTTP 200, `finish_reason=stop`), *and* built the ladder so a future model can't fall off it. Round 2 **CLEAR**, with all mutations re-run independently. Four Lows accepted (env-parse guard unpinned by a test, a defensive sort corner, one untested all-rungs-refused path, and the two deferrals above).

AIOS-Work: ARCHEAD-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)