### PR TITLE
docs(railway): correct the template contract against what the code actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ curl -fsSL https://aiosbrain.dev/install.sh | sh
 ```
 
 It checks your prerequisites, fetches the repo, and hands you to an interview: run it **on this
-machine** (your own team, real install), **on Railway** (opens the official one-click template), or
+machine** (your own team, real install), **on Railway** (opens the maintained one-click template), or
 **just the demo**. It asks only what your choice needs, **proves your model key works
 before going further** — a wrong paste is caught there, not three steps later at an empty query box —
 then shows the plan before touching anything. Already cloned? `npm run setup` is the same wizard.
 
-It never uses `sudo` or overwrites an existing install. The Railway choice opens the official
+It never uses `sudo` or overwrites an existing install. The Railway choice opens the maintained
 template; the selected Railway workspace must have an **active plan** first. Activate one at
 **https://railway.com/workspace/plans**. Railway then shows the complete app + Postgres plan and asks
 for confirmation before deploying.
@@ -109,7 +109,7 @@ concluding the product is broken:
 | | |
 |---|---|
 | **1 · A host** | anything that builds a Next.js app — **Node ≥ 20**. We recommend **Railway**: it detects the app, ships Postgres with pgvector already enabled, and adds Neo4j in one click if you later want the context engine. Nothing in the code depends on it |
-| **2 · Postgres 16** | the source of truth — every item, task, decision and attribution |
+| **2 · Postgres 16+** | the source of truth — every item, task, decision and attribution |
 | **3 · Two secrets** | `AUTH_SECRET` signs sessions, `SECRETS_KEY` encrypts connector tokens at rest. Each is one generated command |
 
 **Needed for the brain to answer anything**
@@ -180,7 +180,7 @@ Everything below is that sequence in dependency order, with the failure modes ca
 ### 1.1 Runtime and tooling
 
 **To deploy it**, your host needs to build a standard Next.js app — **Node ≥ 20** — and give it a
-**Postgres 16** database. Nothing else. Railway and Render detect this automatically.
+**Postgres 16 or newer** database. Nothing else. Railway and Render detect this automatically.
 
 **On your own machine** you only need tooling if you're going to run the admin CLI, the ingestion
 sidecar, or the app itself:
@@ -200,9 +200,9 @@ There is no `.nvmrc` or `.node-version` in the repo.
 | Service | Required? | Notes |
 |---|---|---|
 | **A host for the app** | **Required** | Railway is what we run and the best-supported path. Render, Fly, a VPS with Docker, or Kubernetes all work — it's a plain Next.js app with no platform-specific APIs. |
-| **Postgres 16** | **Required** | Managed (Railway, Neon, RDS…) or your own. Plain SQL schema, no vendor lock-in. |
+| **Postgres 16 or newer** | **Required** | Managed (Railway, Neon, RDS…) or your own. Plain SQL schema, no vendor lock-in. 16 is what CI and `compose.yml` run; the Railway template provisions Railway's own current Postgres image, which is newer. No version is enforced at runtime. |
 | **Neo4j 5.26.2** + **Graphiti** | Optional | Powers narrative arcs, the "what the brain is learning" panel, and graph-grounded answers. Everything else works without it. Self-hosted via `graphiti/docker-compose.yml`. **Neo4j Aura is untested** — no code path references `neo4j+s://`, so treat cloud Aura as unverified. |
-| **Email (Resend or SMTP)** | Recommended | Magic links and invites. Without it, in non-production the login link is printed to the server console; **in production the mail is dropped** (logged server-side as `[mailer] no provider`, and nowhere else). |
+| **Email (Resend or SMTP)** | Recommended | Magic links and invites. Without it the mail is **dropped in every environment** — logged server-side as `[mailer] no provider` (production) or `[mailer] (dev, no provider) would send …` (development), and nowhere else. The link itself is **never** printed: it carries a one-time token, so `mailer.ts` deliberately logs only the subject and recipient. To sign in locally without email, use `/auth/dev-login` (dev only) or the password from `npm run admin -- create-member`. |
 
 There is no Supabase dependency. It was removed — if you see Supabase env vars anywhere in your
 notes or in a stale `.env.local`, they are read by nothing.
@@ -293,19 +293,26 @@ Each step explains *why*, so you can tell when something has gone wrong rather t
 on green output.
 
 > **Railway users don't need to read §2.1–§2.4.** Start at the
-> [official one-click template](https://aiosbrain.dev/deploy/team-brain/). An active Railway plan is
-> required. The template creates Team Brain, Postgres, Graphiti, and Neo4j, generates the
+> [maintained one-click template](https://aiosbrain.dev/deploy/team-brain/) — reached by that direct
+> link, since it is deliberately unlisted in Railway's public template gallery. An active Railway
+> plan is required. The template creates Team Brain, Postgres, Graphiti, and Neo4j, generates the
 > application and graph secrets, asks only for the team and first-admin details, applies the schema,
 > and bootstraps the login.
+>
+> It does **not** configure email, and those keys are env-only — `RESEND_API_KEY` or `SMTP_URL` as
+> service variables plus a redeploy, not an Admin setting. Until then, magic-link sign-in is hidden
+> from the login form, and **member invites fall back to a manual password** the admin copies and
+> hands over — visibly, not silently. Sign in with the admin password you supplied.
 >
 > Read on only for a non-Railway host, local development, or debugging a failed deployment.
 
 ### 2.1 — Create the services
 
-On Railway, use the [official template](https://aiosbrain.dev/deploy/team-brain/); it deploys the
-four-service stack from the official repository without a fork, local CLI, or `--resume` step.
+On Railway, use the [maintained template](https://aiosbrain.dev/deploy/team-brain/); it deploys the
+four-service stack from the official repository without a fork, local CLI, or `--resume` step. It is
+unlisted in Railway's template gallery, so reach it by that link rather than by searching.
 
-On another host, deploy this repository as one web service and attach one Postgres 16 database.
+On another host, deploy this repository as one web service and attach one Postgres 16-or-newer database.
 
 For another host, add the graph services (§2.8) when you want narrative arcs.
 
@@ -330,7 +337,7 @@ RESEND_FROM="AIOS <noreply@yourdomain.com>"
 
 `APP_URL` matters more than it looks: invite and magic links are built in server actions where there
 is no request origin to fall back on, so without it every login link your team receives is broken.
-For the official Railway template this is wired to the generated public domain automatically; on a
+For the maintained Railway template this is wired to the generated public domain automatically; on a
 manual host, set it after the domain exists rather than guessing it in advance.
 
 Full reference in §3, including everything optional. `npm run doctor` checks the ones above that
@@ -374,7 +381,7 @@ fast instead of queueing every query in the database behind it.
 
 ### 2.4 — Create your team and your first admin
 
-The official Railway template performs this step idempotently from the form values on first boot.
+The maintained Railway template performs this step idempotently from the form values on first boot.
 The password is never printed to deployment logs, and restarts preserve an existing credential.
 
 For a manual non-template deployment, run these against the production database:
@@ -692,7 +699,7 @@ shipping app code ahead of its database.
 | `APP_URL` | Absolute base URL. No throw, but invite/magic links are built in server actions where there is no request origin — without it they come out broken. |
 | `SECRETS_KEY` | 32 bytes, base64 or hex. **Throws** the first time you save a connector secret — not at boot. |
 | One LLM path | `ANTHROPIC_API_KEY`, or `LLM_BASE_URL` (+ `LLM_MODEL`), or an OpenRouter key set per-team in Admin. |
-| One email path | `RESEND_API_KEY` + `RESEND_FROM`, or `SMTP_URL` + `SMTP_FROM`. Dev logs the link to console instead; in production the mail is **dropped**, noted only in the server log. |
+| One email path | `RESEND_API_KEY` + `RESEND_FROM`, or `SMTP_URL` + `SMTP_FROM`. Without one the mail is **dropped in every environment**, noted only in the server log — the link itself is never printed. Member invites fall back to a manual password you hand over yourself. |
 
 ### Optional subsystems
 
@@ -913,10 +920,15 @@ which distinguishes a scope failure from the far more common "ran fine, nothing 
 
 ### Login link never arrives
 
-No email transport configured. In development the link is printed to the server console. In
-production, set `RESEND_API_KEY` + `RESEND_FROM` (a verified domain — Resend's `onboarding@resend.dev`
-only delivers to the account owner) or `SMTP_URL` + `SMTP_FROM`. Also confirm `APP_URL` is set, or
-links are built against nothing.
+No email transport configured. **The link is never printed to the console** — it is a one-time
+credential, so the mailer logs only the subject and recipient (`[mailer] (dev, no provider) would
+send …`). In development, sign in via `/auth/dev-login` or with the password `npm run admin --
+create-member` prints. In production, set `RESEND_API_KEY` + `RESEND_FROM` (a verified domain —
+Resend's `onboarding@resend.dev` only delivers to the account owner) or `SMTP_URL` + `SMTP_FROM`.
+Also confirm `APP_URL` is set, or links are built against nothing. Note that
+`POST /api/auth/request-magic-link` returns `200` whether or not the mail went anywhere, so a
+successful response there proves nothing. The admin **invite** flow is more honest: it reports
+`emailDelivered`, and hands back a usable `loginUrl` or password when delivery failed.
 
 `npm run doctor` flags both — a missing transport (as a failure in production, where the mail is
 dropped rather than logged) and an unset `APP_URL`.

--- a/docs/RAILWAY-TEMPLATE.md
+++ b/docs/RAILWAY-TEMPLATE.md
@@ -1,8 +1,13 @@
-# Official Railway template contract
+# Railway template contract (maintained, unlisted)
 
 The stable product entry point is **https://aiosbrain.dev/deploy/team-brain/**. That page points to
-the currently published Railway template, so installers and onboarding contracts do not need to
+the current maintained Railway template, so installers and onboarding contracts do not need to
 change when Railway rotates a template code.
+
+The template's Railway status is **`UNPUBLISHED`**, which means **unlisted, not disabled**: it does
+not appear in Railway's public template gallery, and the direct deploy link works and returns `200`.
+Describe it as the maintained template reached by direct link — not as a listed or gallery-published
+one.
 
 ## Prerequisite
 
@@ -34,26 +39,49 @@ that will own the deployment.
 | `NEO4J_USER` | fixed to `neo4j` |
 | `NEO4J_PASSWORD` | generated secret shared with Neo4j and Graphiti |
 | `GRAPH_PROJECT_ENABLED` | fixed to `true` |
-| `SECRETS_KEY` | `${{ secret(43, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_") }}` (32 bytes when base64url-decoded) |
+| `SECRETS_KEY` | a generated secret that must decode to **exactly 32 bytes**. The live template uses `${{ secret(64, "0123456789abcdef") }}` (64 hex chars). A 43-char base64url secret also works and was what earlier revisions of this document described. `decodeKey` (`lib/secrets/crypto.ts:55-59`) takes 64-char hex, else base64 — validation is on decoded length alone, so both forms are accepted. Anything else fails on the first connector save, not at boot. |
 | `TEAM_NAME` | required user input |
 | `TEAM_SLUG` | required user input; lowercase letters, digits, hyphens |
 | `ADMIN_NAME` | required user input |
 | `ADMIN_EMAIL` | required user input |
 | `ADMIN_PASSWORD` | required user input, minimum 10 characters; never printed by bootstrap |
-| `SEED_DEMO` | fixed to `false` |
-| `AIOS_TEMPLATE_BOOTSTRAP` | fixed to `true`; provisions the team and admin before the app starts |
+| `SEED_DEMO` | fixed to `false`; inert on this path — `bootstrap.mjs` returns after provisioning a real team and never reads it |
+
+**Bootstrap is gated on `TEAM_SLUG`, not on a flag.** `docker/bootstrap.mjs:228` branches on
+`if (process.env.TEAM_SLUG)` — setting it is what provisions the team and admin. `ADMIN_EMAIL` is
+also required on that path; bootstrap exits if it is absent. Earlier revisions of this document
+listed an `AIOS_TEMPLATE_BOOTSTRAP` variable as the gate. **No code has ever read it** — the only
+other reference in the repo is `test/setup-wizard.test.ts:184`, which asserts the start script does
+*not* mention it. Do not add it to a template.
 
 Graphiti reaches Neo4j at `bolt://${{neo4j.RAILWAY_PRIVATE_DOMAIN}}:7687` and reaches Team Brain's
-internal OpenAI-compatible proxy at
-`http://${{aios-team-brain.RAILWAY_PRIVATE_DOMAIN}}/api/internal/llm/v1`, authenticating with
-`${{aios-team-brain.GRAPH_LLM_PROXY_SECRET}}`. This keeps the provider key and extraction-model
-choice in Team Brain Admin rather than requiring Graphiti to hold a second provider key. Optional
-model and mail-provider keys are configured after deployment in Admin and are never encoded in a
-deploy URL.
+internal OpenAI-compatible proxy by setting **`OPENAI_BASE_URL`** to
+`http://${{aios-team-brain.RAILWAY_PRIVATE_DOMAIN}}:3000/api/internal/llm/v1` and **`OPENAI_API_KEY`**
+to `${{aios-team-brain.GRAPH_LLM_PROXY_SECRET}}` (the shared proxy secret, not a provider key).
+
+The **`:3000` is required**. Railway private domains resolve no default port, so a port-less
+`http://…/api/internal/llm/v1` attempts port 80, where nothing is listening, and graph extraction
+fails. The app listens on 3000 (`Dockerfile:39-40`, `ENV PORT=3000` / `EXPOSE 3000`). The canonical
+form is in `.env.example:81-82`.
+
+This keeps the provider key and extraction-model choice in Team Brain Admin rather than requiring
+Graphiti to hold a second provider key.
+
+Optional **model/provider** keys are configured after deployment in Admin → Integrations and are
+never encoded in a deploy URL.
+
+**Mail keys are not.** `RESEND_API_KEY`, `SMTP_URL`, `RESEND_FROM` and `SMTP_FROM` are read from
+`process.env` only (`lib/auth/mailer.ts:15,38,59,128`); there is no Admin surface that stores them.
+Configuring mail on Railway means adding service variables and redeploying. Until that happens
+`magicLinkAvailable()` is false: magic-link sign-in is hidden from the login form, and
+`inviteMember` switches to **manual mode**, returning a generated password and a ready-to-paste
+invite message for the admin to deliver. Nothing is silently lost on that path — only a direct
+`POST /api/auth/request-magic-link` is swallowed (it returns `200` regardless). Password sign-in
+works throughout, so this is a degraded feature rather than a broken deploy.
 
 ## Maintenance and verification
 
-The published Railway template is a derived deployment asset. For every Team Brain release:
+The Railway template is a derived deployment asset. For every Team Brain release:
 
 1. Confirm the template still points at the official repository and `main`.
 2. Compare its services and variables to this document and `railway.json`.


### PR DESCRIPTION
Documentation only. `docs/RAILWAY-TEMPLATE.md` had drifted far enough that rebuilding a Railway template from it would produce a deployment with broken graph extraction and a variable that does nothing. Every correction below was verified against this worktree's source.

## Review — Reviewed by Fable code review (subagent, full branch diff + source re-verification) — verdict Conditionally ready: all load-bearing corrections verified against code; the two blocking findings (a leftover "dev logs the link" row and an overstated "invites are silently dropped") were fixed in this branch before push.

Findings raised and how each was handled:

| Severity | Finding | Resolution |
|---|---|---|
| HIGH | `README.md` quick-reference row still said "Dev logs the link to console instead" — the exact falsehood corrected elsewhere in the same diff | Fixed. Row now says mail is dropped in every environment and the link is never printed. |
| HIGH | New wording "member invites are silently dropped" was itself wrong | Fixed. Verified `app/t/[team]/admin/actions.ts:79` — `useMagicLink = magicLinkAvailable() && !form.manualInvite`, so `inviteMember` falls back to **manual mode** and returns a generated password + paste-ready message. Nothing is dropped or silent; only a direct `POST /api/auth/request-magic-link` is swallowed. |
| MEDIUM | "a successful-looking invite proves nothing" overstated | Fixed. Scoped to the magic-link route; noted the invite flow reports `emailDelivered` and returns a `loginUrl`/password on failure. |
| MEDIUM | `RAILWAY-TEMPLATE.md` contradicted itself — asserted `UNPUBLISHED` at the top while the title said "Official" and §Maintenance said "The published Railway template" | Fixed. Retitled "Railway template contract (maintained, unlisted)"; dropped "published". |
| LOW | Two surviving "official Railway template" phrases in README (`:339`, `:383`) | Fixed. |
| LOW | Off-by-one citation `crypto.ts:54-58` | Fixed to `55-59`. |
| LOW | `lib/auth/mailer.ts:6-9` docblock still claims the link is dev-logged — the stale comment that likely seeded the doc error | **Deferred deliberately.** This PR is docs-only by scope; a code-comment fix belongs with whoever is next in that file. Worth a follow-up, since it is the drift source. |

## `AIOS_TEMPLATE_BOOTSTRAP` is a variable nothing reads

Documented at `:44` as the bootstrap gate. `git log -S 'AIOS_TEMPLATE_BOOTSTRAP'` across all history returns exactly one commit (16a4a983, AIO-445), which added it to this document **and** to a negative assertion in `test/setup-wizard.test.ts:184` (`expect(start).not.toContain(...)`). No source file has ever read it.

The real gate is `docker/bootstrap.mjs:228`:

```js
if (process.env.TEAM_SLUG) {
  await provisionRealTeam();
  return;
}
```

`ADMIN_EMAIL` is also required there (bootstrap `exit(1)`s without it, `:178-182`). `SEED_DEMO` is genuinely unread on that path because of the `return` at `:230` — the doc's `SEED_DEMO=false` row is harmless but inert, now labelled as such.

## The graphiti → Team Brain proxy URL was missing its port

`:47-48` documented `http://${{aios-team-brain.RAILWAY_PRIVATE_DOMAIN}}/api/internal/llm/v1`. The app listens on **3000** (`Dockerfile:39-40`, `ENV PORT=3000` / `EXPOSE 3000`), and Railway private domains resolve no default port — a port-less `http://` attempts port 80, where nothing is bound, so graph extraction fails for anyone rebuilding from this doc. The canonical form is already in `.env.example:81-82`.

Two notes: the string `8080` appears nowhere in this repo except inside unrelated sha256 digests, so 8080 is not the answer. And the doc never named the env vars carrying this value (`OPENAI_BASE_URL` / `OPENAI_API_KEY`) — added, because the values live only in the external Railway template, making this document their sole specification.

## Mail keys are env-only, not "configured in Admin"

`:51-52` lumped model keys and mail keys together as post-deploy Admin settings. Only the first half is true. `RESEND_API_KEY`, `SMTP_URL`, `RESEND_FROM`, `SMTP_FROM` are read from `process.env` exclusively (`lib/auth/mailer.ts:15,38,59,128`), and grepping `app/t/[team]/admin/**` for `RESEND|SMTP` returns nothing. Configuring mail on Railway is service variables + redeploy. Split into two claims.

## `SECRETS_KEY` format

The doc described a 43-char base64url secret; the live template uses `secret(64, "0123456789abcdef")`. Both decode to 32 bytes and both are accepted — `decodeKey` (`lib/secrets/crypto.ts:55-59`) takes 64-char hex, else base64, validating on decoded length alone. The row now states that rule instead of one incidental encoding, and notes the failure lands on the first connector save rather than at boot.

## Template status: softened, not published

Railway reports the template as `status: UNPUBLISHED`. That means **unlisted, not disabled** — the direct deploy link works and returns `200` (verified by curl). Three claims called it "the currently published template" / "the official one-click template". All softened to describe it as maintained and reached by direct link. **No attempt was made to publish the template.**

## Two further errors found while verifying the above

- **The login link is never printed to the console.** README claimed it is, in development. `lib/auth/mailer.ts:77-84` carries the comment `// No provider configured. NEVER log the body/link — it carries a one-time token.` and logs only subject + recipient. A reader following the old text would hunt for a console line that structurally cannot appear. Corrected in both places, with the real recovery paths: `/auth/dev-login` (dev-gated) or the password `npm run admin -- create-member` prints once.
- **Postgres 16 was stated as a hard requirement** in four places. No runtime version gate exists anywhere (`server_version` grep is empty). 16 is what `compose.yml:18` and `ci.yml:86,118` run; the Railway template provisions Railway's own current image, which is newer. Softened to "16 or newer" rather than documenting a constraint the code does not enforce.

## Verification

```
$ npm run check:docs
✓ routes: 64 item(s) in sync
✓ tables: 84 item(s) in sync
✓ sources: 8 item(s) in sync
Docs are congruent with the code. ✓

$ npm test
Test Files  301 passed | 1 skipped (302)
     Tests  2723 passed | 11 skipped (2734)
```

Markdown table integrity was checked by field count rather than by eye — every modified row matches its header.

## Scope and coordination

Docs only: `README.md` and `docs/RAILWAY-TEMPLATE.md`. `CLAUDE.md`, `scripts/service-guard.mjs` and `docker/bootstrap.mjs` are deliberately untouched, as another agent is working in them.

No Linear task — this is a documentation correctness fix rather than a feature, so the task gate does not apply; the `PR references a brain task` check is advisory.

The client-facing website half of this work is `aiosbrain/aios-alpha.github.io#131`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime or deployment logic touched; risk is limited to documentation accuracy for operators.
> 
> **Overview**
> **Documentation-only** updates to `README.md` and `docs/RAILWAY-TEMPLATE.md` so Railway onboarding and troubleshooting match the code instead of drift that would break graph extraction or mislead operators.
> 
> The Railway template is described as **maintained and unlisted** (`UNPUBLISHED` = direct link works, not in the gallery), with wording shifted away from “official/published.” The template contract now states bootstrap is gated on **`TEAM_SLUG`** (and **`ADMIN_EMAIL`**), removes the unused **`AIOS_TEMPLATE_BOOTSTRAP`** variable, documents **`SECRETS_KEY`** as any secret that decodes to 32 bytes, and fixes Graphiti’s Team Brain LLM proxy to **`OPENAI_BASE_URL`** / **`OPENAI_API_KEY`** with **`:3000`** on the private domain. Mail is clarified as **env-only** (not Admin): without it, magic-link UI is hidden and **invites use manual password mode**, while direct magic-link API still returns 200.
> 
> `README.md` mirrors these fixes: Postgres **16+** (not a hard runtime gate), no console printing of magic links (with **`/auth/dev-login`** / admin password recovery), Railway email limitations, and invite vs magic-link behavior in troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02bc0df40ecbae848e835eea4993078d0f5d9b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->