### PR TITLE
fix(ui): shrink the sidebar eyebrow, and no AIOS lockup in the sidebar

### DIFF
--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -74,11 +74,15 @@ export default async function TeamLayout({
   return (
     <div className="flex min-h-dvh flex-1 bg-surface-raised">
       <aside className="frosted sticky top-0 flex h-dvh w-60 shrink-0 flex-col border-r border-border-subtle px-4 py-6">
+        {/* No AIOS lockup here on purpose. This is the team's workspace, so the team name is
+            the subject and AIOS is the tool it runs on — the mark lives in the favicon, the way
+            Slack keeps its own logo out of a workspace sidebar. If this sidebar ever gains a
+            collapsed state, collapse to the bare mark in currentColor (DESIGN.md § Brand & Logo). */}
         <div className="mb-8 px-3">
-          <p className="font-display text-[11px] uppercase tracking-[0.18em] text-ink-tertiary">
+          <p className="font-display text-[10px] uppercase tracking-[0.18em] text-ink-tertiary">
             Team Brain
           </p>
-          <h2 className="mt-1 truncate font-display text-lg text-ink" title={team.name}>
+          <h2 className="mt-1.5 truncate font-display text-lg text-ink" title={team.name}>
             {team.name}
           </h2>
         </div>


### PR DESCRIPTION
## Review — Reviewed by Claude Code (Opus 5) — verdict ship: two Tailwind class changes plus a comment, no logic, tsc clean

John reviewed a mockup of an AIOS lockup in this sidebar and rejected it:

> The logo in the top left of the actual team brain feels too big and too close to the team title 'Vibrana'. I honestly don't think we even need it. […] Maybe we just keep the AIOS favicon for the team brain and that's it.

Slack does the same thing — its own logo is nowhere in a workspace sidebar. The team's name is the subject; the platform is the tool it runs on. So: **no lockup here**, and a comment so nobody re-adds it.

## Changes

- Eyebrow `text-[11px]` → `text-[10px]` — sits under the team name rather than competing with it.
- Team name `mt-1` → `mt-1.5` — 4px was tight under an uppercase tracked eyebrow against an 18px serif.
- A comment recording the decision and the collapsed-nav rule (bare mark in `currentColor`) for whenever this sidebar gains a collapsed state. It has none today, so that's documentation, not a feature.

## On the alignment request

John also asked to make sure the team name is fully left-aligned, as it looked indented. **It isn't, and it wasn't.** In this file the header block (`px-3` inside `aside px-4`), the nav section headers (`px-3`), and the nav item icons (`px-3`) all sit on the same 28px column. I verified with a pixel-faithful mock of these exact classes and a ruler at 28px.

The indent came from the **review mockup**, whose nav had no padding — my error in building it, not a bug in this file. So there is no alignment change here, deliberately.

## Verification

- `npx tsc --noEmit` — clean
- Rendered before/after with the real class values at both eyebrow sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Tailwind and comment changes in the team layout with no behavior or data impact.
> 
> **Overview**
> Tweaks the team sidebar header so the **Team Brain** eyebrow reads smaller and the team name sits slightly lower, reducing visual competition with the title.
> 
> Adds an inline comment that the sidebar intentionally omits an AIOS lockup (brand stays in the favicon; future collapsed nav should use the bare mark per `DESIGN.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb76f5f374ebfb6edcf92faa1d2224fb309dedc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->