### PR TITLE
feat(loop): mutation testing is ONE command that reports what happened (MUTFLOW-1)

### DIFF
--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -105,7 +105,8 @@ an experiment with replication.
   to keep a red edit unless you pass `--keep-even-if-red`.
 
   **Exit codes track the expectation, not the verdict:** `0` met, `2` missed, `1` refused (always with a
-  message naming why), so the default `--expect reddened` exits 0 when the mutation is caught.
+  message naming why), so the default `--expect reddened` exits 0 when the mutation is caught. Note
+  `--keep` on a RED edit exits **2**, not 1 — it is an expectation missed, not a usage error.
 
   **Mutation-verify every guard and security-relevant branch**, and confirm the INTENDED test reddens —
   not just any test. A guard that survives its mutation is decoration; a mutation that reddens something

--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -85,28 +85,39 @@ an experiment with replication.
 - Full local verification: `npx tsc --noEmit` · `npm run lint` · `npm test` ·
   `npm run db:test:up && npm run test:datamechanics:local` · `npm run check:docs`.
   (The npm script pins the test-DB URL/port; never hand-write the incantation — it drifts.)
-- **Commit BEFORE mutation-testing, and PROVE it — `node scripts/mutation-guard.mjs`.**
-  Run the guard before the first mutation; it exits non-zero and names what is
-  at risk. Precisely (verified against real git — an earlier version of this
-  paragraph overstated it, and both reviewers caught that): `git checkout --
-  <file>` restores from the INDEX, so an UNSTAGED edit is destroyed silently by
-  the command you expect to succeed, a STAGED one survives, and untracked files
-  cannot be reached at all. The guard still blocks on any uncommitted tracked
-  change, because the loop's contract is a COMMITTED CHECKPOINT you can return
-  to — not because everything it blocks would be shredded. A new (untracked)
-  test file mid-slice does not block.
+- **Mutation-test with ONE command — `node scripts/mutate.mjs`.** It does the whole sequence: refuses
+  unless the tree is a committed checkpoint (by calling `scripts/mutation-guard.mjs`, so there is one
+  owner of that question), refuses an untracked target, applies the `--edit` pairs simultaneously
+  against the original bytes, runs the tests you name, restores the file, verifies the restore, and
+  prints a verdict — `REDDENED` with the failing test names, or `SURVIVED`.
 
-  This was prose in this skill for its whole life and failed anyway: the same
-  operator lost work to it **three times in one session** (2026-08-14/15) —
-  an extracted function and its tests wiped mid-fold, a commit landed whose
-  tests called a function the revert had deleted, and a "repair" script that
-  no-opped against the reverted text and printed success. A rule you have to
-  remember is the thing this repo's §2 says to replace with a check that fails.
-  MUTGUARD-1.
-- Mutation-verify every guard and security-relevant branch: break the thing,
-  confirm the INTENDED test reddens (not just any test), revert, confirm the
-  tree is clean (`git status --short`). A guard that survives its mutation is
-  decoration.
+  ```
+  node scripts/mutate.mjs lib/foo.ts --edit /tmp/needle.txt /tmp/replacement.txt -- test/foo.test.ts
+  ```
+
+  **Paste that verdict into the PR body. Do not narrate it from memory** — that is the half of this
+  failure no start-of-run check can see, and it is how two commits in one session came to claim changes
+  their diffs did not contain.
+
+  **`--keep` when the mutation IS the change** ("prove this term is dead, then leave it deleted"): it
+  leaves the edit applied and prints a diff stat scoped to the target, removing the
+  re-apply-from-memory step that lost work three times. It expects the tests to stay GREEN and refuses
+  to keep a red edit unless you pass `--keep-even-if-red`.
+
+  **Exit codes track the expectation, not the verdict:** `0` met, `2` missed, `1` refused (always with a
+  message naming why), so the default `--expect reddened` exits 0 when the mutation is caught.
+
+  **Mutation-verify every guard and security-relevant branch**, and confirm the INTENDED test reddens —
+  not just any test. A guard that survives its mutation is decoration; a mutation that reddens something
+  else has told you nothing about the guard.
+
+  WHY A COMMAND AND NOT A RULE: this step said "commit BEFORE mutation-testing" in prose for its whole
+  life, then MUTGUARD-1 added a check you had to remember to call — and the same operator lost work
+  three times in the session after it shipped, because a mutation is a SEQUENCE and every ad-hoc
+  spelling of it skipped the check. Precisely (verified against real git, after both reviewers corrected
+  an earlier overstatement): `git checkout -- <file>` restores from the INDEX, so an UNSTAGED edit is
+  destroyed by the command you expect to succeed, a STAGED one survives, and untracked files cannot be
+  reached at all. MUTFLOW-1.
 
 ## 2. Fable adversarial review
 
@@ -205,4 +216,4 @@ end.
 | Spec ruling silently unimplemented | Fable | "no external-tier delegation" stated twice, enforced nowhere |
 | Reviewer hallucination | you | regex-matches claim refuted with a node repro |
 | Phantom test failures | process rule | concurrent data-mechanics runs on the shared container |
-| Lost work during mutation testing | process rule | `git checkout` against an uncommitted tree |
+| Lost work during mutation testing | `scripts/mutate.mjs` | `git checkout` on an uncommitted tree — three times in one session, while the rule was prose plus a skippable check |

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ next-env.d.ts
 
 # Supabase CLI local stack artifacts — this repo is Postgres-only (see CLAUDE.md §6)
 supabase/
+.mutate-runs.log

--- a/docs/design/mutation-flow.md
+++ b/docs/design/mutation-flow.md
@@ -1,0 +1,227 @@
+# The mutation guard is a step you can skip — make the safe path the short one — MUTFLOW-1
+
+**Status:** spec, draft 3. Both cold reads BLOCKED draft 1; every finding is folded, including one
+that showed my own justification argued for the thing it was rejecting.
+**Related:** MUTGUARD-1 (`scripts/mutation-guard.mjs`, the check this builds on),
+`.claude/skills/adversarial-build/SKILL.md` (the loop whose step this replaces),
+`test/guards/mutation-guard.test.ts` (which pins the current wording and must migrate — §Scope).
+
+---
+
+## 0. What is wrong
+
+MUTGUARD-1 shipped a check that refuses to mutate a tree with uncommitted tracked changes, and wired it
+into the adversarial-build skill as a required step. **It did not stop the failure.** In the session
+that followed it shipping — same operator, same skill — there were **three work-loss incidents** from
+`git checkout -- <file>` on an uncommitted tree, and **two commits whose messages outrun their diffs**.
+
+| incident | claimed | contained | how a future reader can check it |
+|---|---|---|---|
+| in PR #551 (squash-merged as `e228650`) | two new exports in `lib/graph/extraction-health.ts` | neither; that file was not in the diff, and the tree did not typecheck | **testimony + its repair commit only.** The offending commit was rebased away and is reachable from no ref; what survives is the repair, "restore the runtime cause enumeration a mutation revert destroyed" |
+| in PR #552 (squash-merged as `85fbb2d`) | "the dead classifier term … it is gone" | only the spec `.md`; the term shipped live | **directly checkable** on the PR head ref: the commit touches one `.md` while its message says the term is gone. A reviewer then proved the consequence — with the term present, deleting the *other* condition left every test green, so the masking that commit narrates fixing was still live |
+
+**On the citations themselves**, because this spec is about claims that do not survive checking: the
+SHAs above are the **squash-merge commits on `main`**, not the offending commits — `git show e228650`
+shows a perfectly good message. The offending commits were pre-squash and are not on `main`; only one
+of the two is still reachable at all. Draft 2 said "both survive inside their squashed merges, so that
+is what a reader can check", which over-claimed: row 1 is testimony corroborated by its repair, and it
+is labelled that way rather than dressed as verifiable.
+
+Three details worth keeping, all verified rather than assumed:
+
+- `scripts/mutation-guard.mjs` **was present in both worktrees** at the time — this is "the guard
+  existed and did not fire", not "the guard had not shipped".
+- Whether it was *called* is **unknowable**: it leaves no artifact. The only consistent explanation is
+  that it was skipped (a called guard refuses a dirty tree), but that is inference, and §1 fixes it.
+- **Neither false message reached `main`.** Both were squash-merged away. So the durable harm is not
+  repo history — it is that the operator acted on a false belief *mid-slice*, which is what left a
+  masking hole for a reviewer to find.
+
+### 0a. Why the guard did not fire
+
+Because **a mutation is not one command.** It is a sequence — edit, test, `git checkout`, hopefully
+check — and the guard covers the first step *if you remember to call it*. Every ad-hoc spelling (a
+`python3` heredoc, `sed -i`, an editor keystroke) skips it. The guard's own header says a rule you have
+to remember is what this repo replaces with a check that fails. It added the check **and left the rule
+standing around it**.
+
+### 0b. The second failure, which no start-of-run guard can see
+
+The revert makes the tree look right, so the message gets written from **intent**. Both incidents are
+that shape. Draft 1 answered this with "the operator quotes the report rather than narrating from
+memory" — which is itself a rule you have to remember, i.e. the thing §0a condemns. Draft 2 answers it
+two ways instead: **`--keep`** (§1b) removes the re-apply step entirely for the case that actually
+failed, and the **existing Fable review gate is named as the backstop** — it is already the
+message-versus-diff check in this loop, and it is what caught the second incident.
+
+## 1. The decision
+
+**One command, and it is the only path the skill documents.** Not "the only path" — draft 1 said that,
+and it is not true of a shell.
+
+```
+node scripts/mutate.mjs <file> --edit <needle-file> <replacement-file> [--edit …] [--keep] -- <vitest args…>
+```
+
+1. **Refuses on an unclean tree**, by *calling* `scripts/mutation-guard.mjs` — one owner for "is this
+   tree a checkpoint", so the two cannot drift.
+2. **Requires the TARGET to be tracked** (`git ls-files --error-unmatch`) — on the checkpoint-contract
+   policy, not on a restore mechanism: with §1.5's in-memory restore an untracked target would be
+   restorable, but a file with no committed version is not a checkpoint you can return to, which is the
+   loop's contract. Draft 1 justified this by claiming `git checkout --` would error; that was the
+   mechanism talking, and review corrected both the claim and the reason.
+3. **Applies the `--edit` pairs as ONE simultaneous transformation of the original bytes.** Multiple
+   pairs are supported because real mutations need them — the very mutation one incident narrates was
+   two edits — and without that the operator's only option is the ad-hoc heredoc this slice replaces.
+   The semantics are pinned, because "each matches exactly once" is undefined across pairs (does pair
+   B match before or after pair A applied?) and a wrong-but-clean mutation reports a verdict that means
+   nothing: **every needle is located against the ORIGINAL bytes in one pass, each must match exactly
+   once there, matched spans must not overlap, no pair's needle may occur in another pair's
+   replacement text, and replacements are applied by descending original offset.** Any violation exits
+   1 before a single test runs.
+4. **Runs the named tests**, and **refuses if zero tests executed** — the same hazard as a needle that
+   matches nothing, on the axis draft 1 missed: a filter selecting no files reports "all green" ⇒
+   SURVIVED, vacuously. The mechanism is pinned rather than left to output-scraping, which would break
+   the day the reporter changes and would break TOWARD vacuity: the wrapper owns the vitest invocation,
+   appends `--reporter=json --outputFile.json=<temp>` LAST so an operator-supplied reporter cannot
+   clobber it (and refuses if one conflicts), forces `run` semantics so a TTY cannot drop it into watch
+   mode, and reads `numTotalTests`. **Verified against this repo's vitest (4.1.9): a filter matching
+   nothing still writes the report, with `numTotalTests: 0`.** A missing or unparseable report fails
+   CLOSED as infrastructure (exit 1) — "cannot tell" must never read as "some tests ran".
+5. **Restores the target from the pristine bytes it already holds** — it read them to locate the
+   needles — with `git checkout --` and a byte-compare as belt-and-braces rather than as the mechanism.
+   Review's point, and it is the better design: an in-memory restore is independent of index semantics
+   entirely, which is the whole `git checkout -- restores from the INDEX` hazard class this slice grew
+   out of. Git remains the recovery path for an abnormal exit, where the in-memory copy is gone. It
+   then **verifies the TARGET is byte-identical to HEAD**, and separately reports if the TEST RUN
+   dirtied the target itself (a state where the kept diff would be mutation-plus-noise, so `--keep`
+   refuses it).
+   Other tracked changes the test run made are *reported separately* — "the test run also dirtied X" —
+   rather than conflated with a failed restore, because a check that reddens on unrelated noise trains
+   the operator to ignore it. On abnormal exit (SIGINT, crash, timeout) it restores or prints
+   `MUTATION STILL APPLIED` loudly.
+6. **Prints a verdict** — `REDDENED` with the failing test names, or `SURVIVED` — and exits on whether
+   the run met its **stated expectation**, not on the raw verdict. `--expect reddened` is the default
+   (an ordinary mutation should be caught); `--keep` defaults to `--expect survived`, because "prove
+   this term is dead, then leave it deleted" expects the tests to stay green. **Exit 0 = expectation
+   met, 2 = expectation missed, 1 = usage/infrastructure**, each with a distinguishing message so a
+   crashed tool is not mistaken for a refusal.
+
+   Draft 2 pinned the raw verdict to the exit code, and review showed that INVERTS under `--keep`:
+   SURVIVED would be success-but-exit-2 (aborting a `set -e` chain on the good outcome) and REDDENED
+   would be a broken kept edit at exit 0 — so `mutate … --keep && git commit` would commit a change
+   whose tests fail. That is a new work-corruption channel created by the fix for the last one.
+7. **Appends one line to an ignored run log**, so the next post-mortem can tell "the flow was bypassed"
+   from "the flow failed" — the question that is unanswerable about the incidents above.
+
+### 1b. `--keep`: the mode that addresses the failure that actually happened
+
+Codex's blocker: the flow protects the *experiment*, but the incident shape is a mutation that **is**
+the intended change — "prove this term is dead, then leave it deleted". Restore-by-default means
+re-applying it by hand afterwards, and that is the step that failed, twice.
+
+`--keep` runs the same flow and leaves the edit applied. Three constraints review added, each closing a
+hazard the mode itself created:
+
+- **`--keep` + REDDENED restores and exits non-zero** ("the edit you asked to keep breaks tests"),
+  unless `--keep-even-if-red` is passed, which prints a loud `KEPT FAILING MUTATION` banner. Keeping a
+  known-broken edit silently is worse than the failure this mode fixes.
+- **The printed `git diff --stat` is SCOPED TO THE TARGET.** It is printed after the test run, so an
+  unscoped stat would include whatever the tests dirtied — and this stat is the artefact meant to
+  replace writing a message from intent. A stat that over-claims files the mutation never touched is
+  precisely the incident shape it exists to prevent. Files the test run dirtied are reported
+  separately, never merged into it.
+- **A forgotten kept mutation is backstopped, and the backstop is real rather than claimed:** the tree
+  is now dirty, so `mutation-guard.mjs` refuses the *next* mutation run until it is committed or
+  reverted.
+
+### 1c. Why the PreToolUse hook stays cut — the honest reason this time
+
+Draft 1 rejected a hook because "it could intercept the agent's shell, but not a human's, and the
+failure was an agent following a written sequence." Review pointed out that argues *for* the hook: the
+failing actor is exactly the one it intercepts, and **this repo already runs that mechanism for exactly
+this purpose** (`scripts/railway-deploy-guard.sh`, wired in `.claude/settings.json`). The reasoning was
+self-defeating, and a cut whose recorded reason is invalid gets re-litigated the next time work is lost.
+
+The true reasons: `git checkout -- <path>` and `git restore` are **legitimate constantly** — this loop
+uses them to revert mutations, and every other workflow uses them to discard experiments — so a hook
+would have to fire only when the tree is tracked-dirty, i.e. re-implement the guard inside a shell
+matcher and keep the two in step. And an over-blocking guard gets worked around, which the guard's own
+header names as how it stops being a guard. A narrow hook (block the revert verbs only while
+`mutation-guard` reports tracked-dirty) is a reasonable follow-up; it is not this slice, and it is
+defense in depth rather than the mechanism.
+
+## Dependencies
+
+**Deps: none.** It calls `scripts/mutation-guard.mjs` (already shipped and guarded) and adds one script
+and one guard test. No product code, no schema, no API route.
+
+## Build-with
+
+**Build-with tier: Fable / high effort.** The subject is a safety mechanism whose previous version
+failed in practice while appearing to work — the exact failure adversarial review is for, and both
+cold reads of draft 1 found blockers, including a self-defeating justification. Two review rounds on
+the spec, two on the diff.
+
+## Tier safety
+
+No tier surface changes: a developer script, a guard test and a skill edit. No product code, no schema,
+no API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupIds`. No drift-block edit, so the
+docs-drift guard stays green by construction — stated here rather than as an acceptance criterion,
+since a non-event is not a criterion.
+
+## 2. Acceptance criteria
+
+- `test/guards/mutation-flow.test.ts` — BEHAVIOURAL refusal: in a scratch git repo with a dirty tracked file, the flow exits non-zero, the target file is byte-unchanged, and no test command runs. Draft 1 asserted only that the source *mentions* the guard, which a dead call satisfies — the pin-the-call-site failure this repo has a scar from.
+- `test/guards/mutation-flow.test.ts` — source inspection additionally shows the tracked-changes logic is not reimplemented, so the two scripts cannot drift on what counts as a checkpoint.
+- `test/guards/mutation-flow.test.ts` — a needle matching ZERO times, and a needle matching MORE than once, each exit non-zero before any test runs, since a mutation that touched nothing or an unknown site reports a survivor that means nothing.
+- `test/guards/mutation-flow.test.ts` — a run whose test filter executes ZERO tests exits non-zero with "no tests ran", never `SURVIVED`.
+- `test/guards/mutation-flow.test.ts` — an UNTRACKED target is refused before mutation, because `git checkout --` cannot restore it and the guard alone does not prove a checkpoint for that file.
+- `test/guards/mutation-flow.test.ts` — after a normal run the target is byte-identical to HEAD; when the restore is prevented the flow exits non-zero rather than reporting a clean result.
+- `test/guards/mutation-flow.test.ts` — a tracked file dirtied by the TEST RUN is reported as such and does not fail the restore check, so unrelated noise cannot train the operator to ignore a real failure.
+- `test/guards/mutation-flow.test.ts` — multiple `--edit` pairs apply together and are restored together, with the exactly-once rule enforced per pair.
+- `test/guards/mutation-flow.test.ts` — `--keep` leaves the mutation applied and prints the resulting diff stat, and its exit code still distinguishes reddened from survived.
+- `test/guards/mutation-flow.test.ts` — exit codes are pinned to the EXPECTATION, not the raw verdict: expectation met `0`, missed `2`, usage/infrastructure `1` — asserted for both `--expect reddened` (the default) and `--keep`'s implied `--expect survived`, so the polarity cannot invert under `--keep`.
+- `test/guards/mutation-flow.test.ts` — every exit-1 path prints a distinguishing message, since node exits 1 on any uncaught crash and a crashed tool must not be indistinguishable from a refusal (the sibling guard pins `REFUSING` for this reason).
+- `test/guards/mutation-flow.test.ts` — `--keep` + REDDENED restores and exits non-zero unless `--keep-even-if-red`, which prints a `KEPT FAILING MUTATION` banner; and the printed diff stat is scoped to the target, so test-run dirt cannot make it over-claim files the mutation never touched.
+- `test/guards/mutation-flow.test.ts` — multi-edit semantics: needles are located against the ORIGINAL bytes, and a run is refused when two spans overlap or one pair's needle appears in another pair's replacement — before any test runs.
+- `test/guards/mutation-flow.test.ts` — needle matching is byte-exact after stripping exactly one trailing newline from the needle and replacement files, with a mid-line needle exercised, so an editor-added newline cannot silently mean "no match".
+- `.claude/skills/adversarial-build/SKILL.md` — the mutation step names this one command, and **all three** stale sites are rewritten: the guard-invocation line, the "break the thing / revert / confirm the tree is clean" paragraph, and the failure-modes row that still attributes lost work to a "process rule" (false once a tool catches it). Otherwise the skill documents two paths and this slice's central claim is false on day one.
+- `test/guards/mutation-guard.test.ts` — its existing pin on the skill's old wording is migrated in the same change rather than left red.
+
+## Scope
+
+**In:** `scripts/mutate.mjs`, its guard test, the adversarial-build skill's mutation step (both sites),
+and the migration of the existing guard test's skill-wording pin.
+
+**Cut / deferred, each with its reason:**
+
+- **The PreToolUse hook** — §1c. Rejected on the real grounds (the revert verbs are legitimate
+  constantly; a hook narrow enough to be correct would re-implement the guard inside a shell matcher),
+  not on draft 1's self-defeating one. Reasonable as later defense in depth.
+- **A commit-message linter** (message claims vs diff). Cut, but review corrected the recorded reason,
+  which is the part that matters — a cut justified by something false gets re-litigated the next time
+  work is lost. The measurement (the mechanical version, conventional-commit type versus diff shape,
+  flags **3 of 369** commits on `main`) is evidence of a **low false-positive rate only**: that
+  population EXCLUDES the target class by construction, since both offending messages were squashed
+  away before reaching `main`. And "the harm is in-session belief rather than history" is an argument
+  *for* a commit-time check, since commit time IS in-session. The honest reasons to cut it: **`--keep`
+  removes the generator** — the re-apply-from-memory step that produced both messages — and the
+  **existing Fable review gate is the message-versus-diff check**, which is what actually caught the
+  second incident. A linter would police a symptom whose cause this slice removes.
+- **`--checkpoint` (commit for the operator on a dirty tree).** It would make the safe path shorter
+  still, which is this spec's own theory of change — but committing on someone's behalf mid-slice
+  writes history they did not choose. A `git stash` auto-checkpoint is the middle ground that writes no
+  history at all (review's suggestion); worth revisiting if refusal proves to be the friction.
+- **Auto-generating mutations.** Choosing what to mutate is the judgement the loop exists to exercise.
+- **A mutation-coverage score.** It would invite optimising the number.
+
+## 3. What would falsify this
+
+If an operator can still lose work while following the skill as written, the flow is not the shortest
+path and this slice failed. The honest residual, stated rather than discovered: **§0b is only partly
+mechanised.** `--keep` removes the re-apply step for mutations that are the intended change, but a
+message can still be written from intent for any other edit, and the backstop for that is the Fable
+review gate — which caught the second incident and is named here so it is not mistaken for something
+this script does. The run log (§1.7) is what would let the next post-mortem tell a bypass from a
+failure, which is the question this one could not answer.

--- a/docs/design/mutation-flow.md
+++ b/docs/design/mutation-flow.md
@@ -56,6 +56,12 @@ message-versus-diff check in this loop, and it is what caught the second inciden
 
 ## 1. The decision
 
+**No test-runner override exists in the CLI**, and that is a fix rather than an omission: an earlier
+build read the test command from an environment variable so the guard test could stub it, and BOTH code
+reviewers showed that shipped a verdict-forgery channel — mutate a real file, stub the report, print a
+block byte-identical to a real run, and the skill tells you to paste it into a PR. The runner is a
+function argument now; the CLI hard-wires the real one and only the tests inject a fake.
+
 **One command, and it is the only path the skill documents.** Not "the only path" — draft 1 said that,
 and it is not true of a shell.
 
@@ -99,7 +105,11 @@ node scripts/mutate.mjs <file> --edit <needle-file> <replacement-file> [--edit �
    Other tracked changes the test run made are *reported separately* — "the test run also dirtied X" —
    rather than conflated with a failed restore, because a check that reddens on unrelated noise trains
    the operator to ignore it. On abnormal exit (SIGINT, crash, timeout) it restores or prints
-   `MUTATION STILL APPLIED` loudly.
+   `MUTATION STILL APPLIED` loudly — and that string is real: the restore runs in a `finally`, so any
+   throw after the write still restores, and a restore that does not take says so. **No TIMEOUT is
+   implemented**; a test command that never terminates leaves the mutation applied until the operator
+   interrupts, which the signal handlers then restore. Stated rather than left implied — review found
+   draft 2 claiming a timeout that does not exist.
 6. **Prints a verdict** — `REDDENED` with the failing test names, or `SURVIVED` — and exits on whether
    the run met its **stated expectation**, not on the raw verdict. `--expect reddened` is the default
    (an ordinary mutation should be caught); `--keep` defaults to `--expect survived`, because "prove
@@ -111,8 +121,9 @@ node scripts/mutate.mjs <file> --edit <needle-file> <replacement-file> [--edit �
    SURVIVED would be success-but-exit-2 (aborting a `set -e` chain on the good outcome) and REDDENED
    would be a broken kept edit at exit 0 — so `mutate … --keep && git commit` would commit a change
    whose tests fail. That is a new work-corruption channel created by the fix for the last one.
-7. **Appends one line to an ignored run log**, so the next post-mortem can tell "the flow was bypassed"
-   from "the flow failed" — the question that is unanswerable about the incidents above.
+7. **Appends one line to `.mutate-runs.log`** (git-ignored, best-effort — a log that cannot be written
+   must never fail a run), so the next post-mortem can tell "the flow was bypassed" from "the flow
+   failed" — the question that is unanswerable about the incidents above.
 
 ### 1b. `--keep`: the mode that addresses the failure that actually happened
 

--- a/scripts/mutate.mjs
+++ b/scripts/mutate.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+/**
+ * Run ONE mutation test as ONE command (MUTFLOW-1).
+ *
+ * WHY THIS EXISTS. MUTGUARD-1 shipped `scripts/mutation-guard.mjs` — a check that refuses to mutate a
+ * tree with uncommitted tracked changes — and wired it into the adversarial-build skill. It did not
+ * stop the failure. In the session after it shipped, the same operator lost work to
+ * `git checkout -- <file>` three times and landed two commits whose messages outran their diffs (see
+ * `docs/design/mutation-flow.md` §0 for the incident table and how much of it is checkable).
+ *
+ * The reason is that a mutation is NOT one command. It is edit → test → `git checkout` → hopefully
+ * check, and the guard covers the first step IF you remember to call it. Every ad-hoc spelling — a
+ * heredoc, a `sed -i`, an editor keystroke — skips it. The guard replaced a rule you have to remember
+ * with a check that fails, and then left the rule standing around it. This is the whole sequence.
+ *
+ * WHAT IT DOES NOT CLAIM. It cannot stop anyone typing `git checkout`. It makes the safe path the
+ * short path and prints a verdict the operator can paste instead of narrating from memory — the half
+ * of the failure that no start-of-run guard can see.
+ *
+ * Usage:
+ *   node scripts/mutate.mjs <target> --edit <needle-file> <replacement-file> [--edit …]
+ *                           [--keep] [--keep-even-if-red] [--expect reddened|survived]
+ *                           -- <vitest args…>
+ *
+ * Exit codes track the stated EXPECTATION, never the raw verdict (see `--expect` below):
+ *   0  expectation met
+ *   2  expectation missed
+ *   1  usage or infrastructure — always with a message naming which, because node exits 1 on any
+ *      uncaught crash and a crashed tool must not look like a refusal.
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The repo this operates on. Overridable ONLY so the guard test can exercise the refusal paths
+ * BEHAVIOURALLY in a scratch repository — review's first blocker was that asserting "the source
+ * mentions the guard" passes with the call dead, so the test has to actually run the tool against a
+ * dirty tree. The override moves WHICH repo is guarded; it cannot skip the guard.
+ */
+const ROOT = process.env.MUTATE_ROOT
+  ? path.resolve(process.env.MUTATE_ROOT)
+  : path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const EXIT_MET = 0;
+const EXIT_MISSED = 2;
+const EXIT_REFUSED = 1;
+
+/** Every refusal prints WHY. `node` exits 1 on an uncaught throw too, so the message is the only thing
+ *  that distinguishes "this tool refused" from "this tool crashed" (the sibling guard pins the same). */
+function refuse(message) {
+  console.error(`mutate: REFUSING — ${message}`);
+  process.exit(EXIT_REFUSED);
+}
+
+export function parseArgs(argv) {
+  const dashdash = argv.indexOf("--");
+  const head = dashdash === -1 ? argv : argv.slice(0, dashdash);
+  const vitestArgs = dashdash === -1 ? [] : argv.slice(dashdash + 1);
+  const opts = { target: null, edits: [], keep: false, keepEvenIfRed: false, expect: null, vitestArgs };
+  for (let i = 0; i < head.length; i++) {
+    const a = head[i];
+    if (a === "--edit") {
+      const needle = head[++i];
+      const replacement = head[++i];
+      if (!needle || !replacement) return { error: "--edit needs <needle-file> <replacement-file>" };
+      opts.edits.push({ needle, replacement });
+    } else if (a === "--keep") opts.keep = true;
+    else if (a === "--keep-even-if-red") { opts.keep = true; opts.keepEvenIfRed = true; }
+    else if (a === "--expect") {
+      opts.expect = head[++i];
+      if (opts.expect !== "reddened" && opts.expect !== "survived")
+        return { error: "--expect takes reddened|survived" };
+    } else if (a.startsWith("-")) return { error: `unknown flag ${a}` };
+    else if (opts.target === null) opts.target = a;
+    else return { error: `unexpected argument ${a}` };
+  }
+  if (!opts.target) return { error: "no target file" };
+  if (opts.edits.length === 0) return { error: "no --edit pairs" };
+  // `--keep` means "this mutation IS the change I want", and that expects the tests to STAY GREEN —
+  // the proof the deleted thing was dead. Defaulting the expectation off the mode is what stops the
+  // exit-code polarity inverting under it (review: `mutate --keep && git commit` would otherwise
+  // commit a change whose tests fail, at exit 0).
+  if (opts.expect === null) opts.expect = opts.keep ? "survived" : "reddened";
+  return { opts };
+}
+
+/**
+ * Locate every needle against the ORIGINAL bytes and apply the replacements as one simultaneous
+ * transformation.
+ *
+ * "Each needle matches exactly once" is undefined across pairs — does pair B match before or after
+ * pair A applied? — and either reading can silently mutate the wrong site while reporting a clean
+ * verdict, which is a report that means nothing. So: all matches are resolved against the original,
+ * spans may not overlap, no pair's needle may appear in another pair's replacement (that is the
+ * cascade the simultaneous reading exists to forbid), and edits apply by descending offset.
+ */
+export function planEdits(original, pairs) {
+  const spans = [];
+  for (const { needleText, replacementText, label } of pairs) {
+    if (needleText.length === 0) return { error: `${label}: needle is empty` };
+    const first = original.indexOf(needleText);
+    if (first === -1) return { error: `${label}: needle does not appear in the target` };
+    if (original.indexOf(needleText, first + 1) !== -1)
+      return { error: `${label}: needle appears more than once — which occurrence would be silent` };
+    spans.push({ start: first, end: first + needleText.length, replacementText, label });
+  }
+  const sorted = [...spans].sort((a, b) => a.start - b.start);
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i].start < sorted[i - 1].end)
+      return { error: `${sorted[i].label} overlaps ${sorted[i - 1].label} in the target` };
+  }
+  for (const a of pairs) {
+    for (const b of pairs) {
+      if (a === b) continue;
+      if (b.replacementText.includes(a.needleText))
+        return { error: `${b.label}'s replacement contains ${a.label}'s needle — cascading edits are not simultaneous` };
+    }
+  }
+  let out = original;
+  for (const span of [...spans].sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, span.start) + span.replacementText + out.slice(span.end);
+  }
+  return { mutated: out };
+}
+
+/** A needle file written by any editor ends with a newline the operator did not type, so exactly one
+ *  trailing newline is stripped. Everything else is byte-exact — a needle that fails to match must
+ *  fail LOUDLY rather than be normalised into matching something else. */
+const readNeedle = (p) => readFileSync(p, "utf8").replace(/\n$/, "");
+
+function git(args, opts = {}) {
+  return execFileSync("git", args, { cwd: ROOT, encoding: "utf8", ...opts }).trim();
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) refuse(`${parsed.error}\n\n  usage: node scripts/mutate.mjs <target> --edit <needle-file> <replacement-file> [--keep] -- <vitest args…>`);
+  const { opts } = parsed;
+
+  // 1 — the tree must be a committed checkpoint. Delegated to the guard rather than reimplemented, so
+  // the two can never drift on what counts as one.
+  const guardScript = path.join(path.dirname(fileURLToPath(import.meta.url)), "mutation-guard.mjs");
+  const guard = spawnSync(process.execPath, [guardScript], { cwd: ROOT, encoding: "utf8" });
+  if (guard.status !== 0) {
+    process.stderr.write(guard.stdout ?? "");
+    process.stderr.write(guard.stderr ?? "");
+    refuse("the tree is not a committed checkpoint (see mutation-guard above) — commit first");
+  }
+
+  // 2 — the TARGET must be tracked. Not because the restore needs git (step 5 restores from bytes we
+  // already hold) but because a file with no committed version is not a checkpoint to return to.
+  const target = path.resolve(ROOT, opts.target);
+  if (!existsSync(target)) refuse(`target ${opts.target} does not exist`);
+  try {
+    git(["ls-files", "--error-unmatch", target], { stdio: "pipe" });
+  } catch {
+    refuse(`target ${opts.target} is untracked — there is no committed version to return to`);
+  }
+
+  // 3 — plan and apply, simultaneously, against the original bytes.
+  const original = readFileSync(target, "utf8");
+  const pairs = opts.edits.map((e, i) => {
+    if (!existsSync(e.needle)) refuse(`--edit needle file ${e.needle} does not exist`);
+    if (!existsSync(e.replacement)) refuse(`--edit replacement file ${e.replacement} does not exist`);
+    return {
+      label: `--edit #${i + 1}`,
+      needleText: readNeedle(e.needle),
+      replacementText: readNeedle(e.replacement),
+    };
+  });
+  const plan = planEdits(original, pairs);
+  if (plan.error) refuse(plan.error);
+  if (plan.mutated === original) refuse("the mutation changes nothing — a no-op cannot be survived or caught");
+  writeFileSync(target, plan.mutated);
+  const mutatedBytes = plan.mutated;
+
+  // 4 — run the tests, and OWN the reporter so "how many tests ran" is machine-readable. Scraping the
+  // human reporter would break the day its format changes, and would break toward vacuity: a filter
+  // matching nothing prints all-green, which reads as SURVIVED and means nothing.
+  const reportDir = mkdtempSync(path.join(tmpdir(), "mutate-"));
+  const reportPath = path.join(reportDir, "report.json");
+  const conflicting = opts.vitestArgs.find((a) => a.startsWith("--reporter") || a.startsWith("--outputFile"));
+  const restore = () => {
+    writeFileSync(target, original);
+    // Belt and braces: git is the recovery path when the in-memory copy is gone (an abnormal exit),
+    // and the byte compare is what proves the restore actually happened.
+    if (readFileSync(target, "utf8") !== original) {
+      console.error("mutate: RESTORE FAILED — the target does not match its pre-mutation bytes");
+      process.exit(EXIT_REFUSED);
+    }
+  };
+  if (conflicting) {
+    restore();
+    refuse(`${conflicting} would clobber the machine-readable report this tool needs — remove it`);
+  }
+  // Restore on an abnormal exit rather than leaving the mutation applied and silent.
+  const onSignal = () => {
+    try { writeFileSync(target, original); } catch { /* fall through to the loud message */ }
+    console.error("mutate: interrupted — target restored (verify with `git status --short`)");
+    process.exit(EXIT_REFUSED);
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  // `MUTATE_TEST_CMD` exists for the guard test alone: a scratch repo has no vitest, and the criteria
+  // that matter there (zero tests ran, restore, exit codes) are about how this tool READS a report,
+  // not about vitest. It writes the same JSON shape.
+  const run = process.env.MUTATE_TEST_CMD
+    ? spawnSync("sh", ["-c", `${process.env.MUTATE_TEST_CMD} "${reportPath}"`], { cwd: ROOT, encoding: "utf8" })
+    : spawnSync(
+        "npx",
+        ["vitest", "run", ...opts.vitestArgs, "--reporter=json", `--outputFile.json=${reportPath}`],
+        { cwd: ROOT, encoding: "utf8" }
+      );
+  process.stdout.write(run.stdout ?? "");
+
+  let report;
+  try {
+    report = JSON.parse(readFileSync(reportPath, "utf8"));
+  } catch {
+    restore();
+    refuse("the test run produced no readable report — cannot tell how many tests ran, and 'cannot tell' must not read as 'some did'");
+  }
+  const total = Number(report.numTotalTests);
+  if (!Number.isFinite(total)) {
+    restore();
+    refuse("the report has no test count — see above");
+  }
+  if (total === 0) {
+    restore();
+    refuse("ZERO tests ran — a filter that matches nothing reports all-green, which is not a survivor");
+  }
+
+  const failed = (report.testResults ?? [])
+    .flatMap((f) => f.assertionResults ?? [])
+    .filter((t) => t.status === "failed")
+    .map((t) => t.fullName ?? t.title);
+  const verdict = failed.length > 0 ? "REDDENED" : "SURVIVED";
+
+  // 5 — did the TEST RUN dirty the target itself? Then a kept diff would be mutation-plus-noise, and a
+  // default restore would silently discard those writes. Reported either way, refused under --keep.
+  const afterTests = readFileSync(target, "utf8");
+  const testDirtiedTarget = afterTests !== mutatedBytes;
+
+  // 6 — restore unless the mutation IS the change, and say what the tree looks like afterwards.
+  const keeping = opts.keep && !(verdict === "REDDENED" && !opts.keepEvenIfRed) && !testDirtiedTarget;
+  if (!keeping) restore();
+
+  console.log(`\nmutate: ${verdict}`);
+  for (const name of failed) console.log(`  red: ${name}`);
+  console.log(`  tests run: ${total}`);
+
+  if (testDirtiedTarget) {
+    console.error("mutate: TEST DIRTIED TARGET — the test run wrote to the file under mutation; restored, and --keep refused");
+    process.exit(EXIT_REFUSED);
+  }
+  if (opts.keep && verdict === "REDDENED" && !opts.keepEvenIfRed) {
+    console.error("mutate: NOT KEPT — the edit you asked to keep breaks tests. Re-run with --keep-even-if-red if that is intended.");
+    process.exit(EXIT_MISSED);
+  }
+  if (keeping) {
+    if (verdict === "REDDENED") console.error("mutate: *** KEPT FAILING MUTATION *** — the tree now holds a change whose tests fail");
+    // Scoped to the target: an unscoped stat printed AFTER the tests would list whatever they dirtied,
+    // and this stat is the artefact meant to replace writing a commit message from intent.
+    console.log("\nkept (target only):");
+    console.log(git(["diff", "--stat", "--", target]));
+  }
+
+  // Other tracked files the test run dirtied are REPORTED, never conflated with a failed restore — a
+  // check that reddens on unrelated noise is one the operator learns to ignore.
+  const otherDirt = git(["status", "--porcelain", "--untracked-files=no"])
+    .split("\n")
+    .filter(Boolean)
+    .filter((line) => !line.endsWith(path.relative(ROOT, target)));
+  if (otherDirt.length > 0) {
+    console.error("\nmutate: the test run also dirtied:");
+    for (const line of otherDirt) console.error(`  ${line}`);
+  }
+
+  const met = verdict === (opts.expect === "reddened" ? "REDDENED" : "SURVIVED");
+  console.log(`  expected: ${opts.expect} — ${met ? "met" : "MISSED"}`);
+  process.exit(met ? EXIT_MET : EXIT_MISSED);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  main();
+}

--- a/scripts/mutate.mjs
+++ b/scripts/mutate.mjs
@@ -6,53 +6,46 @@
  * tree with uncommitted tracked changes — and wired it into the adversarial-build skill. It did not
  * stop the failure. In the session after it shipped, the same operator lost work to
  * `git checkout -- <file>` three times and landed two commits whose messages outran their diffs (see
- * `docs/design/mutation-flow.md` §0 for the incident table and how much of it is checkable).
+ * `docs/design/mutation-flow.md` §0, which is explicit about how much of that is checkable).
  *
  * The reason is that a mutation is NOT one command. It is edit → test → `git checkout` → hopefully
  * check, and the guard covers the first step IF you remember to call it. Every ad-hoc spelling — a
  * heredoc, a `sed -i`, an editor keystroke — skips it. The guard replaced a rule you have to remember
  * with a check that fails, and then left the rule standing around it. This is the whole sequence.
  *
- * WHAT IT DOES NOT CLAIM. It cannot stop anyone typing `git checkout`. It makes the safe path the
- * short path and prints a verdict the operator can paste instead of narrating from memory — the half
- * of the failure that no start-of-run guard can see.
+ * WHAT IT DOES NOT CLAIM. It cannot stop anyone typing `git checkout`. It makes the safe path the short
+ * path and prints a verdict the operator pastes instead of narrating from memory — the half of the
+ * failure no start-of-run guard can see.
+ *
+ * NO TEST-RUNNER OVERRIDE EXISTS IN THIS CLI, and that is a fix, not an omission. An earlier version
+ * read the test command from an env var so the guard test could stub it; both code reviewers pointed
+ * out that this ships a way to forge the verdict — mutate a real file, stub the report, and print a
+ * block byte-identical to a real run, which the skill then tells you to paste into a PR. The runner is
+ * now an argument to `runMutationFlow`, the CLI hard-wires the real one, and the tests inject a fake by
+ * calling the function. A slice about closing a bypass must not ship one.
  *
  * Usage:
  *   node scripts/mutate.mjs <target> --edit <needle-file> <replacement-file> [--edit …]
  *                           [--keep] [--keep-even-if-red] [--expect reddened|survived]
  *                           -- <vitest args…>
  *
- * Exit codes track the stated EXPECTATION, never the raw verdict (see `--expect` below):
+ * Exit codes track the stated EXPECTATION, never the raw verdict:
  *   0  expectation met
- *   2  expectation missed
+ *   2  expectation missed (including "you asked to keep an edit whose tests fail")
  *   1  usage or infrastructure — always with a message naming which, because node exits 1 on any
  *      uncaught crash and a crashed tool must not look like a refusal.
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-/**
- * The repo this operates on. Overridable ONLY so the guard test can exercise the refusal paths
- * BEHAVIOURALLY in a scratch repository — review's first blocker was that asserting "the source
- * mentions the guard" passes with the call dead, so the test has to actually run the tool against a
- * dirty tree. The override moves WHICH repo is guarded; it cannot skip the guard.
- */
-const ROOT = process.env.MUTATE_ROOT
-  ? path.resolve(process.env.MUTATE_ROOT)
-  : path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
-const EXIT_MET = 0;
-const EXIT_MISSED = 2;
-const EXIT_REFUSED = 1;
-
-/** Every refusal prints WHY. `node` exits 1 on an uncaught throw too, so the message is the only thing
- *  that distinguishes "this tool refused" from "this tool crashed" (the sibling guard pins the same). */
-function refuse(message) {
-  console.error(`mutate: REFUSING — ${message}`);
-  process.exit(EXIT_REFUSED);
-}
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = path.join(HERE, "..");
+export const EXIT_MET = 0;
+export const EXIT_MISSED = 2;
+export const EXIT_REFUSED = 1;
 
 export function parseArgs(argv) {
   const dashdash = argv.indexOf("--");
@@ -78,23 +71,23 @@ export function parseArgs(argv) {
   }
   if (!opts.target) return { error: "no target file" };
   if (opts.edits.length === 0) return { error: "no --edit pairs" };
-  // `--keep` means "this mutation IS the change I want", and that expects the tests to STAY GREEN —
-  // the proof the deleted thing was dead. Defaulting the expectation off the mode is what stops the
-  // exit-code polarity inverting under it (review: `mutate --keep && git commit` would otherwise
-  // commit a change whose tests fail, at exit 0).
+  // `--keep` means "this mutation IS the change I want", which expects the tests to STAY GREEN — that
+  // is the proof the deleted thing was dead. Defaulting the expectation off the mode is what stops the
+  // exit polarity inverting under it: otherwise `mutate --keep && git commit` commits a change whose
+  // tests fail, at exit 0 (review's blocker on draft 2).
   if (opts.expect === null) opts.expect = opts.keep ? "survived" : "reddened";
   return { opts };
 }
 
 /**
- * Locate every needle against the ORIGINAL bytes and apply the replacements as one simultaneous
+ * Locate every needle against the ORIGINAL bytes and apply the replacements as ONE simultaneous
  * transformation.
  *
  * "Each needle matches exactly once" is undefined across pairs — does pair B match before or after
  * pair A applied? — and either reading can silently mutate the wrong site while reporting a clean
- * verdict, which is a report that means nothing. So: all matches are resolved against the original,
- * spans may not overlap, no pair's needle may appear in another pair's replacement (that is the
- * cascade the simultaneous reading exists to forbid), and edits apply by descending offset.
+ * verdict, which is a report that means nothing. So: all matches resolve against the original, spans
+ * may not overlap, no pair's needle may appear in another pair's replacement (the cascade the
+ * simultaneous reading forbids), and edits apply by descending offset.
  */
 export function planEdits(original, pairs) {
   const spans = [];
@@ -125,165 +118,218 @@ export function planEdits(original, pairs) {
   return { mutated: out };
 }
 
-/** A needle file written by any editor ends with a newline the operator did not type, so exactly one
- *  trailing newline is stripped. Everything else is byte-exact — a needle that fails to match must
- *  fail LOUDLY rather than be normalised into matching something else. */
-const readNeedle = (p) => readFileSync(p, "utf8").replace(/\n$/, "");
-
-function git(args, opts = {}) {
-  return execFileSync("git", args, { cwd: ROOT, encoding: "utf8", ...opts }).trim();
+/**
+ * The verdict, from the AGGREGATE count rather than the nested assertion shape.
+ *
+ * Both reviewers landed on this independently: deriving RED/GREEN only from
+ * `testResults[].assertionResults[].status` fails OPEN when that shape drifts — a report with failures
+ * recorded only in aggregate reads as SURVIVED, and under `--keep` that keeps a broken edit at exit 0.
+ * `numFailedTests` is the aggregate vitest 4.1.9 publishes; if it is missing this refuses, because
+ * "cannot tell" must never read as "nothing failed". Nested assertions are used for the NAMES only,
+ * best-effort, since a name list that comes up empty costs nothing.
+ */
+export function verdictFrom(report) {
+  const total = Number(report?.numTotalTests);
+  if (!Number.isFinite(total)) return { error: "the report has no test count" };
+  if (total === 0)
+    return { error: "ZERO tests ran — a filter that matches nothing reports all-green, which is not a survivor" };
+  const failedCount = Number(report?.numFailedTests);
+  if (!Number.isFinite(failedCount))
+    return { error: "the report has no failure count — cannot tell red from green, and that must not read as green" };
+  const names = Array.isArray(report?.testResults)
+    ? report.testResults
+        .flatMap((f) => (Array.isArray(f?.assertionResults) ? f.assertionResults : []))
+        .filter((t) => t?.status === "failed")
+        .map((t) => t.fullName ?? t.title ?? "(unnamed)")
+    : [];
+  return { verdict: failedCount > 0 ? "REDDENED" : "SURVIVED", total, failedCount, names };
 }
 
-function main() {
-  const parsed = parseArgs(process.argv.slice(2));
-  if (parsed.error) refuse(`${parsed.error}\n\n  usage: node scripts/mutate.mjs <target> --edit <needle-file> <replacement-file> [--keep] -- <vitest args…>`);
+/** A needle file written by any editor ends with a newline the operator did not type, so exactly one
+ *  trailing newline is stripped. Everything else is byte-exact — a needle that fails to match must fail
+ *  LOUDLY rather than be normalised into matching something else. */
+export const readNeedle = (p) => readFileSync(p, "utf8").replace(/\n$/, "");
+
+/**
+ * The whole sequence. `testRunner` is injected so the guard test can drive every branch without the
+ * production CLI carrying an override that could forge a verdict — see the header.
+ *
+ * `io` is likewise injected so the tests can capture output instead of racing stdout.
+ */
+export function runMutationFlow({ root, argv, testRunner, io = console, log = appendRunLog }) {
+  const out = (s) => io.log(s);
+  const err = (s) => io.error(s);
+  const refuse = (message) => {
+    err(`mutate: REFUSING — ${message}`);
+    return EXIT_REFUSED;
+  };
+  const git = (args, opts = {}) =>
+    execFileSync("git", args, { cwd: root, encoding: "utf8", ...opts }).trim();
+
+  const parsed = parseArgs(argv);
+  if (parsed.error) return refuse(`${parsed.error}\n  usage: node scripts/mutate.mjs <target> --edit <needle> <replacement> [--keep] -- <vitest args…>`);
   const { opts } = parsed;
 
   // 1 — the tree must be a committed checkpoint. Delegated to the guard rather than reimplemented, so
   // the two can never drift on what counts as one.
-  const guardScript = path.join(path.dirname(fileURLToPath(import.meta.url)), "mutation-guard.mjs");
-  const guard = spawnSync(process.execPath, [guardScript], { cwd: ROOT, encoding: "utf8" });
+  const guard = spawnSync(process.execPath, [path.join(HERE, "mutation-guard.mjs")], {
+    cwd: root,
+    encoding: "utf8",
+  });
   if (guard.status !== 0) {
-    process.stderr.write(guard.stdout ?? "");
-    process.stderr.write(guard.stderr ?? "");
-    refuse("the tree is not a committed checkpoint (see mutation-guard above) — commit first");
+    err(guard.stdout ?? "");
+    err(guard.stderr ?? "");
+    return refuse("the tree is not a committed checkpoint (see mutation-guard above) — commit first");
   }
 
   // 2 — the TARGET must be tracked. Not because the restore needs git (step 5 restores from bytes we
   // already hold) but because a file with no committed version is not a checkpoint to return to.
-  const target = path.resolve(ROOT, opts.target);
-  if (!existsSync(target)) refuse(`target ${opts.target} does not exist`);
+  const target = path.resolve(root, opts.target);
+  if (!existsSync(target)) return refuse(`target ${opts.target} does not exist`);
   try {
     git(["ls-files", "--error-unmatch", target], { stdio: "pipe" });
   } catch {
-    refuse(`target ${opts.target} is untracked — there is no committed version to return to`);
+    return refuse(`target ${opts.target} is untracked — there is no committed version to return to`);
   }
 
-  // 3 — plan and apply, simultaneously, against the original bytes.
+  // 3 — plan (still no write, so every refusal above and below is before the file is touched).
   const original = readFileSync(target, "utf8");
-  const pairs = opts.edits.map((e, i) => {
-    if (!existsSync(e.needle)) refuse(`--edit needle file ${e.needle} does not exist`);
-    if (!existsSync(e.replacement)) refuse(`--edit replacement file ${e.replacement} does not exist`);
-    return {
-      label: `--edit #${i + 1}`,
-      needleText: readNeedle(e.needle),
-      replacementText: readNeedle(e.replacement),
-    };
-  });
+  const pairs = [];
+  for (const [i, e] of opts.edits.entries()) {
+    if (!existsSync(e.needle)) return refuse(`--edit needle file ${e.needle} does not exist`);
+    if (!existsSync(e.replacement)) return refuse(`--edit replacement file ${e.replacement} does not exist`);
+    pairs.push({ label: `--edit #${i + 1}`, needleText: readNeedle(e.needle), replacementText: readNeedle(e.replacement) });
+  }
   const plan = planEdits(original, pairs);
-  if (plan.error) refuse(plan.error);
-  if (plan.mutated === original) refuse("the mutation changes nothing — a no-op cannot be survived or caught");
-  writeFileSync(target, plan.mutated);
-  const mutatedBytes = plan.mutated;
-
-  // 4 — run the tests, and OWN the reporter so "how many tests ran" is machine-readable. Scraping the
-  // human reporter would break the day its format changes, and would break toward vacuity: a filter
-  // matching nothing prints all-green, which reads as SURVIVED and means nothing.
-  const reportDir = mkdtempSync(path.join(tmpdir(), "mutate-"));
-  const reportPath = path.join(reportDir, "report.json");
+  if (plan.error) return refuse(plan.error);
+  if (plan.mutated === original) return refuse("the mutation changes nothing — a no-op cannot be survived or caught");
   const conflicting = opts.vitestArgs.find((a) => a.startsWith("--reporter") || a.startsWith("--outputFile"));
+  if (conflicting) return refuse(`${conflicting} would clobber the machine-readable report this tool needs — remove it`);
+
+  // Everything that can throw BEFORE the write happens before it (review: `mkdtempSync` used to run
+  // after, so an unusable TMPDIR left the mutation applied with a raw stack trace).
+  const reportPath = path.join(mkdtempSync(path.join(tmpdir(), "mutate-")), "report.json");
+  let applied = false;
+  let keeping = false;
   const restore = () => {
     writeFileSync(target, original);
-    // Belt and braces: git is the recovery path when the in-memory copy is gone (an abnormal exit),
-    // and the byte compare is what proves the restore actually happened.
     if (readFileSync(target, "utf8") !== original) {
-      console.error("mutate: RESTORE FAILED — the target does not match its pre-mutation bytes");
-      process.exit(EXIT_REFUSED);
+      err("mutate: *** MUTATION STILL APPLIED *** — the restore did not take; `git checkout -- <file>` is your recovery");
+      return false;
     }
+    return true;
   };
-  if (conflicting) {
-    restore();
-    refuse(`${conflicting} would clobber the machine-readable report this tool needs — remove it`);
-  }
-  // Restore on an abnormal exit rather than leaving the mutation applied and silent.
-  const onSignal = () => {
-    try { writeFileSync(target, original); } catch { /* fall through to the loud message */ }
-    console.error("mutate: interrupted — target restored (verify with `git status --short`)");
+  const onSignal = (sig) => {
+    if (applied && !restore()) process.exit(EXIT_REFUSED);
+    err(`mutate: interrupted (${sig}) — target ${applied ? "restored" : "untouched"}`);
     process.exit(EXIT_REFUSED);
   };
-  process.on("SIGINT", onSignal);
-  process.on("SIGTERM", onSignal);
+  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) process.on(sig, () => onSignal(sig));
 
-  // `MUTATE_TEST_CMD` exists for the guard test alone: a scratch repo has no vitest, and the criteria
-  // that matter there (zero tests ran, restore, exit codes) are about how this tool READS a report,
-  // not about vitest. It writes the same JSON shape.
-  const run = process.env.MUTATE_TEST_CMD
-    ? spawnSync("sh", ["-c", `${process.env.MUTATE_TEST_CMD} "${reportPath}"`], { cwd: ROOT, encoding: "utf8" })
-    : spawnSync(
-        "npx",
-        ["vitest", "run", ...opts.vitestArgs, "--reporter=json", `--outputFile.json=${reportPath}`],
-        { cwd: ROOT, encoding: "utf8" }
-      );
-  process.stdout.write(run.stdout ?? "");
-
-  let report;
+  // 4 — mutate, run, and restore under `finally`, so ANY throw from here down still restores. Review
+  // demonstrated two live crash windows that left the mutation in the tree with a raw stack.
   try {
-    report = JSON.parse(readFileSync(reportPath, "utf8"));
+    writeFileSync(target, plan.mutated);
+    applied = true;
+    const run = testRunner({ root, vitestArgs: opts.vitestArgs, reportPath });
+    if (run?.stdout) out(run.stdout);
+
+    let report;
+    try {
+      report = JSON.parse(readFileSync(reportPath, "utf8"));
+    } catch {
+      return refuse("the test run produced no readable report — cannot tell how many tests ran, and 'cannot tell' must not read as 'some did'");
+    }
+    const v = verdictFrom(report);
+    if (v.error) return refuse(v.error);
+
+    // Did the TEST RUN write to the file under mutation? Then a kept diff would be mutation-plus-noise.
+    // Reported either way; only `--keep` refuses on it (review: this used to refuse unconditionally and
+    // blamed a flag the operator never passed).
+    let testDirtiedTarget = false;
+    try {
+      testDirtiedTarget = readFileSync(target, "utf8") !== plan.mutated;
+    } catch {
+      testDirtiedTarget = true; // the test deleted it; `finally` restores from the bytes we hold
+    }
+
+    const keepRefusedForRed = opts.keep && v.verdict === "REDDENED" && !opts.keepEvenIfRed;
+    keeping = opts.keep && !keepRefusedForRed && !testDirtiedTarget;
+
+    out(`\nmutate: ${v.verdict}`);
+    for (const name of v.names) out(`  red: ${name}`);
+    out(`  tests run: ${v.total}${v.names.length === 0 && v.failedCount > 0 ? ` (${v.failedCount} failed, names unavailable)` : ""}`);
+
+    if (testDirtiedTarget) {
+      err(`mutate: TEST DIRTIED TARGET — the test run wrote to the file under mutation${opts.keep ? "; --keep refused, restored" : "; restored"}`);
+      if (opts.keep) return EXIT_REFUSED;
+    }
+    if (keepRefusedForRed) {
+      err("mutate: NOT KEPT — the edit you asked to keep breaks tests. Re-run with --keep-even-if-red if that is intended.");
+      return EXIT_MISSED;
+    }
+    if (keeping && v.verdict === "REDDENED")
+      err("mutate: *** KEPT FAILING MUTATION *** — the tree now holds a change whose tests fail");
+    if (keeping) {
+      // Scoped to the target: an unscoped stat printed AFTER the tests would list whatever they
+      // dirtied, and this stat is the artefact meant to replace writing a message from intent.
+      out("\nkept (target only):");
+      out(git(["diff", "--stat", "--", target]));
+    }
+
+    // Other tracked files the test run dirtied are REPORTED, never conflated with a failed restore — a
+    // check that reddens on unrelated noise is one the operator learns to ignore. Compared on the
+    // parsed path, not a line suffix: `endsWith` swallowed `sub/target.txt` while mutating `target.txt`.
+    const rel = path.relative(root, target);
+    const otherDirt = git(["status", "--porcelain", "--untracked-files=no"])
+      .split("\n")
+      .filter(Boolean)
+      .filter((line) => line.slice(3).split(" -> ").pop() !== rel);
+    if (otherDirt.length > 0) {
+      err("\nmutate: the test run also dirtied:");
+      for (const line of otherDirt) err(`  ${line}`);
+    }
+
+    const met = v.verdict === (opts.expect === "reddened" ? "REDDENED" : "SURVIVED");
+    out(`  expected: ${opts.expect} — ${met ? "met" : "MISSED"}`);
+    log(root, { target: rel, verdict: v.verdict, expect: opts.expect, met, keep: keeping, total: v.total });
+    return met ? EXIT_MET : EXIT_MISSED;
+  } finally {
+    if (applied && !keeping && !restore()) return EXIT_REFUSED;
+  }
+}
+
+/**
+ * One line per run, to a git-ignored log.
+ *
+ * It exists because of a question the incidents could not answer: was the guard SKIPPED, or did it run
+ * and fail? Nothing recorded an invocation, so the post-mortem could only infer. This makes the next
+ * one answerable. Best-effort — a log that cannot be written must never fail a mutation run.
+ */
+export function appendRunLog(root, entry) {
+  try {
+    appendFileSync(
+      path.join(root, ".mutate-runs.log"),
+      `${new Date().toISOString()} ${JSON.stringify(entry)}\n`
+    );
   } catch {
-    restore();
-    refuse("the test run produced no readable report — cannot tell how many tests ran, and 'cannot tell' must not read as 'some did'");
+    /* the log is evidence, not a gate */
   }
-  const total = Number(report.numTotalTests);
-  if (!Number.isFinite(total)) {
-    restore();
-    refuse("the report has no test count — see above");
-  }
-  if (total === 0) {
-    restore();
-    refuse("ZERO tests ran — a filter that matches nothing reports all-green, which is not a survivor");
-  }
+}
 
-  const failed = (report.testResults ?? [])
-    .flatMap((f) => f.assertionResults ?? [])
-    .filter((t) => t.status === "failed")
-    .map((t) => t.fullName ?? t.title);
-  const verdict = failed.length > 0 ? "REDDENED" : "SURVIVED";
-
-  // 5 — did the TEST RUN dirty the target itself? Then a kept diff would be mutation-plus-noise, and a
-  // default restore would silently discard those writes. Reported either way, refused under --keep.
-  const afterTests = readFileSync(target, "utf8");
-  const testDirtiedTarget = afterTests !== mutatedBytes;
-
-  // 6 — restore unless the mutation IS the change, and say what the tree looks like afterwards.
-  const keeping = opts.keep && !(verdict === "REDDENED" && !opts.keepEvenIfRed) && !testDirtiedTarget;
-  if (!keeping) restore();
-
-  console.log(`\nmutate: ${verdict}`);
-  for (const name of failed) console.log(`  red: ${name}`);
-  console.log(`  tests run: ${total}`);
-
-  if (testDirtiedTarget) {
-    console.error("mutate: TEST DIRTIED TARGET — the test run wrote to the file under mutation; restored, and --keep refused");
-    process.exit(EXIT_REFUSED);
-  }
-  if (opts.keep && verdict === "REDDENED" && !opts.keepEvenIfRed) {
-    console.error("mutate: NOT KEPT — the edit you asked to keep breaks tests. Re-run with --keep-even-if-red if that is intended.");
-    process.exit(EXIT_MISSED);
-  }
-  if (keeping) {
-    if (verdict === "REDDENED") console.error("mutate: *** KEPT FAILING MUTATION *** — the tree now holds a change whose tests fail");
-    // Scoped to the target: an unscoped stat printed AFTER the tests would list whatever they dirtied,
-    // and this stat is the artefact meant to replace writing a commit message from intent.
-    console.log("\nkept (target only):");
-    console.log(git(["diff", "--stat", "--", target]));
-  }
-
-  // Other tracked files the test run dirtied are REPORTED, never conflated with a failed restore — a
-  // check that reddens on unrelated noise is one the operator learns to ignore.
-  const otherDirt = git(["status", "--porcelain", "--untracked-files=no"])
-    .split("\n")
-    .filter(Boolean)
-    .filter((line) => !line.endsWith(path.relative(ROOT, target)));
-  if (otherDirt.length > 0) {
-    console.error("\nmutate: the test run also dirtied:");
-    for (const line of otherDirt) console.error(`  ${line}`);
-  }
-
-  const met = verdict === (opts.expect === "reddened" ? "REDDENED" : "SURVIVED");
-  console.log(`  expected: ${opts.expect} — ${met ? "met" : "MISSED"}`);
-  process.exit(met ? EXIT_MET : EXIT_MISSED);
+/** The real runner. The CLI is hard-wired to it; there is no override (see the header). */
+function vitestRunner({ root, vitestArgs, reportPath }) {
+  return spawnSync(
+    "npx",
+    ["vitest", "run", ...vitestArgs, "--reporter=json", `--outputFile.json=${reportPath}`],
+    { cwd: root, encoding: "utf8" }
+  );
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
-  main();
+  // `MUTATE_ROOT` moves WHICH repo is guarded — never whether it is. Both reviewers checked it for a
+  // bypass and cleared it: the guard, `ls-files` and the target all resolve under the same root, so a
+  // target outside it is refused as untracked.
+  const root = process.env.MUTATE_ROOT ? path.resolve(process.env.MUTATE_ROOT) : DEFAULT_ROOT;
+  process.exit(runMutationFlow({ root, argv: process.argv.slice(2), testRunner: vitestRunner }));
 }

--- a/test/guards/mutation-flow.test.ts
+++ b/test/guards/mutation-flow.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseArgs, planEdits } from "../../scripts/mutate.mjs";
+import { parseArgs, planEdits, runMutationFlow, verdictFrom } from "../../scripts/mutate.mjs";
 
 /**
  * BUILD-FAILING GUARD for the mutation flow (MUTFLOW-1).
@@ -16,9 +16,10 @@ import { parseArgs, planEdits } from "../../scripts/mutate.mjs";
  * scratch git repositories, and the source scan survives only for the one property a run cannot show:
  * that the tracked-changes logic is not reimplemented.
  *
- * The tool is pointed at a scratch repo with `MUTATE_ROOT`, and its test command is replaced with
- * `MUTATE_TEST_CMD` (a scratch repo has no vitest). Neither can skip the guard — they move which repo
- * is guarded and which command produces the report this tool then READS.
+ * The tool is pointed at a scratch repo with `MUTATE_ROOT` — which both reviewers checked for a bypass
+ * and cleared, since the guard, `ls-files` and the target all resolve under one root. The fake test
+ * RUNNER is injected as a function argument, never an env override: the first version used one, and both
+ * reviewers showed it let the production CLI forge a verdict.
  */
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -27,15 +28,42 @@ const MUTATE = path.join(ROOT, "scripts", "mutate.mjs");
 let scratch: string;
 const files: string[] = [];
 
-/** A JSON report in vitest's shape, written by a shell command — the tool must READ it, not scrape. */
-const reportCmd = (total: number, failedNames: string[] = []) => {
-  const results =
-    failedNames.length === 0
-      ? `[{"assertionResults":[{"status":"passed","fullName":"ok"}]}]`
-      : `[{"assertionResults":[${failedNames
-          .map((n) => `{"status":"failed","fullName":"${n}"}`)
-          .join(",")}]}]`;
-  return `printf '{"numTotalTests":${total},"testResults":${results}}' >`;
+/**
+ * A fake test runner, INJECTED — not an env override.
+ *
+ * The first version of this file stubbed the runner with `MUTATE_TEST_CMD`, and both code reviewers
+ * showed that shipped a verdict-forgery channel in the production CLI: mutate a real file, stub the
+ * report, and print a block byte-identical to a real run — which the skill then tells you to paste into
+ * a PR. The override is gone from the CLI; the runner is a parameter, and only the tests pass a fake.
+ *
+ * `sideEffect` lets a test observe WHEN the runner ran (a sentinel) and WHAT it saw (the target's bytes
+ * at run time), which is how "refuses before running tests" and "the tests see the mutant" get pinned.
+ */
+const fakeRunner = (
+  report: Record<string, unknown>,
+  sideEffect?: (ctx: { root: string }) => void
+) => {
+  const calls: { root: string }[] = [];
+  const run = ({ root, reportPath }: { root: string; reportPath: string }) => {
+    calls.push({ root });
+    sideEffect?.({ root });
+    writeFileSync(reportPath, JSON.stringify(report));
+    return { stdout: "" };
+  };
+  return Object.assign(run, { calls });
+};
+
+const green = (total = 2) => ({ numTotalTests: total, numFailedTests: 0, testResults: [] });
+const red = (names: string[], total = 2) => ({
+  numTotalTests: total,
+  numFailedTests: names.length,
+  testResults: [{ assertionResults: names.map((n) => ({ status: "failed", fullName: n })) }],
+});
+
+/** Captures the tool's output instead of racing stdout. */
+const capture = () => {
+  const lines: string[] = [];
+  return { io: { log: (s: string) => lines.push(s), error: (s: string) => lines.push(s) }, text: () => lines.join("\n") };
 };
 
 function newRepo(name: string, content = "alpha\nbeta\ngamma\n"): { dir: string; target: string } {
@@ -51,6 +79,9 @@ function newRepo(name: string, content = "alpha\nbeta\ngamma\n"): { dir: string;
   return { dir, target };
 }
 
+/** Reads a needle file the way the tool does — one trailing newline stripped, bytes otherwise. */
+const readNeedleFor = (p: string) => readFileSync(p, "utf8").replace(/\n$/, "");
+
 function needleFile(name: string, text: string): string {
   const p = path.join(scratch, name);
   writeFileSync(p, text);
@@ -58,11 +89,26 @@ function needleFile(name: string, text: string): string {
   return p;
 }
 
-function run(dir: string, args: string[], testCmd = reportCmd(1)) {
+/** In-process, with an injected runner — the only way a fake runner exists anywhere now. */
+function flow(
+  dir: string,
+  args: string[],
+  report: Record<string, unknown> = green(),
+  sideEffect?: (ctx: { root: string }) => void
+) {
+  const cap = capture();
+  const runner = fakeRunner(report, sideEffect);
+  const status = runMutationFlow({ root: dir, argv: args, testRunner: runner, io: cap.io, log: () => {} });
+  return { status, out: cap.text(), runner };
+}
+
+/** Through the real CLI, for the properties that must hold of the shipped binary. It has no runner
+ *  override, so this is only used where the flow refuses BEFORE any test would run. */
+function cli(dir: string, args: string[]) {
   return spawnSync(process.execPath, [MUTATE, ...args], {
     cwd: dir,
     encoding: "utf8",
-    env: { ...process.env, MUTATE_ROOT: dir, MUTATE_TEST_CMD: testCmd },
+    env: { ...process.env, MUTATE_ROOT: dir },
   });
 }
 
@@ -74,127 +120,209 @@ afterAll(() => {
 });
 
 describe("guard: the flow refuses before it can destroy anything", () => {
-  it("REFUSES on a dirty tracked tree, before mutating and before running tests", () => {
-    // THE core property, and the one a source scan cannot show. If this passes while the guard call is
-    // dead, everything else in this file is decoration.
+  it("REFUSES on a dirty tracked tree — before mutating, and before any test runs", () => {
+    // THE core property, and the one a source scan cannot show. The sentinel is what proves "before any
+    // test runs": review pointed out that asserting refusal + unchanged bytes would still pass if the
+    // flow had run the tests first.
     const { dir, target } = newRepo("dirty");
-    writeFileSync(path.join(dir, "target.txt"), "alpha\nBETA-uncommitted\ngamma\n");
+    writeFileSync(target, "alpha\nBETA-uncommitted\ngamma\n");
     const dirtyBytes = readFileSync(target, "utf8");
-    const r = run(dir, [target, "--edit", needleFile("n1", "alpha"), needleFile("r1", "ALPHA")]);
+    const r = flow(dir, [target, "--edit", needleFile("n1", "alpha"), needleFile("r1", "ALPHA")]);
+    expect(r.status).toBe(1);
+    expect(r.out).toContain("REFUSING");
+    expect(r.runner.calls).toHaveLength(0); // the tests never ran
+    expect(readFileSync(target, "utf8")).toBe(dirtyBytes); // the operator's work is untouched
+  });
+
+  it("REFUSES on a dirty tree THROUGH THE SHIPPED CLI too, not only in-process", () => {
+    // The in-process tests inject a runner; this one runs the binary an operator actually invokes, to
+    // prove the wiring in `main()` is the same wiring the tests exercise.
+    const { dir, target } = newRepo("dirty-cli");
+    writeFileSync(target, "alpha\nDIRTY\ngamma\n");
+    const r = cli(dir, [target, "--edit", needleFile("nc", "alpha"), needleFile("rc", "ALPHA")]);
     expect(r.status).toBe(1);
     expect(r.stderr).toContain("REFUSING");
-    // …and the operator's uncommitted work is untouched.
-    expect(readFileSync(target, "utf8")).toBe(dirtyBytes);
+  });
+
+  it("has NO env override for the test runner — the CLI cannot be made to forge a verdict", () => {
+    // Both reviewers found this as a HIGH: an env-substituted test command lets someone mutate a real
+    // file, stub the report, and print a verdict block byte-identical to a real run — which the skill
+    // tells you to paste into a PR. The runner is a function parameter now, and nothing in the script
+    // reads a command from the environment.
+    const src = readFileSync(MUTATE, "utf8");
+    expect(src).not.toContain("MUTATE_TEST_CMD");
+    expect(src).not.toMatch(/process\.env\.[A-Z_]*(CMD|COMMAND|RUNNER)/);
   });
 
   it("REFUSES an untracked target — a file with no committed version is not a checkpoint", () => {
     const { dir } = newRepo("untracked");
     const loose = path.join(dir, "loose.txt");
     writeFileSync(loose, "alpha\n");
-    const r = run(dir, [loose, "--edit", needleFile("n2", "alpha"), needleFile("r2", "ALPHA")]);
+    const r = flow(dir, [loose, "--edit", needleFile("n2", "alpha"), needleFile("r2", "ALPHA")]);
     expect(r.status).toBe(1);
-    expect(r.stderr).toContain("untracked");
+    expect(r.out).toContain("untracked");
+    expect(r.runner.calls).toHaveLength(0);
   });
 
   it("REFUSES a needle that matches zero times, and one that matches twice", () => {
-    // A mutation that touched nothing, or an unknown one of two sites, reports a verdict that means
-    // nothing — the same vacuity the zero-tests rule below covers on the other axis.
     const { dir, target } = newRepo("cardinality", "alpha\nbeta\nalpha\n");
-    const zero = run(dir, [target, "--edit", needleFile("n3", "omega"), needleFile("r3", "X")]);
+    const zero = flow(dir, [target, "--edit", needleFile("n3", "omega"), needleFile("r3", "X")]);
     expect(zero.status).toBe(1);
-    expect(zero.stderr).toContain("does not appear");
-    const twice = run(dir, [target, "--edit", needleFile("n4", "alpha"), needleFile("r4", "X")]);
+    expect(zero.out).toContain("does not appear");
+    const twice = flow(dir, [target, "--edit", needleFile("n4", "alpha"), needleFile("r4", "X")]);
     expect(twice.status).toBe(1);
-    expect(twice.stderr).toContain("more than once");
+    expect(twice.out).toContain("more than once");
     expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\nalpha\n");
   });
 
   it("REFUSES when ZERO tests ran, rather than reporting a survivor", () => {
-    // The hazard draft 1 missed: a filter selecting no files prints all-green, which reads as SURVIVED.
     const { dir, target } = newRepo("zerotests");
-    const r = run(dir, [target, "--edit", needleFile("n5", "beta"), needleFile("r5", "BETA")], reportCmd(0));
+    const r = flow(dir, [target, "--edit", needleFile("n5", "beta"), needleFile("r5", "BETA")], green(0));
     expect(r.status).toBe(1);
-    expect(r.stderr).toContain("ZERO tests");
+    expect(r.out).toContain("ZERO tests");
     expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n"); // and restored
   });
 
-  it("REFUSES when the report is unreadable — 'cannot tell' must not read as 'some tests ran'", () => {
-    const { dir, target } = newRepo("noreport");
-    const r = run(dir, [target, "--edit", needleFile("n6", "beta"), needleFile("r6", "BETA")], "true");
+  it("REFUSES a report with no FAILURE count — red/green must not fail open", () => {
+    // Review's third HIGH: the verdict used to come only from the nested assertion shape, so a report
+    // recording failures in aggregate read as SURVIVED — and under --keep that keeps a broken edit at
+    // exit 0. The count is authoritative now, and its absence refuses.
+    const { dir, target } = newRepo("noverdict");
+    const r = flow(dir, [target, "--edit", needleFile("n6", "beta"), needleFile("r6", "BETA")], {
+      numTotalTests: 3,
+      testResults: [],
+    });
     expect(r.status).toBe(1);
-    expect(r.stderr).toMatch(/no readable report|test count/);
+    expect(r.out).toContain("failure count");
     expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n");
   });
 
+  it("reads RED from the aggregate count even when the assertion shape drifts", () => {
+    const { dir, target } = newRepo("drift");
+    const r = flow(dir, [target, "--edit", needleFile("n7", "beta"), needleFile("r7", "BETA")], {
+      numTotalTests: 3,
+      numFailedTests: 2,
+      testResults: [{ somethingElse: [] }],
+    });
+    expect(r.out).toContain("REDDENED");
+    expect(r.out).toContain("names unavailable");
+    expect(r.status).toBe(0); // default --expect reddened
+  });
+
   it("every refusal names itself, so a crashed tool is not mistaken for a refusal", () => {
-    // node exits 1 on any uncaught throw; the message is the only discriminator.
     const { dir } = newRepo("usage");
-    const r = run(dir, ["nope.txt"]);
+    const r = cli(dir, ["nope.txt"]);
     expect(r.status).toBe(1);
     expect(r.stderr).toContain("mutate: REFUSING");
   });
 });
 
-describe("guard: the flow restores, and says what it did", () => {
-  it("restores the target to its committed bytes after a run", () => {
-    const { dir, target } = newRepo("restore");
-    const before = readFileSync(target, "utf8");
-    const r = run(dir, [target, "--edit", needleFile("n7", "beta"), needleFile("r7", "BETA")], reportCmd(3, ["a test"]));
-    expect(readFileSync(target, "utf8")).toBe(before);
-    expect(r.stdout).toContain("REDDENED");
-    expect(r.stdout).toContain("a test");
+describe("guard: the tests see the MUTANT, and the tree comes back", () => {
+  it("runs the tests against the MUTATED bytes", () => {
+    // Review's M1: nothing pinned this. A regression of the form "only write the file under --keep"
+    // passed every other test in this file — and the tool's entire purpose is that the tests run
+    // against the mutant.
+    const { dir, target } = newRepo("observed");
+    let seen = "";
+    const r = flow(
+      dir,
+      [target, "--edit", needleFile("n8", "beta"), needleFile("r8", "BETA")],
+      green(),
+      () => { seen = readFileSync(target, "utf8"); }
+    );
+    expect(seen).toContain("BETA");
+    expect(r.runner.calls).toHaveLength(1);
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n"); // restored afterwards
   });
 
+  it("restores even when the run throws after the mutation is applied", () => {
+    // Review demonstrated two live crash windows that left the mutation in the tree with a raw stack.
+    const { dir, target } = newRepo("throws");
+    const cap = capture();
+    const boom = () => { throw new Error("runner exploded"); };
+    expect(() =>
+      runMutationFlow({ root: dir, argv: [target, "--edit", needleFile("n9", "beta"), needleFile("r9", "BETA")], testRunner: boom, io: cap.io, log: () => {} })
+    ).toThrow(/exploded/);
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n");
+  });
+
+  it("restores when the test run DELETES the target", () => {
+    const { dir, target } = newRepo("deleted");
+    const r = flow(dir, [target, "--edit", needleFile("n10", "beta"), needleFile("r10", "BETA")], green(), () => {
+      rmSync(target);
+    });
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n");
+    expect(r.out).toContain("TEST DIRTIED TARGET");
+  });
+
+  it("reports a target the TEST RUN dirtied — and only --keep refuses on it", () => {
+    // Review's M2: this used to exit 1 unconditionally and blame a flag the operator never passed.
+    const { dir, target } = newRepo("dirtied");
+    const dirty = () => writeFileSync(target, "clobbered\n");
+    const plain = flow(dir, [target, "--edit", needleFile("n11", "beta"), needleFile("r11", "BETA")], red(["x"]), dirty);
+    expect(plain.out).toContain("TEST DIRTIED TARGET");
+    expect(plain.status).toBe(0); // default --expect reddened was still met
+    const kept = flow(dir, [target, "--edit", needleFile("n12", "beta"), needleFile("r12", "BETA"), "--keep"], green(), dirty);
+    expect(kept.status).toBe(1); // --keep refuses mutation-plus-noise
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n");
+  });
+
+  it("reports OTHER tracked files the test run dirtied, matching on the path not a suffix", () => {
+    // Review's L1: `endsWith` swallowed `sub/target.txt` while mutating `target.txt`.
+    const { dir, target } = newRepo("otherdirt");
+    mkdirSync(path.join(dir, "sub"), { recursive: true });
+    writeFileSync(path.join(dir, "sub", "target.txt"), "one\n");
+    execFileSync("git", ["add", "-A"], { cwd: dir });
+    execFileSync("git", ["commit", "-qm", "sub"], { cwd: dir });
+    const r = flow(dir, [target, "--edit", needleFile("n13", "beta"), needleFile("r13", "BETA")], red(["x"]), () => {
+      writeFileSync(path.join(dir, "sub", "target.txt"), "two\n");
+    });
+    expect(r.out).toContain("also dirtied");
+    expect(r.out).toContain("sub/target.txt");
+    execFileSync("git", ["checkout", "--", "."], { cwd: dir });
+  });
+});
+
+describe("guard: the verdict, the expectation, and --keep", () => {
   it("exit tracks the EXPECTATION, not the verdict — so --keep cannot invert the polarity", () => {
-    // Review's blocker on draft 2: pinning exit to the raw verdict makes SURVIVED (the success case
-    // under --keep) exit non-zero, and REDDENED (a broken kept edit) exit 0.
     const { dir, target } = newRepo("expect");
-    const n = needleFile("n8", "beta");
-    const rep = needleFile("r8", "BETA");
-    const caught = run(dir, [target, "--edit", n, rep], reportCmd(2, ["red"]));
-    expect(caught.status).toBe(0); // default --expect reddened, and it reddened
-    const survived = run(dir, [target, "--edit", n, rep], reportCmd(2));
-    expect(survived.status).toBe(2); // survived when it should have been caught
-    const wanted = run(dir, [target, "--edit", n, rep, "--expect", "survived"], reportCmd(2));
-    expect(wanted.status).toBe(0);
+    const n = needleFile("n14", "beta");
+    const rep = needleFile("r14", "BETA");
+    expect(flow(dir, [target, "--edit", n, rep], red(["red"])).status).toBe(0);
+    expect(flow(dir, [target, "--edit", n, rep], green()).status).toBe(2);
+    expect(flow(dir, [target, "--edit", n, rep, "--expect", "survived"], green()).status).toBe(0);
   });
 
   it("--keep leaves the edit applied when green, and REFUSES to keep a red one", () => {
     const { dir, target } = newRepo("keep");
-    const n = needleFile("n9", "beta");
-    const rep = needleFile("r9", "BETA");
+    const n = needleFile("n15", "beta");
+    const rep = needleFile("r15", "BETA");
 
-    const red = run(dir, [target, "--edit", n, rep, "--keep"], reportCmd(2, ["red"]));
-    expect(red.status).not.toBe(0);
-    expect(red.stderr).toContain("NOT KEPT");
-    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n"); // restored, not kept
+    const redRun = flow(dir, [target, "--edit", n, rep, "--keep"], red(["red"]));
+    expect(redRun.status).toBe(2);
+    expect(redRun.out).toContain("NOT KEPT");
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n");
 
-    const green = run(dir, [target, "--edit", n, rep, "--keep"], reportCmd(2));
-    expect(green.status).toBe(0);
-    expect(readFileSync(target, "utf8")).toContain("BETA"); // kept
-    expect(green.stdout).toContain("kept (target only)");
+    const greenRun = flow(dir, [target, "--edit", n, rep, "--keep"], green());
+    expect(greenRun.status).toBe(0);
+    expect(readFileSync(target, "utf8")).toContain("BETA");
+    expect(greenRun.out).toContain("kept (target only)");
+    execFileSync("git", ["checkout", "--", "."], { cwd: dir });
   });
 
   it("--keep-even-if-red keeps it, but says so in capitals", () => {
     const { dir, target } = newRepo("keepred");
-    const r = run(
-      dir,
-      [target, "--edit", needleFile("n10", "beta"), needleFile("r10", "BETA"), "--keep-even-if-red"],
-      reportCmd(2, ["red"])
-    );
+    const r = flow(dir, [target, "--edit", needleFile("n16", "beta"), needleFile("r16", "BETA"), "--keep-even-if-red"], red(["red"]));
     expect(readFileSync(target, "utf8")).toContain("BETA");
-    expect(r.stderr).toContain("KEPT FAILING MUTATION");
+    expect(r.out).toContain("KEPT FAILING MUTATION");
+    execFileSync("git", ["checkout", "--", "."], { cwd: dir });
   });
 
-  it("reports a target the TEST RUN dirtied instead of silently discarding it", () => {
-    // Under --keep the kept diff would otherwise be mutation-plus-noise; under restore the write would
-    // vanish without a word.
-    const { dir, target } = newRepo("dirtied");
-    const cmd = `printf 'clobbered\\n' > "${target}"; ${reportCmd(1)}`;
-    const r = run(dir, [target, "--edit", needleFile("n11", "beta"), needleFile("r11", "BETA")], cmd);
-    expect(r.status).toBe(1);
-    expect(r.stderr).toContain("TEST DIRTIED TARGET");
-    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n");
+  it("verdictFrom fails closed on a missing count, and never treats absence as green", () => {
+    expect(verdictFrom({ numTotalTests: 1 }).error).toContain("failure count");
+    expect(verdictFrom({}).error).toContain("test count");
+    expect(verdictFrom({ numTotalTests: 0, numFailedTests: 0 }).error).toContain("ZERO tests");
+    expect(verdictFrom({ numTotalTests: 2, numFailedTests: 0 }).verdict).toBe("SURVIVED");
   });
 });
 
@@ -216,14 +344,23 @@ describe("guard: multi-edit semantics are simultaneous against the original", ()
   });
 
   it("refuses a replacement that contains another pair's needle — cascade, not simultaneity", () => {
-    // The ordering hazard both reviewers named: if #1's replacement creates #2's needle, "matches
-    // exactly once" means different things before and after, and the mutation is silently not the one
-    // the operator described.
     const plan = planEdits("alpha beta", [
       { label: "#1", needleText: "alpha", replacementText: "beta" },
       { label: "#2", needleText: "beta", replacementText: "gamma" },
     ]);
     expect(plan.error).toContain("cascading");
+  });
+
+  it("matches a MID-LINE needle: exactly one trailing newline is stripped, nothing else", () => {
+    // The acceptance criterion had no test (review's M4). An editor adds the newline the operator did
+    // not type; anything beyond that must fail loudly rather than be normalised into matching.
+    const n = needleFile("mid-needle", "b > at &&\n"); // as any editor would save it
+    const r = needleFile("mid-repl", "b > at ||\n");
+    expect(readNeedleFor(n)).toBe("b > at &&");
+    const plan = planEdits("if (b > at && x) {", [
+      { label: "#1", needleText: readNeedleFor(n), replacementText: readNeedleFor(r) },
+    ]);
+    expect(plan.mutated).toBe("if (b > at || x) {");
   });
 
   it("--keep defaults the expectation to survived, and --expect overrides it", () => {
@@ -233,14 +370,13 @@ describe("guard: multi-edit semantics are simultaneous against the original", ()
   });
 });
 
-describe("guard: the flow owns the guard and the skill names the flow", () => {
+describe("guard: the skill names the flow, and the flow owns the guard", () => {
   const src = readFileSync(MUTATE, "utf8");
 
   it("delegates the checkpoint question rather than reimplementing it", () => {
-    // The one property a run cannot show. The behavioural refusal above proves the call is live; this
-    // proves there is no second definition of "is this tree a checkpoint" to drift from the first.
+    // Stated for what it is (review's L2): a best-effort scan. The BEHAVIOURAL proof that the call is
+    // live is the dirty-tree refusal above; this only says there is no obvious second definition.
     expect(src).toContain("mutation-guard.mjs");
-    expect(src).not.toMatch(/status\s+--porcelain[^\n]*\n[^\n]*trackedChanges/);
   });
 
   it("owns the reporter, so the test count cannot be scraped from human output", () => {
@@ -249,9 +385,6 @@ describe("guard: the flow owns the guard and the skill names the flow", () => {
   });
 
   it("the skill names this command and no longer narrates the manual sequence", () => {
-    // Three sites, all of which review found: the guard-invocation paragraph, the break/revert/confirm
-    // step, and the failure-modes row that still credited a "process rule". If any survives, the skill
-    // documents two paths and this slice's central claim is false on day one.
     const skill = readFileSync(path.join(ROOT, ".claude", "skills", "adversarial-build", "SKILL.md"), "utf8");
     expect(skill).toContain("scripts/mutate.mjs");
     expect(skill).not.toMatch(/revert, confirm the tree is clean/);

--- a/test/guards/mutation-flow.test.ts
+++ b/test/guards/mutation-flow.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs, planEdits } from "../../scripts/mutate.mjs";
+
+/**
+ * BUILD-FAILING GUARD for the mutation flow (MUTFLOW-1).
+ *
+ * WHY IT IS BEHAVIOURAL AND NOT A SOURCE SCAN. The first draft of this slice's acceptance criteria
+ * asserted only that `mutate.mjs` *mentions* `mutation-guard.mjs`. Review pointed out that a tool which
+ * calls the guard and ignores its result satisfies that completely — the pin-the-call-site failure this
+ * repo already carries a scar from. So the refusal paths are exercised by RUNNING the tool against
+ * scratch git repositories, and the source scan survives only for the one property a run cannot show:
+ * that the tracked-changes logic is not reimplemented.
+ *
+ * The tool is pointed at a scratch repo with `MUTATE_ROOT`, and its test command is replaced with
+ * `MUTATE_TEST_CMD` (a scratch repo has no vitest). Neither can skip the guard — they move which repo
+ * is guarded and which command produces the report this tool then READS.
+ */
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const MUTATE = path.join(ROOT, "scripts", "mutate.mjs");
+
+let scratch: string;
+const files: string[] = [];
+
+/** A JSON report in vitest's shape, written by a shell command — the tool must READ it, not scrape. */
+const reportCmd = (total: number, failedNames: string[] = []) => {
+  const results =
+    failedNames.length === 0
+      ? `[{"assertionResults":[{"status":"passed","fullName":"ok"}]}]`
+      : `[{"assertionResults":[${failedNames
+          .map((n) => `{"status":"failed","fullName":"${n}"}`)
+          .join(",")}]}]`;
+  return `printf '{"numTotalTests":${total},"testResults":${results}}' >`;
+};
+
+function newRepo(name: string, content = "alpha\nbeta\ngamma\n"): { dir: string; target: string } {
+  const dir = path.join(scratch, name);
+  mkdirSync(dir, { recursive: true });
+  execFileSync("git", ["init", "-q", "."], { cwd: dir });
+  execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "t"], { cwd: dir });
+  const target = path.join(dir, "target.txt");
+  writeFileSync(target, content);
+  execFileSync("git", ["add", "-A"], { cwd: dir });
+  execFileSync("git", ["commit", "-qm", "init"], { cwd: dir });
+  return { dir, target };
+}
+
+function needleFile(name: string, text: string): string {
+  const p = path.join(scratch, name);
+  writeFileSync(p, text);
+  files.push(p);
+  return p;
+}
+
+function run(dir: string, args: string[], testCmd = reportCmd(1)) {
+  return spawnSync(process.execPath, [MUTATE, ...args], {
+    cwd: dir,
+    encoding: "utf8",
+    env: { ...process.env, MUTATE_ROOT: dir, MUTATE_TEST_CMD: testCmd },
+  });
+}
+
+beforeAll(() => {
+  scratch = mkdtempSync(path.join(tmpdir(), "mutflow-guard-"));
+});
+afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("guard: the flow refuses before it can destroy anything", () => {
+  it("REFUSES on a dirty tracked tree, before mutating and before running tests", () => {
+    // THE core property, and the one a source scan cannot show. If this passes while the guard call is
+    // dead, everything else in this file is decoration.
+    const { dir, target } = newRepo("dirty");
+    writeFileSync(path.join(dir, "target.txt"), "alpha\nBETA-uncommitted\ngamma\n");
+    const dirtyBytes = readFileSync(target, "utf8");
+    const r = run(dir, [target, "--edit", needleFile("n1", "alpha"), needleFile("r1", "ALPHA")]);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("REFUSING");
+    // …and the operator's uncommitted work is untouched.
+    expect(readFileSync(target, "utf8")).toBe(dirtyBytes);
+  });
+
+  it("REFUSES an untracked target — a file with no committed version is not a checkpoint", () => {
+    const { dir } = newRepo("untracked");
+    const loose = path.join(dir, "loose.txt");
+    writeFileSync(loose, "alpha\n");
+    const r = run(dir, [loose, "--edit", needleFile("n2", "alpha"), needleFile("r2", "ALPHA")]);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("untracked");
+  });
+
+  it("REFUSES a needle that matches zero times, and one that matches twice", () => {
+    // A mutation that touched nothing, or an unknown one of two sites, reports a verdict that means
+    // nothing — the same vacuity the zero-tests rule below covers on the other axis.
+    const { dir, target } = newRepo("cardinality", "alpha\nbeta\nalpha\n");
+    const zero = run(dir, [target, "--edit", needleFile("n3", "omega"), needleFile("r3", "X")]);
+    expect(zero.status).toBe(1);
+    expect(zero.stderr).toContain("does not appear");
+    const twice = run(dir, [target, "--edit", needleFile("n4", "alpha"), needleFile("r4", "X")]);
+    expect(twice.status).toBe(1);
+    expect(twice.stderr).toContain("more than once");
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\nalpha\n");
+  });
+
+  it("REFUSES when ZERO tests ran, rather than reporting a survivor", () => {
+    // The hazard draft 1 missed: a filter selecting no files prints all-green, which reads as SURVIVED.
+    const { dir, target } = newRepo("zerotests");
+    const r = run(dir, [target, "--edit", needleFile("n5", "beta"), needleFile("r5", "BETA")], reportCmd(0));
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("ZERO tests");
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n"); // and restored
+  });
+
+  it("REFUSES when the report is unreadable — 'cannot tell' must not read as 'some tests ran'", () => {
+    const { dir, target } = newRepo("noreport");
+    const r = run(dir, [target, "--edit", needleFile("n6", "beta"), needleFile("r6", "BETA")], "true");
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/no readable report|test count/);
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n");
+  });
+
+  it("every refusal names itself, so a crashed tool is not mistaken for a refusal", () => {
+    // node exits 1 on any uncaught throw; the message is the only discriminator.
+    const { dir } = newRepo("usage");
+    const r = run(dir, ["nope.txt"]);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("mutate: REFUSING");
+  });
+});
+
+describe("guard: the flow restores, and says what it did", () => {
+  it("restores the target to its committed bytes after a run", () => {
+    const { dir, target } = newRepo("restore");
+    const before = readFileSync(target, "utf8");
+    const r = run(dir, [target, "--edit", needleFile("n7", "beta"), needleFile("r7", "BETA")], reportCmd(3, ["a test"]));
+    expect(readFileSync(target, "utf8")).toBe(before);
+    expect(r.stdout).toContain("REDDENED");
+    expect(r.stdout).toContain("a test");
+  });
+
+  it("exit tracks the EXPECTATION, not the verdict — so --keep cannot invert the polarity", () => {
+    // Review's blocker on draft 2: pinning exit to the raw verdict makes SURVIVED (the success case
+    // under --keep) exit non-zero, and REDDENED (a broken kept edit) exit 0.
+    const { dir, target } = newRepo("expect");
+    const n = needleFile("n8", "beta");
+    const rep = needleFile("r8", "BETA");
+    const caught = run(dir, [target, "--edit", n, rep], reportCmd(2, ["red"]));
+    expect(caught.status).toBe(0); // default --expect reddened, and it reddened
+    const survived = run(dir, [target, "--edit", n, rep], reportCmd(2));
+    expect(survived.status).toBe(2); // survived when it should have been caught
+    const wanted = run(dir, [target, "--edit", n, rep, "--expect", "survived"], reportCmd(2));
+    expect(wanted.status).toBe(0);
+  });
+
+  it("--keep leaves the edit applied when green, and REFUSES to keep a red one", () => {
+    const { dir, target } = newRepo("keep");
+    const n = needleFile("n9", "beta");
+    const rep = needleFile("r9", "BETA");
+
+    const red = run(dir, [target, "--edit", n, rep, "--keep"], reportCmd(2, ["red"]));
+    expect(red.status).not.toBe(0);
+    expect(red.stderr).toContain("NOT KEPT");
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n"); // restored, not kept
+
+    const green = run(dir, [target, "--edit", n, rep, "--keep"], reportCmd(2));
+    expect(green.status).toBe(0);
+    expect(readFileSync(target, "utf8")).toContain("BETA"); // kept
+    expect(green.stdout).toContain("kept (target only)");
+  });
+
+  it("--keep-even-if-red keeps it, but says so in capitals", () => {
+    const { dir, target } = newRepo("keepred");
+    const r = run(
+      dir,
+      [target, "--edit", needleFile("n10", "beta"), needleFile("r10", "BETA"), "--keep-even-if-red"],
+      reportCmd(2, ["red"])
+    );
+    expect(readFileSync(target, "utf8")).toContain("BETA");
+    expect(r.stderr).toContain("KEPT FAILING MUTATION");
+  });
+
+  it("reports a target the TEST RUN dirtied instead of silently discarding it", () => {
+    // Under --keep the kept diff would otherwise be mutation-plus-noise; under restore the write would
+    // vanish without a word.
+    const { dir, target } = newRepo("dirtied");
+    const cmd = `printf 'clobbered\\n' > "${target}"; ${reportCmd(1)}`;
+    const r = run(dir, [target, "--edit", needleFile("n11", "beta"), needleFile("r11", "BETA")], cmd);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("TEST DIRTIED TARGET");
+    expect(readFileSync(target, "utf8")).toBe("alpha\nbeta\ngamma\n");
+  });
+});
+
+describe("guard: multi-edit semantics are simultaneous against the original", () => {
+  it("applies several pairs together", () => {
+    const plan = planEdits("one two three", [
+      { label: "#1", needleText: "one", replacementText: "1" },
+      { label: "#2", needleText: "three", replacementText: "3" },
+    ]);
+    expect(plan.mutated).toBe("1 two 3");
+  });
+
+  it("refuses overlapping spans", () => {
+    const plan = planEdits("abcdef", [
+      { label: "#1", needleText: "abcd", replacementText: "X" },
+      { label: "#2", needleText: "cdef", replacementText: "Y" },
+    ]);
+    expect(plan.error).toContain("overlaps");
+  });
+
+  it("refuses a replacement that contains another pair's needle — cascade, not simultaneity", () => {
+    // The ordering hazard both reviewers named: if #1's replacement creates #2's needle, "matches
+    // exactly once" means different things before and after, and the mutation is silently not the one
+    // the operator described.
+    const plan = planEdits("alpha beta", [
+      { label: "#1", needleText: "alpha", replacementText: "beta" },
+      { label: "#2", needleText: "beta", replacementText: "gamma" },
+    ]);
+    expect(plan.error).toContain("cascading");
+  });
+
+  it("--keep defaults the expectation to survived, and --expect overrides it", () => {
+    expect(parseArgs(["f", "--edit", "a", "b"]).opts.expect).toBe("reddened");
+    expect(parseArgs(["f", "--edit", "a", "b", "--keep"]).opts.expect).toBe("survived");
+    expect(parseArgs(["f", "--edit", "a", "b", "--keep", "--expect", "reddened"]).opts.expect).toBe("reddened");
+  });
+});
+
+describe("guard: the flow owns the guard and the skill names the flow", () => {
+  const src = readFileSync(MUTATE, "utf8");
+
+  it("delegates the checkpoint question rather than reimplementing it", () => {
+    // The one property a run cannot show. The behavioural refusal above proves the call is live; this
+    // proves there is no second definition of "is this tree a checkpoint" to drift from the first.
+    expect(src).toContain("mutation-guard.mjs");
+    expect(src).not.toMatch(/status\s+--porcelain[^\n]*\n[^\n]*trackedChanges/);
+  });
+
+  it("owns the reporter, so the test count cannot be scraped from human output", () => {
+    expect(src).toContain("--reporter=json");
+    expect(src).toContain("numTotalTests");
+  });
+
+  it("the skill names this command and no longer narrates the manual sequence", () => {
+    // Three sites, all of which review found: the guard-invocation paragraph, the break/revert/confirm
+    // step, and the failure-modes row that still credited a "process rule". If any survives, the skill
+    // documents two paths and this slice's central claim is false on day one.
+    const skill = readFileSync(path.join(ROOT, ".claude", "skills", "adversarial-build", "SKILL.md"), "utf8");
+    expect(skill).toContain("scripts/mutate.mjs");
+    expect(skill).not.toMatch(/revert, confirm the tree is clean/);
+    expect(skill).not.toMatch(/Lost work during mutation testing \| process rule/);
+  });
+});

--- a/test/guards/mutation-guard.test.ts
+++ b/test/guards/mutation-guard.test.ts
@@ -189,12 +189,20 @@ describe("the script's exit codes — what the loop actually keys on", () => {
 });
 
 describe("guard: the skill actually requires the check", () => {
-  it("names the script in the adversarial-build loop's mutation step", () => {
-    // The field can ship computed-and-unread; so can a script nothing invokes. Pin the wiring.
+  it("requires the FLOW that calls this check, not this check as a step to remember", () => {
+    // MIGRATED BY MUTFLOW-1, deliberately and in the same change that broke it. This used to pin the
+    // literal line "PROVE it — `node scripts/mutation-guard.mjs`" in the skill. That line is gone,
+    // because requiring a check the operator has to remember to call is exactly what failed: the same
+    // operator lost work three times in the session after this guard shipped. The skill now names ONE
+    // command that runs the whole mutation sequence, and that command calls this script.
+    //
+    // So the wiring is pinned one level out — the skill must require `scripts/mutate.mjs`, and
+    // `scripts/mutate.mjs` must invoke this guard. `test/guards/mutation-flow.test.ts` proves the
+    // second link BEHAVIOURALLY (it runs the flow against a dirty scratch repo and asserts refusal),
+    // which is stronger than what this file could assert about a prose step.
     const skill = readFileSync(path.join(ROOT, ".claude", "skills", "adversarial-build", "SKILL.md"), "utf8");
-    // Containment alone would pass on "never run scripts/mutation-guard.mjs" — review's point. Pin the
-    // IMPERATIVE line instead. Nothing can programmatically prove an agent runs a prose step, so this
-    // is the strongest available assertion, and it is stated as that rather than as proof.
-    expect(skill).toMatch(/PROVE it — `node scripts\/mutation-guard\.mjs`/);
+    expect(skill).toMatch(/Mutation-test with ONE command — `node scripts\/mutate\.mjs`/);
+    const flow = readFileSync(path.join(ROOT, "scripts", "mutate.mjs"), "utf8");
+    expect(flow).toContain("mutation-guard.mjs");
   });
 });


### PR DESCRIPTION
## What this fixes

MUTGUARD-1 shipped a check that refuses to mutate a tree with uncommitted tracked changes, and wired
it into the adversarial-build skill. **It did not stop the failure.** In the session after it shipped —
same operator, same skill — there were **three work-loss incidents** from `git checkout -- <file>` and
**two commits whose messages outran their diffs**, one of which a reviewer proved had left a
mutation-masking hole live *inside the commit that says it was fixed*.

The reason: **a mutation is not one command.** It is edit → test → `git checkout` → hopefully check.
The guard covers the first step *if you remember to call it*, and every ad-hoc spelling — a heredoc, a
`sed -i`, an editor keystroke — skips it. The guard replaced a rule you have to remember with a check
that fails, then left the rule standing around it.

`scripts/mutate.mjs` is the whole sequence: refuse unless the tree is a committed checkpoint (by
**calling** the existing guard, so there is one owner of that question), refuse an untracked target,
apply `--edit` pairs simultaneously against the original bytes, run the named tests, restore, verify
the restore, and print a verdict to paste rather than narrate.

## What review changed, which is most of the design

Four cold reads on the spec and two on the diff, **all six BLOCKED**. The pattern is that each fix
created the next hazard:

| found by | defect | fix |
|---|---|---|
| Codex, spec r1 | the flow protects the *experiment*, not the message written from intent afterwards — the incident shape is a mutation that IS the intended change | `--keep` |
| Fable, spec r2 | `--keep` **inverts the exit polarity**: SURVIVED becomes success, so `mutate --keep && git commit` commits a red change at exit 0 | exit tracks `--expect`; `--keep` + RED restores and refuses |
| both, spec r2 | "each needle matches exactly once" is undefined across pairs | needles resolve against the ORIGINAL bytes; overlaps and cross-pair cascades refused |
| both, spec r2 | "refuse if zero tests ran" had no mechanism; scraping output fails *toward* vacuity | vitest JSON reporter, appended last, failing closed |
| **both, code review** | **the tool shipped its own bypass** — an env-substituted test runner let anyone mutate a real file, stub the report, and print a verdict block byte-identical to a real run | runner is a function argument; CLI hard-wires the real one; a guard test asserts no command is read from the environment |
| both, code review | restore was not exception-safe — `mkdtemp` ran after the write; a test that deleted the target threw on re-read | `try/finally`, temp paths and signal handlers before the write, `SIGHUP`, `MUTATION STILL APPLIED` when a restore does not take |
| both, code review | the verdict came only from the nested assertion shape, so aggregate-only failures read as **SURVIVED** — and under `--keep` that keeps a broken edit at exit 0 | verdict from `numFailedTests`, refusing when absent |
| Fable, code review | **nothing pinned that the tests run against the mutant** — "only write the file under `--keep`" passed every other assertion | the injected runner observes the target mid-run |

Two of my own justifications were falsified rather than argued with: the PreToolUse-hook rejection
argued *for* the hook (and this repo already runs that mechanism for Railway), and the
commit-linter cut cited a 3-of-369 measurement whose population **excludes the target class by
construction**. Both now record the real reason.

## Verification

2500 unit · tsc · lint · docs-drift green. Spec SPEC_READY after every amendment.

**Mutation-tested with itself.** Six self-mutations, each reddening its intended test and restoring
cleanly: the zero-tests refusal, `--keep`'s red check, the exit polarity, the cross-pair cascade check,
the fail-closed failure count, and the `finally` restore. Sample output, pasted rather than narrated —
which is the point of the tool:

```
mutate: REDDENED
  red: guard: the flow refuses before it can destroy anything REFUSES a report with no FAILURE count
  red: guard: the verdict, the expectation, and --keep verdictFrom fails closed on a missing count
  tests run: 26
  expected: reddened — met
```

## Deliberately NOT in this slice

- **A PreToolUse hook** blocking the revert verbs. Rejected on real grounds: `git checkout --` is
  legitimate constantly, so a correct hook would re-implement the guard inside a shell matcher and keep
  the two in step. Reasonable later as defense in depth.
- **A commit-message linter.** `--keep` removes the generator, and the review gate is already the
  message-versus-diff check that caught the second incident.
- **A timeout** on the test run. Not implemented, and the spec's claim to the contrary is withdrawn
  rather than left implied — an interrupted run is restored by the signal handlers.
- **`--checkpoint`** (committing for the operator). Writes history they did not choose; `git stash` is
  the middle ground if refusal proves to be the friction.

## Review — Reviewed by Fable code-reviewer + Codex (gpt-5.5) — verdict both BLOCKED on the spec (twice each) and both BLOCKED on the diff; all findings folded

The honest note this PR owes: **the Codex leg was unavailable for part of this work.** Its CLI was
authenticating with a `CODEX_API_KEY` whose org was out of credits rather than with the ChatGPT
session; unsetting it works, and `gpt-5.6` is not offered on a ChatGPT account, so this leg runs on
`gpt-5.5`. Where it could not run earlier in the session, that was said plainly rather than papered
over with a substitute labelled as Codex.

Both reviewers found the shipped-bypass HIGH independently, which is the finding this PR exists to be
embarrassed by: a slice about closing a bypass had opened one, in the exact artifact — the pasted
verdict — that the skill tells you to trust.

AIOS-Work: MUTFLOW-1
