### PR TITLE
chore(codacy): track the Codacy Cursor rule instead of ignoring it

### DIFF
--- a/.cursor/rules/codacy.mdc
+++ b/.cursor/rules/codacy.mdc
@@ -1,0 +1,73 @@
+---
+    description: Configuration for AI behavior when interacting with Codacy's MCP Server
+    globs: 
+    alwaysApply: true
+---
+---
+# Codacy Rules
+Configuration for AI behavior when interacting with Codacy's MCP Server
+
+## CRITICAL: After ANY successful `edit_file` or `reapply` operation
+- YOU MUST IMMEDIATELY run the `codacy_cli_analyze` tool from Codacy's MCP Server for each file that was edited, with:
+ - `rootPath`: set to the workspace path
+ - `file`: set to the path of the edited file
+ - `tool`: leave empty or unset
+- If any issues are found in the new edits, propose and apply fixes for them.
+- > NOTE: Failure to follow this rule is considered a critical error.
+
+## When you tried to run the `codacy_cli_analyze` tool and the Codacy CLI is not installed
+- Ask the user 'Codacy CLI is not installed. Would you like me to install it now?'
+- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task
+- If the user responds with "no", instruct the user that they can disable automatic analysis in the extension settings
+- Wait for the user to respond before proceeding with any other actions
+
+## After every response
+- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server 
+
+## When there are no Codacy MCP Server tools available, or the MCP Server is not reachable
+- Suggest the user the following troubleshooting steps:
+ - Try to reset the MCP on the extension
+ - If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
+- If none of the above steps work, suggest the user to contact Codacy support
+
+## Trying to call a tool that needs a rootPath as a parameter
+- Always use the standard, non-URL-encoded file system path
+
+## CRITICAL: Dependencies and Security Checks
+- IMMEDIATELY after ANY of these actions:
+ - Running npm/yarn/pnpm install
+ - Adding dependencies to package.json
+ - Adding requirements to requirements.txt
+ - Adding dependencies to pom.xml
+ - Adding dependencies to build.gradle
+ - Any other package manager operations
+- You MUST run the `codacy_cli_analyze` tool with:
+ - `rootPath`: set to the workspace path
+ - `tool`: set to "trivy"
+ - `file`: leave empty or unset
+- If any vulnerabilities are found because of the newly added packages:
+ - Stop all other operations
+ - Propose and apply fixes for the security issues
+ - Only continue with the original task after security issues are resolved
+- EXAMPLE:
+ - After: npm install react-markdown
+ - Do: Run codacy_cli_analyze with trivy
+ - Before: Continuing with any other tasks
+
+## General
+- Repeat the relevant steps for each modified file.
+- "Propose fixes" means to both suggest and, if possible, automatically apply the fixes.
+- You MUST NOT wait for the user to ask for analysis or remind you to run the tool.
+- Do not run `codacy_cli_analyze` looking for changes in duplicated code or code complexity metrics.
+- Complexity metrics are different from complexity issues. When trying to fix complexity in a repository or file, focus on solving the complexity issues and ignore the complexity metric.
+- Do not run `codacy_cli_analyze` looking for changes in code coverage.
+- Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
+- If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
+- When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.
+
+## Whenever a call to a Codacy tool that uses `repository` or `organization` as a parameter returns a 404 error
+- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy
+- If the user accepts, run the `codacy_setup_repository` tool
+- Do not ever try to run the `codacy_setup_repository` tool on your own
+- After setup, immediately retry the action that failed (only retry once)
+---

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,3 @@ supabase/
 # commit. Recorded fixtures belong in test/fixtures/, redacted, never here.
 tmp/
 
-# Codacy CLI extension output — a per-machine Cursor rules file it regenerates on install.
-# The shared, reviewed Codacy config is .codacy.yaml at the repo root; this one is local noise.
-.cursor/rules/codacy.mdc


### PR DESCRIPTION
## Review — Reviewed by Claude Code (Opus 5) — verdict ship: adds one 72-line rules file and removes an ignore line; no source, config, or CI behaviour changes

John: *"go ahead and track the codacy stuff it's meant to be there"*.

## This reverses a recent, deliberate decision — on purpose

#569 added the ignore two days ago with an explicit rationale:

> Codacy CLI extension output — a per-machine Cursor rules file it regenerates on install. The shared, reviewed Codacy config is `.codacy.yaml` at the repo root; this one is local noise.

That's right about **how the file is produced** and wrong about **what it contains**. I checked before overriding: 72 lines of MCP behaviour instructions, and a grep for absolute paths, usernames, tokens, and drive letters returns nothing. There's no per-machine content in it.

The practical effect of ignoring it was that a contributor's agent got Codacy behaviour only if they happened to have the extension installed — the opposite of what a shared rule is for. The repo already tracks four sibling rules (`connect`, `pr-review-attestation`, `railway-deploy-verify`, `setup-brain`); this is the fifth and belongs with them.

**The trade this accepts:** if the extension regenerates the file differently on someone's machine, it shows up as a diff. That's a visible, reviewable event rather than a silent per-machine divergence — the better failure mode of the two.

## Scope

Only this repo. `.cursor/rules/codacy.mdc` doesn't exist in `aios-website`, `aios-workspace-gui`, `aios-marketing`, or `aios-design`, so there's nothing to track there.

Separately, and deliberately not swept in here: the **hub** repo (`aios`) gitignores a `.codacy/` directory holding ~450KB of CLI config plus `generated/` and `tmp/` working state. That's a different case from a 4KB rules file and wants its own decision.

## Note on timing

This was committed before #608 and held unpushed rather than bypassing the NDA pre-push gate — the gate was failing on pre-existing content in the tree, not on anything in this diff. Rebased onto the scrubbed `main` (`a2d77e0a`); `nda-leak-gate.sh tree` now reports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Cursor rule plus a one-line `.gitignore` change; no runtime, auth, or build behaviour affected.
> 
> **Overview**
> **Tracks the shared Codacy Cursor rule** instead of treating it as local extension output. The repo now includes `.cursor/rules/codacy.mdc` (~72 lines of Codacy MCP behaviour: post-edit `codacy_cli_analyze`, Trivy after dependency changes, setup/troubleshooting flows) and **removes** the `.gitignore` entry that had excluded that path since #569.
> 
> This aligns Codacy with the other committed rules under `.cursor/rules/` and makes agent behaviour consistent for everyone, not only machines with the Codacy extension installed. **No application source, CI, or `.codacy.yaml` changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0014cf1af935e4513bf883a83a19a28d66a7ad06. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->