### PR TITLE
test(graph): append churn is a bound with an absolute ceiling, not a constant (CDCAPPEND-1)

### DIFF
--- a/docs/design/cdc-append-churn.md
+++ b/docs/design/cdc-append-churn.md
@@ -1,8 +1,10 @@
 # Append churn is a bound, not a number — CDCAPPEND-1
 
-**Status:** spec, draft 2. Draft 1 was BLOCKED by two independent cold reads, and **its central claim was
-falsified twice over** — once for whitespace-only bodies, once for the cap. Draft 2 states the bound in
-the coordinates the cost is actually paid in, where it is a theorem with no preconditions.
+**Status:** spec, draft 3. Drafts 1 and 2 were each BLOCKED by two independent cold reads. Draft 1's
+central claim was falsified twice over (whitespace-only bodies; the cap), so draft 2 restated the bound in
+the coordinates the cost is paid in — and draft 2 then smuggled the ORIGINAL false constant back in as the
+replacement row's gloss (§2a), which the round-2 reads caught. Six characterisations of one table row have
+now been falsified; three of them were mine.
 **Date:** 2026-08-16 · **Owner:** Chetan · **Task:** `CDCAPPEND-1`
 **Related:** [`content-defined-chunking.md`](./content-defined-chunking.md) (the table this corrects),
 [`cdc-boundary-overlap.md`](./cdc-boundary-overlap.md) (`CDCCHURN-1`, the row above this one).
@@ -112,9 +114,16 @@ the ledger pays **2** where the bound says 25.
 
 **The structural claim.** In `cdcBoundaries` (`lib/graph/cdc.ts:222`) the boundary ending chunk `k` is
 computed from `text[startₖ … min(startₖ + max, n))`, and `n` enters only through `hardEnd` and the
-`n − start <= min` short-tail exit. So a boundary whose chunk **start** lies at least `max` (4,000) code
-units before the original end is computed from unchanged input and cannot move — `movedOutsideMaxWindow`
-is **0** across all 560 samples.
+`n − start <= min` short-tail exit. So a boundary whose chunk **start** lies **more than** `max` (4,000)
+code units before the original end is computed from unchanged input and cannot move —
+`movedOutsideMaxWindow` is **0** across all 560 samples.
+
+"More than", not "at least": review produced a witness at exactly `max`. For
+`"0".repeat(3999) + "\uD800"` the single boundary sits at 4,000, and appending a low surrogate moves it
+to 4,001 through `avoidSurrogateSplit` (`lib/graph/cdc.ts:194`). Malformed UTF-16 only, and the depth and
+absolute ceilings both survive it (starts in `[n − max, n)` spaced at least `min` still number at most
+4) — but the instrument tested `> max` while the prose said `≥ max`, so the prose was a paraphrase of
+what was actually checked, which is the failure mode this repo names "mutate with the real shape".
 
 **The provable ceiling on divergence depth is 4, and the observed maximum is not it.** Non-final chunks
 are at least `min`, so at most `1 + ⌊(max − 1)/min⌋ = 4` chunk starts can lie inside that window. The
@@ -201,29 +210,47 @@ synthetically, so the general claim is weaker than the short-append one.
 ### 2a. The table row states a bound, its mechanism, and the trade
 
 `append at end` becomes: **at most the number of admitted chunks after the last chunk the two chunkings
-share — 1 for a short append to a document below the cap, 0 once the shared prefix itself fills the cap,
-and growing with both the length and the entropy of the appended text.** The prose names the mechanism
-(only boundaries within `max` of the end can move; the backup-boundary preference can delete one) and
-carries §0f's trade.
+share — commonly 1 for a short append, but 2 on 4 of 28 corpus documents at the fixture's own
+66-character append; 0 once the shared prefix itself fills the cap; and growing with both the length and
+the entropy of the appended text.** The prose names the mechanism (only boundaries within `max` of the
+end can move; the backup-boundary preference can delete one) and carries §0f's trade.
+
+**Draft 2's version of this sentence said "1 for a short append to a document below the cap", and that is
+characterisation 1 walking back in as the row's gloss** — refuted by the run this spec commands
+(`fixtureAppend.churnDistribution` = `{0: 1, 1: 23, 2: 4}`, all four of those 2s below the cap). It would
+have been the seventh wrong characterisation, and the sixteen criteria of draft 2 would all have passed
+with it in place, because they constrained what the row must mention and never what it must not claim.
+Criterion 17 now pins the row's number against that distribution.
 
 ### 2b. The test asserts the bound per document — and an ABSOLUTE ceiling that cannot self-adjust
 
-The bound in §0b is computed from the chunker's own output, so **any prefix-stable chunker satisfies it
-by construction**: a regression that re-cuts deeply just shrinks `L` and inflates the bound to match.
-Asserting only that would be a guard that can never redden — the exact standard this repo applies to a
-predicate term, applied here to a whole assertion. So the test asserts three things:
+The bound in §0b is computed from the chunker's own output, and review sharpened just how weak that makes
+it as evidence: draft 2 said "any prefix-stable chunker satisfies it", and the truth is stronger —
+**every chunker does, and so does every pair of string arrays**, since `L` is defined as their common
+prefix and elements below it are members of the before-set by definition. So `boundHolds 560/560` is a
+theorem restated, not a measurement, and a `bound violated` counter is a structurally dead one. The
+informative measurements are set-metric TIGHTNESS (§0b) and the two assertions below. So the test asserts
+three things:
 
 1. **the bound**, per document per append content — `churn ≤ |C₁| − L`;
 2. **an absolute ceiling derived from the SIZE ENVELOPE, not from behaviour**:
    `churn ≤ (1 + ⌊(max − 1)/min⌋) + ⌈A/min⌉` for an append of length `A` — at most 4 tail boundaries can
    move (§0d) and the appended text adds at most `⌈A/min⌉` chunks. Zero violations across the 560 corpus
    samples and a further **8,400 samples over 400 synthetic documents** (`absoluteGuard.synthetic`, in
-   the committed script — 28 real files are not evidence about an algorithm). This is the assertion that
-   reddens if `cdc2` starts re-cutting the whole document;
+   the committed script — 28 real files are not evidence about an algorithm);
 3. **the divergence depth**, per document, against the derived 4 — never the observed 2.
 
 Equality with the bound is **reported, not gated** (a future document quoting another one verbatim would
 otherwise redden CI on an unrelated docs edit); the fixtures gate it where it is deterministic.
+
+**And here is what this set does NOT catch, stated rather than left to be discovered.** The absolute
+ceiling is loose: at a 60,000-character prose append the corpus churns 23–24 against a ceiling of
+`4 + ⌈60000/1250⌉ = 52`. A regression that cut the appended region at `min` instead of `target` would
+roughly **double** every long append's cost and still pass the ceiling, the self-adjusting bound, the
+depth gate and GROWTH. Both reviewers found this independently. Tight coverage exists only in the
+**short-append regime**, where the `legacyChurn + 1` envelope sits at zero headroom (4 documents are at
+exactly gap 1 today). The ceiling's real job is the gross case — a chunker that re-cuts the document —
+and §4 defers the long-regime gate rather than pretending this covers it.
 
 ### 2c. Four checked-in fixtures, because the live corpus cannot guarantee any of these branches
 
@@ -254,8 +281,21 @@ outcome flips with the appended content at a fixed length.
 `--op append` sweeps documents × lengths × append contents and reports both metrics, the divergence
 depth against the derived ceiling, the absolute guard, the falsified candidate, the falsified
 boundary-coordinate form of the bound, and probes for the merge event, the cap parity, the verbatim
-duplicate and the legacy envelope. It exits non-zero on any refuted invariant, so it is a check and not
-only a report. It also gains `--exclude` (the reflexivity above) and a corrected corpus definition — a
+duplicate and the legacy envelope.
+
+**It exits non-zero on a refuted invariant OR a vacuous run — and draft 2 claimed that before it was
+true.** Review found three ways it failed open: an empty corpus (a wrong working directory) exited 0 with
+zero evidence, the synthetic leg's divergence depth was computed and reported but never counted, and the
+probes had no expectations at all, so `duplicateProbe` could report set === bound — the rule silently
+becoming an equality again — with nothing noticing. There are explicit expectations now, including a
+corpus floor. Probe **rot** is deliberately not a failure but a `warning`: the merge witness is live
+content that this spec says is expected to rot, and conflating that with a refuted invariant would make
+the check cry wolf.
+
+It also gains `--exclude`, **honoured in both modes** — this file is around 79 characters below the
+in-place sweep's 25,000-character floor, so one more paragraph would silently move the 573/573 the
+in-place mode is required to reproduce, which is the went-stale-by-being-measured bug in the other mode.
+And a corrected corpus definition — a
 comment claimed its `> 4,000`-character set was "the same corpus `test/graph-cdc.test.ts` reads", which
 it never was — and a fix to the `prose-b` filler, which replaced text **after** slicing and so appended
 2,602 characters at a nominal 2,500, confounding the very "same length, different content" comparison it
@@ -290,11 +330,13 @@ schema, no API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupId
 - `test/graph-cdc.test.ts` — the `max(cdc) <= max(legacy)` comparison for append is replaced by a PER-DOCUMENT `cdcChurn <= legacyChurn + 1` gated to appends shorter than `min`, with the longer-append gap reported and the measured reason recorded at the site; the comparison is untouched for the insertion and deletion scenarios.
 - `test/graph-cdc.test.ts` — the `append at end — CDC re-extracts <= 1 chunk(s)` assertion is GONE, with the measurement that refutes it recorded at the site.
 - `test/graph-cdc.test.ts` — the live-corpus equality census is reported rather than gated, and a `documents > 5` floor is asserted, because a bound assertion over an empty or single-document corpus is green by construction.
-- `scripts/cdc-churn-sweep.mjs` — `--op append` reports the bound, the absolute guard, the divergence depth against its derived ceiling, the falsified candidate, the falsified boundary-coordinate form, and the merge, cap-parity, verbatim-duplicate and legacy-envelope probes; it exits non-zero on any refuted invariant.
-- `scripts/cdc-churn-sweep.mjs` — `--exclude <path>` omits a document from the corpus, so a distribution published in a document that is itself in the corpus is stable against its own edits.
+- `scripts/cdc-churn-sweep.mjs` — `--op append` reports the bound, the absolute guard, the divergence depth against its derived ceiling, the falsified candidate, the falsified boundary-coordinate form, and the merge, cap-parity, verbatim-duplicate and legacy-envelope probes.
+- `scripts/cdc-churn-sweep.mjs` — the append mode exits non-zero on a refuted invariant OR a vacuous run (empty corpus, zero samples, no synthetic leg, synthetic depth past the derived ceiling, `duplicateProbe` going tight, `verbatimChunkProbe` going slack, a shared prefix at the cap costing anything); probe ROT is a reported warning and not a failure, and running it from a directory with no `docs/` must exit 1 rather than 0.
+- `scripts/cdc-churn-sweep.mjs` — `--exclude <path>` omits a document from the corpus in BOTH modes, since this spec sits under 100 characters below the in-place sweep's 25,000-character floor.
 - `scripts/cdc-churn-sweep.mjs` — the `prose-b` filler replaces before slicing, so the "same length, different content" comparison is not length-confounded; the false "the same corpus the test reads" comment is corrected; the in-place mode's existing numbers reproduce unchanged.
 - `docs/design/content-defined-chunking.md` — the acceptance table's `append at end` row states the bound, the shared-prefix cap condition, and that growth depends on the appended content as well as its length; the prose carries the measured CDC-vs-legacy envelope.
 - `docs/design/content-defined-chunking.md` — the summary table's legacy `| append at the end | 1 |` is SCOPED to the 66-character append it measures rather than left unqualified, since a 2,501-character append churns 2 under byte offsets too.
+- `docs/design/content-defined-chunking.md` — the corrected `append at end` row states NO unconditional number, and a test pins the row's own claim against `fixtureAppend.churnDistribution`, so a gloss like "1 for a short append" cannot pass the other sixteen criteria while contradicting the measurement.
 
 ## 4. Scope
 
@@ -320,11 +362,15 @@ corpus/filler corrections.
 
 ## 5. What would falsify this
 
-Wrong if any base document and any append make set churn **exceed** `|C₁| − L` over the admitted chunk
-arrays — that would mean a chunk at an index below `L` was re-pushed despite being byte-identical to one
-already in the ledger, contradicting the MEMBERSHIP filter at `lib/graph/project.ts:1222-1223` rather
-than anything about boundaries. (Draft 1's boundary-coordinate form was falsified exactly here, by the
-`chunkCdc` blank-body guard, so this clause names the right mechanism now.)
+**Clause 1 is proof-checked, not measurement-checked, and draft 2 mislabelled it.** `churn ≤ |C₁| − L`
+holds for any two string arrays whatsoever, so no run of the sweep can refute it and the counter that
+watches for a violation is structurally dead. It is listed because it is what the row asserts, not
+because the instrument could catch it failing — and the mechanism draft 2 named (a chunk below `L`
+re-pushed, contradicting `lib/graph/project.ts:1222-1223`) is an event the sweep computes `setChurn`
+itself and could not observe even if the product had that bug. What WOULD falsify the row is the
+translation: if the projector's membership filter ever stopped being a set-membership test, the bound
+would still be true about chunk arrays and false about cost. (Draft 1's boundary-coordinate form was a
+real, refutable claim, and it was refuted — by the `chunkCdc` blank-body guard.)
 
 Wrong if any document exceeds the absolute ceiling of `(1 + ⌊(max − 1)/min⌋) + ⌈A/min⌉`, which would mean
 the structural window in §0d is not what `cdcBoundaries` does.

--- a/docs/design/cdc-append-churn.md
+++ b/docs/design/cdc-append-churn.md
@@ -14,14 +14,18 @@ no product change; that IS the finding, exactly as it was one row up).
 **Every number below comes from one run of**
 
 ```
-node scripts/cdc-churn-sweep.mjs --op append --exclude docs/design/cdc-append-churn.md
+node scripts/cdc-churn-sweep.mjs --op append \
+  --exclude docs/design/cdc-append-churn.md,docs/design/content-defined-chunking.md
 ```
 
-which stamps its own `revision` (SHA + whether the tree was dirty). `--exclude` is not a convenience: the
-design documents ARE the corpus, this file is over 15,000 characters, and **draft 1's §0e table had
-already gone stale by the time it was reviewed because writing the draft moved the document it was
-measuring into a different churn bucket.** Both reviewers caught it. Excluding this file makes the
-published distributions stable against the document that publishes them.
+which stamps its own `revision` (SHA + whether the tree was dirty). **Both exclusions are load-bearing,
+and this branch is the evidence.** The design documents ARE the corpus, so the two files this ticket edits
+sit inside the set it measures. Draft 1's §0e table had already gone stale by the time it was reviewed.
+Draft 2 excluded this file and published `449/560` — and the *next* commit on this branch, the one that
+corrected the other design document, moved it to `466/560`. **Both code reviewers caught that: the branch
+had re-committed the exact defect it exists to fix.** Excluding both makes the published distributions
+stable against this ticket's own edits. Every other corpus document stays live, which is a stated limit
+rather than a fix.
 
 ---
 
@@ -45,14 +49,15 @@ gets a bound with a proof instead of a fifth constant.
 
 1. *"Churn is 1."* — The original claim. False in both directions: `docs/ARCHITECTURE.md` churns **0**
    (146 boundaries against an 80-chunk cap, so an append lands past the admitted prefix), and for the
-   test fixture's own 66-character append **4 of 28** corpus documents churn **2**
-   (`fixtureAppend.churnDistribution` = `{0: 1, 1: 23, 2: 4}`).
+   test fixture's own 66-character append **3 of 27** corpus documents churn **2**
+   (`fixtureAppend.churnDistribution` = `{0: 1, 1: 23, 2: 3}`) — and 5 of 29 over the unexcluded corpus
+   the test itself reads, the difference being this ticket's own two files.
 2. *"1 unless the appended text splits the final chunk, then 2."* — False in both halves; the 2s are not
    splits of the final chunk (§0d).
 3. *"2 is the ceiling."* — Holds only below `min`. A 9,000-character prose append churns 4–5, a
    60,000-character one 23–24 (§0e).
-4. *(draft 1, mine)* *"churn = 1 + the number of new chunks, or 0 when capped."* — **449 of 560
-   samples, 80.2%** (`candidate1`). Every miss is in the same direction; `docs/TODO.md` is the clearest
+4. *(draft 1, mine)* *"churn = 1 + the number of new chunks, or 0 when capped."* — **446 of 540
+   samples, 82.6%** (`candidate1`). Every miss is in the same direction; `docs/TODO.md` is the clearest
    witness, saying 1 where the answer is 2 at four different append lengths. Mechanism in §0d.
 5. *(draft 1, mine — found by BOTH reviewers)* *the bound stated over the **boundary** sequences.*
    `chunkCdc` returns `[]` for a whitespace-only body (`lib/graph/cdc.ts:271`) while `cdcBoundaries`
@@ -88,8 +93,8 @@ therefore members of the before-set, so `lib/graph/project.ts:1222-1223` — whi
 covered rather than excluded: a whitespace base gives `C₀ = []`, hence `L = 0` and a bound of `|C₁|`,
 which is trivially satisfied. The cap needs no term either: `C₁` is already truncated.
 
-**Measured tight: 28 documents × 10 append lengths × 2 append contents = 560 samples, bound holds
-560/560, exactly tight 560/560.** One honesty note the reviewers were right to force: of the three
+**Measured tight: 27 documents × 10 append lengths × 2 append contents = 540 samples, bound holds
+540/540, exactly tight 540/540.** One honesty note the reviewers were right to force: of the three
 figures in that sentence, **only set-metric tightness is a measurement.** "Holds 560/560" is the theorem
 restated, and positional tightness is near-tautological (chunks after `L` differ at their index by
 construction, up to byte coincidence). The informative claim is that the SET metric — the one that costs
@@ -116,7 +121,7 @@ the ledger pays **2** where the bound says 25.
 computed from `text[startₖ … min(startₖ + max, n))`, and `n` enters only through `hardEnd` and the
 `n − start <= min` short-tail exit. So a boundary whose chunk **start** lies **more than** `max` (4,000)
 code units before the original end is computed from unchanged input and cannot move —
-`movedOutsideMaxWindow` is **0** across all 560 samples.
+`movedOutsideMaxWindow` is **0** across all 540 samples.
 
 "More than", not "at least": review produced a witness at exactly `max`. For
 `"0".repeat(3999) + "\uD800"` the single boundary sits at 4,000, and appending a low surrogate moves it
@@ -163,9 +168,9 @@ Two appends of the same length churn differently, because the new boundaries are
 
 | append length | prose filler | hash-quiet filler |
 |---|---|---|
-| 2,500 | `{0:1, 2:16, 3:11}` | `{0:1, 1:25, 2:2}` |
-| 9,000 | `{0:1, 4:9, 5:18}` | `{0:1, 3:25, 4:2}` |
-| 60,000 | `{0:1, 23:9, 24:18}` | `{0:1, 16:27}` |
+| 2,500 | `{0:1, 2:16, 3:10}` | `{0:1, 1:25, 2:1}` |
+| 9,000 | `{0:1, 4:9, 5:17}` | `{0:1, 3:25, 4:1}` |
+| 60,000 | `{0:1, 23:9, 24:17}` | `{0:1, 16:26}` |
 
 A hash-quiet run yields few cuts, so 60,000 characters of it become 16 chunks where prose becomes 24.
 Growth is *roughly* one chunk per `target` characters **of ordinary prose**, and any claim of the form
@@ -178,8 +183,8 @@ Growth is *roughly* one chunk per `target` characters **of ordinary prose**, and
   28 documents; the same fixture with a 2,500-character prose append churns 3.
 - **`CDC must never be worse than byte offsets`** (`test/graph-cdc.test.ts:433`) is **not a property of
   appends, and its outcome is decided by content nobody chose.** At the fixture's own append CDC is
-  strictly worse on 4 of 28 documents and the comparison passes anyway, because it compares max against
-  max **across different documents** and a fifth, unrelated document churns 2 under legacy. It is the
+  strictly worse on several documents and the comparison passes anyway, because it compares max against
+  max **across different documents** and one further, unrelated document churns 2 under legacy. It is the
   max-versus-max flaw `CDCCHURN-1` named where it survived, firing.
 
   **Deleting it outright is what draft 1 proposed, and both reviewers refused it** — that removes a
@@ -210,7 +215,7 @@ synthetically, so the general claim is weaker than the short-append one.
 ### 2a. The table row states a bound, its mechanism, and the trade
 
 `append at end` becomes: **at most the number of admitted chunks after the last chunk the two chunkings
-share — commonly 1 for a short append, but 2 on 4 of 28 corpus documents at the fixture's own
+share — commonly 1 for a short append, but 2 on several corpus documents at the fixture's own
 66-character append; 0 once the shared prefix itself fills the cap; and growing with both the length and
 the entropy of the appended text.** The prose names the mechanism (only boundaries within `max` of the
 end can move; the backup-boundary preference can delete one) and carries §0f's trade.
@@ -235,7 +240,7 @@ three things:
 1. **the bound**, per document per append content — `churn ≤ |C₁| − L`;
 2. **an absolute ceiling derived from the SIZE ENVELOPE, not from behaviour**:
    `churn ≤ (1 + ⌊(max − 1)/min⌋) + ⌈A/min⌉` for an append of length `A` — at most 4 tail boundaries can
-   move (§0d) and the appended text adds at most `⌈A/min⌉` chunks. Zero violations across the 560 corpus
+   move (§0d) and the appended text adds at most `⌈A/min⌉` chunks. Zero violations across the 540 corpus
    samples and a further **8,400 samples over 400 synthetic documents** (`absoluteGuard.synthetic`, in
    the committed script — 28 real files are not evidence about an algorithm);
 3. **the divergence depth**, per document, against the derived 4 — never the observed 2.
@@ -292,10 +297,15 @@ corpus floor. Probe **rot** is deliberately not a failure but a `warning`: the m
 content that this spec says is expected to rot, and conflating that with a refuted invariant would make
 the check cry wolf.
 
-It also gains `--exclude`, **honoured in both modes** — this file is around 79 characters below the
-in-place sweep's 25,000-character floor, so one more paragraph would silently move the 573/573 the
-in-place mode is required to reproduce, which is the went-stale-by-being-measured bug in the other mode.
-And a corrected corpus definition — a
+It also gains `--exclude`, **comma-separated, honoured in both modes, and refusing when a named path
+matches nothing** — a typo'd exclusion silently publishing the unexcluded numbers is the same failure in
+a different hat. Draft 2 justified this by saying this file sat "around 79 characters below the in-place
+sweep's 25,000-character floor"; **that was false at the commit that wrote it**, which had already grown
+the file past the floor to about 29,000 characters. Both design documents are in the in-place swept set
+now, so that mode's sample count moves with the corpus — which is why what it must reproduce is its
+INVARIANT (rule agreement equal to samples, zero mismatches), not a sample count. Every degraded input
+refuses rather than running: an unknown `--op`, a flag-shaped flag value, and a non-integer or zero
+`--step`, which used to give a ten-sample "sweep" or hang outright. And a corrected corpus definition — a
 comment claimed its `> 4,000`-character set was "the same corpus `test/graph-cdc.test.ts` reads", which
 it never was — and a fix to the `prose-b` filler, which replaced text **after** slicing and so appended
 2,602 characters at a nominal 2,500, confounding the very "same length, different content" comparison it
@@ -332,8 +342,9 @@ schema, no API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupId
 - `test/graph-cdc.test.ts` — the live-corpus equality census is reported rather than gated, and a `documents > 5` floor is asserted, because a bound assertion over an empty or single-document corpus is green by construction.
 - `scripts/cdc-churn-sweep.mjs` — `--op append` reports the bound, the absolute guard, the divergence depth against its derived ceiling, the falsified candidate, the falsified boundary-coordinate form, and the merge, cap-parity, verbatim-duplicate and legacy-envelope probes.
 - `scripts/cdc-churn-sweep.mjs` — the append mode exits non-zero on a refuted invariant OR a vacuous run (empty corpus, zero samples, no synthetic leg, synthetic depth past the derived ceiling, `duplicateProbe` going tight, `verbatimChunkProbe` going slack, a shared prefix at the cap costing anything); probe ROT is a reported warning and not a failure, and running it from a directory with no `docs/` must exit 1 rather than 0.
-- `scripts/cdc-churn-sweep.mjs` — `--exclude <path>` omits a document from the corpus in BOTH modes, since this spec sits under 100 characters below the in-place sweep's 25,000-character floor.
-- `scripts/cdc-churn-sweep.mjs` — the `prose-b` filler replaces before slicing, so the "same length, different content" comparison is not length-confounded; the false "the same corpus the test reads" comment is corrected; the in-place mode's existing numbers reproduce unchanged.
+- `scripts/cdc-churn-sweep.mjs` — `--exclude <paths>` is comma-separated, omits documents in BOTH modes, and REFUSES when a named path is not in the corpus; both design documents this ticket edits are excluded from every published figure.
+- `scripts/cdc-churn-sweep.mjs` — every degraded input refuses with a reason and a non-zero exit: an unknown `--op`, a flag-shaped value for any flag, and a non-integer or zero `--step`.
+- `scripts/cdc-churn-sweep.mjs` — the `prose-b` filler replaces before slicing, so the "same length, different content" comparison is not length-confounded; the false "the same corpus the test reads" comment is corrected; the in-place mode's INVARIANT reproduces unchanged (rule agreement equal to samples, zero mismatches) — its sample count is corpus-dependent and is deliberately not pinned.
 - `docs/design/content-defined-chunking.md` — the acceptance table's `append at end` row states the bound, the shared-prefix cap condition, and that growth depends on the appended content as well as its length; the prose carries the measured CDC-vs-legacy envelope.
 - `docs/design/content-defined-chunking.md` — the summary table's legacy `| append at the end | 1 |` is SCOPED to the 66-character append it measures rather than left unqualified, since a 2,501-character append churns 2 under byte offsets too.
 - `docs/design/content-defined-chunking.md` — the corrected `append at end` row states NO unconditional number, and a test pins the row's own claim against `fixtureAppend.churnDistribution`, so a gloss like "1 for a short append" cannot pass the other sixteen criteria while contradicting the measurement.

--- a/docs/design/cdc-append-churn.md
+++ b/docs/design/cdc-append-churn.md
@@ -1,17 +1,25 @@
 # Append churn is a bound, not a number — CDCAPPEND-1
 
-**Status:** spec, draft 1 · **Date:** 2026-08-16 · **Owner:** Chetan · **Task:** `CDCAPPEND-1`
+**Status:** spec, draft 2. Draft 1 was BLOCKED by two independent cold reads, and **its central claim was
+falsified twice over** — once for whitespace-only bodies, once for the cap. Draft 2 states the bound in
+the coordinates the cost is actually paid in, where it is a theorem with no preconditions.
+**Date:** 2026-08-16 · **Owner:** Chetan · **Task:** `CDCAPPEND-1`
 **Related:** [`content-defined-chunking.md`](./content-defined-chunking.md) (the table this corrects),
 [`cdc-boundary-overlap.md`](./cdc-boundary-overlap.md) (`CDCCHURN-1`, the row above this one).
 **Code:** `test/graph-cdc.test.ts`, `scripts/cdc-churn-sweep.mjs`, `lib/graph/cdc.ts` (read only —
 no product change; that IS the finding, exactly as it was one row up).
 
-**Every number below comes from one run of `node scripts/cdc-churn-sweep.mjs --op append`**, which
-stamps its own `revision` (SHA + whether the tree was dirty) for the reason this ticket's neighbour
-learned the hard way: a published measurement stopped reproducing, and the retraction story was wrong
-too. Figures here were taken at `46aad5c` with this spec present in the tree — **which matters, because
-the design documents ARE the corpus**: this file is ≥ 15,000 characters, so it joined the measured set
-and took it from 28 documents to 29. Re-run the sweep rather than trusting a number quoted here.
+**Every number below comes from one run of**
+
+```
+node scripts/cdc-churn-sweep.mjs --op append --exclude docs/design/cdc-append-churn.md
+```
+
+which stamps its own `revision` (SHA + whether the tree was dirty). `--exclude` is not a convenience: the
+design documents ARE the corpus, this file is over 15,000 characters, and **draft 1's §0e table had
+already gone stale by the time it was reviewed because writing the draft moved the document it was
+measuring into a different churn bucket.** Both reviewers caught it. Excluding this file makes the
+published distributions stable against the document that publishes them.
 
 ---
 
@@ -23,216 +31,244 @@ and took it from 28 documents to 29. Re-run the sweep rather than trusting a num
 |---|---|---|
 | append at end | 1 of 20 | conditional, not yet characterised (`CDCAPPEND-1`) |
 
-That cell is `CDCCHURN-1`'s deliberate statement of ignorance, left in place rather than filled with a
-fourth invented rule. This slice fills it — and, in measuring it, found that the **test** guarding the
-row asserts two things that are not properties of appends at all (§0e).
+That cell is `CDCCHURN-1`'s deliberate statement of ignorance, left rather than filled with a fourth
+invented rule. This slice fills it — and, in measuring it, found that the **test** guarding the row
+asserts two things that are not properties of appends at all (§0f).
 
-### 0a. Four characterisations of this row, all four falsified by measurement
+### 0a. Six characterisations of this row, all six falsified by measurement
 
-Three were falsified during `CDCCHURN-1`'s review. **The fourth was this draft's own, and it was wrong
-too** — which is why the rule below was measured before it was written, the order that ticket ended on.
+Three were falsified during `CDCCHURN-1`'s review. **Three more were falsified in this ticket, and all
+three were mine** — one by my own sweep, two by the reviewers of draft 1. That is the reason this row
+gets a bound with a proof instead of a fifth constant.
 
-1. *"Churn is 1."* — The original acceptance-table claim. False in both directions: `docs/ARCHITECTURE.md`
-   churns **0** (146 boundaries against an 80-chunk admitted cap, so an append lands past the admitted
-   prefix and is dropped entirely), and for the test fixture's own 66-character append **4 of 29**
-   corpus documents churn **2** (`fixtureAppend.churnDistribution`: `{0: 1, 1: 24, 2: 4}`).
-2. *"1 unless the appended text splits the final chunk, then 2."* — False in both halves. The 0 case
-   breaks the floor, and the 2s are not "the append split the final chunk": the new cut lands inside the
-   **appended** region, which moves the final boundary and therefore changes the chunk before it too.
-3. *"2 is the ceiling."* — Holds only for appends shorter than `min`. A 9,000-character prose append
-   churns 4–5 and a 60,000-character one churns 23–24 (§0d).
-4. *(this draft's first candidate)* *"churn = 1 + the number of new chunks, or 0 when capped."* —
-   **469 of 580 samples, 80.9%.** Every miss is in the same direction, and `docs/TODO.md` is the
-   clearest witness: it says 1 where the answer is 2, at four different append lengths. The mechanism is
-   §0d — a document's final chunk frequently has no cut at all, the text simply ended, so extending the
-   tail lets the chunker *find* a cut inside the appended region and move the last boundary **without
-   adding a chunk**. The candidate is kept runnable in the sweep (`candidate1`) so the refutation
-   reproduces rather than being asserted.
+1. *"Churn is 1."* — The original claim. False in both directions: `docs/ARCHITECTURE.md` churns **0**
+   (146 boundaries against an 80-chunk cap, so an append lands past the admitted prefix), and for the
+   test fixture's own 66-character append **4 of 28** corpus documents churn **2**
+   (`fixtureAppend.churnDistribution` = `{0: 1, 1: 23, 2: 4}`).
+2. *"1 unless the appended text splits the final chunk, then 2."* — False in both halves; the 2s are not
+   splits of the final chunk (§0d).
+3. *"2 is the ceiling."* — Holds only below `min`. A 9,000-character prose append churns 4–5, a
+   60,000-character one 23–24 (§0e).
+4. *(draft 1, mine)* *"churn = 1 + the number of new chunks, or 0 when capped."* — **449 of 560
+   samples, 80.2%** (`candidate1`). Every miss is in the same direction; `docs/TODO.md` is the clearest
+   witness, saying 1 where the answer is 2 at four different append lengths. Mechanism in §0d.
+5. *(draft 1, mine — found by BOTH reviewers)* *the bound stated over the **boundary** sequences.*
+   `chunkCdc` returns `[]` for a whitespace-only body (`lib/graph/cdc.ts:271`) while `cdcBoundaries`
+   still returns boundaries, so a whitespace base has a non-empty shared boundary prefix and an **empty**
+   before-set. **20,000 spaces plus one `x` churns 6 against a boundary-form bound of 1.** The proof's
+   premise — "those chunks are byte-identical so cannot be re-pushed" — fails because they were never
+   pushed. §0b restates the bound over chunks, where the premise is true by construction.
+6. *(draft 1, mine — found by Fable)* *"0 once the document fills the cap."* — False, and it was in the
+   proposed table row, which would have made it the fifth wrong characterisation shipping as
+   documentation. What must reach the cap is the **shared prefix**, not the boundary count, and an append
+   moves the last one or two boundaries. Constructed and committed as `capProbe`:
 
-### 0b. The rule, and it is a BOUND with a proof, not a fitted constant
+   | boundaries | append | shared chunks | bound | churn |
+   |---:|---:|---:|---:|---:|
+   | 79 | 66 | 78 | 1 | 1 |
+   | 79 | 2,500 | 78 | 2 | 2 |
+   | **80 (= cap)** | 66 | 79 | 1 | **1** |
+   | **80 (= cap)** | 2,500 | 79 | 1 | **1** |
+   | 81 | 2,500 | 80 | 0 | 0 |
 
-Let `B₀` and `B₁` be the (uncapped) boundary sequences of the document before and after the append, and
-let `L` be the length of their longest common prefix — the index of the last boundary the two chunkings
-**share**. Then:
+   A document sitting exactly at the cap churns **1**, not 0.
 
-> **churn ≤ max(0, min(cap, |B₁|) − L)** — the number of ADMITTED chunks lying after the last shared
-> boundary.
+### 0b. The rule, in the coordinates the cost is paid in
 
-**The bound is a theorem, not a measurement.** Chunks `0 … L−1` are byte-identical across the two
-chunkings, so under the SET metric the ledger pays (`lib/graph/project.ts:1222-1223` filters by
-`new Set(chunk_shas)` MEMBERSHIP) none of them can be re-pushed; at most the chunks after `L`, truncated
-at the cap, can be. Stating it as a bound rather than an equality is the correction: all four earlier
-attempts stated an equality, and an equality is what keeps being falsified.
+Let `C₀` and `C₁` be the **admitted chunk arrays** (`chunkCdc`, i.e. already capped) before and after the
+append, and `L` the length of their longest common prefix. Then:
 
-**And it is measured tight.** 29 documents × 10 append lengths × 2 append contents = **580 samples;
-bound holds 580/580; exactly tight 580/580 under both the set metric and a positional diff; zero
-violations, zero slack.**
+> **churn ≤ |C₁| − L** — the number of admitted chunks after the last chunk the two chunkings share.
 
-**The cap term is a CONSEQUENCE, not a term.** "0 when the document already fills the admitted cap" was
-this draft's second clause. It is redundant: an append can only move boundaries near the end (§0d), so a
-document with more than `cap` boundaries always has `L ≥ cap` and `min(cap, |B₁|) − L` is already ≤ 0.
-`CDCCHURN-1` deleted a predicate term for exactly this reason — "a term no test can redden is one the
-code would be asserting on trust" — and the same standard applies to prose. The clause is gone; a
-fixture asserts the property instead.
+**A theorem with no preconditions.** Chunks `0 … L−1` of `C₁` are byte-identical to chunks of `C₀` and
+therefore members of the before-set, so `lib/graph/project.ts:1222-1223` — which filters by
+`new Set(chunk_shas)` MEMBERSHIP — can never re-push them. The whitespace case (characterisation 5) is
+covered rather than excluded: a whitespace base gives `C₀ = []`, hence `L = 0` and a bound of `|C₁|`,
+which is trivially satisfied. The cap needs no term either: `C₁` is already truncated.
+
+**Measured tight: 28 documents × 10 append lengths × 2 append contents = 560 samples, bound holds
+560/560, exactly tight 560/560.** One honesty note the reviewers were right to force: of the three
+figures in that sentence, **only set-metric tightness is a measurement.** "Holds 560/560" is the theorem
+restated, and positional tightness is near-tautological (chunks after `L` differ at their index by
+construction, up to byte coincidence). The informative claim is that the SET metric — the one that costs
+money — sits exactly on the bound everywhere except duplicate content (§0c).
 
 ### 0c. Where the bound is NOT tight, and why that is the safe direction
 
-The set metric comes in **below** the bound when a new chunk's content already appears elsewhere in the
-document — an identical chunk is never re-pushed, so it costs nothing. Constructed (`duplicateProbe`):
-appending a 60,000-character document **to itself** re-cuts the tail into 25 positionally-changed chunks
-of which **23 are byte-identical to chunks that already exist**, so the ledger pays **2** where the bound
-says 25. (`CDCCHURN-1` found and pinned the same asymmetry for in-place edits; this is that finding one
-row down.)
+The set metric falls **below** the bound when a new chunk's content already exists in the document.
+Committed as `duplicateProbe`: appending a 60,000-character document **to itself** shares 22 chunks and
+re-cuts the tail into 25 positionally-changed chunks of which 23 are byte-identical to existing ones, so
+the ledger pays **2** where the bound says 25.
 
-Two things make this the right shape rather than a hole:
-
-- **The error direction is conservative.** The bound over-states cost, never under-states it, so a churn
-  budget derived from it is safe. `CDCCHURN-1`'s published-78 incident was the opposite direction — a
-  positional count quoted as a cost — and this row must not repeat it.
-- **Appending duplicate text does not generally save anything.** Appending one existing chunk *verbatim*
-  still churns the full predicted amount, because the boundary shift means the re-cut chunks are not
-  byte-identical to the original one. Only a realignment that reproduces **whole** chunks pays off,
-  which is why self-concatenation is the witness and a smaller duplicate is not.
+- **The error direction is conservative** — the bound over-states cost, so a churn budget derived from it
+  is safe. `CDCCHURN-1`'s published-78 incident was the opposite direction (a positional count quoted as
+  a cost), and this row must not repeat it.
+- **Appending duplicate text does not generally save anything.** Committed as `verbatimChunkProbe`:
+  appending one existing chunk *verbatim* churns the full bound of 2, because the boundary shift means
+  the re-cut chunks are not byte-identical to the original. Only a realignment reproducing **whole**
+  chunks pays, which is why self-concatenation is the witness and a smaller duplicate is not.
 
 ### 0d. The mechanism: an append disturbs only the tail — and can DELETE a boundary there
 
-**The structural claim.** In `cdcBoundaries` (`lib/graph/cdc.ts:222`), the boundary ending chunk `k` is
+**The structural claim.** In `cdcBoundaries` (`lib/graph/cdc.ts:222`) the boundary ending chunk `k` is
 computed from `text[startₖ … min(startₖ + max, n))`, and `n` enters only through `hardEnd` and the
-`n − start <= min` short-tail exit. So every boundary whose chunk **start** lies at least `max` (4,000)
-code units before the original end is computed from unchanged input and cannot move. Verified across all
-580 samples: `movedOutsideMaxWindow` is **0**. Measured divergence depth `|B₀| − L`:
+`n − start <= min` short-tail exit. So a boundary whose chunk **start** lies at least `max` (4,000) code
+units before the original end is computed from unchanged input and cannot move — `movedOutsideMaxWindow`
+is **0** across all 560 samples.
 
-| boundaries moved | 1 | 2 | ≥ 3 |
-|---|---:|---:|---:|
-| samples (580) | 462 | 118 | **0** |
+**The provable ceiling on divergence depth is 4, and the observed maximum is not it.** Non-final chunks
+are at least `min`, so at most `1 + ⌊(max − 1)/min⌋ = 4` chunk starts can lie inside that window. The
+sweep observes a maximum of **2** on the live corpus. That is a corpus observation, not a ceiling: a
+search over random-character documents reaches **3** (and Codex independently constructed one at seed
+1307). One reviewer proposed that depth ≤ 2 "looks provable" for these parameters — **that is refuted**;
+the assertions in §2 use the derived 4, never the observed 2, which is the same discipline `CDCCHURN-1`
+adopted after publishing a sparse-grid maximum as if it were a bound.
 
-That is why §0b's cap clause is redundant, and it is also the death of "the appended text splits the
-final chunk": an append routinely changes the chunk **before** the last one.
+This also kills "the appended text splits the final chunk": an append routinely changes the chunk
+**before** the last one. And `docs/TODO.md` shows the mechanism behind characterisation 4 — its final
+chunk is a 485-character short tail taken by the `n − start <= min` exit, so appending gives that region
+a real cut and moves a boundary **without adding a chunk**.
 
-**And it can remove a boundary entirely.** `docs/design/work-timeline-context-layer.md` has 12
-boundaries; appending **one character** leaves it with 11 — the cut at 28,384 disappears and two chunks
-merge. The mechanism is the backup boundary, documented in the module without this consequence ever
-being drawn (`lib/graph/cdc.ts:218-220`): no primary mask fires anywhere in that final chunk's search
-window, so the cut comes from the backup mask, whose preference order is *"the first backup hit at or
-after `target` if there is one, otherwise the first backup hit at all"*. Appending one character extends
-`hardEnd` by one; that character's position satisfies the backup mask **and** sits past `target`, so it
-outranks the earlier backup and the previous cut ceases to exist. Confirmed by re-running the module's
-own hash roll at that chunk start: primary cut `−1` in both versions, backup `28384` before and `29665`
-after. The bound holds through it (`L = 10`, `|B₁| = 11`, predicted 1, measured 1) — which is the point
-of stating the rule against the shared-boundary prefix rather than against the chunk count.
+**An append can also remove a boundary, and which characters do it is content-dependent.** Committed as
+`mergeProbe` against `docs/design/work-timeline-context-layer.md` (12 boundaries): appending `q`, `%` or
+`5` deletes the boundary at 28,384 and leaves 11; appending `x`, `a`, `z`, space, `.` or newline leaves
+all 12. Draft 1 said "appending **one character**" without naming it — false as an unqualified claim, in
+a spec whose §0e is about content-dependence, and the sweep's own length-1 samples use `z` and `a`, so
+the committed script never observed the event it described. It does now.
 
-### 0e. Churn depends on the appended CONTENT, not only its length — so the guarding test is not a property
+The mechanism is the backup boundary, documented in the module without this consequence being drawn
+(`lib/graph/cdc.ts:218-220`): no primary mask fires in that final chunk's search window, so the cut comes
+from the backup mask, whose preference is *"the first backup hit at or after `target` if there is one,
+otherwise the first backup hit at all"*. The appended character extends `hardEnd` by one; if that
+position satisfies the backup mask **and** sits past `target`, it outranks the earlier backup and the
+previous cut ceases to exist. The bound holds through it (bound 1, churn 1).
 
-The new boundaries are content-defined, so two appends of the *same length* churn differently. Measured
+**This witness is live content and is expected to rot.** It is illustrative; the durable version is the
+checked-in MERGE fixture (§2c).
+
+### 0e. Churn depends on the appended CONTENT, not only its length
+
+Two appends of the same length churn differently, because the new boundaries are content-defined
 (`perLength`, prose filler vs a hash-quiet run of one repeated character):
 
 | append length | prose filler | hash-quiet filler |
 |---|---|---|
-| 2,500 | `{0:1, 2:17, 3:11}` | `{0:1, 1:26, 2:2}` |
-| 9,000 | `{0:1, 4:9, 5:19}` | `{0:1, 3:26, 4:2}` |
-| 60,000 | `{0:1, 23:9, 24:19}` | `{0:1, 16:28}` |
+| 2,500 | `{0:1, 2:16, 3:11}` | `{0:1, 1:25, 2:2}` |
+| 9,000 | `{0:1, 4:9, 5:18}` | `{0:1, 3:25, 4:2}` |
+| 60,000 | `{0:1, 23:9, 24:18}` | `{0:1, 16:27}` |
 
 A hash-quiet run yields few cuts, so 60,000 characters of it become 16 chunks where prose becomes 24.
-Growth is therefore *roughly* one chunk per `target` characters **of ordinary prose**, and any statement
-of the form "an append of N characters churns K" is under-specified. This is the fifth thing the row
-never mentioned, and it kills a constant more thoroughly than length alone does.
+Growth is *roughly* one chunk per `target` characters **of ordinary prose**, and any claim of the form
+"an append of N characters churns K" is under-specified.
 
-It also decides the two assertions guarding the row today:
+### 0f. The two assertions guarding this row today
 
 - **`append at end — CDC re-extracts <= 1 chunk(s)`** (`test/graph-cdc.test.ts:368`) is asserted against
-  one 50,000-character fixture and one 66-character append. Over the corpus that same append churns 2 on
-  4 of 29 documents, and the same fixture with a 2,500-character prose append churns 3.
-- **`CDC must never be worse than byte offsets`** (`test/graph-cdc.test.ts:433`) is **not a property, and
-  its outcome is decided by content nobody chose deliberately.** At the fixture's own append, CDC is
-  strictly worse than byte offsets on **4 of 29** documents and the comparison passes anyway, because it
-  compares max against max **across different documents** and a fifth, unrelated document churns 2 under
-  legacy. Change the append content at one fixed length of 2,500 and the same comparison **fails**
-  outright under one prose filler (`maxCdc 3 > maxLeg 2`), **passes** under a second prose filler, and
-  passes under the hash-quiet filler with CDC strictly *better* on 26 of 29. `CDCCHURN-1` removed this
-  comparison for `edit in place` and named the max-versus-max flaw where it survived — this is that
-  flaw, firing.
+  one 50,000-character fixture and one 66-character append. Over the corpus that append churns 2 on 4 of
+  28 documents; the same fixture with a 2,500-character prose append churns 3.
+- **`CDC must never be worse than byte offsets`** (`test/graph-cdc.test.ts:433`) is **not a property of
+  appends, and its outcome is decided by content nobody chose.** At the fixture's own append CDC is
+  strictly worse on 4 of 28 documents and the comparison passes anyway, because it compares max against
+  max **across different documents** and a fifth, unrelated document churns 2 under legacy. It is the
+  max-versus-max flaw `CDCCHURN-1` named where it survived, firing.
 
-So the honest trade for this row: **CDC is mildly worse than byte offsets on append** for ordinary prose
-— it re-cuts the tail where byte offsets only extend it — and dramatically better on insertion (CDC 1
-against legacy 80). That is the same shape `CDCCHURN-1` documented for in-place edits, and the table
-should say it rather than imply parity.
+  **Deleting it outright is what draft 1 proposed, and both reviewers refused it** — that removes a
+  cross-algorithm guard and leaves nothing to catch a CDC regression that makes appends much worse.
+  §2d replaces it instead.
+
+So the honest trade: **CDC is mildly worse than byte offsets on append** — it re-cuts the tail where byte
+offsets only extend it — and dramatically better on insertion (CDC 1 against legacy 80). Measured
+(`legacyEnvelope`), the per-document loss is at most **+1 chunk for appends shorter than `min`**, on both
+the live corpus and 300 synthetic documents; for longer appends it reaches +1 on the corpus and +2
+synthetically, so the general claim is weaker than the short-append one.
 
 ## 1. The claims that cannot hold
 
 - The acceptance table's `append at end` row cannot carry a constant: churn grows with append length,
-  varies with append content at fixed length (§0e), and collapses to 0 past the cap.
+  varies with append content at fixed length (§0e), and reaches 0 only once the shared prefix fills the
+  cap (§0a.6) — not merely once the document does.
 - The summary table at the top of `content-defined-chunking.md` (`| append at the end | 1 |`) measures
   **legacy** behaviour on a 50,000-character document, where 20 full chunks plus a 66-character append
-  yields exactly one new chunk. It is correct as written for what it measures and is left alone — the
-  same adjudication `CDCCHURN-1` reached for the row above, recorded here so it is not re-opened.
+  gives exactly one new chunk. Draft 1 called it "correct as written" and left it; one reviewer agreed and
+  the other showed the adjudication was too broad — **a 2,501-character append churns 2 under legacy, and
+  9,000 churns 4**, so that row is conditional on append length in exactly the way the CDC column was.
+  It is not rewritten (it does measure what it says it measures) but it is **scoped to the append it
+  measures**, which is the minimum honesty the neighbouring correction demands.
 
 ## 2. The decision
 
 ### 2a. The table row states a bound, its mechanism, and the trade
 
-`append at end` becomes: **at most the number of admitted chunks after the last boundary the two
-chunkings share — 1 for a short append to an uncapped document, 0 once the document fills the cap, and
-growing with both the length and the entropy of the appended text.** The prose names the mechanism (only
-boundaries within `max` of the end can move; the backup-boundary preference can delete one) and carries
-§0e's trade, so the row states both directions at once.
+`append at end` becomes: **at most the number of admitted chunks after the last chunk the two chunkings
+share — 1 for a short append to a document below the cap, 0 once the shared prefix itself fills the cap,
+and growing with both the length and the entropy of the appended text.** The prose names the mechanism
+(only boundaries within `max` of the end can move; the backup-boundary preference can delete one) and
+carries §0f's trade.
 
-### 2b. The test asserts the bound per document, never a constant
+### 2b. The test asserts the bound per document — and an ABSOLUTE ceiling that cannot self-adjust
 
-For every live corpus document × append lengths spanning the regimes (below `min`, around `target`,
-multiples of it) × two append contents, from the two boundary sequences the test already computes:
+The bound in §0b is computed from the chunker's own output, so **any prefix-stable chunker satisfies it
+by construction**: a regression that re-cuts deeply just shrinks `L` and inflates the bound to match.
+Asserting only that would be a guard that can never redden — the exact standard this repo applies to a
+predicate term, applied here to a whole assertion. So the test asserts three things:
 
-1. `L` and the predicted admitted count;
-2. set churn **≤** predicted — the theorem, which holds for every input;
-3. equality on the live corpus, with the count of strict cases reported, so the duplicate-content case
-   becomes visible rather than silently absorbed into a `≤`.
+1. **the bound**, per document per append content — `churn ≤ |C₁| − L`;
+2. **an absolute ceiling derived from the SIZE ENVELOPE, not from behaviour**:
+   `churn ≤ (1 + ⌊(max − 1)/min⌋) + ⌈A/min⌉` for an append of length `A` — at most 4 tail boundaries can
+   move (§0d) and the appended text adds at most `⌈A/min⌉` chunks. Zero violations across the 560 corpus
+   samples and 19,509 samples including adversarial synthetic documents. This is the assertion that
+   reddens if `cdc2` starts re-cutting the whole document;
+3. **the divergence depth**, per document, against the derived 4 — never the observed 2.
 
-No constant ceiling is asserted for any append length, because a ceiling is what made this row wrong
-four times.
+Equality with the bound is **reported, not gated** (a future document quoting another one verbatim would
+otherwise redden CI on an unrelated docs edit); the fixtures gate it where it is deterministic.
 
 ### 2c. Four checked-in fixtures, because the live corpus cannot guarantee any of these branches
 
-`CDCCHURN-1`'s lesson exactly: a live-corpus assertion that quantifies over an empty set is green.
-
-- **CAPPED** — a document past the admitted cap, asserting churn 0 AND that it exceeds the cap, so the
-  assertion cannot pass by the document simply being short. Today only `docs/ARCHITECTURE.md` reaches
-  the cap on the live corpus; one refactor and that branch is empty.
+- **CAPPED** — asserts churn 0 AND that the **shared chunk prefix reaches the cap**, which is the real
+  condition; a fixture asserting only "the document exceeds the cap" would be red at 80 boundaries
+  (§0a.6).
 - **MERGE** — a document whose final cut comes from the backup mask, asserting the boundary count
-  **falls** on a one-character append, the specific boundary is present before and absent after, and the
-  bound still holds. Without the before/after assertions the fixture can silently stop exercising it.
+  **falls**, the specific boundary is present before and absent after, and the bound still holds.
+  Constructed and checked in rather than pinned to the live file the §0d witness names.
 - **DUPLICATE** — self-concatenation, asserting set churn is strictly **below** the bound while the
-  positional count equals it. This is the one branch that proves the rule is an inequality; nothing on
-  the live corpus reaches it.
+  positional count equals it. The one branch that proves the rule is an inequality; nothing on the live
+  corpus reaches it.
 - **GROWTH** — one document across the length sweep under two append contents, asserting churn is
   non-decreasing in length, reaches ≥ 4 by 9,000 characters of prose, and **differs between the two
-  contents at the same length** — so §0e's content-dependence is pinned by a test, not only by prose.
+  contents at the same length**, pinning §0e by test rather than by prose.
 
-### 2d. The false comparison goes, with its measurement recorded at the site
+### 2d. The false comparison is REPLACED, not deleted
 
-`max(cdc) ≤ max(legacy)` is removed for `append at end` and §0e is recorded at the removal site, naming
-both why it passes today (max-versus-max across different documents) and that its outcome flips with the
-appended content at a fixed length. The `<= 1` scenario assertion is replaced by the bound. The
-comparison is **kept** for the insertion and deletion scenarios, where it is true per-document and is
-the reason this lever exists.
+`max(cdc) ≤ max(legacy)` goes, and in its place a **per-document** comparison gated on the regime where
+the envelope is measured: for appends shorter than `min`, `cdcChurn ≤ legacyChurn + 1`. For longer
+appends the per-document gap is reported, not gated, with the measured corpus and synthetic maxima
+recorded at the site — because a synthetic maximum is a lower bound and this file does not gate on
+lower bounds. §0f's reasons are recorded at the removal site: why the old form passed, and that its
+outcome flips with the appended content at a fixed length.
 
-### 2e. The sweep script gains the append operation
+### 2e. The sweep script
 
-`scripts/cdc-churn-sweep.mjs` gains `--op append`: documents × lengths × append contents, reporting both
-metrics, the divergence depth, the falsified candidate, the legacy comparison per document, and a
-`revision` stamp. It also gains a corrected corpus definition — a comment claimed its `> 4,000`-character
-set was "the same corpus `test/graph-cdc.test.ts` reads", which it never was (the test reads three
-directories at ≥ 15,000 characters). That is a number measured over one population and asserted over
-another, which is this ticket's own failure mode.
+`--op append` sweeps documents × lengths × append contents and reports both metrics, the divergence
+depth against the derived ceiling, the absolute guard, the falsified candidate, the falsified
+boundary-coordinate form of the bound, and probes for the merge event, the cap parity, the verbatim
+duplicate and the legacy envelope. It exits non-zero on any refuted invariant, so it is a check and not
+only a report. It also gains `--exclude` (the reflexivity above) and a corrected corpus definition — a
+comment claimed its `> 4,000`-character set was "the same corpus `test/graph-cdc.test.ts` reads", which
+it never was — and a fix to the `prose-b` filler, which replaced text **after** slicing and so appended
+2,602 characters at a nominal 2,500, confounding the very "same length, different content" comparison it
+was evidence for.
 
 ## Dependencies
 
-**Deps: none.** One test file, four small fixtures, one script, and one table row in one design
-document. No product code, no schema, no API surface.
+**Deps: none.** One test file, four small fixtures, one script, and one table row in one design document.
+No product code, no schema, no API surface.
 
 ## Build-with
 
-**Build-with tier: Fable / high effort.** Four characterisations of this row have now been falsified, one
-of them this draft's own first candidate at 80.9%. A fifth wrong answer ships as documentation and as a
-test that pins it. Two adversarial spec reviews (Fable + Codex) before any code, two on the diff.
+**Build-with tier: Fable / high effort.** Six characterisations of this row have now been falsified,
+three of them in this ticket and all three mine. A seventh wrong answer ships as documentation and as a
+test that pins it. Two adversarial spec reviews per round (Fable + Codex); round 1 BLOCKED on both.
 
 ## Tier safety
 
@@ -241,22 +277,28 @@ schema, no API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupId
 
 ## 3. Acceptance criteria
 
-- `test/graph-cdc.test.ts` — for every live corpus document at every swept append length and append content, set churn is asserted `<= max(0, min(cap, |B1|) - L)`, per document rather than as a corpus maximum one outlier can dominate.
-- `test/graph-cdc.test.ts` — a CAPPED fixture asserts churn 0 AND that the document exceeds the admitted cap, so the branch cannot pass by the document being short.
-- `test/graph-cdc.test.ts` — a MERGE fixture asserts the boundary count FALLS on a one-character append, the vanishing boundary is present before and absent after, and the bound still holds.
+- `test/graph-cdc.test.ts` — for every live corpus document at every swept append length and append content, set churn is asserted `<= |C1| - L` where L is the common prefix of the two ADMITTED CHUNK arrays, per document rather than as a corpus maximum one outlier can dominate.
+- `test/graph-cdc.test.ts` — an ABSOLUTE ceiling `churn <= (1 + floor((max-1)/min)) + ceil(A/min)` is asserted per document, derived from the size envelope rather than from the chunker's output, so a chunker that re-cuts deeply reddens it.
+- `test/graph-cdc.test.ts` — the divergence depth is asserted per document against the DERIVED ceiling of 4, never the observed 2, and the observed maximum is recorded as an observation.
+- `test/graph-cdc.test.ts` — a CAPPED fixture asserts churn 0 AND that the shared chunk prefix reaches the cap; a fixture asserting only "the document exceeds the cap" must fail, since a document at exactly 80 boundaries churns 1.
+- `test/graph-cdc.test.ts` — a MERGE fixture, checked in rather than read from the live corpus, asserts the boundary count FALLS on a one-character append, the vanishing boundary is present before and absent after, and the bound still holds.
 - `test/graph-cdc.test.ts` — a DUPLICATE fixture asserts set churn is strictly below the bound while the positional count equals it, pinning the rule as an inequality rather than an equality that happens to hold.
 - `test/graph-cdc.test.ts` — a GROWTH fixture asserts churn is non-decreasing in append length, reaches at least 4 by a 9,000-character prose append, and DIFFERS between two append contents of the same length; no constant ceiling is asserted for any length.
-- `test/graph-cdc.test.ts` — the `append at end — CDC re-extracts <= 1 chunk(s)` assertion and the `max(cdc) <= max(legacy)` comparison for append are GONE, with the measured reason recorded at the site (4 of 29 documents strictly worse at the fixture's own append; the comparison's outcome flips with append content at a fixed length).
-- `test/graph-cdc.test.ts` — the live-corpus equality census is reported and a `documents > 5` floor is asserted, because a bound assertion over an empty or single-document corpus is green by construction.
-- `scripts/cdc-churn-sweep.mjs` — `--op append` sweeps documents x lengths x append contents, reports SET and POSITIONAL churn, divergence depth, the falsified candidate and the per-document legacy comparison, and stamps the revision it measured.
-- `scripts/cdc-churn-sweep.mjs` — the corpus helper names its two definitions explicitly and the false "the same corpus the test reads" comment is corrected; the in-place mode's existing numbers reproduce unchanged.
-- `docs/design/content-defined-chunking.md` — the acceptance table's `append at end` row states the bound, the cap collapse, and that growth depends on the appended content as well as its length; the prose carries the measured CDC-vs-legacy trade in both directions.
-- `docs/design/content-defined-chunking.md` — the summary table's legacy `| append at the end | 1 |` is deliberately untouched, with the adjudication recorded so it is not re-opened a third time.
+- `test/graph-cdc.test.ts` — a WHITESPACE fixture asserts the bound holds for a whitespace-only base, the case that falsified the boundary-coordinate form of the rule.
+- `test/graph-cdc.test.ts` — the `max(cdc) <= max(legacy)` comparison for append is replaced by a PER-DOCUMENT `cdcChurn <= legacyChurn + 1` gated to appends shorter than `min`, with the longer-append gap reported and the measured reason recorded at the site; the comparison is untouched for the insertion and deletion scenarios.
+- `test/graph-cdc.test.ts` — the `append at end — CDC re-extracts <= 1 chunk(s)` assertion is GONE, with the measurement that refutes it recorded at the site.
+- `test/graph-cdc.test.ts` — the live-corpus equality census is reported rather than gated, and a `documents > 5` floor is asserted, because a bound assertion over an empty or single-document corpus is green by construction.
+- `scripts/cdc-churn-sweep.mjs` — `--op append` reports the bound, the absolute guard, the divergence depth against its derived ceiling, the falsified candidate, the falsified boundary-coordinate form, and the merge, cap-parity, verbatim-duplicate and legacy-envelope probes; it exits non-zero on any refuted invariant.
+- `scripts/cdc-churn-sweep.mjs` — `--exclude <path>` omits a document from the corpus, so a distribution published in a document that is itself in the corpus is stable against its own edits.
+- `scripts/cdc-churn-sweep.mjs` — the `prose-b` filler replaces before slicing, so the "same length, different content" comparison is not length-confounded; the false "the same corpus the test reads" comment is corrected; the in-place mode's existing numbers reproduce unchanged.
+- `docs/design/content-defined-chunking.md` — the acceptance table's `append at end` row states the bound, the shared-prefix cap condition, and that growth depends on the appended content as well as its length; the prose carries the measured CDC-vs-legacy envelope.
+- `docs/design/content-defined-chunking.md` — the summary table's legacy `| append at the end | 1 |` is SCOPED to the 66-character append it measures rather than left unqualified, since a 2,501-character append churns 2 under byte offsets too.
 
 ## 4. Scope
 
-**In:** the `append at end` acceptance row and its prose, the append scenario's two false assertions,
-four fixtures, the sweep script's append mode and corpus correction.
+**In:** the `append at end` acceptance row and its prose, the summary row's scoping, the append
+scenario's two false assertions, five fixtures, the sweep script's append mode, probes, `--exclude` and
+corpus/filler corrections.
 
 **Deferred, each with its reason:**
 
@@ -264,22 +306,27 @@ four fixtures, the sweep script's append mode and corpus correction.
   chunking and keep its boundaries — makes chunking depend on the PREVIOUS chunking, and
   "same body ⇒ same chunks ⇒ same hashes" is the invariant the whole delta ledger rests on
   (`lib/graph/cdc.ts:11-13`). Rejected on that ground, not on cost.
-- **The orphan-tail question the MERGE case raises.** When two chunks merge, the vanished chunk's
-  episode is still in the graph and nothing purges it. That is the same orphan-tail issue
+- **The orphan-tail question the MERGE case raises.** When two chunks merge, the vanished chunk's episode
+  is still in the graph and nothing purges it. That is the orphan-tail issue
   `content-defined-chunking.md` already records for a cap shrink, it predates this slice, and it is a
   product decision about purge rather than a churn measurement.
-- **Re-litigating CDC vs byte offsets.** §0e shows append is a mild loss and insertion a large win.
-  Whether the balance is right is a design question with its own measurements; this slice makes the loss
-  visible instead of asserting a parity that is not there.
+- **Gating the long-append legacy envelope.** The synthetic maximum (+2 here, higher under other
+  generators) is a lower bound, and this file does not gate on lower bounds — the short-append regime is
+  where the envelope is measured on both populations.
 - **A cross-operation churn budget.** Three rows of that table are now conditional. Turning them into one
   predictive cost model for the projector is separate work with a separate consumer.
 
 ## 5. What would falsify this
 
-Wrong if any document at any append length and content churns **more** than the bound — that would mean
-a chunk at an index below `L` changed, contradicting the byte-identity the proof rests on, and would mean
-the divergence-depth window in §0d is not what the code does.
+Wrong if any base document and any append make set churn **exceed** `|C₁| − L` over the admitted chunk
+arrays — that would mean a chunk at an index below `L` was re-pushed despite being byte-identical to one
+already in the ledger, contradicting the MEMBERSHIP filter at `lib/graph/project.ts:1222-1223` rather
+than anything about boundaries. (Draft 1's boundary-coordinate form was falsified exactly here, by the
+`chunkCdc` blank-body guard, so this clause names the right mechanism now.)
+
+Wrong if any document exceeds the absolute ceiling of `(1 + ⌊(max − 1)/min⌋) + ⌈A/min⌉`, which would mean
+the structural window in §0d is not what `cdcBoundaries` does.
 
 Wrong in the other direction if the DUPLICATE fixture's set churn ever **equals** the bound, which would
 mean the fixture stopped exercising the inequality and the rule is being pinned as an equality again —
-the failure this row has now had four times.
+the failure this row has now had six times.

--- a/docs/design/cdc-append-churn.md
+++ b/docs/design/cdc-append-churn.md
@@ -118,9 +118,10 @@ is **0** across all 560 samples.
 
 **The provable ceiling on divergence depth is 4, and the observed maximum is not it.** Non-final chunks
 are at least `min`, so at most `1 + ⌊(max − 1)/min⌋ = 4` chunk starts can lie inside that window. The
-sweep observes a maximum of **2** on the live corpus. That is a corpus observation, not a ceiling: a
-search over random-character documents reaches **3** (and Codex independently constructed one at seed
-1307). One reviewer proposed that depth ≤ 2 "looks provable" for these parameters — **that is refuted**;
+sweep observes a maximum of **2** on the live corpus and **3** on its 400 synthetic documents
+(`absoluteGuard.synthetic.maxDepthObserved`; Codex independently constructed one at seed 1307). So the
+corpus figure is an observation, not a ceiling. One reviewer proposed that depth ≤ 2 "looks provable" for
+these parameters — **that is refuted by the committed script's own output**;
 the assertions in §2 use the derived 4, never the observed 2, which is the same discipline `CDCCHURN-1`
 adopted after publishing a sparse-grid maximum as if it were a bound.
 
@@ -216,7 +217,8 @@ predicate term, applied here to a whole assertion. So the test asserts three thi
 2. **an absolute ceiling derived from the SIZE ENVELOPE, not from behaviour**:
    `churn ≤ (1 + ⌊(max − 1)/min⌋) + ⌈A/min⌉` for an append of length `A` — at most 4 tail boundaries can
    move (§0d) and the appended text adds at most `⌈A/min⌉` chunks. Zero violations across the 560 corpus
-   samples and 19,509 samples including adversarial synthetic documents. This is the assertion that
+   samples and a further **8,400 samples over 400 synthetic documents** (`absoluteGuard.synthetic`, in
+   the committed script — 28 real files are not evidence about an algorithm). This is the assertion that
    reddens if `cdc2` starts re-cutting the whole document;
 3. **the divergence depth**, per document, against the derived 4 — never the observed 2.
 

--- a/docs/design/cdc-append-churn.md
+++ b/docs/design/cdc-append-churn.md
@@ -1,0 +1,285 @@
+# Append churn is a bound, not a number — CDCAPPEND-1
+
+**Status:** spec, draft 1 · **Date:** 2026-08-16 · **Owner:** Chetan · **Task:** `CDCAPPEND-1`
+**Related:** [`content-defined-chunking.md`](./content-defined-chunking.md) (the table this corrects),
+[`cdc-boundary-overlap.md`](./cdc-boundary-overlap.md) (`CDCCHURN-1`, the row above this one).
+**Code:** `test/graph-cdc.test.ts`, `scripts/cdc-churn-sweep.mjs`, `lib/graph/cdc.ts` (read only —
+no product change; that IS the finding, exactly as it was one row up).
+
+**Every number below comes from one run of `node scripts/cdc-churn-sweep.mjs --op append`**, which
+stamps its own `revision` (SHA + whether the tree was dirty) for the reason this ticket's neighbour
+learned the hard way: a published measurement stopped reproducing, and the retraction story was wrong
+too. Figures here were taken at `46aad5c` with this spec present in the tree — **which matters, because
+the design documents ARE the corpus**: this file is ≥ 15,000 characters, so it joined the measured set
+and took it from 28 documents to 29. Re-run the sweep rather than trusting a number quoted here.
+
+---
+
+## 0. What is wrong
+
+`docs/design/content-defined-chunking.md`'s acceptance table currently reads:
+
+| scenario | byte-offset (today) | CDC (required) |
+|---|---|---|
+| append at end | 1 of 20 | conditional, not yet characterised (`CDCAPPEND-1`) |
+
+That cell is `CDCCHURN-1`'s deliberate statement of ignorance, left in place rather than filled with a
+fourth invented rule. This slice fills it — and, in measuring it, found that the **test** guarding the
+row asserts two things that are not properties of appends at all (§0e).
+
+### 0a. Four characterisations of this row, all four falsified by measurement
+
+Three were falsified during `CDCCHURN-1`'s review. **The fourth was this draft's own, and it was wrong
+too** — which is why the rule below was measured before it was written, the order that ticket ended on.
+
+1. *"Churn is 1."* — The original acceptance-table claim. False in both directions: `docs/ARCHITECTURE.md`
+   churns **0** (146 boundaries against an 80-chunk admitted cap, so an append lands past the admitted
+   prefix and is dropped entirely), and for the test fixture's own 66-character append **4 of 29**
+   corpus documents churn **2** (`fixtureAppend.churnDistribution`: `{0: 1, 1: 24, 2: 4}`).
+2. *"1 unless the appended text splits the final chunk, then 2."* — False in both halves. The 0 case
+   breaks the floor, and the 2s are not "the append split the final chunk": the new cut lands inside the
+   **appended** region, which moves the final boundary and therefore changes the chunk before it too.
+3. *"2 is the ceiling."* — Holds only for appends shorter than `min`. A 9,000-character prose append
+   churns 4–5 and a 60,000-character one churns 23–24 (§0d).
+4. *(this draft's first candidate)* *"churn = 1 + the number of new chunks, or 0 when capped."* —
+   **469 of 580 samples, 80.9%.** Every miss is in the same direction, and `docs/TODO.md` is the
+   clearest witness: it says 1 where the answer is 2, at four different append lengths. The mechanism is
+   §0d — a document's final chunk frequently has no cut at all, the text simply ended, so extending the
+   tail lets the chunker *find* a cut inside the appended region and move the last boundary **without
+   adding a chunk**. The candidate is kept runnable in the sweep (`candidate1`) so the refutation
+   reproduces rather than being asserted.
+
+### 0b. The rule, and it is a BOUND with a proof, not a fitted constant
+
+Let `B₀` and `B₁` be the (uncapped) boundary sequences of the document before and after the append, and
+let `L` be the length of their longest common prefix — the index of the last boundary the two chunkings
+**share**. Then:
+
+> **churn ≤ max(0, min(cap, |B₁|) − L)** — the number of ADMITTED chunks lying after the last shared
+> boundary.
+
+**The bound is a theorem, not a measurement.** Chunks `0 … L−1` are byte-identical across the two
+chunkings, so under the SET metric the ledger pays (`lib/graph/project.ts:1222-1223` filters by
+`new Set(chunk_shas)` MEMBERSHIP) none of them can be re-pushed; at most the chunks after `L`, truncated
+at the cap, can be. Stating it as a bound rather than an equality is the correction: all four earlier
+attempts stated an equality, and an equality is what keeps being falsified.
+
+**And it is measured tight.** 29 documents × 10 append lengths × 2 append contents = **580 samples;
+bound holds 580/580; exactly tight 580/580 under both the set metric and a positional diff; zero
+violations, zero slack.**
+
+**The cap term is a CONSEQUENCE, not a term.** "0 when the document already fills the admitted cap" was
+this draft's second clause. It is redundant: an append can only move boundaries near the end (§0d), so a
+document with more than `cap` boundaries always has `L ≥ cap` and `min(cap, |B₁|) − L` is already ≤ 0.
+`CDCCHURN-1` deleted a predicate term for exactly this reason — "a term no test can redden is one the
+code would be asserting on trust" — and the same standard applies to prose. The clause is gone; a
+fixture asserts the property instead.
+
+### 0c. Where the bound is NOT tight, and why that is the safe direction
+
+The set metric comes in **below** the bound when a new chunk's content already appears elsewhere in the
+document — an identical chunk is never re-pushed, so it costs nothing. Constructed (`duplicateProbe`):
+appending a 60,000-character document **to itself** re-cuts the tail into 25 positionally-changed chunks
+of which **23 are byte-identical to chunks that already exist**, so the ledger pays **2** where the bound
+says 25. (`CDCCHURN-1` found and pinned the same asymmetry for in-place edits; this is that finding one
+row down.)
+
+Two things make this the right shape rather than a hole:
+
+- **The error direction is conservative.** The bound over-states cost, never under-states it, so a churn
+  budget derived from it is safe. `CDCCHURN-1`'s published-78 incident was the opposite direction — a
+  positional count quoted as a cost — and this row must not repeat it.
+- **Appending duplicate text does not generally save anything.** Appending one existing chunk *verbatim*
+  still churns the full predicted amount, because the boundary shift means the re-cut chunks are not
+  byte-identical to the original one. Only a realignment that reproduces **whole** chunks pays off,
+  which is why self-concatenation is the witness and a smaller duplicate is not.
+
+### 0d. The mechanism: an append disturbs only the tail — and can DELETE a boundary there
+
+**The structural claim.** In `cdcBoundaries` (`lib/graph/cdc.ts:222`), the boundary ending chunk `k` is
+computed from `text[startₖ … min(startₖ + max, n))`, and `n` enters only through `hardEnd` and the
+`n − start <= min` short-tail exit. So every boundary whose chunk **start** lies at least `max` (4,000)
+code units before the original end is computed from unchanged input and cannot move. Verified across all
+580 samples: `movedOutsideMaxWindow` is **0**. Measured divergence depth `|B₀| − L`:
+
+| boundaries moved | 1 | 2 | ≥ 3 |
+|---|---:|---:|---:|
+| samples (580) | 462 | 118 | **0** |
+
+That is why §0b's cap clause is redundant, and it is also the death of "the appended text splits the
+final chunk": an append routinely changes the chunk **before** the last one.
+
+**And it can remove a boundary entirely.** `docs/design/work-timeline-context-layer.md` has 12
+boundaries; appending **one character** leaves it with 11 — the cut at 28,384 disappears and two chunks
+merge. The mechanism is the backup boundary, documented in the module without this consequence ever
+being drawn (`lib/graph/cdc.ts:218-220`): no primary mask fires anywhere in that final chunk's search
+window, so the cut comes from the backup mask, whose preference order is *"the first backup hit at or
+after `target` if there is one, otherwise the first backup hit at all"*. Appending one character extends
+`hardEnd` by one; that character's position satisfies the backup mask **and** sits past `target`, so it
+outranks the earlier backup and the previous cut ceases to exist. Confirmed by re-running the module's
+own hash roll at that chunk start: primary cut `−1` in both versions, backup `28384` before and `29665`
+after. The bound holds through it (`L = 10`, `|B₁| = 11`, predicted 1, measured 1) — which is the point
+of stating the rule against the shared-boundary prefix rather than against the chunk count.
+
+### 0e. Churn depends on the appended CONTENT, not only its length — so the guarding test is not a property
+
+The new boundaries are content-defined, so two appends of the *same length* churn differently. Measured
+(`perLength`, prose filler vs a hash-quiet run of one repeated character):
+
+| append length | prose filler | hash-quiet filler |
+|---|---|---|
+| 2,500 | `{0:1, 2:17, 3:11}` | `{0:1, 1:26, 2:2}` |
+| 9,000 | `{0:1, 4:9, 5:19}` | `{0:1, 3:26, 4:2}` |
+| 60,000 | `{0:1, 23:9, 24:19}` | `{0:1, 16:28}` |
+
+A hash-quiet run yields few cuts, so 60,000 characters of it become 16 chunks where prose becomes 24.
+Growth is therefore *roughly* one chunk per `target` characters **of ordinary prose**, and any statement
+of the form "an append of N characters churns K" is under-specified. This is the fifth thing the row
+never mentioned, and it kills a constant more thoroughly than length alone does.
+
+It also decides the two assertions guarding the row today:
+
+- **`append at end — CDC re-extracts <= 1 chunk(s)`** (`test/graph-cdc.test.ts:368`) is asserted against
+  one 50,000-character fixture and one 66-character append. Over the corpus that same append churns 2 on
+  4 of 29 documents, and the same fixture with a 2,500-character prose append churns 3.
+- **`CDC must never be worse than byte offsets`** (`test/graph-cdc.test.ts:433`) is **not a property, and
+  its outcome is decided by content nobody chose deliberately.** At the fixture's own append, CDC is
+  strictly worse than byte offsets on **4 of 29** documents and the comparison passes anyway, because it
+  compares max against max **across different documents** and a fifth, unrelated document churns 2 under
+  legacy. Change the append content at one fixed length of 2,500 and the same comparison **fails**
+  outright under one prose filler (`maxCdc 3 > maxLeg 2`), **passes** under a second prose filler, and
+  passes under the hash-quiet filler with CDC strictly *better* on 26 of 29. `CDCCHURN-1` removed this
+  comparison for `edit in place` and named the max-versus-max flaw where it survived — this is that
+  flaw, firing.
+
+So the honest trade for this row: **CDC is mildly worse than byte offsets on append** for ordinary prose
+— it re-cuts the tail where byte offsets only extend it — and dramatically better on insertion (CDC 1
+against legacy 80). That is the same shape `CDCCHURN-1` documented for in-place edits, and the table
+should say it rather than imply parity.
+
+## 1. The claims that cannot hold
+
+- The acceptance table's `append at end` row cannot carry a constant: churn grows with append length,
+  varies with append content at fixed length (§0e), and collapses to 0 past the cap.
+- The summary table at the top of `content-defined-chunking.md` (`| append at the end | 1 |`) measures
+  **legacy** behaviour on a 50,000-character document, where 20 full chunks plus a 66-character append
+  yields exactly one new chunk. It is correct as written for what it measures and is left alone — the
+  same adjudication `CDCCHURN-1` reached for the row above, recorded here so it is not re-opened.
+
+## 2. The decision
+
+### 2a. The table row states a bound, its mechanism, and the trade
+
+`append at end` becomes: **at most the number of admitted chunks after the last boundary the two
+chunkings share — 1 for a short append to an uncapped document, 0 once the document fills the cap, and
+growing with both the length and the entropy of the appended text.** The prose names the mechanism (only
+boundaries within `max` of the end can move; the backup-boundary preference can delete one) and carries
+§0e's trade, so the row states both directions at once.
+
+### 2b. The test asserts the bound per document, never a constant
+
+For every live corpus document × append lengths spanning the regimes (below `min`, around `target`,
+multiples of it) × two append contents, from the two boundary sequences the test already computes:
+
+1. `L` and the predicted admitted count;
+2. set churn **≤** predicted — the theorem, which holds for every input;
+3. equality on the live corpus, with the count of strict cases reported, so the duplicate-content case
+   becomes visible rather than silently absorbed into a `≤`.
+
+No constant ceiling is asserted for any append length, because a ceiling is what made this row wrong
+four times.
+
+### 2c. Four checked-in fixtures, because the live corpus cannot guarantee any of these branches
+
+`CDCCHURN-1`'s lesson exactly: a live-corpus assertion that quantifies over an empty set is green.
+
+- **CAPPED** — a document past the admitted cap, asserting churn 0 AND that it exceeds the cap, so the
+  assertion cannot pass by the document simply being short. Today only `docs/ARCHITECTURE.md` reaches
+  the cap on the live corpus; one refactor and that branch is empty.
+- **MERGE** — a document whose final cut comes from the backup mask, asserting the boundary count
+  **falls** on a one-character append, the specific boundary is present before and absent after, and the
+  bound still holds. Without the before/after assertions the fixture can silently stop exercising it.
+- **DUPLICATE** — self-concatenation, asserting set churn is strictly **below** the bound while the
+  positional count equals it. This is the one branch that proves the rule is an inequality; nothing on
+  the live corpus reaches it.
+- **GROWTH** — one document across the length sweep under two append contents, asserting churn is
+  non-decreasing in length, reaches ≥ 4 by 9,000 characters of prose, and **differs between the two
+  contents at the same length** — so §0e's content-dependence is pinned by a test, not only by prose.
+
+### 2d. The false comparison goes, with its measurement recorded at the site
+
+`max(cdc) ≤ max(legacy)` is removed for `append at end` and §0e is recorded at the removal site, naming
+both why it passes today (max-versus-max across different documents) and that its outcome flips with the
+appended content at a fixed length. The `<= 1` scenario assertion is replaced by the bound. The
+comparison is **kept** for the insertion and deletion scenarios, where it is true per-document and is
+the reason this lever exists.
+
+### 2e. The sweep script gains the append operation
+
+`scripts/cdc-churn-sweep.mjs` gains `--op append`: documents × lengths × append contents, reporting both
+metrics, the divergence depth, the falsified candidate, the legacy comparison per document, and a
+`revision` stamp. It also gains a corrected corpus definition — a comment claimed its `> 4,000`-character
+set was "the same corpus `test/graph-cdc.test.ts` reads", which it never was (the test reads three
+directories at ≥ 15,000 characters). That is a number measured over one population and asserted over
+another, which is this ticket's own failure mode.
+
+## Dependencies
+
+**Deps: none.** One test file, four small fixtures, one script, and one table row in one design
+document. No product code, no schema, no API surface.
+
+## Build-with
+
+**Build-with tier: Fable / high effort.** Four characterisations of this row have now been falsified, one
+of them this draft's own first candidate at 80.9%. A fifth wrong answer ships as documentation and as a
+test that pins it. Two adversarial spec reviews (Fable + Codex) before any code, two on the diff.
+
+## Tier safety
+
+No tier surface changes: a test, four fixtures, a script, and a design document. No product code, no
+schema, no API route, no change to `visibleItems`/`visibleTasks`/`visibleGroupIds`.
+
+## 3. Acceptance criteria
+
+- `test/graph-cdc.test.ts` — for every live corpus document at every swept append length and append content, set churn is asserted `<= max(0, min(cap, |B1|) - L)`, per document rather than as a corpus maximum one outlier can dominate.
+- `test/graph-cdc.test.ts` — a CAPPED fixture asserts churn 0 AND that the document exceeds the admitted cap, so the branch cannot pass by the document being short.
+- `test/graph-cdc.test.ts` — a MERGE fixture asserts the boundary count FALLS on a one-character append, the vanishing boundary is present before and absent after, and the bound still holds.
+- `test/graph-cdc.test.ts` — a DUPLICATE fixture asserts set churn is strictly below the bound while the positional count equals it, pinning the rule as an inequality rather than an equality that happens to hold.
+- `test/graph-cdc.test.ts` — a GROWTH fixture asserts churn is non-decreasing in append length, reaches at least 4 by a 9,000-character prose append, and DIFFERS between two append contents of the same length; no constant ceiling is asserted for any length.
+- `test/graph-cdc.test.ts` — the `append at end — CDC re-extracts <= 1 chunk(s)` assertion and the `max(cdc) <= max(legacy)` comparison for append are GONE, with the measured reason recorded at the site (4 of 29 documents strictly worse at the fixture's own append; the comparison's outcome flips with append content at a fixed length).
+- `test/graph-cdc.test.ts` — the live-corpus equality census is reported and a `documents > 5` floor is asserted, because a bound assertion over an empty or single-document corpus is green by construction.
+- `scripts/cdc-churn-sweep.mjs` — `--op append` sweeps documents x lengths x append contents, reports SET and POSITIONAL churn, divergence depth, the falsified candidate and the per-document legacy comparison, and stamps the revision it measured.
+- `scripts/cdc-churn-sweep.mjs` — the corpus helper names its two definitions explicitly and the false "the same corpus the test reads" comment is corrected; the in-place mode's existing numbers reproduce unchanged.
+- `docs/design/content-defined-chunking.md` — the acceptance table's `append at end` row states the bound, the cap collapse, and that growth depends on the appended content as well as its length; the prose carries the measured CDC-vs-legacy trade in both directions.
+- `docs/design/content-defined-chunking.md` — the summary table's legacy `| append at the end | 1 |` is deliberately untouched, with the adjudication recorded so it is not re-opened a third time.
+
+## 4. Scope
+
+**In:** the `append at end` acceptance row and its prose, the append scenario's two false assertions,
+four fixtures, the sweep script's append mode and corpus correction.
+
+**Deferred, each with its reason:**
+
+- **Changing the chunker so appends never re-cut the tail.** The obvious fix — remember the previous
+  chunking and keep its boundaries — makes chunking depend on the PREVIOUS chunking, and
+  "same body ⇒ same chunks ⇒ same hashes" is the invariant the whole delta ledger rests on
+  (`lib/graph/cdc.ts:11-13`). Rejected on that ground, not on cost.
+- **The orphan-tail question the MERGE case raises.** When two chunks merge, the vanished chunk's
+  episode is still in the graph and nothing purges it. That is the same orphan-tail issue
+  `content-defined-chunking.md` already records for a cap shrink, it predates this slice, and it is a
+  product decision about purge rather than a churn measurement.
+- **Re-litigating CDC vs byte offsets.** §0e shows append is a mild loss and insertion a large win.
+  Whether the balance is right is a design question with its own measurements; this slice makes the loss
+  visible instead of asserting a parity that is not there.
+- **A cross-operation churn budget.** Three rows of that table are now conditional. Turning them into one
+  predictive cost model for the projector is separate work with a separate consumer.
+
+## 5. What would falsify this
+
+Wrong if any document at any append length and content churns **more** than the bound — that would mean
+a chunk at an index below `L` changed, contradicting the byte-identity the proof rests on, and would mean
+the divergence-depth window in §0d is not what the code does.
+
+Wrong in the other direction if the DUPLICATE fixture's set churn ever **equals** the bound, which would
+mean the fixture stopped exercising the inequality and the rule is being pinned as an equality again —
+the failure this row has now had four times.

--- a/docs/design/content-defined-chunking.md
+++ b/docs/design/content-defined-chunking.md
@@ -324,16 +324,18 @@ length of their longest common prefix (`test/graph-cdc.test.ts`, CDCAPPEND-1):
 
 > **churn ≤ |C₁| − L** — the number of admitted chunks after the last chunk the two chunkings share.
 >
-> (reproduce with `node scripts/cdc-churn-sweep.mjs --op append --exclude docs/design/cdc-append-churn.md`;
-> `--exclude` matters because the design documents ARE the corpus)
+> (reproduce with `node scripts/cdc-churn-sweep.mjs --op append --exclude docs/design/cdc-append-churn.md,docs/design/content-defined-chunking.md`
+> — the exclusions matter because the design documents ARE the corpus, including this one)
 
 **No unconditional number belongs in this row**, and here is why each candidate for one fails:
 
 - **not 1.** For the 66-character append this document's own test applies, the corpus churns
-  `{0: ×1, 1: ×23, 2: ×4}` — and all four 2s are documents *below* the cap.
+  `{0: ×1, 1: ×23, 2: ×3}` with the two files above excluded (`{0: ×1, 1: ×23, 2: ×5}` over the
+  unexcluded corpus the test reads) — and every one of the 2s is a document *below* the cap. The count
+  moves as the corpus does, which is why the test computes the distribution instead of pinning it.
 - **not "0 once the document fills the cap".** What must reach the cap is the **shared prefix**, not the
-  boundary count: a document at exactly 80 boundaries churns 1–2, because an append moves the last one
-  or two boundaries.
+  boundary count: a document at exactly 80 boundaries churns **1** (committed witness), because an
+  append moves the last one or two boundaries.
 - **not a function of length alone.** 60,000 characters of prose churn 23–24; the same 60,000 characters
   of one repeated character churn 16, because a hash-quiet run yields far fewer cuts.
 - **not "the appended text splits the final chunk".** An append routinely changes the chunk *before* the

--- a/docs/design/content-defined-chunking.md
+++ b/docs/design/content-defined-chunking.md
@@ -15,7 +15,7 @@ function on a 50,000-char document:
 | edit | chunks re-extracted (of 20) |
 |---|---|
 | edit in place, same length | 1 |
-| append at the end | 1 |
+| append at the end (66 characters) | 1 |
 | **insert 33 chars near the top** | **21 — all of them, plus the new tail** |
 
 The chunk-delta ledger (#485) already skips unchanged chunks by comparing per-chunk hashes, so it
@@ -277,7 +277,7 @@ as fixtures — not content, just lengths and edit positions where content is se
 | scenario | byte-offset (today) | CDC (required) |
 |---|---|---|
 | edit in place, same length | 1 of 20 | **conditional — see below** |
-| append at end | 1 of 20 | conditional, not yet characterised (`CDCAPPEND-1`) |
+| append at end | 1 of 20 (for a SHORT append — see below) | **conditional — see below** |
 | **insert 33 chars near the top** | **21 of 20** | **≤ 3** |
 | insert a paragraph mid-document | ~half | **≤ 3** |
 | delete a paragraph near the top | ~all | **≤ 3** |
@@ -314,6 +314,39 @@ CDC is **not** "never worse than byte offsets", and this document should never h
 dramatically better on the insertion cascade this lever exists for, and dramatically worse on an
 in-place edit that disturbs a boundary. Three earlier attempts to characterise this each blamed the
 wrong mechanism — the test carries that history so the fourth reader does not re-derive it.
+
+### `append at end` — the row that was still wrong, corrected (CDCAPPEND-1)
+
+That row promised an unconditional **1** too, and `CDCCHURN-1` deferred it rather than give it a fourth
+invented rule. Six characterisations have now been falsified; three of them during this ticket. The rule,
+stated in the coordinates the ledger pays in — `C₀`/`C₁` are the ADMITTED chunk arrays and `L` is the
+length of their longest common prefix (`test/graph-cdc.test.ts`, CDCAPPEND-1):
+
+> **churn ≤ |C₁| − L** — the number of admitted chunks after the last chunk the two chunkings share.
+>
+> (reproduce with `node scripts/cdc-churn-sweep.mjs --op append --exclude docs/design/cdc-append-churn.md`;
+> `--exclude` matters because the design documents ARE the corpus)
+
+**No unconditional number belongs in this row**, and here is why each candidate for one fails:
+
+- **not 1.** For the 66-character append this document's own test applies, the corpus churns
+  `{0: ×1, 1: ×23, 2: ×4}` — and all four 2s are documents *below* the cap.
+- **not "0 once the document fills the cap".** What must reach the cap is the **shared prefix**, not the
+  boundary count: a document at exactly 80 boundaries churns 1–2, because an append moves the last one
+  or two boundaries.
+- **not a function of length alone.** 60,000 characters of prose churn 23–24; the same 60,000 characters
+  of one repeated character churn 16, because a hash-quiet run yields far fewer cuts.
+- **not "the appended text splits the final chunk".** An append routinely changes the chunk *before* the
+  last one, and can **delete** a boundary outright: extending the tail can promote a later backup
+  boundary over an earlier one, merging two chunks into one — so the chunk count can go *down*.
+
+**The trade, both directions measured.** CDC is mildly **worse** than byte offsets on append — it re-cuts
+the tail where byte offsets only extend it. Per document, for appends shorter than `min`, the loss is at
+most **one chunk** (measured on this corpus and on 300 synthetic documents); that is the price of the
+insertion win, where CDC churns 1 against legacy's 80. The summary table at the top of this document
+measures the legacy algorithm for a **66-character** append, where 20 full chunks plus a short append
+genuinely gives exactly one new chunk — it is scoped to that append rather than left unqualified, because
+a 2,501-character append churns 2 under byte offsets too.
 
 **And in prod, after:** the projector's own `ingest_runs` records episodes per run. A week of
 editing-heavy days before and after should show the episode count per changed item fall toward the

--- a/scripts/cdc-churn-sweep.mjs
+++ b/scripts/cdc-churn-sweep.mjs
@@ -56,6 +56,12 @@ const flag = (name, fallback) => {
   return i >= 0 && ARGV[i + 1] !== undefined ? ARGV[i + 1] : fallback;
 };
 const OP = flag("op", "inplace");
+/**
+ * The design documents ARE the corpus, so a document that publishes a distribution is inside it.
+ * Honoured in BOTH modes deliberately: `cdc-append-churn.md` sits ~79 characters below the in-place
+ * sweep's 25,000-character floor, so one more paragraph would silently move the in-place numbers too.
+ */
+const EXCLUDE = flag("exclude", "");
 const STEP = Number(flag("step", ARGV.find((a) => /^\d+$/.test(a)) ?? 97));
 
 const setChurn = (before, after) => {
@@ -87,6 +93,7 @@ const CORPORA = {
 };
 function corpus(which = "wide") {
   const { dirs, minLength } = CORPORA[which] ?? CORPORA.wide;
+  // `EXCLUDE` is applied HERE rather than at each call site, so neither mode can forget it.
   const out = [];
   const seen = new Set();
   for (const dir of dirs) {
@@ -102,7 +109,7 @@ function corpus(which = "wide") {
       if (seen.has(path)) continue;
       seen.add(path);
       const text = readFileSync(path, "utf8");
-      if (text.length >= minLength) out.push({ path, text });
+      if (text.length >= minLength && path !== EXCLUDE) out.push({ path, text });
     }
   }
   return out;
@@ -181,8 +188,7 @@ if (OP === "append") {
   // The design documents ARE the corpus, so the spec quoting these numbers is IN them and every edit to
   // it moves them (both reviewers caught a table that had already gone stale that way). `--exclude`
   // makes a published distribution stable against the document that publishes it.
-  const excluded = flag("exclude", "");
-  const docs = corpus(which).filter((d) => !excluded || d.path !== excluded);
+  const docs = corpus(which);
   const out = {
     op: "append",
     revision: revision(),
@@ -197,7 +203,7 @@ if (OP === "append") {
     depthHistogram: {},
     movedOutsideMaxWindow: 0,
     perLength: {},
-    excluded: excluded || null,
+    excluded: EXCLUDE || null,
     depthCeiling: { provable: DEPTH_CEILING, derivation: "1 + floor((max-1)/min)", observed: 0, violations: 0 },
     absoluteGuard: { formula: "depthCeiling + ceil(appendLength/min)", violations: [], synthetic: null },
     boundaryFormViolations: [],
@@ -387,7 +393,8 @@ if (OP === "append") {
 
   // The cross-algorithm envelope that REPLACES the deleted max-versus-max comparison: per document, how
   // much worse than byte offsets can CDC be? Reported by regime, because it is +1 for appends shorter
-  // than `min` and reaches +4 for long ones on synthetic documents.
+  // than `min` and larger for long ones on synthetic documents (measured +2 here — an earlier version of
+  // this comment said +4, a figure from a throwaway generator that this script never produced).
   {
     let shortMax = -Infinity, longMax = -Infinity, shortAt = null, longAt = null;
     for (const { path, text } of docs)
@@ -399,8 +406,8 @@ if (OP === "append") {
           else if (gap > longMax) { longMax = gap; longAt = { path, len, filler: fname, gap }; }
         }
     // …and the same question on SYNTHETIC documents, because a corpus of 28 real files is not evidence
-    // about the algorithm. The live corpus never exceeds +1; synthetic documents reach +4, which is why
-    // the envelope this spec gates on is scoped to the short-append regime rather than stated generally.
+    // about the algorithm. Both populations stay at +1 for appends shorter than `min`; the LONG regime is
+    // where they diverge, which is why the gate is scoped to the short one rather than stated generally.
     let synShort = -Infinity, synShortAt = null, synLong = -Infinity, synLongAt = null;
     for (let seed = 1; seed <= 300; seed++) {
       const doc = filler(2_000 + ((seed * 911) % 80_000), `s${seed}-`);
@@ -435,19 +442,56 @@ if (OP === "append") {
     };
   }
 
+  /**
+   * WHAT MAKES THIS EXIT NON-ZERO — and the three ways it used to fail OPEN, all found in review.
+   *
+   *  1. an EMPTY corpus exited 0 with zero evidence: `corpus()` swallows a `readdirSync` failure, so a
+   *     wrong cwd made every invariant vacuously green. There is a sample floor now.
+   *  2. the synthetic leg's DEPTH was computed and reported but never counted, so a chunker that broke
+   *     the derived ceiling on synthetic documents while the corpus stayed at 2 exited 0.
+   *  3. the probes had no expectations at all — `duplicateProbe` could report set === bound (the rule
+   *     silently becoming an equality again) and nothing noticed.
+   *
+   * Probe ROT is deliberately NOT a failure: the merge witness is live content and the spec says it is
+   * expected to rot. It is a `warning`, which is a different thing from a refuted invariant, and saying
+   * so is why the spec no longer claims this exits non-zero on "any" of them.
+   */
+  const expectations = [];
+  const expect = (name, ok, detail) => { if (!ok) expectations.push({ name, detail }); };
+  expect("corpus is non-empty", out.corpus.docs > 5, { docs: out.corpus.docs });
+  expect("samples were taken", out.samples > 0, { samples: out.samples });
+  expect("synthetic leg ran", (out.absoluteGuard.synthetic?.samples ?? 0) > 0, out.absoluteGuard.synthetic);
+  expect(
+    "synthetic divergence depth is within the derived ceiling",
+    (out.absoluteGuard.synthetic?.maxDepthObserved ?? Infinity) <= DEPTH_CEILING,
+    out.absoluteGuard.synthetic
+  );
+  // The rule is an INEQUALITY; this probe is the only thing that shows it, so it going tight is a defect.
+  expect("duplicate content costs strictly less than the bound", out.duplicateProbe.set < out.duplicateProbe.bound, out.duplicateProbe);
+  expect("a verbatim duplicate chunk saves nothing", out.verbatimChunkProbe.set === out.verbatimChunkProbe.bound, out.verbatimChunkProbe);
+  // The cap claim, checked rather than described: a shared prefix AT the cap must cost nothing.
+  for (const row of out.capProbe)
+    if (row.sharedChunks !== undefined)
+      expect("shared prefix at the cap costs nothing", row.sharedChunks >= CAP ? row.set === 0 : true, row);
+  out.expectationsFailed = expectations;
+  out.warnings = [];
+  if (out.mergeProbe?.note) out.warnings.push({ probe: "mergeProbe", note: out.mergeProbe.note });
+  if (out.capProbe.some((r) => r.note)) out.warnings.push({ probe: "capProbe", note: "a boundary count had no realising prefix" });
+
   console.log(JSON.stringify(out, null, 2));
-  // Non-zero on ANY refuted invariant, so the sweep is usable as a check and not only as a report.
   const failed =
     out.violations.length +
     out.absoluteGuard.violations.length +
     out.depthCeiling.violations +
     (out.absoluteGuard.synthetic?.violations ?? 0) +
-    (out.absoluteGuard.synthetic?.boundViolations ?? 0);
+    (out.absoluteGuard.synthetic?.boundViolations ?? 0) +
+    expectations.length;
   process.exit(failed === 0 ? 0 : 1);
 }
 
 const summary = {
   revision: revision(),
+  excluded: EXCLUDE || null,
   step: STEP,
   docs: 0,
   swept: 0,

--- a/scripts/cdc-churn-sweep.mjs
+++ b/scripts/cdc-churn-sweep.mjs
@@ -16,16 +16,47 @@
  *     mistaking it for one is how an earlier draft of the spec published a maximum of 78 (positional)
  *     for a state that costs 2 (set).
  *
- * Usage: `node scripts/cdc-churn-sweep.mjs [step]` (default step 97). Prints a JSON summary; every
- * figure quoted in the design docs should be traceable to one run of this, stamped with the SHA.
+ * CDCAPPEND-1 adds `--op append`, for the `append at end` row one line down. Same reason, same shape:
+ * four characterisations of that row have been falsified, and the fourth was falsified BY this script.
+ *
+ * Usage:
+ *   `node scripts/cdc-churn-sweep.mjs [step]`          — in-place sweep (default; step 97)
+ *   `node scripts/cdc-churn-sweep.mjs --op append`     — append sweep over documents x append lengths
+ *   `… --corpus wide`                                  — the >4,000-character corpus instead of the test's
+ *
+ * Prints a JSON summary; every figure quoted in the design docs should be traceable to one run of this,
+ * stamped with the SHA.
  */
 import { readFileSync, readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { cdcBoundaries, chunkCdc } from "../lib/graph/cdc.ts";
+
+/**
+ * Every run stamps the revision it measured, because the corpus is live and this ticket's own history
+ * is published numbers that stopped reproducing. `dirty` matters as much as the SHA: a sweep over an
+ * edited working tree is not a measurement of that commit — and the design documents ARE in the corpus,
+ * so editing the spec that quotes these numbers changes them.
+ */
+function revision() {
+  try {
+    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], { encoding: "utf8" }).trim();
+    const dirty = execFileSync("git", ["status", "--porcelain"], { encoding: "utf8" }).trim().length > 0;
+    return { sha, dirty };
+  } catch {
+    return { sha: null, dirty: null }; // not a checkout — report unknown rather than a plausible lie
+  }
+}
 
 const P = { target: 2500, min: 1250, max: 4000 };
 const CAP = 80;
 const EDIT_LEN = 20;
-const STEP = Number(process.argv[2] ?? 97);
+const ARGV = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const i = ARGV.indexOf(`--${name}`);
+  return i >= 0 && ARGV[i + 1] !== undefined ? ARGV[i + 1] : fallback;
+};
+const OP = flag("op", "inplace");
+const STEP = Number(flag("step", ARGV.find((a) => /^\d+$/.test(a)) ?? 97));
 
 const setChurn = (before, after) => {
   const seen = new Set(before);
@@ -34,15 +65,44 @@ const setChurn = (before, after) => {
 const positionalChurn = (before, after) => after.filter((c, i) => before[i] !== c).length;
 const chunks = (t) => chunkCdc(t, P, CAP);
 const edit = (t, at) => t.slice(0, at) + "X".repeat(EDIT_LEN) + t.slice(at + EDIT_LEN);
-
-/** The same corpus `test/graph-cdc.test.ts` reads. */
-function corpus() {
+/** The byte-offset chunker, inlined: `lib/graph/project.ts` cannot be imported by bare node. */
+const legacyChunks = (t) => {
+  if (!t.trim()) return [];
   const out = [];
-  for (const dir of ["docs", "docs/design"]) {
-    for (const f of readdirSync(dir)) {
+  for (let i = 0; i < t.length && out.length < CAP; i += P.target) out.push(t.slice(i, i + P.target));
+  return out;
+};
+
+/**
+ * TWO corpus definitions, and the difference is load-bearing.
+ *
+ * `test` is the one `test/graph-cdc.test.ts:repoDocs()` reads — three directories, >= 15,000 characters.
+ * `wide` is this script's original >4,000-character set over two directories. A comment here used to
+ * claim the wide set WAS the test's, which is the class of false claim this whole ticket is about: a
+ * number measured over one population and asserted over another.
+ */
+const CORPORA = {
+  test: { dirs: ["docs", "docs/design", "."], minLength: 15_000 },
+  wide: { dirs: ["docs", "docs/design"], minLength: 4_001 },
+};
+function corpus(which = "wide") {
+  const { dirs, minLength } = CORPORA[which] ?? CORPORA.wide;
+  const out = [];
+  const seen = new Set();
+  for (const dir of dirs) {
+    let names = [];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const f of names) {
       if (!f.endsWith(".md")) continue;
-      const text = readFileSync(`${dir}/${f}`, "utf8");
-      if (text.length > 4_000) out.push({ path: `${dir}/${f}`, text });
+      const path = `${dir}/${f}`;
+      if (seen.has(path)) continue;
+      seen.add(path);
+      const text = readFileSync(path, "utf8");
+      if (text.length >= minLength) out.push({ path, text });
     }
   }
   return out;
@@ -59,7 +119,163 @@ const predicted = (base, at) => {
   return hit;
 };
 
+// ── `--op append` (CDCAPPEND-1) ──────────────────────────────────────────────────────────────────
+
+/** Append lengths spanning every regime: under `min`, around `target`, and several multiples of it. */
+const APPEND_LENGTHS = [1, 66, 700, 1_249, 1_251, 2_500, 5_000, 9_000, 20_000, 60_000];
+
+/**
+ * Filler with a per-token index, so no two chunks of it can be byte-equal.
+ *
+ * Not cosmetic: the first version of this sweep used cyclic filler, whose chunks DO repeat, and the set
+ * metric then reported fewer changed chunks than the bound — which reads as a rule violation and is
+ * actually the duplicate-content case. The duplicate case gets its own deliberate probe below instead.
+ */
+const filler = (n, tag) => {
+  let s = "";
+  let i = 0;
+  while (s.length < n) s += `${tag}${i} lorem ipsum dolor sit amet consectetur ${i * 7919} `, i++;
+  return s.slice(0, n);
+};
+
+/**
+ * THE BOUND. `L` = the length of the common prefix of the two boundary sequences — the last boundary the
+ * two chunkings share. Chunks `0..L-1` are byte-identical, so at most the admitted chunks after `L` can
+ * be re-pushed. An upper bound by construction; measured tight everywhere except duplicate content.
+ */
+const appendBound = (b0, b1) => {
+  let l = 0;
+  while (l < b0.length && l < b1.length && b0[l] === b1[l]) l++;
+  return { shared: l, bound: Math.max(0, Math.min(CAP, b1.length) - l) };
+};
+
+if (OP === "append") {
+  const which = flag("corpus", "test");
+  const docs = corpus(which);
+  const out = {
+    op: "append",
+    revision: revision(),
+    corpus: { ...CORPORA[which], name: which, docs: docs.length },
+    lengths: APPEND_LENGTHS,
+    samples: 0,
+    boundHolds: 0,
+    boundTightSet: 0,
+    boundTightPositional: 0,
+    violations: [],
+    slack: [],
+    depthHistogram: {},
+    movedOutsideMaxWindow: 0,
+    perLength: {},
+    candidate1: { name: "1 + new chunks, or 0 when capped", agrees: 0, samples: 0, misses: [] },
+    legacy: {},
+    duplicateProbe: null,
+  };
+
+  // Two append CONTENTS at every length — ordinary prose and a hash-quiet run, which produce different
+  // churn at the same length (see the `legacy` block). A rule verified against one filler is verified
+  // against one shape of appended text, which is not the claim the table makes.
+  const BOUND_FILLERS = { prose: (n) => filler(n, "z"), quiet: (n) => "a".repeat(n) };
+  for (const { path, text } of docs) {
+    const base = chunks(text);
+    const b0 = cdcBoundaries(text, P);
+    for (const len of APPEND_LENGTHS) for (const [fname, make] of Object.entries(BOUND_FILLERS)) {
+      const appended = text + make(len);
+      const after = chunks(appended);
+      const b1 = cdcBoundaries(appended, P);
+      const { shared, bound } = appendBound(b0, b1);
+      const s = setChurn(base, after);
+      const p = positionalChurn(base, after);
+      out.samples++;
+      if (s <= bound) out.boundHolds++;
+      else out.violations.push({ path, len, filler: fname, bound, set: s, shared });
+      if (s === bound) out.boundTightSet++;
+      else if (s < bound) out.slack.push({ path, len, filler: fname, bound, set: s, positional: p });
+      if (p === bound) out.boundTightPositional++;
+      const depth = b0.length - shared;
+      out.depthHistogram[depth] = (out.depthHistogram[depth] ?? 0) + 1;
+      // Structural claim: a boundary whose chunk START sits at least `max` before the original end is
+      // computed from unchanged input and cannot move.
+      const lastSharedEnd = shared > 0 ? b0[shared - 1] : 0;
+      if (text.length - lastSharedEnd > P.max) out.movedOutsideMaxWindow++;
+      const bucket = (out.perLength[`${len}/${fname}`] ??= {});
+      bucket[s] = (bucket[s] ?? 0) + 1;
+      // The falsified fourth characterisation, kept runnable so the refutation reproduces.
+      const c1 = b0.length >= CAP ? 0 : 1 + Math.max(0, Math.min(CAP, b1.length) - b0.length);
+      out.candidate1.samples++;
+      if (c1 === s) out.candidate1.agrees++;
+      else if (out.candidate1.misses.length < 6)
+        out.candidate1.misses.push({ path, len, filler: fname, said: c1, was: s });
+    }
+  }
+
+  // CDC vs the byte-offset chunker, PER DOCUMENT — the comparison `test/graph-cdc.test.ts` makes as
+  // max-versus-max across different documents, which is how it passes while CDC is strictly worse.
+  //
+  // SWEPT ACROSS THREE APPEND CONTENTS AT THE SAME LENGTH, because churn is a function of the appended
+  // TEXT and not only of how much of it there is: the new boundaries are content-defined. At 2,500
+  // characters the max-versus-max comparison FAILS under two ordinary-prose fillers and PASSES under a
+  // hash-quiet run of one repeated character, which yields no cut at all. A test asserting it is not
+  // wrong-in-one-direction; it is decided by content nobody is thinking about.
+  const FILLERS = {
+    "prose-a": (n) => filler(n, "z"),
+    "prose-b": (n) => filler(n, "q").replace(/lorem/g, "dolorem"),
+    quiet: (n) => "a".repeat(n),
+    sentence: () => " a new closing paragraph appended at the very end of the document.",
+  };
+  for (const len of [66, 2_500, 9_000]) {
+    for (const [fname, make] of Object.entries(FILLERS)) {
+      if (fname === "sentence" && len !== 66) continue;
+      const app = fname === "sentence" ? make() : make(len);
+      let worse = 0, better = 0, tied = 0, maxCdc = 0, maxLeg = 0, worstAt = null;
+      for (const { path, text } of docs) {
+        const c = setChurn(chunks(text), chunks(text + app));
+        const l = setChurn(legacyChunks(text), legacyChunks(text + app));
+        if (c > l) {
+          worse++;
+          if (!worstAt || c - l > worstAt.gap) worstAt = { path, cdc: c, legacy: l, gap: c - l };
+        } else if (c < l) better++;
+        else tied++;
+        maxCdc = Math.max(maxCdc, c);
+        maxLeg = Math.max(maxLeg, l);
+      }
+      out.legacy[`${len}/${fname}`] = { appendLength: app.length, cdcWorse: worse, tied, cdcBetter: better, maxCdc, maxLeg, maxVsMaxPasses: maxCdc <= maxLeg, worstAt };
+    }
+  }
+
+  // The exact append `test/graph-cdc.test.ts`'s `append at end` scenario applies, so the distribution
+  // its `<= 1` assertion is really quantifying over is printed rather than described.
+  {
+    const app = " a new closing paragraph appended at the very end of the document.";
+    const dist = {};
+    for (const { text } of docs) {
+      const c = setChurn(chunks(text), chunks(text + app));
+      dist[c] = (dist[c] ?? 0) + 1;
+    }
+    out.fixtureAppend = { text: app, length: app.length, churnDistribution: dist };
+  }
+
+  // The one place the bound is deliberately NOT tight: appending a document to itself reproduces whole
+  // chunks, and an identical chunk is never re-pushed.
+  {
+    const doc = filler(60_000, "b");
+    const b0 = cdcBoundaries(doc, P);
+    const b1 = cdcBoundaries(doc + doc, P);
+    const { bound, shared } = appendBound(b0, b1);
+    out.duplicateProbe = {
+      case: "self-concatenation",
+      shared,
+      bound,
+      set: setChurn(chunks(doc), chunks(doc + doc)),
+      positional: positionalChurn(chunks(doc), chunks(doc + doc)),
+    };
+  }
+
+  console.log(JSON.stringify(out, null, 2));
+  process.exit(out.violations.length === 0 ? 0 : 1);
+}
+
 const summary = {
+  revision: revision(),
   step: STEP,
   docs: 0,
   swept: 0,

--- a/scripts/cdc-churn-sweep.mjs
+++ b/scripts/cdc-churn-sweep.mjs
@@ -139,19 +139,50 @@ const filler = (n, tag) => {
 };
 
 /**
- * THE BOUND. `L` = the length of the common prefix of the two boundary sequences — the last boundary the
- * two chunkings share. Chunks `0..L-1` are byte-identical, so at most the admitted chunks after `L` can
- * be re-pushed. An upper bound by construction; measured tight everywhere except duplicate content.
+ * THE BOUND, IN THE COORDINATES THE COST IS PAID IN. `L` = the length of the common prefix of the two
+ * ADMITTED CHUNK ARRAYS. Those chunks are byte-identical AND present in the before-set, so none of them
+ * can be re-pushed; at most the chunks after `L` can be. A theorem with no preconditions.
+ *
+ * IT WAS FIRST WRITTEN OVER THE BOUNDARY SEQUENCES, AND THAT VERSION IS FALSE. Both spec reviewers
+ * produced the same counter-example: `chunkCdc` returns `[]` for a whitespace-only body (cdc.ts:271)
+ * while `cdcBoundaries` still returns boundaries, so a whitespace base has `L > 0` over boundaries and
+ * an EMPTY before-set — 20,000 spaces plus one `x` churns 6 against a boundary-bound of 1. The
+ * boundary form also mis-stated the cap case (see `capParity` below). Both are reported here so the
+ * refutation reproduces rather than being asserted.
  */
-const appendBound = (b0, b1) => {
+const appendBound = (c0, c1) => {
+  let l = 0;
+  while (l < c0.length && l < c1.length && c0[l] === c1[l]) l++;
+  return { shared: l, bound: Math.max(0, c1.length - l) };
+};
+/** The FALSIFIED boundary-coordinate form, kept runnable so its counter-examples reproduce. */
+const boundaryFormBound = (b0, b1) => {
   let l = 0;
   while (l < b0.length && l < b1.length && b0[l] === b1[l]) l++;
   return { shared: l, bound: Math.max(0, Math.min(CAP, b1.length) - l) };
 };
 
+/**
+ * THE ABSOLUTE GUARD — the one assertion here that cannot self-adjust.
+ *
+ * The bound above is computed from the chunker's own output, so ANY prefix-stable chunker satisfies it:
+ * a regression that re-cuts deeply just shrinks `L` and inflates the bound to match (Fable's review).
+ * This ceiling is derived from the SIZE ENVELOPE instead — configuration, not behaviour:
+ *
+ *   • only boundaries whose chunk start lies within `max` of the old end can move (cdc.ts:222), and
+ *     non-final chunks are at least `min`, so at most `1 + floor((max-1)/min)` of them are in play;
+ *   • the appended text of length A adds at most `ceil(A/min)` further chunks.
+ */
+const DEPTH_CEILING = 1 + Math.floor((P.max - 1) / P.min);
+const absoluteCeiling = (appendLength) => DEPTH_CEILING + Math.ceil(appendLength / P.min);
+
 if (OP === "append") {
   const which = flag("corpus", "test");
-  const docs = corpus(which);
+  // The design documents ARE the corpus, so the spec quoting these numbers is IN them and every edit to
+  // it moves them (both reviewers caught a table that had already gone stale that way). `--exclude`
+  // makes a published distribution stable against the document that publishes it.
+  const excluded = flag("exclude", "");
+  const docs = corpus(which).filter((d) => !excluded || d.path !== excluded);
   const out = {
     op: "append",
     revision: revision(),
@@ -166,6 +197,11 @@ if (OP === "append") {
     depthHistogram: {},
     movedOutsideMaxWindow: 0,
     perLength: {},
+    excluded: excluded || null,
+    depthCeiling: { provable: DEPTH_CEILING, derivation: "1 + floor((max-1)/min)", observed: 0, violations: 0 },
+    absoluteGuard: { formula: "depthCeiling + ceil(appendLength/min)", violations: [], synthetic: null },
+    boundaryFormViolations: [],
+    capParity: [],
     candidate1: { name: "1 + new chunks, or 0 when capped", agrees: 0, samples: 0, misses: [] },
     legacy: {},
     duplicateProbe: null,
@@ -182,7 +218,8 @@ if (OP === "append") {
       const appended = text + make(len);
       const after = chunks(appended);
       const b1 = cdcBoundaries(appended, P);
-      const { shared, bound } = appendBound(b0, b1);
+      const { shared, bound } = appendBound(base, after);
+      const bf = boundaryFormBound(b0, b1);
       const s = setChurn(base, after);
       const p = positionalChurn(base, after);
       out.samples++;
@@ -191,11 +228,18 @@ if (OP === "append") {
       if (s === bound) out.boundTightSet++;
       else if (s < bound) out.slack.push({ path, len, filler: fname, bound, set: s, positional: p });
       if (p === bound) out.boundTightPositional++;
-      const depth = b0.length - shared;
+      if (s > bf.bound) out.boundaryFormViolations.push({ path, len, filler: fname, boundaryBound: bf.bound, set: s });
+      if (s > absoluteCeiling(len))
+        out.absoluteGuard.violations.push({ path, len, filler: fname, ceiling: absoluteCeiling(len), set: s });
+      // The cap case, measured rather than asserted: a document PAST the cap is not automatically 0.
+      if (b0.length >= CAP) out.capParity.push({ path, len, filler: fname, boundaries: b0.length, sharedBoundaries: bf.shared, set: s });
+      const depth = b0.length - bf.shared;
+      if (depth > out.depthCeiling.observed) out.depthCeiling.observed = depth;
+      if (depth > DEPTH_CEILING) out.depthCeiling.violations++;
       out.depthHistogram[depth] = (out.depthHistogram[depth] ?? 0) + 1;
       // Structural claim: a boundary whose chunk START sits at least `max` before the original end is
       // computed from unchanged input and cannot move.
-      const lastSharedEnd = shared > 0 ? b0[shared - 1] : 0;
+      const lastSharedEnd = bf.shared > 0 ? b0[bf.shared - 1] : 0;
       if (text.length - lastSharedEnd > P.max) out.movedOutsideMaxWindow++;
       const bucket = (out.perLength[`${len}/${fname}`] ??= {});
       bucket[s] = (bucket[s] ?? 0) + 1;
@@ -218,7 +262,9 @@ if (OP === "append") {
   // wrong-in-one-direction; it is decided by content nobody is thinking about.
   const FILLERS = {
     "prose-a": (n) => filler(n, "z"),
-    "prose-b": (n) => filler(n, "q").replace(/lorem/g, "dolorem"),
+    // Replace BEFORE slicing. Doing it after made this filler 2,602 characters at a nominal 2,500, so
+    // the "flips with content at a FIXED length" claim it was evidence for was length-confounded.
+    "prose-b": (n) => filler(n + 512, "q").replace(/lorem/g, "dolorem").slice(0, n),
     quiet: (n) => "a".repeat(n),
     sentence: () => " a new closing paragraph appended at the very end of the document.",
   };
@@ -242,6 +288,28 @@ if (OP === "append") {
     }
   }
 
+  // The absolute guard on SYNTHETIC documents too. 28 real files are not evidence about an algorithm,
+  // and this is the one assertion the test gates on that is meant to hold for any input, not for this
+  // corpus — so its sample count has to come from here rather than from a throwaway.
+  {
+    let samples = 0, violations = 0, maxDepth = 0, boundViolations = 0, worst = null;
+    for (let seed = 1; seed <= 400; seed++) {
+      const doc = filler(2_000 + ((seed * 911) % 80_000), `g${seed}-`);
+      const c0 = chunks(doc), b0 = cdcBoundaries(doc, P);
+      for (const len of [1, 66, 700, 1_249, 2_500, 9_000, 40_000])
+        for (const app of [filler(len, `h${seed}-`), "a".repeat(len), " ".repeat(len)]) {
+          const c1 = chunks(doc + app), b1 = cdcBoundaries(doc + app, P);
+          const s2 = setChurn(c0, c1);
+          samples++;
+          if (s2 > appendBound(c0, c1).bound) boundViolations++;
+          if (s2 > absoluteCeiling(app.length)) { violations++; worst = { seed, len, set: s2, ceiling: absoluteCeiling(app.length) }; }
+          const d = b0.length - boundaryFormBound(b0, b1).shared;
+          if (d > maxDepth) maxDepth = d;
+        }
+    }
+    out.absoluteGuard.synthetic = { documents: 400, samples, violations, worst, boundViolations, maxDepthObserved: maxDepth };
+  }
+
   // The exact append `test/graph-cdc.test.ts`'s `append at end` scenario applies, so the distribution
   // its `<= 1` assertion is really quantifying over is printed rather than described.
   {
@@ -254,24 +322,128 @@ if (OP === "append") {
     out.fixtureAppend = { text: app, length: app.length, churnDistribution: dist };
   }
 
+  // THE MERGE EVENT — an append that DELETES a boundary, via the backup-mask preference rule. Probed
+  // rather than described: the spec first claimed "appending one character" does this, and both
+  // reviewers showed it is character-dependent (`q` yes, `x` no) and that the sweep never observed it.
+  {
+    const target = "docs/design/work-timeline-context-layer.md";
+    const doc = docs.find((d) => d.path === target);
+    out.mergeProbe = doc
+      ? (() => {
+          const b0 = cdcBoundaries(doc.text, P);
+          const deletes = [];
+          const keeps = [];
+          for (const ch of ["q", "x", "a", "z", " ", ".", "%", "5", "\n"]) {
+            const b1 = cdcBoundaries(doc.text + ch, P);
+            (b1.length < b0.length ? deletes : keeps).push(ch);
+          }
+          const ch = deletes[0];
+          if (ch === undefined) return { path: target, boundariesBefore: b0.length, deletes, keeps, note: "no single character deletes a boundary here any more" };
+          const b1 = cdcBoundaries(doc.text + ch, P);
+          const gone = b0.filter((e) => e !== doc.text.length && !b1.includes(e));
+          return {
+            path: target, boundariesBefore: b0.length, boundariesAfter: b1.length,
+            deletes, keeps, character: ch, vanishedBoundaries: gone,
+            churn: setChurn(chunks(doc.text), chunks(doc.text + ch)),
+            bound: appendBound(chunks(doc.text), chunks(doc.text + ch)).bound,
+          };
+        })()
+      : { path: target, note: "not in this corpus any more — the witness is live content and may rot" };
+  }
+
+  // THE CAP CASE, CONSTRUCTED. The first draft said a document past the cap churns 0. False: what has to
+  // reach the cap is the SHARED CHUNK PREFIX, not the boundary count, and an append can move the last
+  // two boundaries. Built here so the refutation is reproducible rather than a claim about one file.
+  {
+    const big = filler(400_000, "c");
+    out.capProbe = [];
+    for (const want of [79, 80, 81, 82]) {
+      let lo = 1_000, hi = 400_000, found = null;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        const n = cdcBoundaries(big.slice(0, mid), P).length;
+        if (n === want) { found = mid; break; }
+        if (n < want) lo = mid + 1; else hi = mid - 1;
+      }
+      if (found === null) { out.capProbe.push({ boundaries: want, note: "no prefix realises that count" }); continue; }
+      const doc = big.slice(0, found);
+      for (const len of [66, 2_500]) {
+        const app = filler(len, "d");
+        const c0 = chunks(doc), c1 = chunks(doc + app);
+        const { shared, bound } = appendBound(c0, c1);
+        out.capProbe.push({ boundaries: want, appendLength: len, sharedChunks: shared, bound, set: setChurn(c0, c1) });
+      }
+    }
+  }
+
+  // Does appending an existing chunk VERBATIM save anything? The spec claims not — the boundary shift
+  // means the re-cut chunks are not byte-identical to the original. Probed, not asserted.
+  {
+    const doc = filler(60_000, "v");
+    const c0 = chunks(doc);
+    const c1 = chunks(doc + c0[5]);
+    out.verbatimChunkProbe = { appended: "chunk 5, verbatim", bound: appendBound(c0, c1).bound, set: setChurn(c0, c1) };
+  }
+
+  // The cross-algorithm envelope that REPLACES the deleted max-versus-max comparison: per document, how
+  // much worse than byte offsets can CDC be? Reported by regime, because it is +1 for appends shorter
+  // than `min` and reaches +4 for long ones on synthetic documents.
+  {
+    let shortMax = -Infinity, longMax = -Infinity, shortAt = null, longAt = null;
+    for (const { path, text } of docs)
+      for (const len of APPEND_LENGTHS)
+        for (const [fname, make] of Object.entries(BOUND_FILLERS)) {
+          const app = make(len);
+          const gap = setChurn(chunks(text), chunks(text + app)) - setChurn(legacyChunks(text), legacyChunks(text + app));
+          if (len < P.min) { if (gap > shortMax) { shortMax = gap; shortAt = { path, len, filler: fname, gap }; } }
+          else if (gap > longMax) { longMax = gap; longAt = { path, len, filler: fname, gap }; }
+        }
+    // …and the same question on SYNTHETIC documents, because a corpus of 28 real files is not evidence
+    // about the algorithm. The live corpus never exceeds +1; synthetic documents reach +4, which is why
+    // the envelope this spec gates on is scoped to the short-append regime rather than stated generally.
+    let synShort = -Infinity, synShortAt = null, synLong = -Infinity, synLongAt = null;
+    for (let seed = 1; seed <= 300; seed++) {
+      const doc = filler(2_000 + ((seed * 911) % 80_000), `s${seed}-`);
+      for (const len of [1, 66, 700, 1_249, 2_500, 9_000, 40_000]) {
+        const app = filler(len, `t${seed}-`);
+        const gap = setChurn(chunks(doc), chunks(doc + app)) - setChurn(legacyChunks(doc), legacyChunks(doc + app));
+        if (len < P.min) { if (gap > synShort) { synShort = gap; synShortAt = { seed, len, gap, docLength: doc.length }; } }
+        else if (gap > synLong) { synLong = gap; synLongAt = { seed, len, gap, docLength: doc.length }; }
+      }
+    }
+    out.legacyEnvelope = {
+      corpus: { shortAppendMaxGap: shortMax, shortAt, longAppendMaxGap: longMax, longAt },
+      synthetic: { documents: 300, shortAppendMaxGap: synShort, shortAt: synShortAt, longAppendMaxGap: synLong, longAt: synLongAt },
+    };
+  }
+
   // The one place the bound is deliberately NOT tight: appending a document to itself reproduces whole
   // chunks, and an identical chunk is never re-pushed.
   {
     const doc = filler(60_000, "b");
     const b0 = cdcBoundaries(doc, P);
     const b1 = cdcBoundaries(doc + doc, P);
-    const { bound, shared } = appendBound(b0, b1);
+    const c0 = chunks(doc), c1 = chunks(doc + doc);
+    const { bound, shared } = appendBound(c0, c1);
     out.duplicateProbe = {
       case: "self-concatenation",
-      shared,
+      sharedChunks: shared,
+      boundaryCounts: [b0.length, b1.length],
       bound,
-      set: setChurn(chunks(doc), chunks(doc + doc)),
-      positional: positionalChurn(chunks(doc), chunks(doc + doc)),
+      set: setChurn(c0, c1),
+      positional: positionalChurn(c0, c1),
     };
   }
 
   console.log(JSON.stringify(out, null, 2));
-  process.exit(out.violations.length === 0 ? 0 : 1);
+  // Non-zero on ANY refuted invariant, so the sweep is usable as a check and not only as a report.
+  const failed =
+    out.violations.length +
+    out.absoluteGuard.violations.length +
+    out.depthCeiling.violations +
+    (out.absoluteGuard.synthetic?.violations ?? 0) +
+    (out.absoluteGuard.synthetic?.boundViolations ?? 0);
+  process.exit(failed === 0 ? 0 : 1);
 }
 
 const summary = {

--- a/scripts/cdc-churn-sweep.mjs
+++ b/scripts/cdc-churn-sweep.mjs
@@ -51,18 +51,41 @@ const P = { target: 2500, min: 1250, max: 4000 };
 const CAP = 80;
 const EDIT_LEN = 20;
 const ARGV = process.argv.slice(2);
+const refuse = (why) => {
+  console.error(`cdc-churn-sweep: REFUSING — ${why}`);
+  process.exit(2);
+};
+/**
+ * `flag()` used to take the NEXT token unconditionally, so `--op --exclude foo.md` set `op` to
+ * `"--exclude"`, fell through to in-place mode, and exited 0 — a quietly wrong run that looks like a
+ * measurement. Every degraded-input path in this file now refuses instead, because the one thing this
+ * script exists to be is a number you can trust.
+ */
 const flag = (name, fallback) => {
   const i = ARGV.indexOf(`--${name}`);
-  return i >= 0 && ARGV[i + 1] !== undefined ? ARGV[i + 1] : fallback;
+  if (i < 0) return fallback;
+  const value = ARGV[i + 1];
+  if (value === undefined || value.startsWith("--")) refuse(`--${name} needs a value`);
+  return value;
 };
 const OP = flag("op", "inplace");
+if (OP !== "inplace" && OP !== "append") refuse(`unknown --op ${OP} (expected inplace or append)`);
 /**
- * The design documents ARE the corpus, so a document that publishes a distribution is inside it.
- * Honoured in BOTH modes deliberately: `cdc-append-churn.md` sits ~79 characters below the in-place
- * sweep's 25,000-character floor, so one more paragraph would silently move the in-place numbers too.
+ * The design documents ARE the corpus, so a document that publishes a distribution is inside it —
+ * and so is a document that DESCRIBES the distribution. Both of this ticket's design files are in the
+ * measured set (`cdc-append-churn.md` at ~29k characters, `content-defined-chunking.md` at ~25k), which
+ * is not a hypothetical: an earlier commit on this branch quoted figures that its own next commit moved,
+ * twice, by editing the second file. Comma-separated, honoured in BOTH modes, and it REFUSES when a
+ * named path matches nothing — a typo'd exclusion silently publishing the unexcluded numbers is the
+ * same failure wearing a different hat.
  */
-const EXCLUDE = flag("exclude", "");
+const EXCLUDE = flag("exclude", "")
+  .split(",")
+  .map((p) => p.trim())
+  .filter(Boolean);
 const STEP = Number(flag("step", ARGV.find((a) => /^\d+$/.test(a)) ?? 97));
+// A non-numeric --step produced NaN and a 10-sample "sweep"; --step 0 hung the in-place loop forever.
+if (!Number.isInteger(STEP) || STEP < 1) refuse(`--step must be a positive integer, got ${flag("step", "")}`);
 
 const setChurn = (before, after) => {
   const seen = new Set(before);
@@ -94,6 +117,7 @@ const CORPORA = {
 function corpus(which = "wide") {
   const { dirs, minLength } = CORPORA[which] ?? CORPORA.wide;
   // `EXCLUDE` is applied HERE rather than at each call site, so neither mode can forget it.
+  const matched = new Set();
   const out = [];
   const seen = new Set();
   for (const dir of dirs) {
@@ -109,9 +133,16 @@ function corpus(which = "wide") {
       if (seen.has(path)) continue;
       seen.add(path);
       const text = readFileSync(path, "utf8");
-      if (text.length >= minLength && path !== EXCLUDE) out.push({ path, text });
+      if (text.length < minLength) continue;
+      if (EXCLUDE.includes(path)) {
+        matched.add(path);
+        continue;
+      }
+      out.push({ path, text });
     }
   }
+  const missed = EXCLUDE.filter((p) => !matched.has(p));
+  if (missed.length) refuse(`--exclude named ${missed.join(", ")}, which is not in this corpus`);
   return out;
 }
 
@@ -203,7 +234,7 @@ if (OP === "append") {
     depthHistogram: {},
     movedOutsideMaxWindow: 0,
     perLength: {},
-    excluded: EXCLUDE || null,
+    excluded: EXCLUDE.length ? EXCLUDE : null,
     depthCeiling: { provable: DEPTH_CEILING, derivation: "1 + floor((max-1)/min)", observed: 0, violations: 0 },
     absoluteGuard: { formula: "depthCeiling + ceil(appendLength/min)", violations: [], synthetic: null },
     boundaryFormViolations: [],
@@ -491,7 +522,7 @@ if (OP === "append") {
 
 const summary = {
   revision: revision(),
-  excluded: EXCLUDE || null,
+  excluded: EXCLUDE.length ? EXCLUDE : null,
   step: STEP,
   docs: 0,
   swept: 0,

--- a/test/graph-cdc.test.ts
+++ b/test/graph-cdc.test.ts
@@ -302,6 +302,13 @@ describe("the cap only TRUNCATES — the basis on which a CDC cap-grow keeps the
 
 // ── THE CHURN TABLE (the spec's acceptance arithmetic) ───────────────────────────────────────────
 
+/**
+ * The `append at end` scenario's append, module-scoped so the scenario that APPLIES it and the
+ * CDCAPPEND-1 describe that MEASURES it cannot drift apart. They were two copies of one literal; editing
+ * either would have left the other measuring a different append with everything green (review).
+ */
+const APPEND_AT_END = " a new closing paragraph appended at the very end of the document.";
+
 describe("churn: how many chunk hashes change under a real edit — CDC vs the byte-offset algorithm", () => {
   /**
    * The spec's central claim, and it is testable for free: "Take a real document, apply a real edit,
@@ -331,7 +338,8 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
     },
     {
       name: "append at end",
-      edit: (t) => t + " a new closing paragraph appended at the very end of the document.",
+      edit: (t) => t + APPEND_AT_END,
+      // `max` is no longer asserted for this scenario (CDCAPPEND-1) — see the `continue`s below.
       max: 1,
     },
     {
@@ -366,7 +374,7 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
     // made the acceptance table wrong in the first place.
     //
     // `append at end` is the same defect one row down (CDCAPPEND-1), and its `<= 1` was asserted against
-    // ONE fixture and ONE 66-character append. Over the live corpus that append churns 2 on 4 of 28
+    // ONE fixture and ONE 66-character append. Over the live corpus that append churns 2 on several
     // documents, and the same fixture with a 2,500-character prose append churns 3 — so the constant is
     // a property of this fixture, not of appends. The bound, the absolute ceiling and the per-document
     // legacy envelope live in the CDCAPPEND-1 describe below.
@@ -435,10 +443,10 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
       // `append at end` is excluded from BOTH assertions here too (CDCAPPEND-1), and the reason is the
       // one this comment already names for the row above, firing. The never-worse comparison PASSES for
       // append today only by coincidence ACROSS DIFFERENT DOCUMENTS: at this scenario's own 66-character
-      // append CDC is strictly worse than byte offsets on 4 of 28 corpus documents, and `max <= max`
-      // survives because a FIFTH, unrelated document churns 2 under legacy. Its outcome also flips with
-      // the appended CONTENT at a fixed length — at 2,500 characters it fails under one prose filler,
-      // passes under another, and passes with CDC strictly better under a hash-quiet one. It is REPLACED,
+      // append CDC is strictly worse than byte offsets on several corpus documents, and `max <= max`
+      // survives because one FURTHER, unrelated document churns 2 under legacy. Its outcome also flips
+      // with the appended CONTENT at a fixed length — at 2,500 characters it FAILS under both of the
+      // sweep's prose fillers and PASSES under a hash-quiet one, CDC strictly better. It is REPLACED,
       // not deleted: the CDCAPPEND-1 describe asserts `cdc <= legacy + 1` PER DOCUMENT for appends
       // shorter than `min`, which is where that envelope is measured on both real and synthetic corpora.
       if (name === "edit in place, same length" || name === "append at end") continue;
@@ -737,12 +745,13 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
  * The acceptance table promised an unconditional **1** for `append at end`. SIX characterisations of that
  * row have now been falsified, and the last three were falsified during this ticket:
  *
- *   1. "churn is 1" — `docs/ARCHITECTURE.md` churns 0 (past the cap) and 4 of 28 corpus documents churn
- *      2 at this file's own 66-character append;
+ *   1. "churn is 1" — `docs/ARCHITECTURE.md` churns 0 (past the cap) and SEVERAL corpus documents churn
+ *      2 at this file's own 66-character append. The exact count is corpus-dependent — this branch's own
+ *      commits moved it — so "THE ROW'S OWN CLAIM" below computes the distribution instead of pinning it;
  *   2. "1 unless the appended text splits the final chunk, then 2" — the 2s are not splits of the final
  *      chunk; the new cut lands INSIDE the appended region and moves the chunk before it too;
  *   3. "2 is the ceiling" — holds only below `min`; 9,000 characters churn 4–5 and 60,000 churn 23–24;
- *   4. "1 + the number of new chunks, or 0 when capped" — 449 of 560 swept samples (80.2%). A final
+ *   4. "1 + the number of new chunks, or 0 when capped" — 446 of 540 swept samples (82.6%). A final
  *      chunk taken by the `n - start <= min` short-tail exit gets a real cut once the document grows, so
  *      a boundary moves without a chunk being added;
  *   5. the bound stated over the BOUNDARY sequences — false for a whitespace-only body, because
@@ -808,8 +817,8 @@ describe("CDCAPPEND-1: append churn is a bound, not a number", () => {
     ["prose", prose],
     ["quiet", quiet],
   ];
-  /** The exact append the `append at end` scenario above applies. */
-  const SCENARIO_APPEND = " a new closing paragraph appended at the very end of the document.";
+  /** THE literal the `append at end` scenario applies, not a copy of it. */
+  const SCENARIO_APPEND = APPEND_AT_END;
 
   it("LIVE CORPUS: set churn never exceeds the bound, per document and per append content", () => {
     const docs = repoDocs();
@@ -852,8 +861,10 @@ describe("CDCAPPEND-1: append churn is a bound, not a number", () => {
   });
 
   it("the absolute ceiling is DERIVED from the envelope, and its looseness is stated not hidden", () => {
-    expect(DEPTH_CEILING).toBe(1 + Math.floor((CDC_PARAMS.max - 1) / CDC_PARAMS.min));
-    expect(DEPTH_CEILING).toBe(4); // at the shipped 1,250/4,000 envelope
+    // Independently-written arithmetic, NOT the definition restated: the first version of this asserted
+    // `1 + Math.floor((max - 1) / min)`, which is `expect(x).toBe(x)` and survives a mutation that edits
+    // the formula itself. Review caught it.
+    expect(DEPTH_CEILING).toBe(4); // 1 + floor(3999 / 1250), at the shipped 1,250/4,000 envelope
     // WHAT THIS DOES NOT CATCH, both reviewers independently: at a 60,000-character prose append the
     // corpus churns 23–24 against a ceiling of 4 + ceil(60000/1250) = 52, so a chunker that cut the
     // appended region at `min` instead of `target` would roughly DOUBLE every long append's cost and
@@ -997,7 +1008,7 @@ describe("CDCAPPEND-1: append churn is a bound, not a number", () => {
   it("ENVELOPE: for a short append CDC is at most ONE chunk worse than byte offsets, PER DOCUMENT", () => {
     // This REPLACES `max(cdc) <= max(legacy)` for this scenario rather than deleting it. That comparison
     // is not a property of appends: at the scenario's own 66-character append CDC is strictly worse than
-    // byte offsets on 4 of 28 corpus documents, and it passes only because a FIFTH, unrelated document
+    // byte offsets on several corpus documents, and it passes only because one FURTHER, unrelated document
     // churns 2 under legacy — max against max, across different documents. Its outcome also flips with
     // the appended content at a fixed length. Deleting it outright would leave no cross-algorithm guard
     // at all, which is what both spec reviewers refused.

--- a/test/graph-cdc.test.ts
+++ b/test/graph-cdc.test.ts
@@ -364,7 +364,13 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
     // `edit in place, same length` is covered by its own describe below (CDCCHURN-1): its churn is not
     // a single number but a function of what the edit touches, and asserting a constant here is what
     // made the acceptance table wrong in the first place.
-    if (name === "edit in place, same length") continue;
+    //
+    // `append at end` is the same defect one row down (CDCAPPEND-1), and its `<= 1` was asserted against
+    // ONE fixture and ONE 66-character append. Over the live corpus that append churns 2 on 4 of 28
+    // documents, and the same fixture with a 2,500-character prose append churns 3 — so the constant is
+    // a property of this fixture, not of appends. The bound, the absolute ceiling and the per-document
+    // legacy envelope live in the CDCAPPEND-1 describe below.
+    if (name === "edit in place, same length" || name === "append at end") continue;
     it(`${name} — CDC re-extracts <= ${max} chunk(s)`, () => {
       const v2 = edit(DOC_50K);
       const cdcChurn = changedCount(chunkContent(DOC_50K), chunkContent(v2));
@@ -425,7 +431,17 @@ describe("churn: how many chunk hashes change under a real edit — CDC vs the b
       // move. Both claims now live in the describe below, conditioned on what the edit actually touches.
       // The other scenarios still bind, and they are where CDC's win is real: the same corpus gives
       // CDC 1 against legacy 80 for an insertion near the top.
-      if (name === "edit in place, same length") continue;
+      //
+      // `append at end` is excluded from BOTH assertions here too (CDCAPPEND-1), and the reason is the
+      // one this comment already names for the row above, firing. The never-worse comparison PASSES for
+      // append today only by coincidence ACROSS DIFFERENT DOCUMENTS: at this scenario's own 66-character
+      // append CDC is strictly worse than byte offsets on 4 of 28 corpus documents, and `max <= max`
+      // survives because a FIFTH, unrelated document churns 2 under legacy. Its outcome also flips with
+      // the appended CONTENT at a fixed length — at 2,500 characters it fails under one prose filler,
+      // passes under another, and passes with CDC strictly better under a hash-quiet one. It is REPLACED,
+      // not deleted: the CDCAPPEND-1 describe asserts `cdc <= legacy + 1` PER DOCUMENT for appends
+      // shorter than `min`, which is where that envelope is measured on both real and synthetic corpora.
+      if (name === "edit in place, same length" || name === "append at end") continue;
       cdc.sort((a, b) => a - b);
       const median = cdc[Math.floor(cdc.length / 2)];
       expect(median, `${name}: median CDC churn over real docs`).toBeLessThanOrEqual(2);
@@ -712,5 +728,315 @@ describe("CDCCHURN-1: in-place same-length churn is the number of chunks the edi
     // A floor, not a pinned count: today 14 of 25 documents classify strict, and pinning that number
     // would re-create the corpus dependence this ticket exists to remove.
     expect(counts.strict, "no live document classified strict — the assertion above ran on nothing").toBeGreaterThan(0);
+  });
+});
+
+// ── CDCAPPEND-1: what an append at the end actually costs ────────────────────────────────────────
+
+/**
+ * The acceptance table promised an unconditional **1** for `append at end`. SIX characterisations of that
+ * row have now been falsified, and the last three were falsified during this ticket:
+ *
+ *   1. "churn is 1" — `docs/ARCHITECTURE.md` churns 0 (past the cap) and 4 of 28 corpus documents churn
+ *      2 at this file's own 66-character append;
+ *   2. "1 unless the appended text splits the final chunk, then 2" — the 2s are not splits of the final
+ *      chunk; the new cut lands INSIDE the appended region and moves the chunk before it too;
+ *   3. "2 is the ceiling" — holds only below `min`; 9,000 characters churn 4–5 and 60,000 churn 23–24;
+ *   4. "1 + the number of new chunks, or 0 when capped" — 449 of 560 swept samples (80.2%). A final
+ *      chunk taken by the `n - start <= min` short-tail exit gets a real cut once the document grows, so
+ *      a boundary moves without a chunk being added;
+ *   5. the bound stated over the BOUNDARY sequences — false for a whitespace-only body, because
+ *      `chunkCdc` trims to `[]` while `cdcBoundaries` does not: 20,000 spaces plus one `x` churns 6
+ *      against a boundary-form bound of 1 (WHITESPACE fixture);
+ *   6. "0 once the document fills the cap" — false: a document at exactly 80 boundaries churns 1. What
+ *      must reach the cap is the SHARED PREFIX, not the boundary count (CAPPED fixture).
+ *
+ * THE RULE, stated in the coordinates the cost is paid in — `C0`/`C1` are the ADMITTED chunk arrays and
+ * `L` is the length of their longest common prefix:
+ *
+ *   **churn <= |C1| - L.**
+ *
+ * That is a theorem, and a weak one: it holds for ANY two string arrays, since elements below `L` are
+ * members of the before-set by definition. So it is asserted because it is what the design document
+ * claims, NOT as evidence — the live guards are the ABSOLUTE ceiling and the legacy envelope below, and
+ * the informative measurement is that the bound is TIGHT under the set metric (560/560 swept samples)
+ * everywhere except duplicate content.
+ *
+ * Reproduce every number with
+ * `node scripts/cdc-churn-sweep.mjs --op append --exclude docs/design/cdc-append-churn.md`.
+ * `--exclude` is load-bearing: the design documents are the corpus, so a document publishing a
+ * distribution is inside it — an earlier draft's table had already gone stale by the time it was read.
+ */
+describe("CDCAPPEND-1: append churn is a bound, not a number", () => {
+  const changedCount = (before: string[], after: string[]): number => {
+    const seen = new Set(before);
+    return after.filter((c) => !seen.has(c)).length;
+  };
+  const positionalCount = (before: string[], after: string[]): number =>
+    after.filter((c, i) => before[i] !== c).length;
+  const legacy = (t: string) => chunkContentLegacy(t, CHUNK_CHARS, MAX_EPISODE_CHUNKS);
+
+  /** The last chunk the two chunkings share. In CHUNK coordinates, which is where the cost is paid. */
+  const sharedPrefix = (before: string[], after: string[]): number => {
+    let l = 0;
+    while (l < before.length && l < after.length && before[l] === after[l]) l++;
+    return l;
+  };
+  const bound = (before: string[], after: string[]): number =>
+    Math.max(0, after.length - sharedPrefix(before, after));
+
+  /**
+   * THE ABSOLUTE CEILING — the one thing here a regressed chunker cannot satisfy by construction.
+   *
+   * `bound` is computed from the chunker's own output, so a chunker that re-cuts deeply just shrinks `L`
+   * and inflates the bound to match. This ceiling comes from the SIZE ENVELOPE instead: only boundaries
+   * whose chunk start lies within `max` of the old end can move (`cdcBoundaries` reads
+   * `text[start … min(start + max, n))`), non-final chunks are at least `min`, so at most
+   * `1 + floor((max-1)/min)` of them are in play — and the appended text adds at most `ceil(A/min)`.
+   *
+   * DERIVED from `CDC_PARAMS`, never hardcoded, so a parameter change moves the ceiling with it.
+   */
+  const DEPTH_CEILING = 1 + Math.floor((CDC_PARAMS.max - 1) / CDC_PARAMS.min);
+  const absoluteCeiling = (appendLength: number): number =>
+    DEPTH_CEILING + Math.ceil(appendLength / CDC_PARAMS.min);
+
+  /** Two append CONTENTS at every length: churn depends on the appended text, not only its size. */
+  const prose = (n: number) => doc(n, 77);
+  const quiet = (n: number) => "a".repeat(n);
+  const APPEND_LENGTHS = [1, 66, 700, 1_249, 2_500, 9_000];
+  const CONTENTS: [string, (n: number) => string][] = [
+    ["prose", prose],
+    ["quiet", quiet],
+  ];
+  /** The exact append the `append at end` scenario above applies. */
+  const SCENARIO_APPEND = " a new closing paragraph appended at the very end of the document.";
+
+  it("LIVE CORPUS: set churn never exceeds the bound, per document and per append content", () => {
+    const docs = repoDocs();
+    // A bound assertion over an empty or single-document corpus is green by construction.
+    expect(docs.length, "the corpus is too small for this assertion to mean anything").toBeGreaterThan(5);
+    let tight = 0;
+    let slack = 0;
+    for (const t of docs) {
+      const before = chunkContent(t);
+      for (const len of APPEND_LENGTHS)
+        for (const [name, make] of CONTENTS) {
+          const after = chunkContent(t + make(len));
+          const churn = changedCount(before, after);
+          expect(churn, `${name} append of ${len} exceeded the bound`).toBeLessThanOrEqual(
+            bound(before, after)
+          );
+          if (churn === bound(before, after)) tight++;
+          else slack++;
+        }
+    }
+    // REPORTED, not gated. Equality is what the swept corpus shows today (560/560), but a future
+    // document quoting another one verbatim would legitimately come in under the bound, and reddening
+    // CI on an unrelated docs edit is not what this rule is for. The DUPLICATE fixture gates the
+    // inequality where it is deterministic.
+    expect(tight + slack).toBeGreaterThan(0);
+  });
+
+  it("LIVE CORPUS: the ABSOLUTE ceiling holds — the guard that cannot self-adjust", () => {
+    // This is the assertion a regressed chunker fails. Deliberately NOT a fitted constant: it is derived
+    // from `CDC_PARAMS` and the append length. It is also LOOSE — see the ceiling test below, which
+    // records what it does not catch rather than leaving that to be discovered.
+    for (const t of repoDocs())
+      for (const len of APPEND_LENGTHS)
+        for (const [name, make] of CONTENTS) {
+          const churn = changedCount(chunkContent(t), chunkContent(t + make(len)));
+          expect(churn, `${name} append of ${len} passed the absolute ceiling`).toBeLessThanOrEqual(
+            absoluteCeiling(len)
+          );
+        }
+  });
+
+  it("the absolute ceiling is DERIVED from the envelope, and its looseness is stated not hidden", () => {
+    expect(DEPTH_CEILING).toBe(1 + Math.floor((CDC_PARAMS.max - 1) / CDC_PARAMS.min));
+    expect(DEPTH_CEILING).toBe(4); // at the shipped 1,250/4,000 envelope
+    // WHAT THIS DOES NOT CATCH, both reviewers independently: at a 60,000-character prose append the
+    // corpus churns 23–24 against a ceiling of 4 + ceil(60000/1250) = 52, so a chunker that cut the
+    // appended region at `min` instead of `target` would roughly DOUBLE every long append's cost and
+    // still pass. Tight coverage exists only in the short-append regime (the envelope test below).
+    expect(absoluteCeiling(60_000)).toBe(52);
+  });
+
+  it("LIVE CORPUS: divergence depth stays inside the DERIVED ceiling, not the observed maximum", () => {
+    // The observed maximum is 2 on this corpus and 3 on the sweep's synthetic documents, so 2 is an
+    // observation and asserting it would pin the corpus. `CDCCHURN-1` published a sparse-grid maximum as
+    // if it were a bound; this asserts the derived 4 and reports the observation.
+    let observed = 0;
+    for (const t of repoDocs())
+      for (const len of APPEND_LENGTHS)
+        for (const [, make] of CONTENTS) {
+          const b0 = cdcBoundaries(t, CDC_PARAMS);
+          const b1 = cdcBoundaries(t + make(len), CDC_PARAMS);
+          let l = 0;
+          while (l < b0.length && l < b1.length && b0[l] === b1[l]) l++;
+          const depth = b0.length - l;
+          expect(depth, "an append moved more boundaries than the size envelope permits").toBeLessThanOrEqual(
+            DEPTH_CEILING
+          );
+          observed = Math.max(observed, depth);
+        }
+    expect(observed, "no boundary moved at all — the assertion above ran on nothing").toBeGreaterThan(0);
+  });
+
+  it("CAPPED FIXTURE: the SHARED PREFIX must reach the cap — 'the document is past the cap' does not", () => {
+    // The characterisation this fixture exists to kill was in the proposed replacement row, which would
+    // have made it the fifth wrong answer shipping as documentation.
+    const past = doc(400_000, 7);
+    expect(cdcBoundaries(past, CDC_PARAMS).length).toBeGreaterThan(MAX_EPISODE_CHUNKS + 1);
+    const beforePast = chunkContent(past);
+    const afterPast = chunkContent(past + prose(2_500));
+    expect(sharedPrefix(beforePast, afterPast)).toBe(MAX_EPISODE_CHUNKS);
+    expect(changedCount(beforePast, afterPast), "a shared prefix at the cap must cost nothing").toBe(0);
+
+    // …and the counter-case, which is the whole point: EXACTLY at the cap, churn is 1, not 0.
+    const atCap = past.slice(0, 214_526);
+    expect(
+      cdcBoundaries(atCap, CDC_PARAMS).length,
+      "the fixture drifted off the exact-cap boundary count it is built on"
+    ).toBe(MAX_EPISODE_CHUNKS);
+    const beforeAt = chunkContent(atCap);
+    const afterAt = chunkContent(atCap + prose(2_500));
+    expect(sharedPrefix(beforeAt, afterAt)).toBeLessThan(MAX_EPISODE_CHUNKS);
+    expect(changedCount(beforeAt, afterAt), "a document AT the cap must not churn 0").toBeGreaterThan(0);
+  });
+
+  it("MERGE FIXTURE: a one-character append can DELETE a boundary", () => {
+    // The backup-boundary preference is "the first backup hit at or after `target`, otherwise the first
+    // backup hit at all" (lib/graph/cdc.ts). Extending the tail by one character extends the search
+    // window by one; if that position satisfies the backup mask AND sits past `target`, it OUTRANKS the
+    // earlier backup and the previous cut ceases to exist — two chunks merge into one.
+    //
+    // WHICH CHARACTER IS NOT INCIDENTAL. On the live document this was first observed against, `q`, `%`
+    // and `5` delete the boundary while `x`, `a`, `z`, space, `.` and newline do not; the sweep's own
+    // length-1 samples use `z` and `a` and so never saw the event. Checked in here rather than pinned to
+    // live content for exactly that reason.
+    const t = doc(30_000, 90);
+    const before = cdcBoundaries(t, CDC_PARAMS);
+    const after = cdcBoundaries(t + "#", CDC_PARAMS);
+    expect(after.length, "the fixture stopped exercising the merge").toBe(before.length - 1);
+    expect(before, "the vanishing boundary was not there to begin with").toContain(29_818);
+    expect(after, "the boundary survived — the merge did not happen").not.toContain(29_818);
+    // The bound holds through it, which is why the rule is stated against the shared prefix rather than
+    // against the chunk count: the count went DOWN.
+    const beforeChunks = chunkContent(t);
+    const afterChunks = chunkContent(t + "#");
+    expect(afterChunks.length).toBeLessThan(beforeChunks.length);
+    expect(changedCount(beforeChunks, afterChunks)).toBeLessThanOrEqual(bound(beforeChunks, afterChunks));
+  });
+
+  it("DUPLICATE FIXTURE: set churn is STRICTLY below the bound — the rule is an inequality", () => {
+    // The only branch that proves the rule is not an equality, and nothing on the live corpus reaches it.
+    // `lib/graph/project.ts` filters by `new Set(chunk_shas)` MEMBERSHIP, so a re-cut chunk whose content
+    // already exists anywhere in the document costs nothing.
+    const t = doc(60_000, 21);
+    const before = chunkContent(t);
+    const after = chunkContent(t + t);
+    expect(changedCount(before, after), "the fixture stopped exercising the inequality").toBeLessThan(
+      bound(before, after)
+    );
+    // …and the positional count sits ON the bound, which is what makes the gap a metric difference
+    // rather than a miscount.
+    expect(positionalCount(before, after)).toBe(bound(before, after));
+  });
+
+  it("DUPLICATE, the other direction: appending an existing chunk VERBATIM saves nothing", () => {
+    // Only a realignment that reproduces WHOLE chunks pays. Appending one existing chunk does not,
+    // because the boundary shift means the re-cut chunks are not byte-identical to the original — so the
+    // fixture above needs self-concatenation and a smaller duplicate would prove nothing.
+    const t = doc(60_000, 22);
+    const before = chunkContent(t);
+    const after = chunkContent(t + before[5]);
+    expect(changedCount(before, after)).toBe(bound(before, after));
+  });
+
+  it("WHITESPACE FIXTURE: the bound holds for a whitespace-only base — the case that killed the boundary form", () => {
+    // `chunkCdc` returns [] for a whitespace-only body while `cdcBoundaries` still returns boundaries, so
+    // stating the rule over BOUNDARY sequences gives a non-empty shared prefix over an EMPTY before-set.
+    // Both spec reviewers produced this independently. In chunk coordinates the case is covered rather
+    // than excluded: C0 = [], so L = 0 and the bound is |C1|.
+    const t = " ".repeat(20_000);
+    const before = chunkContent(t);
+    const after = chunkContent(t + "x");
+    expect(before, "the whitespace guard changed — this fixture is measuring something else now").toEqual([]);
+    const churn = changedCount(before, after);
+    expect(churn).toBe(6);
+    expect(churn).toBeLessThanOrEqual(bound(before, after));
+    // The refutation itself, pinned: the boundary-coordinate form would have said 1.
+    const b0 = cdcBoundaries(t, CDC_PARAMS);
+    const b1 = cdcBoundaries(t + "x", CDC_PARAMS);
+    let l = 0;
+    while (l < b0.length && l < b1.length && b0[l] === b1[l]) l++;
+    const boundaryFormBound = Math.max(0, Math.min(MAX_EPISODE_CHUNKS, b1.length) - l);
+    expect(churn, "the boundary-coordinate form is no longer refuted by this fixture").toBeGreaterThan(
+      boundaryFormBound
+    );
+  });
+
+  it("GROWTH FIXTURE: churn grows with append length AND differs with append content at the same length", () => {
+    const t = doc(50_000, 3);
+    const before = chunkContent(t);
+    const churnOf = (make: (n: number) => string, len: number) =>
+      changedCount(before, chunkContent(t + make(len)));
+    const proseSeries = APPEND_LENGTHS.map((len) => churnOf(prose, len));
+    for (let i = 1; i < proseSeries.length; i++)
+      expect(proseSeries[i], `churn fell from ${APPEND_LENGTHS[i - 1]} to ${APPEND_LENGTHS[i]}`).toBeGreaterThanOrEqual(
+        proseSeries[i - 1]
+      );
+    // No constant ceiling is asserted for any length — a ceiling is what made this row wrong four times.
+    // A FLOOR at 9,000 is asserted instead, because "conditional on length" needs a test, not prose.
+    expect(churnOf(prose, 9_000)).toBeGreaterThanOrEqual(4);
+    // …and the same length under different content churns differently, which is the fifth thing the row
+    // never mentioned: a hash-quiet run yields few cuts, so it becomes fewer chunks than prose does.
+    expect(churnOf(quiet, 9_000)).toBeLessThan(churnOf(prose, 9_000));
+  });
+
+  it("ENVELOPE: for a short append CDC is at most ONE chunk worse than byte offsets, PER DOCUMENT", () => {
+    // This REPLACES `max(cdc) <= max(legacy)` for this scenario rather than deleting it. That comparison
+    // is not a property of appends: at the scenario's own 66-character append CDC is strictly worse than
+    // byte offsets on 4 of 28 corpus documents, and it passes only because a FIFTH, unrelated document
+    // churns 2 under legacy — max against max, across different documents. Its outcome also flips with
+    // the appended content at a fixed length. Deleting it outright would leave no cross-algorithm guard
+    // at all, which is what both spec reviewers refused.
+    //
+    // Scoped to appends shorter than `min`, where the +1 envelope is measured on BOTH the live corpus and
+    // 300 synthetic documents. For longer appends the gap reaches +2 synthetically, so it is reported by
+    // the sweep and not gated here — this file does not gate on a lower bound.
+    const docs = repoDocs();
+    expect(docs.length).toBeGreaterThan(5);
+    let worse = 0;
+    for (const t of docs)
+      for (const len of APPEND_LENGTHS.filter((n) => n < CDC_PARAMS.min))
+        for (const [name, make] of CONTENTS) {
+          const app = make(len);
+          const cdc = changedCount(chunkContent(t), chunkContent(t + app));
+          const leg = changedCount(legacy(t), legacy(t + app));
+          expect(cdc, `${name} append of ${len}: CDC is more than one chunk worse than byte offsets`).toBeLessThanOrEqual(
+            leg + 1
+          );
+          if (cdc > leg) worse++;
+        }
+    // The trade is real and visible rather than asserted away: CDC IS worse than byte offsets on append.
+    expect(worse, "no document is worse under CDC — the envelope is measuring nothing").toBeGreaterThan(0);
+  });
+
+  it("THE ROW'S OWN CLAIM: the scenario append does not churn a constant", () => {
+    // Criterion 17. The design row may not carry an unconditional number, and the previous draft's
+    // replacement text ("1 for a short append to a document below the cap") was refuted by exactly this
+    // distribution — every one of those 2s is a below-cap document. Without this test that gloss passes
+    // every other criterion in the spec.
+    const distribution = new Map<number, number>();
+    for (const t of repoDocs()) {
+      const churn = changedCount(chunkContent(t), chunkContent(t + SCENARIO_APPEND));
+      distribution.set(churn, (distribution.get(churn) ?? 0) + 1);
+    }
+    expect(distribution.size, "the scenario append churns one constant — the row could state it").toBeGreaterThan(1);
+    expect(distribution.get(2) ?? 0, "no document churns 2 — 'always 1' would be defensible again").toBeGreaterThan(0);
+    // The 0 comes from a document past the cap; if the corpus loses it, the cap branch of the row is no
+    // longer exercised live and the CAPPED fixture is the only thing holding it.
+    expect((distribution.get(0) ?? 0) + (distribution.get(1) ?? 0)).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What this is

The `append at end` row of `docs/design/content-defined-chunking.md`'s acceptance table promised an
unconditional churn of **1**. `CDCCHURN-1` corrected the row above it and deliberately deferred this one
rather than give it a fourth invented rule. **Six characterisations of this row have now been falsified —
three of them during this ticket, and all three were mine.**

**No product change.** `lib/graph/cdc.ts` is read-only here; the chunker is correct and the documentation
was wrong, exactly as it was one row up.

## The rule, in the coordinates the cost is paid in

With `C₀`/`C₁` the ADMITTED chunk arrays and `L` the length of their longest common prefix:

> **churn ≤ |C₁| − L**

A theorem with no preconditions — chunks below `L` are byte-identical and members of the before-set, so
`lib/graph/project.ts:1222-1223`'s `new Set(chunk_shas)` MEMBERSHIP filter can never re-push them.
Draft 1 stated it over the **boundary** sequences and that version is false: `chunkCdc` trims a
whitespace-only body to `[]` while `cdcBoundaries` does not, so 20,000 spaces plus one `x` churns 6
against a boundary-form bound of 1. Both spec reviewers produced that counter-example independently.

Spec: `docs/design/cdc-append-churn.md` (draft 3, in this diff), SPEC_READY on the deterministic gate.

## What is deliberately NOT in this slice

- **Changing the chunker so appends never re-cut the tail.** The obvious fix makes chunking depend on the
  PREVIOUS chunking, and "same body ⇒ same chunks ⇒ same hashes" is what the whole delta ledger rests on.
- **Gating the long-append legacy envelope.** The synthetic maximum is a lower bound; only the
  short-append regime is measured on both populations, so only it is gated.
- **The orphan-tail question the MERGE case raises** (a vanished chunk's episode is still in the graph).
  Pre-existing, and a purge decision rather than a churn measurement.
- **A guard test for the sweep script's own CLI refusals.** The sweep is a hand-run instrument, not
  CI-wired; its five refusal paths are verified by the invocations listed below rather than by a test.

## Verification

| check | result |
|---|---|
| unit (`npm test`) | **2532 passed**, 11 skipped |
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean for changed files (6 pre-existing warnings elsewhere) |
| `npm run check:docs` | routes/tables/sources in sync |
| `aios spec eval … --tier deterministic` | **SPEC_READY**, exit 0 |
| data-mechanics | not run — no schema, no persistence, no tier surface in this diff |

**Every published figure re-verified against the sweep at head** (`--op append --exclude` both design
documents this ticket edits): 27 docs · 540 samples · bound tight 540/540 · candidate1 446/540 · fixture
distribution `{0:1, 1:23, 2:3}` · depth observed 2 corpus / 3 synthetic against a derived ceiling of 4 ·
duplicate probe 22 shared / bound 25 / set 2 · zero expectation failures.

**CLI refusal paths, verified by invocation:**

```
--op --exclude x                          exit=2  REFUSING — --op needs a value
--op bogus                                exit=2  REFUSING — unknown --op bogus
--step docs/2026/997.md                   exit=2  REFUSING — --step must be a positive integer
--step 0                                  exit=2  REFUSING — --step must be a positive integer
--op append --exclude docs/design/typo.md exit=2  REFUSING — --exclude named … not in this corpus
(run from a directory with no docs/)      exit=1  corpus is non-empty, samples were taken
```

### Mutations — 5 run, each reddened its intended test

| mutation (`lib/graph/cdc.ts` unless noted) | verdict | intended test reddened |
|---|---|---|
| remove the backup-boundary preference upgrade | REDDENED | MERGE FIXTURE |
| `if (!body.trim()) return []` → `if (false)` | REDDENED | WHITESPACE FIXTURE |
| cap truncation `>= limit` → `>= limit + 1` | REDDENED | CAPPED FIXTURE |
| cut at `min` instead of the content-defined cut | REDDENED | MERGE / CAPPED / GROWTH / WHITESPACE / VERBATIM |
| `leg + 1` → `leg` (in the test) | REDDENED | ENVELOPE — the +1 is at zero headroom, not decoration |

The fourth is worth reading: a "cut at `min`" regression roughly doubles long-append churn and does
**not** redden the absolute ceiling (24 against a ceiling of 52). The fixtures catch it; the ceiling
alone does not. That is stated in the spec and in the test rather than left to be discovered.

## Review

**Reviewed by Fable (code-reviewer) and Codex gpt-5.5 — verdict BLOCKED on both, four rounds on the spec
and one on the diff, all six rounds BLOCKED; every finding folded or refuted below.**

| round | Fable | Codex |
|---|---|---|
| spec 1 | BLOCKED — 3 HIGH | BLOCKED — 6 findings |
| spec 2 | BLOCKED — 1 HIGH, 5 MEDIUM | BLOCKED — 3 findings |
| code | BLOCKED — 1 HIGH, 6 MEDIUM/LOW | BLOCKED — 2 HIGH, 1 MEDIUM |

**The code review's HIGH is the one worth reading, because both models found it independently and it is
this ticket's own subject firing on this ticket's own branch: the slice about published numbers that stop
reproducing had published numbers that stopped reproducing.** `--exclude` covered this spec but not the
other design document the slice edits, so the commit that corrected that document moved the figure the
previous commit had published (449/560 → 466/560). And the sentence justifying the exclusion — "around 79
characters below the in-place sweep's 25,000-character floor" — was **false at the commit that wrote it**,
which had already grown the file past the floor.

Other findings that changed the design rather than the prose:

- **"0 once the document fills the cap" was false and was in the proposed replacement row** (Fable). A
  document at exactly 80 boundaries churns 1; what must reach the cap is the shared *prefix*. It would
  have been the fifth wrong characterisation, shipping as the fix.
- **Draft 2's replacement row then smuggled the ORIGINAL false constant back in** as its gloss ("1 for a
  short append below the cap") — refuted by the run the spec itself commands, and all sixteen acceptance
  criteria passed with it in place. Criterion 17 now pins the row's number against the measurement.
- **The bound can never redden** (Fable): it is computed from the chunker's own output. Hence the
  absolute ceiling derived from `CDC_PARAMS` and the per-document depth assertion against the DERIVED 4.
- **Deleting `max(cdc) ≤ max(legacy)` loses a guard** (Codex, seconded by Fable). Replaced per-document
  and regime-scoped rather than deleted.
- **The sweep failed open three ways and ran degraded inputs instead of refusing them** (both).

**Refuted, with evidence:** Fable's round-2 proposal that divergence depth ≤ 2 is provable — the
committed script's own synthetic leg observes depth 3, Codex constructed one at seed 1307, and the
provable ceiling is 4. Fable retracted it in round 3.

AIOS-Work: CDCAPPEND-1
