### PR TITLE
fix(license): make LICENSE detectable by GitHub, and guard the shape (RELIC-1)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,4 @@
-AIOS Team Brain
 Copyright (C) 2026 Chetan Nandakumar and John Ellison
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU Affero General Public License as published by the Free
-Software Foundation, version 3.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License along
-with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-Earlier releases of this software were published under the MIT License, which is
-reproduced in LICENSE-MIT and continues to govern those releases.
-
-The full text of the GNU Affero General Public License version 3 follows.
-
-================================================================================
 
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007

--- a/NOTICE
+++ b/NOTICE
@@ -5,6 +5,15 @@ This product is licensed under the GNU Affero General Public License v3.0 only
 (AGPL-3.0-only), except for the directories listed in LICENSING.md, which are
 licensed under the Apache License 2.0.
 
+The grant is version 3 ONLY, not "version 3 or (at your option) any later version":
+a future FSF revision does not apply to this software on its own. The LICENSE file is
+the verbatim FSF text with a copyright line and nothing else, so that automated license
+detection recognises it; this NOTICE, LICENSING.md and package.json are where the
+version choice is recorded.
+
+Earlier releases were published under the MIT License, reproduced in LICENSE-MIT, and
+those releases remain available under those terms.
+
 This file records third-party components that carry an attribution or notice
 obligation, or whose license is worth stating plainly for anyone running a
 compliance review. It is not a complete dependency list — see package.json,

--- a/test/guards/license-import-direction.test.ts
+++ b/test/guards/license-import-direction.test.ts
@@ -143,21 +143,34 @@ describe("guard: Apache-2.0 directories must not import from AGPL-3.0 code", () 
     );
   });
 
-  it("the root LICENSE is AGPL-3.0-only and the prior MIT text is preserved", () => {
+  it("the root LICENSE stays machine-detectable: a copyright line, then verbatim text", () => {
     const root = readFileSync(join(REPO, "LICENSE"), "utf8");
     expect(root).toContain("GNU AFFERO GENERAL PUBLIC LICENSE");
-    expect(root).toContain("Chetan Nandakumar and John Ellison");
-
-    // AGPL-3.0-only, never -or-later. Scope this to OUR grant header — the verbatim
-    // license body that follows contains the FSF's "How to Apply These Terms" appendix,
-    // which legitimately shows the "or (at your option) any later version" template.
-    // Asserting over the whole file would fail on the upstream text itself.
-    const header = root.split("=".repeat(80))[0];
-    // "Free Software Foundation" wraps across a line break in the header, so match the
-    // half that carries the version restriction.
-    expect(header).toContain("Software Foundation, version 3.");
-    expect(header).not.toMatch(/at your option.*later version/s);
-
     expect(readFileSync(join(REPO, "LICENSE-MIT"), "utf8")).toContain("MIT License");
+
+    // GitHub runs the `licensee` gem, which normalises away a leading COPYRIGHT LINE but
+    // NOT prose. An earlier version of this file opened with a ~20-line grant header and
+    // every relicensed repo dropped to NOASSERTION — the sidebar stopped naming the
+    // license at all, which defeats the point of picking an OSI-approved one. So the
+    // shape is the invariant: copyright line, blank line, then the license verbatim.
+    const lines = root.split("\n");
+    expect(lines[0]).toBe("Copyright (C) 2026 Chetan Nandakumar and John Ellison");
+    expect(lines[1]).toBe("");
+    expect(lines[2]).toContain("GNU AFFERO GENERAL PUBLIC LICENSE");
+  });
+
+  it("the AGPL-3.0-ONLY choice is recorded where it now lives", () => {
+    // The version choice used to be stated in the LICENSE header. Moving that prose out
+    // (above) would have silently dropped the only machine-checkable record of "-only"
+    // versus "-or-later", so pin it in each of its new homes instead.
+    const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8"));
+    expect(pkg.license).toBe("AGPL-3.0-only");
+
+    const notice = readFileSync(join(REPO, "NOTICE"), "utf8");
+    expect(notice).toContain("AGPL-3.0-only");
+    expect(notice).toMatch(/version 3 ONLY/i);
+    expect(notice).toContain("LICENSE-MIT");
+
+    expect(readFileSync(join(REPO, "LICENSING.md"), "utf8")).toContain("AGPL-3.0-only");
   });
 });


### PR DESCRIPTION
The relicense left this repo showing NOASSERTION in GitHub's sidebar instead of
"AGPL-3.0". Detection worked before the change (it read MIT), so this is a regression the
relicense introduced, and it defeats the point: the reason for choosing an OSI-approved
license over a source-available one is that people can see what it is at a glance.

Cause: GitHub runs the `licensee` gem, which normalises a leading COPYRIGHT LINE away
before matching but not prose paragraphs. LICENSE opened with a ~20-line grant header —
copyright, the version-3-only statement, the warranty disclaimer, a pointer to LICENSE-MIT
— and that prose put the file too far from the canonical text to match.

Confirmed empirically rather than argued: the same fix shipped first to aios-devtools as a
canary, and that repo flipped from NOASSERTION to AGPL-3.0 on merge.

LICENSE is now a copyright line, a blank line, and the verbatim license body — what both
the FSF and Apache intend a LICENSE file to be.

Nothing is lost. The version-3-ONLY choice and the prior-MIT pointer move into NOTICE,
which now states both explicitly, and they were already in LICENSING.md, the README and
package.json's `license` field. The FSF's own guidance is that the "only" versus "or
later" choice belongs in the accompanying notice rather than in edits to the license text.

THE GUARD MOVED WITH THE INVARIANT

test/guards/license-import-direction.test.ts previously asserted the "-only" grant by
reading the LICENSE header. Removing that prose would have silently disarmed the only
machine-checkable record of version-3-only versus -or-later, so the guard now pins two
things instead: the detectable SHAPE of LICENSE (copyright line, blank, license text), and
the "-only" choice in each of its new homes (package.json, NOTICE, LICENSING.md).

Both new assertions are mutation-tested. Re-adding a prose header reddens the shape test;
weakening "version 3 ONLY" in NOTICE reddens the version test. Each hits its intended
assertion and no other.

Verified: the AGPL body remains byte-identical to gnu.org/licenses/agpl-3.0.txt.

AIOS-Work: RELIC-1

## Review — Reviewed by code-reviewer subagent (Sonnet) across this relicense series — verdict the regression is empirically established and the fix is verified end-to-end on a canary repo

This is not an argued defect. Detection read MIT on these repos before the relicense and NOASSERTION immediately after, with the LICENSE header as the only change; the fix was then shipped to `aios-devtools` first, which flipped back to AGPL-3.0 on merge. The license body is unchanged and byte-identical to the canonical FSF text, and the guard was moved to cover the invariant that actually changed rather than left pinning a header that no longer exists.

`npm test`: 2943 pass, 0 fail.