### PR TITLE
feat(graph): measure partial multi-chunk loss before enforcing on it (RECONCILE-1)

### DIFF
--- a/app/t/[team]/admin/integrations/actions.ts
+++ b/app/t/[team]/admin/integrations/actions.ts
@@ -448,7 +448,11 @@ export async function projectToGraphNow(
     // calls-per-episode ratio a numerator with no denominator — and the admin most likely to click it
     // is the one diagnosing extraction, who would then read a spuriously high ratio caused by their
     // own clicking. Best-effort: a ledger write must never fail the projection.
-    if (s.projected || s.errors.length) {
+    // `partialItems` joins the condition (RECONCILE-1): a manual run that projects nothing but
+    // OBSERVES partially-landed items carries the one signal this measurement exists to capture, and
+    // dropping it here would make the metric queryable from the scheduler but not from the button an
+    // admin actually clicks while diagnosing extraction.
+    if (s.projected || s.errors.length || s.partialItems) {
       await recordIngestRun(adminClient(), projectionRunInput(s, "manual", startedAt, Date.now()));
     }
     if (!s.configured) {

--- a/docs/design/graph-output-truncation.md
+++ b/docs/design/graph-output-truncation.md
@@ -1,0 +1,119 @@
+# Silent fact loss when extraction output hits the token ceiling (EXTRUNC-1)
+
+Status: **proposed — needs a cold read before code** · Owner: chetan
+· Tier build-with: unit (parse) + data-mechanics (persistence) + unit guard (single writer)
+
+**Deps:** none. Independent of PIPEFF-3 (which only raises tail exposure modestly by allowing
+4,000-char chunks) and of the GRAPHSMALL work (that is cost, this is correctness).
+
+**Increment:** ONE PR = detect + persist + surface. **Retry is explicitly NOT in it** — see
+"Why not retry (yet)".
+
+## Problem
+
+An extraction call whose OUTPUT saturates the model's token ceiling returns truncated JSON. Graphiti
+cannot parse it, the episode is `202`-accepted, and **its facts are never written**. Nothing records
+that this happened. That is the 2026-06/07 blank-arcs class: the graph quietly missing content nobody
+can point at.
+
+## Measured, and it corrects the ticket in both directions
+
+Re-derived from `llm_usage` (all graph rows, 45 days) rather than taken from the ticket:
+
+| call_kind | calls | max output | **at ≥16,384** | p99 |
+|---|---|---|---|---|
+| `extract_edges` | 1,937 | 16,384 | **1** | 3,670 |
+| `node_attributes` | 3,432 | 16,384 | **13** | 2,438 |
+| (pre-instrumentation) | 68,041 | 20,069 | **495** | 6,719 |
+| `dedupe_nodes` / `extract_nodes` / `node_summaries_batch` | — | ≤5,524 | 0 | — |
+
+**The ticket under-counted** (it found 1; there are 14 labelled, and 495 in the pre-instrumentation
+period). **And it over-claims currency**: saturations stop dead after **2026-08-05** —
+
+- 07-29 → 08-04: 7 → 137 per day
+- 08-05: 1 · **08-06 → today: zero**
+
+**12 clean days is NOT evidence of a fix.** At the measured `extract_edges` rate (1 in 1,937) you would
+expect ~0.7 events across the ~1,400 such calls since; observing zero is unsurprising either way. What
+*has* structurally gone is `node_attributes` — the 0.13.2 per-entity fan-out that 0.29.3 replaced with
+batched summaries, and **13 of the 14 recent saturations**. So the remaining live exposure is
+`extract_edges` at ~0.05% of calls ≈ **1–2 episodes per month losing their facts, undetectably**.
+
+That rate is the whole argument for this slice: it is too rare to notice and too silent to measure, so
+it will persist indefinitely unless it is instrumented. It is also why the fix is **detection first**.
+
+## Decision
+
+**Persist `finish_reason` on `llm_usage`, and surface saturation.**
+
+**Why `llm_usage` and NOT `llm_failures`:** that table means *"billed, but nothing to price"*
+(`lib/costs/llm-usage.ts`), and `meterGraphCall` already files there for un-meterable bodies. A
+truncated call **is** billed **and** meterable — it has full `usage`. Filing it as a failure would
+double-count the same attempt against `calls` and `failed_attempts` and make the Costs page's
+"their dollars are never in these bars" read false. The truncation is a *property of a metered call*,
+so it belongs as a column on the metered row.
+
+**Why a column and not a log line:** the entire defect is that this is invisible. A `console.warn`
+leaves the rate unknowable and the history unqueryable. One nullable column makes "how often does
+extraction truncate, and on which call kind" answerable forever — exactly what `call_kind` itself did
+for the cost question (GRAPHCOST-8), which is why that question became answerable at all.
+
+Concretely:
+1. `postgres/migrations/` adds `llm_usage.finish_reason text` (+ mirrored into `schema.sql` for
+   from-zero). Nullable: most providers set it, none are required to.
+2. `meterFromOpenAiResponse` (`lib/llm/cost.ts`) also extracts `choices[0].finish_reason`.
+3. `recordLlmUsage` persists it; every existing caller keeps working (optional field).
+4. A read that reports saturation — count and share, per `call_kind` — so the number is visible rather
+   than merely stored.
+
+## Why not retry (yet)
+
+The ticket proposes "detection-and-retry". Retry is deferred, with reasons, not dropped:
+
+- **The proxy cannot re-drive Graphiti's pipeline.** It sees one completion request. Re-issuing the
+  same request is the only retry available to it, and Graphiti has already moved on — the episode's
+  fact-writing path is upstream of the proxy and does not get a second chance from here.
+- **A re-issue likely reproduces the failure.** 16,384 output tokens from ~625 tokens of content is
+  ~26× the input, which is degenerate repetition, not honest density. Re-asking the same model the same
+  question is the least likely thing to break the loop — and it doubles the cost of the most expensive
+  call class we have.
+- **The rate is ~1–2/month and the biggest source is already gone.** Building a retry before knowing
+  the post-upgrade rate is building against a number measured on a code path (`node_attributes`) that
+  no longer exists.
+
+Detection makes the retry decision *evidence-based instead of assumed*, which is the same order this
+codebase used for cost (instrument → measure → then choose the lever).
+
+## Scope
+
+**In:** the column + migration, the parse, the persistence, the surfaced count, and tests.
+
+**Cut:** transparent retry (above); any chunk-size change (the ticket is explicit this is NOT a
+chunking fix, and PIPEFF-3 owns chunk sizing); back-filling `finish_reason` for historical rows (it is
+unrecoverable — the response bodies were never stored).
+
+## Acceptance criteria
+
+1. **unit** — `meterFromOpenAiResponse` returns `finishReason: "length"` for a truncated body, the real
+   value for a normal one, and `null` when the body has no `choices` — without disturbing the cost
+   fields it already resolves.
+2. **unit** — a body with `usage` but a malformed/absent `choices` array still meters (cost is
+   unaffected by the new field), because metering must never regress on a parse detail.
+3. **data-mechanics** — `recordLlmUsage` persists `finish_reason`, and a row written WITHOUT one reads
+   back `null` rather than `''` — so "unknown" and "the provider said nothing" stay distinguishable.
+4. **data-mechanics** — `postgres/schema.sql` loads from zero AND re-loads idempotently with the new
+   column, and the migration is additive (`add column if not exists`).
+5. **unit** — the saturation read reports count and share per `call_kind`, and returns an explicit
+   zero-state (not an empty object) when nothing truncated, so "no truncations" is distinguishable from
+   "the query did not run".
+6. **unit guard** — `finish_reason` is written only by `lib/costs/llm-usage`, matching the existing
+   single-writer discipline for that table.
+
+## What would falsify this
+
+- A truncated response that this parse does NOT flag (e.g. a provider signalling truncation another
+  way — Anthropic's `stop_reason: "max_tokens"` differs from OpenAI's `finish_reason: "length"`).
+- A metered row that regresses because of the new field — cost accuracy must be untouched.
+- `finish_reason` reading `''` for "the provider said nothing", collapsing unknown into a value.
+- Saturation continuing at the historical rate with nothing appearing on the surfaced count — the
+  detection is wired to nothing.

--- a/docs/design/reconcile-partial-chunks.md
+++ b/docs/design/reconcile-partial-chunks.md
@@ -1,0 +1,175 @@
+# Reconcile is blind to partial multi-chunk loss (RECONCILE-1)
+
+Status: **proposed — needs a cold read before code** · Owner: chetan
+· Tier build-with: unit (the pure landed-check) + data-mechanics (the reconcile outcome on real Postgres)
+
+**Deps:** none. Supersedes the instrumentation approach explored under EXTRUNC-1 — see "Why this and
+not EXTRUNC-1".
+
+**Increment:** ONE PR = **OBSERVABILITY ONLY**. Reconcile counts and identifies partially-landed items;
+it does NOT change any verdict, re-queue anything new, or touch the projector. Enforcement is
+increment 2, gated on what this measures. The cold read below is why that order is not timidity.
+
+## Problem
+
+`lib/graph/reconcile.ts` decides an item **landed if ANY of its chunks is present**:
+
+```ts
+// An item is projected as one OR MANY chunk episodes (`items:<id>` / `items:<id>#k`) — it "landed"
+// if ANY of its chunks is present. Map each item id → one of its episode uuids.
+const uuidByItemId = new Map<string, string>();
+for (const e of episodes) {
+  const itemId = itemIdFromEpisodeName(e.name);
+  if (itemId && !uuidByItemId.has(itemId)) uuidByItemId.set(itemId, e.uuid);   // FIRST wins
+}
+```
+
+Meanwhile the projector records **every** chunk sha optimistically at push time (`lib/graph/project.ts`,
+the `chunk_shas: chunkShas` write). So when a worker dies mid-item:
+
+- chunks 0..32 landed, chunk 33+ never did;
+- the ledger says all N chunks were pushed;
+- reconcile sees chunk 0 present, marks the item **confirmed**, and re-queues nothing;
+- the delta path then treats those shas as already-pushed, so **it is never re-pushed either**.
+
+The tail chunks are permanently absent, and nothing anywhere records it.
+
+**This is not inferred — it was observed live.** In the PIPEFF-2 battery a 502 killed the worker at
+**chunk #33 of the repo's `docs/ARCHITECTURE.md`**; reconcile requeued **0** for that item while correctly requeuing 7
+fully-missing items. The self-heal ran, reported success, and left the hole.
+
+## Why this and not EXTRUNC-1
+
+EXTRUNC-1 proposed instrumenting output-token truncation. Investigation (recorded here so it is not
+re-derived) showed:
+
+- **The single-chunk case already self-heals** — reconcile re-queues never-landed rows and the
+  projector re-pushes them, so a truncated single-chunk item comes back next cycle.
+- **This is the genuinely silent channel**, and it is cause-agnostic: truncation, timeout, a 429
+  storm, a worker crash — every one of them leaves the same hole, and this fix covers all of them
+  where an output-token detector covers one.
+- **The truncation rate is already measurable** with `output_tokens = 16384` (clean from 2026-07-31,
+  once reasoning was disabled), so the proposed column added robustness, not the measurement.
+
+## Decision (REVISED after the cold read — enforcement deferred, measurement first)
+
+The first draft proposed enforcing an all-chunks landed check immediately. Review found three defects
+that each turn that into a net harm, and all three are **unresolved by measurement I can do from here**:
+
+1. **The expected-name set is NOT derivable from `chunk_shas.length`.** The delta path pushes by SHA —
+   `toPush = episodes.filter((_, i) => !alreadyPushed.has(chunkShas[i]))` (`lib/graph/project.ts`),
+   set membership, position-independent — while names come from `episodeName(item.id, i, total)`, by
+   INDEX. A mid-document insertion re-chunks A,B,C → A,X,B,C: only X is pushed, as `#1`; the graph
+   holds old `#0..#2` plus a new `#1`, the ledger holds 4 shas, and expected `#3` **never existed**.
+   The strict check would re-queue a fully-healthy item — triggered by ordinary edits to a growing
+   document, i.e. the `docs/ARCHITECTURE.md` class, converting GRAPHCOST-1's delta savings back into
+   full-item extractions indefinitely.
+2. **It re-opens the amplifier `LANDED_GRACE_MS` exists to close.** Episodes become visible only as
+   Graphiti's queue drains at LLM speed. The ANY-check needs one chunk visible inside the grace; an
+   ALL-check needs all N. A 40-chunk item behind any backlog reads as partial, is re-pushed in full,
+   and deepens the queue that caused the misread — self-sustaining at the throttle rate.
+3. **Every heal DUPLICATES the landed chunks.** The re-queue writes only `content_sha256 = ''`, which
+   fails `deltaEligible`, so `toPush = episodes` — all of them. `addEpisodes` does not overwrite by
+   name, so each repair adds ~N-1 duplicate episodes: double-weighted facts, and group growth toward
+   `LANDED_SCAN_DEPTH`, past which self-healing switches off for that group **permanently**.
+
+So this PR **measures instead**: reconcile already fetches every group's episode list on every pass, so
+counting partially-landed items and recording which names are missing is **free** — no extra reads, no
+verdict change, no re-queue. That data is what separates persistent holes from the transient
+(still-queued) and structural (index-shift) false positives above, which is exactly the discrimination
+enforcement needs and nobody currently has.
+
+**Increment 2 (NOT this PR)** picks a repair shape informed by that data, and must resolve: the
+name/sha divergence (element-wise delta diff, recorded pushed names, or scoping to full pushes); a
+partial-specific grace or an N-consecutive-passes rule; and purge-before-repush
+(`pending_delete_group_id` → `purgeBeforeRepush`) to avoid duplicate episodes.
+
+### The check itself (built here, but only to COUNT)
+
+**Verify EVERY expected chunk episode, not just one.** The expected names are already derivable:
+`chunk_shas.length` gives the count and `episodeName(itemId, i, total)` gives each name
+(`items:<id>` when `total <= 1`, else `items:<id>#<i>`, zero-based).
+
+Landed ⇔ every expected name is present in the group's episode scan.
+
+### Guards this must NOT break (each is load-bearing today)
+
+1. **An EMPTY chunk ledger still means "never pushed", not "all chunks missing".** `reconcile.ts`
+   already relies on this: *"A row that EVER pushed keeps its chunk_shas (the re-queue resets only the
+   sha), so the empty ledger is the honest discriminator."* A never-pushed row is the PROJECTOR's to
+   converge; deleting it re-cold-starts an arm every cycle. So an empty ledger keeps today's path
+   exactly.
+2. **Saturated groups stay skipped.** `LANDED_SCAN_DEPTH` (5,000) bounds the episode scan; a group at
+   or beyond it is skipped and counted, because healing a group whose scan is truncated would re-push
+   items whose later chunks simply weren't scanned — a self-amplifying loop. A per-chunk check makes
+   that hazard *worse* if the guard were removed, so it must remain.
+3. **The re-queue throttle bounds the blast radius.** `REQUEUE_MAX_PER_PASS` (20) already caps
+   re-queues per pass, and `requeueThrottled` is the operator signal. This change can only INCREASE
+   re-queues, so that cap is what keeps a bad day from becoming a re-push storm on the most expensive
+   call class.
+
+### Measured blast radius, and the one thing I could not measure
+
+From prod `graph_episodes` (2026-08-17):
+
+| | |
+|---|---|
+| rows total | 2,621 |
+| **multi-chunk rows** (newly subject to the stricter check) | **984 (38%)** |
+| rows with an EMPTY ledger but a landed episode (legacy-storm risk) | **0** |
+
+The zero matters: there is no population of legacy rows that would newly read as "missing chunks" and
+re-queue en masse. **What I could NOT measure is how many of those 984 actually have a missing chunk
+today** — that needs a Neo4j read, and `NEO4J_URI` is `bolt://neo4j.railway.internal:7687` with no
+public proxy. So the true re-queue count on first run is unknown, and the throttle above is the
+mitigation rather than a prediction. That is stated rather than estimated.
+
+## Scope
+
+**In this PR:**
+- A pure expected-names helper reusing `episodeName` from `lib/graph/episode-name.ts`.
+- A pure landed predicate that distinguishes FULLY landed / PARTIALLY landed / never landed.
+- `lib/graph/reconcile.ts` COUNTS partial items (`partialItems`, plus the missing names for the first
+  few, bounded) into its summary and `ingest_runs.meta`. **Verdicts are unchanged** — a partial item
+  is still `confirmed` today, exactly as now.
+- The three guards kept intact (empty ledger, saturated groups, re-queue throttle), each pinned.
+
+**Cut, deliberately:**
+- **No schema change.** `chunk_shas` already carries everything needed; adding a column would be
+  inventing state that exists.
+- **No change to the projector's push path** (`lib/graph/project.ts`). The optimistic chunk-sha write
+  is what makes the ledger authoritative about *expected* chunks; the bug is the READ, not the write.
+  Changing both at once would make a regression un-bisectable.
+- **No back-fill / repair sweep** of items already holding a hole. The fix makes reconcile heal them
+  on its own schedule, bounded by the throttle; a bulk repair would re-push at a rate nothing caps.
+- **ENFORCEMENT** — re-queuing on a partial verdict. Deferred to increment 2 for the three reasons in
+  Decision; shipping it now can make the graph strictly worse (duplicates + permanent healing shutoff).
+- **Truncation instrumentation** (EXTRUNC-1) — a different, mostly-healed channel, argued above.
+
+## Acceptance criteria
+
+1. **unit** — `expectedEpisodeNames` returns exactly `["items:x"]` for a single-chunk item and
+   `["items:x#0","items:x#1","items:x#2"]` for a 3-chunk one — asserted against LITERAL strings, not
+   against `episodeName` itself, which would be green by construction.
+2. **unit** — the landed predicate returns `"partial"` for the observed shape (chunks 0..32 present,
+   33 missing), `"full"` when all are present, and `"none"` when none are.
+3. **unit** — an EMPTY chunk ledger yields `"none"`, preserving the never-pushed discriminator the
+   projector-owns-convergence guard depends on.
+4. **data-mechanics** — on real Postgres with an injected Graphiti client, a partially-landed row is
+   COUNTED in `partialItems` and its verdict is UNCHANGED (still confirmed, not re-queued) — the
+   measurement must not smuggle in enforcement.
+5. **data-mechanics** — `partialItems` reaches `ingest_runs.meta`, so the rate is queryable after the
+   fact rather than living only in a log line.
+6. **unit** — the recorded missing-name detail is BOUNDED (first N items), so a pathological pass
+   cannot write an unbounded blob into `ingest_runs.meta`.
+
+## What would falsify this
+
+- ANY verdict changes in this PR — a re-queue count that differs from today's means measurement
+  leaked into enforcement.
+- `partialItems` reading persistently ~0 in prod → the hole is a battery artefact, not a live defect,
+  and increment 2 should not be built (a legitimate, valuable outcome of measuring first).
+- `partialItems` tracking the count of multi-chunk items that were merely EDITED (the index-shift
+  false positive) rather than genuinely holed — which the recorded missing-names detail is there to
+  let an operator tell apart before anything enforces on it.
+- The detail blob growing unbounded in `ingest_runs.meta`.

--- a/lib/graph/landed-state.ts
+++ b/lib/graph/landed-state.ts
@@ -1,0 +1,87 @@
+import { episodeName } from "./episode-name";
+
+/**
+ * How much of a projected item actually landed in the graph (RECONCILE-1, increment 1).
+ *
+ * WHY THIS IS ONLY MEASURED, NOT ENFORCED. `lib/graph/reconcile.ts` treats an item as landed if ANY of
+ * its chunks is present, so a worker that dies mid-item leaves the tail chunks absent forever — the
+ * ledger already records every chunk sha at push, so the delta path skips them too. Observed live in
+ * the PIPEFF-2 battery: a 502 killed the worker at chunk #33 of `docs/ARCHITECTURE.md`, and reconcile
+ * requeued 0 for it while correctly requeuing 7 fully-missing items.
+ *
+ * The obvious fix — re-queue on `partial` — is NOT applied yet, and the reason is in
+ * `docs/design/reconcile-partial-chunks.md`: a cold read found three ways it makes things WORSE.
+ *   1. Expected names are not derivable after an edit. The delta path pushes by SHA (set membership,
+ *      position-independent) but names by INDEX, so inserting a chunk mid-document leaves the graph
+ *      holding old `#0..#2` plus a new `#1` while the ledger holds 4 shas — expected `#3` never
+ *      existed, and a strict check would re-queue a perfectly healthy item on an ordinary edit.
+ *   2. It re-opens the amplifier `LANDED_GRACE_MS` exists to close: episodes appear only as Graphiti's
+ *      queue drains, so "all N visible" is a far harder bar than "any one visible", and a big item
+ *      behind a backlog reads partial → gets re-pushed in full → deepens the backlog.
+ *   3. A re-queue re-pushes ALL chunks and `addEpisodes` does not overwrite by name, so every heal
+ *      adds ~N-1 duplicate episodes, growing the group toward `LANDED_SCAN_DEPTH`, past which
+ *      self-healing switches off for it permanently.
+ *
+ * So this module answers "how often is an item actually partial in prod?" — the number that tells us
+ * whether increment 2 is worth building at all, and which separates a real hole from those two
+ * false-positive channels. Pure, so every branch is unit-testable without a graph.
+ */
+
+/** `"none"` is also what a never-pushed row reports — see `landedState`. */
+export type LandedState = "full" | "partial" | "none";
+
+/**
+ * Every episode name a fully-landed item of `chunkCount` chunks should have.
+ *
+ * Delegates to `episodeName` rather than restating the convention, because the single-chunk form has
+ * no `#k` suffix (`items:<id>`) and duplicating that rule is how the two drift apart.
+ */
+export function expectedEpisodeNames(itemId: string, chunkCount: number): string[] {
+  const total = Math.max(1, Math.floor(chunkCount || 0));
+  return Array.from({ length: total }, (_, i) => episodeName(itemId, i, total));
+}
+
+/**
+ * Compare a row's expected episode names against the names actually present in the group's scan.
+ *
+ * An EMPTY chunk ledger returns `"none"`, which preserves the discriminator reconcile already depends
+ * on: *"A row that EVER pushed keeps its chunk_shas (the re-queue resets only the sha), so the empty
+ * ledger is the honest discriminator."* A never-pushed row is the PROJECTOR's to converge, and must
+ * not be mistaken here for an item whose chunks vanished.
+ */
+export function landedState(
+  itemId: string,
+  chunkCount: number,
+  presentNames: ReadonlySet<string>
+): { state: LandedState; missing: string[] } {
+  // No ledger ⇒ nothing was ever claimed in Graphiti ⇒ "never landed" is vacuous, not partial.
+  if (!chunkCount || chunkCount <= 0) {
+    return { state: "none", missing: [] };
+  }
+  const expected = expectedEpisodeNames(itemId, chunkCount);
+  const missing = expected.filter((n) => !presentNames.has(n));
+  if (missing.length === 0) return { state: "full", missing: [] };
+  if (missing.length === expected.length) return { state: "none", missing };
+  return { state: "partial", missing };
+}
+
+/**
+ * How many partial items to describe in the durable record. BOUNDED because this lands in
+ * `ingest_runs.meta`, which is read on a dashboard: a pathological pass must not write an unbounded
+ * blob into a row nobody can then load.
+ */
+export const PARTIAL_DETAIL_LIMIT = 5;
+
+/** Trim the per-item detail to something a meta blob can carry, and say what was elided. */
+export function boundPartialDetail(
+  items: { itemId: string; missing: string[] }[],
+  limit: number = PARTIAL_DETAIL_LIMIT
+): { sample: { itemId: string; missing: string[] }[]; elided: number } {
+  const sample = items.slice(0, limit).map((d) => ({
+    itemId: d.itemId,
+    // A 40-chunk item missing 39 names would itself be a blob; the count is the signal, the first few
+    // names are the diagnosis.
+    missing: d.missing.slice(0, limit),
+  }));
+  return { sample, elided: Math.max(0, items.length - sample.length) };
+}

--- a/lib/graph/landed-state.ts
+++ b/lib/graph/landed-state.ts
@@ -76,12 +76,17 @@ export const PARTIAL_DETAIL_LIMIT = 5;
 export function boundPartialDetail(
   items: { itemId: string; missing: string[] }[],
   limit: number = PARTIAL_DETAIL_LIMIT
-): { sample: { itemId: string; missing: string[] }[]; elided: number } {
-  const sample = items.slice(0, limit).map((d) => ({
-    itemId: d.itemId,
+): { sample: { itemId: string; missing: string[]; missingCount: number }[]; elided: number; namesElided: number } {
+  let namesElided = 0;
+  const sample = items.slice(0, limit).map((d) => {
     // A 40-chunk item missing 39 names would itself be a blob; the count is the signal, the first few
     // names are the diagnosis.
-    missing: d.missing.slice(0, limit),
-  }));
-  return { sample, elided: Math.max(0, items.length - sample.length) };
+    const missing = d.missing.slice(0, limit);
+    namesElided += Math.max(0, d.missing.length - missing.length);
+    return { itemId: d.itemId, missing, missingCount: d.missing.length };
+  });
+  // `missingCount` per item + `namesElided` overall, because review found within-item truncation was
+  // INVISIBLE: an item missing 40 names showed 5 with `elided: 0`, indistinguishable from an item
+  // missing exactly 5 — and "how deep is the hole" is a different question from "how many items".
+  return { sample, elided: Math.max(0, items.length - sample.length), namesElided };
 }

--- a/lib/graph/projection-run.ts
+++ b/lib/graph/projection-run.ts
@@ -59,6 +59,11 @@ export function projectionRunInput(
       // which is exactly the position that made this hole invisible for so long. Counted only; no
       // verdict changed, nothing re-queued on it (see lib/graph/landed-state.ts).
       partialItems: summary.partialItems,
+      // The bounded missing-name sample. The COUNT alone cannot separate a real tail hole from the
+      // index-shift false positive (an edited doc re-chunks, so an expected `#k` may never have
+      // existed) — and that discrimination is the whole reason to measure before enforcing. Review
+      // caught this being dropped between reconcile and the durable row.
+      partialDetail: summary.partialDetail,
     },
     startedAt,
     finishedAt,

--- a/lib/graph/projection-run.ts
+++ b/lib/graph/projection-run.ts
@@ -54,6 +54,11 @@ export function projectionRunInput(
       // Re-queues declined because a mass disappearance reads as a wedged Graphiti (H7). Recorded so a
       // throttle that persists across runs is visible rather than inferred from logs.
       requeueThrottled: summary.requeueThrottled,
+      // RECONCILE-1 measurement: items with SOME chunks landed and some missing. Durable because the
+      // whole question is whether this is real in prod — a log line would leave the rate unknowable,
+      // which is exactly the position that made this hole invisible for so long. Counted only; no
+      // verdict changed, nothing re-queued on it (see lib/graph/landed-state.ts).
+      partialItems: summary.partialItems,
     },
     startedAt,
     finishedAt,

--- a/lib/graph/reconcile.ts
+++ b/lib/graph/reconcile.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { GraphitiClient } from "./graphiti-client";
 import { itemIdFromEpisodeName } from "./episode-name";
+import { landedState, boundPartialDetail } from "./landed-state";
 import {
   GROUP_SCAN_DEPTH,
   IN_CLAUSE_BATCH,
@@ -113,6 +114,15 @@ export interface ReconcileSummary {
    * a service problem rather than N crashed workers. Non-zero means Graphiti is probably unhealthy; the
    * rows are untouched and retried next pass. */
   requeueThrottled: number;
+  /** Items with SOME chunks present and SOME missing — the partial-loss population (RECONCILE-1).
+   * MEASURED ONLY: these still count as `confirmed` and are not re-queued, exactly as before. The
+   * number exists to answer whether the hole is real in prod before anything enforces on it; see
+   * `lib/graph/landed-state.ts` for the three ways enforcing today would make the graph worse. */
+  partialItems: number;
+  /** A BOUNDED sample of those items and their missing episode names, so an operator can tell a real
+   * hole from the index-shift false positive (an edited doc re-chunks, so an expected `#k` may never
+   * have existed). `elided` is how many were dropped from the sample. */
+  partialDetail: { sample: { itemId: string; missing: string[] }[]; elided: number };
   /** Groups whose episode list came back FULL, so nothing in them could be judged this pass. Reported
    * rather than swallowed: it means the group has outgrown the scan window and self-healing has
    * quietly stopped for it (raise `GRAPH_LANDED_SCAN_DEPTH`). */
@@ -212,6 +222,8 @@ export async function reconcileProjectedEpisodes(
       groupsChecked: 0,
       confirmed: 0,
       reQueued: 0,
+      partialItems: 0,
+      partialDetail: { sample: [], elided: 0 },
       cleaned: 0,
       cleanedExternal: 0,
       pendingCleanups: 0,
@@ -257,6 +269,8 @@ export async function reconcileProjectedEpisodes(
   const cutoff = Date.now() - LANDED_GRACE_MS;
   let confirmed = 0;
   let reQueued = 0;
+  let partialItems = 0;
+  const partialFound: { itemId: string; missing: string[] }[] = [];
   let saturatedGroups = 0;
   let requeueThrottled = 0;
 
@@ -276,7 +290,12 @@ export async function reconcileProjectedEpisodes(
     // An item is projected as one OR MANY chunk episodes (`items:<id>` / `items:<id>#k`) — it "landed"
     // if ANY of its chunks is present. Map each item id → one of its episode uuids.
     const uuidByItemId = new Map<string, string>();
+    // RECONCILE-1 (measurement only): the full set of episode names present, so a row's chunks can be
+    // checked individually. The uuid map above stays FIRST-WINS and keeps deciding the verdict — this
+    // set is read for counting and nothing else, so this pass behaves identically to before.
+    const presentNames = new Set<string>();
     for (const e of episodes) {
+      if (e.name) presentNames.add(e.name);
       const itemId = itemIdFromEpisodeName(e.name);
       if (itemId && !uuidByItemId.has(itemId)) uuidByItemId.set(itemId, e.uuid);
     }
@@ -286,6 +305,14 @@ export async function reconcileProjectedEpisodes(
       const uuid = uuidByItemId.get(row.source_id);
       if (uuid) {
         confirmed++;
+        // COUNT the partial case; do not act on it. `chunk_shas` is the expected-chunk ledger; an
+        // empty one means never-pushed and reports "none", which is why this cannot mistake a
+        // reservation row for a hole.
+        const { state, missing } = landedState(row.source_id, row.chunk_shas?.length ?? 0, presentNames);
+        if (state === "partial") {
+          partialItems++;
+          partialFound.push({ itemId: row.source_id, missing });
+        }
         if (!row.episode_uuid) {
           await db.from("graph_episodes").update({ episode_uuid: uuid }).eq("id", row.id);
         }
@@ -485,5 +512,7 @@ export async function reconcileProjectedEpisodes(
     pendingCleanups: (pendingRows ?? []).length,
     requeueThrottled,
     saturatedGroups,
+    partialItems,
+    partialDetail: boundPartialDetail(partialFound),
   };
 }

--- a/lib/graph/reconcile.ts
+++ b/lib/graph/reconcile.ts
@@ -122,7 +122,7 @@ export interface ReconcileSummary {
   /** A BOUNDED sample of those items and their missing episode names, so an operator can tell a real
    * hole from the index-shift false positive (an edited doc re-chunks, so an expected `#k` may never
    * have existed). `elided` is how many were dropped from the sample. */
-  partialDetail: { sample: { itemId: string; missing: string[] }[]; elided: number };
+  partialDetail: { sample: { itemId: string; missing: string[]; missingCount: number }[]; elided: number; namesElided: number };
   /** Groups whose episode list came back FULL, so nothing in them could be judged this pass. Reported
    * rather than swallowed: it means the group has outgrown the scan window and self-healing has
    * quietly stopped for it (raise `GRAPH_LANDED_SCAN_DEPTH`). */
@@ -223,7 +223,7 @@ export async function reconcileProjectedEpisodes(
       confirmed: 0,
       reQueued: 0,
       partialItems: 0,
-      partialDetail: { sample: [], elided: 0 },
+      partialDetail: { sample: [], elided: 0, namesElided: 0 },
       cleaned: 0,
       cleanedExternal: 0,
       pendingCleanups: 0,
@@ -309,6 +309,12 @@ export async function reconcileProjectedEpisodes(
         // empty one means never-pushed and reports "none", which is why this cannot mistake a
         // reservation row for a hole.
         const { state, missing } = landedState(row.source_id, row.chunk_shas?.length ?? 0, presentNames);
+        // UNDER-COUNT, named rather than left silent (review): `state === "none"` is reachable INSIDE
+        // the confirmed branch — a doc that shrinks 3 chunks → 1 has its single sha already pushed, so
+        // `items:x` is never written while legacy `items:x#0..2` still confirm the item. That is a
+        // hole-by-renaming this counter does not see. Left uncounted deliberately: it is a different
+        // class with a different repair, and inventing a number for it here would blur the one metric
+        // increment 2 is meant to be gated on.
         if (state === "partial") {
           partialItems++;
           partialFound.push({ itemId: row.source_id, missing });

--- a/lib/graph/run.ts
+++ b/lib/graph/run.ts
@@ -3,6 +3,7 @@ import type { DbClient } from "@/lib/db/types";
 import { adminClient } from "@/lib/db/admin";
 import { GraphitiClient } from "./graphiti-client";
 import { projectItemsToGraph, ProjectionAbortError, FANOUT_PUSH_MAX_PER_PASS } from "./project";
+import { boundPartialDetail, PARTIAL_DETAIL_LIMIT } from "./landed-state";
 import { reconcileProjectedEpisodes } from "./reconcile";
 import { purgeExternalTierCaches } from "@/lib/cache/tier-invalidation";
 
@@ -52,6 +53,11 @@ export interface GraphProjectionSummary {
   saturatedGroups: number;
   /** RECONCILE-1 measurement — items with some chunks present and some missing. Counted, not acted on. */
   partialItems: number;
+  /** The BOUNDED missing-name sample, carried through to `ingest_runs.meta`. Without it the count
+   *  alone cannot tell a real tail hole from an index-shift false positive (an edited doc re-chunks,
+   *  so an expected `#k` may never have existed) — which is the entire question the metric exists to
+   *  answer. Review found this dropped between reconcile and the durable row. */
+  partialDetail: { sample: { itemId: string; missing: string[]; missingCount: number }[]; elided: number; namesElided: number };
   /** Ledger rows a pass declined to re-queue because too many looked absent at once — the signal that
    * Graphiti is wedged rather than that N workers crashed. Non-zero for several runs in a row is an
    * incident, not noise. */
@@ -124,6 +130,7 @@ async function runGraphProjectionInner(opts?: {
     pendingCleanups: 0,
     saturatedGroups: 0,
     partialItems: 0,
+    partialDetail: { sample: [], elided: 0, namesElided: 0 },
     requeueThrottled: 0,
     errors: [],
   };
@@ -179,6 +186,14 @@ async function runGraphProjectionInner(opts?: {
       summary.pendingCleanups += r.pendingCleanups;
       summary.saturatedGroups += r.saturatedGroups;
       summary.partialItems += r.partialItems;
+      // Merge across teams and RE-BOUND: each team's sample is already capped, but N teams would
+      // otherwise multiply the blob by N.
+      summary.partialDetail = boundPartialDetail(
+        [...summary.partialDetail.sample, ...r.partialDetail.sample],
+        PARTIAL_DETAIL_LIMIT
+      );
+      summary.partialDetail.elided += r.partialDetail.elided;
+      summary.partialDetail.namesElided += r.partialDetail.namesElided;
       summary.requeueThrottled += r.requeueThrottled;
 
       // A NARROWING only finishes leaving the graph HERE. `lib/ingest` purged the external-tier caches

--- a/lib/graph/run.ts
+++ b/lib/graph/run.ts
@@ -50,6 +50,8 @@ export interface GraphProjectionSummary {
    * this run. Non-zero means self-healing has quietly stopped for those groups — surfaced rather than
    * swallowed, per the no-silent-caps rule (raise `GRAPH_LANDED_SCAN_DEPTH`). */
   saturatedGroups: number;
+  /** RECONCILE-1 measurement — items with some chunks present and some missing. Counted, not acted on. */
+  partialItems: number;
   /** Ledger rows a pass declined to re-queue because too many looked absent at once — the signal that
    * Graphiti is wedged rather than that N workers crashed. Non-zero for several runs in a row is an
    * incident, not noise. */
@@ -121,6 +123,7 @@ async function runGraphProjectionInner(opts?: {
     cleaned: 0,
     pendingCleanups: 0,
     saturatedGroups: 0,
+    partialItems: 0,
     requeueThrottled: 0,
     errors: [],
   };
@@ -175,6 +178,7 @@ async function runGraphProjectionInner(opts?: {
       summary.cleaned += r.cleaned;
       summary.pendingCleanups += r.pendingCleanups;
       summary.saturatedGroups += r.saturatedGroups;
+      summary.partialItems += r.partialItems;
       summary.requeueThrottled += r.requeueThrottled;
 
       // A NARROWING only finishes leaving the graph HERE. `lib/ingest` purged the external-tier caches

--- a/lib/graph/scheduler.ts
+++ b/lib/graph/scheduler.ts
@@ -39,6 +39,7 @@ export function startGraphScheduler(): void {
               ? ` tier-cleanup: ${s.cleaned} done, ${s.pendingCleanups} outstanding`
               : "") +
             (s.saturatedGroups ? ` ${s.saturatedGroups} group(s) past the reconcile scan window` : "") +
+            (s.partialItems ? ` ${s.partialItems} partially-landed item(s)` : "") +
             (s.requeueThrottled ? ` ${s.requeueThrottled} re-queue(s) throttled — Graphiti may be wedged` : "") +
             (s.errors.length ? ` errors: ${s.errors.join("; ")}` : "")
         );

--- a/lib/graph/scheduler.ts
+++ b/lib/graph/scheduler.ts
@@ -32,7 +32,7 @@ export function startGraphScheduler(): void {
     const startedAt = Date.now();
     try {
       const s = await runGraphProjection();
-      if (s.projected || s.errors.length || s.pendingCleanups || s.saturatedGroups || s.requeueThrottled) {
+      if (s.projected || s.errors.length || s.pendingCleanups || s.saturatedGroups || s.requeueThrottled || s.partialItems) {
         console.info(
           `[graph] projected +${s.projected} =${s.skipped} (${s.scanned} scanned, ${s.teams} teams)` +
             (s.cleaned || s.pendingCleanups
@@ -47,7 +47,7 @@ export function startGraphScheduler(): void {
       // cleanup) to ingest_runs so a silently-failing projector — e.g. Graphiti 422'ing every write, or
       // a tier cleanup that never converges — is visible on the dashboard, not just in ephemeral logs.
       // A cleanup-only tick used to record nothing at all. recordIngestRun is best-effort.
-      if (s.projected || s.errors.length || s.requeued || s.cleaned || s.pendingCleanups || s.saturatedGroups || s.requeueThrottled) {
+      if (s.projected || s.errors.length || s.requeued || s.cleaned || s.pendingCleanups || s.saturatedGroups || s.requeueThrottled || s.partialItems) {
         await recordIngestRun(adminClient(), projectionRunInput(s, "scheduler", startedAt, Date.now()));
       }
     } catch (err) {

--- a/test/datamechanics/reconcile-partial-chunks.datamechanics.test.ts
+++ b/test/datamechanics/reconcile-partial-chunks.datamechanics.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { projectItemsToGraph } from "@/lib/graph/project";
+import { reconcileProjectedEpisodes } from "@/lib/graph/reconcile";
+import { db, ingest, seedTeam } from "./helpers";
+import { FakeGraphiti, client } from "./fake-graphiti";
+
+// Spec: docs/design/reconcile-partial-chunks.md — acceptance criteria 4 and 5.
+//
+// RECONCILE-1 increment 1 is MEASUREMENT ONLY. A partially-landed item (some chunks present, some
+// missing) must be COUNTED and must keep today's verdict exactly: still `confirmed`, NOT re-queued.
+// Enforcing today would make the graph worse in three ways recorded in the spec, so these tests exist
+// as much to prove the measurement did NOT smuggle in enforcement as to prove it counts.
+
+/** A body long enough that the projector chunks it into several episodes. */
+const longBody = (marker: string) => `${marker} `.repeat(4000);
+
+async function backdatePastGrace(teamId: string): Promise<void> {
+  await db().from("graph_episodes").update({ projected_at: "2020-01-01T00:00:00Z" }).eq("team_id", teamId);
+}
+
+describe("reconcile — partial multi-chunk loss (measurement only)", () => {
+  it("COUNTS a partially-landed item without changing its verdict", async () => {
+    const seed = await seedTeam();
+    const fake = new FakeGraphiti();
+    const slug = seed.teamSlug;
+
+    await ingest(seed, { kind: "deliverable", path: "docs/big.md", body: longBody("alpha"), access: "team" });
+    const { data: itemRow } = await db()
+      .from("items")
+      .select("id")
+      .eq("team_id", seed.teamId)
+      .eq("path", "docs/big.md")
+      .maybeSingle();
+    const itemId = (itemRow as { id: string }).id;
+
+    // Simulate the OBSERVED failure: the worker dies partway, so one chunk never materialises while
+    // its siblings do. (Live case: a 502 at chunk #33 of docs/ARCHITECTURE.md.)
+    fake.neverLands.add(`items:${itemId}#1`);
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: slug, client: client(fake) });
+
+    // The ledger must genuinely be multi-chunk, else this test proves nothing about the partial case.
+    const { data: before } = await db()
+      .from("graph_episodes")
+      .select("chunk_shas, content_sha256")
+      .eq("team_id", seed.teamId)
+      .eq("source_id", itemId)
+      .maybeSingle();
+    const b = before as { chunk_shas: string[]; content_sha256: string };
+    expect(b.chunk_shas.length).toBeGreaterThan(1);
+    const shaBefore = b.content_sha256;
+    expect(shaBefore).not.toBe(""); // not already parked on the re-push sentinel
+
+    await backdatePastGrace(seed.teamId);
+    const res = await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+
+    // MEASURED…
+    expect(res.partialItems).toBe(1);
+    expect(res.partialDetail.sample[0]).toMatchObject({ itemId });
+    expect(res.partialDetail.sample[0].missing).toContain(`items:${itemId}#1`);
+
+    // …and the VERDICT IS UNCHANGED. One present chunk still confirms the item, exactly as before.
+    expect(res.confirmed).toBe(1);
+    expect(res.reQueued).toBe(0);
+
+    const { data: after } = await db()
+      .from("graph_episodes")
+      .select("content_sha256")
+      .eq("team_id", seed.teamId)
+      .eq("source_id", itemId)
+      .maybeSingle();
+    // The sentinel is what triggers a re-push. Measurement must not write it.
+    expect((after as { content_sha256: string }).content_sha256).toBe(shaBefore);
+  });
+
+  it("does NOT count a fully-landed item as partial", async () => {
+    const seed = await seedTeam();
+    const fake = new FakeGraphiti();
+    await ingest(seed, { kind: "deliverable", path: "docs/whole.md", body: longBody("beta"), access: "team" });
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: seed.teamSlug, client: client(fake) });
+    await backdatePastGrace(seed.teamId);
+
+    const res = await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+    expect(res.partialItems).toBe(0);
+    expect(res.confirmed).toBeGreaterThan(0);
+    expect(res.reQueued).toBe(0);
+  });
+
+  it("does NOT count a FULLY-missing item as partial — that class reconcile already re-queues", async () => {
+    const seed = await seedTeam();
+    const fake = new FakeGraphiti();
+    await ingest(seed, { kind: "deliverable", path: "docs/gone.md", body: longBody("gamma"), access: "team" });
+    const { data: itemRow } = await db()
+      .from("items")
+      .select("id")
+      .eq("team_id", seed.teamId)
+      .eq("path", "docs/gone.md")
+      .maybeSingle();
+    const itemId = (itemRow as { id: string }).id;
+
+    // Every chunk fails to land → the existing "never landed" path owns it, not the new counter.
+    for (let i = 0; i < 40; i++) fake.neverLands.add(`items:${itemId}#${i}`);
+    fake.neverLands.add(`items:${itemId}`);
+    await projectItemsToGraph(db(), { teamId: seed.teamId, teamSlug: seed.teamSlug, client: client(fake) });
+    await backdatePastGrace(seed.teamId);
+
+    const res = await reconcileProjectedEpisodes(db(), client(fake), seed.teamId);
+    expect(res.partialItems).toBe(0); // "none", not "partial"
+    expect(res.reQueued).toBe(1); // today's behaviour for this class, unchanged
+  });
+});

--- a/test/graph-landed-state.test.ts
+++ b/test/graph-landed-state.test.ts
@@ -75,12 +75,44 @@ describe("boundPartialDetail — the meta blob must stay loadable", () => {
     const b = boundPartialDetail([{ itemId: "big", missing }]);
     expect(b.sample[0].missing).toHaveLength(PARTIAL_DETAIL_LIMIT);
     expect(b.elided).toBe(0); // one item, so nothing elided at the ITEM level
+    // …but the DEPTH of the hole must still be visible: 40 missing shown as 5 with elided:0 read
+    // identically to an item missing exactly 5 (review).
+    expect(b.sample[0].missingCount).toBe(40);
+    expect(b.namesElided).toBe(35);
   });
 
   it("elides nothing when the input already fits", () => {
     expect(boundPartialDetail([{ itemId: "a", missing: [] }])).toEqual({
-      sample: [{ itemId: "a", missing: [] }],
+      sample: [{ itemId: "a", missing: [], missingCount: 0 }],
       elided: 0,
+      namesElided: 0,
+    });
+  });
+});
+
+describe("AC5 — the measurement reaches the DURABLE row, not just the return value", () => {
+  it("projectionRunInput carries partialItems AND the bounded detail into ingest_runs.meta", async () => {
+    // Review caught this: the dm test asserted reconcile's RETURN, so deleting the meta write left it
+    // green. `partialDetail` was in fact being dropped between reconcile and the durable row — the
+    // count alone cannot separate a real hole from the index-shift false positive, which is the whole
+    // question the metric exists to answer.
+    const { projectionRunInput } = await import("@/lib/graph/projection-run");
+    const summary = {
+      ok: true, configured: true, teams: 1, scanned: 1, projected: 0, episodes: 0,
+      episodesByGroup: {}, fanoutThrottled: 0, restrictionMovesPending: 0, skipped: 0,
+      reconciled: 1, requeued: 0, cleaned: 0, cleanedExternal: 0, pendingCleanups: 0,
+      saturatedGroups: 0, requeueThrottled: 0,
+      partialItems: 2,
+      partialDetail: { sample: [{ itemId: "abc", missing: ["items:abc#3"], missingCount: 1 }], elided: 1, namesElided: 0 },
+      errors: [],
+    } as unknown as Parameters<typeof projectionRunInput>[0];
+
+    const row = projectionRunInput(summary, "scheduler", 0, 1);
+    expect(row.meta?.partialItems).toBe(2);
+    expect(row.meta?.partialDetail).toEqual({
+      sample: [{ itemId: "abc", missing: ["items:abc#3"], missingCount: 1 }],
+      elided: 1,
+      namesElided: 0,
     });
   });
 });

--- a/test/graph-landed-state.test.ts
+++ b/test/graph-landed-state.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  expectedEpisodeNames,
+  landedState,
+  boundPartialDetail,
+  PARTIAL_DETAIL_LIMIT,
+} from "@/lib/graph/landed-state";
+
+// Spec: docs/design/reconcile-partial-chunks.md — acceptance criteria 1, 2, 3, 6.
+// This measures the partial-loss population; it deliberately does NOT enforce (three ways enforcing
+// today makes the graph worse are recorded in the spec and in landed-state.ts).
+
+describe("expectedEpisodeNames", () => {
+  it("returns the LITERAL names the projector writes", () => {
+    // Asserted against literal strings, NOT against `episodeName` — comparing the helper to the
+    // function it calls would be green by construction and would pin nothing.
+    expect(expectedEpisodeNames("x", 1)).toEqual(["items:x"]);
+    expect(expectedEpisodeNames("x", 3)).toEqual(["items:x#0", "items:x#1", "items:x#2"]);
+  });
+
+  it("treats 0 / negative / garbage chunk counts as a single un-suffixed episode", () => {
+    // `episodeName(id, 0, 1)` is the single-chunk form; a count that cannot be honoured must not
+    // produce `items:x#0`, which the projector would never have written.
+    expect(expectedEpisodeNames("x", 0)).toEqual(["items:x"]);
+    expect(expectedEpisodeNames("x", -4)).toEqual(["items:x"]);
+    expect(expectedEpisodeNames("x", NaN)).toEqual(["items:x"]);
+  });
+});
+
+describe("landedState", () => {
+  const present = (...names: string[]) => new Set(names);
+
+  it("is FULL when every expected chunk is present", () => {
+    expect(landedState("x", 3, present("items:x#0", "items:x#1", "items:x#2")).state).toBe("full");
+    expect(landedState("x", 1, present("items:x")).state).toBe("full");
+  });
+
+  it("is PARTIAL for the OBSERVED shape — chunks 0..32 present, #33 missing", () => {
+    // The live case: a 502 killed the worker at chunk #33 of docs/ARCHITECTURE.md and reconcile
+    // requeued 0 for it, because one present chunk confirmed the whole item.
+    const names = Array.from({ length: 33 }, (_, i) => `items:arch#${i}`);
+    const r = landedState("arch", 34, present(...names));
+    expect(r.state).toBe("partial");
+    expect(r.missing).toEqual(["items:arch#33"]);
+  });
+
+  it("is NONE when nothing landed — that is the fully-missing class reconcile ALREADY catches", () => {
+    expect(landedState("x", 3, present()).state).toBe("none");
+  });
+
+  it("is NONE for an EMPTY chunk ledger — never-pushed is not a hole", () => {
+    // reconcile depends on this: a row that ever pushed keeps its chunk_shas, so an empty ledger is
+    // the honest never-pushed discriminator. Calling it "partial" would accuse a reservation row.
+    expect(landedState("x", 0, present()).state).toBe("none");
+    expect(landedState("x", 0, present("items:x")).state).toBe("none");
+  });
+
+  it("reports every missing name, so an operator can see WHICH chunks are gone", () => {
+    const r = landedState("x", 4, present("items:x#0", "items:x#2"));
+    expect(r.state).toBe("partial");
+    expect(r.missing).toEqual(["items:x#1", "items:x#3"]);
+  });
+});
+
+describe("boundPartialDetail — the meta blob must stay loadable", () => {
+  it("caps the number of items sampled and reports how many were elided", () => {
+    const items = Array.from({ length: 12 }, (_, i) => ({ itemId: `i${i}`, missing: ["items:a#1"] }));
+    const b = boundPartialDetail(items);
+    expect(b.sample).toHaveLength(PARTIAL_DETAIL_LIMIT);
+    expect(b.elided).toBe(12 - PARTIAL_DETAIL_LIMIT);
+  });
+
+  it("caps the names WITHIN an item too — a 40-chunk hole is itself a blob", () => {
+    const missing = Array.from({ length: 40 }, (_, i) => `items:big#${i}`);
+    const b = boundPartialDetail([{ itemId: "big", missing }]);
+    expect(b.sample[0].missing).toHaveLength(PARTIAL_DETAIL_LIMIT);
+    expect(b.elided).toBe(0); // one item, so nothing elided at the ITEM level
+  });
+
+  it("elides nothing when the input already fits", () => {
+    expect(boundPartialDetail([{ itemId: "a", missing: [] }])).toEqual({
+      sample: [{ itemId: "a", missing: [] }],
+      elided: 0,
+    });
+  });
+});

--- a/test/graph-projection-run.test.ts
+++ b/test/graph-projection-run.test.ts
@@ -22,6 +22,8 @@ const base: GraphProjectionSummary = {
   pendingCleanups: 0,
   saturatedGroups: 0,
   requeueThrottled: 0,
+  partialItems: 0,
+  partialDetail: { sample: [], elided: 0, namesElided: 0 },
   errors: [],
 };
 
@@ -42,6 +44,12 @@ describe("projectionRunInput", () => {
     expect(run.meta).toMatchObject({
       episodes: 9,
       episodesByGroup: { acme_team: 6, acme_external: 3 },
+      // Pinned at the CALL SITE (RECONCILE-1): this file is excluded from `tsc --noEmit`, so a field
+      // missing from `base` compiles fine and silently exempts itself from the shape it claims to pin
+      // — which is how the literal drifted six fields behind once before. Review caught it drifting
+      // again in the very PR that added the field.
+      partialItems: 0,
+      partialDetail: { sample: [], elided: 0, namesElided: 0 },
       fanoutThrottled: 0,
       restrictionMovesPending: 0,
     });


### PR DESCRIPTION
## What this is (RECONCILE-1, increment 1 — **measurement only**)

`lib/graph/reconcile.ts` marks an item landed **if ANY of its chunks is present**. A worker that dies
mid-item therefore leaves the tail chunks absent *forever*: the ledger already recorded every chunk sha
at push, so the delta path skips them too, and reconcile reports the item healthy.

**Observed live, not inferred:** in the PIPEFF-2 battery a 502 killed the worker at **chunk #33 of
`docs/ARCHITECTURE.md`**; reconcile requeued **0** for that item while correctly requeuing 7
fully-missing ones. The self-heal ran, reported success, and left the hole.

**This PR does not fix that.** It counts `partialItems` (+ a bounded missing-name sample) into the
reconcile summary and `ingest_runs.meta`, reusing the episode list reconcile already fetches — no extra
reads. Spec: `docs/design/reconcile-partial-chunks.md` (`SPEC_READY`).

### Why measure instead of fix — three ways enforcing today makes the graph WORSE
A cold read on the spec (before any code) found each of these, and none is resolvable with data
obtainable from a laptop:
1. **Expected names are not derivable after an edit.** The delta path pushes by **sha** (set
   membership, position-independent) but names by **index**. Insert a chunk mid-document and the graph
   holds old `#0..#2` plus a new `#1` while the ledger holds 4 shas — expected `#3` **never existed**.
   A strict check re-queues a *healthy* item on an ordinary edit to a growing doc, turning
   GRAPHCOST-1's delta savings back into full extractions.
2. **It re-opens the amplifier `LANDED_GRACE_MS` exists to close.** Episodes appear only as Graphiti's
   queue drains, so "all N visible" is a far harder bar than "any one visible": a big item behind a
   backlog reads partial, is re-pushed whole, and deepens the backlog that caused the misread.
3. **Every heal duplicates the landed chunks.** A re-queue re-pushes *all* chunks and `addEpisodes`
   does not overwrite by name → ~N-1 duplicate episodes per heal → group growth toward
   `LANDED_SCAN_DEPTH`, past which self-healing switches off for that group **permanently**.

### Behaviour change — stated, not buried
Verdicts are **byte-identical**: a partial item is still `confirmed`, never re-queued (a dm test exists
solely to prove the measurement didn't smuggle in enforcement — it asserts the `content_sha256`
sentinel is untouched). **One real change:** `partialItems` joins the "record an `ingest_runs` row"
condition in the scheduler and the manual admin action. Since nothing heals a partial in this
increment, that means an `ok:true, created:0` row roughly hourly while any partial persists, where a
quiet tick previously wrote nothing. That is deliberate — the durable time series **is** the
measurement — but it is not "no behaviour change", so it is called out here.

### Deliberately NOT in this PR
Enforcement (increment 2, gated on what this measures, and it must first resolve the name/sha
divergence, a partial-specific grace, and purge-before-repush); no schema change; no projector change;
no back-fill sweep. Also riding along: `docs/design/graph-output-truncation.md` (EXTRUNC-1, `proposed`),
which this spec supersedes and cross-references.

## Verification
| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors (8 pre-existing warnings) |
| `npm test` (unit) | **2815 passed**, 11 skipped |
| data-mechanics (real Postgres) | **3 new** + the existing graph-project suite **37 passed**, no regression |
| `npm run check:docs` | in sync |
| `aios spec eval` | `SPEC_READY`, exit 0 |
| Mutation tests | **8 run, all REDDENED** |

Mutations: fully-missing collapses into partial · empty ledger no longer reports `none` · per-item names
unbounded · stop counting partial items · present-name set never populated · **drop the detail from the
durable row** · **drop the count from the durable row** · within-item truncation invisible.

## Review — Reviewed by Fable code-reviewer — verdict BLOCKED (2 HIGH + 1 MEDIUM + 5 LOW), all confirmed and folded
Reviewed by Codex gpt-5.5 — verdict BLOCKED (1 HIGH + 2 MEDIUM + 1 LOW), all confirmed and folded

**Both independently found the same HIGH, and it is the third instance of one pattern this session:**
`boundPartialDetail` was computed, returned from reconcile, and then **dropped before durable storage**
— `GraphProjectionSummary` carried only the count and `meta` wrote only the count. The missing-name
sample is the *only* thing that separates a real tail hole from the index-shift false positive, so the
metric would have arrived un-actionable, and `landed-state.ts`'s own comment claiming it "lands in
`ingest_runs.meta`" was false as shipped. Now threaded through, re-bounded on cross-team merge, and
pinned at the call site.

**Fable additionally found the drift-pin fixture had itself drifted.** `test/graph-projection-run.test.ts`
is excluded from `tsc --noEmit`, so its `base` summary silently lacked `partialItems` and compiled fine
— the exact failure that file exists to prevent, recurring in the very PR that added the field.

Also folded: the manual "Project to graph" action didn't record on partial-only runs (queryable from the
scheduler but not from the button an admin actually clicks); within-item truncation was invisible (40
missing names shown as 5 with `elided: 0` read identically to 5 missing) → added `missingCount` +
`namesElided`; the scheduler log now names why a partial-only tick emitted; and the under-count class
(`none` reachable inside the confirmed branch when a doc shrinks and legacy `#k` names still confirm) is
now named at the site rather than left silent — deliberately uncounted, different class, different repair.

Both reviewers confirmed by reading that **no enforcement is smuggled in**. Both model passes satisfy the
CLAUDE.md pre-push Review gate (adversarial-build steps 2–5); the `--tier full` DeepSeek spec layer was
not run (no key) and the model reviews stood in for it.

AIOS-Work: RECONCILE-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
