### PR TITLE
fix(ingest): a whole workspace pushes, and ClickUp work reaches its author (AIO-923, AIO-924)

### DIFF
--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -10,6 +10,7 @@ import {
   IngestValidationError,
   TierViolationError,
 } from "@/lib/api/schemas";
+import { MAX_PAYLOAD_ROWS } from "@/lib/api/item-payload-schema";
 import { ingestItem } from "@/lib/ingest";
 import { attributeIncomingItem } from "@/lib/attribution/resolve-authors";
 import { projectChangedTasksAfterWrite } from "@/lib/pm-sync";
@@ -20,7 +21,28 @@ import {
 
 export const runtime = "nodejs";
 
+/** The per-item `body` cap. Also enforced by `commonItemFields.body` in the payload schema. */
 const MAX_PAYLOAD = 1_000_000; // 1 MB per contract
+
+/**
+ * The whole-REQUEST transport ceiling (brain-api 1.20, AIO-923) — deliberately NOT `MAX_PAYLOAD`.
+ *
+ * A `task`/`decision` payload is `body` PLUS up to `MAX_PAYLOAD_ROWS` rows, and this gate used to be
+ * `MAX_PAYLOAD * 1.2` ≈ 1.2 MB — so it fired at roughly 1,100 rows, long before any row bound, with a
+ * bare `413 payload_too_large / "max 1 MB"` that named no field. Since chunking client-side is not
+ * available (the row sweep in `lib/ingest/tasks.ts` deletes every synced row the incoming item omits,
+ * so chunk 2 deletes chunk 1), a whole workspace has to fit in ONE request or fail with a reason.
+ * 5,000 rows × ~700 B ≈ 3.5 MB, +1 MB of body, +20% slack for JSON framing.
+ *
+ * The ceiling is now a bound on abuse, not on legitimate use: anything under it that is still too big
+ * is rejected by the SCHEMA, naming `rows` and the limit (422), which is the diagnosable failure.
+ * DoS surface: this raises the max bytes one authenticated key can push per request ~4.5×, bounded by
+ * the 120 pushes/min rate limit below (≈ 5.4 GB/min/key worst case, vs ≈ 1.2 GB/min before) — a
+ * ceiling on an ALREADY-AUTHENTICATED principal in a self-hosted, single-org deployment, where the
+ * same key can already push 120 × 1.2 MB/min. Untrusted volume is gated by authentication, not by
+ * this number.
+ */
+const MAX_REQUEST_BYTES = Math.ceil((MAX_PAYLOAD + MAX_PAYLOAD_ROWS * 700) * 1.2);
 const PAGE_SIZE = 200;
 
 export async function POST(req: NextRequest) {
@@ -33,7 +55,13 @@ export async function POST(req: NextRequest) {
   }
 
   const len = parseInt(req.headers.get("content-length") || "0", 10);
-  if (len > MAX_PAYLOAD * 1.2) return errorResponse("payload_too_large", "max 1 MB", 413);
+  if (len > MAX_REQUEST_BYTES) {
+    return errorResponse(
+      "payload_too_large",
+      `request exceeds ${MAX_REQUEST_BYTES} bytes (body max 1 MB, rows max ${MAX_PAYLOAD_ROWS})`,
+      413
+    );
+  }
 
   let json: unknown;
   try {

--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -29,9 +29,9 @@ const MAX_PAYLOAD = 1_000_000; // 1 MB per contract
  * A `task`/`decision` payload is `body` PLUS up to `MAX_PAYLOAD_ROWS` rows, and this gate used to be
  * `MAX_PAYLOAD * 1.2` = 1.2 MB — so it fired at roughly 1,100 rows, long before any row bound, with a
  * bare `413 payload_too_large / "max 1 MB"` that named no field. Since chunking client-side is not
- * available for `task`/`decision` (the row sweep in `lib/ingest/tasks.ts` deletes every synced row in
- * the project that the incoming item omits, so chunk 2 deletes chunk 1), a whole workspace has to fit
- * in ONE request or fail with a reason. 1 MB body + 5,000 rows × ~700 B, +20% JSON framing slack =
+ * available for `task` (the sweep in `lib/ingest/tasks.ts` is PROJECT-wide, so chunk 2 deletes chunk
+ * 1 — the other row kinds sweep per-item and could be split), a whole workspace has to fit in ONE
+ * request or fail with a reason. 1 MB body + 5,000 rows × ~700 B, +20% JSON framing slack =
  * **5,400,000 B (5.4 MB)**, a 4.5× raise.
  *
  * NOT a guarantee that 5,000 rows always fit: 700 B is the measured ClickUp average, and 5,000 rows
@@ -77,6 +77,11 @@ export async function POST(req: NextRequest) {
   if (!parsed.success) {
     return errorResponse("invalid_payload", parsed.error.issues[0]?.message ?? "invalid", 422);
   }
+  // UNREACHABLE, and kept deliberately. `commonItemFields.body` is `z.string().max(1_000_000)`, so an
+  // over-cap body already 422'd at the parse above — a body overflow is `invalid_payload`, NOT this
+  // 413, which is why the brain-api 1.20 envelope says 413 means the TRANSPORT ceiling. Left as a
+  // belt-and-braces backstop in case the schema's own cap is ever relaxed or decoupled from
+  // `MAX_PAYLOAD`; if it fires, the two have drifted.
   if (parsed.data.body.length > MAX_PAYLOAD) {
     return errorResponse("payload_too_large", "body exceeds 1 MB", 413);
   }

--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -4,13 +4,12 @@ import { authenticateApiKey, authenticateAgentToken, isAgentBearer } from "@/lib
 import { isRestrictedTier } from "@/lib/auth/visibility";
 import { rateLimit } from "@/lib/api/rate-limit";
 import {
-  itemPayloadSchema,
   normalizeTier,
   errorResponse,
   IngestValidationError,
   TierViolationError,
 } from "@/lib/api/schemas";
-import { MAX_PAYLOAD_ROWS } from "@/lib/api/item-payload-schema";
+import { MAX_PAYLOAD_ROWS, wireItemPayloadSchema } from "@/lib/api/item-payload-schema";
 import { ingestItem } from "@/lib/ingest";
 import { attributeIncomingItem } from "@/lib/attribution/resolve-authors";
 import { projectChangedTasksAfterWrite } from "@/lib/pm-sync";
@@ -28,19 +27,24 @@ const MAX_PAYLOAD = 1_000_000; // 1 MB per contract
  * The whole-REQUEST transport ceiling (brain-api 1.20, AIO-923) — deliberately NOT `MAX_PAYLOAD`.
  *
  * A `task`/`decision` payload is `body` PLUS up to `MAX_PAYLOAD_ROWS` rows, and this gate used to be
- * `MAX_PAYLOAD * 1.2` ≈ 1.2 MB — so it fired at roughly 1,100 rows, long before any row bound, with a
+ * `MAX_PAYLOAD * 1.2` = 1.2 MB — so it fired at roughly 1,100 rows, long before any row bound, with a
  * bare `413 payload_too_large / "max 1 MB"` that named no field. Since chunking client-side is not
- * available (the row sweep in `lib/ingest/tasks.ts` deletes every synced row the incoming item omits,
- * so chunk 2 deletes chunk 1), a whole workspace has to fit in ONE request or fail with a reason.
- * 5,000 rows × ~700 B ≈ 3.5 MB, +1 MB of body, +20% slack for JSON framing.
+ * available for `task`/`decision` (the row sweep in `lib/ingest/tasks.ts` deletes every synced row in
+ * the project that the incoming item omits, so chunk 2 deletes chunk 1), a whole workspace has to fit
+ * in ONE request or fail with a reason. 1 MB body + 5,000 rows × ~700 B, +20% JSON framing slack =
+ * **5,400,000 B (5.4 MB)**, a 4.5× raise.
  *
- * The ceiling is now a bound on abuse, not on legitimate use: anything under it that is still too big
- * is rejected by the SCHEMA, naming `rows` and the limit (422), which is the diagnosable failure.
- * DoS surface: this raises the max bytes one authenticated key can push per request ~4.5×, bounded by
- * the 120 pushes/min rate limit below (≈ 5.4 GB/min/key worst case, vs ≈ 1.2 GB/min before) — a
- * ceiling on an ALREADY-AUTHENTICATED principal in a self-hosted, single-org deployment, where the
- * same key can already push 120 × 1.2 MB/min. Untrusted volume is gated by authentication, not by
- * this number.
+ * NOT a guarantee that 5,000 rows always fit: 700 B is the measured ClickUp average, and 5,000 rows
+ * of schema-legal maximums (2,000-char titles, 50 × 80-char labels) exceed this and still 413. That
+ * failure is now at least diagnosable — the message names both bounds — but the two limits are
+ * independent, and neither implies the other.
+ *
+ * DoS surface: worst case per key is 120 × 5.4 MB ≈ **648 MB/min**, up from 120 × 1.2 MB ≈ 144 MB/min.
+ * The mitigation is the rate limit below plus authentication: this is a ceiling on an ALREADY-
+ * AUTHENTICATED principal in a self-hosted, single-org deployment, so the population that can reach
+ * it is the team's own issued keys, and the pre-existing 144 MB/min was already well past what a
+ * malicious key needs to hurt. A 4.5× raise on an authenticated, rate-limited path is a real but
+ * small increase in blast radius, taken deliberately so that legitimate imports stop failing.
  */
 const MAX_REQUEST_BYTES = Math.ceil((MAX_PAYLOAD + MAX_PAYLOAD_ROWS * 700) * 1.2);
 const PAGE_SIZE = 200;
@@ -69,7 +73,7 @@ export async function POST(req: NextRequest) {
   } catch {
     return errorResponse("invalid_payload", "body must be JSON", 422);
   }
-  const parsed = itemPayloadSchema.safeParse(json);
+  const parsed = wireItemPayloadSchema.safeParse(json);
   if (!parsed.success) {
     return errorResponse("invalid_payload", parsed.error.issues[0]?.message ?? "invalid", 422);
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,7 +207,7 @@ unversioned `/api/brain/*` + `/api/dashboard/*` surfaces; `GET /api/v1/timeline`
 and `GET /api/v1/tasks` still discards its computed `truncated` (both need a brain-api bump, so they are
 deliberately not in this change).
 
-This server **implements brain-api v1.19** (the shipped member-facing wire contract; source of truth:
+This server **implements brain-api v1.20** (the shipped member-facing wire contract; source of truth:
 `aios-workspace/docs/brain-api.md`; see the v1.14 by-key lookup on
 `GET /api/v1/tasks` below; v1.8 added the subscriptions endpoint,
 `POST /api/v1/subscriptions`; the optional `context_health` object on `POST /api/v1/metrics`,
@@ -379,6 +379,28 @@ sequenceDiagram
   I->>DB: append audit_log
   I-->>R: {status, id}
 ```
+
+**Payload limits (brain-api 1.20, AIO-923).** Three DIFFERENT bounds, deliberately not one:
+
+| Bound | Value | Where | Failure |
+|---|---|---|---|
+| `body` (one item's prose) | 1 MB | `commonItemFields.body` in `lib/api/item-payload-schema.ts`, re-checked in the route | `422 invalid_payload` (schema) |
+| `rows` (a `task`/`decision`/`fact`/`stakeholder_mention` payload's row count) | 5,000 — `MAX_PAYLOAD_ROWS` | same file, on every row-bearing kind | `422 invalid_payload`, message names `rows` and the limit |
+| whole request | `MAX_REQUEST_BYTES` ≈ 4.2 MB — `(1 MB + 5,000 × 700 B) × 1.2` | `content-length` gate in the route | `413 payload_too_large` |
+
+The transport gate was `1 MB × 1.2` and `rows` was UNBOUNDED, so the only thing that stopped a large
+workspace was the 413 — firing at roughly **1,100 rows** with a message naming no field (measured:
+1,000 rows = 1,089,970 B accepted, 3,500 = 1,918,564 B rejected). A 35-List ClickUp workspace failed
+atomically at ~32 tasks per List.
+
+**The client cannot fix this by chunking**, which is why the bound had to move server-side: the row
+sweep in `lib/ingest/tasks.ts` DELETES every synced row in the project the incoming item omits, so a
+second chunk deletes the first — splitting one project's rows across pushes silently destroys data. A
+source above 5,000 rows must be split into separate **projects** (fewer Lists per integration), never
+into two pushes of the same project. The transport gate is now sized to fit the row ceiling, so it is
+a bound on abuse rather than on legitimate use; anything under it that is still too big is rejected by
+the schema, which can say why. DoS exposure is bounded by the existing **120 pushes/min per key** rate
+limit on an already-authenticated principal.
 
 ### Grounded query — `POST /api/v1/query` (SSE)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -393,14 +393,18 @@ workspace was the 413 — firing at roughly **1,100 rows** with a message naming
 1,000 rows = 1,089,970 B accepted, 3,500 = 1,918,564 B rejected). A 35-List ClickUp workspace failed
 atomically at ~32 tasks per List.
 
-**The client cannot fix this by chunking**, which is why the bound had to move server-side: for
-`task`/`decision` the row sweep (`lib/ingest/tasks.ts`, `lib/ingest/decisions.ts`) DELETES every
-synced row in the PROJECT the incoming item omits, so a second chunk deletes the first — splitting one
-project's rows across pushes silently destroys data. A source above 5,000 rows must be split into
-separate **projects** (fewer Lists per integration), never into two pushes of the same project.
-(`fact`/`stakeholder_mention` sweep per-ITEM instead — `lib/ingest/evidence.ts` — so distinct paths
-would be safe there; the shared error message stays conservative rather than giving advice that is
-only sometimes true.)
+**For `task`, the client cannot fix this by chunking** — which is why the bound had to move
+server-side. `lib/ingest/tasks.ts` sweeps **PROJECT-wide** (`project_id` + `origin='sync'`, no item
+filter), so a second `task` item in the same project deletes the first one's rows: splitting one
+project's tasks across pushes silently destroys data. A task source above 5,000 rows must be split
+into separate **projects** (fewer Lists per integration), never into two pushes of the same project.
+
+**`task` is the exception, not the rule.** The other three row-bearing kinds sweep **per-ITEM**:
+`lib/ingest/decisions.ts` scopes its diff-delete to `source_item_id = itemId` (so a UI-created
+decision and other items' rows are never touched), and `lib/ingest/evidence.ts` does the same for
+`fact`/`stakeholder_mention`. For those, splitting across distinct paths **is** safe. The shared
+`rows` error message stays conservative — "narrow the selection" is true for every kind, where
+"never split across pushes" would be true only for tasks.
 
 **The cap is WIRE-ONLY, and that distinction is load-bearing.** `ingestItem` re-parses every payload
 through `itemPayloadSchema`, including the ones the in-process mirror legs build — and those have no

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -385,22 +385,38 @@ sequenceDiagram
 | Bound | Value | Where | Failure |
 |---|---|---|---|
 | `body` (one item's prose) | 1 MB | `commonItemFields.body` in `lib/api/item-payload-schema.ts`, re-checked in the route | `422 invalid_payload` (schema) |
-| `rows` (a `task`/`decision`/`fact`/`stakeholder_mention` payload's row count) | 5,000 — `MAX_PAYLOAD_ROWS` | same file, on every row-bearing kind | `422 invalid_payload`, message names `rows` and the limit |
-| whole request | `MAX_REQUEST_BYTES` ≈ 4.2 MB — `(1 MB + 5,000 × 700 B) × 1.2` | `content-length` gate in the route | `413 payload_too_large` |
+| `rows` (a `task`/`decision`/`fact`/`stakeholder_mention` payload's row count) | 5,000 — `MAX_PAYLOAD_ROWS`, **wire only** | `wireItemPayloadSchema`, parsed by the route; `itemPayloadSchema` (what `ingestItem` re-parses) is UNCAPPED | `422 invalid_payload`, message names `rows` and the limit |
+| whole request | `MAX_REQUEST_BYTES` = 5,400,000 B (5.4 MB) — `(1 MB + 5,000 × 700 B) × 1.2` | `content-length` gate in the route | `413 payload_too_large` |
 
 The transport gate was `1 MB × 1.2` and `rows` was UNBOUNDED, so the only thing that stopped a large
 workspace was the 413 — firing at roughly **1,100 rows** with a message naming no field (measured:
 1,000 rows = 1,089,970 B accepted, 3,500 = 1,918,564 B rejected). A 35-List ClickUp workspace failed
 atomically at ~32 tasks per List.
 
-**The client cannot fix this by chunking**, which is why the bound had to move server-side: the row
-sweep in `lib/ingest/tasks.ts` DELETES every synced row in the project the incoming item omits, so a
-second chunk deletes the first — splitting one project's rows across pushes silently destroys data. A
-source above 5,000 rows must be split into separate **projects** (fewer Lists per integration), never
-into two pushes of the same project. The transport gate is now sized to fit the row ceiling, so it is
-a bound on abuse rather than on legitimate use; anything under it that is still too big is rejected by
-the schema, which can say why. DoS exposure is bounded by the existing **120 pushes/min per key** rate
-limit on an already-authenticated principal.
+**The client cannot fix this by chunking**, which is why the bound had to move server-side: for
+`task`/`decision` the row sweep (`lib/ingest/tasks.ts`, `lib/ingest/decisions.ts`) DELETES every
+synced row in the PROJECT the incoming item omits, so a second chunk deletes the first — splitting one
+project's rows across pushes silently destroys data. A source above 5,000 rows must be split into
+separate **projects** (fewer Lists per integration), never into two pushes of the same project.
+(`fact`/`stakeholder_mention` sweep per-ITEM instead — `lib/ingest/evidence.ts` — so distinct paths
+would be safe there; the shared error message stays conservative rather than giving advice that is
+only sometimes true.)
+
+**The cap is WIRE-ONLY, and that distinction is load-bearing.** `ingestItem` re-parses every payload
+through `itemPayloadSchema`, including the ones the in-process mirror legs build — and those have no
+transport step and legitimately exceed 5,000 (`fetchLinearTeam` paginates 200 × 100 = up to 20,000
+issues into ONE `task` item; GitHub and Plane are shaped the same). So the route parses with
+`wireItemPayloadSchema` (capped) and `ingestItem` with `itemPayloadSchema` (uncapped); collapsing the
+two would turn a working Linear import into an `IngestValidationError` on every scheduler tick.
+Guarded by `test/guards/wire-vs-storage-payload-schema.test.ts`, which pins both the ceilings and the
+two call sites.
+
+The transport gate is sized to fit the row ceiling **for average rows** — 700 B is the measured
+ClickUp figure; 5,000 rows of schema-legal maximums still 413, so neither limit implies the other.
+DoS: worst case per key rises from ~144 MB/min to ~648 MB/min (120 × 5.4 MB), mitigated by the
+existing **120 pushes/min per key** rate limit on an already-authenticated principal in a self-hosted,
+single-org deployment — a real but small increase in blast radius, taken so legitimate imports stop
+failing.
 
 ### Grounded query — `POST /api/v1/query` (SSE)
 

--- a/lib/api/item-payload-schema.ts
+++ b/lib/api/item-payload-schema.ts
@@ -10,10 +10,13 @@ import { z } from "zod";
  * 1,918,564 B rejected), so a 35-List workspace failed atomically at ~32 tasks per List with an
  * error that read like a server limit rather than a payload one.
  *
- * WHY NOT CHUNK CLIENT-SIDE: for `task` and `decision` the row sweep (`lib/ingest/tasks.ts`,
- * `lib/ingest/decisions.ts`) DELETES every synced row in the PROJECT that the incoming item omits,
- * so a second chunk deletes the first. Splitting one project's rows across pushes silently destroys
- * data; the contract has to accept the whole set or say why not.
+ * WHY NOT CHUNK CLIENT-SIDE — for `task`, which is the kind this actually bit. `lib/ingest/tasks.ts`
+ * sweeps PROJECT-wide (`project_id` + `origin='sync'`, no item filter), so a second `task` item in the
+ * same project deletes the first one's rows. Splitting one project's tasks across pushes silently
+ * destroys data; the contract has to accept the whole set or say why not.
+ * The other three row kinds sweep per-ITEM — `decisions.ts` scopes its diff-delete to
+ * `source_item_id = itemId`, and `evidence.ts` does the same for `fact`/`stakeholder_mention` — so
+ * for those, splitting across DISTINCT PATHS is in fact safe. `task` is the exception, not the rule.
  *
  * So the bound moves to where it can be DIAGNOSED: Zod rejects at a stated row count and `route.ts`
  * surfaces that message as a `422 invalid_payload` naming the limit, while the transport gate is

--- a/lib/api/item-payload-schema.ts
+++ b/lib/api/item-payload-schema.ts
@@ -1,31 +1,46 @@
 import { z } from "zod";
 
 /**
- * The maximum number of `rows` one item payload may carry (brain-api 1.20, AIO-923).
+ * The maximum number of `rows` one item payload may carry OVER THE WIRE (brain-api 1.20, AIO-923).
  *
- * WHY A ROW BOUND AND NOT A BIGGER TRANSPORT ONE: `rows` was unbounded, so the only thing that
+ * WHY A ROW BOUND AND NOT JUST A BIGGER TRANSPORT ONE: `rows` was unbounded, so the only thing that
  * actually stopped an over-large push was `POST /api/v1/items`'s `content-length` gate — a bare
- * `413 payload_too_large / "max 1 MB"` naming no field and no ceiling. A real ClickUp/Linear
- * workspace crossed it at roughly 1,100 tasks (measured: 1,000 rows = 1,089,970 B accepted;
- * 3,500 = 1,918,564 B rejected), so a 35-List workspace failed atomically at ~32 tasks per List
- * with an error that read like a server limit rather than a payload one.
+ * `413 payload_too_large / "max 1 MB"` naming no field and no ceiling. A real ClickUp workspace
+ * crossed it at roughly 1,100 tasks (measured: 1,000 rows = 1,089,970 B accepted; 3,500 =
+ * 1,918,564 B rejected), so a 35-List workspace failed atomically at ~32 tasks per List with an
+ * error that read like a server limit rather than a payload one.
  *
- * WHY NOT CHUNK CLIENT-SIDE: the row sweep in `lib/ingest/tasks.ts` DELETES every synced row in the
- * project that the incoming item omits, so a second chunk deletes the first. Splitting a workspace
- * across pushes silently destroys data; the contract has to accept the whole set or say why not.
+ * WHY NOT CHUNK CLIENT-SIDE: for `task` and `decision` the row sweep (`lib/ingest/tasks.ts`,
+ * `lib/ingest/decisions.ts`) DELETES every synced row in the PROJECT that the incoming item omits,
+ * so a second chunk deletes the first. Splitting one project's rows across pushes silently destroys
+ * data; the contract has to accept the whole set or say why not.
  *
- * So the bound moves to where it can be DIAGNOSED: Zod rejects at a stated row count and
- * `route.ts` surfaces that message as a `422 invalid_payload` naming the real limit, while the
- * transport gate is raised to fit 5,000 rows (~700 B/row ≈ 3.5 MB). `body` stays capped at 1 MB
- * independently — a huge document and a huge row set are different failures and keep different caps.
+ * So the bound moves to where it can be DIAGNOSED: Zod rejects at a stated row count and `route.ts`
+ * surfaces that message as a `422 invalid_payload` naming the limit, while the transport gate is
+ * raised so 5,000 rows fit. `body` keeps its independent 1 MB cap — a huge document and a huge row
+ * set are different failures and deserve different errors.
+ *
+ * ⚠️ WIRE ONLY — this is deliberately NOT applied by `itemPayloadSchema`. `ingestItem`
+ * (`lib/ingest/index.ts`) re-parses every payload through that schema, including the ones the
+ * IN-PROCESS mirror legs build, and those have no transport step and legitimately exceed 5,000:
+ * `fetchLinearTeam` paginates 200 × 100 = up to 20,000 issues into ONE `task` item, and the GitHub
+ * and Plane legs are shaped the same way. Capping the shared schema would have turned a working
+ * import into a permanent `IngestValidationError` on every tick, for a source whose admin cannot act
+ * on the remediation ("select fewer Lists" means nothing to a Linear team). The cap belongs on
+ * untrusted HTTP input, which is the only place a transport gate ever bounded it.
  */
 export const MAX_PAYLOAD_ROWS = 5_000;
 
 /**
  * `route.ts` returns `issues[0].message` VERBATIM and drops the issue `path`, so the field name and
  * the ceiling both have to be inside the message or the 422 is as undiagnosable as the 413 it replaces.
+ *
+ * The advice is "narrow the selection", not "split into two pushes": for `task`/`decision` a second
+ * push of the same project deletes the first (project-scoped sweep). For `fact`/`stakeholder_mention`
+ * the sweep is per-ITEM (`lib/ingest/evidence.ts`), so distinct paths would in fact be safe — the
+ * message stays conservative rather than offering advice that is only sometimes true.
  */
-const ROWS_LIMIT_MESSAGE = `rows: at most ${MAX_PAYLOAD_ROWS} rows per item payload (split the source across projects, never across pushes — a second push deletes the first)`;
+const ROWS_LIMIT_MESSAGE = `rows: at most ${MAX_PAYLOAD_ROWS} rows per item payload — narrow the source selection so it maps to more than one project; do NOT split one project's rows across pushes`;
 
 export const taskRowSchema = z.strictObject({
   row_key: z.string().min(1).max(200),
@@ -100,30 +115,6 @@ const commonItemFields = {
   body: z.string().max(1_000_000),
 };
 
-const taskPayloadSchema = z.strictObject({
-  ...commonItemFields,
-  kind: z.literal("task"),
-  rows: z.array(taskRowSchema).max(MAX_PAYLOAD_ROWS, ROWS_LIMIT_MESSAGE).optional(),
-});
-
-const decisionPayloadSchema = z.strictObject({
-  ...commonItemFields,
-  kind: z.literal("decision"),
-  rows: z.array(decisionRowSchema).max(MAX_PAYLOAD_ROWS, ROWS_LIMIT_MESSAGE).optional(),
-});
-
-const factPayloadSchema = z.strictObject({
-  ...commonItemFields,
-  kind: z.literal("fact"),
-  rows: z.array(factRowSchema).min(1).max(MAX_PAYLOAD_ROWS, ROWS_LIMIT_MESSAGE),
-});
-
-const stakeholderMentionPayloadSchema = z.strictObject({
-  ...commonItemFields,
-  kind: z.literal("stakeholder_mention"),
-  rows: z.array(stakeholderMentionRowSchema).min(1).max(MAX_PAYLOAD_ROWS, ROWS_LIMIT_MESSAGE),
-});
-
 const nonRowPayloadSchema = (
   kind: "deliverable" | "transcript" | "artifact" | "skill" | "blueprint",
 ) =>
@@ -133,16 +124,47 @@ const nonRowPayloadSchema = (
     rows: z.never().optional(),
   });
 
-export const itemPayloadSchema = z.discriminatedUnion("kind", [
-  taskPayloadSchema,
-  decisionPayloadSchema,
-  factPayloadSchema,
-  stakeholderMentionPayloadSchema,
-  nonRowPayloadSchema("deliverable"),
-  nonRowPayloadSchema("transcript"),
-  nonRowPayloadSchema("artifact"),
-  nonRowPayloadSchema("skill"),
-  nonRowPayloadSchema("blueprint"),
-]);
+/**
+ * The payload union, parameterized by the `rows` cap — the ONE difference between the wire schema
+ * and the storage schema. `maxRows: null` means unbounded (the pre-1.20 shape).
+ *
+ * Both unions are built from the same field definitions, so a shape change can only ever apply to
+ * both: the wire schema is the storage schema PLUS a row ceiling, never a different contract.
+ */
+function buildItemPayloadSchema(maxRows: number | null) {
+  const rows = <T extends z.ZodType>(row: T) => {
+    const arr = z.array(row);
+    return maxRows === null ? arr : arr.max(maxRows, ROWS_LIMIT_MESSAGE);
+  };
+  return z.discriminatedUnion("kind", [
+    z.strictObject({ ...commonItemFields, kind: z.literal("task"), rows: rows(taskRowSchema).optional() }),
+    z.strictObject({ ...commonItemFields, kind: z.literal("decision"), rows: rows(decisionRowSchema).optional() }),
+    z.strictObject({ ...commonItemFields, kind: z.literal("fact"), rows: rows(factRowSchema).min(1) }),
+    z.strictObject({
+      ...commonItemFields,
+      kind: z.literal("stakeholder_mention"),
+      rows: rows(stakeholderMentionRowSchema).min(1),
+    }),
+    nonRowPayloadSchema("deliverable"),
+    nonRowPayloadSchema("transcript"),
+    nonRowPayloadSchema("artifact"),
+    nonRowPayloadSchema("skill"),
+    nonRowPayloadSchema("blueprint"),
+  ]);
+}
+
+/**
+ * The STORAGE shape — what `ingestItem` re-parses, and what every normalizer test asserts against.
+ * `rows` is UNBOUNDED here on purpose (see `MAX_PAYLOAD_ROWS`): the in-process Linear/Plane/GitHub
+ * mirror legs build one `task` item per team/repo and can legitimately exceed the wire ceiling.
+ */
+export const itemPayloadSchema = buildItemPayloadSchema(null);
+
+/**
+ * The WIRE shape — what `POST /api/v1/items` parses. Identical to `itemPayloadSchema` except that
+ * `rows` is capped at `MAX_PAYLOAD_ROWS`, so untrusted HTTP input fails as a diagnosable 422 rather
+ * than an opaque 413. Guarded by `test/guards/wire-vs-storage-payload-schema.test.ts`.
+ */
+export const wireItemPayloadSchema = buildItemPayloadSchema(MAX_PAYLOAD_ROWS);
 
 export type ItemPayload = z.infer<typeof itemPayloadSchema>;

--- a/lib/api/item-payload-schema.ts
+++ b/lib/api/item-payload-schema.ts
@@ -1,5 +1,32 @@
 import { z } from "zod";
 
+/**
+ * The maximum number of `rows` one item payload may carry (brain-api 1.20, AIO-923).
+ *
+ * WHY A ROW BOUND AND NOT A BIGGER TRANSPORT ONE: `rows` was unbounded, so the only thing that
+ * actually stopped an over-large push was `POST /api/v1/items`'s `content-length` gate — a bare
+ * `413 payload_too_large / "max 1 MB"` naming no field and no ceiling. A real ClickUp/Linear
+ * workspace crossed it at roughly 1,100 tasks (measured: 1,000 rows = 1,089,970 B accepted;
+ * 3,500 = 1,918,564 B rejected), so a 35-List workspace failed atomically at ~32 tasks per List
+ * with an error that read like a server limit rather than a payload one.
+ *
+ * WHY NOT CHUNK CLIENT-SIDE: the row sweep in `lib/ingest/tasks.ts` DELETES every synced row in the
+ * project that the incoming item omits, so a second chunk deletes the first. Splitting a workspace
+ * across pushes silently destroys data; the contract has to accept the whole set or say why not.
+ *
+ * So the bound moves to where it can be DIAGNOSED: Zod rejects at a stated row count and
+ * `route.ts` surfaces that message as a `422 invalid_payload` naming the real limit, while the
+ * transport gate is raised to fit 5,000 rows (~700 B/row ≈ 3.5 MB). `body` stays capped at 1 MB
+ * independently — a huge document and a huge row set are different failures and keep different caps.
+ */
+export const MAX_PAYLOAD_ROWS = 5_000;
+
+/**
+ * `route.ts` returns `issues[0].message` VERBATIM and drops the issue `path`, so the field name and
+ * the ceiling both have to be inside the message or the 422 is as undiagnosable as the 413 it replaces.
+ */
+const ROWS_LIMIT_MESSAGE = `rows: at most ${MAX_PAYLOAD_ROWS} rows per item payload (split the source across projects, never across pushes — a second push deletes the first)`;
+
 export const taskRowSchema = z.strictObject({
   row_key: z.string().min(1).max(200),
   title: z.string().max(2000),
@@ -76,25 +103,25 @@ const commonItemFields = {
 const taskPayloadSchema = z.strictObject({
   ...commonItemFields,
   kind: z.literal("task"),
-  rows: z.array(taskRowSchema).optional(),
+  rows: z.array(taskRowSchema).max(MAX_PAYLOAD_ROWS, ROWS_LIMIT_MESSAGE).optional(),
 });
 
 const decisionPayloadSchema = z.strictObject({
   ...commonItemFields,
   kind: z.literal("decision"),
-  rows: z.array(decisionRowSchema).optional(),
+  rows: z.array(decisionRowSchema).max(MAX_PAYLOAD_ROWS, ROWS_LIMIT_MESSAGE).optional(),
 });
 
 const factPayloadSchema = z.strictObject({
   ...commonItemFields,
   kind: z.literal("fact"),
-  rows: z.array(factRowSchema).min(1),
+  rows: z.array(factRowSchema).min(1).max(MAX_PAYLOAD_ROWS, ROWS_LIMIT_MESSAGE),
 });
 
 const stakeholderMentionPayloadSchema = z.strictObject({
   ...commonItemFields,
   kind: z.literal("stakeholder_mention"),
-  rows: z.array(stakeholderMentionRowSchema).min(1),
+  rows: z.array(stakeholderMentionRowSchema).min(1).max(MAX_PAYLOAD_ROWS, ROWS_LIMIT_MESSAGE),
 });
 
 const nonRowPayloadSchema = (

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -35,8 +35,17 @@
  *        written; rate limits and cost metering attribute to the launching member. The
  *        Phase A 403 `delegation_not_supported` is retired for this route. Member `aios_*`
  *        keys are byte-for-byte unchanged.
+ * 1.20 — POST /api/v1/items payload limits become explicit and STRICTLY MORE PERMISSIVE (AIO-923).
+ *        `rows` is bounded at 5,000 per payload (`MAX_PAYLOAD_ROWS`) on every row-bearing kind, and
+ *        the whole-request transport gate is raised from ~1.2 MB to ~4.2 MB so 5,000 rows actually
+ *        fit. `body` stays capped at 1 MB. Net effect for a client: a push that used to die at
+ *        ~1,100 rows on a bare `413 payload_too_large / "max 1 MB"` now succeeds, and a push that
+ *        genuinely exceeds the ceiling gets a `422 invalid_payload` naming `rows` and the limit.
+ *        No request that was accepted before is rejected now, so no client change is required and
+ *        an old client against a new server is unaffected; a NEW client sending >1.2 MB against an
+ *        OLD server still gets the pre-1.20 413, which is the same failure it already handled.
  */
-export const BRAIN_API_VERSION = "1.19";
+export const BRAIN_API_VERSION = "1.20";
 
 /** Server-only Executor gateway negotiation; independent of the member API surface. */
 export const GATEWAY_CONTRACT_VERSION = "1.10";

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -35,15 +35,20 @@
  *        written; rate limits and cost metering attribute to the launching member. The
  *        Phase A 403 `delegation_not_supported` is retired for this route. Member `aios_*`
  *        keys are byte-for-byte unchanged.
- * 1.20 — POST /api/v1/items payload limits become explicit and STRICTLY MORE PERMISSIVE (AIO-923).
- *        `rows` is bounded at 5,000 per payload (`MAX_PAYLOAD_ROWS`) on every row-bearing kind, and
- *        the whole-request transport gate is raised from ~1.2 MB to ~4.2 MB so 5,000 rows actually
- *        fit. `body` stays capped at 1 MB. Net effect for a client: a push that used to die at
- *        ~1,100 rows on a bare `413 payload_too_large / "max 1 MB"` now succeeds, and a push that
- *        genuinely exceeds the ceiling gets a `422 invalid_payload` naming `rows` and the limit.
- *        No request that was accepted before is rejected now, so no client change is required and
- *        an old client against a new server is unaffected; a NEW client sending >1.2 MB against an
- *        OLD server still gets the pre-1.20 413, which is the same failure it already handled.
+ * 1.20 — POST /api/v1/items payload limits become explicit and, for every realistic client, MORE
+ *        PERMISSIVE (AIO-923). `rows` is bounded at 5,000 per payload (`MAX_PAYLOAD_ROWS`) on every
+ *        row-bearing kind, and the whole-request transport gate rises from 1.2 MB to 5.4 MB
+ *        (`MAX_REQUEST_BYTES` = (1 MB + 5,000 x 700 B) x 1.2) so 5,000 rows actually fit. `body`
+ *        keeps its independent 1 MB cap. Net effect: a push that used to die at ~1,100 rows on a
+ *        bare `413 payload_too_large / "max 1 MB"` now succeeds, and a push that genuinely exceeds
+ *        the ceiling gets a `422 invalid_payload` naming `rows` and the limit.
+ *        HONEST EDGE: this is not a pure superset. >5,000 rows that were COMPACT enough to fit the
+ *        old 1.2 MB gate (~60-130 B/row minimal rows) were accepted before and now 422. That window
+ *        is narrow and the new failure names its cause, where the old one did not; the alternative
+ *        (no row bound) leaves the opaque 413 in place. A NEW client sending >1.2 MB to an OLD
+ *        server still gets the pre-1.20 413 — the failure it already handles — so no negotiation is
+ *        needed. The cap is WIRE-ONLY: `ingestItem` re-parses with the uncapped storage schema, so
+ *        the in-process Linear/GitHub/Plane mirrors (up to 20,000 rows) are unaffected.
  */
 export const BRAIN_API_VERSION = "1.20";
 

--- a/lib/ingest/sources/clickup-normalize.ts
+++ b/lib/ingest/sources/clickup-normalize.ts
@@ -257,6 +257,47 @@ function taskMetadata(record: ClickUpTaskRecord, workspaceId: ClickUpId): Record
   };
 }
 
+/**
+ * The task's assignees as the SOURCE-AGNOSTIC author refs `lib/attribution/resolve-authors` reads.
+ *
+ * `taskMetadata` already stamps `assignee_ids`/`assignee_emails`, but nothing consumes them:
+ * `parseAuthorRefs` handles the SINGULAR `assignee_id` for linear/plane only, and `lib/ingest/run.ts`
+ * reads that same singular key — so every ClickUp task document resolved to zero authors and the work
+ * landed unattributed while every test stayed green (AIO-924).
+ *
+ * The fix is branch #1 of `parseAuthorRefs` — structured `frontmatter.authors[]`, which takes
+ * precedence over every source-specific branch — rather than a fifth per-source special case. It also
+ * carries what a singular key structurally cannot: ClickUp tasks are MULTI-assignee, and it ships the
+ * provider id AND the email on each ref, so a team that has never run a ClickUp identity sync still
+ * resolves people by email (`resolveRef` tries the id, misses, then the email).
+ *
+ * `assignee_ids`/`assignee_emails` stay as provenance — this is additive.
+ *
+ * FOR WHOEVER BUILDS `runClickUpIngestion`: attribute these documents through
+ * `attributeIncomingItem` (or `resolveAuthors(map, parseAuthorRefs(fm), connectors)`), NOT by
+ * copying the `resolveByProviderId(idMap, "linear", doc.frontmatter.assignee_id)` line the Linear
+ * and Plane legs of `lib/ingest/run.ts` use. That line reads a key ClickUp does not emit, would
+ * silently resolve to null for every task, and would throw away every assignee after the first.
+ */
+function authorRefsFor(task: ClickUpTask): Array<Record<string, string>> {
+  return (task.assignees ?? [])
+    .map((assignee) => {
+      const ref: Record<string, string> = {
+        role: "assignee",
+        provider: "clickup",
+        external_id: String(assignee.id),
+      };
+      const email = assignee.email?.trim();
+      const name = assignee.username?.trim();
+      if (email) ref.email = email;
+      if (name) ref.display_name = name;
+      return ref;
+    })
+    // A blank id with no email and no name is no author at all; `parseAuthorRefs` would drop it
+    // anyway, and an entry it drops is one the "add a mapping" queue never gets to see.
+    .filter((ref) => ref.external_id.trim() !== "" || ref.email || ref.display_name);
+}
+
 function dedupeRecords(records: ClickUpTaskRecord[]): ClickUpTaskRecord[] {
   const byId = new Map<string, ClickUpTaskRecord>();
   for (const record of records) {
@@ -313,8 +354,13 @@ export function normalizeClickUpTasks(input: NormalizeClickUpTasksInput): ItemPa
   // roughly 700 B/task the body crossed the cap around 1,400 tasks and the strict parser then rejected
   // the payload, importing NOTHING. Chunking into several `task` items is NOT the fix: the row sweep in
   // `lib/ingest/tasks.ts` deletes every synced row in the PROJECT that the incoming item omits, so a
-  // second chunk would delete the first. So `rows` (unbounded in the schema) stays complete and carries
-  // the data, and only the human-readable detail in the body is bounded.
+  // second chunk would delete the first. So `rows` stays complete and carries the data, and only the
+  // human-readable detail in the body is bounded.
+  //
+  // `rows` is no longer UNBOUNDED, though: brain-api 1.20 caps it at `MAX_PAYLOAD_ROWS` (5,000) so an
+  // over-large workspace fails as a 422 naming `rows` and the limit rather than an opaque 413 (AIO-923).
+  // A workspace above that ceiling must be split by SELECTING FEWER LISTS — i.e. into separate brain
+  // projects — never into two pushes of the same project, which is the delete-the-first case above.
   //
   // The digest is what preserves the idempotency property: it covers EVERY line, including any the body
   // drops, so a metadata-only change still advances `content_sha256` and an identical replay still
@@ -372,6 +418,9 @@ export function normalizeClickUpTaskDocs(input: NormalizeClickUpTasksInput): Ite
         source: "clickup",
         workspace_id: String(input.workspaceId),
         ...taskMetadata(record, input.workspaceId),
+        // Read by `parseAuthorRefs` branch #1 — see `authorRefsFor`. Must stay AFTER the spread so a
+        // future `taskMetadata` key can never shadow the one signal attribution depends on.
+        authors: authorRefsFor(task),
         status: resolveStatus(record, input.statusMaps),
         source_ts: clickUpWorkedAt(task),
       },
@@ -472,6 +521,17 @@ export function normalizeClickUpDoc(workspaceId: ClickUpId, input: ClickUpReadDo
       url: input.doc.url ?? "",
       creator_id: input.doc.creator === undefined ? "" : String(input.doc.creator),
       editor_ids: editors,
+      // Same AIO-924 gap as the task documents: `creator_id`/`editor_ids` are provenance nothing reads.
+      // A Doc's creator outranks its editors (ROLE_RANK: creator 1, editor 2), so the primary author is
+      // the person who wrote it, and every editor still gets multi-author credit.
+      authors: [
+        ...(input.doc.creator === undefined
+          ? []
+          : [{ role: "creator", provider: "clickup", external_id: String(input.doc.creator) }]),
+        ...editors
+          .filter((id) => String(input.doc.creator ?? "") !== id)
+          .map((id) => ({ role: "editor", provider: "clickup", external_id: id })),
+      ],
       page_ids: pages.map(({ page }) => String(page.id)),
       source_ts: docSourceTimestamp(input.doc, pages),
       content_format: "text/md",

--- a/test/datamechanics/clickup-attribution.datamechanics.test.ts
+++ b/test/datamechanics/clickup-attribution.datamechanics.test.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  attributeIncomingItem,
+  connectorMemberIds,
+  parseAuthorRefs,
+  resolveAuthors,
+} from "@/lib/attribution/resolve-authors";
+import { buildIdentityMap } from "@/lib/identity/resolve";
+import { ingestItem } from "@/lib/ingest";
+import type { ClickUpTaskRecord } from "@/lib/ingest/sources/clickup";
+import {
+  normalizeClickUpTaskDocs,
+  type ClickUpStatusMap,
+} from "@/lib/ingest/sources/clickup-normalize";
+import { db, seedTeam, type Seed } from "./helpers";
+
+/**
+ * Spec (AIO-924): a ClickUp task document attributes to the REAL human its ClickUp assignee maps to —
+ * verified to the stored `items.member_id`, on real Postgres, through the same
+ * `attributeIncomingItem` → `ingestItem` seam the push route uses.
+ *
+ * The unit tier can only prove `parseAuthorRefs` returns the right refs. Whether those refs actually
+ * resolve depends on `member_identities` rows and the identity map built from them — persistence and
+ * lookup, which is this tier's job (CLAUDE §4). The bug shipped green precisely because no test ever
+ * crossed from the normalizer into a resolver backed by a real roster.
+ */
+
+const STATUS_MAP: ClickUpStatusMap = {
+  backlog: "backlog",
+  ready: "to do",
+  in_progress: "in progress",
+  blocked: "blocked",
+  done: "complete",
+};
+
+function record(assignees: Array<{ id: number | string; username?: string; email?: string }>): ClickUpTaskRecord {
+  return {
+    task: {
+      id: `t-${randomUUID().slice(0, 8)}`,
+      name: "Ship the ClickUp read leg",
+      markdown_description: "Body text that makes the document searchable.",
+      status: { status: "in progress" },
+      list: { id: "101", name: "Pilot" },
+      assignees,
+    },
+    observedListIds: ["101"],
+  };
+}
+
+/** A connector member — the identity a real ClickUp sync would push as. */
+async function addConnector(teamId: string): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: teamId,
+      email: `clickup-sync-${randomUUID()}@test.local`,
+      display_name: "ClickUp Sync",
+      actor_handle: `clickup-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+      is_connector: true,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`addConnector failed: ${error?.message}`);
+  return (data as { id: string }).id;
+}
+
+/** Drive the route's own path: normalize → derive attribution opts → ingest → read the stored owner. */
+async function ingestDoc(seed: Seed, pusherId: string, records: ClickUpTaskRecord[]): Promise<string | null> {
+  const [doc] = normalizeClickUpTaskDocs({ workspaceId: 9001, records, statusMaps: { "101": STATUS_MAP } });
+  const { opts } = await attributeIncomingItem(db(), seed.teamId, doc, pusherId);
+  const res = await ingestItem(
+    db(),
+    { teamId: seed.teamId, memberId: pusherId, apiKeyId: randomUUID() },
+    doc,
+    "team",
+    opts
+  );
+  const { data } = await db().from("items").select("member_id").eq("id", res.id).single();
+  return (data as { member_id: string | null }).member_id;
+}
+
+describe("ClickUp task documents → stored items.member_id (real Postgres)", () => {
+  it("attributes to the human behind the ClickUp assignee id, not the sync connector", async () => {
+    const seed = await seedTeam();
+    const connectorId = await addConnector(seed.teamId);
+    await db().from("member_identities").insert({
+      team_id: seed.teamId,
+      member_id: seed.memberId,
+      provider: "clickup",
+      external_id: "7",
+      handle: "alex",
+    });
+
+    const stored = await ingestDoc(seed, connectorId, [record([{ id: 7, username: "Alex" }])]);
+    expect(stored).toBe(seed.memberId);
+    expect(stored).not.toBe(connectorId); // the INVARIANT: never the ingesting connector
+  });
+
+  it("falls back to the assignee's EMAIL when no clickup provider id is mapped", async () => {
+    // A team that has never run the ClickUp identity sync still has emails on the roster. The
+    // structured `authors[]` ref carries both signals, so `resolveRef` can try the id, miss, and
+    // still land the person — which a bare `{provider, external_id}` ref could not.
+    const seed = await seedTeam();
+    const connectorId = await addConnector(seed.teamId);
+    await db()
+      .from("member_emails")
+      .insert({ team_id: seed.teamId, member_id: seed.memberId, email: "alex@corp.example" });
+
+    const stored = await ingestDoc(seed, connectorId, [
+      record([{ id: 4242, username: "Alex", email: "alex@corp.example" }]),
+    ]);
+    expect(stored).toBe(seed.memberId);
+  });
+
+  it("credits EVERY mapped assignee, not just the one a singular assignee_id could have named", async () => {
+    // The reason the fix is `authors[]` and not a singular `assignee_id`: ClickUp tasks are
+    // multi-assignee, and `resolvedMemberIds` is what the credit/health layer reads.
+    const seed = await seedTeam();
+    const connectorId = await addConnector(seed.teamId);
+    const { data: second } = await db()
+      .from("members")
+      .insert({
+        team_id: seed.teamId,
+        email: `robin-${randomUUID()}@test.local`,
+        display_name: "Robin",
+        actor_handle: `robin-${randomUUID().slice(0, 8)}`,
+        role: "member",
+        tier: "team",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    const robinId = (second as { id: string }).id;
+    await db().from("member_identities").insert([
+      { team_id: seed.teamId, member_id: seed.memberId, provider: "clickup", external_id: "7" },
+      { team_id: seed.teamId, member_id: robinId, provider: "clickup", external_id: "9" },
+    ]);
+
+    const [doc] = normalizeClickUpTaskDocs({
+      workspaceId: 9001,
+      statusMaps: { "101": STATUS_MAP },
+      records: [record([{ id: 7, username: "Alex" }, { id: 9, username: "Robin" }])],
+    });
+    const [map, connectors] = await Promise.all([
+      buildIdentityMap(db(), seed.teamId),
+      connectorMemberIds(db(), seed.teamId),
+    ]);
+    const resolution = resolveAuthors(map, parseAuthorRefs(doc.frontmatter ?? {}), connectors);
+    expect([...resolution.resolvedMemberIds].sort()).toEqual([seed.memberId, robinId].sort());
+    expect(resolution.method).toBe("provider");
+    expect(resolution.resolvedMemberIds).not.toContain(connectorId);
+  });
+
+  it("leaves an UNASSIGNED ClickUp task unattributed rather than crediting the connector", async () => {
+    const seed = await seedTeam();
+    const connectorId = await addConnector(seed.teamId);
+    const stored = await ingestDoc(seed, connectorId, [record([])]);
+    expect(stored).toBeNull();
+  });
+});

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -1,7 +1,7 @@
 {
   "$schema": "aios-brain-contract/v1",
   "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: node scripts/gen-contract-fixture.mjs.",
-  "version": "1.19",
+  "version": "1.20",
   "tierAliases": {
     "shared": {
       "team": "team",
@@ -99,5 +99,5 @@
       "sha256": "9862e47581b9bdd68ecfd7aa92216011a6b56bc9dc7abaee3bd5e301240bfbea"
     }
   },
-  "contentHash": "99e8704bc67c1cb345d8861a7aa318759758f9fbd53d408528b3324670136333"
+  "contentHash": "b09cbb3b87b1cc4911b5f19b78456b72b0087c51428501c36e851271a4046e9a"
 }

--- a/test/guards/wire-vs-storage-payload-schema.test.ts
+++ b/test/guards/wire-vs-storage-payload-schema.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  MAX_PAYLOAD_ROWS,
+  itemPayloadSchema,
+  wireItemPayloadSchema,
+} from "@/lib/api/item-payload-schema";
+
+/**
+ * The `rows` ceiling is a WIRE bound, not a storage invariant (AIO-923). This guard pins the
+ * distinction, because collapsing the two is a silent, total outage rather than a visible error.
+ *
+ * Spec = the regression this split exists to prevent. `ingestItem` (`lib/ingest/index.ts`)
+ * re-parses EVERY payload through `itemPayloadSchema`, including the ones the in-process mirror
+ * legs build — and those have no transport step and legitimately exceed the wire ceiling:
+ * `fetchLinearTeam` paginates `issues(first: 100)` over up to 200 pages into ONE `task` item
+ * (20,000 rows), with the GitHub and Plane legs shaped the same. Applying the cap to the shared
+ * schema turns a working Linear import into an `IngestValidationError` on every scheduler tick,
+ * caught by the per-integration `catch` in `lib/ingest/run.ts` — so the task mirror AND all its
+ * per-issue documents stop importing, permanently, with remediation advice ("narrow the source
+ * selection") that a Linear-team admin cannot act on.
+ *
+ * So: the route parses with `wireItemPayloadSchema`, `ingestItem` with `itemPayloadSchema`, and
+ * neither may drift into the other.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+
+function payload(rowCount: number) {
+  return {
+    project: "p",
+    path: "tasks.md",
+    kind: "task" as const,
+    content_sha256: "a".repeat(64),
+    access: "team" as const,
+    body: "x",
+    rows: Array.from({ length: rowCount }, (_, i) => ({ row_key: `k-${i}`, title: `t-${i}` })),
+  };
+}
+
+describe("wire vs storage item-payload schema", () => {
+  it("the WIRE schema rejects above the ceiling, naming rows and the limit", () => {
+    const parsed = wireItemPayloadSchema.safeParse(payload(MAX_PAYLOAD_ROWS + 1));
+    expect(parsed.success).toBe(false);
+    // route.ts returns `issues[0].message` verbatim and drops the path.
+    expect(parsed.error!.issues[0].message).toContain("rows");
+    expect(parsed.error!.issues[0].message).toContain(String(MAX_PAYLOAD_ROWS));
+  });
+
+  it("the WIRE schema accepts exactly the ceiling (the cap is off-by-one clean)", () => {
+    expect(wireItemPayloadSchema.safeParse(payload(MAX_PAYLOAD_ROWS)).success).toBe(true);
+  });
+
+  it("the STORAGE schema accepts a Linear-sized mirror payload the wire would refuse", () => {
+    // 20,000 = fetchLinearTeam's own ceiling (200 pages × first: 100). If this ever goes red, an
+    // in-process import has started failing on every tick.
+    expect(itemPayloadSchema.safeParse(payload(20_000)).success).toBe(true);
+    expect(wireItemPayloadSchema.safeParse(payload(20_000)).success).toBe(false);
+  });
+
+  it("ingestItem parses with the STORAGE schema and the items route with the WIRE one", () => {
+    // A call-site pin: the two schemas only mean anything if each is used in exactly one place.
+    // Nothing else in the codebase pins which parser each seam uses, so a one-word import change
+    // would silently reinstate the outage above with every test still green.
+    const ingest = readFileSync(join(ROOT, "lib", "ingest", "index.ts"), "utf8");
+    expect(ingest).toContain("itemPayloadSchema.safeParse");
+    expect(ingest).not.toContain("wireItemPayloadSchema");
+
+    const route = readFileSync(join(ROOT, "app", "api", "v1", "items", "route.ts"), "utf8");
+    expect(route).toContain("wireItemPayloadSchema.safeParse");
+    // ...and NOT the uncapped one (`wireItemPayloadSchema` contains the substring, so match the
+    // bare identifier at an import/usage boundary rather than a naive `includes`).
+    expect(/(?<!wire)(?<![A-Za-z])itemPayloadSchema\b/.test(route)).toBe(false);
+  });
+
+  it("the fetchLinearTeam pagination ceiling this guard is calibrated to still holds", () => {
+    // Non-vacuity: the 20,000 above is only meaningful while Linear's fetch really can reach it.
+    const linear = readFileSync(join(ROOT, "lib", "ingest", "sources", "linear.ts"), "utf8");
+    expect(linear).toMatch(/issues\(first:\s*100/);
+    expect(linear).toMatch(/i\s*<\s*200/);
+  });
+});

--- a/test/ingest-clickup-normalize.test.ts
+++ b/test/ingest-clickup-normalize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { itemPayloadSchema, taskRowSchema } from "@/lib/api/schemas";
-import { MAX_PAYLOAD_ROWS as MAX_ROWS } from "@/lib/api/item-payload-schema";
+import { MAX_PAYLOAD_ROWS as MAX_ROWS, wireItemPayloadSchema } from "@/lib/api/item-payload-schema";
 import { parseAuthorRefs, primaryAuthorRef } from "@/lib/attribution/resolve-authors";
 import type { ClickUpDoc, ClickUpDocPage, ClickUpTask, ClickUpTaskRecord } from "@/lib/ingest/sources/clickup";
 import {
@@ -312,12 +312,14 @@ describe("ClickUp task normalization", () => {
       });
 
     // The documented ceiling itself still parses — the cap must not shrink the supported workspace.
-    expect(() => itemPayloadSchema.parse(workspaceOf(MAX_ROWS))).not.toThrow();
+    expect(() => wireItemPayloadSchema.parse(workspaceOf(MAX_ROWS))).not.toThrow();
 
-    const parsed = itemPayloadSchema.safeParse(workspaceOf(MAX_ROWS + 1));
+    const parsed = wireItemPayloadSchema.safeParse(workspaceOf(MAX_ROWS + 1));
     expect(parsed.success).toBe(false);
-    // route.ts surfaces `issues[0].message` verbatim as a 422 `invalid_payload`, so the limit has to be
-    // IN that message — a diagnosable ceiling, not a number the caller has to guess at.
+    // The bound is on the WIRE schema only: `itemPayloadSchema` (what `ingestItem` re-parses) stays
+    // uncapped so the in-process Linear/GitHub/Plane mirrors keep working — see
+    // test/guards/wire-vs-storage-payload-schema.test.ts. route.ts surfaces `issues[0].message`
+    // verbatim as a 422 `invalid_payload`, so the limit has to be IN that message.
     expect(parsed.error!.issues[0].message).toContain(String(MAX_ROWS));
   });
 

--- a/test/ingest-clickup-normalize.test.ts
+++ b/test/ingest-clickup-normalize.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { itemPayloadSchema, taskRowSchema } from "@/lib/api/schemas";
+import { MAX_PAYLOAD_ROWS as MAX_ROWS } from "@/lib/api/item-payload-schema";
+import { parseAuthorRefs, primaryAuthorRef } from "@/lib/attribution/resolve-authors";
 import type { ClickUpDoc, ClickUpDocPage, ClickUpTask, ClickUpTaskRecord } from "@/lib/ingest/sources/clickup";
 import {
   ClickUpNormalizationError,
@@ -166,6 +168,53 @@ describe("ClickUp task normalization", () => {
     });
   });
 
+  it("emits authors[] that the source-agnostic attribution resolver actually reads", () => {
+    // AIO-924. `taskMetadata` stamps `assignee_ids`/`assignee_emails` (PLURAL), but nothing consumes
+    // them: `parseAuthorRefs` handles `assignee_id` (SINGULAR) for linear/plane only, and there is no
+    // `clickup` branch at all — so every ClickUp task document resolved to ZERO author refs and the
+    // work landed unattributed, with every existing test still green because none of them crossed the
+    // normalizer→resolver seam. Asserting through `parseAuthorRefs` is the point: an assertion on the
+    // normalizer's own output shape is exactly what let this ship.
+    const docs = normalizeClickUpTaskDocs(input);
+    const assigned = docs.find((doc) => doc.frontmatter.native_id === "1001")!;
+
+    const refs = parseAuthorRefs(assigned.frontmatter);
+    expect(refs).not.toHaveLength(0);
+    expect(refs).toContainEqual({
+      role: "assignee",
+      provider: "clickup",
+      externalId: "7",
+      email: "alex@example.invalid",
+      displayName: "Alex",
+      handle: undefined,
+    });
+    // The plural provenance keys stay — `authors[]` is additive, not a replacement.
+    expect(assigned.frontmatter.assignee_ids).toEqual(["7"]);
+
+    // Multi-assignee is carried in full: the singular `assignee_id` the other connectors use could
+    // only ever have named one of them.
+    const multi = normalizeClickUpTaskDocs({
+      ...input,
+      records: [
+        {
+          task: {
+            ...records[0].task,
+            assignees: [
+              { id: 7, username: "Alex", email: "alex@example.invalid" },
+              { id: 9, username: "Robin", email: "robin@example.invalid" },
+            ],
+          },
+          observedListIds: ["101"],
+        },
+      ],
+    });
+    expect(parseAuthorRefs(multi[0].frontmatter).map((ref) => ref.externalId)).toEqual(["7", "9"]);
+
+    // An unassigned task claims nobody — an empty `authors[]` must not invent an author.
+    const unassigned = docs.find((doc) => doc.frontmatter.native_id === "1002")!;
+    expect(parseAuthorRefs(unassigned.frontmatter)).toHaveLength(0);
+  });
+
   it("keeps its ticket documents out of the timeline's evidence lane", () => {
     // The timeline gate is `str(fm.identifier) && sourceRules(source).emitsTicketDocuments`
     // (lib/dashboard/work-timeline.ts). BOTH halves have to hold or a workspace of N tasks pushes N
@@ -244,6 +293,32 @@ describe("ClickUp task normalization", () => {
     expect(payload.frontmatter.detail_truncated).toBe(true);
     // Truncation must be declared, not silent.
     expect(payload.frontmatter.detail_count).toBeLessThan(4000);
+  });
+
+  it("names the row limit instead of failing a 5,001-task workspace as an opaque transport error", () => {
+    // AIO-923. `rows` used to be unbounded, so the ONLY thing that stopped an over-large workspace was
+    // the transport gate on `content-length` — a bare `413 payload_too_large / "max 1 MB"` that names
+    // no field and no limit, firing at ~1,100 tasks. Client-side chunking is not the escape hatch (the
+    // row sweep in lib/ingest/tasks.ts deletes every synced row the incoming item omits, so chunk 2
+    // deletes chunk 1), so the bound has to be a SERVER-side one that says what it is.
+    const workspaceOf = (count: number) =>
+      normalizeClickUpTasks({
+        workspaceId: 9001,
+        statusMaps: { "101": list101Map },
+        records: Array.from({ length: count }, (_, index) => ({
+          task: { ...records[0].task, id: `big-${index}`, custom_id: null, parent: null, name: `Task ${index}` },
+          observedListIds: ["101"],
+        })),
+      });
+
+    // The documented ceiling itself still parses — the cap must not shrink the supported workspace.
+    expect(() => itemPayloadSchema.parse(workspaceOf(MAX_ROWS))).not.toThrow();
+
+    const parsed = itemPayloadSchema.safeParse(workspaceOf(MAX_ROWS + 1));
+    expect(parsed.success).toBe(false);
+    // route.ts surfaces `issues[0].message` verbatim as a 422 `invalid_payload`, so the limit has to be
+    // IN that message — a diagnosable ceiling, not a number the caller has to guess at.
+    expect(parsed.error!.issues[0].message).toContain(String(MAX_ROWS));
   });
 
   it("advances the item sha when a task the body omitted changes", () => {
@@ -338,6 +413,24 @@ describe("ClickUp Doc normalization", () => {
     expect(payload.body.indexOf("## Agenda")).toBeLessThan(payload.body.indexOf("### Decisions"));
     expect(payload.body.indexOf("### Decisions")).toBeLessThan(payload.body.indexOf("## Action items"));
     expect(payload.body).toContain("Proceed with the read-only pilot.");
+  });
+
+  it("emits authors[] the resolver reads, creator ranked above editors", () => {
+    // AIO-924, Doc half: `creator_id`/`editor_ids` were provenance nothing consumed, so a team writing
+    // its specs in ClickUp Docs got zero attribution for them. Asserting through `parseAuthorRefs` and
+    // `primaryAuthorRef` — the resolver's OWN ordering — rather than the raw frontmatter, which is the
+    // assertion that stayed green while the behaviour was broken.
+    const payload = normalizeClickUpDoc(9001, {
+      doc: docAlpha as ClickUpDoc,
+      pages: docAlphaPages as ClickUpDocPage[],
+    });
+    const refs = parseAuthorRefs(payload.frontmatter);
+
+    // creator 7 once (not repeated as an editor) + editor 8.
+    expect(refs.map((ref) => `${ref.role}:${ref.externalId}`)).toEqual(["creator:7", "editor:8"]);
+    for (const ref of refs) expect(ref.provider).toBe("clickup");
+    // The Doc's author is whoever wrote it, not whoever last touched a page.
+    expect(primaryAuthorRef(refs)).toMatchObject({ role: "creator", externalId: "7" });
   });
 
   it("de-duplicates editors across ClickUp's mixed number/string user ids", () => {


### PR DESCRIPTION
Two data-correctness bugs on the ClickUp read leg, which merged green as `343ac89c` (AIO-819).

## AIO-923 — the payload cap silently rejected a whole workspace

`rows` was unbounded in `lib/api/item-payload-schema.ts`, so the only thing bounding an over-large push was `POST /api/v1/items`'s `content-length` gate at `MAX_PAYLOAD * 1.2` (1.2 MB) — firing at roughly **1,100 rows** with a bare `413 {"error":"payload_too_large","message":"max 1 MB"}` naming no field and no ceiling. Measured: 1,000 rows = 1,089,970 B accepted, 3,500 = 1,918,564 B rejected. A 35-List ClickUp workspace failed atomically at ~32 tasks per List.

**For `task`, the client cannot fix this by chunking.** `lib/ingest/tasks.ts` sweeps PROJECT-wide (`project_id` + `origin='sync'`, no item filter), so a second `task` item in the same project deletes the first one's rows — splitting one project's tasks across pushes silently destroys data. `task` is the **exception, not the rule**: `decision`, `fact` and `stakeholder_mention` all diff-delete per-ITEM (`source_item_id`), so splitting those across distinct paths is safe. An earlier revision of this branch said the project-wide sweep covered decisions too; the second review caught it and `db17dd90` corrects it in all three places plus `ARCHITECTURE.md`.

So the bound moves server-side where it can be diagnosed:
- `rows` capped at `MAX_PAYLOAD_ROWS` (5,000) → `422 invalid_payload` whose message names `rows` and the limit.
- transport gate raised to `MAX_REQUEST_BYTES` = **5,400,000 B (5.4 MB)** = `(1 MB + 5,000 × 700 B) × 1.2`, so 5,000 rows actually fit.
- `body` keeps its independent 1 MB cap.

### The cap is WIRE-only — this is the load-bearing detail

`ingestItem` re-parses **every** payload through `itemPayloadSchema`, including the ones the in-process mirror legs build. Those have no transport step and legitimately exceed 5,000: `fetchLinearTeam` paginates `issues(first: 100)` over up to 200 pages into ONE `task` item (20,000 rows); GitHub and Plane are shaped the same. Capping the shared schema would have turned a working Linear import into an `IngestValidationError` on every scheduler tick — swallowed by the per-integration `catch` in `run.ts`, so the task mirror *and* all its per-issue documents stop importing, permanently.

The union is therefore built once and parameterized by the ceiling: `itemPayloadSchema` (uncapped, storage) vs `wireItemPayloadSchema` (capped, the route). Both from the same field definitions, so the wire schema can only ever be the storage schema plus a row ceiling. Pinned by `test/guards/wire-vs-storage-payload-schema.test.ts`, which asserts both ceilings, that a 20,000-row payload still parses for storage, **that each schema is used at exactly one call site** (nothing else pinned that — a one-word import change would silently reinstate the outage with every test green), and that Linear's pagination ceiling this is calibrated to still holds.

### DoS

Worst case per key rises from ~144 MB/min to **~648 MB/min** (120 × 5.4 MB). The mitigation is the existing **120 pushes/min per key** rate limit plus authentication: this is a ceiling on an already-authenticated principal in a self-hosted, single-org deployment, so the population that can reach it is the team's own issued keys, and 144 MB/min was already well past what a malicious key needs. **My read: adequate for this deployment model, and I would not raise it further without a byte-budget-per-key mechanism.** The honest caveat is that the gate is `content-length`-header-based, so it is a cooperative bound, not an enforced one — unchanged by this PR, but worth knowing.

### Honest compat edge

Not a pure superset. >5,000 rows that were *compact* enough to fit the old 1.2 MB gate (~60–130 B/row minimal rows) were accepted before and now 422. Narrow window, and the new failure names its cause where the old one did not.

## AIO-924 — attribution silently failed

`clickup-normalize.ts` emitted `assignee_ids` (**plural**) while `parseAuthorRefs` handles the **singular** `assignee_id` for linear/plane only, with no `clickup` branch at all. Every ClickUp task document resolved to zero author refs and landed unattributed — with every test green, because none crossed the normalizer→resolver seam.

Fixed via the source-agnostic path that already exists rather than a fifth per-source special case: the task documents (**and ClickUp Docs**, which had the identical gap on `creator_id`/`editor_ids`) now emit structured `frontmatter.authors[]` — branch #1 of `parseAuthorRefs`, which outranks every source-specific branch. **No change to `run.ts` or `resolve-authors.ts`.** Deliberately *not* a singular `assignee_id`: ClickUp is multi-assignee, and each ref ships the provider id AND the email, so a team that has never run a ClickUp identity sync still resolves people by email. `assignee_ids`/`assignee_emails` stay as provenance.

## Contract

brain-api **1.19 → 1.20** (the limits are wire-visible), with `docs/ARCHITECTURE.md` and the pinned conformance fixture updated in lockstep.

⚠️ **Cross-repo drift, pre-existing and now wider.** `aios-workspace/docs/brain-api.md` is at **1.17** and its canonical `docs/contract/brain-contract.json` is at **1.17**, while this repo's vendored copy was already at **1.19** — 1.18 and 1.19 shipped without landing the contract change in the workspace doc first, which `docs/OPS.md` §7 requires. A matching `aios-workspace` PR backfilling 1.18/1.19 and adding 1.20 accompanies this one, restoring the two fixture copies to byte-identical.

## Tests

Spec-first, verified **RED before the fix**:
- unit `test/ingest-clickup-normalize.test.ts` (25 passed) — assertions go through `parseAuthorRefs`/`primaryAuthorRef`, not the normalizer's own output shape, since asserting the output shape is exactly what let this ship.
- unit `test/guards/wire-vs-storage-payload-schema.test.ts` (5 passed) — new.
- data-mechanics `test/datamechanics/clickup-attribution.datamechanics.test.ts` (4 passed, real Postgres) — proves attribution to the stored `items.member_id`. **3 of its 4 cases fail with the fix reverted** (verified).

| Tier | Result |
|---|---|
| unit (`npm test`) | **2730 passed**, 11 skipped, 1 failed |
| data-mechanics (`test:datamechanics:iso`) | **1139 passed**, 4 skipped, 0 failed (198 files) |
| `npm run check:docs` | ✓ routes/tables/sources in sync |
| `npm run lint` | 0 errors (8 pre-existing warnings) |
| `npx tsc --noEmit` | clean |

The 1 unit failure is `test/guards/single-writer-company-graph.test.ts > the SQL scanner catches a planted offender migration` — **pre-existing and unrelated**, confirmed by `git stash`-ing this branch's changes and re-running on a clean tree. It also passes in a sibling worktree, so it looks environment/temp-dir dependent rather than a real regression.

## Second review pass

An adversarial review of the paired workspace contract PR re-derived this branch's claims against the code and found that "chunking deletes your data" is a **task** property, not a rows-in-general one — repeated in three comments here plus `ARCHITECTURE.md`. Fixed in `db17dd90`. It also established that the body-cap `413` at the end of the route is **unreachable** (the schema's own `body.max(1_000_000)` 422s first), which is now labelled rather than left as an accidental truth behind the 1.20 envelope wording.

## Review — Reviewed by Fable code-reviewer — verdict Conditionally ready: found a HIGH second-order regression (the rows cap binding `ingestItem`'s re-parse would have permanently broken the in-process Linear/GitHub/Plane mirrors) plus three false numeric claims; all fixed in b23ab3e3 (rebased onto the merged #574) and re-verified, remaining LOWs are documented above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public ingest contract and raises authenticated upload volume (~648 MB/min ceiling per key), but limits are wire-only and rate-limited; incorrect schema unification would break scheduled mirror imports.
> 
> **Overview**
> **brain-api 1.20 (AIO-923)** makes `POST /api/v1/items` limits explicit and more usable for full-workspace imports. Untrusted HTTP bodies now parse through **`wireItemPayloadSchema`**, which caps **`rows` at 5,000** (`MAX_PAYLOAD_ROWS`) with a **`422 invalid_payload`** message that names the field and limit, while **`ingestItem`** keeps using the **uncapped** **`itemPayloadSchema`** so in-process Linear/GitHub/Plane mirrors (tens of thousands of rows) are not broken.
> 
> The whole-request **`content-length`** gate moves from ~1.2 MB to **`MAX_REQUEST_BYTES` (~5.4 MB)** so ~5,000 average-sized rows can pass before transport rejection; **`body`** stays capped at 1 MB. Docs and **`BRAIN_API_VERSION`** / contract fixture are bumped to **1.20**, with a new guard test pinning wire vs storage schema usage at the route vs ingest call sites.
> 
> **ClickUp attribution (AIO-924)** adds structured **`frontmatter.authors[]`** on normalized task and doc items (multi-assignee ClickUp ids plus email/name), which **`parseAuthorRefs`** already prefers over source-specific singular keys that ClickUp never emitted—so pushes can attribute to mapped humans instead of leaving work unattributed or on the sync connector. Unit and Postgres data-mechanics tests assert through the resolver/ingest seam, not only normalizer output shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103ce0896cc510dd897a3ee24d122794a6f7a2a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

