### PR TITLE
fix(clickup): pagination guard, rate-window re-check, path collision suffix (AIO-924)

### DIFF
--- a/lib/ingest/sources/clickup-normalize.ts
+++ b/lib/ingest/sources/clickup-normalize.ts
@@ -39,8 +39,14 @@ function sha256(value: string): string {
 }
 
 function pathSegment(value: ClickUpId): string {
-  const segment = String(value).replace(/[^A-Za-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
-  return segment || sha256(String(value)).slice(0, 16);
+  const raw = String(value);
+  const segment = raw.replace(/[^A-Za-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  // Sanitizing is LOSSY: 'a.b' and 'a-b' both collapse to 'a-b', and `items` is unique on
+  // (team_id, project_id, path) — so two colliding ids meant one item silently overwrote the other.
+  // A sanitized id therefore carries a short digest of the raw id; an already-clean id returns
+  // unchanged, keeping every historical path stable.
+  if (segment === raw) return segment;
+  return segment ? `${segment}-${sha256(raw).slice(0, 8)}` : sha256(raw).slice(0, 16);
 }
 
 function projectFor(workspaceId: ClickUpId): string {

--- a/lib/ingest/sources/clickup.ts
+++ b/lib/ingest/sources/clickup.ts
@@ -274,8 +274,15 @@ export class ClickUpClient {
   }
 
   private async waitForRateWindow(): Promise<void> {
-    const delay = this.blockedUntilMs - this.now();
-    if (delay > 0) await this.sleep(Math.min(delay, this.maxRetryDelayMs));
+    // Re-check after every nap: a single capped sleep wakes early whenever the reset window exceeds
+    // maxRetryDelayMs, and a request fired into a window this client itself observed earns exactly
+    // the 429 the block exists to avoid. Each individual sleep stays capped so an injected clock —
+    // or a corrected `blockedUntilMs` — is consulted at least once per cap interval.
+    for (;;) {
+      const delay = this.blockedUntilMs - this.now();
+      if (delay <= 0) return;
+      await this.sleep(Math.min(delay, this.maxRetryDelayMs));
+    }
   }
 
   private observeRateLimit(response: Response): void {
@@ -370,6 +377,7 @@ export class ClickUpClient {
   async getTasksForList(listId: ClickUpId): Promise<ClickUpTask[]> {
     const id = encodeURIComponent(String(listId));
     const tasks: ClickUpTask[] = [];
+    let previousPageIds: string | undefined;
 
     for (let page = 0; page < this.maxPages; page += 1) {
       const query = new URLSearchParams({
@@ -388,6 +396,15 @@ export class ClickUpClient {
         idValue(value.id, "task");
         return value;
       });
+      // Mirror of the Docs repeated-cursor guard. A server that ignores `page` and keeps returning
+      // the same full page (with no `last_page`) never trips either termination check below, so it
+      // used to be walked for all maxPages (default 10,000) requests — accumulating up to 1M tasks
+      // in memory before the page-cap error finally fired. Detect the repeat on page two instead.
+      const pageIds = pageTasks.map((task) => String(task.id)).join("\n");
+      if (pageTasks.length > 0 && pageIds === previousPageIds) {
+        throw new ClickUpClientError("ClickUp task pagination repeated a page", "pagination");
+      }
+      previousPageIds = pageIds;
       tasks.push(...pageTasks);
 
       if (payload.last_page === true || pageTasks.length === 0) return tasks;

--- a/test/ingest-clickup-client.test.ts
+++ b/test/ingest-clickup-client.test.ts
@@ -53,6 +53,27 @@ describe("ClickUpClient task reads", () => {
     }
   });
 
+  it("fails closed when task pagination repeats a page instead of buffering toward maxPages", async () => {
+    // The Docs reader already guards a repeated cursor; the task reader had no equivalent. A server
+    // that ignores `page` and keeps returning the same full 100-task page (no `last_page`) used to be
+    // walked for all maxPages (default 10,000) requests — up to 1M tasks accumulated in memory before
+    // the page-cap error finally fired. The repeat must be detected on the SECOND page, not the cap.
+    let calls = 0;
+    const fullPage = {
+      tasks: Array.from({ length: 100 }, (_, index) => ({ id: `task-${index}`, name: `Task ${index}` })),
+    };
+    const transport: ClickUpTransport = async () => {
+      calls += 1;
+      return jsonResponse(fullPage);
+    };
+    const client = new ClickUpClient({ token: "test-clickup-token", transport, maxPages: 50 });
+
+    await expect(client.getTasksForList("101")).rejects.toThrow(
+      "ClickUp task pagination repeated a page"
+    );
+    expect(calls).toBe(2);
+  });
+
   it("supports string and integer task ids without using custom ids as identity", async () => {
     const transport: ClickUpTransport = async (input, init) => {
       expect(init.method).toBe("GET");
@@ -255,6 +276,38 @@ describe("ClickUpClient retry and rate-limit handling", () => {
     await client.getAuthorizedUser();
     await client.getAuthorizedUser();
     expect(sleeps).toEqual([2000]);
+  });
+
+  it("re-checks the rate window after a capped sleep instead of firing early into it", async () => {
+    // A reset window LONGER than maxRetryDelayMs used to be slept exactly once, capped — the waiter
+    // woke with the window still in force and fired anyway, earning precisely the 429 the block
+    // exists to avoid. It must keep sleeping (each nap still capped) until the window has passed.
+    let now = 1_000_000;
+    const sleeps: number[] = [];
+    const requestTimes: number[] = [];
+    const client = new ClickUpClient({
+      token: "test-clickup-token",
+      transport: async () => {
+        requestTimes.push(now);
+        // Reset epoch 150s ahead of the first request — 2.5x the 60s sleep cap below.
+        return jsonResponse({ user: { id: 7 } }, 200, {
+          "X-RateLimit-Remaining": "0",
+          "X-RateLimit-Reset": "1150",
+        });
+      },
+      maxRetryDelayMs: 60_000,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+        now += milliseconds;
+      },
+    });
+
+    await client.getAuthorizedUser();
+    await client.getAuthorizedUser();
+
+    expect(requestTimes[1]).toBeGreaterThanOrEqual(1_150_000);
+    expect(sleeps).toEqual([60_000, 60_000, 30_000]);
   });
 
   it("retries transient GET failures with bounded exponential delay", async () => {

--- a/test/ingest-clickup-normalize.test.ts
+++ b/test/ingest-clickup-normalize.test.ts
@@ -266,6 +266,27 @@ describe("ClickUp task normalization", () => {
     });
   });
 
+  it("keeps native ids that sanitize identically on distinct item paths", () => {
+    // `pathSegment` collapses every non-[A-Za-z0-9_-] run to '-', so 'ID.7' and 'ID-7' landed on the
+    // SAME path — and `items` is unique on (team_id, project_id, path), so one task document silently
+    // overwrote the other. A sanitized id now carries a short digest of the raw id; an already-clean
+    // id keeps its historical path, so nothing re-imports under a new name.
+    const collisionRecords: ClickUpTaskRecord[] = [
+      { task: { id: "ID.7", name: "Dotted" }, observedListIds: ["101"] },
+      { task: { id: "ID-7", name: "Dashed" }, observedListIds: ["101"] },
+    ];
+    const docs = normalizeClickUpTaskDocs({ workspaceId: 9001, records: collisionRecords });
+
+    const paths = docs.map((doc) => doc.path);
+    expect(new Set(paths).size).toBe(2);
+    // The clean id is untouched; only the sanitized one is disambiguated.
+    expect(paths).toContain("clickup/9001/tasks/ID-7.md");
+    // Deterministic: the same raw id maps to the same path on every import.
+    const dotted = docs.find((doc) => doc.frontmatter.native_id === "ID.7")!;
+    const again = normalizeClickUpTaskDocs({ workspaceId: 9001, records: [collisionRecords[0]] });
+    expect(again[0].path).toBe(dotted.path);
+  });
+
   it("emits authors[] that the source-agnostic attribution resolver actually reads", () => {
     // AIO-924. `taskMetadata` stamps `assignee_ids`/`assignee_emails` (PLURAL), but nothing consumes
     // them: `parseAuthorRefs` handles `assignee_id` (SINGULAR) for linear/plane only, and there is no


### PR DESCRIPTION
Reopened AIO-924, items 2–4 only. Item 1 (ClickUp task/Doc attribution) previously shipped in PR #573 (62c01e0c); this PR covers the three remaining read-hardening items. All three were re-verified present on the frozen base (`06ad6d6d`, `lib/ingest/sources/clickup.ts` unmodified since 343ac89c) before any change, and each fix is spec-first: the test below failed on the base, then went green after the fix.

## Item 2 — task pagination non-advancing-page guard

`searchDocs` already fails closed on a repeated cursor; `getTasksForList` had no equivalent. A server that ignores `page` and keeps returning the same full 100-task page (no `last_page`) was walked for all `maxPages` (default 10,000) requests, accumulating up to 1M tasks in memory before the page-cap error fired. Now a page whose task ids match the previous page's throws `ClickUpClientError("ClickUp task pagination repeated a page", "pagination")` on request two.

**RED** (on `06ad6d6d`): `npx vitest run test/ingest-clickup-client.test.ts` →
`AssertionError: expected [Function] to throw error including 'ClickUp task pagination repeated a pa…' but got 'ClickUp task pagination exceeded 50 p…'` — the base walked all 50 fixture pages to the cap.
**GREEN**: same command — `fails closed when task pagination repeats a page instead of buffering toward maxPages` passes (2 transport calls, named error).

## Item 3 — `waitForRateWindow` re-checks after a capped sleep

It slept `min(delay, maxRetryDelayMs)` once, so a reset window longer than the cap woke the waiter early and it fired into a window it had itself observed — earning a 429. It now loops until `now() >= blockedUntilMs`, each individual nap still capped, using the module's existing injectable `now`/`sleep`.

**RED** (on `06ad6d6d`): `npx vitest run test/ingest-clickup-client.test.ts` →
`AssertionError: expected 1060000 to be greater than or equal to 1150000` — with a 150s window and a 60s cap, the second request fired 90s early.
**GREEN**: same command — `re-checks the rate window after a capped sleep instead of firing early into it` passes (request fires at 1,150,000; sleeps `[60000, 60000, 30000]`).

## Item 4 — `pathSegment` collision suffix

`pathSegment` collapses every non-`[A-Za-z0-9_-]` run to `-`, so `ID.7` and `ID-7` landed on the SAME item path — and `items` is unique on `(team_id, project_id, path)` (schema.sql:1136), so one item silently overwrote the other. When sanitizing changed the input, the segment now carries a deterministic 8-hex sha256 suffix of the raw id. Already-clean ids return byte-identical paths (all existing fixture ids are clean — no pinned path assertion moved), and the empty-segment fallback (16-hex digest) is untouched. Nothing depends on the old collision: the overwrite was the bug, item identity lives in `frontmatter.identity`/`row_key`, and no consumer parses these paths back.

**RED** (on `06ad6d6d`): `npx vitest run test/ingest-clickup-normalize.test.ts` →
`AssertionError: expected 1 to be 2` — both records normalized onto `clickup/9001/tasks/ID-7.md`.
**GREEN**: same command — `keeps native ids that sanitize identically on distinct item paths` passes (`ID-7.md` + `ID-7-8c368a01.md`, deterministic across imports).

## Local gates

- `npm test` — 3154 passed | 11 skipped (341 files)
- `npm run lint` — 0 errors, 16 pre-existing warnings (none in touched files)
- `npm run typecheck` — clean
- `npm run check:docs` — congruent

No secret-shaped fixture values added (synthetic ids/names only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ingest path and rate-limit behavior change: colliding ClickUp ids get new document paths (clean ids stay put), and stuck pagination now errors instead of silently over-fetching. No auth or write-path changes.
> 
> **Overview**
> Hardens ClickUp ingest against three silent-failure modes: unbounded task paging, firing into a still-active rate window, and two native ids collapsing onto one item path.
> 
> `getTasksForList` now fails closed if a page’s task ids match the previous page, instead of walking all `maxPages` (default 10,000) and buffering up to ~1M tasks. `waitForRateWindow` loops with capped sleeps until `blockedUntilMs` has actually passed, so a reset longer than `maxRetryDelayMs` no longer wakes early into a 429.
> 
> `pathSegment` appends a short sha256 of the raw id when sanitizing changes the string (`ID.7` vs `ID-7`). Already-clean ids keep their historical paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e98ad84a306c91d91d9353dbeadaf0daa0d4e62. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


## Review — Reviewed by Codex CLI (gpt-5.6-sol, exec review vs origin/main) — verdict no reportable findings: pagination guard, rate-window loop, and collision-resistant path generation address the stated failure modes without evident regression
