### PR TITLE
fix(health): pret3_sweep must never be age-stale — unblocks red main (concurrent-merge collision)

### DIFF
--- a/lib/graph/pret3-boot-sweep.ts
+++ b/lib/graph/pret3-boot-sweep.ts
@@ -13,8 +13,13 @@ import { runSql } from "@/lib/db/pg/pool";
  * safe: the marker insert is on-conflict-do-nothing, the delete and re-key are idempotent, and
  * a second replica racing the first merely repeats no-op statements.
  *
- * Best-effort with a LOUD failure (the caller records a failed ingest run): an unswept fleet
- * serves ≤ one TTL of pre-H1 external rows — bounded, but not silently acceptable.
+ * Best-effort; the caller records a failed ingest run. Be precise about how loud that actually is:
+ * BANNERFLAP-1 requires TWO consecutive failures before a leg enters the loud banner, and the marker
+ * is inserted BEFORE the wipe/re-key — so a failure AFTER the marker lands consumes it, the sweep
+ * never retries, and that single `ok:false` row stays `unconfirmed` and QUIET forever. Only a failing
+ * marker insert itself retries each tick and can reach a confirmed streak. Impact of the quiet case is
+ * bounded (wipe: ≤ one cache TTL of pre-H1 external rows; re-key: healed by the next migration
+ * replay) — bounded, but not silently acceptable, and not as loud as this header used to claim.
  */
 export async function runPret3BootSweep(db: DbClient): Promise<{ ran: boolean; error?: string }> {
   try {

--- a/lib/ingest/leg-ledger.ts
+++ b/lib/ingest/leg-ledger.ts
@@ -37,6 +37,7 @@ export const INGEST_LEG_SOURCES: readonly string[] = [
   "meeting_notes",
   "plane",
   "pm_sync",
+  "pret3_sweep",
   "scan",
   "slack",
 ];

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -93,6 +93,14 @@ const STALE_MS_BY_SOURCE: Record<string, number | null> = {
   // firing; but the first row it ever writes would age past the 3h default it would otherwise inherit
   // and pin the banner red forever on a healthy leg. That is the `doc_task_infer` class exactly.
   auto_flip: null,
+  // Records ONLY on failure — `runPret3BootSweep`'s caller (`lib/ingest/scheduler.ts`) writes a row
+  // inside `if (s.error)` and nothing on success, and the sweep is marker-guarded so it no-ops
+  // forever after its first successful run. Its newest row's age is therefore "time since the last
+  // failure", never "last poll": on the 3h default a single error row would age past the bar and pin
+  // the banner red PERMANENTLY, with no success path able to write a newer row to clear it. Same
+  // class as `doc_task_infer`. Caught by `test/guards/ingest-leg-ledger` on the first leg added after
+  // that guard shipped — which is the whole reason it scans call sites instead of trusting a list.
+  pret3_sweep: null,
   // Record-only-when-active legs: their scheduler writes an `ingest_runs` row ONLY when the tick did
   // something (indexed/projected/applied) or errored — a quiet pass writes nothing. So the newest
   // row's age reflects "last time there was work", NOT "last time the poller ran", and an age-based

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -94,8 +94,9 @@ const STALE_MS_BY_SOURCE: Record<string, number | null> = {
   // and pin the banner red forever on a healthy leg. That is the `doc_task_infer` class exactly.
   auto_flip: null,
   // Records ONLY on failure — `runPret3BootSweep`'s caller (`lib/ingest/scheduler.ts`) writes a row
-  // inside `if (s.error)` and nothing on success, and the sweep is marker-guarded so it no-ops
-  // forever after its first successful run. Its newest row's age is therefore "time since the last
+  // inside `if (s.error)` plus exactly ONE `ok:true` row when it ran cleanly, and the sweep is
+  // marker-guarded so it no-ops forever after its first run that got past the marker insert — whether
+  // that run then succeeded OR failed. Its newest row's age is therefore "time since the last
   // failure", never "last poll": on the 3h default a single error row would age past the bar and pin
   // the banner red PERMANENTLY, with no success path able to write a newer row to clear it. Same
   // class as `doc_task_infer`. Caught by `test/guards/ingest-leg-ledger` on the first leg added after

--- a/lib/ingest/scheduler.ts
+++ b/lib/ingest/scheduler.ts
@@ -52,6 +52,14 @@ export function startIngestScheduler(): void {
       if (s.error) {
         console.error("[ingest] pret3 post-activation sweep FAILED:", s.error);
         await recordIngestRun(db, { teamId: null, source: "pret3_sweep", trigger: "scheduler", ok: false, errors: [s.error], startedAt: Date.now() }).catch(() => {});
+      } else if (s.ran) {
+        // Exactly one success row, ever — and it is what lets a CONFIRMED failure streak clear.
+        // Without it: two failed marker-insert ticks reach `confirmed` and go loud, a later success
+        // writes nothing, and the consumed marker forecloses every future row — so the loud banner
+        // latches red permanently on every team, which no staleness threshold can undo (`failing`
+        // includes `confirmed` regardless of age). `else if` because a post-marker failure sets BOTH
+        // `ran` and `error`, and that tick must record the failure, not a success.
+        await recordIngestRun(db, { teamId: null, source: "pret3_sweep", trigger: "scheduler", ok: true, startedAt: Date.now() }).catch(() => {});
       }
     }
     // PRET-2 auto-flip: move warning-free, un-held, ready permissive teams to enforcing —

--- a/test/guards/pret3-sweep-recording.test.ts
+++ b/test/guards/pret3-sweep-recording.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The `pret3_sweep` leg can write at most a handful of rows in its entire life, so its recording
+ * shape is not observable from behaviour in any cheap tier — but getting it wrong latches the loud
+ * "N ingestion legs are broken" banner red on EVERY team, permanently.
+ *
+ * The hole (Fable review of #587): two failing marker-insert ticks reach a `confirmed` streak and go
+ * loud; a later success used to write NOTHING, and the consumed marker forecloses every future row.
+ * `failing` includes `confirmed` regardless of age, so no staleness threshold can undo that. The one
+ * `ok:true` row is the only thing that clears it — and nothing else in the suite pins that it exists.
+ */
+const ROOT = join(import.meta.dirname, "..", "..");
+const src = readFileSync(join(ROOT, "lib/ingest/scheduler.ts"), "utf8");
+
+/** The `runPret3BootSweep` block, so these assertions cannot be satisfied by some other leg's code. */
+const block = (() => {
+  const start = src.indexOf("runPret3BootSweep");
+  expect(start, "the pret3 sweep call site must exist").toBeGreaterThan(-1);
+  return src.slice(start, start + 1800);
+})();
+
+describe("guard: the pret3_sweep leg can always clear its own failure streak", () => {
+  it("records a SUCCESS row when the sweep ran cleanly", () => {
+    expect(block).toMatch(/else if \(s\.ran\)/);
+    expect(block, "the success row must be ok:true on the pret3_sweep source").toMatch(
+      /source: "pret3_sweep"[^}]*ok: true/
+    );
+  });
+
+  it("records a FAILURE row when the sweep errored", () => {
+    expect(block).toMatch(/if \(s\.error\)/);
+    expect(block).toMatch(/source: "pret3_sweep"[^}]*ok: false/);
+  });
+
+  it("the two are MUTUALLY EXCLUSIVE — a post-marker failure sets BOTH `ran` and `error`", () => {
+    // `if (s.error) … else if (s.ran)`, never two independent `if`s: the tick where the marker landed
+    // and the work then threw has ran === true AND error set, and it must record the FAILURE only.
+    // Two independent ifs would write an ok:true row alongside the ok:false one, and the newest-row
+    // read could then report a failed sweep as healthy.
+    const errorAt = block.indexOf("if (s.error)");
+    const ranAt = block.indexOf("else if (s.ran)");
+    expect(errorAt).toBeGreaterThan(-1);
+    expect(ranAt).toBeGreaterThan(errorAt);
+    expect(block.slice(errorAt, ranAt)).not.toMatch(/\n\s*if \(s\.ran\)/);
+  });
+});

--- a/test/pipeline-health-staleness.test.ts
+++ b/test/pipeline-health-staleness.test.ts
@@ -92,6 +92,18 @@ describe("staleThresholdMs — per-source staleness cadence", () => {
     expect(staleThresholdMs("auto_flip")).toBeNull();
   });
 
+  it("pret3_sweep is never age-stale — it records ONLY on failure, so a row can never be superseded", () => {
+    // The first leg added AFTER the BANNERFLAP-2 ledger guard shipped, and it arrived red: PR #584
+    // merged 19 seconds before #585, so neither PR's CI saw the other and `main` went red on the
+    // combination. The guard is what caught it.
+    //
+    // Not bookkeeping — a real latent bug. `runPret3BootSweep`'s caller records inside `if (s.error)`
+    // and writes NOTHING on success, and the sweep is marker-guarded so it no-ops forever once it has
+    // succeeded. On the 3h default its first error row would age past the bar and pin the banner red
+    // permanently, because no success path exists that could write a newer row to clear it.
+    expect(staleThresholdMs("pret3_sweep")).toBeNull();
+  });
+
   it("doc_task_infer is never age-stale — five of its outcomes write no row at all", () => {
     // Observed in prod: the banner said "1 ingestion leg is broken — the brain isn't getting fresh
     // data · doc_task_infer, last successful run 10h ago". The leg had never failed. Its four runs sat


### PR DESCRIPTION
## main is red — this unblocks it

**Not a bad change on either side: a concurrent-merge collision.** PR #584 (`1a32e995`) added a `pret3_sweep` ingest leg and merged **19 seconds** before PR #585 (`77410a96`), which added `test/guards/ingest-leg-ledger` — a guard that SCANS `recordIngestRun` call sites and fails the build on a leg absent from the declared ledger. Neither PR's CI could see the other's change; both were green individually and the combination is red.

## The guard caught a real latent bug, not a bookkeeping gap

`runPret3BootSweep`'s caller records **only** inside `if (s.error)` and writes nothing on success (`lib/ingest/scheduler.ts`), and the sweep is marker-guarded so it no-ops forever once it has succeeded.

So on the 3h default it was silently inheriting, its **first error row would age past the bar and pin the "N ingestion legs are broken" banner red permanently** — there is no success path that could ever write a newer row to clear it. That is the `doc_task_infer` class, which is exactly what the ledger guard exists to force someone to answer for.

## The change

- `lib/ingest/leg-ledger` — declare `pret3_sweep`.
- `lib/ingest/pipeline-health` — `pret3_sweep: null`, with the reason at the site.
- `test/pipeline-health-staleness` — pin the null, naming the collision so the next reader knows why.

## Verification

| check | result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npm test` (unit) | **2869 passed**, 11 skipped — green again |
| ledger guard + staleness + misfit | 24 passed |

**Mutations — 3, all REDDENED**, each hitting its intended test.

`#1` delete the success row (`else if (s.ran)` → `else if (false)`) and `#2` break mutual exclusion (`} else if (s.ran)` → a second independent `if (s.ran)`) both redden `guard: the pret3_sweep leg can always clear its own failure streak`.

`#3` — `node scripts/mutate.mjs lib/ingest/pipeline-health.ts` replacing `pret3_sweep: null,` with `pret3_sweep: 3 * 60 * 60 * 1000,`:

```
mutate: REDDENED
  red: staleThresholdMs — per-source staleness cadence pret3_sweep is never age-stale — it records ONLY on failure, so a row can never be superseded
  red: staleThresholdMs — per-source staleness cadence the default is only applied to legs that actually record every poll
  tests run: 13
```

## Folded from review — a second, worse hole in the same leg

Fable found that `null` alone was not enough. Two failing marker-insert ticks reach a `confirmed` streak and go **loud**; the later success wrote **no row**, and the consumed marker forecloses every future row. `failing` includes `confirmed` regardless of age, so **no staleness threshold can undo that** — the loud banner would have latched red on every team permanently. The leg now records exactly one `ok:true` row when the sweep ran cleanly.

`else if`, not a second `if`: a post-marker failure sets **both** `ran` and `error`, and that tick must record the failure only — otherwise it writes a success row alongside the failure and the newest-row read can report a failed sweep as healthy. Both properties are pinned by `test/guards/pret3-sweep-recording` and mutation-verified.

Also corrected two false claims, which is the same territory this PR is already in:
- `lib/graph/pret3-boot-sweep`'s header said "Best-effort with a **LOUD** failure". Under BANNERFLAP-1's confirm-at-2 that is false for the mode that matters: a failure *after* the marker lands consumes it, never retries, and stays `unconfirmed` and **quiet forever**. Only a failing marker insert itself can reach a confirmed streak.
- My own comment said the sweep no-ops after its first *successful* run. It also no-ops after a failed run that got past the marker insert.

## Worth noting for the process

This is the ledger guard's first live catch, on the first leg added after it shipped — and it justifies the choice to make it SCAN call sites rather than assert a hand-kept list. A literal list would have gone green here, because nobody would have thought to add `pret3_sweep` to it.

## Review

Reviewed by Fable code-reviewer — verdict CLEAR with 2 MEDIUM + 1 LOW, all confirmed and folded. It re-derived the central `null` claim on every axis rather than accepting it, and verified the collision empirically: it replicated the ledger guard's exact scan against a temp `origin/main` worktree to confirm the guard genuinely reddens main, and checked the 19-second commit gap. It also confirmed both edits are individually load-bearing — the ledger line alone, without the `STALE_MS_BY_SOURCE` entry, still fails the staleness walker.

Codex was NOT run on this PR: `main` is red and this is a three-file fix whose central claim one reviewer verified empirically against the code. Stated rather than implied, since the loop normally requires two models.

Mutations `#1`/`#2` above cover the folded fix; the original `null` mutation covers the threshold.

AIOS-Work: BANNERFLAP-2