### PR TITLE
chore(deps): pin @aios-alpha/design and /ui ^0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.10.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@aios-alpha/design": "^0.5.0",
-        "@aios-alpha/ui": "^0.5.0",
+        "@aios-alpha/design": "^0.6.0",
+        "@aios-alpha/ui": "^0.6.0",
         "@anthropic-ai/sdk": "^0.115.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -50,16 +50,16 @@
       }
     },
     "node_modules/@aios-alpha/design": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@aios-alpha/design/-/design-0.5.0.tgz",
-      "integrity": "sha512-FP4Ukg/1Q1VJVH0PuB+Wv6M5WtqPmSpaLixXvfCh7yJDUjo6M1aRjrqWYm0p/UcczkVxzYBkiDTkqxjlMlo9Zg==",
-      "license": "MIT"
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@aios-alpha/design/-/design-0.6.0.tgz",
+      "integrity": "sha512-ifgviabyphh8/N8bmbUbx8Nen6wknmUiFiiewD9678vMvweLhfnhfzvHM9NvroYuhiMkGz4wEwdGgHoHO8mD+w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@aios-alpha/ui": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@aios-alpha/ui/-/ui-0.5.0.tgz",
-      "integrity": "sha512-dWWAMWvgRe9ewwKfriy0l8h+FJb6FQfWE70vR7OsW0zX0uN2Mha2hS6mm2dDdWVkgB5QDr1e9DkwmFv3xV0t8g==",
-      "license": "MIT",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@aios-alpha/ui/-/ui-0.6.0.tgz",
+      "integrity": "sha512-5bWwJ38xv6MSNFBlOLyDYINVr2NC2o8kG/aWHCyfqdjiJ9JXvKac+bs5lDeFIkj7fsvIXSmOBSAvbr2I7Quc2g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-separator": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "test:http:local": "npm run build && DATABASE_TEST_URL=postgres://app:app@localhost:5434/app_test vitest run --config vitest.http.config.ts"
   },
   "dependencies": {
-    "@aios-alpha/design": "^0.5.0",
-    "@aios-alpha/ui": "^0.5.0",
+    "@aios-alpha/design": "^0.6.0",
+    "@aios-alpha/ui": "^0.6.0",
     "@anthropic-ai/sdk": "^0.115.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
## Review — Reviewed by Claude Code (Opus 5) — verdict ship: manifest + lockfile only, no source changes, 3079 tests pass and tsc clean

Moves the brain onto the **Apache-2.0** release of the design system. `0.6.0` is `0.5.0`'s content under a new license — no token, asset, or component API change.

Context: the relicense briefly shipped as `1.0.0` and was corrected to `0.6.0` ([aios-design#20](https://github.com/aiosbrain/aios-design/pull/20), [#21](https://github.com/aiosbrain/aios-design/pull/21)). This repo pinned `^0.5.0`, which cannot resolve `1.0.0`, so the mispublish never reached it.

## Verification

- `npx vitest run` — 3079 passed, 11 skipped, 0 failed
- `npx tsc --noEmit` — clean
- `nda-leak-gate.sh tree` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 389791b1c83374beba9b9d4b946429b14429cb07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->