### PR TITLE
docs(skill): review the spec with a model before the eval, not after

### DIFF
--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -2,9 +2,9 @@
 name: adversarial-build
 description: >
   The full build loop for a feature slice in this repo: AIOS-CLI ticket
-  (create-or-update) → spec gate (author via `aios spec init` if none exists,
-  then `aios spec eval` must say SPEC_READY) → write code with spec-first
-  tests → Fable adversarial
+  (create-or-update) → write the spec → CODEX REVIEWS THE SPEC (before any
+  code, and before the eval) → spec gate (`aios spec eval` must say
+  SPEC_READY) → write code with spec-first tests → Fable adversarial
   review → fold → Codex adversarial review → fold → push the PR → update the
   ticket. Use when asked to "build the next phase/slice", "build X with
   reviews", or /adversarial-build. Every step below traces to a defect one of
@@ -17,9 +17,9 @@ description: >
 
 The spine, from the operator (spec gate added by operator revision):
 
-> **aios ticket (create or update) → spec gate (author if none + `aios spec eval`) →
-> write code → Fable adversarial review → fold → Codex adversarial review → fold →
-> push the PR → aios ticket update**
+> **aios ticket (create or update) → write the spec → Codex reviews the SPEC → fold →
+> spec gate (`aios spec eval`) → write code → Fable adversarial review → fold →
+> Codex adversarial review → fold → push the PR → aios ticket update**
 
 Two different models review because they demonstrably catch different defect
 distributions: on the slices this loop was built on, Fable found the
@@ -73,6 +73,53 @@ an experiment with replication.
     against the blocker list is usually faster for a spec you just wrote.
 - Re-run the eval after ANY spec amendment mid-build — SPEC_READY is a state,
   not a milestone.
+
+## 0.6 Codex reviews the SPEC — before the eval, before any code
+
+**Order matters and is not arbitrary: the model reads the spec FIRST, then the
+eval runs.** The eval is deterministic and checks SHAPE (anchors, tiers,
+resolvable paths); a model reads the spec cold and attacks the DESIGN. Running
+the eval first only tidies a document that may not deserve to exist, and worse,
+a `SPEC_READY` verdict reads like a green light and makes the design review feel
+like a formality. Review first, fold, then gate the result — so the thing the
+eval blesses is the design that survived.
+
+```
+codex exec --sandbox read-only -m gpt-5.5 "<prompt>" < /dev/null
+```
+
+Prompt discipline (same shape as the diff reviews, aimed at the design):
+
+- Name the spec path and tell it **no code has been written yet**.
+- Name the files/specs it must read to judge the design, and the tests that
+  define behaviour the spec would CHANGE — a spec that quietly reverses shipped
+  intent is the failure this step catches most often.
+- Give it the measured terrain (numbers from prod, read-only) and tell it to
+  **attack the INFERENCES drawn from them**, not the numbers.
+- Ask explicitly whether the slice should be **built at all, built differently,
+  or DECLINED** — and say a decline is a legitimate, non-embarrassing outcome.
+  Require `VERDICT: BLOCKED | CLEAR-WITH-CONDITIONS | CLEAR | DECLINE` plus the
+  one sentence that most changes what to do next.
+- Same evidence bar as a diff review: file:line or a concrete
+  inputs→wrong-outcome scenario; same DB-test prohibition.
+
+**Fold with re-derivation both ways** (step 3's discipline applies here):
+verify each finding against the code before accepting it, and REFUTE with
+evidence what does not hold. Then re-run the review on the REVISED spec — a
+second round attacks the fix, and in practice that is where over-correction gets
+caught.
+
+WHY THIS STEP EXISTS (MTGATT-2, 2026-08-18 — every clause is a real outcome):
+round 1 returned **DECLINE**, killing a safety premise the spec asserted while
+the code it consumed did the opposite, and killing an identifier that would have
+fused unrelated meetings. Round 2 returned **DECLINE on the fix for round 1** —
+the rewrite reversed a shipped, tested product contract (`Bob pushed nothing…
+the meeting is still a record of work he did`) and leaned on a field that is the
+resolved AUTHOR rather than the pusher. Both were re-derived and both held. The
+slice that shipped was a fraction of what was specced, and the two rounds cost
+minutes against a build that would have had to be reversed. Note also what the
+eval could NOT have caught: it passed `SPEC_READY` on the version that was later
+declined **twice** — shape was never the problem.
 
 ## 1. Write the code
 
@@ -221,6 +268,8 @@ end.
 | Fail-open direction untested | Fable | `[]`→`NULL` scope conflation had no red test; suite stayed green |
 | Guard evasion | both | backtick quotes, variable-table idiom, SQL files unscanned |
 | Spec ruling silently unimplemented | Fable | "no external-tier delegation" stated twice, enforced nowhere |
+| A spec whose premise the code contradicts | Codex, on the SPEC | "each person only asserts about themselves" while the code credited every invitee |
+| A fix that reverses shipped intent | Codex, on the REVISED spec | narrowing attendance to the pusher deleted a deliberate, tested behaviour |
 | Reviewer hallucination | you | regex-matches claim refuted with a node repro |
 | Phantom test failures | process rule | concurrent data-mechanics runs on the shared container |
 | Lost work during mutation testing | `scripts/mutate.mjs` | `git checkout` on an uncommitted tree — three times in one session, while the rule was prose plus a skippable check |

--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -2,9 +2,10 @@
 name: adversarial-build
 description: >
   The full build loop for a feature slice in this repo: AIOS-CLI ticket
-  (create-or-update) → write the spec → CODEX REVIEWS THE SPEC (before any
-  code, and before the eval) → spec gate (`aios spec eval` must say
-  SPEC_READY) → write code with spec-first tests → Fable adversarial
+  (create-or-update) → write the spec → A MODEL REVIEWS THE SPEC (Codex, before
+  any code and before the eval — additive to CLAUDE.md's Fable plan review, not
+  a replacement) → spec gate (`aios spec eval` must say SPEC_READY) → write code
+  with spec-first tests → Fable adversarial
   review → fold → Codex adversarial review → fold → push the PR → update the
   ticket. Use when asked to "build the next phase/slice", "build X with
   reviews", or /adversarial-build. Every step below traces to a defect one of
@@ -43,7 +44,7 @@ an experiment with replication.
   — both `push` and `status` print that line).
   Cite the BRAIN row key in branch/PR/trailer, never the Linear `AIO-*` key.
 
-## 0.5 Spec gate (AIOS CLI)
+## 0.5 Author the spec (no eval yet)
 
 - **Locate the governing spec.** A build slice must trace to a written spec
   (CLAUDE.md task gate: anything touching schema, money, or more than one
@@ -51,38 +52,32 @@ an experiment with replication.
   `docs/specs/project-context-classification-v1.md` §-references in the PR.
 - **If no spec exists**: author one before any code — scaffold with
   `/opt/homebrew/bin/aios spec init <path>` (writes the issue-template shape)
-  or write it in `docs/design/`/`docs/specs/`, then run it through review
-  rounds (a fresh Fable cold read at minimum) before building against it.
-- **Gate the spec** with the eval tool, and mind two sharp edges learned in
-  practice:
-  - Run **from the repo root** with the workspace env loaded:
-    `set -a && . ~/Projects/chetan-workspace/.env && set +a &&
-    /opt/homebrew/bin/aios spec eval <file> --tier deterministic --no-llm`.
-    Running from the workspace directory resolves the spec's repo-relative
-    code paths against the wrong tree and emits dozens of FALSE `SR3` blockers
-    (observed; cost a full debugging detour).
-  - Required outcome: `verdict: SPEC_READY`, exit 0. Real blockers this gate
-    has caught: acceptance criteria with no observable anchor (it reads only
-    each bullet's FIRST source line — put the test-tier/backtick anchor
-    there), a missing build-with tier, module references that don't resolve.
-  - `--tier full` adds the adversarial LLM layer when its key
-    (`DEEPSEEK_API_KEY`) is configured; when absent, the loop's two model
-    reviews stand in as the adversarial layer — say so in the PR, don't
-    pretend the layer ran.
-  - `aios spec fix <file>` exists for the bounded auto-fix loop; hand-fixing
-    against the blocker list is usually faster for a spec you just wrote.
-- Re-run the eval after ANY spec amendment mid-build — SPEC_READY is a state,
-  not a milestone.
+  or write it in `docs/design/`/`docs/specs/`.
+- **Measure before designing.** Read the terrain the spec's claims rest on
+  (prod, read-only), put the numbers IN the spec, and name what is NOT measured
+  as such. On MTGATT-2 the plan-review blockers were inferences drawn from real
+  numbers, never the numbers themselves.
+- **Then §0.6 — do not run the eval yet.** §0.6 explains why that way round.
 
 ## 0.6 Codex reviews the SPEC — before the eval, before any code
 
 **Order matters and is not arbitrary: the model reads the spec FIRST, then the
 eval runs.** The eval is deterministic and checks SHAPE (anchors, tiers,
-resolvable paths); a model reads the spec cold and attacks the DESIGN. Running
-the eval first only tidies a document that may not deserve to exist, and worse,
-a `SPEC_READY` verdict reads like a green light and makes the design review feel
-like a formality. Review first, fold, then gate the result — so the thing the
+resolvable paths); a model reads the spec cold and attacks the DESIGN. Gating
+first tidies a document that may not deserve to exist — and worse, a
+`SPEC_READY` verdict reads like a green light, which makes the design review
+feel like the formality it is not. Review, fold, then gate, so the thing the
 eval blesses is the design that survived.
+
+Nothing stops you running the eval as a cheap PREFLIGHT and handing its blocker
+list to the reviewer — those findings are real (§0.7 lists what it catches).
+What must not happen is `SPEC_READY` being the last word before code.
+
+**ADDITIVE to the Fable plan review CLAUDE.md requires, not a replacement.**
+Where both models are available the spec gets both: on MTGATT-2 the first Fable
+DIFF round found a HIGH that five Codex rounds had already cleared, so extra
+rounds of one model are correlated rather than additive. When one is
+unavailable, name which, and say so in the PR.
 
 ```
 codex exec --sandbox read-only -m gpt-5.5 "<prompt>" < /dev/null
@@ -120,6 +115,29 @@ slice that shipped was a fraction of what was specced, and the two rounds cost
 minutes against a build that would have had to be reversed. Note also what the
 eval could NOT have caught: it passed `SPEC_READY` on the version that was later
 declined **twice** — shape was never the problem.
+
+## 0.7 Spec gate (AIOS CLI) — run AFTER the design has survived §0.6
+
+- **Gate the spec** with the eval tool, and mind two sharp edges learned in
+  practice:
+  - Run **from the repo root** with the workspace env loaded:
+    `set -a && . ~/Projects/chetan-workspace/.env && set +a &&
+    /opt/homebrew/bin/aios spec eval <file> --tier deterministic --no-llm`.
+    Running from the workspace directory resolves the spec's repo-relative
+    code paths against the wrong tree and emits dozens of FALSE `SR3` blockers
+    (observed; cost a full debugging detour).
+  - Required outcome: `verdict: SPEC_READY`, exit 0. Real blockers this gate
+    has caught: acceptance criteria with no observable anchor (it reads only
+    each bullet's FIRST source line — put the test-tier/backtick anchor
+    there), a missing build-with tier, module references that don't resolve.
+  - `--tier full` adds the adversarial LLM layer when its key
+    (`DEEPSEEK_API_KEY`) is configured; when absent, the loop's two model
+    reviews stand in as the adversarial layer — say so in the PR, don't
+    pretend the layer ran.
+  - `aios spec fix <file>` exists for the bounded auto-fix loop; hand-fixing
+    against the blocker list is usually faster for a spec you just wrote.
+- Re-run the eval after ANY spec amendment mid-build — SPEC_READY is a state,
+  not a milestone.
 
 ## 1. Write the code
 


### PR DESCRIPTION
## What

Adds one step to the `adversarial-build` loop: **a model reviews the SPEC before the eval runs**, not after.

```
ticket → write the spec → Codex reviews the SPEC → fold → aios spec eval → write code → Fable → fold → Codex → fold → PR
```

## Why the order, specifically

The eval is deterministic and checks **shape** — acceptance-criterion anchors, a build-with tier, resolvable module paths. A model reads the spec cold and attacks the **design**. Running the eval first only tidies a document that may not deserve to exist, and a `SPEC_READY` verdict reads like a green light that makes the design review feel like a formality.

**This is not hypothetical.** On MTGATT-2 (2026-08-18) the spec passed `SPEC_READY` — and was then **DECLINED twice**:

- **Round 1** killed a safety premise the spec asserted while the code it consumed did the opposite ("each person only asserts about themselves", against a call site that credited every invitee), and killed an identifier that would have fused unrelated meetings.
- **Round 2 declined the fix for round 1**: the rewrite reversed a shipped, tested product contract, and leaned on a field that is the resolved *author* rather than the pusher.

Both were re-derived against the code before being accepted. The slice that shipped was a fraction of what was specced. **Shape was never the problem** — which is exactly why the eval could not have caught either one.

The step also inherits the loop's existing discipline rather than inventing new rules: re-derive every finding both ways, refute what does not hold with evidence, and re-review the *revised* spec — that second round is where over-correction gets caught, and on MTGATT-2 it did.

## Also

Two rows added to the failure-mode table, both observed: *a spec whose premise the code contradicts*, and *a fix that reverses shipped intent*.

Docs-only. No runtime code, no tests affected. `adversarial-build` is not one of the four published skills, so no runtime mirrors change (`sync-skill-runtimes.sh --check` passes).

## Review

**Reviewed by Codex gpt-5.5 — verdict CLEAR-WITH-NITS, both findings folded.**

It caught that the *section numbers* contradicted the new rule: §0.5 still said "Gate the spec" and
came before the new §0.6, so a reader following the numbering would run the eval first — the exact
order this change exists to prevent. §0.5 is now "Author the spec (no eval yet)", the review is §0.6,
and the gate is §0.7, physically in that order.

It also flagged that the frontmatter implied Codex *replaces* the Fable plan review CLAUDE.md
requires. It doesn't — corrected to say additive, with this session's evidence for why: the first
Fable diff round found a HIGH that five Codex rounds had cleared.

Its nit that "running the eval first only tidies" overstated the case is fair and folded too: the
eval's findings are real, and running it as a preflight to hand the reviewer is fine. The rule is
narrower — `SPEC_READY` must not be the last word before code.

AIOS-Work: MTGATT-2