### PR TITLE
feat(graph): the Q10/Q11 readout, and a metric that proves it can move (GRAPHSMALL-2)

### DIFF
--- a/docs/design/graph-small-model-activation.md
+++ b/docs/design/graph-small-model-activation.md
@@ -226,7 +226,10 @@ So for this arm:
 - The per-`call_kind` cost split in the battery readout, so savings are measured.
 - `scripts/graph-window-battery/RUNBOOK.md` updated with the arm and its config step.
 
-**DEFERRED after review, with the reason (not silently):** the **Neo4j read path** for Q10/Q11.
+**GRAPHSMALL-2 (this follow-up) lands the deferred Neo4j read path** and the informativeness guard
+below. The paragraph that follows describes what GRAPHSMALL-1 shipped without.
+
+**DEFERRED in GRAPHSMALL-1, with the reason (not silently):** the **Neo4j read path** for Q10/Q11.
 `scripts/graph-window-battery/measure.ts` does not yet query `(:Entity){name, summary}` or
 `RELATES_TO.valid_at`, so the scorers are reachable by the judge but not yet fed by a live readout.
 Both reviewers flagged this and both offered the same two options — wire it, or re-scope and say so.
@@ -246,6 +249,32 @@ left for an operator to discover mid-session.
 - **PIPEFF-5** — merging `extract_nodes` + `extract_edges` ($8.46, 46.1%) is the larger lever, changes
   the extraction prompt, and needs its own battery.
 - **GRAPHCOST-2** — excluding zero-payoff paths is 0.6% of spend; tracked as graph hygiene, not cost.
+
+## The informativeness guard (GRAPHSMALL-2) — Q3's lesson, mechanised
+
+**Q11 may be a structural constant, and that is the exact trap that killed Q3.**
+`lib/graph/extraction-health.ts:348` records that graphiti **backdates `valid_at` to the episode's
+work time**. If it does that for essentially every edge, then "share of `RELATES_TO` edges carrying a
+resolved `valid_at`" is ~1.0 on every arm — a metric that *cannot move*, scoring a meaningless 1.0
+ratio as PASS. Q3 read a structural zero the same way and was only caught LIVE, mid-session, after
+the money was spent.
+
+**It could not be settled empirically from this machine.** `NEO4J_URI` is
+`bolt://neo4j.railway.internal:7687` and the neo4j service exposes no public TCP proxy (checked), so
+there is no read path from a laptop, and provisioning one is a production change.
+
+So rather than assume informativeness, the metric must **prove** it:
+
+- `assessInformativeness(incumbentReps, metric)` reads the INCUMBENT's own two reps and reports
+  `UNINFORMATIVE` when the metric sits at a structural floor/ceiling — a coverage of ~1.0 has no room
+  to fall, ~0.0 no room to drop further — with the threshold in band units, so "room to move" means
+  "room to move *by the amount the band would need to see*".
+- An `UNINFORMATIVE` metric **does not gate** and is reported as such. It is NOT a PASS: a metric that
+  cannot fail is not evidence of safety, and silently counting it as PASS is how a battery ships an
+  arm on a gate that was never armed.
+- This generalises rather than special-casing Q11: any future metric that lands at a structural
+  extreme is caught by the same rule, on the corpus it is actually run against, instead of being
+  re-discovered per metric.
 
 ## Acceptance criteria
 
@@ -269,6 +298,11 @@ left for an operator to discover mid-session.
 8b. **unit** — the judge gates this arm on `C2` (USD/episode) and NOT on `C1` (input tokens/episode):
    an arm that halves cost while leaving token count flat PASSES, which is precisely the shape this
    lever produces and the shape `C1`'s `ratio-fall` would have failed.
+8c. **unit** — `assessInformativeness` reports UNINFORMATIVE for an incumbent at a structural
+   ceiling (coverage ~1.0, no room to fall by the band) and for one at a floor, and INFORMATIVE for a
+   mid-range incumbent — and an UNINFORMATIVE metric is excluded from gating rather than counted PASS.
+8d. **unit** — `summaryRows`/`temporalEdges` produce the exact shapes the pure scorers consume, so the
+   readout cannot drift from `scoreSummaryHealth`/`scoreTemporalCoverage`'s inputs.
 9. **docs** — `scripts/graph-window-battery/RUNBOOK.md` gains the small-model arm, and this spec is
    referenced from the ticket; no `docs/ARCHITECTURE.md` drift block changes (no new route/table/source).
 10. **script** — a FREE pre-flight reports which `call_kind`s actually carry

--- a/docs/design/graph-small-model-activation.md
+++ b/docs/design/graph-small-model-activation.md
@@ -265,10 +265,20 @@ there is no read path from a laptop, and provisioning one is a production change
 
 So rather than assume informativeness, the metric must **prove** it:
 
-- `assessInformativeness(incumbentReps, metric)` reads the INCUMBENT's own two reps and reports
-  `UNINFORMATIVE` when the metric sits at a structural floor/ceiling — a coverage of ~1.0 has no room
-  to fall, ~0.0 no room to drop further — with the threshold in band units, so "room to move" means
-  "room to move *by the amount the band would need to see*".
+- `assessInformativeness(reps, { bandMargin, direction })` is **direction-aware**. An earlier draft
+  excluded any metric whose incumbent sat at a CEILING, reasoning it had "no room to move". **That was
+  backwards** and both reviewers produced the same counter-scenario: STRONG dates every edge
+  (Q11 = 1.0), SMALL loses 20%, Q11 correctly FAILS — and the guard excluded it *because* the
+  incumbent was perfect, shipping the arm having lost the behaviour Q11 exists to detect. A ceiling
+  incumbent is the **best** baseline for detecting a fall; only the rise half is unarmable, and that
+  is reported (`riseUntestable`) rather than used to disarm. The genuinely uninformative case is the
+  **floor / no-evidence** one — the literal Q3 shape, where the mechanism produces nothing on either
+  arm.
+- **It is computed inside `decide`, from the registry's own margins**, and consults **every arm's**
+  reps — not just the incumbent's. If an arm departs the extreme the metric demonstrably can move, so
+  it is judged. (If both arms sit at the extreme the exclusion changes nothing, so the only case where
+  it alters a verdict is the case where excluding would be wrong.) A hand-passed `uninformative` key
+  is validated against an allowlist and throws for a cost or core-quality gate.
 - An `UNINFORMATIVE` metric **does not gate** and is reported as such. It is NOT a PASS: a metric that
   cannot fail is not evidence of safety, and silently counting it as PASS is how a battery ships an
   arm on a gate that was never armed.

--- a/scripts/graph-window-battery/RUNBOOK.md
+++ b/scripts/graph-window-battery/RUNBOOK.md
@@ -245,12 +245,18 @@ Do **not** pick from a price list. `EXMODEL-1` found candidates that 400 outrigh
 entities, *while advertising structured outputs*. Run its probe first; a model that fails it produces a
 broken battery, not a battery result.
 
-## NOT YET RUNNABLE TO A Q10/Q11 VERDICT
+## Q10/Q11 are now readable — and may declare themselves UNINFORMATIVE
 
-`measure.ts` does not yet read `(:Entity){name, summary}` or `RELATES_TO.valid_at` out of Neo4j, so
-`Q10`/`Q10F`/`Q10L`/`Q11` have scorers and bands but **no live readout**. Everything else — the
-registry, the C2 cost parse, arm separation, the pre-flight — is wired and tested.
+`measure.ts` reads `(:Entity){name, summary}` plus each entity's own adjacent `RELATES_TO.fact`
+(`summaryRows`) and every fact edge's `valid_at` (`temporalEdges`); `harvest.ts` scores them with the
+same pure functions the judge bands, so the readout cannot drift from the judged definition.
 
-Deferred deliberately after review (see the spec's Scope). Do not start a paid session expecting a
-summary/temporal verdict until the Cypher lands; the cost and dedupe questions (C2, Q1/Q7) are
-answerable today.
+**Read the `uninformative` list on the verdict before reading anything else.** A metric pinned at a
+structural floor or ceiling on this corpus is EXCLUDED from gating and listed there — it is *not* a
+pass. This matters most for **Q11**: graphiti backdates `valid_at` to the episode's work time
+(`lib/graph/extraction-health.ts:348`), so coverage may be ~1.0 on every arm, which is the same shape
+of trap that made Q3 a structural zero and burned a live session. Feed the incumbent's reps through
+`assessInformativeness(reps, { bandMargin })` and pass the excluded keys to `decide({ uninformative })`.
+
+If Q11 comes back uninformative, that is a real result about the corpus, not a failure — the summary
+and cost questions still answer.

--- a/scripts/graph-window-battery/decision.mjs
+++ b/scripts/graph-window-battery/decision.mjs
@@ -57,6 +57,8 @@
  *   pp-upper      arm - incumbent in percentage points must stay at or below `margin`
  *   ratio-fall    the arm's value must be at most `1 - margin` of the incumbent's (a REQUIRED fall)
  */
+import { assessInformativeness } from "./small-model-metrics.mjs";
+
 export const METRICS = Object.freeze({
   // Two-sided: fragmentation RAISES node count, and a one-sided floor waved that through. It is also
   // the catch-all for the variant-form inflation Q6 cannot see — a node named "John" carries no
@@ -352,6 +354,51 @@ export const MIN_UNIVERSE = 15;
  * `arms` is ordered — SAME before W1 — and the FIRST arm to pass every gate wins. An arm ships only
  * if every metric PASSes; INCONCLUSIVE blocks exactly as FAIL does.
  */
+/**
+ * The ONLY metrics an informativeness assessment may exclude from gating. Deliberately narrow: the
+ * cost gates (C1/C2) and the shared quality floor (Q1/Q2/Q4/Q5/Q7) must never be disabled by a
+ * caller's data-dependent judgement — if one of those cannot be measured, the session is broken.
+ */
+export const EXCLUDABLE_METRICS = Object.freeze(new Set(["Q10", "Q10F", "Q10L", "Q11"]));
+
+/**
+ * Which excludable metrics cannot fail on THIS session — computed from the registry's own margins,
+ * the incumbent, and every arm's reps.
+ *
+ * A metric is only excluded when the incumbent cannot express a fall AND no arm departs that extreme.
+ * If an arm moved, the metric demonstrably CAN move, so it is judged — which is the whole correction
+ * review forced: the excluded-and-arm-moved case is precisely a regression being hidden.
+ */
+export function autoUninformative({ registry, incumbent, arms }) {
+  const out = [];
+  for (const key of Object.keys(registry)) {
+    if (!EXCLUDABLE_METRICS.has(key)) continue;
+    const margin = registry[key]?.margin;
+    if (typeof margin !== "number" || !(margin > 0)) continue;
+    const incReps = (incumbent ?? {})[key];
+    let verdict;
+    try {
+      verdict = assessInformativeness(incReps, { bandMargin: margin, direction: "fall" });
+    } catch {
+      continue; // a malformed band is a registry bug, not grounds to disarm
+    }
+    if (verdict.informative) continue;
+    const incMean = meanOf(incReps);
+    const armMoved = (arms ?? []).some(({ metrics }) => {
+      const m = meanOf((metrics ?? {})[key]);
+      return m !== null && incMean !== null && Math.abs(m - incMean) > 1e-9;
+    });
+    if (armMoved) continue; // it CAN move — judge it
+    out.push({ key, reason: verdict.reason });
+  }
+  return out;
+}
+
+const meanOf = (reps) => {
+  const usable = (Array.isArray(reps) ? reps : []).filter((v) => typeof v === "number" && Number.isFinite(v));
+  return usable.length ? usable.reduce((a, b) => a + b, 0) / usable.length : null;
+};
+
 export function decide({ session, incumbent, arms, registry = METRICS, uninformative = [] }) {
   if (!session.valid) {
     return { outcome: "INVALID", reasons: session.problems, arms: [] };
@@ -361,7 +408,44 @@ export function decide({ session, incumbent, arms, registry = METRICS, uninforma
   // Q11 carries the same risk from the ceiling. Excluding it is honest; passing it is a gate that was
   // never armed. The excluded keys are reported on the result so a readout says which questions this
   // corpus could not answer.
-  const skip = new Set(uninformative.map((u) => (typeof u === "string" ? u : u.key)));
+  // COMPUTED HERE, not trusted from a caller. Review (Fable) found the guard had NO caller at all —
+  // an exported function plus a RUNBOOK sentence, which is the identical defect #567 was dinged for
+  // one slice earlier in this very file. An operator who skipped the manual step got a verdict
+  // indistinguishable from one where informativeness had been assessed.
+  //
+  // It also consults the ARM reps, not just the incumbent. Excluding on the incumbent alone cannot
+  // tell "structurally pinned" from "legitimately perfect", and it resolves that ambiguity in the
+  // dangerous direction: if both arms sit at the extreme the exclusion changes nothing (the ratio
+  // passes trivially), so the ONLY case where it alters the outcome is the case where the arm moved
+  // — i.e. a real regression being waved through.
+  const auto = autoUninformative({ registry, incumbent, arms });
+  uninformative = [...uninformative, ...auto];
+
+  // VALIDATED, because this parameter DISABLES GATES. Review's scenario: `uninformative: ["C2"]`
+  // silently turns off the required cost gate and ships a no-savings arm; a caller mapping raw
+  // `assessInformativeness` results without attaching `key` yields `undefined`, which skips nothing
+  // while the readout claims something was excluded. Both fail loudly now.
+  //
+  // Only the metrics whose informativeness is genuinely corpus-dependent may be excluded. C1/C2 are
+  // cost gates and Q1/Q2/Q4/Q5/Q7 are the shared quality floor: if one of those cannot be measured
+  // the session is broken, not "informative-ly reduced".
+  const skip = new Set(
+    uninformative.map((u) => {
+      const key = typeof u === "string" ? u : u?.key;
+      if (typeof key !== "string" || key.length === 0) {
+        throw new Error(`decide: malformed uninformative entry ${JSON.stringify(u)} — expected a metric key string or { key }`);
+      }
+      if (!EXCLUDABLE_METRICS.has(key)) {
+        throw new Error(
+          `decide: ${key} may not be excluded as uninformative (allowed: ${[...EXCLUDABLE_METRICS].join(", ")}) — cost and core quality gates must not be silently disabled`
+        );
+      }
+      if (!(key in registry)) {
+        throw new Error(`decide: uninformative key ${key} is not in this registry — a typo would silently exclude nothing`);
+      }
+      return key;
+    })
+  );
   const judged = arms.map(({ name, metrics, extras = {} }) => {
     const results = Object.keys(registry)
       .filter((key) => !skip.has(key))

--- a/scripts/graph-window-battery/decision.mjs
+++ b/scripts/graph-window-battery/decision.mjs
@@ -352,17 +352,26 @@ export const MIN_UNIVERSE = 15;
  * `arms` is ordered — SAME before W1 — and the FIRST arm to pass every gate wins. An arm ships only
  * if every metric PASSes; INCONCLUSIVE blocks exactly as FAIL does.
  */
-export function decide({ session, incumbent, arms, registry = METRICS }) {
+export function decide({ session, incumbent, arms, registry = METRICS, uninformative = [] }) {
   if (!session.valid) {
     return { outcome: "INVALID", reasons: session.problems, arms: [] };
   }
+  // A metric the corpus cannot move does not gate — and is NOT counted as a pass. See
+  // `assessInformativeness`: Q3 read a structural zero on every arm and was only caught live, and
+  // Q11 carries the same risk from the ceiling. Excluding it is honest; passing it is a gate that was
+  // never armed. The excluded keys are reported on the result so a readout says which questions this
+  // corpus could not answer.
+  const skip = new Set(uninformative.map((u) => (typeof u === "string" ? u : u.key)));
   const judged = arms.map(({ name, metrics, extras = {} }) => {
-    const results = Object.keys(registry).map((key) => judgeMetric(key, metrics[key], incumbent[key], extras, registry));
+    const results = Object.keys(registry)
+      .filter((key) => !skip.has(key))
+      .map((key) => judgeMetric(key, metrics[key], incumbent[key], extras, registry));
     const blocking = results.filter((r) => r.verdict !== VERDICT.PASS);
     return { name, results, ships: blocking.length === 0, blocking };
   });
   const winner = judged.find((a) => a.ships);
   return {
+    uninformative: [...skip],
     outcome: winner ? "SHIP" : "NO_SHIP",
     winner: winner?.name ?? null,
     arms: judged,

--- a/scripts/graph-window-battery/harvest.ts
+++ b/scripts/graph-window-battery/harvest.ts
@@ -10,7 +10,10 @@
  * Usage: npx tsx --conditions react-server scripts/graph-window-battery/harvest.ts
  */
 import { Client } from "pg";
-import { entityYield, dupeShare, crossChunkContinuity, peopleMetrics, memberPresence, episodicCount, entityNameCounts } from "./measure";
+import { entityYield, dupeShare, crossChunkContinuity, peopleMetrics, memberPresence, episodicCount, entityNameCounts, summaryRows, temporalEdges } from "./measure";
+// The pure scorers own what "healthy" and "dated" mean; this file only supplies their inputs, so the
+// readout and the judged definition cannot drift apart.
+import { scoreSummaryHealth, scoreTemporalCoverage } from "./small-model-metrics.mjs";
 
 import { countFromBody } from "./corpus.mjs";
 
@@ -32,14 +35,21 @@ async function main(): Promise<void> {
   const multiChunkItemIds = new Set(items.filter((r) => countFromBody(r.body) > 1).map((r) => r.id));
   const presence = memberPresence(members, items);
 
-  const [q1, q3, q4, people, landed, nameCounts] = await Promise.all([
+  const [q1, q3, q4, people, landed, nameCounts, sumRows, tEdges] = await Promise.all([
     entityYield(GROUP_ID, episodes),
     dupeShare(GROUP_ID),
     crossChunkContinuity(GROUP_ID, multiChunkItemIds),
     peopleMetrics(GROUP_ID, presence),
     episodicCount(GROUP_ID),
     entityNameCounts(GROUP_ID),
+    // GRAPHSMALL-2: the small-model arm's two readouts. Harvested for EVERY arm — an incumbent value
+    // is what Q10/Q11's ratios are taken against, and what `assessInformativeness` inspects to decide
+    // whether the metric can move on this corpus at all.
+    summaryRows(GROUP_ID),
+    temporalEdges(GROUP_ID),
   ]);
+  const q10 = scoreSummaryHealth(sumRows);
+  const q11 = scoreTemporalCoverage(tEdges);
 
   // One JSON object on stdout — the runner parses this, so nothing else may print to stdout.
   console.log(
@@ -53,6 +63,10 @@ async function main(): Promise<void> {
         Q3: q3.share,
         Q4: q4,
         Q6: people.convergence,
+        // Shapes fixed by `judge.mjs`'s smallModelReps: r.q.Q10.{distinctness,factOverlap,meanLength}
+        // and r.q.Q11.share.
+        Q10: q10,
+        Q11: q11,
         personsLost: people.personsLost,
         qualifyingLost: people.qualifyingLost,
         dupeEdges: q3.total,

--- a/scripts/graph-window-battery/measure.ts
+++ b/scripts/graph-window-battery/measure.ts
@@ -175,6 +175,47 @@ export function peopleFrom(
  * node count. Q7 is computed FROM these (plus the corpus bodies) at judge time, because its universe
  * is the union of the INCUMBENT's two reps and rep 2 does not exist while rep 1 is harvested.
  */
+/**
+ * Q10's input — every entity's summary plus the facts on its OWN adjacent edges (GRAPHSMALL-2).
+ *
+ * Schema (verified in `lib/graph/learning.ts`):
+ * `(:Entity)-[:RELATES_TO {fact, created_at, valid_at, group_id, episodes}]->(:Entity)`.
+ *
+ * Facts come from edges in EITHER direction: a fact about an entity is as often the object as the
+ * subject, and taking only outgoing edges would score a perfectly good summary as "detached" purely
+ * because of edge direction — an artefact, not a quality signal. Scoped to one `group_id` on both the
+ * node and the relationship, per the tier note at the top of this file.
+ */
+export async function summaryRows(
+  groupId: string
+): Promise<{ name: string; summary: string; facts: string[] }[]> {
+  const rows = await runRead<{ name: string; summary: string | null; facts: (string | null)[] }>(
+    `MATCH (n:Entity {group_id: $g})
+     OPTIONAL MATCH (n)-[r:RELATES_TO {group_id: $g}]-()
+     RETURN n.name AS name, n.summary AS summary, collect(r.fact) AS facts`,
+    { g: groupId }
+  );
+  return rows.map((r) => ({
+    name: r.name ?? "",
+    summary: r.summary ?? "",
+    facts: (r.facts ?? []).filter((f): f is string => typeof f === "string" && f.length > 0),
+  }));
+}
+
+/**
+ * Q11's input — the `valid_at` of every fact edge in the group (GRAPHSMALL-2).
+ *
+ * Returns the raw values rather than a count so `scoreTemporalCoverage` owns what "dated" means (it
+ * rejects blank strings), keeping one definition instead of two that can drift apart.
+ */
+export async function temporalEdges(groupId: string): Promise<{ valid_at: string | null }[]> {
+  const rows = await runRead<{ valid_at: string | null }>(
+    "MATCH ()-[r:RELATES_TO {group_id: $g}]->() RETURN r.valid_at AS valid_at",
+    { g: groupId }
+  );
+  return rows.map((r) => ({ valid_at: r.valid_at ?? null }));
+}
+
 export async function entityNameCounts(groupId: string): Promise<{ name: string; nodes: number }[]> {
   const rows = await runRead<{ name: string; nodes: number }>(
     "MATCH (n:Entity {group_id: $g}) RETURN n.name AS name, count(n) AS nodes",

--- a/scripts/graph-window-battery/measure.ts
+++ b/scripts/graph-window-battery/measure.ts
@@ -181,6 +181,10 @@ export function peopleFrom(
  * Schema (verified in `lib/graph/learning.ts`):
  * `(:Entity)-[:RELATES_TO {fact, created_at, valid_at, group_id, episodes}]->(:Entity)`.
  *
+ * `IS_DUPLICATE_OF` edges are excluded, matching every fact read in `lib/graph/learning.ts`. Dormant
+ * on the deployed 0.29.3 image (that relation is no longer written — it is why Q3 died), but a graph
+ * upgrade that revives it would otherwise feed dup-edge prose into Q10's fact-overlap denominator.
+ *
  * Facts come from edges in EITHER direction: a fact about an entity is as often the object as the
  * subject, and taking only outgoing edges would score a perfectly good summary as "detached" purely
  * because of edge direction — an artefact, not a quality signal. Scoped to one `group_id` on both the
@@ -189,10 +193,19 @@ export function peopleFrom(
 export async function summaryRows(
   groupId: string
 ): Promise<{ name: string; summary: string; facts: string[] }[]> {
-  const rows = await runRead<{ name: string; summary: string | null; facts: (string | null)[] }>(
+  const rows = await runRead<{ id: string; name: string; summary: string | null; facts: (string | null)[] }>(
+    // GROUP BY NODE IDENTITY, not by returned properties. Cypher groups on the non-aggregate
+    // expressions in RETURN, so `RETURN n.name, n.summary, collect(...)` would collapse two DISTINCT
+    // entities that share a name and a summary into ONE row with merged facts — precisely the shape
+    // this metric runs against, since fragmentation (the thing Q1/Q7 watch for) produces duplicate
+    // names, and boilerplate (the thing Q10 watches for) produces duplicate summaries. That would
+    // shrink Q10's denominator and inflate distinctness exactly when the arm is misbehaving.
+    // `WITH n, collect(...)` groups on the node itself.
     `MATCH (n:Entity {group_id: $g})
      OPTIONAL MATCH (n)-[r:RELATES_TO {group_id: $g}]-()
-     RETURN n.name AS name, n.summary AS summary, collect(r.fact) AS facts`,
+     WHERE r IS NULL OR r.name IS NULL OR r.name <> 'IS_DUPLICATE_OF'
+     WITH n, collect(r.fact) AS facts
+     RETURN elementId(n) AS id, n.name AS name, n.summary AS summary, facts`,
     { g: groupId }
   );
   return rows.map((r) => ({

--- a/scripts/graph-window-battery/small-model-metrics.mjs
+++ b/scripts/graph-window-battery/small-model-metrics.mjs
@@ -137,3 +137,52 @@ export function scoreTemporalCoverage(edges) {
   if (dated === 0) return { total, share: null };
   return { total, share: dated / total };
 }
+
+/**
+ * Is a metric capable of MOVING on this corpus, or is it pinned at a structural extreme?
+ *
+ * WHY THIS EXISTS — it is Q3's lesson, mechanised. Q3 (IS_DUPLICATE_OF share) read a structural ZERO
+ * on every arm because graphiti 0.29.3 stopped writing the relation, and that was only discovered
+ * LIVE, mid-session, after the money was spent (`decision.mjs` Amendment 2). Q11 has the same shape of
+ * risk from the other end: `lib/graph/extraction-health.ts:348` records that graphiti BACKDATES
+ * `valid_at` to the episode's work time, so coverage may be ~1.0 on every arm — a metric that cannot
+ * fall, quietly scoring a meaningless ratio of 1.0 as PASS. It could not be settled empirically before
+ * building: NEO4J_URI is an internal Railway address with no public proxy.
+ *
+ * So the metric proves informativeness on the corpus it is ACTUALLY run against, instead of a human
+ * asserting it once. `bandMargin` makes "room to move" concrete: room to move *by the amount the band
+ * would need to see*. A ceiling metric (coverage 0.99 against a 15% band) cannot fall 15% without
+ * going below what the data can express; a floor metric cannot fall at all.
+ *
+ * UNINFORMATIVE IS NOT PASS. A metric that cannot fail is not evidence of safety — counting it as a
+ * pass is how a battery ships an arm on a gate that was never armed. The caller must exclude it from
+ * gating AND report it, so the readout says which questions this corpus could not answer.
+ */
+export function assessInformativeness(incumbentReps, { bandMargin, floor = 0, ceiling = 1 } = {}) {
+  if (!Array.isArray(incumbentReps) || incumbentReps.length === 0) {
+    return { informative: false, reason: "no incumbent reps" };
+  }
+  const usable = incumbentReps.filter((v) => typeof v === "number" && Number.isFinite(v));
+  if (usable.length === 0) {
+    // `null` is what the scorers return for "no evidence" — an absence, not a zero.
+    return { informative: false, reason: "incumbent produced no measurable value (null/NaN)" };
+  }
+  const mean = usable.reduce((a, b) => a + b, 0) / usable.length;
+  if (typeof bandMargin !== "number" || !(bandMargin > 0)) {
+    return { informative: false, reason: "no band margin supplied — cannot judge room to move" };
+  }
+  // Room to FALL by the band's own margin, expressed in the metric's units.
+  const roomBelow = mean - mean * (1 - bandMargin);
+  if (mean - roomBelow < floor - 1e-9) {
+    return { informative: false, reason: `incumbent mean ${mean.toFixed(4)} cannot fall by the band without passing the floor ${floor}` };
+  }
+  // A metric already AT the ceiling has nowhere to rise, which matters for two-sided bands, and a
+  // metric at the floor has nowhere to fall — both make the gate unarmable in the direction that counts.
+  if (mean >= ceiling - 1e-9) {
+    return { informative: false, reason: `incumbent mean ${mean.toFixed(4)} sits at the structural ceiling ${ceiling} — no room to move` };
+  }
+  if (mean <= floor + 1e-9) {
+    return { informative: false, reason: `incumbent mean ${mean.toFixed(4)} sits at the structural floor ${floor} — no room to move` };
+  }
+  return { informative: true, mean };
+}

--- a/scripts/graph-window-battery/small-model-metrics.mjs
+++ b/scripts/graph-window-battery/small-model-metrics.mjs
@@ -139,26 +139,29 @@ export function scoreTemporalCoverage(edges) {
 }
 
 /**
- * Is a metric capable of MOVING on this corpus, or is it pinned at a structural extreme?
+ * Can this metric still FAIL on this corpus, or is the gate unarmable?
  *
- * WHY THIS EXISTS — it is Q3's lesson, mechanised. Q3 (IS_DUPLICATE_OF share) read a structural ZERO
- * on every arm because graphiti 0.29.3 stopped writing the relation, and that was only discovered
- * LIVE, mid-session, after the money was spent (`decision.mjs` Amendment 2). Q11 has the same shape of
- * risk from the other end: `lib/graph/extraction-health.ts:348` records that graphiti BACKDATES
- * `valid_at` to the episode's work time, so coverage may be ~1.0 on every arm — a metric that cannot
- * fall, quietly scoring a meaningless ratio of 1.0 as PASS. It could not be settled empirically before
- * building: NEO4J_URI is an internal Railway address with no public proxy.
+ * WHY THIS EXISTS — Q3's lesson. Q3 (IS_DUPLICATE_OF share) read a structural ZERO on every arm
+ * because graphiti 0.29.3 stopped writing the relation, and it was only discovered LIVE, mid-session,
+ * after the money was spent (`decision.mjs` Amendment 2). A metric that cannot fail is not evidence
+ * of safety.
  *
- * So the metric proves informativeness on the corpus it is ACTUALLY run against, instead of a human
- * asserting it once. `bandMargin` makes "room to move" concrete: room to move *by the amount the band
- * would need to see*. A ceiling metric (coverage 0.99 against a 15% band) cannot fall 15% without
- * going below what the data can express; a floor metric cannot fall at all.
+ * DIRECTION-AWARE, and this is the correction that matters. An earlier version excluded any metric
+ * whose incumbent sat at a CEILING — reasoning that coverage ~1.0 "has no room to move". That was
+ * backwards, and review produced the scenario that proves it: STRONG dates every fact edge (Q11 =
+ * 1.0), SMALL stops resolving dates for 20% of them, Q11 correctly FAILS the lower edge — and the
+ * old guard excluded Q11 from gating precisely because the incumbent was perfect, letting the arm
+ * ship having lost the one behaviour Q11 exists to detect. A ceiling incumbent is the BEST baseline
+ * for detecting a fall, not a reason to disarm.
  *
- * UNINFORMATIVE IS NOT PASS. A metric that cannot fail is not evidence of safety — counting it as a
- * pass is how a battery ships an arm on a gate that was never armed. The caller must exclude it from
- * gating AND report it, so the readout says which questions this corpus could not answer.
+ * What is genuinely uninformative is the FLOOR / no-evidence case — the literal Q3 shape, where the
+ * mechanism produces nothing on either arm so a fall cannot be expressed at all.
+ *
+ * `direction: "fall"` (default) asks "can this metric fall?"; `"rise"` asks the mirror question, for
+ * the upper edge of a two-sided band. A two-sided metric at the ceiling is reported
+ * `riseUntestable` — the fall edge stays armed, and only the untestable half is named.
  */
-export function assessInformativeness(incumbentReps, { bandMargin, floor = 0, ceiling = 1 } = {}) {
+export function assessInformativeness(incumbentReps, { bandMargin, floor = 0, ceiling = 1, direction = "fall" } = {}) {
   if (!Array.isArray(incumbentReps) || incumbentReps.length === 0) {
     return { informative: false, reason: "no incumbent reps" };
   }
@@ -167,22 +170,41 @@ export function assessInformativeness(incumbentReps, { bandMargin, floor = 0, ce
     // `null` is what the scorers return for "no evidence" — an absence, not a zero.
     return { informative: false, reason: "incumbent produced no measurable value (null/NaN)" };
   }
-  const mean = usable.reduce((a, b) => a + b, 0) / usable.length;
   if (typeof bandMargin !== "number" || !(bandMargin > 0)) {
-    return { informative: false, reason: "no band margin supplied — cannot judge room to move" };
+    // THROW, do not return uninformative. The caller reads `informative:false` as "exclude from
+    // gating", so a caller who passed the wrong registry field (the registry names it `margin`;
+    // this parameter is `bandMargin` — a mismatch that invites exactly this) would disarm EVERY
+    // metric and ship an arm with no gates at all. `assessSession` throws on missing safety inputs
+    // for the same reason: an omission must not read as a valid verdict.
+    throw new Error("assessInformativeness: bandMargin is required (the registry field is `margin`) — a missing band must not silently disarm a gate");
   }
-  // Room to FALL by the band's own margin, expressed in the metric's units.
-  const roomBelow = mean - mean * (1 - bandMargin);
-  if (mean - roomBelow < floor - 1e-9) {
-    return { informative: false, reason: `incumbent mean ${mean.toFixed(4)} cannot fall by the band without passing the floor ${floor}` };
+  const mean = usable.reduce((a, b) => a + b, 0) / usable.length;
+
+  // The value the arm would have to reach to trip each edge of the band. Written as explicit edges
+  // rather than the previous `mean - (mean - mean*(1-bandMargin))`, which simplified to
+  // `mean*(1-bandMargin)` and so could never cross a floor of 0 — dead code whose comment claimed a
+  // check it did not perform (verified numerically before removal, not argued).
+  const lowerEdge = mean * (1 - bandMargin);
+  const upperEdge = mean * (1 + bandMargin);
+
+  if (direction === "fall") {
+    // A fall is expressible unless the incumbent is already at/below the floor.
+    if (mean <= floor + 1e-9) {
+      return { informative: false, reason: `incumbent mean ${mean.toFixed(4)} sits at the structural floor ${floor} — a fall cannot be expressed` };
+    }
+    return {
+      informative: true,
+      mean,
+      lowerEdge,
+      // Named, not excluded: for a two-sided band, the rise half is untestable from a ceiling.
+      riseUntestable: upperEdge > ceiling + 1e-9,
+    };
   }
-  // A metric already AT the ceiling has nowhere to rise, which matters for two-sided bands, and a
-  // metric at the floor has nowhere to fall — both make the gate unarmable in the direction that counts.
-  if (mean >= ceiling - 1e-9) {
-    return { informative: false, reason: `incumbent mean ${mean.toFixed(4)} sits at the structural ceiling ${ceiling} — no room to move` };
+  if (direction === "rise") {
+    if (mean >= ceiling - 1e-9) {
+      return { informative: false, reason: `incumbent mean ${mean.toFixed(4)} sits at the structural ceiling ${ceiling} — a rise cannot be expressed` };
+    }
+    return { informative: true, mean, upperEdge };
   }
-  if (mean <= floor + 1e-9) {
-    return { informative: false, reason: `incumbent mean ${mean.toFixed(4)} sits at the structural floor ${floor} — no room to move` };
-  }
-  return { informative: true, mean };
+  return { informative: false, reason: `unknown direction ${String(direction)}` };
 }

--- a/test/graph-small-model-battery.test.ts
+++ b/test/graph-small-model-battery.test.ts
@@ -385,60 +385,107 @@ describe("the judge is WIRED to the small-model registry (the critical fold)", (
 });
 
 describe("informativeness guard — Q3's lesson, mechanised (GRAPHSMALL-2)", () => {
-  it("calls a CEILING metric uninformative: coverage ~1.0 has no room to fall by the band", async () => {
-    // The Q11 risk: graphiti backdates valid_at to the episode's work time, so coverage may be ~1.0
-    // on every arm — a metric that cannot move, scoring a meaningless 1.0 ratio as PASS. Q3 read a
-    // structural ZERO exactly this way and was only caught live, after the money was spent.
-    const { assessInformativeness } = await import("../scripts/graph-window-battery/small-model-metrics.mjs");
+  const load = () => import("../scripts/graph-window-battery/small-model-metrics.mjs");
+
+  it("a CEILING incumbent is INFORMATIVE for a fall — the guard was backwards", async () => {
+    // Review's scenario: STRONG dates every edge (Q11=1.0), SMALL loses 20%. Q11 SHOULD fail. The
+    // first version excluded Q11 precisely because the incumbent was perfect, shipping an arm that
+    // lost the one behaviour Q11 detects. A ceiling incumbent is the BEST baseline for a fall.
+    const { assessInformativeness } = await load();
     const r = assessInformativeness([1.0, 1.0], { bandMargin: 0.15 });
+    expect(r.informative).toBe(true);
+    expect(r.riseUntestable).toBe(true); // only the RISE half is unarmable, and it is named
+  });
+
+  it("a FLOOR incumbent is uninformative — the literal Q3 shape (mechanism produces nothing)", async () => {
+    const { assessInformativeness } = await load();
+    const r = assessInformativeness([0, 0], { bandMargin: 0.15 });
     expect(r.informative).toBe(false);
-    expect(r.reason).toMatch(/ceiling|no room/i);
+    expect(r.reason).toMatch(/floor|cannot be expressed/i);
   });
 
-  it("calls a FLOOR metric uninformative (the literal Q3 shape)", async () => {
-    const { assessInformativeness } = await import("../scripts/graph-window-battery/small-model-metrics.mjs");
-    expect(assessInformativeness([0, 0], { bandMargin: 0.15 }).informative).toBe(false);
-  });
-
-  it("calls a MID-RANGE incumbent informative — the guard must not disarm a working metric", async () => {
-    const { assessInformativeness } = await import("../scripts/graph-window-battery/small-model-metrics.mjs");
+  it("a mid-range incumbent is informative and its rise edge is testable", async () => {
+    const { assessInformativeness } = await load();
     const r = assessInformativeness([0.5, 0.52], { bandMargin: 0.15 });
     expect(r.informative).toBe(true);
+    expect(r.riseUntestable).toBe(false);
+  });
+
+  it("THROWS on a missing band rather than disarming every gate", async () => {
+    // `informative:false` means "exclude from gating", so returning it for a caller mistake (the
+    // registry field is `margin`, this parameter is `bandMargin`) would ship an arm with NO gates.
+    const { assessInformativeness } = await load();
+    await expect(async () => assessInformativeness([0.5, 0.5], {})).rejects.toThrow(/bandMargin is required/i);
   });
 
   it("treats a null/absent incumbent as uninformative, not as zero", async () => {
-    const { assessInformativeness } = await import("../scripts/graph-window-battery/small-model-metrics.mjs");
-    // `null` is what the scorers return for "no evidence"; scoring it 0 would read as total collapse.
+    const { assessInformativeness } = await load();
     expect(assessInformativeness([null, null], { bandMargin: 0.15 }).informative).toBe(false);
     expect(assessInformativeness([], { bandMargin: 0.15 }).informative).toBe(false);
-    expect(assessInformativeness([0.5, 0.5], {}).informative).toBe(false); // no band → cannot judge room
+  });
+});
+
+describe("autoUninformative — computed in decide, and it consults the ARMS", () => {
+  const base = { Q1: [10, 10], Q2: [1, 1], Q4: [0.5, 0.5], Q5: [0, 0], Q7: [1, 1],
+    Q10: [0.9, 0.9], Q10F: [0.6, 0.6], Q10L: [120, 120], Q11: [0.5, 0.5], C2: [0.01, 0.01] };
+  const reg = () => smallModelMetrics({ addressableShare: 0.287 });
+  const session = () => assessSession({
+    incumbent: base, universeSize: 20, underpowered: [], armsCompleted: true,
+    harnessRefused: false, crossCheckAvailable: true, registry: reg(),
   });
 
-  it("an UNINFORMATIVE metric is EXCLUDED from gating, never counted as a pass", () => {
-    // A metric that cannot fail is not evidence of safety. Here Q11 would FAIL if judged (arm well
-    // below the incumbent), but it is excluded — and the result reports which questions went unanswered.
-    const base = { Q1: [10, 10], Q2: [1, 1], Q4: [0.5, 0.5], Q5: [0, 0], Q7: [1, 1],
-      Q10: [0.9, 0.9], Q10F: [0.6, 0.6], Q10L: [120, 120], Q11: [1.0, 1.0], C2: [0.01, 0.01] };
-    const session = assessSession({
-      incumbent: base, universeSize: 20, underpowered: [], armsCompleted: true,
-      harnessRefused: false, crossCheckAvailable: true,
-      registry: smallModelMetrics({ addressableShare: 0.287 }),
-    });
+  it("EXCLUDES a floor-pinned metric only when NO arm departs the extreme", () => {
+    const inc = { ...base, Q11: [0, 0] };
     const out = decide({
-      session,
-      incumbent: base,
-      arms: [{ name: "SMALL", metrics: { ...base, Q11: [0.2, 0.2], C2: [0.005, 0.005] }, extras: { personsLost: 0 } }],
-      registry: smallModelMetrics({ addressableShare: 0.287 }),
-      uninformative: ["Q11"],
+      session: session(), incumbent: inc,
+      arms: [{ name: "SMALL", metrics: { ...inc, C2: [0.005, 0.005] }, extras: { personsLost: 0 } }],
+      registry: reg(),
     });
     expect(out.uninformative).toContain("Q11");
-    expect(out.arms[0].results.map((r: { key: string }) => r.key)).not.toContain("Q11");
-    // …and with Q11 JUDGED instead, that same arm is blocked — proving the exclusion is doing work.
-    const judgedOut = decide({
-      session, incumbent: base,
-      arms: [{ name: "SMALL", metrics: { ...base, Q11: [0.2, 0.2], C2: [0.005, 0.005] }, extras: { personsLost: 0 } }],
-      registry: smallModelMetrics({ addressableShare: 0.287 }),
+    expect(out.arms[0].ships).toBe(true); // the other half of the contrast pair
+    expect(out.outcome).toBe("SHIP");
+  });
+
+  it("JUDGES a floor-pinned metric when an ARM moved — the regression must not be hidden", () => {
+    // Incumbent pinned at 0, but the arm produced 0.4: the metric demonstrably CAN move, so
+    // excluding it would hide real movement. This is the case where exclusion changes the outcome,
+    // and therefore the only case where getting it wrong matters.
+    const inc = { ...base, Q11: [0, 0] };
+    const out = decide({
+      session: session(), incumbent: inc,
+      arms: [{ name: "SMALL", metrics: { ...inc, Q11: [0.4, 0.4], C2: [0.005, 0.005] }, extras: { personsLost: 0 } }],
+      registry: reg(),
     });
-    expect(judgedOut.arms[0].ships).toBe(false);
+    expect(out.uninformative).not.toContain("Q11");
+  });
+
+  it("REFUSES to disable a cost or core-quality gate", () => {
+    expect(() => decide({
+      session: session(), incumbent: base,
+      arms: [{ name: "SMALL", metrics: base, extras: { personsLost: 0 } }],
+      registry: reg(), uninformative: ["C2"],
+    })).toThrow(/may not be excluded/i);
+    expect(() => decide({
+      session: session(), incumbent: base,
+      arms: [{ name: "SMALL", metrics: base, extras: { personsLost: 0 } }],
+      registry: reg(), uninformative: [{ informative: false, reason: "no key attached" }],
+    })).toThrow(/malformed/i);
+  });
+});
+
+describe("AC8d — the readout shapes the pure scorers consume", () => {
+  it("summaryRows' row shape feeds scoreSummaryHealth, and temporalEdges' feeds scoreTemporalCoverage", () => {
+    // The judge reads r.q.Q10?.distinctness etc through OPTIONAL chaining, so a renamed field would
+    // harvest [undefined, undefined] SILENTLY rather than throwing. Pin the contract here.
+    const rows = [{ name: "Chetan", summary: "Chetan shipped the importer.", facts: ["Chetan shipped the importer"] }];
+    const health = scoreSummaryHealth(rows);
+    for (const k of ["total", "nonEmptyShare", "meanLength", "distinctness", "factOverlap"]) {
+      expect(health).toHaveProperty(k);
+    }
+    const cov = scoreTemporalCoverage([{ valid_at: "2026-08-01T00:00:00Z" }, { valid_at: null }]);
+    expect(cov).toHaveProperty("share");
+    expect(cov.share).toBe(0.5);
+    // An entity with NO facts is the OPTIONAL MATCH case — must score, not throw.
+    expect(() => scoreSummaryHealth([{ name: "X", summary: "a summary", facts: [] }])).not.toThrow();
   });
 });

--- a/test/graph-small-model-battery.test.ts
+++ b/test/graph-small-model-battery.test.ts
@@ -383,3 +383,62 @@ describe("the judge is WIRED to the small-model registry (the critical fold)", (
     expect(broken.problems.join(" ")).toMatch(/IDENTICAL|inherited|separation/i);
   });
 });
+
+describe("informativeness guard — Q3's lesson, mechanised (GRAPHSMALL-2)", () => {
+  it("calls a CEILING metric uninformative: coverage ~1.0 has no room to fall by the band", async () => {
+    // The Q11 risk: graphiti backdates valid_at to the episode's work time, so coverage may be ~1.0
+    // on every arm — a metric that cannot move, scoring a meaningless 1.0 ratio as PASS. Q3 read a
+    // structural ZERO exactly this way and was only caught live, after the money was spent.
+    const { assessInformativeness } = await import("../scripts/graph-window-battery/small-model-metrics.mjs");
+    const r = assessInformativeness([1.0, 1.0], { bandMargin: 0.15 });
+    expect(r.informative).toBe(false);
+    expect(r.reason).toMatch(/ceiling|no room/i);
+  });
+
+  it("calls a FLOOR metric uninformative (the literal Q3 shape)", async () => {
+    const { assessInformativeness } = await import("../scripts/graph-window-battery/small-model-metrics.mjs");
+    expect(assessInformativeness([0, 0], { bandMargin: 0.15 }).informative).toBe(false);
+  });
+
+  it("calls a MID-RANGE incumbent informative — the guard must not disarm a working metric", async () => {
+    const { assessInformativeness } = await import("../scripts/graph-window-battery/small-model-metrics.mjs");
+    const r = assessInformativeness([0.5, 0.52], { bandMargin: 0.15 });
+    expect(r.informative).toBe(true);
+  });
+
+  it("treats a null/absent incumbent as uninformative, not as zero", async () => {
+    const { assessInformativeness } = await import("../scripts/graph-window-battery/small-model-metrics.mjs");
+    // `null` is what the scorers return for "no evidence"; scoring it 0 would read as total collapse.
+    expect(assessInformativeness([null, null], { bandMargin: 0.15 }).informative).toBe(false);
+    expect(assessInformativeness([], { bandMargin: 0.15 }).informative).toBe(false);
+    expect(assessInformativeness([0.5, 0.5], {}).informative).toBe(false); // no band → cannot judge room
+  });
+
+  it("an UNINFORMATIVE metric is EXCLUDED from gating, never counted as a pass", () => {
+    // A metric that cannot fail is not evidence of safety. Here Q11 would FAIL if judged (arm well
+    // below the incumbent), but it is excluded — and the result reports which questions went unanswered.
+    const base = { Q1: [10, 10], Q2: [1, 1], Q4: [0.5, 0.5], Q5: [0, 0], Q7: [1, 1],
+      Q10: [0.9, 0.9], Q10F: [0.6, 0.6], Q10L: [120, 120], Q11: [1.0, 1.0], C2: [0.01, 0.01] };
+    const session = assessSession({
+      incumbent: base, universeSize: 20, underpowered: [], armsCompleted: true,
+      harnessRefused: false, crossCheckAvailable: true,
+      registry: smallModelMetrics({ addressableShare: 0.287 }),
+    });
+    const out = decide({
+      session,
+      incumbent: base,
+      arms: [{ name: "SMALL", metrics: { ...base, Q11: [0.2, 0.2], C2: [0.005, 0.005] }, extras: { personsLost: 0 } }],
+      registry: smallModelMetrics({ addressableShare: 0.287 }),
+      uninformative: ["Q11"],
+    });
+    expect(out.uninformative).toContain("Q11");
+    expect(out.arms[0].results.map((r: { key: string }) => r.key)).not.toContain("Q11");
+    // …and with Q11 JUDGED instead, that same arm is blocked — proving the exclusion is doing work.
+    const judgedOut = decide({
+      session, incumbent: base,
+      arms: [{ name: "SMALL", metrics: { ...base, Q11: [0.2, 0.2], C2: [0.005, 0.005] }, extras: { personsLost: 0 } }],
+      registry: smallModelMetrics({ addressableShare: 0.287 }),
+    });
+    expect(judgedOut.arms[0].ships).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this is (GRAPHSMALL-2) — **stacked on #567**

Base is `feat/graph-small-model-battery` (PR #567, all checks green, unmerged). **Retarget to `main`
after #567 merges.** Spec: `docs/design/graph-small-model-activation.md` (`SPEC_READY`).

#567 shipped Q10/Q11 scorers and bands with **no Neo4j read behind them** — deferred loudly after both
reviewers caught the wiring gap. This lands the read path, and the guard that writing it turned up.

### Changes
- **`measure.ts`** — `summaryRows()` reads `(:Entity){name, summary}` plus each entity's own adjacent
  `RELATES_TO.fact` (both directions, `IS_DUPLICATE_OF` excluded, grouped by **node identity**);
  `temporalEdges()` reads every fact edge's raw `valid_at`. Schema verified in `lib/graph/learning.ts`.
- **`harvest.ts`** — feeds both into the existing pure scorers and emits `Q10`/`Q11` in the shapes
  `judge.mjs`'s `smallModelReps` already expects.
- **`small-model-metrics.mjs`** — `assessInformativeness`, direction-aware.
- **`decision.mjs`** — `autoUninformative` computes exclusions **inside `decide`** from the registry's
  own margins and every arm's reps; `EXCLUDABLE_METRICS` refuses to disable a cost or quality gate.

### The idea: Q3's lesson, mechanised
`lib/graph/extraction-health.ts:348` records that graphiti **backdates `valid_at` to the episode's work
time**, so Q11 coverage might be ~1.0 on every arm — a metric that cannot move. That is the shape that
made **Q3 a structural zero and burned a live session**. It could not be settled empirically:
`NEO4J_URI` is `bolt://neo4j.railway.internal:7687` with no public proxy, so there is no read path from
a laptop and provisioning one is a production change. So the metric must **prove** it can move, on the
corpus it actually runs against.

## Verification
| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors (7 pre-existing warnings) |
| `npm test` (unit) | **2759 passed**, 11 skipped |
| `npm run check:docs` | in sync |
| `aios spec eval` | `SPEC_READY`, exit 0 |
| Mutation tests | **18 across both slices, all REDDENED** |

This slice's mutations: ceiling metrics no longer flagged · `decide` stops excluding · null incumbent
reads as measurable · **the guard loses its caller again** · stop consulting arm reps · allow a cost
gate to be disabled · missing band disarms instead of throwing.

## Review — Reviewed by Fable code-reviewer — verdict BLOCKED (3 HIGH + 4 MEDIUM + 3 LOW), all confirmed and folded
Reviewed by Codex gpt-5.5 — verdict BLOCKED (1 BLOCKER + 2 HIGH + 2 MEDIUM), all confirmed and folded

**The guard had NO CALLER.** Fable found it: an exported function plus a RUNBOOK sentence — *the
identical defect #567 was dinged for, one slice earlier, in this same file.* An operator who skipped the
manual step got a verdict indistinguishable from one where informativeness had been assessed. It is now
computed inside `decide()`, and a mutation proves it cannot silently lose its caller again.

**The guard was also BACKWARDS**, and both reviewers produced the same counter-scenario independently:
STRONG dates every edge (Q11 = 1.0), SMALL loses 20%, Q11 correctly FAILS — and the guard excluded it
*because* the incumbent was perfect, shipping an arm that lost the one behaviour Q11 detects. **My own
test enshrined that wave-through as desired behaviour.** A ceiling incumbent is the *best* baseline for
a fall; only the rise half is unarmable, and it is now reported rather than used to disarm. It also
consults **every arm's** reps: if both sit at the extreme the exclusion changes nothing, so the only
case where it alters a verdict is the case where excluding would be wrong.

Also folded:
- **Dead math, proven by execution before removal** — `roomBelow` simplified to `mean*(1-bandMargin)`,
  which at floor 0 can never cross; its comment claimed a check the code did not perform.
- **A missing band now throws** — the caller reads `informative:false` as "exclude", so the
  registry/param name mismatch (`margin` vs `bandMargin`) could have disarmed every gate at once.
- **`uninformative:["C2"]` would have silently disabled the required cost gate**; a `{informative,reason}`
  object with no `key` skipped nothing while the readout claimed an exclusion. Both throw now.
- **`summaryRows` grouped by `(n.name, n.summary)`** — two distinct entities sharing a name and a
  boilerplate summary merged into one row, collapsing exactly the duplicates Q10 counts, in the graph
  where fragmentation is expected. Now grouped by node identity.
- AC8d delivered (the judge reads these shapes through optional chaining, so a rename would harvest
  `undefined` in silence); `IS_DUPLICATE_OF` excluded from facts, matching `lib/graph/learning.ts`.

Both model passes satisfy the CLAUDE.md pre-push Review gate (adversarial-build steps 2–5). The
`--tier full` DeepSeek spec layer was not run (no key); the model reviews stood in for it.

### Still deliberately NOT in this slice
Flipping `teams.extraction_small_model` (a human action after readout), running the battery (it spends),
choosing the model (consumes EXMODEL-1's probe), and PIPEFF-5.

AIOS-Work: GRAPHSMALL-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
