### PR TITLE
chore(test): per-worktree isolated dm runner (test:datamechanics:iso)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,8 +224,19 @@ npm run lint           # eslint
 npm run pg:schema      # load postgres/schema.sql (canonical) into DATABASE_URL — also the prod rollout step
 npm run db:test:up     # ephemeral test Postgres + load schema (migrate-from-zero = replay guard)
 npm run test:datamechanics  # real-Postgres tier: persistence + tier isolation
+npm run test:datamechanics:iso  # SAME tier, PER-WORKTREE isolated container (see below)
 bash scripts/e2e.sh    # system-level integration: seed → push → materialize → 422 → pull → live query
 ```
+
+- **Parallel worktrees + the dm tier — use `test:datamechanics:iso`.** `test:datamechanics:local`
+  points every worktree at the ONE shared compose container (`localhost:5434`), so when two
+  Conductor worktrees run the dm tier at once they contend on the same rows/locks and Postgres
+  aborts transactions — surfacing as `deadlock detected` + `null.id` seed failures that read like
+  product bugs but are pure collision. `npm run test:datamechanics:iso [files…]`
+  (`scripts/dm-isolated.sh`) gives THIS worktree its own throwaway Postgres — a per-worktree-named
+  container on a **docker-assigned** port (so two worktrees can't pick the same "free" port) —
+  created + schema-loaded on first use and reused after; `npm run db:test:iso:down` removes it.
+  Prefer `:iso` whenever another worktree might be running dm.
 
 - **Schema:** canonical = `postgres/schema.sql` (idempotent; `npm run pg:schema` loads it and is the
   prod rollout step against Railway). Additive deltas live in `postgres/migrations/` (the only

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "db:test:down": "docker compose -f compose.test.yml down -v",
     "test:datamechanics": "vitest run --config vitest.datamechanics.config.ts",
     "test:datamechanics:local": "DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.datamechanics.config.ts",
+    "test:datamechanics:iso": "bash scripts/dm-isolated.sh",
+    "db:test:iso:down": "bash scripts/dm-isolated.sh --down",
     "test:http": "vitest run --config vitest.http.config.ts",
     "test:http:gateway-approval": "AIOS_GATEWAY_INTERNAL_ENABLED=true vitest run --config vitest.http.config.ts gateway-approval-enabled",
     "test:gateway-contracts": "vitest run test/gateway/gateway-contracts.test.ts",

--- a/scripts/dm-isolated.sh
+++ b/scripts/dm-isolated.sh
@@ -18,22 +18,29 @@
 #
 # The container is left UP between runs (fast reuse). It's a throwaway — safe to `--down` anytime.
 set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
+
+ROOT="$(git rev-parse --show-toplevel)" || { echo "[dm-isolated] not in a git repo"; exit 1; }
+cd "$ROOT"
 
 # Stable identity from the worktree path: same worktree → same container name every run.
 WT_HASH=$(pwd | shasum | cut -c1-8)
 NAME="aios-dm-${WT_HASH}"
 
+# Exact-name existence check — no pipe to grep (avoids a SIGPIPE-under-pipefail flip).
+exists() { [[ -n "$(docker ps -a --filter "name=^${NAME}$" --format '{{.Names}}')" ]]; }
+
+# `-v` so the postgres image's anonymous data volume goes with the container (no orphans).
 if [[ "${1:-}" == "--down" ]]; then
-  docker rm -f "$NAME" >/dev/null 2>&1 && echo "[dm-isolated] removed $NAME" || echo "[dm-isolated] no container $NAME"
+  docker rm -f -v "$NAME" >/dev/null 2>&1 && echo "[dm-isolated] removed $NAME" || echo "[dm-isolated] no container $NAME"
   exit 0
 fi
 
 if [[ "${AIOS_DM_RESET:-}" == "1" ]]; then
-  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  docker rm -f -v "$NAME" >/dev/null 2>&1 || true
 fi
 
-if ! docker ps -a --format '{{.Names}}' | grep -qx "$NAME"; then
+fresh=""
+if ! exists; then
   # Create with a DOCKER-ASSIGNED port (`-p 0:5432`) — never a hardcoded or derived one: two
   # worktrees picking the "same free port" is exactly the collision one layer down (the
   # `shared-test-postgres-collision` note). `fsync=off` etc. is safe for a throwaway test DB and
@@ -44,15 +51,33 @@ if ! docker ps -a --format '{{.Names}}' | grep -qx "$NAME"; then
     -e POSTGRES_USER=app -e POSTGRES_PASSWORD=app -e POSTGRES_DB=app_test \
     -p 0:5432 postgres:16 \
     -c fsync=off -c full_page_writes=off -c synchronous_commit=off -c max_wal_size=1GB >/dev/null
-  until docker exec "$NAME" pg_isready -U app >/dev/null 2>&1; do sleep 1; done
-  PORT=$(docker port "$NAME" 5432/tcp | head -1 | sed 's/.*://')
-  DATABASE_URL="postgres://app:app@localhost:${PORT}/app_test" npm run pg:schema
+  fresh=1
 else
   docker start "$NAME" >/dev/null 2>&1 || true
 fi
 
-# Always read the ACTUAL mapped port (assigned at create) — never re-derive it.
+# Wait for readiness on BOTH paths (a just-started stopped container is still booting), bounded so a
+# container that dies at startup fails loudly instead of hanging.
+ready=""
+for _ in $(seq 1 60); do
+  if docker exec "$NAME" pg_isready -U app >/dev/null 2>&1; then ready=1; break; fi
+  sleep 1
+done
+if [[ -z "$ready" ]]; then
+  echo "[dm-isolated] $NAME did not become ready in 60s"; docker logs --tail 20 "$NAME" || true; exit 1
+fi
+
+# Read the ACTUAL mapped port (assigned at create), every run — never re-derive or cache it. An
+# EMPTY port would make libpq fall back to 5432 and truncate whatever Postgres is there, so guard it.
 PORT=$(docker port "$NAME" 5432/tcp | head -1 | sed 's/.*://')
+if [[ -z "$PORT" ]]; then
+  echo "[dm-isolated] no port mapping for $NAME (is it running?)"; exit 1
+fi
 URL="postgres://app:app@localhost:${PORT}/app_test"
+
+if [[ -n "$fresh" ]]; then
+  DATABASE_URL="$URL" npm run pg:schema
+fi
+
 echo "[dm-isolated] $NAME → $URL"
 DATABASE_TEST_URL="$URL" npx vitest run --config vitest.datamechanics.config.ts "$@"

--- a/scripts/dm-isolated.sh
+++ b/scripts/dm-isolated.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Run the data-mechanics tier against a PER-WORKTREE dedicated Postgres, so parallel Conductor
+# worktrees never collide on the one shared compose container (`compose.test.yml`, port 5434).
+#
+# WHY: `npm run test:datamechanics:local` points every worktree at localhost:5434. When two
+# worktrees run the dm tier at once (common with parallel Conductor sessions) they contend on the
+# same rows/locks and Postgres aborts transactions — surfacing as `deadlock detected` and
+# `null.id` seed failures that read like product bugs but are pure collision (see the
+# `shared-test-postgres-collision` note). This script gives each worktree its OWN container (named
+# per worktree path) on a DOCKER-ASSIGNED port, so runs are hermetic and reusable.
+#
+# USAGE:
+#   bash scripts/dm-isolated.sh                       # run the whole dm tier, isolated
+#   bash scripts/dm-isolated.sh test/datamechanics/access-enforce-arcs.datamechanics.test.ts  # one file
+#   bash scripts/dm-isolated.sh --down                # stop+remove THIS worktree's container
+#   AIOS_DM_RESET=1 bash scripts/dm-isolated.sh       # recreate the container fresh (reload schema)
+#
+# The container is left UP between runs (fast reuse). It's a throwaway — safe to `--down` anytime.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+# Stable identity from the worktree path: same worktree → same container name every run.
+WT_HASH=$(pwd | shasum | cut -c1-8)
+NAME="aios-dm-${WT_HASH}"
+
+if [[ "${1:-}" == "--down" ]]; then
+  docker rm -f "$NAME" >/dev/null 2>&1 && echo "[dm-isolated] removed $NAME" || echo "[dm-isolated] no container $NAME"
+  exit 0
+fi
+
+if [[ "${AIOS_DM_RESET:-}" == "1" ]]; then
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+fi
+
+if ! docker ps -a --format '{{.Names}}' | grep -qx "$NAME"; then
+  # Create with a DOCKER-ASSIGNED port (`-p 0:5432`) — never a hardcoded or derived one: two
+  # worktrees picking the "same free port" is exactly the collision one layer down (the
+  # `shared-test-postgres-collision` note). `fsync=off` etc. is safe for a throwaway test DB and
+  # keeps the TRUNCATE-per-test churn fast; disk-backed (NOT --tmpfs, which the dm tier's ~40-table
+  # truncate × N files can blow through mid-run).
+  echo "[dm-isolated] creating $NAME (docker-assigned port)"
+  docker run -d --name "$NAME" \
+    -e POSTGRES_USER=app -e POSTGRES_PASSWORD=app -e POSTGRES_DB=app_test \
+    -p 0:5432 postgres:16 \
+    -c fsync=off -c full_page_writes=off -c synchronous_commit=off -c max_wal_size=1GB >/dev/null
+  until docker exec "$NAME" pg_isready -U app >/dev/null 2>&1; do sleep 1; done
+  PORT=$(docker port "$NAME" 5432/tcp | head -1 | sed 's/.*://')
+  DATABASE_URL="postgres://app:app@localhost:${PORT}/app_test" npm run pg:schema
+else
+  docker start "$NAME" >/dev/null 2>&1 || true
+fi
+
+# Always read the ACTUAL mapped port (assigned at create) — never re-derive it.
+PORT=$(docker port "$NAME" 5432/tcp | head -1 | sed 's/.*://')
+URL="postgres://app:app@localhost:${PORT}/app_test"
+echo "[dm-isolated] $NAME → $URL"
+DATABASE_TEST_URL="$URL" npx vitest run --config vitest.datamechanics.config.ts "$@"


### PR DESCRIPTION
## What this is

Fixes the recurring **shared test-Postgres collision** that lets parallel Conductor worktrees clobber each other's data-mechanics runs. `npm run test:datamechanics:local` points *every* worktree at the one shared compose container (`localhost:5434`), so when two worktrees run the dm tier at once they contend on the same rows/locks — Postgres aborts transactions and it surfaces as `deadlock detected` + `null.id` seed failures that read like product bugs but are pure collision.

`npm run test:datamechanics:iso [files…]` (`scripts/dm-isolated.sh`) gives **this worktree** its own throwaway Postgres:
- a **per-worktree-named** container on a **docker-assigned** port (`-p 0:5432`) — never a hardcoded/derived one, because two worktrees picking the same "free" port is the same bug one layer down;
- `fsync=off`, disk-backed (**not** `--tmpfs` — the dm tier's ~40-table truncate × N files can blow through a tmpfs mid-run);
- created + schema-loaded on first use, **reused** after (with a readiness wait + empty-port guard on both paths); `npm run db:test:iso:down` removes it (with `-v`, no orphaned volume).

Both worktrees can now run the dm tier at the same time without touching each other. `test:datamechanics:local`, `db:test:up`, and CI (dedicated Postgres per job) are unchanged.

## Verification

- Script verified end-to-end: create (docker-assigned port, schema loaded) → run (`6 passed`) → reuse-after-stop (readiness wait exercised, ephemeral port re-read) → `--down` removes it. `bash -n` + `shellcheck` clean; `check:docs` congruent; lint clean.

## Review — Reviewed by Fable code-reviewer — verdict CLEAR, folded

Fable (fresh read of the diff) returned CLEAR with should-fixes, all folded in `053593b`: **2 Medium** shell-correctness bugs — the empty-PORT hazard (an empty port → libpq default 5432 → truncating a stray local Postgres) and the missing readiness wait on the reuse path (a just-restarted container still booting → "database system is starting up" flakes) — plus Lows (bounded readiness loop, `rm -f -v` to avoid orphaned volumes, exact-name existence check, `cd` guard). Verified-safe by Fable: collision safety (name per-worktree, docker-assigned port, `pg-load-schema` reads `DATABASE_URL` with no dotenv so the inline env is authoritative — never the shared 5434), the `docker port` sed across IPv4/IPv6, no run→port race, docs honesty.

Dev-tooling only — no app code, no schema, no runtime path. Ungated chore (no `AIOS-Work:` key); the brain-task check is advisory.