### PR TITLE
chore(license): relicense the brain MIT → AGPL-3.0-only, with Apache-2.0 pockets (RELIC-1)

### DIFF
--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -1,0 +1,67 @@
+# Commercial licensing
+
+AIOS Team Brain is licensed under the [GNU AGPL v3.0](LICENSE). For most people that is
+the end of it: **running AIOS inside your company is unrestricted and always will be**,
+and the AGPL asks nothing of you for internal use.
+
+Two situations call for something else.
+
+---
+
+## 1. Free commercial license — internal use
+
+**If your organization's legal policy prohibits AGPL software, we will give you a
+commercial license at no charge.**
+
+It covers running AIOS internally — as many users, as many instances, modified however
+you like — as long as you are not offering AIOS or a derivative of it to third parties as
+a service.
+
+There is no fee, no seat count, no expiry, and no sales process. Email us, tell us your
+organization's name, and we will send you the license.
+
+We do this because a blanket AGPL ban is a policy about license text, not about what you
+actually intend to do with the software, and we would rather you evaluate AIOS than be
+stopped by a checklist. **An AGPL ban should never be the reason someone can't try AIOS.**
+
+---
+
+## 2. Paid commercial license — hosting it for others
+
+If you want to **offer AIOS, or something derived from it, to third parties as a hosted
+service** without the AGPL's source-sharing obligations, you need a paid commercial
+license.
+
+This is the case the AGPL exists to catch, and we're direct about it: AIOS is
+self-hostable and our business is hosting it. If you want to run that business too, we
+should talk about terms rather than have you route around the license.
+
+Email us with what you're building and we'll work something out.
+
+---
+
+## Contact
+
+**cn@fluora.ai**
+
+We answer within a couple of business days. If you don't hear back, send it again — it
+means we dropped it, not that the answer is no.
+
+---
+
+## What you do *not* need a commercial license for
+
+To save you the email:
+
+- Running AIOS inside your company, at any scale. **Free under the AGPL.**
+- Modifying it for your own internal use. **Free under the AGPL.**
+- Self-hosting it unmodified, even with external users on it. **Free under the AGPL.**
+- Building software that calls the AIOS API over a network. **Free — the AGPL doesn't
+  reach it.**
+- Using the Apache-2.0 parts (`ingestion/`, `graphiti/`) in your own products. **Free
+  under Apache-2.0.**
+
+You need one only if an AGPL ban blocks you (case 1, free), or if you're offering AIOS
+itself as a service to others (case 2, paid).
+
+More detail in the [licensing FAQ](docs/LICENSING-FAQ.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,17 @@ changes bump the major version.
 - Label status honestly: ✅ done-and-verified / 🟡 partial / 🔴 blocked. Never claim done without
   a green test or the observable outcome.
 
+## Licensing of contributions
+
+Contributions are accepted under **AGPL-3.0-only**, or **Apache-2.0** for the `ingestion/` and
+`graphiti/` directories — see [`LICENSING.md`](LICENSING.md). A Contributor License Agreement will
+be introduced once our company is formed, at which point contributors will be asked to sign one.
+
+One rule worth knowing before you write an import: **Apache-2.0 code must never import from
+AGPL-3.0 code.** Apache → AGPL is fine; the reverse is a license violation. It's pinned by
+[`test/guards/license-import-direction.test.ts`](test/guards/license-import-direction.test.ts),
+which runs in CI as part of `npm test`.
+
 ## Code of conduct
 
 Be kind and direct. This is real work for real teams — assume good faith, prefer the durable fix

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,682 @@
-MIT License
+AIOS Team Brain
+Copyright (C) 2026 Chetan Nandakumar and John Ellison
 
-Copyright (c) 2026 AIOS contributors
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, version 3.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Earlier releases of this software were published under the MIT License, which is
+reproduced in LICENSE-MIT and continues to govern those releases.
+
+The full text of the GNU Affero General Public License version 3 follows.
+
+================================================================================
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,34 @@
+Prior license — MIT
+===================
+
+The current license for AIOS Team Brain is the GNU Affero General Public License
+version 3 (AGPL-3.0-only). See LICENSE.
+
+This file preserves the MIT License, under which earlier releases of this
+software were published. Those releases remain available under these terms —
+the relicense is going-forward only and takes nothing away. The copyright
+notice below is retained here as the MIT License requires.
+
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2026 AIOS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,96 @@
+# Licensing
+
+AIOS Team Brain is open source. The server is under the **GNU Affero General Public
+License v3.0 only** (`AGPL-3.0-only`); the pieces meant to be embedded in other people's
+systems are under the **Apache License 2.0**.
+
+Both are OSI-approved, and both are listed by the FSF as free software licenses.
+
+Copyright (C) 2026 Chetan Nandakumar and John Ellison.
+
+---
+
+## What is under which license
+
+| Path | License | Why |
+| --- | --- | --- |
+| `app/`, `lib/`, `components/`, `scripts/`, `postgres/`, `test/`, and everything else not listed below | `AGPL-3.0-only` | This is the server application. It's the thing we host, and the AGPL is what stops someone else selling hosted AIOS without contributing back. |
+| `ingestion/` | `Apache-2.0` | A separately packaged connector service (`aios-ingest`) with its own `pyproject.toml`. It reaches the brain only over HTTP and is never imported by the brain's TypeScript. It is meant to run inside other people's systems, so it needs a license that lets it. |
+| `graphiti/` | `Apache-2.0` | The `patch-*.py` scripts patch `graphiti_core`, which is Apache-2.0 upstream. Matching that license keeps our patches contributable back; an Apache-2.0 project cannot accept an AGPL contribution. |
+
+Prior releases were published under the MIT License. **They remain MIT** — the change is
+going-forward only and takes nothing away. That text is preserved verbatim in
+[`LICENSE-MIT`](LICENSE-MIT), including the original copyright notice, as the MIT License
+requires.
+
+---
+
+## What this means for you
+
+**Running AIOS inside your company is unrestricted.** The AGPL places no obligation on
+internal use, however many people use it, however much you modify it. You do not owe
+anyone anything.
+
+**Self-hosting it as-is publishes nothing.** The obligation only arises if you *modify*
+AIOS *and* offer network access to your modified version to third parties — and then it
+covers your modified AIOS, not your infrastructure, your Terraform, or your other
+services.
+
+**Your other software can talk to the AIOS API freely.** The AGPL reaches code combined
+into the same program. Separate services communicating over a network ordinarily are
+not that, and an HTTP API caller is the clearest case of it.
+
+**If your company's policy bans AGPL**, there is a free-of-charge commercial license for
+internal use. See [`COMMERCIAL-LICENSE.md`](COMMERCIAL-LICENSE.md). An AGPL ban should
+never be the reason someone can't try AIOS.
+
+Longer answers: [`docs/LICENSING-FAQ.md`](docs/LICENSING-FAQ.md).
+
+---
+
+## The dependency-direction rule
+
+Two licenses in one org means one rule, and it only runs one way:
+
+> **An Apache-2.0 package must never import from an AGPL-3.0 package.**
+> Apache → AGPL is fine. AGPL → Apache is a license violation.
+
+The reason is that the AGPL is contagious across a combined program and Apache-2.0 is
+not. An AGPL module pulled into an Apache-2.0 package makes that package's Apache grant
+undeliverable — we would be promising permissions on code we cannot grant them for. The
+reverse is harmless: AGPL code may absorb Apache-2.0 code, and the result is AGPL.
+
+In practice, for this repository:
+
+- `ingestion/` and `graphiti/` **must not** import from `lib/`, `app/`, `components/`, or
+  `scripts/`. Neither does today: `ingestion/` is a separate Python package that speaks
+  HTTP, and `graphiti/` is a Dockerfile plus patch scripts against a third-party library.
+- The AGPL side may freely use either.
+
+This is enforced by a build-failing guard rather than by memory, because the failure mode
+is someone adding one convenient import eighteen months from now and nobody noticing:
+[`test/guards/license-import-direction.test.ts`](test/guards/license-import-direction.test.ts),
+which runs in CI as part of `npm test`. It also pins the licensing metadata itself, so the
+rule cannot go quietly vacuous by a directory ceasing to be Apache-licensed.
+
+The same rule holds across repositories in the `aiosbrain` organization. An Apache-2.0
+repo may not depend on an AGPL-3.0 one.
+
+---
+
+## Third-party components
+
+[`NOTICE`](NOTICE) records the third-party components carrying an attribution obligation,
+plus plain-language answers on the two that show up in compliance scans:
+`@img/sharp-libvips` (LGPL) and `@sentry/cli` (FSL-1.1, source-available and not
+OSI-approved). Neither conflicts with the AGPL, and `NOTICE` says exactly why.
+
+FalkorDB (SSPL) is **not** a dependency and is not installed by anything here. It appears
+only in design documents, as an option that was evaluated and declined.
+
+---
+
+## Contributing
+
+Contributions are accepted under `AGPL-3.0-only`, or `Apache-2.0` for `ingestion/` and
+`graphiti/`. See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,105 @@
+AIOS Team Brain
+Copyright (C) 2026 Chetan Nandakumar and John Ellison
+
+This product is licensed under the GNU Affero General Public License v3.0 only
+(AGPL-3.0-only), except for the directories listed in LICENSING.md, which are
+licensed under the Apache License 2.0.
+
+This file records third-party components that carry an attribution or notice
+obligation, or whose license is worth stating plainly for anyone running a
+compliance review. It is not a complete dependency list — see package.json,
+package-lock.json, and ingestion/THIRD_PARTY_LICENSES.md for that.
+
+
+--------------------------------------------------------------------------------
+Services AIOS runs alongside (not redistributed)
+--------------------------------------------------------------------------------
+
+Graphiti — Apache License 2.0
+    https://github.com/getzep/graphiti
+    A temporal knowledge-graph engine. AIOS calls it over its REST API and never
+    imports it. The graphiti/ directory in this repository contains a Dockerfile
+    and patch scripts that build on the upstream image; those files are licensed
+    Apache-2.0 to match upstream. We do not redistribute the upstream image.
+
+Neo4j Community Edition — GNU General Public License v3.0
+    https://github.com/neo4j/neo4j
+    The graph database Graphiti stores into. Our Compose files reference the
+    upstream `neo4j:5.26.2` image by tag; Docker pulls it from Docker Hub at run
+    time. We do not bundle, modify, or redistribute Neo4j, and AIOS communicates
+    with it over the network (Bolt) as a separate program.
+
+PostgreSQL — PostgreSQL License
+    https://www.postgresql.org/
+    Referenced by upstream image tag in the same way. Not bundled.
+
+
+--------------------------------------------------------------------------------
+Bundled dependencies with notice obligations
+--------------------------------------------------------------------------------
+
+@img/sharp-libvips — GNU LGPL v3.0-or-later
+    https://github.com/libvips/libvips
+    The prebuilt binary packaging of libvips, reached transitively through `sharp`,
+    the image-processing library. The npm packages declare LGPL-3.0-or-later; libvips
+    itself is upstream licensed LGPL-2.1-or-later.
+
+    libvips remains licensed under the LGPL; nothing about it is relicensed by
+    its use here. The obligations the LGPL places on us are attribution — this
+    notice — and the ability for a recipient to run AIOS against a modified
+    version of the library. Both are satisfied structurally rather than by any
+    special step: libvips is installed unmodified as a separate npm package and
+    is loaded dynamically at run time, so a recipient can replace it by
+    substituting the installed package. It is not modified and not statically
+    linked into AIOS.
+
+@sentry/cli — Functional Source License 1.1 (FSL-1.1-MIT)
+    https://github.com/getsentry/sentry-cli
+    Reached transitively: @sentry/nextjs -> @sentry/bundler-plugin-core ->
+    @sentry/cli. Every hop is an ordinary non-optional runtime dependency of the
+    package above it, so this installs under `npm ci --omit=dev` and is present
+    in the container image.
+
+    FSL-1.1-MIT is a source-available license, not an OSI-approved one. It
+    permits use, modification, and redistribution, and restricts only competing
+    commercial offerings of the software itself — a restriction AIOS does not
+    engage, because AIOS is not a Sentry competitor and does not offer
+    sentry-cli as a service. It carries no copyleft obligation and does not
+    affect the licensing of AIOS.
+
+    It is recorded here because automated license scanners flag any non-OSI
+    license, and this is the answer to that finding. Under FSL-1.1-MIT's own
+    terms each release converts to the MIT License two years after its
+    publication date.
+
+    We cannot relocate it to devDependencies: it is not a dependency we declare.
+    Removing it would mean removing the Sentry SDK, which is application code
+    and out of scope for a licensing change.
+
+caniuse-lite — Creative Commons Attribution 4.0 International
+    Browser-support data. Attribution given here.
+
+
+--------------------------------------------------------------------------------
+Build and development tooling (not present in the production image)
+--------------------------------------------------------------------------------
+
+These are devDependencies. They are absent from an `npm ci --omit=dev` install and
+from the container image, so they are not redistributed. Recorded because license
+scanners run against the full dependency tree and will surface them.
+
+lightningcss — Mozilla Public License 2.0
+axe-core — Mozilla Public License 2.0
+    MPL-2.0 is file-level copyleft: it attaches to the MPL-licensed files
+    themselves, which we do not modify. It places no obligation on AIOS's own
+    source and is compatible with the AGPL in any case.
+
+
+--------------------------------------------------------------------------------
+Not a dependency
+--------------------------------------------------------------------------------
+
+FalkorDB (SSPL v1) is NOT a dependency of AIOS, is not installed by any script,
+and appears in no Compose file. It is referenced only in design documents, as a
+graph backend that was evaluated and declined. If you adopt it yourself, its
+SSPL terms are between you and FalkorDB.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AIOS Team Brain
 
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
+[![Connectors: Apache 2.0](https://img.shields.io/badge/Connectors-Apache_2.0-blue.svg)](LICENSING.md)
+
 **The collective organ of [AIOS](https://aiosbrain.dev) — the operating system for teams of humans and agents.**
 
 Team Brain is **a shared context layer for humans and agents**: one queryable store of what your team
@@ -25,8 +28,10 @@ every surface, and every agent.
   <img alt="Users working in Claude Code, Conductor and Cursor, plus integrations with Slack, Notion, Linear, GitHub and Google, all feeding one Team Brain (knowledge, memory, reasoning, policy, insights) with a Context Engine beneath it; the brain in turn drives surfaces — a kanban board, a KPI dashboard and a query interface — and actions such as spawning agents, executing tasks and improving the harness" src="docs/images/team-brain-schematic-light.png">
 </picture>
 
-**MIT licensed. Self-hosted. Private by default.** Postgres is the only required backend. Nothing
-leaves your instance unless you push it, and it runs fully on-machine at $0 if you want it to.
+**Open source. Self-hosted. Private by default.** Postgres and the graph engine (Neo4j + Graphiti)
+are the required backends. Nothing leaves your instance unless you push it, and it runs fully
+on-machine at $0 if you want it to. The server is [AGPL-3.0](LICENSE); the connector and
+graph-deployment directories are Apache-2.0. **Internal use is unrestricted** — see [LICENSING.md](LICENSING.md).
 
 ---
 
@@ -118,12 +123,12 @@ concluding the product is broken:
 |---|---|
 | **4 · One LLM key — any provider** | The brain is model-agnostic: **Anthropic**, **OpenAI**, **OpenRouter** (one key, hundreds of models from every major lab), or any **OpenAI-compatible endpoint** — including a model on your own hardware for **$0**. Switchable per team from Admin → Integrations with no redeploy, and **answering / reasoning / embeddings are chosen independently**, so a cheap model can do the routine work while a stronger one handles synthesis. Without a key the dashboard works, but the query box can't answer. See [docs/PROVIDERS.md](docs/PROVIDERS.md) |
 | **5 · Embeddings + pgvector** | `npm run pg:schema:vector` once, then an embeddings model (Admin → Integrations, or `EMBEDDINGS_*` env). **Skipping this is quiet:** retrieval silently degrades to keyword-only FTS, so a question whose answer never uses the question's words stops being findable |
+| **6 · Neo4j + Graphiti** | the **context engine**, and a required part of the architecture. Two more services and a **second** LLM key (Graphiti runs its own entity extraction). Powers the **narrative arcs on Pulse**, the learning panel, and graph-grounded answers. The app starts without it and timeline, search, tasks and meetings keep working — but **Pulse opens without its headline** and answers lose their temporal grounding, so treat a graph-less instance as incomplete rather than as a supported configuration. §2.8 |
 
-**Optional — but each one turns something off**
+**Optional**
 
 | | |
 |---|---|
-| **6 · Neo4j + Graphiti** | the **context engine**. Two more services and a **second** LLM key (Graphiti runs its own entity extraction). Powers the **narrative arcs on Pulse**, the learning panel, and graph-grounded answers. Leave it out and timeline, search, tasks and meetings are unaffected — but **Pulse opens without its headline**. §2.8 |
 | **7 · Python ≥ 3.11 + `uv`** | **only** for the sidecar connectors — Notion / Google Drive / Confluence / RSS / web / local files. Slack, GitHub, Linear and Plane run inside the app and need none of it |
 
 **What it costs:** every connector API is free. You pay for embeddings and LLM calls — plus a second
@@ -151,7 +156,7 @@ drive it yourself.
 | 4 | Load the vector schema (`npm run pg:schema:vector`) | ~1 min | **yours** — needs an embeddings model chosen first |
 | 5 | Create the first team + admin | ~1 min | bootstrap during first start |
 | 6 | Connect one source | ~4 min | **yours** — the Admin UI is the only legal writer for tokens |
-| + | Add Neo4j + Graphiti | later, or never | **yours**, §2.8 |
+| 7 | Add Neo4j + Graphiti | ~10 min | **yours**, §2.8 — required for the context engine |
 
 On the Railway path, the wizard opens **https://aiosbrain.dev/deploy/team-brain/**. The template
 deploys directly from the official repository, so a GitHub fork and `--resume` run are not required.
@@ -201,7 +206,7 @@ There is no `.nvmrc` or `.node-version` in the repo.
 |---|---|---|
 | **A host for the app** | **Required** | Railway is what we run and the best-supported path. Render, Fly, a VPS with Docker, or Kubernetes all work — it's a plain Next.js app with no platform-specific APIs. |
 | **Postgres 16 or newer** | **Required** | Managed (Railway, Neon, RDS…) or your own. Plain SQL schema, no vendor lock-in. 16 is what CI and `compose.yml` run; the Railway template provisions Railway's own current Postgres image, which is newer. No version is enforced at runtime. |
-| **Neo4j 5.26.2** + **Graphiti** | Optional | Powers narrative arcs, the "what the brain is learning" panel, and graph-grounded answers. Everything else works without it. Self-hosted via `graphiti/docker-compose.yml`. **Neo4j Aura is untested** — no code path references `neo4j+s://`, so treat cloud Aura as unverified. |
+| **Neo4j 5.26.2** + **Graphiti** | **Required** | The context engine. Powers narrative arcs, the "what the brain is learning" panel, and graph-grounded answers. The app degrades gracefully rather than crashing if it's absent — everything else keeps working — but a graph-less instance is an incomplete one, not a supported configuration. Self-hosted via `graphiti/docker-compose.yml`. **Neo4j Aura is untested** — no code path references `neo4j+s://`, so treat cloud Aura as unverified. |
 | **Email (Resend or SMTP)** | Recommended | Magic links and invites. Without it the mail is **dropped in every environment** — logged server-side as `[mailer] no provider` (production) or `[mailer] (dev, no provider) would send …` (development), and nowhere else. The link itself is **never** printed: it carries a one-time token, so `mailer.ts` deliberately logs only the subject and recipient. To sign in locally without email, use `/auth/dev-login` (dev only) or the password from `npm run admin -- create-member`. |
 
 There is no Supabase dependency. It was removed — if you see Supabase env vars anywhere in your
@@ -513,10 +518,14 @@ the route 404s when `NODE_ENV=production`.
 asserts that ≥ 8 tasks and ≥ 20 decisions materialised, so it doubles as a regression test of the
 write path.
 
-### 2.8 — Graph memory: Neo4j + Graphiti (optional)
+### 2.8 — Graph memory: Neo4j + Graphiti (required)
 
-This is the most involved part of the setup and the easiest to get subtly wrong. Skip it entirely if
-you don't need narrative arcs or the learning panel — the app is fully functional without it.
+This is the most involved part of the setup and the easiest to get subtly wrong, but it is part of
+the architecture rather than an add-on. The app **boots and degrades gracefully** without it —
+timeline, search, tasks and meetings are unaffected — so nothing crashes if you defer it. What you
+lose is the narrative arcs on Pulse, the learning panel, and the temporal grounding under
+graph-backed answers. Treat a graph-less instance as incomplete rather than as a supported
+configuration.
 
 **Topology.** Three processes. The Next.js app talks to Graphiti over REST (writing episodes,
 searching facts) *and* to Neo4j directly over bolt, read-only, for the learning panel — the Graphiti
@@ -974,4 +983,22 @@ narrow single-writer module and the contract-level 422.
 
 ---
 
-MIT licensed. See [`LICENSE`](LICENSE).
+## License
+
+AIOS Team Brain is open source.
+
+- **The server is [AGPL-3.0-only](LICENSE).** Running it inside your company is
+  **unrestricted** — the AGPL creates no obligation for internal use, at any scale, however
+  much you modify it. The obligation appears only if you modify AIOS *and* offer your
+  modified version to third parties as a service.
+- **The connector and graph-deployment directories (`ingestion/`, `graphiti/`) are
+  Apache-2.0**, so they
+  can be embedded in your own software with no strings.
+- **If your organization's policy bans AGPL**, there is a
+  [**free commercial license**](COMMERCIAL-LICENSE.md) for internal use. No charge, no seat
+  count. Email **cn@fluora.ai**.
+- **Earlier releases remain MIT**, preserved in [`LICENSE-MIT`](LICENSE-MIT). The change is
+  going-forward only.
+
+Full breakdown in [`LICENSING.md`](LICENSING.md); the questions people actually ask are
+answered in the [licensing FAQ](docs/LICENSING-FAQ.md).

--- a/docs/LICENSING-FAQ.md
+++ b/docs/LICENSING-FAQ.md
@@ -1,0 +1,132 @@
+# Licensing FAQ
+
+AIOS Team Brain is licensed under the **GNU AGPL v3.0** (`AGPL-3.0-only`). The connector
+and graph-deployment directories are **Apache-2.0**. Both are OSI-approved open source licenses.
+
+This page answers the questions people actually ask. If yours isn't here, email
+**cn@fluora.ai** — we'd rather answer it than have you guess.
+
+---
+
+### Can I use AIOS inside my company for free?
+
+**Yes. Unrestricted.**
+
+The AGPL creates no obligation for internal use. Any number of employees, any number of
+instances, modified as much as you like. You don't owe anyone source code, notification,
+or money. This does not change and is not a trial.
+
+---
+
+### Do I have to publish anything if I self-host AIOS?
+
+**No** — not unless you do two things together: *modify* AIOS, *and* offer network access
+to your modified version to third parties.
+
+Running it unmodified publishes nothing. Modifying it for internal use publishes nothing.
+Only "modified **and** offered to outsiders as a service" triggers the obligation.
+
+---
+
+### Does AGPL affect my other software that talks to AIOS over its API?
+
+**No.**
+
+The AGPL reaches code that is combined into the same program. Separate services
+communicating over a network are ordinarily not combined into the same program, and an
+HTTP API caller is the clearest case of it. Your application can
+call the AIOS API, store its results, and build on them, and its license is entirely your
+own business.
+
+This is the question that generates the most unnecessary fear about the AGPL, so to be
+concrete: if you run AIOS and your internal tools query it over HTTP, nothing about the
+AGPL touches those tools.
+
+---
+
+### What exactly do I owe if I do modify it and host it for others?
+
+**The source of your modified AIOS, offered to the users of that service.** That's it.
+
+Not your infrastructure. Not your Terraform, Kubernetes manifests, or deployment scripts.
+Not your other services, even ones that talk to AIOS. Not your data, your prompts, or
+your configuration. The obligation is scoped to the AIOS source you changed, offered to
+the people using your hosted version of it.
+
+---
+
+### My company bans AGPL. What now?
+
+**Email cn@fluora.ai and we'll give you a free commercial license for internal use.**
+
+No charge, no seat count, no expiry, no sales call. See
+[`COMMERCIAL-LICENSE.md`](../COMMERCIAL-LICENSE.md).
+
+A blanket AGPL ban is usually a policy about license text rather than about what you
+intend to do with the software. We'd rather remove the blocker than lose the conversation
+over it.
+
+---
+
+### What about the older MIT versions?
+
+**They remain MIT. Permanently.**
+
+The relicense is going-forward only. Every release published under MIT stays available
+under MIT — we haven't retracted anything, and we can't. The MIT text is preserved in
+[`LICENSE-MIT`](../LICENSE-MIT), including the original copyright notice.
+
+---
+
+### Why did you change?
+
+**Straight answer: AIOS is self-hostable and our business is hosting it.**
+
+The AGPL keeps someone else from taking AIOS, running it as a paid hosted service, and
+contributing nothing back. MIT allowed that; the AGPL doesn't.
+
+That's the whole reason. It isn't about restricting users — internal use was free under
+MIT and is free under the AGPL, and we've added a free commercial license so that even an
+AGPL policy ban doesn't block you. It's about the one specific case of a competitor
+selling hosted AIOS.
+
+We picked the AGPL over a source-available license (BUSL, SSPL, Elastic) deliberately.
+Those aren't open source. The AGPL is OSI-approved and is listed by the FSF as a free software
+license, and we wanted to
+keep being able to say "open source" and have it be true.
+
+---
+
+### Which parts are Apache-2.0, and why?
+
+`ingestion/` (the connector sidecar) and `graphiti/` (deployment and patches for the
+graph engine).
+
+Both are meant to end up inside someone else's system, and copyleft would defeat that.
+`graphiti/` has a second reason: its patches modify `graphiti_core`, which is Apache-2.0
+upstream, and matching the license is what lets us contribute them back.
+
+The design system and SDK packages in our other repositories are Apache-2.0 for the same
+reason — we want them embedded everywhere, with no strings.
+
+---
+
+### Can I fork it?
+
+Yes. It's open source. Fork it, modify it, run it, redistribute it — under the AGPL's
+terms, which mainly means keeping it open and passing along the same freedoms.
+
+---
+
+### Is there a CLA?
+
+Not currently. There's no legal entity yet to be the counterparty. One will be introduced
+once our company is formed, and contributors will be asked to sign at that point. See
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+---
+
+### Who holds the copyright?
+
+Chetan Nandakumar and John Ellison, as individuals. It will be assigned to a company once
+one exists.

--- a/docs/announcements/license-change.md
+++ b/docs/announcements/license-change.md
@@ -1,0 +1,84 @@
+# AIOS is now AGPL-3.0
+
+**This is going-forward only. Every version released before this one remains MIT, forever.
+Nothing is being taken away.** If you're running an MIT release today, you can keep running
+it under MIT for as long as you like. We couldn't retract that even if we wanted to, and we
+don't.
+
+From here on, the AIOS server is licensed under the **GNU AGPL v3.0**.
+
+## Why
+
+AIOS is self-hostable and our business is hosting it. Under MIT, someone could take AIOS,
+run it as a paid hosted service, and contribute nothing back. The AGPL stops that. That's
+the whole reason — there isn't a second one.
+
+We're saying it plainly because the alternative is a paragraph about "sustainability" and
+"community stewardship" that means the same thing while pretending not to.
+
+## What doesn't change
+
+**Running AIOS inside your company is unrestricted.** It was free under MIT and it's free
+under the AGPL. Any number of users, any number of instances, modified however you like.
+The AGPL creates no obligation for internal use — none.
+
+**Your software can still call the AIOS API.** The AGPL reaches code combined into the same
+program, not separate services talking over a network. If your internal tools query AIOS
+over HTTP, nothing here touches them.
+
+**Self-hosting unmodified publishes nothing.** The obligation only appears if you modify
+AIOS *and* offer your modified version to third parties as a service. Then you owe the
+source of your modified AIOS to that service's users — not your infrastructure, not your
+Terraform, not your other services.
+
+## If your company bans AGPL
+
+**Email cn@fluora.ai and we'll give you a free commercial license for internal use.** No
+charge, no seat count, no expiry, no sales call.
+
+A blanket AGPL ban is usually a policy about license text rather than about what you
+actually plan to do. An AGPL ban should never be the reason someone can't try AIOS, so
+we've made sure it isn't one.
+
+## The SDKs stay Apache-2.0
+
+Deliberately. The connector sidecar, the Graphiti patches, the design system and SDK
+packages are all Apache-2.0 and will stay that way. Those are meant to be embedded in your
+software, and copyleft would defeat the point. We want them everywhere, with no strings.
+
+## On calling this open source
+
+The AGPL is OSI-approved and is listed by the FSF as a free software license. It is
+open source, and we chose it over
+BUSL, SSPL, and the Elastic License specifically because those aren't. We wanted to keep
+saying "open source" and have it be true.
+
+## Ask us hard questions
+
+If you think we've got this wrong, or you're stuck on something the license makes awkward,
+say so — open an issue or email **cn@fluora.ai**. We'll answer, publicly where it's useful
+to others.
+
+Full detail: [LICENSING.md](../../LICENSING.md) ·
+[licensing FAQ](../LICENSING-FAQ.md) ·
+[commercial licensing](../../COMMERCIAL-LICENSE.md)
+
+---
+
+<!-- Short versions for other channels. Not part of the post. -->
+
+## Short versions
+
+**For X (two sentences):**
+
+> AIOS is now AGPL-3.0. Every prior release stays MIT forever, running it inside your
+> company is still completely unrestricted, and if your policy bans AGPL we'll give you a
+> free commercial license — just email us.
+
+**For GitHub release notes (three sentences):**
+
+> AIOS is now licensed under the GNU AGPL v3.0. This is going-forward only — every version
+> released before this one remains available under MIT, and internal use of AIOS remains
+> completely unrestricted, with no obligations of any kind. If your organization's policy
+> prohibits AGPL, email cn@fluora.ai for a free commercial license for internal use; the
+> SDK and connector packages stay Apache-2.0.

--- a/graphiti/LICENSE
+++ b/graphiti/LICENSE
@@ -1,0 +1,228 @@
+AIOS Team Brain — Graphiti deployment and patches
+Copyright (C) 2026 Chetan Nandakumar and John Ellison
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this component except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+This component is licensed permissively because its patch-*.py files patch
+graphiti_core, which is itself Apache-2.0. Matching the upstream license keeps
+these patches contributable back to that project; under AGPL they could not be.
+
+NOTE: this directory is licensed Apache-2.0 and is a deliberate exception to the
+repository's default license. The rest of AIOS Team Brain is AGPL-3.0-only; see
+../LICENSE and ../LICENSING.md.
+
+The full text of the Apache License, Version 2.0 follows.
+
+================================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/graphiti/NOTICE
+++ b/graphiti/NOTICE
@@ -1,0 +1,40 @@
+AIOS Team Brain — Graphiti deployment and patches
+Copyright (C) 2026 Chetan Nandakumar and John Ellison
+
+This component is licensed under the Apache License, Version 2.0. See LICENSE
+in this directory.
+
+This is a deliberate exception to the repository default. The rest of AIOS Team
+Brain is AGPL-3.0-only. This directory is permissively licensed because its
+patch scripts patch graphiti_core, which is itself Apache-2.0 — matching the
+upstream license is what keeps these patches contributable back to that
+project. Under the AGPL they could not be sent upstream at all.
+
+Because this directory is Apache-2.0 and the rest of the repository is AGPL,
+the import direction is one-way: nothing in this directory may import from the
+AGPL portions of the repository. See ../LICENSING.md.
+
+
+Third-party components
+----------------------
+
+Graphiti — Apache License 2.0
+    https://github.com/getzep/graphiti
+    Copyright Zep Software, Inc.
+
+    The Dockerfile in this directory builds FROM a digest-pinned upstream
+    `zepai/graphiti` image and installs a pinned `graphiti-core` into it. The
+    patch-*.py scripts modify graphiti_core's behaviour at build time. Those
+    modifications are covered by Section 4 of the Apache License; this notice
+    records that files from Graphiti have been changed.
+
+    The resulting image is built locally by whoever deploys it. We do not
+    redistribute a modified Graphiti image.
+
+Neo4j Community Edition — GNU General Public License v3.0
+    https://github.com/neo4j/neo4j
+
+    docker-compose.yml references the upstream `neo4j:5.26.2` image by tag;
+    Docker pulls it from Docker Hub at run time. Neo4j is not bundled, not
+    modified, and not redistributed here. Graphiti and AIOS both communicate
+    with it over the network (Bolt) as separate programs.

--- a/ingestion/LICENSE
+++ b/ingestion/LICENSE
@@ -1,0 +1,229 @@
+AIOS Team Brain — ingestion sidecar (aios-ingest)
+Copyright (C) 2026 Chetan Nandakumar and John Ellison
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this component except in compliance with the License. You may obtain a copy of
+the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+This component is licensed permissively because it is a separately packaged
+connector service. It has its own pyproject.toml, talks to the brain only over
+HTTP, and is never imported by the brain's TypeScript code — so it is intended
+to be embedded in and deployed alongside other people's systems.
+
+NOTE: this directory is licensed Apache-2.0 and is a deliberate exception to the
+repository's default license. The rest of AIOS Team Brain is AGPL-3.0-only; see
+../LICENSE and ../LICENSING.md.
+
+The full text of the Apache License, Version 2.0 follows.
+
+================================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ingestion/NOTICE
+++ b/ingestion/NOTICE
@@ -1,0 +1,32 @@
+AIOS Team Brain — ingestion sidecar (aios-ingest)
+Copyright (C) 2026 Chetan Nandakumar and John Ellison
+
+This component is licensed under the Apache License, Version 2.0. See LICENSE
+in this directory.
+
+This is a deliberate exception to the repository default. The rest of AIOS Team
+Brain is AGPL-3.0-only. The sidecar is permissively licensed because it is a
+separately packaged connector service: it has its own pyproject.toml, reaches
+the brain only over HTTP, and is never imported by the brain's TypeScript code.
+It is meant to be embedded in and deployed alongside other people's systems.
+
+Because this directory is Apache-2.0 and the rest of the repository is AGPL,
+the import direction is one-way: nothing in this directory may import from the
+AGPL portions of the repository. See ../LICENSING.md.
+
+
+Third-party components
+----------------------
+
+The reader and parser libraries this sidecar can import are listed with their
+licenses in THIRD_PARTY_LICENSES.md. All are permissive (MIT / Apache-2.0 /
+BSD). They are declared as optional extras rather than required dependencies,
+so a default install pulls none of them.
+
+Notable Apache-2.0 components, which carry an attribution obligation:
+
+    Unstructured — https://github.com/Unstructured-IO/unstructured
+    Apache License 2.0
+
+LlamaHub readers (llama-index-readers-google, -notion, -confluence) and
+llama-index-core are MIT licensed.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -120,4 +120,13 @@ next step (see `docs/TODO.md`).
   timeline. Tracked in `docs/TODO.md`.
 - Large backfills are throttled under the brain's 120 POST/min/key limit.
 
-See `THIRD_PARTY_LICENSES.md` for imported-dependency licenses. This package is MIT.
+## License
+
+This package is **Apache-2.0** (see `LICENSE` and `NOTICE` in this directory) — a deliberate
+exception to the repository default of AGPL-3.0-only, because the sidecar is meant to run inside
+other people's systems. See [`../LICENSING.md`](../LICENSING.md).
+
+Because this directory is Apache-2.0, it must never import from the AGPL portions of the
+repository. It doesn't today: it's a separate Python package that reaches the brain over HTTP.
+
+See `THIRD_PARTY_LICENSES.md` for imported-dependency licenses.

--- a/ingestion/THIRD_PARTY_LICENSES.md
+++ b/ingestion/THIRD_PARTY_LICENSES.md
@@ -1,7 +1,7 @@
 # Third-party licenses
 
-`aios-ingest` is MIT-licensed. It imports the following open-source components. All are
-permissive (MIT / Apache-2.0 / BSD) and compatible with redistribution under MIT.
+`aios-ingest` is **Apache-2.0** licensed. It imports the following open-source components. All are
+permissive (MIT / Apache-2.0 / BSD) and compatible with redistribution under Apache-2.0.
 
 | Component | Purpose | License |
 |-----------|---------|---------|
@@ -30,4 +30,7 @@ uv run pip-licenses --format=markdown \
   --fail-on 'GPL;AGPL;LGPL;Server Side Public License;Elastic License'
 ```
 
-This keeps the package cleanly MIT-redistributable.
+This keeps the package cleanly Apache-2.0-redistributable. The `--fail-on` list matters more now
+than it did under MIT: this directory is the permissive side of a repository whose default license
+is AGPL-3.0-only, and a copyleft dependency arriving here would make its Apache grant
+undeliverable. See [`../LICENSING.md`](../LICENSING.md) for the dependency-direction rule.

--- a/ingestion/pyproject.toml
+++ b/ingestion/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "AIOS Team Brain ingestion sidecar — imports open-source readers (LlamaHub, Unstructured) and pushes normalized content into the brain over HTTP."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 dependencies = [
   "httpx>=0.27",
   "pydantic>=2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "aios-team-brain",
       "version": "0.10.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@aios-alpha/design": "^0.3.0",
         "@aios-alpha/ui": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aios-team-brain",
   "version": "0.10.0",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/test/guards/license-import-direction.test.ts
+++ b/test/guards/license-import-direction.test.ts
@@ -33,7 +33,14 @@ const APACHE_DIRS = ["ingestion", "graphiti"] as const;
 
 /** Top-level directories that are AGPL-3.0-only. Importing any of these from an
  *  Apache dir is the violation. `test/` is included: it is AGPL too. */
-const AGPL_DIRS = ["lib", "app", "components", "scripts", "postgres", "test"] as const;
+const AGPL_DIRS: ReadonlySet<string> = new Set([
+  "lib",
+  "app",
+  "components",
+  "scripts",
+  "postgres",
+  "test",
+]);
 
 /** Never walk into build output, virtualenvs, or vendored trees. */
 const SKIP_DIRS = new Set([
@@ -64,27 +71,38 @@ function walk(dir: string, out: string[] = []): string[] {
 }
 
 /**
- * Import-ish references to an AGPL directory, in the forms a real violation would take:
- *   Python   `from lib.x import y`, `import lib.x`, `sys.path.append("../lib")`
+ * Import-ish references to a directory, in the forms a real violation would take:
+ *   Python   `from lib.x import y`, `import lib.x`
  *   JS/TS    `from "../lib/x"`, `require("../../app/y")`, `import("../scripts/z")`
- *   shell    sourcing or running a path that escapes into an AGPL dir
- * Anchored on a path escape (`../`) or a bare module import, so that an ordinary word
- * ("this app", "the lib") in a comment cannot trip it.
+ *   TS alias `"@/lib/db"`
+ *   shell    sourcing or running a path that escapes into another directory
+ *
+ * Each pattern captures the referenced directory name in group 1, which is then checked
+ * against AGPL_DIRS. Keeping the alternation in DATA rather than string-building a regex
+ * means these stay literal — which reads better and satisfies the static-analysis rule
+ * against non-literal `RegExp` construction.
+ *
+ * Anchored on a path escape (`../`), a statement-position import, or a bare module
+ * specifier, so an ordinary word ("this app", "the lib") in prose cannot trip it.
  */
+const IMPORT_PATTERNS: readonly RegExp[] = [
+  // Python: `from lib.x import y` / `import lib.x` at statement position
+  /^[ \t]*(?:from|import)[ \t]+([A-Za-z_][A-Za-z0-9_]*)(?:[.\s]|$)/gm,
+  // Any relative path escaping upward: `../lib/`, `../../app/`
+  /(?:\.\.\/)+([A-Za-z0-9_-]+)\//g,
+  // Bare specifier import/require: `from "lib/x"`, `require("app/y")`
+  /(?:from|require\(|import\()\s*["'`]([A-Za-z0-9_-]+)\//g,
+  // The repo's own TS path alias into AGPL code: `"@/lib/db"`
+  /["'`]@\/([A-Za-z0-9_-]+)\//g,
+];
+
 function violations(source: string): string[] {
-  const alt = AGPL_DIRS.join("|");
-  const patterns = [
-    // Python: `from lib...` / `import lib...` at statement position
-    new RegExp(`^\\s*(?:from|import)\\s+(?:${alt})(?:[.\\s]|$)`, "gm"),
-    // Any relative path that escapes upward into an AGPL directory
-    new RegExp(`(?:\\.\\./)+(?:${alt})/`, "g"),
-    // Bare specifier import/require of an AGPL dir (JS/TS)
-    new RegExp(`(?:from|require\\(|import\\()\\s*["'\`](?:${alt})/`, "g"),
-    // The repo's own TS path alias into AGPL code
-    new RegExp(`["'\`]@/(?:${alt})/`, "g"),
-  ];
   const hits: string[] = [];
-  for (const re of patterns) for (const m of source.matchAll(re)) hits.push(m[0].trim());
+  for (const re of IMPORT_PATTERNS) {
+    for (const m of source.matchAll(re)) {
+      if (AGPL_DIRS.has(m[1])) hits.push(m[0].trim());
+    }
+  }
   return hits;
 }
 

--- a/test/guards/license-import-direction.test.ts
+++ b/test/guards/license-import-direction.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Guard: the license dependency-direction rule (RELIC-1).
+ *
+ * This repository carries two licenses. The server is AGPL-3.0-only; `ingestion/` and
+ * `graphiti/` are deliberate Apache-2.0 pockets (see LICENSING.md). That split is only
+ * safe in ONE direction:
+ *
+ *     Apache-2.0 code must NEVER import from AGPL-3.0 code.
+ *     Apache -> AGPL is fine. AGPL -> Apache is a license violation.
+ *
+ * The reason is that the AGPL is contagious across a combined program and Apache-2.0 is
+ * not. An AGPL module pulled into an Apache-2.0 package makes that package's Apache grant
+ * undeliverable — we would be promising permissions we cannot grant.
+ *
+ * The failure mode this exists to catch is not today's code (which is clean) but someone
+ * adding one convenient import eighteen months from now. LICENSING.md and CONTRIBUTING.md
+ * both state the rule is enforced in CI; `npm test` runs in CI, so this file is what makes
+ * that statement true rather than aspirational.
+ *
+ * It also pins the licensing METADATA, because the rule is meaningless if a directory
+ * quietly stops being Apache-licensed: the moment `ingestion/LICENSE` disappears or the
+ * root manifest stops saying AGPL-3.0-only, "Apache must not import AGPL" no longer
+ * describes this repo.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const REPO = join(__dirname, "..", "..");
+
+/** Directories licensed Apache-2.0 — the permissive side that must stay import-clean. */
+const APACHE_DIRS = ["ingestion", "graphiti"] as const;
+
+/** Top-level directories that are AGPL-3.0-only. Importing any of these from an
+ *  Apache dir is the violation. `test/` is included: it is AGPL too. */
+const AGPL_DIRS = ["lib", "app", "components", "scripts", "postgres", "test"] as const;
+
+/** Never walk into build output, virtualenvs, or vendored trees. */
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".venv",
+  "venv",
+  "__pycache__",
+  ".pytest_cache",
+  "dist",
+  "build",
+  ".next",
+  ".git",
+  "egg-info",
+]);
+
+/** Only files that can express an import. Docs and license files are exempt by
+ *  construction — LICENSING.md necessarily *names* the AGPL directories. */
+const CODE_EXT = new Set([".py", ".ts", ".tsx", ".js", ".mjs", ".cjs", ".sh", ".toml"]);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry) || entry.endsWith(".egg-info")) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (CODE_EXT.has(entry.slice(entry.lastIndexOf(".")))) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Import-ish references to an AGPL directory, in the forms a real violation would take:
+ *   Python   `from lib.x import y`, `import lib.x`, `sys.path.append("../lib")`
+ *   JS/TS    `from "../lib/x"`, `require("../../app/y")`, `import("../scripts/z")`
+ *   shell    sourcing or running a path that escapes into an AGPL dir
+ * Anchored on a path escape (`../`) or a bare module import, so that an ordinary word
+ * ("this app", "the lib") in a comment cannot trip it.
+ */
+function violations(source: string): string[] {
+  const alt = AGPL_DIRS.join("|");
+  const patterns = [
+    // Python: `from lib...` / `import lib...` at statement position
+    new RegExp(`^\\s*(?:from|import)\\s+(?:${alt})(?:[.\\s]|$)`, "gm"),
+    // Any relative path that escapes upward into an AGPL directory
+    new RegExp(`(?:\\.\\./)+(?:${alt})/`, "g"),
+    // Bare specifier import/require of an AGPL dir (JS/TS)
+    new RegExp(`(?:from|require\\(|import\\()\\s*["'\`](?:${alt})/`, "g"),
+    // The repo's own TS path alias into AGPL code
+    new RegExp(`["'\`]@/(?:${alt})/`, "g"),
+  ];
+  const hits: string[] = [];
+  for (const re of patterns) for (const m of source.matchAll(re)) hits.push(m[0].trim());
+  return hits;
+}
+
+describe("guard: Apache-2.0 directories must not import from AGPL-3.0 code", () => {
+  it("no file under an Apache-2.0 directory imports from an AGPL-3.0 directory", () => {
+    const found: string[] = [];
+    for (const dir of APACHE_DIRS) {
+      for (const file of walk(join(REPO, dir))) {
+        const hits = violations(readFileSync(file, "utf8"));
+        for (const h of hits) found.push(`${relative(REPO, file)} -> ${h}`);
+      }
+    }
+    expect(
+      found,
+      "An Apache-2.0 directory imports AGPL-3.0 code. This makes that directory's Apache " +
+        "grant undeliverable — we would be promising permissions we cannot grant. Either " +
+        "move the shared code into the Apache directory, or reach it over HTTP as the " +
+        "ingestion sidecar already does. See LICENSING.md.",
+    ).toEqual([]);
+  });
+
+  // The rule above only means something while these directories really are Apache-licensed
+  // and the root really is AGPL. Pin that, so the guard cannot go quietly vacuous.
+  it.each(APACHE_DIRS)("%s/ still carries its own Apache-2.0 LICENSE and NOTICE", (dir) => {
+    const license = readFileSync(join(REPO, dir, "LICENSE"), "utf8");
+    const notice = readFileSync(join(REPO, dir, "NOTICE"), "utf8");
+    expect(license).toContain("Apache License");
+    expect(license).toContain("Version 2.0, January 2004");
+    expect(license).toContain("Chetan Nandakumar and John Ellison");
+    expect(notice).toContain("Chetan Nandakumar and John Ellison");
+  });
+
+  it("the root manifest declares AGPL-3.0-only and the sidecar declares Apache-2.0", () => {
+    const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8"));
+    expect(pkg.license).toBe("AGPL-3.0-only");
+    expect(readFileSync(join(REPO, "ingestion", "pyproject.toml"), "utf8")).toContain(
+      'license = { text = "Apache-2.0" }',
+    );
+  });
+
+  it("the root LICENSE is AGPL-3.0-only and the prior MIT text is preserved", () => {
+    const root = readFileSync(join(REPO, "LICENSE"), "utf8");
+    expect(root).toContain("GNU AFFERO GENERAL PUBLIC LICENSE");
+    expect(root).toContain("Chetan Nandakumar and John Ellison");
+
+    // AGPL-3.0-only, never -or-later. Scope this to OUR grant header — the verbatim
+    // license body that follows contains the FSF's "How to Apply These Terms" appendix,
+    // which legitimately shows the "or (at your option) any later version" template.
+    // Asserting over the whole file would fail on the upstream text itself.
+    const header = root.split("=".repeat(80))[0];
+    // "Free Software Foundation" wraps across a line break in the header, so match the
+    // half that carries the version restriction.
+    expect(header).toContain("Software Foundation, version 3.");
+    expect(header).not.toMatch(/at your option.*later version/s);
+
+    expect(readFileSync(join(REPO, "LICENSE-MIT"), "utf8")).toContain("MIT License");
+  });
+});


### PR DESCRIPTION
Going-forward relicense of AIOS Team Brain from MIT to **AGPL-3.0-only**, with deliberate
Apache-2.0 pockets. Nothing retroactive: the MIT commits stay where they are, no history is
rewritten, and every release published under MIT remains available under MIT. Per operator
ruling, **no relicense date is stated anywhere** — the docs say only that the current license
is AGPL-3.0.

PR 1 of a sequence. **Licensing, metadata and docs only — no application logic is touched.**

## What changes

| | |
|---|---|
| `LICENSE` | GNU AGPL-3.0, verbatim FSF text, under a grant header naming `Chetan Nandakumar and John Ellison` (2026). Says "version 3", never "or later" — AGPL-3.0-**only**, so a future FSF version does not apply on its own. |
| `LICENSE-MIT` | The prior MIT text, verbatim. Retains the original `Copyright (c) 2026 AIOS contributors` line, because the MIT License requires that notice be kept. This is the one intentional exception to replacing that stale name. |
| `ingestion/`, `graphiti/` | Apache-2.0 pockets, each with its own `LICENSE` + `NOTICE`. |
| `NOTICE` | Third-party attribution, plus plain answers for the two components that trip compliance scanners. |
| `LICENSING.md` | The per-directory table and the dependency-direction rule. |
| `COMMERCIAL-LICENSE.md` | Free internal-use license for orgs whose policy bans AGPL; paid license for offering AIOS as a hosted service. Contact cn@fluora.ai. |
| `docs/LICENSING-FAQ.md`, `docs/announcements/license-change.md` | The questions people actually ask, and the announcement (with short X / release-note versions). |
| Manifests | `package.json` → `AGPL-3.0-only`, `ingestion/pyproject.toml` → `Apache-2.0`, `package-lock.json` root entry regenerated to match — it still said MIT, which is the file license scanners read first. |

**Why `ingestion/` and `graphiti/` are Apache.** `ingestion/` is a separately packaged connector
service that reaches the brain only over HTTP. `graphiti/`'s patch scripts patch `graphiti_core`,
which is Apache-2.0 upstream — an Apache project cannot accept an AGPL contribution, so matching
the license is what keeps those patches contributable back.

**`@sentry/cli` (FSL-1.1, non-OSI) cannot be moved to `devDependencies`.** It arrives transitively
under `@sentry/nextjs` → `@sentry/bundler-plugin-core`, every hop a plain runtime dependency, so it
does ship in the image. Documented in `NOTICE` rather than hidden — removing it would mean removing
the Sentry SDK, which is application logic and out of scope here.

## The guard

`test/guards/license-import-direction.test.ts` fails the build if an Apache-2.0 directory imports
AGPL-3.0 code, and pins the licensing metadata so the rule cannot go vacuous by a directory quietly
ceasing to be Apache-licensed. Runs in CI via `npm test`; `LICENSING.md` and `CONTRIBUTING.md` link
it by path, so "this is enforced" is checkable rather than asserted.

**Six mutations, each reddening its intended assertion and no other:** a Python `from lib.query` in
`ingestion/`; a `../../lib/graph/` path escape in `graphiti/`; an `@/lib/db` alias import; deleting
`ingestion/LICENSE`; reverting `package.json` to MIT; and weakening the AGPL header to "or (at your
option) any later version".

## Also in here

The README carried a **three-way contradiction** about the graph backend: line 28 said Postgres was
the only required backend, §1's table listed Neo4j+Graphiti as a numbered requirement, §2.8 said it
was optional and the app "fully functional without it", and the Railway template provisions all four
services. Resolved toward **required**, consistently, with the honest qualifier that the app still
boots and degrades gracefully — a graph-less instance is incomplete, not a supported configuration.

## Verification

- AGPL body byte-identical to `gnu.org/licenses/agpl-3.0.txt`; both Apache bodies byte-identical to
  `apache.org/licenses/LICENSE-2.0.txt`; MIT body byte-identical to the previous `LICENSE` at HEAD.
- `npm test` — **314 files / 2872 tests pass.**
- `npm run check:docs` — congruent.
- Every relative markdown link in the new and changed files resolves on disk.

**Two pre-existing failures, both reproduced on a clean stashed tree, neither caused here and
neither fixed here:**
- `test/guards/ingest-leg-ledger.test.ts` — `pret3_sweep` undeclared, from the PRET-3 merge.
- `npm run lint` — `node_modules` is symlinked to another checkout in this worktree, so
  `eslint-plugin-import` resolves inconsistently. CI installs fresh.

## Review — Reviewed by Fable code-reviewer — verdict BLOCKED on 2 self-consistency defects, both fixed here, plus 4 findings folded; legal-text integrity verified clean

Fable returned **BLOCKED** on two defects I could not see in my own work:
1. A leftover README paragraph under the §2.8 heading I had just marked "(required)" still read
   *"Skip it entirely… the app is fully functional without it."*
2. `LICENSING.md` and `CONTRIBUTING.md` claimed a CI check that **did not exist**. Fixed by shipping
   the guard rather than downgrading the claim.

Four more folded: the `package-lock.json` MIT field; a phantom `@parcel/*` entry and two dev-only
packages mislabelled as bundled in `NOTICE`; "FSF-approved" (the FSF classifies licenses as free,
it does not approve them); and an absolute "separate services are not a combined program" softened
to "ordinarily are not".

Fable independently confirmed: no AGPL §13 overclaim, no date leak, all links resolving, and the
LGPL and FSL analyses correct.

AIOS-Work: RELIC-1
