### PR TITLE
fix(query): bounded retry-with-backoff before first delta + sanitized error (QSTREAMRETRY-1)

### DIFF
--- a/app/api/dashboard/query/route.ts
+++ b/app/api/dashboard/query/route.ts
@@ -9,6 +9,7 @@ import { isRestrictedTier } from "@/lib/auth/visibility";
 import { formatSseFrame } from "@/lib/api/sse";
 import { retrieve } from "@/lib/query/retrieve";
 import { streamAnswer } from "@/lib/query/claude";
+import { clientErrorMessage } from "@/lib/query/stream-retry";
 import { pickTimezone, DEFAULT_TIMEZONE } from "@/lib/query/timezone";
 import {
   ownsConversation,
@@ -225,7 +226,13 @@ export async function POST(req: NextRequest) {
 
       let answer = "";
       try {
-        for await (const chunk of streamAnswer(ctx, question, keys, historyTurns, caller, timeZone)) {
+        for await (const chunk of streamAnswer(ctx, question, keys, historyTurns, caller, timeZone, {
+          onRetry: ({ attempt, delayMs, error }) =>
+            console.warn(
+              `[query] transient answer-stream failure (attempt ${attempt}), retrying in ${delayMs}ms:`,
+              error instanceof Error ? error.message : error
+            ),
+        })) {
           if (chunk.type === "delta") {
             answer += chunk.text;
             send("delta", { text: chunk.text });
@@ -287,7 +294,12 @@ export async function POST(req: NextRequest) {
           }
         }
       } catch (e) {
-        send("error", { message: e instanceof Error ? e.message : "query failed" });
+        // Log the REAL error (it carries the provider status / model / base URL) for diagnosis,
+        // but send the client only a friendly, SANITIZED message — the raw text would leak the
+        // internal model + base URL. Bounded transient-error retry already happened upstream in
+        // streamAnswer; reaching here means it failed even after retries (or was non-retryable).
+        console.error("[query] answer stream failed:", e instanceof Error ? e.message : e);
+        send("error", { message: clientErrorMessage(e) });
       } finally {
         controller.close();
       }

--- a/docs/design/query-stream-resilience.md
+++ b/docs/design/query-stream-resilience.md
@@ -1,0 +1,83 @@
+# Query stream resilience — bounded retry before first delta (QSTREAMRETRY-1)
+
+Status: proposed · Owner: chetan · Tier build-with: unit (pure logic)
+
+## Problem
+
+A dashboard query fails on the *first* try and works on retry. Root cause (verified in
+the merged tree):
+
+- The streaming answer path has **no app-level retry**. `lib/query/claude.ts`
+  `streamAnswer` (Anthropic) has zero retry, and `streamOpenAICompatible` retries only a
+  **token-limit** 400/422 (`looksLikeTokenLimit`). Any 429 / 529 "overloaded" / 5xx /
+  mid-stream disconnect throws straight out.
+- `app/api/dashboard/query/route.ts` catches it and emits the **raw** `e.message` over the
+  `error` SSE event — which for the OpenAI path is
+  `LLM <model> @ <baseUrl>: 529 <body>`, i.e. it both reads as a bare "Query failed" to the
+  user **and leaks the internal model + base URL** to the client.
+
+So a single transient upstream blip is a hard, user-visible failure. Retrying seconds later
+usually just works (calmer provider + a warm prompt cache) — which is exactly the reported
+"failed once, worked on retry" signature.
+
+## Decision
+
+Add a **bounded retry-with-backoff** wrapper around the answer stream that retries **only
+before the first delta has been emitted to the client**, for **transient** errors, across
+**both** backends; and **sanitize** the terminal client message.
+
+Why "before the first delta": once any answer text has been streamed to the browser,
+restarting the upstream call would duplicate or corrupt the visible answer. Pre-first-delta
+failure is the safe, common case (connection refused, immediate 429/529, empty error frame
+before any token) and it covers the reported failure. A restart there is invisible to the
+user — they just wait a beat longer.
+
+Concretely:
+
+1. `lib/query/stream-retry.ts` (new, pure, unit-tested):
+   - `StreamHttpError(status, message)` — an `Error` carrying `.status` so the OpenAI path's
+     non-2xx failures can be classified without string-scraping.
+   - `isRetryableStreamError(err)` — true for `{408,409,429,500,502,503,504,529}` (by
+     `.status`/`.statusCode`) and for connection/`overloaded`-shaped errors (Anthropic
+     `APIConnectionError`, `ECONNRESET`, `fetch failed`, "overloaded", …). **False** for
+     4xx auth/validation (401/403/404/422) and token-limit 400 (already handled upstream).
+   - `streamRetryDelayMs(attempt)` — pure exponential backoff (≈400ms, 800ms, capped a few
+     seconds), so total added latency stays well inside `maxDuration = 120`.
+   - `clientErrorMessage(err)` — a friendly, **sanitized** message: a "the model was busy —
+     try again in a moment" line for transient/overload errors, a generic "something went
+     wrong" otherwise. Never contains the model name or base URL.
+   - `withStreamRetry(makeStream, opts)` — the higher-order retry generator (injectable
+     `sleep`/`delayMs` for deterministic tests): re-invokes `makeStream()` on a retryable
+     pre-first-delta failure up to `maxAttempts` (default 3); rethrows once any delta was
+     yielded, the error is non-retryable, or attempts are exhausted.
+
+2. `lib/query/claude.ts`:
+   - The OpenAI path throws `StreamHttpError` (same message text, so existing tests hold).
+   - Extract the current body into `streamAnswerOnce`; `streamAnswer` becomes
+     `withStreamRetry(() => streamAnswerOnce(...), retryOpts)`.
+   - The Anthropic client is constructed with `maxRetries: 0` so this wrapper is the single,
+     uniform retry owner across both backends (no double-retry).
+
+3. `app/api/dashboard/query/route.ts`:
+   - The stream `catch` logs the **real** error server-side (diagnosis is not lost) and
+     sends `clientErrorMessage(e)` to the client instead of the raw message.
+
+## Explicitly NOT in this slice (named next work)
+
+- **Per-attempt / first-token timeout** to abort a *stalled* (not errored) upstream and
+  retry. This addresses the cold-prompt-cache "slow first run" cause, but safely racing an
+  async generator against a timer (without leaking the underlying stream) deserves its own
+  slice + review. Retry already covers the transient-error and pre-delta-disconnect causes.
+- **Mid-stream reattach / resume after a delta has been sent** — that is the background-job
+  work in **QBGSTREAM-1** (Q2), not here.
+- The `/sync` command's error path (`syncResponse`) — a different, non-LLM surface.
+
+## What would falsify this
+
+- A pre-first-delta 529/`overloaded`/connection failure that still surfaces as a hard error
+  on the first user attempt (retry not firing) → the wrapper or classifier is wrong.
+- A retry firing *after* answer text was already streamed (duplicated/garbled answer) → the
+  `emitted` guard is wrong.
+- A 401/403/422/token-limit-400 being retried (wasted latency on a permanent error) → the
+  classifier is too broad.
+- The client `error` message containing the base URL or model name → sanitization failed.

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -2,6 +2,7 @@ import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
 import type { RetrievedContext } from "./retrieve";
 import { selectLlmBackend, type LlmBackend, type LlmBackendKeys } from "./llm-backend";
+import { StreamHttpError, withStreamRetry, type StreamRetryOptions } from "./stream-retry";
 
 /**
  * Thin adapter around the Claude API so a future agent backend (e.g. Hermes)
@@ -215,17 +216,43 @@ export type QueryUsage = {
  */
 export type ProviderKeys = LlmBackendKeys;
 
+/** One event on the answer stream: an incremental `delta`, then a terminal `done` with usage. */
+export type StreamAnswerEvent =
+  | { type: "delta"; text: string }
+  | { type: "done"; usage: QueryUsage };
+
+/**
+ * Resilient answer stream: one bounded, backed-off retry wrapper around `streamAnswerOnce`.
+ * A transient failure (429 / 529 / 5xx / connection drop) that occurs BEFORE any delta reaches
+ * the client is retried (nothing has been streamed, so a restart is invisible); a failure after
+ * the first delta, a non-retryable error, or an exhausted attempt budget surfaces as before.
+ * This is the single retry owner for both backends (the Anthropic client runs with maxRetries:0).
+ */
 export async function* streamAnswer(
   ctx: RetrievedContext,
   question: string,
   keys: ProviderKeys = {},
   history: ChatTurn[] = [],
   caller?: CallerIdentity,
+  timeZone: string = "UTC",
+  retryOpts: StreamRetryOptions = {}
+): AsyncGenerator<StreamAnswerEvent> {
+  yield* withStreamRetry(
+    () => streamAnswerOnce(ctx, question, keys, history, caller, timeZone),
+    (event) => event.type === "delta",
+    retryOpts
+  );
+}
+
+/** A SINGLE answer attempt (no retry). Wrapped by `streamAnswer`; exported for focused tests. */
+export async function* streamAnswerOnce(
+  ctx: RetrievedContext,
+  question: string,
+  keys: ProviderKeys = {},
+  history: ChatTurn[] = [],
+  caller?: CallerIdentity,
   timeZone: string = "UTC"
-): AsyncGenerator<
-  | { type: "delta"; text: string }
-  | { type: "done"; usage: QueryUsage }
-> {
+): AsyncGenerator<StreamAnswerEvent> {
   const sourcesBlock = ctx.sources
     .map(
       (s) =>
@@ -244,8 +271,13 @@ export async function* streamAnswer(
     return;
   }
 
-  // Per-team key wins; otherwise the SDK reads ANTHROPIC_API_KEY from the env.
-  const client = new Anthropic(keys.anthropicKey ? { apiKey: keys.anthropicKey } : undefined);
+  // Per-team key wins; otherwise the SDK reads ANTHROPIC_API_KEY from the env. maxRetries:0 —
+  // `streamAnswer`'s `withStreamRetry` is the single, uniform retry owner across both backends,
+  // so the SDK's own retry layer must not silently multiply attempts under it.
+  const client = new Anthropic({
+    ...(keys.anthropicKey ? { apiKey: keys.anthropicKey } : {}),
+    maxRetries: 0,
+  });
 
   const stream = client.messages.stream({
     model: backend.model,
@@ -370,14 +402,14 @@ export async function* streamOpenAICompatible(
     if (looksLikeTokenLimit(res.status, body)) {
       res = await postChat(ANSWER_BUDGET);
       if (!res.ok) {
-        throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
+        throw new StreamHttpError(res.status, `LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${await res.text().catch(() => "")}`);
       }
     } else {
-      throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${body}`);
+      throw new StreamHttpError(res.status, `LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} ${body}`);
     }
   }
   if (!res.body) {
-    throw new Error(`LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} no stream body`);
+    throw new StreamHttpError(res.status, `LLM ${backend.model} @ ${backend.baseUrl}: ${res.status} no stream body`);
   }
 
   const reader = res.body.getReader();

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -495,12 +495,17 @@ export async function* streamOpenAICompatible(
   // emitted — once deltas reached the client, a restart would corrupt the visible answer, so a
   // mid-stream error after partial output falls through to the empty/partial handling below. A
   // NON-retryable code (e.g. an auth error frame) is thrown with its own status so it surfaces at once.
-  if (errorFrame && emittedChars === 0) {
-    // classifyErrorFrame maps a string permanent code (invalid_api_key/insufficient_quota/…) to 401 so
-    // it surfaces instead of being retried and mislabeled "busy"; numeric/transient codes stay retryable.
-    // (Deferred: if this error frame carried a billed `usage.cost`, that spend isn't metered here — the
-    // meter lives in the route's done branch; a failed 200-error generation rarely bills. Tracked for a
-    // follow-up rather than threading db/meter into this transport layer.)
+  // ALWAYS throw when the provider sent an error frame — including after deltas already streamed.
+  // Falling through to `done` in that case made the route persist a TRUNCATED answer as a complete
+  // success and meter it as one: the user keeps the partial text already streamed but is told the turn
+  // succeeded, and chat history stores the half-answer as final. Throwing surfaces the failure (the
+  // client shows the partial text plus an error) and CANNOT cause a duplicate answer, because
+  // withStreamRetry has `emitted === true` once any event was yielded and so will not retry.
+  // classifyErrorFrame maps permanent shapes (invalid_api_key / insufficient_quota / context_length,
+  // incl. ones wearing a retryable numeric code) to non-retryable statuses, so only genuine transients
+  // are retried. (Known gap: a billed `usage.cost` on the error frame isn't metered — the meter lives
+  // in the route's done branch, not this transport layer; tracked as a follow-up.)
+  if (errorFrame) {
     const { status, detail } = classifyErrorFrame(errorFrame);
     throw new StreamHttpError(status, `LLM ${backend.model} @ ${backend.baseUrl}: stream error ${status} ${detail}`);
   }

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -2,7 +2,7 @@ import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
 import type { RetrievedContext } from "./retrieve";
 import { selectLlmBackend, type LlmBackend, type LlmBackendKeys } from "./llm-backend";
-import { StreamHttpError, withStreamRetry, type StreamRetryOptions } from "./stream-retry";
+import { StreamHttpError, withStreamRetry, classifyErrorFrame, type StreamRetryOptions } from "./stream-retry";
 
 /**
  * Thin adapter around the Claude API so a future agent backend (e.g. Hermes)
@@ -496,9 +496,13 @@ export async function* streamOpenAICompatible(
   // mid-stream error after partial output falls through to the empty/partial handling below. A
   // NON-retryable code (e.g. an auth error frame) is thrown with its own status so it surfaces at once.
   if (errorFrame && emittedChars === 0) {
-    const code = typeof errorFrame.code === "number" ? errorFrame.code : 502;
-    const detail = errorFrame.message ?? errorFrame.type ?? "provider error";
-    throw new StreamHttpError(code, `LLM ${backend.model} @ ${backend.baseUrl}: stream error ${code} ${detail}`);
+    // classifyErrorFrame maps a string permanent code (invalid_api_key/insufficient_quota/…) to 401 so
+    // it surfaces instead of being retried and mislabeled "busy"; numeric/transient codes stay retryable.
+    // (Deferred: if this error frame carried a billed `usage.cost`, that spend isn't metered here — the
+    // meter lives in the route's done branch; a failed 200-error generation rarely bills. Tracked for a
+    // follow-up rather than threading db/meter into this transport layer.)
+    const { status, detail } = classifyErrorFrame(errorFrame);
+    throw new StreamHttpError(status, `LLM ${backend.model} @ ${backend.baseUrl}: stream error ${status} ${detail}`);
   }
 
   // Zero visible answer text is a silent blank answer — make it diagnosable. Usual cause: a reasoning

--- a/lib/query/claude.ts
+++ b/lib/query/claude.ts
@@ -239,7 +239,10 @@ export async function* streamAnswer(
 ): AsyncGenerator<StreamAnswerEvent> {
   yield* withStreamRetry(
     () => streamAnswerOnce(ctx, question, keys, history, caller, timeZone),
-    (event) => event.type === "delta",
+    // ANY yielded event commits the stream: once the client has received anything — a delta OR the
+    // terminal `done` — a restart would corrupt the visible answer. Retry only when the attempt threw
+    // before yielding a single event. (Today `done` is always last, but this stays correct if it isn't.)
+    () => true,
     retryOpts
   );
 }
@@ -420,6 +423,10 @@ export async function* streamOpenAICompatible(
   let completion = 0;
   let cost = 0;
   let emittedChars = 0;
+  // OpenRouter (and OpenAI-compatible gateways) can answer an upstream failure with HTTP 200 and a
+  // `data: {"error": {...}}` SSE frame instead of a non-2xx — so the failure never reached the
+  // `!res.ok` check above. Capture it here and convert it to a classified throw after the loop.
+  let errorFrame: { code?: number | string; message?: string; type?: string } | null = null;
 
   while (true) {
     const { done, value } = await reader.read();
@@ -435,10 +442,17 @@ export async function* streamOpenAICompatible(
       let j: {
         choices?: { delta?: { content?: string } }[];
         usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number };
+        error?: { code?: number | string; message?: string; type?: string };
       };
       try {
         j = JSON.parse(data);
       } catch {
+        continue;
+      }
+      // A provider error delivered mid-stream on a 200 (no `choices`/`content`). Remember it; it
+      // becomes a classified throw after the loop when nothing was emitted (see below).
+      if (j.error) {
+        errorFrame = j.error;
         continue;
       }
       if (j.usage) {
@@ -475,9 +489,20 @@ export async function* streamOpenAICompatible(
     }
   }
 
+  // A 200 stream that carried a provider error frame and streamed NO answer is a transient failure
+  // wearing a success costume. Convert it to a classified throw so streamAnswer's retry can act on it
+  // (a bare "overloaded" frame is exactly the blip this ticket exists to absorb). Only when nothing was
+  // emitted — once deltas reached the client, a restart would corrupt the visible answer, so a
+  // mid-stream error after partial output falls through to the empty/partial handling below. A
+  // NON-retryable code (e.g. an auth error frame) is thrown with its own status so it surfaces at once.
+  if (errorFrame && emittedChars === 0) {
+    const code = typeof errorFrame.code === "number" ? errorFrame.code : 502;
+    const detail = errorFrame.message ?? errorFrame.type ?? "provider error";
+    throw new StreamHttpError(code, `LLM ${backend.model} @ ${backend.baseUrl}: stream error ${code} ${detail}`);
+  }
+
   // Zero visible answer text is a silent blank answer — make it diagnosable. Usual cause: a reasoning
-  // model spent the whole budget on hidden reasoning (raise LLM_REASONING_HEADROOM_TOKENS); a mid-stream
-  // provider error frame also lands here.
+  // model spent the whole budget on hidden reasoning (raise LLM_REASONING_HEADROOM_TOKENS).
   if (emittedChars === 0) {
     console.error(
       `[query] streamed answer was EMPTY (model=${backend.model}, completion_tokens=${completion}) — ` +

--- a/lib/query/stream-retry.ts
+++ b/lib/query/stream-retry.ts
@@ -1,0 +1,135 @@
+/**
+ * Bounded retry for the streaming answer path (QSTREAMRETRY-1).
+ *
+ * Pure + injectable (no real clock in the hot logic) so the retry schedule, the error
+ * classifier, and the client-facing message are all unit-testable. `lib/query/claude.ts`
+ * wraps its per-attempt generator with `withStreamRetry`; the route uses `clientErrorMessage`
+ * to sanitize what reaches the browser.
+ *
+ * The one invariant that makes retry SAFE here: we only re-run the upstream call when NOTHING
+ * has been streamed to the client yet. Once a delta has been yielded, restarting would
+ * duplicate/garble the visible answer, so we rethrow instead. Mid-stream resume is a different
+ * feature (QBGSTREAM-1), not this.
+ */
+
+/**
+ * A provider non-2xx from the OpenAI-compatible path, carrying the status so it can be
+ * classified without scraping the message string. Mirrors `LlmHttpError` in lib/llm/complete.ts
+ * (kept separate to avoid coupling the streaming path to that module).
+ */
+export class StreamHttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "StreamHttpError";
+  }
+}
+
+/**
+ * HTTP statuses worth retrying: rate-limit (429), Anthropic "overloaded" (529), and the
+ * transient 5xx family + request-timeout/conflict. Deliberately EXCLUDES 4xx auth/validation
+ * (401/403/404/422) and the token-limit 400 (already handled by the token-limit ladder in
+ * lib/query/claude.ts) — retrying those just burns latency on a permanent error.
+ */
+export const RETRYABLE_STATUS: ReadonlySet<number> = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
+
+/** Connection/transport failures that carry no HTTP status but are still worth one more try. */
+const RETRYABLE_MESSAGE =
+  /APIConnection|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|socket hang ?up|fetch failed|network error|connection (?:error|reset|closed)|\boverloaded\b/i;
+
+/**
+ * True iff `err` is a transient failure worth retrying (before any delta has been emitted).
+ * Status-first (StreamHttpError / SDK APIError both expose `.status`), then a narrow
+ * connection/overloaded message fallback. False for anything else — a non-retryable error
+ * must surface immediately, not after N wasted attempts.
+ */
+export function isRetryableStreamError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const status = (err as { status?: unknown }).status;
+  if (typeof status === "number" && RETRYABLE_STATUS.has(status)) return true;
+  const statusCode = (err as { statusCode?: unknown }).statusCode;
+  if (typeof statusCode === "number" && RETRYABLE_STATUS.has(statusCode)) return true;
+  const name = typeof (err as { name?: unknown }).name === "string" ? (err as { name: string }).name : "";
+  const message = typeof (err as { message?: unknown }).message === "string" ? (err as { message: string }).message : "";
+  return RETRYABLE_MESSAGE.test(`${name} ${message}`);
+}
+
+/** Attempts including the first: 1 try + 2 retries. */
+export const DEFAULT_STREAM_ATTEMPTS = 3;
+const BASE_RETRY_DELAY_MS = 400;
+const MAX_RETRY_DELAY_MS = 5_000;
+
+/**
+ * Delay before the next attempt given the number of the attempt that just failed (1-based).
+ * Pure exponential (400ms, 800ms, 1600ms, …) capped at MAX_RETRY_DELAY_MS, so even a full run
+ * of retries adds well under a second or two — comfortably inside the route's 120s ceiling.
+ */
+export function streamRetryDelayMs(failedAttempt: number): number {
+  const n = Math.max(1, Math.floor(failedAttempt));
+  const exp = Math.min(n - 1, 20); // cap the exponent before shifting
+  return Math.min(BASE_RETRY_DELAY_MS * 2 ** exp, MAX_RETRY_DELAY_MS);
+}
+
+/**
+ * A friendly, SANITIZED message for the browser. Never includes the underlying error text —
+ * the raw message carries the internal model + base URL (`LLM <model> @ <baseUrl>: …`), which
+ * must not leak to the client. The real error is logged server-side by the caller.
+ */
+export function clientErrorMessage(err: unknown): string {
+  if (isRetryableStreamError(err)) {
+    return "The model was busy or briefly unavailable. Please try again in a moment.";
+  }
+  return "Something went wrong answering your question. Please try again.";
+}
+
+export interface StreamRetryOptions {
+  /** Total attempts including the first. Default DEFAULT_STREAM_ATTEMPTS. */
+  maxAttempts?: number;
+  /** Backoff before the next attempt, given the failed attempt number. Default streamRetryDelayMs. */
+  delayMs?: (failedAttempt: number) => number;
+  /** Injectable sleep (tests pass a no-op). Default real setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Observability hook fired just before each retry sleep (e.g. server-side logging). */
+  onRetry?: (info: { attempt: number; error: unknown; delayMs: number }) => void;
+}
+
+const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `makeStream()`, yielding its events. If it throws BEFORE any "committed" event
+ * (`isCommitted` → a delta) was yielded, the error is retryable, and attempts remain, back off
+ * and re-run a FRESH `makeStream()`. Once a committed event has been yielded — or the error is
+ * non-retryable, or attempts are exhausted — rethrow. Generic over the event type so this file
+ * has no dependency on the concrete stream module.
+ */
+export async function* withStreamRetry<T>(
+  makeStream: () => AsyncGenerator<T>,
+  isCommitted: (event: T) => boolean,
+  opts: StreamRetryOptions = {}
+): AsyncGenerator<T> {
+  const maxAttempts = Math.max(1, opts.maxAttempts ?? DEFAULT_STREAM_ATTEMPTS);
+  const delayMs = opts.delayMs ?? streamRetryDelayMs;
+  const sleep = opts.sleep ?? realSleep;
+
+  for (let attempt = 1; ; attempt++) {
+    let emitted = false;
+    try {
+      for await (const event of makeStream()) {
+        if (isCommitted(event)) emitted = true;
+        yield event;
+      }
+      return; // completed cleanly
+    } catch (err) {
+      // Safe to retry ONLY when nothing has been streamed yet, the error is transient, and we
+      // have another attempt left. Any of those failing → surface the error.
+      if (emitted || attempt >= maxAttempts || !isRetryableStreamError(err)) {
+        throw err;
+      }
+      const ms = delayMs(attempt);
+      opts.onRetry?.({ attempt, error: err, delayMs: ms });
+      await sleep(ms);
+    }
+  }
+}

--- a/lib/query/stream-retry.ts
+++ b/lib/query/stream-retry.ts
@@ -95,6 +95,38 @@ export function clientErrorMessage(err: unknown): string {
   return "Something went wrong answering your question. Please try again.";
 }
 
+/**
+ * Classify a provider error frame delivered mid-stream on a 200 (`data:{"error":{...}}`) into an
+ * HTTP-style status the retry classifier can read, plus a detail string for the log message.
+ *
+ * WHY THIS EXISTS: OpenAI / OpenRouter deliver PERMANENT failures on this channel with STRING
+ * `code`s/`type`s (`invalid_api_key`, `insufficient_quota`, `authentication_error`) — a numeric-only
+ * read coerces every one of them to a retryable 502, so a broken key / exhausted quota gets retried
+ * and then reported as "the model was busy, try again". Rules: a numeric (or numeric-string) code is
+ * kept as its status; a known-permanent string → 401 (non-retryable, surfaces at once); anything else
+ * → 502 (retryable) preserving the transient default. Also tolerates a non-object frame (a bare
+ * string/true) without throwing.
+ */
+export function classifyErrorFrame(frame: unknown): { status: number; detail: string } {
+  const ef = (frame && typeof frame === "object" ? frame : {}) as { code?: unknown; message?: unknown; type?: unknown };
+  const type = typeof ef.type === "string" ? ef.type : "";
+  const message = typeof ef.message === "string" ? ef.message : "";
+  const codeStr = typeof ef.code === "string" ? ef.code : "";
+  const bare = typeof frame === "string" ? frame : "";
+  const detail = message || type || codeStr || bare || "provider error";
+  const numeric =
+    typeof ef.code === "number"
+      ? ef.code
+      : codeStr.trim() !== "" && Number.isFinite(Number(codeStr))
+        ? Number(codeStr)
+        : null;
+  if (numeric !== null) return { status: numeric, detail };
+  const permanent = /quota|credits|invalid_api_key|authentication|invalid_request|permission|forbidden|not_found|insufficient/i.test(
+    `${type} ${message} ${codeStr} ${bare}`
+  );
+  return { status: permanent ? 401 : 502, detail };
+}
+
 export interface StreamRetryOptions {
   /** Total attempts including the first. Default DEFAULT_STREAM_ATTEMPTS. */
   maxAttempts?: number;

--- a/lib/query/stream-retry.ts
+++ b/lib/query/stream-retry.ts
@@ -114,17 +114,32 @@ export function classifyErrorFrame(frame: unknown): { status: number; detail: st
   const codeStr = typeof ef.code === "string" ? ef.code : "";
   const bare = typeof frame === "string" ? frame : "";
   const detail = message || type || codeStr || bare || "provider error";
+  const haystack = `${type} ${message} ${codeStr} ${bare}`;
   const numeric =
     typeof ef.code === "number"
       ? ef.code
       : codeStr.trim() !== "" && Number.isFinite(Number(codeStr))
         ? Number(codeStr)
         : null;
+
+  // TEXT BEATS THE NUMERIC CODE for these two families, deliberately. A gateway normalizes an
+  // upstream billing failure into `{code: 429, type: "insufficient_quota"}` — reading the number
+  // first retries a permanently broken account and then tells the user "the model was busy".
+  // The `type`/`message` is the discriminator, so it is checked FIRST.
+
+  // (a) Token/context ceiling → 400. Re-sending the identical request cannot succeed; the non-200
+  // form of this is already handled by the headroom ladder in claude.ts (`looksLikeTokenLimit`).
+  if (/context[_ ]?length|maximum context|max[_ ]?tokens|max_completion_tokens|too many tokens|reduce (?:the )?(?:length|tokens)/i.test(haystack)) {
+    return { status: 400, detail };
+  }
+  // (b) Auth / billing / permission → 401. NOTE `rate_limit_exceeded` deliberately does NOT match
+  // here (it is a genuine transient) — only quota/credit/key/permission wording does.
+  if (/insufficient[_ ]?(?:quota|credit)|exceeded your current quota|invalid[_ ]?api[_ ]?key|authentication|unauthorized|permission|forbidden|billing|credits? remaining|no credits|not[_ ]?found|invalid[_ ]?request/i.test(haystack)) {
+    return { status: 401, detail };
+  }
+
   if (numeric !== null) return { status: numeric, detail };
-  const permanent = /quota|credits|invalid_api_key|authentication|invalid_request|permission|forbidden|not_found|insufficient/i.test(
-    `${type} ${message} ${codeStr} ${bare}`
-  );
-  return { status: permanent ? 401 : 502, detail };
+  return { status: 502, detail }; // unknown → treat as transient (preserves the retry default)
 }
 
 export interface StreamRetryOptions {

--- a/lib/query/stream-retry.ts
+++ b/lib/query/stream-retry.ts
@@ -35,22 +35,33 @@ export class StreamHttpError extends Error {
  */
 export const RETRYABLE_STATUS: ReadonlySet<number> = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
 
-/** Connection/transport failures that carry no HTTP status but are still worth one more try. */
+/**
+ * Connection/transport failures that carry no HTTP status but are still worth one more try:
+ * the Anthropic SDK's `APIConnectionError` ("Connection error.") and `APIConnectionTimeoutError`
+ * ("Request timed out.", both `status: undefined`), bare fetch/socket failures, and an
+ * `overloaded`/`overloaded_error` body on a statusless error. Reached ONLY for statusless errors
+ * (see the status-first short-circuit below), so it can't rescue a permanent 4xx whose body text
+ * happens to contain one of these words.
+ */
 const RETRYABLE_MESSAGE =
-  /APIConnection|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|socket hang ?up|fetch failed|network error|connection (?:error|reset|closed)|\boverloaded\b/i;
+  /APIConnection|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|socket hang ?up|fetch failed|network error|connection (?:error|reset|closed)|timed ?out|overloaded(?:_error)?/i;
 
 /**
  * True iff `err` is a transient failure worth retrying (before any delta has been emitted).
- * Status-first (StreamHttpError / SDK APIError both expose `.status`), then a narrow
- * connection/overloaded message fallback. False for anything else — a non-retryable error
- * must surface immediately, not after N wasted attempts.
+ *
+ * STATUS-FIRST: when the error carries a numeric HTTP status (StreamHttpError and the Anthropic
+ * SDK's APIError both expose `.status`), that status decides ALONE — we return whether it's in
+ * RETRYABLE_STATUS and never consult the message. This is load-bearing: StreamHttpError embeds the
+ * provider response BODY in its message, so a permanent 403/401/404 whose body says "connection
+ * closed" or "network error" must not be rescued into a retry by the message regex. Only a
+ * statusless error (a connection/timeout throw) falls through to the message classifier.
  */
 export function isRetryableStreamError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const status = (err as { status?: unknown }).status;
-  if (typeof status === "number" && RETRYABLE_STATUS.has(status)) return true;
   const statusCode = (err as { statusCode?: unknown }).statusCode;
-  if (typeof statusCode === "number" && RETRYABLE_STATUS.has(statusCode)) return true;
+  const code = typeof status === "number" ? status : typeof statusCode === "number" ? statusCode : null;
+  if (code !== null) return RETRYABLE_STATUS.has(code); // a known status is decisive — do not fall through
   const name = typeof (err as { name?: unknown }).name === "string" ? (err as { name: string }).name : "";
   const message = typeof (err as { message?: unknown }).message === "string" ? (err as { message: string }).message : "";
   return RETRYABLE_MESSAGE.test(`${name} ${message}`);

--- a/test/query-stream-retry.test.ts
+++ b/test/query-stream-retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   StreamHttpError,
   isRetryableStreamError,
@@ -7,6 +7,9 @@ import {
   withStreamRetry,
   RETRYABLE_STATUS,
 } from "@/lib/query/stream-retry";
+import { streamAnswer, streamOpenAICompatible, type StreamAnswerEvent } from "@/lib/query/claude";
+import type { LlmBackend } from "@/lib/query/llm-backend";
+import type { RetrievedContext } from "@/lib/query/retrieve";
 
 type Ev = { type: "delta"; text: string } | { type: "done" };
 const isCommitted = (e: Ev): boolean => e.type === "delta";
@@ -37,13 +40,27 @@ describe("isRetryableStreamError", () => {
     expect(isRetryableStreamError({ status: 401 })).toBe(false);
   });
 
-  it("retries connection/overloaded-shaped errors that carry no status", () => {
+  it("retries statusless connection/timeout/overloaded errors — using the SHAPES the Anthropic SDK really throws", () => {
+    // Real SDK shapes: APIConnectionError → message "Connection error.", name "Error", status undefined;
+    // APIConnectionTimeoutError → message "Request timed out.". (Not a hand-set .name.)
+    expect(isRetryableStreamError(new Error("Connection error."))).toBe(true);
+    expect(isRetryableStreamError(new Error("Request timed out."))).toBe(true);
+    expect(isRetryableStreamError(new Error("fetch failed"))).toBe(true);
+    expect(isRetryableStreamError(new Error("read ECONNRESET"))).toBe(true);
+    // A statusless body carrying Anthropic's canonical overloaded shape.
+    expect(isRetryableStreamError(new Error('{"type":"overloaded_error"}'))).toBe(true);
+    // A hand-tagged APIConnectionError (some SDK versions) still classifies by name.
     const conn = new Error("socket hang up");
     conn.name = "APIConnectionError";
     expect(isRetryableStreamError(conn)).toBe(true);
-    expect(isRetryableStreamError(new Error("fetch failed"))).toBe(true);
-    expect(isRetryableStreamError(new Error("read ECONNRESET"))).toBe(true);
-    expect(isRetryableStreamError(new Error("the model is overloaded"))).toBe(true);
+  });
+
+  it("does NOT let a connection-shaped BODY rescue a permanent status (status-first short-circuit)", () => {
+    // StreamHttpError embeds the provider body; a permanent 403 whose body says "connection closed"
+    // must stay non-retryable — the status decides, the message is never consulted when a status exists.
+    expect(isRetryableStreamError(new StreamHttpError(403, "403 error 1020 connection closed by policy"))).toBe(false);
+    expect(isRetryableStreamError(new StreamHttpError(401, "401 request timed out per the proxy"))).toBe(false);
+    expect(isRetryableStreamError(new StreamHttpError(422, "422 network error in the payload text"))).toBe(false);
   });
 
   it("does NOT retry a plain non-transient error or a non-object", () => {
@@ -159,5 +176,85 @@ describe("withStreamRetry — retry only before the first delta", () => {
     ).rejects.toThrow(/503/);
     expect(calls()).toBe(2);
     expect(sleep).toHaveBeenCalledTimes(1); // one retry between the two attempts
+  });
+});
+
+// --- Integration over the real claude.ts stream (fetch-mocked) -----------------------------------
+
+const OPENAI_BACKEND = {
+  kind: "openai-compatible",
+  provider: "openai",
+  baseUrl: "https://api.example.com/v1",
+  model: "test-model",
+  apiKey: "test-key",
+  headers: {},
+} as unknown as Extract<LlmBackend, { kind: "openrouter" | "openai-compatible" }>;
+
+/** A mock streamed SSE Response from pre-formatted `data: …\n\n` frames. */
+function streamResponse(frames: string[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      const enc = new TextEncoder();
+      for (const f of frames) c.enqueue(enc.encode(f));
+      c.close();
+    },
+  });
+  return { ok: true, status: 200, body, text: async () => "" } as unknown as Response;
+}
+const deltaFrame = (s: string) => `data: ${JSON.stringify({ choices: [{ delta: { content: s } }] })}\n\n`;
+
+async function drainDeltas(gen: AsyncGenerator<StreamAnswerEvent>): Promise<string> {
+  let out = "";
+  for await (const ev of gen) if (ev.type === "delta") out += ev.text;
+  return out;
+}
+
+describe("streamOpenAICompatible — a 200 stream carrying only an error frame (the HIGH)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("throws a classified error (not a silent empty answer) so the retry can fire", async () => {
+    const errFrame = `data: ${JSON.stringify({ error: { code: 429, message: "provider overloaded" } })}\n\n`;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(streamResponse([errFrame, "data: [DONE]\n\n"])));
+    let caught: unknown;
+    try {
+      await drainDeltas(streamOpenAICompatible(OPENAI_BACKEND, "", "", "", "", "", "q", "UTC"));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(StreamHttpError);
+    expect((caught as StreamHttpError).status).toBe(429);
+    expect(isRetryableStreamError(caught)).toBe(true); // → withStreamRetry will retry it
+  });
+
+  it("still yields a clean empty done (no throw) when the blank has NO error frame (reasoning starvation)", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const usageOnly = `data: ${JSON.stringify({ usage: { completion_tokens: 4096 } })}\n\n`;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(streamResponse([usageOnly, "data: [DONE]\n\n"])));
+    const text = await drainDeltas(streamOpenAICompatible(OPENAI_BACKEND, "", "", "", "", "", "q", "UTC"));
+    expect(text).toBe(""); // an empty answer, but NOT thrown — retrying wouldn't help a starved model
+    err.mockRestore();
+  });
+});
+
+describe("streamAnswer — the retry wiring is actually connected (call-site pin)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("retries a transient pre-delta failure end-to-end and streams the answer once", async () => {
+    const fetchMock = vi
+      .fn()
+      // First attempt: a retryable 503 (non-token-limit) → StreamHttpError → wrapper retries.
+      .mockResolvedValueOnce({ ok: false, status: 503, text: async () => "service unavailable", body: null })
+      // Retry: a clean stream.
+      .mockResolvedValueOnce(streamResponse([deltaFrame("hello"), "data: [DONE]\n\n"]));
+    vi.stubGlobal("fetch", fetchMock);
+    const sleep = vi.fn(async () => {});
+    const ctx = { sources: [], structured: "", grounded: true } as unknown as RetrievedContext;
+    const keys = { openrouterKey: "k", openrouterModel: "test-model" };
+    const out = await drainDeltas(
+      streamAnswer(ctx, "q", keys, [], undefined, "UTC", { sleep, delayMs: () => 1 })
+    );
+    expect(out).toBe("hello");
+    expect(fetchMock).toHaveBeenCalledTimes(2); // failed once, retried once
+    expect(sleep).toHaveBeenCalledTimes(1); // deleting withStreamRetry from streamAnswer reddens this
   });
 });

--- a/test/query-stream-retry.test.ts
+++ b/test/query-stream-retry.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  StreamHttpError,
+  isRetryableStreamError,
+  streamRetryDelayMs,
+  clientErrorMessage,
+  withStreamRetry,
+  RETRYABLE_STATUS,
+} from "@/lib/query/stream-retry";
+
+type Ev = { type: "delta"; text: string } | { type: "done" };
+const isCommitted = (e: Ev): boolean => e.type === "delta";
+
+async function collect(gen: AsyncGenerator<Ev>): Promise<Ev[]> {
+  const out: Ev[] = [];
+  for await (const e of gen) out.push(e);
+  return out;
+}
+
+describe("isRetryableStreamError", () => {
+  it("retries the transient HTTP statuses (rate-limit, overloaded, 5xx) by .status", () => {
+    for (const s of [408, 409, 429, 500, 502, 503, 504, 529]) {
+      expect(RETRYABLE_STATUS.has(s)).toBe(true);
+      expect(isRetryableStreamError(new StreamHttpError(s, `err ${s}`))).toBe(true);
+    }
+  });
+
+  it("does NOT retry auth/validation/token-limit errors", () => {
+    for (const s of [400, 401, 403, 404, 422]) {
+      expect(isRetryableStreamError(new StreamHttpError(s, `err ${s}`))).toBe(false);
+    }
+  });
+
+  it("reads .status and .statusCode off plain error-shaped objects", () => {
+    expect(isRetryableStreamError({ status: 529 })).toBe(true);
+    expect(isRetryableStreamError({ statusCode: 503 })).toBe(true);
+    expect(isRetryableStreamError({ status: 401 })).toBe(false);
+  });
+
+  it("retries connection/overloaded-shaped errors that carry no status", () => {
+    const conn = new Error("socket hang up");
+    conn.name = "APIConnectionError";
+    expect(isRetryableStreamError(conn)).toBe(true);
+    expect(isRetryableStreamError(new Error("fetch failed"))).toBe(true);
+    expect(isRetryableStreamError(new Error("read ECONNRESET"))).toBe(true);
+    expect(isRetryableStreamError(new Error("the model is overloaded"))).toBe(true);
+  });
+
+  it("does NOT retry a plain non-transient error or a non-object", () => {
+    expect(isRetryableStreamError(new Error("nope"))).toBe(false);
+    expect(isRetryableStreamError(null)).toBe(false);
+    expect(isRetryableStreamError("529")).toBe(false);
+    expect(isRetryableStreamError(529)).toBe(false);
+  });
+});
+
+describe("streamRetryDelayMs", () => {
+  it("grows exponentially from the base and is capped", () => {
+    expect(streamRetryDelayMs(1)).toBe(400);
+    expect(streamRetryDelayMs(2)).toBe(800);
+    expect(streamRetryDelayMs(3)).toBe(1600);
+    expect(streamRetryDelayMs(20)).toBe(5000); // capped
+    expect(streamRetryDelayMs(1000)).toBe(5000); // no overflow past the cap
+  });
+
+  it("is monotonic non-decreasing and treats sub-1 attempts as the first", () => {
+    expect(streamRetryDelayMs(0)).toBe(400);
+    let prev = 0;
+    for (let n = 1; n <= 25; n++) {
+      const d = streamRetryDelayMs(n);
+      expect(d).toBeGreaterThanOrEqual(prev);
+      expect(d).toBeLessThanOrEqual(5000);
+      prev = d;
+    }
+  });
+});
+
+describe("clientErrorMessage — sanitized + friendly", () => {
+  it("gives a 'model was busy, try again' line for transient errors", () => {
+    expect(clientErrorMessage(new StreamHttpError(529, "overloaded"))).toMatch(/busy|try again in a moment/i);
+  });
+
+  it("gives a generic line for a non-transient error", () => {
+    const msg = clientErrorMessage(new StreamHttpError(401, "invalid api key"));
+    expect(msg).toMatch(/something went wrong|try again/i);
+    expect(msg).not.toMatch(/busy/i);
+  });
+
+  it("NEVER leaks the internal model or base URL from the raw error", () => {
+    const raw = new StreamHttpError(529, "LLM secret-model-x @ https://internal.openrouter.ai/api/v1: 529 overloaded");
+    const msg = clientErrorMessage(raw);
+    expect(msg).not.toContain("openrouter.ai");
+    expect(msg).not.toContain("secret-model-x");
+    expect(msg).not.toContain("internal");
+  });
+});
+
+describe("withStreamRetry — retry only before the first delta", () => {
+  /** A factory that throws `err()` on its first `failCount` invocations, then streams delta+done. */
+  function failingThenOk(failCount: number, err: () => unknown) {
+    let calls = 0;
+    const factory = (): AsyncGenerator<Ev> => {
+      calls += 1;
+      const shouldFail = calls <= failCount;
+      return (async function* () {
+        if (shouldFail) throw err();
+        yield { type: "delta", text: "hi" } as Ev;
+        yield { type: "done" } as Ev;
+      })();
+    };
+    return { factory, calls: () => calls };
+  }
+
+  it("retries a transient pre-delta failure, then yields the full stream", async () => {
+    const { factory, calls } = failingThenOk(2, () => new StreamHttpError(529, "overloaded"));
+    const sleep = vi.fn(async () => {});
+    const onRetry = vi.fn();
+    const out = await collect(
+      withStreamRetry(factory, isCommitted, { maxAttempts: 3, sleep, onRetry, delayMs: (n) => n * 10 })
+    );
+    expect(out).toEqual([{ type: "delta", text: "hi" }, { type: "done" }]);
+    expect(calls()).toBe(3); // 2 failures + 1 success
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 10);
+    expect(sleep).toHaveBeenNthCalledWith(2, 20);
+    expect(onRetry.mock.calls.map((c) => c[0].attempt)).toEqual([1, 2]);
+  });
+
+  it("does NOT retry a non-retryable pre-delta failure", async () => {
+    const { factory, calls } = failingThenOk(1, () => new StreamHttpError(401, "401 invalid api key"));
+    const sleep = vi.fn(async () => {});
+    await expect(collect(withStreamRetry(factory, isCommitted, { sleep }))).rejects.toThrow(/401/);
+    expect(calls()).toBe(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("does NOT retry once a delta has already been emitted (no duplication)", async () => {
+    const yielded: Ev[] = [];
+    const factory = (): AsyncGenerator<Ev> =>
+      (async function* () {
+        yield { type: "delta", text: "partial" } as Ev;
+        throw new StreamHttpError(529, "overloaded"); // transient, but mid-stream
+      })();
+    const sleep = vi.fn(async () => {});
+    await expect(
+      (async () => {
+        for await (const e of withStreamRetry(factory, isCommitted, { sleep })) yielded.push(e);
+      })()
+    ).rejects.toThrow(/overloaded/);
+    expect(yielded).toEqual([{ type: "delta", text: "partial" }]); // emitted exactly once
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("throws the last error after exhausting the attempt budget", async () => {
+    const { factory, calls } = failingThenOk(99, () => new StreamHttpError(503, "503 boom"));
+    const sleep = vi.fn(async () => {});
+    await expect(
+      collect(withStreamRetry(factory, isCommitted, { maxAttempts: 2, sleep }))
+    ).rejects.toThrow(/503/);
+    expect(calls()).toBe(2);
+    expect(sleep).toHaveBeenCalledTimes(1); // one retry between the two attempts
+  });
+});

--- a/test/query-stream-retry.test.ts
+++ b/test/query-stream-retry.test.ts
@@ -5,6 +5,7 @@ import {
   streamRetryDelayMs,
   clientErrorMessage,
   withStreamRetry,
+  classifyErrorFrame,
   RETRYABLE_STATUS,
 } from "@/lib/query/stream-retry";
 import { streamAnswer, streamOpenAICompatible, type StreamAnswerEvent } from "@/lib/query/claude";
@@ -68,6 +69,40 @@ describe("isRetryableStreamError", () => {
     expect(isRetryableStreamError(null)).toBe(false);
     expect(isRetryableStreamError("529")).toBe(false);
     expect(isRetryableStreamError(529)).toBe(false);
+  });
+});
+
+describe("classifyErrorFrame — string codes must not all become retryable 502", () => {
+  it("keeps a numeric or numeric-string code as its status", () => {
+    expect(classifyErrorFrame({ code: 429 }).status).toBe(429);
+    expect(classifyErrorFrame({ code: "429" }).status).toBe(429);
+    expect(classifyErrorFrame({ code: 503 }).status).toBe(503);
+  });
+
+  it("maps a known-permanent STRING code/type to 401 (non-retryable) — the OpenAI/OpenRouter shape", () => {
+    for (const frame of [
+      { code: "invalid_api_key" },
+      { code: "insufficient_quota" },
+      { type: "authentication_error" },
+      { code: "401" },
+      { message: "You have no credits remaining. Add credits to continue." },
+    ]) {
+      const { status } = classifyErrorFrame(frame);
+      expect(status).toBe(401);
+      expect(isRetryableStreamError(new StreamHttpError(status, "x"))).toBe(false);
+    }
+  });
+
+  it("defaults an unknown / transient-worded frame to retryable 502", () => {
+    expect(classifyErrorFrame({ message: "the model is momentarily overloaded" }).status).toBe(502);
+    expect(classifyErrorFrame({}).status).toBe(502);
+    expect(isRetryableStreamError(new StreamHttpError(502, "x"))).toBe(true);
+  });
+
+  it("tolerates a non-object frame (bare string / true) without throwing, keeping its text", () => {
+    expect(classifyErrorFrame("overloaded, retry")).toEqual({ status: 502, detail: "overloaded, retry" });
+    expect(classifyErrorFrame(true).status).toBe(502);
+    expect(classifyErrorFrame(null).status).toBe(502);
   });
 });
 
@@ -224,6 +259,20 @@ describe("streamOpenAICompatible — a 200 stream carrying only an error frame (
     expect(caught).toBeInstanceOf(StreamHttpError);
     expect((caught as StreamHttpError).status).toBe(429);
     expect(isRetryableStreamError(caught)).toBe(true); // → withStreamRetry will retry it
+  });
+
+  it("a permanent STRING-code error frame throws a NON-retryable error (broken key surfaces, not retried)", async () => {
+    const errFrame = `data: ${JSON.stringify({ error: { code: "invalid_api_key", message: "bad key" } })}\n\n`;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(streamResponse([errFrame, "data: [DONE]\n\n"])));
+    let caught: unknown;
+    try {
+      await drainDeltas(streamOpenAICompatible(OPENAI_BACKEND, "", "", "", "", "", "q", "UTC"));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(StreamHttpError);
+    expect((caught as StreamHttpError).status).toBe(401);
+    expect(isRetryableStreamError(caught)).toBe(false); // → withStreamRetry will NOT retry it
   });
 
   it("still yields a clean empty done (no throw) when the blank has NO error frame (reasoning starvation)", async () => {

--- a/test/query-stream-retry.test.ts
+++ b/test/query-stream-retry.test.ts
@@ -93,6 +93,36 @@ describe("classifyErrorFrame — string codes must not all become retryable 502"
     }
   });
 
+  it("lets a PERMANENT type/message override a retryable NUMERIC code (gateway-normalized billing failure)", () => {
+    // A gateway wraps an upstream billing failure in a 429. Reading the number first would retry a
+    // permanently broken account and then report "the model was busy".
+    expect(classifyErrorFrame({ code: 429, type: "insufficient_quota", message: "You exceeded your current quota" }).status).toBe(401);
+    expect(classifyErrorFrame({ code: 503, type: "invalid_api_key" }).status).toBe(401);
+  });
+
+  it("keeps rate_limit_exceeded RETRYABLE (it is a genuine transient, unlike a quota failure)", () => {
+    const { status } = classifyErrorFrame({ code: 429, type: "rate_limit_exceeded", message: "Rate limit reached" });
+    expect(status).toBe(429);
+    expect(isRetryableStreamError(new StreamHttpError(status, "x"))).toBe(true);
+  });
+
+  it("classifies a 200-frame token/context-ceiling error as NON-retryable 400 (retrying can't help)", () => {
+    for (const frame of [
+      { code: "context_length_exceeded", message: "maximum context length is 8192 tokens" },
+      { message: "max_tokens is greater than the maximum" },
+      { code: 502, type: "context_length_exceeded" }, // text beats the transient-looking number
+    ]) {
+      const { status } = classifyErrorFrame(frame);
+      expect(status).toBe(400);
+      expect(isRetryableStreamError(new StreamHttpError(status, "x"))).toBe(false);
+    }
+  });
+
+  it("does NOT over-match 'insufficient' on non-billing wording", () => {
+    // "insufficient context" is not a billing failure — it must stay on the transient default.
+    expect(classifyErrorFrame({ message: "insufficient context to answer" }).status).toBe(502);
+  });
+
   it("defaults an unknown / transient-worded frame to retryable 502", () => {
     expect(classifyErrorFrame({ message: "the model is momentarily overloaded" }).status).toBe(502);
     expect(classifyErrorFrame({}).status).toBe(502);
@@ -273,6 +303,44 @@ describe("streamOpenAICompatible — a 200 stream carrying only an error frame (
     expect(caught).toBeInstanceOf(StreamHttpError);
     expect((caught as StreamHttpError).status).toBe(401);
     expect(isRetryableStreamError(caught)).toBe(false); // → withStreamRetry will NOT retry it
+  });
+
+  it("THROWS on an error frame that arrives AFTER deltas — a truncated answer must not persist as success", async () => {
+    const frames = [
+      deltaFrame("partial answer"),
+      `data: ${JSON.stringify({ error: { code: 529, message: "upstream overloaded" } })}\n\n`,
+      "data: [DONE]\n\n",
+    ];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(streamResponse(frames)));
+    const seen: StreamAnswerEvent[] = [];
+    let caught: unknown;
+    try {
+      for await (const ev of streamOpenAICompatible(OPENAI_BACKEND, "", "", "", "", "", "q", "UTC")) seen.push(ev);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(StreamHttpError);
+    expect((caught as StreamHttpError).status).toBe(529);
+    // The partial text was streamed, but NO terminal `done` — so the route can't persist/meter it as
+    // a completed answer; it takes the catch and reports the failure instead.
+    expect(seen.map((e) => e.type)).toEqual(["delta"]);
+  });
+
+  it("does NOT retry after a post-delta error frame (no duplicated answer) — end-to-end", async () => {
+    const frames = [
+      deltaFrame("partial"),
+      `data: ${JSON.stringify({ error: { code: 529, message: "overloaded" } })}\n\n`,
+      "data: [DONE]\n\n",
+    ];
+    const fetchMock = vi.fn().mockResolvedValue(streamResponse(frames));
+    vi.stubGlobal("fetch", fetchMock);
+    const sleep = vi.fn(async () => {});
+    const ctx = { sources: [], structured: "", grounded: true } as unknown as RetrievedContext;
+    await expect(
+      drainDeltas(streamAnswer(ctx, "q", { openrouterKey: "k", openrouterModel: "m" }, [], undefined, "UTC", { sleep }))
+    ).rejects.toThrow(/529/);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // committed → no retry, despite a retryable status
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it("still yields a clean empty done (no throw) when the blank has NO error frame (reasoning starvation)", async () => {


### PR DESCRIPTION
## What this is (QSTREAMRETRY-1)

A dashboard Team Brain query failed on the first try and worked on retry. Root cause: the
streaming **answer** path had **no app-level retry**. `lib/query/claude.ts` `streamAnswer`
(Anthropic) had zero retry, and `streamOpenAICompatible` retried only a **token-limit** 400/422 —
so any 429 / 529 "overloaded" / 5xx / mid-stream disconnect (and, on OpenRouter, an **HTTP-200
stream carrying a `data:{"error":{…}}` frame**) surfaced as a bare "Query failed", and the raw
error even leaked the internal model + base URL to the client.

This adds a **bounded retry-with-backoff** that retries a **fresh attempt only before the first
delta reaches the client** (a safe, invisible restart), for **transient** errors, across **both**
backends, plus a **sanitized** client-facing message.

Spec: `docs/design/query-stream-resilience.md`.

### Changes
- **`lib/query/stream-retry.ts`** (new, pure, unit-tested): `StreamHttpError` (carries `.status`),
  `isRetryableStreamError` (**status-first**: a known HTTP status decides alone; message regex only
  for statusless connection/timeout errors), `streamRetryDelayMs` (exp backoff ≈400/800ms, capped
  5s), `clientErrorMessage` (friendly + never leaks model/URL), `classifyErrorFrame` (maps a
  provider error frame's numeric/**string** code to a status), and `withStreamRetry` (retries only
  before the first yielded event).
- **`lib/query/claude.ts`**: `streamAnswer` wraps `streamAnswerOnce` via `withStreamRetry`; the
  OpenAI path throws `StreamHttpError`, and a 200 stream carrying **any** provider error frame now
  throws a **classified** error instead of a silent empty answer (before the first delta → retried
  when transient; after deltas → surfaced, never retried, so a truncated answer can't persist as a
  success; permanent shapes like `invalid_api_key`/`insufficient_quota`/`context_length_exceeded` →
  surfaced at once even when they wear a retryable numeric code); the Anthropic client runs
  `maxRetries:0` so this wrapper is the single retry owner across both backends.
- **`app/api/dashboard/query/route.ts`**: logs the **real** error server-side, sends only
  `clientErrorMessage(e)`; passes an `onRetry` logging hook.
- The machine-API twin `app/api/v1/query/route.ts` uses the same `streamAnswer`, so it **gains retry
  for free**, and it already sanitized its error — no leak-parity gap.

### Deliberately NOT in this slice (named next work)
- **Per-attempt / first-token timeout** to abort a *stalled* (not errored) upstream — safely racing
  an async generator against a timer deserves its own slice; retry already covers the transient-error
  and pre-delta-disconnect causes.
- **Mid-stream reattach / resume after a delta was sent** → **QBGSTREAM-1** (the tab-switch fix).
- **Resuming** a stream after a post-delta failure (the partial is shown with an error, not
  continued) → **QBGSTREAM-1**.
- A 200 error-frame that carried a billed `usage.cost` doesn't meter that failed-attempt spend (the
  meter lives in the route's `done` branch, not the transport layer) — tiny; tracked follow-up.
- `syncResponse` (`/sync`, non-LLM, team-tier only) still forwards its raw error — out of scope.

## Verification
| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors (5 pre-existing warnings, unrelated) |
| `npm test` (unit tier) | **2550 passed**, 11 skipped |
| `npm run check:docs` | in sync (no route/table/source touched) |
| Mutation tests (`scripts/mutate.mjs`) | **10 run, all REDDENED**, each reddening its intended test |

Mutations: (1) classifier status membership; (2) `withStreamRetry` `emitted` guard removal → "no
retry after a delta"; (3) `clientErrorMessage` leak; (4) sever `streamAnswer→withStreamRetry` wiring
→ call-site pin; (5) neutralize the 200-error-frame throw; (6) defeat status-first short-circuit;
(7) force permanent error-frame codes to retryable 502; (8) restore the `emittedChars===0` guard so a
post-delta error frame is swallowed; (9) let the numeric code beat permanent text again; (10) remove the
token/context-ceiling classification.

## Review — Reviewed by Fable code-reviewer — verdict BLOCKED (1 HIGH + 3 MEDIUM + 3 LOW), all confirmed and folded, then re-verified green
- **HIGH:** an OpenRouter 200-status error frame was a silent empty answer the retry never saw → now throws a classified error so retry fires. **MEDIUMs:** status-first classifier (a permanent 403 whose body says "connection closed" is no longer retried); `"Request timed out."` coverage restored after `maxRetries:0`; a real call-site pin for the retry wiring. **LOWs:** real SDK-shape fixtures, `overloaded_error`, any-yielded-event-commits.

Reviewed by Opus code-reviewer (extra independent pass) — verdict CLEAR (no BLOCKER/HIGH); it verified the folds against the installed `@anthropic-ai/sdk` and empirically probed the edge cases. One **MEDIUM folded**: string error-frame codes (`invalid_api_key`/`insufficient_quota`) were coerced to a retryable 502 → now classified permanent (401).

Reviewed by Codex gpt-5.5 — verdict BLOCKED (1 HIGH + 2 MEDIUM), **all three missed by both prior reviewers**, all confirmed and folded:
- **HIGH:** an error frame arriving **after** deltas fell through to `done`, so the route persisted a **truncated answer as a complete success** and metered it (chat history stored the half-answer as final). Now **any** error frame throws; `withStreamRetry` already has `emitted===true`, so it still cannot retry after client-visible output — no duplicate answer, and the client keeps its partial text plus an error.
- **MEDIUM:** a gateway-normalized permanent failure wearing a retryable numeric code (`{code:429, type:"insufficient_quota"}`) was retried and reported as "the model was busy" → `classifyErrorFrame` now checks `type`/`message` **before** the numeric code for the auth/billing family, while keeping `rate_limit_exceeded` retryable.
- **MEDIUM:** a 200-frame `context_length_exceeded` became a retryable 502, bypassing the token-limit ladder that handles the non-200 form → token/context-ceiling wording now classifies as non-retryable 400.
- Its LOW (a billed `usage.cost` on an error frame isn't metered) is deferred above with a reason.

Three model passes (Fable → Opus → Codex) satisfy the CLAUDE.md pre-push Review gate and the adversarial-build loop's steps 2–5; the `--tier full` DeepSeek adversarial spec layer was not run (no key) — the model reviews stood in for it. Each round found defects the previous rounds missed, which is the point of using different models.

AIOS-Work: QSTREAMRETRY-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)