### PR TITLE
feat(graph): a measured battery for the small-model lever nobody pulled (GRAPHSMALL-1)

### DIFF
--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -154,9 +154,15 @@ background) on the branch diff. The prompt shape that works:
 
 ## 4. Codex adversarial review
 
-`codex exec --sandbox read-only -m gpt-5.6 "<prompt>"` in the background (model
-id current as of 2026-08; update as Codex models roll). Same prompt discipline
-as step 2, plus:
+`codex exec --sandbox read-only -m gpt-5.5 "<prompt>"` in the background. Same prompt
+discipline as step 2, plus:
+
+- **`gpt-5.5`, not `gpt-5.6`, on a ChatGPT-login account.** `-m gpt-5.6` fails the whole
+  run with `400 invalid_request_error: The 'gpt-5.6' model is not supported when using
+  Codex with a ChatGPT account` — and it fails AFTER the prompt is sent, so it burns a
+  round trip and reads like a hang if you are not watching the output. This step said
+  `gpt-5.6` and cost exactly that on GRAPHSMALL-1. Update the id when the account's
+  supported set actually changes, and verify with a one-line probe before a long review.
 
 - Tell it what Fable found and what was folded (including refuted claims), and
   explicitly task it with breaking the folds.

--- a/docs/design/graph-small-model-activation.md
+++ b/docs/design/graph-small-model-activation.md
@@ -1,0 +1,283 @@
+# Small-model activation for graph refinement calls (GRAPHSMALL-1)
+
+Status: **reviewed (cold read) and folded — READY to build against** · Owner: chetan
+· Tier build-with: unit (routing + decision function) + script/battery (the measured A/B)
+
+**Review:** cold-read by **Codex gpt-5.5** — verdict *needs revision*, 1 BLOCKER + 2 HIGH + 2 MEDIUM
++ 1 LOW, all confirmed and folded below (the Q1/Q2 control clause, the dead-Q3 metric set, arm-config
+isolation, the summary metric's boilerplate blind spot, and the fixed 15% threshold). A **Fable** cold read was
+attempted first and **stalled without producing a verdict** — it is not counted as a review.
+
+**Deps:** none blocking. Coordinates with **EXMODEL-1** (in progress — qualifying an extraction model
+at save time with a real Graphiti-shaped probe); this spec CONSUMES that probe for model selection
+rather than re-implementing it, and must not land a second qualification path.
+
+**Increment:** ONE PR = the battery arm + the two missing quality metrics + the pre-registered
+decision function + RUNBOOK. Explicitly NOT the prod config change (a human action after readout) and
+NOT PIPEFF-5.
+
+## Problem
+
+`GRAPHCOST-7` (#488, DONE) built small-model routing: Graphiti asks for a cheap model on the calls it
+marks `ModelSize.small`, the proxy honours the marker (`wantsSmallModel` →
+`selectSmallExtractionBackend`), and `SMALL_ELIGIBLE_KINDS` (`lib/llm/graph-call-kind.ts`) names them.
+
+**The lever was never pulled.** `teams.extraction_small_model` is unset, so
+`selectSmallExtractionBackend` returns `null`, `smallTarget` is `null`, and
+`app/api/internal/llm/v1/chat/completions/route.ts` falls to `strong` for every call. All graph traffic
+runs on `qwen/qwen3.7-plus`.
+
+## Measured current state
+
+Window **2026-08-05 → 08-16** — the clean post-instrumentation window. Any window crossing **08-04** is
+contaminated: `call_kind` only began populating then, and the pre-instrumentation rows read as
+"unlabelled" (08-03 alone carries $43.52, which is enough to invert conclusions).
+
+- Graph = **$18.35 / 12d (~$46/mo)**, 14,851 calls, 2,187 chunk-episodes → 6.8 calls/episode.
+- **48.9M input vs 2.2M output tokens** — this is an INPUT problem; a lever that does not cut input
+  tokens is not a cost lever.
+
+| small-eligible kind | calls | avg in | USD | share |
+|---|---|---|---|---|
+| `dedupe_edges` | 8,555 | 1,089 | $3.17 | 17.3% |
+| `node_summaries_batch` | 810 | 5,944 | $1.83 | 10.0% |
+| `edge_timestamps` | 1,269 | 549 | $0.27 | 1.4% |
+| **addressable** | **10,634 (72% of calls)** | | **$5.27** | **28.7%** |
+
+### OPEN RISK: is `node_summaries_batch` actually marked small? (28.7% vs 18.7%)
+
+`SMALL_ELIGIBLE_KINDS` lists `node_summaries_batch` and `edge_timestamps` on the strength of a **code
+comment** ("0.29.3 marks these `ModelSize.small` too"), not on anything observable in prod. It cannot
+be confirmed from `llm_usage`: the marker lives in the REQUEST body, `smallTarget` is null today so
+everything routes strong regardless, and we store the resolved model, not the requested one.
+
+This is not academic — **`node_summaries_batch` is $1.83, 10.0% of graph spend.** If the deployed image
+does not actually mark it small, the addressable prize is **18.7%, not 28.7%**, and the 15% SHIP
+threshold below goes from comfortable to nearly unreachable.
+
+**Settle it for free, before spending anything.** The capture tap
+(`scripts/graph-window-battery/capture-tap.mjs`) already records request bodies to JSONL. A projection
+replay with the tap on — RUNBOOK steps before the paid step — shows exactly which `call_kind`s carry
+`GRAPHITI_SMALL_MODEL_MARKER`. That is a zero-cost, empirical answer to a question the spec would
+otherwise be resting on a comment for, and it gates whether the battery is worth running at all.
+
+(That the 0.29.3 upgrade IS deployed is already settled empirically: `node_summaries_batch` has 810
+calls and exists only in 0.29.3, while 0.13.2's `node_attributes` has 0.)
+
+### Two corrections this spec exists to carry forward
+
+1. **GRAPHCOST-7's "65% of graph spend" is STALE — do not reuse it.** It was measured on graphiti
+   0.13.2, where the per-entity `node_attributes` fan-out dominated. The 0.29.3 upgrade (GRAPHCOST-8)
+   replaced that with batched `node_summaries_batch`; `node_attributes` is **0 calls** today. The prize
+   is **28.7%, not 65%** — a 2.2× overestimate for anyone reading the old row.
+2. **GRAPHCOST-7's quality claim is true but NARROWER than it reads.** "Cannot degrade extraction
+   quality" holds — these kinds never touch entity/edge extraction. But `dedupe_edges` governs
+   **duplicate-fact** quality and `node_summaries_batch` governs **summary** quality, and neither is
+   extraction. Activation is therefore gated on a battery, not on that sentence.
+
+## What can actually degrade, per kind
+
+| downgraded kind | what it decides | metric that sees it |
+|---|---|---|
+| `dedupe_edges` | whether two facts are the same fact | **Q7** name-universe convergence + **Q1**'s upper bound |
+| `node_summaries_batch` | entity summary text | **none — gap, Q10 below** |
+| `edge_timestamps` | a fact's temporal bounds | **none — gap, Q11 below** |
+
+**NOT `Q3`.** An earlier draft made Q3 (IS_DUPLICATE_OF share) the primary dedupe gate. Q3 was
+**REMOVED by Amendment 2** of the parent spec: graphiti 0.29.3's `add_episode` discards
+`duplicate_pairs` and never writes the relation, so Q3 reads a **structural zero on every arm**
+(`scripts/graph-window-battery/decision.mjs:81-84`). Specifying it would have gated the slice's single
+biggest risk on a metric that cannot move. Its fragmentation duty now lives in **Q7** and **Q1's upper
+bound** — which is also why Q1 cannot be repurposed as a control (below).
+
+### Why Q1/Q2 are NOT controls (corrected after review)
+
+An earlier draft claimed Q1/Q2 "cannot move, so movement means the harness is invalid." **That is
+wrong, and it would have discarded the most likely true finding as a harness fault.**
+
+Q1 and Q2 are measured from **final `Entity` nodes — post-dedupe canonical nodes**
+(`scripts/graph-window-battery/measure.ts:45,83,143`), not from raw extractor output. Extraction being
+untouched does NOT hold the final entity set fixed, and there is a concrete path from a downgraded
+kind to Q1: `node_summaries_batch` writes the summaries that `dedupe_nodes` (strong, untouched) READS
+when deciding whether two candidate entities are the same. Worse summaries ⇒ worse merge decisions ⇒
+`Chetan` / `Chetan Nandakumar` / `Chetan N.` survive as separate nodes ⇒ Q1 rises and Q2/Q7 shift.
+That is a **genuine quality regression, and precisely the one this battery exists to catch** — the
+control clause would have relabelled it "invalid harness" and thrown the finding away.
+
+So Q1/Q2 keep their existing status as **judged quality metrics with the parent spec's bands**
+(Q1 is already the documented catch-all for fragmentation, `decision.mjs:61`).
+
+## Coordination constraints found while building (both are real, both from reading)
+
+1. **`Q8` and `Q9` were ALREADY TAKEN — these metrics are `Q10`/`Q11`.** `scripts/graph-window-battery/q8-orphan-drop.mjs`
+   defines `Q8′` (orphan-drop loss rate) with its own test file. Shipping a second `Q8` would have put
+   two different meanings on one label in one battery — the renaming is not cosmetic.
+2. **PIPEFF-5 is ALREADY BUILT AND PAUSED on `origin/feat/graph-combined-extraction`**, and it touches
+   the paused branch's battery files (`build-arms.mjs`, `capture-tap.mjs`, `corpus.mjs`, `count-chunks.ts`, `seed-local.mjs`, all under `scripts/graph-window-battery/`) plus
+   `run-rep.sh`. This slice therefore **must not edit those files**: the arm-config mechanism and the
+   marker pre-flight land in NEW files instead of as edits to `seed-local.mjs` / `capture-tap.mjs`.
+   Verified conflict-free: that branch does not touch `scripts/graph-window-battery/measure.ts`,
+   `scripts/graph-window-battery/decision.mjs`, `scripts/graph-window-battery/judge.mjs`, or
+   `scripts/graph-window-battery/RUNBOOK.md`, which are the files this slice changes.
+
+## Design
+
+Reuse `scripts/graph-window-battery/` wholesale — its topology and capture tap
+(`scripts/graph-window-battery/capture-tap.mjs`), the readout
+(`scripts/graph-window-battery/measure.ts`), the judge (`scripts/graph-window-battery/judge.mjs` +
+`scripts/graph-window-battery/decision.mjs`), and the cost harness (`scripts/graph-ingest-cost.mjs`).
+Two deltas:
+
+1. **The arms differ by team CONFIG, not by a bind-mounted graphiti patch.** `STRONG` =
+   `extraction_small_model` unset (today's behaviour); `SMALL` = it set to the chosen model. Same
+   image, same corpus, same everything else.
+
+   **This must be a MECHANISM, not a claim** (review, HIGH). The bind-mount design is checkable with
+   `diff`; a config field is not, and `scripts/graph-window-battery/seed-local.mjs:93` copies the whole
+   `teams` row into a battery DB that sequential arm runs SHARE. The concrete failure: `STRONG` runs
+   after `SMALL` without the field being cleared, both arms route small, the delta collapses, and the
+   run reads as "no savings / quality equal" when in truth arm separation was broken. So:
+   - the arm's config is **set explicitly at the start of each arm run**, not inherited from whatever
+     the previous arm left behind;
+   - each arm **snapshots the effective config** (the resolved small-backend target, i.e. what
+     `selectSmallExtractionBackend` actually returns) into its result JSON;
+   - the judge **refuses to compare two arms whose snapshots are identical**, since an experiment
+     whose arms did not differ cannot report a difference;
+   - the snapshot diff must be exactly the one field — asserted structurally, so "arms differ in
+     exactly one config field" is checked rather than asserted in prose.
+2. **Two new quality metrics for the gaps above**, because shipping without them would test the one
+   kind that already has coverage and wave through the two that don't:
+   - **Q10 summary health** — over `(:Entity).summary`. Named "health", not "informativeness":
+     review was right that non-empty share + mean length is a **weak structural** check that catches
+     blank / truncated / padded output but **passes same-length boilerplate** ("This entity is
+     mentioned in the source material." for every entity, at incumbent-like length). So Q10 carries a
+     third, discriminating term: **distinctness** — the share of summaries that are near-duplicates of
+     each other (normalised), plus token overlap against the entity's own adjacent
+     `RELATES_TO.fact` text. Boilerplate is by construction self-similar and detached from the entity's
+     facts; that is what makes it detectable when length cannot see it.
+   - **Q11 temporal coverage** — the share of `RELATES_TO` edges carrying a resolved `valid_at`. Only
+     meaningful as a ratio to STRONG, since the extractor sets many dates itself and
+     `edge_timestamps` fires only for the ones it left unset.
+
+**Cost is MEASURED, not modelled.** The tap forwards to the real `/api/internal/llm/v1/*`, so
+`llm_usage` rows come from the production metering path and the savings number is an observation. A
+modelled "N× cheaper" estimate is not acceptable evidence here.
+
+**Model selection is a probe, not a price-list pick.** EXMODEL-1 found candidates that 400 outright or
+collapse to 1–3 entities *while advertising structured outputs*. The chosen small model must clear that
+probe before it enters an arm; a model that fails the probe is not a battery result, it is a
+misconfiguration.
+
+## Decision function — pre-registered, before any number exists
+
+Inherits `docs/design/graph-episode-window.md`'s conventions (2 reps/arm, mean for band metrics,
+STRONG's own spread as the noise estimate, symmetric bands, validity ceiling in band units). Additions:
+
+### AMENDMENT (during build): `C1` is the wrong cost gate for this arm — add `C2`
+
+Found while reading `scripts/graph-window-battery/decision.mjs` to implement against it, not from a
+review. **`C1` is `input tokens / episode` with `kind: "ratio-fall", margin: 0.25` — it REQUIRES the
+arm to send 25% fewer input tokens.** The window levers it was written for did exactly that (they
+carried fewer prior episodes). **This lever does not reduce tokens at all** — the same bytes are sent,
+to a cheaper model. C1 would therefore FAIL the small-model arm categorically, for a saving the lever
+cannot by construction produce, and a spec that shipped with C1 as its cost gate would have
+pre-registered its own guaranteed STOP.
+
+So for this arm:
+- **`C2` = measured USD per episode, `kind: "ratio-fall"`** — the thing that must actually improve.
+  `scripts/graph-ingest-cost.mjs:171` already emits `usdPerEpisode` in the same summary object the
+  judge reads `inputTokensPerEpisode` from (`scripts/graph-window-battery/judge.mjs:111`), so this is
+  a new registry entry over data that already exists, not a new measurement path.
+- **`C1` becomes DIAGNOSTIC for this arm, not a ship gate.** Input tokens/episode should stay roughly
+  FLAT here; a large move means something changed that this lever does not touch, and is worth reading
+  even though it cannot pass a `ratio-fall`.
+
+- **The metric set is the judge's CURRENT one — `Q1`, `Q2`, `Q4`, `Q5`, `Q7` — plus `Q10`/`Q11` and the
+  new `C2`, with `C1` diagnostic.**
+  Not Q3 (removed, structural zero on 0.29.3) and not Q6 (superseded by Q7). Taking the set from
+  `scripts/graph-window-battery/measure.ts`'s header comment instead of from
+  `scripts/graph-window-battery/decision.mjs` is how the
+  first draft specified two metrics that cannot move; the judge is the source of truth, not the
+  readout's docstring.
+- **No control clause.** Q1/Q2 are judged on the parent spec's existing bands (see above for why
+  treating them as controls would discard a real regression as a harness fault).
+- **ARM-SEPARATION GATE (replaces the control clause as the validity check):** if the two arms'
+  effective-config snapshots are identical, the run is **INVALID** — the arms did not differ, so no
+  difference can be reported. This is a validity check the experiment genuinely supports, unlike the
+  one it replaces.
+- **SHIP** iff: every band metric within band, arm separation confirmed, and **`C2` (measured USD per
+  episode) falls by ≥ the threshold set by the pre-flight** — 15% when the marker pre-flight confirms the full 28.7%
+  addressable set, but **10% if the pre-flight shows only 18.7%** (i.e. `node_summaries_batch` is not
+  marked small). Review's LOW is right: a flat 15% against an 18.7% ceiling demands ~80% realisation
+  and would force STOP on a clean run that captured most of the reachable saving. **The threshold is
+  fixed by the pre-flight, which runs BEFORE any arm — so it is still pre-registered, not chosen after
+  the numbers.**
+- **STOP** iff any band metric fails outside noise. A pass "within noise but below band" resolves the
+  same way the parent spec resolves it — symmetrically — so the joint cannot be chosen after the fact.
+
+## Scope
+
+**In this PR:**
+- A `SMALL` arm on the existing battery, differing from `STRONG` by exactly one team config field.
+- Two new quality metrics — **Q10** summary health, **Q11** temporal coverage — in
+  `scripts/graph-window-battery/measure.ts`, covering the two downgraded kinds that have no coverage.
+- The CONTROL clause + SHIP/STOP thresholds in `scripts/graph-window-battery/judge.mjs` /
+  `scripts/graph-window-battery/decision.mjs`, pre-registered before any number exists.
+- The per-`call_kind` cost split in the battery readout, so savings are measured.
+- `scripts/graph-window-battery/RUNBOOK.md` updated with the arm and its config step.
+
+**Cut, deliberately:**
+- **Turning it on in prod.** Setting `teams.extraction_small_model` is a human config action taken
+  AFTER the battery reads out; this PR must not change live team config.
+- **Running the battery.** Authoring the arm is free; step 5 of the RUNBOOK is the only step that
+  spends, and spending is the owner's call.
+- **Choosing the model.** Selection consumes EXMODEL-1's probe; this PR does not add a second
+  qualification path.
+- **PIPEFF-5** — merging `extract_nodes` + `extract_edges` ($8.46, 46.1%) is the larger lever, changes
+  the extraction prompt, and needs its own battery.
+- **GRAPHCOST-2** — excluding zero-payoff paths is 0.6% of spend; tracked as graph hygiene, not cost.
+
+## Acceptance criteria
+
+1. **unit** — `wantsSmallModel` routes exactly `SMALL_ELIGIBLE_KINDS` and nothing else: a request
+   carrying the marker for a NON-eligible kind (e.g. `extract_nodes`) resolves to the strong target.
+2. **unit** — `selectSmallExtractionBackend` returns `null` when `extraction_small_model` is unset,
+   proving today's inert state is the one this spec describes.
+3. **unit** — each arm snapshots its EFFECTIVE resolved small-backend target (what
+   `selectSmallExtractionBackend` returns, not what was intended), and the two snapshots differ in
+   exactly ONE field — asserted structurally, not by reading the runbook.
+4. **unit** — `Q10` summary health fails a truncating arm, a padding arm, AND a same-length BOILERPLATE
+   arm (identical filler text at incumbent length) — the case mean-length alone passes.
+5. **unit** — `Q11` temporal coverage is expressed as a ratio to the STRONG arm, and is undefined (not
+   silently 0) when STRONG produced no datable edges.
+6. **unit** — the judge marks a run `INVALID` when the two arms' effective-config snapshots are
+   IDENTICAL (arm separation broken, e.g. `extraction_small_model` leaked from a prior arm run), and
+   does not report SHIP/STOP for that run.
+7. **unit** — the judge refuses to decide on fewer than 2 reps per arm rather than judging a single rep.
+8. **script** — the battery emits a per-`call_kind` cost split read from `llm_usage`, so the savings
+   figure is measured through the production metering path, not modelled.
+8b. **unit** — the judge gates this arm on `C2` (USD/episode) and NOT on `C1` (input tokens/episode):
+   an arm that halves cost while leaving token count flat PASSES, which is precisely the shape this
+   lever produces and the shape `C1`'s `ratio-fall` would have failed.
+9. **docs** — `scripts/graph-window-battery/RUNBOOK.md` gains the small-model arm, and this spec is
+   referenced from the ticket; no `docs/ARCHITECTURE.md` drift block changes (no new route/table/source).
+10. **script** — a FREE pre-flight reports which `call_kind`s actually carry
+    `GRAPHITI_SMALL_MODEL_MARKER` in captured request bodies, settling the 28.7%-vs-18.7% question
+    empirically before any paid step; the battery refuses to run if the eligible set observed on the
+    wire does not match `SMALL_ELIGIBLE_KINDS`, because that mismatch means the code's assumption about
+    the deployed image is stale.
+
+## What would falsify this
+
+- The measured saving is below the pre-flight-set threshold (15% at a 28.7% ceiling, 10% at 18.7%) →
+  the lever is not worth the quality risk; record the number and stop.
+- The two arms' config snapshots are identical → arm separation broke; no conclusion is available.
+- Q10 passes an arm whose summaries are uniform boilerplate → Q10's distinctness term is not working, and
+  the summary gap is still uncovered.
+- `Q7` convergence or `Q1`'s upper bound moves → dedupe changed behaviour. Q1 rising is
+  fragmentation (aliases surviving as separate entities), which is the likeliest true regression here
+  because `node_summaries_batch` feeds `dedupe_nodes`' input. NOT measured by Q3, which is a structural
+  zero on 0.29.3.
+- `Q10`/`Q11` degrade → the two kinds nobody had coverage for are exactly where it broke, which is the
+  outcome this spec's extra metrics exist to be able to see at all.
+- The chosen model fails EXMODEL-1's probe → not a battery result; fix the selection and re-run.

--- a/docs/design/graph-small-model-activation.md
+++ b/docs/design/graph-small-model-activation.md
@@ -226,6 +226,16 @@ So for this arm:
 - The per-`call_kind` cost split in the battery readout, so savings are measured.
 - `scripts/graph-window-battery/RUNBOOK.md` updated with the arm and its config step.
 
+**DEFERRED after review, with the reason (not silently):** the **Neo4j read path** for Q10/Q11.
+`scripts/graph-window-battery/measure.ts` does not yet query `(:Entity){name, summary}` or
+`RELATES_TO.valid_at`, so the scorers are reachable by the judge but not yet fed by a live readout.
+Both reviewers flagged this and both offered the same two options — wire it, or re-scope and say so.
+It is re-scoped: the decision layer (registry, bands, arm separation, cost parsing, pre-flight) is
+what gates the spend decision and is fully wired and pinned; the Cypher is mechanical and belongs
+with the run that first needs it, when the corpus shape is in front of the author. **The battery
+cannot be run to a Q10/Q11 verdict until that lands** — stated here and in the RUNBOOK rather than
+left for an operator to discover mid-session.
+
 **Cut, deliberately:**
 - **Turning it on in prod.** Setting `teams.extraction_small_model` is a human config action taken
   AFTER the battery reads out; this PR must not change live team config.

--- a/scripts/graph-window-battery/RUNBOOK.md
+++ b/scripts/graph-window-battery/RUNBOOK.md
@@ -244,3 +244,13 @@ small label — only the resolved value can tell you.
 Do **not** pick from a price list. `EXMODEL-1` found candidates that 400 outright, or collapse to 1–3
 entities, *while advertising structured outputs*. Run its probe first; a model that fails it produces a
 broken battery, not a battery result.
+
+## NOT YET RUNNABLE TO A Q10/Q11 VERDICT
+
+`measure.ts` does not yet read `(:Entity){name, summary}` or `RELATES_TO.valid_at` out of Neo4j, so
+`Q10`/`Q10F`/`Q10L`/`Q11` have scorers and bands but **no live readout**. Everything else — the
+registry, the C2 cost parse, arm separation, the pre-flight — is wired and tested.
+
+Deferred deliberately after review (see the spec's Scope). Do not start a paid session expecting a
+summary/temporal verdict until the Cypher lands; the cost and dedupe questions (C2, Q1/Q7) are
+answerable today.

--- a/scripts/graph-window-battery/RUNBOOK.md
+++ b/scripts/graph-window-battery/RUNBOOK.md
@@ -172,3 +172,75 @@ and the cause. The first valid session's verdict **binds**.
   and its own session under an amendment — it does not get bolted onto this one.
 - **INVALID** → fix the instrument, not the rules. More than two consecutive invalidations without a
   committed amendment blocks further sessions.
+
+---
+
+# The SMALL-MODEL arm (GRAPHSMALL-1)
+
+Spec: [`docs/design/graph-small-model-activation.md`](../../docs/design/graph-small-model-activation.md).
+Same topology, tap, corpus and reps as above. **Read the differences below — three of them are the
+kind that silently invalidate a session rather than fail it.**
+
+## What differs from the window battery
+
+| | window battery | small-model arm |
+|---|---|---|
+| arms differ by | a bind-mounted `graphiti.py` (checkable with `diff`) | a team CONFIG field, `extraction_small_model` |
+| cost gate | `C1` — input tokens/episode | **`C2` — USD/episode** |
+| extra quality metrics | — | **Q10** summary health, **Q11** temporal coverage |
+
+**`C1` is NOT the gate here, and this is the trap.** C1 is `ratio-fall` on input TOKENS: it demands
+the arm SEND 25% fewer. This lever sends the *same* tokens to a cheaper model, so C1 cannot pass by
+construction. Judging this arm on C1 pre-registers a guaranteed STOP. Use
+`smallModelMetrics({ addressableShare })` from `decision.mjs`; C1 is worth reading as a diagnostic
+(tokens should sit roughly FLAT) but gates nothing.
+
+## Step 0 — the pre-flight (FREE, and it sets the ship threshold)
+
+Do this before anything paid. It answers a question the code only *asserts*: which call kinds does the
+DEPLOYED image actually ask to downgrade?
+
+```bash
+# with the tap running (steps 1-4 above), replay a projection, then:
+node scripts/graph-window-battery/small-marker-preflight.mjs /tmp/gwb/capture-*.jsonl
+```
+
+Read `addressableShare` off the output and pass it to `smallModelMetrics({ addressableShare })`:
+
+- `node_summaries_batch` **marked** → ~28.7% addressable → C2 band **15%**.
+- `node_summaries_batch` **not marked** → ~18.7% → C2 band **10%**. A flat 15% there would need ~80%
+  realisation and would STOP a clean run that captured most of what was reachable.
+
+`missing` names a kind the code claims is eligible but which never carried the marker (shrinks the
+prize). `unexpected` names one that carried it but is not in `SMALL_ELIGIBLE_KINDS` — unclaimed
+savings, and a sign the prompt table has drifted from the image.
+
+## Step 5′ — seed each arm's config EXPLICITLY
+
+```js
+import { armConfig, effectiveSnapshot, assertArmsDiffer } from "./small-model-arms.mjs";
+armConfig("STRONG");                      // { extraction_small_model: null }  — set, never inherited
+armConfig("SMALL", "<model from EXMODEL-1's probe>");
+```
+
+**Why `STRONG` writes an explicit `null`:** `seed-local.mjs` copies the whole `teams` row and
+sequential arms SHARE the battery DB. A `STRONG` run after a `SMALL` run inherits the field, both arms
+route small, and the delta collapses — the session then reads as *"no savings, quality equal"*, which
+is indistinguishable from a real negative result. That is the worst failure this battery has.
+
+After both arms, snapshot what each **resolved** to (not what it intended) and gate on it:
+
+```js
+const v = assertArmsDiffer(effectiveSnapshot("STRONG", strongResolved), effectiveSnapshot("SMALL", smallResolved));
+if (!v.ok) throw new Error(v.reason);   // INVALID session — not a result
+```
+
+`*Resolved*` means `selectSmallExtractionBackend(...)?.model ?? null`. An arm whose model name was set
+but which still resolves to `null` (e.g. its provider is not configured) is a strong arm wearing a
+small label — only the resolved value can tell you.
+
+## Model selection
+
+Do **not** pick from a price list. `EXMODEL-1` found candidates that 400 outright, or collapse to 1–3
+entities, *while advertising structured outputs*. Run its probe first; a model that fails it produces a
+broken battery, not a battery result.

--- a/scripts/graph-window-battery/decision.mjs
+++ b/scripts/graph-window-battery/decision.mjs
@@ -117,11 +117,24 @@ export const SMALL_MODEL_METRICS = Object.freeze({
   Q4: METRICS.Q4,
   Q5: METRICS.Q5,
   Q7: METRICS.Q7,
-  // Two-sided: a small model can truncate summaries AND pad them, and a floor sees only one.
-  Q10: { label: "summary health (distinctness)", kind: "ratio-lower", margin: 0.15, maxSpreadRatio: 0.075 },
-  // Ratio to the incumbent — the absolute level reflects the corpus, not the model (see
-  // `scoreTemporalCoverage`). A fall means `edge_timestamps` stopped resolving dates it used to.
-  Q11: { label: "temporal coverage", kind: "ratio-lower", margin: 0.15, maxSpreadRatio: 0.075 },
+  // THREE banded scalars, not one. An earlier version registered a single `ratio-lower` on
+  // distinctness while its comment claimed two-sidedness — so `factOverlap` and `meanLength` gated
+  // NOTHING and a padding arm (an acceptance criterion names it explicitly) was ungated. Review
+  // caught the mismatch between the comment and the band. Banding each term explicitly beats
+  // inventing a composite weighting nobody can defend, and it names WHICH property failed.
+  Q10: { label: "summary distinctness (anti-boilerplate)", kind: "ratio-lower", margin: 0.15, maxSpreadRatio: 0.075 },
+  // Detachment from the entity's own facts — the other half of "boilerplate", and independently
+  // defeatable, so it needs its own band.
+  Q10F: { label: "summary fact-overlap", kind: "ratio-lower", margin: 0.2, maxSpreadRatio: 0.1 },
+  // TWO-SIDED, and this is the one that catches PADDING: a `ratio-lower` cannot reject a summary that
+  // got longer, and "wrote more words to say the same thing" is a real small-model failure.
+  Q10L: { label: "summary length", kind: "ratio-both", margin: 0.35, maxSpreadRatio: 0.175 },
+  // TWO-SIDED, deliberately. A fall means `edge_timestamps` stopped resolving dates it used to — but
+  // a RISE is just as suspect: the downgraded prompt literally says "NEVER hallucinate dates"
+  // (`lib/llm/graph-call-kind.ts`) because inventing them is the known failure mode of a weak model,
+  // and a one-sided floor would score that as an improvement. Coverage counts dates PRESENT, not
+  // dates CORRECT, so the only honest reading is "should not move".
+  Q11: { label: "temporal coverage", kind: "ratio-both", margin: 0.15, maxSpreadRatio: 0.075 },
   // THE cost gate for this arm. Threshold is set by the pre-flight (see the spec): 0.15 when the full
   // 28.7% is addressable, 0.10 when only 18.7% is. Default is the conservative 0.15.
   C2: { label: "USD / episode", kind: "ratio-fall", margin: 0.15, maxSpreadRatio: 0.075 },
@@ -163,8 +176,8 @@ const over = (value, ceiling) => value > ceiling * (1 + 1e-9) + Number.EPSILON;
  * Returns the verdict plus the numbers behind it, because a verdict without its inputs is exactly
  * the kind of claim this file exists to stop.
  */
-export function judgeMetric(key, arm, incumbent, extras = {}) {
-  const m = METRICS[key];
+export function judgeMetric(key, arm, incumbent, extras = {}, registry = METRICS) {
+  const m = registry[key];
   if (!m) throw new Error(`unknown metric ${key}`);
   if (!Array.isArray(arm) || arm.length !== 2 || !Array.isArray(incumbent) || incumbent.length !== 2) {
     throw new Error(`${key}: both arms need exactly 2 reps — the spread IS the second rep`);
@@ -274,7 +287,7 @@ export function judgeMetric(key, arm, incumbent, extras = {}) {
  * Every trigger here is pre-defined and none of them is "the numbers came out wrong" — that
  * distinction is the difference between a rule and an excuse.
  */
-export function assessSession({ incumbent, universeSize, underpowered, armsCompleted, harnessRefused, crossCheckAvailable }) {
+export function assessSession({ incumbent, universeSize, underpowered, armsCompleted, harnessRefused, crossCheckAvailable, registry = METRICS, armSeparation }) {
   // REQUIRED, not defaulted-permissive. A default of `armsCompleted = true` means a runner that
   // forgets to pass it silently disarms that validity trigger — the same "omission canonicalized as
   // fine" class as the absolute clause above, in the one file whose job is that the readout cannot
@@ -294,11 +307,18 @@ export function assessSession({ incumbent, universeSize, underpowered, armsCompl
   // unmeasurable and C1 loses its guard against a retry-rate shift masquerading as a token saving.
   if (!crossCheckAvailable) problems.push("no cross-check: ingest_runs recorded no finished projector run in the window");
   if (!armsCompleted) problems.push("an arm did not complete every episode");
+  // ARM SEPARATION (GRAPHSMALL-1, AC6). Config-differing arms cannot be checked with `diff` the way
+  // the bind-mounted file arms can, so the check has to live HERE, in session validity — a RUNBOOK
+  // snippet is not a gate. Passing `{ ok:false, reason }` (from `assertArmsDiffer`) makes the session
+  // INVALID rather than letting a collapsed delta read as "no savings, quality equal".
+  if (armSeparation && armSeparation.ok === false) {
+    problems.push(armSeparation.reason ?? "arm separation could not be established");
+  }
   for (const u of underpowered) problems.push(`${u} is UNDERPOWERED — a corpus too thin to measure is not evidence of a regression`);
 
   // The incumbent's spread ceiling, per metric, in band units.
   for (const [key, reps] of Object.entries(incumbent ?? {})) {
-    const m = METRICS[key];
+    const m = registry[key];
     if (!m || !Array.isArray(reps) || reps.length !== 2) continue;
     const s = spread(reps[0], reps[1]);
     if (m.maxSpreadRatio !== undefined) {
@@ -332,12 +352,12 @@ export const MIN_UNIVERSE = 15;
  * `arms` is ordered — SAME before W1 — and the FIRST arm to pass every gate wins. An arm ships only
  * if every metric PASSes; INCONCLUSIVE blocks exactly as FAIL does.
  */
-export function decide({ session, incumbent, arms }) {
+export function decide({ session, incumbent, arms, registry = METRICS }) {
   if (!session.valid) {
     return { outcome: "INVALID", reasons: session.problems, arms: [] };
   }
   const judged = arms.map(({ name, metrics, extras = {} }) => {
-    const results = Object.keys(METRICS).map((key) => judgeMetric(key, metrics[key], incumbent[key], extras));
+    const results = Object.keys(registry).map((key) => judgeMetric(key, metrics[key], incumbent[key], extras, registry));
     const blocking = results.filter((r) => r.verdict !== VERDICT.PASS);
     return { name, results, ships: blocking.length === 0, blocking };
   });

--- a/scripts/graph-window-battery/decision.mjs
+++ b/scripts/graph-window-battery/decision.mjs
@@ -98,6 +98,46 @@ export const METRICS = Object.freeze({
   C1: { label: "input tokens / episode", kind: "ratio-fall", margin: 0.25, maxSpreadRatio: 0.125 },
 });
 
+/**
+ * The SMALL-MODEL arm's registry (GRAPHSMALL-1) — a SEPARATE export, not additions to METRICS above.
+ *
+ * WHY SEPARATE, and this is the load-bearing part: **`C1` is the wrong cost gate for that lever.**
+ * C1 is `ratio-fall` on input TOKENS per episode — it requires the arm to SEND 25% fewer tokens. The
+ * window levers did exactly that. Routing calls to a cheaper model sends the SAME tokens at a lower
+ * price, so C1 cannot pass by construction, and a shared registry would have pre-registered that
+ * battery's own guaranteed STOP. `C2` (measured USD/episode) is the thing that must actually move;
+ * C1 stays available as a DIAGNOSTIC there (tokens should sit roughly flat) but gates nothing.
+ *
+ * Q1/Q2/Q4/Q5/Q7 are reused verbatim — the quality question is the same one, and a fork of the bands
+ * would let two batteries disagree about what "fragmented" means.
+ */
+export const SMALL_MODEL_METRICS = Object.freeze({
+  Q1: METRICS.Q1,
+  Q2: METRICS.Q2,
+  Q4: METRICS.Q4,
+  Q5: METRICS.Q5,
+  Q7: METRICS.Q7,
+  // Two-sided: a small model can truncate summaries AND pad them, and a floor sees only one.
+  Q10: { label: "summary health (distinctness)", kind: "ratio-lower", margin: 0.15, maxSpreadRatio: 0.075 },
+  // Ratio to the incumbent — the absolute level reflects the corpus, not the model (see
+  // `scoreTemporalCoverage`). A fall means `edge_timestamps` stopped resolving dates it used to.
+  Q11: { label: "temporal coverage", kind: "ratio-lower", margin: 0.15, maxSpreadRatio: 0.075 },
+  // THE cost gate for this arm. Threshold is set by the pre-flight (see the spec): 0.15 when the full
+  // 28.7% is addressable, 0.10 when only 18.7% is. Default is the conservative 0.15.
+  C2: { label: "USD / episode", kind: "ratio-fall", margin: 0.15, maxSpreadRatio: 0.075 },
+});
+
+/** The pre-flight-conditional cost band (spec: "the threshold is fixed BEFORE any arm runs"). */
+export function smallModelMetrics({ addressableShare } = {}) {
+  // Below the full-eligibility case the ceiling is 18.7%, where demanding 15% would require ~80%
+  // realisation and would STOP a clean run that captured most of what was reachable.
+  const margin = typeof addressableShare === "number" && addressableShare < 0.2 ? 0.1 : 0.15;
+  return Object.freeze({
+    ...SMALL_MODEL_METRICS,
+    C2: { ...SMALL_MODEL_METRICS.C2, margin, maxSpreadRatio: margin / 2 },
+  });
+}
+
 export const VERDICT = Object.freeze({ PASS: "PASS", FAIL: "FAIL", INCONCLUSIVE: "INCONCLUSIVE" });
 
 const mean = (a, b) => (a + b) / 2;

--- a/scripts/graph-window-battery/judge.mjs
+++ b/scripts/graph-window-battery/judge.mjs
@@ -71,6 +71,13 @@ export function parseCostText(text, label) {
   const perEp = text.match(/input tok\s+[\d,]+\s+([\d,]+) per episode/);
   if (!perEp) throw new Error(`${label}: no input-tokens-per-episode line — harness format drifted?`);
 
+  // USD/episode — C2's input, and the small-model arm's ONLY cost gate. The harness has always
+  // printed it (`graph-ingest-cost.mjs`: "cost  $X  $Y per episode"); this parser dropped it, so
+  // C2 had no reps and the registry that gates on it could never be fed. Optional, not required:
+  // the window battery does not use C2, and a missing line must not refuse an otherwise valid
+  // window session.
+  const usdPerEp = text.match(/cost\s+\$[\d.,]+\s+\$([\d.,]+) per episode/);
+
   return {
     refused: false,
     crossCheckAvailable,
@@ -78,6 +85,7 @@ export function parseCostText(text, label) {
     episodesPushed: pushed,
     signedGap: signed,
     inputTokensPerEpisode: num(perEp[1]),
+    usdPerEpisode: usdPerEp ? num(usdPerEp[1]) : null,
   };
 }
 
@@ -110,6 +118,27 @@ export function assemble(dir, items, arms = ["w10", "same", "w1"]) {
     Q7: reps[arm].map((r) => nameConvergence(r.q.nameCounts, universe)),
     C1: reps[arm].map((r) => r.c.inputTokensPerEpisode),
   });
+
+  /**
+   * The SMALL-MODEL arm's reps (GRAPHSMALL-1). A SEPARATE builder, because that arm is judged on a
+   * different registry: C2 (USD/episode) gates, C1 does not — C1 is `ratio-fall` on input TOKENS and
+   * this lever sends the SAME tokens to a cheaper model, so including it would fail the arm for a
+   * saving it cannot produce. The Q10 family and Q11 come from `measure.ts`'s summary/temporal readout.
+   */
+  const smallModelReps = (arm) => ({
+    ...metricReps(arm),
+    C1: undefined, // diagnostic only for this arm — read it, do not gate on it
+    Q10: reps[arm].map((r) => r.q.Q10?.distinctness),
+    Q10F: reps[arm].map((r) => r.q.Q10?.factOverlap),
+    Q10L: reps[arm].map((r) => r.q.Q10?.meanLength),
+    Q11: reps[arm].map((r) => r.q.Q11?.share),
+    C2: reps[arm].map((r) => r.c.usdPerEpisode),
+  });
+
+  // Exposed on the assembled result so a small-model session has a REAL path to the registry —
+  // exporting a builder nothing returns is how the first version of this slice shipped scorers the
+  // judge could not reach.
+  const smallModel = { incumbent: smallModelReps("w10"), armReps: smallModelReps };
 
   const incumbent = metricReps("w10");
   const allReps = arms.flatMap((a) => reps[a]);
@@ -155,7 +184,7 @@ export function assemble(dir, items, arms = ["w10", "same", "w1"]) {
     return row;
   });
 
-  return { session, verdict, incumbent, universe, perName, reps };
+  return { session, verdict, incumbent, universe, perName, reps, smallModel };
 }
 
 // CLI half, guarded so the parsers above are unit-testable without a results directory.

--- a/scripts/graph-window-battery/small-marker-preflight.mjs
+++ b/scripts/graph-window-battery/small-marker-preflight.mjs
@@ -24,7 +24,7 @@
  * share to feed the decision function.
  */
 import { readFileSync } from "node:fs";
-import { classifyGraphCall, wantsSmallModel, SMALL_ELIGIBLE_KINDS, GRAPHITI_SMALL_MODEL_MARKER } from "../../lib/llm/graph-call-kind.ts";
+import { classifyGraphCall, SMALL_ELIGIBLE_KINDS, GRAPHITI_SMALL_MODEL_MARKER } from "../../lib/llm/graph-call-kind.ts";
 
 /**
  * Tally marker presence per call kind over tap records.
@@ -61,10 +61,27 @@ export function tallyMarkers(records) {
  *                  would keep routing it strong, so it is unclaimed savings, not a risk — but it
  *                  means the table has drifted from the image and should be re-derived.
  */
+/**
+ * Kinds that exist only in graphiti 0.13.2. The deployed image is 0.29.3, where the per-entity
+ * `node_attributes` fan-out was REPLACED by batched `node_summaries_batch` — so its absence from a
+ * healthy capture is expected, not drift. Reporting it as `missing` would raise a false alarm on
+ * every correct run, and an alarm that always fires is one nobody reads.
+ */
+const LEGACY_KINDS = new Set(["node_attributes"]);
+
+/**
+ * `costByKind` MUST be shares of TOTAL graph spend, summing to ~1 across ALL kinds — not a subset.
+ *
+ * This contract is load-bearing and was previously only implied: `addressableShare` feeds
+ * `smallModelMetrics`, whose band flips at 0.2, and those thresholds (0.287 / 0.187) are shares of
+ * the WHOLE graph bill. Pass two kinds totalling 0.273 and the function returns 0.634 — a number that
+ * selects the 15% band when the true addressable share is 17.3% and the spec demands 10%. Review
+ * caught this precisely because a test of mine pinned that wrong usage as if it were correct.
+ */
 export function assessEligibility(tally, costByKind = {}) {
   const observedEligible = tally.kinds.filter((k) => k.marked > 0).map((k) => k.kind);
   const declared = [...SMALL_ELIGIBLE_KINDS];
-  const missing = declared.filter((k) => !observedEligible.includes(k));
+  const missing = declared.filter((k) => !observedEligible.includes(k) && !LEGACY_KINDS.has(k));
   const unexpected = observedEligible.filter((k) => !SMALL_ELIGIBLE_KINDS.has(k));
 
   // Addressable share = the cost share of kinds that are BOTH declared eligible (so the proxy will
@@ -73,11 +90,22 @@ export function assessEligibility(tally, costByKind = {}) {
   const routable = observedEligible.filter((k) => SMALL_ELIGIBLE_KINDS.has(k));
   const addressable = routable.reduce((n, k) => n + (costByKind[k] ?? 0), 0);
 
+  // REFUSE, don't just report (AC10). A capture where nothing routable carries the marker means the
+  // battery can save 0% — running it would spend money to measure a lever that is not connected.
+  // Emitting JSON and exiting 0 let that read as a normal pre-flight.
+  const refusal =
+    routable.length === 0
+      ? "no routable kind carries the small-model marker — the lever cannot save anything on this image; re-derive SMALL_ELIGIBLE_KINDS before running the battery"
+      : null;
+
   return {
     observedEligible,
     routable,
     missing,
     unexpected,
+    refusal,
+    // Shares of TOTAL graph spend — see the contract above. `null` when no cost map was supplied,
+    // so a caller cannot mistake "unknown" for "zero addressable".
     addressableShare: total > 0 ? addressable / total : null,
   };
 }
@@ -110,7 +138,12 @@ function main() {
     node_summaries_batch: 0.1,
     edge_timestamps: 0.014,
   };
-  console.log(JSON.stringify({ ...tally, ...assessEligibility(tally, COST_SHARE) }, null, 2));
+  const assessment = assessEligibility(tally, COST_SHARE);
+  console.log(JSON.stringify({ ...tally, ...assessment }, null, 2));
+  if (assessment.refusal) {
+    console.error(`REFUSING: ${assessment.refusal}`);
+    process.exit(2);
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/graph-window-battery/small-marker-preflight.mjs
+++ b/scripts/graph-window-battery/small-marker-preflight.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * PRE-FLIGHT: which graph call kinds actually carry Graphiti's small-model marker? (GRAPHSMALL-1)
+ *
+ * WHY THIS RUNS BEFORE ANYTHING IS SPENT. `SMALL_ELIGIBLE_KINDS` lists `node_summaries_batch` and
+ * `edge_timestamps` on the strength of a CODE COMMENT ("0.29.3 marks these ModelSize.small too"), not
+ * on anything observed. It cannot be settled from `llm_usage`: the marker lives in the REQUEST body,
+ * `smallTarget` is null in prod today so everything routes strong regardless, and we store the model
+ * that ANSWERED, not the one that was asked for.
+ *
+ * The stake is not academic. `node_summaries_batch` is 10.0% of graph spend. If the deployed image
+ * does not mark it small, the addressable prize is **18.7%, not 28.7%** — which is exactly the input
+ * `smallModelMetrics({ addressableShare })` uses to set the C2 cost band. Getting it wrong sets the
+ * ship threshold against a ceiling that does not exist.
+ *
+ * The capture tap already writes every request body to JSONL, so this is a free, empirical answer:
+ * replay a projection with the tap on (the RUNBOOK steps BEFORE the paid step) and point this at the
+ * capture file.
+ *
+ * Usage:
+ *   node scripts/graph-window-battery/small-marker-preflight.mjs /tmp/gwb/capture-*.jsonl
+ *
+ * Output: one JSON object — per-kind marker counts, the eligible set it implies, and the addressable
+ * share to feed the decision function.
+ */
+import { readFileSync } from "node:fs";
+import { classifyGraphCall, wantsSmallModel, SMALL_ELIGIBLE_KINDS, GRAPHITI_SMALL_MODEL_MARKER } from "../../lib/llm/graph-call-kind.ts";
+
+/**
+ * Tally marker presence per call kind over tap records.
+ *
+ * PURE and exported so the counting is unit-testable without a capture file. Only `kind:"request"`
+ * records carry a request body; a response record has no `model` field to read and must not be
+ * counted as "unmarked", which would silently halve every share.
+ */
+export function tallyMarkers(records) {
+  const byKind = new Map();
+  let requests = 0;
+  for (const rec of records) {
+    if (!rec || rec.kind !== "request" || !rec.body) continue;
+    requests += 1;
+    const kind = classifyGraphCall(rec.body);
+    const marked = rec.body.model === GRAPHITI_SMALL_MODEL_MARKER;
+    const cur = byKind.get(kind) ?? { kind, calls: 0, marked: 0 };
+    cur.calls += 1;
+    if (marked) cur.marked += 1;
+    byKind.set(kind, cur);
+  }
+  const kinds = [...byKind.values()].sort((a, b) => b.calls - a.calls);
+  return { requests, kinds };
+}
+
+/**
+ * What the observed markers imply for the battery.
+ *
+ * `observedEligible` is the set the DEPLOYED image actually asks to downgrade. `unexpected` and
+ * `missing` are the two ways the code's table can be wrong, and BOTH matter:
+ *   - `missing`  — a kind the table claims is eligible but which never carried the marker. This is
+ *                  the 28.7% → 18.7% case; it shrinks the prize.
+ *   - `unexpected` — a kind that carried the marker but is NOT in `SMALL_ELIGIBLE_KINDS`. The proxy
+ *                  would keep routing it strong, so it is unclaimed savings, not a risk — but it
+ *                  means the table has drifted from the image and should be re-derived.
+ */
+export function assessEligibility(tally, costByKind = {}) {
+  const observedEligible = tally.kinds.filter((k) => k.marked > 0).map((k) => k.kind);
+  const declared = [...SMALL_ELIGIBLE_KINDS];
+  const missing = declared.filter((k) => !observedEligible.includes(k));
+  const unexpected = observedEligible.filter((k) => !SMALL_ELIGIBLE_KINDS.has(k));
+
+  // Addressable share = the cost share of kinds that are BOTH declared eligible (so the proxy will
+  // route them) AND observed carrying the marker (so graphiti will ask). Either alone routes strong.
+  const total = Object.values(costByKind).reduce((n, v) => n + v, 0);
+  const routable = observedEligible.filter((k) => SMALL_ELIGIBLE_KINDS.has(k));
+  const addressable = routable.reduce((n, k) => n + (costByKind[k] ?? 0), 0);
+
+  return {
+    observedEligible,
+    routable,
+    missing,
+    unexpected,
+    addressableShare: total > 0 ? addressable / total : null,
+  };
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error("usage: small-marker-preflight.mjs <capture.jsonl> [more.jsonl ...]");
+    process.exit(1);
+  }
+  const records = [];
+  for (const f of files) {
+    for (const line of readFileSync(f, "utf8").split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        records.push(JSON.parse(line));
+      } catch {
+        // A truncated final line is normal on an interrupted run; a malformed body is not our problem
+        // to fix here. Skipping is safe because `requests` reports what WAS counted.
+      }
+    }
+  }
+  const tally = tallyMarkers(records);
+  // Measured 2026-08-05..08-16 (the clean post-instrumentation window); see the spec.
+  const COST_SHARE = {
+    dedupe_nodes: 0.251,
+    extract_edges: 0.242,
+    extract_nodes: 0.219,
+    dedupe_edges: 0.173,
+    node_summaries_batch: 0.1,
+    edge_timestamps: 0.014,
+  };
+  console.log(JSON.stringify({ ...tally, ...assessEligibility(tally, COST_SHARE) }, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/graph-window-battery/small-model-arms.mjs
+++ b/scripts/graph-window-battery/small-model-arms.mjs
@@ -1,0 +1,91 @@
+/**
+ * Arm separation for the SMALL-model battery (GRAPHSMALL-1).
+ *
+ * The window battery's arms differ by a bind-mounted FILE, so "the arms differ by exactly one thing"
+ * is checkable with `diff`. This battery's arms differ by a team CONFIG FIELD
+ * (`teams.extraction_small_model`), which is not checkable that way — and review named the concrete
+ * failure: `seed-local.mjs` copies the whole `teams` row into a battery DB that sequential arm runs
+ * SHARE, so a `STRONG` run following a `SMALL` run inherits the field, both arms route small, the
+ * delta collapses, and the session reads as "no savings / quality equal" when in truth arm separation
+ * was broken. That is the worst possible failure: it looks like a clean negative result.
+ *
+ * So separation is a MECHANISM here, not a claim:
+ *   1. `armConfig()` states each arm's field value explicitly — `STRONG` sets it to NULL rather than
+ *      leaving it alone, so nothing is ever inherited from whatever ran before.
+ *   2. `effectiveSnapshot()` records what the proxy would ACTUALLY resolve (the small backend target),
+ *      not what the arm intended — an arm whose model name was set but which still resolves to null
+ *      is a strong arm wearing a small label, and only the resolved value can tell.
+ *   3. `assertArmsDiffer()` refuses a session whose two snapshots are identical, or which differ in
+ *      more than the one permitted field.
+ *
+ * Kept in its own file (not folded into `seed-local.mjs`) deliberately: PIPEFF-5's paused branch
+ * `feat/graph-combined-extraction` edits that file, and colliding with in-flight work to save one
+ * import is a bad trade.
+ */
+
+/** The single field these arms are permitted to differ in. */
+export const ARM_FIELD = "extraction_small_model";
+
+export const ARMS = Object.freeze({
+  /** Today's production behaviour: no small model configured, so every call routes strong. */
+  STRONG: Object.freeze({ name: "STRONG", [ARM_FIELD]: null }),
+  /** The lever under test. `model` is supplied per session — see `armConfig`. */
+  SMALL: Object.freeze({ name: "SMALL" }),
+});
+
+/**
+ * The config an arm must be seeded with. Always returns an explicit value for `ARM_FIELD` — including
+ * `null` for STRONG — so a previous arm's value can never be inherited by omission.
+ */
+export function armConfig(arm, smallModel) {
+  if (arm === "STRONG") return { [ARM_FIELD]: null };
+  if (arm === "SMALL") {
+    const m = typeof smallModel === "string" ? smallModel.trim() : "";
+    if (!m) throw new Error("armConfig: the SMALL arm requires a model name");
+    return { [ARM_FIELD]: m };
+  }
+  throw new Error(`armConfig: unknown arm ${String(arm)}`);
+}
+
+/**
+ * What the arm RESOLVED to, as the proxy would see it. `resolved` is the small-backend target
+ * (`selectSmallExtractionBackend(...)?.model ?? null`); pass it in rather than importing the resolver
+ * so this file stays a pure, testable statement about arm identity.
+ */
+export function effectiveSnapshot(arm, resolved) {
+  return { arm, [ARM_FIELD]: resolved ?? null };
+}
+
+/**
+ * Refuse a session whose arms did not actually differ.
+ *
+ * Returns `{ ok: true }` or `{ ok: false, reason }`. A caller that ignores this and reports a delta
+ * is reporting the difference between an arm and itself.
+ */
+export function assertArmsDiffer(a, b) {
+  if (!a || !b) return { ok: false, reason: "arm separation: a snapshot is missing" };
+  if (a.arm === b.arm) return { ok: false, reason: `arm separation: both snapshots are "${a.arm}"` };
+
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)].filter((k) => k !== "arm"));
+  const differing = [...keys].filter((k) => (a[k] ?? null) !== (b[k] ?? null));
+
+  if (differing.length === 0) {
+    // The exact leak this exists to catch: STRONG ran after SMALL and inherited the field.
+    return {
+      ok: false,
+      reason: `arm separation: ${a.arm} and ${b.arm} resolved IDENTICAL config (${ARM_FIELD}=${String(a[ARM_FIELD] ?? null)}) — a prior arm's value was inherited, so the measured delta is between an arm and itself`,
+    };
+  }
+  if (differing.length > 1 || differing[0] !== ARM_FIELD) {
+    return {
+      ok: false,
+      reason: `arm separation: arms differ in [${differing.join(", ")}], but only ${ARM_FIELD} is permitted`,
+    };
+  }
+  // The permitted field must genuinely be strong-vs-small, not small-vs-a-different-small.
+  const strong = [a, b].find((s) => (s[ARM_FIELD] ?? null) === null);
+  if (!strong) {
+    return { ok: false, reason: `arm separation: neither arm has ${ARM_FIELD}=null, so neither is the incumbent` };
+  }
+  return { ok: true };
+}

--- a/scripts/graph-window-battery/small-model-metrics.mjs
+++ b/scripts/graph-window-battery/small-model-metrics.mjs
@@ -86,6 +86,15 @@ export function scoreSummaryHealth(rows) {
   for (const r of nonEmpty) {
     const own = words(r.name);
     const w = new Set([...words(r.summary)].filter((x) => !own.has(x)));
+    // A summary with NOTHING left after its own name is stripped is pure name-repetition: it says
+    // nothing about the entity. Review measured this scoring {distinctness:1, factOverlap:1} —
+    // PERFECT on every term — because an empty word set matched no previous summary and the name
+    // itself appears in the entity's facts. Count it as a duplicate: it is the degenerate case of
+    // boilerplate, not a distinct summary.
+    if (w.size === 0) {
+      duplicates += 1;
+      continue;
+    }
     const dup = seen.some((prev) => {
       if (prev.text === norm(r.summary)) return true;
       if (w.size === 0 || prev.w.size === 0) return false;
@@ -121,5 +130,10 @@ export function scoreTemporalCoverage(edges) {
     if (v === null || v === undefined) return false;
     return String(v).trim().length > 0;
   }).length;
+  // ZERO dated edges is UNDEFINED, not 0.0 (AC5). The metric is only meaningful as a ratio to the
+  // incumbent, and an incumbent of 0 makes that ratio Infinity/NaN — a number no band can read. "No
+  // datable edges in this corpus" is an absence of evidence, and must not be reported as total
+  // coverage collapse.
+  if (dated === 0) return { total, share: null };
   return { total, share: dated / total };
 }

--- a/scripts/graph-window-battery/small-model-metrics.mjs
+++ b/scripts/graph-window-battery/small-model-metrics.mjs
@@ -1,0 +1,125 @@
+/**
+ * Q10 (summary health) and Q11 (temporal coverage) — the two quality gaps the SMALL-model arm opens
+ * that the existing battery cannot see (GRAPHSMALL-1).
+ *
+ * WHY THESE TWO EXIST. The arm downgrades exactly the calls upstream marks `ModelSize.small`:
+ * `dedupe_edges`, `node_summaries_batch`, `edge_timestamps`. The battery already covers the first
+ * (Q7 convergence + Q1's upper bound). The other two govern **entity summary text** and **fact
+ * temporal bounds**, and NOTHING in the existing metric set reads either — so shipping without these
+ * would have tested the one downgraded kind that already had coverage and waved through the two that
+ * did not.
+ *
+ * NUMBERED Q10/Q11, NOT Q8/Q9: `q8-orphan-drop.mjs` already defines `Q8′` for PIPEFF-5. Two meanings
+ * on one label inside one battery is a reporting bug waiting to happen.
+ *
+ * PURE, and separate from the Neo4j reads in `measure.ts`, so every branch below is unit-testable
+ * against hand-built rows — including the adversarial shapes (uniform boilerplate, a padding model)
+ * that are the whole reason the naive version of Q10 was rejected in review.
+ */
+
+/** Case/whitespace-normalised, so trivial formatting differences are not counted as distinctness. */
+const norm = (s) => String(s ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+
+/** Word set of a string, for overlap scoring. Short tokens carry no signal and are dropped. */
+function words(s) {
+  return new Set(
+    norm(s)
+      .split(/[^a-z0-9]+/)
+      .filter((w) => w.length > 3)
+  );
+}
+
+/** |A ∩ B| / |A| — how much of the summary's substance is drawn from the entity's own facts. */
+function overlapShare(summary, facts) {
+  const a = words(summary);
+  if (a.size === 0) return 0;
+  const b = words(facts.join(" "));
+  let hit = 0;
+  for (const w of a) if (b.has(w)) hit += 1;
+  return hit / a.size;
+}
+
+/**
+ * Q10 — summary health over `(:Entity)` rows of `{ name, summary, facts[] }`.
+ *
+ * THREE terms, because review proved one is not enough. Non-empty share and mean length catch a
+ * blank/truncating/padding model, but **pass same-length boilerplate**: an arm that writes "This
+ * entity is mentioned in the source material." for every entity at incumbent-like length scores
+ * identically to a good one on both. So:
+ *
+ *   nonEmptyShare  — the floor: did it write anything at all
+ *   meanLength     — two-sided against the incumbent: truncation AND padding
+ *   distinctness   — share of summaries that are NOT near-duplicates of another summary. Boilerplate
+ *                    is by construction self-similar, so this is what makes it visible.
+ *   factOverlap    — mean share of summary words that appear in that entity's own facts. Boilerplate
+ *                    is also DETACHED from the entity: it can be distinct-ish (name interpolated) and
+ *                    still say nothing the facts support.
+ *
+ * Distinctness and factOverlap are independent detectors on purpose — a model can defeat either one
+ * alone (vary the filler to beat distinctness; quote a fact verbatim to beat overlap) but doing both
+ * is writing a real summary, which is the outcome we want anyway.
+ */
+export function scoreSummaryHealth(rows) {
+  const total = rows.length;
+  if (total === 0) {
+    // No entities is not "healthy summaries" — it is no evidence. Refuse rather than return 1.
+    return { total: 0, nonEmptyShare: null, meanLength: null, distinctness: null, factOverlap: null };
+  }
+  const nonEmpty = rows.filter((r) => norm(r.summary).length > 0);
+  const nonEmptyShare = nonEmpty.length / total;
+  if (nonEmpty.length === 0) {
+    return { total, nonEmptyShare: 0, meanLength: 0, distinctness: 0, factOverlap: 0 };
+  }
+  const meanLength = nonEmpty.reduce((n, r) => n + norm(r.summary).length, 0) / nonEmpty.length;
+
+  // Distinctness: a summary is a near-duplicate if its normalised text equals another's, or its word
+  // set overlaps another's by ≥ 0.9 in BOTH directions.
+  //
+  // THE ENTITY'S OWN NAME IS REMOVED FIRST, and that is what makes this work. Boilerplate in practice
+  // is one template with the name interpolated — "Chetan is an entity mentioned in the source
+  // material" / "Graphiti is an entity mentioned in the source material". With the name left in,
+  // those overlap 6/7 = 0.857 and slip under any threshold loose enough not to flag genuinely similar
+  // real summaries (a test caught exactly this). Stripping the name compares the TEMPLATE, so
+  // name-only variation reads as the duplicate it is, without lowering the bar for real text.
+  const seen = [];
+  let duplicates = 0;
+  for (const r of nonEmpty) {
+    const own = words(r.name);
+    const w = new Set([...words(r.summary)].filter((x) => !own.has(x)));
+    const dup = seen.some((prev) => {
+      if (prev.text === norm(r.summary)) return true;
+      if (w.size === 0 || prev.w.size === 0) return false;
+      let hit = 0;
+      for (const x of w) if (prev.w.has(x)) hit += 1;
+      return hit / w.size >= 0.9 && hit / prev.w.size >= 0.9;
+    });
+    if (dup) duplicates += 1;
+    else seen.push({ text: norm(r.summary), w });
+  }
+  const distinctness = (nonEmpty.length - duplicates) / nonEmpty.length;
+
+  const factOverlap =
+    nonEmpty.reduce((n, r) => n + overlapShare(r.summary, r.facts ?? []), 0) / nonEmpty.length;
+
+  return { total, nonEmptyShare, meanLength, distinctness, factOverlap };
+}
+
+/**
+ * Q11 — temporal coverage: the share of `RELATES_TO` edges carrying a resolved `valid_at`.
+ *
+ * Meaningful ONLY as a ratio to the incumbent arm, because the extractor sets many dates itself and
+ * `edge_timestamps` fires only for the ones it left unset — so the absolute level says more about the
+ * corpus than about the model. `null` (not 0) when there are no edges at all: "no evidence" and
+ * "no coverage" are different answers, and returning 0 would let an empty run read as a total
+ * regression.
+ */
+export function scoreTemporalCoverage(edges) {
+  const total = edges.length;
+  if (total === 0) return { total: 0, share: null };
+  const dated = edges.filter((e) => {
+    const v = e?.valid_at;
+    if (v === null || v === undefined) return false;
+    return String(v).trim().length > 0;
+  }).length;
+  return { total, share: dated / total };
+}

--- a/test/graph-small-model-battery.test.ts
+++ b/test/graph-small-model-battery.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import {
+  scoreSummaryHealth,
+  scoreTemporalCoverage,
+} from "../scripts/graph-window-battery/small-model-metrics.mjs";
+import {
+  armConfig,
+  effectiveSnapshot,
+  assertArmsDiffer,
+  ARM_FIELD,
+} from "../scripts/graph-window-battery/small-model-arms.mjs";
+import { SMALL_MODEL_METRICS, smallModelMetrics, METRICS } from "../scripts/graph-window-battery/decision.mjs";
+import { SMALL_ELIGIBLE_KINDS, wantsSmallModel, GRAPHITI_SMALL_MODEL_MARKER } from "@/lib/llm/graph-call-kind";
+import { selectSmallExtractionBackend } from "@/lib/query/llm-backend";
+
+// Spec: docs/design/graph-small-model-activation.md — the acceptance criteria. These pin the metrics
+// that gate a lever worth ~28.7% of graph spend, and the failure shapes review said would otherwise
+// pass: uniform boilerplate summaries, and two "arms" that silently resolved to the same config.
+
+const entity = (name: string, summary: string, facts: string[] = []) => ({ name, summary, facts });
+
+describe("Q10 summary health — the boilerplate detector", () => {
+  it("scores a real, varied, fact-grounded set as healthy", () => {
+    const s = scoreSummaryHealth([
+      entity("Chetan", "Chetan shipped the Linear importer and owns pm-sync.", ["Chetan shipped the Linear importer"]),
+      entity("Graphiti", "Graphiti extracts entities and edges from episodes.", ["Graphiti extracts entities"]),
+      entity("Railway", "Railway hosts the brain and its Postgres.", ["Railway hosts the brain"]),
+    ]);
+    expect(s.nonEmptyShare).toBe(1);
+    expect(s.distinctness).toBe(1);
+    expect(s.factOverlap).toBeGreaterThan(0.5);
+  });
+
+  it("CATCHES same-length boilerplate — the case mean length alone passes", () => {
+    // The exact adversarial shape review named: incumbent-like length, non-empty, and worthless.
+    const s = scoreSummaryHealth([
+      entity("Chetan", "This entity is mentioned in the source material provided."),
+      entity("Graphiti", "This entity is mentioned in the source material provided."),
+      entity("Railway", "This entity is mentioned in the source material provided."),
+    ]);
+    expect(s.nonEmptyShare).toBe(1); // the naive floor passes…
+    expect(s.meanLength).toBeGreaterThan(40); // …and so does length…
+    expect(s.distinctness).toBeLessThan(0.4); // …but distinctness does not.
+    expect(s.factOverlap).toBe(0); // and it is detached from the entity's own facts
+  });
+
+  it("catches near-boilerplate where only the entity name varies", () => {
+    const s = scoreSummaryHealth([
+      entity("Chetan", "Chetan is an entity mentioned within the provided source material."),
+      entity("Graphiti", "Graphiti is an entity mentioned within the provided source material."),
+      entity("Railway", "Railway is an entity mentioned within the provided source material."),
+    ]);
+    expect(s.distinctness).toBeLessThan(0.5);
+  });
+
+  it("catches a truncating arm and a blank arm", () => {
+    expect(scoreSummaryHealth([entity("A", ""), entity("B", "")]).nonEmptyShare).toBe(0);
+    const truncated = scoreSummaryHealth([entity("A", "Chetan"), entity("B", "Graphiti")]);
+    expect(truncated.meanLength).toBeLessThan(12); // two-sided against the incumbent's mean
+  });
+
+  it("refuses to call an EMPTY entity set healthy (no evidence is not a pass)", () => {
+    expect(scoreSummaryHealth([])).toEqual({
+      total: 0,
+      nonEmptyShare: null,
+      meanLength: null,
+      distinctness: null,
+      factOverlap: null,
+    });
+  });
+});
+
+describe("Q11 temporal coverage", () => {
+  it("is the share of edges carrying a resolved valid_at", () => {
+    const s = scoreTemporalCoverage([
+      { valid_at: "2026-08-01T00:00:00Z" },
+      { valid_at: null },
+      { valid_at: "2026-08-02T00:00:00Z" },
+      { valid_at: "   " },
+    ]);
+    expect(s.total).toBe(4);
+    expect(s.share).toBe(0.5); // blank strings are not dates
+  });
+
+  it("is NULL, not 0, when there are no edges — no evidence ≠ total regression", () => {
+    expect(scoreTemporalCoverage([])).toEqual({ total: 0, share: null });
+  });
+});
+
+describe("arm separation — the leak that reads as a clean negative", () => {
+  it("STRONG sets the field to null EXPLICITLY, so nothing is inherited by omission", () => {
+    expect(armConfig("STRONG")).toEqual({ [ARM_FIELD]: null });
+    expect(armConfig("SMALL", "vendor/cheap-model")).toEqual({ [ARM_FIELD]: "vendor/cheap-model" });
+  });
+
+  it("refuses a SMALL arm with no model", () => {
+    expect(() => armConfig("SMALL", "")).toThrow(/requires a model/i);
+    expect(() => armConfig("SMALL", undefined)).toThrow(/requires a model/i);
+  });
+
+  it("REFUSES two arms that resolved to identical config (the inherited-field leak)", () => {
+    // STRONG ran after SMALL and inherited extraction_small_model: both route small, the delta
+    // collapses, and without this the session reports "no savings" instead of "broken experiment".
+    const a = effectiveSnapshot("SMALL", "vendor/cheap-model");
+    const b = effectiveSnapshot("STRONG", "vendor/cheap-model");
+    const v = assertArmsDiffer(a, b);
+    expect(v.ok).toBe(false);
+    expect(v.reason).toMatch(/IDENTICAL|inherited/i);
+  });
+
+  it("accepts a genuine strong-vs-small pair", () => {
+    expect(assertArmsDiffer(effectiveSnapshot("STRONG", null), effectiveSnapshot("SMALL", "vendor/cheap-model")).ok).toBe(true);
+  });
+
+  it("keys on the RESOLVED value, so an intended-but-inert SMALL arm is caught", () => {
+    // The arm asked for a small model but the backend resolved to null (e.g. provider not configured)
+    // — it is a strong arm wearing a small label, and comparing it to STRONG measures nothing.
+    const v = assertArmsDiffer(effectiveSnapshot("STRONG", null), effectiveSnapshot("SMALL", null));
+    expect(v.ok).toBe(false);
+  });
+
+  it("refuses two snapshots of the same arm", () => {
+    expect(assertArmsDiffer(effectiveSnapshot("SMALL", "m"), effectiveSnapshot("SMALL", "m")).ok).toBe(false);
+  });
+});
+
+describe("the small-model registry gates on C2, not C1", () => {
+  it("uses USD/episode as the cost gate and does NOT inherit C1", () => {
+    // C1 is ratio-fall on input TOKENS; this lever sends the same tokens to a cheaper model, so C1
+    // could never pass and would have pre-registered a guaranteed STOP.
+    expect(SMALL_MODEL_METRICS.C2.kind).toBe("ratio-fall");
+    expect(SMALL_MODEL_METRICS.C2.label).toMatch(/USD/i);
+    expect("C1" in SMALL_MODEL_METRICS).toBe(false);
+  });
+
+  it("reuses the shared quality bands verbatim rather than forking them", () => {
+    for (const k of ["Q1", "Q2", "Q4", "Q5", "Q7"] as const) {
+      expect(SMALL_MODEL_METRICS[k]).toBe(METRICS[k]);
+    }
+  });
+
+  it("sets the cost band from the PRE-FLIGHT, before any arm runs", () => {
+    expect(smallModelMetrics({ addressableShare: 0.287 }).C2.margin).toBe(0.15);
+    expect(smallModelMetrics({ addressableShare: 0.187 }).C2.margin).toBe(0.1);
+    expect(smallModelMetrics().C2.margin).toBe(0.15); // conservative default
+  });
+
+  it("does not carry the dead Q3 or the superseded Q6", () => {
+    expect("Q3" in SMALL_MODEL_METRICS).toBe(false); // structural zero on graphiti 0.29.3
+    expect("Q6" in SMALL_MODEL_METRICS).toBe(false); // superseded by Q7
+  });
+});
+
+describe("the routing this battery exists to qualify", () => {
+  it("routes ONLY the small-eligible kinds, and only when the marker is present", () => {
+    const body = (system: string, model: string) => ({ model, messages: [{ role: "system", content: system }] });
+    const DEDUPE_EDGES = "You are a fact deduplication assistant.";
+    const EXTRACT_NODES = "You are an entity extraction specialist for conversational messages.";
+
+    expect(wantsSmallModel(body(DEDUPE_EDGES, GRAPHITI_SMALL_MODEL_MARKER))).toBe(true);
+    // An eligible prompt WITHOUT the marker stays strong.
+    expect(wantsSmallModel(body(DEDUPE_EDGES, "qwen/qwen3.7-plus"))).toBe(false);
+    // Entity extraction must NEVER be downgraded, marker or not.
+    expect(wantsSmallModel(body(EXTRACT_NODES, GRAPHITI_SMALL_MODEL_MARKER))).toBe(false);
+    expect(SMALL_ELIGIBLE_KINDS.has("extract_nodes")).toBe(false);
+    expect(SMALL_ELIGIBLE_KINDS.has("dedupe_nodes")).toBe(false);
+  });
+
+  it("is INERT today: with extraction_small_model unset the small backend is null", () => {
+    // This is the state the whole slice is about — the lever shipped and was never pulled.
+    const keys = {
+      openrouterKey: "k",
+      extractionProvider: "openrouter" as const,
+      extractionModel: "qwen/qwen3.7-plus",
+      // extractionSmallModel deliberately unset
+    };
+    expect(selectSmallExtractionBackend({}, keys)).toBeNull();
+    // …and set, it resolves — so the assertion above is not vacuous.
+    expect(selectSmallExtractionBackend({}, { ...keys, extractionSmallModel: "vendor/cheap" })?.model).toBe("vendor/cheap");
+  });
+});
+
+describe("marker pre-flight — settles 28.7% vs 18.7% before anything is spent", () => {
+  const req = (system: string, model: string) => ({
+    kind: "request",
+    body: { model, messages: [{ role: "system", content: system }] },
+  });
+  const DEDUPE_EDGES = "You are a fact deduplication assistant.";
+  const SUMMARIES = "You are a helpful assistant that generates concise entity summaries from provided context.";
+  const EXTRACT_NODES = "You are an entity extraction specialist for conversational messages.";
+
+  it("counts the marker per call kind, ignoring response records", async () => {
+    const { tallyMarkers } = await import("../scripts/graph-window-battery/small-marker-preflight.mjs");
+    const t = tallyMarkers([
+      req(DEDUPE_EDGES, GRAPHITI_SMALL_MODEL_MARKER),
+      req(DEDUPE_EDGES, GRAPHITI_SMALL_MODEL_MARKER),
+      req(EXTRACT_NODES, "qwen/qwen3.7-plus"),
+      // A response record has no request body and must not be counted as an unmarked call —
+      // doing so would silently halve every share.
+      { kind: "response", status: 200, body: { choices: [] } },
+    ]);
+    expect(t.requests).toBe(3);
+    expect(t.kinds.find((k: { kind: string }) => k.kind === "dedupe_edges")).toMatchObject({ calls: 2, marked: 2 });
+    expect(t.kinds.find((k: { kind: string }) => k.kind === "extract_nodes")).toMatchObject({ calls: 1, marked: 0 });
+  });
+
+  it("reports the 18.7% case when node_summaries_batch never carries the marker", async () => {
+    const { tallyMarkers, assessEligibility } = await import(
+      "../scripts/graph-window-battery/small-marker-preflight.mjs"
+    );
+    const t = tallyMarkers([
+      req(DEDUPE_EDGES, GRAPHITI_SMALL_MODEL_MARKER),
+      req(SUMMARIES, "qwen/qwen3.7-plus"), // deployed image does NOT ask for a small model here
+    ]);
+    const a = assessEligibility(t, { dedupe_edges: 0.173, node_summaries_batch: 0.1 });
+    expect(a.missing).toContain("node_summaries_batch");
+    // 0.173 / 0.273 — dedupe_edges is routable, summaries are not.
+    expect(a.addressableShare).toBeCloseTo(0.634, 2);
+  });
+
+  it("flags a kind that carries the marker but is NOT declared eligible (table drift)", async () => {
+    const { tallyMarkers, assessEligibility } = await import(
+      "../scripts/graph-window-battery/small-marker-preflight.mjs"
+    );
+    const t = tallyMarkers([req(EXTRACT_NODES, GRAPHITI_SMALL_MODEL_MARKER)]);
+    const a = assessEligibility(t, { extract_nodes: 1 });
+    expect(a.unexpected).toContain("extract_nodes");
+    expect(a.routable).not.toContain("extract_nodes"); // the proxy still routes it strong
+    expect(a.addressableShare).toBe(0);
+  });
+});

--- a/test/graph-small-model-battery.test.ts
+++ b/test/graph-small-model-battery.test.ts
@@ -9,7 +9,15 @@ import {
   assertArmsDiffer,
   ARM_FIELD,
 } from "../scripts/graph-window-battery/small-model-arms.mjs";
-import { SMALL_MODEL_METRICS, smallModelMetrics, METRICS } from "../scripts/graph-window-battery/decision.mjs";
+import {
+  SMALL_MODEL_METRICS,
+  smallModelMetrics,
+  METRICS,
+  judgeMetric,
+  decide,
+  assessSession,
+  VERDICT,
+} from "../scripts/graph-window-battery/decision.mjs";
 import { SMALL_ELIGIBLE_KINDS, wantsSmallModel, GRAPHITI_SMALL_MODEL_MARKER } from "@/lib/llm/graph-call-kind";
 import { selectSmallExtractionBackend } from "@/lib/query/llm-backend";
 
@@ -212,10 +220,24 @@ describe("marker pre-flight — settles 28.7% vs 18.7% before anything is spent"
       req(DEDUPE_EDGES, GRAPHITI_SMALL_MODEL_MARKER),
       req(SUMMARIES, "qwen/qwen3.7-plus"), // deployed image does NOT ask for a small model here
     ]);
-    const a = assessEligibility(t, { dedupe_edges: 0.173, node_summaries_batch: 0.1 });
+    // The cost map MUST be shares of TOTAL graph spend. An earlier version of this test passed only
+    // two kinds and pinned 0.173/0.273 = 0.634 as correct — which would select the 15% band when the
+    // true addressable share is 17.3% and the spec demands 10%. The test itself taught the wrong
+    // contract; review caught it.
+    const FULL_COST_SHARE = {
+      dedupe_nodes: 0.251,
+      extract_edges: 0.242,
+      extract_nodes: 0.219,
+      dedupe_edges: 0.173,
+      node_summaries_batch: 0.1,
+      edge_timestamps: 0.014,
+    };
+    const a = assessEligibility(t, FULL_COST_SHARE);
     expect(a.missing).toContain("node_summaries_batch");
-    // 0.173 / 0.273 — dedupe_edges is routable, summaries are not.
-    expect(a.addressableShare).toBeCloseTo(0.634, 2);
+    // dedupe_edges routable only → 17.3% of ALL graph spend, i.e. the 18.7%-ish case…
+    expect(a.addressableShare).toBeCloseTo(0.173, 3);
+    // …and that share must select the 10% band, which is the whole point of measuring it.
+    expect(smallModelMetrics({ addressableShare: a.addressableShare! }).C2.margin).toBe(0.1);
   });
 
   it("flags a kind that carries the marker but is NOT declared eligible (table drift)", async () => {
@@ -227,5 +249,137 @@ describe("marker pre-flight — settles 28.7% vs 18.7% before anything is spent"
     expect(a.unexpected).toContain("extract_nodes");
     expect(a.routable).not.toContain("extract_nodes"); // the proxy still routes it strong
     expect(a.addressableShare).toBe(0);
+  });
+});
+
+describe("folded review findings — regressions", () => {
+  it("a name-repetition arm is NOT scored as distinct (Fable: perfect score on every term)", () => {
+    // Summaries that are just the entity name repeated. Before the fold these emptied the word set
+    // after name-stripping, were exempted from duplicate detection, and scored
+    // {distinctness:1, factOverlap:1} — a PERFECT score for the exact shape Q10 exists to catch.
+    const s = scoreSummaryHealth([
+      entity("Chetan", "Chetan Chetan Chetan Chetan Chetan Chetan Chetan Chetan.", ["Chetan shipped it"]),
+      entity("Graphiti", "Graphiti Graphiti Graphiti Graphiti Graphiti Graphiti.", ["Graphiti extracts"]),
+    ]);
+    expect(s.distinctness).toBe(0);
+  });
+
+  it("Q11 is UNDEFINED when edges exist but none is datable (AC5), not 0", () => {
+    // 0 would make the ratio-to-incumbent Infinity/NaN and read as a total coverage collapse.
+    expect(scoreTemporalCoverage([{ valid_at: null }, { valid_at: "" }])).toEqual({ total: 2, share: null });
+  });
+
+  it("Q11's band is TWO-SIDED — hallucinated dates must not score as an improvement", () => {
+    // The downgraded prompt says "NEVER hallucinate dates" because that is the weak-model failure
+    // mode; a ratio-lower floor would reward inventing them.
+    expect(SMALL_MODEL_METRICS.Q11.kind).toBe("ratio-both");
+  });
+
+  it("every Q10 term is BANDED — distinctness, fact-overlap, and (two-sided) length", () => {
+    // An earlier registry banded distinctness alone while claiming two-sidedness, leaving a padding
+    // arm ungated despite an acceptance criterion naming it.
+    expect(SMALL_MODEL_METRICS.Q10.kind).toBe("ratio-lower");
+    expect(SMALL_MODEL_METRICS.Q10F.kind).toBe("ratio-lower");
+    expect(SMALL_MODEL_METRICS.Q10L.kind).toBe("ratio-both"); // padding AND truncation
+  });
+
+  it("the pre-flight REFUSES when nothing routable carries the marker (AC10)", async () => {
+    const { tallyMarkers, assessEligibility } = await import(
+      "../scripts/graph-window-battery/small-marker-preflight.mjs"
+    );
+    const t = tallyMarkers([
+      { kind: "request", body: { model: "qwen/qwen3.7-plus", messages: [{ role: "system", content: "You are a fact deduplication assistant." }] } },
+    ]);
+    const a = assessEligibility(t, { dedupe_edges: 1 });
+    expect(a.refusal).toMatch(/cannot save anything|re-derive/i);
+    expect(a.routable).toEqual([]);
+  });
+
+  it("legacy node_attributes absence is NOT reported as drift on a 0.29.3 capture", async () => {
+    const { tallyMarkers, assessEligibility } = await import(
+      "../scripts/graph-window-battery/small-marker-preflight.mjs"
+    );
+    const t = tallyMarkers([
+      { kind: "request", body: { model: GRAPHITI_SMALL_MODEL_MARKER, messages: [{ role: "system", content: "You are a fact deduplication assistant." }] } },
+    ]);
+    const a = assessEligibility(t, { dedupe_edges: 1 });
+    // 0.13.2-only; its absence on the deployed image is expected, and an always-firing alarm is noise.
+    expect(a.missing).not.toContain("node_attributes");
+  });
+});
+
+describe("the judge is WIRED to the small-model registry (the critical fold)", () => {
+  // Both reviewers independently found that SMALL_MODEL_METRICS had zero consumers: judgeMetric
+  // hardcoded METRICS and decide iterated Object.keys(METRICS), so a small-model session would have
+  // been judged on C1 — the guaranteed STOP the C2 amendment exists to remove. These pin the wiring.
+  const flat = [1000, 1000]; // input tokens/episode: UNCHANGED, which is what this lever does
+  const halved = { inc: [0.01, 0.01], arm: [0.005, 0.005] }; // USD/episode: cut in half
+
+  const smallSession = () =>
+    assessSession({
+      incumbent: {
+        Q1: [10, 10], Q2: [1, 1], Q4: [0.5, 0.5], Q5: [0, 0], Q7: [1, 1],
+        Q10: [0.9, 0.9], Q10F: [0.6, 0.6], Q10L: [120, 120], Q11: [0.5, 0.5], C2: halved.inc,
+      },
+      universeSize: 20,
+      underpowered: [],
+      armsCompleted: true,
+      harnessRefused: false,
+      crossCheckAvailable: true,
+      registry: smallModelMetrics({ addressableShare: 0.287 }),
+    });
+
+  it("judgeMetric can judge C2/Q10/Q11 when handed the small-model registry", () => {
+    const reg = smallModelMetrics({ addressableShare: 0.287 });
+    // Before the fold this threw `unknown metric C2` — the registry was unreachable.
+    const r = judgeMetric("C2", halved.arm, halved.inc, {}, reg);
+    expect(r.verdict).toBe(VERDICT.PASS); // a 50% cost fall clears the 15% band
+    expect(() => judgeMetric("Q10", [0.9, 0.9], [0.9, 0.9], {}, reg)).not.toThrow();
+  });
+
+  it("SHIPS an arm that halves cost while leaving tokens flat (AC8b)", () => {
+    const session = smallSession();
+    expect(session.valid).toBe(true);
+    const out = decide({
+      session,
+      incumbent: {
+        Q1: [10, 10], Q2: [1, 1], Q4: [0.5, 0.5], Q5: [0, 0], Q7: [1, 1],
+        Q10: [0.9, 0.9], Q10F: [0.6, 0.6], Q10L: [120, 120], Q11: [0.5, 0.5], C2: halved.inc,
+      },
+      arms: [{
+        name: "SMALL",
+        metrics: {
+          Q1: [10, 10], Q2: [1, 1], Q4: [0.5, 0.5], Q5: [0, 0], Q7: [1, 1],
+          Q10: [0.9, 0.9], Q10F: [0.6, 0.6], Q10L: [120, 120], Q11: [0.5, 0.5], C2: halved.arm,
+        },
+        extras: { personsLost: 0 },
+      }],
+      registry: smallModelMetrics({ addressableShare: 0.287 }),
+    });
+    expect(out.outcome).toBe("SHIP");
+    // …and C1 is not even considered for this arm.
+    expect(out.arms[0].results.map((r: { key: string }) => r.key)).not.toContain("C1");
+  });
+
+  it("PROVES the C1 trap was real: the same flat-token data FAILS the default registry", () => {
+    // ratio-fall demands a 25% token reduction. This lever sends the same tokens at a lower price,
+    // so judging it on C1 is a pre-registered STOP for a saving it cannot produce.
+    const r = judgeMetric("C1", flat, flat, {}, METRICS);
+    expect(r.verdict).not.toBe(VERDICT.PASS);
+  });
+
+  it("marks a session INVALID when arm separation failed (AC6, wired not documented)", () => {
+    const broken = assessSession({
+      incumbent: { C2: halved.inc },
+      universeSize: 20,
+      underpowered: [],
+      armsCompleted: true,
+      harnessRefused: false,
+      crossCheckAvailable: true,
+      registry: smallModelMetrics({ addressableShare: 0.287 }),
+      armSeparation: assertArmsDiffer(effectiveSnapshot("STRONG", "m"), effectiveSnapshot("SMALL", "m")),
+    });
+    expect(broken.valid).toBe(false);
+    expect(broken.problems.join(" ")).toMatch(/IDENTICAL|inherited|separation/i);
   });
 });


### PR DESCRIPTION
## What this is (GRAPHSMALL-1)

`GRAPHCOST-7` (#488, DONE) shipped small-model routing for the graph calls upstream marks
`ModelSize.small`. **Nobody ever pulled the lever:** `teams.extraction_small_model` is unset, so
`selectSmallExtractionBackend` returns `null` and all 14,851 graph calls run on `qwen/qwen3.7-plus`.

This PR builds the **battery that gates flipping it**. It does **not** flip it, and does not run the
battery (running spends money). Spec: `docs/design/graph-small-model-activation.md` (`SPEC_READY`).

### Measured, on the clean window (2026-08-05 → 08-16)
Graph = **$18.35 / 12d (~$46/mo)**, 14,851 calls, 2,187 chunk-episodes. **48.9M input vs 2.2M output
tokens — this is an INPUT problem.** Small-eligible kinds = `dedupe_edges` $3.17 + `node_summaries_batch`
$1.83 + `edge_timestamps` $0.27 = **$5.27 = 28.7% of graph spend on 72% of all calls**.

> ⚠️ **`GRAPHCOST-7`'s headline "65% of graph spend" is STALE — do not reuse it.** It was measured on
> graphiti 0.13.2 where the per-entity `node_attributes` fan-out dominated; 0.29.3 replaced that with
> batched summaries and `node_attributes` is **0 calls** today. The prize is 28.7%, a **2.2× smaller**
> number than the old row implies.

### Changes
- **`small-model-metrics.mjs`** — `Q10` summary health (distinctness + fact-overlap + length) and
  `Q11` temporal coverage: the two downgraded kinds that **no existing metric reads**.
- **`small-model-arms.mjs`** — arm separation as a *mechanism*: STRONG writes an explicit `null`,
  snapshots record the **resolved** backend, identical snapshots are refused.
- **`decision.mjs`** — `SMALL_MODEL_METRICS` + `smallModelMetrics({addressableShare})`, and
  `judgeMetric`/`assessSession`/`decide` now take a **registry** so it is reachable.
- **`judge.mjs`** — `parseCostText` extracts `usdPerEpisode` (C2's input); `smallModelReps` builds the
  small-model set with C1 excluded.
- **`small-marker-preflight.mjs`** — free, empirical answer to whether the deployed image really marks
  `node_summaries_batch` small (28.7% vs 18.7%), which sets the C2 band. Refuses a zero-savings image.

### Deliberately NOT in this slice
- **Flipping `teams.extraction_small_model` in prod** — a human action after the battery reads out.
- **Running the battery** — step 5 is the only step that spends; that is the owner's call.
- **Choosing the model** — consumes `EXMODEL-1`'s probe (it found candidates that 400 or collapse to
  1–3 entities *while advertising structured outputs*), rather than adding a second qualification path.
- **The Neo4j read path for Q10/Q11** — deferred *loudly* (spec Scope + top of RUNBOOK) after both
  reviewers flagged it. The decision layer that gates the spend decision is wired and pinned; the
  Cypher lands with the run that first needs it. **The battery cannot reach a Q10/Q11 verdict until then.**
- **PIPEFF-5** — the larger 46.1% extraction-merge lever, already built and **paused** on
  `origin/feat/graph-combined-extraction`. This slice avoids every file that branch edits.

## Verification
| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors (7 pre-existing warnings, other slices' files) |
| `npm test` (unit) | **2750 passed**, 11 skipped |
| `npm run check:docs` | in sync (no route/table/source touched) |
| `aios spec eval` | `SPEC_READY`, exit 0 |
| Mutation tests | **11 run, all REDDENED**, each reddening its intended test |

Mutations: arm-separation stops catching the inherited-field leak · entity-name normalisation removed
from distinctness · gate on C1 instead of C2 · fixed band ignoring the pre-flight · Q11 reports 0 for
no evidence · **judgeMetric ignores the registry** · **decide reverts to the default registry** ·
name-repetition exemption returns · Q11 zero-datable returns 0 · session validity ignores arm
separation · pre-flight stops refusing a zero-savings image.

## Review — Reviewed by Fable code-reviewer — verdict BLOCKED (2 CRITICAL + 2 HIGH + 4 MEDIUM + 3 LOW), all confirmed and folded
Reviewed by Codex gpt-5.5 — verdict BLOCKED (3 BLOCKER + 4 HIGH + 1 MEDIUM), all confirmed and folded

**Both reviewers independently found the same core defect, and it was severe:** `SMALL_MODEL_METRICS`
and `smallModelMetrics` had **zero consumers outside the test file**. `judgeMetric` hardcoded
`METRICS[key]` and `decide` iterated `Object.keys(METRICS)`, so a small-model session would still have
been judged on **C1** — the guaranteed STOP the entire C2 amendment exists to remove — while the
RUNBOOK instructed operators to pass a registry nothing accepted. That is this repo's own *"pin the
call site, not just the function"* and *"never attest a surface that does not render"*, committed
together. Now wired, and pinned by a test that SHIPS an arm halving cost with tokens flat plus a
sibling proving the same data FAILS C1 on the default registry.

Other folds, all confirmed by re-derivation:
- **Q10 scored a name-repetition arm PERFECT** (Fable measured `{distinctness:1, factOverlap:1}`):
  stripping the entity's name emptied the word set, which exempted the row from duplicate detection.
- **Q10 banded one scalar while claiming two-sidedness** — `factOverlap`/`meanLength` gated nothing,
  leaving the padding arm an acceptance criterion names unprotected. Now three explicit bands.
- **Q11 was one-sided**, so an arm *hallucinating* dates scored as improved — the downgraded prompt
  literally says "NEVER hallucinate dates". Now `ratio-both`; zero datable edges returns `null`, not 0.
- **Arm separation** moved from a RUNBOOK snippet into session validity (AC6).
- **Pre-flight denominator**: my own test pinned the *wrong* semantic (0.634 from a two-kind subset,
  which selects the 15% band when the truth is 17.3% and the spec demands 10%). Contract written down,
  test corrected, AC10 refusal added, legacy `node_attributes` no longer reported as drift.

Both model passes satisfy the CLAUDE.md pre-push Review gate (adversarial-build steps 2–5). The
`--tier full` DeepSeek spec layer was not run (no key); the model reviews stood in for it. Note the
spec's own cold read was **Codex-only** — a Fable attempt stalled without a verdict and is not counted.

AIOS-Work: GRAPHSMALL-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
