### PR TITLE
feat(staging): prod-shaped Postgres in staging, with the credentials excluded from the dump (STAGING-1)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1175,6 +1175,13 @@ guard enforces it, it's named.
   fork, and `scripts/migrate-from-existing.mjs` requires the release tag to be DECLARED in
   `DEFAULT_TAGS` before it is cut (`nextTagPolicy`) — the lane runs on every PR, so getting that
   order wrong reds the whole repo.
+- **Copy production data anywhere** (e.g. refreshing staging) → `scripts/staging-refresh.sh` is the
+  only sanctioned path, and its refusals are pure + unit-tested in
+  `scripts/staging-refresh-decision.mjs`. The dump EXCLUDES the data of every table carrying a
+  `*_ciphertext` column (reversible secrets, found by a scan over `postgres/schema.sql` — not a
+  hand-kept list) plus `graph_episodes`, whose copied rows would manufacture a permanently
+  unclearable `graph_extract` alarm in an environment that does not run the graph. Runbook +
+  the staging variable set: `docs/OPS.md` §11. Design: `docs/design/staging-prod-shaped-data.md`.
 - **Cross the module boundary** → `lib/` is the backend domain layer (never imports `app/`), and
   `app/` reaches the DB only through the data-client factories (`lib/db/server|admin`), never
   `lib/db/pg` internals. Both directions are enforced by `import/no-restricted-paths` in

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -613,3 +613,95 @@ The graph cleanup finishes asynchronously: the ledger row survives as a
 `pending_delete_group_id` tombstone so `reconcileProjectedEpisodes` can retry a Graphiti blip, and
 drops only once the group is verified empty. When Graphiti isn't configured the row is dropped
 outright — nothing was ever pushed, so there is nothing to retry.
+
+## 11. Staging refresh — prod-shaped data in staging (`scripts/staging-refresh.sh`)
+
+Copies **production's** Postgres into **staging's own** Postgres so a branch can be looked at against
+real data. Design + the reasoning behind every refusal: `docs/design/staging-prod-shaped-data.md`
+(STAGING-1). Staging URL: `https://aios-team-brain-staging.up.railway.app`.
+
+**The dangerous direction is the reverse one.** `pg_restore --clean` drops what it is about to
+recreate, so a target pointed at production destroys production. Read the refusals below before
+reaching for a manual `pg_dump`.
+
+### One-time: declare the target a staging database
+
+The script refuses any target that does not carry a `staging_marker` table. That table exists **only**
+in staging — it is deliberately absent from `postgres/schema.sql` and from every migration, which is
+why production can never have one, and why `pg_restore --clean` (which drops only what the archive
+contains) leaves it standing.
+
+```bash
+psql "$STAGING_REFRESH_TARGET_URL" -c \
+  "create table if not exists staging_marker (note text primary key)"
+```
+
+⚠️ **Never add `staging_marker` to `postgres/schema.sql` or `postgres/migrations/`.** The moment it
+ships to prod it enters the dump archive, the restore drops it, and the marker guard dies silently. A
+build-failing guard enforces this (`test/guards/staging-refresh.test.ts`).
+
+### One-time: the staging variable set
+
+Apply these on the staging `aios-team-brain` service, then **read them back** with
+`railway variables -s aios-team-brain -e staging` — a push that reported ok is not proof the value
+moved. This table is machine-checked against `STAGING_VARIABLES` in
+`scripts/staging-refresh-decision.mjs`; the check is a documentation-drift guard, not a check on
+Railway's real state, which is why the read-back is a required step and not a nicety.
+
+| variable | expected | why |
+|---|---|---|
+| `GRAPHITI_URL` | unset | **The load-bearing one.** The refresh empties `graph_episodes`, so every restored item looks unprojected. `GRAPH_PROJECT_ENABLED=false` does **not** stop projection — it gates the interval poller only, while the admin "Project to graph now" button calls `runGraphProjection` directly. Unset, the projector returns before it opens the database. Set, one click bills real entity extraction across the whole restored corpus. |
+| `NEO4J_URL` | unset | staging's own Neo4j holds demo-seed data; wired up it would render *demo* facts beside *prod-shaped* content. Cosmetic honesty, not safety — re-wiring this alone is safe. |
+| `RESEND_API_KEY` | unset | staging's key is the same as production's, with a verified sender domain: an invite or magic-link triggered in staging reaches a **real person**. |
+| `SMTP_URL` | unset | the invariant is "no mail **provider**": `deliver()` falls through Resend to SMTP, so unsetting one is a boundary only while the other happens to be empty. |
+| `SENTRY_DSN` | unset | staging and production share the identical DSN; staging errors would land in prod's alerting. |
+| `NEXT_PUBLIC_SENTRY_DSN` | unset | same, for browser events. |
+| `SENTRY_AUTH_TOKEN` | unset | the DSNs are only the runtime half — releases and source maps upload at **build** time under this token (`next.config.ts`), into the same Sentry project prod uses. Deploy verification reads the running app's release tag, so staging releases degrade that signal. |
+| `INGEST_POLL_ENABLED` | `false` | no second scheduler. |
+| `GRAPH_PROJECT_ENABLED` | `false` | defence in depth — **not** the projection boundary (see `GRAPHITI_URL`). |
+| `AUTO_FLIP_ENABLED` | `false` | nothing in staging flips a real team's access enforcement. |
+| `SEED_DEMO` | `false` | no demo rows on top of prod-shaped data. |
+
+### Running it
+
+```bash
+STAGING_REFRESH_SOURCE_URL="<prod DATABASE_PUBLIC_URL>" \
+STAGING_REFRESH_TARGET_URL="<staging DATABASE_PUBLIC_URL>" \
+  bash scripts/staging-refresh.sh
+```
+
+Neither URL has a default, on purpose: a default source is a second silent opinion about which
+database production is, and a default target is the URL a `--clean` restore destroys.
+
+`PG_BIN=/opt/homebrew/opt/postgresql@18/bin` pins the client binaries. The script refuses when
+`pg_dump`'s major is **below** the server's — `pg_dump` cannot dump a newer server, and a mismatched
+client is how a *partially* restored archive gets made. The refusal names the remedy.
+
+### What the dump deliberately leaves out
+
+Table **data** excluded (the tables themselves are created, empty):
+
+- `integrations`, `member_secrets`, `gateway_connections` — every table carrying a `*_ciphertext`
+  column, i.e. **reversible secrets**. Not a hand-kept list: a guard scans `postgres/schema.sql` plus
+  the migrations for `*_ciphertext` columns and fails the build when one is missing from the exclusion
+  set. `member_secrets` in particular holds write-capable Slack **user** tokens that
+  `GET /api/v1/me/slack-token` hands back to an authenticated caller.
+- `graph_episodes` — the graph activity ledger. Copied against staging's empty graph it drives the
+  extraction verdict to "stalled", and the resulting synthetic `graph_extract` leg is the one
+  **confirmation-exempt** leg in the system: no staleness threshold could ever clear it. A permanently
+  red "graph extraction is broken" banner, manufactured by our own refresh.
+
+Kept deliberately: `auth_users` / `auth_tokens` / `api_keys` / `agent_tokens` (hashes, not reversible
+secrets — dropping them leaves nobody able to log into staging), `members`, and `ingest_runs` (its
+legs go stale in staging, but that alarm is *thresholded* and *true*).
+
+### After a refresh
+
+- Staging renders prod-shaped **Postgres**. Graph-backed surfaces — the learning panel, `graph-query`,
+  the semantic retrieval leg — render **empty by design**. Narrative arcs show prod's cached arcs for
+  4h, then linger up to 48h before blanking.
+- **The residual hazard, which no code here closes:** the emptied `graph_episodes` ledger means that if
+  `GRAPHITI_URL` is ever set on staging, the whole restored corpus looks unprojected and projection
+  starts billing real extraction. Three non-test entrypoints reach it — the scheduler, the admin
+  button, and `scripts/graph-window-battery/run-projection.ts`.
+- Staging is **disposable**: anything created there is destroyed by the next refresh.

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -636,13 +636,17 @@ why production can never have one, and why `pg_restore --clean` (which drops onl
 contains) leaves it standing.
 
 ```bash
+node scripts/staging-refresh-decision.mjs check-url --url "$STAGING_REFRESH_TARGET_URL" && \
 env -u PGHOST -u PGHOSTADDR -u PGPORT -u PGDATABASE -u PGUSER -u PGPASSWORD \
     -u PGPASSFILE -u PGSERVICE -u PGSERVICEFILE -u PGOPTIONS \
   psql -X "$STAGING_REFRESH_TARGET_URL" -c \
   "create table if not exists staging_marker (note text primary key)"
 ```
 
-⚠️ **Run it with the scrub above, exactly as written.** `PGHOSTADDR` in your shell redirects a libpq
+⚠️ **Run it exactly as written — the `check-url &&` prefix included.** This is the only libpq call the
+runbook asks a human to make, so it is the only one the script cannot wrap; the prefix applies the same
+url-shape refusals the refresh uses (no `hostaddr`, no multi-host list, no unknown parameter), and `&&`
+makes it fail closed. `PGHOSTADDR` in your shell redirects a libpq
 connection while the URL still reads as staging — verified: a URL naming a nonexistent host connects
 to `127.0.0.1` when `PGHOSTADDR=127.0.0.1` is set. Plant the marker through a redirected connection
 and it lands on **production**, after which the refresh's marker check passes and `--clean` follows it

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -249,9 +249,13 @@ railway run -s Postgres bash -lc \
   service.
 - `--no-owner` avoids failing on role/owner mismatches between the environment the dump was taken
   in and the one being restored into (Railway-managed Postgres roles can differ across projects).
-- After a restore, run `npm run pg:schema` (`DATABASE_URL=$DATABASE_PUBLIC_URL npm run pg:schema`
-  in a Railway shell, or the CLI's own `pg:schema` subcommand — see §6) once more to reapply any
-  migration that postdates the dump. `postgres/schema.sql` and every file in `postgres/migrations/`
+- After a restore, run `npm run pg:schema` once more to reapply any migration that postdates the
+  dump — **from a plain shell with `DATABASE_URL` set to the target's public URL, NOT through
+  `railway run`.** This bullet used to say "in a Railway shell" and that is wrong: `railway run -s
+  Postgres` injects `RAILWAY_SERVICE_NAME=Postgres` plus the project marker, and
+  `assertServiceIdentity` (`scripts/service-guard.mjs`) then **refuses before opening the database**
+  (§4, Runtime backstop). Off-Railway the same guard no-ops, so the plain shell is the working path.
+  Corrected while building the staging refresh (§11), which hit it. `postgres/schema.sql` and every file in `postgres/migrations/`
   are idempotent by design (`create table if not exists`, `alter table … add column if not
 exists` — see `postgres/migrations/README.md`), so re-running it after a restore is always safe.
 
@@ -632,9 +636,33 @@ why production can never have one, and why `pg_restore --clean` (which drops onl
 contains) leaves it standing.
 
 ```bash
-psql "$STAGING_REFRESH_TARGET_URL" -c \
+env -u PGHOST -u PGHOSTADDR -u PGPORT -u PGDATABASE -u PGUSER -u PGPASSWORD \
+    -u PGPASSFILE -u PGSERVICE -u PGSERVICEFILE -u PGOPTIONS \
+  psql -X "$STAGING_REFRESH_TARGET_URL" -c \
   "create table if not exists staging_marker (note text primary key)"
 ```
+
+⚠️ **Run it with the scrub above, exactly as written.** `PGHOSTADDR` in your shell redirects a libpq
+connection while the URL still reads as staging — verified: a URL naming a nonexistent host connects
+to `127.0.0.1` when `PGHOSTADDR=127.0.0.1` is set. Plant the marker through a redirected connection
+and it lands on **production**, after which the refresh's marker check passes and `--clean` follows it
+there. The script scrubs the same variables for every call it makes; this one-time command is the only
+libpq call the runbook asks a human to make, so it carries the same armour. The refresh also refuses a
+URL carrying connection parameters outside a small allowlist, `hostaddr` among them.
+
+**Then read it back on PRODUCTION, and expect nothing.** The declare above is the only libpq call this
+runbook asks a human to make, and the moment it can be misdirected the marker becomes a liability
+rather than a guard — a production database that quietly acquired one would make every later target
+check pass for a swapped pair:
+
+```bash
+env -u PGHOST -u PGHOSTADDR -u PGSERVICE psql -X "$PROD_URL" -tAc \
+  "select to_regclass('public.staging_marker')"    # must print an EMPTY line
+```
+
+If that prints `staging_marker`, stop: production is marked, and `drop table staging_marker` on prod is
+the fix. The refresh also refuses when the **source** carries the marker, which catches the swapped pair
+from the other side — but a human read-back costs one command and does not depend on the script.
 
 ⚠️ **Never add `staging_marker` to `postgres/schema.sql` or `postgres/migrations/`.** The moment it
 ships to prod it enters the dump archive, the restore drops it, and the marker guard dies silently. A
@@ -672,6 +700,11 @@ STAGING_REFRESH_TARGET_URL="<staging DATABASE_PUBLIC_URL>" \
 
 Neither URL has a default, on purpose: a default source is a second silent opinion about which
 database production is, and a default target is the URL a `--clean` restore destroys.
+
+The dump is written to a private temp file and **deleted on every exit path** — it contains production
+items, member email addresses and API-key hashes, and a copy of production with no expiry date is not
+something to leave in `/tmp`. Set `STAGING_REFRESH_DUMP=/path/to/file` to keep it (useful when debugging
+a failed restore); it is then yours to delete.
 
 `PG_BIN=/opt/homebrew/opt/postgresql@18/bin` pins the client binaries. The script refuses when
 `pg_dump`'s major is **below** the server's — `pg_dump` cannot dump a newer server, and a mismatched

--- a/docs/design/staging-prod-shaped-data.md
+++ b/docs/design/staging-prod-shaped-data.md
@@ -1,0 +1,465 @@
+# Staging on prod-shaped data (STAGING-1)
+
+Status: **revised after a design review returned BLOCKED / build-differently** (Codex, pre-code: the
+post-restore sanitise had an armed crash window; `SECRETS_KEY` divergence is not a boundary; reactive PM
+writes survive a disabled scheduler; and my "only the projector writes to the graph" claim was false),
+then **amended 2026-08-20 by an operator ruling: the prod Neo4j TCP proxy is NOT to be enabled** —
+which removes the shared-graph half of the design entirely (Decision 4) — then **BLOCKED twice more**:
+round 3 on a copied `graph_episodes` ledger driving a permanently-unclearable `graph_extract` alarm
+(Decision 6) and on staging's live `RESEND_API_KEY` reaching real member addresses (Decision 7), round
+4 on the second-order effect of that first fix — an emptied ledger turns the admin "Project to graph
+now" button into a paid re-projection of the whole restored corpus (Decision 4, round-4 fold) — plus a
+Sentry DSN shared with production. Round 5 returned **CLEAR-WITH-CONDITIONS** and its four conditions
+are folded (Sentry's build-time upload vars, the confirmation-exemption observable, the third projection
+entrypoint, and relabelling criterion 13 as a documentation-drift guard) · Owner: chetan
+· Tier build-with: unit (the refuse/allow decision + every guard, pure)
+
+**Deps:** none.
+
+**Increment:** ONE PR = a refresh script that copies prod's Postgres into STAGING's own Postgres,
+plus the staging variable set that keeps every writer off. **No graph at all in staging** — both graph
+pointers (`GRAPHITI_URL`, `NEO4J_URL`) are unset, so staging neither reaches prod's graph nor pays to
+build its own. No app-code change, no schema change, no new surface.
+
+## Problem
+
+Staging exists and serves, but cannot be used to look at a branch against real data.
+
+Measured 2026-08-20 (prod read-only, Railway CLI):
+
+| | staging | production |
+|---|---|---|
+| Railway env | `staging` (own `aios-team-brain` / `Postgres` / `graphiti` / `neo4j`) | `production` |
+| URL | `https://aios-team-brain-staging.up.railway.app` → **HTTP 307** (healthy) | `…-production…` |
+| Last deploy | **2026-07-25** | today |
+| Branch | `staging` @ `05a771ff` — **221 commits behind `main`** | `main` |
+| Postgres | 1 team / **10 items** / 5 members (demo seed) | 1 team / **2,833 items** / 10 members, **535 MB** |
+
+Railway's `*.railway.internal` DNS is environment-scoped, so staging is fully self-contained today.
+With 10 demo items the brain renders empty regardless of which graph it reads.
+
+**Row counts measured in prod 2026-08-20** (read-only, public proxy) — every exclusion below is sized
+against these rather than asserted:
+
+| table | rows | why it is here |
+|---|---|---|
+| `integrations` | 5 | reversible secrets, reaches outward — **excluded** |
+| `member_secrets` | **2** | write-capable Slack USER tokens — **excluded**, and the rows exist, so this is a live exposure and not a tidiness argument |
+| `gateway_connections` | 0 | reversible secrets — **excluded on category grounds while empty today**, which is the point of a category |
+| `graph_episodes` | **2,821** | the graph activity ledger — **excluded** (Decision 6); this count is exactly what pushes the false alarm past its "too few items to judge" floor |
+| `ingest_runs` | 16,584 | **kept** (Decision 6) |
+| `arc_cache` | 3 | **kept** — the arcs surface is worth having prod-shaped |
+| `arc_corrections` | **0** | **kept**; matters because a non-zero corrections table makes every post-TTL arc view in staging run the LLM against zero facts (`lib/graph/arcs.ts:762`). Zero today — stated as a measurement with an expiry, not a property |
+
+### What actually writes to the graph — and the claim I got WRONG first time
+
+Two separate paths, and conflating them is what produced a false safety argument:
+
+- **BOLT (the app → Neo4j): read-only, verified.** `lib/graph/neo4j.ts`'s `runRead` is the only
+  driver use in the app; it opens `session({ defaultAccessMode: neo4j.session.READ })` and calls
+  `executeRead`. There is no write helper, and `lib/graph/group.ts` — the only other bolt module —
+  contains no write verbs. This *would have* made reading prod's Neo4j directly safe. **It is
+  historical context only: this design no longer reads prod's Neo4j at all** (Decision 4), so nothing
+  below rests on it — recorded so the killed shared-graph argument cannot be re-imported by a later
+  reader who finds the verified half and assumes the conclusion.
+- **HTTP (the app → Graphiti → Neo4j): the app DOES write.** I first wrote that "every graph write
+  comes from the projector". **That is false.** `lib/graph/graphiti-client.ts:151,198` exposes
+  `POST /messages` and `DELETE /episode`, and `lib/graph/arcs.ts:1485` calls `addEpisodes` for
+  correction write-back entirely outside `lib/graph/project.ts` — so disabling the projector does NOT
+  make the app a pure graph reader.
+
+The safety property is therefore about the URL, not the code — and the operator ruling of 2026-08-20
+(*no TCP proxy on prod's Neo4j*) settles it by topology instead: **staging reaches neither prod's
+Neo4j nor prod's Graphiti**, because both are only addressable on environment-scoped internal DNS
+(Decision 4). This subsection stays because the corrected claim is the reason the safety argument
+moved off "the app can't write" — not because the shared-graph design survives.
+
+## Decision
+
+**Reordered after a design review returned BLOCKED / "build differently".** The first draft
+sanitised the target AFTER restoring; three of its four blockers dissolve by never putting the
+dangerous data in the dump.
+
+**1. EXCLUDE every REVERSIBLE-SECRET table's DATA from the DUMP — as a CATEGORY, enforced by a scan.**
+Not `--exclude-table-data=integrations`. That was round 1's fix and round 2 blocked it: I had excluded
+one instance while asserting the category.
+
+The category is **columns holding decryptable ciphertext**, and there are THREE — enumerated from
+`postgres/schema.sql`, not from memory:
+
+| table | column | how I found it |
+|---|---|---|
+| `integrations` | `secret_ciphertext` | the one I thought of |
+| `member_secrets` | `secret_ciphertext` | the review found it |
+| `gateway_connections` | `credential_ciphertext` | **neither of us — only the scan** |
+
+The concrete wrong outcome that makes `member_secrets` a blocker rather than tidiness: it holds
+per-member **write-capable Slack USER tokens**, and `GET /api/v1/me/slack-token`
+(`app/api/v1/me/slack-token/route.ts:32`) authenticates with an `api_keys` row — which this refresh
+deliberately keeps — then reads `member_secrets`, decrypts, and RETURNS the token. So a prod API key
+pointed at staging would hand back a live prod Slack token the moment staging held a compatible
+`SECRETS_KEY`. Same class as the mistake this spec already corrected once, one table over.
+
+**A hand-maintained exclusion list would rot the same way.** So a guard SCANS `postgres/schema.sql`
+for `*_ciphertext` columns and fails the build when the owning table is not in the script's exclusion
+set. Precedent in this repo, and it worked within hours: `test/guards/ingest-leg-ledger` scans
+`recordIngestRun` call sites, and PRET-4 declared its new leg rather than tripping over it.
+
+**Inbound auth is KEPT, deliberately.** `auth_users`, `auth_tokens`, `api_keys`, `agent_tokens` hold
+HASHES, not reversible secrets, and dropping them would leave nobody able to log into staging at all.
+The consequence — a prod API key authenticates against staging — is acceptable for a single-operator
+environment behind the same auth, and it is safe ONLY because the reversible tables above are gone:
+authentication with nothing to retrieve. If a future table pairs inbound auth with a decryptable
+payload, the scan is what catches it.
+
+Why exclusion beats sanitising-after (round 1's blocker, kept because it is why this changed): with
+disable-after, a crash between `pg_restore --clean` committing and the sanitation running leaves
+staging LIVE with prod-shaped rows and usable credentials. "The next refresh refuses" is no help — the
+harmful state already exists. Excluding removes the window instead of narrowing it.
+
+It also closes two holes in the old reasoning, both verified:
+- **`SECRETS_KEY` divergence is NOT a boundary.** Slack falls back to `process.env.SLACK_BOT_TOKEN`
+  (`lib/ingest/run.ts:54,186`), GitHub imports PUBLIC repos with no token at all
+  (`lib/ingest/run.ts:611`), provider keys fall through to env (`lib/integrations/manage.ts:273`).
+- **A disabled scheduler does NOT stop outbound PM writes.** `INGEST_POLL_ENABLED=false` only skips
+  scheduler registration (`instrumentation.ts:55`); `projectTask` runs from REACTIVE write paths and
+  `linearAdapter` issues real `issueUpdate`/`issueCreate` (`lib/pm-sync/project.ts:95`,
+  `lib/pm-sync/linear.ts:423,443`). With no enabled integration rows the path resolves nothing.
+
+**2. The staging MARKER survives the restore — because `--clean` only drops what the archive
+contains.** `pg_restore --clean` emits DROP only for objects it is about to recreate, so a
+`staging_marker` table that exists ONLY in staging (never in `postgres/schema.sql`, never in prod) is
+untouched. That removes the first draft's check→restore→re-stamp ordering entirely: the marker is
+durable, the guard is a plain precondition, and there is no re-stamp step to fail. **The script must
+therefore never pass `--create`**, which would drop and recreate the database and take the marker with
+it — pinned by a guard.
+
+**3. Follow the restore procedure this repo ALREADY documents** (`docs/OPS.md` §Restore), rather than
+inventing one: `pg_restore --clean --if-exists --no-owner` (`--no-owner` because Railway roles differ
+across environments) followed by `npm run pg:schema` against the target to replay any migration that postdates the dump —
+**from a plain laptop shell with `DATABASE_URL` set to staging's public URL, NOT via `railway run`.**
+That distinction is load-bearing and `docs/OPS.md` currently gets it wrong for this case: the loader
+calls `assertServiceIdentity` before touching the DB (`scripts/pg-load-schema.mjs:37`), which no-ops
+off-Railway when `RAILWAY_SERVICE_NAME` is unset (`scripts/service-guard.mjs:119`) but REFUSES under
+`railway run -s Postgres`, which injects a non-AIOS service name plus the project marker. Following the
+existing runbook literally would abort the replay. `postgres/schema.sql` and `postgres/migrations/` are idempotent by design. Watch
+`citext` (required, `schema.sql:19`), the generated `items.search` tsvector (`schema.sql:1134`), and
+pgvector, which is optional and not in the base schema — the replay must preserve whatever prod has.
+
+**4. GRAPH — CUT. Staging does not touch prod's graph at all** (operator ruling, 2026-08-20:
+*"don't enable the TCP proxy on prod's Neo4j"*).
+
+Reaching prod's Neo4j from staging required a public TCP proxy on the prod `neo4j` service, because
+Railway's `*.railway.internal` DNS is environment-scoped. That proxy is refused, so the shared-graph
+arrangement is not reachable and is out of this slice. Nothing is deferred here in the hope of doing
+it later; **there is no graph work in this PR.**
+
+Two things this makes better rather than worse:
+
+- The safety property collapses from a claim about code behaviour into a claim about topology.
+  Round 2 replaced *"the app can't write the graph"* (false — `lib/graph/graphiti-client.ts:151,198`
+  exposes `POST /messages` / `DELETE /episode`, and `lib/graph/arcs.ts:1485` calls `addEpisodes`
+  outside `lib/graph/project.ts`) with *"staging's `GRAPHITI_URL` must never be prod's"*. With the
+  proxy refused, **neither of staging's graph pointers can resolve prod at all** — `neo4j.railway.internal`
+  and `graphiti.railway.internal` resolve inside staging's own environment by construction. The
+  boundary is now Railway's DNS, not a variable someone has to keep correct.
+- Prod's production datastore is not exposed to the public internet, which is the thing the proxy
+  would have done. The `DATABASE_PUBLIC_URL` proxy this script does use already exists and is already
+  how `docs/OPS.md` backs prod up; this slice adds no new public surface.
+
+**The cost, stated plainly rather than discovered later.** Staging renders prod-shaped *Postgres*, and
+its graph is its own near-empty one. Concretely, in staging after a refresh:
+
+| surface | source | in staging after a refresh |
+|---|---|---|
+| Pulse, timeline, items, tasks, decisions, meetings, codebases | Postgres | **prod-shaped** — the substance of what this slice buys |
+| Narrative arcs | Postgres `arc_cache`, computed from graph facts | **two stages, not one** (review round 3, verified): served fresh until `ARC_CACHE_TTL_MS` = 4h (`lib/graph/arc-cache.ts:22`); after that a background recompute finds no facts (`lib/graph/arcs.ts:762`) and `commitArcs` KEEPS the prior rather than clobbering it while it is younger than `EMPTY_CLOBBER_MAX_AGE_MS` = **48h** (`lib/graph/arcs.ts:106,1146`) — so prod arcs linger, stamped stale-but-real, for up to 48h from their snapshot time and only then blank |
+| Learning panel | direct bolt reads (`lib/graph/learning.ts`) | **empty** — self-gates on `neo4jConfigured()` and degrades rather than 500 (`lib/graph/neo4j.ts:20`) |
+| Extraction-health cards + the Pulse pipeline banner | Postgres `graph_episodes` ledger **×** Neo4j facts | **was the round-3 HIGH — see Decision 6.** Left alone this is not "empty", it is a *permanently loud false alarm*. Fixed by excluding the ledger's data. |
+| Graph-backed answering / `GET /api/v1/graph-query` | Graphiti HTTP | staging's own graph — effectively empty; the retrieval graph leg degrades to `[]` (`lib/query/retrieve.ts:156`) |
+
+**Round-4 fold (HIGH, re-derived and confirmed): staging's graph POINTERS are unset, and
+`GRAPH_PROJECT_ENABLED=false` is not the boundary I thought it was.** This is a second-order bug in my
+own round-3 fix, which is the class this loop exists to catch:
+
+1. Decision 6 empties `graph_episodes` — and that table IS the projector's idempotency state
+   (`lib/graph/project.ts:441,464`: the projector reads it to decide what has already been pushed).
+   An empty ledger against a full `items` table means **every restored item looks unprojected**.
+2. `GRAPH_PROJECT_ENABLED=false` only stops the interval poller (`lib/graph/scheduler.ts:21`). The
+   admin **"Project to graph now"** button calls `runGraphProjection` directly
+   (`app/t/[team]/admin/integrations/actions.ts:446`), which gates on `client.configured` — i.e. on
+   `GRAPHITI_URL` — and nothing else (`lib/graph/run.ts:137`).
+3. Measured on staging today: `GRAPHITI_URL=http://graphiti.railway.internal:8000`,
+   `GRAPH_PROJECT_ENABLED=true`, and live `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`.
+
+So after a refresh, **one admin click pushes up to `GRAPH_PROJECT_LIMIT`=500 restored items into
+staging's Graphiti** (`lib/graph/run.ts:71`) and bills real extraction — the ~99%-of-the-LLM-bill path
+— with the scheduler draining the remaining ~2,300 over the following ticks if it is left on.
+
+The fix is the master switch, not another flag: **the runbook unsets `GRAPHITI_URL` on staging.**
+Unset, `GraphitiClient().configured` is false and `runGraphProjection` returns before it opens the
+database at all — and that is not an assumption, it is already pinned by an existing unit test
+(`lib/graph/run.test.ts:9`, "never touches the DB"), so no new test is owed here. The admin action then
+reports "not configured" (`app/t/[team]/admin/integrations/actions.ts:460`), `GET /api/v1/graph-query`
+returns 503 (`app/api/v1/graph-query/route.ts:45`), and the retrieval graph leg degrades to `[]`
+(`lib/query/retrieve.ts:156`).
+
+**`NEO4J_URL` is unset too, and for a weaker reason that is worth separating.** `GRAPHITI_URL` is the
+safety boundary; `NEO4J_URL` is honesty — staging's own Neo4j still holds July's demo-seed graph, and
+leaving it wired would render *demo* facts in the learning panel beside *prod-shaped* content, which is
+worse than an empty panel. If someone later wants that panel populated in staging, re-wiring
+`NEO4J_URL` is safe on its own; re-wiring `GRAPHITI_URL` is the one that costs money.
+
+**The residual hazard, stated because no code can close it:** the day someone sets `GRAPHITI_URL` on
+staging to "make the graph work", the emptied ledger makes the whole restored corpus look unprojected
+and the first click or tick starts paying for it. `docs/OPS.md` and the script's completion message both
+say so at the point where someone would do it.
+
+There are **three** non-test entrypoints, enumerated rather than assumed (round-5 finding, confirmed):
+the interval scheduler (`lib/graph/scheduler.ts:34`), the admin button
+(`app/t/[team]/admin/integrations/actions.ts:446`), and `scripts/graph-window-battery/run-projection.ts:28`,
+which calls `runGraphProjection()` against whatever `DATABASE_URL` and `GRAPHITI_URL` the shell holds.
+**Refuting the other half of that finding:** a call-site ledger guard for `runGraphProjection` would add
+nothing to the boundary, because all three funnel through the same `client.configured` gate
+(`lib/graph/run.ts:137`) and are equally inert when `GRAPHITI_URL` is unset. What the enumeration buys
+is the honesty that the hazard is not "one button" — it is "any of these, if the variable comes back".
+
+So staging is a **Postgres-shaped** preview environment, not a graph one. If a branch's behaviour
+depends on graph substrate, staging cannot validate it, and this spec does not claim it can. The
+upgrade path if that becomes a real need is named in Scope, and it is **not** the TCP proxy: it is
+projecting staging's own Graphiti over the restored corpus (costly — graph extraction is ~99% of the
+LLM bill) or a private network peering that does not put prod's Neo4j on the internet.
+
+**5. Writers off, as defence in depth, not as the boundary.** `INGEST_POLL_ENABLED=false`,
+`GRAPH_PROJECT_ENABLED=false`, `AUTO_FLIP_ENABLED=false`, `SEED_DEMO=false`. Each is a distinct layer
+from decision 1 and is pinned separately — a stack tested only through its outcome lets one layer rot
+invisibly.
+
+**And `GRAPH_PROJECT_ENABLED=false` is explicitly NOT the projection boundary** (round-4 fold): it
+gates the interval poller only (`lib/graph/scheduler.ts:21`) and the admin button walks straight past
+it. The boundary is `GRAPHITI_URL` being unset (Decision 4). This line exists so the flag is never
+again read as the thing that stops projection.
+
+**Measured on staging today, and it is not the state this assumes** (`railway variables -s
+aios-team-brain -e staging`, 39 vars): `GRAPH_PROJECT_ENABLED` is **`true`**, and `INGEST_POLL_ENABLED`
+/ `AUTO_FLIP_ENABLED` are **unset, which means ON by default**. So all three are changes to make, not
+settings to confirm — the runbook says so rather than assuming a clean start.
+
+**6. EXCLUDE the graph ACTIVITY LEDGER's data too — `graph_episodes` (round-3 review, HIGH,
+re-derived and confirmed).** This is a different category from decision 1 and had to be found the same
+way: by following what the copied rows *drive*, not by looking at what they *contain*.
+
+The chain, verified end to end:
+
+1. `readLedger` reads `graph_episodes` from **Postgres** (`lib/graph/extraction-health.ts:432`) — prod
+   holds **2,821** rows (measured 2026-08-20), so staging inherits a full ledger.
+2. Staging's own Neo4j is empty, so `readTeamFacts` returns `facts: 0`
+   (`lib/graph/extraction-health.ts:365`) and `readEpisodicLiveness` returns `none` (`:565`).
+3. `deriveExtractionVerdict` (`:248`) passes its "too few items to judge" floor (`:253`) *because the
+   copied ledger is large*, takes the `facts === 0` → `no-facts` branch (`:264`), passes the age gate
+   on **prod's** `first_seen_at` (`:267`), finds no worker liveness to excuse it (`:306`), and returns
+   **stalled**.
+4. `getPipelineHealth` then appends a synthetic `graph_extract` **failing** leg
+   (`lib/ingest/pipeline-health.ts:433`) carrying `failureClass: "confirmed"` (`:446`), which is
+   **the only confirmation-exempt leg in the system** — verified: one occurrence in that file. Exempt
+   means no staleness threshold can ever clear it. It renders on Pulse (`app/t/[team]/page.tsx:202`)
+   and Admin → Integrations (`app/t/[team]/admin/integrations/page.tsx:167`).
+
+So a straight copy gives staging a **permanently red "graph extraction is broken" banner that nothing
+can clear** — the exact `pret3_sweep` shape this repo shipped a hotfix for on 2026-08-18, reproduced
+deliberately by our own refresh. Excluding the table's data returns `items = 0`, below the floor at
+`:253`, and the verdict is quiet.
+
+**The category, not the instance** (this spec has now made the instance mistake once, at decision 1):
+exclude the activity ledger of a subsystem staging deliberately does not run **when the alarm derived
+from it is exempt from the staleness thresholds**, because that is the alarm no configuration can
+turn off. Today `graph_episodes` is the only such table.
+
+**`ingest_runs` is KEPT, and this is the line that decides it.** Its legs go stale in staging (the
+scheduler is off), so the banner will say ingestion is stale — but that is *thresholded*, *true of
+staging*, and clears the moment someone turns ingestion on. It also carries TICKSTALL-1's durable
+backfill cursor in `meta`. Prod holds 16,584 rows. A thresholded true alarm is not the same object as
+an unclearable false one, and this spec refuses to blur them.
+
+**7. Two credential facts measured on staging that the earlier drafts got wrong.** Staging's live
+variable set contains `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` and `EMBEDDINGS_API_KEY` — so "staging has
+no credentials" is false for the LLM providers, which is why decision 1 stopped relying on
+`SECRETS_KEY` divergence. Those cost money on use and nothing on idle, which is acceptable.
+
+`RESEND_API_KEY` is the one that is not: **staging can send real email to the real member addresses
+this refresh copies** — and measured 2026-08-20, staging's key is byte-identical to prod's, with
+`RESEND_FROM` set to a verified domain (`noreply@updates.john-ellison.com`), so delivery is real, not
+sandboxed. `members` is copied deliberately (decision 1's Scope note), so an invite or a
+magic-link login triggered in staging reaches a real person from a staging box. The runbook therefore
+**unsets `RESEND_API_KEY` on staging** — an outbound path that survives every other layer here, found
+by reading the variables rather than reasoning about the design. Verified non-breaking: password login
+is the default and needs no mailer, and `magicLinkAvailable()` (`lib/auth/mailer.ts:127`) then stops
+*offering* magic-link rather than failing sign-in; `deliver()` drops with a logged error and never
+throws (`lib/auth/mailer.ts:82`).
+
+**Round-4 fold: the invariant is "no mail PROVIDER", not "no Resend key."** `deliver()` tries Resend
+*then* SMTP (`lib/auth/mailer.ts:38,59`) and `mailerConfigured()` is true for either
+(`lib/auth/mailer.ts:97`), so unsetting one variable is a boundary only while the other happens to be
+unset. Measured: `SMTP_URL` is unset on staging today — which is exactly the "protection by accident"
+shape this spec has already refused twice. The runbook and criterion 11 therefore state **both**
+`RESEND_API_KEY` and `SMTP_URL` unset.
+
+**Round-4 fold: staging reports to PROD's Sentry project.** Measured 2026-08-20 — staging and
+production carry the **identical** `SENTRY_DSN` and `NEXT_PUBLIC_SENTRY_DSN`
+(`a86a2ee3…@o4510314175397888`). Two concrete costs, one of them process-critical: staging-only errors
+raise noise in prod's alerting, and this repo **verifies prod deploys by reading the running app's
+Sentry release tag** (done twice in the sessions that produced TICKSTALL-1/BANNERFLAP-2) — a staging
+instance publishing releases into the same project degrades the one signal used to prove which commit
+is live. The runbook unsets both DSNs on staging. Whether Sentry event context would carry copied prod
+row values is **unverified**, and is deliberately not claimed as the reason.
+
+**Round-5 fold: the DSNs are only the RUNTIME half of Sentry.** Release and source-map upload happen at
+BUILD time and are driven by `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN`
+(`next.config.ts:70-76`), not by the DSN — and measured 2026-08-20 staging carries all three, with
+`SENTRY_PROJECT` set to the very same project as production (`aios-team-brain`, org `pravos-llc`). So
+unsetting the DSNs alone would have stopped staging's *events* while leaving its *builds* creating
+releases in prod's project — which is precisely the signal the release-tag argument above rests on. The
+runbook therefore also unsets **`SENTRY_AUTH_TOKEN`**, which `next.config.ts:63` documents as the
+switch ("with no `SENTRY_AUTH_TOKEN`, the build skips the upload step and proceeds normally");
+`SENTRY_ORG`/`SENTRY_PROJECT` are inert without it and are left alone rather than padding the list.
+This is the second time in this spec that a boundary turned out to be one variable narrower than
+claimed.
+
+**8. The script must REFUSE on a client/server version mismatch — because the default toolchain on
+this machine cannot run this design at all.** Measured 2026-08-20, before writing a line:
+
+| | version |
+|---|---|
+| prod Postgres server | **18.4** |
+| staging Postgres server | **18.4** (same major — an 18 archive restores cleanly) |
+| `pg_dump` on `PATH` | **14.19** (`/opt/homebrew/bin`, Homebrew `postgresql@14`) |
+| available but keg-only | `postgresql@18` → `/opt/homebrew/opt/postgresql@18/bin/pg_dump` 18.3 |
+
+`pg_dump` aborts when the server's major exceeds its own, so the runbook as written would have failed
+on its first invocation — an hour of confusion, not a data risk, but the kind of thing that gets a
+runbook labelled unreliable. Two consequences, both in scope:
+
+- The script resolves its binaries: an explicit `PG_BIN` override, else a discovered
+  `postgresql@<major>` prefix matching the SERVER's major, else **refuse with the remedy named**
+  (`brew install postgresql@18`, or run the dump in `docker run --rm postgres:18`; Docker 28 is
+  present). Refusing beats proceeding: a mismatched client is exactly how you get an archive that
+  restores *partially*.
+- The comparison is a **pure function** (`clientMajor >= serverMajor`) and is unit-tested, so the
+  refusal cannot rot into a string match on one machine's paths.
+
+## Scope
+
+**In:** `scripts/staging-refresh.sh`; the pure refuse/allow decision it calls; the staging variable
+set; a `docs/OPS.md` runbook section; tests for each guard layer separately.
+
+**Cut, each with the reason:**
+- **The prod Neo4j TCP proxy, and with it the whole shared-graph arrangement** — **refused by the
+  operator on 2026-08-20**, not deferred. Exposing a production datastore to the public internet is a
+  human decision and the human said no. The consequence (staging is Postgres-shaped, not
+  graph-shaped) is priced in Decision 4 rather than left to be discovered.
+- **Making staging's graph real by other means** — projecting the restored corpus through staging's
+  own Graphiti would work, and is the named upgrade path, but graph extraction is ~99% of the LLM
+  bill and this slice's purpose is looking at a branch against real data, not validating graph
+  behaviour.
+- **A PITR/fork-based copy.** The reviewer's suggestion — restore prod to a NEW sibling Postgres
+  service, sanitise there, then wire staging to it — is genuinely safer (prod's live DB is never the
+  source of a destructive command) but adds a service and a manual PITR step per refresh. Named as the
+  upgrade path if the dump route proves risky in practice.
+- **Scheduling the nightly cron.** Ship it runnable by hand; schedule once it has been boring.
+- **Excluding other sensitive tables** (`api_keys`, `members` emails). Copied deliberately: staging is
+  behind the same auth, operated by the same person, and the brain is unusable without members. Stated
+  so it is a decision, not an oversight. `integrations` is excluded because it reaches OUTWARD.
+
+## Acceptance criteria
+
+1. **unit** — the dump excludes the DATA of every table carrying a `*_ciphertext` column, and a guard
+   SCANS `postgres/schema.sql` and fails when one is missing from the exclusion set. The categorical
+   form is the point: round 1 excluded `integrations` alone and two more tables existed.
+2. **unit** — the scan is proven NON-VACUOUS: it finds the three known tables by name, so a broken
+   pattern cannot report "nothing missing" and read as a clean bill of health.
+3. **unit** — the guard REFUSES when the target lacks the staging marker, and names the marker.
+4. **unit** — the guard REFUSES when source and target resolve to the same host, independently of the
+   marker, so the copy-paste case dies before any connection is opened.
+5. **unit** — each guard layer is asserted to fail ALONE, so a defence-in-depth stack cannot rot behind
+   a sibling that happens to catch everything.
+6. **unit** — a guard fails the build if the script gains a DEFAULT for either URL, or ever passes
+   `--create` (which drops the database and takes the durable marker with it).
+7. **unit** — a guard fails the build if `staging_marker` appears in `postgres/schema.sql` or
+   `postgres/migrations/`: the moment it ships to prod it enters the dump archive, `--clean` drops it,
+   and the durable-marker property silently dies.
+8. **unit** — the restore flags match `docs/OPS.md` §Restore (`--clean --if-exists --no-owner`) and the
+   replay is pinned to a NON-`railway run` invocation, since the service guard refuses the other one.
+9. **unit** — a guard pins that `scripts/staging-refresh.sh` performs **no Railway mutation of any
+   kind**: no `railway variables --set`, no `railway up`/`redeploy`/`down`/`delete`. The refresh
+   touches one database and nothing else. *(Round 3 narrowed this: the draft also banned the script
+   from naming `NEO4J_URL`/`GRAPHITI_URL`, and the reviewer was right that with variable writes banned
+   and no public proxy on prod's Neo4j, the name-ban has no reachable failure mode behind it —
+   ceremony by CLAUDE.md §7. The variable-write ban keeps a real one: the obvious future "convenience"
+   edit that makes the refresh set staging's flags for you.)*
+10. **unit** — `graph_episodes` is in the exclusion set (Decision 6) as its own assertion, and a
+    SEPARATE guard keeps the *reason* live: exactly one **hardcoded** `failureClass: "confirmed"`
+    exists under `lib/`, and it is the `graph_extract` leg. Rounds 4 and 5 both attacked the observable
+    and the second one produced it: a free-text scan for "confirmed" is vacuous-or-noisy because
+    ordinary confirmed failures exist by design — but they are *derived*, from `classifyFailure(...)`
+    into a variable (`lib/ingest/pipeline-health.ts:409`), while an exemption can only be written as a
+    LITERAL. Verified: that literal occurs exactly once in `lib/` + `app/` today. So the guard reds
+    when a second unclearable alarm is hardcoded anywhere, and does not red when the derived path is
+    refactored — and comments are stripped before counting, so it cannot be satisfied or broken by
+    prose.
+11. **unit** — the refresh script never sends mail and never enables a mailer: a guard pins that it
+    does not set `RESEND_API_KEY`/`SMTP_URL`, and the runbook's variable table lists **both** as
+    **unset on staging** — the invariant is "no mail provider", since `deliver()` falls through Resend
+    to SMTP (`lib/auth/mailer.ts:38,59`). Verified safe: password login does not need it, and
+    `magicLinkAvailable()` (`lib/auth/mailer.ts:127`) simply stops offering magic-link rather than
+    breaking sign-in.
+12. **unit** — a pure `pg_dump`-version decision refuses when the client major is below the server
+    major (Decision 8), names the remedy in the refusal, and is asserted to ACCEPT an equal or higher
+    client — so a refusal that fires on everything cannot pass as a working check.
+13. **unit, and it is a DOCUMENTATION-DRIFT guard — not a check on Railway's actual state**
+    (round-5 correction; labelling it honestly is the point, because a guard mistaken for the stronger
+    thing is worse than none). It machine-checks the runbook's staging variable table against the
+    script's declared list — `GRAPHITI_URL`, `NEO4J_URL`, `RESEND_API_KEY`, `SMTP_URL`, `SENTRY_DSN`,
+    `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN` **unset**; `INGEST_POLL_ENABLED` /
+    `GRAPH_PROJECT_ENABLED` / `AUTO_FLIP_ENABLED` / `SEED_DEMO` **`false`** — so a variable dropped
+    from the prose cannot silently drop from the design. The real state lives in Railway, so the
+    runbook makes a `railway variables -s aios-team-brain -e staging` READ-BACK a required step, the
+    same way this repo reads a pushed ticket back rather than trusting that the push said ok. **No new test is owed for the
+    projector gate itself**: `lib/graph/run.test.ts:9` already pins that an unconfigured Graphiti means
+    `runGraphProjection` never touches the DB, which is what makes "unset `GRAPHITI_URL`" a boundary
+    rather than an assumption (Decision 4).
+14. **unit** — the script's completion message names the residual hazard in Decision 4 — that the
+    emptied `graph_episodes` ledger makes the whole restored corpus look unprojected, so setting
+    `GRAPHITI_URL` on staging later starts billing real extraction. A hazard no code can close is
+    stated where the person who would create it is looking.
+
+15. **unit** — the script uses no bash-4-only builtin (`mapfile`/`readarray`, associative arrays,
+    `${x,,}`), because the operator's macOS shell is **bash 3.2** — measured, not assumed. The first
+    draft used `mapfile` and would have aborted at the DUMP step, *after* connecting to production.
+    Same class as Decision 8's version trap, and the same remedy: refuse or avoid, never discover.
+16. **unit** — an EMPTY exclusion list is a REFUSAL, not an empty set of `--exclude-table-data` flags.
+    An empty list produces a perfectly valid `pg_dump` invocation that copies every reversible-secret
+    table, so "nothing to exclude" and "the exclusion step broke" must not be the same observable.
+
+## What would falsify this
+
+- **A refresh that writes to prod** — the catastrophic direction. Nothing else on this list matters as
+  much.
+- Staging connectors reaching Slack/Linear/GitHub after a refresh, which would mean the excluded
+  `integrations` data came across after all.
+- **Any email leaving staging** to a copied member address (Decision 7).
+- **The Pulse banner in staging showing a `graph_extract` failure** after a refresh — Decision 6
+  predicts quiet, and a red one means the ledger exclusion did not take.
+- **Any graph projection running in staging after a refresh** — a `graph_project` row in staging's
+  `ingest_runs`, or Graphiti extraction spend on staging's keys. Decision 4 predicts none, because
+  `GRAPHITI_URL` is unset; one means the master switch is not the boundary it is claimed to be.
+- **A staging-originated error or release appearing in prod's Sentry project** after the runbook has
+  been applied (Decision 7).
+- Staging's brain still rendering empty after a refresh — the copy did not achieve its purpose.
+- The staging app **500ing** rather than degrading on its graph-backed surfaces once staging's own
+  graph is empty against a prod-shaped corpus. Decision 4 predicts empty panels, not errors, on the
+  strength of the `neo4jConfigured()` self-gates; an error means that prediction is wrong and the
+  Postgres-only arrangement is less usable than claimed.
+- Narrative arcs going empty in staging **sooner than the 4h cache TTL**, which would mean the
+  degradation Decision 4 prices is larger than stated.
+- The `preDeployCommand` running `pg:schema` against prod — meaning `DATABASE_URL` was repointed after
+  all, against decision 2.

--- a/docs/design/staging-prod-shaped-data.md
+++ b/docs/design/staging-prod-shaped-data.md
@@ -56,9 +56,11 @@ against these rather than asserted:
 Two separate paths, and conflating them is what produced a false safety argument:
 
 - **BOLT (the app → Neo4j): read-only, verified.** `lib/graph/neo4j.ts`'s `runRead` is the only
-  driver use in the app; it opens `session({ defaultAccessMode: neo4j.session.READ })` and calls
-  `executeRead`. There is no write helper, and `lib/graph/group.ts` — the only other bolt module —
-  contains no write verbs. This *would have* made reading prod's Neo4j directly safe. **It is
+  `neo4j-driver` use in the app; it opens `session({ defaultAccessMode: neo4j.session.READ })` and calls
+  `executeRead`. There is no write helper. (An earlier draft called `lib/graph/group` "the only other
+  bolt module" — **wrong in both directions**, found in code review: that module holds no bolt at all, and
+  the other bolt *call sites* are `lib/graph/learning.ts` and `lib/graph/extraction-health.ts`, both
+  through `runRead`. The read-only conclusion survives; the supporting sentence did not.) This *would have* made reading prod's Neo4j directly safe. **It is
   historical context only: this design no longer reads prod's Neo4j at all** (Decision 4), so nothing
   below rests on it — recorded so the killed shared-graph argument cannot be re-imported by a later
   reader who finds the verified half and assumes the conclusion.
@@ -379,7 +381,13 @@ set; a `docs/OPS.md` runbook section; tests for each guard layer separately.
    pattern cannot report "nothing missing" and read as a clean bill of health.
 3. **unit** — the guard REFUSES when the target lacks the staging marker, and names the marker.
 4. **unit** — the guard REFUSES when source and target resolve to the same host, independently of the
-   marker, so the copy-paste case dies before any connection is opened.
+   marker, so the copy-paste case dies before any connection is opened. Host comparison normalises a
+   trailing dot (`example.net.` and `example.net` are one DNS name): the marker layer would also catch
+   that pair, and a layer that only works with help is not a layer (criterion 5). **Refuted in review,
+   with the reason recorded:** a suggestion to compare `host:port` instead was declined — Railway's
+   proxy domains are regional and could one day be shared port-distinguished, but host-only comparison
+   fails in the SAFE direction (it refuses a legitimate refresh) while `host:port` would let a genuinely
+   same-host pair through. If it ever fires wrongly, the answer is not to weaken it.
 5. **unit** — each guard layer is asserted to fail ALONE, so a defence-in-depth stack cannot rot behind
    a sibling that happens to catch everything.
 6. **unit** — a guard fails the build if the script gains a DEFAULT for either URL, or ever passes
@@ -439,6 +447,40 @@ set; a `docs/OPS.md` runbook section; tests for each guard layer separately.
 16. **unit** — an EMPTY exclusion list is a REFUSAL, not an empty set of `--exclude-table-data` flags.
     An empty list produces a perfectly valid `pg_dump` invocation that copies every reversible-secret
     table, so "nothing to exclude" and "the exclusion step broke" must not be the same observable.
+
+17. **unit** — a connection URL is accepted only with a `postgres`/`postgresql` scheme and query
+    parameters from a small ALLOWLIST. **Verified by running it, not inferred:** libpq honours
+    `hostaddr` from a URI query string, so `postgresql://staging-proxy…/db?hostaddr=<prod-ip>` reads as
+    staging and connects to production — which defeats the same-host refusal (the parsed hosts differ)
+    **and** the marker refusal, because the operator's one-time `create table staging_marker` runs
+    through the same libpq and would plant the marker on prod. An allowlist, because a denylist would
+    have to enumerate every redirecting parameter forever.
+18. **unit** — every libpq invocation runs with the libpq ENVIRONMENT scrubbed and `psql -X`. Measured:
+    `PGHOSTADDR=127.0.0.1` sent a connection whose URL named a nonexistent host to 127.0.0.1, with the
+    URL untouched — so criterion 17 alone is half a fix. The scrub list has ONE owner (the decision
+    module; the shell reads it from there), and the runbook's one-time marker command carries the same
+    armour, since it is the only libpq call this design asks a human to make.
+19. **unit** — the restore runs in a SINGLE TRANSACTION. Without it, a restore that fails halfway has
+    already committed its drops: staging serves a half-dropped, half-restored database and the
+    completion warning never prints. Rolled back, staging keeps the environment it had.
+
+20. **unit** — the refresh REFUSES when the SOURCE carries the staging marker. The target-marker check
+    cannot see a swapped pair: if production ever acquired a marker (an operator declaring staging with
+    the target variable mis-set — the one moment they are juggling both urls), it keeps it forever and
+    every later swapped run passes. Reading the marker from the other side catches it, and the runbook
+    adds a human read-back against prod that does not depend on this script.
+21. **unit** — the exclusion set covers the FK-dependent CLOSURE of every excluded table, computed
+    transitively from the schema. Excluding a parent's data while dumping a child's is a restore that
+    fails at constraint creation. Measured: `gateway_connections` has three dependents and
+    `gateway_approvals` hangs off one of THEM — the one-level check read clean until the three were
+    added. All five hold zero rows in prod today, which is precisely why it is computed and not
+    remembered.
+22. **unit** — the decision CLI cannot approve by SILENCE. Its entry guard compared
+    `` `file://${process.argv[1]}` `` to `import.meta.url`, so from a symlinked path or one containing a
+    space it printed nothing and exited **0** — every refusal dead, with the shell reading exit 0 as
+    approval. Verified as a live bug, then fixed by realpathing both sides (`pathToFileURL` alone fixes
+    only the percent-encoding half). The durable half is a positive ACK token the shell requires, so any
+    future spelling of that bug stops the refresh instead of waving it through.
 
 ## What would falsify this
 

--- a/docs/design/staging-prod-shaped-data.md
+++ b/docs/design/staging-prod-shaped-data.md
@@ -482,6 +482,20 @@ set; a `docs/OPS.md` runbook section; tests for each guard layer separately.
     only the percent-encoding half). The durable half is a positive ACK token the shell requires, so any
     future spelling of that bug stops the refresh instead of waving it through.
 
+23. **unit** — a connection url naming MORE THAN ONE HOST is refused. libpq tries a comma-separated
+    host list in order (verified: `psql "postgresql://u@nonexistent-host-xyz.invalid,127.0.0.1/db"` fell
+    through to 127.0.0.1), so a target of `staging…,prod…` passes every check here — the marker read
+    reaches staging and finds its marker — and a restore run while staging is briefly unreachable lands
+    on PRODUCTION. This was a second-order miss inside the fix for the query-parameter half, and the
+    reason it hid is worth keeping: the port-bearing spelling (`a:1,b:2`) makes `new URL()` throw and was
+    refused **by accident**, while the portless spelling parsed cleanly and was accepted. A shape refused
+    by accident is not a layer. A url whose parsed and raw forms differ (a `#` fragment) is refused for
+    the same reason: this script validates a parse while libpq dials the string.
+24. **unit** — the runbook's one-time marker command carries the same url armour, chained with `&&` so
+    it fails closed (`check-url`). It is the only libpq call this design asks a human to make, and a
+    poisoned url there plants the marker on production — after which the target-marker refusal passes
+    forever and nothing in this repo would notice.
+
 ## What would falsify this
 
 - **A refresh that writes to prod** — the catastrophic direction. Nothing else on this list matters as

--- a/lib/graph/run.ts
+++ b/lib/graph/run.ts
@@ -11,8 +11,11 @@ import { purgeExternalTierCaches } from "@/lib/cache/tier-invalidation";
 /**
  * Graph-projection runner — the on-ramp that actually drives `projectSlackToGraph` (which is
  * otherwise just a library function nobody calls). Mirrors `lib/ingest/run.ts`: resolve the
- * team(s), then project each. Two callers: the admin "Project to graph" action (on-demand) and
- * `lib/graph/scheduler.ts` (interval). Inert when Graphiti isn't configured (no GRAPHITI_URL) — it
+ * team(s), then project each. THREE non-test callers, enumerated because a stale count of them was
+ * load-bearing once: the admin "Project to graph" action (on-demand), `lib/graph/scheduler.ts`
+ * (interval), and `scripts/graph-window-battery/run-projection.ts` (manual battery). This docstring
+ * said "two" until STAGING-1 counted them — and the count matters because `GRAPH_PROJECT_ENABLED=false`
+ * gates only the scheduler, so the configured-gate below is the sole boundary the other two respect. Inert when Graphiti isn't configured (no GRAPHITI_URL) — it
  * returns a clean `configured:false` skip instead of throwing, so prod (where the graph is off)
  * is a cheap no-op.
  */

--- a/scripts/staging-refresh-decision.mjs
+++ b/scripts/staging-refresh-decision.mjs
@@ -34,6 +34,7 @@ export const REFUSAL = Object.freeze({
   MISSING_SOURCE: "missing-source-url",
   MISSING_TARGET: "missing-target-url",
   UNSUPPORTED_SCHEME: "unsupported-scheme",
+  MULTI_HOST: "multi-host-url",
   UNSAFE_CONNECTION_PARAMS: "unsafe-connection-params",
   SAME_HOST: "same-host",
   NO_MARKER: "no-staging-marker",
@@ -305,6 +306,30 @@ function refusalsForUrlShape(url, label) {
       reason: `${label} uses the "${scheme}" scheme; only postgres:// and postgresql:// are accepted. A URL this script cannot reason about is a URL it must not hand to pg_restore.`,
     });
   }
+  // MULTI-HOST FAILOVER — the half of the routing attack the query-param allowlist does not touch,
+  // and a second-order miss in the fix for the first half. libpq accepts a comma-separated host list in
+  // the AUTHORITY and tries each in turn until one connects. Verified:
+  //   psql "postgresql://u@nonexistent-host-xyz.invalid,127.0.0.1/db"  → fell through to 127.0.0.1
+  // A target of `staging…,prod…` therefore passes every check here (the marker read reaches staging and
+  // finds its marker) and then, if staging is unreachable when the restore runs, `pg_restore --clean`
+  // lands on PRODUCTION. Note the asymmetry that hid it: the port-bearing spelling
+  // (`a:1,b:2`) makes `new URL()` throw, so it was already refused as unparseable — while the PORTLESS
+  // spelling parses cleanly and was accepted. One shape refused by accident is not a layer.
+  if (parsed.hostname.includes(",")) {
+    out.push({
+      code: REFUSAL.MULTI_HOST,
+      reason: `${label} lists more than one host (${parsed.hostname}). libpq tries them in order, so the database this script INSPECTS need not be the one it WRITES. Exactly one host, or no refusal here means anything.`,
+    });
+  }
+  // Our parser and libpq's must see the same string. A fragment is dropped by `new URL()` and handed to
+  // libpq as part of the connection string — not a routing risk today, but a divergence between what is
+  // validated and what is dialled, which is precisely the class of bug this function exists for.
+  if (parsed.hash) {
+    out.push({
+      code: REFUSAL.UNSAFE_CONNECTION_PARAMS,
+      reason: `${label} contains a "#" fragment. This script validates a parsed url while libpq dials the raw string; anything the two read differently is refused rather than reasoned about.`,
+    });
+  }
   const allowed = new Set(ALLOWED_URL_PARAMS);
   const offending = [...parsed.searchParams.keys()].filter((k) => !allowed.has(k.toLowerCase()));
   if (offending.length > 0) {
@@ -511,6 +536,15 @@ function main(argv) {
       }).refusals
     );
   }
+  if (cmd === "check-url") {
+    // For the runbook's one-time marker command: the human's psql call is the only libpq invocation this
+    // design cannot wrap, and a poisoned url there plants the marker on PRODUCTION — after which the
+    // target-marker refusal passes forever. Chained with `&&`, this makes that step fail closed too.
+    return print(refusalsForUrlShape(arg("url"), "the url") .concat(hostOf(arg("url")) ? [] : [{
+      code: REFUSAL.MISSING_TARGET,
+      reason: "the url is unset or unparseable.",
+    }]));
+  }
   if (cmd === "scrubbed-env") {
     console.log(SCRUBBED_PG_ENV.join("\n"));
     return 0;
@@ -523,7 +557,7 @@ function main(argv) {
     console.log(completionMessage());
     return 0;
   }
-  console.error("usage: staging-refresh-decision.mjs <preflight|check|exclude-args|scrubbed-env|completion>");
+  console.error("usage: staging-refresh-decision.mjs <preflight|check|check-url|exclude-args|scrubbed-env|completion>");
   return 2;
 }
 

--- a/scripts/staging-refresh-decision.mjs
+++ b/scripts/staging-refresh-decision.mjs
@@ -1,0 +1,344 @@
+/**
+ * The refuse/allow decision behind `scripts/staging-refresh.sh` — pure, so every refusal is testable
+ * without a database (STAGING-1, `docs/design/staging-prod-shaped-data.md`).
+ *
+ * WHAT THE SCRIPT DOES: copies PRODUCTION's Postgres into STAGING's own Postgres so a branch can be
+ * looked at against real data. The catastrophic direction is the reverse — a restore that lands on
+ * prod — and `pg_restore --clean` is destructive, so the interesting part of this file is what it
+ * REFUSES.
+ *
+ * ── Why the decision is pure and lives here, not in the shell ───────────────────────────────────
+ * A guard written in bash is a guard nothing runs until the day it matters. This repo has been bitten
+ * by exactly that: `pr-task-link.yml` shipped a response parser "in a shape it never returns …
+ * because it lived in a YAML heredoc that no tier could reach". Every layer below is a pure function
+ * over plain values, unit-tested in `test/guards/staging-refresh.test.ts`, and the shell's only job is
+ * to gather the values and obey the answer.
+ *
+ * ── Why refusals are COLLECTED, not short-circuited ─────────────────────────────────────────────
+ * `refusalsFor…` return EVERY refusal that applies rather than the first. That is not a nicety: the
+ * spec's criterion 5 requires each layer to be provably able to fail ALONE, because a defence-in-depth
+ * stack tested only through its outcome lets one layer rot invisibly behind a sibling that happens to
+ * catch everything (this repo's "defense-in-depth masks mutations" lesson). Collecting is what makes
+ * "input violates exactly this layer → exactly this code" an assertable statement.
+ *
+ * ── Fail CLOSED on unknowns ─────────────────────────────────────────────────────────────────────
+ * A missing marker answer or a missing version reading is a REFUSAL, never a pass. The shell can fail
+ * to gather a value for a hundred boring reasons; none of them should end with a `--clean` restore.
+ */
+
+/** Refusal codes. Exported so tests name the layer they are pinning instead of matching prose. */
+export const REFUSAL = Object.freeze({
+  MISSING_SOURCE: "missing-source-url",
+  MISSING_TARGET: "missing-target-url",
+  SAME_HOST: "same-host",
+  NO_MARKER: "no-staging-marker",
+  MARKER_UNKNOWN: "staging-marker-unknown",
+  PG_CLIENT_TOO_OLD: "pg-client-too-old",
+  PG_VERSION_UNKNOWN: "pg-version-unknown",
+});
+
+/**
+ * The table whose EXISTENCE proves a database is staging. It lives ONLY in staging: never in
+ * `postgres/schema.sql`, never in a migration, therefore never in prod and never in the dump archive.
+ * That is what makes it survive `pg_restore --clean`, which emits DROP only for objects it is about to
+ * recreate — so the marker is a durable precondition rather than a check→restore→re-stamp dance.
+ * `test/guards/staging-refresh.test.ts` fails the build the day it appears in the schema, because on
+ * that day it enters the archive, gets dropped, and this whole guard silently dies.
+ */
+export const STAGING_MARKER_TABLE = "staging_marker";
+
+/** The remedy the refusal prints, so the operator is never left guessing how to make the target legal. */
+export const STAGING_MARKER_REMEDY = `psql "$STAGING_REFRESH_TARGET_URL" -c 'create table if not exists ${STAGING_MARKER_TABLE} (note text primary key)'`;
+
+/**
+ * Tables whose DATA never enters the dump. Two different categories, kept in one set because the
+ * script needs one list, but distinguished here because the REASONS are what a future reader has to
+ * re-derive:
+ *
+ *   1. REVERSIBLE SECRETS — a `*_ciphertext` column. Copying these hands staging live outbound
+ *      credentials. Enumerated from the schema by `ciphertextTables()` rather than typed here, and
+ *      cross-checked by a guard: an earlier draft of this spec excluded `integrations` alone and TWO
+ *      more tables existed, one of them (`member_secrets`) holding write-capable Slack user tokens
+ *      that `GET /api/v1/me/slack-token` will hand back to an authenticated caller.
+ *   2. AN ACTIVITY LEDGER FEEDING AN UNCLEARABLE ALARM — `graph_episodes`. Staging does not run the
+ *      graph, so copied ledger rows against an empty local graph drive `deriveExtractionVerdict` to
+ *      "stalled", and `getPipelineHealth` then appends a synthetic `graph_extract` leg that is the one
+ *      CONFIRMATION-EXEMPT leg in the system — no staleness threshold can ever clear it. A permanently
+ *      red "graph extraction is broken" banner, manufactured by our own refresh.
+ */
+export const EXCLUDED_TABLE_DATA = Object.freeze([
+  "gateway_connections",
+  "graph_episodes",
+  "integrations",
+  "member_secrets",
+]);
+
+/**
+ * The staging variable set the runbook applies, declared HERE so `docs/OPS.md`'s table can be checked
+ * against it. Prose and code drifting apart is how a safety step quietly stops being part of the
+ * design; the guard compares the two.
+ *
+ * `GRAPHITI_URL` is the load-bearing one and the reason is not obvious: with `graph_episodes` excluded
+ * (above), every restored item looks UNPROJECTED to the projector, and `GRAPH_PROJECT_ENABLED=false`
+ * does NOT stop projection — it gates the interval poller only, while the admin "Project to graph now"
+ * button calls `runGraphProjection` directly, gated on `GRAPHITI_URL` alone. Unset, the projector
+ * returns before it opens the database (pinned by `lib/graph/run.test.ts`). Set, one click bills real
+ * extraction on the whole restored corpus.
+ */
+export const STAGING_VARIABLES = Object.freeze([
+  Object.freeze({ name: "GRAPHITI_URL", expected: "unset" }),
+  Object.freeze({ name: "NEO4J_URL", expected: "unset" }),
+  Object.freeze({ name: "RESEND_API_KEY", expected: "unset" }),
+  Object.freeze({ name: "SMTP_URL", expected: "unset" }),
+  Object.freeze({ name: "SENTRY_DSN", expected: "unset" }),
+  Object.freeze({ name: "NEXT_PUBLIC_SENTRY_DSN", expected: "unset" }),
+  // The DSNs are the RUNTIME half. Releases and source maps upload at BUILD time driven by
+  // SENTRY_AUTH_TOKEN (next.config.ts:76) — and staging's SENTRY_PROJECT is the same project as
+  // production's, so without this line staging stops sending events while its builds keep creating
+  // releases in prod's project. SENTRY_ORG/SENTRY_PROJECT are inert without the token and are
+  // deliberately not listed: padding a safety list with no-ops is how the load-bearing entry gets lost.
+  Object.freeze({ name: "SENTRY_AUTH_TOKEN", expected: "unset" }),
+  Object.freeze({ name: "INGEST_POLL_ENABLED", expected: "false" }),
+  Object.freeze({ name: "GRAPH_PROJECT_ENABLED", expected: "false" }),
+  Object.freeze({ name: "AUTO_FLIP_ENABLED", expected: "false" }),
+  Object.freeze({ name: "SEED_DEMO", expected: "false" }),
+]);
+
+/**
+ * SQL comments are prose, not schema. Stripping them first is what stops a docstring ABOUT a
+ * ciphertext column (`postgres/schema.sql` has several, e.g. "DISTINCT from team
+ * `integrations.secret_ciphertext`") from being attributed to whichever table block it sits in — which
+ * would invent a table name and make the exclusion check fail against a table that does not exist.
+ * Same discipline as `pr-work-keys.mjs` refusing to count a work key written inside backticks.
+ */
+function stripSqlComments(sql) {
+  return String(sql ?? "")
+    .replace(/\/\*[\s\S]*?\*\//g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/--.*$/, ""))
+    .join("\n");
+}
+
+const CREATE_TABLE_RE = /^\s*create\s+table\s+(?:if\s+not\s+exists\s+)?(?:"?public"?\.)?"?([a-z0-9_]+)"?/i;
+const ALTER_TABLE_RE = /^\s*alter\s+table\s+(?:only\s+)?(?:"?public"?\.)?"?([a-z0-9_]+)"?/i;
+const CIPHERTEXT_COLUMN_RE = /\b([a-z0-9_]*ciphertext)\b/i;
+
+/**
+ * Every table owning a column whose name ends in `ciphertext`, found by SCANNING the schema rather
+ * than by remembering. Handles both shapes the schema actually uses: a column inside a `create table`
+ * body, and `alter table … add column if not exists …_ciphertext` (which is how `integrations` got its
+ * column, and is invisible to anyone reading only the create statements).
+ *
+ * @param {string} sql one or more SQL files, concatenated
+ * @returns {string[]} sorted, de-duplicated table names
+ */
+export function ciphertextTables(sql) {
+  const lines = stripSqlComments(sql).split("\n");
+  const found = new Set();
+  let current = null;
+  for (const line of lines) {
+    const created = CREATE_TABLE_RE.exec(line);
+    if (created) current = created[1].toLowerCase();
+    const altered = ALTER_TABLE_RE.exec(line);
+    if (altered) current = altered[1].toLowerCase();
+    if (CIPHERTEXT_COLUMN_RE.test(line) && current) found.add(current);
+  }
+  return [...found].sort();
+}
+
+/**
+ * Ciphertext-bearing tables the script would COPY — i.e. the gap between what the schema has and what
+ * the exclusion set covers. Empty is the only acceptable answer; the guard fails the build otherwise,
+ * so a new reversible-secret table cannot ship without someone deciding about it.
+ *
+ * @param {string} sql schema + migrations, concatenated
+ * @param {readonly string[]} excluded
+ * @returns {string[]}
+ */
+export function missingCiphertextExclusions(sql, excluded = EXCLUDED_TABLE_DATA) {
+  const set = new Set(excluded.map((t) => t.toLowerCase()));
+  return ciphertextTables(sql).filter((t) => !set.has(t));
+}
+
+/** `--exclude-table-data=` arguments, in a stable order so the guard can compare them literally. */
+export function excludeTableDataArgs(excluded = EXCLUDED_TABLE_DATA) {
+  return [...excluded].sort().map((t) => `--exclude-table-data=${t}`);
+}
+
+/**
+ * The host a connection string points at, lowercased, or null when it cannot be parsed. Null is NOT
+ * "different from everything": `refusalsForPreflight` treats an unparseable URL as a refusal, because
+ * "I could not tell whether these are the same database" must never read as "they differ".
+ */
+export function hostOf(url) {
+  const raw = String(url ?? "").trim();
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    const host = parsed.hostname.toLowerCase();
+    return host || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The layers that need NO connection, so the copy-paste case (both URLs pointing at prod) dies before
+ * a socket is opened rather than after a successful login to production.
+ *
+ * @param {{ sourceUrl?: string|null, targetUrl?: string|null }} input
+ * @returns {{ code: string, reason: string }[]}
+ */
+export function refusalsForPreflight(input) {
+  const out = [];
+  const sourceHost = hostOf(input?.sourceUrl);
+  const targetHost = hostOf(input?.targetUrl);
+  if (!sourceHost) {
+    out.push({
+      code: REFUSAL.MISSING_SOURCE,
+      reason:
+        "STAGING_REFRESH_SOURCE_URL is unset or unparseable. There is deliberately no default: a default source is how a script that copies FROM production acquires a second, silent opinion about which database that is.",
+    });
+  }
+  if (!targetHost) {
+    out.push({
+      code: REFUSAL.MISSING_TARGET,
+      reason:
+        "STAGING_REFRESH_TARGET_URL is unset or unparseable. There is deliberately no default: this URL is the one a `pg_restore --clean` destroys.",
+    });
+  }
+  if (sourceHost && targetHost && sourceHost === targetHost) {
+    out.push({
+      code: REFUSAL.SAME_HOST,
+      reason: `source and target resolve to the same host (${sourceHost}). That is the copy-paste mistake this refusal exists for, and it is checked before any connection is opened.`,
+    });
+  }
+  return out;
+}
+
+/**
+ * The layers that need a reading from the databases. Every input is REQUIRED; an absent one is its own
+ * refusal rather than a skipped check, so a shell that fails to gather a value cannot fail open.
+ *
+ * @param {{ markerPresent?: boolean|null, clientMajor?: number|null, serverMajor?: number|null }} input
+ * @returns {{ code: string, reason: string }[]}
+ */
+export function refusalsForConnected(input) {
+  const out = [];
+  const marker = input?.markerPresent;
+  if (marker !== true && marker !== false) {
+    out.push({
+      code: REFUSAL.MARKER_UNKNOWN,
+      reason: `could not determine whether the target has the "${STAGING_MARKER_TABLE}" table. Unknown is a refusal, not a pass.`,
+    });
+  } else if (marker === false) {
+    out.push({
+      code: REFUSAL.NO_MARKER,
+      reason: `the target database has no "${STAGING_MARKER_TABLE}" table, so it has not been declared a staging database. Production does not have this table and never will (it is absent from postgres/schema.sql by design), which is exactly what makes its absence a refusal. To declare a target: ${STAGING_MARKER_REMEDY}`,
+    });
+  }
+  out.push(...pgVersionRefusals(input?.clientMajor, input?.serverMajor));
+  return out;
+}
+
+/**
+ * `pg_dump` aborts when the server's major version exceeds its own. On the machine this was designed
+ * on, `pg_dump` on PATH was 14 and both servers were 18 — so the runbook as first written could not
+ * have run at all. Refusing with the remedy named beats proceeding: a mismatched client is how you get
+ * an archive that restores PARTIALLY, which is worse than one that never existed.
+ *
+ * A client NEWER than the server is fine and must be ACCEPTED — a refusal that fires on everything
+ * would pass every "does it refuse?" test while making the script unusable.
+ */
+export function pgVersionRefusals(clientMajor, serverMajor) {
+  const client = Number(clientMajor);
+  const server = Number(serverMajor);
+  if (!Number.isInteger(client) || !Number.isInteger(server) || client <= 0 || server <= 0) {
+    return [
+      {
+        code: REFUSAL.PG_VERSION_UNKNOWN,
+        reason:
+          "could not read both the pg_dump client major version and the server major version. Unknown is a refusal: an unverified client/server pairing is how a partial archive gets made.",
+      },
+    ];
+  }
+  if (client < server) {
+    return [
+      {
+        code: REFUSAL.PG_CLIENT_TOO_OLD,
+        reason: `pg_dump is major ${client} but the server is major ${server}; pg_dump refuses to dump a newer server. Remedy: brew install postgresql@${server} and re-run with PG_BIN=$(brew --prefix postgresql@${server})/bin, or run the dump inside docker run --rm postgres:${server}.`,
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * The whole decision, for tests that need to assert a single input violates a single layer.
+ * @returns {{ ok: boolean, refusals: { code: string, reason: string }[] }}
+ */
+export function decideRefresh(input) {
+  const refusals = [...refusalsForPreflight(input), ...refusalsForConnected(input)];
+  return { ok: refusals.length === 0, refusals };
+}
+
+/**
+ * The message printed after a successful refresh. It names a hazard NO CODE HERE CAN CLOSE: the
+ * exclusion of `graph_episodes` leaves staging's projection ledger empty, so the day someone sets
+ * `GRAPHITI_URL` on staging to "make the graph work", the entire restored corpus looks unprojected and
+ * the first tick or admin click starts paying for real entity extraction — the ~99%-of-the-LLM-bill
+ * path. Stated where the person who would do it is looking, because the alternative is discovering it
+ * on an invoice.
+ */
+export function completionMessage({ excluded = EXCLUDED_TABLE_DATA } = {}) {
+  return [
+    "staging refresh complete.",
+    `Excluded table DATA: ${[...excluded].sort().join(", ")}.`,
+    "Staging now holds prod-shaped Postgres and NO graph: GRAPHITI_URL and NEO4J_URL are expected to be unset there.",
+    "HAZARD, deliberately left open and stated instead: graph_episodes is empty, so if GRAPHITI_URL is ever set on staging, every restored item looks unprojected and projection will bill real extraction for the whole corpus.",
+    "Graph-backed surfaces (learning panel, graph-query, semantic retrieval) render empty in staging by design.",
+  ].join("\n");
+}
+
+/** CLI: `node scripts/staging-refresh-decision.mjs <preflight|check|exclude-args|completion>`. */
+function main(argv) {
+  const cmd = argv[2];
+  const arg = (name) => {
+    const i = argv.indexOf(`--${name}`);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const print = (refusals) => {
+    if (refusals.length === 0) return 0;
+    for (const r of refusals) console.error(`staging-refresh REFUSED [${r.code}]: ${r.reason}`);
+    return 1;
+  };
+
+  if (cmd === "preflight") {
+    return print(refusalsForPreflight({ sourceUrl: arg("source"), targetUrl: arg("target") }));
+  }
+  if (cmd === "check") {
+    const markerRaw = arg("marker");
+    const marker = markerRaw === "true" ? true : markerRaw === "false" ? false : null;
+    return print(
+      decideRefresh({
+        sourceUrl: arg("source"),
+        targetUrl: arg("target"),
+        markerPresent: marker,
+        clientMajor: Number(arg("client-major")),
+        serverMajor: Number(arg("server-major")),
+      }).refusals
+    );
+  }
+  if (cmd === "exclude-args") {
+    console.log(excludeTableDataArgs().join("\n"));
+    return 0;
+  }
+  if (cmd === "completion") {
+    console.log(completionMessage());
+    return 0;
+  }
+  console.error("usage: staging-refresh-decision.mjs <preflight|check|exclude-args|completion>");
+  return 2;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) process.exit(main(process.argv));

--- a/scripts/staging-refresh-decision.mjs
+++ b/scripts/staging-refresh-decision.mjs
@@ -26,13 +26,19 @@
  * to gather a value for a hundred boring reasons; none of them should end with a `--clean` restore.
  */
 
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 /** Refusal codes. Exported so tests name the layer they are pinning instead of matching prose. */
 export const REFUSAL = Object.freeze({
   MISSING_SOURCE: "missing-source-url",
   MISSING_TARGET: "missing-target-url",
+  UNSUPPORTED_SCHEME: "unsupported-scheme",
+  UNSAFE_CONNECTION_PARAMS: "unsafe-connection-params",
   SAME_HOST: "same-host",
   NO_MARKER: "no-staging-marker",
   MARKER_UNKNOWN: "staging-marker-unknown",
+  SOURCE_IS_STAGING: "source-carries-staging-marker",
   PG_CLIENT_TOO_OLD: "pg-client-too-old",
   PG_VERSION_UNKNOWN: "pg-version-unknown",
 });
@@ -67,7 +73,11 @@ export const STAGING_MARKER_REMEDY = `psql "$STAGING_REFRESH_TARGET_URL" -c 'cre
  *      red "graph extraction is broken" banner, manufactured by our own refresh.
  */
 export const EXCLUDED_TABLE_DATA = Object.freeze([
+  "gateway_approvals",
+  "gateway_audit_log",
   "gateway_connections",
+  "gateway_executions",
+  "gateway_resolution_leases",
   "graph_episodes",
   "integrations",
   "member_secrets",
@@ -160,22 +170,170 @@ export function missingCiphertextExclusions(sql, excluded = EXCLUDED_TABLE_DATA)
   return ciphertextTables(sql).filter((t) => !set.has(t));
 }
 
+const REFERENCES_RE = /\breferences\s+(?:"?public"?\.)?"?([a-z0-9_]+)"?/i;
+
+/**
+ * Tables holding a FOREIGN KEY to `table`. Excluding a parent's DATA while dumping a child's is not a
+ * tidy subset — it is a restore that FAILS: `pg_restore` loads the child rows and then cannot create
+ * the constraint. With `--single-transaction` the whole refresh rolls back, so the failure is loud
+ * rather than corrupting, but staging simply never refreshes again once the child table has a row.
+ *
+ * Measured 2026-08-20: `gateway_connections` has three dependents (`gateway_executions`,
+ * `gateway_resolution_leases`, `gateway_audit_log`) and every one of them holds ZERO rows in prod
+ * today — which is exactly why this is computed rather than remembered. A latent break that waits for
+ * the gateway subsystem to be used is the kind this spec has already been caught by once.
+ */
+export function fkDependents(sql, table) {
+  const lines = stripSqlComments(sql).split("\n");
+  const target = String(table).toLowerCase();
+  const out = new Set();
+  let current = null;
+  for (const line of lines) {
+    const created = CREATE_TABLE_RE.exec(line);
+    if (created) current = created[1].toLowerCase();
+    const altered = ALTER_TABLE_RE.exec(line);
+    if (altered) current = altered[1].toLowerCase();
+    const ref = REFERENCES_RE.exec(line);
+    if (ref && ref[1].toLowerCase() === target && current && current !== target) out.add(current);
+  }
+  return [...out].sort();
+}
+
+/**
+ * Dependents of an excluded table that are NOT themselves excluded — i.e. the restore breakage.
+ *
+ * TRANSITIVE, and that is not theoretical: excluding `gateway_connections` pulls in `gateway_executions`,
+ * and `gateway_approvals` hangs off THAT. A one-level check reported a clean closure right up until the
+ * three direct dependents were added, and then found a fourth. Walk it to a fixed point or the answer
+ * depends on how many rounds someone happened to run.
+ */
+export function missingFkClosure(sql, excluded = EXCLUDED_TABLE_DATA) {
+  const set = new Set(excluded.map((t) => t.toLowerCase()));
+  const missing = new Set();
+  const queue = [...set];
+  const seen = new Set(queue);
+  while (queue.length > 0) {
+    const table = queue.shift();
+    for (const dep of fkDependents(sql, table)) {
+      if (!set.has(dep)) missing.add(dep);
+      if (!seen.has(dep)) {
+        seen.add(dep);
+        queue.push(dep);
+      }
+    }
+  }
+  return [...missing].sort();
+}
+
 /** `--exclude-table-data=` arguments, in a stable order so the guard can compare them literally. */
 export function excludeTableDataArgs(excluded = EXCLUDED_TABLE_DATA) {
   return [...excluded].sort().map((t) => `--exclude-table-data=${t}`);
 }
 
 /**
+ * Query parameters a connection URL may carry. An ALLOWLIST, not a denylist, and that direction is the
+ * whole point.
+ *
+ * ── The attack this closes, verified by running it ──────────────────────────────────────────────
+ * libpq accepts connection PARAMETERS in a URI's query string, including `hostaddr` — which overrides
+ * where the socket actually goes while leaving the hostname for authentication. Measured:
+ *
+ *     psql "postgresql://u@nonexistent-host-xyz.invalid:5432/db"
+ *       → could not translate host name "nonexistent-host-xyz.invalid"
+ *     psql "postgresql://u@nonexistent-host-xyz.invalid:5432/db?hostaddr=127.0.0.1"
+ *       → connection to server at "127.0.0.1" … role "u" does not exist
+ *
+ * So a target URL reading `staging-proxy.rlwy.net` can connect to production. That defeats the
+ * same-host refusal (the parsed hosts differ) AND the marker refusal — because the operator's one-time
+ * `create table staging_marker` runs through the same libpq and would plant the marker ON PRODUCTION,
+ * after which a `pg_restore --clean` follows it there. Two layers, one bypass, and the outcome is the
+ * catastrophic direction this whole script exists to prevent.
+ *
+ * A denylist would have to enumerate every libpq parameter that can redirect a connection, forever. The
+ * allowlist inverts the default: anything not known-inert is a refusal.
+ */
+export const ALLOWED_URL_PARAMS = Object.freeze([
+  "application_name",
+  "connect_timeout",
+  "sslcert",
+  "sslkey",
+  "sslmode",
+  "sslrootcert",
+]);
+
+/**
+ * The libpq environment variables that can redirect or re-authenticate a connection independently of
+ * the URL — `PGHOSTADDR` does it with the URL untouched, measured the same way as above. The shell
+ * scrubs every one of these before invoking psql/pg_dump/pg_restore; this list is exported so the
+ * script and its guard cannot drift apart.
+ */
+export const SCRUBBED_PG_ENV = Object.freeze([
+  "PGHOST",
+  "PGHOSTADDR",
+  "PGPORT",
+  "PGDATABASE",
+  "PGUSER",
+  "PGPASSWORD",
+  "PGPASSFILE",
+  "PGSERVICE",
+  "PGSERVICEFILE",
+  "PGOPTIONS",
+  "PGTARGETSESSIONATTRS",
+  "PGREQUIRESSL",
+  "PGSSLMODE",
+]);
+
+/**
+ * Refusals about the SHAPE of one connection URL: an unsupported scheme, or any query parameter
+ * outside the allowlist above. Returns [] for a URL that cannot be parsed at all — that case is
+ * `hostOf`'s missing-url refusal, and reporting both would be one fault wearing two hats.
+ */
+function refusalsForUrlShape(url, label) {
+  const raw = String(url ?? "").trim();
+  if (!raw) return [];
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return [];
+  }
+  const out = [];
+  const scheme = parsed.protocol.replace(/:$/, "").toLowerCase();
+  if (scheme !== "postgres" && scheme !== "postgresql") {
+    out.push({
+      code: REFUSAL.UNSUPPORTED_SCHEME,
+      reason: `${label} uses the "${scheme}" scheme; only postgres:// and postgresql:// are accepted. A URL this script cannot reason about is a URL it must not hand to pg_restore.`,
+    });
+  }
+  const allowed = new Set(ALLOWED_URL_PARAMS);
+  const offending = [...parsed.searchParams.keys()].filter((k) => !allowed.has(k.toLowerCase()));
+  if (offending.length > 0) {
+    out.push({
+      code: REFUSAL.UNSAFE_CONNECTION_PARAMS,
+      reason: `${label} carries connection parameter(s) this script will not accept: ${offending.join(", ")}. libpq lets a query parameter such as hostaddr send the connection somewhere other than the hostname says — which would defeat both the same-host and the staging-marker refusals. Allowed: ${ALLOWED_URL_PARAMS.join(", ")}.`,
+    });
+  }
+  return out;
+}
+
+/**
  * The host a connection string points at, lowercased, or null when it cannot be parsed. Null is NOT
  * "different from everything": `refusalsForPreflight` treats an unparseable URL as a refusal, because
  * "I could not tell whether these are the same database" must never read as "they differ".
+ *
+ * A TRAILING DOT is stripped: `example.net.` and `example.net` are the same DNS name, and without this
+ * the same-host layer would let that pair through — the marker layer would still catch it, but a
+ * defence-in-depth stack whose layers only work together is one this spec explicitly refuses.
+ *
+ * What this is NOT: proof of the TCP destination. That guarantee comes from `ALLOWED_URL_PARAMS` plus
+ * the shell's `SCRUBBED_PG_ENV`; without those two, the hostname is a label rather than an address.
  */
 export function hostOf(url) {
   const raw = String(url ?? "").trim();
   if (!raw) return null;
   try {
     const parsed = new URL(raw);
-    const host = parsed.hostname.toLowerCase();
+    const host = parsed.hostname.toLowerCase().replace(/\.$/, "");
     return host || null;
   } catch {
     return null;
@@ -207,6 +365,8 @@ export function refusalsForPreflight(input) {
         "STAGING_REFRESH_TARGET_URL is unset or unparseable. There is deliberately no default: this URL is the one a `pg_restore --clean` destroys.",
     });
   }
+  out.push(...refusalsForUrlShape(input?.sourceUrl, "the SOURCE url"));
+  out.push(...refusalsForUrlShape(input?.targetUrl, "the TARGET url"));
   if (sourceHost && targetHost && sourceHost === targetHost) {
     out.push({
       code: REFUSAL.SAME_HOST,
@@ -235,6 +395,23 @@ export function refusalsForConnected(input) {
     out.push({
       code: REFUSAL.NO_MARKER,
       reason: `the target database has no "${STAGING_MARKER_TABLE}" table, so it has not been declared a staging database. Production does not have this table and never will (it is absent from postgres/schema.sql by design), which is exactly what makes its absence a refusal. To declare a target: ${STAGING_MARKER_REMEDY}`,
+    });
+  }
+  // The SWAPPED PAIR, which the target-marker check alone cannot see. If the operator once declared a
+  // database staging while their shell pointed at production, prod carries the marker permanently and
+  // nothing in this repo would ever notice — so a later `--source staging --target prod` passes both
+  // the host check (they differ) and the marker check. Reading the marker on the SOURCE catches it from
+  // the other side: the source of a legitimate refresh is production, and production has no marker.
+  const sourceMarker = input?.sourceMarkerPresent;
+  if (sourceMarker === true) {
+    out.push({
+      code: REFUSAL.SOURCE_IS_STAGING,
+      reason: `the SOURCE database carries the "${STAGING_MARKER_TABLE}" table, so it is a staging database. This refresh copies production INTO staging; a staging source means the two urls are swapped, and continuing would restore over the database you meant to read.`,
+    });
+  } else if (sourceMarker !== false) {
+    out.push({
+      code: REFUSAL.MARKER_UNKNOWN,
+      reason: `could not determine whether the SOURCE has the "${STAGING_MARKER_TABLE}" table. Unknown is a refusal, not a pass.`,
     });
   }
   out.push(...pgVersionRefusals(input?.clientMajor, input?.serverMajor));
@@ -308,7 +485,10 @@ function main(argv) {
     return i >= 0 ? argv[i + 1] : undefined;
   };
   const print = (refusals) => {
-    if (refusals.length === 0) return 0;
+    if (refusals.length === 0) {
+      console.log(DECISION_ACK);
+      return 0;
+    }
     for (const r of refusals) console.error(`staging-refresh REFUSED [${r.code}]: ${r.reason}`);
     return 1;
   };
@@ -317,17 +497,23 @@ function main(argv) {
     return print(refusalsForPreflight({ sourceUrl: arg("source"), targetUrl: arg("target") }));
   }
   if (cmd === "check") {
-    const markerRaw = arg("marker");
-    const marker = markerRaw === "true" ? true : markerRaw === "false" ? false : null;
+    const asBool = (v) => (v === "true" ? true : v === "false" ? false : null);
+    const marker = asBool(arg("marker"));
+    const sourceMarker = asBool(arg("source-marker"));
     return print(
       decideRefresh({
         sourceUrl: arg("source"),
         targetUrl: arg("target"),
         markerPresent: marker,
+        sourceMarkerPresent: sourceMarker,
         clientMajor: Number(arg("client-major")),
         serverMajor: Number(arg("server-major")),
       }).refusals
     );
+  }
+  if (cmd === "scrubbed-env") {
+    console.log(SCRUBBED_PG_ENV.join("\n"));
+    return 0;
   }
   if (cmd === "exclude-args") {
     console.log(excludeTableDataArgs().join("\n"));
@@ -337,8 +523,35 @@ function main(argv) {
     console.log(completionMessage());
     return 0;
   }
-  console.error("usage: staging-refresh-decision.mjs <preflight|check|exclude-args|completion>");
+  console.error("usage: staging-refresh-decision.mjs <preflight|check|exclude-args|scrubbed-env|completion>");
   return 2;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) process.exit(main(process.argv));
+/**
+ * Realpath both sides, not a template string. `file://${process.argv[1]}` silently fails to match whenever
+ * the path is symlinked or contains a character a URL percent-encodes — node resolves `argv[1]` without
+ * realpath while `import.meta.url` follows symlinks and encodes. VERIFIED: run from `/tmp/…` (a symlink
+ * to `/private/tmp`) or from a directory with a SPACE in its name, this file printed nothing and exited
+ * **0** — every refusal above dead, and the shell reads exit 0 as approval.
+ *
+ * The comparison is the fix; `ACK` is the reason it cannot silently break again. The shell requires the
+ * ack token on stdout, so a CLI that no-ops for ANY future reason produces no token and the refresh
+ * stops. "Unknown is a refusal" has to hold at the process boundary too, not only inside it.
+ */
+export const DECISION_ACK = "staging-refresh: DECISION OK";
+
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    // BOTH sides realpath'd. `pathToFileURL` alone fixes the percent-encoding half and NOT the symlink
+    // half — measured: from `/tmp/…` (a symlink to `/private/tmp`) the encoded urls still differ, so the
+    // CLI kept no-opping. Two distinct causes, one symptom; fixing the visible one would have looked
+    // like a fix and left the refusals dead.
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(entry);
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) process.exit(main(process.argv));

--- a/scripts/staging-refresh.sh
+++ b/scripts/staging-refresh.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# STAGING-1 — copy PRODUCTION's Postgres into STAGING's own Postgres, so a branch can be looked at
+# against real data. Spec: docs/design/staging-prod-shaped-data.md. Runbook: docs/OPS.md §"Staging
+# refresh".
+#
+# THE DANGEROUS DIRECTION is the reverse of the intended one. `pg_restore --clean` drops every object
+# it is about to recreate, so pointing the TARGET at production destroys production. Every refusal in
+# scripts/staging-refresh-decision.mjs exists for that sentence. The decision is pure and unit-tested
+# there rather than written here, because a guard living only in bash is a guard nothing runs until
+# the day it matters.
+#
+# WHAT THIS SCRIPT DELIBERATELY DOES NOT DO:
+#   * It does not mutate Railway. Not variables, not deploys, nothing. It touches one database and
+#     writes one dump file. The obvious future convenience edit — "have it set the staging flags for
+#     you" — is what a guard forbids, because a script that can set variables can point staging at
+#     production.
+#   * It does not sanitise the target after restoring. Credentials are excluded from the DUMP instead:
+#     a crash between a committed restore and a post-hoc sanitation would leave staging live with
+#     prod-shaped rows and usable credentials, and "the next run refuses" is no help once the harmful
+#     state exists.
+#   * It never passes the pg_restore database-recreate flag. Recreating the database would drop the
+#     staging marker with it, and the marker is the only thing that distinguishes a legal target from
+#     production.
+#
+# USAGE
+#   STAGING_REFRESH_SOURCE_URL=<prod public URL, read-only use> \
+#   STAGING_REFRESH_TARGET_URL=<staging public URL> \
+#     bash scripts/staging-refresh.sh
+#
+# Optional: PG_BIN=/path/to/postgres/bin to pin the client binaries (see the version refusal below).
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DECIDE="$REPO_ROOT/scripts/staging-refresh-decision.mjs"
+
+# No defaults, on purpose (spec criterion 6). The `:-` below is an EMPTY fallback so `set -u` does not
+# abort before the refusal can be printed with its explanation — it is not a default value, and a
+# guard asserts that these two never acquire one.
+SOURCE_URL="${STAGING_REFRESH_SOURCE_URL:-}"
+TARGET_URL="${STAGING_REFRESH_TARGET_URL:-}"
+
+# ── Layer 1: connection-free refusals ───────────────────────────────────────────────────────────
+# Missing URLs and same-host must die BEFORE a socket is opened: the copy-paste case is both URLs
+# pointing at production, and "we refused, but only after logging into prod" is a worse story.
+node "$DECIDE" preflight --source "$SOURCE_URL" --target "$TARGET_URL"
+
+# ── Readings the remaining refusals need ────────────────────────────────────────────────────────
+# `psql` from PATH is fine for reading a version: only pg_dump refuses a newer server.
+read_server_major() {
+  local url="$1"
+  psql "$url" -tAc "select current_setting('server_version_num')::int / 10000" 2>/dev/null | tr -d '[:space:]'
+}
+
+SOURCE_MAJOR="$(read_server_major "$SOURCE_URL" || true)"
+TARGET_MAJOR="$(read_server_major "$TARGET_URL" || true)"
+
+# Binary resolution: an explicit override, else a Homebrew keg matching the SOURCE server's major,
+# else whatever is on PATH — and if that is too old, the version refusal below names the remedy
+# rather than letting pg_dump fail with its own less actionable message.
+if [[ -n "${PG_BIN:-}" ]]; then
+  PG_DUMP="$PG_BIN/pg_dump"
+  PG_RESTORE="$PG_BIN/pg_restore"
+elif [[ -n "$SOURCE_MAJOR" && -x "/opt/homebrew/opt/postgresql@$SOURCE_MAJOR/bin/pg_dump" ]]; then
+  PG_DUMP="/opt/homebrew/opt/postgresql@$SOURCE_MAJOR/bin/pg_dump"
+  PG_RESTORE="/opt/homebrew/opt/postgresql@$SOURCE_MAJOR/bin/pg_restore"
+else
+  PG_DUMP="$(command -v pg_dump || true)"
+  PG_RESTORE="$(command -v pg_restore || true)"
+fi
+
+CLIENT_MAJOR=""
+if [[ -n "$PG_DUMP" && -x "$PG_DUMP" ]]; then
+  CLIENT_MAJOR="$("$PG_DUMP" --version | sed -E 's/[^0-9]*([0-9]+).*/\1/')"
+fi
+
+# Does the target carry the staging marker? An error reads as UNKNOWN, and unknown is a refusal.
+# The `[[ … ]] && VAR=…` pairs below look like the classic `set -e` footgun and are not: bash exempts
+# every member of an && list except the one after the final `&&`, so a false test assigns nothing and
+# the script continues to the refusal. Verified by running it, not by reading the manual — a silent
+# exit here would swallow the very refusal that names the remedy.
+MARKER="unknown"
+if MARKER_RAW="$(psql "$TARGET_URL" -tAc "select to_regclass('public.staging_marker') is not null" 2>/dev/null)"; then
+  MARKER_RAW="$(echo "$MARKER_RAW" | tr -d '[:space:]')"
+  [[ "$MARKER_RAW" == "t" ]] && MARKER="true"
+  [[ "$MARKER_RAW" == "f" ]] && MARKER="false"
+fi
+
+# ── Layer 2: the full decision ──────────────────────────────────────────────────────────────────
+node "$DECIDE" check \
+  --source "$SOURCE_URL" \
+  --target "$TARGET_URL" \
+  --marker "$MARKER" \
+  --client-major "${CLIENT_MAJOR:-0}" \
+  --server-major "${SOURCE_MAJOR:-0}"
+
+if [[ -n "$TARGET_MAJOR" && -n "$SOURCE_MAJOR" && "$TARGET_MAJOR" != "$SOURCE_MAJOR" ]]; then
+  echo "staging-refresh: NOTE — source server is major $SOURCE_MAJOR, target is major $TARGET_MAJOR." >&2
+  echo "  A dump from a newer server does not restore into an older one; verify before trusting a partial restore." >&2
+fi
+
+# ── Dump ────────────────────────────────────────────────────────────────────────────────────────
+DUMP_FILE="${STAGING_REFRESH_DUMP:-$(mktemp -t staging-refresh-XXXXXX).dump}"
+
+# A while-read loop, not `mapfile`: macOS ships bash 3.2, where `mapfile`/`readarray` do not exist.
+# This script's own operator is on that bash, so the convenient spelling would have aborted here —
+# AFTER connecting to production — which is the same shape as the pg_dump version trap the refusals
+# above exist for. A guard pins that no bash-4-only builtin creeps back in.
+EXCLUDE_ARGS=()
+while IFS= read -r line; do
+  [ -n "$line" ] && EXCLUDE_ARGS+=("$line")
+done < <(node "$DECIDE" exclude-args)
+if [ ${#EXCLUDE_ARGS[@]} -eq 0 ]; then
+  echo "staging-refresh REFUSED: the exclusion list came back EMPTY." >&2
+  echo "  An empty list would dump every reversible-secret table's data into staging. Refusing." >&2
+  exit 1
+fi
+
+echo "staging-refresh: dumping source → $DUMP_FILE"
+echo "staging-refresh: excluding table DATA: ${EXCLUDE_ARGS[*]}"
+"$PG_DUMP" --format=custom --no-owner "${EXCLUDE_ARGS[@]}" --file "$DUMP_FILE" "$SOURCE_URL"
+
+# ── Restore ─────────────────────────────────────────────────────────────────────────────────────
+# Flags per docs/OPS.md §Restore. `--no-owner` because Railway roles differ across environments.
+# The staging marker survives this because pg_restore drops only what the archive contains, and the
+# marker exists in no archive — which is why it must never be added to postgres/schema.sql.
+echo "staging-refresh: restoring into target (destructive to the target's copies of dumped objects)"
+"$PG_RESTORE" --clean --if-exists --no-owner --dbname "$TARGET_URL" "$DUMP_FILE"
+
+# ── Replay migrations that postdate the dump ────────────────────────────────────────────────────
+# From a PLAIN SHELL, never through the Railway CLI: scripts/pg-load-schema.mjs calls
+# assertServiceIdentity before it connects, which no-ops off-Railway but REFUSES under a Railway shell
+# (that injects a non-AIOS service name plus the project marker). docs/OPS.md §Restore says to use a
+# Railway shell and is wrong for this case.
+echo "staging-refresh: replaying schema + migrations against the target"
+DATABASE_URL="$TARGET_URL" npm --prefix "$REPO_ROOT" run pg:schema
+
+node "$DECIDE" completion

--- a/scripts/staging-refresh.sh
+++ b/scripts/staging-refresh.sh
@@ -108,7 +108,7 @@ fi
 
 CLIENT_MAJOR=""
 if [[ -n "$PG_DUMP" && -x "$PG_DUMP" ]]; then
-  CLIENT_MAJOR="$("$PG_DUMP" --version | sed -E 's/[^0-9]*([0-9]+).*/\1/')"
+  CLIENT_MAJOR="$("${PG_SCRUB[@]}" "$PG_DUMP" --version | sed -E 's/[^0-9]*([0-9]+).*/\1/')"
 fi
 
 # Does a database carry the staging marker? An error reads as UNKNOWN, and unknown is a refusal.

--- a/scripts/staging-refresh.sh
+++ b/scripts/staging-refresh.sh
@@ -201,7 +201,10 @@ echo "staging-refresh: restoring into target (destructive to the target's copies
 # assertServiceIdentity before it connects, which no-ops off-Railway but REFUSES under a Railway shell
 # (that injects a non-AIOS service name plus the project marker). docs/OPS.md §Restore says to use a
 # Railway shell and is wrong for this case.
+# Scrubbed too, though this one goes through node-postgres rather than libpq (so `PGHOSTADDR` would not
+# route it anyway) and runs AFTER the destructive step. Uniformity is the point: an exception here would
+# make the guard's silence mean "everything except that one", which is how exceptions become holes.
 echo "staging-refresh: replaying schema + migrations against the target"
-DATABASE_URL="$TARGET_URL" npm --prefix "$REPO_ROOT" run pg:schema
+DATABASE_URL="$TARGET_URL" "${PG_SCRUB[@]}" npm --prefix "$REPO_ROOT" run pg:schema
 
 node "$DECIDE" completion

--- a/scripts/staging-refresh.sh
+++ b/scripts/staging-refresh.sh
@@ -35,22 +35,58 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DECIDE="$REPO_ROOT/scripts/staging-refresh-decision.mjs"
 
+# Every libpq call goes through this. `PGHOSTADDR` redirects a connection with the URL untouched —
+# measured: a URL naming a nonexistent host connected to 127.0.0.1 with PGHOSTADDR set — so an ambient
+# variable in the operator's shell could send a `--clean` restore to production while every refusal
+# above read the innocent hostname. `psql -X` for the same reason one level up: a `\c other_db` in
+# ~/.psqlrc would move the session after the marker was read. The list is exported by the decision
+# module so the guard can prove the script scrubs exactly what the module declares.
+PG_SCRUB=(env)
+while IFS= read -r pg_var; do
+  [ -n "$pg_var" ] && PG_SCRUB+=(-u "$pg_var")
+done < <(node "$DECIDE" scrubbed-env)
+if [ ${#PG_SCRUB[@]} -le 1 ]; then
+  echo "staging-refresh REFUSED: the libpq environment scrub list came back EMPTY." >&2
+  echo "  Without it, PGHOSTADDR/PGSERVICE can point this run at a database no refusal here inspected." >&2
+  exit 1
+fi
+
 # No defaults, on purpose (spec criterion 6). The `:-` below is an EMPTY fallback so `set -u` does not
 # abort before the refusal can be printed with its explanation — it is not a default value, and a
 # guard asserts that these two never acquire one.
 SOURCE_URL="${STAGING_REFRESH_SOURCE_URL:-}"
 TARGET_URL="${STAGING_REFRESH_TARGET_URL:-}"
 
+# A decision is only an approval when it SAYS SO. Exit 0 alone is not enough: the decision CLI once
+# no-opped entirely — printing nothing, exiting 0 — whenever it ran from a symlinked path or one with a
+# space in it, because its entry guard compared unresolved path strings. Every refusal was dead and this
+# script would have read the silence as a green light. Requiring a positive token means any future
+# spelling of that bug stops the refresh instead of waving it through.
+decide() {
+  local out
+  if ! out="$(node "$DECIDE" "$@")"; then
+    return 1
+  fi
+  case "$out" in
+    *"staging-refresh: DECISION OK"*) return 0 ;;
+    *)
+      echo "staging-refresh REFUSED: the decision step produced no verdict (exit 0, no ack)." >&2
+      echo "  Refusing rather than treating silence as approval." >&2
+      return 1
+      ;;
+  esac
+}
+
 # ── Layer 1: connection-free refusals ───────────────────────────────────────────────────────────
 # Missing URLs and same-host must die BEFORE a socket is opened: the copy-paste case is both URLs
 # pointing at production, and "we refused, but only after logging into prod" is a worse story.
-node "$DECIDE" preflight --source "$SOURCE_URL" --target "$TARGET_URL"
+decide preflight --source "$SOURCE_URL" --target "$TARGET_URL"
 
 # ── Readings the remaining refusals need ────────────────────────────────────────────────────────
 # `psql` from PATH is fine for reading a version: only pg_dump refuses a newer server.
 read_server_major() {
   local url="$1"
-  psql "$url" -tAc "select current_setting('server_version_num')::int / 10000" 2>/dev/null | tr -d '[:space:]'
+  "${PG_SCRUB[@]}" psql -X "$url" -tAc "select current_setting('server_version_num')::int / 10000" 2>/dev/null | tr -d '[:space:]'
 }
 
 SOURCE_MAJOR="$(read_server_major "$SOURCE_URL" || true)"
@@ -75,23 +111,34 @@ if [[ -n "$PG_DUMP" && -x "$PG_DUMP" ]]; then
   CLIENT_MAJOR="$("$PG_DUMP" --version | sed -E 's/[^0-9]*([0-9]+).*/\1/')"
 fi
 
-# Does the target carry the staging marker? An error reads as UNKNOWN, and unknown is a refusal.
+# Does a database carry the staging marker? An error reads as UNKNOWN, and unknown is a refusal.
 # The `[[ … ]] && VAR=…` pairs below look like the classic `set -e` footgun and are not: bash exempts
 # every member of an && list except the one after the final `&&`, so a false test assigns nothing and
-# the script continues to the refusal. Verified by running it, not by reading the manual — a silent
-# exit here would swallow the very refusal that names the remedy.
-MARKER="unknown"
-if MARKER_RAW="$(psql "$TARGET_URL" -tAc "select to_regclass('public.staging_marker') is not null" 2>/dev/null)"; then
-  MARKER_RAW="$(echo "$MARKER_RAW" | tr -d '[:space:]')"
-  [[ "$MARKER_RAW" == "t" ]] && MARKER="true"
-  [[ "$MARKER_RAW" == "f" ]] && MARKER="false"
-fi
+# the function returns its default. Verified by running it, not by reading the manual — a silent exit
+# here would swallow the very refusal that names the remedy.
+read_marker() {
+  local url="$1" raw answer="unknown"
+  if raw="$("${PG_SCRUB[@]}" psql -X "$url" -tAc "select to_regclass('public.staging_marker') is not null" 2>/dev/null)"; then
+    raw="$(echo "$raw" | tr -d '[:space:]')"
+    [[ "$raw" == "t" ]] && answer="true"
+    [[ "$raw" == "f" ]] && answer="false"
+  fi
+  echo "$answer"
+}
+
+MARKER="$(read_marker "$TARGET_URL")"
+# Read it on the SOURCE too. A production database that once acquired the marker by accident (an
+# operator with the target variable mis-set while declaring it) would make the target check pass for a
+# swapped pair forever, and nothing else in this repo would ever notice. The source of a legitimate
+# refresh is production, which has no marker — so a marked source means the two urls are swapped.
+SOURCE_MARKER="$(read_marker "$SOURCE_URL")"
 
 # ── Layer 2: the full decision ──────────────────────────────────────────────────────────────────
-node "$DECIDE" check \
+decide check \
   --source "$SOURCE_URL" \
   --target "$TARGET_URL" \
   --marker "$MARKER" \
+  --source-marker "$SOURCE_MARKER" \
   --client-major "${CLIENT_MAJOR:-0}" \
   --server-major "${SOURCE_MAJOR:-0}"
 
@@ -101,7 +148,24 @@ if [[ -n "$TARGET_MAJOR" && -n "$SOURCE_MAJOR" && "$TARGET_MAJOR" != "$SOURCE_MA
 fi
 
 # ── Dump ────────────────────────────────────────────────────────────────────────────────────────
-DUMP_FILE="${STAGING_REFRESH_DUMP:-$(mktemp -t staging-refresh-XXXXXX).dump}"
+# The dump holds prod items, member emails and api-key hashes. It is written to a private temp file and
+# REMOVED on every exit path — leaving it in /tmp is a copy of production sitting on a laptop with no
+# expiry. `STAGING_REFRESH_DUMP` keeps it deliberately (for debugging a failed restore) and is then the
+# operator's to delete; that is documented in docs/OPS.md §11 rather than left as folklore.
+if [[ -n "${STAGING_REFRESH_DUMP:-}" ]]; then
+  DUMP_FILE="$STAGING_REFRESH_DUMP"
+  KEEP_DUMP=1
+else
+  # `mktemp` creates the file it names; naming the dump `<that>.dump` would leave the original behind
+  # empty. Use the file mktemp actually made.
+  DUMP_FILE="$(mktemp -t staging-refresh)"
+  KEEP_DUMP=0
+fi
+cleanup() {
+  [[ "$KEEP_DUMP" -eq 0 && -f "$DUMP_FILE" ]] && rm -f "$DUMP_FILE"
+  return 0
+}
+trap cleanup EXIT
 
 # A while-read loop, not `mapfile`: macOS ships bash 3.2, where `mapfile`/`readarray` do not exist.
 # This script's own operator is on that bash, so the convenient spelling would have aborted here —
@@ -119,14 +183,18 @@ fi
 
 echo "staging-refresh: dumping source → $DUMP_FILE"
 echo "staging-refresh: excluding table DATA: ${EXCLUDE_ARGS[*]}"
-"$PG_DUMP" --format=custom --no-owner "${EXCLUDE_ARGS[@]}" --file "$DUMP_FILE" "$SOURCE_URL"
+"${PG_SCRUB[@]}" "$PG_DUMP" --format=custom --no-owner "${EXCLUDE_ARGS[@]}" --file "$DUMP_FILE" "$SOURCE_URL"
 
 # ── Restore ─────────────────────────────────────────────────────────────────────────────────────
 # Flags per docs/OPS.md §Restore. `--no-owner` because Railway roles differ across environments.
 # The staging marker survives this because pg_restore drops only what the archive contains, and the
 # marker exists in no archive — which is why it must never be added to postgres/schema.sql.
+# `--single-transaction`: without it a restore that fails halfway leaves staging LIVE with a half-dropped,
+# half-restored database — the drops have already committed. Wrapped, a failure rolls back to whatever
+# staging had before, which is a working environment rather than a broken one. It implies
+# --exit-on-error, which is the direction we want: a partial success must not read as a refresh.
 echo "staging-refresh: restoring into target (destructive to the target's copies of dumped objects)"
-"$PG_RESTORE" --clean --if-exists --no-owner --dbname "$TARGET_URL" "$DUMP_FILE"
+"${PG_SCRUB[@]}" "$PG_RESTORE" --single-transaction --clean --if-exists --no-owner --dbname "$TARGET_URL" "$DUMP_FILE"
 
 # ── Replay migrations that postdate the dump ────────────────────────────────────────────────────
 # From a PLAIN SHELL, never through the Railway CLI: scripts/pg-load-schema.mjs calls

--- a/test/guards/staging-refresh.test.ts
+++ b/test/guards/staging-refresh.test.ts
@@ -84,8 +84,11 @@ function unscrubbedCalls(script: string): string[] {
     // pg_dump/pg_restore were matched only as `"$PG_DUMP"`/`"$PG_RESTORE"`, so a future edit invoking a
     // literal `pg_restore …` — the most dangerous binary of the three — would have walked past.
     .filter((line) => /(?:\bpsql\b|\bpg_dump\b|\bpg_restore\b|"\$PG_DUMP"|"\$PG_RESTORE")/.test(line))
-    // An ASSIGNMENT names the binary, it does not run it (`PG_DUMP="$PG_BIN/pg_dump"`).
-    .filter((line) => !/^\s*[A-Z_]+=/.test(line))
+    // An ASSIGNMENT names the binary, it does not run it (`PG_DUMP="$PG_BIN/pg_dump"`) — but only when
+    // the line is NOTHING BUT an assignment. `VAR=x psql …` is a command with an env prefix, and the
+    // first spelling of this filter (`^\s*[A-Z_]+=`) swallowed exactly that shape: a hole opened by the
+    // fix for a false positive, which is the usual way one arrives.
+    .filter((line) => !/^\s*[A-Z_]+=("[^"]*"|\S*)\s*$/.test(line))
     // A `[[ -n "$PG_DUMP" ]]` test REFERENCES the binary, it does not run it — flagging it was the
     // detector's other failure direction, found the same way as the first: by running it on real input.
     .filter((line) => !line.includes("[["))
@@ -353,10 +356,18 @@ describe("staging-refresh — the URL is not the destination (criteria 17, 18)",
     expect(unscrubbedCalls('if [[ -n "$PG_DUMP" && -x "$PG_DUMP" ]]; then')).toEqual([]); // a test, not a call
     expect(unscrubbedCalls('  PG_DUMP="$PG_BIN/pg_dump"')).toEqual([]); // an assignment, not a call
     expect(unscrubbedCalls('pg_restore --clean --dbname "$TARGET_URL" "$DUMP"')).not.toEqual([]); // literal binary
+    expect(unscrubbedCalls('DATABASE_URL="$T" psql -X -c "select 1"')).not.toEqual([]); // env prefix is not an assignment
     expect(unscrubbedCalls(script)).toEqual([]);
     expect(script).toMatch(/PG_SCRUB\[@\]\}" psql -X/);
     expect(script).toMatch(/PG_SCRUB\[@\]\}" "\$PG_DUMP"/);
     expect(script).toMatch(/PG_SCRUB\[@\]\}" "\$PG_RESTORE"/);
+  });
+
+  it("scrubs the post-restore schema replay too, so the guard has no exception", () => {
+    // node-postgres ignores PGHOSTADDR and this runs after the destructive step, so it is uniformity
+    // rather than a fix — but an unpinned uniformity change is one silent edit from being an exception,
+    // and an exception makes the guard's silence mean "everything except that one".
+    expect(shellCode(SCRIPT)).toMatch(/DATABASE_URL="\$TARGET_URL" "\$\{PG_SCRUB\[@\]\}" npm/);
   });
 
   it("REFUSES if the scrub list itself comes back empty", () => {

--- a/test/guards/staging-refresh.test.ts
+++ b/test/guards/staging-refresh.test.ts
@@ -80,7 +80,12 @@ function unscrubbedCalls(script: string): string[] {
     // No non-quote prefix class here: the first spelling used `[^\w"]`, which can never match a token
     // that STARTS with a quote — so `"$PG_RESTORE" …` at line start was invisible and the detector
     // reported clean. Caught by the known-bad sample below, which is the only reason this comment exists.
-    .filter((line) => /(?:\bpsql\b|"\$PG_DUMP"|"\$PG_RESTORE")/.test(line))
+    // Binary NAMES as well as the variable spellings, symmetrically: `psql` was matched by name while
+    // pg_dump/pg_restore were matched only as `"$PG_DUMP"`/`"$PG_RESTORE"`, so a future edit invoking a
+    // literal `pg_restore …` — the most dangerous binary of the three — would have walked past.
+    .filter((line) => /(?:\bpsql\b|\bpg_dump\b|\bpg_restore\b|"\$PG_DUMP"|"\$PG_RESTORE")/.test(line))
+    // An ASSIGNMENT names the binary, it does not run it (`PG_DUMP="$PG_BIN/pg_dump"`).
+    .filter((line) => !/^\s*[A-Z_]+=/.test(line))
     // A `[[ -n "$PG_DUMP" ]]` test REFERENCES the binary, it does not run it — flagging it was the
     // detector's other failure direction, found the same way as the first: by running it on real input.
     .filter((line) => !line.includes("[["))
@@ -95,10 +100,17 @@ function sourceFiles(dir: string): string[] {
     .map((f) => join(dir, f));
 }
 
-/** An input that violates NOTHING — the baseline every single-layer test perturbs by exactly one field. */
+/**
+ * An input that violates NOTHING — the baseline every single-layer test perturbs by exactly one field.
+ *
+ * The urls carry NO userinfo on purpose. Written as `postgresql://u:p@host/db` they are indistinguishable
+ * to a secret scanner from a real hardcoded credential, and a repo that trains its readers to skim past
+ * "it's only a test fixture" has taught them the wrong reflex. Nothing here reads the userinfo: every
+ * refusal under test keys on scheme, host, or query parameters.
+ */
 const VALID = Object.freeze({
-  sourceUrl: "postgresql://u:p@prod-proxy.rlwy.net:33781/railway",
-  targetUrl: "postgresql://u:p@staging-proxy.rlwy.net:41999/railway",
+  sourceUrl: "postgresql://prod-proxy.rlwy.net:33781/railway",
+  targetUrl: "postgresql://staging-proxy.rlwy.net:41999/railway",
   markerPresent: true,
   sourceMarkerPresent: false, // production has no staging marker
   clientMajor: 18,
@@ -198,7 +210,7 @@ describe("staging-refresh — the refusals, each proven to fail ALONE (criteria 
   it("REFUSES same-host INDEPENDENTLY of the marker — the copy-paste case dies on its own", () => {
     // Marker present, versions fine: the ONLY violation is that both URLs point at the same database.
     // Asserted as the exact refusal set, so this can never pass because some other layer caught it.
-    const sameHost = { ...VALID, targetUrl: "postgresql://u:p@prod-proxy.rlwy.net:33781/railway" };
+    const sameHost = { ...VALID, targetUrl: "postgresql://prod-proxy.rlwy.net:33781/railway" };
     expect(codes(decideRefresh(sameHost).refusals)).toEqual([REFUSAL.SAME_HOST]);
     // And it is a PREFLIGHT refusal, i.e. reachable with no database reading at all.
     expect(codes(refusalsForPreflight(sameHost))).toEqual([REFUSAL.SAME_HOST]);
@@ -300,15 +312,15 @@ describe("staging-refresh — the URL is not the destination (criteria 17, 18)",
     // So `staging…,prod…` passes the marker read (it reaches staging) and a later restore can land on
     // production if staging is briefly unreachable. Note WHY this was missed: the port-bearing spelling
     // makes `new URL()` throw and was refused by accident, while the portless one parsed cleanly.
-    expect(codes(decideRefresh({ ...VALID, targetUrl: "postgresql://u:p@staging.example,prod.example/db" }).refusals)).toEqual([
+    expect(codes(decideRefresh({ ...VALID, targetUrl: "postgresql://staging.example,prod.example/db" }).refusals)).toEqual([
       REFUSAL.MULTI_HOST,
     ]);
     // The accidentally-refused spelling must still be refused, but that is not what proves the layer.
-    expect(decideRefresh({ ...VALID, targetUrl: "postgresql://u:p@a.example:1,b.example:2/db" }).ok).toBe(false);
+    expect(decideRefresh({ ...VALID, targetUrl: "postgresql://a.example:1,b.example:2/db" }).ok).toBe(false);
   });
 
   it("REFUSES a url whose parsed form and raw form differ (a fragment)", () => {
-    expect(codes(decideRefresh({ ...VALID, targetUrl: "postgresql://u:p@staging.example/db#x" }).refusals)).toEqual([
+    expect(codes(decideRefresh({ ...VALID, targetUrl: "postgresql://staging.example/db#x" }).refusals)).toEqual([
       REFUSAL.UNSAFE_CONNECTION_PARAMS,
     ]);
   });
@@ -339,6 +351,8 @@ describe("staging-refresh — the URL is not the destination (criteria 17, 18)",
     expect(unscrubbedCalls('"$PG_RESTORE" --clean --dbname "$TARGET_URL" "$DUMP"')).not.toEqual([]);
     expect(unscrubbedCalls('"${PG_SCRUB[@]}" "$PG_RESTORE" --clean --dbname "$T" "$D"')).toEqual([]);
     expect(unscrubbedCalls('if [[ -n "$PG_DUMP" && -x "$PG_DUMP" ]]; then')).toEqual([]); // a test, not a call
+    expect(unscrubbedCalls('  PG_DUMP="$PG_BIN/pg_dump"')).toEqual([]); // an assignment, not a call
+    expect(unscrubbedCalls('pg_restore --clean --dbname "$TARGET_URL" "$DUMP"')).not.toEqual([]); // literal binary
     expect(unscrubbedCalls(script)).toEqual([]);
     expect(script).toMatch(/PG_SCRUB\[@\]\}" psql -X/);
     expect(script).toMatch(/PG_SCRUB\[@\]\}" "\$PG_DUMP"/);

--- a/test/guards/staging-refresh.test.ts
+++ b/test/guards/staging-refresh.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  EXCLUDED_TABLE_DATA,
+  REFUSAL,
+  STAGING_MARKER_TABLE,
+  STAGING_VARIABLES,
+  ciphertextTables,
+  completionMessage,
+  decideRefresh,
+  excludeTableDataArgs,
+  hostOf,
+  missingCiphertextExclusions,
+  pgVersionRefusals,
+  refusalsForConnected,
+  refusalsForPreflight,
+} from "../../scripts/staging-refresh-decision.mjs";
+
+/**
+ * STAGING-1 — `scripts/staging-refresh.sh` copies PRODUCTION's Postgres into STAGING's own Postgres.
+ * Spec: `docs/design/staging-prod-shaped-data.md`, acceptance criteria 1–14.
+ *
+ * These assertions are derived from the SPEC, not from the implementation. The thing being guarded is
+ * a script whose failure mode is "restores over production", which no test can observe after the fact
+ * — so every layer below is asserted to fail ON ITS OWN. A defence-in-depth stack tested only through
+ * its outcome lets one layer rot invisibly behind a sibling that happens to catch everything, which is
+ * this repo's "defense-in-depth masks mutations" lesson.
+ *
+ * Two of these guards exist because a review round found the design wrong, and they encode the reason
+ * rather than the fix:
+ *   - the `*_ciphertext` SCAN exists because a draft excluded `integrations` alone while asserting the
+ *     category, and two more tables existed;
+ *   - the confirmation-exemption count exists because excluding `graph_episodes` is only correct while
+ *     the alarm it feeds remains unclearable — if a second unclearable alarm is ever hardcoded, someone
+ *     has to answer whether ITS ledger needs excluding too.
+ */
+
+const ROOT = join(__dirname, "..", "..");
+const SCRIPT_PATH = join(ROOT, "scripts", "staging-refresh.sh");
+const SCRIPT = readFileSync(SCRIPT_PATH, "utf8");
+const SCHEMA = readFileSync(join(ROOT, "postgres", "schema.sql"), "utf8");
+const MIGRATIONS_DIR = join(ROOT, "postgres", "migrations");
+const MIGRATIONS = readdirSync(MIGRATIONS_DIR)
+  .filter((f) => f.endsWith(".sql"))
+  .map((f) => readFileSync(join(MIGRATIONS_DIR, f), "utf8"))
+  .join("\n");
+const ALL_SQL = `${SCHEMA}\n${MIGRATIONS}`;
+
+/** Shell lines with whole-line comments removed — so a guard can scan for a FLAG without a comment
+ *  that merely names the flag either satisfying it or tripping it. */
+function shellCode(script: string): string {
+  return script
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+}
+
+/** TypeScript with comments removed. `//` is only treated as a comment at line start or after
+ *  whitespace, so a `https://` inside a string is not mistaken for one. */
+function tsCode(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "\n").replace(/(^|\s)\/\/.*$/gm, "$1");
+}
+
+/** Every .ts/.tsx file under a directory, recursively. */
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { recursive: true, encoding: "utf8" })
+    .filter((f) => (f.endsWith(".ts") || f.endsWith(".tsx")) && !f.endsWith(".test.ts"))
+    .map((f) => join(dir, f));
+}
+
+/** An input that violates NOTHING — the baseline every single-layer test perturbs by exactly one field. */
+const VALID = Object.freeze({
+  sourceUrl: "postgresql://u:p@prod-proxy.rlwy.net:33781/railway",
+  targetUrl: "postgresql://u:p@staging-proxy.rlwy.net:41999/railway",
+  markerPresent: true,
+  clientMajor: 18,
+  serverMajor: 18,
+});
+
+const codes = (refusals: { code: string }[]) => refusals.map((r) => r.code).sort();
+
+describe("staging-refresh — the exclusion CATEGORY (criteria 1, 2, 10)", () => {
+  it("excludes the data of every table in the real schema that carries a *_ciphertext column", () => {
+    expect(missingCiphertextExclusions(ALL_SQL)).toEqual([]);
+  });
+
+  it("is NON-VACUOUS: the scan finds the three known ciphertext tables by name", () => {
+    // Without this, a pattern that matched nothing would report "nothing missing" and read as a clean
+    // bill of health — the failure this repo has already shipped once ("a parser that matches nothing
+    // reports zero"). The names are asserted exactly: a scan that found FOUR things, or the wrong
+    // three, is not the check it claims to be.
+    expect(ciphertextTables(ALL_SQL)).toEqual([
+      "gateway_connections",
+      "integrations",
+      "member_secrets",
+    ]);
+  });
+
+  it("REPORTS a newly added ciphertext table as missing — the reason this is a scan and not a list", () => {
+    const future = `${ALL_SQL}\ncreate table if not exists webhook_targets (\n  id uuid primary key,\n  signing_ciphertext text not null\n);\n`;
+    expect(ciphertextTables(future)).toContain("webhook_targets");
+    expect(missingCiphertextExclusions(future)).toEqual(["webhook_targets"]);
+  });
+
+  it("finds a ciphertext column added by ALTER TABLE, not just one declared inside CREATE TABLE", () => {
+    // `integrations.secret_ciphertext` is added this way in the real schema. A scanner that only read
+    // create-table bodies would miss it and pass, while copying live connector credentials.
+    const sql = `create table if not exists plain (id uuid primary key);\nalter table widgets add column if not exists secret_ciphertext text;`;
+    expect(ciphertextTables(sql)).toEqual(["widgets"]);
+  });
+
+  it("does not invent a table from a COMMENT that merely mentions a ciphertext column", () => {
+    const sql = [
+      "create table if not exists innocent (",
+      "  id uuid primary key",
+      ");",
+      "-- DISTINCT from team `integrations.secret_ciphertext` (team-scoped): prose, not schema.",
+      "/* another_ciphertext mentioned in a block comment */",
+    ].join("\n");
+    expect(ciphertextTables(sql)).toEqual([]);
+  });
+
+  it("excludes graph_episodes — the ledger that feeds the one alarm no threshold can clear", () => {
+    expect(EXCLUDED_TABLE_DATA).toContain("graph_episodes");
+    expect(excludeTableDataArgs()).toContain("--exclude-table-data=graph_episodes");
+  });
+
+  it("keeps that reason live: exactly ONE hardcoded confirmation exemption exists under lib/, on graph_extract", () => {
+    // The observable is a LITERAL `failureClass: "confirmed"`. Ordinary confirmed failures are legion
+    // and legitimate, but they are DERIVED — `classifyFailure(...)` into a variable — so they cannot
+    // match. Only an exemption someone hardcodes can. That distinction is what makes this guard
+    // neither vacuous (it matches one thing today) nor noisy (refactoring the derived path cannot red
+    // it). If a second exemption appears, whoever added it must answer whether the ledger feeding it
+    // also needs excluding from the staging dump.
+    const hits = sourceFiles(join(ROOT, "lib"))
+      .map((f) => ({ file: f, src: tsCode(readFileSync(f, "utf8")) }))
+      .filter((f) => /failureClass:\s*"confirmed"/.test(f.src));
+    expect(hits.map((h) => h.file.replace(`${ROOT}/`, ""))).toEqual(["lib/ingest/pipeline-health.ts"]);
+    const src = hits[0].src;
+    expect(src.match(/failureClass:\s*"confirmed"/g)).toHaveLength(1);
+    // …and it belongs to the graph_extract leg, not to something else that drifted into the file.
+    const exemptBlock = src.slice(src.lastIndexOf("legs.push(", src.indexOf('failureClass: "confirmed"')));
+    expect(exemptBlock).toContain('source: "graph_extract"');
+  });
+});
+
+describe("staging-refresh — the refusals, each proven to fail ALONE (criteria 3, 4, 5, 12)", () => {
+  it("accepts the valid baseline — a check that refuses everything proves nothing", () => {
+    expect(decideRefresh(VALID)).toEqual({ ok: true, refusals: [] });
+  });
+
+  it("REFUSES a target with no staging marker, and names the marker and the remedy", () => {
+    const { ok, refusals } = decideRefresh({ ...VALID, markerPresent: false });
+    expect(ok).toBe(false);
+    expect(codes(refusals)).toEqual([REFUSAL.NO_MARKER]);
+    expect(refusals[0].reason).toContain(STAGING_MARKER_TABLE);
+    expect(refusals[0].reason).toContain("create table if not exists");
+  });
+
+  it("REFUSES when the marker is UNKNOWN — an unreadable answer is not a pass", () => {
+    expect(codes(decideRefresh({ ...VALID, markerPresent: null }).refusals)).toEqual([
+      REFUSAL.MARKER_UNKNOWN,
+    ]);
+  });
+
+  it("REFUSES same-host INDEPENDENTLY of the marker — the copy-paste case dies on its own", () => {
+    // Marker present, versions fine: the ONLY violation is that both URLs point at the same database.
+    // Asserted as the exact refusal set, so this can never pass because some other layer caught it.
+    const sameHost = { ...VALID, targetUrl: "postgresql://u:p@prod-proxy.rlwy.net:33781/railway" };
+    expect(codes(decideRefresh(sameHost).refusals)).toEqual([REFUSAL.SAME_HOST]);
+    // And it is a PREFLIGHT refusal, i.e. reachable with no database reading at all.
+    expect(codes(refusalsForPreflight(sameHost))).toEqual([REFUSAL.SAME_HOST]);
+  });
+
+  it("REFUSES a missing source URL alone, and a missing target URL alone", () => {
+    expect(codes(decideRefresh({ ...VALID, sourceUrl: "" }).refusals)).toEqual([REFUSAL.MISSING_SOURCE]);
+    expect(codes(decideRefresh({ ...VALID, targetUrl: undefined }).refusals)).toEqual([
+      REFUSAL.MISSING_TARGET,
+    ]);
+  });
+
+  it("treats an UNPARSEABLE url as missing, never as 'different from the other one'", () => {
+    expect(hostOf("not a url")).toBeNull();
+    expect(codes(decideRefresh({ ...VALID, targetUrl: "not a url" }).refusals)).toEqual([
+      REFUSAL.MISSING_TARGET,
+    ]);
+  });
+
+  it("REFUSES a pg_dump older than the server, names the remedy, and ACCEPTS equal or newer", () => {
+    const [refusal] = pgVersionRefusals(14, 18);
+    expect(refusal.code).toBe(REFUSAL.PG_CLIENT_TOO_OLD);
+    expect(refusal.reason).toContain("postgresql@18");
+    expect(pgVersionRefusals(18, 18)).toEqual([]);
+    expect(pgVersionRefusals(19, 18)).toEqual([]);
+    expect(pgVersionRefusals(null, 18)[0].code).toBe(REFUSAL.PG_VERSION_UNKNOWN);
+    expect(pgVersionRefusals(18, NaN)[0].code).toBe(REFUSAL.PG_VERSION_UNKNOWN);
+  });
+
+  it("reports EVERY violated layer at once, so one layer cannot mask another", () => {
+    const allBad = { sourceUrl: "", targetUrl: "", markerPresent: null, clientMajor: 14, serverMajor: 18 };
+    expect(codes(decideRefresh(allBad).refusals)).toEqual(
+      [REFUSAL.MISSING_SOURCE, REFUSAL.MISSING_TARGET, REFUSAL.MARKER_UNKNOWN, REFUSAL.PG_CLIENT_TOO_OLD].sort()
+    );
+  });
+
+  it("keeps the connected layers reachable on their own", () => {
+    expect(codes(refusalsForConnected({ markerPresent: true, clientMajor: 14, serverMajor: 18 }))).toEqual([
+      REFUSAL.PG_CLIENT_TOO_OLD,
+    ]);
+  });
+});
+
+describe("staging-refresh — what the SCRIPT may and may not contain (criteria 6, 8, 9, 11, 14)", () => {
+  const code = shellCode(SCRIPT);
+
+  it("has no DEFAULT for either connection URL", () => {
+    // `${VAR:-}` — an EMPTY fallback — is required under `set -u` so the refusal can be printed with
+    // its explanation. A non-empty default is the thing being forbidden: a default source is a second
+    // silent opinion about which database production is, and a default target is what gets destroyed.
+    for (const name of ["STAGING_REFRESH_SOURCE_URL", "STAGING_REFRESH_TARGET_URL"]) {
+      const defaults = [...code.matchAll(new RegExp(`\\$\\{${name}:-([^}]*)\\}`, "g"))].map((m) => m[1]);
+      expect(defaults.length).toBeGreaterThan(0); // it IS read — otherwise this test guards nothing
+      expect(defaults.every((d) => d.trim() === "")).toBe(true);
+    }
+  });
+
+  it("never passes the pg_restore flag that would recreate the database", () => {
+    // `--create` drops and recreates the target database, which takes the staging marker with it —
+    // and the marker is the only thing distinguishing a legal target from production.
+    expect(code).not.toMatch(/--create\b/);
+  });
+
+  it("uses exactly the restore flags docs/OPS.md §Restore documents", () => {
+    expect(code).toMatch(/--clean\s+--if-exists\s+--no-owner/);
+    const ops = readFileSync(join(ROOT, "docs", "OPS.md"), "utf8");
+    expect(ops).toContain("--clean --if-exists --no-owner");
+  });
+
+  it("replays the schema from a plain shell, NOT through the Railway CLI", () => {
+    // `scripts/pg-load-schema.mjs` calls assertServiceIdentity before it connects: off-Railway that
+    // no-ops, but under `railway run` it REFUSES, because Railway injects a non-AIOS service name.
+    // docs/OPS.md §Restore says to use a Railway shell and is wrong for this case.
+    expect(code).toMatch(/run pg:schema/);
+    expect(code).not.toMatch(/railway\s+run/);
+  });
+
+  it("performs NO Railway mutation of any kind", () => {
+    // Not variables, not deploys. A script that can set variables can point staging at production —
+    // and the obvious future convenience edit ("have it set the staging flags for you") is exactly
+    // the one this forbids.
+    expect(code).not.toMatch(/\brailway\b/);
+  });
+
+  it("never sets a mail provider", () => {
+    for (const name of ["RESEND_API_KEY", "SMTP_URL"]) {
+      expect(code).not.toMatch(new RegExp(`${name}\\s*=`));
+    }
+  });
+
+  it("uses no bash-4-only builtin — the operator's macOS shell is bash 3.2 (criterion 15)", () => {
+    // `mapfile` was the first spelling of the exclusion-argument read, and on bash 3.2 it does not
+    // exist — so the script would have aborted at the DUMP step, i.e. after connecting to production,
+    // with a "command not found". Same shape as the pg_dump major-version trap: a toolchain fact that
+    // turns a correct design into a runbook nobody trusts. Verified: /usr/bin/env bash here is 3.2.57.
+    for (const builtin of [/\bmapfile\b/, /\breadarray\b/, /declare\s+-A\b/, /\$\{[A-Za-z_]+,,\}/]) {
+      expect(code).not.toMatch(builtin);
+    }
+  });
+
+  it("REFUSES rather than dumping everything if the exclusion list comes back empty", () => {
+    // Fail-closed on the one output whose emptiness is indistinguishable from "nothing to exclude":
+    // an empty list is a valid-looking `pg_dump` invocation that copies every reversible-secret table.
+    expect(code).toMatch(/EXCLUDE_ARGS\[@\]\}\s*-eq\s*0/);
+    expect(code).toMatch(/REFUSED: the exclusion list came back EMPTY/);
+  });
+
+  it("prints a completion message naming the hazard no code here can close", () => {
+    const msg = completionMessage();
+    expect(msg).toMatch(/GRAPHITI_URL/);
+    expect(msg).toMatch(/graph_episodes is empty/);
+    expect(msg).toMatch(/bill real extraction/);
+    expect(code).toMatch(/completion/); // and the script actually prints it
+  });
+});
+
+describe("staging-refresh — the durable marker and the runbook (criteria 7, 13)", () => {
+  it("fails the build if staging_marker ever enters the schema or a migration", () => {
+    // The marker survives `pg_restore --clean` only because the archive does not contain it. The day
+    // it ships to prod it enters the dump, the restore drops it, and the refusal above silently stops
+    // protecting anything. Keyed on the INVARIANT (absent from what prod runs), not on a filename.
+    expect(SCHEMA).not.toMatch(new RegExp(`\\b${STAGING_MARKER_TABLE}\\b`));
+    expect(MIGRATIONS).not.toMatch(new RegExp(`\\b${STAGING_MARKER_TABLE}\\b`));
+  });
+
+  it("keeps docs/OPS.md's staging variable table in step with the script's declared list", () => {
+    // A DOCUMENTATION-DRIFT guard, and labelled as one: the real state lives in Railway, so the
+    // runbook also requires a `railway variables` read-back. What this catches is a variable quietly
+    // dropping out of the prose while the design still depends on it.
+    const ops = readFileSync(join(ROOT, "docs", "OPS.md"), "utf8");
+    const section = ops.slice(ops.indexOf("## 11. Staging refresh"));
+    const documented = new Map<string, string>();
+    // `[A-Z0-9_]+`, with the digits: the first spelling of this pattern was `[A-Z_]+` and silently
+    // skipped `NEO4J_URL` — the row's absence read as agreement rather than as drift. The
+    // exact-set comparison below is what turned that into a failure instead of a quiet pass.
+    for (const m of section.matchAll(/^\|\s*`([A-Z0-9_]+)`\s*\|\s*(unset|`false`)\s*\|/gm)) {
+      documented.set(m[1], m[2] === "unset" ? "unset" : "false");
+    }
+    const declared = new Map(STAGING_VARIABLES.map((v) => [v.name, v.expected]));
+    expect([...documented.entries()].sort()).toEqual([...declared.entries()].sort());
+  });
+
+  it("declares GRAPHITI_URL unset — the boundary, not GRAPH_PROJECT_ENABLED", () => {
+    // GRAPH_PROJECT_ENABLED=false gates the interval poller only; the admin action and the
+    // graph-window battery script both call runGraphProjection directly. Unsetting GRAPHITI_URL is
+    // what makes all three inert, which `lib/graph/run.test.ts` pins behaviourally.
+    const graphiti = STAGING_VARIABLES.find((v) => v.name === "GRAPHITI_URL");
+    expect(graphiti?.expected).toBe("unset");
+    const flag = STAGING_VARIABLES.find((v) => v.name === "GRAPH_PROJECT_ENABLED");
+    expect(flag?.expected).toBe("false");
+  });
+});

--- a/test/guards/staging-refresh.test.ts
+++ b/test/guards/staging-refresh.test.ts
@@ -69,6 +69,25 @@ function tsCode(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, "\n").replace(/(^|\s)\/\/.*$/gm, "$1");
 }
 
+/**
+ * Lines invoking a libpq client WITHOUT the environment scrub in front of it. Written as a function so
+ * the test can prove it fires on a known-bad sample before trusting its silence on the real script.
+ */
+function unscrubbedCalls(script: string): string[] {
+  return script
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    // No non-quote prefix class here: the first spelling used `[^\w"]`, which can never match a token
+    // that STARTS with a quote — so `"$PG_RESTORE" …` at line start was invisible and the detector
+    // reported clean. Caught by the known-bad sample below, which is the only reason this comment exists.
+    .filter((line) => /(?:\bpsql\b|"\$PG_DUMP"|"\$PG_RESTORE")/.test(line))
+    // A `[[ -n "$PG_DUMP" ]]` test REFERENCES the binary, it does not run it — flagging it was the
+    // detector's other failure direction, found the same way as the first: by running it on real input.
+    .filter((line) => !line.includes("[["))
+    .filter((line) => !line.includes("PG_SCRUB[@]"))
+    .map((line) => line.trim());
+}
+
 /** Every .ts/.tsx file under a directory, recursively. */
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir, { recursive: true, encoding: "utf8" })
@@ -275,6 +294,37 @@ describe("staging-refresh — the URL is not the destination (criteria 17, 18)",
     ).toEqual([REFUSAL.SAME_HOST]);
   });
 
+  it("REFUSES a multi-host url — the half the query-param allowlist does not touch", () => {
+    // libpq tries a comma-separated host list in order, verified:
+    //   psql "postgresql://u@nonexistent-host-xyz.invalid,127.0.0.1/db" → fell through to 127.0.0.1
+    // So `staging…,prod…` passes the marker read (it reaches staging) and a later restore can land on
+    // production if staging is briefly unreachable. Note WHY this was missed: the port-bearing spelling
+    // makes `new URL()` throw and was refused by accident, while the portless one parsed cleanly.
+    expect(codes(decideRefresh({ ...VALID, targetUrl: "postgresql://u:p@staging.example,prod.example/db" }).refusals)).toEqual([
+      REFUSAL.MULTI_HOST,
+    ]);
+    // The accidentally-refused spelling must still be refused, but that is not what proves the layer.
+    expect(decideRefresh({ ...VALID, targetUrl: "postgresql://u:p@a.example:1,b.example:2/db" }).ok).toBe(false);
+  });
+
+  it("REFUSES a url whose parsed form and raw form differ (a fragment)", () => {
+    expect(codes(decideRefresh({ ...VALID, targetUrl: "postgresql://u:p@staging.example/db#x" }).refusals)).toEqual([
+      REFUSAL.UNSAFE_CONNECTION_PARAMS,
+    ]);
+  });
+
+  it("gives the runbook's one-time marker command the same url armour, chained to fail closed", () => {
+    const decision = join(ROOT, "scripts", "staging-refresh-decision.mjs");
+    const poisoned = spawnSync(process.execPath, [decision, "check-url", "--url", "postgresql://staging.example/db?hostaddr=1.2.3.4"], { encoding: "utf8" });
+    expect(poisoned.status).toBe(1);
+    expect(poisoned.stdout).not.toContain(DECISION_ACK);
+    const clean = spawnSync(process.execPath, [decision, "check-url", "--url", "postgresql://staging.example/db"], { encoding: "utf8" });
+    expect(clean.status).toBe(0);
+    const ops = readFileSync(join(ROOT, "docs", "OPS.md"), "utf8");
+    const section = ops.slice(ops.indexOf("## 11. Staging refresh"));
+    expect(section).toMatch(/check-url --url "\$STAGING_REFRESH_TARGET_URL" && \\/);
+  });
+
   it("scrubs the libpq environment for every call, and the script uses the module's list", () => {
     // PGHOSTADDR redirects with the URL untouched, so the allowlist above is only half the fix.
     expect(SCRUBBED_PG_ENV).toContain("PGHOSTADDR");
@@ -282,9 +332,14 @@ describe("staging-refresh — the URL is not the destination (criteria 17, 18)",
     const script = shellCode(SCRIPT);
     expect(script).toMatch(/scrubbed-env/); // the list comes FROM the module — one owner, no drift
     // Every libpq invocation goes through the scrub: no bare psql/pg_dump/pg_restore call.
-    for (const m of script.matchAll(/^\s*(?:if\s+\w+="\$\()?"?(psql|\$PG_DUMP|\$PG_RESTORE)/gm)) {
-      throw new Error(`unscrubbed libpq invocation: ${m[0].trim()}`);
-    }
+    // The detector is applied to a KNOWN-BAD sample first. A scan that matches nothing reports a clean
+    // bill of health identically to a scan that found nothing wrong, and this repo has shipped that
+    // exact failure before — so the pattern proves it can fire before it is trusted to say "clean".
+    expect(unscrubbedCalls('  raw="$(psql -X "$url" -tAc "select 1")"')).not.toEqual([]);
+    expect(unscrubbedCalls('"$PG_RESTORE" --clean --dbname "$TARGET_URL" "$DUMP"')).not.toEqual([]);
+    expect(unscrubbedCalls('"${PG_SCRUB[@]}" "$PG_RESTORE" --clean --dbname "$T" "$D"')).toEqual([]);
+    expect(unscrubbedCalls('if [[ -n "$PG_DUMP" && -x "$PG_DUMP" ]]; then')).toEqual([]); // a test, not a call
+    expect(unscrubbedCalls(script)).toEqual([]);
     expect(script).toMatch(/PG_SCRUB\[@\]\}" psql -X/);
     expect(script).toMatch(/PG_SCRUB\[@\]\}" "\$PG_DUMP"/);
     expect(script).toMatch(/PG_SCRUB\[@\]\}" "\$PG_RESTORE"/);

--- a/test/guards/staging-refresh.test.ts
+++ b/test/guards/staging-refresh.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { readdirSync, readFileSync } from "node:fs";
+import { copyFileSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
 import {
   EXCLUDED_TABLE_DATA,
   REFUSAL,
   STAGING_MARKER_TABLE,
+  DECISION_ACK,
+  SCRUBBED_PG_ENV,
+  ALLOWED_URL_PARAMS,
+  fkDependents,
+  missingFkClosure,
   STAGING_VARIABLES,
   ciphertextTables,
   completionMessage,
@@ -74,6 +81,7 @@ const VALID = Object.freeze({
   sourceUrl: "postgresql://u:p@prod-proxy.rlwy.net:33781/railway",
   targetUrl: "postgresql://u:p@staging-proxy.rlwy.net:41999/railway",
   markerPresent: true,
+  sourceMarkerPresent: false, // production has no staging marker
   clientMajor: 18,
   serverMajor: 18,
 });
@@ -104,8 +112,12 @@ describe("staging-refresh — the exclusion CATEGORY (criteria 1, 2, 10)", () =>
   });
 
   it("finds a ciphertext column added by ALTER TABLE, not just one declared inside CREATE TABLE", () => {
-    // `integrations.secret_ciphertext` is added this way in the real schema. A scanner that only read
-    // create-table bodies would miss it and pass, while copying live connector credentials.
+    // The real schema uses BOTH shapes for `integrations.secret_ciphertext` — declared in the create-table
+    // body AND re-applied by an `alter … add column if not exists` (the migration-mirror pattern), so a
+    // create-only scanner would not miss THAT one. The gap this closes is the next column that arrives by
+    // migration alone, which is the documented way to add a column to an existing table in this repo.
+    // (An earlier version of this comment claimed the create-only scanner would miss `integrations`
+    // today. It would not; the claim was wrong and the test is still worth having.)
     const sql = `create table if not exists plain (id uuid primary key);\nalter table widgets add column if not exists secret_ciphertext text;`;
     expect(ciphertextTables(sql)).toEqual(["widgets"]);
   });
@@ -133,7 +145,7 @@ describe("staging-refresh — the exclusion CATEGORY (criteria 1, 2, 10)", () =>
     // neither vacuous (it matches one thing today) nor noisy (refactoring the derived path cannot red
     // it). If a second exemption appears, whoever added it must answer whether the ledger feeding it
     // also needs excluding from the staging dump.
-    const hits = sourceFiles(join(ROOT, "lib"))
+    const hits = [...sourceFiles(join(ROOT, "lib")), ...sourceFiles(join(ROOT, "app"))]
       .map((f) => ({ file: f, src: tsCode(readFileSync(f, "utf8")) }))
       .filter((f) => /failureClass:\s*"confirmed"/.test(f.src));
     expect(hits.map((h) => h.file.replace(`${ROOT}/`, ""))).toEqual(["lib/ingest/pipeline-health.ts"]);
@@ -198,16 +210,182 @@ describe("staging-refresh — the refusals, each proven to fail ALONE (criteria 
   });
 
   it("reports EVERY violated layer at once, so one layer cannot mask another", () => {
-    const allBad = { sourceUrl: "", targetUrl: "", markerPresent: null, clientMajor: 14, serverMajor: 18 };
+    const allBad = { sourceUrl: "", targetUrl: "", markerPresent: null, sourceMarkerPresent: null, clientMajor: 14, serverMajor: 18 };
     expect(codes(decideRefresh(allBad).refusals)).toEqual(
-      [REFUSAL.MISSING_SOURCE, REFUSAL.MISSING_TARGET, REFUSAL.MARKER_UNKNOWN, REFUSAL.PG_CLIENT_TOO_OLD].sort()
+      [
+        REFUSAL.MISSING_SOURCE,
+        REFUSAL.MISSING_TARGET,
+        REFUSAL.MARKER_UNKNOWN,
+        REFUSAL.MARKER_UNKNOWN, // target and source are separate readings, separately unknown
+        REFUSAL.PG_CLIENT_TOO_OLD,
+      ].sort()
     );
   });
 
   it("keeps the connected layers reachable on their own", () => {
-    expect(codes(refusalsForConnected({ markerPresent: true, clientMajor: 14, serverMajor: 18 }))).toEqual([
-      REFUSAL.PG_CLIENT_TOO_OLD,
+    expect(
+      codes(refusalsForConnected({ markerPresent: true, sourceMarkerPresent: false, clientMajor: 14, serverMajor: 18 }))
+    ).toEqual([REFUSAL.PG_CLIENT_TOO_OLD]);
+  });
+});
+
+describe("staging-refresh — the URL is not the destination (criteria 17, 18)", () => {
+  // VERIFIED BY RUNNING IT, not inferred: libpq honours `hostaddr` from a URI query string AND from
+  // the ambient environment, so a URL reading `staging-proxy…` can open a socket to production.
+  //   psql "postgresql://u@nonexistent-host-xyz.invalid:5432/db"                 → DNS failure
+  //   psql "postgresql://u@nonexistent-host-xyz.invalid:5432/db?hostaddr=127.0.0.1" → reached 127.0.0.1
+  //   PGHOSTADDR=127.0.0.1 psql "postgresql://u@nonexistent-host-xyz.invalid…"     → reached 127.0.0.1
+  // That defeats same-host (the parsed hosts differ) and the marker (the one-time create runs through
+  // the same libpq, so the marker gets planted on prod). Two layers, one bypass.
+  it("REFUSES a url carrying hostaddr — the parameter that moves the socket", () => {
+    const poisoned = { ...VALID, targetUrl: `${VALID.targetUrl}?hostaddr=10.0.0.9` };
+    expect(codes(decideRefresh(poisoned).refusals)).toEqual([REFUSAL.UNSAFE_CONNECTION_PARAMS]);
+    expect(decideRefresh(poisoned).refusals[0].reason).toMatch(/hostaddr/);
+  });
+
+  it("is an ALLOWLIST: an unknown parameter is refused even though it is not hostaddr", () => {
+    // The direction is the point. A denylist would have to enumerate every libpq parameter that can
+    // redirect a connection, forever; this refuses anything not known-inert.
+    expect(codes(decideRefresh({ ...VALID, sourceUrl: `${VALID.sourceUrl}?service=prod` }).refusals)).toEqual([
+      REFUSAL.UNSAFE_CONNECTION_PARAMS,
     ]);
+    expect(codes(decideRefresh({ ...VALID, sourceUrl: `${VALID.sourceUrl}?options=-csearch_path%3Devil` }).refusals)).toEqual([
+      REFUSAL.UNSAFE_CONNECTION_PARAMS,
+    ]);
+  });
+
+  it("ACCEPTS the inert parameters an operator actually needs — a refusal that fires on everything is not a check", () => {
+    expect(ALLOWED_URL_PARAMS).toContain("sslmode");
+    expect(decideRefresh({ ...VALID, targetUrl: `${VALID.targetUrl}?sslmode=require&connect_timeout=10` }).ok).toBe(true);
+  });
+
+  it("REFUSES a non-postgres scheme", () => {
+    expect(codes(decideRefresh({ ...VALID, targetUrl: "https://evil.example/db" }).refusals)).toEqual([
+      REFUSAL.UNSUPPORTED_SCHEME,
+    ]);
+    expect(decideRefresh({ ...VALID, targetUrl: "postgres://u:p@staging.example/db" }).ok).toBe(true);
+  });
+
+  it("treats a TRAILING DOT as the same host — the same-host layer must work alone", () => {
+    // `example.net.` and `example.net` are one DNS name. The marker layer would also catch this pair,
+    // which is exactly why it needed its own test: a layer that only works with help is not a layer.
+    expect(hostOf("postgresql://h.example.net./db")).toBe("h.example.net");
+    expect(
+      codes(refusalsForPreflight({ sourceUrl: "postgresql://h.example.net/db", targetUrl: "postgresql://h.example.net./db" }))
+    ).toEqual([REFUSAL.SAME_HOST]);
+  });
+
+  it("scrubs the libpq environment for every call, and the script uses the module's list", () => {
+    // PGHOSTADDR redirects with the URL untouched, so the allowlist above is only half the fix.
+    expect(SCRUBBED_PG_ENV).toContain("PGHOSTADDR");
+    expect(SCRUBBED_PG_ENV).toContain("PGSERVICE");
+    const script = shellCode(SCRIPT);
+    expect(script).toMatch(/scrubbed-env/); // the list comes FROM the module — one owner, no drift
+    // Every libpq invocation goes through the scrub: no bare psql/pg_dump/pg_restore call.
+    for (const m of script.matchAll(/^\s*(?:if\s+\w+="\$\()?"?(psql|\$PG_DUMP|\$PG_RESTORE)/gm)) {
+      throw new Error(`unscrubbed libpq invocation: ${m[0].trim()}`);
+    }
+    expect(script).toMatch(/PG_SCRUB\[@\]\}" psql -X/);
+    expect(script).toMatch(/PG_SCRUB\[@\]\}" "\$PG_DUMP"/);
+    expect(script).toMatch(/PG_SCRUB\[@\]\}" "\$PG_RESTORE"/);
+  });
+
+  it("REFUSES if the scrub list itself comes back empty", () => {
+    expect(shellCode(SCRIPT)).toMatch(/scrub list came back EMPTY/);
+  });
+
+  it("asks the one-time marker command in the runbook to carry the same armour", () => {
+    // The marker is created by a HUMAN running psql. If that call can be redirected, the marker lands
+    // on production and every later refusal reads a database it never inspected.
+    const ops = readFileSync(join(ROOT, "docs", "OPS.md"), "utf8");
+    const section = ops.slice(ops.indexOf("## 11. Staging refresh"));
+    const marker = section.slice(section.indexOf("create table if not exists staging_marker") - 600, section.indexOf("create table if not exists staging_marker") + 200);
+    expect(marker).toMatch(/-u PGHOSTADDR/);
+    expect(marker).toMatch(/psql -X/);
+  });
+
+  it("restores inside ONE transaction, so a failure leaves staging as it was", () => {
+    // Without it, a restore that dies halfway has already committed its drops: staging serves a
+    // half-dropped, half-restored database and the completion warning never prints.
+    expect(shellCode(SCRIPT)).toMatch(/--single-transaction\s+--clean\s+--if-exists\s+--no-owner/);
+  });
+});
+
+describe("staging-refresh — the swapped pair and the FK closure (criteria 20, 21)", () => {
+  it("REFUSES when the SOURCE carries the staging marker — the swap the target check cannot see", () => {
+    // If production ever acquired the marker by accident (an operator declaring staging with the target
+    // variable mis-set), the target check passes for a swapped pair FOREVER and nothing notices. Read
+    // the marker from the other side: a legitimate source is production, and production has no marker.
+    const swapped = { ...VALID, sourceMarkerPresent: true };
+    expect(codes(decideRefresh(swapped).refusals)).toEqual([REFUSAL.SOURCE_IS_STAGING]);
+    expect(decideRefresh(swapped).refusals[0].reason).toMatch(/swapped/);
+  });
+
+  it("REFUSES when the SOURCE marker is unreadable — unknown is a refusal on both sides", () => {
+    expect(codes(decideRefresh({ ...VALID, sourceMarkerPresent: null }).refusals)).toEqual([
+      REFUSAL.MARKER_UNKNOWN,
+    ]);
+  });
+
+  it("excludes the FK-dependent CLOSURE of every excluded table, transitively", () => {
+    // Excluding a parent's data while dumping a child's is not a subset — it is a restore that fails at
+    // constraint creation. Measured: gateway_connections has three dependents and gateway_approvals
+    // hangs off one of THEM, so a one-level check reported clean until the three were added.
+    expect(missingFkClosure(ALL_SQL)).toEqual([]);
+  });
+
+  it("is NON-VACUOUS about the closure: dropping one dependent reports it", () => {
+    const partial = EXCLUDED_TABLE_DATA.filter((t) => t !== "gateway_executions");
+    expect(missingFkClosure(ALL_SQL, partial)).toContain("gateway_executions");
+    expect(fkDependents(ALL_SQL, "gateway_connections")).toContain("gateway_executions");
+  });
+
+  it("does not claim a dependency that is not there", () => {
+    // graph_episodes deliberately has NO foreign key to items (docs/OPS.md §10 depends on that), so a
+    // scanner reporting one would be inventing edges.
+    expect(fkDependents(ALL_SQL, "graph_episodes")).toEqual([]);
+  });
+});
+
+describe("staging-refresh — the decision CLI cannot approve by silence (criterion 22)", () => {
+  it("refuses from a symlinked path and a path containing a space", () => {
+    // VERIFIED as a live bug before it was fixed: the entry guard compared `file://${process.argv[1]}`
+    // to import.meta.url, so from /tmp (a symlink to /private/tmp) or a directory with a space, main()
+    // never ran — no output, exit 0 — and the shell reads exit 0 as approval. Realpath BOTH sides:
+    // pathToFileURL alone fixes only the percent-encoding half.
+    const dir = mkdtempSync(join(tmpdir(), "staging refresh guard "));
+    const copy = join(dir, "decision.mjs");
+    copyFileSync(join(ROOT, "scripts", "staging-refresh-decision.mjs"), copy);
+    const res = spawnSync(process.execPath, [copy, "preflight", "--source", "", "--target", ""], {
+      encoding: "utf8",
+    });
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/REFUSED/);
+    expect(res.stdout).not.toContain(DECISION_ACK);
+  });
+
+  it("prints a positive ack when it allows, and the shell REQUIRES that ack", () => {
+    const res = spawnSync(
+      process.execPath,
+      [
+        join(ROOT, "scripts", "staging-refresh-decision.mjs"),
+        "preflight",
+        "--source",
+        "postgresql://a.example/db",
+        "--target",
+        "postgresql://b.example/db",
+      ],
+      { encoding: "utf8" }
+    );
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain(DECISION_ACK);
+    // The shell must not treat exit 0 alone as approval — silence is the failure this pins.
+    const script = shellCode(SCRIPT);
+    expect(script).toContain(DECISION_ACK);
+    expect(script).toMatch(/produced no verdict/);
+    // …and every decision call goes through the ack-checking wrapper, not bare `node "$DECIDE"`.
+    const bare = [...script.matchAll(/^\s*node "\$DECIDE" (preflight|check)/gm)];
+    expect(bare).toEqual([]);
   });
 });
 
@@ -222,6 +400,8 @@ describe("staging-refresh — what the SCRIPT may and may not contain (criteria 
       const defaults = [...code.matchAll(new RegExp(`\\$\\{${name}:-([^}]*)\\}`, "g"))].map((m) => m[1]);
       expect(defaults.length).toBeGreaterThan(0); // it IS read — otherwise this test guards nothing
       expect(defaults.every((d) => d.trim() === "")).toBe(true);
+      // `:=` ASSIGNS a default and would sail past the check above, which only reads the `:-` form.
+      expect(code).not.toMatch(new RegExp(`\\$\\{${name}:=`));
     }
   });
 
@@ -229,6 +409,7 @@ describe("staging-refresh — what the SCRIPT may and may not contain (criteria 
     // `--create` drops and recreates the target database, which takes the staging marker with it —
     // and the marker is the only thing distinguishing a legal target from production.
     expect(code).not.toMatch(/--create\b/);
+    expect(code).not.toMatch(/\s-C\b/); // the short spelling does the same thing and read as clean
   });
 
   it("uses exactly the restore flags docs/OPS.md §Restore documents", () => {
@@ -275,6 +456,13 @@ describe("staging-refresh — what the SCRIPT may and may not contain (criteria 
     expect(code).toMatch(/REFUSED: the exclusion list came back EMPTY/);
   });
 
+  it("removes the dump on every exit path", () => {
+    // The dump holds prod items, member emails and api-key hashes. Left in /tmp it is a copy of
+    // production with no expiry, created by a script whose whole subject is not leaking production.
+    expect(code).toMatch(/trap cleanup EXIT/);
+    expect(code).toMatch(/rm -f "\$DUMP_FILE"/);
+  });
+
   it("prints a completion message naming the hazard no code here can close", () => {
     const msg = completionMessage();
     expect(msg).toMatch(/GRAPHITI_URL/);
@@ -299,13 +487,22 @@ describe("staging-refresh — the durable marker and the runbook (criteria 7, 13
     // dropping out of the prose while the design still depends on it.
     const ops = readFileSync(join(ROOT, "docs", "OPS.md"), "utf8");
     const section = ops.slice(ops.indexOf("## 11. Staging refresh"));
-    const documented = new Map<string, string>();
+    // Parse EVERY env-var row, not only the well-formed ones. A Map built from matches alone can
+    // equal the declared set while a second, contradictory row for the same variable sits beside it —
+    // the human reads the wrong one and the guard is still green.
     // `[A-Z0-9_]+`, with the digits: the first spelling of this pattern was `[A-Z_]+` and silently
-    // skipped `NEO4J_URL` — the row's absence read as agreement rather than as drift. The
-    // exact-set comparison below is what turned that into a failure instead of a quiet pass.
-    for (const m of section.matchAll(/^\|\s*`([A-Z0-9_]+)`\s*\|\s*(unset|`false`)\s*\|/gm)) {
-      documented.set(m[1], m[2] === "unset" ? "unset" : "false");
+    // skipped `NEO4J_URL` — the row's absence read as agreement rather than as drift.
+    const rows = [...section.matchAll(/^\|\s*`([A-Z0-9_]+)`\s*\|([^|]*)\|/gm)].map((m) => ({
+      name: m[1],
+      expected: m[2].trim(),
+    }));
+    expect(rows.length).toBe(STAGING_VARIABLES.length);
+    const names = rows.map((r) => r.name);
+    expect(names).toEqual([...new Set(names)]); // no variable documented twice
+    for (const row of rows) {
+      expect(["unset", "`false`"]).toContain(row.expected); // no free-text expectation
     }
+    const documented = new Map(rows.map((r) => [r.name, r.expected === "unset" ? "unset" : "false"]));
     const declared = new Map(STAGING_VARIABLES.map((v) => [v.name, v.expected]));
     expect([...documented.entries()].sort()).toEqual([...declared.entries()].sort());
   });


### PR DESCRIPTION
Staging exists and serves, but its Postgres holds 10 demo items against production's 2,833 — so it cannot be used to look at a branch against real data. This adds the refresh that fixes that, and nothing else.

`scripts/staging-refresh.sh` copies **production's** Postgres into **staging's own** Postgres. The dangerous direction is the reverse one — `pg_restore --clean` is destructive, so a target pointed at prod destroys prod — and most of this PR is what the script refuses.

## What ships

- **The dump excludes the DATA of every table carrying a `*_ciphertext` column** — reversible secrets — found by **scanning** `postgres/schema.sql` + `postgres/migrations/`, not by a hand-kept list. A draft of this spec excluded `integrations` alone while asserting the category; two more tables existed, one of them `member_secrets`, which holds write-capable Slack **user** tokens that `GET /api/v1/me/slack-token` hands back to an authenticated caller.
- **`graph_episodes` is excluded too**, for a different reason: copied against staging's empty graph it drives `deriveExtractionVerdict` to "stalled", and the synthetic `graph_extract` leg that follows is the one **confirmation-exempt** leg in the system — a red "graph extraction is broken" banner that no staleness threshold could ever clear, manufactured by our own refresh.
- **Refusals, each proven to fail alone:** no `staging_marker` on the target · source and target on the same host (checked **before any connection**) · a missing or unparseable URL · an unreadable marker or version reading (unknown fails **closed**) · a `pg_dump` older than the server · an empty exclusion list.
- **The script mutates no Railway state and sets no mail provider.** Guards pin both — a script that can set variables can point staging at production.
- `docs/OPS.md` §11: the runbook, plus the staging variable set, machine-checked against the script's own declared list.

## What is deliberately NOT in it

- **No graph.** The operator ruled out enabling a TCP proxy on prod's Neo4j, so staging reaches neither prod's Neo4j nor prod's Graphiti. Staging is a **Postgres-shaped** preview: the learning panel, `graph-query` and the semantic retrieval leg render empty; narrative arcs show prod's cached arcs for 4h and linger up to 48h before blanking. Priced in the spec rather than discovered.
- **No cron.** Runnable by hand; schedule it once it has been boring.
- **No PITR/fork copy.** Named as the upgrade path if the dump route proves risky.
- **The residual hazard is stated, not closed:** the emptied `graph_episodes` ledger means that if `GRAPHITI_URL` is ever set on staging, the whole restored corpus looks unprojected and projection bills real extraction. Three non-test entrypoints reach it. Said in the runbook and in the script's completion message, where the person who would do it is looking.

## Verification

| | |
|---|---|
| tsc | clean |
| lint | 0 errors (16 pre-existing warnings) |
| unit | **3200 passed**, 11 skipped |
| docs drift | in sync (routes 64 · tables 85 · sources 8) |
| spec gate | `SPEC_READY`, exit 0, 24 criteria |
| data-mechanics | **passed on CI in 10m20s.** Not run locally and not applicable: this PR adds no `lib/`/`app/` runtime code (the one `lib/` edit is a docstring) and no schema; everything it adds is pure and covered by the unit tier. |
| integration (HTTP) | passed on CI |
| CI | all required checks green |

**37 mutations run; 36 REDDENED on their intended test and one SURVIVED and was acted on** (verdicts pasted from `scripts/mutate.mjs`, not narrated). 1–18 are the original build; 19–37 pin the layers added while folding four rounds of code review. The survivor is the interesting one and is described under "Two things the mutations caught" below.

| # | mutation | reddened |
|---|---|---|
| 1 | drop `graph_episodes` from the exclusion set | "excludes graph_episodes — the ledger that feeds the one alarm no threshold can clear" |
| 2 | drop `member_secrets` from the exclusion set | "excludes the data of every table … that carries a `*_ciphertext` column" |
| 3 | ciphertext pattern matches nothing | "is NON-VACUOUS: the scan finds the three known ciphertext tables by name" |
| 4 | stop stripping SQL comments | 4 tests incl. "does not invent a table from a COMMENT" |
| 5 | ignore `ALTER TABLE` ownership | "finds a ciphertext column added by ALTER TABLE" |
| 6 | drop the same-host refusal | "REFUSES same-host INDEPENDENTLY of the marker" |
| 7 | treat a missing marker as fine | "REFUSES a target with no staging marker, and names the marker and the remedy" |
| 8 | treat an unknown marker as a pass | "REFUSES when the marker is UNKNOWN — an unreadable answer is not a pass" |
| 9 | never refuse an old `pg_dump` | "REFUSES a pg_dump older than the server … and ACCEPTS equal or newer" |
| 10 | drop `--if-exists --no-owner` | "uses exactly the restore flags docs/OPS.md §Restore documents" |
| 11 | let the script set a Railway variable | "performs NO Railway mutation of any kind" |
| 12 | pass the database-recreate flag | "never passes the pg_restore flag that would recreate the database" |
| 13 | reintroduce `mapfile` | "uses no bash-4-only builtin — the operator's macOS shell is bash 3.2" |
| 14 | disable the empty-exclusion refusal | "REFUSES rather than dumping everything if the exclusion list comes back empty" |
| 15 | drop `SENTRY_AUTH_TOKEN` from the OPS table | "keeps docs/OPS.md's staging variable table in step with the script's declared list" |
| 16 | a SECOND hardcoded confirmation exemption in `lib/` | "exactly ONE hardcoded confirmation exemption exists under lib/, on graph_extract" |
| 17 | `staging_marker` ships in `postgres/schema.sql` | "fails the build if staging_marker ever enters the schema or a migration" |
| 18 | completion message loses the billing hazard | "prints a completion message naming the hazard no code here can close" |
| 19 | drop the URL-parameter allowlist | "REFUSES a url carrying hostaddr" + "is an ALLOWLIST" |
| 20 | drop the scheme check | "REFUSES a non-postgres scheme" |
| 21 | stop normalising a trailing dot | "treats a TRAILING DOT as the same host" |
| 22 | drop the source-carries-marker refusal | "REFUSES when the SOURCE carries the staging marker" |
| 23 | revert the entry guard to the template string | "refuses from a symlinked path and a path containing a space" |
| 24 | stop printing the decision ack | "prints a positive ack when it allows, and the shell REQUIRES that ack" |
| 25 | `fkDependents` finds nothing | "is NON-VACUOUS about the closure" |
| 26 | use the short `-C` recreate flag | "never passes the pg_restore flag that would recreate the database" |
| 27 | give the target URL an assigned (`:=`) default | "has no DEFAULT for either connection URL" |
| 28 | drop `--single-transaction` | "restores inside ONE transaction, so a failure leaves staging as it was" |
| 29 | call the decision CLI without the ack wrapper | "the shell REQUIRES that ack" |
| 30 | run psql unscrubbed | "scrubs the libpq environment for every call" |
| 31 | drop the dump cleanup trap | "removes the dump on every exit path" |
| 32 | accept a multi-host authority | "REFUSES a multi-host url — the half the query-param allowlist does not touch" |
| 33 | accept a `#` fragment | "REFUSES a url whose parsed form and raw form differ" |
| 34 | drop the `check-url` subcommand | "gives the runbook's one-time marker command the same url armour" |
| 35 | break the unscrubbed-call detector the original way | "scrubs the libpq environment for every call" |
| 36 | detector loses the binary-name half again | "scrubs the libpq environment for every call" |
| 37 | unscrub the schema replay | **SURVIVED** first — then REDDENED "scrubs the post-restore schema replay too" once pinned |

## Two things the mutations caught

- **M37 SURVIVED.** Scrubbing the post-restore replay was a uniformity change nothing pinned — i.e. decoration, one silent edit from being an exception, and an exception makes the guard's silence mean "everything except that one". Pinned, then it reddens.
- **Chasing M37 found a hole in the detector's own assignment filter.** The filter `^\s*[A-Z_]+=` (added minutes earlier to stop a false positive on `PG_DUMP="$PG_BIN/pg_dump"`) also swallowed `VAR=x psql …`, which is a *command with an env prefix*, not an assignment. A hole opened by the fix for a false positive, which is the usual way one arrives. Both directions now carry samples.

## Two things found by building rather than by reviewing

- **The first draft used `mapfile`.** macOS ships **bash 3.2**, where it does not exist — so the script would have aborted at the DUMP step, *after* connecting to production, with a "command not found". Same shape as the `pg_dump` major-version trap the spec already records (`pg_dump` on PATH here is 14; both servers are 18). Both are now refusals or avoidances, and criterion 15 guards the shell one.
- **The runbook-drift guard's own regex was `[A-Z_]+`**, which silently skipped `NEO4J_URL` — a row's *absence* read as agreement. Caught because the guard compares the two sets exactly rather than checking containment.

## Review

Reviewed by Fable code-reviewer — verdict CLEAR after two rounds (round 1 BLOCKED: 2 High, 4 Medium, 5 Low; round 2 CLEAR: 1 Medium, 3 Low) — all folded
Reviewed by Codex gpt-5.5 — verdict BLOCKED in both rounds (round 1: 1 High, 1 Medium, 2 Low; round 2: 1 High, 1 Medium, 1 Low) — all folded

### The two HIGHs, both in the direction that matters

**Both reviewers, independently: the URL is not the destination.** libpq honours connection parameters from a URI query string and from the ambient environment. Verified by running it, not inferred:

```
psql "postgresql://u@nonexistent-host-xyz.invalid:5432/db"                    → could not translate host name
psql "postgresql://u@nonexistent-host-xyz.invalid:5432/db?hostaddr=127.0.0.1" → reached 127.0.0.1
PGHOSTADDR=127.0.0.1 psql "postgresql://u@nonexistent-host-xyz.invalid…"      → reached 127.0.0.1
```

That defeats *two* layers at once: same-host (the parsed hosts differ) **and** the staging marker — because the operator's one-time `create table staging_marker` runs through the same libpq, so the marker gets planted on **production**, after which `--clean` follows it there. Closed with an allowlist of URL parameters (a denylist would have to enumerate every redirecting parameter forever), a scrubbed libpq environment on every call, `psql -X`, and a `check-url &&` prefix on the runbook's marker command — the only libpq call this design asks a human to make.

**Fable alone: my refusals could approve by silence.** The decision CLI's entry guard compared `` `file://${process.argv[1]}` `` to `import.meta.url`. From a symlinked path or one containing a space it printed nothing and exited **0** — every refusal dead, with the shell reading exit 0 as a green light. Verified as a live bug before fixing. Realpathing both sides is the fix; `pathToFileURL` alone was verified insufficient (it addresses the percent-encoding half, not the symlink half). The durable half is a positive ACK token the shell now requires.

### Round 2 found a second-order miss inside the fix for round 1

**Codex: multi-host failover.** The query-parameter allowlist closed one half of the routing attack; libpq's comma-separated host list in the *authority* is the other. `psql "postgresql://u@nonexistent-host-xyz.invalid,127.0.0.1/db"` fell through to 127.0.0.1 — so a target of `staging…,prod…` passes every refusal (the marker read reaches staging and finds its marker) and a restore run while staging is briefly unreachable lands on production. **What hid it:** the port-bearing spelling (`a:1,b:2`) makes `new URL()` throw and was refused **by accident**, while the portless spelling parsed cleanly. A shape refused by accident is not a layer.

**Codex: one of my guards was vacuous.** The "no unscrubbed libpq call" scan used a prefix class `[^\w"]`, which can never match a token that *starts* with a quote — so `"$PG_RESTORE" …` at line start was invisible and the scan reported clean. It is now a named function asserted to **fire on known-bad samples** before its silence is trusted, and that assertion immediately caught a second bug in it (a false positive on a `[[ -n "$PG_DUMP" ]]` test), then a third (the assignment-filter hole above).

**Fable round 2, Medium — Codacy: my first triage was WRONG, and here is the verified state.** I hypothesised the "5 new issues" were six test fixtures written `postgresql://u:p@host/db` — credential-shaped connection strings, six added lines against five issues. I removed the userinfo (a good change on its own: nothing depended on it, and a repo that trains readers to skim past "it's only a fixture" has taught the wrong reflex) — **and the count did not change. That hypothesis is refuted.**

What is actually established, by running Codacy's own vendored tooling from `.codacy/codacy.yaml` against the changed files:

| probe | result |
|---|---|
| ShellCheck 0.11.0 on `scripts/staging-refresh.sh` | clean |
| trivy 0.69.3 `fs --scanners secret` on every changed file | clean |
| opengrep 1.16.4 (631 rules) on the script and the decision module | **0 findings** |
| gitleaks (CI) | pass |
| a grep of the whole diff against the live credential values read from Railway | no match |

The Codacy check exposes no per-issue detail through the API (`"5 new issues (0 max.) of at least  severity."` is the entire payload; the detail lives in the Codacy UI), and it is **not** in this repo's required check set — every required check is green. So: unreproduced locally with three of its own tools, no secret material in the diff, and I am **not** claiming it is benign, because I could not see what it says. It wants a human with Codacy UI access before merge. Recording it that way rather than as "triaged, non-substantive" — the earlier framing asserted a cause I had not verified, and the count is what disproved it.

### Refuted, with the reason recorded rather than quietly folded

- **Compare `host:port` instead of host.** Declined: host-only fails in the *safe* direction (it refuses a legitimate refresh); `host:port` would let a genuinely same-host pair through. Fable round 2 agreed on re-attack.
- **A call-site ledger guard for `runGraphProjection`.** Declined: all three entrypoints funnel through the same `client.configured` gate and are equally inert when `GRAPHITI_URL` is unset.
- **`docs/ARCHITECTURE.md:115` carries a stale "two callers" claim.** Not present there — it lived only in `lib/graph/run.ts`, and is fixed.

### Known residual, stated because it is the design's trust boundary

For a `--clean` restore to reach production, prod would have to *already carry a `staging_marker`* **and** the source be a third non-marker database on a different host. Target-is-prod-with-an-accidental-marker is fundamentally indistinguishable from target-is-staging, because the marker *is* the discriminator. What stands against it: the marker can only be created deliberately, the runbook's command now refuses a redirected URL, the runbook requires a read-back proving prod has none, the refresh refuses a marked *source*, and a build-failing guard keeps the marker out of `schema.sql` forever.

### Design review — five rounds before a line of code existed

- **Round 1 (BLOCKED)** — the sanitise-after design had an armed crash window; `SECRETS_KEY` divergence is not a boundary; a disabled scheduler does not stop reactive Linear write-back; "only the projector writes to the graph" was false.
- **Round 2 (BLOCKED)** — I had fixed an instance and called it a category: `member_secrets` existed, and scanning found a third table neither of us had looked at.
- **Round 3 (BLOCKED)** — the `graph_episodes` unclearable-alarm chain, and staging's live `RESEND_API_KEY` (byte-identical to prod's, verified sender domain) reaching real member addresses.
- **Round 4 (BLOCKED)** — the second-order bug in round 3's own fix: emptying the projector's ledger turns the admin "Project to graph now" button into a paid re-projection, because `GRAPH_PROJECT_ENABLED=false` gates only the interval poller. Plus staging and prod sharing one Sentry DSN.
- **Round 5 (CLEAR-WITH-CONDITIONS)** — the DSNs are only Sentry's runtime half (release upload is build-time under `SENTRY_AUTH_TOKEN`, into the same project); the confirmation-exemption guard needed a precise observable; a third projection entrypoint exists; criterion 13 is a documentation-drift guard and must be labelled as one.

**One earlier "review" was a non-result and is not counted as a pass:** a round-4 run exited 0 after ~125k tokens having produced no verdict — it died on overnight network errors and the exit code lied. It was re-run rather than recorded.

**No `--tier full` adversarial spec layer ran** (`DEEPSEEK_API_KEY` unset); the model reviews above stand in for it, stated rather than implied.

## Deferred, with reasons

- **The nightly cron** — ship it runnable by hand first.
- **A `staging_marker` creation step in the script** — deliberately manual. If the script created the marker it would create one on prod too, and the guard would be vacuous.
- **Excluding `api_keys` / `members`** — copied on purpose: staging sits behind the same auth, operated by the same person, and the brain is unusable without members. Safe *only* because the reversible-secret tables are gone — authentication with nothing to retrieve — and the ciphertext scan is what catches a future table that pairs the two.

AIOS-Work: STAGING-1
