### PR TITLE
docs(ops): the contract-bump runbook now names the schema work a bump implies (AIO-950)

### DIFF
--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -361,9 +361,9 @@ that an older brain doesn't yet serve.
 
 | File                                                       | Role                                                                                                                                                                  |
 | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `aios-workspace/docs/brain-api.md`                         | Source of truth for the wire contract; states the version in its first line (`**Version: 1.17**`) and carries a dated _Revisions_ changelog for every additive change. |
-| `docs/ARCHITECTURE.md` (this repo, §"Auth & access tiers") | Carries the canonical implemented-version claim in prose: `"This server implements brain-api v1.17"`.                                                                  |
-| `lib/api/version.ts`                                       | `export const BRAIN_API_VERSION = "1.17"` — the single server-side declaration of which contract version this codebase targets.                                        |
+| `aios-workspace/docs/brain-api.md`                         | Source of truth for the wire contract; states the version in its first line (`**Version: 1.21**`) and carries a dated _Revisions_ changelog for every additive change. |
+| `docs/ARCHITECTURE.md` (this repo, §"Auth & access tiers") | Carries the canonical implemented-version claim in prose: `"This server implements brain-api v1.21"`.                                                                  |
+| `lib/api/version.ts`                                       | `export const BRAIN_API_VERSION = "1.21"` — the single server-side declaration of which contract version this codebase targets.                                        |
 | `test/guards/contract-version.test.ts`                     | Fails the build if `BRAIN_API_VERSION` and the `ARCHITECTURE.md` prose claim drift apart — forces both to move together.                                              |
 | `aios-workspace/docs/contract/brain-contract.json`         | Canonical conformance fixture (`version`, `tierAliases`, `sse.frames`, `provisioningTools`, `contentHash`).                                                           |
 | `test/fixtures/contract/brain-contract.json` (this repo)   | A vendored **copy** of the file above — must match byte-for-byte (`contentHash` pins the content) or `test/guards/contract-conformance.test.ts` fails.                |
@@ -378,14 +378,41 @@ that an older brain doesn't yet serve.
 2. **Re-vendor the fixture into this repo**: copy the updated `brain-contract.json` into
    `test/fixtures/contract/brain-contract.json` verbatim so the `contentHash` matches.
 3. **Bump `lib/api/version.ts`**'s `BRAIN_API_VERSION` to the new value.
-4. **Update the prose claim in `docs/ARCHITECTURE.md`** ("...implements brain-api v1.9...") to
-   the new version — `test/guards/contract-version.test.ts` matches that exact sentence.
+4. **Update the prose claim in `docs/ARCHITECTURE.md`** — the one sentence of the form
+   `This server **implements brain-api v<OLD>**` — to the new version;
+   `test/guards/contract-version.test.ts` matches that exact sentence.
 5. **Implement the actual endpoint/field change** in this codebase (new route, new optional
    field, etc.), keeping old behavior intact if the bump is additive.
-6. **Run the guards before opening the PR**: `npm test` (covers both
+6. **Ask what the change costs the SCHEMA, and write the migration if it costs anything.** If the
+   contract change touches a persisted vocabulary or shape — an enum value, a column, a
+   constraint — editing `postgres/schema.sql` alone is **not enough**. That file expresses its
+   objects with `create ... if not exists` (and guarded `do $$ ... $$` blocks), so it is a silent
+   no-op against an already-deployed database; the catch-up delta belongs under
+   `postgres/migrations/`. Read `postgres/migrations/README.md` for the rules that directory
+   enforces (idempotence, replay order, the CHECK-widening trap) rather than guessing.
+   - **The worked example is v1.21 itself (AIO-950).** `tasks.status` is the Postgres ENUM
+     `task_status`, created in `schema.sql` inside a
+     `do $$ ... exception when duplicate_object then null $$` guard. On every already-deployed
+     brain that type already exists, so adding a value to the `create type` line does **nothing**,
+     `npm run pg:schema` still runs green, and the failure surfaces only at the first write of the
+     new value, as `invalid input value for enum task_status`. The fix was **both** files, as the
+     README's mirroring rule requires: the widened `create type` in `schema.sql` for a from-zero
+     load, plus the catch-up delta
+     `postgres/migrations/20260819180000_task_status_in_review.sql` for every DB that already
+     exists.
+   - **Enum ordering is part of the change.** Where the new value has a natural position, pin it
+     (`alter type ... add value ... before 'blocked'`). `order by status` sorts on the enum's own
+     sort order, so appending at the end silently re-orders every status-sorted surface.
+   - **Migrations self-apply — do not plan a manual prod step.** `scripts/pg-load-schema.mjs` is
+     Railway's `preDeployCommand` (§4), so a deploy applies pending migrations *before* the new
+     app version goes live, and a failure there aborts the release instead of shipping code ahead
+     of its schema. **Never** run `npm run pg:schema` by hand as a rollout step — locally the
+     loader targets whatever `DATABASE_URL` your shell holds, which in a worktree is the dev/test
+     database, not prod.
+7. **Run the guards before opening the PR**: `npm test` (covers both
    `contract-version.test.ts` and `contract-conformance.test.ts`) and `npm run check:docs`
    (the drift guard for enumerable surfaces).
-7. **Ship both repos in the same change window.** Because clients are required to tolerate a
+8. **Ship both repos in the same change window.** Because clients are required to tolerate a
    `404` on endpoints an older brain doesn't yet serve, an additive bump can deploy the brain
    first; but keep the version bump in `aios-workspace` and `aios-team-brain` as close together
    as possible so `docs/brain-api.md` never describes a contract neither side has actually shipped.


### PR DESCRIPTION
## What & Why

`docs/OPS.md` §7 "Upgrading across a brain-api contract bump" walked from "bump the version line" straight to "run the guards" without ever mentioning the database. **PR #618 / AIO-950 (brain-api v1.21, `in_review`) is what that omission costs**: the change needed a Postgres enum migration, and that requirement was a surprise to the people running the upgrade because the runbook never asked for one. This adds the missing step and refreshes the section's stale version examples.

**1. New step 6 — the schema question.** Between "implement the change" and "run the guards", §7 now asks what a contract change costs the schema:

- If it touches a persisted vocabulary or shape (enum value, column, constraint), editing `postgres/schema.sql` alone is not enough — that file uses `create ... if not exists` and guarded `do $$ ... $$` blocks, so it is a silent no-op against an already-deployed database. It cross-references `postgres/migrations/README.md` for that directory's rules rather than restating them.
- The v1.21 trap as the worked example: `tasks.status` is the ENUM `task_status`, created inside a `duplicate_object` guard, so adding a value via `schema.sql` does nothing on a deployed brain, `npm run pg:schema` still runs green, and the first write fails with `invalid input value for enum task_status`. The fix was **both** files (widened `create type` for from-zero + the catch-up delta), per the README's mirroring rule.
- Enum ordering: pin the position (`... add value ... before 'blocked'`), because `order by status` sorts on the enum's own order and appending at the end silently re-orders status-sorted surfaces.
- Migrations **self-apply**: `pg-load-schema.mjs` is Railway's `preDeployCommand` (§4), so a deploy applies pending migrations before the new app version goes live and a failure there aborts the release. Never run `npm run pg:schema` by hand as a rollout step — locally it targets whatever `DATABASE_URL` the shell holds.

Old steps 6 and 7 become 7 and 8. The closing paragraph's "steps 1–4" still names exactly the four version-pin steps, so it needed no change.

**2. Stale version examples in §7.** The section prose already said v1.21 while its own pin table cited `**Version: 1.17**`, `"This server implements brain-api v1.17"` and `BRAIN_API_VERSION = "1.17"` — a real internal contradiction. All three now read 1.21, verified against `lib/api/version.ts` (`"1.21"`), `docs/ARCHITECTURE.md:231` and `aios-workspace/docs/brain-api.md`. Step 4's example, which was `v1.9`, is now a `<OLD>` placeholder so it cannot go stale again or be mistaken for the live claim.

**Deliberately not changed:** `docs/ARCHITECTURE.md`'s real claim, `lib/api/version.ts`, §4's `preDeployCommand` statements (already accurate, twice), and `postgres/migrations/README.md` (already states replay-on-every-rollout and that it is the Railway rollout path). Docs-only; no code, guard, or test weakened.

## Work item

Documentation follow-up to AIO-950 / #618; no separate brain task.

## Checklist

- [x] `node scripts/check-docs-drift.mjs` passes locally
- [x] Unit tests pass: `npm test` — 336 files, 3109 passed / 11 skipped, 0 failed
- [x] Datamechanics tests pass if persistence changed: n/a (docs only)
- [x] Ingestion tests pass if Python changed: n/a
- [x] `brain-api.md` version bumped if sync protocol changed: n/a — no protocol change
- [x] No secrets or admin-tier content in diff (NDA gate clean, staged + tree)
- [x] Local diff review recorded below

## Review summary

Reviewed by Fable (fresh-context reviewer, GPT-5.5 cross-check) — verdict CLEAR, no P1; the one P2 (worked example read as "migration instead of schema.sql") and two P3s (unbolded ARCHITECTURE.md quote form, "not normally" weaker than the repo's "never run pg:schema by hand" rule) were all fixed in the current head before push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an ops runbook; no application, schema, or test behavior is modified.
> 
> **Overview**
> **§7 brain-api upgrade runbook** now treats database work as a first-class part of a contract bump, not only version pins and guards.
> 
> A new **step 6** tells operators to ask whether the change touches persisted shapes (enums, columns, constraints). It explains why **`postgres/schema.sql` alone is a no-op** on deployed DBs, points at **`postgres/migrations/README.md`**, and uses **v1.21 / `task_status` / `in_review` (AIO-950)** as the worked example (schema + migration, enum ordering, and that migrations run via Railway **`preDeployCommand`** — **do not** hand-run `npm run pg:schema` for prod rollout). Former steps 6–7 are now **7–8**.
> 
> The **version pin table** and related examples are aligned from **1.17 → 1.21**; step 4’s `ARCHITECTURE.md` example uses **`v<OLD>`** so it won’t go stale again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508816cecd8ef864a0f2b10957bba260135c4ffe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->