### PR TITLE
test(pm-sync): pin the outcome the adoption fixes exist to produce (ADOPTINV-1)

### DIFF
--- a/docs/design/pm-link-uniqueness-invariant.md
+++ b/docs/design/pm-link-uniqueness-invariant.md
@@ -1,6 +1,6 @@
 # Nothing enforces the invariant the two adoption fixes exist to protect — ADOPTINV-1
 
-**Status:** spec, draft 2. Draft 1 was BLOCKED by both reviewers. The sharpest finding was that draft 1's
+**Status:** spec, draft 3 (built). Draft 1 was BLOCKED by both reviewers. The sharpest finding was that draft 1's
 own mutation criterion **could not go red** — it named the wrong file, and the mutant it described makes
 the adapter refuse *everything*, so no duplicate forms and the test stays green. · **Date:** 2026-08-18 ·
 **Owner:** Chetan · **Task:** `ADOPTINV-1`
@@ -13,7 +13,7 @@ the adapter refuse *everything*, so no duplicate forms and the test stays green.
 
 ## 0. What is wrong
 
-`ADOPTDECL-1` and `ADOPTFOOT-1` between them shipped nine tests across the unit and data-mechanics
+`ADOPTDECL-1` and `ADOPTFOOT-1` between them shipped their tests across the unit and data-mechanics
 tiers. Every one of them pins **a rung's decision** — the footer rung's scope, the declared rung's
 error, the ownership refusal, the single-writer guard on the declared column.
 
@@ -90,9 +90,16 @@ the two previous fixes did not close, which is a result, not a setback** — see
   so a footered fixture would prove the wrong path — and the prod shape is footerless, which
   `linear.ts:377-379` says in as many words.
 - **The inbound writer is covered too** (§3 explains why it is in): a mirror-adopt of an issue a
-  workspace link already owns does not produce a second link. `lib/pm-sync/inbound.ts:448-457` inserts
-  `provider_resource_id` directly with `on conflict (team_id, project_id, row_key, provider) do nothing`
-  — conflict on **row identity only**, so nothing there stops a second link to an owned issue.
+  workspace link already owns does not produce a second link. The insert at
+  `lib/pm-sync/inbound.ts:448-457` conflicts on **row identity only**, so the conflict clause is not
+  what protects the invariant — the team-wide candidate filter at `inbound.ts:405-414`
+  (`!ownedIds.has(it.id)`) is. That filter is the mutation target for this scenario. (Draft 2 named the
+  conflict clause as the protection, which was wrong; round-2 review caught it.)
+  **Two fixture preconditions, both learned by a SURVIVING mutation rather than by reading:** the
+  integration config must set `inboundApply: true` or `runInboundForTeam` returns an empty result at
+  `inbound.ts:526` before reading an issue, and a **mirror task** must exist under the
+  `linear-<teamKey>` project or the candidate is skipped as "no mirror task yet" (`:416-428`). Missing
+  either, the scenario is green and proves nothing.
 
 ### The test is not green by construction
 
@@ -104,7 +111,10 @@ the two previous fixes did not close, which is a result, not a setback** — see
 - **Count anchor:** each scenario asserts the expected number of links with a non-null
   `provider_resource_id` exists, so a scenario that silently projected nothing cannot pass.
 - **The inverse control:** insert two links that deliberately share `(team_id, provider,
-  provider_resource_id)` and assert the §1 query **returns** that group. Draft 1's "the query returns
+  provider_resource_id)` and assert the §1 query **returns** that group. **Note for whoever lands
+  `ADOPTUNIQ-1`:** this control deliberately writes the exact state that index forbids, so the insert
+  will start failing the day the index ships. That is expected, not a regression — convert it then to
+  asserting a unique-violation error. Draft 1's "the query returns
   zero rows on a team with no links" proved the opposite of what it claimed — that the query passes on
   nothing, which is the vacuity, not a control against it. The surviving mutant it missed is any query
   typo that matches nothing at all.
@@ -116,6 +126,11 @@ the two previous fixes did not close, which is a result, not a setback** — see
   in that file, and both refusals (`linear.ts:360-362`, `:389-395`) **fail closed** on
   `ownedResourceIds === undefined`, so removing the owner set makes the adapter refuse *everything* —
   every row creates its own issue, no duplicate forms, and the test stays green.
+- **What the deleted-issue scenario does NOT guard, stated so nobody deletes its sibling.**
+  Reintroducing `ADOPTFOOT-1`'s original load gate (owner set loaded only when a declaration exists and
+  the resource id is null) survives this whole file: the refusals fail CLOSED, so an unloaded set means
+  over-refusal, and over-refusal preserves the invariant. What kills that mutant is the RECOVERY case in
+  `test/datamechanics/pm-sync-footer-adoption-scope.datamechanics.test.ts`. This file does not replace it.
 - **A mutation per scenario, not one for the suite.** The mutant above only exercises the footer path,
   so a deleted-issue scenario seeded with an unchanged `projection_fingerprint` would short-circuit and
   be silently vacuous while the suite still reddens elsewhere. Each scenario carries its own positive

--- a/docs/design/pm-link-uniqueness-invariant.md
+++ b/docs/design/pm-link-uniqueness-invariant.md
@@ -1,0 +1,137 @@
+# Nothing enforces the invariant the two adoption fixes exist to protect — ADOPTINV-1
+
+**Status:** spec, draft 1 · **Date:** 2026-08-18 · **Owner:** Chetan · **Task:** `ADOPTINV-1`
+**Follows:** [`pm-sync-declared-issue-adoption.md`](./pm-sync-declared-issue-adoption.md) (`ADOPTDECL-1`,
+#581) and [`pm-sync-footer-adoption-scope.md`](./pm-sync-footer-adoption-scope.md) (`ADOPTFOOT-1`, #588).
+**Unblocks:** `ADOPTUNIQ-1` — proves the code cannot violate the constraint *before* the constraint is added.
+**Code:** `test/datamechanics/` only. No production code changes are planned; see §4.
+
+---
+
+## 0. What is wrong
+
+`ADOPTDECL-1` and `ADOPTFOOT-1` between them shipped nine tests across the unit and data-mechanics
+tiers. Every one of them pins **a rung's decision**:
+
+- `test/pm-sync-footer-adoption-scope.test.ts` — the adapter refuses an owned footer match when it is
+  handed an owner set.
+- `test/datamechanics/pm-sync-footer-adoption-scope.datamechanics.test.ts` — the orchestrator builds
+  that set correctly from real rows (`a SAME-KEYED row in another project does not take the owner's
+  issue`), and the recovery direction still works.
+- `test/pm-sync-declared-adoption.test.ts`, `test/datamechanics/pm-sync-declared-adoption.datamechanics.test.ts`
+  — a declaration is persisted, adopted, short-circuits on the second run, errors when unresolvable,
+  and withdraws cleanly.
+- `test/guards/declared-external-id-single-writer.test.ts` — only ingest writes the column.
+
+**Not one of them asserts the outcome those rungs exist to produce:** that after a projection,
+`task_pm_links` does not contain two rows in the same team pointing at the same
+`provider_resource_id`. Every assertion is on a return value, a call, or one link's stored fields.
+
+That is the difference CLAUDE.md §2.3 names — *"a claim isn't real until a red test reproduces the bad
+outcome (wrong row in the DB…), not a name, a proxy, or a call-site reading."* The rungs are proxies
+for the invariant. They are individually correct and the invariant can still break, because the rungs
+are not the only writers of that column and no test looks at the table as a whole.
+
+**And the DB cannot cover it either, today.** `ADOPTUNIQ-1` would add
+`unique (team_id, provider, provider_resource_id) where provider_resource_id is not null`, but it
+cannot ship: production currently holds exactly one violating group — three links on `AIO-444` — and
+`npm run pg:schema` is Railway's `preDeployCommand`, so an index that fails to build takes the release
+down with it. Reconciling those three rows is an outward-facing decision (detaching them mints new
+issues on a colleague's board), and it is still open.
+
+So the invariant is enforced by **nothing** in CI right now, and will stay that way until a decision
+that has no deadline. That is the gap this slice closes.
+
+## 1. The decision
+
+Add a **data-mechanics** test that drives the real projector through the collision shapes that actually
+occurred, and asserts the **table state** after each: no `(team_id, provider, provider_resource_id)`
+group has more than one row.
+
+The assertion is one SQL query, expressed once and reused:
+
+```sql
+select provider_resource_id, count(*) from task_pm_links
+where team_id = $1 and provider_resource_id is not null
+group by provider_resource_id having count(*) > 1
+```
+
+**Why data-mechanics and not unit** (CLAUDE.md §4): the invariant is a property of *stored rows across
+projects*, and the legacy in-memory fake has no constraints and no real grouping. The live defect was
+exactly a cross-project stored-state bug that an adapter-level assertion greened straight past.
+
+**Why this is not a re-run of the existing tests.** Those assert one scenario each, in isolation, and
+each asserts the rung. This asserts the *composition*: several rows projecting in one run, and paths
+run back to back, which is the shape the incident actually had (three workspaces, months apart, each
+individually behaving "correctly" by the rung's own lights).
+
+## 2. Acceptance criteria
+
+Spec-first: these are written from what the product must guarantee, not from what the code does. **If
+any goes red it has found a live path the two previous fixes did not close, and that is a result, not a
+setback** — see §4.
+
+- `npm run test:datamechanics:iso test/datamechanics/pm-link-uniqueness.datamechanics.test.ts` passes,
+  and every case ends with the no-duplicate-group query returning zero rows.
+- The incident's exact shape: **three** rows keyed `TT1` in three different projects of one team, all
+  projected in the same run against a Linear team whose existing issue carries `aios-ext: TT1` — one
+  row keeps the issue, the other two do not share it.
+- Rung 1 missing because the issue was **deleted** at the provider (the path `ADOPTFOOT-1` found its
+  load-gate blind to), run twice in succession, still ends with no duplicate group.
+- A row that **declares** an id already owned by another row's link does not end up sharing it, and the
+  declaring row records an error rather than silently inventing a second issue (`ADOPTDECL-1`'s rule).
+- The invariant query is **mutation-verified**: with the ownership refusal removed from
+  `lib/pm-sync/project.ts`, the new test goes **red**, and it is the *invariant* assertion that fails,
+  not an incidental one.
+- A **negative control**: the same query returns zero rows on a team with no links at all, so a passing
+  run cannot be explained by the query matching nothing. (`grep-before-claiming` / vacuity: a
+  `having count(*) > 1` assertion is trivially satisfiable by an empty table.)
+- `npm test`, `npx tsc --noEmit`, `npm run lint`, `npm run check:docs` all pass.
+
+## 3. Scope
+
+**In:** one new file, `test/datamechanics/pm-link-uniqueness.datamechanics.test.ts`, plus a line in
+`docs/ARCHITECTURE.md` if the drift guard requires one.
+
+**Deliberately out:**
+
+- **The DB constraint itself** (`ADOPTUNIQ-1`) — blocked on the production reconciliation, which is a
+  human, outward-facing call. This slice is explicitly the *interim* enforcement, and does not replace
+  it: a test binds this repo's code paths, an index binds the data whatever writes it.
+- **Repairing the three live links.** No production write happens here.
+- **A runtime health signal for duplicate links.** Considered and rejected for now: it would go red
+  immediately on the known violation and stay red until that decision is made, and this repo has been
+  bitten six times by a banner that cries wolf (`docs/design/staleness-threshold-fit.md`). It belongs
+  *with* the repair, not before it.
+- **The Plane adapter's copy of the defect** (`ADOPTPLANE-1`). The invariant query is provider-scoped
+  and would cover Plane if a case were added, but Plane's live status is itself an open question —
+  the workspace CLI's `parsePmCell` already treats Plane as retired while the brain still ships an
+  adapter.
+
+## 4. What would falsify this
+
+The spec claims the invariant is currently unenforced but *held* by the code. Two ways that is wrong,
+both of which the slice is designed to surface rather than hide:
+
+1. **The test goes red on first run.** Then a live path still produces duplicates, `ADOPTFOOT-1` is
+   incomplete, and the fix belongs in `lib/pm-sync/` — the slice grows a production change and says so.
+2. **The test is green for the wrong reason** — the scenarios never actually reach the adoption rungs
+   (e.g. the fingerprint short-circuit skips the provider call, so nothing is ever at risk of
+   adopting). The mutation criterion above exists precisely to detect this: if removing the ownership
+   refusal does not redden the test, the test is not exercising the path it claims to.
+
+## Dependencies
+
+Depends on: `ADOPTFOOT-1` (#588, merged) for the ownership machinery being keyed correctly. Sequenced
+before `ADOPTUNIQ-1`, which it de-risks but does not replace.
+
+## Build-with
+
+Build-with: Sonnet 5, medium effort. One test file against an existing dm harness
+(`test/datamechanics/helpers.ts` + the Linear mock already used by the two adoption tests), with the
+mutation check as the real work.
+
+## Tier safety
+
+No tier boundary moves; no read path changes. The test seeds its own team via `seedTeam()` and asserts
+only within that `team_id`, so it cannot pass by observing another team's rows.

--- a/docs/design/pm-link-uniqueness-invariant.md
+++ b/docs/design/pm-link-uniqueness-invariant.md
@@ -1,137 +1,185 @@
 # Nothing enforces the invariant the two adoption fixes exist to protect — ADOPTINV-1
 
-**Status:** spec, draft 1 · **Date:** 2026-08-18 · **Owner:** Chetan · **Task:** `ADOPTINV-1`
+**Status:** spec, draft 2. Draft 1 was BLOCKED by both reviewers. The sharpest finding was that draft 1's
+own mutation criterion **could not go red** — it named the wrong file, and the mutant it described makes
+the adapter refuse *everything*, so no duplicate forms and the test stays green. · **Date:** 2026-08-18 ·
+**Owner:** Chetan · **Task:** `ADOPTINV-1`
 **Follows:** [`pm-sync-declared-issue-adoption.md`](./pm-sync-declared-issue-adoption.md) (`ADOPTDECL-1`,
 #581) and [`pm-sync-footer-adoption-scope.md`](./pm-sync-footer-adoption-scope.md) (`ADOPTFOOT-1`, #588).
 **Unblocks:** `ADOPTUNIQ-1` — proves the code cannot violate the constraint *before* the constraint is added.
-**Code:** `test/datamechanics/` only. No production code changes are planned; see §4.
+**Code:** `test/datamechanics/` only, unless §4.1 fires.
 
 ---
 
 ## 0. What is wrong
 
 `ADOPTDECL-1` and `ADOPTFOOT-1` between them shipped nine tests across the unit and data-mechanics
-tiers. Every one of them pins **a rung's decision**:
-
-- `test/pm-sync-footer-adoption-scope.test.ts` — the adapter refuses an owned footer match when it is
-  handed an owner set.
-- `test/datamechanics/pm-sync-footer-adoption-scope.datamechanics.test.ts` — the orchestrator builds
-  that set correctly from real rows (`a SAME-KEYED row in another project does not take the owner's
-  issue`), and the recovery direction still works.
-- `test/pm-sync-declared-adoption.test.ts`, `test/datamechanics/pm-sync-declared-adoption.datamechanics.test.ts`
-  — a declaration is persisted, adopted, short-circuits on the second run, errors when unresolvable,
-  and withdraws cleanly.
-- `test/guards/declared-external-id-single-writer.test.ts` — only ingest writes the column.
+tiers. Every one of them pins **a rung's decision** — the footer rung's scope, the declared rung's
+error, the ownership refusal, the single-writer guard on the declared column.
 
 **Not one of them asserts the outcome those rungs exist to produce:** that after a projection,
-`task_pm_links` does not contain two rows in the same team pointing at the same
-`provider_resource_id`. Every assertion is on a return value, a call, or one link's stored fields.
+`task_pm_links` does not contain two rows in one team, for one provider, pointing at the same
+`provider_resource_id`. Both reviewers went looking for a counter-example and neither found one. Two
+specifics worth recording, because they show how close the existing tests get without arriving:
 
-That is the difference CLAUDE.md §2.3 names — *"a claim isn't real until a red test reproduces the bad
-outcome (wrong row in the DB…), not a name, a proxy, or a call-site reading."* The rungs are proxies
-for the invariant. They are individually correct and the invariant can still break, because the rungs
-are not the only writers of that column and no test looks at the table as a whole.
+- `test/datamechanics/pm-sync-inbound.datamechanics.test.ts:554` asserts `toHaveLength(1)` for links
+  filtered `.eq("row_key", "ENG-1")` — keyed on **row_key**, so two links with *different* row keys
+  sharing one `provider_resource_id`, which is the incident's exact shape, pass it.
+- `test/datamechanics/pm-sync-footer-adoption-scope.datamechanics.test.ts:146` asserts the **mock's**
+  recorded calls, never the scaffold row's stored id. A `persistSuccess` bug writing `issue-444` into
+  the scaffold's link while the adapter dutifully created a new issue would stay green today.
 
-**And the DB cannot cover it either, today.** `ADOPTUNIQ-1` would add
+**And the DB cannot cover it either.** `postgres/schema.sql:1280` carries only
+`unique (team_id, project_id, row_key, provider)`; lines 1282-1283 add plain, non-unique indexes, and
+no migration adds more. `ADOPTUNIQ-1` would add
 `unique (team_id, provider, provider_resource_id) where provider_resource_id is not null`, but it
-cannot ship: production currently holds exactly one violating group — three links on `AIO-444` — and
-`npm run pg:schema` is Railway's `preDeployCommand`, so an index that fails to build takes the release
-down with it. Reconciling those three rows is an outward-facing decision (detaching them mints new
-issues on a colleague's board), and it is still open.
+cannot ship: a prod query on **2026-08-18** found exactly one violating group — three links on
+`AIO-444` — and `npm run pg:schema` is Railway's `preDeployCommand`, so an index that fails to build
+takes the release down. (That count is a dated measurement taken outside this repo and is not
+verifiable from it.) Reconciling those rows is an outward-facing decision that is still open.
 
-So the invariant is enforced by **nothing** in CI right now, and will stay that way until a decision
-that has no deadline. That is the gap this slice closes.
+So the invariant is enforced by **nothing** in CI, and will stay that way until a decision with no
+deadline. That is the gap this slice closes.
 
 ## 1. The decision
 
 Add a **data-mechanics** test that drives the real projector through the collision shapes that actually
-occurred, and asserts the **table state** after each: no `(team_id, provider, provider_resource_id)`
-group has more than one row.
+occurred, and asserts the **table state** after each.
 
-The assertion is one SQL query, expressed once and reused:
+The invariant, expressed once and reused — note the `provider` term, which draft 1 omitted from the SQL
+while claiming it in prose:
 
 ```sql
-select provider_resource_id, count(*) from task_pm_links
+select provider, provider_resource_id, count(*) from task_pm_links
 where team_id = $1 and provider_resource_id is not null
-group by provider_resource_id having count(*) > 1
+group by provider, provider_resource_id having count(*) > 1
 ```
 
-**Why data-mechanics and not unit** (CLAUDE.md §4): the invariant is a property of *stored rows across
-projects*, and the legacy in-memory fake has no constraints and no real grouping. The live defect was
-exactly a cross-project stored-state bug that an adapter-level assertion greened straight past.
+It must match `ADOPTUNIQ-1`'s index exactly, or it does not pre-verify it. Without `provider`, a Plane
+link and a Linear link sharing an id string are a false positive against a constraint that would
+permit them.
 
-**Why this is not a re-run of the existing tests.** Those assert one scenario each, in isolation, and
-each asserts the rung. This asserts the *composition*: several rows projecting in one run, and paths
-run back to back, which is the shape the incident actually had (three workspaces, months apart, each
-individually behaving "correctly" by the rung's own lights).
+**Team-wide is the right scope, verified rather than assumed:** both owner sets in production code —
+the projector's (`lib/pm-sync/project.ts:312-317`) and the inbound path's (`lib/pm-sync/inbound.ts:402-412`)
+— are already team-wide across projects, including the `linear-*` mirror project. The code already
+treats team-wide uniqueness as intended, so the test is not inventing a rule the product does not want.
+
+**Why data-mechanics and not unit** (CLAUDE.md §4): the invariant is a property of *stored rows across
+projects*, and the in-memory fake has no constraints and no real grouping.
 
 ## 2. Acceptance criteria
 
-Spec-first: these are written from what the product must guarantee, not from what the code does. **If
-any goes red it has found a live path the two previous fixes did not close, and that is a result, not a
-setback** — see §4.
+Spec-first: written from what the product must guarantee. **If any goes red it has found a live path
+the two previous fixes did not close, which is a result, not a setback** — see §4.
+
+### The invariant holds
 
 - `npm run test:datamechanics:iso test/datamechanics/pm-link-uniqueness.datamechanics.test.ts` passes,
-  and every case ends with the no-duplicate-group query returning zero rows.
-- The incident's exact shape: **three** rows keyed `TT1` in three different projects of one team, all
-  projected in the same run against a Linear team whose existing issue carries `aios-ext: TT1` — one
-  row keeps the issue, the other two do not share it.
-- Rung 1 missing because the issue was **deleted** at the provider (the path `ADOPTFOOT-1` found its
-  load-gate blind to), run twice in succession, still ends with no duplicate group.
-- A row that **declares** an id already owned by another row's link does not end up sharing it, and the
-  declaring row records an error rather than silently inventing a second issue (`ADOPTDECL-1`'s rule).
-- The invariant query is **mutation-verified**: with the ownership refusal removed from
-  `lib/pm-sync/project.ts`, the new test goes **red**, and it is the *invariant* assertion that fails,
-  not an incidental one.
-- A **negative control**: the same query returns zero rows on a team with no links at all, so a passing
-  run cannot be explained by the query matching nothing. (`grep-before-claiming` / vacuity: a
-  `having count(*) > 1` assertion is trivially satisfiable by an empty table.)
+  and every scenario ends with the §1 query returning **zero rows**.
+- **The incident's shape:** three rows keyed `TT1` in three different projects of one team, projected in
+  **three back-to-back per-project runs** — not one run. `projectAllTasks` is `(team, project)`-scoped
+  (`lib/pm-sync/project.ts:432-437`), so a single run cannot span three projects; draft 1's "all
+  projected in the same run" was impossible. Each run's bootstrap listing must reflect the previous
+  run's state. Only the first row ends up owning the issue.
+- **Rung 1 missing because the issue was deleted** at the provider, run twice in succession, ends with
+  no duplicate group.
+- **A declared id already owned by another row's link** does not end up shared, and the declaring row
+  records an error (`persistError`, `lib/pm-sync/project.ts:354-357`) rather than inventing a second
+  issue. The owned issue in this fixture **must carry no `aios-ext` footer**: `linear.ts:381-386`
+  throws on a footer naming another row *before* the `ownedResourceIds` check at `:388-395` is reached,
+  so a footered fixture would prove the wrong path — and the prod shape is footerless, which
+  `linear.ts:377-379` says in as many words.
+- **The inbound writer is covered too** (§3 explains why it is in): a mirror-adopt of an issue a
+  workspace link already owns does not produce a second link. `lib/pm-sync/inbound.ts:448-457` inserts
+  `provider_resource_id` directly with `on conflict (team_id, project_id, row_key, provider) do nothing`
+  — conflict on **row identity only**, so nothing there stops a second link to an owned issue.
+
+### The test is not green by construction
+
+- **Positive anchor per scenario:** each scenario asserts that the projection actually *reached the
+  adapter for the row under test* — a recorded issue mutation/update for that row, and its report
+  status not `skipped`. "The fetch mock was called" is **not** sufficient: `projectRows` calls the
+  adapter's `prepare` before any row projects (`lib/pm-sync/project.ts:401`), so bootstrap alone
+  satisfies it even when every row short-circuits at `:284`.
+- **Count anchor:** each scenario asserts the expected number of links with a non-null
+  `provider_resource_id` exists, so a scenario that silently projected nothing cannot pass.
+- **The inverse control:** insert two links that deliberately share `(team_id, provider,
+  provider_resource_id)` and assert the §1 query **returns** that group. Draft 1's "the query returns
+  zero rows on a team with no links" proved the opposite of what it claimed — that the query passes on
+  nothing, which is the vacuity, not a control against it. The surviving mutant it missed is any query
+  typo that matches nothing at all.
+- **Mutation — the right mutant, and why the obvious one is wrong.** Re-key the self-exclusion at
+  `lib/pm-sync/project.ts:320` to `row_key` alone (drop the `o.project_id === row.project_id &&` term):
+  that is the live bug's exact shape, it drops the true owner from the owner set, and all three `TT1`
+  rows adopt `issue-444`. The **invariant assertion specifically** must be the one that reddens.
+  Do **not** use draft 1's mutant ("remove the ownership refusal from `project.ts`"): the refusal is not
+  in that file, and both refusals (`linear.ts:360-362`, `:389-395`) **fail closed** on
+  `ownedResourceIds === undefined`, so removing the owner set makes the adapter refuse *everything* —
+  every row creates its own issue, no duplicate forms, and the test stays green.
+- **A mutation per scenario, not one for the suite.** The mutant above only exercises the footer path,
+  so a deleted-issue scenario seeded with an unchanged `projection_fingerprint` would short-circuit and
+  be silently vacuous while the suite still reddens elsewhere. Each scenario carries its own positive
+  anchor for this reason.
+
+### Fixture hygiene
+
+- **The create mock must mint unique ids.** The two adoption dm tests' mock returns a constant
+  `id: "brand-new"` for every `issueCreate`. In the three-`TT1` scenario two rows are refused and each
+  mints its own issue, so that mock makes both links persist the same id and the invariant query flags
+  a duplicate that is a **pure fixture artifact**. Use the `li-${++n}` pattern already in
+  `test/datamechanics/pm-sync-refusal.datamechanics.test.ts:48`.
 - `npm test`, `npx tsc --noEmit`, `npm run lint`, `npm run check:docs` all pass.
 
 ## 3. Scope
 
-**In:** one new file, `test/datamechanics/pm-link-uniqueness.datamechanics.test.ts`, plus a line in
-`docs/ARCHITECTURE.md` if the drift guard requires one.
+**In:** one new file, `test/datamechanics/pm-link-uniqueness.datamechanics.test.ts`, plus an
+`docs/ARCHITECTURE.md` line if the drift guard requires one.
 
-**Deliberately out:**
+**The inbound writer is IN, not fenced out.** Draft 1 justified the slice with "the rungs are not the
+only writers of that column" and then tested only the outbound projector — fencing out the second
+writer with no stated destination. `adoptInbound` (`lib/pm-sync/inbound.ts:448`) writes the column
+directly under its own ownership logic, so one inbound scenario is part of this slice.
 
-- **The DB constraint itself** (`ADOPTUNIQ-1`) — blocked on the production reconciliation, which is a
-  human, outward-facing call. This slice is explicitly the *interim* enforcement, and does not replace
-  it: a test binds this repo's code paths, an index binds the data whatever writes it.
-- **Repairing the three live links.** No production write happens here.
-- **A runtime health signal for duplicate links.** Considered and rejected for now: it would go red
-  immediately on the known violation and stay red until that decision is made, and this repo has been
-  bitten six times by a banner that cries wolf (`docs/design/staleness-threshold-fit.md`). It belongs
-  *with* the repair, not before it.
-- **The Plane adapter's copy of the defect** (`ADOPTPLANE-1`). The invariant query is provider-scoped
-  and would cover Plane if a case were added, but Plane's live status is itself an open question —
-  the workspace CLI's `parsePmCell` already treats Plane as retired while the brain still ships an
-  adapter.
+**Deliberately out, each with a destination:**
+
+- **The DB constraint itself** (`ADOPTUNIQ-1`) — blocked on the production reconciliation, a human,
+  outward-facing call. This slice is the *interim* enforcement and does not replace it: a test binds
+  this repo's code paths, an index binds the data whatever writes it.
+- **Repairing the three live links.** No production write happens here. `ADOPTUNIQ-1`.
+- **A runtime health signal for duplicate links.** It would go red immediately on the known violation
+  and stay red until that decision is made, and this repo has been bitten six times by a banner that
+  cries wolf (`docs/design/staleness-threshold-fit.md`). The obvious middle option — baseline or
+  allowlist the one known group — is real, and is deliberately deferred with the repair rather than
+  rejected: allowlisting a violation before anyone has decided to fix it is how a known-issue
+  suppression becomes permanent. Revisit as part of `ADOPTUNIQ-1`.
+- **The Plane adapter's copy of the defect** (`ADOPTPLANE-1`). The §1 query is provider-scoped and
+  would cover Plane if a case were added, but Plane's live status is itself open — the workspace CLI's
+  `parsePmCell` already treats Plane as retired while the brain still ships an adapter.
 
 ## 4. What would falsify this
 
-The spec claims the invariant is currently unenforced but *held* by the code. Two ways that is wrong,
-both of which the slice is designed to surface rather than hide:
-
-1. **The test goes red on first run.** Then a live path still produces duplicates, `ADOPTFOOT-1` is
-   incomplete, and the fix belongs in `lib/pm-sync/` — the slice grows a production change and says so.
-2. **The test is green for the wrong reason** — the scenarios never actually reach the adoption rungs
-   (e.g. the fingerprint short-circuit skips the provider call, so nothing is ever at risk of
-   adopting). The mutation criterion above exists precisely to detect this: if removing the ownership
-   refusal does not redden the test, the test is not exercising the path it claims to.
+1. **The test goes red on first run.** Then a live path still produces duplicates and the fix belongs in
+   `lib/pm-sync/`. Decision rule, pre-committed: if the failing path is the **outbound** projector the
+   fix lands in this slice; if it is the **inbound** writer it becomes its own ticket (`ADOPTINB-1`)
+   unless the fix is a one-line conflict-target change, because inbound has its own echo-loop contract
+   that a hurried fix would break.
+2. **The test is green for the wrong reason** — the scenarios never reach the adoption rungs because the
+   fingerprint short-circuit fires. The per-scenario positive anchors above exist to detect exactly
+   this, and the mutation criterion is deliberately not relied on alone for it.
 
 ## Dependencies
 
-Depends on: `ADOPTFOOT-1` (#588, merged) for the ownership machinery being keyed correctly. Sequenced
+Depends on `ADOPTFOOT-1` (#588, merged) for the ownership machinery being keyed correctly. Sequenced
 before `ADOPTUNIQ-1`, which it de-risks but does not replace.
 
 ## Build-with
 
-Build-with: Sonnet 5, medium effort. One test file against an existing dm harness
-(`test/datamechanics/helpers.ts` + the Linear mock already used by the two adoption tests), with the
-mutation check as the real work.
+Build-with: Sonnet 5, medium effort. One test file against the existing dm harness
+(`test/datamechanics/helpers.ts`), copying the mock shape from
+`test/datamechanics/pm-sync-refusal.datamechanics.test.ts` (unique create ids) rather than from the two
+adoption tests (constant id). The real work is the anchors and the mutation, not the scenarios.
 
 ## Tier safety
 
-No tier boundary moves; no read path changes. The test seeds its own team via `seedTeam()` and asserts
-only within that `team_id`, so it cannot pass by observing another team's rows.
+No tier boundary moves; no read path changes. The test seeds its own team via `seedTeam()` and every
+assertion is scoped to that `team_id`, so it cannot pass by observing another team's rows.

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -264,21 +264,23 @@ async function duplicateGroups(teamId: string): Promise<{ provider: string; id: 
     .select("provider, provider_resource_id")
     .eq("team_id", teamId)
     .not("provider_resource_id", "is", null);
-  // NUL as the separator, not a space: a space still GROUPS correctly (the `provider` CHECK at
-  // postgres/schema.sql forbids spaces) but the reporting split would truncate a resource id that
-  // contained one, naming the wrong id in the failure message.
+  // Keyed on a JSON tuple, not a delimited string: no separator can collide with either component and
+  // nothing has to be split back apart to report. An earlier draft joined on a space (which truncated
+  // the reported id if one contained a space) and then on a NUL (which put a control character in the
+  // source for no benefit).
   const counts = new Map<string, number>();
   for (const row of (data ?? []) as { provider: string; provider_resource_id: string }[]) {
-    const key = `${row.provider}\u0000${row.provider_resource_id}`;
+    const key = JSON.stringify([row.provider, row.provider_resource_id]);
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }
   return [...counts.entries()]
     .filter(([, n]) => n > 1)
-    .map(([key, n]) => ({ provider: key.split("\u0000")[0], id: key.split("\u0000")[1], n }));
+    .map(([key, n]) => {
+      const [provider, id] = JSON.parse(key) as [string, string];
+      return { provider, id, n };
+    });
 }
 
-/** How many links actually hold a resource id — the COUNT ANCHOR. A scenario that silently projected
- *  nothing would otherwise satisfy `duplicateGroups() === []` trivially. */
 async function ownedLinkCount(teamId: string): Promise<number> {
   const { data } = await db()
     .from("task_pm_links")

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { projectTaskByIdAfterWrite } from "@/lib/pm-sync";
+import { runInboundForTeam } from "@/lib/pm-sync/inbound";
 import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
 import { db, ingest, seedTeam, type Seed } from "./helpers";
 
 /**
  * ADOPTINV-1 — the OUTCOME the adoption fixes exist to produce, asserted on the table.
  *
- * `ADOPTDECL-1` (#581) and `ADOPTFOOT-1` (#588) shipped nine tests between them and every one pins a
+ * `ADOPTDECL-1` (#581) and `ADOPTFOOT-1` (#588) shipped a suite of tests between them and every one pins a
  * RUNG'S DECISION: the footer rung's scope, the declared rung's error, the ownership refusal, the
  * single-writer guard. None asserts the state those rungs exist to produce — that no two links in one
  * team, for one provider, point at the same `provider_resource_id`.
@@ -96,6 +97,17 @@ function linearMock(opts: { issues?: unknown[] } = {}) {
           },
         },
       });
+    if (query.includes("ImportIssues")) {
+      return Response.json({
+        data: {
+          team: {
+            key: "AIO",
+            members: { nodes: [] },
+            issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: opts.issues ?? [] },
+          },
+        },
+      });
+    }
     if (query.includes("IssueForPmSync")) {
       const wanted = (opts.issues ?? []).find((i) => (i as { id: string }).id === variables?.id);
       return Response.json({ data: { issue: wanted ?? null } });
@@ -165,7 +177,7 @@ const taskIdOf = async (teamId: string, rowKey: string, projectSlug = "acme"): P
 const linkOf = async (teamId: string, rowKey: string) => {
   const { data } = await db()
     .from("task_pm_links")
-    .select("id, project_id, provider_resource_id, projection_fingerprint")
+    .select("id, project_id, provider_resource_id, projection_fingerprint, last_error")
     .eq("team_id", teamId)
     .eq("row_key", rowKey)
     .maybeSingle();
@@ -174,8 +186,29 @@ const linkOf = async (teamId: string, rowKey: string) => {
     project_id: string;
     provider_resource_id: string | null;
     projection_fingerprint: string | null;
+    last_error: string | null;
   } | null;
 };
+
+/** The resource id stored on ONE project's link. Resolved by (project, row_key) rather than a join:
+ *  the pg adapter does not implement Supabase's `!inner` embed, and a silently-undefined join reads
+ *  exactly like a missing id. */
+async function storedIdIn(teamId: string, projectSlug: string, rowKey: string): Promise<string | null> {
+  const { data: project } = await db()
+    .from("projects")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("slug", projectSlug)
+    .single();
+  const { data } = await db()
+    .from("task_pm_links")
+    .select("provider_resource_id")
+    .eq("team_id", teamId)
+    .eq("project_id", (project as { id: string }).id)
+    .eq("row_key", rowKey)
+    .maybeSingle();
+  return (data as { provider_resource_id: string | null } | null)?.provider_resource_id ?? null;
+}
 
 /** A real second project — `task_pm_links.project_id` is an FK, so a made-up uuid silently no-ops
  *  the update and the test passes for the wrong reason. */
@@ -198,14 +231,17 @@ async function duplicateGroups(teamId: string): Promise<{ provider: string; id: 
     .select("provider, provider_resource_id")
     .eq("team_id", teamId)
     .not("provider_resource_id", "is", null);
+  // NUL as the separator, not a space: a space still GROUPS correctly (the `provider` CHECK at
+  // postgres/schema.sql forbids spaces) but the reporting split would truncate a resource id that
+  // contained one, naming the wrong id in the failure message.
   const counts = new Map<string, number>();
   for (const row of (data ?? []) as { provider: string; provider_resource_id: string }[]) {
-    const key = `${row.provider} ${row.provider_resource_id}`;
+    const key = `${row.provider}\u0000${row.provider_resource_id}`;
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }
   return [...counts.entries()]
     .filter(([, n]) => n > 1)
-    .map(([key, n]) => ({ provider: key.split(" ")[0], id: key.split(" ")[1], n }));
+    .map(([key, n]) => ({ provider: key.split("\u0000")[0], id: key.split("\u0000")[1], n }));
 }
 
 /** How many links actually hold a resource id — the COUNT ANCHOR. A scenario that silently projected
@@ -297,15 +333,24 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     // alone) the scaffold row adopts the owner's issue, `issueCreate` never happens, and the anchor
     // fires before the invariant assertion is ever evaluated. The invariant would then be caught by a
     // sibling layer instead of proving itself, which is how a guard ends up decorative.
-    const anchors: { slug: string; mutations: string[]; updated: string[] }[] = [];
-    for (const slug of ["ws-two", "ws-three"]) {
+    const anchors: { slug: string; mutations: string[]; updated: string[]; created: string[] }[] = [];
+    // Each run's listing carries what the PREVIOUS run created, footer and all. Without that, run 3 never
+    // sees a scaffold-owned candidate, and `issuesByExt` is last-write-wins on `TT1`
+    // (linear.ts:186-187) — so the refusal against another SCAFFOLD's issue, not just the original
+    // owner's, would go unexercised.
+    const listing: unknown[] = [FOOTERED_ISSUE];
+    const anchorsFor = async (slug: string) => {
       await pushTasks(seed, slug, [{ row_key: "TT1", title: "Example team task", status: "ready" }], slug);
-      const scaffold = linearMock({ issues: [FOOTERED_ISSUE] });
+      const scaffold = linearMock({ issues: [...listing] });
       await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", slug), {
         fetchImpl: scaffold.fetchImpl,
       });
-      anchors.push({ slug, mutations: scaffold.mutations, updated: scaffold.updated });
-    }
+      for (const id of scaffold.created) {
+        listing.push({ ...FOOTERED_ISSUE, id, identifier: `AIO-${id}`, url: `u/${id}` });
+      }
+      anchors.push({ slug, mutations: scaffold.mutations, updated: scaffold.updated, created: scaffold.created });
+    };
+    for (const slug of ["ws-two", "ws-three"]) await anchorsFor(slug);
 
     // THE INVARIANT, first.
     expect(await duplicateGroups(seed.teamId)).toEqual([]);
@@ -317,6 +362,13 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     for (const a of anchors) {
       expect(a.mutations, `scaffold ${a.slug} never reached the adapter`).toContain("issueCreate");
       expect(a.updated, "it must not write into the owner's issue").not.toContain(OWNED_ISSUE_ID);
+      // Bind the STORED id to what the adapter actually created. The invariant alone cannot see a
+      // persist bug that swaps two links' ids: two non-null, distinct, WRONG ids are still not a
+      // duplicate group.
+      expect(
+        await storedIdIn(seed.teamId, a.slug, "TT1"),
+        `${a.slug}'s link must store the id its own run created`
+      ).toBe(a.created[0]);
     }
   });
 
@@ -352,21 +404,79 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
         .eq("project_id", secondProjectId);
     };
 
-    // TWICE, because the re-fire sequence needs a second bite: pass 1 resolves and stamps a fingerprint,
-    // so a naive second pass would legitimately SKIP at project.ts:284 and prove nothing. Re-seeding the
-    // deleted id and clearing the fingerprint is the "a later edit breaks the short-circuit" step that
-    // reopened the hijack in the real incident.
+    // TWICE, and the two passes must not be the same test run twice. Pass 1 arrives with the fingerprint
+    // NULLED (a fresh link). Pass 2 arrives the way the incident actually re-fired: the link still holds
+    // a dead id, but its fingerprint is a STALE NON-NULL value, and a content edit is what breaks the
+    // short-circuit at project.ts:284. Re-nulling the fingerprint before both passes — as an earlier
+    // draft did — makes pass 2 a byte-identical replay with no unique kill power.
     for (const pass of [1, 2]) {
-      await setDeleted();
+      if (pass === 1) {
+        await setDeleted();
+      } else {
+        // Keep whatever fingerprint pass 1 stamped; only re-point the id at a dead issue, then edit the
+        // row so the fingerprint no longer matches.
+        await db()
+          .from("task_pm_links")
+          .update({ provider_resource_id: "issue-deleted-2" })
+          .eq("team_id", seed.teamId)
+          .eq("project_id", secondProjectId);
+        const before = await linkOf(seed.teamId, "TT1");
+        expect(
+          before?.projection_fingerprint,
+          "pass 2 must start from a STALE fingerprint, not a null one, or it is a replay of pass 1"
+        ).toBeTruthy();
+        await pushTasks(seed, "d3", [{ row_key: "TT1", title: "Example team task (edited)", status: "ready" }], "ws-deleted");
+      }
+
       const run = linearMock({ issues: [FOOTERED_ISSUE] });
       await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", "ws-deleted"), {
         fetchImpl: run.fetchImpl,
       });
       // Invariant first, anchors second — see the note in the scenario above.
       expect(await duplicateGroups(seed.teamId), `pass ${pass} produced a duplicate group`).toEqual([]);
+      expect(await ownedLinkCount(seed.teamId), `pass ${pass}: owner + this row, no more, no fewer`).toBe(2);
       expect(run.mutations.length, `pass ${pass} never reached the adapter`).toBeGreaterThan(0);
       expect(run.updated, `pass ${pass} wrote into the owner's issue`).not.toContain(OWNED_ISSUE_ID);
     }
+  });
+
+  it("THE INBOUND WRITER: mirror-adopt must not take an issue a workspace link already owns", async () => {
+    // The outbound projector is not the only writer of `provider_resource_id`. `adoptInbound`
+    // (lib/pm-sync/inbound.ts:448) inserts it directly, and its `on conflict` clause is keyed on ROW
+    // IDENTITY, so the clause is not what protects the invariant — the team-wide candidate filter at
+    // inbound.ts:405-414 (`!ownedIds.has(it.id)`) is. A test that drove only the outbound path would
+    // leave the second writer unbound, which is the whole reason this scenario is in scope.
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+
+    // A workspace row legitimately owns a FOOTERLESS issue — footerless because the inbound candidate
+    // filter also excludes anything carrying an `aios-ext` footer, so a footered fixture would be
+    // skipped for the wrong reason and prove nothing about ownership.
+    await pushTasks(seed, "i1", [
+      {
+        row_key: "TT1",
+        title: "Finish verified operator loop",
+        status: "in_progress",
+        pm_provider: "linear",
+        pm_external_id: "AIO-444",
+      },
+    ]);
+    const owner = linearMock({ issues: [OWNED_ISSUE] });
+    await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1"), { fetchImpl: owner.fetchImpl });
+    expect(
+      await storedIdIn(seed.teamId, "acme", "TT1"),
+      "the owner must hold the issue or the inbound filter has nothing to exclude"
+    ).toBe(OWNED_ISSUE_ID);
+    const before = await ownedLinkCount(seed.teamId);
+
+    // Now the inbound leg sees that same issue in the Linear team and tries to mirror it in.
+    const inbound = linearMock({ issues: [OWNED_ISSUE] });
+    await runInboundForTeam(db(), seed.teamId, { fetchImpl: inbound.fetchImpl });
+
+    expect(await duplicateGroups(seed.teamId), "mirror-adopt claimed an already-owned issue").toEqual([]);
+    expect(await ownedLinkCount(seed.teamId), "inbound must not have added a link for an owned issue").toBe(
+      before
+    );
   });
 
   it("A DECLARED id already owned by another row is refused, and the row records an error", async () => {
@@ -402,10 +512,23 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     });
 
     expect(await duplicateGroups(seed.teamId)).toEqual([]);
-    const claimantLink = await linkOf(seed.teamId, "TT9");
-    expect(claimantLink?.provider_resource_id, "the claimant must not end up holding the owner's issue").not.toBe(
-      OWNED_ISSUE_ID
+
+    // The invariant alone cannot tell "refused with an error" from "silently invented a SECOND issue" —
+    // and the second is exactly the behaviour ADOPTDECL-1 removed. A mutant that turns the throw at
+    // linear.ts:389-395 into a silent fall-through creates `li-N` for the claimant: no duplicate, a
+    // non-null id that is not the owner's, nothing written into the owner's issue — green, while the
+    // product regressed. So pin the refusal itself: nothing was created, the link claims NO id, and the
+    // error says why.
+    expect(claimant.mutations, "a refused declaration must not create a replacement issue").not.toContain(
+      "issueCreate"
     );
+    expect(
+      await ownedLinkCount(seed.teamId),
+      "only the owner may hold an id — the claimant's link must stay unresolved"
+    ).toBe(1);
+    const claimantLink = await linkOf(seed.teamId, "TT9");
+    expect(claimantLink?.provider_resource_id, "the claimant must not end up holding the owner's issue").toBeNull();
+    expect(claimantLink?.last_error ?? "", "the refusal must be recorded on the row").toContain("already linked");
     expect(claimant.updated, "and must not have written into it").not.toContain(OWNED_ISSUE_ID);
   });
 });

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -292,22 +292,32 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
 
     // Workspaces 2 and 3: their OWN projects, each with its own scaffold `TT1` — the live shape, where
     // the owner keeps its link and the newcomers have none.
+    // The anchors are RECORDED here and asserted AFTER the invariant, deliberately. Asserted inline they
+    // abort the scenario first — under the canonical mutant (self-exclusion re-keyed to `row_key`
+    // alone) the scaffold row adopts the owner's issue, `issueCreate` never happens, and the anchor
+    // fires before the invariant assertion is ever evaluated. The invariant would then be caught by a
+    // sibling layer instead of proving itself, which is how a guard ends up decorative.
+    const anchors: { slug: string; mutations: string[]; updated: string[] }[] = [];
     for (const slug of ["ws-two", "ws-three"]) {
       await pushTasks(seed, slug, [{ row_key: "TT1", title: "Example team task", status: "ready" }], slug);
       const scaffold = linearMock({ issues: [FOOTERED_ISSUE] });
       await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", slug), {
         fetchImpl: scaffold.fetchImpl,
       });
-
-      // POSITIVE ANCHOR: this row actually reached the adapter. "The fetch mock was called" would not
-      // do — `projectRows` calls `prepare` before any row projects (project.ts:401), so bootstrap
-      // alone satisfies it even when every row short-circuits at :284.
-      expect(scaffold.mutations, `scaffold ${slug} never reached the adapter`).toContain("issueCreate");
-      expect(scaffold.updated, "it must not write into the owner's issue").not.toContain(OWNED_ISSUE_ID);
+      anchors.push({ slug, mutations: scaffold.mutations, updated: scaffold.updated });
     }
 
+    // THE INVARIANT, first.
     expect(await duplicateGroups(seed.teamId)).toEqual([]);
     expect(await ownedLinkCount(seed.teamId), "three rows must have produced three distinct links").toBe(3);
+
+    // Then the anti-vacuity anchors: each row actually reached the adapter. "The fetch mock was called"
+    // would not do — `projectRows` calls `prepare` before any row projects (project.ts:401), so
+    // bootstrap alone satisfies it even when every row short-circuits at :284.
+    for (const a of anchors) {
+      expect(a.mutations, `scaffold ${a.slug} never reached the adapter`).toContain("issueCreate");
+      expect(a.updated, "it must not write into the owner's issue").not.toContain(OWNED_ISSUE_ID);
+    }
   });
 
   it("RUNG 1 MISSING because the issue was DELETED at the provider, twice in succession", async () => {
@@ -352,9 +362,10 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
       await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", "ws-deleted"), {
         fetchImpl: run.fetchImpl,
       });
+      // Invariant first, anchors second — see the note in the scenario above.
+      expect(await duplicateGroups(seed.teamId), `pass ${pass} produced a duplicate group`).toEqual([]);
       expect(run.mutations.length, `pass ${pass} never reached the adapter`).toBeGreaterThan(0);
       expect(run.updated, `pass ${pass} wrote into the owner's issue`).not.toContain(OWNED_ISSUE_ID);
-      expect(await duplicateGroups(seed.teamId), `pass ${pass} produced a duplicate group`).toEqual([]);
     }
   });
 
@@ -390,11 +401,11 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
       fetchImpl: claimant.fetchImpl,
     });
 
+    expect(await duplicateGroups(seed.teamId)).toEqual([]);
     const claimantLink = await linkOf(seed.teamId, "TT9");
     expect(claimantLink?.provider_resource_id, "the claimant must not end up holding the owner's issue").not.toBe(
       OWNED_ISSUE_ID
     );
     expect(claimant.updated, "and must not have written into it").not.toContain(OWNED_ISSUE_ID);
-    expect(await duplicateGroups(seed.teamId)).toEqual([]);
   });
 });

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -132,14 +132,10 @@ function linearMock(opts: { issues?: unknown[] } = {}) {
   return { fetchImpl, mutations, updated, created };
 }
 
-async function seedLinearPrimary(seed: Seed) {
+async function seedLinearPrimary(seed: Seed, config: Record<string, unknown> = { teamId: "team-uuid" }) {
   await db().from("teams").update({ primary_pm_provider: "linear" }).eq("id", seed.teamId);
   const auth = { teamId: seed.teamId, memberId: seed.memberId };
-  const { id } = await upsertIntegration(db(), auth, {
-    type: "linear",
-    name: "linear",
-    config: { teamId: "team-uuid" },
-  });
+  const { id } = await upsertIntegration(db(), auth, { type: "linear", name: "linear", config });
   await setIntegrationSecret(db(), auth, id, "lin_api_x");
 }
 
@@ -447,7 +443,10 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     // inbound.ts:405-414 (`!ownedIds.has(it.id)`) is. A test that drove only the outbound path would
     // leave the second writer unbound, which is the whole reason this scenario is in scope.
     const seed = await seedTeam();
-    await seedLinearPrimary(seed);
+    // `inboundApply: true` is not decoration: without it `runInboundForTeam` returns an empty result at
+    // inbound.ts:526 before reading a single issue, and this scenario asserts nothing at all. A mutation
+    // deleting the ownership filter SURVIVED until this flag was set — the test was green and vacuous.
+    await seedLinearPrimary(seed, { teamId: "team-uuid", inboundApply: true });
 
     // A workspace row legitimately owns a FOOTERLESS issue — footerless because the inbound candidate
     // filter also excludes anything carrying an `aios-ext` footer, so a footered fixture would be
@@ -471,9 +470,12 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
 
     // Now the inbound leg sees that same issue in the Linear team and tries to mirror it in.
     const inbound = linearMock({ issues: [OWNED_ISSUE] });
-    await runInboundForTeam(db(), seed.teamId, { fetchImpl: inbound.fetchImpl });
+    const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl: inbound.fetchImpl });
 
     expect(await duplicateGroups(seed.teamId), "mirror-adopt claimed an already-owned issue").toEqual([]);
+    // POSITIVE ANCHOR: the leg actually ran. `enabled: false` is the silent no-op above.
+    expect(result.enabled, "the inbound leg did not run — this scenario would prove nothing").toBe(true);
+    expect(result.reason ?? "", "the inbound leg bailed early").toBe("");
     expect(await ownedLinkCount(seed.teamId), "inbound must not have added a link for an owned issue").toBe(
       before
     );

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -171,7 +171,20 @@ const taskIdOf = async (teamId: string, rowKey: string, projectSlug = "acme"): P
   return (data as { id: string }).id;
 };
 
+/** Reads the ONE link for a row key, and fails loudly if there is more than one.
+ *  `.maybeSingle()` returns the FIRST row when several match (lib/db/pg/query-builder.ts:331 — only
+ *  `.single()` errors), and several scenarios here deliberately create two links keyed `TT1`. Reading
+ *  "the" link in that state silently answers about the wrong project, which is how an anchor ends up
+ *  asserting something true of a row it was not testing. */
 const linkOf = async (teamId: string, rowKey: string) => {
+  const { data: all } = await db()
+    .from("task_pm_links")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("row_key", rowKey);
+  if ((all ?? []).length > 1) {
+    throw new Error(`linkOf(${rowKey}) is ambiguous — ${(all ?? []).length} links; use linkIn(project)`);
+  }
   const { data } = await db()
     .from("task_pm_links")
     .select("id, project_id, provider_resource_id, projection_fingerprint, last_error")
@@ -205,6 +218,29 @@ async function storedIdIn(teamId: string, projectSlug: string, rowKey: string): 
     .eq("row_key", rowKey)
     .maybeSingle();
   return (data as { provider_resource_id: string | null } | null)?.provider_resource_id ?? null;
+}
+
+/** The link for ONE project's row — the unambiguous read. */
+async function linkIn(teamId: string, projectSlug: string, rowKey: string) {
+  const { data: project } = await db()
+    .from("projects")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("slug", projectSlug)
+    .single();
+  const { data } = await db()
+    .from("task_pm_links")
+    .select("id, provider_resource_id, projection_fingerprint, last_error")
+    .eq("team_id", teamId)
+    .eq("project_id", (project as { id: string }).id)
+    .eq("row_key", rowKey)
+    .maybeSingle();
+  return data as {
+    id: string;
+    provider_resource_id: string | null;
+    projection_fingerprint: string | null;
+    last_error: string | null;
+  } | null;
 }
 
 /** A real second project — `task_pm_links.project_id` is an FK, so a made-up uuid silently no-ops
@@ -339,9 +375,10 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     const anchorsFor = async (slug: string) => {
       await pushTasks(seed, slug, [{ row_key: "TT1", title: "Example team task", status: "ready" }], slug);
       const scaffold = linearMock({ issues: [...listing] });
-      await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", slug), {
+      const report = await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", slug), {
         fetchImpl: scaffold.fetchImpl,
       });
+      expect(report?.status, `${slug} short-circuited instead of projecting`).not.toBe("skipped");
       for (const id of scaffold.created) {
         listing.push({ ...FOOTERED_ISSUE, id, identifier: `AIO-${id}`, url: `u/${id}` });
       }
@@ -417,18 +454,19 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
           .update({ provider_resource_id: "issue-deleted-2" })
           .eq("team_id", seed.teamId)
           .eq("project_id", secondProjectId);
-        const before = await linkOf(seed.teamId, "TT1");
+        const before = await linkIn(seed.teamId, "ws-deleted", "TT1");
         expect(
           before?.projection_fingerprint,
-          "pass 2 must start from a STALE fingerprint, not a null one, or it is a replay of pass 1"
+          "pass 2 must start from a STALE fingerprint ON THE ROW UNDER TEST, not a null one, or it is a replay of pass 1"
         ).toBeTruthy();
         await pushTasks(seed, "d3", [{ row_key: "TT1", title: "Example team task (edited)", status: "ready" }], "ws-deleted");
       }
 
       const run = linearMock({ issues: [FOOTERED_ISSUE] });
-      await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", "ws-deleted"), {
+      const report = await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", "ws-deleted"), {
         fetchImpl: run.fetchImpl,
       });
+      expect(report?.status, `pass ${pass} short-circuited instead of projecting`).not.toBe("skipped");
       // Invariant first, anchors second — see the note in the scenario above.
       expect(await duplicateGroups(seed.teamId), `pass ${pass} produced a duplicate group`).toEqual([]);
       expect(await ownedLinkCount(seed.teamId), `pass ${pass}: owner + this row, no more, no fewer`).toBe(2);
@@ -488,7 +526,6 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl: inbound.fetchImpl });
 
     expect(await duplicateGroups(seed.teamId), "mirror-adopt claimed an already-owned issue").toEqual([]);
-    // POSITIVE ANCHOR: the leg actually ran. `enabled: false` is the silent no-op above.
     expect(result.enabled, "the inbound leg did not run — this scenario would prove nothing").toBe(true);
     expect(result.reason ?? "", "the inbound leg bailed early").toBe("");
     expect(
@@ -499,6 +536,21 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     expect(await ownedLinkCount(seed.teamId), "inbound must not have added a link for an owned issue").toBe(
       before
     );
+
+    // THE PAIRED POSITIVE. Everything above is satisfied by an inbound leg that considered NOTHING —
+    // empty the candidate list for any reason and it stays green. So prove ownership is the actual
+    // discriminator: drop the owner's claim, change nothing else, and the SAME issue must now adopt.
+    const ownerLink = await linkIn(seed.teamId, "acme", "TT1");
+    await db()
+      .from("task_pm_links")
+      .update({ provider_resource_id: null, projection_fingerprint: null })
+      .eq("id", ownerLink!.id);
+    const unowned = linearMock({ issues: [OWNED_ISSUE] });
+    const second = await runInboundForTeam(db(), seed.teamId, { fetchImpl: unowned.fetchImpl });
+    expect(
+      second.adopted,
+      "with nobody owning it the same issue MUST adopt — otherwise the case above proved nothing"
+    ).toContain(OWNED_ISSUE.identifier);
   });
 
   it("A DECLARED id already owned by another row is refused, and the row records an error", async () => {
@@ -529,9 +581,10 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
       "ws-claimant"
     );
     const claimant = linearMock({ issues: [OWNED_ISSUE] });
-    await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT9", "ws-claimant"), {
+    const claimantReport = await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT9", "ws-claimant"), {
       fetchImpl: claimant.fetchImpl,
     });
+    expect(claimantReport?.status, "the claimant short-circuited instead of projecting").not.toBe("skipped");
 
     expect(await duplicateGroups(seed.teamId)).toEqual([]);
 

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { projectTaskByIdAfterWrite } from "@/lib/pm-sync";
 import { runInboundForTeam } from "@/lib/pm-sync/inbound";
+import { linearMirrorProject } from "@/lib/ingest/sources/linear-normalize";
 import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
 import { db, ingest, seedTeam, type Seed } from "./helpers";
 
@@ -468,6 +469,20 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     ).toBe(OWNED_ISSUE_ID);
     const before = await ownedLinkCount(seed.teamId);
 
+    // Inbound only ADOPTS an issue that already has a mirror task under the deterministic
+    // `linear-<teamKey>` project (inbound.ts:416-428 skips "no mirror task yet"). Without one the leg
+    // skips for an unrelated reason and the scenario proves nothing — a mutation deleting the ownership
+    // filter SURVIVED at this exact step until the mirror was seeded.
+    const mirror = await makeProject(seed, linearMirrorProject("AIO"));
+    await db().from("tasks").insert({
+      team_id: seed.teamId,
+      project_id: mirror,
+      row_key: OWNED_ISSUE.identifier,
+      title: `Native ${OWNED_ISSUE.identifier}`,
+      status: "in_progress",
+      origin: "sync",
+    });
+
     // Now the inbound leg sees that same issue in the Linear team and tries to mirror it in.
     const inbound = linearMock({ issues: [OWNED_ISSUE] });
     const result = await runInboundForTeam(db(), seed.teamId, { fetchImpl: inbound.fetchImpl });
@@ -476,6 +491,11 @@ describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgre
     // POSITIVE ANCHOR: the leg actually ran. `enabled: false` is the silent no-op above.
     expect(result.enabled, "the inbound leg did not run — this scenario would prove nothing").toBe(true);
     expect(result.reason ?? "", "the inbound leg bailed early").toBe("");
+    expect(
+      result.skipped.join(" "),
+      "the issue was skipped for a FIXTURE reason (no mirror task), not because it is owned"
+    ).not.toContain("no mirror task yet");
+    expect(result.adopted, "an owned issue must never be adopted by the mirror").toEqual([]);
     expect(await ownedLinkCount(seed.teamId), "inbound must not have added a link for an owned issue").toBe(
       before
     );

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it, vi } from "vitest";
+import { projectTaskByIdAfterWrite } from "@/lib/pm-sync";
+import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+
+/**
+ * ADOPTINV-1 — the OUTCOME the adoption fixes exist to produce, asserted on the table.
+ *
+ * `ADOPTDECL-1` (#581) and `ADOPTFOOT-1` (#588) shipped nine tests between them and every one pins a
+ * RUNG'S DECISION: the footer rung's scope, the declared rung's error, the ownership refusal, the
+ * single-writer guard. None asserts the state those rungs exist to produce — that no two links in one
+ * team, for one provider, point at the same `provider_resource_id`.
+ *
+ * The closest existing assertions stop just short, both deliberately-looking and both blind to the
+ * incident's actual shape:
+ *   • `pm-sync-inbound.datamechanics.test.ts:554` asserts one link for one ROW KEY — two links with
+ *     DIFFERENT row keys sharing one issue (exactly what happened in prod) pass it.
+ *   • `pm-sync-footer-adoption-scope.datamechanics.test.ts:146` asserts the MOCK's recorded calls, not
+ *     the row's stored id — a persist bug writing the owner's id into the scaffold's link while the
+ *     adapter dutifully created a new issue would stay green.
+ *
+ * And the DB does not cover it: `postgres/schema.sql:1280` has only
+ * `unique (team_id, project_id, row_key, provider)`. `ADOPTUNIQ-1` would add the index this file's
+ * query mirrors, but it cannot ship while production holds a violating group and `pg:schema` is
+ * Railway's preDeployCommand — a failing index build takes the release down. So until that outward-facing
+ * repair happens, THIS is the only thing enforcing the invariant.
+ *
+ * WHY THE QUERY CARRIES `provider`: it must match `ADOPTUNIQ-1`'s
+ * `unique (team_id, provider, provider_resource_id)` exactly, or it does not pre-verify it. Without the
+ * provider term a Plane link and a Linear link sharing an id string would be a false positive against a
+ * constraint that permits them.
+ */
+
+const OWNED_ISSUE_ID = "issue-444";
+
+/** The owner's issue carries NO `aios-ext` footer, and that is load-bearing, not incidental.
+ *  `linear.ts:381-386` throws when a DECLARED issue's footer names another row — BEFORE the
+ *  `ownedResourceIds` check at `:388-395` is reached. A footered fixture would therefore prove the
+ *  footer path and leave the ownership refusal unpinned. The prod shape is footerless too
+ *  (`linear.ts:377-379`). */
+const OWNED_ISSUE = {
+  id: OWNED_ISSUE_ID,
+  identifier: "AIO-444",
+  url: "https://linear.app/AIO-444",
+  title: "Finish verified operator loop",
+  description: "A real write-up with no footer.",
+  priority: 0,
+  parent: null,
+  state: { id: "ls-todo", name: "Todo", type: "unstarted" },
+  labels: { nodes: [] },
+  team: { id: "team-uuid" },
+};
+
+/** The footer-bearing variant, for the rung that resolves by `aios-ext:` alone. */
+const FOOTERED_ISSUE = {
+  ...OWNED_ISSUE,
+  description: "A real write-up.\n\naios-ext: TT1 · source: aios-backlog",
+};
+
+/**
+ * UNIQUE create ids, and this is the difference between a real result and a fixture artifact. The two
+ * adoption dm tests' mock returns a constant `id: "brand-new"` for every `issueCreate`. In the
+ * three-TT1 scenario below, two rows are refused adoption and each mints its OWN issue — with a
+ * constant id both links persist the same `provider_resource_id` and the invariant query reports a
+ * duplicate that the product never created. Same pattern as
+ * `pm-sync-refusal.datamechanics.test.ts:48`.
+ */
+/** MODULE-scoped, deliberately. A per-mock counter is not enough: each scenario builds a FRESH mock
+ *  per projection, so two independently-created issues would both be `li-1` and the invariant query
+ *  would report a duplicate the product never made — the same fixture artifact as the constant id,
+ *  one level down. A real provider never reuses an id, and neither does this. */
+let issueSeq = 0;
+
+function linearMock(opts: { issues?: unknown[] } = {}) {
+  const mutations: string[] = [];
+  const updated: string[] = [];
+  const created: string[] = [];
+  const states = [
+    { id: "ls-todo", name: "Todo", type: "unstarted" },
+    { id: "ls-started", name: "In Progress", type: "started" },
+    { id: "ls-done", name: "Done", type: "completed" },
+  ];
+  const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+    const { query, variables } = JSON.parse(String(init?.body));
+    if (query.includes("ProjectionBootstrap"))
+      return Response.json({ data: { team: { key: "AIO", states: { nodes: states }, labels: { nodes: [] } } } });
+    if (query.includes("ProjectionMembers"))
+      return Response.json({
+        data: { team: { members: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } },
+      });
+    if (query.includes("ProjectionIssues"))
+      return Response.json({
+        data: {
+          team: {
+            issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: opts.issues ?? [] },
+          },
+        },
+      });
+    if (query.includes("IssueForPmSync")) {
+      const wanted = (opts.issues ?? []).find((i) => (i as { id: string }).id === variables?.id);
+      return Response.json({ data: { issue: wanted ?? null } });
+    }
+    if (query.includes("issueCreate")) {
+      mutations.push("issueCreate");
+      const id = `li-${++issueSeq}`;
+      created.push(id);
+      return Response.json({
+        data: { issueCreate: { success: true, issue: { id, identifier: `AIO-9${issueSeq}`, url: `u/${id}` } } },
+      });
+    }
+    if (query.includes("issueUpdate")) {
+      mutations.push("issueUpdate");
+      updated.push(String(variables?.id));
+      return Response.json({
+        data: { issueUpdate: { success: true, issue: { id: variables.id, identifier: "AIO-444", url: "u" } } },
+      });
+    }
+    return Response.json({ data: {} });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations, updated, created };
+}
+
+async function seedLinearPrimary(seed: Seed) {
+  await db().from("teams").update({ primary_pm_provider: "linear" }).eq("id", seed.teamId);
+  const auth = { teamId: seed.teamId, memberId: seed.memberId };
+  const { id } = await upsertIntegration(db(), auth, {
+    type: "linear",
+    name: "linear",
+    config: { teamId: "team-uuid" },
+  });
+  await setIntegrationSecret(db(), auth, id, "lin_api_x");
+}
+
+/** Push into a NAMED project. The incident was three workspaces = three projects, each with its own
+ *  `TT1` task, so the scenarios seed three real projects rather than moving one link around: a moved
+ *  link leaves the original project's link in place holding a resolved id and a matching fingerprint,
+ *  which short-circuits at `project.ts:284` and never reaches the rungs. */
+const pushTasks = (seed: Seed, salt: string, rows: Record<string, unknown>[], project = "acme") =>
+  ingest(seed, {
+    project,
+    kind: "task",
+    path: `3-log/${project}-tasks.md`,
+    body: `${salt}\n` + rows.map((r) => `| ${r.row_key} | ${r.title} | | |`).join("\n"),
+    access: "team",
+    rows,
+  } as never);
+
+const taskIdOf = async (teamId: string, rowKey: string, projectSlug = "acme"): Promise<string> => {
+  const { data: project } = await db()
+    .from("projects")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("slug", projectSlug)
+    .single();
+  const { data } = await db()
+    .from("tasks")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("project_id", (project as { id: string }).id)
+    .eq("row_key", rowKey)
+    .single();
+  return (data as { id: string }).id;
+};
+
+const linkOf = async (teamId: string, rowKey: string) => {
+  const { data } = await db()
+    .from("task_pm_links")
+    .select("id, project_id, provider_resource_id, projection_fingerprint")
+    .eq("team_id", teamId)
+    .eq("row_key", rowKey)
+    .maybeSingle();
+  return data as {
+    id: string;
+    project_id: string;
+    provider_resource_id: string | null;
+    projection_fingerprint: string | null;
+  } | null;
+};
+
+/** A real second project — `task_pm_links.project_id` is an FK, so a made-up uuid silently no-ops
+ *  the update and the test passes for the wrong reason. */
+async function makeProject(seed: Seed, slug: string): Promise<string> {
+  const { data } = await db()
+    .from("projects")
+    .insert({ team_id: seed.teamId, slug, name: slug })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+/**
+ * THE INVARIANT. Mirrors `ADOPTUNIQ-1`'s index exactly:
+ *   unique (team_id, provider, provider_resource_id) where provider_resource_id is not null
+ */
+async function duplicateGroups(teamId: string): Promise<{ provider: string; id: string; n: number }[]> {
+  const { data } = await db()
+    .from("task_pm_links")
+    .select("provider, provider_resource_id")
+    .eq("team_id", teamId)
+    .not("provider_resource_id", "is", null);
+  const counts = new Map<string, number>();
+  for (const row of (data ?? []) as { provider: string; provider_resource_id: string }[]) {
+    const key = `${row.provider} ${row.provider_resource_id}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .filter(([, n]) => n > 1)
+    .map(([key, n]) => ({ provider: key.split(" ")[0], id: key.split(" ")[1], n }));
+}
+
+/** How many links actually hold a resource id — the COUNT ANCHOR. A scenario that silently projected
+ *  nothing would otherwise satisfy `duplicateGroups() === []` trivially. */
+async function ownedLinkCount(teamId: string): Promise<number> {
+  const { data } = await db()
+    .from("task_pm_links")
+    .select("id")
+    .eq("team_id", teamId)
+    .not("provider_resource_id", "is", null);
+  return (data ?? []).length;
+}
+
+describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgres)", () => {
+  it("THE DETECTOR WORKS: two links deliberately sharing one issue are REPORTED", async () => {
+    // The inverse control. Draft 1 of the spec proposed "the query returns zero rows on a team with no
+    // links", which proves the opposite of what it claimed — that the query passes on nothing, which IS
+    // the vacuity. Any query typo that matches nothing would survive that. This is the assertion that
+    // makes every `toEqual([])` below mean something.
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const projectA = await makeProject(seed, "dup-a");
+    const projectB = await makeProject(seed, "dup-b");
+    for (const [i, projectId] of [projectA, projectB].entries()) {
+      // `provider_external_id` is NOT NULL with no default — omitting it makes the insert fail and the
+      // whole control silently pass over an empty table, which is the exact vacuity this case exists to
+      // rule out. So the error is checked rather than discarded.
+      const { error } = await db()
+        .from("task_pm_links")
+        .insert({
+          team_id: seed.teamId,
+          project_id: projectId,
+          row_key: `DUP${i}`,
+          provider: "linear",
+          provider_external_id: `DUP${i}`,
+          provider_resource_id: OWNED_ISSUE_ID,
+        });
+      expect(error, "the seeded duplicate link must actually insert").toBeFalsy();
+    }
+    expect(await duplicateGroups(seed.teamId)).toEqual([
+      { provider: "linear", id: OWNED_ISSUE_ID, n: 2 },
+    ]);
+
+    // And it is provider-scoped, matching the index it pre-verifies: the SAME id under a different
+    // provider is NOT a violation, because the index would permit it.
+    const seed2 = await seedTeam();
+    const p1 = await makeProject(seed2, "mixed-a");
+    const p2 = await makeProject(seed2, "mixed-b");
+    for (const [i, [projectId, provider]] of [
+      [p1, "linear"],
+      [p2, "plane"],
+    ].entries()) {
+      const { error } = await db()
+        .from("task_pm_links")
+        .insert({
+          team_id: seed2.teamId,
+          project_id: projectId,
+          row_key: `MIX${i}`,
+          provider,
+          provider_external_id: `MIX${i}`,
+          provider_resource_id: "same-string",
+        });
+      expect(error, "the mixed-provider link must actually insert").toBeFalsy();
+    }
+    expect(await duplicateGroups(seed2.teamId)).toEqual([]);
+  });
+
+  it("THE INCIDENT'S SHAPE: three same-keyed rows in three projects, projected back to back", async () => {
+    // `projectAllTasks` is (team, project)-scoped, so three projects cannot share one run — these are
+    // three successive projections, each seeing the state the previous one left.
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+
+    // Workspace 1 legitimately owns AIO-444 via its footer.
+    await pushTasks(seed, "o1", [
+      { row_key: "TT1", title: "Finish verified operator loop", status: "in_progress" },
+    ]);
+    const first = linearMock({ issues: [FOOTERED_ISSUE] });
+    await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1"), { fetchImpl: first.fetchImpl });
+    const ownerLink = await linkOf(seed.teamId, "TT1");
+    expect(ownerLink?.provider_resource_id, "the owner must hold the issue or this proves nothing").toBe(
+      OWNED_ISSUE_ID
+    );
+
+    // Workspaces 2 and 3: their OWN projects, each with its own scaffold `TT1` — the live shape, where
+    // the owner keeps its link and the newcomers have none.
+    for (const slug of ["ws-two", "ws-three"]) {
+      await pushTasks(seed, slug, [{ row_key: "TT1", title: "Example team task", status: "ready" }], slug);
+      const scaffold = linearMock({ issues: [FOOTERED_ISSUE] });
+      await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", slug), {
+        fetchImpl: scaffold.fetchImpl,
+      });
+
+      // POSITIVE ANCHOR: this row actually reached the adapter. "The fetch mock was called" would not
+      // do — `projectRows` calls `prepare` before any row projects (project.ts:401), so bootstrap
+      // alone satisfies it even when every row short-circuits at :284.
+      expect(scaffold.mutations, `scaffold ${slug} never reached the adapter`).toContain("issueCreate");
+      expect(scaffold.updated, "it must not write into the owner's issue").not.toContain(OWNED_ISSUE_ID);
+    }
+
+    expect(await duplicateGroups(seed.teamId)).toEqual([]);
+    expect(await ownedLinkCount(seed.teamId), "three rows must have produced three distinct links").toBe(3);
+  });
+
+  it("RUNG 1 MISSING because the issue was DELETED at the provider, twice in succession", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+
+    await pushTasks(seed, "d1", [{ row_key: "TT1", title: "Finish verified operator loop", status: "in_progress" }]);
+    const owner = linearMock({ issues: [FOOTERED_ISSUE] });
+    await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1"), { fetchImpl: owner.fetchImpl });
+    const ownerLink = await linkOf(seed.teamId, "TT1");
+    expect(ownerLink?.provider_resource_id).toBe(OWNED_ISSUE_ID);
+
+    // A second workspace's row whose link points at an id the provider no longer returns — the deleted
+    // issue that made rung 1 MISS, which is the path ADOPTFOOT-1 found its load gate blind to.
+    await pushTasks(seed, "d2", [{ row_key: "TT1", title: "Example team task", status: "ready" }], "ws-deleted");
+    const seeded = linearMock({ issues: [] });
+    await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", "ws-deleted"), {
+      fetchImpl: seeded.fetchImpl,
+    });
+    const secondProject = await db()
+      .from("projects")
+      .select("id")
+      .eq("team_id", seed.teamId)
+      .eq("slug", "ws-deleted")
+      .single();
+    const secondProjectId = (secondProject.data as { id: string }).id;
+    const setDeleted = async () => {
+      await db()
+        .from("task_pm_links")
+        .update({ provider_resource_id: "issue-deleted", projection_fingerprint: null })
+        .eq("team_id", seed.teamId)
+        .eq("project_id", secondProjectId);
+    };
+
+    // TWICE, because the re-fire sequence needs a second bite: pass 1 resolves and stamps a fingerprint,
+    // so a naive second pass would legitimately SKIP at project.ts:284 and prove nothing. Re-seeding the
+    // deleted id and clearing the fingerprint is the "a later edit breaks the short-circuit" step that
+    // reopened the hijack in the real incident.
+    for (const pass of [1, 2]) {
+      await setDeleted();
+      const run = linearMock({ issues: [FOOTERED_ISSUE] });
+      await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1", "ws-deleted"), {
+        fetchImpl: run.fetchImpl,
+      });
+      expect(run.mutations.length, `pass ${pass} never reached the adapter`).toBeGreaterThan(0);
+      expect(run.updated, `pass ${pass} wrote into the owner's issue`).not.toContain(OWNED_ISSUE_ID);
+      expect(await duplicateGroups(seed.teamId), `pass ${pass} produced a duplicate group`).toEqual([]);
+    }
+  });
+
+  it("A DECLARED id already owned by another row is refused, and the row records an error", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+
+    await pushTasks(seed, "c1", [
+      {
+        row_key: "TT1",
+        title: "Finish verified operator loop",
+        status: "in_progress",
+        pm_provider: "linear",
+        pm_external_id: "AIO-444",
+      },
+    ]);
+    const owner = linearMock({ issues: [OWNED_ISSUE] });
+    await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT1"), { fetchImpl: owner.fetchImpl });
+    const ownerLink = await linkOf(seed.teamId, "TT1");
+    expect(ownerLink?.provider_resource_id, "the owner must hold the issue").toBe(OWNED_ISSUE_ID);
+
+    // A DIFFERENT row, in its own project, declaring the SAME issue. The fixture issue is footerless on
+    // purpose, so this exercises the ownedResourceIds refusal rather than the ownerExt throw that
+    // precedes it at linear.ts:381-386.
+    await pushTasks(
+      seed,
+      "c2",
+      [{ row_key: "TT9", title: "Another row", status: "ready", pm_provider: "linear", pm_external_id: "AIO-444" }],
+      "ws-claimant"
+    );
+    const claimant = linearMock({ issues: [OWNED_ISSUE] });
+    await projectTaskByIdAfterWrite(db(), await taskIdOf(seed.teamId, "TT9", "ws-claimant"), {
+      fetchImpl: claimant.fetchImpl,
+    });
+
+    const claimantLink = await linkOf(seed.teamId, "TT9");
+    expect(claimantLink?.provider_resource_id, "the claimant must not end up holding the owner's issue").not.toBe(
+      OWNED_ISSUE_ID
+    );
+    expect(claimant.updated, "and must not have written into it").not.toContain(OWNED_ISSUE_ID);
+    expect(await duplicateGroups(seed.teamId)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this is

`ADOPTDECL-1` (#581) and `ADOPTFOOT-1` (#588) shipped a suite of tests between them, and **every one
pins a rung's decision** — the footer rung's scope, the declared rung's error, the ownership refusal,
the single-writer guard. **None asserts the state those rungs exist to produce:** that no two
`task_pm_links` rows in one team, for one provider, point at the same `provider_resource_id`.

Two existing assertions get close and miss:

- `pm-sync-inbound.datamechanics.test.ts:554` asserts one link per **row key** — two links with
  *different* row keys sharing one issue, which is exactly the prod incident, pass it.
- `pm-sync-footer-adoption-scope.datamechanics.test.ts:146` asserts the **mock's** calls, not the row's
  stored id — a persist bug writing the owner's id into the scaffold's link would stay green.

The DB doesn't cover it either: `postgres/schema.sql:1280` has only
`unique (team_id, project_id, row_key, provider)`. `ADOPTUNIQ-1` would add the index this test mirrors,
but it **cannot ship** while production holds a violating group and `pg:schema` is Railway's
`preDeployCommand` — a failing index build takes the release down. That repair is an outward-facing
decision with no deadline. Until then, this file is the only thing enforcing the invariant.

**No production code changed: the invariant already holds.** The spec pre-committed to what would
happen if it didn't (§4.1), and that branch did not fire.

## The five scenarios

1. **Inverse control** — deliberately-inserted duplicate links MUST be reported, and a Linear + Plane
   pair sharing an id string must NOT be (the index permits it).
2. **The incident's shape** — three rows keyed `TT1` in three projects, projected back to back, each
   run's bootstrap carrying what the previous run created.
3. **Rung 1 missing because the issue was deleted**, run twice, the second pass arriving the way the
   incident actually re-fired: a stale non-null fingerprint plus a content edit.
4. **A declared id already owned** — refused, with the refusal itself pinned.
5. **The inbound writer** — mirror-adopt must not take an issue a workspace link already owns.

## Verification

| Check | Result |
|---|---|
| `test:datamechanics:iso` (this file) | **5/5** |
| `test:datamechanics:iso` (full tier, fresh container) | **1200 passed**, 1 failed — pre-existing, see below |
| `npm test` | 2943 passed |
| `tsc --noEmit` · `lint` · `check:docs` | clean · 0 errors · congruent |
| `aios spec eval` | `SPEC_READY`, exit 0 (deterministic tier) |

**Mutations — four, each reddening the scenario it targets:**

| Mutant | Reddens |
|---|---|
| `project.ts:320` self-exclusion re-keyed to `row_key` alone (the live bug's shape) | incident + deleted-issue, **on the invariant assertion** |
| `linear.ts:389-395` declared ownership check removed | declared-collision |
| `inbound.ts:414` `!ownedIds.has(it.id)` removed | inbound |
| `inbound.ts` candidate list emptied entirely | inbound (via the paired positive) |

**The one dm failure is pre-existing.** `task-update-action … persists every projectable field`
(`expected [2030, 2, 28] to deeply equal [2030, 3, 1]`) reproduces at `origin/main` in the same
container. An earlier run also showed `context-backfill-budget` failing; it passes standalone on both
trees and disappeared once I tore down the container my repeated mutation runs had accumulated state
in — my own contention, not a defect.

## Review

Reviewed by Fable and Codex (gpt-5.5) — verdict BLOCKED on all four passes, then folded; the tests were
wrong three separate times and mutation testing is what proved it each time.

- **Codex, spec — BLOCKED, 5 findings.** The SQL omitted the `provider` term my own prose claimed, so
  it did not match the index it exists to pre-verify. My "negative control" (query returns zero on an
  empty team) proved the *opposite* of what it claimed — that the query passes on nothing, which is the
  vacuity itself. "The fetch mock was called" is not a positive anchor, because `projectRows` calls
  `prepare` before any row projects. And the inbound writer was fenced out with no destination.
- **Fable, spec — BLOCKED, 9 findings.** The sharpest: **my mutation criterion could not go red.** The
  ownership refusal is not in `project.ts`, and both refusals fail **closed** on a missing owner set —
  so "remove the refusal" makes the adapter refuse *everything*, no duplicate forms, test stays green.
  Also: the mock I pointed at mints a constant create id, which would have fabricated the very
  duplicate under test; three projections cannot share one run because `projectAllTasks` is
  `(team, project)`-scoped; and the declared fixture must be footerless or `linear.ts:381-386` throws
  before the ownership check is reached.
- **Fable, diff — BLOCKED, 10 findings.** My spec claimed inbound coverage **the code did not have** —
  the earlier fold had moved the fence, not covered the writer. And the declared scenario could not
  distinguish "refused with an error" from "silently invented a second issue", which is precisely what
  `ADOPTDECL-1` removed; a silent fall-through mutant passed it.
- **Codex, diff — BLOCKED, 3 findings.** The pass-2 stale-fingerprint anchor read `task_pm_links` by
  `(team, row_key)` while that scenario deliberately has two `TT1` links, and `.maybeSingle()` returns
  the **first** row rather than erroring — so the anchor could assert about the owner's row instead of
  the row under test. `linkOf` now fails loudly on ambiguity and a project-scoped `linkIn` does the
  work. It also showed the inbound scenario would pass with the candidate list emptied; a **paired
  positive** (drop the owner's claim, same issue must now adopt) closes it, verified by mutant 4.

**What mutation testing caught that no reviewer did:** the inbound scenario **SURVIVED its mutant
twice** — first because the integration config lacked `inboundApply: true` (the leg returns empty at
`inbound.ts:526` before reading an issue), then because no mirror task existed under
`linear-<teamKey>`. Green and worthless both times. Separately, my anchors originally **aborted each
scenario before the invariant assertion was ever evaluated**, so the invariant was being caught by a
sibling layer instead of proving itself; assertions are now ordered invariant-first.

## Deliberately not here

- **The DB constraint** (`ADOPTUNIQ-1`) — blocked on the production reconciliation, a human call. A
  test binds this repo's code paths; an index binds the data whatever writes it. This does not replace it.
- **Repairing the three live links.** No production write happens here.
- **A runtime health signal** — it would go red on the known violation and stay red until that decision
  is made, and this repo has been bitten six times by a banner that cries wolf. The allowlist variant is
  named in the spec and deferred *with* the repair, not rejected.
- **What this file does NOT guard, stated so nobody deletes the sibling:** reintroducing `ADOPTFOOT-1`'s
  original load gate survives this whole file, because the refusals fail closed and over-refusal
  preserves the invariant. The RECOVERY case in `pm-sync-footer-adoption-scope` is what kills that.

**Note for whoever lands `ADOPTUNIQ-1`:** the inverse control deliberately writes the state that index
forbids, so its insert starts failing the day the index ships. Expected, not a regression — convert it
then to asserting a unique violation.

AIOS-Work: ADOPTINV-1
