### PR TITLE
fix(security): replace engagement identifiers with synthetic fixtures (AIO-1036)

### DIFF
--- a/docs/design/meeting-attendance-truth.md
+++ b/docs/design/meeting-attendance-truth.md
@@ -33,7 +33,7 @@ transcript ingestion or chunking.
 ## 0. The bug, reproduced on live data
 
 The owner reported that "Content creation strategy session" (2026-08-11) lists **Fatma** and **Abe
-Isleem** as attendees when neither was there. Confirmed, and the mechanism is exact.
+Doe** as attendees when neither was there. Confirmed, and the mechanism is exact.
 
 `lib/meetings/llm-extract.ts` asks a model for *"the full names of every person who appears to have
 attended or spoken"*, then `matchAttendees` keeps only names that resolve against the member roster.
@@ -51,7 +51,7 @@ The transcript's only speaker label is `**John Ellison:**`.
 1. **The roster filter concentrates the error onto real teammates.** Carol, Pranita, Yana and Chayton
    are mentioned too and were dropped for not being members. So every false attendee is, necessarily,
    someone who plausibly *could* have been there.
-2. **Stefan escaped by one letter.** Mentioned three times; the roster spells him `Stephan Ledain`, so
+2. **Stefan escaped by one letter.** Mentioned three times; the roster spells him `Stephan Doe`, so
    `matchAttendees`'s first-name fallback compared `stefan` ≠ `stephan`. A spelling coincidence is the
    only reason there were two false attendees rather than three.
 
@@ -193,7 +193,7 @@ agrees with what is already recorded, it is doing something other than what it c
 | AC5 the reported bug | ✅ **at unit level** (`resolveAttendance` with the shipped hallucination mocked). The spec asked for data-mechanics; **not built** |
 | AC6 calendar + transcript → one note | ❌ **not delivered — the merge is DORMANT** |
 | AC7 merge never crosses dates / merged notes | ❌ deferred with AC6 |
-| AC8 backfill corrects the bad meeting, leaves correct ones | ✅ **proven on prod, dry-run**: 17 changed, **22 already correct**, and exactly `REMOVE: Abe Isleem, Fatma` on the reported meeting |
+| AC8 backfill corrects the bad meeting, leaves correct ones | ✅ **proven on prod, dry-run**: 17 changed, **22 already correct**, and exactly `REMOVE: Abe Doe, Fatma` on the reported meeting |
 
 **AC6/AC7 are not delivered, and the first review is why this says so.** The title comparator was
 built and tested, and I wrote in `docs/ARCHITECTURE.md` and the commit message that a calendar event

--- a/docs/design/pm-link-uniqueness-invariant.md
+++ b/docs/design/pm-link-uniqueness-invariant.md
@@ -1,9 +1,9 @@
-# Nothing enforces the invariant the two adoption fixes exist to protect — ADOPTINV-1
+# Nothing enforces the invariant the two adoption fixes exist to protect — ADOPT-TASK-8
 
 **Status:** spec, draft 3 (built). Draft 1 was BLOCKED by both reviewers. The sharpest finding was that draft 1's
 own mutation criterion **could not go red** — it named the wrong file, and the mutant it described makes
 the adapter refuse *everything*, so no duplicate forms and the test stays green. · **Date:** 2026-08-18 ·
-**Owner:** Chetan · **Task:** `ADOPTINV-1`
+**Owner:** Chetan · **Task:** `ADOPT-TASK-8`
 **Follows:** [`pm-sync-declared-issue-adoption.md`](./pm-sync-declared-issue-adoption.md) (`ADOPTDECL-1`,
 #581) and [`pm-sync-footer-adoption-scope.md`](./pm-sync-footer-adoption-scope.md) (`ADOPTFOOT-1`, #588).
 **Unblocks:** `ADOPTUNIQ-1` — proves the code cannot violate the constraint *before* the constraint is added.

--- a/lib/meetings/attendance.ts
+++ b/lib/meetings/attendance.ts
@@ -5,7 +5,7 @@
  * WHY THIS EXISTS. Attendance used to be inferred by asking an LLM to name "every person who appears
  * to have attended or spoken", then keeping whatever matched the roster. That has no representation
  * of PRESENT versus DISCUSSED, so on 2026-08-11's "Content creation strategy session" it recorded
- * Abe Isleem and Fatma — both named only in the third person, and explicitly as absent ("one day to
+ * Abe Doe and Fatma — both named only in the third person, and explicitly as absent ("one day to
  * get Abe, who's in Germany… can we get him on Zoom?"). Meanwhile the item's own frontmatter said
  * `participants: "[John Ellison]"`, which was exactly right, and was ignored.
  *
@@ -36,7 +36,7 @@ export interface AttendanceResult {
  *
  * SHAPES THAT ACTUALLY OCCUR (measured across every row in prod carrying the field, 2026-08-17):
  *   granola, 45 rows, STRING:  "[John Ellison]"
- *                              "[John Ellison, Chetan, Stephan Ledain, Fatma Ghedira]"
+ *                              "[John Ellison, Chetan, Stephan Doe, Fatma Doe]"
  *                              "[John Ellison, Alex Marchetti, Mira, Daniel 'Dash' Okonkwo]"
  *   slack,   19 rows, ARRAY of objects: [{ author_id: "U0B9…", first_ts: …, last_ts: … }]
  *
@@ -111,7 +111,7 @@ function norm(s: string): string {
  * Priya Raghavan, Sam Fielding — real people in production, not named here; the repo is public).
  *
  * The rule: normalised equality, or one name is a WHOLE-WORD PREFIX of the other. That keeps prod's
- * real cases (`Chetan Nandakumar` → roster `Chetan`, `Fatma Ghedira` → roster `Fatma`) and rejects
+ * real cases (`Chetan Nandakumar` → roster `Chetan`, `Fatma Doe` → roster `Fatma`) and rejects
  * `John Smith` → `John Ellison`, because neither is a prefix of the other.
  *
  * Ambiguity resolves to NOTHING, reported. If an asserted name matches two members, or two asserted

--- a/scripts/backfill-meeting-attendance.mjs
+++ b/scripts/backfill-meeting-attendance.mjs
@@ -4,7 +4,7 @@
  *
  * The fix in `lib/meetings/attendance.ts` only governs notes created from now on. The notes already
  * on the Meetings page carry the old inference, including the reported one: "Content creation
- * strategy session" (2026-08-11) lists Abe Isleem and Fatma, neither of whom attended, while its item
+ * strategy session" (2026-08-11) lists Abe Doe and Fatma, neither of whom attended, while its item
  * says `participants: "[John Ellison]"`.
  *
  * DRY RUN BY DEFAULT. This removes named people from meetings the owner has already read, so it

--- a/test/datamechanics/enfb2-inquery-provenance.datamechanics.test.ts
+++ b/test/datamechanics/enfb2-inquery-provenance.datamechanics.test.ts
@@ -158,7 +158,7 @@ describe("ENFB-2 AC4 — starvation dies at the capped windows", () => {
     await db().from("tasks").insert({ team_id: seed.teamId, project_id: projectId, row_key: "VIS-1", title: "visible", status: "backlog", origin: "sync", source_item_id: openItem.id, updated_at: old });
     // 500 newer INVISIBLE rows (restricted source) — the full window size.
     const bulk = Array.from({ length: 500 }, (_, i) => ({
-      team_id: seed.teamId, project_id: projectId, row_key: `INV-${i}`, title: `inv ${i}`, status: "backlog", origin: "sync", source_item_id: secretItem.id,
+      team_id: seed.teamId, project_id: projectId, row_key: `HID-${i}`, title: `inv ${i}`, status: "backlog", origin: "sync", source_item_id: secretItem.id,
     }));
     const { error } = await db().from("tasks").insert(bulk);
     expect(error, "bulk fixture insert").toBeNull();
@@ -171,18 +171,18 @@ describe("ENFB-2 AC4 — starvation dies at the capped windows", () => {
     const body = (await res.json()) as { tasks: { project: string; rows: { row_key: string }[] }[] };
     const served = body.tasks.flatMap((g) => g.rows.map((r) => r.row_key));
     expect(served, "the visible row survives 500 newer invisible rows").toContain("VIS-1");
-    expect(served.some((k2) => k2.startsWith("INV-")), "no invisible row serves").toBe(false);
+    expect(served.some((k2) => k2.startsWith("HID-")), "no invisible row serves").toBe(false);
 
     // unknown_keys: a membership-hidden key reports unknown, truncated:false (§5.7 for keys).
-    const keyRes = await tasksGET(req("mode=table&keys=VIS-1,INV-3,NOPE-1"));
+    const keyRes = await tasksGET(req("mode=table&keys=VIS-1,HID-3,NOPE-1"));
     const keyBody = (await keyRes.json()) as { unknown_keys: string[] | null };
-    expect(keyBody.unknown_keys, "hidden and absent keys are indistinguishable").toEqual(["INV-3", "NOPE-1"]);
+    expect(keyBody.unknown_keys, "hidden and absent keys are indistinguishable").toEqual(["HID-3", "NOPE-1"]);
 
     // The insider sees the restricted rows (non-vacuity of the wall).
     const { key: insiderKey } = await issueApiKey(db(), seed.teamId, insider, "k2");
     const inRes = await tasksGET(new Request(`http://test/api/v1/tasks?all=1`, { headers: { authorization: `Bearer ${insiderKey}` } }) as unknown as NextRequest);
     const inBody = (await inRes.json()) as { tasks: { rows: { row_key: string }[] }[] };
-    expect(inBody.tasks.flatMap((g) => g.rows.map((r) => r.row_key)).filter((k3) => k3.startsWith("INV-")).length).toBeGreaterThan(0);
+    expect(inBody.tasks.flatMap((g) => g.rows.map((r) => r.row_key)).filter((k3) => k3.startsWith("HID-")).length).toBeGreaterThan(0);
   });
 
   it("decisions writeback window: visible-but-NOT-writeback rows cannot starve a writeback row (round-1 F3), and invisible rows cannot starve visible ones", async () => {

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -6,7 +6,7 @@ import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/mana
 import { db, ingest, seedTeam, type Seed } from "./helpers";
 
 /**
- * ADOPTINV-1 — the OUTCOME the adoption fixes exist to produce, asserted on the table.
+ * ADOPT-TASK-8 — the OUTCOME the adoption fixes exist to produce, asserted on the table.
  *
  * `ADOPTDECL-1` (#581) and `ADOPTFOOT-1` (#588) shipped a suite of tests between them and every one pins a
  * RUNG'S DECISION: the footer rung's scope, the declared rung's error, the ownership refusal, the
@@ -290,7 +290,7 @@ async function ownedLinkCount(teamId: string): Promise<number> {
   return (data ?? []).length;
 }
 
-describe("ADOPTINV-1 — no two links in a team share one PM issue (real Postgres)", () => {
+describe("ADOPT-TASK-8 — no two links in a team share one PM issue (real Postgres)", () => {
   it("THE DETECTOR WORKS: two links deliberately sharing one issue are REPORTED", async () => {
     // The inverse control. Draft 1 of the spec proposed "the query returns zero rows on a team with no
     // links", which proves the opposite of what it claimed — that the query passes on nothing, which IS

--- a/test/meetings-attendance-source.test.ts
+++ b/test/meetings-attendance-source.test.ts
@@ -8,7 +8,7 @@ import type { RosterPerson } from "@/lib/meetings/llm-extract";
  * MTGATT-1 / AIO-962 — attendance comes from what the producer asserted, and a model is the LAST
  * resort rather than the default.
  *
- * The bug this pins: "Content creation strategy session" (2026-08-11) recorded Abe Isleem and Fatma
+ * The bug this pins: "Content creation strategy session" (2026-08-11) recorded Abe Doe and Fatma
  * as attendees. Both appear in the transcript only in the third person and explicitly as ABSENT,
  * while the item's own frontmatter said `participants: "[John Ellison]"`.
  *
@@ -17,10 +17,10 @@ import type { RosterPerson } from "@/lib/meetings/llm-extract";
  */
 const ROSTER: RosterPerson[] = [
   { id: "m-john", displayName: "John Ellison" },
-  { id: "m-abe", displayName: "Abe Isleem" },
+  { id: "m-abe", displayName: "Abe Doe" },
   { id: "m-fatma", displayName: "Fatma" },
   { id: "m-chetan", displayName: "Chetan" },
-  { id: "m-stephan", displayName: "Stephan Ledain" },
+  { id: "m-stephan", displayName: "Stephan Doe" },
 ];
 
 describe("parseParticipantNames — the shapes that actually occur in prod", () => {
@@ -30,11 +30,11 @@ describe("parseParticipantNames — the shapes that actually occur in prod", () 
   });
 
   it("parses the multi-name granola shape", () => {
-    expect(parseParticipantNames("[John Ellison, Chetan, Stephan Ledain, Fatma Ghedira]")).toEqual([
+    expect(parseParticipantNames("[John Ellison, Chetan, Stephan Doe, Fatma Doe]")).toEqual([
       "John Ellison",
       "Chetan",
-      "Stephan Ledain",
-      "Fatma Ghedira",
+      "Stephan Doe",
+      "Fatma Doe",
     ]);
   });
 
@@ -139,9 +139,9 @@ describe("resolveAttendance — precedence, and the model as a last resort", () 
   });
 
   it("resolves granola's fuller name against a shorter roster entry, and vice versa", async () => {
-    // Prod says `Chetan Nandakumar` / `Fatma Ghedira`; the roster says `Chetan` / `Fatma`.
+    // Prod says `Chetan Nandakumar` / `Fatma Doe`; the roster says `Chetan` / `Fatma`.
     const out = await resolveAttendance({
-      participants: "[Chetan Nandakumar, Fatma Ghedira]",
+      participants: "[Chetan Nandakumar, Fatma Doe]",
       roster: ROSTER,
       llm: async () => [],
     });
@@ -181,7 +181,7 @@ describe("matchAsserted — strict, because an asserted name is not a guess", ()
   });
 
   it("still resolves prod's real shape — a fuller asserted name onto a shorter roster entry", () => {
-    const out = matchAsserted(["Chetan Nandakumar", "Fatma Ghedira"], ROSTER);
+    const out = matchAsserted(["Chetan Nandakumar", "Fatma Doe"], ROSTER);
     expect(out.memberIds.sort()).toEqual(["m-chetan", "m-fatma"]);
     expect(out.unresolved).toEqual([]);
   });


### PR DESCRIPTION
The v0.12.0 release gate's private NDA scan (fail-closed, term list held outside every repo) flagged this repo's tip. The 2026-08-19 scrub removed the organisation name from HEAD but left two residues:

- **Person surnames** in the meeting-attendance feature (design doc, `lib/meetings/attendance.ts` docstrings, backfill script header, test fixtures). Replaced with a synthetic family name; first names and the parsing/roster-matching semantics are unchanged.
- **Protected ticket/reference shapes** as literal fixture keys in two datamechanics suites and one design doc. The doc/task token becomes a neutral one; in the starvation test the invisible-row prefix is renamed wholesale so the queried hidden key still names a row that exists among the 500 hidden rows — a naive key swap would have left both queried keys absent and the hidden-vs-absent assertion hollow.

## Verification

- `leak-gate.sh` on this tree: CLEAN (was: 2 categories, 7 files).
- `test/meetings-attendance-source.test.ts`: 26/26.
- `enfb2-inquery-provenance` + `pm-link-uniqueness` datamechanics against the shared test Postgres: 12/12.
- No behaviour changes — docs, comments, and test fixture literals only.

History note: identifiers remain in earlier commits (known trade from the 08-19 scrub); this PR cleans the tip that release gates and clones see. Blocks the v0.12.0 release gate re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs, comments, and test fixture literals only; matching and API behavior are unchanged.
> 
> **Overview**
> Clears NDA-scan residues from HEAD so v0.12.0’s fail-closed leak-gate can re-run clean. No product behavior changes.
> 
> Meeting-attendance docs, comments, and roster fixtures replace real surnames with a synthetic family name (`Doe`). First names and prefix-matching cases stay the same.
> 
> Protected ticket/reference shapes are neutralized: the uniqueness-spec task token becomes `ADOPT-TASK-8`, and the starvation suite’s invisible-row prefix is renamed `INV-` → `HID-` so the queried hidden key still exists among the 500 rows (a naive swap would have made hidden-vs-absent vacuous).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce94f86f4a5ccd081a66c0c23071872b51a5a83. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Reviewed by Codex CLI (codex exec review, current head) - verdict: no actionable regressions — identifiers replaced consistently with synthetic values, test semantics and runtime behavior preserved; meetings 26/26 + datamechanics 12/12 green locally.