### PR TITLE
test(graph): CDC in-place churn is the number of chunks the edit touches (CDCCHURN-1)

### DIFF
--- a/docs/design/cdc-boundary-overlap.md
+++ b/docs/design/cdc-boundary-overlap.md
@@ -37,12 +37,16 @@ Each wrong answer was cheap prose that would have shipped as documentation:
 
 **When the boundary sequence is unchanged, churn equals the number of ADMITTED chunk intervals that
 intersect the changed span.** Exactly 1 requires two things together: the edit changes text, and it
-lies wholly inside one admitted chunk. (This draft first wrote a third condition — "no boundary strictly
+lies wholly inside one admitted chunk — **and one more under the SET metric the ledger actually pays**:
+a touched chunk whose post-edit content already exists elsewhere in the document costs NOTHING, so such
+a document legitimately churns 0. Constructed by the third reviewer and pinned as the DUPLICATE
+fixture; the other two judged it unreachable from real prose, which is true and beside the point, since
+the rule is a general claim. (This draft first wrote a third condition — "no boundary strictly
 inside the edit span" — which a mutation then proved redundant; see §2b.)
 
 Verified by sweeping every corpus document ≥25k characters at 97-character offset steps and comparing
-the count this rule predicts against the measured churn: **5,658 unchanged-sequence samples, 5,658
-agreements, zero mismatches** (measured at `2b1778d`; see the staleness note below). The 0-churn (past-cap) and 2-churn (spans a surviving boundary) cases
+the count this rule predicts against the measured churn: **5,743 unchanged-sequence samples, 5,743
+agreements, zero mismatches**. The 0-churn (past-cap) and 2-churn (spans a surviving boundary) cases
 fall out of the same rule rather than needing exceptions.
 
 ### 0c. When the sequence DOES change, there is no usable ceiling
@@ -129,8 +133,8 @@ move. For CDC it cannot be: a content-defined boundary **is** content.
 ### 2a. Both tables state the property that is true, and the severity
 
 `edit in place, same length` becomes: **1 when the edit lies wholly inside one chunk and disturbs no
-boundary; otherwise the number of chunks it touches, which is unbounded in practice — measured to 78 of
-80 on this repo's own corpus.** The prose names the mechanism (a cut is decided by the ~32 code units
+boundary; otherwise the number of chunks it touches, with no useful ceiling — observed to at least 9 of
+80 on this repo's own corpus, under the metric the ledger pays.** The prose names the mechanism (a cut is decided by the ~32 code units
 ending at it) and carries §0d's trade table, so the next reader sees both directions at once.
 
 `append at end` is marked **conditional and not yet fully characterised**, pointing at the follow-up
@@ -184,7 +188,7 @@ document can redden it: a document that disturbs a boundary simply classifies in
 
 The `it.fails` exists only because the assertion was wrong. The `max(cdc) ≤ max(legacy)` comparison is
 **removed for the same-length scenario**, with §0d's measurement recorded at the site: it asserts
-`78 ≤ 1` in the general case and `1 ≤ 1` on the strict subset, so it is either false or vacuous. It is
+`9 ≤ 1` in the general case and `1 ≤ 1` on the strict subset, so it is either false or vacuous. It is
 also max-versus-max across *different* documents, which is named where it survives for other scenarios.
 
 ## Dependencies
@@ -241,7 +245,7 @@ removal of the `it.fails` and of the same-length never-worse comparison.
 ## 5. What would falsify this
 
 Wrong if a document classified strict — sequence unchanged, edit inside one admitted chunk, no interior
-boundary — still churns anything but 1. That is the rule verified at 4,962/4,962, so a counterexample
+boundary — still churns anything but 1. That is the rule verified at 5,743/5,743, so a counterexample
 means a fifth mechanism exists and the classifier is measuring the wrong thing.
 
 Wrong in the other direction if the changed fixture's targeted boundary survives its own centred edit,

--- a/docs/design/cdc-boundary-overlap.md
+++ b/docs/design/cdc-boundary-overlap.md
@@ -36,8 +36,9 @@ Each wrong answer was cheap prose that would have shipped as documentation:
 ### 0b. The rule that is actually true, verified before being written
 
 **When the boundary sequence is unchanged, churn equals the number of ADMITTED chunk intervals that
-intersect the changed span.** Exactly 1 requires three things together: the edit changes text, it lies
-wholly inside one admitted chunk, and no boundary falls strictly inside the edit span.
+intersect the changed span.** Exactly 1 requires two things together: the edit changes text, and it
+lies wholly inside one admitted chunk. (Draft 3 first wrote a third condition — "no boundary strictly
+inside the edit span" — which a mutation then proved redundant; see §2b.)
 
 Verified by sweeping every corpus document ≥25k characters at 97-character offset steps and comparing
 the count this rule predicts against the measured churn: **4,962 unchanged-sequence samples, 4,962
@@ -114,7 +115,13 @@ Per document, from the same two chunkings the test already computes:
 1. is the document long enough to receive an in-place edit (else it is excluded — the operation is an
    append and belongs to that scenario);
 2. is the `cdcBoundaries` sequence unchanged;
-3. does the edit span lie wholly inside one **admitted** chunk, with no boundary strictly inside it.
+3. does the edit span lie wholly inside one **admitted** chunk.
+
+The third condition draft 3 first specified — "and no boundary strictly inside the edit span" — turned
+out to be DEAD, and a mutation is what proved it: a boundary strictly inside the span necessarily
+splits it across two admitted intervals, so condition 3 already covers it. Deleting the redundant term
+reddened nothing, and this repo's rule is that a predicate term no test can redden is one the code
+would be asserting on trust. It is gone; the SPANNING fixture pins the property it was reaching for.
 
 Only documents satisfying all three are asserted `churn === 1`. Everything else is classified and
 reported, never gated. **The coordinate mismatch is named rather than left to be re-derived:**
@@ -172,7 +179,7 @@ API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupIds`.
 - `test/graph-cdc.test.ts` — a checked-in STRICT fixture (edit far from every boundary) asserts sequence-unchanged AND churn exactly 1, so the strict branch cannot go vacuous when the classifier is wrong.
 - `test/graph-cdc.test.ts` — a checked-in CHANGED fixture asserts the targeted boundary exists before the edit, is ABSENT after, the sequences differ, and churn ≥ 2 — proving the branch is exercised rather than assuming a centred edit destroys a cut.
 - `test/graph-cdc.test.ts` — no ceiling is asserted for the changed branch on any input; the measured envelope is recorded in a comment with its witness, because the live corpus already reaches 78 of 80.
-- `test/graph-cdc.test.ts` — for every LIVE document classified strict (long enough, sequence unchanged, edit inside one admitted chunk with no interior boundary), churn is exactly 1, asserted per document rather than as a corpus maximum one outlier can dominate.
+- `test/graph-cdc.test.ts` — for every LIVE document classified strict (long enough, sequence unchanged, edit inside one admitted chunk), churn is exactly 1, asserted per document rather than as a corpus maximum one outlier can dominate.
 - `test/graph-cdc.test.ts` — the three buckets partition the corpus (`strict + changed + excluded === total`), so a classifier that moves every document into an ungated bucket reddens instead of greening.
 - `test/graph-cdc.test.ts` — a checked-in SHORT fixture makes the excluded bucket non-empty regardless of the live corpus; the live excluded count is reported, never gated.
 - `test/graph-cdc.test.ts` — the `it.fails` for CDCCHURN-1 is GONE and the `max(cdc) ≤ max(legacy)` comparison is removed for the same-length scenario, with the measured reason (78 vs 1) recorded at the site.

--- a/docs/design/cdc-boundary-overlap.md
+++ b/docs/design/cdc-boundary-overlap.md
@@ -55,19 +55,37 @@ prefix, the changed-sequence bucket is:
 |---|---:|---:|---:|
 | samples | 223 | 211 | 5 |
 
-**Maximum 8 of 80 admitted chunks**, from a 20-character in-place edit at `docs/ARCHITECTURE.md`
-@181,517 — against a legacy churn of **1** for the same edit. A reviewer independently *constructed* a
-document reaching 8 at the test's own fixed offset. So the existing ceiling of 6 is fitted to one
-offset, it is already exceeded on live content, and **no ceiling is assertable** — asserting one
-against a fixture would pin the fixture, not the algorithm. This slice therefore asserts the changed
-branch's *classification* and *direction* (≥ 2, boundary provably destroyed), never a magnitude.
+**Observed maximum 9 of 80 admitted chunks** at `docs/ARCHITECTURE.md`@178,189 — against a legacy
+churn of **1** for the same edit — measured at `9c81efd`. Stated as an OBSERVED LOWER BOUND, not "the
+maximum": the sweep steps 97 characters, so it samples ~1% of offsets, and two runs differing only in
+start offset reported 8 and 9. A reviewer independently constructed a document reaching 8 at the test's
+own fixed offset. The existing ceiling of 6 is therefore fitted to one offset, is already exceeded on
+live content, and **no ceiling is assertable** — asserting one against a fixture would pin the fixture,
+not the algorithm. This slice asserts the changed branch's *classification* and *direction* (≥ 2,
+boundary provably destroyed), never a magnitude.
 
-**STALENESS, stated because this spec's whole argument is about claims that do not reproduce.** Earlier
-drafts published a maximum of **78** from `docs/ARCHITECTURE.md` @7111. It reproduced when measured —
-and stopped reproducing when this session's own earlier merge appended a paragraph to that very file,
-which is exactly the live-corpus hazard §2c takes off the gating path. Review caught it. Every number
-here is now stamped `2b1778d`, and none of them gates a test: the shipped assertions are the rule, the
-classification and the direction, all of which survive a corpus that moves under them.
+### 0f. The retracted "78" was the wrong METRIC, not stale data
+
+An earlier draft published a maximum of **78 of 80** here, and then — worse — explained the retraction
+as corpus drift ("a merge lengthened `ARCHITECTURE.md`"). Review falsified BOTH. The number reproduces
+identically on the pre-merge and post-merge file, and the pre-merge file was *shorter*, so the drift
+story had its direction backwards. That was the fifth wrong characterisation in this ticket, and the
+first one that was mine to catch.
+
+The real cause is the metric. Churn can be counted two ways:
+
+- **SET** — chunks in the edited version whose content appears nowhere in the original;
+- **POSITIONAL** — chunks that differ at the same index.
+
+**Only the set count is a cost the product pays.** `lib/graph/project.ts:1222-1223` builds
+`alreadyPushed = new Set(existingRow.chunk_shas)` and filters `episodes` by MEMBERSHIP, so a chunk
+whose content survives while its index shifts is never re-pushed and costs nothing. The 78 was a
+positional count of a state that costs **2**. `scripts/cdc-churn-sweep.mjs` now reports both, precisely
+so the two cannot be confused again: at `9c81efd` the same sweep gives set max 9 and positional max 80.
+
+The rule in §0b agrees with both metrics — but only in the unchanged-sequence bucket, where they are
+provably equal (every non-intersected chunk is byte-identical). Carrying "agrees under both" across to
+the changed bucket, where they diverge by ~40x, is what produced the 78.
 
 ### 0d. The trade, with both directions measured
 
@@ -138,8 +156,10 @@ reported, never gated. **The coordinate mismatch is named rather than left to be
 `cdcBoundaries` is uncapped while churn is measured on the cap-80 chunking, which is exactly why a
 past-cap edit can change the sequence and still churn 0.
 
-The partition is asserted arithmetically — `strict + changed + excluded === total` — so a classifier
-bug cannot quietly move every document into an ungated bucket.
+The partition sum (`strict + reported + excluded === total`) is asserted, and stated for what it is: a
+TAUTOLOGY for any total classifier, which pins totality and nothing else. What actually stops a
+reports-everything classifier is the STRICT fixture plus a `strict > 0` floor on the live census — an
+earlier draft claimed the sum caught it, which review showed it cannot.
 
 ### 2c. Both branches get a checked-in fixture, because a live corpus cannot guarantee either
 
@@ -188,11 +208,11 @@ API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupIds`.
 
 - `test/graph-cdc.test.ts` — a checked-in STRICT fixture (edit far from every boundary) asserts sequence-unchanged AND churn exactly 1, so the strict branch cannot go vacuous when the classifier is wrong.
 - `test/graph-cdc.test.ts` — a checked-in CHANGED fixture asserts the targeted boundary exists before the edit, is ABSENT after, the sequences differ, and churn ≥ 2 — proving the branch is exercised rather than assuming a centred edit destroys a cut.
-- `test/graph-cdc.test.ts` — no ceiling is asserted for the changed branch on any input; the measured envelope is recorded in a comment with its witness, because the live corpus already reaches 78 of 80.
+- `test/graph-cdc.test.ts` — no ceiling is asserted for the changed branch on any input, and the median assertion is KEPT for the in-place scenario (metric-robust, and it would have caught the original defect); the observed envelope is recorded with its witness and its metric.
 - `test/graph-cdc.test.ts` — for every LIVE document classified strict (long enough, sequence unchanged, edit inside one admitted chunk), churn is exactly 1, asserted per document rather than as a corpus maximum one outlier can dominate.
-- `test/graph-cdc.test.ts` — the three buckets partition the corpus (`strict + changed + excluded === total`), so a classifier that moves every document into an ungated bucket reddens instead of greening.
+- `test/graph-cdc.test.ts` — a `strict > 0` floor on the live census, because the partition sum is a tautology for any total classifier and cannot catch a reports-everything one; the STRICT fixture is the other half of that guard.
 - `test/graph-cdc.test.ts` — a checked-in SHORT fixture makes the excluded bucket non-empty regardless of the live corpus; the live excluded count is reported, never gated.
-- `test/graph-cdc.test.ts` — the `it.fails` for CDCCHURN-1 is GONE and the `max(cdc) ≤ max(legacy)` comparison is removed for the same-length scenario, with the measured reason (78 vs 1) recorded at the site.
+- `test/graph-cdc.test.ts` — the `it.fails` for CDCCHURN-1 is GONE and the `max(cdc) ≤ max(legacy)` comparison is removed for the same-length scenario, with the measured reason recorded at the site.
 - `docs/design/content-defined-chunking.md` — the ACCEPTANCE table's unconditional 1 for `edit in place, same length` is corrected to the conditional property and the prose carries the measured trade in both directions; the summary table above it measures byte offsets, where 1 is a theorem, and is deliberately untouched.
 - `docs/design/content-defined-chunking.md` — the `append at end` row is marked conditional and points at the follow-up ticket, rather than carrying either the old unconditional 1 or an unverified replacement.
 

--- a/docs/design/cdc-boundary-overlap.md
+++ b/docs/design/cdc-boundary-overlap.md
@@ -1,9 +1,11 @@
-# CDC churn 1 holds unless the edit destroys a boundary — CDCCHURN-1
+# CDC churn is the number of chunks the edit touches — CDCCHURN-1
 
-**Status:** spec, pre-review.
-**Related:** `docs/design/content-defined-chunking.md` (the requirement table this corrects). Surfaced by the
-LLMOBS-2 slice, whose spec document joined this test's live corpus and happened to straddle a chunk
-boundary — that document is on an unmerged branch, hence no path reference here.
+**Status:** spec, draft 3. Drafts 1 and 2 were each BLOCKED by two independent cold reads, and **each
+draft's central claim was falsified by measurement, not by argument**. Draft 3's rule is the first that
+was tested against the corpus BEFORE being written down (§0b).
+**Related:** `docs/design/content-defined-chunking.md` (the requirement tables this corrects).
+**Code:** `test/graph-cdc.test.ts`, three checked-in fixtures. `lib/graph/cdc.ts` is read only — no
+product change; that IS the finding, not a shortcut.
 
 ---
 
@@ -13,133 +15,198 @@ boundary — that document is on an unmerged branch, hence no path reference her
 markdown, one document churns **4** chunks for a same-length in-place edit where
 `docs/design/content-defined-chunking.md`'s acceptance table requires **1**.
 
-**The ticket blamed the wrong thing, and so did the comment in the test.** Both said the edit lands in
-"a run of structurally repetitive markdown bullets — low entropy — and the boundary realignment
-propagates". That was a guess. Measured:
+### 0a. Four characterisations, three of them wrong
 
-| edit offset | churn | distance to nearest boundary |
-|---:|---:|---:|
-| **20,000** | **4** | **1** |
-| 19,000 | 1 | 1,001 |
-| 18,000 | 1 | 841 |
-| 17,000 | 1 | 159 |
-| 21,000 | 1 | 999 |
-| 22,000 | 1 | 519 |
-| 15,000 | 1 | 491 |
+Each wrong answer was cheap prose that would have shipped as documentation:
 
-The scenario edits 20 characters at a FIXED offset of 20,000. In this one document a boundary sits at
-**20,001**, so the edit overwrites the very content that produced the cut. The chunk merges with its
-successor and the anchor chain re-syncs three chunks later. At every other offset tested — including
-ones only 159 bytes from a boundary — CDC delivers exactly the required churn of 1.
+1. *"The test over-asserts; the spec disclaims the guarantee."* — False: the table **requires** 1.
+2. *"Low-entropy repetitive bullets propagate the realignment."* — False: churn is indifferent to entropy.
+3. *(draft 1)* *"The edit OVERLAPS a boundary, destroying the cut."* — True of the failing document,
+   not the rule: a cut is decided by the ~32 code units ending at it, so an edit **near** a boundary
+   destroys one it never touches, and spliced text can **create** one. Swept across the hazard band,
+   9,480 of 15,719 non-overlapping offsets churn > 1.
+4. *(draft 2)* *"Churn is exactly 1 when the boundary SEQUENCE is unchanged."* — False in **both**
+   directions, and both reviewers constructed witnesses:
+   - **churn 2** with the sequence unchanged — `docs/ARCHITECTURE.md` @[5132,5152) spans a *surviving*
+     boundary at 5142, so both adjacent chunks change (reproduced here, exactly);
+   - **churn 0** with the sequence unchanged — an edit past the 80-chunk admitted prefix is dropped
+     entirely (`docs/ARCHITECTURE.md` admits 80 of its 145 boundaries, prefix ending at 226,302), and
+     an edit whose replacement equals the original text changes nothing at all.
 
-**So the chunker is behaving correctly and as designed.** Zero of the ten chunks in that document take
-the `max`-length fallback, which was the other plausible mechanism and is refuted. What is wrong is a
-documented claim and a test's construction.
+### 0b. The rule that is actually true, verified before being written
 
-## 1. The claim that cannot hold
+**When the boundary sequence is unchanged, churn equals the number of ADMITTED chunk intervals that
+intersect the changed span.** Exactly 1 requires three things together: the edit changes text, it lies
+wholly inside one admitted chunk, and no boundary falls strictly inside the edit span.
 
-`docs/design/content-defined-chunking.md`'s acceptance table states:
+Verified by sweeping every corpus document ≥25k characters at 97-character offset steps and comparing
+the count this rule predicts against the measured churn: **4,962 unchanged-sequence samples, 4,962
+agreements, zero mismatches.** The 0-churn (past-cap) and 2-churn (spans a surviving boundary) cases
+fall out of the same rule rather than needing exceptions.
 
-| scenario | byte-offset (today) | CDC (required) |
-|---|---|---|
-| edit in place, same length | 1 of 20 | **1** |
+### 0c. When the sequence DOES change, there is no usable ceiling
 
-For byte offsets that 1 is a theorem: offsets do not move, so exactly the containing chunk changes.
-For CDC it cannot be a theorem, because a content-defined boundary is part of the content: an edit
-that OVERLAPS a boundary destroys it, and the chunk necessarily merges with its neighbour. The spec's
-own prose already concedes the general shape — *"realignment after an insertion is empirical rather
-than guaranteed"* — but the table promises an unconditional 1 for this row, and that is what the test
-was asserting.
+Draft 2 proposed asserting a re-synchronisation ceiling of 6 (the existing test's threshold, one over a
+measured worst case of 5). Measured across the same sweep, restricted to edits inside the admitted
+prefix, the changed-sequence bucket is:
 
-The exposure is small and quantifiable: for a 20-character edit against a ~2,500-character target
-chunk, roughly **20 in 2,500 ≈ 0.8%** of offsets overlap a boundary. Across a 23-document corpus with
-one fixed offset, the chance that at least one document is hit is substantial — which is exactly what
-happened, and only when a 26k-character document was added.
+| churn | 2 | 3–6 | 7–20 | 21–50 | 51–78 |
+|---|---:|---:|---:|---:|---:|
+| samples | 202 | 111 | 13 | 25 | 63 |
+
+**Maximum 78 of 80 admitted chunks**, from a 20-character in-place edit at `docs/ARCHITECTURE.md`
+@7111. Codex separately constructed a document reaching 8 at the test's own fixed offset. So 6 is
+fitted to one offset on today's corpus, and **no ceiling is assertable at all** — asserting one against
+a fixture would pin the fixture, not the algorithm. Draft 3 therefore asserts the changed branch's
+*classification* and *direction* (≥ 2, boundary provably destroyed), never a magnitude.
+
+### 0d. The trade, with both directions measured
+
+This is what the acceptance table is really claiming, so it belongs in it:
+
+| edit | CDC | byte offsets |
+|---|---:|---:|
+| in-place, same length, boundary-changing (`ARCHITECTURE.md` @7111) | **78** | **1** |
+| in-place, same length, boundary-preserving (@20,000) | 1 | 1 |
+| insertion of 33 chars near the top | **5** | **78** |
+
+CDC is **not** "never worse than byte offsets". It is dramatically better on insertion — the case it
+was adopted for, where byte offsets churn the entire downstream tail — and dramatically worse on an
+in-place edit that disturbs a boundary. That is the trade; the tables currently state only the half
+that flatters it.
+
+### 0e. Two more things the earlier drafts got wrong
+
+- **10 of 25 corpus documents never receive the edit.** Below 20,020 characters,
+  `slice(0,20000) + "X"*20 + slice(20020)` is a 20-char **append**. The scenario has been silently
+  measuring two operations under one name.
+- **The `append at end` row is also false, and draft 2's replacement for it was false too:**
+  `ARCHITECTURE.md` churns **0** on append (the appended text lands past the cap), and the "2" ceiling
+  holds only for appends shorter than `min` — a 9,000-character append churns 5. Correcting that row
+  properly needs its own measurement pass (§4).
+
+**So the chunker is behaving correctly and as designed.** What is wrong is a documented claim, and a
+test whose outcome depends on content nobody is thinking about.
+
+## 1. The claims that cannot hold
+
+`docs/design/content-defined-chunking.md` states an unconditional `1` for `edit in place, same length`
+in **two** tables (the summary near the top and the acceptance table below), so correcting one leaves
+the claim re-derivable from the other. For byte offsets that 1 is a theorem, because offsets do not
+move. For CDC it cannot be: a content-defined boundary **is** content.
 
 ## 2. The decision
 
-**Correct the claim, and make the test measure the property that is actually true.**
+### 2a. Both tables state the property that is true, and the severity
 
-### 2a. The requirement table states the real property
+`edit in place, same length` becomes: **1 when the edit lies wholly inside one chunk and disturbs no
+boundary; otherwise the number of chunks it touches, which is unbounded in practice — measured to 78 of
+80 on this repo's own corpus.** The prose names the mechanism (a cut is decided by the ~32 code units
+ending at it) and carries §0d's trade table, so the next reader sees both directions at once.
 
-The `edit in place, same length` row becomes: **1 when the edit does not overlap a chunk boundary;
-bounded realignment when it does** (measured ceiling 6 over this corpus, the same bound the other
-scenarios already carry). The prose beside it names the mechanism — a content-defined boundary is part
-of the content, so an edit through it removes the cut — so the next reader does not have to re-derive
-what this ticket re-derived.
+`append at end` is marked **conditional and not yet fully characterised**, pointing at the follow-up
+(§4) — a true statement of ignorance rather than a fourth invented rule.
 
-### 2b. The test asserts that property, and stops depending on luck
+### 2b. The test classifies by what determines the outcome, in the right coordinates
 
-`repoDocs()` reads a LIVE corpus and the scenario edits at a fixed offset, so which documents overlap
-a boundary changes whenever anyone adds or edits a long markdown file. That is the real defect in the
-test: not that its assertion was too strict, but that whether it passes depends on content nobody is
-thinking about when they write it.
+Per document, from the same two chunkings the test already computes:
 
-The scenario therefore SPLITS by the thing that actually determines the outcome:
+1. is the document long enough to receive an in-place edit (else it is excluded — the operation is an
+   append and belongs to that scenario);
+2. is the `cdcBoundaries` sequence unchanged;
+3. does the edit span lie wholly inside one **admitted** chunk, with no boundary strictly inside it.
 
-- documents whose edit does NOT overlap a boundary must churn exactly **1** — the strict property,
-  asserted strictly, on every such document;
-- documents whose edit DOES overlap must churn within the existing ceiling (**6**), which is the
-  honest bound for realignment.
+Only documents satisfying all three are asserted `churn === 1`. Everything else is classified and
+reported, never gated. **The coordinate mismatch is named rather than left to be re-derived:**
+`cdcBoundaries` is uncapped while churn is measured on the cap-80 chunking, which is exactly why a
+past-cap edit can change the sequence and still churn 0.
 
-Boundary overlap is computable from `cdcBoundaries` directly, so the split is derived from the corpus
-rather than hard-coded, and a future document that happens to straddle a cut is classified rather than
-breaking the build.
+The partition is asserted arithmetically — `strict + changed + excluded === total` — so a classifier
+bug cannot quietly move every document into an ungated bucket.
 
-### 2c. The `it.fails` goes away
+### 2c. Both branches get a checked-in fixture, because a live corpus cannot guarantee either
 
-It exists only because the assertion was wrong. Once the assertion states a true property, a passing
-test is the honest artefact and an `it.fails` would be recording a defect that does not exist.
+Draft 2 put the changed branch on a fixture and left the strict branch live. Review showed both need
+one, for the same reason in mirror image:
+
+- **A strict fixture** — an edit verifiably far from every boundary, asserting sequence-unchanged and
+  churn 1 — because if the classifier ever marks every document "changed", the live strict assertion
+  quantifies over an empty set and greens.
+- **A changed fixture** — an edit centred on one of its own boundaries — asserting the branch is
+  *actually* exercised: the boundary exists before, is **absent** after, the sequences differ, and churn
+  ≥ 2. Centring is not a guarantee of destruction (the mask can re-fire on the new content, which is one
+  of the constructed witnesses above), so without those assertions the branch can go silently dead.
+- **A short fixture** (~16k characters) so the excluded bucket is non-empty deterministically. Draft 2
+  asserted the live excluded count is non-zero, which re-pins corpus contents:
+  `docs/design/graph-extraction-cap.md` is 56 characters from leaving that set.
+
+The live corpus keeps the strict assertion, which is where its liveness pays and where no unrelated
+document can redden it: a document that disturbs a boundary simply classifies into the reported bucket.
+
+### 2d. The `it.fails` goes, and the never-worse comparison goes with it
+
+The `it.fails` exists only because the assertion was wrong. The `max(cdc) ≤ max(legacy)` comparison is
+**removed for the same-length scenario**, with §0d's measurement recorded at the site: it asserts
+`78 ≤ 1` in the general case and `1 ≤ 1` on the strict subset, so it is either false or vacuous. It is
+also max-versus-max across *different* documents, which is named where it survives for other scenarios.
 
 ## Dependencies
 
-**Deps: none.** `test/graph-cdc.test.ts` and one table in `docs/design/content-defined-chunking.md`. No product
-code changes — which is the finding, not a shortcut.
+**Deps: none.** `test/graph-cdc.test.ts`, three small fixtures, and two tables in one design document.
+No product code changes.
 
 ## Build-with
 
-**Build-with tier: Fable / high effort.** Justification: the whole slice is a claim about an algorithm's
-guarantees, and the previous two attempts to characterise this failure were BOTH wrong (a "the spec
-disclaims it" argument that the spec contradicts, and a "low-entropy content" mechanism the measurement
-refutes). A third wrong characterisation would be worse than the original bug, because it would ship as
-documentation. Two adversarial review rounds.
+**Build-with tier: Fable / high effort.** Three of the four characterisations of this defect were wrong,
+including both previous drafts of this spec, each falsified by a reviewer's constructed or measured
+witness. A fourth wrong answer ships as documentation. Two adversarial review rounds on the spec (done —
+both BLOCKED, twice) and two on the diff.
 
 ## Tier safety
 
-No tier surface changes: a test and a design document. No product code, no schema, no API route, no
-change to `visibleItems`/`visibleTasks`/`visibleGroupIds`.
+No tier surface changes: a test, three fixtures, and a design document. No product code, no schema, no
+API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupIds`.
 
 ## 3. Acceptance criteria
 
-- `test/graph-cdc.test.ts` — for every corpus document whose same-length in-place edit does NOT overlap a chunk boundary, CDC churn is exactly 1, asserted per document rather than as a corpus-wide maximum that one outlier can dominate.
-- `test/graph-cdc.test.ts` — for a document whose edit DOES overlap a boundary, churn is within the existing ceiling of 6 — and the test proves such a document is actually present in the corpus, so the branch is not vacuous.
-- `test/graph-cdc.test.ts` — the boundary-overlap classification is derived from `cdcBoundaries`, not from a hard-coded document name or offset, so a corpus change reclassifies rather than reddens.
-- `test/graph-cdc.test.ts` — the `it.fails` for CDCCHURN-1 is GONE, and no scenario is skipped: the "never worse than byte offsets" comparison is restored for every scenario, since the reason it was scoped out no longer stands.
-- `docs/design/content-defined-chunking.md` — the acceptance table's `edit in place, same length` row states the conditional property and names the mechanism, so the unconditional claim cannot be re-derived from the document.
+- `test/graph-cdc.test.ts` — a checked-in STRICT fixture (edit far from every boundary) asserts sequence-unchanged AND churn exactly 1, so the strict branch cannot go vacuous when the classifier is wrong.
+- `test/graph-cdc.test.ts` — a checked-in CHANGED fixture asserts the targeted boundary exists before the edit, is ABSENT after, the sequences differ, and churn ≥ 2 — proving the branch is exercised rather than assuming a centred edit destroys a cut.
+- `test/graph-cdc.test.ts` — no ceiling is asserted for the changed branch on any input; the measured envelope is recorded in a comment with its witness, because the live corpus already reaches 78 of 80.
+- `test/graph-cdc.test.ts` — for every LIVE document classified strict (long enough, sequence unchanged, edit inside one admitted chunk with no interior boundary), churn is exactly 1, asserted per document rather than as a corpus maximum one outlier can dominate.
+- `test/graph-cdc.test.ts` — the three buckets partition the corpus (`strict + changed + excluded === total`), so a classifier that moves every document into an ungated bucket reddens instead of greening.
+- `test/graph-cdc.test.ts` — a checked-in SHORT fixture makes the excluded bucket non-empty regardless of the live corpus; the live excluded count is reported, never gated.
+- `test/graph-cdc.test.ts` — the `it.fails` for CDCCHURN-1 is GONE and the `max(cdc) ≤ max(legacy)` comparison is removed for the same-length scenario, with the measured reason (78 vs 1) recorded at the site.
+- `docs/design/content-defined-chunking.md` — BOTH tables stating an unconditional 1 for `edit in place, same length` are corrected to the conditional property, and the prose carries the measured trade in both directions.
+- `docs/design/content-defined-chunking.md` — the `append at end` row is marked conditional and points at the follow-up ticket, rather than carrying either the old unconditional 1 or an unverified replacement.
 
 ## 4. Scope
 
-**In:** the acceptance-table row and its prose, the split scenario in `test/graph-cdc.test.ts`, removal
-of the `it.fails` and of the scoped-out comparison.
+**In:** the two `edit in place` table rows and their prose, the reclassified scenario, three fixtures,
+removal of the `it.fails` and of the same-length never-worse comparison.
 
 **Deferred, each with its reason:**
 
-- **Changing the chunker.** Nothing is wrong with it. Making a same-length edit through a boundary
-  churn only 1 would require boundaries that are not content-defined, which is the property being
-  bought.
-- **Making the corpus a fixture.** `docs/design/content-defined-chunking.md` explicitly chose a live corpus
-  ("measuring against the corpus as it is now, and a snapshot would stop being real the week after").
-  This slice removes the luck without removing the liveness; freezing it is a different trade and
-  would need its own argument.
-- **The other scenarios' offsets.** Insertion and deletion have the same fixed-offset property, but
-  their assertions are ranges rather than an exact 1, so a boundary-overlap document does not break
-  them. Worth revisiting only if it ever does.
+- **`CDCAPPEND-1` — characterising the append row properly.** Draft 2's replacement was falsified twice
+  (a past-cap document churns 0; an append longer than `min` churns 5), and inventing a third rule here
+  would repeat this ticket's entire history one row down. This slice removes the false claim and states
+  the gap; measuring the real rule is its own pass.
+- **Changing the chunker.** Draft 1 said no scheme could do better, which review correctly called too
+  strong: the cascade length is partly a consequence of restarting the search at the previous chunk's
+  start plus the 4,000-character maximum. It is rejected on a different ground — any prior-boundary-aware
+  recovery makes chunking depend on the PREVIOUS chunking, and "same body ⇒ same chunks ⇒ same hashes"
+  is the invariant the whole delta ledger rests on (`lib/graph/cdc.ts:11-13`).
+- **Re-litigating CDC vs byte offsets.** §0d shows the trade is real in both directions. Whether the
+  in-place tail justifies the insertion win is a design question with its own measurements; this slice
+  makes the trade visible instead of documenting only its good half.
+- **Making the whole corpus a fixture.** The live corpus was a deliberate choice and still pays for the
+  strict assertion; §2c removes the luck from everything that gates.
 
 ## 5. What would falsify this
 
-Wrong if a document whose edit does NOT overlap a boundary still churns more than 1 — that would mean
-overlap is not the mechanism and the low-entropy theory (or another) is back in play. The per-document
-strict assertion is what would catch it, where the old corpus-wide maximum hid it behind one outlier.
+Wrong if a document classified strict — sequence unchanged, edit inside one admitted chunk, no interior
+boundary — still churns anything but 1. That is the rule verified at 4,962/4,962, so a counterexample
+means a fifth mechanism exists and the classifier is measuring the wrong thing.
 
-Wrong in the other direction if realignment for an overlapping edit ever exceeds 6, which would mean
-the bound is not a bound. Both directions are asserted rather than assumed.
+Wrong in the other direction if the changed fixture's targeted boundary survives its own centred edit,
+which would mean the fixture is not exercising the branch it claims — the reason that assertion exists
+rather than trusting the construction.

--- a/docs/design/cdc-boundary-overlap.md
+++ b/docs/design/cdc-boundary-overlap.md
@@ -37,12 +37,12 @@ Each wrong answer was cheap prose that would have shipped as documentation:
 
 **When the boundary sequence is unchanged, churn equals the number of ADMITTED chunk intervals that
 intersect the changed span.** Exactly 1 requires two things together: the edit changes text, and it
-lies wholly inside one admitted chunk. (Draft 3 first wrote a third condition — "no boundary strictly
+lies wholly inside one admitted chunk. (This draft first wrote a third condition — "no boundary strictly
 inside the edit span" — which a mutation then proved redundant; see §2b.)
 
 Verified by sweeping every corpus document ≥25k characters at 97-character offset steps and comparing
-the count this rule predicts against the measured churn: **4,962 unchanged-sequence samples, 4,962
-agreements, zero mismatches.** The 0-churn (past-cap) and 2-churn (spans a surviving boundary) cases
+the count this rule predicts against the measured churn: **5,658 unchanged-sequence samples, 5,658
+agreements, zero mismatches** (measured at `2b1778d`; see the staleness note below). The 0-churn (past-cap) and 2-churn (spans a surviving boundary) cases
 fall out of the same rule rather than needing exceptions.
 
 ### 0c. When the sequence DOES change, there is no usable ceiling
@@ -51,25 +51,33 @@ Draft 2 proposed asserting a re-synchronisation ceiling of 6 (the existing test'
 measured worst case of 5). Measured across the same sweep, restricted to edits inside the admitted
 prefix, the changed-sequence bucket is:
 
-| churn | 2 | 3–6 | 7–20 | 21–50 | 51–78 |
-|---|---:|---:|---:|---:|---:|
-| samples | 202 | 111 | 13 | 25 | 63 |
+| churn | 2 | 3–6 | 7–20 |
+|---|---:|---:|---:|
+| samples | 223 | 211 | 5 |
 
-**Maximum 78 of 80 admitted chunks**, from a 20-character in-place edit at `docs/ARCHITECTURE.md`
-@7111. Codex separately constructed a document reaching 8 at the test's own fixed offset. So 6 is
-fitted to one offset on today's corpus, and **no ceiling is assertable at all** — asserting one against
-a fixture would pin the fixture, not the algorithm. Draft 3 therefore asserts the changed branch's
-*classification* and *direction* (≥ 2, boundary provably destroyed), never a magnitude.
+**Maximum 8 of 80 admitted chunks**, from a 20-character in-place edit at `docs/ARCHITECTURE.md`
+@181,517 — against a legacy churn of **1** for the same edit. A reviewer independently *constructed* a
+document reaching 8 at the test's own fixed offset. So the existing ceiling of 6 is fitted to one
+offset, it is already exceeded on live content, and **no ceiling is assertable** — asserting one
+against a fixture would pin the fixture, not the algorithm. This slice therefore asserts the changed
+branch's *classification* and *direction* (≥ 2, boundary provably destroyed), never a magnitude.
+
+**STALENESS, stated because this spec's whole argument is about claims that do not reproduce.** Earlier
+drafts published a maximum of **78** from `docs/ARCHITECTURE.md` @7111. It reproduced when measured —
+and stopped reproducing when this session's own earlier merge appended a paragraph to that very file,
+which is exactly the live-corpus hazard §2c takes off the gating path. Review caught it. Every number
+here is now stamped `2b1778d`, and none of them gates a test: the shipped assertions are the rule, the
+classification and the direction, all of which survive a corpus that moves under them.
 
 ### 0d. The trade, with both directions measured
 
 This is what the acceptance table is really claiming, so it belongs in it:
 
-| edit | CDC | byte offsets |
+| edit (measured at `2b1778d`) | CDC | byte offsets |
 |---|---:|---:|
-| in-place, same length, boundary-changing (`ARCHITECTURE.md` @7111) | **78** | **1** |
+| in-place, same length, boundary-changing (`docs/ARCHITECTURE.md` @181,517) | **8** | **1** |
 | in-place, same length, boundary-preserving (@20,000) | 1 | 1 |
-| insertion of 33 chars near the top | **5** | **78** |
+| insertion of 33 chars near the top | **1** | **80** |
 
 CDC is **not** "never worse than byte offsets". It is dramatically better on insertion — the case it
 was adopted for, where byte offsets churn the entire downstream tail — and dramatically worse on an
@@ -92,8 +100,10 @@ test whose outcome depends on content nobody is thinking about.
 ## 1. The claims that cannot hold
 
 `docs/design/content-defined-chunking.md` states an unconditional `1` for `edit in place, same length`
-in **two** tables (the summary near the top and the acceptance table below), so correcting one leaves
-the claim re-derivable from the other. For byte offsets that 1 is a theorem, because offsets do not
+in its **acceptance table**. One reviewer read the summary table near the top as making the same claim
+and asked for both to be corrected; the other adjudicated and the first was wrong — that table sits
+under "Chunking is byte-offset … verified directly against the real function" and measures LEGACY
+behaviour, where 1 is a theorem. It is correct as written and is left alone. For byte offsets that 1 is a theorem, because offsets do not
 move. For CDC it cannot be: a content-defined boundary **is** content.
 
 ## 2. The decision
@@ -183,7 +193,7 @@ API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupIds`.
 - `test/graph-cdc.test.ts` — the three buckets partition the corpus (`strict + changed + excluded === total`), so a classifier that moves every document into an ungated bucket reddens instead of greening.
 - `test/graph-cdc.test.ts` — a checked-in SHORT fixture makes the excluded bucket non-empty regardless of the live corpus; the live excluded count is reported, never gated.
 - `test/graph-cdc.test.ts` — the `it.fails` for CDCCHURN-1 is GONE and the `max(cdc) ≤ max(legacy)` comparison is removed for the same-length scenario, with the measured reason (78 vs 1) recorded at the site.
-- `docs/design/content-defined-chunking.md` — BOTH tables stating an unconditional 1 for `edit in place, same length` are corrected to the conditional property, and the prose carries the measured trade in both directions.
+- `docs/design/content-defined-chunking.md` — the ACCEPTANCE table's unconditional 1 for `edit in place, same length` is corrected to the conditional property and the prose carries the measured trade in both directions; the summary table above it measures byte offsets, where 1 is a theorem, and is deliberately untouched.
 - `docs/design/content-defined-chunking.md` — the `append at end` row is marked conditional and points at the follow-up ticket, rather than carrying either the old unconditional 1 or an unverified replacement.
 
 ## 4. Scope

--- a/docs/design/content-defined-chunking.md
+++ b/docs/design/content-defined-chunking.md
@@ -291,18 +291,23 @@ create one where none was, or span a surviving one. The true rule, verified over
 with zero mismatches (`test/graph-cdc.test.ts`, CDCCHURN-1):
 
 > **churn = the number of admitted chunk intervals the changed span intersects.**
+>
+> (measured at `2b1778d` — the corpus is deliberately live, so these numbers carry a SHA)
 
-Exactly 1 requires all three: the edit changes text, it lies wholly inside one admitted chunk, and no
-boundary falls strictly inside it. Otherwise there is no useful ceiling — measured over this repo's own
-markdown, a 20-character in-place edit reaches **78 of the 80 admitted chunks**.
+Exactly 1 requires two things: the edit changes text, and it lies wholly inside one admitted chunk.
+(A third condition — "no boundary strictly inside the edit span" — is implied by the second, and was
+deleted after a mutation showed nothing could redden it.) Otherwise there is no useful ceiling —
+measured over this repo's own markdown, a 20-character in-place edit reaches **8 of the 80 admitted
+chunks**, and that number moves as the corpus does: an earlier measurement, on a longer
+`docs/ARCHITECTURE.md`, reached 78.
 
 **So the honest trade, both directions measured on the same corpus:**
 
-| edit | CDC | byte offsets |
+| edit (measured at `2b1778d`) | CDC | byte offsets |
 |---|---:|---:|
-| in-place, same length, boundary-changing (`docs/ARCHITECTURE.md` @7111) | **78** | **1** |
+| in-place, same length, boundary-changing (`docs/ARCHITECTURE.md` @181,517) | **8** | **1** |
 | in-place, same length, boundary-preserving (@20,000) | 1 | 1 |
-| insertion of 33 chars near the top | **5** | **78** |
+| insertion of 33 chars near the top | **1** | **80** |
 
 CDC is **not** "never worse than byte offsets", and this document should never have implied it. It is
 dramatically better on the insertion cascade this lever exists for, and dramatically worse on an

--- a/docs/design/content-defined-chunking.md
+++ b/docs/design/content-defined-chunking.md
@@ -287,7 +287,7 @@ as fixtures — not content, just lengths and edit positions where content is se
 That row promised an unconditional **1** and it cannot be one. For byte offsets 1 IS a theorem: offsets
 do not move, so exactly the containing chunk changes. For CDC a boundary **is** content — a cut is
 decided by roughly the 32 code units ENDING at it — so an edit can destroy a boundary it never touches,
-create one where none was, or span a surviving one. The true rule, verified over 4,962 swept samples
+create one where none was, or span a surviving one. The true rule, verified over 5,743 swept samples
 with zero mismatches (`test/graph-cdc.test.ts`, CDCCHURN-1):
 
 > **churn = the number of admitted chunk intervals the changed span intersects.**
@@ -299,7 +299,8 @@ Exactly 1 requires two things: the edit changes text, and it lies wholly inside 
 deleted after a mutation showed nothing could redden it.) Otherwise there is no useful ceiling —
 measured over this repo's own markdown, a 20-character in-place edit reaches **8 of the 80 admitted
 chunks**, and that number moves as the corpus does: an earlier measurement, on a longer
-`docs/ARCHITECTURE.md`, reached 78.
+`docs/ARCHITECTURE.md`, reached 78 — but that was a POSITIONAL count, and positional churn is not a
+cost (see the note above the table).
 
 **So the honest trade, both directions measured on the same corpus:**
 

--- a/docs/design/content-defined-chunking.md
+++ b/docs/design/content-defined-chunking.md
@@ -276,11 +276,38 @@ as fixtures — not content, just lengths and edit positions where content is se
 
 | scenario | byte-offset (today) | CDC (required) |
 |---|---|---|
-| edit in place, same length | 1 of 20 | 1 |
-| append at end | 1 of 20 | 1 |
+| edit in place, same length | 1 of 20 | **conditional — see below** |
+| append at end | 1 of 20 | conditional, not yet characterised (`CDCAPPEND-1`) |
 | **insert 33 chars near the top** | **21 of 20** | **≤ 3** |
 | insert a paragraph mid-document | ~half | **≤ 3** |
 | delete a paragraph near the top | ~all | **≤ 3** |
+
+### `edit in place, same length` — the row that was wrong, corrected (CDCCHURN-1)
+
+That row promised an unconditional **1** and it cannot be one. For byte offsets 1 IS a theorem: offsets
+do not move, so exactly the containing chunk changes. For CDC a boundary **is** content — a cut is
+decided by roughly the 32 code units ENDING at it — so an edit can destroy a boundary it never touches,
+create one where none was, or span a surviving one. The true rule, verified over 4,962 swept samples
+with zero mismatches (`test/graph-cdc.test.ts`, CDCCHURN-1):
+
+> **churn = the number of admitted chunk intervals the changed span intersects.**
+
+Exactly 1 requires all three: the edit changes text, it lies wholly inside one admitted chunk, and no
+boundary falls strictly inside it. Otherwise there is no useful ceiling — measured over this repo's own
+markdown, a 20-character in-place edit reaches **78 of the 80 admitted chunks**.
+
+**So the honest trade, both directions measured on the same corpus:**
+
+| edit | CDC | byte offsets |
+|---|---:|---:|
+| in-place, same length, boundary-changing (`docs/ARCHITECTURE.md` @7111) | **78** | **1** |
+| in-place, same length, boundary-preserving (@20,000) | 1 | 1 |
+| insertion of 33 chars near the top | **5** | **78** |
+
+CDC is **not** "never worse than byte offsets", and this document should never have implied it. It is
+dramatically better on the insertion cascade this lever exists for, and dramatically worse on an
+in-place edit that disturbs a boundary. Three earlier attempts to characterise this each blamed the
+wrong mechanism — the test carries that history so the fourth reader does not re-derive it.
 
 **And in prod, after:** the projector's own `ingest_runs` records episodes per run. A week of
 editing-heavy days before and after should show the episode count per changed item fall toward the

--- a/scripts/cdc-churn-sweep.mjs
+++ b/scripts/cdc-churn-sweep.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * CDCCHURN-1 — the sweep behind every number in `docs/design/cdc-boundary-overlap.md`.
+ *
+ * Committed rather than described, because this ticket's entire history is published measurements that
+ * did not reproduce: a prose recipe ("corpus ≥25k, 97-character steps") was re-run by a reviewer and
+ * produced different totals, which is exactly the failure the spec is about.
+ *
+ * IT REPORTS BOTH METRICS, and the difference is the point:
+ *
+ *   • SET churn — chunks in the edited version whose content is not present anywhere in the original.
+ *     This is what the product pays: `lib/graph/project.ts` builds `alreadyPushed = new Set(chunk_shas)`
+ *     and filters by MEMBERSHIP, so a chunk whose content survives but whose index shifts is never
+ *     re-pushed and costs nothing.
+ *   • POSITIONAL churn — chunks whose content differs at the same index. This is NOT a cost, and
+ *     mistaking it for one is how an earlier draft of the spec published a maximum of 78 (positional)
+ *     for a state that costs 2 (set).
+ *
+ * Usage: `node scripts/cdc-churn-sweep.mjs [step]` (default step 97). Prints a JSON summary; every
+ * figure quoted in the design docs should be traceable to one run of this, stamped with the SHA.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { cdcBoundaries, chunkCdc } from "../lib/graph/cdc.ts";
+
+const P = { target: 2500, min: 1250, max: 4000 };
+const CAP = 80;
+const EDIT_LEN = 20;
+const STEP = Number(process.argv[2] ?? 97);
+
+const setChurn = (before, after) => {
+  const seen = new Set(before);
+  return after.filter((c) => !seen.has(c)).length;
+};
+const positionalChurn = (before, after) => after.filter((c, i) => before[i] !== c).length;
+const chunks = (t) => chunkCdc(t, P, CAP);
+const edit = (t, at) => t.slice(0, at) + "X".repeat(EDIT_LEN) + t.slice(at + EDIT_LEN);
+
+/** The same corpus `test/graph-cdc.test.ts` reads. */
+function corpus() {
+  const out = [];
+  for (const dir of ["docs", "docs/design"]) {
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".md")) continue;
+      const text = readFileSync(`${dir}/${f}`, "utf8");
+      if (text.length > 4_000) out.push({ path: `${dir}/${f}`, text });
+    }
+  }
+  return out;
+}
+
+const predicted = (base, at) => {
+  let start = 0;
+  let hit = 0;
+  for (const c of base) {
+    const end = start + c.length;
+    if (at < end && at + EDIT_LEN > start) hit++;
+    start = end;
+  }
+  return hit;
+};
+
+const summary = {
+  step: STEP,
+  docs: 0,
+  swept: 0,
+  unchangedSequence: { samples: 0, ruleAgreesSet: 0, ruleAgreesPositional: 0, mismatches: [] },
+  changedSequence: { samples: 0, maxSet: 0, maxSetAt: null, maxPositional: 0, histogramSet: {} },
+};
+
+for (const { path, text } of corpus()) {
+  summary.docs++;
+  if (text.length < 25_000) continue;
+  summary.swept++;
+  const base = chunks(text);
+  const admitted = base.reduce((n, c) => n + c.length, 0);
+  const b0 = JSON.stringify(cdcBoundaries(text, P));
+  // From 0, not from an arbitrary 1,000: two runs of "the same" sweep differing only in start offset
+  // reported different maxima (8 vs 9), which is the whole reason a sparse-grid maximum must be
+  // published as an OBSERVED LOWER BOUND rather than as "the maximum".
+  for (let at = 0; at + EDIT_LEN < text.length; at += STEP) {
+    const after = chunks(edit(text, at));
+    const same = JSON.stringify(cdcBoundaries(edit(text, at), P)) === b0;
+    const s = setChurn(base, after);
+    const p = positionalChurn(base, after);
+    if (same) {
+      const u = summary.unchangedSequence;
+      u.samples++;
+      const want = predicted(base, at);
+      if (s === want) u.ruleAgreesSet++;
+      else if (u.mismatches.length < 5) u.mismatches.push({ path, at, want, set: s });
+      if (p === want) u.ruleAgreesPositional++;
+      continue;
+    }
+    if (at + EDIT_LEN >= admitted) continue; // past the admitted prefix: not a cost, not a sample
+    const c = summary.changedSequence;
+    c.samples++;
+    const bucket = s <= 2 ? "2" : s <= 6 ? "3-6" : s <= 20 ? "7-20" : "21+";
+    c.histogramSet[bucket] = (c.histogramSet[bucket] ?? 0) + 1;
+    if (s > c.maxSet) {
+      c.maxSet = s;
+      c.maxSetAt = `${path}@${at}`;
+    }
+    if (p > c.maxPositional) c.maxPositional = p;
+  }
+}
+
+console.log(JSON.stringify(summary, null, 2));

--- a/test/graph-cdc.test.ts
+++ b/test/graph-cdc.test.ts
@@ -550,6 +550,45 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
     expect(classify(doc(EDIT_AT + EDIT_LEN, 5))).not.toBe("excluded"); // exactly eligible
   });
 
+  it("SPANNING FIXTURE: an unchanged sequence is NOT enough — the edit must sit inside one chunk", () => {
+    // MUTATION-FOUND GAP. Deleting the interior-boundary condition — i.e. restoring draft 2's false
+    // rule, "unchanged sequence ⇒ churn 1" — left every test green, because on today's corpus the
+    // sequence check catches the one document that would expose it first. Two conditions masking each
+    // other is defense-in-depth hiding a mutation, so each now has a fixture that isolates it.
+    //
+    // Here the boundary at 8,543 SURVIVES the edit (the sequence is identical) but the edit spans it,
+    // so both adjacent chunks change: churn 2, not 1.
+    const t = doc(50_000, 3);
+    const at = 8_528;
+    const boundary = 8_543;
+    const before = cdcBoundaries(t, CDC_PARAMS);
+    const edited = t.slice(0, at) + "X".repeat(EDIT_LEN) + t.slice(at + EDIT_LEN);
+    expect(before).toContain(boundary);
+    expect(cdcBoundaries(edited, CDC_PARAMS)).toEqual(before); // sequence UNCHANGED…
+    expect(at).toBeLessThan(boundary);
+    expect(at + EDIT_LEN).toBeGreaterThan(boundary); // …but the edit spans the surviving boundary
+    expect(classify(t, at)).toBe("reported");
+    expect(changedCount(chunkContent(t), chunkContent(edited))).toBe(2);
+  });
+
+  it("WINDOW FIXTURE: fitting inside one chunk is NOT enough — the sequence must also survive", () => {
+    // The mirror mutation: deleting the boundary-sequence comparison also left everything green, for the
+    // same masking reason. Here the edit sits wholly inside one original chunk and still changes the
+    // sequence, because a cut is decided by the ~32 code units ENDING at it — so an edit 25 characters
+    // short of the boundary at 4,374 destroys it without touching it. This is mechanism (3) from the
+    // header, the one that killed draft 1's overlap rule.
+    const t = doc(50_000, 1);
+    const at = 4_349;
+    const boundary = 4_374;
+    const before = cdcBoundaries(t, CDC_PARAMS);
+    const edited = t.slice(0, at) + "X".repeat(EDIT_LEN) + t.slice(at + EDIT_LEN);
+    expect(before).toContain(boundary);
+    expect(at + EDIT_LEN).toBeLessThan(boundary); // the edit does NOT overlap the boundary…
+    expect(cdcBoundaries(edited, CDC_PARAMS)).not.toEqual(before); // …and destroys it anyway
+    expect(admittedIntervals(t).some(([lo, hi]) => at >= lo && at + EDIT_LEN <= hi)).toBe(true);
+    expect(classify(t, at)).toBe("reported");
+  });
+
   it("LIVE CORPUS: every strictly-classified document churns exactly 1", () => {
     const docs = repoDocs();
     expect(docs.length).toBeGreaterThan(5);

--- a/test/graph-cdc.test.ts
+++ b/test/graph-cdc.test.ts
@@ -459,8 +459,9 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
  *
  *   **churn = the number of ADMITTED chunk intervals the changed span intersects.**
  *
- * So exactly 1 needs three things together: the edit changes text, it lies wholly inside one admitted
- * chunk, and no boundary falls strictly inside it. Anything else is reported, not gated — because when
+ * So exactly 1 needs two things together: the edit changes text, and it lies wholly inside one admitted
+ * chunk. (A third condition — "no boundary strictly inside the edit span" — was specified and then
+ * deleted as provably dead; see `classify`.) Anything else is reported, not gated — because when
  * the boundary sequence does change there is NO usable ceiling: the same sweep reaches **78 of 80**
  * admitted chunks for a 20-character edit (`docs/ARCHITECTURE.md` @7111) against a legacy churn of 1.
  * A ceiling asserted on a fixture would pin the fixture, not the algorithm.
@@ -498,11 +499,22 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
   const classify = (t: string, at = EDIT_AT, len = EDIT_LEN): Bucket => {
     if (t.length < at + len) return "excluded";
     const edited = t.slice(0, at) + "X".repeat(len) + t.slice(at + len);
+    // The rule's first precondition, which all three documents stated and the classifier omitted
+    // (review): an edit that changes nothing churns 0, not 1. Latent today — no corpus document holds
+    // a 20-character X-run at the edit site — but the classifier should match the rule it implements.
+    if (edited === t) return "excluded";
     const before = cdcBoundaries(t, CDC_PARAMS);
     if (JSON.stringify(before) !== JSON.stringify(cdcBoundaries(edited, CDC_PARAMS))) return "reported";
+    // ONE term, not two — and the second time this deletion has been attempted: the first went into a
+    // commit message while a mutation revert quietly took the edit itself (found by review; the same
+    // "commit claims vs file state" scar this repo already carries). The deleted term was
+    // `before.some((b) => b > at && b < at + len)`, and it is provably dead: admitted intervals are
+    // delimited by consecutive `before` boundaries, so a boundary strictly inside the edit span cannot
+    // sit inside one interval — `holding` is already undefined there. A predicate term no test can
+    // redden is one the code asserts on trust, and with it present, deleting the `holding` check left
+    // every test green: the two conditions masked each other.
     const holding = admittedIntervals(t).find(([s, e]) => at >= s && at + len <= e);
-    if (holding === undefined) return "reported"; // spans two chunks, or lies past the cap
-    return before.some((b) => b > at && b < at + len) ? "reported" : "strict";
+    return holding === undefined ? "reported" : "strict"; // spans two chunks, or lies past the cap
   };
 
   it("STRICT FIXTURE: an edit far from every boundary churns exactly 1", () => {
@@ -601,8 +613,14 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
       // original defect hid — and how it was then mis-diagnosed three times.
       expect(changedCount(chunkContent(t), chunkContent(inPlace(t))), "strict document churn").toBe(1);
     }
-    // The partition is asserted, so a classifier that quietly moves every document into the ungated
-    // bucket reddens instead of greening.
+    // HONEST ABOUT WHAT THIS IS (review): the sum is a TAUTOLOGY for any total classifier — one that
+    // returned "reported" for everything would satisfy it. It is kept because it pins TOTALITY (every
+    // document lands in exactly one bucket); what it does NOT do is catch a reports-everything
+    // classifier. The STRICT fixture above catches that, and the floor below keeps the live assertion
+    // from silently measuring nothing.
     expect(counts.excluded + counts.strict + counts.reported).toBe(docs.length);
+    // A floor, not a pinned count: today 14 of 25 documents classify strict, and pinning that number
+    // would re-create the corpus dependence this ticket exists to remove.
+    expect(counts.strict, "no live document classified strict — the assertion above ran on nothing").toBeGreaterThan(0);
   });
 });

--- a/test/graph-cdc.test.ts
+++ b/test/graph-cdc.test.ts
@@ -361,6 +361,10 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
   });
 
   for (const { name, edit, max } of scenarios) {
+    // `edit in place, same length` is covered by its own describe below (CDCCHURN-1): its churn is not
+    // a single number but a function of what the edit touches, and asserting a constant here is what
+    // made the acceptance table wrong in the first place.
+    if (name === "edit in place, same length") continue;
     it(`${name} — CDC re-extracts <= ${max} chunk(s)`, () => {
       const v2 = edit(DOC_50K);
       const cdcChurn = changedCount(chunkContent(DOC_50K), chunkContent(v2));
@@ -402,33 +406,6 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
    * — see the asymmetry note in lib/graph/cdc.ts). Every one of those is against a legacy worst case of
    * 80 — i.e. the entire capped document.
    */
-  /**
-   * KNOWN FAILURE — CDCCHURN-1. `it.fails` on purpose: this asserts the requirement the spec actually
-   * makes, and it currently does NOT hold, so the test passes while the gap is open and flips RED the
-   * moment CDC is fixed. That is this repo's sanctioned way to record a confirmed-but-unfixed gap; a
-   * skip would rot silently.
-   *
-   * THE SPEC REQUIRES 1. `docs/design/content-defined-chunking.md`'s acceptance table reads
-   * `| edit in place, same length | 1 of 20 | 1 |` — byte-offset today, CDC required. Measured over
-   * this live corpus on 2026-08-15: 22 of 23 documents churn 1, and
-   * `docs/design/answering-model-observability.md` churns 4, because the offset-20,000 edit lands in a
-   * run of structurally repetitive markdown bullets and the boundary realignment propagates.
-   *
-   * HOW THIS NEARLY WENT WRONG, recorded because it is the more useful half. The slice that added that
-   * document first SCOPED this assertion away, arguing the spec disclaimed the guarantee. It does not:
-   * that argument cited the spec's quality-neutrality passage, while the acceptance table above states
-   * the requirement outright. One reviewer accepted the argument; the other went and read the table.
-   * The assertion was right and the implementation is what is off — which is the opposite conclusion,
-   * and the difference between filing a real defect and quietly disarming a guard.
-   */
-  it.fails("KNOWN GAP (CDCCHURN-1): in-place same-length churn beats byte offsets on every real doc", () => {
-    const docs = repoDocs();
-    const edit = (t: string) => t.slice(0, 20_000) + "XXXXXXXXXXXXXXXXXXXX" + t.slice(20_020);
-    const cdc = docs.map((t) => changedCount(chunkContent(t), chunkContent(edit(t))));
-    const leg = docs.map((t) => changedCount(legacy(t), legacy(edit(t))));
-    expect(Math.max(...cdc)).toBeLessThanOrEqual(Math.max(...leg));
-  });
-
   it("real repo documents: median churn 1-2, ceiling 6, against a legacy ceiling of the whole document", () => {
     const docs = repoDocs();
     expect(docs.length).toBeGreaterThan(5);
@@ -440,18 +417,153 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
         cdc.push(changedCount(chunkContent(t), chunkContent(v2)));
         leg.push(changedCount(legacy(t), legacy(v2)));
       }
+      // `edit in place, same length` is excluded from BOTH assertions here, not just the second one
+      // (CDCCHURN-1). The ceiling of 6 is fitted to this one fixed offset: swept across the same corpus,
+      // a boundary-disturbing 20-character in-place edit reaches **78 of 80 admitted chunks**
+      // (`docs/ARCHITECTURE.md` @7111), against a legacy churn of 1. And "never worse than byte offsets"
+      // is simply false for that scenario — byte offsets churn 1 by construction, since offsets do not
+      // move. Both claims now live in the describe below, conditioned on what the edit actually touches.
+      // The other scenarios still bind, and they are where CDC's win is real: the same corpus gives
+      // CDC 5 against legacy 78 for an insertion near the top.
+      if (name === "edit in place, same length") continue;
       cdc.sort((a, b) => a - b);
       const median = cdc[Math.floor(cdc.length / 2)];
       expect(median, `${name}: median CDC churn over real docs`).toBeLessThanOrEqual(2);
       expect(Math.max(...cdc), `${name}: worst-case CDC churn over real docs`).toBeLessThanOrEqual(6);
-      // The `edit in place, same length` scenario is asserted SEPARATELY below, as a documented
-      // known failure (CDCCHURN-1). It is excluded here rather than deleted, and the exclusion is
-      // narrow: every other scenario still binds.
-      if (name !== "edit in place, same length") {
-        expect(Math.max(...cdc), `${name}: CDC must never be worse than byte offsets`).toBeLessThanOrEqual(
-          Math.max(...leg)
-        );
-      }
+      expect(Math.max(...cdc), `${name}: CDC must never be worse than byte offsets`).toBeLessThanOrEqual(
+        Math.max(...leg)
+      );
     }
+  });
+});
+
+// ── CDCCHURN-1: what an in-place same-length edit actually costs ─────────────────────────────────
+
+/**
+ * The acceptance table promised an unconditional **1** for `edit in place, same length`, and one real
+ * document churns 4. This is the fourth characterisation of that gap; the first three were wrong, and
+ * each was cheap prose that would have shipped as documentation:
+ *
+ *   1. "the test over-asserts, the spec disclaims it" — the table REQUIRES 1;
+ *   2. "low-entropy repeated bullets propagate the realignment" — churn is indifferent to entropy;
+ *   3. "the edit OVERLAPS a boundary" — true of that document, not the rule: a cut is decided by the
+ *      ~32 code units ENDING at it, so an edit near a boundary destroys one it never touches, and
+ *      spliced text can create one (9,480 of 15,719 non-overlapping offsets churn > 1);
+ *   4. "churn is 1 whenever the boundary SEQUENCE is unchanged" — false in both directions: an edit
+ *      spanning a SURVIVING boundary changes both adjacent chunks (churn 2), and an edit past the
+ *      80-chunk admitted prefix changes nothing at all (churn 0).
+ *
+ * THE RULE, verified before it was written down — 4,962 unchanged-sequence samples swept across the
+ * corpus at 97-character steps, 4,962 agreements, zero mismatches, under both this file's set-based
+ * `changedCount` and a positional diff:
+ *
+ *   **churn = the number of ADMITTED chunk intervals the changed span intersects.**
+ *
+ * So exactly 1 needs three things together: the edit changes text, it lies wholly inside one admitted
+ * chunk, and no boundary falls strictly inside it. Anything else is reported, not gated — because when
+ * the boundary sequence does change there is NO usable ceiling: the same sweep reaches **78 of 80**
+ * admitted chunks for a 20-character edit (`docs/ARCHITECTURE.md` @7111) against a legacy churn of 1.
+ * A ceiling asserted on a fixture would pin the fixture, not the algorithm.
+ */
+describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edit touches", () => {
+  const EDIT_AT = 20_000;
+  const EDIT_LEN = 20;
+  const inPlace = (t: string) => t.slice(0, EDIT_AT) + "X".repeat(EDIT_LEN) + t.slice(EDIT_AT + EDIT_LEN);
+  const changedCount = (before: string[], after: string[]): number => {
+    const seen = new Set(before);
+    return after.filter((c) => !seen.has(c)).length;
+  };
+
+  /** Admitted chunk intervals — CAPPED, because churn is measured on the capped chunking while
+   *  `cdcBoundaries` is not. That coordinate mismatch is exactly why a past-cap edit can change the
+   *  boundary sequence and still churn 0, so it is named here rather than left to be re-derived. */
+  const admittedIntervals = (t: string): [number, number][] => {
+    const out: [number, number][] = [];
+    let start = 0;
+    for (const c of chunkContent(t)) {
+      out.push([start, start + c.length]);
+      start += c.length;
+    }
+    return out;
+  };
+
+  type Bucket = "excluded" | "strict" | "reported";
+
+  /**
+   * Three independent facts, in the order that makes each one meaningful. `strict` is the only gated
+   * bucket; `reported` covers every way the rule's preconditions fail (boundary disturbed, edit spans a
+   * surviving boundary, edit past the admitted prefix), and `excluded` is the documents for which this
+   * "in-place edit" is really an append.
+   */
+  const classify = (t: string, at = EDIT_AT, len = EDIT_LEN): Bucket => {
+    if (t.length < at + len) return "excluded";
+    const edited = t.slice(0, at) + "X".repeat(len) + t.slice(at + len);
+    const before = cdcBoundaries(t, CDC_PARAMS);
+    if (JSON.stringify(before) !== JSON.stringify(cdcBoundaries(edited, CDC_PARAMS))) return "reported";
+    const holding = admittedIntervals(t).find(([s, e]) => at >= s && at + len <= e);
+    if (holding === undefined) return "reported"; // spans two chunks, or lies past the cap
+    return before.some((b) => b > at && b < at + len) ? "reported" : "strict";
+  };
+
+  it("STRICT FIXTURE: an edit far from every boundary churns exactly 1", () => {
+    // Checked in rather than relying on the live corpus, because the live strict assertion below
+    // quantifies over a bucket a broken classifier could empty — and an assertion over an empty set is
+    // green. This fixture makes the strict branch impossible to lose.
+    const t = doc(50_000, 7);
+    const intervals = admittedIntervals(t);
+    const widest = intervals.reduce((a, b) => (b[1] - b[0] > a[1] - a[0] ? b : a));
+    const at = Math.floor((widest[0] + widest[1]) / 2) - EDIT_LEN / 2;
+    expect(classify(t, at), "the fixture must land in the strict bucket").toBe("strict");
+    const edited = t.slice(0, at) + "X".repeat(EDIT_LEN) + t.slice(at + EDIT_LEN);
+    expect(changedCount(chunkContent(t), chunkContent(edited))).toBe(1);
+  });
+
+  it("CHANGED FIXTURE: an edit centred on a boundary destroys it — asserted, not assumed", () => {
+    // Centring is NOT a guarantee of destruction: the mask can re-fire on the spliced content, and a
+    // reviewer constructed exactly that. Without these assertions the branch could go silently dead
+    // while the test stayed green, which is the failure this whole ticket is about.
+    const t = doc(50_000, 11);
+    const before = cdcBoundaries(t, CDC_PARAMS);
+    const target = before.find((b) => b > 5_000 && b < t.length - 5_000);
+    expect(target, "the fixture has no interior boundary to target").toBeDefined();
+    const at = target! - EDIT_LEN / 2;
+    const edited = t.slice(0, at) + "X".repeat(EDIT_LEN) + t.slice(at + EDIT_LEN);
+    const after = cdcBoundaries(edited, CDC_PARAMS);
+    expect(before).toContain(target!); // it was there…
+    expect(after).not.toContain(target!); // …and the edit really destroyed it
+    expect(JSON.stringify(after)).not.toBe(JSON.stringify(before));
+    expect(classify(t, at)).toBe("reported");
+    // A DIRECTION, never a magnitude: the corpus already reaches 78 of 80, so any ceiling here would be
+    // a property of this fixture rather than of the chunker.
+    expect(changedCount(chunkContent(t), chunkContent(edited))).toBeGreaterThanOrEqual(2);
+  });
+
+  it("SHORT FIXTURE: a document under the edit span is excluded, not silently measured as an append", () => {
+    // The scenario has been applying `slice(0,20000) + X*20 + slice(20020)` to documents shorter than
+    // 20,020 characters, where it is a 20-char APPEND — 10 of the 25 live documents today. Two
+    // operations under one name is how the ceiling absorbed a number nobody attributed. The fixture is
+    // checked in so the excluded bucket is non-empty regardless of what the corpus holds; pinning the
+    // LIVE excluded count would re-create the corpus dependence this ticket exists to remove
+    // (`docs/design/graph-extraction-cap.md` is ~56 characters from leaving that set).
+    expect(classify(doc(16_000, 5))).toBe("excluded");
+    expect(classify(doc(EDIT_AT + EDIT_LEN - 1, 5))).toBe("excluded"); // one short of eligible
+    expect(classify(doc(EDIT_AT + EDIT_LEN, 5))).not.toBe("excluded"); // exactly eligible
+  });
+
+  it("LIVE CORPUS: every strictly-classified document churns exactly 1", () => {
+    const docs = repoDocs();
+    expect(docs.length).toBeGreaterThan(5);
+    const counts: Record<Bucket, number> = { excluded: 0, strict: 0, reported: 0 };
+    for (const t of docs) {
+      const bucket = classify(t);
+      counts[bucket]++;
+      if (bucket !== "strict") continue;
+      // Per document, not as a corpus maximum: a maximum lets one outlier dominate, which is how the
+      // original defect hid — and how it was then mis-diagnosed three times.
+      expect(changedCount(chunkContent(t), chunkContent(inPlace(t))), "strict document churn").toBe(1);
+    }
+    // The partition is asserted, so a classifier that quietly moves every document into the ungated
+    // bucket reddens instead of greening.
+    expect(counts.excluded + counts.strict + counts.reported).toBe(docs.length);
   });
 });

--- a/test/graph-cdc.test.ts
+++ b/test/graph-cdc.test.ts
@@ -419,12 +419,12 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
       }
       // `edit in place, same length` is excluded from BOTH assertions here, not just the second one
       // (CDCCHURN-1). The ceiling of 6 is fitted to this one fixed offset: swept across the same corpus,
-      // a boundary-disturbing 20-character in-place edit reaches **78 of 80 admitted chunks**
-      // (`docs/ARCHITECTURE.md` @7111), against a legacy churn of 1. And "never worse than byte offsets"
+      // a boundary-disturbing 20-character in-place edit reaches **at least 9 of 80 admitted chunks**
+      // (`docs/ARCHITECTURE.md`@178,189), against a legacy churn of 1. And "never worse than byte offsets"
       // is simply false for that scenario — byte offsets churn 1 by construction, since offsets do not
       // move. Both claims now live in the describe below, conditioned on what the edit actually touches.
       // The other scenarios still bind, and they are where CDC's win is real: the same corpus gives
-      // CDC 5 against legacy 78 for an insertion near the top.
+      // CDC 1 against legacy 80 for an insertion near the top.
       if (name === "edit in place, same length") continue;
       cdc.sort((a, b) => a - b);
       const median = cdc[Math.floor(cdc.length / 2)];
@@ -499,6 +499,22 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
     return out;
   };
 
+  /**
+   * What the rule predicts for a STRICT document, under the metric the product actually pays.
+   *
+   * The interval count is 1 by construction (that is what `strict` means). The subtraction is the
+   * corner a third reviewer constructed and this test now pins: `lib/graph/project.ts` filters by
+   * `new Set(chunk_shas)` MEMBERSHIP, so if the edited chunk's new content already exists elsewhere in
+   * the document, nothing is re-pushed and the cost is 0. Derived from the rule — never from the churn
+   * it is checking — so it cannot pass by restating the answer.
+   */
+  const expectedStrictChurn = (t: string, at = EDIT_AT, len = EDIT_LEN): number => {
+    const holding = admittedIntervals(t).find(([s, e]) => at >= s && at + len <= e);
+    if (holding === undefined) return 0; // not strict; the caller does not reach this
+    const editedChunk = (t.slice(0, at) + "X".repeat(len) + t.slice(at + len)).slice(holding[0], holding[1]);
+    return new Set(chunkContent(t)).has(editedChunk) ? 0 : 1;
+  };
+
   type Bucket = "excluded" | "strict" | "reported";
 
   /**
@@ -556,7 +572,7 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
     expect(after).not.toContain(target!); // …and the edit really destroyed it
     expect(JSON.stringify(after)).not.toBe(JSON.stringify(before));
     expect(classify(t, at)).toBe("reported");
-    // A DIRECTION, never a magnitude: the corpus already reaches 78 of 80, so any ceiling here would be
+    // A DIRECTION, never a magnitude: the corpus already reaches ≥9 of 80, so any ceiling here would be
     // a property of this fixture rather than of the chunker.
     expect(changedCount(chunkContent(t), chunkContent(edited))).toBeGreaterThanOrEqual(2);
   });
@@ -625,6 +641,33 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
     expect(changedCount(chunkContent(t), chunkContent(inPlace(t)))).toBe(0);
   });
 
+  it("DUPLICATE FIXTURE: a touched chunk that coincides with an existing one costs NOTHING", () => {
+    // Constructed by the third reviewer (Codex) and reproduced here: a document built from a repeated
+    // block, with the post-edit content of the edited chunk planted in an earlier copy. The edit
+    // changes text, the boundary sequence is unchanged and the span sits inside one admitted chunk —
+    // every precondition of "strict" — yet SET churn is 0, because the edited chunk is byte-identical
+    // to one already in the ledger and `lib/graph/project.ts:1222` filters by set membership.
+    //
+    // The other two reviewers judged this unconstructible from real markdown, and they were right that
+    // it needs contrived content — but the RULE is a general claim, and a general claim with a
+    // counterexample is what this whole ticket is about.
+    const block = doc(10_000, 21);
+    const t0 = block.repeat(5);
+    const holding = admittedIntervals(t0).find(([s, e]) => EDIT_AT >= s && EDIT_AT + EDIT_LEN <= e)!;
+    const editedChunk =
+      t0.slice(holding[0], EDIT_AT) + "X".repeat(EDIT_LEN) + t0.slice(EDIT_AT + EDIT_LEN, holding[1]);
+    const twinAt = holding[0] - block.length;
+    const t = t0.slice(0, twinAt) + editedChunk + t0.slice(twinAt + (holding[1] - holding[0]));
+
+    expect(classify(t)).toBe("strict"); // every precondition of the strict bucket holds…
+    expect(changedCount(chunkContent(t), chunkContent(inPlace(t)))).toBe(0); // …and the cost is 0
+    // Positional churn is still 1 — which is exactly why the two metrics must not be conflated.
+    const before = chunkContent(t);
+    const after = chunkContent(inPlace(t));
+    expect(after.filter((c, i) => before[i] !== c).length).toBe(1);
+    expect(expectedStrictChurn(t)).toBe(0); // and the rule predicts it
+  });
+
   it("LIVE CORPUS: the in-place median stays at 1 — the assertion that would have caught this", () => {
     // Dropping the ceiling took the MEDIAN with it, and review was right that this went too far: the
     // median is metric-robust (set and positional agree in the strict bucket, which is most of the
@@ -649,7 +692,16 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
       if (bucket !== "strict") continue;
       // Per document, not as a corpus maximum: a maximum lets one outlier dominate, which is how the
       // original defect hid — and how it was then mis-diagnosed three times.
-      expect(changedCount(chunkContent(t), chunkContent(inPlace(t))), "strict document churn").toBe(1);
+      //
+      // And the expectation is DERIVED from the rule, not the constant 1, because of the corner the
+      // third reviewer constructed: under the SET metric the ledger pays, a touched chunk whose
+      // post-edit content already exists elsewhere in the document costs NOTHING, so a strict document
+      // can legitimately churn 0. Asserting a flat 1 would redden on a true negative. This computes
+      // what the rule predicts and asserts that.
+      expect(
+        changedCount(chunkContent(t), chunkContent(inPlace(t))),
+        "strict document churn must equal what the rule predicts"
+      ).toBe(expectedStrictChurn(t));
     }
     // HONEST ABOUT WHAT THIS IS (review): the sum is a TAUTOLOGY for any total classifier — one that
     // returned "reported" for everything would satisfy it. It is kept because it pins TOTALITY (every

--- a/test/graph-cdc.test.ts
+++ b/test/graph-cdc.test.ts
@@ -453,20 +453,29 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
  *      spanning a SURVIVING boundary changes both adjacent chunks (churn 2), and an edit past the
  *      80-chunk admitted prefix changes nothing at all (churn 0).
  *
- * THE RULE, verified before it was written down — 5,658 unchanged-sequence samples swept across the
- * corpus at 97-character steps, 5,658 agreements, zero mismatches, under both this file's set-based
- * `changedCount` and a positional diff:
+ * THE RULE, verified before it was written down — 5,743 unchanged-sequence samples swept across the
+ * corpus at 97-character steps, 5,743 agreements, zero mismatches, under both this file's set-based
+ * `changedCount` and a positional diff (they are provably equal in that bucket). Reproduce with
+ * `node scripts/cdc-churn-sweep.mjs`, which is committed because a prose recipe did NOT reproduce:
  *
  *   **churn = the number of ADMITTED chunk intervals the changed span intersects.**
  *
  * So exactly 1 needs two things together: the edit changes text, and it lies wholly inside one admitted
  * chunk. (A third condition — "no boundary strictly inside the edit span" — was specified and then
  * deleted as provably dead; see `classify`.) Anything else is reported, not gated — because when
- * the boundary sequence does change there is NO usable ceiling: the same sweep reaches **8 of 80**
- * admitted chunks for a 20-character edit (`docs/ARCHITECTURE.md` @181,517) against a legacy churn of
- * 1 — already past the ceiling of 6 this file used to assert. An earlier measurement reached 78 before
- * a merge changed that document, which is the live-corpus hazard in miniature: none of these numbers
- * gates anything, and the assertions below rest on the rule and the classification instead.
+ * the boundary sequence does change there is NO usable ceiling: the same sweep observes **≥ 9 of 80**
+ * admitted chunks for a 20-character edit (`docs/ARCHITECTURE.md`@178,189) against a legacy churn of 1
+ * — already past the ceiling of 6 this file used to assert. "≥" is deliberate: the sweep steps 97
+ * characters, so a maximum from it is a lower bound, and two runs differing only in start offset gave
+ * 8 and 9.
+ *
+ * AND MIND THE METRIC. An earlier draft published 78 here. That is a POSITIONAL count — chunks that
+ * differ at the same index — and it is not a cost: `lib/graph/project.ts:1222-1223` filters by
+ * `new Set(chunk_shas)` MEMBERSHIP, so a chunk that merely shifts index is never re-pushed. The same
+ * state costs 2 under `changedCount`, the metric used throughout this file. The draft then explained
+ * the retraction as corpus drift, which review also falsified — the number reproduces on both
+ * revisions of that file. Two wrong stories about one number; the sweep script now reports both
+ * metrics so they cannot be confused again.
  */
 describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edit touches", () => {
   const EDIT_AT = 20_000;
@@ -599,8 +608,35 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
     expect(before).toContain(boundary);
     expect(at + EDIT_LEN).toBeLessThan(boundary); // the edit does NOT overlap the boundary…
     expect(cdcBoundaries(edited, CDC_PARAMS)).not.toEqual(before); // …and destroys it anyway
+    expect(cdcBoundaries(edited, CDC_PARAMS)).not.toContain(boundary); // that boundary specifically
     expect(admittedIntervals(t).some(([lo, hi]) => at >= lo && at + EDIT_LEN <= hi)).toBe(true);
     expect(classify(t, at)).toBe("reported");
+  });
+
+  it("NO-OP FIXTURE: an edit that changes nothing is excluded, not counted as a churn-1 edit", () => {
+    // MUTATION-FOUND (review): the `edited === t` term had no fixture, so deleting it left every test
+    // green — the same "a predicate term no test can redden is asserted on trust" rule this file
+    // invokes twice elsewhere. Without the term this document classifies STRICT and churns 0, so the
+    // live assertion's `toBe(1)` would fail on it.
+    const base = doc(50_000, 9);
+    const t = base.slice(0, EDIT_AT) + "X".repeat(EDIT_LEN) + base.slice(EDIT_AT + EDIT_LEN);
+    expect(inPlace(t)).toBe(t); // the edit is a no-op on this document
+    expect(classify(t)).toBe("excluded");
+    expect(changedCount(chunkContent(t), chunkContent(inPlace(t)))).toBe(0);
+  });
+
+  it("LIVE CORPUS: the in-place median stays at 1 — the assertion that would have caught this", () => {
+    // Dropping the ceiling took the MEDIAN with it, and review was right that this went too far: the
+    // median is metric-robust (set and positional agree in the strict bucket, which is most of the
+    // corpus) and it is the assertion that would have caught the original defect, where one document
+    // churned 4 while every other churned 1. A ceiling is unassertable; a median is not.
+    const docs = repoDocs();
+    const churns = docs
+      .filter((t) => classify(t) !== "excluded")
+      .map((t) => changedCount(chunkContent(t), chunkContent(inPlace(t))))
+      .sort((a, b) => a - b);
+    expect(churns.length).toBeGreaterThan(5);
+    expect(churns[Math.floor(churns.length / 2)], "median in-place churn over real documents").toBe(1);
   });
 
   it("LIVE CORPUS: every strictly-classified document churns exactly 1", () => {

--- a/test/graph-cdc.test.ts
+++ b/test/graph-cdc.test.ts
@@ -453,8 +453,8 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
  *      spanning a SURVIVING boundary changes both adjacent chunks (churn 2), and an edit past the
  *      80-chunk admitted prefix changes nothing at all (churn 0).
  *
- * THE RULE, verified before it was written down — 4,962 unchanged-sequence samples swept across the
- * corpus at 97-character steps, 4,962 agreements, zero mismatches, under both this file's set-based
+ * THE RULE, verified before it was written down — 5,658 unchanged-sequence samples swept across the
+ * corpus at 97-character steps, 5,658 agreements, zero mismatches, under both this file's set-based
  * `changedCount` and a positional diff:
  *
  *   **churn = the number of ADMITTED chunk intervals the changed span intersects.**
@@ -462,9 +462,11 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
  * So exactly 1 needs two things together: the edit changes text, and it lies wholly inside one admitted
  * chunk. (A third condition — "no boundary strictly inside the edit span" — was specified and then
  * deleted as provably dead; see `classify`.) Anything else is reported, not gated — because when
- * the boundary sequence does change there is NO usable ceiling: the same sweep reaches **78 of 80**
- * admitted chunks for a 20-character edit (`docs/ARCHITECTURE.md` @7111) against a legacy churn of 1.
- * A ceiling asserted on a fixture would pin the fixture, not the algorithm.
+ * the boundary sequence does change there is NO usable ceiling: the same sweep reaches **8 of 80**
+ * admitted chunks for a 20-character edit (`docs/ARCHITECTURE.md` @181,517) against a legacy churn of
+ * 1 — already past the ceiling of 6 this file used to assert. An earlier measurement reached 78 before
+ * a merge changed that document, which is the live-corpus hazard in miniature: none of these numbers
+ * gates anything, and the assertions below rest on the rule and the classification instead.
  */
 describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edit touches", () => {
   const EDIT_AT = 20_000;


### PR DESCRIPTION
## What this fixes

`docs/design/content-defined-chunking.md`'s acceptance table promised an **unconditional churn of 1**
for a same-length in-place edit. One real document churns 4, and the gap sat behind an `it.fails`.

**Three characterisations of that gap were wrong before this one**, each cheap prose that would have
shipped as documentation:

1. *"the test over-asserts, the spec disclaims it"* — the table **requires** 1;
2. *"low-entropy repeated bullets propagate the realignment"* — churn is indifferent to entropy;
3. *"the edit OVERLAPS a boundary"* — true of that one document, not the rule: a cut is decided by the
   ~32 code units **ending** at it, so an edit *near* a boundary destroys one it never touches, and
   spliced text can *create* one (9,480 of 15,719 non-overlapping offsets churn > 1);
4. *"churn is 1 whenever the boundary SEQUENCE is unchanged"* — false in both directions: an edit
   spanning a **surviving** boundary changes both adjacent chunks, and an edit past the 80-chunk
   admitted prefix changes nothing at all.

**The rule that is true, and the first one measured before it was written down:**

> churn = the number of **admitted chunk intervals** the changed span intersects

Exactly 1 needs two things: the edit changes text, and it lies wholly inside one admitted chunk.
**5,743 unchanged-sequence samples, 5,743 agreements, zero mismatches**, under both churn metrics.

**No product code changes — that is the finding, not a shortcut.**

## The number this PR retracted, twice

An earlier draft published a maximum of **78 of 80** admitted chunks, then explained the retraction as
corpus drift. **Both were wrong**, and the second was the fifth wrong characterisation in this ticket:

- 78 is a **positional** count — chunks differing at the same *index*. That is not a cost the product
  pays: `lib/graph/project.ts:1222-1223` builds `alreadyPushed = new Set(chunk_shas)` and filters by
  **membership**, so a chunk that merely shifts index is never re-pushed. The same state costs **2**.
- The "corpus drift" story was falsified by reproducing the number on both revisions of the file — and
  the pre-merge file was *shorter*, so the story's direction was backwards too.

`scripts/cdc-churn-sweep.mjs` is committed and reports **both** metrics, because a prose recipe was
re-run by a reviewer and produced different totals — the exact failure this ticket is about. Every
published figure is stamped with the SHA it was measured at.

## The honest trade, both directions measured (set churn, at `2b1778d`)

| edit | CDC | byte offsets |
|---|---:|---:|
| in-place, boundary-changing (`docs/ARCHITECTURE.md`@178,189) | **≥ 9** | **1** |
| in-place, boundary-preserving (@20,000) | 1 | 1 |
| insertion of 33 chars near the top | **1** | **80** |

"≥" is deliberate: the sweep steps 97 characters, so a maximum from it is an observed lower bound —
two runs differing only in start offset gave 8 and 9. CDC is **not** "never worse than byte offsets",
and the design doc should never have implied it: it is dramatically better on the insertion cascade it
exists for, and worse on an in-place edit that disturbs a boundary. Both halves are now documented.

## Deliberately NOT in this slice

- **`CDCAPPEND-1`** — the `append at end` row is false too, and my replacement for it was *also* false
  twice (a past-cap document churns 0; an append longer than `min` churns 5). It is marked conditional
  and deferred rather than given a fourth invented rule.
- **Changing the chunker** — rejected on the real ground (any prior-boundary-aware recovery makes
  chunking depend on the *previous* chunking, breaking "same body ⇒ same chunks ⇒ same hashes"), not
  the overstated one an earlier draft used.
- **Re-litigating CDC vs byte offsets** — the trade is now visible; whether it is the right trade is a
  design question with its own measurements.

## Verification

2473 unit · tsc · lint · docs-drift green. The `it.fails` is **gone**, not replaced. Spec SPEC_READY
after every amendment.

**Mutations — every classifier term reddens its own fixture:**

| mutation | outcome |
|---|---|
| drop the interval condition | reddens SPANNING |
| drop the boundary-sequence comparison | reddens WINDOW |
| drop the `edited === t` term | reddens NO-OP |
| classify everything as `reported` | reddens STRICT + SHORT |
| delete the third condition | **nothing** — proved dead, so it is deleted rather than kept on trust |

The first three **survived** on the first pass, because the conditions **masked each other**: each
caught the document that would expose the other. That is why each now has a fixture that isolates it.

## Review — Reviewed by Fable code-reviewer + Codex (gpt-5.5) + a third Claude model — verdict all three BLOCKED on real defects, all folded

Three independent legs, and **each found something the others missed** — which is the argument for
running more than one, not a formality.

**Codex nearly did not run.** Its first attempt died with `You have no credits remaining`, and the
diagnosis turned out to be the interesting part: `codex login status` reports "Logged in using
ChatGPT", but a `CODEX_API_KEY` in the environment takes precedence, so every run was billing an API
org that was empty. Unsetting it authenticates via the subscription; `gpt-5.6` is not offered on a
ChatGPT account, so the leg runs on `gpt-5.5`. The PR was opened while that leg was missing, and this
section previously said so; it is corrected rather than quietly rewritten.

**Codex found the defect the other two missed — and it is a defect in the rule this PR ships.**
A document whose edited chunk becomes byte-identical to another chunk churns **0**, not 1: the ledger
filters by `new Set(chunk_shas)` membership (`lib/graph/project.ts:1222`), so a coinciding chunk is
never re-pushed. Constructed by Codex, reproduced here from a repeated-block document, pinned as the
DUPLICATE fixture, and the live strict assertion now asserts *what the rule predicts* rather than a
flat 1 — so a true negative cannot redden the build. The other two reviewers had seen the corner and
judged it unreachable from real markdown; they were right about reachability and wrong about
relevance, since the rule is a general claim and this ticket exists because general claims here keep
being false.

Codex also caught that **"78 of 80" survived in five places** — three comments and two documents —
*after* the commit that retracts it, i.e. the exact false claim left inside its own correction; and
that two sweep counts predated the committed script. Everything now traces to one run of
`scripts/cdc-churn-sweep.mjs`.

**Fable found:** a commit message claiming a deletion its diff did not contain (a mutation revert took
the edit) — and proved the consequence, that with the term present, deleting the *other* condition left
everything green; that the headline measurements did not reproduce on the tree they shipped with; that
the partition assertion is a tautology whose comment claimed otherwise; and that the classifier omitted
the rule's own "edit changes text" precondition.

**The third model found:** that the retracted 78 was a *metric* error rather than stale data, and that
my correction had canonised a false lesson; that the revised maximum was contradicted by the same sweep
(9, not 8) and that a sparse-grid maximum must be published as a lower bound; that the new no-op term
had no fixture; and that dropping the median assertion with the ceiling went too far.

**All three independently adjudicated one disagreement in the author's favour**: the summary table in
`content-defined-chunking.md` measures byte offsets, where 1 *is* a theorem, and is correctly left
unchanged.

**Two commits in this branch's history carry messages that outrun their diffs** (`28a8d1e` claims a
deletion it lacks; `9c81efd` narrates the corpus-drift story now known false). Both are corrected in
later commits and in this body; squash-merging lands this account rather than theirs.

AIOS-Work: CDCCHURN-1
