### PR TITLE
feat(meetings): credit a person on someone else's meeting when their own calendar push carries the same event id (MTGATT-3)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1142,7 +1142,9 @@ writes): live notes are grouped into CONNECTED COMPONENTS over shared event keys
 key, a series key, a title, or a date pre-filter — the note **with a body** survives (so a transcript
 can never fold into a bodyless calendar event and lose its text, whatever the arrival order), and the
 folded note's attendees + submitters are ADDED to it before it is hidden via `merged_into`. Credit
-first, hide second: a crash between leaves a visible duplicate, never a hidden uncredited note. Two
+first, hide second — AND every read is error-checked before anything is hidden, because the pg adapter
+RETURNS errors rather than throwing, so an unchecked failed read looks exactly like "no attendees" and
+would hide a note whose credit never moved (permanently: the next tick excludes `merged_into` notes). Two
 refusals, counted by reason: a component with two bodies (the transcript-overlap merge owns that) and
 one whose dates span more than a day or are unknown (the residual undetectable-series case). It runs
 each tick from `backfillMeetingNotesFromItems` BEFORE the overlap merge, and a calendar push now

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1135,9 +1135,21 @@ deliberately taken away is visible rather than indistinguishable from a parser t
 See `lib/meetings/from-calendar.ts`.
 **Event IDENTITY** (`lib/meetings/event-identity.ts`) parses `calendar_event_id`/`ical_uid`/
 `conference_url` (flat, camelCase, or nested under Granola's `google_calendar_event`) into
-kind-qualified keys (`eid:` / `uid:`). **Nothing joins on them yet** — the calendar↔transcript link is
-MTGATT-3, to be fitted to what `scripts/meeting-pairing-report.ts` (read-only) measures: how many
-CROSS-source pairs actually share a key. A **conference link is measured and NEVER joined on** — a Zoom
+kind-qualified keys (`eid:` / `uid:`), with a recurring occurrence's UID routed to `seriesKeys`
+instead (all occurrences of a series share one iCalUID). **The IDENTITY LINK joins on them**
+(MTGATT-3, `lib/meetings/identity-link.ts` = the pure decision + `lib/meetings/link-notes.ts` = the
+writes): live notes are grouped into CONNECTED COMPONENTS over shared event keys — never a conference
+key, a series key, a title, or a date pre-filter — the note **with a body** survives (so a transcript
+can never fold into a bodyless calendar event and lose its text, whatever the arrival order), and the
+folded note's attendees + submitters are ADDED to it before it is hidden via `merged_into`. Credit
+first, hide second: a crash between leaves a visible duplicate, never a hidden uncredited note. Two
+refusals, counted by reason: a component with two bodies (the transcript-overlap merge owns that) and
+one whose dates span more than a day or are unknown (the residual undetectable-series case). It runs
+each tick from `backfillMeetingNotesFromItems` BEFORE the overlap merge, and a calendar push now
+triggers the immediate backfill too (`shouldScheduleMeetingBackfill` was transcript-only, so your own
+calendar push waited for a tick while someone else's transcript was instant). `scripts/meeting-pairing-report.ts`
+(read-only) is how the join is confirmed against the first REAL pair — prod carries zero identifiers
+as of 2026-08-18, so the suite proves the rule, not the wiring to reality. A **conference link is measured and NEVER joined on** — a Zoom
 personal meeting room is reused for every meeting its owner hosts and one Meet room serves a whole
 recurring series, so matching on it fuses unrelated meetings; pinned by
 `test/guards/meeting-identity-not-a-join-key.test.ts`. Producer side: `~/scripts/granola_sync.py` +

--- a/docs/design/meeting-identity-link.md
+++ b/docs/design/meeting-identity-link.md
@@ -1,0 +1,285 @@
+# Credit a person on someone else's meeting — MTGATT-3
+
+**Status:** spec, revised after TWO review rounds (round 1 **DECLINE**, round 2 **BLOCKED**). §6
+records what each folded, and the two findings that did not survive re-derivation.
+**Build with:** opus / high — it decides whether a named colleague appears on a meeting they may not
+have attended, and it hides one note behind another. Both are the failure classes MTGATT-1 and
+MTGATT-2 were opened for.
+
+**Deps: MTGATT-2 (PR #598), not yet merged.** This stacks on `feat/meeting-attendance-identity` and
+consumes `lib/meetings/event-identity.ts` (kind-qualified `eid:` / `uid:` keys, `seriesKeys`) and the
+RSVP filter. PR base is that branch; retarget to `main` after it merges.
+
+---
+
+## What and why
+
+**What:** when a person pushes a calendar event that carries the same identifier as a meeting already
+in the system, the two are recognised as one meeting: the person's attendance is **added** to the
+existing note, both submitters are credited, and the bodyless event stops showing as a second meeting.
+
+**Why it matters — the operator's question, in their words:** *"John may be uploading meetings and if
+they do they're gonna come saying just John Ellison but I would have already also been in that
+meeting… my calendar is the only way we could do that."* Today those are two separate meetings on the
+Meetings page and the second person is credited on neither. This is the mechanism that fixes it, and
+it is the only one available: for a meeting John uploads, every signal that credits somebody else is
+either that person asserting something themselves, or an inference from John's artifact (§1).
+
+**The operator's ruling this implements (2026-08-18):** a declined invitee was not there — shipped in
+MTGATT-2. An invitee who accepted **and pushes the event in their own daily update** was there. The
+**push is the assertion**; the RSVP only vetoes, because people attend meetings they never RSVP to.
+
+## Scope
+
+**In:** grouping live notes by exact event key, the survivor rule, the additive attendance claim,
+the two refusals, and the tick wiring.
+
+**Out, deliberately:** per-attendee provenance columns (**MTGATT-4** — this slice writes attendance
+rows indistinguishable from any other, which is precisely why MTGATT-4 exists); non-member attendees
+(**MTGATT-5**); any fuzzy matcher — time windows, title similarity, conference links; any change to
+the transcript-overlap merge.
+
+---
+
+## 0. Terrain, measured before designing (prod, read-only, 2026-08-18)
+
+| | |
+|---|---|
+| calendar-source items | **0** |
+| items carrying `calendar_event_id` / `ical_uid` / `conference_url` | **0 / 0 / 0** |
+| live meeting notes / folded as duplicates | **66 / 6** |
+| granola transcripts with named speaker labels | 41 of 63 — **but the names are the recorder plus a generic `Speaker`** |
+
+**This slice ships ahead of its data. Review round 1 declined it on exactly that ground, and the
+operator overrode the decline after being told the number** — so it is built, with the reviewer's
+condition attached rather than dismissed: the first real pair must be confirmed with
+`scripts/meeting-pairing-report.ts` before anyone treats the join as working.
+
+What has changed since that decline: the producer emits the keys, and the operator has ruled on the
+product question so the join is needed under every reading of it. What has **not** changed: a green
+suite here proves the RULE, not the wiring to reality.
+
+## 1. Why there is no cleverer signal
+
+Ranked, and each one checked rather than assumed:
+
+1. **The person's own calendar push** — first-person, exact once an identifier is shared. This slice.
+2. **They recorded the meeting too** — very strong (their recorder was in the room). **Already
+   works**: the transcript-overlap merge credits both submitters; 6 meetings folded all-time.
+3. **Speaker diarization** — would be strong, and is **unusable here**: 41 of 63 transcripts carry
+   named labels, but the names are `John Ellison` (the recorder) and a generic `Speaker`. Zoom/Gong/
+   Otter carry real per-speaker names; prod has none of those sources.
+4. **Addressed in the second person** in the transcript — model-inferred, and the path that produced
+   MTGATT-1's invented attendees. A suggestion, never an assertion.
+5. **Meet/Zoom attendance reports** — actual join/leave records, the *only* true verification of
+   presence. No connector exists.
+
+So the ceiling is honest and worth stating: **this cannot catch someone who accepted, pushed their
+calendar, and then skipped the meeting.** Only (5) closes that.
+
+## 2. The join
+
+**Group live notes into CONNECTED COMPONENTS over shared `eventKeys` — and over nothing else.**
+
+Components rather than one group per key, because round 2 built the case that breaks per-key
+grouping: A carries `eid:x`, B carries **both** `eid:x` and `uid:x@google.com` (the ordinary shape — a
+UID also emits its bare event id), C is the transcript carrying only the uid. Per key, `eid:x` is
+processed first, folds B into A, and C — the note with the body — is stranded as a separate meeting
+while a bodyless note survives. That is exactly the outcome §2.1 exists to make unreachable, arriving
+through the grouping layer.
+
+- **Never** `conferenceKey`: a Zoom Personal Meeting ID is reused for every meeting its owner hosts.
+- **Never** `seriesKeys`: every occurrence of a recurring event shares one `iCalUID`.
+- **Never** `titleSimilarity`: two same-day meetings titled with a person's name score 1.0.
+- **Never date-pre-filtered.** A 19:00 PDT meeting is 02:00Z the next day, so a calendar event and its
+  transcript legitimately carry different `occurred_at`. Requiring the same date would silently drop
+  exactly the evening meetings, and look like the feature simply not matching.
+
+### 2.1 The survivor is chosen by CONTENT, not arrival order
+
+"Has a body" means `body.trim().length > 0`. A whitespace-only item is bodyless — otherwise a
+producer emitting `"\n"` for an invite would become the content-bearing survivor and hide the real
+transcript, which is the exact hazard this rule exists to remove.
+
+| the group | outcome |
+|---|---|
+| exactly one note has a body, the rest do not (N ≥ 2 pushes of one event) | **the body wins**, whichever arrived first; every bodyless member folds into it |
+| no note has a body (two people pushed the same event) | the **earliest-created** survives — deterministic, so processing order cannot change the result |
+| **two or more notes have bodies** | **REFUSE.** Two transcripts of one meeting are the overlap merge's job; folding one away here would hide content |
+
+That single rule removes MTGATT-1's deferred hazard structurally rather than by ordering the pushes:
+a transcript arriving after its calendar event can never fold into the bodyless note and lose its
+text, because it is the one with the body.
+
+### 2.2 The second refusal: a day apart is not the same meeting
+
+Members of one group whose `occurred_at` differ by **more than one day** are not linked.
+
+This is a **veto applied AFTER an identifier match, never a filter that decides which notes are
+compared** — and the review was right that calling it "not a date filter" was too cute. It is one,
+narrowly: it can only ever remove a link, never create or find one, so it cannot reintroduce the
+failure §2 forbids (dropping the evening meetings before they are ever compared). One day of slack is
+exactly the timezone case; a fortnight is the residual series case `seriesKeys` cannot catch — a
+producer sending only `ical_uid`, with no instance suffix and no `recurringEventId`, is
+indistinguishable from a single event.
+
+**An unknown `occurred_at` REFUSES the link** — the reverse of this spec's first draft, and round 2
+is why. Its case: an undetectable weekly series where the transcript is dated 11 Aug and the calendar
+event for 18 Aug carries no date at all. Skipping nulls switches the veto off precisely where it is
+the only defence. Refusing costs little (a calendar event is dated by its `start`, a granola
+transcript by `created`, and `deriveOccurredAt` has three fallbacks, so an undated note is rare) and
+it fails in the safe direction: a duplicate meeting is visible and fixable, two meetings fused into
+one are neither. Vetoes are counted by reason, never silent.
+
+### 2.3 It is a claim, not a merge
+
+The link **adds**: attendance rows from the folded note, and its submitter. It **does not** rewrite a
+body, re-ingest an item, retire an item, or call a model — all of which `mergeIntoMeetingNote` does.
+The folded note gets `merged_into` so one meeting shows once; that is one reversible column, and the
+item behind it is untouched.
+
+Idempotent by construction: a folded note is excluded from the next scan (`merged_into is null`), and
+attendee/submitter writes are upserts. **Every write goes through `lib/meetings/notes.ts`** — the
+audited single writer for all three tables (`test/guards/single-writer-meeting-notes.test.ts`).
+
+**One fix this slice must carry, because it makes an existing hazard reachable.** The overlap merge
+runs in the same tick, right after (`from-items.ts`), and `mergeIntoMeetingNote` propagates only two
+submitter ids (`merge.ts:278-279`). So a survivor that has just ACCUMULATED submitters from a linked
+calendar event can lose them when it is itself folded into a richer transcript moments later. MTGATT-2
+recorded that as a latent defect; this slice is what makes it fire, so it is fixed here:
+`backfillMergeDuplicateMeetings` passes the folded note's **full** submitter set, not just its
+`submitted_by`.
+
+**A pushed calendar event must also trigger the immediate backfill.**
+`shouldScheduleMeetingBackfill` currently returns `isMeetingTranscript(kind, source)`, which is false
+for a calendar event (`kind:'artifact'`), so today it waits up to a scheduler tick. The whole point of
+this slice is that someone pushes their calendar and is credited; a silent half-hour asymmetry between
+the two producers is the kind of thing that reads as "it didn't work".
+
+## 3. Where it runs
+
+`backfillMeetingNotesFromItems`, after note creation and **before** `backfillMergeDuplicateMeetings`,
+so a linked calendar note is already folded and cannot be reconsidered by the overlap merge.
+
+Bounded: one metadata query for live notes (capped at 500 newest), one for their items' `frontmatter`
++ a body-emptiness flag. At today's 66 notes that is two small reads; with zero identifiers it forms
+zero groups and returns immediately. The cap is stated in code, because an unbounded per-tick scan is
+how `TICKSTALL-1` starved the chain.
+
+## 4. Acceptance
+
+- **AC1 — unit, `test/meetings-identity-link.test.ts`:** grouping is by exact event key only — notes
+  sharing a `conferenceKey`, a `seriesKey`, or an identical title but no event key form **no** group.
+- **AC2 — unit, `test/meetings-identity-link.test.ts`:** the survivor is the note with a body, for
+  both arrival orders; with no bodies it is the earliest-created; with **two** bodies the group is
+  refused; with one body and **two** bodyless members, both fold into the body one.
+- **AC3 — unit, `test/meetings-identity-link.test.ts`:** a whitespace-only body counts as **no** body.
+- **AC4 — unit, `test/meetings-identity-link.test.ts`:** a component spanning more than a day is
+  vetoed, including when only its widest pair exceeds the span; one spanning exactly a day (the
+  timezone case) is **linked**; an unknown date refuses. The middle case is the inverse half — it is
+  what stops the veto quietly becoming the date pre-filter §2 forbids.
+- **AC4b — unit, `test/meetings-identity-link.test.ts`:** a three-note component bridged by a note
+  carrying two keys folds into the one with the body, and two components sharing no key are not
+  bridged.
+- **AC5 — data-mechanics, `test/datamechanics/meeting-identity-link.datamechanics.test.ts`:** a
+  transcript pushed by one member and a calendar event pushed by another, sharing a
+  `calendar_event_id`, end as **one live note — the transcript's** (asserted by its `source_item_id`
+  and its intact body, not by a uuid), carrying the calendar member as an attendee and both as
+  submitters.
+- **AC6 — data-mechanics, same file:** the identical pair created in the **reverse order** produces
+  the same outcome — survivor identified the same way, body intact. Order-independence asserted, not
+  argued.
+- **AC7 — data-mechanics, same file:** the folded note is hidden (`merged_into` set), its **item
+  still exists**, and a second tick does **not** resurrect it as a new note.
+- **AC8 — data-mechanics, same file:** running the tick twice is a no-op the second time — attendee
+  count, submitter count and survivor unchanged.
+- **AC9 — data-mechanics, same file:** two notes with **no shared identifier** are both still live
+  after the tick, even with identical titles on the same date. Mutation-verified against its own gate.
+- **AC10 — data-mechanics, same file:** two notes that both have bodies and share an identifier are
+  **not** folded by this path, and both keep their text.
+- **AC11 — data-mechanics, same file:** a survivor that has just accumulated a submitter from a linked
+  calendar event, and is then folded by the overlap merge in the SAME tick, **keeps that submitter on
+  the final survivor** — the stranding hazard §2.3 fixes, asserted end to end rather than at the unit
+  that changed.
+- **AC12 — unit, `test/meetings-schedule-backfill.test.ts`:** a pushed calendar event schedules the
+  immediate backfill for every calendar source and either `kind`; an unchanged re-push still does
+  not, and a non-calendar artifact still does not — the two inverse halves that stop the widening
+  becoming "schedule on everything".
+- **AC13 — unit, `test/guards/meeting-identity-not-a-join-key.test.ts` (existing, extended by
+  coverage):** the linker references no conference key, no series key and no `titleSimilarity` — it
+  is under `lib/`, which that guard already walks.
+- **AC14 — unit, `test/guards/single-writer-meeting-notes.test.ts` (existing):** stays green — the
+  linker writes `meeting_notes` / `meeting_note_attendees` / `meeting_note_submitters` only through
+  `lib/meetings/notes.ts`.
+
+**Falsifier:** if any two notes are linked without sharing a normalised event key, the design has
+failed regardless of how right the outcome looks. And if AC9 is deleted, nothing else in the suite
+notices — which is why it asserts an absence and is mutation-verified.
+
+## 5. Deliberately not in this slice
+
+- **Per-attendee provenance (MTGATT-4).** A calendar-derived attendee is written exactly like a
+  model-derived one, so a wrong claim is not yet diagnosable and the UI cannot say *"from Chetan's
+  calendar"*. This is the strongest argument for doing MTGATT-4 next, and the operator has been asked
+  whether invitees should be demoted to a weaker class at the same time.
+- **Non-member attendees (MTGATT-5).**
+- **Correcting the survivor's `occurred_at`** from the calendar's exact start, even though the
+  calendar knows the true local date and the transcript's UTC-derived one can be a day off.
+- **Any use of the pairing report inside product code.** It stays a hand-run instrument.
+
+## 6. Review round 1 — what it changed, and what it got wrong
+
+**DECLINE**, and the folds are in §0/§2 above. The blocker it led with — *ships ahead of its data* —
+is the same one that correctly killed this slice inside MTGATT-2; the operator overrode it after being
+shown the number, so it is recorded, not argued away, and the reviewer's condition (confirm the first
+real pair with the instrument) is kept.
+
+**Folded:**
+
+- *"Claim, not merge" makes an existing hazard reachable.* Correct, and the sharpest finding: the
+  overlap merge runs in the same tick and propagates only two submitter ids, so submitters this slice
+  ACCUMULATES on a survivor can be stranded when that survivor is itself folded. Fixed here (§2.3),
+  with AC11 asserting it end to end.
+- *N-way groups and whitespace bodies* — both now specified (§2.1), with ACs.
+- *Null-date policy and the "not a date filter" claim* — the claim was too cute; §2.2 now says what it
+  actually is and why that is still safe, and states the null policy.
+- *AC5's "same surviving note id" across two scenarios was ill-formed* — uuids differ by construction.
+  Survivor identity is now asserted by `source_item_id` and body.
+- *Counters, or "refusal is counted" is vacuous* — the summary gains them, and the deep-equal test in
+  `meeting-notes-backfill.datamechanics.test.ts` will redden and be updated.
+- *A calendar push does not trigger the immediate backfill* — true (`shouldScheduleMeetingBackfill`
+  requires `kind='transcript'`), and fixed here rather than left as a silent half-hour asymmetry.
+
+**Did NOT survive re-derivation, with evidence:**
+
+- *"A team-tier calendar note folding into an external transcript leaks attendance externally."*
+  It cannot. Meeting notes are team-tier by construction (`notes.ts:16-27`), and the timeline's whole
+  meetings leg is gated on `canSeeMeetingNotes(tier)` (`work-timeline.ts:672-675`), which is false for
+  external. No attendee row this slice writes is readable by an external viewer.
+- *"It skips the invariants `mergeIntoMeetingNote` learned the hard way — merge-owned item, access
+  floor, action-item remap, tombstone."* Those exist because that path WRITES A NEW BODY into an item:
+  the merge-owned path stops a connector re-sync clobbering merged text, the floor stops merged text
+  widening tier, the remap follows action items to the new item. This slice writes no body and creates
+  no item, so each has nothing to protect. The one consequence that did carry over is the submitter
+  stranding, folded above.
+
+## 7. Review round 2 — attacking the fold
+
+**BLOCKED**, on the fold rather than the original — which is the point of a second round.
+
+- **HIGH, and it was real: per-key grouping stranded the transcript.** Reproduced against the module
+  as written (A `eid:x` / B both keys / C the transcript on `uid:` → survivor A, C left live). Now
+  connected components, §2 and AC4b.
+- **MEDIUM, accepted: the null-date policy reopened the series hole it was written to close.** §2.2
+  is reversed.
+- **MEDIUM, deferred with a destination: `getMeetingNote` does not filter `merged_into`,** so a
+  direct URL to a folded note still renders a dead-end detail page, and the meeting server actions
+  resolve by id without excluding folded notes. That is **pre-existing** — the overlap merge has set
+  `merged_into` since MTGATT-1 and produces the same page — and this slice increases how often it can
+  be reached without changing its nature. Fixing it is a routing/product decision (should a folded
+  note redirect to its survivor, or 404?), so it is **MTGATT-6**, not folded here.
+
+It also re-checked and **confirmed both round-1 refutations** — no external tier leak, and no missing
+merge invariant — and confirmed the submitter fix does not break the overlap merge's contract
+provided `authorFallbackMemberId` is not credited as a submitter. It is not: only the folded note's
+real submitter rows and its `submitted_by` are passed.

--- a/docs/design/meeting-identity-link.md
+++ b/docs/design/meeting-identity-link.md
@@ -161,8 +161,10 @@ the two producers is the kind of thing that reads as "it didn't work".
 `backfillMeetingNotesFromItems`, after note creation and **before** `backfillMergeDuplicateMeetings`,
 so a linked calendar note is already folded and cannot be reconsidered by the overlap merge.
 
-Bounded: one metadata query for live notes (capped at 500 newest), one for their items' `frontmatter`
-+ a body-emptiness flag. At today's 66 notes that is two small reads; with zero identifiers it forms
+Bounded: one metadata query for live notes (capped at 500 newest), one for their items'
+`frontmatter`, and then FULL BODIES — but only for the notes that actually carry an identity key. The
+adapter cannot select an expression, so there is no cheaper emptiness flag; the saving comes from the
+narrow set, not from a narrow column. At today's 66 notes that is two small reads; with zero identifiers it forms
 zero groups and returns immediately. The cap is stated in code, because an unbounded per-tick scan is
 how `TICKSTALL-1` starved the chain.
 
@@ -257,7 +259,10 @@ real pair with the instrument) is kept.
   meetings leg is gated on `canSeeMeetingNotes(tier)` (`work-timeline.ts:672-675`), which is false for
   external. No attendee row this slice writes is readable by an external viewer.
 - *"It skips the invariants `mergeIntoMeetingNote` learned the hard way — merge-owned item, access
-  floor, action-item remap, tombstone."* Those exist because that path WRITES A NEW BODY into an item:
+  floor, action-item remap, tombstone."* The diff review supplied the proof this argument was missing:
+  **a folded note can never have a body** — a one-body component folds only its bodyless members, and
+  a no-body component has none — and action items are only ever extracted where a body exists, so
+  there is nothing to remap; no body write means no access floor; and `merged_into` IS the tombstone. Those exist because that path WRITES A NEW BODY into an item:
   the merge-owned path stops a connector re-sync clobbering merged text, the floor stops merged text
   widening tier, the remap follows action items to the new item. This slice writes no body and creates
   no item, so each has nothing to protect. The one consequence that did carry over is the submitter

--- a/lib/meetings/from-items.ts
+++ b/lib/meetings/from-items.ts
@@ -6,6 +6,7 @@ import { extractAndStoreActionItems } from "./action-items";
 import type { ExtractedTodo } from "./extract-todos";
 import { createMeetingNoteFromItem } from "./notes";
 import { backfillMergeDuplicateMeetings } from "./merge";
+import { EMPTY_LINK_SUMMARY, linkMeetingNotesByIdentity, type LinkSummary } from "./link-notes";
 import { buildIdentityMap } from "@/lib/identity/resolve";
 import { CALENDAR_SOURCES, attendingAttendees, calendarAttendees, calendarTitle, isCalendarEvent } from "./from-calendar";
 
@@ -128,6 +129,8 @@ export interface BackfillSummary {
    * RSVP field is being misread — which only a count makes visible.
    */
   calendarDeclined: number;
+  /** Identity-link outcome (MTGATT-3): what folded, and what was refused and why. */
+  link: LinkSummary;
 }
 
 /**
@@ -149,6 +152,7 @@ export async function backfillMeetingNotesFromItems(
     merged: 0,
     unresolvedAttendees: 0,
     calendarDeclined: 0,
+    link: EMPTY_LINK_SUMMARY,
   };
 
   // Which transcript items already have a note — exclude them.
@@ -309,6 +313,14 @@ export async function backfillMeetingNotesFromItems(
     } catch {
       summary.skipped++; // best-effort — one bad item never fails the batch
     }
+  }
+
+  // IDENTITY LINK (MTGATT-3) — before the overlap merge, so a calendar event that belongs to a
+  // transcript is already folded and cannot be reconsidered by a comparator that reads bodies.
+  try {
+    summary.link = await linkMeetingNotesByIdentity(admin, teamId);
+  } catch {
+    // best-effort, like every other leg here: a link hiccup must not cost the notes just created
   }
 
   // Auto-merge same-day duplicate meetings — a re-record / re-push creates a second note for the same

--- a/lib/meetings/identity-link.ts
+++ b/lib/meetings/identity-link.ts
@@ -1,0 +1,174 @@
+/**
+ * One meeting, two pushes — the join MTGATT-2 deliberately did not build (MTGATT-3).
+ *
+ * THE PROBLEM, in the operator's words: *"John may be uploading meetings and if they do they're gonna
+ * come saying just John Ellison but I would have already also been in that meeting… my calendar is the
+ * only way we could do that."* Today those are two meetings on the Meetings page and the second person
+ * is credited on neither.
+ *
+ * THE RULE the operator settled on: a person's own calendar push is a first-person assertion that they
+ * were there. The push IS the assertion; their RSVP only vetoes it (a `declined` is filtered upstream
+ * by `attendingAttendees`), because people attend meetings they never RSVP to.
+ *
+ * WHAT THIS IS NOT. It is not a matcher. Groups are formed by an EXACT shared event key and nothing
+ * else — never a conference link (a Zoom personal room is reused for every meeting its owner hosts),
+ * never a series key (every occurrence of a recurring event shares one iCalUID), never title
+ * similarity (two same-day meetings named after the same person score 1.0). And candidates are never
+ * pre-filtered by date: a 19:00 PDT meeting is 02:00Z the next day, so a calendar event and its
+ * transcript legitimately carry different `occurred_at`, and filtering first would silently drop
+ * exactly the evening meetings.
+ *
+ * Pure — the decisions live here so they are testable without a database; the caller does the I/O.
+ */
+
+/** The minimum a note must expose for this module to decide anything about it. */
+export interface LinkCandidate {
+  noteId: string;
+  /** Every kind-qualified meeting key the note's item carries (`eid:` / `uid:`). NEVER series keys. */
+  eventKeys: string[];
+  /** True when the note's item has real content. Whitespace does not count — see `plan`. */
+  hasBody: boolean;
+  /** `YYYY-MM-DD`, or null when the producer dated nothing. */
+  occurredAt: string | null;
+  /** Note creation time, ISO. The deterministic tie-break when nothing has a body. */
+  createdAt: string;
+}
+
+export interface LinkGroup {
+  /** The note everything else folds INTO. */
+  survivorId: string;
+  /** Notes to hide behind the survivor, and whose attendance/submitters it inherits. */
+  foldedIds: string[];
+  /** The keys that connected this component — carried for logging, never re-derived downstream. */
+  keys: string[];
+}
+
+export type RefusalReason = "two-bodies" | "dates-too-far-apart" | "unknown-date";
+
+export interface LinkPlan {
+  groups: LinkGroup[];
+  /** Why a group was refused, counted by reason — a silent refusal is indistinguishable from no match. */
+  refusals: Record<RefusalReason, number>;
+}
+
+const NO_REFUSALS: Record<RefusalReason, number> = {
+  "two-bodies": 0,
+  "dates-too-far-apart": 0,
+  "unknown-date": 0,
+};
+
+/** A calendar event and its transcript can be a day apart legitimately; a fortnight cannot. */
+export const MAX_DAY_SPAN = 1;
+
+function daysApart(a: string, b: string): number {
+  const ms = Math.abs(Date.parse(`${a}T00:00:00Z`) - Date.parse(`${b}T00:00:00Z`));
+  return Number.isFinite(ms) ? Math.round(ms / 86_400_000) : 0;
+}
+
+/**
+ * The date VETO. It runs only on a component an identifier has already formed, and it can only ever
+ * REMOVE a link — never find or widen one — which is why it does not reintroduce the date pre-filter
+ * this module refuses. What it catches is the residual series case `seriesKeys` cannot: a producer
+ * sending only `ical_uid`, with no instance suffix and no `recurringEventId`, is indistinguishable
+ * from a single event, so two occurrences weeks apart would otherwise link.
+ *
+ * AN UNKNOWN DATE REFUSES THE LINK. The first draft said the opposite — the identifier is the
+ * evidence, so an unknown date is not counter-evidence — and review round 2 broke it with a concrete
+ * case: an undetectable weekly series where the transcript is dated 11 Aug and the calendar event for
+ * 18 Aug carries no date at all. With nulls skipped, the veto's only defence against that series is
+ * switched off precisely when it is needed. Refusing costs little (a calendar event is dated by its
+ * `start`, a granola transcript by `created`, and `deriveOccurredAt` has three fallbacks, so an
+ * undated note is rare) and it fails in the safe direction: a duplicate meeting is visible and
+ * fixable, two meetings fused into one are neither.
+ */
+function dateVerdict(members: LinkCandidate[]): "ok" | RefusalReason {
+  if (members.some((m) => !m.occurredAt)) return "unknown-date";
+  const dated = members.map((m) => m.occurredAt as string);
+  for (let i = 0; i < dated.length; i++) {
+    for (let j = i + 1; j < dated.length; j++) {
+      if (daysApart(dated[i], dated[j]) > MAX_DAY_SPAN) return "dates-too-far-apart";
+    }
+  }
+  return "ok";
+}
+
+/**
+ * Which notes fold into which — the whole decision, as data.
+ *
+ * THE SURVIVOR IS CHOSEN BY CONTENT, NOT ARRIVAL ORDER, and that is what makes this safe. MTGATT-1
+ * deferred this join partly because `mergeIntoMeetingNote` keeps whichever note existed FIRST, so a
+ * transcript arriving after its calendar event would fold into the bodyless note and lose its text.
+ * Here the note with a body always wins, so that outcome is unreachable rather than merely unlikely,
+ * and processing order cannot change the result.
+ *
+ * TWO BODIES ARE REFUSED. Two transcripts of one meeting are the overlap merge's job — it combines
+ * their text; this path would hide one. Refusing is the conservative direction: a duplicate meeting is
+ * visible and fixable, lost content is neither.
+ */
+export function plan(candidates: LinkCandidate[]): LinkPlan {
+  // CONNECTED COMPONENTS over shared keys, not one group per key. Review round 2 built the case that
+  // killed per-key grouping: A carries `eid:x`, B carries BOTH `eid:x` and `uid:x@google.com` (the
+  // ordinary shape — a UID also emits its bare event id), C is the TRANSCRIPT carrying only the uid.
+  // Per-key, `eid:x` is processed first, folds B into A, and C — the one with the body — is left
+  // stranded as a separate meeting while a bodyless note survives. That is the precise outcome the
+  // survivor rule exists to make unreachable, entering through the grouping layer instead.
+  const byKey = new Map<string, LinkCandidate[]>();
+  for (const c of candidates) {
+    for (const k of c.eventKeys) byKey.set(k, [...(byKey.get(k) ?? []), c]);
+  }
+
+  const parent = new Map<string, string>();
+  const find = (x: string): string => {
+    let root = x;
+    while (parent.get(root) !== root) root = parent.get(root) ?? root;
+    return root;
+  };
+  const union = (a: string, b: string): void => {
+    const [ra, rb] = [find(a), find(b)];
+    if (ra !== rb) parent.set(rb, ra);
+  };
+  for (const c of candidates) parent.set(c.noteId, c.noteId);
+  for (const members of byKey.values()) {
+    for (const m of members.slice(1)) union(members[0].noteId, m.noteId);
+  }
+
+  const components = new Map<string, LinkCandidate[]>();
+  for (const c of candidates) {
+    // A note with no keys is in no component — it cannot be connected to anything, and grouping the
+    // keyless together would fold an entire corpus that carries no identifiers (today: all of prod).
+    if (!c.eventKeys.length) continue;
+    const root = find(c.noteId);
+    components.set(root, [...(components.get(root) ?? []), c]);
+  }
+
+  const groups: LinkGroup[] = [];
+  const refusals: Record<RefusalReason, number> = { ...NO_REFUSALS };
+
+  // Deterministic component order, and deterministic order within one, so two runs over the same
+  // corpus produce byte-identical plans.
+  for (const root of [...components.keys()].sort()) {
+    const members = (components.get(root) ?? []).sort((a, b) =>
+      a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.noteId < b.noteId ? -1 : 1
+    );
+    if (members.length < 2) continue;
+
+    const withBody = members.filter((m) => m.hasBody);
+    if (withBody.length > 1) {
+      refusals["two-bodies"]++;
+      continue;
+    }
+    const dates = dateVerdict(members);
+    if (dates !== "ok") {
+      refusals[dates]++;
+      continue;
+    }
+
+    // One body → it survives. No bodies → the earliest-created survives (members are sorted).
+    const survivor = withBody[0] ?? members[0];
+    const folded = members.filter((m) => m.noteId !== survivor.noteId);
+    const keys = [...new Set(members.flatMap((m) => m.eventKeys))].sort();
+    groups.push({ survivorId: survivor.noteId, foldedIds: folded.map((f) => f.noteId), keys });
+  }
+
+  return { groups, refusals };
+}

--- a/lib/meetings/identity-link.ts
+++ b/lib/meetings/identity-link.ts
@@ -60,9 +60,17 @@ const NO_REFUSALS: Record<RefusalReason, number> = {
 /** A calendar event and its transcript can be a day apart legitimately; a fortnight cannot. */
 export const MAX_DAY_SPAN = 1;
 
+/**
+ * Days between two `YYYY-MM-DD` values, or Infinity if either cannot be parsed.
+ *
+ * INFINITY, NOT ZERO. Returning 0 on an unparseable date would silently disarm the veto — the exact
+ * failure §2.2 exists to prevent — and it would do so on malformed input, which is when a guard is
+ * most needed. Today the adapter pins date columns to `YYYY-MM-DD` so this is unreachable, but
+ * `plan()` is an exported pure API and its callers are not all written yet.
+ */
 function daysApart(a: string, b: string): number {
   const ms = Math.abs(Date.parse(`${a}T00:00:00Z`) - Date.parse(`${b}T00:00:00Z`));
-  return Number.isFinite(ms) ? Math.round(ms / 86_400_000) : 0;
+  return Number.isFinite(ms) ? Math.round(ms / 86_400_000) : Number.POSITIVE_INFINITY;
 }
 
 /**
@@ -144,8 +152,9 @@ export function plan(candidates: LinkCandidate[]): LinkPlan {
   const groups: LinkGroup[] = [];
   const refusals: Record<RefusalReason, number> = { ...NO_REFUSALS };
 
-  // Deterministic component order, and deterministic order within one, so two runs over the same
-  // corpus produce byte-identical plans.
+  // Deterministic order WITHIN each component (so the survivor and the folded set never depend on
+  // input order), and a stable sort across components. The array ORDER of `groups` follows the
+  // union-find root and is not itself a contract — each group is applied independently.
   for (const root of [...components.keys()].sort()) {
     const members = (components.get(root) ?? []).sort((a, b) =>
       a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.noteId < b.noteId ? -1 : 1

--- a/lib/meetings/link-notes.ts
+++ b/lib/meetings/link-notes.ts
@@ -16,6 +16,18 @@ import { addMeetingNoteAttendees, addMeetingNoteSubmitters, setMeetingNoteMerged
  * written to the survivor BEFORE the folded note is hidden. A crash in between leaves a visible
  * duplicate meeting — annoying, and fixable on the next tick — whereas the reverse order would leave
  * a note hidden with its credit never transferred, which nothing would ever report.
+ *
+ * ⚠️ AND WRITE ORDER ALONE IS NOT ENOUGH, which is what the first version of this file got wrong. The
+ * pg adapter RETURNS errors rather than throwing (`lib/db/pg/query-builder.ts` catches and returns
+ * `{data: null, error}`), so a read that fails looks exactly like a read that found nothing:
+ * `addMeetingNoteAttendees([])` no-ops, and `setMeetingNoteMergedInto` — which does throw on ITS own
+ * failure — then succeeds. The note ends up hidden with its credit never transferred, permanently,
+ * because the next tick excludes `merged_into` notes. A failed BODY read is worse still: every
+ * candidate reads as bodyless, the component takes the earliest-created branch, and a transcript can
+ * be folded behind a blank invite — MTGATT-1's exact outcome, silent and uncounted.
+ *
+ * So every read here checks `error` and REFUSES rather than proceeding on an empty-looking result.
+ * Refusing costs one tick; proceeding costs a meeting.
  */
 
 /** Newest live notes considered per run. An unbounded per-tick scan is how TICKSTALL-1 starved the chain. */
@@ -31,10 +43,11 @@ export interface LinkSummary {
 type NoteRow = { id: string; source_item_id: string; occurred_at: string | null; created_at: string };
 type ItemMeta = { id: string; frontmatter: Record<string, unknown> | null };
 
-export const EMPTY_LINK_SUMMARY: LinkSummary = {
+/** Frozen: it is returned by reference on every early exit and used as an initial value. */
+export const EMPTY_LINK_SUMMARY: LinkSummary = Object.freeze({
   linked: 0,
-  refusals: { "two-bodies": 0, "dates-too-far-apart": 0, "unknown-date": 0 },
-};
+  refusals: Object.freeze({ "two-bodies": 0, "dates-too-far-apart": 0, "unknown-date": 0 }),
+}) as LinkSummary;
 
 /**
  * Link this team's live meeting notes that share an event identifier.
@@ -44,20 +57,22 @@ export const EMPTY_LINK_SUMMARY: LinkSummary = {
  * returns after the second query having loaded no transcript text at all.
  */
 export async function linkMeetingNotesByIdentity(admin: DbClient, teamId: string): Promise<LinkSummary> {
-  const { data: noteRows } = await admin
+  const { data: noteRows, error: noteErr } = await admin
     .from("meeting_notes")
     .select("id, source_item_id, occurred_at, created_at")
     .eq("team_id", teamId)
     .is("merged_into", null)
     .order("created_at", { ascending: false })
     .limit(NOTE_SCAN_LIMIT);
+  if (noteErr) return EMPTY_LINK_SUMMARY;
   const notes = (noteRows ?? []) as NoteRow[];
   if (notes.length < 2) return EMPTY_LINK_SUMMARY;
 
-  const { data: itemRows } = await admin
+  const { data: itemRows, error: itemErr } = await admin
     .from("items")
     .select("id, frontmatter")
     .in("id", notes.map((n) => n.source_item_id));
+  if (itemErr) return EMPTY_LINK_SUMMARY;
   const fmByItem = new Map(((itemRows ?? []) as ItemMeta[]).map((i) => [i.id, i.frontmatter]));
 
   // Only notes carrying an identity key can be linked, so only their bodies are worth reading.
@@ -66,10 +81,12 @@ export async function linkMeetingNotesByIdentity(admin: DbClient, teamId: string
     .filter((n) => n.keys.length > 0);
   if (keyed.length < 2) return EMPTY_LINK_SUMMARY;
 
-  const { data: bodyRows } = await admin
+  // A FAILED BODY READ MUST NOT BE READ AS "nothing has a body" — that flips the survivor rule.
+  const { data: bodyRows, error: bodyErr } = await admin
     .from("items")
     .select("id, body")
     .in("id", keyed.map((k) => k.note.source_item_id));
+  if (bodyErr) return EMPTY_LINK_SUMMARY;
   const bodyByItem = new Map(((bodyRows ?? []) as { id: string; body: string | null }[]).map((i) => [i.id, i.body ?? ""]));
 
   const candidates: LinkCandidate[] = keyed.map(({ note, keys }) => ({
@@ -86,18 +103,22 @@ export async function linkMeetingNotesByIdentity(admin: DbClient, teamId: string
 
   for (const group of linkPlan.groups) {
     try {
-      const { data: att } = await admin
+      const { data: att, error: attErr } = await admin
         .from("meeting_note_attendees")
         .select("member_id")
         .in("meeting_note_id", group.foldedIds);
-      const { data: subs } = await admin
+      const { data: subs, error: subsErr } = await admin
         .from("meeting_note_submitters")
         .select("member_id")
         .in("meeting_note_id", group.foldedIds);
-      const { data: folded } = await admin
+      const { data: folded, error: foldedErr } = await admin
         .from("meeting_notes")
         .select("id, submitted_by")
         .in("id", group.foldedIds);
+      // Skip the whole component rather than hide anything on partial evidence. Nothing is written,
+      // so the next tick retries it — the one outcome that is NOT recoverable is a hidden note whose
+      // credit never moved.
+      if (attErr || subsErr || foldedErr) continue;
 
       const attendeeIds = ((att ?? []) as { member_id: string }[]).map((r) => r.member_id);
       const submitterIds = [

--- a/lib/meetings/link-notes.ts
+++ b/lib/meetings/link-notes.ts
@@ -64,9 +64,12 @@ export async function linkMeetingNotesByIdentity(admin: DbClient, teamId: string
     .is("merged_into", null)
     .order("created_at", { ascending: false })
     .limit(NOTE_SCAN_LIMIT);
-  // Belt-and-braces only, and said so rather than left looking load-bearing: a failed read yields
-  // `notes = []`, which the `< 2` guard below already turns into the same early return. No mutation
-  // can redden this line; it is here so the intent survives a future refactor of that guard.
+  // BELT-AND-BRACES, and labelled as such rather than left looking load-bearing. A failed read here
+  // yields `notes = []`, which the `< 2` guard below already turns into the same early return — so no
+  // mutation can redden this line, and the same is true of the frontmatter read further down (no
+  // frontmatter → no keys → the `keyed.length < 2` return). Both are kept so the intent survives a
+  // refactor of those guards. The checks that ARE load-bearing — the BODY read and the three
+  // per-component credit reads — are mutation-proven by `test/meetings-link-read-errors.test.ts`.
   if (noteErr) return EMPTY_LINK_SUMMARY;
   const notes = (noteRows ?? []) as NoteRow[];
   if (notes.length < 2) return EMPTY_LINK_SUMMARY;
@@ -75,7 +78,7 @@ export async function linkMeetingNotesByIdentity(admin: DbClient, teamId: string
     .from("items")
     .select("id, frontmatter")
     .in("id", notes.map((n) => n.source_item_id));
-  if (itemErr) return EMPTY_LINK_SUMMARY;
+  if (itemErr) return EMPTY_LINK_SUMMARY; // belt-and-braces, as above
   const fmByItem = new Map(((itemRows ?? []) as ItemMeta[]).map((i) => [i.id, i.frontmatter]));
 
   // Only notes carrying an identity key can be linked, so only their bodies are worth reading.

--- a/lib/meetings/link-notes.ts
+++ b/lib/meetings/link-notes.ts
@@ -1,0 +1,121 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { eventIdentity } from "./event-identity";
+import { plan, type LinkCandidate, type LinkPlan, type RefusalReason } from "./identity-link";
+import { addMeetingNoteAttendees, addMeetingNoteSubmitters, setMeetingNoteMergedInto } from "./notes";
+
+/**
+ * Apply the identity link (MTGATT-3): fold each bodyless push of a meeting into the note that has the
+ * content, and carry its attendance and submitter credit across.
+ *
+ * The DECISIONS live in `./identity-link` (pure, unit-tested). This module is the I/O around them —
+ * deliberately, because the failure modes here are different in kind: a correct plan written in the
+ * wrong ORDER still loses credit.
+ *
+ * WRITE ORDER IS A SAFETY PROPERTY, not an implementation detail. Attendance and submitters are
+ * written to the survivor BEFORE the folded note is hidden. A crash in between leaves a visible
+ * duplicate meeting — annoying, and fixable on the next tick — whereas the reverse order would leave
+ * a note hidden with its credit never transferred, which nothing would ever report.
+ */
+
+/** Newest live notes considered per run. An unbounded per-tick scan is how TICKSTALL-1 starved the chain. */
+const NOTE_SCAN_LIMIT = 500;
+
+export interface LinkSummary {
+  /** Notes folded into a survivor. */
+  linked: number;
+  /** Components refused, by reason — see `identity-link.RefusalReason`. */
+  refusals: Record<RefusalReason, number>;
+}
+
+type NoteRow = { id: string; source_item_id: string; occurred_at: string | null; created_at: string };
+type ItemMeta = { id: string; frontmatter: Record<string, unknown> | null };
+
+export const EMPTY_LINK_SUMMARY: LinkSummary = {
+  linked: 0,
+  refusals: { "two-bodies": 0, "dates-too-far-apart": 0, "unknown-date": 0 },
+};
+
+/**
+ * Link this team's live meeting notes that share an event identifier.
+ *
+ * Cost is shaped so the common case is nearly free: two metadata reads, and bodies fetched ONLY for
+ * the notes that actually carry an identity key. In production today zero items carry one, so this
+ * returns after the second query having loaded no transcript text at all.
+ */
+export async function linkMeetingNotesByIdentity(admin: DbClient, teamId: string): Promise<LinkSummary> {
+  const { data: noteRows } = await admin
+    .from("meeting_notes")
+    .select("id, source_item_id, occurred_at, created_at")
+    .eq("team_id", teamId)
+    .is("merged_into", null)
+    .order("created_at", { ascending: false })
+    .limit(NOTE_SCAN_LIMIT);
+  const notes = (noteRows ?? []) as NoteRow[];
+  if (notes.length < 2) return EMPTY_LINK_SUMMARY;
+
+  const { data: itemRows } = await admin
+    .from("items")
+    .select("id, frontmatter")
+    .in("id", notes.map((n) => n.source_item_id));
+  const fmByItem = new Map(((itemRows ?? []) as ItemMeta[]).map((i) => [i.id, i.frontmatter]));
+
+  // Only notes carrying an identity key can be linked, so only their bodies are worth reading.
+  const keyed = notes
+    .map((n) => ({ note: n, keys: eventIdentity(fmByItem.get(n.source_item_id)).eventKeys }))
+    .filter((n) => n.keys.length > 0);
+  if (keyed.length < 2) return EMPTY_LINK_SUMMARY;
+
+  const { data: bodyRows } = await admin
+    .from("items")
+    .select("id, body")
+    .in("id", keyed.map((k) => k.note.source_item_id));
+  const bodyByItem = new Map(((bodyRows ?? []) as { id: string; body: string | null }[]).map((i) => [i.id, i.body ?? ""]));
+
+  const candidates: LinkCandidate[] = keyed.map(({ note, keys }) => ({
+    noteId: note.id,
+    eventKeys: keys,
+    // Whitespace is not content. A producer emitting "\n" for an invite must not outrank a transcript.
+    hasBody: (bodyByItem.get(note.source_item_id) ?? "").trim().length > 0,
+    occurredAt: note.occurred_at,
+    createdAt: note.created_at,
+  }));
+
+  const linkPlan: LinkPlan = plan(candidates);
+  let linked = 0;
+
+  for (const group of linkPlan.groups) {
+    try {
+      const { data: att } = await admin
+        .from("meeting_note_attendees")
+        .select("member_id")
+        .in("meeting_note_id", group.foldedIds);
+      const { data: subs } = await admin
+        .from("meeting_note_submitters")
+        .select("member_id")
+        .in("meeting_note_id", group.foldedIds);
+      const { data: folded } = await admin
+        .from("meeting_notes")
+        .select("id, submitted_by")
+        .in("id", group.foldedIds);
+
+      const attendeeIds = ((att ?? []) as { member_id: string }[]).map((r) => r.member_id);
+      const submitterIds = [
+        ...((subs ?? []) as { member_id: string }[]).map((r) => r.member_id),
+        ...((folded ?? []) as { submitted_by: string | null }[]).map((r) => r.submitted_by),
+      ].filter((x): x is string => !!x);
+
+      // Credit FIRST, hide second — see the module header.
+      await addMeetingNoteAttendees(admin, group.survivorId, attendeeIds);
+      await addMeetingNoteSubmitters(admin, group.survivorId, submitterIds);
+      for (const id of group.foldedIds) {
+        await setMeetingNoteMergedInto(admin, id, group.survivorId);
+        linked++;
+      }
+    } catch {
+      // One bad component never fails the rest — the next tick retries it, because nothing was hidden.
+    }
+  }
+
+  return { linked, refusals: linkPlan.refusals };
+}

--- a/lib/meetings/link-notes.ts
+++ b/lib/meetings/link-notes.ts
@@ -64,6 +64,9 @@ export async function linkMeetingNotesByIdentity(admin: DbClient, teamId: string
     .is("merged_into", null)
     .order("created_at", { ascending: false })
     .limit(NOTE_SCAN_LIMIT);
+  // Belt-and-braces only, and said so rather than left looking load-bearing: a failed read yields
+  // `notes = []`, which the `< 2` guard below already turns into the same early return. No mutation
+  // can redden this line; it is here so the intent survives a future refactor of that guard.
   if (noteErr) return EMPTY_LINK_SUMMARY;
   const notes = (noteRows ?? []) as NoteRow[];
   if (notes.length < 2) return EMPTY_LINK_SUMMARY;

--- a/lib/meetings/merge.ts
+++ b/lib/meetings/merge.ts
@@ -246,6 +246,7 @@ export async function mergeIntoMeetingNote(
   // body's, and the merge is silently overwritten. Keying on the surviving note id makes re-merges
   // upsert the same item.
   const mergedPath = notePath(match.noteId);
+  const identityFrontmatter = await carriedIdentity(admin, match.sourceItemId);
   const mergedItem = await ingestItem(
     admin,
     { teamId, memberId: author, apiKeyId: randomUUID() },
@@ -256,7 +257,13 @@ export async function mergeIntoMeetingNote(
       content_sha256: sha256(merged),
       actor: "meeting-notes-merge",
       access: mergedAccess,
-      frontmatter: { title: match.title },
+      // CARRY THE CALENDAR IDENTITY (MTGATT-3). This item REPLACES the ones the merge folds, and it
+      // was written with the title alone — so a meeting that had an event id lost it the moment two
+      // recordings merged, and a calendar event pushed afterwards could never find it again: a second
+      // visible meeting forever, the pusher uncredited, and no refusal counted because no component
+      // ever forms. Only the identity fields are carried; nothing else from a source frontmatter
+      // belongs on a merge-owned item.
+      frontmatter: { title: match.title, ...identityFrontmatter },
       body: merged,
     },
     mergedAccess,
@@ -336,6 +343,34 @@ export async function mergeIntoMeetingNote(
   });
 
   return match.noteId;
+}
+
+/** Frontmatter keys that identify the calendar event a meeting came from (MTGATT-3, `event-identity`). */
+const IDENTITY_KEYS = [
+  "calendar_event_id",
+  "calendarEventId",
+  "event_id",
+  "gcal_event_id",
+  "ical_uid",
+  "icalUID",
+  "iCalUID",
+  "google_calendar_event",
+  "calendar_event",
+] as const;
+
+/**
+ * The identity fields on the item being merged away from, so the merge-owned item keeps them.
+ *
+ * Read-only and best-effort: if the read fails the merge still proceeds — losing the key costs a
+ * future link (a visible duplicate), while refusing the merge here would cost the merge itself.
+ */
+async function carriedIdentity(admin: DbClient, sourceItemId: string): Promise<Record<string, unknown>> {
+  const { data, error } = await admin.from("items").select("frontmatter").eq("id", sourceItemId).maybeSingle();
+  if (error || !data) return {};
+  const fm = ((data as { frontmatter: Record<string, unknown> | null }).frontmatter ?? {}) as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of IDENTITY_KEYS) if (fm[k] !== undefined && fm[k] !== null) out[k] = fm[k];
+  return out;
 }
 
 /** Build a fresh DuplicateMatch for a note by re-reading its (possibly just-merged) transcript. */
@@ -448,10 +483,15 @@ export async function backfillMergeDuplicateMeetings(
         // folded again here (MTGATT-3). `authorFallbackMemberId` is deliberately NOT part of this —
         // it is an attribution fallback for the re-ingest, never a claim that someone submitted the
         // meeting.
-        const { data: dupSubs } = await admin
+        const { data: dupSubs, error: dupSubsErr } = await admin
           .from("meeting_note_submitters")
           .select("member_id")
           .eq("meeting_note_id", dup.id);
+        // The pg adapter RETURNS errors rather than throwing, so an unchecked read here would look
+        // like "this note had no submitters" and strand exactly the credit `newSubmitterIds` exists
+        // to preserve — while the merge went on to hide the note. Skip; the dup stays live and the
+        // next tick retries.
+        if (dupSubsErr) continue;
         try {
           await mergeIntoMeetingNote(admin, teamId, match, {
             newRawText: bodyById.get(dup.source_item_id) ?? "",

--- a/lib/meetings/merge.ts
+++ b/lib/meetings/merge.ts
@@ -513,6 +513,11 @@ export async function backfillMergeDuplicateMeetings(
         // BOTH reads, not just the submitters: since the identity link runs first, this dup may be
         // carrying attendance it absorbed from a calendar event moments ago. An unchecked failure
         // reads as "nobody attended" and the merge then hides the note — losing that credit for good.
+        //
+        // NOT MUTATION-COVERED, and said so rather than implied: forcing a read error here would mean
+        // stubbing the whole merge path, which reaches `ingestItem` and the real ingest pipeline. The
+        // equivalent checks in `link-notes.ts` ARE proven (`test/meetings-link-read-errors.test.ts`)
+        // and this mirrors them; that is the argument for it, not a test.
         if (attErr || dupSubsErr) continue;
         try {
           await mergeIntoMeetingNote(admin, teamId, match, {

--- a/lib/meetings/merge.ts
+++ b/lib/meetings/merge.ts
@@ -190,6 +190,16 @@ export interface MergeInput {
    *  uploads are always "team"; defaults to "team" (fail-safe — never widens). */
   newAccess?: "team" | "external";
   newAttendeeIds?: string[];
+  /**
+   * EVERY submitter already credited on the note being folded away, not just its `submitted_by`
+   * (MTGATT-3).
+   *
+   * The identity link ACCUMULATES submitters on a note — a calendar push folds into a transcript and
+   * both people are credited. If that note is then folded here by transcript overlap, crediting only
+   * `submitted_by` strands everyone the link had added, silently, because nothing counts submitters.
+   * MTGATT-2 recorded this as latent; MTGATT-3 is what makes it reachable, so it is closed here.
+   */
+  newSubmitterIds?: string[];
   roster: RosterPerson[];
   keys: ProviderKeys;
   /** A valid member to attribute the re-ingest to when neither note has a submitter (e.g. backfill). */
@@ -276,7 +286,11 @@ export async function mergeIntoMeetingNote(
   }
 
   // Credit both submitters + union attendees from the new upload.
-  await addMeetingNoteSubmitters(admin, match.noteId, [match.primarySubmitterId, input.newSubmitterId].filter((x): x is string => !!x));
+  await addMeetingNoteSubmitters(
+    admin,
+    match.noteId,
+    [match.primarySubmitterId, input.newSubmitterId, ...(input.newSubmitterIds ?? [])].filter((x): x is string => !!x)
+  );
   if (input.newAttendeeIds?.length) await addMeetingNoteAttendees(admin, match.noteId, input.newAttendeeIds);
 
   // Refresh summary + attendees + action items on the merged text — best-effort (never fail merge).
@@ -430,12 +444,21 @@ export async function backfillMergeDuplicateMeetings(
         const match = await loadMatchForNote(admin, teamId, primary.id);
         if (!match) continue;
         const { data: att } = await admin.from("meeting_note_attendees").select("member_id").eq("meeting_note_id", dup.id);
+        // The dup's FULL submitter set, so credit the identity link accumulated on it survives being
+        // folded again here (MTGATT-3). `authorFallbackMemberId` is deliberately NOT part of this —
+        // it is an attribution fallback for the re-ingest, never a claim that someone submitted the
+        // meeting.
+        const { data: dupSubs } = await admin
+          .from("meeting_note_submitters")
+          .select("member_id")
+          .eq("meeting_note_id", dup.id);
         try {
           await mergeIntoMeetingNote(admin, teamId, match, {
             newRawText: bodyById.get(dup.source_item_id) ?? "",
             newSubmitterId: dup.submitted_by,
             newAccess: accessById.get(dup.source_item_id) ?? "team",
             newAttendeeIds: ((att ?? []) as { member_id: string }[]).map((a) => a.member_id),
+            newSubmitterIds: ((dupSubs ?? []) as { member_id: string }[]).map((r) => r.member_id),
             roster,
             keys: opts.keys,
             // Automatic path has no human actor; fall back to an active member so a pair whose

--- a/lib/meetings/merge.ts
+++ b/lib/meetings/merge.ts
@@ -200,6 +200,8 @@ export interface MergeInput {
    * MTGATT-2 recorded this as latent; MTGATT-3 is what makes it reachable, so it is closed here.
    */
   newSubmitterIds?: string[];
+  /** The item behind the note being folded away — its calendar identity is carried too (MTGATT-3). */
+  newSourceItemId?: string | null;
   roster: RosterPerson[];
   keys: ProviderKeys;
   /** A valid member to attribute the re-ingest to when neither note has a submitter (e.g. backfill). */
@@ -246,7 +248,9 @@ export async function mergeIntoMeetingNote(
   // body's, and the merge is silently overwritten. Keying on the surviving note id makes re-merges
   // upsert the same item.
   const mergedPath = notePath(match.noteId);
-  const identityFrontmatter = await carriedIdentity(admin, match.sourceItemId);
+  // BOTH sides: the keyed meeting is often the one being folded AWAY (it is the newer push), so
+  // reading only the survivor's item silently drops the key on exactly the path that motivated this.
+  const identityFrontmatter = await carriedIdentity(admin, [match.sourceItemId, input.newSourceItemId]);
   const mergedItem = await ingestItem(
     admin,
     { teamId, memberId: author, apiKeyId: randomUUID() },
@@ -257,12 +261,7 @@ export async function mergeIntoMeetingNote(
       content_sha256: sha256(merged),
       actor: "meeting-notes-merge",
       access: mergedAccess,
-      // CARRY THE CALENDAR IDENTITY (MTGATT-3). This item REPLACES the ones the merge folds, and it
-      // was written with the title alone — so a meeting that had an event id lost it the moment two
-      // recordings merged, and a calendar event pushed afterwards could never find it again: a second
-      // visible meeting forever, the pusher uncredited, and no refusal counted because no component
-      // ever forms. Only the identity fields are carried; nothing else from a source frontmatter
-      // belongs on a merge-owned item.
+      // CARRY THE CALENDAR IDENTITY (MTGATT-3) — see `carriedIdentity` for what and why.
       frontmatter: { title: match.title, ...identityFrontmatter },
       body: merged,
     },
@@ -345,31 +344,48 @@ export async function mergeIntoMeetingNote(
   return match.noteId;
 }
 
-/** Frontmatter keys that identify the calendar event a meeting came from (MTGATT-3, `event-identity`). */
-const IDENTITY_KEYS = [
-  "calendar_event_id",
-  "calendarEventId",
-  "event_id",
-  "gcal_event_id",
-  "ical_uid",
-  "icalUID",
-  "iCalUID",
-  "google_calendar_event",
-  "calendar_event",
-] as const;
+/** Flat frontmatter keys that carry a calendar event id, in the spellings `event-identity` accepts. */
+const EVENT_ID_KEYS = ["calendar_event_id", "calendarEventId", "event_id", "gcal_event_id"] as const;
+const UID_KEYS = ["ical_uid", "icalUID", "iCalUID"] as const;
+
+function firstString(fm: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const k of keys) {
+    const v = fm[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return null;
+}
 
 /**
- * The identity fields on the item being merged away from, so the merge-owned item keeps them.
+ * The calendar identity of the items being merged, reduced to TWO flat fields.
  *
- * Read-only and best-effort: if the read fails the merge still proceeds — losing the key costs a
- * future link (a visible duplicate), while refusing the merge here would cost the merge itself.
+ * WHY IT EXISTS. This merge writes a NEW item that replaces the ones it folds, and it used to write
+ * `{ title }` alone — so a meeting that carried an event id lost it the moment two recordings merged,
+ * and a calendar event pushed afterwards could never find it again: a second visible meeting forever,
+ * its pusher uncredited, and no refusal counted because no component ever forms.
+ *
+ * ONLY `calendar_event_id` AND `ical_uid` ARE WRITTEN, extracted from whatever spelling the source
+ * used, INCLUDING a nested `google_calendar_event`. Copying that nested object wholesale would drag a
+ * full Google event — attendees, description, conference data — onto a merge-owned item that has no
+ * business holding it. The linker reads these flat keys, so nothing is lost by narrowing.
+ *
+ * Best-effort: a failed read costs a future link (a visible duplicate), while refusing the merge here
+ * would cost the merge itself.
  */
-async function carriedIdentity(admin: DbClient, sourceItemId: string): Promise<Record<string, unknown>> {
-  const { data, error } = await admin.from("items").select("frontmatter").eq("id", sourceItemId).maybeSingle();
-  if (error || !data) return {};
-  const fm = ((data as { frontmatter: Record<string, unknown> | null }).frontmatter ?? {}) as Record<string, unknown>;
-  const out: Record<string, unknown> = {};
-  for (const k of IDENTITY_KEYS) if (fm[k] !== undefined && fm[k] !== null) out[k] = fm[k];
+async function carriedIdentity(admin: DbClient, itemIds: (string | null | undefined)[]): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const id of itemIds.filter((x): x is string => !!x)) {
+    const { data, error } = await admin.from("items").select("frontmatter").eq("id", id).maybeSingle();
+    if (error || !data) continue;
+    const fm = ((data as { frontmatter: Record<string, unknown> | null }).frontmatter ?? {}) as Record<string, unknown>;
+    const nested = fm.google_calendar_event ?? fm.calendar_event;
+    const nestedObj = nested && typeof nested === "object" ? (nested as Record<string, unknown>) : {};
+    const eventId = firstString(fm, EVENT_ID_KEYS) ?? (typeof nestedObj.id === "string" ? nestedObj.id.trim() : null);
+    const uid = firstString(fm, UID_KEYS) ?? firstString(nestedObj, UID_KEYS);
+    // First side that carries one wins; the two sides of a merge describe one meeting.
+    if (eventId && !out.calendar_event_id) out.calendar_event_id = eventId;
+    if (uid && !out.ical_uid) out.ical_uid = uid;
+  }
   return out;
 }
 
@@ -478,7 +494,10 @@ export async function backfillMergeDuplicateMeetings(
       for (const dup of cl.slice(1)) {
         const match = await loadMatchForNote(admin, teamId, primary.id);
         if (!match) continue;
-        const { data: att } = await admin.from("meeting_note_attendees").select("member_id").eq("meeting_note_id", dup.id);
+        const { data: att, error: attErr } = await admin
+          .from("meeting_note_attendees")
+          .select("member_id")
+          .eq("meeting_note_id", dup.id);
         // The dup's FULL submitter set, so credit the identity link accumulated on it survives being
         // folded again here (MTGATT-3). `authorFallbackMemberId` is deliberately NOT part of this —
         // it is an attribution fallback for the re-ingest, never a claim that someone submitted the
@@ -491,7 +510,10 @@ export async function backfillMergeDuplicateMeetings(
         // like "this note had no submitters" and strand exactly the credit `newSubmitterIds` exists
         // to preserve — while the merge went on to hide the note. Skip; the dup stays live and the
         // next tick retries.
-        if (dupSubsErr) continue;
+        // BOTH reads, not just the submitters: since the identity link runs first, this dup may be
+        // carrying attendance it absorbed from a calendar event moments ago. An unchecked failure
+        // reads as "nobody attended" and the merge then hides the note — losing that credit for good.
+        if (attErr || dupSubsErr) continue;
         try {
           await mergeIntoMeetingNote(admin, teamId, match, {
             newRawText: bodyById.get(dup.source_item_id) ?? "",
@@ -499,6 +521,7 @@ export async function backfillMergeDuplicateMeetings(
             newAccess: accessById.get(dup.source_item_id) ?? "team",
             newAttendeeIds: ((att ?? []) as { member_id: string }[]).map((a) => a.member_id),
             newSubmitterIds: ((dupSubs ?? []) as { member_id: string }[]).map((r) => r.member_id),
+            newSourceItemId: dup.source_item_id,
             roster,
             keys: opts.keys,
             // Automatic path has no human actor; fall back to an active member so a pair whose

--- a/lib/meetings/schedule-backfill.ts
+++ b/lib/meetings/schedule-backfill.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { isMeetingTranscript } from "./from-items";
+import { isCalendarEvent } from "./from-calendar";
 // Type-only — erased at build, so the API route still pays nothing for these server-only modules, but
 // the dependency seam below is checked at compile time instead of behind `never` casts.
 import type { BackfillSummary } from "./from-items";
@@ -45,7 +46,13 @@ export function shouldScheduleMeetingBackfill(input: {
   if (input.status === "unchanged") return false;
   // Meeting sources only. `kind='transcript'` also covers Slack threads, and the Meetings page must never
   // fill up with chat threads — same rule `backfillMeetingNotesFromItems` applies when it scans.
-  return isMeetingTranscript(input.kind, typeof input.source === "string" ? input.source : null);
+  //
+  // A CALENDAR EVENT COUNTS TOO (MTGATT-3). It is keyed on SOURCE, not kind (a producer may send
+  // `artifact`), so the transcript test alone silently excluded it: pushing your calendar would sit
+  // unlinked until a scheduler tick while someone else's transcript was noted instantly. That
+  // asymmetry is invisible from the outside and reads as the feature not working.
+  const source = typeof input.source === "string" ? input.source : null;
+  return isMeetingTranscript(input.kind, source) || isCalendarEvent(source);
 }
 
 export type BackfillRunner = (teamId: string) => Promise<unknown>;

--- a/test/datamechanics/meeting-identity-link.datamechanics.test.ts
+++ b/test/datamechanics/meeting-identity-link.datamechanics.test.ts
@@ -230,6 +230,24 @@ describe("identity link: one meeting, two pushes (real Postgres)", () => {
     expect(await liveNotes(seed), "both meetings stay live").toHaveLength(2);
   });
 
+  it("REFUSES a component where BOTH notes have bodies, and neither loses its text (AC10)", async () => {
+    // Two recordings of one meeting are the overlap merge's job — it combines their text; this path
+    // would hide one. Bodies are deliberately NON-overlapping so the overlap merge does not
+    // legitimately fold them either, leaving this path's refusal as the only thing under test.
+    const seed = await seedTeam();
+    await pushTranscript(seed, { body: "# Design review\n\nAlpha notes about the rollout schedule." });
+    await pushTranscript(seed, { body: "# Design review\n\nCompletely different words, zero overlap here." });
+    const summary = await tick(seed);
+
+    expect(summary.link.linked).toBe(0);
+    expect(summary.link.refusals["two-bodies"]).toBe(1);
+    const notes = await liveNotes(seed);
+    expect(notes, "both recordings stay live").toHaveLength(2);
+    const bodies = (await Promise.all(notes.map((n) => bodyOf(seed, n.id)))).join("\n");
+    expect(bodies, "the first keeps its text").toContain("Alpha notes");
+    expect(bodies, "and so does the second").toContain("Completely different words");
+  });
+
   it("REFUSES a component whose dates are weeks apart — the undetectable-series case", async () => {
     const seed = await seedTeam();
     const old = new Date(Date.now() - 14 * 86_400_000).toISOString().slice(0, 10);

--- a/test/datamechanics/meeting-identity-link.datamechanics.test.ts
+++ b/test/datamechanics/meeting-identity-link.datamechanics.test.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { randomUUID as uuid } from "node:crypto";
+import { db, ingest, seedTeam, sha, type Seed } from "./helpers";
+import { ingestItem } from "@/lib/ingest";
+import { backfillMeetingNotesFromItems } from "@/lib/meetings/from-items";
+import { getMeetingNote, listMeetingNotesForTeam } from "@/lib/meetings/notes";
+
+/**
+ * Spec (MTGATT-3, real Postgres): a calendar event and the transcript of the same meeting become ONE
+ * meeting, and the person who pushed the calendar is credited on it.
+ *
+ * This tier because every failure here is a ROW: a hidden note, a lost submitter, a resurrected
+ * duplicate, an attendee that never arrived. `plan()` being right proves none of that — it is the
+ * write order, the reads, and the interaction with the merge that runs immediately afterwards that
+ * this file exists to pin.
+ */
+
+const EVENT_ID = "evt12345abc";
+const today = () => new Date().toISOString().slice(0, 10);
+
+async function addMember(seed: Seed, name: string, email: string): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      email,
+      display_name: name,
+      actor_handle: `a-${randomUUID().slice(0, 8)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`member insert failed: ${error?.message}`);
+  return (data as { id: string }).id;
+}
+
+/** A recorded meeting: has a body, carries the event id. */
+async function pushTranscript(seed: Seed, opts: { eventId?: string; body?: string; date?: string } = {}) {
+  return ingest(seed, {
+    kind: "transcript",
+    access: "team",
+    path: `1-inbox/transcripts/${randomUUID().slice(0, 8)}.md`,
+    body: opts.body ?? "# Design review\n\nWe agreed the rollout.",
+    frontmatter: {
+      source: "granola",
+      created: `${opts.date ?? today()}T09:00:00.000Z`,
+      ...(opts.eventId === undefined ? { calendar_event_id: EVENT_ID } : opts.eventId ? { calendar_event_id: opts.eventId } : {}),
+    },
+  });
+}
+
+/**
+ * A pushed calendar event: no body, carries the same event id.
+ *
+ * `asMemberId` pushes it as SOMEONE ELSE — which is the whole scenario: John's transcript, my
+ * calendar. Without it the "submitter" under test is the same member on both sides and the credit
+ * assertion passes for the wrong reason.
+ */
+async function pushCalendarEvent(seed: Seed, opts: { eventId?: string; attendees?: unknown; date?: string; asMemberId?: string } = {}) {
+  const frontmatter = {
+    source: "calendar",
+    title: "Design review",
+    occurred_at: opts.date ?? today(),
+    attendees: opts.attendees ?? [],
+    ...(opts.eventId === undefined ? { calendar_event_id: EVENT_ID } : opts.eventId ? { calendar_event_id: opts.eventId } : {}),
+  };
+  if (opts.asMemberId) {
+    const path = `1-inbox/calendar/${uuid().slice(0, 8)}.md`;
+    return ingestItem(
+      db(),
+      { teamId: seed.teamId, memberId: opts.asMemberId, apiKeyId: uuid() },
+      { project: "calendar", kind: "artifact", actor: "tester", frontmatter, content_sha256: sha(""), path, body: "" },
+      "team"
+    );
+  }
+  return ingest(seed, {
+    kind: "artifact",
+    access: "team",
+    path: `1-inbox/calendar/${randomUUID().slice(0, 8)}.md`,
+    body: "",
+    project: "calendar",
+    frontmatter: {
+      source: "calendar",
+      title: "Design review",
+      occurred_at: opts.date ?? today(),
+      attendees: opts.attendees ?? [],
+      ...(opts.eventId === undefined ? { calendar_event_id: EVENT_ID } : opts.eventId ? { calendar_event_id: opts.eventId } : {}),
+    },
+  });
+}
+
+const tick = (seed: Seed) => backfillMeetingNotesFromItems(db(), seed.teamId, { extract: async () => ({ summary: "", attendeeMemberIds: [] }) });
+
+async function liveNotes(seed: Seed) {
+  return listMeetingNotesForTeam(db(), seed.teamId, "team");
+}
+
+/** The surviving note's transcript text — the list view carries no body, the detail read does. */
+async function bodyOf(seed: Seed, noteId: string): Promise<string> {
+  const detail = await getMeetingNote(db(), seed.teamId, noteId, "team");
+  return detail?.rawText ?? "";
+}
+
+async function submitterIds(noteId: string): Promise<string[]> {
+  const { data } = await db().from("meeting_note_submitters").select("member_id").eq("meeting_note_id", noteId);
+  return ((data ?? []) as { member_id: string }[]).map((r) => r.member_id).sort();
+}
+
+describe("identity link: one meeting, two pushes (real Postgres)", () => {
+  it("folds the calendar event into the TRANSCRIPT and credits the calendar pusher", async () => {
+    const seed = await seedTeam();
+    const chetanEmail = `chetan-${randomUUID().slice(0, 6)}@acme.com`;
+    const chetan = await addMember(seed, "Chetan", chetanEmail);
+
+    await pushTranscript(seed);
+    await pushCalendarEvent(seed, { attendees: [{ email: chetanEmail, responseStatus: "accepted" }] });
+    const summary = await tick(seed);
+
+    expect(summary.created, "both items become notes first").toBe(2);
+    expect(summary.link.linked).toBe(1);
+
+    const notes = await liveNotes(seed);
+    expect(notes, "one meeting, not two").toHaveLength(1);
+    // The survivor is identified by CONTENT, not by a uuid — the assertion has to survive being run
+    // in either order (see the reverse-order test below).
+    expect(await bodyOf(seed, notes[0].id), "the transcript's body survived").toContain("We agreed the rollout.");
+    expect(notes[0].attendees.map((a) => a.id), "the calendar pusher is now an attendee").toContain(chetan);
+  });
+
+  it("produces the same outcome when the calendar event arrives FIRST", async () => {
+    const seed = await seedTeam();
+    const chetanEmail = `chetan-${randomUUID().slice(0, 6)}@acme.com`;
+    const chetan = await addMember(seed, "Chetan", chetanEmail);
+
+    await pushCalendarEvent(seed, { attendees: [{ email: chetanEmail }] });
+    await pushTranscript(seed);
+    const summary = await tick(seed);
+
+    expect(summary.link.linked).toBe(1);
+    const notes = await liveNotes(seed);
+    expect(notes).toHaveLength(1);
+    // Order-independence, asserted rather than argued: the note with the BODY survives either way.
+    // The reverse would be MTGATT-1's deferred hazard — a transcript folding into an empty note.
+    expect(await bodyOf(seed, notes[0].id)).toContain("We agreed the rollout.");
+    expect(notes[0].attendees.map((a) => a.id)).toContain(chetan);
+  });
+
+  it("hides the folded note without destroying it, and never resurrects it", async () => {
+    const seed = await seedTeam();
+    const cal = await pushCalendarEvent(seed);
+    await pushTranscript(seed);
+    await tick(seed);
+
+    const { data: folded } = await db()
+      .from("meeting_notes")
+      .select("id, merged_into")
+      .eq("source_item_id", cal.id)
+      .maybeSingle();
+    expect((folded as { merged_into: string | null }).merged_into, "hidden behind the survivor").toBeTruthy();
+
+    // The ITEM is untouched — a link is reversible, unlike the overlap merge's item retirement.
+    const { data: item } = await db().from("items").select("id").eq("id", cal.id).maybeSingle();
+    expect(item, "the calendar item still exists").toBeTruthy();
+
+    // The backfill notes every un-noted meeting item each tick; a folded note must not come back as a
+    // second meeting on the next one.
+    await tick(seed);
+    expect(await liveNotes(seed)).toHaveLength(1);
+  });
+
+  it("is idempotent — a second tick changes nothing", async () => {
+    const seed = await seedTeam();
+    const chetanEmail = `chetan-${randomUUID().slice(0, 6)}@acme.com`;
+    await addMember(seed, "Chetan", chetanEmail);
+    await pushTranscript(seed);
+    await pushCalendarEvent(seed, { attendees: [{ email: chetanEmail }] });
+
+    await tick(seed);
+    const first = await liveNotes(seed);
+    const firstSubs = await submitterIds(first[0].id);
+
+    const second = await tick(seed);
+    const after = await liveNotes(seed);
+    expect(second.link.linked, "nothing left to link").toBe(0);
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe(first[0].id);
+    expect(after[0].attendees.length).toBe(first[0].attendees.length);
+    expect(await submitterIds(after[0].id)).toEqual(firstSubs);
+  });
+
+  it("does NOT link two meetings that share no identifier, even with the same title and date", async () => {
+    // The misassociation the operator asked about at team size, asserted as an absence. If this ever
+    // reddens, the join has started deciding on a resemblance.
+    const seed = await seedTeam();
+    await pushTranscript(seed, { eventId: "" });
+    await pushCalendarEvent(seed, { eventId: "" });
+    const summary = await tick(seed);
+
+    expect(summary.link.linked).toBe(0);
+    expect(await liveNotes(seed), "both meetings stay live").toHaveLength(2);
+  });
+
+  it("REFUSES a component whose dates are weeks apart — the undetectable-series case", async () => {
+    const seed = await seedTeam();
+    const old = new Date(Date.now() - 14 * 86_400_000).toISOString().slice(0, 10);
+    await pushTranscript(seed, { date: old });
+    await pushCalendarEvent(seed);
+    const summary = await tick(seed);
+
+    expect(summary.link.linked).toBe(0);
+    expect(summary.link.refusals["dates-too-far-apart"]).toBe(1);
+    expect(await liveNotes(seed)).toHaveLength(2);
+  });
+
+  it("credits the calendar PUSHER as a submitter of the surviving meeting", async () => {
+    // The operator's scenario end to end: John records, I push my calendar, and the one meeting that
+    // remains says both of us put it there.
+    const seed = await seedTeam();
+    const chetan = await addMember(seed, "Chetan", `chetan-${randomUUID().slice(0, 6)}@acme.com`);
+    await pushTranscript(seed);
+    await pushCalendarEvent(seed, { asMemberId: chetan });
+    await tick(seed);
+
+    const notes = await liveNotes(seed);
+    expect(notes).toHaveLength(1);
+    expect(await submitterIds(notes[0].id)).toContain(chetan);
+  });
+
+  it("keeps the accumulated submitter when the survivor is then folded by the overlap merge", async () => {
+    // The hazard this slice makes reachable: the overlap merge runs in the SAME tick and used to
+    // propagate only two submitter ids, so a submitter the link had just added to the survivor was
+    // stranded on a note nobody can see. Asserted end to end rather than at the unit that changed.
+    const seed = await seedTeam();
+    const chetanEmail = `chetan-${randomUUID().slice(0, 6)}@acme.com`;
+    const chetan = await addMember(seed, "Chetan", chetanEmail);
+
+    const shared = "# Design review\n\nWe agreed the rollout and the launch plan in detail today.";
+    await pushTranscript(seed, { body: shared });
+    await pushCalendarEvent(seed, { asMemberId: chetan, attendees: [{ email: chetanEmail }] });
+    await tick(seed);
+
+    // A second recording of the same meeting — overlapping text, so the overlap merge folds the
+    // survivor into it (or it into the survivor) on the next tick.
+    await pushTranscript(seed, { eventId: "", body: `${shared} Plus a closing note.` });
+    await tick(seed);
+
+    const notes = await liveNotes(seed);
+    const allSubs = (await Promise.all(notes.map((n) => submitterIds(n.id)))).flat();
+    expect(allSubs, "the calendar pusher's credit survived the second fold").toContain(chetan);
+  });
+});

--- a/test/datamechanics/meeting-identity-link.datamechanics.test.ts
+++ b/test/datamechanics/meeting-identity-link.datamechanics.test.ts
@@ -300,5 +300,31 @@ describe("identity link: one meeting, two pushes (real Postgres)", () => {
     const notes = await liveNotes(seed);
     expect(notes, "the two recordings became one meeting").toHaveLength(1);
     expect(await submitterIds(notes[0].id), "the calendar pusher survived the second fold").toContain(chetan);
+
+    // AND THE KEY SURVIVED. The merge writes a NEW item that replaces both, and it wrote `{title}`
+    // alone — so the merged meeting lost its event id and a THIRD push of the same event could never
+    // find it: a second visible meeting forever, uncredited, with no refusal counted. Asserting
+    // submitter survival alone left that green by construction, which is how the second reviewer
+    // found it. Note the keyed note here is the one folded AWAY, so the identity has to be carried
+    // from the duplicate, not just the survivor.
+    const { data: survivor } = await db()
+      .from("meeting_notes")
+      .select("source_item_id")
+      .eq("id", notes[0].id)
+      .maybeSingle();
+    const { data: item } = await db()
+      .from("items")
+      .select("frontmatter")
+      .eq("id", (survivor as { source_item_id: string }).source_item_id)
+      .maybeSingle();
+    const fm = ((item as { frontmatter: Record<string, unknown> }).frontmatter ?? {}) as Record<string, unknown>;
+    expect(fm.calendar_event_id, "the merged item still carries the event id").toBe(EVENT_ID);
+
+    // The proof it is reachable, not just present: a third push of the same event links to it.
+    const third = await addMember(seed, "Third", `third-${randomUUID().slice(0, 6)}@acme.com`);
+    await pushCalendarEvent(seed, { asMemberId: third });
+    const third_tick = await tick(seed);
+    expect(third_tick.link.linked, "a later push of the same event still finds the meeting").toBe(1);
+    expect(await submitterIds(notes[0].id)).toContain(third);
   });
 });

--- a/test/datamechanics/meeting-identity-link.datamechanics.test.ts
+++ b/test/datamechanics/meeting-identity-link.datamechanics.test.ts
@@ -229,26 +229,31 @@ describe("identity link: one meeting, two pushes (real Postgres)", () => {
     expect(await submitterIds(notes[0].id)).toContain(chetan);
   });
 
-  it("keeps the accumulated submitter when the survivor is then folded by the overlap merge", async () => {
-    // The hazard this slice makes reachable: the overlap merge runs in the SAME tick and used to
-    // propagate only two submitter ids, so a submitter the link had just added to the survivor was
-    // stranded on a note nobody can see. Asserted end to end rather than at the unit that changed.
+  it("keeps the accumulated submitter when the linked note is later folded AWAY by the overlap merge", async () => {
+    // The hazard this slice makes reachable, and the direction matters: stranding only happens when
+    // the note carrying the ACCUMULATED credit is the one folded AWAY — i.e. the later-created of an
+    // overlapping pair, since the merge keeps the earliest as primary. The first version of this test
+    // built the opposite direction and passed with the fix reverted; a mutation caught it.
     const seed = await seedTeam();
     const chetanEmail = `chetan-${randomUUID().slice(0, 6)}@acme.com`;
     const chetan = await addMember(seed, "Chetan", chetanEmail);
-
     const shared = "# Design review\n\nWe agreed the rollout and the launch plan in detail today.";
-    await pushTranscript(seed, { body: shared });
+
+    // Tick 1 — the EARLIER note, which will become the merge's primary. No event id.
+    await pushTranscript(seed, { eventId: "", body: shared });
+    await tick(seed);
+
+    // Tick 2 — a second recording of the same meeting, plus Chetan's calendar event for it. The link
+    // folds the calendar event into THIS note (it has the body), crediting Chetan on it...
+    await pushTranscript(seed, { body: `${shared} Plus a closing note.` });
     await pushCalendarEvent(seed, { asMemberId: chetan, attendees: [{ email: chetanEmail }] });
-    await tick(seed);
+    const second = await tick(seed);
+    expect(second.link.linked, "the calendar event linked to the newer transcript").toBe(1);
 
-    // A second recording of the same meeting — overlapping text, so the overlap merge folds the
-    // survivor into it (or it into the survivor) on the next tick.
-    await pushTranscript(seed, { eventId: "", body: `${shared} Plus a closing note.` });
-    await tick(seed);
-
+    // ...and the overlap merge, in that same tick, folds that newer note into the earlier one. Whether
+    // Chetan's credit survives is exactly what `newSubmitterIds` decides.
     const notes = await liveNotes(seed);
-    const allSubs = (await Promise.all(notes.map((n) => submitterIds(n.id)))).flat();
-    expect(allSubs, "the calendar pusher's credit survived the second fold").toContain(chetan);
+    expect(notes, "the two recordings became one meeting").toHaveLength(1);
+    expect(await submitterIds(notes[0].id), "the calendar pusher survived the second fold").toContain(chetan);
   });
 });

--- a/test/datamechanics/meeting-identity-link.datamechanics.test.ts
+++ b/test/datamechanics/meeting-identity-link.datamechanics.test.ts
@@ -59,7 +59,10 @@ async function pushTranscript(seed: Seed, opts: { eventId?: string; body?: strin
  * calendar. Without it the "submitter" under test is the same member on both sides and the credit
  * assertion passes for the wrong reason.
  */
-async function pushCalendarEvent(seed: Seed, opts: { eventId?: string; attendees?: unknown; date?: string; asMemberId?: string } = {}) {
+async function pushCalendarEvent(
+  seed: Seed,
+  opts: { eventId?: string; attendees?: unknown; date?: string; asMemberId?: string; body?: string } = {}
+) {
   const frontmatter = {
     source: "calendar",
     title: "Design review",
@@ -72,7 +75,15 @@ async function pushCalendarEvent(seed: Seed, opts: { eventId?: string; attendees
     return ingestItem(
       db(),
       { teamId: seed.teamId, memberId: opts.asMemberId, apiKeyId: uuid() },
-      { project: "calendar", kind: "artifact", actor: "tester", frontmatter, content_sha256: sha(""), path, body: "" },
+      {
+        project: "calendar",
+        kind: "artifact",
+        actor: "tester",
+        frontmatter,
+        content_sha256: sha(opts.body ?? ""),
+        path,
+        body: opts.body ?? "",
+      },
       "team"
     );
   }
@@ -80,7 +91,7 @@ async function pushCalendarEvent(seed: Seed, opts: { eventId?: string; attendees
     kind: "artifact",
     access: "team",
     path: `1-inbox/calendar/${randomUUID().slice(0, 8)}.md`,
-    body: "",
+    body: opts.body ?? "",
     project: "calendar",
     frontmatter: {
       source: "calendar",
@@ -169,6 +180,22 @@ describe("identity link: one meeting, two pushes (real Postgres)", () => {
     // second meeting on the next one.
     await tick(seed);
     expect(await liveNotes(seed)).toHaveLength(1);
+  });
+
+  it("a WHITESPACE-only calendar body does not outrank the transcript", async () => {
+    // Pins the caller's `body.trim()`, which the pure rule cannot: `plan()` receives `hasBody` already
+    // computed, so without this a producer emitting "\n" for an invite would make the empty note the
+    // survivor and hide the real transcript. Found by a surviving mutation, not by review.
+    const seed = await seedTeam();
+    await pushCalendarEvent(seed, { body: "  \n\t \n" });
+    await pushTranscript(seed);
+    await tick(seed);
+
+    const notes = await liveNotes(seed);
+    expect(notes).toHaveLength(1);
+    expect(await bodyOf(seed, notes[0].id), "the transcript survived, not the blank invite").toContain(
+      "We agreed the rollout."
+    );
   });
 
   it("is idempotent — a second tick changes nothing", async () => {

--- a/test/datamechanics/meeting-notes-backfill.datamechanics.test.ts
+++ b/test/datamechanics/meeting-notes-backfill.datamechanics.test.ts
@@ -70,7 +70,15 @@ describe("meeting-notes backfill (data-mechanics)", () => {
     const s = await backfillMeetingNotesFromItems(db(), seed.teamId, { extract: stubExtract });
     // Deep-equality on the WHOLE summary, deliberately: it is what catches a counter being added and
     // left unwired, or silently defaulting to something other than zero on an empty run.
-    expect(s).toEqual({ scanned: 0, created: 0, skipped: 0, merged: 0, unresolvedAttendees: 0, calendarDeclined: 0 });
+    expect(s).toEqual({
+      scanned: 0,
+      created: 0,
+      skipped: 0,
+      merged: 0,
+      unresolvedAttendees: 0,
+      calendarDeclined: 0,
+      link: { linked: 0, refusals: { "two-bodies": 0, "dates-too-far-apart": 0, "unknown-date": 0 } },
+    });
   });
 
   // Spec: a pushed meeting arrives with its action items ALREADY materialized as tasks, not empty

--- a/test/meetings-identity-link.test.ts
+++ b/test/meetings-identity-link.test.ts
@@ -90,8 +90,10 @@ describe("plan — the survivor is chosen by content, not arrival order", () => 
   });
 
   it("never folds one note twice, so `merged_into` cannot chain onto a hidden note", () => {
-    // A note carrying two keys appears in two groups. Readers filter `merged_into is null` and do not
-    // resolve it transitively, so a chain would hide a note behind something already invisible.
+    // Under connected components this holds BY PARTITION — the three notes below are one component,
+    // not two groups. The test stays because it is what reddens on a regression to per-key grouping,
+    // which produced exactly that chain: readers filter `merged_into is null` and never resolve it
+    // transitively, so a chained note hides behind something already invisible.
     const p = plan([
       note({ noteId: "tx", eventKeys: ["eid:aaa11111"], hasBody: true }),
       note({ noteId: "cal", eventKeys: ["eid:aaa11111", "uid:bbb22222@google.com"] }),

--- a/test/meetings-identity-link.test.ts
+++ b/test/meetings-identity-link.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { plan, type LinkCandidate } from "@/lib/meetings/identity-link";
+
+/**
+ * Spec (MTGATT-3 §2): which notes fold into which, decided by an EXACT shared event key and by
+ * content — never by a resemblance, and never by a date pre-filter.
+ *
+ * These are the rules; `test/datamechanics/meeting-identity-link.datamechanics.test.ts` proves the
+ * rows they produce. Both halves are needed: a correct plan written wrongly to the DB is still a
+ * hidden meeting.
+ */
+
+const note = (over: Partial<LinkCandidate> & { noteId: string }): LinkCandidate => ({
+  eventKeys: [],
+  hasBody: false,
+  occurredAt: "2026-08-11",
+  createdAt: "2026-08-11T09:00:00.000Z",
+  ...over,
+});
+
+describe("plan — groups form on an exact event key and nothing else", () => {
+  it("does not group notes that share no event key, however similar they look", () => {
+    // Same date, same title-shaped situation, no shared identifier: this is the misassociation the
+    // operator asked about at team scale, asserted as an absence.
+    const p = plan([
+      note({ noteId: "a", eventKeys: ["eid:aaa11111"], hasBody: true }),
+      note({ noteId: "b", eventKeys: ["eid:bbb22222"] }),
+    ]);
+    expect(p.groups).toEqual([]);
+  });
+
+  it("does not group on an empty key set — a corpus with no identifiers must form no groups", () => {
+    // The live case today: prod carries zero identifiers. If `[]` grouped, the first tick would fold
+    // the entire Meetings page into one note.
+    const p = plan([note({ noteId: "a", hasBody: true }), note({ noteId: "b" }), note({ noteId: "c" })]);
+    expect(p.groups).toEqual([]);
+  });
+
+  it("groups a calendar event with its transcript on a shared key", () => {
+    const p = plan([
+      note({ noteId: "tx", eventKeys: ["eid:evt12345"], hasBody: true }),
+      note({ noteId: "cal", eventKeys: ["eid:evt12345"] }),
+    ]);
+    expect(p.groups).toEqual([{ survivorId: "tx", foldedIds: ["cal"], keys: ["eid:evt12345"] }]);
+  });
+});
+
+describe("plan — the survivor is chosen by content, not arrival order", () => {
+  it("the note WITH a body survives, whichever arrived first", () => {
+    // MTGATT-1 deferred this join partly because the existing merge keeps whichever note existed
+    // first, so a transcript arriving second would fold into the empty note and lose its text.
+    for (const [txCreated, calCreated] of [
+      ["2026-08-11T09:00:00.000Z", "2026-08-11T10:00:00.000Z"],
+      ["2026-08-11T10:00:00.000Z", "2026-08-11T09:00:00.000Z"],
+    ]) {
+      const p = plan([
+        note({ noteId: "tx", eventKeys: ["eid:evt12345"], hasBody: true, createdAt: txCreated }),
+        note({ noteId: "cal", eventKeys: ["eid:evt12345"], createdAt: calCreated }),
+      ]);
+      expect(p.groups[0].survivorId, `tx created ${txCreated}`).toBe("tx");
+    }
+  });
+
+  it("with no bodies at all, the earliest-created survives — deterministically", () => {
+    const p = plan([
+      note({ noteId: "late", eventKeys: ["eid:evt12345"], createdAt: "2026-08-11T12:00:00.000Z" }),
+      note({ noteId: "early", eventKeys: ["eid:evt12345"], createdAt: "2026-08-11T08:00:00.000Z" }),
+    ]);
+    expect(p.groups[0]).toEqual({ survivorId: "early", foldedIds: ["late"], keys: ["eid:evt12345"] });
+  });
+
+  it("folds N bodyless pushes of one event into the single note that has a body", () => {
+    // Three people share one meeting: one recorded it, two pushed their calendars.
+    const p = plan([
+      note({ noteId: "tx", eventKeys: ["eid:evt12345"], hasBody: true }),
+      note({ noteId: "cal1", eventKeys: ["eid:evt12345"], createdAt: "2026-08-11T09:30:00.000Z" }),
+      note({ noteId: "cal2", eventKeys: ["eid:evt12345"], createdAt: "2026-08-11T09:45:00.000Z" }),
+    ]);
+    expect(p.groups[0].survivorId).toBe("tx");
+    expect(p.groups[0].foldedIds.sort()).toEqual(["cal1", "cal2"]);
+  });
+
+  it("REFUSES a group where two notes have bodies, and counts the refusal", () => {
+    const p = plan([
+      note({ noteId: "tx1", eventKeys: ["eid:evt12345"], hasBody: true }),
+      note({ noteId: "tx2", eventKeys: ["eid:evt12345"], hasBody: true }),
+    ]);
+    expect(p.groups).toEqual([]);
+    expect(p.refusals["two-bodies"]).toBe(1);
+  });
+
+  it("never folds one note twice, so `merged_into` cannot chain onto a hidden note", () => {
+    // A note carrying two keys appears in two groups. Readers filter `merged_into is null` and do not
+    // resolve it transitively, so a chain would hide a note behind something already invisible.
+    const p = plan([
+      note({ noteId: "tx", eventKeys: ["eid:aaa11111"], hasBody: true }),
+      note({ noteId: "cal", eventKeys: ["eid:aaa11111", "uid:bbb22222@google.com"] }),
+      note({ noteId: "other", eventKeys: ["uid:bbb22222@google.com"], createdAt: "2026-08-11T07:00:00.000Z" }),
+    ]);
+    const foldedTwice = p.groups.flatMap((g) => g.foldedIds).filter((id, i, all) => all.indexOf(id) !== i);
+    expect(foldedTwice, "no note may be folded by two groups").toEqual([]);
+    const survivors = new Set(p.groups.map((g) => g.survivorId));
+    const folded = new Set(p.groups.flatMap((g) => g.foldedIds));
+    expect([...folded].filter((id) => survivors.has(id)), "a folded note must not also be a survivor").toEqual([]);
+  });
+});
+
+describe("plan — components, not per-key groups", () => {
+  it("links a THREE-note component bridged by a note carrying both keys", () => {
+    // Review round 2's case, and it is the ordinary shape rather than an exotic one: a UID also emits
+    // its bare event id, so a note can carry both. Grouping per key processed `eid:` first, folded the
+    // bridge into a bodyless note, and left the TRANSCRIPT stranded as a separate meeting — the exact
+    // outcome the survivor rule exists to make unreachable.
+    const p = plan([
+      note({ noteId: "A", eventKeys: ["eid:x1234567"], createdAt: "2026-08-11T08:00:00.000Z" }),
+      note({ noteId: "B", eventKeys: ["eid:x1234567", "uid:x1234567@google.com"], createdAt: "2026-08-11T09:00:00.000Z" }),
+      note({ noteId: "C", eventKeys: ["uid:x1234567@google.com"], hasBody: true, createdAt: "2026-08-11T10:00:00.000Z" }),
+    ]);
+    expect(p.groups).toHaveLength(1);
+    expect(p.groups[0].survivorId, "the note with the body must survive").toBe("C");
+    expect(p.groups[0].foldedIds.sort()).toEqual(["A", "B"]);
+  });
+
+  it("does not bridge two components that share no key", () => {
+    // The inverse: transitivity must follow shared keys, not proximity. Without it, one busy note
+    // could chain unrelated meetings into a single component.
+    const p = plan([
+      note({ noteId: "A", eventKeys: ["eid:aaa11111"], hasBody: true }),
+      note({ noteId: "B", eventKeys: ["eid:aaa11111"] }),
+      note({ noteId: "C", eventKeys: ["eid:zzz99999"], hasBody: true }),
+      note({ noteId: "D", eventKeys: ["eid:zzz99999"] }),
+    ]);
+    expect(p.groups).toHaveLength(2);
+    expect(p.groups.flatMap((g) => g.foldedIds).sort()).toEqual(["B", "D"]);
+  });
+});
+
+describe("plan — a whitespace body is not a body", () => {
+  it("treats a whitespace-only note as bodyless so it cannot outrank the real transcript", () => {
+    // `hasBody` is computed by the caller as `body.trim().length > 0`; this pins the CONSEQUENCE of
+    // getting that wrong — a producer emitting "\n" for an invite would otherwise become the survivor
+    // and hide the transcript.
+    const p = plan([
+      note({ noteId: "blank", eventKeys: ["eid:evt12345"], hasBody: false, createdAt: "2026-08-11T08:00:00.000Z" }),
+      note({ noteId: "tx", eventKeys: ["eid:evt12345"], hasBody: true, createdAt: "2026-08-11T09:00:00.000Z" }),
+    ]);
+    expect(p.groups[0].survivorId).toBe("tx");
+  });
+});
+
+describe("plan — the date veto, and the half that stops it becoming a filter", () => {
+  it("links a pair a DAY apart — the timezone case a date filter would have dropped", () => {
+    // A 19:00 PDT meeting is 02:00Z the next day, so the calendar's local date and the transcript's
+    // UTC-derived one legitimately differ. This is the inverse half: without it, the veto could be
+    // tightened to same-date and nothing else in the suite would notice.
+    const p = plan([
+      note({ noteId: "tx", eventKeys: ["eid:evt12345"], hasBody: true, occurredAt: "2026-08-12" }),
+      note({ noteId: "cal", eventKeys: ["eid:evt12345"], occurredAt: "2026-08-11" }),
+    ]);
+    expect(p.groups[0].survivorId).toBe("tx");
+    expect(p.refusals["dates-too-far-apart"]).toBe(0);
+  });
+
+  it("vetoes a group spanning weeks — the undetectable-series residual", () => {
+    const p = plan([
+      note({ noteId: "w1", eventKeys: ["uid:weekly@google.com"], hasBody: true, occurredAt: "2026-08-11" }),
+      note({ noteId: "w2", eventKeys: ["uid:weekly@google.com"], occurredAt: "2026-08-18" }),
+    ]);
+    expect(p.groups).toEqual([]);
+    expect(p.refusals["dates-too-far-apart"]).toBe(1);
+  });
+
+  it("REFUSES when a member has no date — the veto must not be switchable off by omission", () => {
+    // This rule is the reverse of the first draft, and review round 2 is why: an undetectable weekly
+    // series where the transcript is dated 11 Aug and the calendar event for 18 Aug carries NO date
+    // would link, because skipping nulls disables the veto exactly where it is needed. Refusing is
+    // the safe direction — a duplicate meeting is visible and fixable, two meetings fused are not.
+    const p = plan([
+      note({ noteId: "tx", eventKeys: ["eid:evt12345"], hasBody: true, occurredAt: null }),
+      note({ noteId: "cal", eventKeys: ["eid:evt12345"], occurredAt: "2026-08-11" }),
+    ]);
+    expect(p.groups).toEqual([]);
+    expect(p.refusals["unknown-date"]).toBe(1);
+  });
+
+  it("vetoes on the widest span in the group, not just the first pair", () => {
+    // Three members where the first two are compatible: checking only adjacent pairs would let a
+    // three-week span through on the strength of its narrowest edge.
+    const p = plan([
+      note({ noteId: "a", eventKeys: ["uid:weekly@google.com"], hasBody: true, occurredAt: "2026-08-11" }),
+      note({ noteId: "b", eventKeys: ["uid:weekly@google.com"], occurredAt: "2026-08-12" }),
+      note({ noteId: "c", eventKeys: ["uid:weekly@google.com"], occurredAt: "2026-09-01" }),
+    ]);
+    expect(p.groups).toEqual([]);
+    expect(p.refusals["dates-too-far-apart"]).toBe(1);
+  });
+});

--- a/test/meetings-link-read-errors.test.ts
+++ b/test/meetings-link-read-errors.test.ts
@@ -51,16 +51,25 @@ const BODIES = [
   { id: "i-cal", body: "" },
 ];
 
-/** Everything succeeds unless `failing` names the table (and `bodies` distinguishes the two item reads). */
-function results(failing: string | null, bodyCallSeen: { n: number }) {
+/**
+ * Everything succeeds unless `failing` names the table.
+ *
+ * `"items:bodies"` fails only the SECOND `items` read — the module reads that table twice (frontmatter
+ * for every candidate, then bodies for the keyed subset), and only the second failure exercises the
+ * dangerous branch: bodies missing means every candidate looks bodyless, which flips the survivor
+ * rule from "the transcript wins" to "the earliest-created wins".
+ */
+function results(failing: string | null, itemCalls: { n: number }) {
   return (table: string): Result => {
+    if (table === "items") {
+      itemCalls.n += 1;
+      const first = itemCalls.n === 1;
+      if (failing === "items" && first) return { data: null, error: { message: "connection terminated" } };
+      if (failing === "items:bodies" && !first) return { data: null, error: { message: "connection terminated" } };
+      return { data: first ? FRONTMATTER : BODIES, error: null };
+    }
     if (table === failing) return { data: null, error: { message: "connection terminated" } };
     if (table === "meeting_notes") return { data: NOTES, error: null };
-    if (table === "items") {
-      // The module reads `items` twice: frontmatter first, then bodies for the keyed subset.
-      bodyCallSeen.n += 1;
-      return { data: bodyCallSeen.n === 1 ? FRONTMATTER : BODIES, error: null };
-    }
     return { data: [], error: null };
   };
 }
@@ -74,7 +83,7 @@ describe("linkMeetingNotesByIdentity — a failed read hides nothing", () => {
     expect(writes, "and must actually hide the folded note").toContain("meeting_notes.update");
   });
 
-  for (const table of ["meeting_notes", "items", "meeting_note_attendees", "meeting_note_submitters"]) {
+  for (const table of ["meeting_notes", "items", "items:bodies", "meeting_note_attendees", "meeting_note_submitters"]) {
     it(`refuses to hide anything when the ${table} read fails`, async () => {
       const writes: string[] = [];
       const summary = await linkMeetingNotesByIdentity(stubDb(results(table, { n: 0 }), writes), "team-1");

--- a/test/meetings-link-read-errors.test.ts
+++ b/test/meetings-link-read-errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { DbClient } from "@/lib/db/types";
+import { linkMeetingNotesByIdentity } from "@/lib/meetings/link-notes";
+
+/**
+ * Spec (MTGATT-3 §2.3): a read that FAILS must never be read as "there was nothing there".
+ *
+ * WHY THIS FILE EXISTS AT ALL. The pg adapter RETURNS errors rather than throwing
+ * (`lib/db/pg/query-builder.ts` catches and returns `{data: null, error}`), so the first version of
+ * the linker — which destructured only `data` — turned a transient DB failure into: attendees `[]`
+ * → `addMeetingNoteAttendees` no-ops → `setMeetingNoteMergedInto` succeeds → **the note is hidden
+ * with its credit never transferred, permanently**, because the next tick excludes `merged_into`
+ * notes. A failed BODY read was worse: every candidate reads as bodyless, so a transcript could be
+ * folded behind a blank invite.
+ *
+ * A real DB cannot be made to fail one specific SELECT on demand, so this is a stub — the failure is
+ * in the ADAPTER CONTRACT, not in Postgres, and the contract is what is pinned here.
+ */
+
+type Result = { data: unknown; error: { message: string } | null };
+
+/** The chain shape `link-notes.ts` uses: from().select().eq().is().order().limit() / .in(), awaited. */
+function stubDb(resultFor: (table: string) => Result, writes: string[]): DbClient {
+  const chain = (table: string): Record<string, unknown> => {
+    const self: Record<string, unknown> = {};
+    for (const method of ["select", "eq", "is", "order", "limit", "in", "maybeSingle", "single"]) {
+      self[method] = () => self;
+    }
+    for (const method of ["update", "upsert", "insert", "delete"]) {
+      self[method] = () => {
+        writes.push(`${table}.${method}`);
+        return self;
+      };
+    }
+    self.then = (resolve: (v: Result) => unknown) => resolve(resultFor(table));
+    return self;
+  };
+  return { from: (table: string) => chain(table) } as unknown as DbClient;
+}
+
+const NOTES = [
+  { id: "tx", source_item_id: "i-tx", occurred_at: "2026-08-11", created_at: "2026-08-11T09:00:00.000Z" },
+  { id: "cal", source_item_id: "i-cal", occurred_at: "2026-08-11", created_at: "2026-08-11T10:00:00.000Z" },
+];
+const FRONTMATTER = [
+  { id: "i-tx", frontmatter: { calendar_event_id: "evt12345" } },
+  { id: "i-cal", frontmatter: { calendar_event_id: "evt12345" } },
+];
+const BODIES = [
+  { id: "i-tx", body: "# Design review\n\nWe agreed the rollout." },
+  { id: "i-cal", body: "" },
+];
+
+/** Everything succeeds unless `failing` names the table (and `bodies` distinguishes the two item reads). */
+function results(failing: string | null, bodyCallSeen: { n: number }) {
+  return (table: string): Result => {
+    if (table === failing) return { data: null, error: { message: "connection terminated" } };
+    if (table === "meeting_notes") return { data: NOTES, error: null };
+    if (table === "items") {
+      // The module reads `items` twice: frontmatter first, then bodies for the keyed subset.
+      bodyCallSeen.n += 1;
+      return { data: bodyCallSeen.n === 1 ? FRONTMATTER : BODIES, error: null };
+    }
+    return { data: [], error: null };
+  };
+}
+
+describe("linkMeetingNotesByIdentity — a failed read hides nothing", () => {
+  it("links normally when every read succeeds (the control)", async () => {
+    // Without this, every assertion below would pass on a stub that simply never links.
+    const writes: string[] = [];
+    const summary = await linkMeetingNotesByIdentity(stubDb(results(null, { n: 0 }), writes), "team-1");
+    expect(summary.linked, "the control must actually link").toBe(1);
+    expect(writes, "and must actually hide the folded note").toContain("meeting_notes.update");
+  });
+
+  for (const table of ["meeting_notes", "items", "meeting_note_attendees", "meeting_note_submitters"]) {
+    it(`refuses to hide anything when the ${table} read fails`, async () => {
+      const writes: string[] = [];
+      const summary = await linkMeetingNotesByIdentity(stubDb(results(table, { n: 0 }), writes), "team-1");
+      expect(summary.linked, "nothing may be counted as linked").toBe(0);
+      expect(writes, "nothing may be hidden — the next tick retries").not.toContain("meeting_notes.update");
+    });
+  }
+});

--- a/test/meetings-schedule-backfill.test.ts
+++ b/test/meetings-schedule-backfill.test.ts
@@ -46,6 +46,30 @@ describe("shouldScheduleMeetingBackfill — what earns an immediate run", () => 
     expect(shouldScheduleMeetingBackfill({ kind: "transcript", source: undefined, status: "created" })).toBe(false);
     expect(shouldScheduleMeetingBackfill({ kind: "transcript", source: 42, status: "created" })).toBe(false);
   });
+
+  it("schedules for a CALENDAR EVENT, which is keyed on source and not on kind (MTGATT-3)", () => {
+    // Before this, a pushed calendar event returned false — `isMeetingTranscript` requires
+    // kind='transcript' and a producer may reasonably send `artifact`. So your own calendar push sat
+    // unlinked until a scheduler tick while someone else's transcript was noted instantly: an
+    // invisible half-hour asymmetry between the two producers of the same meeting.
+    for (const kind of ["artifact", "transcript"]) {
+      expect(shouldScheduleMeetingBackfill({ kind, source: "calendar", status: "created" }), `kind=${kind}`).toBe(true);
+    }
+    for (const source of ["gcal", "google_calendar", "googlecalendar"]) {
+      expect(shouldScheduleMeetingBackfill({ kind: "artifact", source, status: "created" }), source).toBe(true);
+    }
+  });
+
+  it("still refuses an UNCHANGED calendar re-push — the widening must not cost the dedupe", () => {
+    // The inverse half. `aios push` re-sends byte-identical files routinely, so a widening that
+    // forgot this would pay for a full scan on every no-op push.
+    expect(shouldScheduleMeetingBackfill({ kind: "artifact", source: "calendar", status: "unchanged" })).toBe(false);
+  });
+
+  it("still refuses a non-meeting artifact — the widening is scoped to calendar sources", () => {
+    expect(shouldScheduleMeetingBackfill({ kind: "artifact", source: "github", status: "created" })).toBe(false);
+    expect(shouldScheduleMeetingBackfill({ kind: "artifact", source: null, status: "created" })).toBe(false);
+  });
 });
 
 describe("createMeetingBackfillScheduler — coalescing", () => {


### PR DESCRIPTION
**Stacked on #598 (MTGATT-2).** Base is `feat/meeting-attendance-identity`; retarget to `main` after that merges. Review `git diff feat/meeting-attendance-identity...HEAD`.

## What this is

When someone pushes a calendar event carrying the same event identifier as a meeting already in the system, the two become **one** meeting: the calendar event's attendance and submitter are **added** to the note that has the body, and the bodyless note is hidden.

This is the operator's ask, in their words: *"John may be uploading meetings and if they do they're gonna come saying just John Ellison but I would have already also been in that meeting… my calendar is the only way we could do that."*

It implements the ruling from that conversation: **the push is the assertion, the RSVP only vetoes** — people attend meetings they never RSVP to.

Spec: `docs/design/meeting-identity-link.md` (`SPEC_READY`, exit 0).

## The rules, and why each one

- **Groups form on an exact shared event key, and nothing else** — never a conference link (a Zoom personal room is reused for every meeting its owner hosts), never a series key (all occurrences of a recurring event share one `iCalUID`), never title similarity, and **never date-pre-filtered** (a 19:00 PDT meeting is 02:00Z the next day).
- **Connected components, not per-key groups.** Per-key grouping stranded the transcript — see the review section.
- **The survivor is chosen by CONTENT**: the note with a body wins, whichever arrived first. That makes MTGATT-1's deferred hazard — a transcript folding into an empty calendar note and losing its text — unreachable rather than unlikely.
- **Credit first, hide second, and every read error-checked.** The pg adapter *returns* errors rather than throwing, so an unchecked failed read looks exactly like "no attendees" — and the note would be hidden with its credit never transferred, permanently.
- **Two refusals, counted by reason**: two bodies (the overlap merge owns that), and dates more than a day apart or unknown (the residual undetectable-series case).

## Honest limits

- **It ships ahead of its data.** Prod still carries **0 calendar identifiers**; the spec review declined on that ground and the operator overrode it after being shown the number. The suite proves the *rule*, not the wiring to reality — **the first real pair must be confirmed with `scripts/meeting-pairing-report.ts`** before this is trusted.
- **It cannot catch someone who accepted, pushed their calendar, and skipped.** Only a Meet/Zoom attendance-report connector closes that.
- Speaker diarization was checked as an alternative signal and is **unusable here**: 41 of 63 transcripts carry named labels, but the names are the recorder plus a generic `Speaker`.

## Verification

| tier | result |
|---|---|
| `npx tsc --noEmit` · `npm run lint` · `npm run check:docs` | clean |
| `npm test` (unit) | **3,010 passed** |
| `npm run test:datamechanics:iso`, single worker | **1,210 passed**, 1 pre-existing TZ artifact (`task-update-action`, green under `TZ=UTC`, untouched by this diff) |

**One thing I am NOT calling green.** Under the default parallel workers, two or three *pre-existing timing-sensitive* tests (`decision races`, `projector re-push`, `writeback`) flake on this branch and do not on its base. Single-worker runs clean, and my own tests never fail. The cause is load: this branch adds a heavy data-mechanics file. It is a pre-existing fragility surfaced by added concurrency rather than a regression here — but it is real and named rather than averaged away. Note that **CI cannot adjudicate it on this PR**: `ci.yml` only fires on PRs targeting `main`/`staging`, so a stacked PR runs the gate workflows only.

| `npm run test:http:local` | **54 passed**, 2 skipped — run by hand because a stacked PR skips `ci.yml` |

**Mutations — 16, each reddening only its intended test.** Four of them only redden *after* I fixed a test they proved was decoration.

## Review

**Reviewed by Fable and Codex gpt-5.5 (2 spec rounds + 2 diff rounds) — verdict BLOCKED in all four, every finding folded.**

**Spec round 1 (Codex) — DECLINE.** Beyond the data objection: my "claim, not merge" design made an existing hazard *reachable* — the overlap merge propagates only two submitter ids, so a submitter this slice accumulates could be stranded when the survivor is itself folded. Also that a calendar push never triggered the immediate backfill at all (`kind='transcript'` only), so your own push waited for a tick while someone else's transcript was instant.

**Spec round 2 (Codex) — BLOCKED,** attacking the fold, and it read the code rather than the prose: **per-key grouping stranded the transcript.** With A carrying `eid:x`, B carrying both keys, and C — the transcript — carrying only the uid, `eid:` is processed first, B folds into A, and C is left live while a *bodyless* note survives. Reproduced against my own module before fixing; now connected components. It also broke my null-date policy with a concrete undetectable-series case, so that rule is reversed: an unknown date now refuses.

**Diff round 1 (Fable) — BLOCKED, and this was the sharpest finding of the slice.** The pg adapter returns `{data: null, error}` instead of throwing, so every unchecked read in the linker turned a transient DB failure into a note hidden with its credit permanently lost — and a failed *body* read flipped the survivor rule, folding a transcript behind a blank invite. My module header and a sentence I had added to `ARCHITECTURE.md` both claimed that was impossible; **both were false and are corrected.** It also caught the same pattern in the `merge.ts` fix I had just written, `daysApart` returning 0 on an unparseable date (silently disarming the veto — now Infinity), the merge-owned item being written with `{title}` only so a merged meeting **lost its event keys**, and an **AC10 the spec claimed and I had never written**.

**Diff round 2 (Codex) — BLOCKED** on the second-order consequences of those folds: the *attendee* read in `merge.ts` was still unchecked (and now carries link-accumulated attendance), and `carriedIdentity` read only the survivor's item — but the keyed note is usually the one folded *away*, so the key was still lost. Both fixed; identity is now carried from both sides and narrowed to two flat fields rather than copying a whole Google event object.

**Both of my refutations survived re-attack** — no external tier leak (meeting notes are team-tier by construction and the timeline's meetings leg is gated on `canSeeMeetingNotes`), and no missing merge invariant. Fable supplied the proof my spec was missing: a folded note can never have a body, so there is nothing to remap.

**Four tests were green by construction and mutation caught them, not review:** the stranding test asserted the wrong fold direction; `body.trim()` was unpinned; the error checks had no test at all; and the identity-survival assertion was missing from AC11. Two checks are redundant-by-outcome and one is argued-not-proven — all three are labelled as such in the code rather than left looking load-bearing.

## Deferrals

- **MTGATT-6:** `getMeetingNote` does not filter `merged_into`, so a direct URL to a folded note renders a dead-end detail page. Pre-existing since MTGATT-1; this slice makes it more reachable. Fixing it is a routing decision (redirect to the survivor, or 404?).
- **MTGATT-4** (per-attendee provenance) is what makes a wrong claim diagnosable — this slice writes attendance rows indistinguishable from any other source.

AIOS-Work: MTGATT-3
