### PR TITLE
feat(loop): a mechanical pre-mutation check (MUTGUARD-1)

### DIFF
--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -86,12 +86,15 @@ an experiment with replication.
   `npm run db:test:up && npm run test:datamechanics:local` · `npm run check:docs`.
   (The npm script pins the test-DB URL/port; never hand-write the incantation — it drifts.)
 - **Commit BEFORE mutation-testing, and PROVE it — `node scripts/mutation-guard.mjs`.**
-  Mutations are reverted with `git checkout <file>`, which restores the file
-  from the index/HEAD, so any uncommitted edit to a TRACKED file is destroyed
-  by the revert — silently, by the command you expect to succeed. Run the guard
-  before the first mutation; it exits non-zero and names the files at risk.
-  Untracked files do not block (a revert cannot reach them), so a new test file
-  mid-slice is fine.
+  Run the guard before the first mutation; it exits non-zero and names what is
+  at risk. Precisely (verified against real git — an earlier version of this
+  paragraph overstated it, and both reviewers caught that): `git checkout --
+  <file>` restores from the INDEX, so an UNSTAGED edit is destroyed silently by
+  the command you expect to succeed, a STAGED one survives, and untracked files
+  cannot be reached at all. The guard still blocks on any uncommitted tracked
+  change, because the loop's contract is a COMMITTED CHECKPOINT you can return
+  to — not because everything it blocks would be shredded. A new (untracked)
+  test file mid-slice does not block.
 
   This was prose in this skill for its whole life and failed anyway: the same
   operator lost work to it **three times in one session** (2026-08-14/15) —

--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -85,11 +85,21 @@ an experiment with replication.
 - Full local verification: `npx tsc --noEmit` · `npm run lint` · `npm test` ·
   `npm run db:test:up && npm run test:datamechanics:local` · `npm run check:docs`.
   (The npm script pins the test-DB URL/port; never hand-write the incantation — it drifts.)
-- **Commit BEFORE mutation-testing.** Mutations are reverted with
-  `git checkout <file>`, which restores the file from the index/HEAD — either
-  way, uncommitted edits are gone. Running it against an uncommitted tree
-  silently destroys unfolded work (this happened; the folds had to be
-  re-applied by hand).
+- **Commit BEFORE mutation-testing, and PROVE it — `node scripts/mutation-guard.mjs`.**
+  Mutations are reverted with `git checkout <file>`, which restores the file
+  from the index/HEAD, so any uncommitted edit to a TRACKED file is destroyed
+  by the revert — silently, by the command you expect to succeed. Run the guard
+  before the first mutation; it exits non-zero and names the files at risk.
+  Untracked files do not block (a revert cannot reach them), so a new test file
+  mid-slice is fine.
+
+  This was prose in this skill for its whole life and failed anyway: the same
+  operator lost work to it **three times in one session** (2026-08-14/15) —
+  an extracted function and its tests wiped mid-fold, a commit landed whose
+  tests called a function the revert had deleted, and a "repair" script that
+  no-opped against the reverted text and printed success. A rule you have to
+  remember is the thing this repo's §2 says to replace with a check that fails.
+  MUTGUARD-1.
 - Mutation-verify every guard and security-relevant branch: break the thing,
   confirm the INTENDED test reddens (not just any test), revert, confirm the
   tree is clean (`git status --short`). A guard that survives its mutation is

--- a/scripts/mutation-guard.mjs
+++ b/scripts/mutation-guard.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Refuse to start mutation testing on a tree with uncommitted work (MUTGUARD-1).
+ *
+ * WHY THIS EXISTS, and why prose was not enough. Mutations are applied in place and reverted with
+ * `git checkout <file>`, which restores that file from the index/HEAD. Any uncommitted edit to a
+ * TRACKED file is therefore destroyed by the revert — silently, because the revert is the thing you
+ * expect to succeed. The adversarial-build skill has said "commit BEFORE mutation-testing" since it
+ * was written, and on 2026-08-14/15 the same operator lost work to it three times in one session:
+ * an extracted function and its tests were wiped mid-fold, and a commit landed whose tests called a
+ * function that no longer existed. A repair script then no-opped against the reverted text and
+ * printed success, so the loss surfaced only on re-reading the file.
+ *
+ * That is a rule you have to remember, which this repo's own §2 says to replace with a check that
+ * fails. This is the check.
+ *
+ * ONLY TRACKED MODIFICATIONS BLOCK, and the precision is deliberate. `git checkout <pathspec>` cannot
+ * destroy an untracked file — the pathspec does not match it, and the command errors instead. So an
+ * untracked new file is not at risk, and blocking on it would make the guard fire on the extremely
+ * normal state of "I just wrote a new test file". A guard that over-blocks gets bypassed, and a
+ * bypassed guard is not a guard.
+ *
+ * Usage:
+ *   node scripts/mutation-guard.mjs            # exits 1 if tracked files are modified
+ *   node scripts/mutation-guard.mjs --json     # machine-readable, for a wrapper
+ */
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * Tracked paths with uncommitted changes — staged or unstaged.
+ *
+ * Pure over its input so the classification is testable without a scratch repo: `git status
+ * --porcelain` emits two status columns then the path. `??` is untracked (safe, ignored) and `!!` is
+ * ignored-by-gitignore (safe). Everything else — ` M`, `M `, `MM`, ` D`, `A `, `R `… — is a tracked
+ * path whose working-tree or index state differs from HEAD, which is exactly what a revert eats.
+ */
+export function trackedChanges(porcelain) {
+  return porcelain
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .filter((line) => {
+      const status = line.slice(0, 2);
+      return status !== "??" && status !== "!!";
+    })
+    .map((line) => ({ status: line.slice(0, 2), path: line.slice(3) }));
+}
+
+function main() {
+  const json = process.argv.includes("--json");
+  let porcelain = "";
+  try {
+    porcelain = execFileSync("git", ["status", "--porcelain"], { encoding: "utf8" });
+  } catch {
+    // Not a git repo, or git is unavailable. FAIL OPEN with a warning rather than blocking the loop
+    // on an environment problem: the cost of a false block here is that mutation testing cannot run
+    // at all, and the thing being protected is a git-specific hazard that cannot occur without git.
+    process.stderr.write("mutation-guard: could not read git status — skipping the check\n");
+    process.exit(0);
+  }
+
+  const dirty = trackedChanges(porcelain);
+  if (json) {
+    process.stdout.write(JSON.stringify({ clean: dirty.length === 0, dirty }, null, 2) + "\n");
+  }
+
+  if (dirty.length === 0) {
+    if (!json) process.stdout.write("mutation-guard: tree is clean — safe to mutate\n");
+    process.exit(0);
+  }
+
+  if (!json) {
+    process.stderr.write(
+      "\nmutation-guard: REFUSING to mutate — these tracked files have uncommitted changes:\n\n" +
+        dirty.map((d) => `  ${d.status}  ${d.path}`).join("\n") +
+        "\n\nMutations are reverted with `git checkout <file>`, which restores from the index/HEAD, so\n" +
+        "every change listed above would be DESTROYED — silently, by the revert you expect to succeed.\n" +
+        "This has cost real work three times.\n\n" +
+        "Commit them first (that is the point: a mutation run should measure a tree you can get back).\n" +
+        "Untracked files are not listed and do not block — a revert cannot reach them.\n\n"
+    );
+  }
+  process.exit(1);
+}
+
+// Only run when invoked directly, so the pure helper above can be imported by its test.
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/mutation-guard.mjs
+++ b/scripts/mutation-guard.mjs
@@ -82,6 +82,7 @@ function main() {
       insideRepo = false;
     }
     if (insideRepo) {
+      if (json) process.stdout.write(JSON.stringify({ clean: false, unreadable: true, dirty: [] }, null, 2) + "\n");
       process.stderr.write(
         "\nmutation-guard: REFUSING to mutate — inside a git worktree but `git status` failed, so the\n" +
           "tree cannot be verified recoverable. Fix the repo state (a stale index.lock, a corrupt index)\n" +
@@ -89,6 +90,9 @@ function main() {
       );
       process.exit(1);
     }
+    // `--json` must ALWAYS emit JSON — it is the machine-readable contract, and a caller parsing it
+    // gets "Unexpected end of JSON input" otherwise. Found by the test written for the branch above.
+    if (json) process.stdout.write(JSON.stringify({ clean: true, noRepo: true, dirty: [] }, null, 2) + "\n");
     process.stderr.write("mutation-guard: not a git repository — nothing a revert could destroy, skipping\n");
     process.exit(0);
   }

--- a/scripts/mutation-guard.mjs
+++ b/scripts/mutation-guard.mjs
@@ -3,9 +3,20 @@
  * Refuse to start mutation testing on a tree with uncommitted work (MUTGUARD-1).
  *
  * WHY THIS EXISTS, and why prose was not enough. Mutations are applied in place and reverted with
- * `git checkout <file>`, which restores that file from the index/HEAD. Any uncommitted edit to a
- * TRACKED file is therefore destroyed by the revert — silently, because the revert is the thing you
- * expect to succeed. The adversarial-build skill has said "commit BEFORE mutation-testing" since it
+ * `git checkout <file>`, and that revert silently destroys work — because the revert is the thing you
+ * expect to succeed.
+ *
+ * PRECISELY WHAT IT DESTROYS, verified against real git rather than asserted (an earlier version of
+ * this comment, the skill, and three test names all overstated it, and BOTH reviewers caught it):
+ * two-argument `git checkout -- <path>` restores the worktree from the INDEX, not from HEAD. So an
+ * UNSTAGED edit (` M`) is lost, a STAGED one (`M `) SURVIVES, and `MM` loses only the unstaged layer.
+ *
+ * The guard blocks on staged changes anyway, and the reason is the policy rather than the blast
+ * radius: the loop's contract is that a mutation run measures a COMMITTED CHECKPOINT you can return
+ * to. A staged-but-uncommitted tree is not one — and an operator who reaches for
+ * `git checkout HEAD -- <file>` or `git restore -s HEAD` does lose it. Stating that honestly matters
+ * more than the stricter-sounding claim, because a guard justified by something false is one argument
+ * away from being switched off. The adversarial-build skill has said "commit BEFORE mutation-testing" since it
  * was written, and on 2026-08-14/15 the same operator lost work to it three times in one session:
  * an extracted function and its tests were wiped mid-fold, and a commit landed whose tests called a
  * function that no longer existed. A repair script then no-opped against the reverted text and
@@ -26,6 +37,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 /**
  * Tracked paths with uncommitted changes — staged or unstaged.
@@ -52,10 +64,32 @@ function main() {
   try {
     porcelain = execFileSync("git", ["status", "--porcelain"], { encoding: "utf8" });
   } catch {
-    // Not a git repo, or git is unavailable. FAIL OPEN with a warning rather than blocking the loop
-    // on an environment problem: the cost of a false block here is that mutation testing cannot run
-    // at all, and the thing being protected is a git-specific hazard that cannot occur without git.
-    process.stderr.write("mutation-guard: could not read git status — skipping the check\n");
+    // The catch used to swallow EVERY failure and exit 0. Review was right that this is the wrong
+    // default inside a real repo: a corrupt index or broken worktree metadata would let the mutation
+    // loop proceed on a tree it could not prove was recoverable — a guard failing open in exactly the
+    // situation it exists for.
+    //
+    // So the two cases are separated. NOT A REPO ⇒ fail OPEN: the hazard is git-specific and cannot
+    // occur, and blocking would stop mutation testing on an environment problem. REPO PRESENT but
+    // status unreadable ⇒ fail CLOSED: we cannot see what is at risk, and "cannot tell" must not read
+    // as "safe" — the standing rule in this codebase.
+    let insideRepo = false;
+    try {
+      insideRepo =
+        execFileSync("git", ["rev-parse", "--is-inside-work-tree"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim() ===
+        "true";
+    } catch {
+      insideRepo = false;
+    }
+    if (insideRepo) {
+      process.stderr.write(
+        "\nmutation-guard: REFUSING to mutate — inside a git worktree but `git status` failed, so the\n" +
+          "tree cannot be verified recoverable. Fix the repo state (a stale index.lock, a corrupt index)\n" +
+          "and re-run.\n\n"
+      );
+      process.exit(1);
+    }
+    process.stderr.write("mutation-guard: not a git repository — nothing a revert could destroy, skipping\n");
     process.exit(0);
   }
 
@@ -73,10 +107,11 @@ function main() {
     process.stderr.write(
       "\nmutation-guard: REFUSING to mutate — these tracked files have uncommitted changes:\n\n" +
         dirty.map((d) => `  ${d.status}  ${d.path}`).join("\n") +
-        "\n\nMutations are reverted with `git checkout <file>`, which restores from the index/HEAD, so\n" +
-        "every change listed above would be DESTROYED — silently, by the revert you expect to succeed.\n" +
-        "This has cost real work three times.\n\n" +
-        "Commit them first (that is the point: a mutation run should measure a tree you can get back).\n" +
+        "\n\nMutation testing must run against a COMMITTED CHECKPOINT you can get back. Commit these first.\n\n" +
+        "What the revert actually eats: `git checkout -- <file>` restores from the INDEX, so an\n" +
+        "UNSTAGED edit is destroyed silently by the command you expect to succeed (this has cost real\n" +
+        "work three times). A STAGED edit survives that particular command — but it is still not a\n" +
+        "checkpoint, and `git checkout HEAD -- <file>` does take it.\n\n" +
         "Untracked files are not listed and do not block — a revert cannot reach them.\n\n"
     );
   }
@@ -84,4 +119,19 @@ function main() {
 }
 
 // Only run when invoked directly, so the pure helper above can be imported by its test.
-if (import.meta.url === `file://${process.argv[1]}`) main();
+//
+// `pathToFileURL`, NOT a `file://` template. `import.meta.url` percent-encodes (a space becomes
+// `%20`) while `process.argv[1]` is raw, so from a directory whose path needs encoding the comparison
+// failed and the script exited 0 WITH NO OUTPUT — the guard the skill had just told you to trust,
+// silently doing nothing. That is the exact failure class this ticket exists to kill, and the same
+// shape as the repair script that printed success over reverted text. Found by review, reproduced
+// live from `/tmp/mut guard .../`.
+const invokedDirectly = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main();
+} else if (process.argv[1] !== undefined && /mutation-guard\.mjs$/.test(process.argv[1])) {
+  // Belt and braces: if this file was clearly the entry point but the URL comparison still disagreed,
+  // say so loudly rather than exiting silently. A guard that declines to run must never do it quietly.
+  process.stderr.write("mutation-guard: could not confirm direct invocation — refusing to stay silent\n");
+  main();
+}

--- a/test/guards/mutation-guard.test.ts
+++ b/test/guards/mutation-guard.test.ts
@@ -143,6 +143,42 @@ describe("the script's exit codes — what the loop actually keys on", () => {
     expect(stderr).toContain("REFUSING");
   });
 
+  it("fails CLOSED when git status fails INSIDE a worktree — cannot tell is not safe", () => {
+    // Codex's finding: the catch swallowed every git failure and exited 0, so a corrupt index let the
+    // mutation loop proceed on a tree it could not prove recoverable — failing open in exactly the
+    // situation the guard exists for. A truncated `.git/index` reproduces it: `git status` dies with
+    // "index file smaller than expected" while `rev-parse --is-inside-work-tree` still answers `true`,
+    // which is precisely the pair the fix keys on.
+    //
+    // This mutation SURVIVED the first fold — the fix shipped untested — which is the third time in
+    // this session that a reviewer's finding was folded without pinning it.
+    const tmp = scratchRepo();
+    execFileSync("git", ["-C", tmp, "commit", "-q", "--allow-empty", "-m", "init"], { env: gitEnv() });
+    execFileSync("sh", ["-c", `echo garbage-not-an-index > "${tmp}/.git/index"`]);
+
+    let code = 0;
+    let stderr = "";
+    try {
+      execFileSync("node", [script], { cwd: tmp, encoding: "utf8", stdio: "pipe", env: gitEnv() });
+    } catch (err) {
+      const e = err as { status?: number; stderr?: string };
+      code = e.status ?? -1;
+      stderr = e.stderr ?? "";
+    }
+    expect(code, "an unreadable repo must block, not wave the loop through").toBe(1);
+    expect(stderr).toContain("REFUSING");
+  });
+
+  it("fails OPEN when there is no repo at all — the hazard cannot exist without git", () => {
+    // The other half, and the reason the two cases are separated: blocking here would stop mutation
+    // testing on an environment problem, and `git checkout` cannot destroy anything where there is no
+    // git. Over-blocking is how a guard gets bypassed.
+    const tmp = execFileSync("mktemp", ["-d", `${tmpdir()}/mutguard-norepo-XXXXXX`], { encoding: "utf8" }).trim();
+    scratch.push(tmp);
+    const out = execFileSync("node", [script, "--json"], { cwd: tmp, encoding: "utf8", env: gitEnv() });
+    expect(JSON.parse(out).clean).toBe(true);
+  });
+
   it("exits 0 with only an untracked file present", () => {
     const tmp = scratchRepo();
     execFileSync("git", ["-C", tmp, "commit", "-q", "--allow-empty", "-m", "init"], { env: gitEnv() });

--- a/test/guards/mutation-guard.test.ts
+++ b/test/guards/mutation-guard.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { trackedChanges } from "../../scripts/mutation-guard.mjs";
@@ -18,6 +19,36 @@ import { trackedChanges } from "../../scripts/mutation-guard.mjs";
  */
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * A throwaway repo, isolated from the developer's global git config.
+ *
+ * `GIT_CONFIG_GLOBAL=/dev/null` because a global `commit.gpgsign = true` (or any broken global
+ * config) would otherwise break every scratch commit here and redden the guard's own tests on a
+ * machine that has nothing wrong with it — review flagged it. Registered for cleanup so runs do not
+ * litter the temp dir, which they previously did.
+ */
+const scratch: string[] = [];
+function scratchRepo(prefix = "mutguard"): string {
+  const dir = execFileSync("mktemp", ["-d", `${tmpdir()}/${prefix}-XXXXXX`], { encoding: "utf8" }).trim();
+  scratch.push(dir);
+  execFileSync("git", ["init", "-q", dir], { env: gitEnv() });
+  return dir;
+}
+function gitEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+}
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
 
 describe("trackedChanges — what a `git checkout` revert can actually destroy", () => {
   it("blocks on modified tracked files, staged or unstaged", () => {
@@ -60,40 +91,63 @@ describe("the script's exit codes — what the loop actually keys on", () => {
 
   it("exits 0 and reports clean when the tree has no tracked changes", () => {
     // Run against a throwaway clean repo so the result does not depend on this worktree's state.
-    const tmp = execFileSync("mktemp", ["-d"], { encoding: "utf8" }).trim();
-    execFileSync("git", ["init", "-q", tmp]);
-    execFileSync("git", ["-C", tmp, "commit", "-q", "--allow-empty", "-m", "init"], {
-      env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" },
-    });
-    const out = execFileSync("node", [script, "--json"], { cwd: tmp, encoding: "utf8" });
+    const tmp = scratchRepo();
+    execFileSync("git", ["-C", tmp, "commit", "-q", "--allow-empty", "-m", "init"], { env: gitEnv() });
+    const out = execFileSync("node", [script, "--json"], { cwd: tmp, encoding: "utf8", env: gitEnv() });
     expect(JSON.parse(out).clean).toBe(true);
   });
 
   it("exits NON-ZERO when a tracked file is modified — the case that ate real work", () => {
-    const tmp = execFileSync("mktemp", ["-d"], { encoding: "utf8" }).trim();
-    const env = { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" };
-    execFileSync("git", ["init", "-q", tmp]);
-    execFileSync("sh", ["-c", `echo one > ${tmp}/f.txt`]);
-    execFileSync("git", ["-C", tmp, "add", "f.txt"]);
-    execFileSync("git", ["-C", tmp, "commit", "-q", "-m", "add"], { env });
-    execFileSync("sh", ["-c", `echo two > ${tmp}/f.txt`]); // the uncommitted edit a revert would eat
+    const tmp = scratchRepo();
+    execFileSync("sh", ["-c", `echo one > "${tmp}/f.txt"`]);
+    execFileSync("git", ["-C", tmp, "add", "f.txt"], { env: gitEnv() });
+    execFileSync("git", ["-C", tmp, "commit", "-q", "-m", "add"], { env: gitEnv() });
+    execFileSync("sh", ["-c", `echo two > "${tmp}/f.txt"`]); // the UNSTAGED edit a revert would eat
 
     let code = 0;
+    let stderr = "";
     try {
-      execFileSync("node", [script], { cwd: tmp, encoding: "utf8", stdio: "pipe" });
+      execFileSync("node", [script], { cwd: tmp, encoding: "utf8", stdio: "pipe", env: gitEnv() });
     } catch (err) {
-      code = (err as { status?: number }).status ?? -1;
+      const e = err as { status?: number; stderr?: string };
+      code = e.status ?? -1;
+      stderr = e.stderr ?? "";
     }
     expect(code, "the guard must refuse to mutate a dirty tree").toBe(1);
+    // Exit 1 alone is not proof: node exits 1 on ANY uncaught crash, so a crash inside the refusal
+    // path would keep this green for the wrong reason. Review's point; pin the message.
+    expect(stderr, "exit 1 must come from the refusal, not from a crash").toContain("REFUSING");
+  });
+
+  it("refuses from a directory whose path needs URL-encoding — the silent no-op", () => {
+    // `import.meta.url` percent-encodes a space while `argv[1]` does not, so the direct-invocation
+    // check compared unequal and the script exited 0 WITH NO OUTPUT: the guard silently doing nothing,
+    // which is the failure class this whole ticket exists to kill. Reproduced by review.
+    const tmp = scratchRepo("mut guard");
+    execFileSync("sh", ["-c", `cp "${script}" "${tmp}/mg.mjs"`]);
+    execFileSync("sh", ["-c", `echo one > "${tmp}/f.txt"`]);
+    execFileSync("git", ["-C", tmp, "add", "f.txt"], { env: gitEnv() });
+    execFileSync("git", ["-C", tmp, "commit", "-q", "-m", "add"], { env: gitEnv() });
+    execFileSync("sh", ["-c", `echo two > "${tmp}/f.txt"`]);
+
+    let code = 0;
+    let stderr = "";
+    try {
+      execFileSync("node", ["./mg.mjs"], { cwd: tmp, encoding: "utf8", stdio: "pipe", env: gitEnv() });
+    } catch (err) {
+      const e = err as { status?: number; stderr?: string };
+      code = e.status ?? -1;
+      stderr = e.stderr ?? "";
+    }
+    expect(code, "a space in the path must not silently disable the guard").toBe(1);
+    expect(stderr).toContain("REFUSING");
   });
 
   it("exits 0 with only an untracked file present", () => {
-    const tmp = execFileSync("mktemp", ["-d"], { encoding: "utf8" }).trim();
-    const env = { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" };
-    execFileSync("git", ["init", "-q", tmp]);
-    execFileSync("git", ["-C", tmp, "commit", "-q", "--allow-empty", "-m", "init"], { env });
-    execFileSync("sh", ["-c", `echo new > ${tmp}/untracked.txt`]);
-    const out = execFileSync("node", [script, "--json"], { cwd: tmp, encoding: "utf8" });
+    const tmp = scratchRepo();
+    execFileSync("git", ["-C", tmp, "commit", "-q", "--allow-empty", "-m", "init"], { env: gitEnv() });
+    execFileSync("sh", ["-c", `echo new > "${tmp}/untracked.txt"`]);
+    const out = execFileSync("node", [script, "--json"], { cwd: tmp, encoding: "utf8", env: gitEnv() });
     expect(JSON.parse(out).clean).toBe(true);
   });
 });
@@ -102,6 +156,9 @@ describe("guard: the skill actually requires the check", () => {
   it("names the script in the adversarial-build loop's mutation step", () => {
     // The field can ship computed-and-unread; so can a script nothing invokes. Pin the wiring.
     const skill = readFileSync(path.join(ROOT, ".claude", "skills", "adversarial-build", "SKILL.md"), "utf8");
-    expect(skill).toContain("scripts/mutation-guard.mjs");
+    // Containment alone would pass on "never run scripts/mutation-guard.mjs" — review's point. Pin the
+    // IMPERATIVE line instead. Nothing can programmatically prove an agent runs a prose step, so this
+    // is the strongest available assertion, and it is stated as that rather than as proof.
+    expect(skill).toMatch(/PROVE it — `node scripts\/mutation-guard\.mjs`/);
   });
 });

--- a/test/guards/mutation-guard.test.ts
+++ b/test/guards/mutation-guard.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { trackedChanges } from "../../scripts/mutation-guard.mjs";
+
+/**
+ * MUTGUARD-1 — the check that stops mutation testing eating uncommitted work.
+ *
+ * The hazard is specific: mutations are reverted with `git checkout <file>`, which restores from the
+ * index/HEAD, so an uncommitted edit to a TRACKED file is destroyed by the revert. It happened three
+ * times in one session, once landing a commit whose tests called a function the revert had deleted.
+ *
+ * The classification is the whole guard, so it is tested directly rather than through a scratch repo:
+ * block on tracked changes, and — just as important — do NOT block on untracked files, because a
+ * revert cannot reach those and a guard that fires on "I just wrote a new test file" gets bypassed.
+ */
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+describe("trackedChanges — what a `git checkout` revert can actually destroy", () => {
+  it("blocks on modified tracked files, staged or unstaged", () => {
+    const porcelain = [" M lib/query/llm-health.ts", "M  lib/ingest/pipeline-health.ts", "MM docs/ARCHITECTURE.md"].join("\n");
+    expect(trackedChanges(porcelain).map((d) => d.path)).toEqual([
+      "lib/query/llm-health.ts",
+      "lib/ingest/pipeline-health.ts",
+      "docs/ARCHITECTURE.md",
+    ]);
+  });
+
+  it("does NOT block on untracked files — a revert cannot reach them", () => {
+    // THE PRECISION THAT KEEPS IT USABLE. Writing a new test file is the normal state mid-slice; a
+    // guard that fires on it gets worked around, and a worked-around guard is not a guard.
+    expect(trackedChanges("?? test/some-new.test.ts\n?? scripts/probe.mjs")).toEqual([]);
+  });
+
+  it("does NOT block on gitignored files", () => {
+    expect(trackedChanges("!! node_modules/x")).toEqual([]);
+  });
+
+  it("blocks on deletions and renames — those are tracked changes too", () => {
+    const porcelain = [" D lib/gone.ts", "R  old.ts -> new.ts", "A  lib/added.ts"].join("\n");
+    expect(trackedChanges(porcelain).map((d) => d.status)).toEqual([" D", "R ", "A "]);
+  });
+
+  it("is clean on an empty status, and tolerates trailing newlines", () => {
+    expect(trackedChanges("")).toEqual([]);
+    expect(trackedChanges("\n\n")).toEqual([]);
+  });
+
+  it("mixes correctly — one tracked change among untracked files still blocks", () => {
+    const porcelain = ["?? test/new.test.ts", " M lib/real.ts", "?? scripts/probe.mjs"].join("\n");
+    expect(trackedChanges(porcelain).map((d) => d.path)).toEqual(["lib/real.ts"]);
+  });
+});
+
+describe("the script's exit codes — what the loop actually keys on", () => {
+  const script = path.join(ROOT, "scripts", "mutation-guard.mjs");
+
+  it("exits 0 and reports clean when the tree has no tracked changes", () => {
+    // Run against a throwaway clean repo so the result does not depend on this worktree's state.
+    const tmp = execFileSync("mktemp", ["-d"], { encoding: "utf8" }).trim();
+    execFileSync("git", ["init", "-q", tmp]);
+    execFileSync("git", ["-C", tmp, "commit", "-q", "--allow-empty", "-m", "init"], {
+      env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" },
+    });
+    const out = execFileSync("node", [script, "--json"], { cwd: tmp, encoding: "utf8" });
+    expect(JSON.parse(out).clean).toBe(true);
+  });
+
+  it("exits NON-ZERO when a tracked file is modified — the case that ate real work", () => {
+    const tmp = execFileSync("mktemp", ["-d"], { encoding: "utf8" }).trim();
+    const env = { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" };
+    execFileSync("git", ["init", "-q", tmp]);
+    execFileSync("sh", ["-c", `echo one > ${tmp}/f.txt`]);
+    execFileSync("git", ["-C", tmp, "add", "f.txt"]);
+    execFileSync("git", ["-C", tmp, "commit", "-q", "-m", "add"], { env });
+    execFileSync("sh", ["-c", `echo two > ${tmp}/f.txt`]); // the uncommitted edit a revert would eat
+
+    let code = 0;
+    try {
+      execFileSync("node", [script], { cwd: tmp, encoding: "utf8", stdio: "pipe" });
+    } catch (err) {
+      code = (err as { status?: number }).status ?? -1;
+    }
+    expect(code, "the guard must refuse to mutate a dirty tree").toBe(1);
+  });
+
+  it("exits 0 with only an untracked file present", () => {
+    const tmp = execFileSync("mktemp", ["-d"], { encoding: "utf8" }).trim();
+    const env = { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" };
+    execFileSync("git", ["init", "-q", tmp]);
+    execFileSync("git", ["-C", tmp, "commit", "-q", "--allow-empty", "-m", "init"], { env });
+    execFileSync("sh", ["-c", `echo new > ${tmp}/untracked.txt`]);
+    const out = execFileSync("node", [script, "--json"], { cwd: tmp, encoding: "utf8" });
+    expect(JSON.parse(out).clean).toBe(true);
+  });
+});
+
+describe("guard: the skill actually requires the check", () => {
+  it("names the script in the adversarial-build loop's mutation step", () => {
+    // The field can ship computed-and-unread; so can a script nothing invokes. Pin the wiring.
+    const skill = readFileSync(path.join(ROOT, ".claude", "skills", "adversarial-build", "SKILL.md"), "utf8");
+    expect(skill).toContain("scripts/mutation-guard.mjs");
+  });
+});


### PR DESCRIPTION
The build loop mutation-tests by editing files in place and reverting with `git checkout <file>`. That revert **silently destroys uncommitted work** — silently, because the revert is the command you expect to succeed.

The skill has said *"commit BEFORE mutation-testing"* in prose since it was written. It failed anyway, **three times in one session** (2026-08-14/15): an extracted function and its tests wiped mid-fold; a commit landed whose tests called a function the revert had deleted (`pickReportedFailure is not a function`, 3 red); and a "repair" script that no-opped against the reverted text while printing success, so the loss surfaced only on re-reading the file.

A rule you have to remember is what this repo's §2 says to replace with a check that fails. This is the check.

## What it does

`scripts/mutation-guard.mjs` exits non-zero and names what's at risk. The skill's mutation step now requires it, and a guard test pins that wiring — a script nothing invokes is as useless as a field nothing renders.

**It blocks on any uncommitted tracked change, but the reason is the policy, not the blast radius.** Verified in a scratch repo rather than asserted:

| status | after `git checkout -- <file>` | at risk? |
|---|---|---|
| `M ` staged-only | **preserved** (restores from the *index*) | no |
| ` M` unstaged | reverted to HEAD content | **yes** |
| `??` untracked | `pathspec did not match`, file survives | no |

So the loop's contract is a **committed checkpoint you can return to** — not that everything blocked would be shredded. Untracked files don't block, deliberately: a revert can't reach them, and firing on "I just wrote a new test file" is how a guard gets worked around.

## Verification

2422 unit tests green · tsc · lint · docs-drift. **9 mutations**, each reddening its intended test — including reverting the `pathToFileURL` fix, failing open inside a repo, dropping `REFUSING` from the message, and the skill keeping a mention while losing the imperative.

## Review

**Reviewed by Fable code-reviewer + Codex (gpt-5.5) — verdict Codex BLOCKED, Fable CLEAR; all findings folded, including one bug of exactly the class this ticket exists to prevent.**

- **Fable MEDIUM — the guard silently no-opped on paths needing URL-encoding.** The direct-invocation check compared `import.meta.url` (which percent-encodes a space) against a raw `file://${process.argv[1]}`, so from a directory with a space the script **exited 0 with no output**: the guard the skill had just told you to trust, quietly not running. Same shape as the repair script that printed success. Reproduced live from `/tmp/mut guard .../`, fixed with `pathToFileURL`, regression test runs the script from exactly such a directory, and it now refuses to decline *silently*.
- **Both — my central git claim was wrong.** I said `git checkout <file>` destroys any uncommitted tracked edit. It restores from the **index**, so staged edits survive. I verified it in a scratch repo rather than folding on assertion; the script, the skill and three test names were all corrected. A guard justified by something false is one argument away from being switched off.
- **Codex HIGH — the catch swallowed *every* git failure and exited 0**, so a corrupt index let the loop proceed on a tree it couldn't prove recoverable — failing open in exactly the situation it exists for. Now: no repo ⇒ fail open (the hazard can't exist); repo present but unreadable ⇒ fail closed, because "cannot tell" must not read as "safe".
- **Fable LOWs on the tests** — scratch repos now isolated with `GIT_CONFIG_GLOBAL=/dev/null` (a developer's global `commit.gpgsign` would otherwise redden the guard's own tests on a healthy machine), cleaned up instead of littering the temp dir, and the dirty-tree test asserts `REFUSING` in stderr: exit 1 alone proved nothing, since node exits 1 on any uncaught crash.
- **Both — the wiring guard** would have passed on *"never run `scripts/mutation-guard.mjs`"*. It pins the imperative line now. Nothing can programmatically prove an agent executes a prose step; that's stated as the limit rather than dressed up.

**One mutation survived the first fold** — reverting the fail-closed fix — so Codex's HIGH shipped untested. That's the third time this session a reviewer's finding was folded without pinning it, which is a pattern, not an accident. Now pinned with a truncated `.git/index`, which reproduces the real shape (status dies, `rev-parse` still answers). Writing that test found a further gap: `--json` promised machine-readable output and the no-repo path emitted none.

**The guard blocked me mid-slice**, refusing a mutation run against a dirty tree — the first time the order was enforced rather than remembered.

AIOS-Work: MUTGUARD-1
