### PR TITLE
test(clickup): declare the fixture token with the AIO-952 value-bound OGR03 marker

### DIFF
--- a/test/datamechanics/integrations-clickup.datamechanics.test.ts
+++ b/test/datamechanics/integrations-clickup.datamechanics.test.ts
@@ -30,7 +30,11 @@ function auth(teamId: string, memberId: string) {
 // anything named *TOKEN* trips a CRITICAL secret finding -- which it did, blocking a
 // release gate on a value that is plainly fake. The shape has to stay realistic for the
 // test to be worth anything, so the binding is what changes. Do not rename this back.
-const FIXTURE_PK = "pk_12345678_REALCLICKUPTOKENABCDEF";
+// AIO-952 (workspace PR #633) closed that rename loophole: OGR03 now matches ClickUp
+// tokens BY VALUE (pk_<digits>_<key>), so this realistic shape needs an explicit,
+// value-bound fixture declaration. The marker names the first 16 chars of the declared
+// value and exempts only tokens starting with that prefix -- nothing else on the line.
+const FIXTURE_PK = "pk_12345678_REALCLICKUPTOKENABCDEF"; // aios-secret-fixture:pk_12345678_REAL
 
 describe("ClickUp integration connect (real Postgres)", () => {
   it("persists a ClickUp token + selection and reads the token back for ingestion", async () => {


### PR DESCRIPTION
## What

Companion to **aiosbrain/aios-workspace#633** (AIO-952). That PR makes OGR03 match ClickUp tokens **by value** (`pk_<digits>_<key>`), closing the rename loophole this fixture's own comment documents (team-brain PR #575: `TOKEN` → `FIXTURE_PK`). The realistically shaped fixture value in `test/datamechanics/integrations-clickup.datamechanics.test.ts` therefore now matches the scanner, and oss-release §3f runs that scanner against this repo fail-closed — without this one-line declaration the next release gate goes CRITICAL on a fake value.

The fix is the new explicit, value-bound fixture declaration: `// aios-secret-fixture:pk_12345678_REAL` names the first 16 chars of the declared value and exempts **only tokens starting with that prefix** — a real secret sharing the line would still be flagged. Test-file-only change; the fixture value and the test itself are untouched.

## Evidence (workspace #633 scanner run against this repo)

```
=== BEFORE ===
    test/datamechanics/integrations-clickup.datamechanics.test.ts:
OGR03 FAILED — 1 pattern(s) matched
=== AFTER (this PR) ===
OGR03 PASSED — no secrets detected
```

`npm run typecheck` clean; eslint clean on the changed file.

## Ordering

**Merge before the next oss-release, before or together with aiosbrain/aios-workspace#633.** DO NOT MERGE without coordinating with #633's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ff6128bd575b05d8cfb24e383345523bbc58cc27. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review
Reviewed by Claude Fable 5 (orchestrator; line-by-line read of the diff after the AIO-952 round-3 adversarial reviews of workspace #633) — verdict approve
