### PR TITLE
AUDITFIX-1: a delegated token's structured context obeys its scope

### DIFF
--- a/app/api/v1/decisions/route.ts
+++ b/app/api/v1/decisions/route.ts
@@ -32,6 +32,9 @@ export async function GET(req: NextRequest) {
     const decisions = await getDecisionWriteback(db, auth.teamId, auth.memberTier, since, {
       visibleItemIds: vis.ids,
       teamPosture: auth.memberTier === "team",
+      // Member-only route (AUDITFIX-1 §2a): authenticateApiKey accepts `aios_` member keys only —
+      // an `aiosd_` delegated token cannot authenticate here (lib/api/auth.ts).
+      principal: "member" as const,
     });
     return Response.json({ decisions, next_cursor: null });
   } catch (e) {

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -189,7 +189,10 @@ export async function GET(req: NextRequest) {
   try {
     const rows = await taskFeedWindow(
       auth.teamId,
-      { visibleItemIds: vis.ids, teamPosture: auth.memberTier === "team" },
+      // Member-only route (AUDITFIX-1 §2a): `authenticateApiKey` accepts `aios_` member keys only —
+      // an `aiosd_` delegated token cannot authenticate here (lib/api/auth.ts). Omitting this closes
+      // the hand-typed arm and drops every UI-origin task out of the writeback feed.
+      { visibleItemIds: vis.ids, teamPosture: auth.memberTier === "team", principal: "member" as const },
       {
         since,
         externalAudienceOnly: auth.memberTier !== "team",

--- a/app/t/[team]/decisions/page.tsx
+++ b/app/t/[team]/decisions/page.tsx
@@ -67,7 +67,7 @@ export default async function DecisionsPage({ params }: { params: Promise<{ team
   ]);
 
   const rows = ((decisions ?? []) as unknown as (Decision & { source_item_id?: string | null; created_by?: string | null; project_id?: string | null })[])
-    .filter((d) => rowVisibleByProvenance(d, vis && !vis.error ? vis.ids : null, tier))
+    .filter((d) => rowVisibleByProvenance(d, vis && !vis.error ? vis.ids : null, tier, "member"))
     // Round-2 H5's class, decisions edition: an entitled row (cross-project curation) must not
     // name a container whose ROW the viewer cannot see — the slug renders only for row-visible
     // containers, absent otherwise (indistinguishable from a container-less decision).

--- a/app/t/[team]/page.tsx
+++ b/app/t/[team]/page.tsx
@@ -192,7 +192,8 @@ export default async function TeamHome({
   const { adminClient } = await import("@/lib/db/admin");
   const { decisionsCardWindow } = await import("@/lib/access/structured-windows");
   const vis = await visibleItemIds(adminClient(), { teamId: team.id, memberId });
-  const provCtx = { visibleItemIds: vis.error ? new Set<string>() : vis.ids, teamPosture: tier === "team" };
+  // Member-only surface (AUDITFIX-1 §2a): session-authenticated dashboard.
+  const provCtx = { visibleItemIds: vis.error ? new Set<string>() : vis.ids, teamPosture: tier === "team", principal: "member" as const };
   const decisionsCardP = decisionsCardWindow(team.id, provCtx, tier === "external").then((rows) => ({ data: rows }));
   const [pulse, { data: decisions }, pipelineHealth, llmHealth] = await Promise.all([
     getPulseMetrics(db, team.id, range, { isAdmin, memberId, tier, provCtx }),

--- a/app/t/[team]/people/[handle]/page.tsx
+++ b/app/t/[team]/people/[handle]/page.tsx
@@ -100,6 +100,9 @@ export default async function PersonPage({
   const context = await getMemberContext(db, team.id, p.member_id, me.tier, {
     visibleItemIds: viewerVis.error ? new Set() : viewerVis.ids,
     teamPosture: me.tier === "team",
+    // Member-only surface (AUDITFIX-1 §2a): session-authenticated profile page. This ctx reaches
+    // the provenance predicate via deriveProjects (lib/identity/context.ts).
+    principal: "member" as const,
   });
   const canEdit = !!context && (me.id === p.member_id || me.role === "admin");
   const isSelf = me.id === p.member_id;

--- a/app/t/[team]/projects/[project]/page.tsx
+++ b/app/t/[team]/projects/[project]/page.tsx
@@ -94,7 +94,7 @@ export default async function ProjectPage({
   // served titles at posture with no provenance columns selected).
   const { rowVisibleByProvenance } = await import("@/lib/access/provenance");
   const decisionRows = ((decisions ?? []) as (Decision & { source_item_id?: string | null; created_by?: string | null })[]).filter((d) =>
-    rowVisibleByProvenance(d, vis.error ? null : vis.ids, me?.tier === "external" ? "external" : "team")
+    rowVisibleByProvenance(d, vis.error ? null : vis.ids, me?.tier === "external" ? "external" : "team", "member")
   );
 
   // Spine: group items by top-level directory of path

--- a/app/t/[team]/tasks/page.tsx
+++ b/app/t/[team]/tasks/page.tsx
@@ -48,7 +48,7 @@ export default async function TasksPage({ params }: { params: Promise<{ team: st
   const { boardTaskWindow } = await import("@/lib/access/structured-windows");
   const boardTasksP = boardTaskWindow<Task & { source_item_id?: string | null; created_by?: string | null }>(
     team.id,
-    { visibleItemIds: vis && !vis.error ? vis.ids : new Set<string>(), teamPosture: tier === "team" },
+    { visibleItemIds: vis && !vis.error ? vis.ids : new Set<string>(), teamPosture: tier === "team", principal: "member" as const },
     tier === "external"
   ).then((rows) => ({ data: rows }));
   const [{ data: tasks }, { data: links }, { data: projects }, { data: members }, { data: me }] =
@@ -90,7 +90,7 @@ export default async function TasksPage({ params }: { params: Promise<{ team: st
   }
   const taskRows = ((tasks ?? []) as (Task & { source_item_id?: string | null; created_by?: string | null })[])
     // ENFB-1 provenance rule — the ONE shared owner (lib/access/provenance).
-    .filter((t) => rowVisibleByProvenance(t, vis && !vis.error ? vis.ids : null, tier))
+    .filter((t) => rowVisibleByProvenance(t, vis && !vis.error ? vis.ids : null, tier, "member"))
     .map((t) => ({
       ...t,
       task_pm_links: linksByTask.get(t.id) ?? [],

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -248,6 +248,22 @@ history; enforcement is the only behavior) — and stateless: `conversation_id` 
 and rate limits/query_log/cost metering attribute to the launching member. Everything else still
 rejects the prefix; `aios_*` member keys are byte-for-byte unchanged.
 
+> ⚠️ **That "ALWAYS attenuated" sentence was FALSE for the STRUCTURED legs until AUDITFIX-1**
+> (`docs/design/auditfix1-token-structured-attenuation.md`). Retrieval's tasks/decisions windows
+> admitted a row with `source_item_id is null` on **team posture alone**, never consulting
+> `visibleItemIds` — and every valid token is team-tier by construction, so an empty-scoped token
+> received every hand-entered task and decision in the team. Reproduced against real Postgres; found
+> by the Phase A audit, not by the suite (the existing token test asserted `ctx.sources` only).
+> **The rule now:** the hand-typed arm is emitted only on the POSITIVE test
+> `principal === "member" && teamPosture === true` (`lib/access/provenance-sql.admitsUnsourced`), so
+> a token, an absent value and any foreign value all close. All THREE owners of the contract take the
+> discriminator — `provenanceRowSqlFromIds`, `provenanceRowSql`, and the TS twin
+> `rowVisibleByProvenance`. The two token-capable consumers (`lib/query/retrieve.ts`,
+> `lib/query/structured-extras.ts`) may only FORWARD `enforce.principal`; deriving it from `tier` or
+> posture would relabel every token as a member, and `test/guards/provenance-principal-callsites.test.ts`
+> fails the build on a member literal in either file. A token still cannot see hand-entered rows in
+> projects it IS granted — those legs carry item ids only, and widening them is AUDITFIX-7.
+
 Brain API 1.18 was ADDITIVE: delegated agent tokens (`aiosd_*`, spec §10) on the Phase A surface
 only — `GET /api/v1/items` accepts them oracle-filtered, everything else rejects the prefix;
 `aios_*` member keys unchanged, so an old server needs no negotiation (it 401s the unknown prefix).

--- a/docs/design/auditfix1-token-structured-attenuation.md
+++ b/docs/design/auditfix1-token-structured-attenuation.md
@@ -137,6 +137,13 @@ examples, to be updated as part of this slice rather than discovered as a myster
 `enfb2-inquery-provenance.datamechanics.test.ts:49`. The inventory covers every test context passed to
 `retrieve`, `matchingDecisions`, either SQL owner, the structured windows and the TS twin.
 
+**Correction (Fable diff review): that list was over-inclusive, in the direction that invites a
+pointless edit.** Two of the named files were NOT touched and must not be —
+`access-agent-tokens…:373` asserts `ctx.sources` paths only, and `graph-read-cutover…:237` asserts
+graph search calls. Neither exercises the hand-typed arm, so an absent `principal` closes an arm they
+never assert. Recorded here so the next reader does not "fix" a file that is already correct. The
+files that DID need updating are the six the dm tier actually reddened, plus `test/access-provenance.test.ts`.
+
 ### 2d. Absent enforcement closes — and the stale "permissive" doc goes with it
 
 `retrieve()`'s public entry already throws when enforcement is absent (`retrieve.ts:1025-1031`), but
@@ -288,6 +295,59 @@ so do the two sibling omissions (M14, M15) that were equally unpinned.
 
 **15 mutations: 14 reddened only their intended test on the first pass; 1 survived, was fixed, and
 now reddens.**
+
+## 5f. Fable's diff review — BLOCKED, and it defeated the guard in one line
+
+The first read by a DIFFERENT model, after four Codex spec rounds. Its HIGH was a working bypass of
+the guard those rounds had shaped twice:
+
+```ts
+const principal = "member" as ProvenancePrincipal;          // a cast the needle did not expect
+const provCtx = { visibleItemIds, teamPosture, principal }; // shorthand — no colon, so every scan blind
+```
+
+**All five checks stayed green.** I planted that exact code in `lib/query/retrieve.ts` and confirmed
+both halves before folding: the guard passed **6/6**, and the same code reddened
+`test/datamechanics/token-structured-attenuation.datamechanics.test.ts` on the real leak — so it was not a cosmetic
+evasion, it was the reproduced disclosure walking back in past its own guard.
+
+Why it matters more than its blast radius: this is *the shape an author reaches for the moment the
+guard reddens on `principal: "member"`* — extract to a variable until green. A guard that teaches its
+own evasion is worse than none. Folded: the binding needle drops its tail requirement (scoped to a
+variable declaration, so the type alias `type ProvenancePrincipal = "member" | "token"` and the SQL
+string `a.target_type = 'member'` — both of which the first loosening over-matched — stay out), a
+shorthand needle forbids `{ …, principal }` in the token-capable files outright, the omission scan
+accepts shorthand, and the twin needle's `[^)]*` becomes lazy so a nested call no longer hides it.
+The bypass is pinned as a non-vacuity case and re-planting it now reddens two tests.
+
+Its other findings, all folded:
+
+- **The omission scan saw only explicit-colon literals** — a whole construction shape, the same class
+  round 3 twice killed this guard for.
+- **The allow-list honesty check named the wrong repair.** If a boundary silently LOSES its member
+  literal — a member regression — the only message said "remove boundaries that no longer manufacture
+  a member literal", i.e. delete the entry and ship it. It now states both causes, tempting one first.
+- **`lib/metrics/pulse.ts`'s absent-ctx fallback synthesised `principal: "member"`** — the exact thing §2d
+  forbids. Inert only because the same fallback pins `teamPosture: false`, which is a dependency on a
+  neighbouring value rather than a rule. It now synthesises nothing and leaves the allow-list.
+- **AC7's sentence was false, not its coverage:** it claimed five principal inputs across three
+  owners; the table crossed three inputs against one. Now it is what the sentence says.
+- **"member-only BY CONSTRUCTION" overstated call-site enumeration** (`lib/access/enforce.ts`) — that is
+  convention plus a guard, which is exactly how §2b already framed it. Two words, corrected.
+- **§2c's update list was over-inclusive**, naming two files that are already correct and need no
+  change at all (this excludes no work: there is nothing to do in them, in this slice or any later
+  one) — recorded above so the next reader doesn't "fix" correct code.
+
+**What it checked and found sound**, which is worth as much as the findings: it re-derived the
+consumer inventory independently and found no production ctx omitting the discriminator; confirmed
+both token routes are closed (`/api/v1/items` has no structured leg); and confirmed the SQL parameter
+numbering is safe — `matchingDecisions` is the only mixed raw-`$N`/`p.add` consumer, and its `$1–$3`
+are pre-seeded before the fragment adds params, so emitting one fewer parameter shifts nothing.
+
+**One residual gap is ACCEPTED, not closed, and is written into the guard's header:** a ctx obtained
+wholesale from an exported factory is invisible to a text guard. The grounds are that it requires a
+visible, reviewable act rather than a one-word edit, and that the dm tier proves the outcome
+independently — which I verified rather than assumed.
 
 Round 1 also **confirmed the core rule is right and not over-correction**: a hand-typed row
 deliberately has no membership axis, and `tasks.project_id` is an ingestion project, not an access

--- a/docs/design/auditfix1-token-structured-attenuation.md
+++ b/docs/design/auditfix1-token-structured-attenuation.md
@@ -29,7 +29,7 @@ a full-visibility principal legitimately sees the same row, so the fixture was n
 | prod members in `external` built-in | **0** (all 10 in `everyone`) |
 | hand-entered rows reachable by the arm (`source_item_id is null and created_by is not null`) | tasks **1**, decisions **0** |
 | routes accepting an `aiosd_` bearer | exactly **2**: `app/api/v1/items/route.ts`, `app/api/v1/query/route.ts` |
-| ctx construction sites feeding the id-array predicate | **7** — retrieve, timeline, pulse, identity/context, structured-windows, structured-extras, **and `lib/sync/decisions.ts:41`** (missed in round 1; already enumerated by `test/guards/dashboard-tier-filter.test.ts:173`) |
+| ctx construction sites feeding the id-array predicate | **9** — retrieve, timeline, pulse, identity/context, structured-windows, structured-extras, `lib/sync/decisions.ts:41` (missed in round 1), **`app/api/v1/tasks/route.ts:192`** and **`app/t/[team]/people/[handle]/page.tsx:100`** (see §5d) |
 | owners of the provenance contract | **3** — `provenanceRowSqlFromIds` (id-array SQL), `provenanceRowSql` (semijoin SQL), `rowVisibleByProvenance` (TS twin) |
 
 **What that means:** severity is CRITICAL by contract violation, not by current data loss. One task row
@@ -68,7 +68,7 @@ const admitUnsourced = ctx.principal === "member" && ctx.teamPosture === true;
 ```
 
 Absent, `null`, `"token"`, and any foreign value all fail this and therefore **close**. This is the
-idiom the codebase already uses for the org-structural legs (`retrieve.ts:533`,
+idiom the codebase already uses for the org-structural legs (`lib/query/retrieve.ts:533`,
 `serveOrgStructural = enforce?.principal === "member"`), so it is a consistency fix, not a new pattern.
 
 **All THREE owners take the discriminator, not just the one the exploit runs through.** The module
@@ -200,7 +200,7 @@ the sentence that would justify re-adding a permissive default.
   site**: any literal `principal: "member"` (or equivalent) in a provenance ctx must appear in an
   allow-list of member-only boundaries, and the two token-capable files (`lib/query/retrieve.ts`,
   `lib/query/structured-extras.ts`) must contain **no** member literal — they may only forward.
-  Mutation-verified by planting a member literal in `retrieve.ts` and confirming THIS test reddens.
+  Mutation-verified by planting a member literal in `lib/query/retrieve.ts` and confirming THIS test reddens.
 - **AC8 — typecheck (honest scope):** `npx tsc --noEmit` covers **production** sources only
   (`tsconfig.json:25` excludes `test/`), so omission is caught in `lib/` and `app/` but **not** in test
   helpers. Recorded as a production-source check with that limitation stated, not as a durable
@@ -245,6 +245,32 @@ rule is not implemented, whatever the tests say.
   specific files named.
 - **MEDIUM: the provider seam still documents "permissive"** — folded into §2d.
 - **MEDIUM: AC7 said four inputs where AC6 has five** — enumerated.
+
+## 5d. What the TEST TIERS found that four review rounds did not
+
+Three defects survived every review round and were caught by running things. Recorded because the
+loop's value is exactly this — the rounds narrow the design, the tiers judge the result.
+
+- **The inventory said 7 consumers; there are 9.** `app/api/v1/tasks/route.ts:192` and
+  `app/t/[team]/people/[handle]/page.tsx:100` both build a provenance ctx and neither was listed.
+  Both are member-only boundaries (`authenticateApiKey` rejects `aiosd_`; a session page), so
+  omitting the discriminator CLOSED the hand-typed arm for members: the tasks writeback feed
+  silently dropped every UI-origin task, which reddened `tasks-sync-origin-feed` in the dm tier.
+  A read of §0 alone would have shipped that. **Both are now on the AC9 guard's allow-list, so the
+  inventory is enforced rather than asserted.**
+- **`visibleProjectCards` builds a SECOND ctx for its counts** (`lib/access/enforce.ts:337`), separate from the
+  row rule, and it too omitted the discriminator — a member's project card would have reported fewer
+  tasks than the project page listed. Nothing caught it: the existing card test asserts `visibleItems`
+  only and never seeds an unsourced row. A `visibleTasks` assertion was added with it.
+- **AC9's guard scored my own code clean.** `lib/access/enforce.ts` names the value once
+  (`MEMBER_ONLY_SURFACE = "member" as const`) rather than repeating a literal, and all of the guard's
+  needles were literal-shaped — so `import { MEMBER_ONLY_SURFACE }` into a token-capable file and
+  `principal: MEMBER_ONLY_SURFACE` would have passed. Round 3 killed the FIRST guard for measuring a
+  spelling; naming a constant is just another spelling. The guard now asserts the
+  spelling-INDEPENDENT property too: in the two token-capable files, every `principal` in a value
+  position must BE the forwarded expression. Its first draft then flagged
+  `enforce?.principal === "member"` — a comparison, not an assertion — and swallowed SCREAMING_SNAKE
+  constants under a PascalCase-means-type heuristic; both are fixed and pinned as non-vacuity cases.
 
 Round 1 also **confirmed the core rule is right and not over-correction**: a hand-typed row
 deliberately has no membership axis, and `tasks.project_id` is an ingestion project, not an access

--- a/docs/design/auditfix1-token-structured-attenuation.md
+++ b/docs/design/auditfix1-token-structured-attenuation.md
@@ -1,0 +1,252 @@
+# A delegated token's structured context must obey its scope — AUDITFIX-1
+
+**Status:** spec, revised twice. Codex round 1 **BLOCKED** (3 HIGH, 2 MEDIUM); round 2 **BLOCKED** (2 HIGH, 3 MEDIUM); round 3 **BLOCKED** (1 HIGH, 3 MEDIUM). §5/5b/5c record all three.
+**Build with:** opus / high — it changes a shared SQL predicate used by six call sites on the
+authorization path, and the defect it closes is a confirmed, reproduced disclosure on a shipped route.
+
+**Deps: none.** Slice 1 of the Phase A audit remediation (AIO-847/848/850/865/872).
+
+---
+
+## What and why
+
+**What:** a delegated agent token stops receiving hand-entered tasks and decisions that its scope does
+not cover.
+
+**Why:** it receives all of them today. `provenanceRowSqlFromIds` admits an unsourced row on team
+posture alone, with **no reference to `visibleItemIds`** — and every valid token is team-tier by
+construction, so the arm is always open for tokens.
+
+**REPRODUCED** (real Postgres, positive control): a principal with an empty visible-item set got
+`sources: 0` and a populated `ctx.structured` containing a planted secret task. The control confirmed
+a full-visibility principal legitimately sees the same row, so the fixture was not inert.
+
+## 0. Terrain, measured before designing
+
+| | |
+|---|---|
+| prod agent tokens (total / active) | **0 / 0** — the leak is live on a shipped route but unexploited |
+| prod members in `external` built-in | **0** (all 10 in `everyone`) |
+| hand-entered rows reachable by the arm (`source_item_id is null and created_by is not null`) | tasks **1**, decisions **0** |
+| routes accepting an `aiosd_` bearer | exactly **2**: `app/api/v1/items/route.ts`, `app/api/v1/query/route.ts` |
+| ctx construction sites feeding the id-array predicate | **7** — retrieve, timeline, pulse, identity/context, structured-windows, structured-extras, **and `lib/sync/decisions.ts:41`** (missed in round 1; already enumerated by `test/guards/dashboard-tier-filter.test.ts:173`) |
+| owners of the provenance contract | **3** — `provenanceRowSqlFromIds` (id-array SQL), `provenanceRowSql` (semijoin SQL), `rowVisibleByProvenance` (TS twin) |
+
+**What that means:** severity is CRITICAL by contract violation, not by current data loss. One task row
+would leak today. The blast radius becomes real the moment tokens are minted — which is the entire
+purpose of the slice that introduced them (AIO-848).
+
+**Not measured:** whether any external consumer has already minted and used a token against a
+non-prod install. Nothing in this repo can answer that.
+
+## 1. The rule
+
+**An unsourced row (`source_item_id is null`) is admitted on posture alone ONLY for a member
+principal. For a token principal it is never admitted.**
+
+A token's authority is its attenuated scope. A row with no source item cannot be tested against that
+scope, so it cannot be shown to a token. Fail closed.
+
+**This does NOT change member behaviour.** Admitting hand-entered rows at team posture is a settled,
+deliberate ENFB-2 rule for members ("hand-typed at team posture"). This slice narrows tokens only.
+
+## 2. The design: a POSITIVE principal check, in all three owners
+
+Round 1 killed the first design (a required `unsourced: "include" | "exclude"` field). Two reasons,
+both correct:
+
+- **A required TypeScript field is not a runtime guarantee.** `tsc` disappears at runtime, existing
+  tests already omit `principal`, and the natural spelling `ctx.unsourced === "exclude" ? closed :
+  open` fails **OPEN** for `undefined`, `null`, or any foreign value.
+- **`tsconfig.json:25` excludes `test/`**, so a missing field in a test helper never fails typecheck
+  at all — the enforcement I claimed does not exist where the omissions actually live.
+
+**The rule, as implemented:** the unsourced arm is emitted only on a positive test.
+
+```ts
+const admitUnsourced = ctx.principal === "member" && ctx.teamPosture === true;
+```
+
+Absent, `null`, `"token"`, and any foreign value all fail this and therefore **close**. This is the
+idiom the codebase already uses for the org-structural legs (`retrieve.ts:533`,
+`serveOrgStructural = enforce?.principal === "member"`), so it is a consistency fix, not a new pattern.
+
+**All THREE owners take the discriminator, not just the one the exploit runs through.** The module
+header claims "one contract, two owners" and the agreement suite
+(`enfb2-inquery-provenance.datamechanics.test.ts:109`) asserts the SQL and TS forms against the same
+expected truth. Changing only the id-array form would delete one false claim and immediately make
+another one false, and would leave a future token surface reusing `rowVisibleByProvenance` or the
+semijoin form to silently reopen this. So:
+
+| owner | change |
+|---|---|
+| `provenanceRowSqlFromIds` (id-array SQL) | ctx gains `principal`; unsourced arm on the positive check |
+| `provenanceRowSql` (semijoin SQL) | same, via `ProvenanceSqlCtx` |
+| `rowVisibleByProvenance` (TS twin) | gains a required `principal` argument; same positive check |
+
+**Fail-closed defaults are preserved where they already exist.** `matchingDecisions` currently
+defaults an absent `enforce` to `{visibleItemIds: new Set(), teamPosture: false}`
+(`structured-extras.ts:67`) — that direction must survive, with an absent principal also closing.
+
+### 2a. Token-capable code FORWARDS the discriminator; it never re-derives it
+
+Round 2 killed the "six member-only sites" premise, and the way it killed it matters: **the fix I
+proposed would have caused the leak it prevents.**
+
+`matchingDecisions` IS token-reachable. `POST /api/v1/query` sets `principal: "token"` correctly
+(`route.ts:137`), but `nativeRetrieve` rebuilds both provenance contexts from ids + `tier` and **drops
+the discriminator** (`retrieve.ts:599`, `retrieve.ts:647`), and `structured-extras.ts:61` rebuilds it
+a third time. A shared "member context" helper applied there — or any helper deriving principal from
+`tier === "team"` — emits `principal: "member"` for a token and **opens the unsourced arm**.
+
+So the rule is:
+
+- **The two token-capable consumers (`retrieve`, `structured-extras`) COPY `enforce.principal`
+  verbatim.** Every ctx construction inside `nativeRetrieve` threads the value it was given; none
+  reconstructs it.
+- **NEVER derive the discriminator from posture or tier.** `tier === "team" ? "member" : "token"` is
+  the likely careless spelling and it is wrong: it mislabels every EXTERNAL MEMBER as a token. It
+  happens not to change today's outcome (their posture is false anyway), which is exactly what makes
+  it a landmine for the next refactor.
+- **The shared member-context helper is for the five genuinely member-only consumers only**
+  (`work-timeline`, `pulse`, `identity/context`, `structured-windows`, `sync/decisions` — the last two
+  reachable only by `aios_` keys, which `authenticateApiKey` accepts and `aiosd_` fails,
+  `lib/api/auth.ts:119`). A **guard enumerates its permitted call sites**, because a member-literal
+  helper is an assertion, not authentication, and a future token surface could reuse it.
+
+### 2b. The semijoin sites are member-only by convention, not by type
+
+`visibleProjectRows` / `canSeeProjectRow` / `visibleProjectCards` take a `Principal`, and that type
+permits `projectScope` — i.e. a token-shaped value (`oracle.ts:26`). Hardcoding `"member"` inside them
+would open the unsourced arm for any future internal token caller. They take the discriminator from
+their caller like everything else, and are documented + guarded as member-only rather than assumed.
+
+### 2c. The TS twin's signature change reaches tests, which `tsc` does not see
+
+`rowVisibleByProvenance` has four production callers (tasks page, decisions page, project detail,
+work-timeline's decision defense) and many test callers. Because `tsconfig.json` excludes `test/`, an
+omitted argument becomes `undefined` at runtime and silently CLOSES the arm — so existing
+member-positive tests fail in their own tier rather than at typecheck.
+
+**And the exposure is much wider than the TS twin** (round 3). Many data-mechanics tests construct a
+`RetrieveEnforce` or a provenance ctx with no `principal`; under verbatim forwarding those become
+`undefined`, the positive check closes, and **existing member-positive assertions go red**. Known
+examples, to be updated as part of this slice rather than discovered as a mystery red suite:
+`access-enforce-retrieve.datamechanics.test.ts:108,184`,
+`access-agent-tokens.datamechanics.test.ts:373`, `graph-read-cutover.datamechanics.test.ts:237`,
+`enfb2-inquery-provenance.datamechanics.test.ts:49`. The inventory covers every test context passed to
+`retrieve`, `matchingDecisions`, either SQL owner, the structured windows and the TS twin.
+
+### 2d. Absent enforcement closes — and the stale "permissive" doc goes with it
+
+`retrieve()`'s public entry already throws when enforcement is absent (`retrieve.ts:1025-1031`), but
+`nativeProvider.retrieve()` is independently callable and `RetrievalRequest.enforce` is optional and
+still documented as "permissive" (`provider.ts:44,56`) — a comment left behind by PRET-6's retirement
+of that model. **Absent enforcement yields `principal: undefined`, which CLOSES the unsourced arm; it
+must never synthesise `"member"`.** The stale comment is corrected in the same change, because it is
+the sentence that would justify re-adding a permissive default.
+
+## 3. What this deliberately does NOT do
+
+- **It does not let a token see hand-entered rows in projects it IS granted.** That needs the token's
+  effective PROJECT set threaded into the structured legs (they carry item ids only). Fail-closed
+  first; widening is a product decision with its own slice — **AUDITFIX-7**.
+- The other audit findings, each its own slice: connector reconcile at ingest (**AUDITFIX-2**),
+  system-project grant guard (**AUDITFIX-3**), membership-writer error handling (**AUDITFIX-4**),
+  invite-default stranding (**AUDITFIX-5**), sweep-vs-curation (**AUDITFIX-6**, needs a product ruling).
+
+## 4. Acceptance
+
+- **AC1 — data-mechanics, `test/datamechanics/token-structured-attenuation.datamechanics.test.ts`:** a
+  token with an **EMPTY** scope receives neither a hand-entered task nor a hand-entered decision in
+  `ctx.structured`, while a **positive control** (member principal, team posture) receives both from
+  the same fixture. Without the control this passes on an inert fixture — which is exactly how the
+  original repro first passed.
+- **AC2 — data-mechanics, same file — THE ONE THAT MATTERS:** a token with a **NON-EMPTY** scope
+  simultaneously (a) receives its in-scope **sourced** task and decision, and (b) receives **no**
+  unsourced row. Round 1 showed the whole suite otherwise passes an implementation reading
+  `principal === "token" && visibleItemIds.size === 0`, which closes only the case I happened to
+  reproduce and leaves every realistically-scoped token leaking. Non-empty scope is the NORMAL
+  delegated case (spec §10 triple intersection).
+- **AC3 — data-mechanics, same file:** a MEMBER principal is unchanged — hand-entered rows still
+  appear at team posture. The regression half; this slice must not narrow the settled ENFB-2 rule.
+- **AC4 — data-mechanics, same file:** with ONE visible sourced decision and ONE keyword-matching
+  unsourced decision present in the SAME invocation, `matchingDecisions` for a non-empty-scoped token
+  returns the sourced marker and excludes the unsourced marker. Stated as both halves because "obeys
+  the rule" also passes an inert keyword fixture, a query that matches nothing, or an implementation
+  that returns `[]` (round 2 MEDIUM).
+- **AC5 — data-mechanics, `test/datamechanics/token-structured-route.datamechanics.test.ts`:** the
+  assertion runs through the **real `POST /api/v1/query` handler** with a **minted `aiosd_` token`**,
+  with only `streamAnswer` stubbed to capture `ctx.structured`. That exercises authentication, the
+  route's own `principal: "token"` assignment, enforcement derivation and real retrieval.
+  **Round 2 killed the http-tier version of this AC:** minting works there, but the http tier has no
+  LLM configured, the route never exposes `ctx.structured` (only deltas and cited sources), and the
+  existing socket test cancels the body after asserting `200` — so a still-leaking implementation
+  passes it. The socket test stays as a transport/admission pin and is explicitly **not** the leak
+  proof.
+- **AC6 — unit, `test/access-provenance-principal.test.ts`:** the generated SQL contains the unsourced
+  disjunct for `principal: "member"` + team posture, and omits it for **each** of: `"token"`,
+  `undefined`, `null`, and a foreign string. The malformed/absent cases are the fail-open direction
+  round 1 identified; asserting only the two valid literals would not catch it.
+- **AC7 — unit, same file:** all three owners are asserted against an explicit TRUTH TABLE — sourced
+  visible, sourced invisible, unsourced authored, unsourced unauthored — crossed with all FIVE principal inputs
+  enumerated in AC6 (`"member"`, `"token"`, `undefined`, `null`, a foreign string) — round 3 caught
+  that "four" here contradicted AC6's five and would let one malformed case vanish from the table. Round 2's point: "the owners agree" is satisfied by three identically WRONG
+  implementations, so agreement is asserted against expected truth, not against each other.
+- **AC9 — unit, `test/guards/provenance-principal-callsites.test.ts`:** guards the PROPERTY, not one
+  spelling. Round 3's point: a token-capable path can obtain member semantics with a bare
+  `principal: "member"` literal and never touch the helper at all, so counting helper references
+  proves nothing about escalation. The guard therefore enumerates **every discriminator construction
+  site**: any literal `principal: "member"` (or equivalent) in a provenance ctx must appear in an
+  allow-list of member-only boundaries, and the two token-capable files (`lib/query/retrieve.ts`,
+  `lib/query/structured-extras.ts`) must contain **no** member literal — they may only forward.
+  Mutation-verified by planting a member literal in `retrieve.ts` and confirming THIS test reddens.
+- **AC8 — typecheck (honest scope):** `npx tsc --noEmit` covers **production** sources only
+  (`tsconfig.json:25` excludes `test/`), so omission is caught in `lib/` and `app/` but **not** in test
+  helpers. Recorded as a production-source check with that limitation stated, not as a durable
+  type-level guard over the whole repo.
+
+**Falsifier:** if a token with ANY scope receives a row it cannot attribute to a visible item, the
+rule is not implemented, whatever the tests say.
+
+## 5. Round 1 — what it changed
+
+**BLOCKED**, and every finding held on re-derivation:
+
+- **The acceptance suite passed a still-leaking fix.** Fixed by AC2/AC4 (non-empty scope) and AC5
+  (route-level, real token).
+- **The discriminator was caller-controlled with no runtime rule.** Fixed by the positive
+  `principal === "member" && teamPosture` check, with AC6 pinning absent/null/foreign as closed.
+- **The rule reached one of three owners.** Fixed by changing all three plus the agreement test (AC7).
+- **A seventh consumer was missing** from the inventory (`lib/sync/decisions.ts`) — added to §0.
+- **AC6 overstated `tsc`** — `test/` is excluded; rewritten as AC8 with the limit stated.
+
+## 5b. Round 2 — attacking the fold
+
+**BLOCKED**, and both HIGHs were second-order bugs in my own fix:
+
+- **The shared helper would have caused this leak.** `matchingDecisions` is token-reachable and
+  `nativeRetrieve` drops the discriminator; applying a member helper there emits `"member"` for a
+  token. Fixed by §2a: forward, never re-derive, and never derive from tier/posture.
+- **AC5 could not fail.** The http tier has no LLM and the route never exposes `ctx.structured`.
+  Replaced with a handler-level dm test that stubs only `streamAnswer`.
+- Three MEDIUMs folded: the semijoin sites are member-only by convention not by type (§2b); the TS
+  twin's signature reaches test callers `tsc` cannot see (§2c); AC4 and AC7 restated as explicit
+  truth conditions rather than "obeys the rule" / "agree".
+
+## 5c. Round 3 — attacking the round-2 fold
+
+**BLOCKED**; the findings narrowed from HIGH to mostly MEDIUM, which is what convergence looks like.
+
+- **HIGH: AC9 guarded a spelling, not the property.** A token path can hardcode `principal: "member"`
+  without referencing the helper. AC9 now guards every discriminator construction site and forbids a
+  member literal in the two token-capable files.
+- **MEDIUM: the test-side blast radius is far wider than the TS twin** — folded into §2c with the
+  specific files named.
+- **MEDIUM: the provider seam still documents "permissive"** — folded into §2d.
+- **MEDIUM: AC7 said four inputs where AC6 has five** — enumerated.
+
+Round 1 also **confirmed the core rule is right and not over-correction**: a hand-typed row
+deliberately has no membership axis, and `tasks.project_id` is an ingestion project, not an access
+project (`enforce.ts:174`) — so admitting unsourced rows to tokens by project would invent a second
+access model.

--- a/docs/design/auditfix1-token-structured-attenuation.md
+++ b/docs/design/auditfix1-token-structured-attenuation.md
@@ -365,6 +365,61 @@ was clean. Both were wrong, in opposite directions:
 
 **19 mutations total: 18 reddened only their intended test; 1 survived, was fixed, and now reddens.**
 
+## 5h. Codex's diff review — no BLOCKER, no HIGH, and it ended the guard's arms race
+
+The second model on the diff, after Fable. Its verdict on the production fix was clean: *"The
+production fix closes the reported token disclosure, and I found no current token-reachable call site
+that omits or manufactures the discriminator."* It independently re-derived the consumer inventory and
+confirmed the SQL parameter numbering (`matchingDecisions` pre-seeds `$1–$3` through the same
+`SqlParams` instance, so emitting one fewer bound parameter shifts nothing). Three MEDIUMs and a LOW.
+
+**MEDIUM 1 — six more guard evasions, and the right conclusion.** A computed key
+`{ ["principal"]: "member" }`, a later `...spread` overwriting the forwarded value,
+`enforce!.principal = "member"`, `||=`, `Reflect.set`, `Object.defineProperty`. Plus: the hand-rolled
+brace scanner mis-pairs on a nested object, a brace inside a string, or a destructuring pattern, and
+`codeOnly` still discards real code after a block-comment terminator.
+
+That is the third review to defeat this guard, and the pattern is the finding: **each defeat was a new
+SPELLING of one act, and a text matcher can only ever enumerate spellings.** Codex's recommendation
+was to stop matching text. So the token-capable half is now a **TypeScript AST walk** — every
+`principal` property must be initialised to exactly `enforce?.principal`; no spread may enter a
+provenance ctx; nothing may assign to `.principal` in any assignment operator; `Reflect.set` and
+`Object.defineProperty` may not target it; and every ctx carrying `visibleItemIds` must carry it. The
+brace, comment and string hazards vanish because the parser owns them. **All twelve historical
+evasions are kept as negative controls**, so a future simplification reddens rather than silently
+reopening the hole. The tree-wide member-literal scan stays regex-based and is relabelled for what it
+is: a coverage inventory over ~700 files whose failure mode is a stale allow-list entry.
+
+**MEDIUM 3 — a footgun the type system endorsed.** `visibleProjectRows`, `canSeeProjectRow` and
+`visibleProjectCards` took a `Principal` — whose `projectScope` makes it token-shaped — while
+asserting memberhood unconditionally inside. A future token route could call them, get the hand-typed
+arm opened, and redden nothing, since the member literal lives in an allow-listed file and the new
+caller need contain none. They now take **`MemberPrincipal`** (`projectScope?: never`), so a
+token-shaped value is a compile error at the call site. Verified both directions: the token call fails
+`tsc` with `Type 'string[]' is not assignable to type 'undefined'`; the member call still compiles.
+The comment above them claimed the parameterisation itself was the safety property — it wasn't, and
+that sentence is corrected rather than deleted.
+
+**MEDIUM 2 — my truth table was mostly decoration, and it was right.** Neither SQL string in the
+`4 rows x 5 principals` loop referenced the row, so 15 of 20 SQL assertions were the same 5 repeated;
+and the trailing `if (unsourced && created_by === null) expect(expected).toBe(false)` re-asserted a
+constant written twenty lines above in the fixture table. **A tautology reads exactly like coverage.**
+The row x principal cross now belongs to the TS twin, which is the only owner that can answer about a
+row at unit level; the SQL owners are asserted once on arm presence and once on arm STRUCTURE — and
+that structural assertion is a full-conjunction regex, not a substring, because Codex pointed out that
+`source_item_id is null OR created_by is not null` also contains `"created_by is not null"`. Row-level
+truth for the SQL owners lives where a database can apply it: the dm agreement suite.
+
+**LOW — a helper that did not resemble its call site.** `pulseCtx()` in the dm tier supplied
+`teamPosture: true` with no principal — a shape the type permits and a real caller could copy, and one
+that silently drops every hand-entered task out of the funnel. There was no production regression (the
+one caller passes an explicit member ctx, and the absent-ctx fallback pins `teamPosture: false`), but
+nothing asserted it either, because every fixture in that suite is sourced. Both are fixed: the helper
+threads the discriminator, and a new test seeds a hand-entered task and asserts a member's funnel
+counts it. Reverting the helper reddens exactly that test.
+
+**24 mutations total: 23 reddened only their intended test; 1 survived, was fixed, and now reddens.**
+
 Round 1 also **confirmed the core rule is right and not over-correction**: a hand-typed row
 deliberately has no membership axis, and `tasks.project_id` is an ingestion project, not an access
 project (`enforce.ts:174`) — so admitting unsourced rows to tokens by project would invent a second

--- a/docs/design/auditfix1-token-structured-attenuation.md
+++ b/docs/design/auditfix1-token-structured-attenuation.md
@@ -349,6 +349,22 @@ wholesale from an exported factory is invisible to a text guard. The grounds are
 visible, reviewable act rather than a one-word edit, and that the dm tier proves the outcome
 independently — which I verified rather than assumed.
 
+### 5g. Two more found by testing the guard's own helpers
+
+Folding Fable's HIGH meant rewriting two matchers, so I probed them rather than assuming the rewrite
+was clean. Both were wrong, in opposite directions:
+
+- **`codeOnly` deleted GENERATOR METHODS.** It stripped any line whose trimmed form starts with `*`,
+  which is a jsdoc continuation — and also `*iter() { … }`. A member literal inside a generator
+  vanished before any needle ran: a hiding place, in the FAIL-OPEN direction. The rule is now narrow
+  (`*` followed by whitespace, end-of-line, or `/`), and a generator body is pinned as surviving.
+- **The twin needle's `[\s\S]*?` left its own statement.** Lazy or not, it matched a `"member"`
+  string many lines later in unrelated code. Only a false POSITIVE — but a guard that cries wolf gets
+  its allow-list widened, which is how a guard dies. `[^;]*?` admits the nested call that motivated
+  the change while being unable to cross a statement boundary.
+
+**19 mutations total: 18 reddened only their intended test; 1 survived, was fixed, and now reddens.**
+
 Round 1 also **confirmed the core rule is right and not over-correction**: a hand-typed row
 deliberately has no membership axis, and `tasks.project_id` is an ingestion project, not an access
 project (`enforce.ts:174`) — so admitting unsourced rows to tokens by project would invent a second

--- a/docs/design/auditfix1-token-structured-attenuation.md
+++ b/docs/design/auditfix1-token-structured-attenuation.md
@@ -272,6 +272,23 @@ loop's value is exactly this — the rounds narrow the design, the tiers judge t
   `enforce?.principal === "member"` — a comparison, not an assertion — and swallowed SCREAMING_SNAKE
   constants under a PascalCase-means-type heuristic; both are fixed and pinned as non-vacuity cases.
 
+### 5e. And one mutation SURVIVED — reported as such
+
+**M13: deleting retrieve's forward to `matchingDecisions` reddened nothing.** All four
+data-mechanics assertions and every unit test still passed. The reason is worth stating precisely,
+because "it fails closed so it doesn't matter" is the wrong conclusion: an absent discriminator
+CLOSES the hand-typed arm, so a **token's** outcome does not change at all and every token assertion
+still holds — what silently changes is the **member's**, whose keyword-matched hand-typed decisions stop
+being served, and no test separates that leg from the recency window that serves the same rows.
+
+A surviving mutation means the suite proves nothing there. Rather than build a fixture that can
+distinguish two overlapping legs, the property moved to AC9's guard: in a token-capable file, every
+provenance ctx must **carry** the discriminator, not merely be able to. M13 re-run now reddens, and
+so do the two sibling omissions (M14, M15) that were equally unpinned.
+
+**15 mutations: 14 reddened only their intended test on the first pass; 1 survived, was fixed, and
+now reddens.**
+
 Round 1 also **confirmed the core rule is right and not over-correction**: a hand-typed row
 deliberately has no membership axis, and `tasks.project_id` is an ingestion project, not an access
 project (`enforce.ts:174`) — so admitting unsourced rows to tokens by project would invent a second

--- a/lib/access/enforce.ts
+++ b/lib/access/enforce.ts
@@ -229,9 +229,32 @@ export interface VisibleProjectRows {
   error?: boolean;
 }
 
-function projectRowVisibleSql(teamId: string, granted: readonly string[], teamPosture: boolean) {
+/**
+ * AUDITFIX-1 §2b. The three project-row helpers below (`visibleProjectRows`, `canSeeProjectRow`,
+ * `visibleProjectCards`) are member-only BY CONSTRUCTION, not by convention: every one of their eight
+ * call sites is a session-authenticated page or an `aios_` member route, and `authenticateApiKey`
+ * (lib/api/auth.ts) rejects an `aiosd_` bearer, so a delegated token cannot reach them.
+ *
+ * The value is named once, HERE, rather than spelled at each call site — a bare `"member"` literal
+ * scattered through the file is exactly what AC9's guard forbids, because it is the shape a future
+ * token path would copy. If any of these ever becomes token-reachable, this constant is the single
+ * place that must change, and the guard will point at it.
+ */
+const MEMBER_ONLY_SURFACE = "member" as const;
+
+/**
+ * The discriminator is a PARAMETER, not a hardcoded "member". These helpers take a
+ * `Principal`, and that type permits `projectScope` — i.e. a token-shaped value — so baking in
+ * "member" here would open the hand-typed arm for any future internal token caller.
+ */
+function projectRowVisibleSql(
+  teamId: string,
+  granted: readonly string[],
+  teamPosture: boolean,
+  principal: "member" | "token" | undefined
+) {
   const p = newSqlParams();
-  const ctx: ProvenanceSqlCtx = { teamId, grantedProjectIds: granted, teamPosture };
+  const ctx: ProvenanceSqlCtx = { teamId, grantedProjectIds: granted, teamPosture, principal };
   const team = p.add(teamId);
   const grantedPh = p.add([...granted]);
   // Posture stays a CONJUNCT on every content arm (Fable diff L10): an external-posture
@@ -251,7 +274,7 @@ export async function visibleProjectRows(db: DbClient, principal: Principal): Pr
   try {
     const { projectIds } = await visibleProjects(db, principal);
     const posture = await teamPostureFor(db, principal);
-    const { p, where } = projectRowVisibleSql(principal.teamId, [...projectIds], posture);
+    const { p, where } = projectRowVisibleSql(principal.teamId, [...projectIds], posture, MEMBER_ONLY_SURFACE);
     const res = await runSql<{ id: string }>(`select p.id from projects p where ${where}`, p.values);
     return { ids: new Set(res.rows.map((r) => r.id)) };
   } catch {
@@ -263,7 +286,7 @@ export async function canSeeProjectRow(db: DbClient, principal: Principal, proje
   try {
     const { projectIds } = await visibleProjects(db, principal);
     const posture = await teamPostureFor(db, principal);
-    const { p, where } = projectRowVisibleSql(principal.teamId, [...projectIds], posture);
+    const { p, where } = projectRowVisibleSql(principal.teamId, [...projectIds], posture, MEMBER_ONLY_SURFACE);
     const idPh = p.add(projectId);
     const res = await runSql<{ id: string }>(
       `select p.id from projects p where p.id = ${idPh} and ${where} limit 1`,
@@ -294,8 +317,17 @@ export async function visibleProjectCards(
   try {
     const { projectIds } = await visibleProjects(db, principal);
     const posture0 = await teamPostureFor(db, principal);
-    const { p, where } = projectRowVisibleSql(principal.teamId, [...projectIds], posture0);
-    const ctx: ProvenanceSqlCtx = { teamId: principal.teamId, grantedProjectIds: [...projectIds], teamPosture: posture0 };
+    const { p, where } = projectRowVisibleSql(principal.teamId, [...projectIds], posture0, MEMBER_ONLY_SURFACE);
+    // AUDITFIX-1: the count ctx takes the SAME discriminator as the row rule above. Omitting it here
+    // is not fail-safe — it silently CLOSES the hand-typed arm for a member, so a card would report
+    // fewer tasks than the project page lists. That is a member-visible regression, and this slice
+    // narrows tokens only (§1). Pinned by the visibleTasks assertion in enfb2-project-rows.
+    const ctx: ProvenanceSqlCtx = {
+      teamId: principal.teamId,
+      grantedProjectIds: [...projectIds],
+      teamPosture: posture0,
+      principal: MEMBER_ONLY_SURFACE,
+    };
     // The card counts carry the SAME posture conjuncts as the row rule and the detail page's
     // walls (Fable diff L10 — counts must never exceed what the container page lists).
     const posture = p.add(posture0);

--- a/lib/access/enforce.ts
+++ b/lib/access/enforce.ts
@@ -231,23 +231,35 @@ export interface VisibleProjectRows {
 
 /**
  * AUDITFIX-1 §2b. The three project-row helpers below (`visibleProjectRows`, `canSeeProjectRow`,
- * `visibleProjectCards`) are member-only by CONVENTION PLUS A GUARD — not by type, and not by
- * construction: the `Principal` they take permits `projectScope`, i.e. a token-shaped value. What
- * makes the convention true today is call-site enumeration: every one of their eight
- * call sites is a session-authenticated page or an `aios_` member route, and `authenticateApiKey`
- * (lib/api/auth.ts) rejects an `aiosd_` bearer, so a delegated token cannot reach them.
+ * `visibleProjectCards`) are member-only, and as of Codex's diff review they are member-only BY
+ * TYPE rather than only by call-site enumeration.
  *
- * The value is named once, HERE, rather than spelled at each call site — a bare `"member"` literal
- * scattered through the file is exactly what AC9's guard forbids, because it is the shape a future
- * token path would copy. If any of these ever becomes token-reachable, this constant is the single
- * place that must change, and the guard will point at it.
+ * The review's point was sharp: they took a `Principal`, whose `projectScope` makes it token-shaped,
+ * while unconditionally asserting memberhood inside. That combination is a footgun the type system
+ * endorsed — a future token route could legitimately call `visibleProjectRows(db, tokenPrincipal)`,
+ * get the hand-typed arm opened for it, and redden nothing, because the member literal lives in this
+ * allow-listed file and the new caller need not contain one. So the parameter is now
+ * `MemberPrincipal`, which cannot carry a scope, and the assertion inside is true by construction.
+ *
+ * The value is still named once, HERE, rather than spelled at each call site — a bare `"member"`
+ * literal scattered through the file is the shape a future token path would copy.
  */
 const MEMBER_ONLY_SURFACE = "member" as const;
 
 /**
- * The discriminator is a PARAMETER, not a hardcoded "member". These helpers take a
- * `Principal`, and that type permits `projectScope` — i.e. a token-shaped value — so baking in
- * "member" here would open the hand-typed arm for any future internal token caller.
+ * A principal that CANNOT be a delegated token. `projectScope?: never` makes a token-shaped value a
+ * compile error at the call site rather than a silent widening inside. Do not infer member-vs-token
+ * from `projectScope` being absent at runtime — an UNATTENUATED token also has a null scope, which
+ * is exactly why this is a type constraint on the caller and not a check in here.
+ */
+export type MemberPrincipal = Principal & { projectScope?: never };
+
+/**
+ * The discriminator is a parameter of this SQL builder so the policy stays in one place
+ * (`admitsUnsourced`), and its three callers below all pass `MEMBER_ONLY_SURFACE` — which is honest
+ * only because they now take a `MemberPrincipal` that cannot be a token. An earlier version of this
+ * comment claimed the parameterisation itself was the safety property; it was not, and Codex's diff
+ * review caught the claim before the type made it true.
  */
 function projectRowVisibleSql(
   teamId: string,
@@ -272,7 +284,7 @@ function projectRowVisibleSql(
   return { p, where };
 }
 
-export async function visibleProjectRows(db: DbClient, principal: Principal): Promise<VisibleProjectRows> {
+export async function visibleProjectRows(db: DbClient, principal: MemberPrincipal): Promise<VisibleProjectRows> {
   try {
     const { projectIds } = await visibleProjects(db, principal);
     const posture = await teamPostureFor(db, principal);
@@ -284,7 +296,7 @@ export async function visibleProjectRows(db: DbClient, principal: Principal): Pr
   }
 }
 
-export async function canSeeProjectRow(db: DbClient, principal: Principal, projectId: string): Promise<boolean> {
+export async function canSeeProjectRow(db: DbClient, principal: MemberPrincipal, projectId: string): Promise<boolean> {
   try {
     const { projectIds } = await visibleProjects(db, principal);
     const posture = await teamPostureFor(db, principal);
@@ -314,7 +326,7 @@ export interface ProjectRowCard {
 
 export async function visibleProjectCards(
   db: DbClient,
-  principal: Principal
+  principal: MemberPrincipal
 ): Promise<{ rows: ProjectRowCard[]; error?: boolean }> {
   try {
     const { projectIds } = await visibleProjects(db, principal);

--- a/lib/access/enforce.ts
+++ b/lib/access/enforce.ts
@@ -231,7 +231,9 @@ export interface VisibleProjectRows {
 
 /**
  * AUDITFIX-1 §2b. The three project-row helpers below (`visibleProjectRows`, `canSeeProjectRow`,
- * `visibleProjectCards`) are member-only BY CONSTRUCTION, not by convention: every one of their eight
+ * `visibleProjectCards`) are member-only by CONVENTION PLUS A GUARD — not by type, and not by
+ * construction: the `Principal` they take permits `projectScope`, i.e. a token-shaped value. What
+ * makes the convention true today is call-site enumeration: every one of their eight
  * call sites is a session-authenticated page or an `aios_` member route, and `authenticateApiKey`
  * (lib/api/auth.ts) rejects an `aiosd_` bearer, so a delegated token cannot reach them.
  *

--- a/lib/access/provenance-sql.ts
+++ b/lib/access/provenance-sql.ts
@@ -36,8 +36,31 @@ export function newSqlParams(initial: readonly unknown[] = []): SqlParams {
   };
 }
 
+/**
+ * WHO is asking. The unsourced (hand-typed) arm is admitted for a MEMBER at team posture and for
+ * nobody else — see `admitsUnsourced`.
+ *
+ * A delegated token's authority is its attenuated scope; a row with no `source_item_id` cannot be
+ * tested against that scope, so it can never be shown to one. Absent/foreign values close.
+ */
+export type ProvenancePrincipal = "member" | "token" | undefined;
+
+/**
+ * THE POLICY, in one place, expressed POSITIVELY (AUDITFIX-1).
+ *
+ * Positive on purpose: `principal !== "token"` would admit `undefined`, `null` and any foreign value
+ * — and those are real runtime states here, because `tsconfig.json` excludes `test/`, so an omitted
+ * discriminator never fails typecheck. Written this way, everything that is not an explicit member at
+ * team posture closes.
+ */
+export function admitsUnsourced(ctx: { principal?: ProvenancePrincipal; teamPosture: boolean }): boolean {
+  return ctx.principal === "member" && ctx.teamPosture === true;
+}
+
 export interface ProvenanceSqlCtx {
   teamId: string;
+  /** WHO is asking (AUDITFIX-1). Absent closes the hand-typed arm — never synthesise "member". */
+  principal?: ProvenancePrincipal;
   /** The oracle's granted project set (`visibleProjects(...).projectIds`) — NOT the §2.1
    *  row-visible set; the semijoin derives item visibility from grants + curations. */
   grantedProjectIds: readonly string[];
@@ -80,32 +103,38 @@ export function itemVisibleSql(expr: string, p: SqlParams, ctx: ProvenanceSqlCtx
  * decisions by ENFB-2 design round 2 H6).
  */
 export function provenanceRowSql(alias: string, p: SqlParams, ctx: ProvenanceSqlCtx): string {
-  const posture = p.add(ctx.teamPosture);
+  const sourced = `(${alias}.source_item_id is not null and ${itemVisibleSql(`${alias}.source_item_id`, p, ctx)})`;
+  // The arm is OMITTED, not parameterised false — a token's SQL simply has no hand-typed disjunct.
+  if (!admitsUnsourced(ctx)) return `(${sourced})`;
   return `(
-    (${alias}.source_item_id is not null and ${itemVisibleSql(`${alias}.source_item_id`, p, ctx)})
-    or (${alias}.source_item_id is null and ${alias}.created_by is not null and ${posture})
+    ${sourced}
+    or (${alias}.source_item_id is null and ${alias}.created_by is not null)
   )`;
 }
 
 /**
- * The ID-ARRAY form — the exact SQL twin of `rowVisibleByProvenance(row, visibleItemIds,
- * tier)` for sites that ALREADY hold the principal's materialized visible-item set (retrieve,
- * the timeline, the board, both API lists): sourced → the source id is in the set; null-source
- * → hand-typed at team posture. This form serves EVERY principal correctly (a delegated
- * token's set is its attenuated set — the semijoin form above would need the granted-project
- * ctx that tokens deliberately do not carry), and it adds zero substrate reads at sites that
- * post-filtered with the same set yesterday. The array binds as ONE parameter. The documented
- * large-corpus deferral (enforce.ts) applies unchanged.
+ * The ID-ARRAY form — the exact SQL twin of `rowVisibleByProvenance` for sites that ALREADY hold the
+ * principal's materialized visible-item set (retrieve, the timeline, the board, both API lists):
+ * sourced → the source id is in the set; null-source → hand-typed, and ONLY for a member at team
+ * posture (`admitsUnsourced`).
+ *
+ * ⚠️ THIS DOCSTRING USED TO CLAIM the form "serves EVERY principal correctly (a delegated token's set
+ * is its attenuated set)". That was false and it was the whole bug: the null-source arm never
+ * consulted `visibleItemIds` at all, so an empty-scoped token received every hand-typed task and
+ * decision in the team. Reproduced against real Postgres before this was written (AUDITFIX-1).
+ *
+ * The array binds as ONE parameter. The documented large-corpus deferral (enforce.ts) is unchanged.
  */
 export function provenanceRowSqlFromIds(
   alias: string,
   p: SqlParams,
-  ctx: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean }
+  ctx: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean; principal?: ProvenancePrincipal }
 ): string {
   const ids = p.add([...ctx.visibleItemIds]);
-  const posture = p.add(ctx.teamPosture);
+  const sourced = `(${alias}.source_item_id is not null and ${alias}.source_item_id = any(${ids}::uuid[]))`;
+  if (!admitsUnsourced(ctx)) return `(${sourced})`;
   return `(
-    (${alias}.source_item_id is not null and ${alias}.source_item_id = any(${ids}::uuid[]))
-    or (${alias}.source_item_id is null and ${alias}.created_by is not null and ${posture})
+    ${sourced}
+    or (${alias}.source_item_id is null and ${alias}.created_by is not null)
   )`;
 }

--- a/lib/access/provenance.ts
+++ b/lib/access/provenance.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { admitsUnsourced, type ProvenancePrincipal } from "@/lib/access/provenance-sql";
 
 /**
  * The settled PROVENANCE rule for structured rows (tasks/decisions) on body-serving surfaces —
@@ -10,13 +11,20 @@ import "server-only";
  *     AND the viewer is team posture (no membership axis exists for a hand-typed row, so the
  *     audience wall survives on exactly this branch).
  * Fail-closed: a missing visibility set denies sourced rows.
+ *
+ * `principal` (AUDITFIX-1) is the THIRD owner of this contract taking the same discriminator as the
+ * two SQL forms, so "one contract, three owners" is true rather than asserted. The hand-typed arm is
+ * admitted only for an explicit member at team posture; a token, an absent value and a foreign value
+ * all close. It is REQUIRED rather than defaulted: a default would be the permissive value, and this
+ * whole slice exists because a permissive default was obtainable by saying nothing.
  */
 export function rowVisibleByProvenance(
   row: { source_item_id?: string | null; created_by?: string | null },
   visibleItemIds: ReadonlySet<string> | null,
-  tier: "team" | "external"
+  tier: "team" | "external",
+  principal: ProvenancePrincipal
 ): boolean {
   const source = row.source_item_id ?? null;
   if (source !== null) return visibleItemIds != null && visibleItemIds.has(source);
-  return (row.created_by ?? null) !== null && tier === "team";
+  return (row.created_by ?? null) !== null && admitsUnsourced({ principal, teamPosture: tier === "team" });
 }

--- a/lib/access/structured-windows.ts
+++ b/lib/access/structured-windows.ts
@@ -13,6 +13,8 @@ import { newSqlParams, provenanceRowSqlFromIds } from "@/lib/access/provenance-s
 export interface ProvenanceCtx {
   visibleItemIds: ReadonlySet<string>;
   teamPosture: boolean;
+  /** WHO is asking (AUDITFIX-1). These windows serve session/aios_ MEMBERS only. */
+  principal?: "member" | "token";
 }
 
 /** The tasks BOARD's 500-row window (app/t/[team]/tasks) — column list matches the board's

--- a/lib/dashboard/work-timeline.ts
+++ b/lib/dashboard/work-timeline.ts
@@ -206,7 +206,8 @@ export async function getWorkTimeline(
   // downstream as the defense-in-depth layer over the SAME contract), so invisible rows can no
   // longer starve the TASK_LIMIT/DECISION_LIMIT windows. `{ data, error }` shape mirrors the
   // builder so the legs' existing error contracts (throw for core, WARN for enrichment) hold.
-  const provCtx = { visibleItemIds: enforce?.visibleItemIds ?? new Set<string>(), teamPosture: tier !== "external" };
+  // Member-only surface (AUDITFIX-1 §2a): the timeline is session-authenticated.
+  const provCtx = { visibleItemIds: enforce?.visibleItemIds ?? new Set<string>(), teamPosture: tier !== "external", principal: "member" as const };
   const provenanceTaskWindow = (opts: { statuses?: readonly string[]; requireRowKey?: boolean }) => {
     const p = newSqlParams();
     const conds = [`t.team_id = ${p.add(teamId)}`];
@@ -666,7 +667,7 @@ export async function getWorkTimeline(
     // The settled provenance rule, decisions edition (ENFB-1 §2.7) — ONE owner
     // (lib/access/provenance); srcVisible's extra enforce-null guard is subsumed: enforce is
     // never null here (the builder throws upstream without a view).
-    if (!rowVisibleByProvenance(d, enforce?.visibleItemIds ?? null, tier === "external" ? "external" : "team")) continue;
+    if (!rowVisibleByProvenance(d, enforce?.visibleItemIds ?? null, tier === "external" ? "external" : "team", "member")) continue;
     if (!d.decided_at) continue; // no day to place it on (mirrors the undated-work drop)
     const by = (d.decided_by ?? "").trim();
     if (!by) continue; // empty / group-level decided_by → dropped (a later team-signal lane's job)

--- a/lib/identity/context.ts
+++ b/lib/identity/context.ts
@@ -111,7 +111,7 @@ export async function getMemberContext(
   // ENFB-2 §2.2: the VIEWER's oracle ctx — the derived-projects read serves restricted
   // project names + per-project task counts, so it computes over the viewer-visible task
   // set. Absent → fail closed (no derived projects), never the ungated team-wide read.
-  viewerCtx?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean }
+  viewerCtx?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean; principal?: "member" | "token" }
 ): Promise<MemberContext | null> {
   if (!canSeeMemberContext(tier)) return null;
 
@@ -212,7 +212,7 @@ async function deriveProjects(
   db: DbClient,
   teamId: string,
   names: string[],
-  viewerCtx?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean }
+  viewerCtx?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean; principal?: "member" | "token" }
 ): Promise<ProjectView[]> {
   if (!names.length) return [];
   if (!viewerCtx) return []; // fail closed — never the ungated team-wide read

--- a/lib/metrics/pulse.ts
+++ b/lib/metrics/pulse.ts
@@ -165,8 +165,12 @@ export async function getPulseMetrics(
   }
 ): Promise<PulseMetrics> {
   const { isAdmin, tier } = viewer;
-  // Member-only surface (AUDITFIX-1 §2a): the Pulse dashboard is session-authenticated.
-  const provCtx = viewer.provCtx ?? { visibleItemIds: new Set<string>(), teamPosture: false, principal: "member" as const };
+  // The FALLBACK synthesises nothing (AUDITFIX-1 §2d): an absent ctx yields an absent principal,
+  // which closes the hand-typed arm. It is inert today only because the fallback also pins
+  // `teamPosture: false` — and relying on that would mean a later "fix" to the default posture
+  // silently opens the arm for a caller that supplied no view at all. The real ctx, carrying an
+  // explicit "member", comes from the session-authenticated page (app/t/[team]/page.tsx).
+  const provCtx = viewer.provCtx ?? { visibleItemIds: new Set<string>(), teamPosture: false };
   const days = rangeDays(range);
   const now = new Date();
   const windowStart = new Date(now.getTime() - days * 86_400_000);

--- a/lib/metrics/pulse.ts
+++ b/lib/metrics/pulse.ts
@@ -161,11 +161,12 @@ export async function getPulseMetrics(
     /** ENFB-2 §2.2: the viewer's oracle ctx — DISPLAYED counts compute over the visible sets
      *  (per-kind item growth and the task funnel were team-wide volume disclosures). Absent →
      *  fail closed (empty sets → zero counts). */
-    provCtx?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean };
+    provCtx?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean; principal?: "member" | "token" };
   }
 ): Promise<PulseMetrics> {
   const { isAdmin, tier } = viewer;
-  const provCtx = viewer.provCtx ?? { visibleItemIds: new Set<string>(), teamPosture: false };
+  // Member-only surface (AUDITFIX-1 §2a): the Pulse dashboard is session-authenticated.
+  const provCtx = viewer.provCtx ?? { visibleItemIds: new Set<string>(), teamPosture: false, principal: "member" as const };
   const days = rangeDays(range);
   const now = new Date();
   const windowStart = new Date(now.getTime() - days * 86_400_000);

--- a/lib/query/provider.ts
+++ b/lib/query/provider.ts
@@ -37,7 +37,7 @@ export type RetrievedContext = {
   grounded: boolean;
   /** PCCC-6 (spec's expansion budget): how many of the principal's visible projects the K-capped
    * graph stage actually covered — the deliberate own-scope disclosure exception to §5.7. Absent
-   * when the graph leg didn't run partitioned (permissive tier path, external omit, no graph). */
+   * when the graph leg didn't run partitioned (no enforcement view, external omit, no graph). */
   graphScope?: { covered: number; total: number };
 };
 
@@ -53,7 +53,10 @@ export interface RetrievalRequest {
    *  K-capped ready partitions (the PCCC-6 read cutover); absent keeps the §5.8b omit (external
    *  principals, delegated tokens). `principal` discriminates the org-structural mirror legs
    *  (QMIR-1) — "member" regains actors + REPORTS_TO; anything else is token semantics.
-   *  Absent/null enforce = permissive. */
+   *  Absent/null enforce does NOT mean permissive — PRET-6 retired that model. `retrieve()`'s
+   *  public entry throws without it, and this seam (independently callable) yields
+   *  `principal: undefined`, which CLOSES the hand-typed structured arm (AUDITFIX-1 §2d).
+   *  Never synthesise "member" here: that is the sentence that would reopen the leak. */
   enforce?: { visibleItemIds: ReadonlySet<string>; graphProjectIds?: readonly string[]; principal: "member" | "token" } | null;
 }
 

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -600,6 +600,10 @@ async function nativeRetrieve(
     ? matchingDecisions(teamId, tier, ftsQuery, 10, {
         visibleItemIds: visibleIds ?? new Set(),
         teamPosture: tier === "team",
+        // FORWARDED, never re-derived (AUDITFIX-1 §2a). This leg is token-reachable, and the
+        // discriminator is the only thing standing between a scoped token and every hand-typed
+        // decision in the team. Deriving it here from `tier` would say "member" for every token.
+        principal: enforce?.principal,
       })
     : Promise.resolve([]);
 
@@ -642,9 +646,15 @@ async function nativeRetrieve(
   // 3. Structured-context queries — ENFB-2 §2.2: the provenance predicate compiles IN-QUERY
   // (before LIMIT), so the recency-50 and task-80 windows fill with rows THIS principal may
   // see — the ENFB-1 deferred starvation class (Codex M1) dies here. The id-array fragment is
-  // the exact SQL twin of `rowVisibleByProvenance` (one contract, two owners, dm-pinned to
+  // the exact SQL twin of `rowVisibleByProvenance` (one contract, THREE owners, dm-pinned to
   // fixture-level expected truth). Audience conjuncts preserved verbatim.
-  const provCtx = { visibleItemIds: visibleIds ?? new Set<string>(), teamPosture: tier === "team" };
+  // `principal` is FORWARDED from the caller's enforcement view — see AUDITFIX-1 §2a. Absent
+  // enforcement yields `undefined`, which CLOSES the hand-typed arm; it must never become "member".
+  const provCtx = {
+    visibleItemIds: visibleIds ?? new Set<string>(),
+    teamPosture: tier === "team",
+    principal: enforce?.principal,
+  };
   const dParams = newSqlParams();
   const dTeam = dParams.add(teamId);
   const dAccess = isRestrictedTier(tier) ? `and d.audience = 'external'` : "";

--- a/lib/query/structured-extras.ts
+++ b/lib/query/structured-extras.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
 import { isRestrictedTier } from "@/lib/auth/visibility";
-import { newSqlParams, provenanceRowSqlFromIds } from "@/lib/access/provenance-sql";
+import { newSqlParams, provenanceRowSqlFromIds, type ProvenancePrincipal } from "@/lib/access/provenance-sql";
 
 /**
  * Structured-context helpers that fix the "digests are recency-capped" scaling gaps (Gaps #5, #6).
@@ -66,7 +66,7 @@ export async function matchingDecisions(
   // ENFB-2 §2.2: the provenance predicate compiles into THIS window too (the keyword leg was
   // one of the deferred post-LIMIT sites). Absent ctx (a caller with no enforcement view)
   // fails CLOSED: an empty visible set admits only nothing-sourced… i.e. no sourced rows.
-  enforce?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean }
+  enforce?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean; principal?: ProvenancePrincipal }
 ): Promise<DecisionMatch[]> {
   if (!orQuery.trim()) return [];
   try {
@@ -75,6 +75,9 @@ export async function matchingDecisions(
     const prov = provenanceRowSqlFromIds("d", p, {
       visibleItemIds: enforce?.visibleItemIds ?? new Set(),
       teamPosture: enforce?.teamPosture ?? false,
+      // Absent enforcement closes the hand-typed arm (undefined), preserving this function's
+      // existing fail-closed default rather than synthesising a member (AUDITFIX-1 §2d).
+      principal: enforce?.principal,
     });
     const params: unknown[] = p.values;
     const sql = `

--- a/lib/sync/decisions.ts
+++ b/lib/sync/decisions.ts
@@ -43,7 +43,7 @@ export async function getDecisionWriteback(
   teamId: string,
   tier: ViewerTier,
   since: string,
-  enforce: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean }
+  enforce: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean; principal?: "member" | "token" }
 ): Promise<DecisionWritebackGroup[]> {
   void db; // the feed reads through the shared pool (raw SQL); kept for signature stability
   const p = newSqlParams();

--- a/test/access-provenance-principal.test.ts
+++ b/test/access-provenance-principal.test.ts
@@ -79,31 +79,42 @@ describe("all three owners agree — against expected truth, not against each ot
     { name: "unsourced + unauthored", row: { source_item_id: null, created_by: null }, member: false, token: false },
   ] as const;
 
-  // AC7 says the table crosses all FIVE principal inputs against all THREE owners. It used to cross
-  // three inputs against one owner, and Fable's diff review caught the sentence being false rather
-  // than the coverage being wrong. Both are now what AC7 says.
+  // Only the TS twin can be asked about a ROW at unit level — the SQL owners return text, and the
+  // row is applied by Postgres. So the row x principal cross belongs to the twin, and the SQL owners
+  // are asserted on the two things they CAN be asserted on here (below): the arm's presence per
+  // principal, and the arm's structure.
+  //
+  // A previous version of this loop built both SQL strings INSIDE the row loop and asserted them
+  // there. Codex's diff review caught it: neither string referenced `r`, so 15 of those 20
+  // assertions were the same 5 assertions repeated — and the trailing
+  // `if (unsourced && created_by === null) expect(expected).toBe(false)` re-asserted a constant
+  // written twenty lines above in ROWS. A tautology reads exactly like coverage.
   for (const r of ROWS) {
     for (const [principal, admitted] of PRINCIPALS) {
       const expected = admitted ? r.member : r.token;
-      it(`${r.name}, principal=${String(principal)} → ${expected}`, () => {
-        // Owner 1 — the TS twin, which answers per row.
+      it(`TS twin — ${r.name}, principal=${String(principal)} → ${expected}`, () => {
         expect(rowVisibleByProvenance(r.row, ids, "team", principal as undefined)).toBe(expected);
-
-        // Owners 2 and 3 — the SQL forms answer with an ARM, not a boolean, so the observable is
-        // whether the unsourced disjunct exists. Only the unsourced rows can distinguish them.
-        const unsourced = r.row.source_item_id === null;
-        for (const [label, sql] of [
-          ["id-array", provenanceRowSqlFromIds("t", newSqlParams(), { visibleItemIds: ids, teamPosture: true, principal: principal as undefined })],
-          ["semijoin", provenanceRowSql("t", newSqlParams(), { teamId: "t1", grantedProjectIds: ["p1"], teamPosture: true, principal: principal as undefined })],
-        ] as const) {
-          expect(sql.includes("created_by is not null"), `${label}, principal=${String(principal)}`).toBe(admitted);
-          // …and an unsourced-and-UNAUTHORED row is denied by every owner regardless, because the
-          // arm the SQL emits still requires `created_by is not null`.
-          if (unsourced && r.row.created_by === null) expect(expected).toBe(false);
-        }
       });
     }
   }
+
+  it("the SQL owners' hand-typed arm carries the SAME two conditions the twin applies", () => {
+    // The structural half of "one contract, three owners": the twin admits an unsourced row only
+    // when `created_by` is non-null, so the SQL the owners emit must test exactly that, on exactly
+    // the null-source branch. Asserted ONCE — it does not vary by row, and pretending otherwise is
+    // what made the previous version look like 20 cases of coverage.
+    for (const [label, sql] of [
+      ["id-array", provenanceRowSqlFromIds("t", newSqlParams(), { visibleItemIds: ids, teamPosture: true, principal: "member" })],
+      ["semijoin", provenanceRowSql("t", newSqlParams(), { teamId: "t1", grantedProjectIds: ["p1"], teamPosture: true, principal: "member" })],
+    ] as const) {
+      expect(sql, `${label}: the arm must require BOTH null source and an author`).toMatch(
+        /source_item_id is null and t\.created_by is not null/
+      );
+    }
+    // Row-level truth for the SQL owners lives where a database can apply it: the agreement suite
+    // in test/datamechanics/enfb2-inquery-provenance.datamechanics.test.ts, which runs both forms
+    // against fixtures and compares them to the twin.
+  });
 
   it("the TS twin and the id-array SQL agree on whether the unsourced arm exists at all", () => {
     for (const [principal, admitted] of PRINCIPALS) {

--- a/test/access-provenance-principal.test.ts
+++ b/test/access-provenance-principal.test.ts
@@ -79,13 +79,30 @@ describe("all three owners agree — against expected truth, not against each ot
     { name: "unsourced + unauthored", row: { source_item_id: null, created_by: null }, member: false, token: false },
   ] as const;
 
+  // AC7 says the table crosses all FIVE principal inputs against all THREE owners. It used to cross
+  // three inputs against one owner, and Fable's diff review caught the sentence being false rather
+  // than the coverage being wrong. Both are now what AC7 says.
   for (const r of ROWS) {
-    it(`${r.name}: member=${r.member} token=${r.token}`, () => {
-      expect(rowVisibleByProvenance(r.row, ids, "team", "member")).toBe(r.member);
-      expect(rowVisibleByProvenance(r.row, ids, "team", "token")).toBe(r.token);
-      // The closed cases behave as a token does.
-      expect(rowVisibleByProvenance(r.row, ids, "team", undefined)).toBe(r.token);
-    });
+    for (const [principal, admitted] of PRINCIPALS) {
+      const expected = admitted ? r.member : r.token;
+      it(`${r.name}, principal=${String(principal)} → ${expected}`, () => {
+        // Owner 1 — the TS twin, which answers per row.
+        expect(rowVisibleByProvenance(r.row, ids, "team", principal as undefined)).toBe(expected);
+
+        // Owners 2 and 3 — the SQL forms answer with an ARM, not a boolean, so the observable is
+        // whether the unsourced disjunct exists. Only the unsourced rows can distinguish them.
+        const unsourced = r.row.source_item_id === null;
+        for (const [label, sql] of [
+          ["id-array", provenanceRowSqlFromIds("t", newSqlParams(), { visibleItemIds: ids, teamPosture: true, principal: principal as undefined })],
+          ["semijoin", provenanceRowSql("t", newSqlParams(), { teamId: "t1", grantedProjectIds: ["p1"], teamPosture: true, principal: principal as undefined })],
+        ] as const) {
+          expect(sql.includes("created_by is not null"), `${label}, principal=${String(principal)}`).toBe(admitted);
+          // …and an unsourced-and-UNAUTHORED row is denied by every owner regardless, because the
+          // arm the SQL emits still requires `created_by is not null`.
+          if (unsourced && r.row.created_by === null) expect(expected).toBe(false);
+        }
+      });
+    }
   }
 
   it("the TS twin and the id-array SQL agree on whether the unsourced arm exists at all", () => {

--- a/test/access-provenance-principal.test.ts
+++ b/test/access-provenance-principal.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { admitsUnsourced, newSqlParams, provenanceRowSql, provenanceRowSqlFromIds } from "@/lib/access/provenance-sql";
+import { rowVisibleByProvenance } from "@/lib/access/provenance";
+
+/**
+ * Spec (AUDITFIX-1 §2): the hand-typed (unsourced) arm is admitted for a MEMBER at team posture and
+ * for nobody else — and that is asserted POSITIVELY, because `!== "token"` would admit `undefined`,
+ * `null` and any foreign value. Those are real runtime states: `tsconfig.json` excludes `test/`, so an
+ * omitted discriminator never fails typecheck.
+ *
+ * The reproduced defect this pins: an empty-scoped delegated token received every hand-typed task and
+ * decision in the team, because the arm never consulted `visibleItemIds` at all.
+ */
+
+/** The five inputs §2 names. `null`/foreign are cast because they are runtime states, not typed ones. */
+const PRINCIPALS = [
+  ["member", true],
+  ["token", false],
+  [undefined, false],
+  [null as unknown as undefined, false],
+  ["administrator" as unknown as undefined, false],
+] as const;
+
+describe("admitsUnsourced — the one policy, positively expressed", () => {
+  for (const [principal, admitted] of PRINCIPALS) {
+    it(`principal=${String(principal)} at team posture → ${admitted ? "admits" : "closes"}`, () => {
+      expect(admitsUnsourced({ principal, teamPosture: true })).toBe(admitted);
+    });
+  }
+
+  it("a member at EXTERNAL posture still closes — posture is the other conjunct", () => {
+    // The audience wall predates this slice and must survive it: this is not a token rule only.
+    expect(admitsUnsourced({ principal: "member", teamPosture: false })).toBe(false);
+  });
+});
+
+describe("the SQL owners emit the arm only when the policy admits it", () => {
+  const idsSql = (principal: unknown) =>
+    provenanceRowSqlFromIds("t", newSqlParams(), {
+      visibleItemIds: new Set(["11111111-1111-1111-1111-111111111111"]),
+      teamPosture: true,
+      principal: principal as undefined,
+    });
+  const semiSql = (principal: unknown) =>
+    provenanceRowSql("t", newSqlParams(), {
+      teamId: "t1",
+      grantedProjectIds: ["p1"],
+      teamPosture: true,
+      principal: principal as undefined,
+    });
+
+  for (const [principal, admitted] of PRINCIPALS) {
+    it(`id-array form, principal=${String(principal)} → unsourced disjunct ${admitted ? "present" : "ABSENT"}`, () => {
+      const sql = idsSql(principal);
+      expect(sql.includes("created_by is not null"), sql).toBe(admitted);
+      // The sourced half must survive in EVERY case — closing the arm must not blank the predicate.
+      expect(sql).toContain("source_item_id is not null");
+    });
+
+    it(`semijoin form, principal=${String(principal)} → unsourced disjunct ${admitted ? "present" : "ABSENT"}`, () => {
+      const sql = semiSql(principal);
+      expect(sql.includes("created_by is not null"), sql).toBe(admitted);
+      expect(sql).toContain("source_item_id is not null");
+    });
+  }
+});
+
+describe("all three owners agree — against expected truth, not against each other", () => {
+  const VISIBLE = "22222222-2222-2222-2222-222222222222";
+  const INVISIBLE = "33333333-3333-3333-3333-333333333333";
+  const ids = new Set([VISIBLE]);
+
+  // The truth table §4 AC7 requires. "agreement" alone is satisfied by three identically WRONG
+  // implementations, so each row states the expected ANSWER.
+  const ROWS = [
+    { name: "sourced + visible", row: { source_item_id: VISIBLE, created_by: null }, member: true, token: true },
+    { name: "sourced + invisible", row: { source_item_id: INVISIBLE, created_by: null }, member: false, token: false },
+    { name: "unsourced + authored", row: { source_item_id: null, created_by: "u1" }, member: true, token: false },
+    { name: "unsourced + unauthored", row: { source_item_id: null, created_by: null }, member: false, token: false },
+  ] as const;
+
+  for (const r of ROWS) {
+    it(`${r.name}: member=${r.member} token=${r.token}`, () => {
+      expect(rowVisibleByProvenance(r.row, ids, "team", "member")).toBe(r.member);
+      expect(rowVisibleByProvenance(r.row, ids, "team", "token")).toBe(r.token);
+      // The closed cases behave as a token does.
+      expect(rowVisibleByProvenance(r.row, ids, "team", undefined)).toBe(r.token);
+    });
+  }
+
+  it("the TS twin and the id-array SQL agree on whether the unsourced arm exists at all", () => {
+    for (const [principal, admitted] of PRINCIPALS) {
+      const tsAdmits = rowVisibleByProvenance({ source_item_id: null, created_by: "u1" }, ids, "team", principal as undefined);
+      const sqlAdmits = provenanceRowSqlFromIds("t", newSqlParams(), {
+        visibleItemIds: ids,
+        teamPosture: true,
+        principal: principal as undefined,
+      }).includes("created_by is not null");
+      expect(tsAdmits, `TS twin, principal=${String(principal)}`).toBe(admitted);
+      expect(sqlAdmits, `SQL form, principal=${String(principal)}`).toBe(admitted);
+    }
+  });
+});

--- a/test/access-provenance.test.ts
+++ b/test/access-provenance.test.ts
@@ -4,30 +4,37 @@ import { rowVisibleByProvenance } from "@/lib/access/provenance";
 // ENFB-1 AC3 (as re-specified): the settled provenance rule has ONE owner; every arm pinned
 // here, and the body-surface pages' WIRING to it is pinned by the dashboard-tier-filter
 // guard's oracle layer (a page dropping the call reddens the guard, not this file).
+//
+// AUDITFIX-1 threaded a 4th argument, `principal`, through this contract. Every assertion below
+// states MEMBER behaviour — the settled ENFB-2 hand-typed rule, which that slice deliberately does
+// NOT change — so "member" is passed EXPLICITLY. It is not defaulted: an omitted discriminator is
+// `undefined` and closes the hand-typed arm, and a permissive default obtainable by saying nothing
+// is the exact defect AUDITFIX-1 exists to remove. The token/absent/foreign inputs are pinned in
+// test/access-provenance-principal.test.ts.
 
 const vis = new Set(["visible-item"]);
 
 describe("rowVisibleByProvenance — every arm", () => {
   it("sourced + visible source → true", () => {
-    expect(rowVisibleByProvenance({ source_item_id: "visible-item", created_by: null }, vis, "team")).toBe(true);
+    expect(rowVisibleByProvenance({ source_item_id: "visible-item", created_by: null }, vis, "team", "member")).toBe(true);
   });
   it("sourced + invisible source → false (restricted basis walled), even for team posture and even hand-typed", () => {
-    expect(rowVisibleByProvenance({ source_item_id: "hidden-item", created_by: null }, vis, "team")).toBe(false);
-    expect(rowVisibleByProvenance({ source_item_id: "hidden-item", created_by: "someone" }, vis, "team")).toBe(false);
+    expect(rowVisibleByProvenance({ source_item_id: "hidden-item", created_by: null }, vis, "team", "member")).toBe(false);
+    expect(rowVisibleByProvenance({ source_item_id: "hidden-item", created_by: "someone" }, vis, "team", "member")).toBe(false);
   });
   it("sourced + NO visibility set → false (fail closed, never fail open)", () => {
-    expect(rowVisibleByProvenance({ source_item_id: "visible-item", created_by: null }, null, "team")).toBe(false);
+    expect(rowVisibleByProvenance({ source_item_id: "visible-item", created_by: null }, null, "team", "member")).toBe(false);
   });
   it("null-source + created_by + team posture → true (the hand-typed round-trip)", () => {
-    expect(rowVisibleByProvenance({ source_item_id: null, created_by: "author" }, vis, "team")).toBe(true);
-    expect(rowVisibleByProvenance({ created_by: "author" }, null, "team")).toBe(true); // vis not needed on this branch
+    expect(rowVisibleByProvenance({ source_item_id: null, created_by: "author" }, vis, "team", "member")).toBe(true);
+    expect(rowVisibleByProvenance({ created_by: "author" }, null, "team", "member")).toBe(true); // vis not needed on this branch
   });
   it("null-source + created_by + EXTERNAL posture → false (no membership axis — the audience wall survives)", () => {
-    expect(rowVisibleByProvenance({ source_item_id: null, created_by: "author" }, vis, "external")).toBe(false);
+    expect(rowVisibleByProvenance({ source_item_id: null, created_by: "author" }, vis, "external", "member")).toBe(false);
   });
   it("null-source + NO created_by → false in every posture (the purged-restricted-basis class)", () => {
-    expect(rowVisibleByProvenance({ source_item_id: null, created_by: null }, vis, "team")).toBe(false);
-    expect(rowVisibleByProvenance({}, vis, "team")).toBe(false);
-    expect(rowVisibleByProvenance({ source_item_id: null }, vis, "external")).toBe(false);
+    expect(rowVisibleByProvenance({ source_item_id: null, created_by: null }, vis, "team", "member")).toBe(false);
+    expect(rowVisibleByProvenance({}, vis, "team", "member")).toBe(false);
+    expect(rowVisibleByProvenance({ source_item_id: null }, vis, "external", "member")).toBe(false);
   });
 });

--- a/test/datamechanics/access-enforce-retrieve.datamechanics.test.ts
+++ b/test/datamechanics/access-enforce-retrieve.datamechanics.test.ts
@@ -181,14 +181,16 @@ describe("enforced retrieval (Phase B slice 2)", () => {
     await backfillTeamContext(db(), seed.teamId);
     const member = await seedMember(seed);
 
-    const teamView = { visibleItemIds: (await visibleItemIds(db(), { teamId: seed.teamId, memberId: member })).ids };
+    // AUDITFIX-1: the discriminator is threaded EXPLICITLY — this test asserts the MEMBER
+    // hand-typed rule, and an omitted `principal` is `undefined`, which closes that arm.
+    const teamView = { visibleItemIds: (await visibleItemIds(db(), { teamId: seed.teamId, memberId: member })).ids, principal: "member" as const };
     const asTeam = await retrieve(db(), seed.teamId, "team", `${TERM} tasks`, null, teamView);
     expect(asTeam.structured, "the hand-typed task survives for a team member").toContain("Hand-typed dashboard task");
     expect(asTeam.structured, "a purged-basis synced task stays dropped").not.toContain("Purged-basis synced task");
 
     const { externalMember } = await import("./helpers");
     const ext = await externalMember(seed);
-    const extView = { visibleItemIds: (await visibleItemIds(db(), { teamId: seed.teamId, memberId: ext })).ids };
+    const extView = { visibleItemIds: (await visibleItemIds(db(), { teamId: seed.teamId, memberId: ext })).ids, principal: "member" as const };
     const asExt = await retrieve(db(), seed.teamId, "external", `${TERM} tasks`, null, extView);
     expect(asExt.structured, "a hand-typed row has no membership axis — the posture wall holds").not.toContain("Hand-typed dashboard task");
   });

--- a/test/datamechanics/decisions-writeback.datamechanics.test.ts
+++ b/test/datamechanics/decisions-writeback.datamechanics.test.ts
@@ -17,7 +17,9 @@ async function wctx(seed: Seed, tier: "team" | "external", memberId?: string) {
   const id = memberId ?? seed.memberId;
   const vis = await visibleItemIds(db(), { teamId: seed.teamId, memberId: id });
   expect(vis.error, "ctx resolution must not error").toBeFalsy();
-  return { visibleItemIds: vis.ids, teamPosture: tier === "team" };
+  // AUDITFIX-1: `principal` is threaded EXPLICITLY. Every assertion in this file states MEMBER
+  // behaviour, and an omitted discriminator is `undefined`, which CLOSES the hand-typed arm.
+  return { visibleItemIds: vis.ids, teamPosture: tier === "team", principal: "member" as const };
 }
 
 async function externalMemberId(seed: Seed): Promise<string> {

--- a/test/datamechanics/enfb-decision-create.datamechanics.test.ts
+++ b/test/datamechanics/enfb-decision-create.datamechanics.test.ts
@@ -52,7 +52,7 @@ describe("ENFB-1 — createDecisionAction writes creation provenance", () => {
 
     // The round-trip: the row the action wrote passes the rule for team posture with ANY vis
     // set (null-source arm needs no items), and fails for external posture.
-    expect(rowVisibleByProvenance(row as { source_item_id: string | null; created_by: string | null }, new Set(), "team")).toBe(true);
-    expect(rowVisibleByProvenance(row as { source_item_id: string | null; created_by: string | null }, new Set(), "external")).toBe(false);
+    expect(rowVisibleByProvenance(row as { source_item_id: string | null; created_by: string | null }, new Set(), "team", "member")).toBe(true);
+    expect(rowVisibleByProvenance(row as { source_item_id: string | null; created_by: string | null }, new Set(), "external", "member")).toBe(false);
   });
 });

--- a/test/datamechanics/enfb2-inquery-provenance.datamechanics.test.ts
+++ b/test/datamechanics/enfb2-inquery-provenance.datamechanics.test.ts
@@ -46,7 +46,9 @@ async function restrictInto(seed: Seed, itemId: string, memberInGroup?: string):
 async function ctxFor(seed: Seed, memberId: string, posture = true) {
   const vis = await visibleItemIds(db(), { teamId: seed.teamId, memberId });
   expect(vis.error, "oracle resolution must not error").toBeFalsy();
-  return { visibleItemIds: vis.ids, teamPosture: posture };
+  // AUDITFIX-1: `principal` is threaded EXPLICITLY. Every assertion in this file states MEMBER
+  // behaviour, and an omitted discriminator is `undefined`, which CLOSES the hand-typed arm.
+  return { visibleItemIds: vis.ids, teamPosture: posture, principal: "member" as const };
 }
 
 describe("ENFB-2 §2.2 — the SQL owner and the TS owner agree with fixture-level EXPECTED TRUTH", () => {
@@ -119,7 +121,7 @@ describe("ENFB-2 §2.2 — the SQL owner and the TS owner agree with fixture-lev
         expect(sqlVisible.has(key), `SQL owner: viewer=${name} row=${key}`).toBe(want);
         const row = (allRows ?? []).find((r) => r.row_key === key)!;
         expect(
-          rowVisibleByProvenance(row as { source_item_id: string | null; created_by: string | null }, ctx.visibleItemIds, posture ? "team" : "external"),
+          rowVisibleByProvenance(row as { source_item_id: string | null; created_by: string | null }, ctx.visibleItemIds, posture ? "team" : "external", "member"),
           `TS owner: viewer=${name} row=${key}`
         ).toBe(want);
       }

--- a/test/datamechanics/enfb2-project-rows.datamechanics.test.ts
+++ b/test/datamechanics/enfb2-project-rows.datamechanics.test.ts
@@ -315,7 +315,7 @@ describe("ENFB-2 D1 — createProjectAction grants its creator (round-2 blockers
     const { data: proj } = await db().from("projects").select("id").eq("team_id", seed.teamId).eq("slug", "cardp").single();
 
     const handTyped = await db().from("tasks").insert({
-      team_id: seed.teamId, row_key: `CARD-${Math.random().toString(36).slice(2, 8)}`,
+      team_id: seed.teamId, row_key: `CARD-${randomUUID().slice(0, 6)}`,
       title: "hand typed, no source item", status: "in_progress",
       source_item_id: null, created_by: member, audience: "team", project_id: (proj as { id: string }).id, origin: "ui",
     });

--- a/test/datamechanics/enfb2-project-rows.datamechanics.test.ts
+++ b/test/datamechanics/enfb2-project-rows.datamechanics.test.ts
@@ -301,4 +301,29 @@ describe("ENFB-2 D1 — createProjectAction grants its creator (round-2 blockers
     const srcCardIn = insiderCards.rows.find((r) => r.id === (srcProj!.id as string))!;
     expect(srcCardIn.visibleItems, "the grantee counts both contained items").toBe(2);
   });
+
+  it("AUDITFIX-1 regression half: a card's task count still includes a MEMBER's hand-typed task", async () => {
+    // The card counts build their OWN provenance ctx, separate from the row rule. When AUDITFIX-1
+    // made the hand-typed arm conditional on `principal === "member"`, that second ctx silently
+    // omitted the discriminator and the arm closed — dropping hand-typed tasks out of every
+    // member's card count while the project page still listed them. Nothing caught it: the M4 test
+    // above asserts `visibleItems` only and never seeds an unsourced row. This is that assertion.
+    const seed = await seedTeam();
+    const member = await seedMember(seed);
+    await ingest(seed, { path: "cards.md", body: "c", access: "team", project: "cardp" });
+    await backfillTeamContext(db(), seed.teamId);
+    const { data: proj } = await db().from("projects").select("id").eq("team_id", seed.teamId).eq("slug", "cardp").single();
+
+    const handTyped = await db().from("tasks").insert({
+      team_id: seed.teamId, row_key: `CARD-${Math.random().toString(36).slice(2, 8)}`,
+      title: "hand typed, no source item", status: "in_progress",
+      source_item_id: null, created_by: member, audience: "team", project_id: (proj as { id: string }).id, origin: "ui",
+    });
+    expect(handTyped.error, handTyped.error?.message).toBeFalsy();
+
+    const { visibleProjectCards } = await import("@/lib/access/enforce");
+    const cards = await visibleProjectCards(db(), { teamId: seed.teamId, memberId: member });
+    const card = cards.rows.find((r) => r.id === (proj as { id: string }).id)!;
+    expect(card.visibleTasks, "a member's card counts their hand-typed task (ENFB-2 rule, unchanged by AUDITFIX-1)").toBe(1);
+  });
 });

--- a/test/datamechanics/member-context.datamechanics.test.ts
+++ b/test/datamechanics/member-context.datamechanics.test.ts
@@ -36,7 +36,9 @@ async function seedTask(
 
 async function viewerCtx(seed: Seed) {
   const vis = await visibleItemIds(db(), { teamId: seed.teamId, memberId: seed.memberId });
-  return { visibleItemIds: vis.ids, teamPosture: true };
+  // AUDITFIX-1: `principal` is threaded EXPLICITLY. Every assertion in this file states MEMBER
+  // behaviour, and an omitted discriminator is `undefined`, which CLOSES the hand-typed arm.
+  return { visibleItemIds: vis.ids, teamPosture: true, principal: "member" as const };
 }
 
 describe("getMemberContext fold (real Postgres)", () => {

--- a/test/datamechanics/pulse-metrics.datamechanics.test.ts
+++ b/test/datamechanics/pulse-metrics.datamechanics.test.ts
@@ -49,11 +49,16 @@ import { backfillTeamContext } from "@/lib/projects/context/backfill";
 import { randomUUID } from "node:crypto";
 
 /** ENFB-2 §2.2: displayed counts compute over the viewer's oracle ctx — resolve it like the
- *  Pulse page does (after a backfill so the fixtures' items carry memberships). */
+ *  Pulse page does (after a backfill so the fixtures' items carry memberships).
+ *
+ *  AUDITFIX-1: `principal` is threaded, matching what app/t/[team]/page.tsx actually passes. Codex's
+ *  diff review caught this helper supplying `teamPosture: true` with NO principal — a shape the type
+ *  permits and a legal caller could copy, and one that silently drops every hand-entered task out of
+ *  the funnel. The helper resembling the real call site is the whole point of it existing. */
 async function pulseCtx(seed: { teamId: string }, memberId: string, teamPosture: boolean) {
   await backfillTeamContext(db(), seed.teamId);
   const vis = await visibleItemIds(db(), { teamId: seed.teamId, memberId });
-  return { visibleItemIds: vis.ids, teamPosture };
+  return { visibleItemIds: vis.ids, teamPosture, principal: "member" as const };
 }
 
 async function externalViewer(seed: { teamId: string }): Promise<string> {
@@ -67,6 +72,41 @@ async function externalViewer(seed: { teamId: string }): Promise<string> {
 }
 
 describe("getPulseMetrics (real Postgres date windowing)", () => {
+  it("AUDITFIX-1: a MEMBER's funnel still counts a hand-entered task (no source item)", async () => {
+    // The regression half. AUDITFIX-1 made the hand-typed arm conditional on an explicit member
+    // principal, so every ctx that omits it silently drops these rows. Nothing here asserted that
+    // before — the suite's fixtures are all sourced — which is why Codex flagged the helper rather
+    // than a failing test. This is the failing test it would have needed.
+    const seed = await seedTeam();
+    // A hand-entered task still needs a container: `tasks.project_id` is not-null. It is an
+    // INGESTION project, deliberately not an access axis — which is exactly why an unsourced row
+    // has no membership to test a token's scope against (spec §3).
+    await ingest(seed, { path: "pulse/anchor.md", body: "anchor", access: "team", project: "pulseproj" });
+    const { data: proj } = await db()
+      .from("projects").select("id").eq("team_id", seed.teamId).eq("slug", "pulseproj").single();
+    const t = await db().from("tasks").insert({
+      team_id: seed.teamId,
+      project_id: (proj as { id: string }).id,
+      row_key: `PULSE-${randomUUID().slice(0, 6)}`,
+      title: "hand entered, no source item",
+      status: "in_progress",
+      source_item_id: null,
+      created_by: seed.memberId,
+      audience: "team",
+      origin: "ui",
+    });
+    expect(t.error, t.error?.message).toBeFalsy();
+
+    const pulse = await getPulseMetrics(db(), seed.teamId, "30d", {
+      isAdmin: false,
+      memberId: seed.memberId,
+      tier: "team",
+      provCtx: await pulseCtx(seed, seed.memberId, true),
+    });
+    const counted = pulse.funnel.reduce((a, r) => a + r.count, 0);
+    expect(counted, "a member's funnel counts their hand-entered task").toBeGreaterThan(0);
+  });
+
   it("counts freshly-synced items and recent queries as CURRENT (not prior)", async () => {
     const seed = await seedTeam();
     // Three items ingested now → synced_at = now(), squarely inside the 30d window.

--- a/test/datamechanics/token-structured-attenuation.datamechanics.test.ts
+++ b/test/datamechanics/token-structured-attenuation.datamechanics.test.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+
+/**
+ * Spec (AUDITFIX-1, real Postgres): a delegated token's STRUCTURED context obeys its scope.
+ *
+ * The reproduced defect: `provenanceRowSqlFromIds` admitted `source_item_id is null and created_by is
+ * not null and <teamPosture>` with no reference to `visibleItemIds`, and every valid token is
+ * team-tier — so a token received every hand-typed task and decision in the team, including rows in
+ * projects it was never granted.
+ *
+ * WHY THE NON-EMPTY-SCOPE ARM IS THE ONE THAT MATTERS (spec review round 1): an implementation
+ * reading `principal === "token" && visibleItemIds.size === 0` closes only the empty case and leaks
+ * for every realistically-scoped token — and non-empty scope is the NORMAL delegated shape.
+ */
+
+const TERM = "zanzibarite"; // rare shared term so the keyword leg matches the fixtures
+
+async function projectsBySlug(seed: Seed): Promise<Map<string, string>> {
+  const { data } = await db().from("projects").select("id, slug").eq("team_id", seed.teamId);
+  return new Map(((data ?? []) as { id: string; slug: string }[]).map((p) => [p.slug, p.id]));
+}
+
+async function curateInto(seed: Seed, itemId: string, projectId: string): Promise<void> {
+  const { data: unit } = await db().from("project_context_units").select("id").eq("source_item_id", itemId).single();
+  await db().from("project_context_memberships").update({ valid_to: new Date().toISOString() })
+    .eq("context_unit_id", (unit as { id: string }).id).is("valid_to", null);
+  const { error } = await db().from("project_context_memberships")
+    .insert({ team_id: seed.teamId, project_id: projectId, context_unit_id: (unit as { id: string }).id, method: "manual" });
+  if (error) throw new Error(`curate failed: ${error.message}`);
+}
+
+/** A hand-entered (unsourced) task + decision: source_item_id NULL, created_by set. */
+async function seedHandEntered(seed: Seed, projectId: string): Promise<{ task: string; decision: string }> {
+  const task = `SECRETTASK-${randomUUID().slice(0, 8)}`;
+  const decision = `SECRETDECISION-${randomUUID().slice(0, 8)} ${TERM}`;
+  const t = await db().from("tasks").insert({
+    team_id: seed.teamId, row_key: `AUD-${randomUUID().slice(0, 6)}`, title: task, status: "in_progress",
+    source_item_id: null, created_by: seed.memberId, audience: "team", project_id: projectId, origin: "ui",
+  });
+  if (t.error) throw new Error(`task seed failed: ${t.error.message}`);
+  const d = await db().from("decisions").insert({
+    team_id: seed.teamId, row_key: `AUDD-${randomUUID().slice(0, 6)}`, title: decision, decided_by: "someone",
+    still_valid: true, source_item_id: null, created_by: seed.memberId, audience: "team", project_id: projectId,
+  });
+  if (d.error) throw new Error(`decision seed failed: ${d.error.message}`);
+  return { task, decision };
+}
+
+const retrieveAs = async (seed: Seed, ids: Set<string>, principal: "member" | "token") => {
+  const { retrieve } = await import("@/lib/query/retrieve");
+  return retrieve(db(), seed.teamId, "team", `tell me about ${TERM}`, null, {
+    visibleItemIds: ids,
+    principal,
+  } as Parameters<typeof retrieve>[5]);
+};
+
+describe("AUDITFIX-1: a delegated token's structured context obeys its scope (real Postgres)", () => {
+  it("EMPTY scope receives no hand-entered rows — while a member control receives both", async () => {
+    const seed = await seedTeam();
+    const { backfillTeamContext } = await import("@/lib/projects/context/backfill");
+    await ingest(seed, { path: "x/doc.md", body: `x ${TERM}`, access: "team", project: "xproj" });
+    await backfillTeamContext(db(), seed.teamId);
+    const secrets = await seedHandEntered(seed, (await projectsBySlug(seed)).get("xproj")!);
+
+    // CONTROL FIRST. Without it a green test proves only that the fixture is inert — which is how
+    // the original audit repro passed before its inserts were found to be failing silently.
+    const control = await retrieveAs(seed, new Set(), "member");
+    expect(control.structured, "CONTROL: a member at team posture DOES see hand-entered rows").toContain(secrets.task);
+    expect(control.structured, "CONTROL: …and the hand-entered decision").toContain(secrets.decision);
+
+    const token = await retrieveAs(seed, new Set(), "token");
+    expect(token.structured ?? "", "a zero-scope token must not receive a hand-entered TASK").not.toContain(secrets.task);
+    expect(token.structured ?? "", "a zero-scope token must not receive a hand-entered DECISION").not.toContain(secrets.decision);
+  });
+
+  it("NON-EMPTY scope receives its sourced rows AND no hand-entered rows — the case that matters", async () => {
+    // The arm review round 1 said the suite otherwise misses entirely: an implementation that only
+    // closes for size===0 passes every other assertion here and still leaks for every real token.
+    const seed = await seedTeam();
+    const { backfillTeamContext } = await import("@/lib/projects/context/backfill");
+    const inScope = await ingest(seed, { path: "a/in-scope.md", body: `in ${TERM}`, access: "team", project: "agentproj" });
+    await backfillTeamContext(db(), seed.teamId);
+    const bySlug = await projectsBySlug(seed);
+    await curateInto(seed, inScope.id, bySlug.get("agentproj")!);
+
+    // A SOURCED task tied to the in-scope item — this must SURVIVE the fix.
+    const sourcedTitle = `SOURCEDTASK-${randomUUID().slice(0, 8)}`;
+    const st = await db().from("tasks").insert({
+      team_id: seed.teamId, row_key: `SRC-${randomUUID().slice(0, 6)}`, title: sourcedTitle, status: "in_progress",
+      source_item_id: inScope.id, created_by: seed.memberId, audience: "team",
+      project_id: bySlug.get("agentproj")!, origin: "ui",
+    });
+    if (st.error) throw new Error(`sourced task seed failed: ${st.error.message}`);
+    const secrets = await seedHandEntered(seed, bySlug.get("agentproj")!);
+
+    const token = await retrieveAs(seed, new Set([inScope.id]), "token");
+    expect(token.structured ?? "", "its in-scope SOURCED task must still be served").toContain(sourcedTitle);
+    expect(token.structured ?? "", "but NOT a hand-entered task").not.toContain(secrets.task);
+    expect(token.structured ?? "", "and NOT a hand-entered decision").not.toContain(secrets.decision);
+  });
+
+  it("a MEMBER is unchanged — the settled ENFB-2 hand-typed rule survives this slice", async () => {
+    const seed = await seedTeam();
+    const { backfillTeamContext } = await import("@/lib/projects/context/backfill");
+    await ingest(seed, { path: "m/doc.md", body: `m ${TERM}`, access: "team", project: "mproj" });
+    await backfillTeamContext(db(), seed.teamId);
+    const secrets = await seedHandEntered(seed, (await projectsBySlug(seed)).get("mproj")!);
+
+    const member = await retrieveAs(seed, new Set(), "member");
+    expect(member.structured, "members still see hand-entered tasks at team posture").toContain(secrets.task);
+    expect(member.structured, "and hand-entered decisions").toContain(secrets.decision);
+  });
+
+  it("the keyword-decision leg obeys the rule too — both halves, one invocation", async () => {
+    // matchingDecisions is the SECOND token-reachable leg; a fix applied only to retrieve's windows
+    // would miss it. Both halves asserted together so an inert keyword fixture cannot pass this.
+    const seed = await seedTeam();
+    const { backfillTeamContext } = await import("@/lib/projects/context/backfill");
+    const inScope = await ingest(seed, { path: "k/in.md", body: `k ${TERM}`, access: "team", project: "kproj" });
+    await backfillTeamContext(db(), seed.teamId);
+    const bySlug = await projectsBySlug(seed);
+    await curateInto(seed, inScope.id, bySlug.get("kproj")!);
+
+    const sourcedDecision = `SOURCEDDECISION-${randomUUID().slice(0, 8)} ${TERM}`;
+    const sd = await db().from("decisions").insert({
+      team_id: seed.teamId, row_key: `KSRC-${randomUUID().slice(0, 6)}`, title: sourcedDecision, decided_by: "x",
+      still_valid: true, source_item_id: inScope.id, created_by: seed.memberId, audience: "team",
+      project_id: bySlug.get("kproj")!,
+    });
+    if (sd.error) throw new Error(`sourced decision seed failed: ${sd.error.message}`);
+    const secrets = await seedHandEntered(seed, bySlug.get("kproj")!);
+
+    const { matchingDecisions } = await import("@/lib/query/structured-extras");
+    const titles = (await matchingDecisions(seed.teamId, "team", TERM, 10, {
+      visibleItemIds: new Set([inScope.id]),
+      teamPosture: true,
+      principal: "token",
+    })).map((d) => d.title);
+
+    expect(titles.join("\n"), "the in-scope SOURCED decision is served").toContain(sourcedDecision);
+    expect(titles.join("\n"), "the hand-entered one is not").not.toContain(secrets.decision);
+  });
+});

--- a/test/datamechanics/token-structured-route.datamechanics.test.ts
+++ b/test/datamechanics/token-structured-route.datamechanics.test.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+
+/**
+ * AUDITFIX-1 AC5 — the leak proof at the ROUTE, not at the library.
+ *
+ * Everything else in this slice calls `retrieve`/`matchingDecisions` directly and hands them a
+ * `principal` the test itself chose. That proves the predicate, and proves nothing about whether the
+ * shipped route reaches it: the reproduced CRITICAL was a real `POST /api/v1/query` disclosure, and
+ * the route builds its own enforcement view (`route.ts` — `enforce = { visibleItemIds: ids,
+ * principal: "token" }`). This test puts the assertion behind real authentication of a minted
+ * `aiosd_` bearer, the route's own principal assignment, and real retrieval.
+ *
+ * WHY NOT THE HTTP TIER (spec review round 2 killed that version): minting works there, but the http
+ * tier has no LLM configured, the route never puts `ctx.structured` on the wire (only deltas and
+ * cited sources), and the existing socket test cancels the body right after asserting 200 — so a
+ * still-leaking implementation passes it. `streamAnswer` is the ONLY thing stubbed here, and it is
+ * stubbed precisely because it is the one component that would otherwise need a model: it is also
+ * the exact seam where `ctx.structured` is handed to the prompt (lib/query/claude.ts:303), which
+ * makes it the right place to capture what the token was actually about to be told.
+ */
+
+/** Captures the ctx the route hands the answerer — i.e. what would reach the model's prompt. */
+const captured: { structured: string[] } = { structured: [] };
+
+vi.mock("@/lib/query/claude", () => ({
+  async *streamAnswer(ctx: { structured: string }) {
+    captured.structured.push(ctx.structured ?? "");
+    yield { type: "delta" as const, text: "ok" };
+    yield { type: "done" as const, usage: { input_tokens: 1, output_tokens: 1, cost_usd: 0 } };
+  },
+}));
+
+const TERM = "zanzibarite";
+
+async function seedMember(seed: Seed, over: Partial<{ kind: string; tier: string }> = {}): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      display_name: `m-${randomUUID().slice(0, 8)}`,
+      email: `${randomUUID()}@test.local`,
+      actor_handle: `h-${randomUUID().slice(0, 10)}`, // not-null in `members`
+      role: "member",
+      status: "active",
+      kind: over.kind ?? "human",
+      tier: over.tier ?? "team",
+    })
+    .select("id")
+    .single();
+  if (error) throw new Error(`member seed failed: ${error.message}`);
+  return (data as { id: string }).id;
+}
+
+async function curateInto(seed: Seed, itemId: string, projectId: string): Promise<void> {
+  const { data: unit } = await db().from("project_context_units").select("id").eq("source_item_id", itemId).single();
+  await db()
+    .from("project_context_memberships")
+    .update({ valid_to: new Date().toISOString() })
+    .eq("context_unit_id", (unit as { id: string }).id)
+    .is("valid_to", null);
+  const { error } = await db()
+    .from("project_context_memberships")
+    .insert({ team_id: seed.teamId, project_id: projectId, context_unit_id: (unit as { id: string }).id, method: "manual" });
+  if (error) throw new Error(`curate failed: ${error.message}`);
+}
+
+function queryReq(token: string, question: string): NextRequest {
+  return new Request("http://test/api/v1/query", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ question }),
+  }) as unknown as NextRequest;
+}
+
+/** Drain the SSE body so the stream's `start` (and therefore `streamAnswer`) actually runs. */
+async function drain(res: Response): Promise<void> {
+  const reader = res.body!.getReader();
+  for (;;) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+}
+
+describe("AUDITFIX-1 AC5: the real POST /api/v1/query attenuates a delegated token's structured context", () => {
+  beforeEach(() => {
+    captured.structured = [];
+  });
+
+  it("a NON-EMPTY-scoped aiosd_ token is served its in-scope sourced rows and NO hand-entered rows", async () => {
+    const seed = await seedTeam();
+    const { backfillTeamContext } = await import("@/lib/projects/context/backfill");
+    const { mintAgentToken } = await import("@/lib/access/agent-tokens");
+    const { addMemberToGroup, createGroup, grantProjectToGroup } = await import("@/lib/access/groups");
+
+    const inScope = await ingest(seed, { path: "r/in.md", body: `in ${TERM}`, access: "team", project: "rproj" });
+    await ingest(seed, { path: "r/out.md", body: `out ${TERM}`, access: "team", project: "otherproj" });
+    await backfillTeamContext(db(), seed.teamId);
+    const { data: projects } = await db().from("projects").select("id, slug").eq("team_id", seed.teamId);
+    const bySlug = new Map(((projects ?? []) as { id: string; slug: string }[]).map((p) => [p.slug, p.id]));
+    await curateInto(seed, inScope.id, bySlug.get("rproj")!);
+
+    // A hand-entered task and decision — no source item, so no membership axis to test a scope
+    // against. These are the rows the reproduced defect handed to every token in the team.
+    const secretTask = `SECRETTASK-${randomUUID().slice(0, 8)}`;
+    const secretDecision = `SECRETDECISION-${randomUUID().slice(0, 8)} ${TERM}`;
+    const t = await db().from("tasks").insert({
+      team_id: seed.teamId, row_key: `RT-${randomUUID().slice(0, 6)}`, title: secretTask, status: "in_progress",
+      source_item_id: null, created_by: seed.memberId, audience: "team", project_id: bySlug.get("rproj")!, origin: "ui",
+    });
+    if (t.error) throw new Error(`task seed failed: ${t.error.message}`);
+    const d = await db().from("decisions").insert({
+      team_id: seed.teamId, row_key: `RD-${randomUUID().slice(0, 6)}`, title: secretDecision, decided_by: "x",
+      still_valid: true, source_item_id: null, created_by: seed.memberId, audience: "team", project_id: bySlug.get("rproj")!,
+    });
+    if (d.error) throw new Error(`decision seed failed: ${d.error.message}`);
+
+    // A SOURCED task on the in-scope item — the survival half. Without it, a route that returned
+    // an empty structured digest for every token would pass this test while breaking the feature.
+    const sourcedTask = `SOURCEDTASK-${randomUUID().slice(0, 8)}`;
+    const st = await db().from("tasks").insert({
+      team_id: seed.teamId, row_key: `RS-${randomUUID().slice(0, 6)}`, title: sourcedTask, status: "in_progress",
+      source_item_id: inScope.id, created_by: seed.memberId, audience: "team", project_id: bySlug.get("rproj")!, origin: "ui",
+    });
+    if (st.error) throw new Error(`sourced task seed failed: ${st.error.message}`);
+
+    const agent = await seedMember(seed, { kind: "agent" });
+    const g = await createGroup(db(), seed.teamId, `rt-${randomUUID().slice(0, 6)}`, "G", seed.memberId);
+    await addMemberToGroup(db(), seed.teamId, g.groupId!, agent, seed.memberId);
+    await grantProjectToGroup(db(), seed.teamId, bySlug.get("rproj")!, g.groupId!, seed.memberId);
+    const minted = await mintAgentToken(
+      db(),
+      seed.teamId,
+      { memberId: agent, projectScope: [bySlug.get("rproj")!] },
+      seed.memberId
+    );
+    expect(minted.ok, minted.error).toBe(true);
+    expect(minted.token).toMatch(/^aiosd_/);
+
+    const { POST: queryPOST } = await import("@/app/api/v1/query/route");
+    const res = await queryPOST(queryReq(minted.token!, `tell me about ${TERM}`));
+    expect(res.status, "the delegated query route admits the token").toBe(200);
+    await drain(res);
+
+    expect(captured.structured.length, "streamAnswer must have run — otherwise nothing was asserted").toBe(1);
+    const structured = captured.structured[0];
+    expect(structured, "the token's in-scope SOURCED task is still served").toContain(sourcedTask);
+    expect(structured, "a hand-entered TASK must never reach a token's prompt").not.toContain(secretTask);
+    expect(structured, "a hand-entered DECISION must never reach a token's prompt").not.toContain(secretDecision);
+  });
+});

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -16,6 +16,20 @@ import { join } from "node:path";
  *
  * Everywhere else, a member literal is legal only at a listed member-only boundary, so the allow-list
  * doubles as the inventory of "who is asserting memberhood, and on what authority".
+ *
+ * ⚠️ WHAT THIS GUARD DOES NOT CLOSE, stated rather than implied. It reads text, so a ctx obtained
+ * WHOLESALE from another module — `const provCtx = buildMemberProvCtx(ids, tier)`, with the factory
+ * exported from an allow-listed file — is invisible to every scan here. That gap is accepted, not
+ * overlooked, on three grounds: (a) it requires adding an exported ctx factory and importing it into
+ * a token path, which is a visible, reviewable act rather than a one-word edit; (b) the guard's job
+ * is to make the CHEAP mistakes impossible, and the cheap mistakes are the literal, the constant,
+ * the alias, the shorthand and the omission — all now caught; (c) the data-mechanics tier catches
+ * the OUTCOME regardless. I verified (c) rather than assuming it: planting
+ * `principal = "member"` in retrieve.ts reddens
+ * `token-structured-attenuation.datamechanics.test.ts` on the real leak, both arms.
+ *
+ * So this guard is the fast, build-failing layer over a tier that independently proves the outcome.
+ * Do not read it as the only thing standing between a token and the hand-typed rows.
  */
 
 const ROOT = join(import.meta.dirname, "..", "..");
@@ -44,7 +58,8 @@ const MEMBER_BOUNDARIES = new Set([
   // The named constant (`MEMBER_ONLY_SURFACE`) feeding the three project-row helpers. Its authority
   // is call-site enumeration: every caller is a session page or an `aios_` member route.
   "lib/access/enforce.ts",
-  "lib/metrics/pulse.ts", // session-authenticated Pulse dashboard
+  // NOT lib/metrics/pulse.ts: its absent-ctx fallback used to synthesise "member", which §2d
+  // forbids outright. It now synthesises nothing and the real ctx arrives from the page below.
   "lib/dashboard/work-timeline.ts", // session-authenticated timeline
   "app/api/v1/decisions/route.ts", // aios_ member key; authenticateApiKey rejects aiosd_
   // Both found by the dm tier, NOT by the spec's §0 inventory, which said "exactly 7 consumers"
@@ -82,7 +97,10 @@ function filesUnder(dir: string): string[] {
 // The whitespace lives INSIDE the lookahead: `\s*(?!\|)` backtracks to zero width and passes on
 // `principal: "member" | "token"`, which is how the first spelling flagged three type declarations.
 const MEMBER_PROP = /principal\s*:\s*["'`]member["'`](?!\s*\|)/;
-const MEMBER_TWIN_ARG = /rowVisibleByProvenance\([^)]*["'`]member["'`]\s*\)/;
+// `[^)]*` stopped at the first `)`, so a twin call containing a nested call
+// (`rowVisibleByProvenance(d, getIds(), tier, "member")`) escaped the tree-wide scan. `[\s\S]*?`
+// is lazy, so it still cannot run past the call it is matching.
+const MEMBER_TWIN_ARG = /rowVisibleByProvenance\([\s\S]*?["'`]member["'`]\s*\)/;
 /**
  * …and the shape a NAMED CONSTANT takes — `const MEMBER_ONLY_SURFACE = "member" as const`.
  *
@@ -96,7 +114,27 @@ const MEMBER_TWIN_ARG = /rowVisibleByProvenance\([^)]*["'`]member["'`]\s*\)/;
 // The lookbehind matters: without it this fires on `enforce?.principal === "member"`, a
 // COMPARISON — which retrieve.ts legitimately performs (`serveOrgStructural`) and which asserts
 // nothing. Reading a discriminator is not manufacturing one.
-const MEMBER_BINDING = /(?<![=!<>])=\s*["'`]member["'`]\s*(?:as\s+const)?\s*;/;
+// No TAIL requirement. The first spelling demanded `as const` or `;`, and Fable's diff review
+// defeated it in one line: `const principal = "member" as ProvenancePrincipal;` — a different cast,
+// so the needle missed, and the guard passed 6/6 with a hardcoded member principal in retrieve.ts.
+// I planted that exact code and confirmed it BOTH evaded the guard AND reddened the dm token tests,
+// so the guard was failing at the one job its header claims. Over-matching a binding is the safe
+// direction: the tree-wide scan already excludes comparisons via the lookbehind.
+// Scoped to a VARIABLE DECLARATION. Dropping the tail requirement outright over-matched two things
+// that assert nothing: the type alias `type ProvenancePrincipal = "member" | "token"` and the SQL
+// string `a.target_type = 'member'` in lib/auth/welcome-context.ts. Requiring `const|let|var <name>`
+// keeps the bypass caught (`const principal = "member" as ProvenancePrincipal`) and both of those out.
+const MEMBER_BINDING = /(?:const|let|var)\s+\w+\s*(?::[^=;]*)?=\s*["'`]member["'`]/;
+
+/**
+ * …and the SHORTHAND property, which has no colon and was therefore invisible to every scan above:
+ * `const provCtx = { visibleItemIds, teamPosture, principal }`. This is the second half of the same
+ * bypass, and it is the shape an author naturally reaches for the moment the guard reddens on
+ * `principal: "member"` — extract to a variable until green. A guard that teaches its own evasion is
+ * worse than none, so shorthand is forbidden outright in the token-capable files: those may only
+ * forward, and forwarding cannot be spelled as shorthand.
+ */
+const MEMBER_SHORTHAND = /[{,]\s*principal\s*[,}]/;
 const MEMBER_LITERAL = {
   test: (src: string) => MEMBER_PROP.test(src) || MEMBER_TWIN_ARG.test(src) || MEMBER_BINDING.test(src),
 };
@@ -124,7 +162,9 @@ const MEMBER_LITERAL = {
  */
 function ctxLiteralsMissingPrincipal(code: string): string[] {
   const out: string[] = [];
-  for (const m of code.matchAll(/visibleItemIds\s*:/g)) {
+  // Shorthand counts too (`{ visibleItemIds, teamPosture }`) — anchoring on the colon alone let a
+  // whole construction shape through, which is the same class round 3 twice killed this guard for.
+  for (const m of code.matchAll(/visibleItemIds\s*[,:}]/g)) {
     // Walk back to the `{` that opens this object literal, then forward to its match.
     let open = m.index!;
     while (open > 0 && code[open] !== "{") open--;
@@ -138,7 +178,7 @@ function ctxLiteralsMissingPrincipal(code: string): string[] {
     // A TYPE declaration (`{ visibleItemIds: ReadonlySet<string>; ... }`) states the shape and is
     // not a construction; it is excluded the same way the assignment scan excludes unions.
     if (/ReadonlySet<|readonly string\[\]/.test(literal)) continue;
-    if (!/principal\s*:/.test(literal)) out.push(literal.split("\n")[1]?.trim() ?? literal.slice(0, 60));
+    if (!/principal\s*[,:}]/.test(literal)) out.push(literal.split("\n")[1]?.trim() ?? literal.slice(0, 60));
   }
   return out;
 }
@@ -164,6 +204,10 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     for (const rel of TOKEN_CAPABLE) {
       const code = codeOnly(read(rel));
       expect(MEMBER_LITERAL.test(code), `${rel} must forward enforce.principal, never assert "member"`).toBe(false);
+      expect(
+        MEMBER_SHORTHAND.test(code),
+        `${rel} may not use shorthand \`{ principal }\` — forwarding cannot be spelled that way, so it can only be hiding a local binding`
+      ).toBe(false);
       expect(code, `${rel} must actually forward the discriminator`).toMatch(/principal:\s*enforce\?\.principal/);
     }
   });
@@ -215,6 +259,17 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     expect(unforwardedPrincipalAssignments("principal: enforce?.principal,")).toEqual([]);
     expect(unforwardedPrincipalAssignments('principal: "member" | "token";'), "a union is a declaration").toEqual([]);
     expect(unforwardedPrincipalAssignments("principal?: ProvenancePrincipal"), "a type name is a declaration").toEqual([]);
+    // THE BYPASS Fable demonstrated, pinned in both halves so it cannot come back.
+    expect(MEMBER_LITERAL.test('const principal = "member" as ProvenancePrincipal;')).toBe(true);
+    expect(MEMBER_LITERAL.test('const principal = "member"')).toBe(true);
+    expect(MEMBER_SHORTHAND.test("const c = { visibleItemIds, teamPosture, principal };")).toBe(true);
+    expect(MEMBER_SHORTHAND.test("const c = { principal };")).toBe(true);
+    expect(MEMBER_SHORTHAND.test("principal: enforce?.principal,"), "forwarding is not shorthand").toBe(false);
+    // …and the shorthand omission the colon-anchored scan could not see.
+    expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds,\n  teamPosture,\n})").length).toBe(1);
+    expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds,\n  teamPosture,\n  principal,\n})")).toEqual([]);
+    // …and a twin call with a nested call in its arguments.
+    expect(MEMBER_LITERAL.test('rowVisibleByProvenance(d, getIds(), tier, "member")')).toBe(true);
     // The omission scan: a ctx with no discriminator at all — the shape a surviving mutation found.
     expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds: ids,\n  teamPosture: true,\n})").length).toBe(1);
     expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds: ids,\n  principal: enforce?.principal,\n})")).toEqual([]);
@@ -227,6 +282,12 @@ describe("guard: a token can never acquire member provenance semantics", () => {
   it("the allow-list is honest — every listed boundary really does assert memberhood", () => {
     // A stale allow-list entry is permission granted to a file that no longer needs it.
     const stale = [...MEMBER_BOUNDARIES].filter((rel) => !MEMBER_LITERAL.test(codeOnly(read(rel))));
-    expect(stale, "remove boundaries that no longer manufacture a member literal").toEqual([]);
+    expect(
+      stale,
+      "TWO possible causes, and the wrong one is the tempting one: EITHER this file LOST a member " +
+        "assertion it needs — a silent member regression, since an absent discriminator closes the " +
+        "hand-typed arm — OR the file genuinely no longer needs the entry. Check which before " +
+        "deleting the allow-list line."
+    ).toEqual([]);
   });
 });

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -110,6 +110,39 @@ const MEMBER_LITERAL = {
  * Type positions are excluded because they are declarations, not assertions: a union (`"member" |
  * "token"`) or a type name (`ProvenancePrincipal`, uppercase by TS convention).
  */
+/**
+ * …and the OTHER half of the property: a ctx that never mentions `principal` at all.
+ *
+ * Found by mutation, not by review. Deleting retrieve's forward to `matchingDecisions` reddened
+ * NOTHING: an absent discriminator closes the hand-typed arm, so a token's outcome is identical and
+ * every token assertion still passes. What silently changes is the MEMBER's — that leg stops serving
+ * their hand-typed decisions — and no test separates it from the recency window that serves the same
+ * rows. A surviving mutation means the suite proves nothing there, so the property moves here:
+ * in a token-capable file, every provenance ctx must CARRY the discriminator, not merely be able to.
+ *
+ * Returns the ctx literals that omit it, by their opening line.
+ */
+function ctxLiteralsMissingPrincipal(code: string): string[] {
+  const out: string[] = [];
+  for (const m of code.matchAll(/visibleItemIds\s*:/g)) {
+    // Walk back to the `{` that opens this object literal, then forward to its match.
+    let open = m.index!;
+    while (open > 0 && code[open] !== "{") open--;
+    let depth = 0;
+    let close = open;
+    for (; close < code.length; close++) {
+      if (code[close] === "{") depth++;
+      else if (code[close] === "}" && --depth === 0) break;
+    }
+    const literal = code.slice(open, close + 1);
+    // A TYPE declaration (`{ visibleItemIds: ReadonlySet<string>; ... }`) states the shape and is
+    // not a construction; it is excluded the same way the assignment scan excludes unions.
+    if (/ReadonlySet<|readonly string\[\]/.test(literal)) continue;
+    if (!/principal\s*:/.test(literal)) out.push(literal.split("\n")[1]?.trim() ?? literal.slice(0, 60));
+  }
+  return out;
+}
+
 const FORWARDED = /^enforce\??\.principal$/;
 function unforwardedPrincipalAssignments(code: string): string[] {
   const out: string[] = [];
@@ -144,6 +177,13 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     }
   });
 
+  it("…and every provenance ctx they BUILD carries the discriminator — none may omit it", () => {
+    for (const rel of TOKEN_CAPABLE) {
+      const missing = ctxLiteralsMissingPrincipal(codeOnly(read(rel)));
+      expect(missing, `${rel} builds a provenance ctx with no principal: ${missing.join(" | ")}`).toEqual([]);
+    }
+  });
+
   it("every member literal in the tree sits at a listed member-only boundary", () => {
     const offenders = [...filesUnder("lib"), ...filesUnder("app"), ...filesUnder("scripts")]
       .filter((rel) => !MEMBER_BOUNDARIES.has(rel))
@@ -175,6 +215,13 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     expect(unforwardedPrincipalAssignments("principal: enforce?.principal,")).toEqual([]);
     expect(unforwardedPrincipalAssignments('principal: "member" | "token";'), "a union is a declaration").toEqual([]);
     expect(unforwardedPrincipalAssignments("principal?: ProvenancePrincipal"), "a type name is a declaration").toEqual([]);
+    // The omission scan: a ctx with no discriminator at all — the shape a surviving mutation found.
+    expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds: ids,\n  teamPosture: true,\n})").length).toBe(1);
+    expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds: ids,\n  principal: enforce?.principal,\n})")).toEqual([]);
+    expect(
+      ctxLiteralsMissingPrincipal("interface X {\n  visibleItemIds: ReadonlySet<string>;\n}"),
+      "a type declaration is not a construction"
+    ).toEqual([]);
   });
 
   it("the allow-list is honest — every listed boundary really does assert memberhood", () => {

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * GUARD: a token must never obtain MEMBER provenance semantics (AUDITFIX-1 AC9).
+ *
+ * WHY THIS SHAPE. The first version of this guard counted references to a shared "member context"
+ * helper. Review round 3 killed it in one line: a token-capable path can write
+ * `principal: "member"` inline and never touch the helper, so the guard measured a spelling rather
+ * than the security property. This one enumerates every place the discriminator can be MANUFACTURED.
+ *
+ * The property: the two TOKEN-CAPABLE files may only FORWARD `enforce.principal`. They may not
+ * contain a member literal at all — that is the exact edit that would reopen the reproduced leak, in
+ * which an empty-scoped token received every hand-typed task and decision in the team.
+ *
+ * Everywhere else, a member literal is legal only at a listed member-only boundary, so the allow-list
+ * doubles as the inventory of "who is asserting memberhood, and on what authority".
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+/** Code only — a guard that reads its own prose fires on documentation. */
+const codeOnly = (src: string): string =>
+  src
+    .split("\n")
+    .map((l) => l.replace(/\/\*.*?\*\//g, " "))
+    .filter((l) => {
+      const t = l.trim();
+      return !(t.startsWith("*") || t.startsWith("//") || t.startsWith("/*"));
+    })
+    .join("\n");
+
+/** Files that see a delegated token and must therefore only ever FORWARD the discriminator. */
+const TOKEN_CAPABLE = ["lib/query/retrieve.ts", "lib/query/structured-extras.ts"];
+
+/**
+ * Member-only boundaries permitted to assert memberhood, each with the authority that makes it true.
+ * `authenticateApiKey` accepts `aios_` keys only, so an `aiosd_` bearer cannot reach an API route
+ * listed here (lib/api/auth.ts).
+ */
+const MEMBER_BOUNDARIES = new Set([
+  // The named constant (`MEMBER_ONLY_SURFACE`) feeding the three project-row helpers. Its authority
+  // is call-site enumeration: every caller is a session page or an `aios_` member route.
+  "lib/access/enforce.ts",
+  "lib/metrics/pulse.ts", // session-authenticated Pulse dashboard
+  "lib/dashboard/work-timeline.ts", // session-authenticated timeline
+  "app/api/v1/decisions/route.ts", // aios_ member key; authenticateApiKey rejects aiosd_
+  // Both found by the dm tier, NOT by the spec's §0 inventory, which said "exactly 7 consumers"
+  // and was wrong by two. Omitting the discriminator here closed the hand-typed arm and dropped
+  // every UI-origin task out of the writeback feed (tasks-sync-origin-feed reddened).
+  "app/api/v1/tasks/route.ts", // aios_ member key; authenticateApiKey rejects aiosd_
+  "app/t/[team]/people/[handle]/page.tsx", // session member; reaches the predicate via deriveProjects
+  "app/api/v1/query/route.ts", // the MEMBER branch, after authenticateApiKey (the token branch forwards "token")
+  "app/api/dashboard/query/route.ts", // session member
+  "app/t/[team]/page.tsx",
+  "app/t/[team]/tasks/page.tsx",
+  "app/t/[team]/decisions/page.tsx", // TS twin, positional
+  "app/t/[team]/projects/[project]/page.tsx", // TS twin, positional
+]);
+
+function filesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(join(ROOT, dir), { withFileTypes: true })) {
+    const rel = `${dir}/${e.name}`;
+    if (e.isDirectory()) out.push(...filesUnder(rel));
+    else if (/\.(ts|tsx|mjs|js)$/.test(e.name)) out.push(rel);
+  }
+  return out;
+}
+
+/**
+ * A member literal being MANUFACTURED, in either shape it can take:
+ *   · an object property — `principal: "member"`;
+ *   · the TS twin's positional 4th argument — `rowVisibleByProvenance(row, ids, tier, "member")`.
+ *
+ * The negative lookahead excludes TYPE positions (`principal: "member" | "token"`), which are
+ * declarations rather than assertions — the first version of this guard flagged three of them and
+ * would have taught the next reader to widen the allow-list instead of tightening the needle.
+ */
+// The whitespace lives INSIDE the lookahead: `\s*(?!\|)` backtracks to zero width and passes on
+// `principal: "member" | "token"`, which is how the first spelling flagged three type declarations.
+const MEMBER_PROP = /principal\s*:\s*["'`]member["'`](?!\s*\|)/;
+const MEMBER_TWIN_ARG = /rowVisibleByProvenance\([^)]*["'`]member["'`]\s*\)/;
+/**
+ * …and the shape a NAMED CONSTANT takes — `const MEMBER_ONLY_SURFACE = "member" as const`.
+ *
+ * This third needle exists because the guard failed its own test: `lib/access/enforce.ts` names the
+ * value once instead of repeating a literal, and the two needles above scored that file clean. The
+ * escalation it left open is the dangerous one — `import { MEMBER_ONLY_SURFACE }` into a
+ * token-capable file and write `principal: MEMBER_ONLY_SURFACE`, and nothing here fires. Round 3
+ * killed the FIRST version of this guard for measuring a spelling; naming a constant is just
+ * another spelling.
+ */
+// The lookbehind matters: without it this fires on `enforce?.principal === "member"`, a
+// COMPARISON — which retrieve.ts legitimately performs (`serveOrgStructural`) and which asserts
+// nothing. Reading a discriminator is not manufacturing one.
+const MEMBER_BINDING = /(?<![=!<>])=\s*["'`]member["'`]\s*(?:as\s+const)?\s*;/;
+const MEMBER_LITERAL = {
+  test: (src: string) => MEMBER_PROP.test(src) || MEMBER_TWIN_ARG.test(src) || MEMBER_BINDING.test(src),
+};
+
+/**
+ * The spelling-INDEPENDENT half, for the two files that see a token: every `principal` in a VALUE
+ * position must be the forwarded expression, whatever it is spelled as. A literal, a named constant,
+ * an imported alias and a re-derivation from `tier` all fail this — the needles above can only catch
+ * the shapes someone thought to enumerate.
+ *
+ * Type positions are excluded because they are declarations, not assertions: a union (`"member" |
+ * "token"`) or a type name (`ProvenancePrincipal`, uppercase by TS convention).
+ */
+const FORWARDED = /^enforce\??\.principal$/;
+function unforwardedPrincipalAssignments(code: string): string[] {
+  const out: string[] = [];
+  for (const m of code.matchAll(/principal\s*\??\s*:\s*([^,;\n}]+)/g)) {
+    const rhs = m[1].trim();
+    if (rhs.includes("|")) continue; // a union type declaration
+    // A TYPE name is PascalCase (`ProvenancePrincipal`). A CONSTANT is SCREAMING_SNAKE
+    // (`MEMBER_ONLY_SURFACE`) — and a bare `/^[A-Z]/` skipped both, which let the exact escalation
+    // this function exists to catch walk straight through it.
+    if (/^[A-Z][a-zA-Z0-9]*$/.test(rhs) && /[a-z]/.test(rhs)) continue;
+    if (FORWARDED.test(rhs)) continue; // the one permitted shape
+    out.push(rhs);
+  }
+  return out;
+}
+
+describe("guard: a token can never acquire member provenance semantics", () => {
+  it("the token-capable files contain NO member literal — they may only forward", () => {
+    for (const rel of TOKEN_CAPABLE) {
+      const code = codeOnly(read(rel));
+      expect(MEMBER_LITERAL.test(code), `${rel} must forward enforce.principal, never assert "member"`).toBe(false);
+      expect(code, `${rel} must actually forward the discriminator`).toMatch(/principal:\s*enforce\?\.principal/);
+    }
+  });
+
+  it("…and every principal they ASSIGN is the forwarded expression — no literal, constant or alias", () => {
+    // The property, not the spelling. `principal: MEMBER_ONLY_SURFACE` passes all three needles
+    // above and reopens the leak; it fails here.
+    for (const rel of TOKEN_CAPABLE) {
+      const bad = unforwardedPrincipalAssignments(codeOnly(read(rel)));
+      expect(bad, `${rel} may only ever assign enforce?.principal — found: ${bad.join(", ")}`).toEqual([]);
+    }
+  });
+
+  it("every member literal in the tree sits at a listed member-only boundary", () => {
+    const offenders = [...filesUnder("lib"), ...filesUnder("app"), ...filesUnder("scripts")]
+      .filter((rel) => !MEMBER_BOUNDARIES.has(rel))
+      .filter((rel) => MEMBER_LITERAL.test(codeOnly(read(rel))));
+    expect(offenders, "a new member literal must be justified by an authenticated member boundary").toEqual([]);
+  });
+
+  it("the needle matches what it claims to — non-vacuity", () => {
+    // A guard whose regex matches nothing passes forever.
+    expect(MEMBER_LITERAL.test('const c = { principal: "member" };')).toBe(true);
+    expect(MEMBER_LITERAL.test("const c = { principal: 'member' };")).toBe(true);
+    expect(MEMBER_LITERAL.test('principal:"member"')).toBe(true);
+    expect(MEMBER_LITERAL.test('rowVisibleByProvenance(d, ids, tier, "member")')).toBe(true);
+    // Forwarding is the permitted shape, and a TYPE declaration is not an assertion.
+    expect(MEMBER_LITERAL.test("principal: enforce?.principal")).toBe(false);
+    expect(MEMBER_LITERAL.test('principal: "member" | "token";')).toBe(false);
+    expect(MEMBER_LITERAL.test('principal: "member" | "token" | undefined')).toBe(false);
+    expect(MEMBER_LITERAL.test('principal: "member" as const')).toBe(true);
+    // The named-constant shape the first two needles missed — the reason this one exists.
+    expect(MEMBER_LITERAL.test('const MEMBER_ONLY_SURFACE = "member" as const;')).toBe(true);
+    expect(MEMBER_LITERAL.test("const M = 'member';")).toBe(true);
+    // …but a COMPARISON is a read, not an assertion — retrieve.ts does exactly this, legally.
+    expect(MEMBER_LITERAL.test('const ok = enforce?.principal === "member";')).toBe(false);
+    expect(MEMBER_LITERAL.test('if (p !== "member") return;')).toBe(false);
+    // …and the forwarding check that catches it wherever it is IMPORTED rather than declared.
+    expect(unforwardedPrincipalAssignments("principal: MEMBER_ONLY_SURFACE,")).toEqual(["MEMBER_ONLY_SURFACE"]);
+    expect(unforwardedPrincipalAssignments('principal: tier === "team" ? "member" : "token",'))
+      .toEqual(['tier === "team" ? "member" : "token"']);
+    expect(unforwardedPrincipalAssignments("principal: enforce?.principal,")).toEqual([]);
+    expect(unforwardedPrincipalAssignments('principal: "member" | "token";'), "a union is a declaration").toEqual([]);
+    expect(unforwardedPrincipalAssignments("principal?: ProvenancePrincipal"), "a type name is a declaration").toEqual([]);
+  });
+
+  it("the allow-list is honest — every listed boundary really does assert memberhood", () => {
+    // A stale allow-list entry is permission granted to a file that no longer needs it.
+    const stale = [...MEMBER_BOUNDARIES].filter((rel) => !MEMBER_LITERAL.test(codeOnly(read(rel))));
+    expect(stale, "remove boundaries that no longer manufacture a member literal").toEqual([]);
+  });
+});

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -1,35 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import ts from "typescript";
 
 /**
  * GUARD: a token must never obtain MEMBER provenance semantics (AUDITFIX-1 AC9).
  *
- * WHY THIS SHAPE. The first version of this guard counted references to a shared "member context"
- * helper. Review round 3 killed it in one line: a token-capable path can write
- * `principal: "member"` inline and never touch the helper, so the guard measured a spelling rather
- * than the security property. This one enumerates every place the discriminator can be MANUFACTURED.
+ * Two layers, because they answer two different questions:
  *
- * The property: the two TOKEN-CAPABLE files may only FORWARD `enforce.principal`. They may not
- * contain a member literal at all — that is the exact edit that would reopen the reproduced leak, in
- * which an empty-scoped token received every hand-typed task and decision in the team.
+ *   1. **The two TOKEN-CAPABLE files** — `lib/query/retrieve.ts`, `lib/query/structured-extras.ts` —
+ *      may only ever FORWARD `enforce.principal`. This is an authorization boundary, so it is checked
+ *      STRUCTURALLY, against the TypeScript AST. See the walk below for why it is not a regex.
+ *   2. **The rest of the tree** — a member literal is legal only at a listed member-only boundary, so
+ *      the allow-list doubles as the inventory of "who is asserting memberhood, and on what
+ *      authority". This layer stays text-based: it spans ~700 files, it is a coverage inventory
+ *      rather than a wall, and its failure mode is a stale allow-list entry, not an escalation.
  *
- * Everywhere else, a member literal is legal only at a listed member-only boundary, so the allow-list
- * doubles as the inventory of "who is asserting memberhood, and on what authority".
- *
- * ⚠️ WHAT THIS GUARD DOES NOT CLOSE, stated rather than implied. It reads text, so a ctx obtained
- * WHOLESALE from another module — `const provCtx = buildMemberProvCtx(ids, tier)`, with the factory
- * exported from an allow-listed file — is invisible to every scan here. That gap is accepted, not
- * overlooked, on three grounds: (a) it requires adding an exported ctx factory and importing it into
- * a token path, which is a visible, reviewable act rather than a one-word edit; (b) the guard's job
- * is to make the CHEAP mistakes impossible, and the cheap mistakes are the literal, the constant,
- * the alias, the shorthand and the omission — all now caught; (c) the data-mechanics tier catches
- * the OUTCOME regardless. I verified (c) rather than assuming it: planting
- * `principal = "member"` in retrieve.ts reddens
- * `token-structured-attenuation.datamechanics.test.ts` on the real leak, both arms.
- *
- * So this guard is the fast, build-failing layer over a tier that independently proves the outcome.
- * Do not read it as the only thing standing between a token and the hand-typed rows.
+ * The defect behind all of it: an empty-scoped delegated token received every hand-typed task and
+ * decision in the team, reproduced against real Postgres.
  */
 
 const ROOT = join(import.meta.dirname, "..", "..");
@@ -42,6 +30,9 @@ const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
  * `*iter() { const principal = "member"; }` vanished entirely, which is a hiding place, and in the
  * FAIL-OPEN direction. A jsdoc continuation is `*` followed by whitespace or end-of-line, or `*​/`;
  * a generator is `*` followed immediately by an identifier. Only the former is stripped.
+ *
+ * This is layer 2 only. Layer 1 does not use it: the parser owns comments and strings, which is
+ * precisely one of the reasons layer 1 is a parser.
  */
 const codeOnly = (src: string): string =>
   src
@@ -92,149 +83,203 @@ function filesUnder(dir: string): string[] {
   return out;
 }
 
+/* ─────────────────────────── LAYER 1 — the token-capable files, structurally ─────────────────── */
+
 /**
- * A member literal being MANUFACTURED, in either shape it can take:
- *   · an object property — `principal: "member"`;
- *   · the TS twin's positional 4th argument — `rowVisibleByProvenance(row, ids, tier, "member")`.
+ * Regexes lost this arms race three times, so this layer stopped being one.
  *
- * The negative lookahead excludes TYPE positions (`principal: "member" | "token"`), which are
- * declarations rather than assertions — the first version of this guard flagged three of them and
- * would have taught the next reader to widen the allow-list instead of tightening the needle.
+ *   · Spec round 3 killed the version that counted references to a shared helper: a token path can
+ *     write the value inline and never touch the helper.
+ *   · Fable's diff review defeated the literal version with `const principal = "member" as
+ *     ProvenancePrincipal` plus a shorthand property. I planted it and confirmed the guard passed
+ *     6/6 while the dm token tests reddened on the real leak.
+ *   · Codex's diff review then listed six more that still passed: a computed key
+ *     `{ ["principal"]: "member" }`, a later `...spread` overwriting the forwarded value,
+ *     `enforce!.principal = "member"`, `||=`, `Reflect.set`, `Object.defineProperty`. It also showed
+ *     the hand-rolled brace scanner mis-pairing on a nested object, a brace inside a string, or a
+ *     destructuring pattern, and `codeOnly` still discarding real code after a block-comment
+ *     terminator.
+ *
+ * Each of those is a new SPELLING of one act, and a text matcher can only enumerate spellings. All of
+ * them are syntax, and syntax is what the parser owns — so this walks the tree instead. The
+ * brace/comment/string hazards disappear with it.
+ *
+ * The property, in the two token-capable files:
+ *   1. every `principal` property is initialised to EXACTLY `enforce?.principal` — no literal,
+ *      constant, alias, computed key, shorthand, or conditional;
+ *   2. no object literal carrying `visibleItemIds` may contain a SPREAD, which could overwrite it;
+ *   3. nothing ASSIGNS to a `.principal` property, in any assignment operator;
+ *   4. `Reflect.set` / `Object.defineProperty` may not target `principal`;
+ *   5. every object literal carrying `visibleItemIds` also carries `principal` — the M13 property,
+ *      which exists because deleting a forward reddened nothing: it fails closed for a token and
+ *      silently drops a MEMBER's hand-typed rows, and no fixture separates that leg from its twin.
+ *
+ * ⚠️ WHAT THIS STILL DOES NOT CLOSE, stated rather than implied: a ctx obtained wholesale from
+ * another module (`const provCtx = buildMemberProvCtx(ids, tier)`) is not analysable without type
+ * resolution across files. That gap is accepted on three grounds — it requires adding an exported ctx
+ * factory and importing it into a token path, which is a visible reviewable act rather than a
+ * one-word edit; the cheap mistakes are all now impossible; and the data-mechanics tier catches the
+ * OUTCOME regardless. I verified the third rather than assuming it: planting
+ * `principal = "member"` in retrieve.ts reddens
+ * `test/datamechanics/token-structured-attenuation.datamechanics.test.ts` on the real leak, both
+ * arms. Read this guard as the fast build-failing layer over a tier that independently proves the
+ * outcome — not as the only thing between a token and the hand-typed rows.
+ */
+function astViolations(code: string, rel = "inline.ts"): string[] {
+  const src = ts.createSourceFile(rel, code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const bad: string[] = [];
+  const at = (n: ts.Node) => `${rel}:${src.getLineAndCharacterOfPosition(n.getStart(src)).line + 1}`;
+
+  /** The ONE permitted initialiser, matched on shape: `enforce?.principal` or `enforce.principal`. */
+  const isForwarded = (e: ts.Expression): boolean => {
+    const inner = ts.isNonNullExpression(e) ? e.expression : e;
+    if (!ts.isPropertyAccessExpression(inner)) return false;
+    return ts.isIdentifier(inner.expression) && inner.expression.text === "enforce" && inner.name.text === "principal";
+  };
+
+  /** A property's name, resolving a literal COMPUTED key — the spelling Codex demonstrated. */
+  const nameOf = (p: ts.ObjectLiteralElementLike): string | null => {
+    if (ts.isSpreadAssignment(p)) return null;
+    const n = p.name;
+    if (!n) return null;
+    if (ts.isIdentifier(n) || ts.isStringLiteral(n)) return n.text;
+    if (ts.isComputedPropertyName(n) && ts.isStringLiteralLike(n.expression)) return n.expression.text;
+    return null;
+  };
+
+  const visit = (node: ts.Node): void => {
+    // (3) an assignment INTO a `.principal` property, in any assignment operator (`=`, `||=`, `??=`).
+    if (
+      ts.isBinaryExpression(node) &&
+      ts.isPropertyAccessExpression(node.left) &&
+      node.left.name.text === "principal" &&
+      node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      node.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+    ) {
+      bad.push(`${at(node)} assigns to .principal — this file may only FORWARD it`);
+    }
+
+    // (4) reaching it reflectively.
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const callee = `${node.expression.expression.getText(src)}.${node.expression.name.text}`;
+      if (callee === "Reflect.set" || callee === "Object.defineProperty") {
+        if (node.arguments.some((a) => ts.isStringLiteralLike(a) && a.text === "principal")) {
+          bad.push(`${at(node)} sets .principal via ${callee}`);
+        }
+      }
+    }
+
+    if (ts.isObjectLiteralExpression(node)) {
+      const names = node.properties.map(nameOf);
+
+      for (const [i, prop] of node.properties.entries()) {
+        if (names[i] !== "principal") continue;
+        if (ts.isShorthandPropertyAssignment(prop)) {
+          // Shorthand carries no initialiser to inspect, so it can only be hiding a local binding.
+          bad.push(`${at(prop)} shorthand \`{ principal }\` — forwarding cannot be spelled that way`);
+        } else if (ts.isPropertyAssignment(prop) && !isForwarded(prop.initializer)) {
+          // A TYPE position never reaches here: an interface member parses as a PropertySignature,
+          // not a PropertyAssignment. The regex version needed an explicit carve-out for that.
+          bad.push(`${at(prop)} principal is \`${prop.initializer.getText(src)}\`, not enforce?.principal`);
+        }
+      }
+
+      if (names.includes("visibleItemIds")) {
+        const spread = node.properties.find(ts.isSpreadAssignment);
+        // (2) a spread can silently overwrite the forwarded value with one from another module.
+        if (spread) bad.push(`${at(spread)} spread into a provenance ctx can overwrite principal`);
+        // (5) the M13 property — carry it, don't merely be able to.
+        if (!names.includes("principal")) bad.push(`${at(node)} provenance ctx omits principal`);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(src);
+  return bad;
+}
+
+/* ─────────────────────────── LAYER 2 — the tree-wide coverage inventory ──────────────────────── */
+
+/**
+ * A member literal being MANUFACTURED, in the shapes it takes across the tree:
+ *   · an object property — `principal: "member"`;
+ *   · the TS twin's positional 4th argument — `rowVisibleByProvenance(row, ids, tier, "member")`;
+ *   · a named constant — `const MEMBER_ONLY_SURFACE = "member" as const`.
+ *
+ * This layer is an INVENTORY, not a wall — see the header. Its job is to keep the allow-list honest
+ * about who asserts memberhood, so a new assertion has to be justified in review.
  */
 // The whitespace lives INSIDE the lookahead: `\s*(?!\|)` backtracks to zero width and passes on
 // `principal: "member" | "token"`, which is how the first spelling flagged three type declarations.
 const MEMBER_PROP = /principal\s*:\s*["'`]member["'`](?!\s*\|)/;
 // `[^)]*` stopped at the first `)`, so a twin call containing a nested call
-// (`rowVisibleByProvenance(d, getIds(), tier, "member")`) escaped the tree-wide scan. `[^;]*?` admits
-// the nested call while still being unable to leave the statement: an argument list contains no `;`.
+// (`rowVisibleByProvenance(d, getIds(), tier, "member")`) escaped this scan. `[^;]*?` admits the
+// nested call while being unable to leave the statement: an argument list contains no `;`.
 // (Plain `[\s\S]*?` did leave it — I checked — matching a `"member"` string many lines later in an
 // unrelated statement. Only a false POSITIVE, but a guard that cries wolf gets its allow-list widened.)
 const MEMBER_TWIN_ARG = /rowVisibleByProvenance\([^;]*?["'`]member["'`]\s*\)/;
-/**
- * …and the shape a NAMED CONSTANT takes — `const MEMBER_ONLY_SURFACE = "member" as const`.
- *
- * This third needle exists because the guard failed its own test: `lib/access/enforce.ts` names the
- * value once instead of repeating a literal, and the two needles above scored that file clean. The
- * escalation it left open is the dangerous one — `import { MEMBER_ONLY_SURFACE }` into a
- * token-capable file and write `principal: MEMBER_ONLY_SURFACE`, and nothing here fires. Round 3
- * killed the FIRST version of this guard for measuring a spelling; naming a constant is just
- * another spelling.
- */
-// The lookbehind matters: without it this fires on `enforce?.principal === "member"`, a
-// COMPARISON — which retrieve.ts legitimately performs (`serveOrgStructural`) and which asserts
-// nothing. Reading a discriminator is not manufacturing one.
-// No TAIL requirement. The first spelling demanded `as const` or `;`, and Fable's diff review
-// defeated it in one line: `const principal = "member" as ProvenancePrincipal;` — a different cast,
-// so the needle missed, and the guard passed 6/6 with a hardcoded member principal in retrieve.ts.
-// I planted that exact code and confirmed it BOTH evaded the guard AND reddened the dm token tests,
-// so the guard was failing at the one job its header claims. Over-matching a binding is the safe
-// direction: the tree-wide scan already excludes comparisons via the lookbehind.
 // Scoped to a VARIABLE DECLARATION. Dropping the tail requirement outright over-matched two things
 // that assert nothing: the type alias `type ProvenancePrincipal = "member" | "token"` and the SQL
 // string `a.target_type = 'member'` in lib/auth/welcome-context.ts. Requiring `const|let|var <name>`
-// keeps the bypass caught (`const principal = "member" as ProvenancePrincipal`) and both of those out.
+// keeps a cast-bearing binding caught and both of those out. The lookbehind excludes comparisons.
 const MEMBER_BINDING = /(?:const|let|var)\s+\w+\s*(?::[^=;]*)?=\s*["'`]member["'`]/;
-
-/**
- * …and the SHORTHAND property, which has no colon and was therefore invisible to every scan above:
- * `const provCtx = { visibleItemIds, teamPosture, principal }`. This is the second half of the same
- * bypass, and it is the shape an author naturally reaches for the moment the guard reddens on
- * `principal: "member"` — extract to a variable until green. A guard that teaches its own evasion is
- * worse than none, so shorthand is forbidden outright in the token-capable files: those may only
- * forward, and forwarding cannot be spelled as shorthand.
- */
-const MEMBER_SHORTHAND = /[{,]\s*principal\s*[,}]/;
 const MEMBER_LITERAL = {
   test: (src: string) => MEMBER_PROP.test(src) || MEMBER_TWIN_ARG.test(src) || MEMBER_BINDING.test(src),
 };
 
-/**
- * The spelling-INDEPENDENT half, for the two files that see a token: every `principal` in a VALUE
- * position must be the forwarded expression, whatever it is spelled as. A literal, a named constant,
- * an imported alias and a re-derivation from `tier` all fail this — the needles above can only catch
- * the shapes someone thought to enumerate.
- *
- * Type positions are excluded because they are declarations, not assertions: a union (`"member" |
- * "token"`) or a type name (`ProvenancePrincipal`, uppercase by TS convention).
- */
-/**
- * …and the OTHER half of the property: a ctx that never mentions `principal` at all.
- *
- * Found by mutation, not by review. Deleting retrieve's forward to `matchingDecisions` reddened
- * NOTHING: an absent discriminator closes the hand-typed arm, so a token's outcome is identical and
- * every token assertion still passes. What silently changes is the MEMBER's — that leg stops serving
- * their hand-typed decisions — and no test separates it from the recency window that serves the same
- * rows. A surviving mutation means the suite proves nothing there, so the property moves here:
- * in a token-capable file, every provenance ctx must CARRY the discriminator, not merely be able to.
- *
- * Returns the ctx literals that omit it, by their opening line.
- */
-function ctxLiteralsMissingPrincipal(code: string): string[] {
-  const out: string[] = [];
-  // Shorthand counts too (`{ visibleItemIds, teamPosture }`) — anchoring on the colon alone let a
-  // whole construction shape through, which is the same class round 3 twice killed this guard for.
-  for (const m of code.matchAll(/visibleItemIds\s*[,:}]/g)) {
-    // Walk back to the `{` that opens this object literal, then forward to its match.
-    let open = m.index!;
-    while (open > 0 && code[open] !== "{") open--;
-    let depth = 0;
-    let close = open;
-    for (; close < code.length; close++) {
-      if (code[close] === "{") depth++;
-      else if (code[close] === "}" && --depth === 0) break;
-    }
-    const literal = code.slice(open, close + 1);
-    // A TYPE declaration (`{ visibleItemIds: ReadonlySet<string>; ... }`) states the shape and is
-    // not a construction; it is excluded the same way the assignment scan excludes unions.
-    if (/ReadonlySet<|readonly string\[\]/.test(literal)) continue;
-    if (!/principal\s*[,:}]/.test(literal)) out.push(literal.split("\n")[1]?.trim() ?? literal.slice(0, 60));
-  }
-  return out;
-}
-
-const FORWARDED = /^enforce\??\.principal$/;
-function unforwardedPrincipalAssignments(code: string): string[] {
-  const out: string[] = [];
-  for (const m of code.matchAll(/principal\s*\??\s*:\s*([^,;\n}]+)/g)) {
-    const rhs = m[1].trim();
-    if (rhs.includes("|")) continue; // a union type declaration
-    // A TYPE name is PascalCase (`ProvenancePrincipal`). A CONSTANT is SCREAMING_SNAKE
-    // (`MEMBER_ONLY_SURFACE`) — and a bare `/^[A-Z]/` skipped both, which let the exact escalation
-    // this function exists to catch walk straight through it.
-    if (/^[A-Z][a-zA-Z0-9]*$/.test(rhs) && /[a-z]/.test(rhs)) continue;
-    if (FORWARDED.test(rhs)) continue; // the one permitted shape
-    out.push(rhs);
-  }
-  return out;
-}
-
 describe("guard: a token can never acquire member provenance semantics", () => {
-  it("the token-capable files contain NO member literal — they may only forward", () => {
+  it("STRUCTURAL: the token-capable files only ever forward, per the TypeScript AST", () => {
     for (const rel of TOKEN_CAPABLE) {
-      const code = codeOnly(read(rel));
-      expect(MEMBER_LITERAL.test(code), `${rel} must forward enforce.principal, never assert "member"`).toBe(false);
-      expect(
-        MEMBER_SHORTHAND.test(code),
-        `${rel} may not use shorthand \`{ principal }\` — forwarding cannot be spelled that way, so it can only be hiding a local binding`
-      ).toBe(false);
-      expect(code, `${rel} must actually forward the discriminator`).toMatch(/principal:\s*enforce\?\.principal/);
+      const bad = astViolations(read(rel), rel);
+      expect(bad, `${rel}:\n  ${bad.join("\n  ")}`).toEqual([]);
+      // …and they must actually DO the forwarding, or a file with no ctx at all would pass above.
+      expect(read(rel), `${rel} must forward the discriminator`).toMatch(/principal:\s*enforce\?\.principal/);
     }
   });
 
-  it("…and every principal they ASSIGN is the forwarded expression — no literal, constant or alias", () => {
-    // The property, not the spelling. `principal: MEMBER_ONLY_SURFACE` passes all three needles
-    // above and reopens the leak; it fails here.
-    for (const rel of TOKEN_CAPABLE) {
-      const bad = unforwardedPrincipalAssignments(codeOnly(read(rel)));
-      expect(bad, `${rel} may only ever assign enforce?.principal — found: ${bad.join(", ")}`).toEqual([]);
+  it("…and the AST walk rejects every spelling the two diff reviews found — non-vacuity", () => {
+    // Each of these passed the regex guard at some point in this slice's history. They are kept as
+    // negative controls so a future simplification of the walk reddens here rather than silently
+    // reopening the hole.
+    const FORWARD = "const ctx = { visibleItemIds, teamPosture, principal: enforce?.principal };";
+    const EVASIONS: [string, string][] = [
+      ["literal", 'const ctx = { visibleItemIds, teamPosture, principal: "member" };'],
+      ["named constant", "const ctx = { visibleItemIds, teamPosture, principal: MEMBER_ONLY_SURFACE };"],
+      [
+        "local binding + shorthand (Fable's HIGH)",
+        'const principal = "member" as ProvenancePrincipal;\nconst ctx = { visibleItemIds, teamPosture, principal };',
+      ],
+      ["computed key", 'const ctx = { visibleItemIds, teamPosture, ["principal"]: "member" };'],
+      [
+        "spread override",
+        'const o = { principal: "member" };\nconst ctx = { visibleItemIds, teamPosture, principal: enforce?.principal, ...o };',
+      ],
+      ["direct assignment", `${FORWARD}\nenforce!.principal = "member";`],
+      ["logical-or assignment", `${FORWARD}\nenforce!.principal ||= "member";`],
+      ["Reflect.set", `${FORWARD}\nReflect.set(enforce, "principal", "member");`],
+      ["defineProperty", `${FORWARD}\nObject.defineProperty(enforce, "principal", { value: "member" });`],
+      ["derived from tier", 'const ctx = { visibleItemIds, teamPosture, principal: tier === "team" ? "member" : "token" };'],
+      ["omitted entirely (M13)", "const ctx = { visibleItemIds, teamPosture };"],
+      ["as-const literal", 'const ctx = { visibleItemIds, principal: "member" as const };'],
+    ];
+    for (const [name, code] of EVASIONS) {
+      expect(astViolations(code).length, `the AST walk must REJECT: ${name}`).toBeGreaterThan(0);
     }
-  });
 
-  it("…and every provenance ctx they BUILD carries the discriminator — none may omit it", () => {
-    for (const rel of TOKEN_CAPABLE) {
-      const missing = ctxLiteralsMissingPrincipal(codeOnly(read(rel)));
-      expect(missing, `${rel} builds a provenance ctx with no principal: ${missing.join(" | ")}`).toEqual([]);
-    }
+    // …and it must ACCEPT the one legal shape, or it is a check that always fails.
+    expect(astViolations(FORWARD), "forwarding must pass").toEqual([]);
+    expect(astViolations("const ctx = { visibleItemIds, teamPosture, principal: enforce.principal };")).toEqual([]);
+    // The three shapes that broke the hand-rolled scanner, all now handled by the parser.
+    expect(
+      astViolations('interface E { visibleItemIds: ReadonlySet<string>; principal?: "member" | "token" }'),
+      "an interface declares, it does not construct"
+    ).toEqual([]);
+    expect(astViolations("const { visibleItemIds } = enforce;"), "destructuring is not a construction").toEqual([]);
+    expect(
+      astViolations('const s = "{ visibleItemIds }";\nconst ctx = { visibleItemIds, principal: enforce?.principal };'),
+      "a brace inside a string no longer misleads anything"
+    ).toEqual([]);
   });
 
   it("every member literal in the tree sits at a listed member-only boundary", () => {
@@ -244,42 +289,22 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     expect(offenders, "a new member literal must be justified by an authenticated member boundary").toEqual([]);
   });
 
-  it("the needle matches what it claims to — non-vacuity", () => {
+  it("the tree-wide needle matches what it claims to — non-vacuity", () => {
     // A guard whose regex matches nothing passes forever.
     expect(MEMBER_LITERAL.test('const c = { principal: "member" };')).toBe(true);
     expect(MEMBER_LITERAL.test("const c = { principal: 'member' };")).toBe(true);
     expect(MEMBER_LITERAL.test('principal:"member"')).toBe(true);
     expect(MEMBER_LITERAL.test('rowVisibleByProvenance(d, ids, tier, "member")')).toBe(true);
-    // Forwarding is the permitted shape, and a TYPE declaration is not an assertion.
-    expect(MEMBER_LITERAL.test("principal: enforce?.principal")).toBe(false);
-    expect(MEMBER_LITERAL.test('principal: "member" | "token";')).toBe(false);
-    expect(MEMBER_LITERAL.test('principal: "member" | "token" | undefined')).toBe(false);
-    expect(MEMBER_LITERAL.test('principal: "member" as const')).toBe(true);
-    // The named-constant shape the first two needles missed — the reason this one exists.
+    expect(MEMBER_LITERAL.test('rowVisibleByProvenance(d, getIds(), tier, "member")'), "nested call").toBe(true);
     expect(MEMBER_LITERAL.test('const MEMBER_ONLY_SURFACE = "member" as const;')).toBe(true);
-    expect(MEMBER_LITERAL.test("const M = 'member';")).toBe(true);
-    // …but a COMPARISON is a read, not an assertion — retrieve.ts does exactly this, legally.
-    expect(MEMBER_LITERAL.test('const ok = enforce?.principal === "member";')).toBe(false);
-    expect(MEMBER_LITERAL.test('if (p !== "member") return;')).toBe(false);
-    // …and the forwarding check that catches it wherever it is IMPORTED rather than declared.
-    expect(unforwardedPrincipalAssignments("principal: MEMBER_ONLY_SURFACE,")).toEqual(["MEMBER_ONLY_SURFACE"]);
-    expect(unforwardedPrincipalAssignments('principal: tier === "team" ? "member" : "token",'))
-      .toEqual(['tier === "team" ? "member" : "token"']);
-    expect(unforwardedPrincipalAssignments("principal: enforce?.principal,")).toEqual([]);
-    expect(unforwardedPrincipalAssignments('principal: "member" | "token";'), "a union is a declaration").toEqual([]);
-    expect(unforwardedPrincipalAssignments("principal?: ProvenancePrincipal"), "a type name is a declaration").toEqual([]);
-    // THE BYPASS Fable demonstrated, pinned in both halves so it cannot come back.
     expect(MEMBER_LITERAL.test('const principal = "member" as ProvenancePrincipal;')).toBe(true);
-    expect(MEMBER_LITERAL.test('const principal = "member"')).toBe(true);
-    expect(MEMBER_SHORTHAND.test("const c = { visibleItemIds, teamPosture, principal };")).toBe(true);
-    expect(MEMBER_SHORTHAND.test("const c = { principal };")).toBe(true);
-    expect(MEMBER_SHORTHAND.test("principal: enforce?.principal,"), "forwarding is not shorthand").toBe(false);
-    // …and the shorthand omission the colon-anchored scan could not see.
-    expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds,\n  teamPosture,\n})").length).toBe(1);
-    expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds,\n  teamPosture,\n  principal,\n})")).toEqual([]);
-    // …and a twin call with a nested call in its arguments.
-    expect(MEMBER_LITERAL.test('rowVisibleByProvenance(d, getIds(), tier, "member")')).toBe(true);
-    // …but it must NOT reach across a statement boundary into an unrelated string.
+    // …and the shapes that assert NOTHING and must not be flagged.
+    expect(MEMBER_LITERAL.test("principal: enforce?.principal"), "forwarding").toBe(false);
+    expect(MEMBER_LITERAL.test('principal: "member" | "token";'), "a union declares").toBe(false);
+    expect(MEMBER_LITERAL.test('export type P = "member" | "token";'), "a type alias declares").toBe(false);
+    expect(MEMBER_LITERAL.test('const ok = enforce?.principal === "member";'), "a comparison reads").toBe(false);
+    expect(MEMBER_LITERAL.test('if (p !== "member") return;'), "so does this one").toBe(false);
+    expect(MEMBER_LITERAL.test("a.target_type = 'member' and a.action"), "a SQL string").toBe(false);
     expect(
       MEMBER_LITERAL.test('rowVisibleByProvenance(d, ids, tier, principal);\nconst x = 1;\nlog("member")'),
       "the twin needle must stay inside its own statement"
@@ -287,17 +312,9 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     // …and codeOnly must not swallow a generator method, which would be a hiding place.
     expect(codeOnly('class C {\n  *iter() { const principal = "member"; }\n}')).toContain("principal");
     expect(codeOnly(" * a jsdoc continuation line"), "prose is still stripped").not.toContain("jsdoc");
-    // The omission scan: a ctx with no discriminator at all — the shape a surviving mutation found.
-    expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds: ids,\n  teamPosture: true,\n})").length).toBe(1);
-    expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds: ids,\n  principal: enforce?.principal,\n})")).toEqual([]);
-    expect(
-      ctxLiteralsMissingPrincipal("interface X {\n  visibleItemIds: ReadonlySet<string>;\n}"),
-      "a type declaration is not a construction"
-    ).toEqual([]);
   });
 
   it("the allow-list is honest — every listed boundary really does assert memberhood", () => {
-    // A stale allow-list entry is permission granted to a file that no longer needs it.
     const stale = [...MEMBER_BOUNDARIES].filter((rel) => !MEMBER_LITERAL.test(codeOnly(read(rel))));
     expect(
       stale,

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -35,14 +35,21 @@ import { join } from "node:path";
 const ROOT = join(import.meta.dirname, "..", "..");
 const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
 
-/** Code only — a guard that reads its own prose fires on documentation. */
+/**
+ * Code only — a guard that reads its own prose fires on documentation.
+ *
+ * The `*` rule is narrow ON PURPOSE. `startsWith("*")` alone deleted GENERATOR METHODS —
+ * `*iter() { const principal = "member"; }` vanished entirely, which is a hiding place, and in the
+ * FAIL-OPEN direction. A jsdoc continuation is `*` followed by whitespace or end-of-line, or `*​/`;
+ * a generator is `*` followed immediately by an identifier. Only the former is stripped.
+ */
 const codeOnly = (src: string): string =>
   src
     .split("\n")
     .map((l) => l.replace(/\/\*.*?\*\//g, " "))
     .filter((l) => {
       const t = l.trim();
-      return !(t.startsWith("*") || t.startsWith("//") || t.startsWith("/*"));
+      return !(/^\*(\s|$)/.test(t) || t.startsWith("*/") || t.startsWith("//") || t.startsWith("/*"));
     })
     .join("\n");
 
@@ -98,9 +105,11 @@ function filesUnder(dir: string): string[] {
 // `principal: "member" | "token"`, which is how the first spelling flagged three type declarations.
 const MEMBER_PROP = /principal\s*:\s*["'`]member["'`](?!\s*\|)/;
 // `[^)]*` stopped at the first `)`, so a twin call containing a nested call
-// (`rowVisibleByProvenance(d, getIds(), tier, "member")`) escaped the tree-wide scan. `[\s\S]*?`
-// is lazy, so it still cannot run past the call it is matching.
-const MEMBER_TWIN_ARG = /rowVisibleByProvenance\([\s\S]*?["'`]member["'`]\s*\)/;
+// (`rowVisibleByProvenance(d, getIds(), tier, "member")`) escaped the tree-wide scan. `[^;]*?` admits
+// the nested call while still being unable to leave the statement: an argument list contains no `;`.
+// (Plain `[\s\S]*?` did leave it — I checked — matching a `"member"` string many lines later in an
+// unrelated statement. Only a false POSITIVE, but a guard that cries wolf gets its allow-list widened.)
+const MEMBER_TWIN_ARG = /rowVisibleByProvenance\([^;]*?["'`]member["'`]\s*\)/;
 /**
  * …and the shape a NAMED CONSTANT takes — `const MEMBER_ONLY_SURFACE = "member" as const`.
  *
@@ -270,6 +279,14 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds,\n  teamPosture,\n  principal,\n})")).toEqual([]);
     // …and a twin call with a nested call in its arguments.
     expect(MEMBER_LITERAL.test('rowVisibleByProvenance(d, getIds(), tier, "member")')).toBe(true);
+    // …but it must NOT reach across a statement boundary into an unrelated string.
+    expect(
+      MEMBER_LITERAL.test('rowVisibleByProvenance(d, ids, tier, principal);\nconst x = 1;\nlog("member")'),
+      "the twin needle must stay inside its own statement"
+    ).toBe(false);
+    // …and codeOnly must not swallow a generator method, which would be a hiding place.
+    expect(codeOnly('class C {\n  *iter() { const principal = "member"; }\n}')).toContain("principal");
+    expect(codeOnly(" * a jsdoc continuation line"), "prose is still stripped").not.toContain("jsdoc");
     // The omission scan: a ctx with no discriminator at all — the shape a surviving mutation found.
     expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds: ids,\n  teamPosture: true,\n})").length).toBe(1);
     expect(ctxLiteralsMissingPrincipal("f({\n  visibleItemIds: ids,\n  principal: enforce?.principal,\n})")).toEqual([]);


### PR DESCRIPTION
Closes the Phase A audit's **only CRITICAL**: a delegated `aiosd_` token read every hand-entered task
and decision in the team, regardless of its scope, including rows in projects it was never granted.

**AIOS-Work: AUDITFIX-1**

## The defect

`provenanceRowSqlFromIds` admitted an unsourced row on team posture **alone**:

```sql
or (source_item_id is null and created_by is not null and <teamPosture>)
```

That arm never references `visibleItemIds`. Every valid token is team-tier by construction
(`agent-tokens.ts` refuses external-tier delegation at mint *and* verify), so the arm was always open
for tokens, and `ctx.structured` goes verbatim into the prompt. No RLS backstop.

**Reproduced against real Postgres with a positive control** before anything was written: a principal
with zero visible items got `sources: 0` and a `structured` containing the planted secret task; the
control confirmed a full-visibility principal legitimately sees the same row, so the fixture was not
inert. **Why it survived review:** the existing token test asserts `ctx.sources.map(s => s.path)` and
never `ctx.structured` — green by construction.

## The fix

One policy, expressed **positively**, in all three owners of the contract:

```ts
admitsUnsourced(ctx) = ctx.principal === "member" && ctx.teamPosture === true
```

Positive on purpose: `!== "token"` fails **open** for `undefined`, `null`, and any foreign value —
and those are real runtime states, because `tsconfig.json` excludes `test/`. Token, absent and
garbage all close.

- All three owners take the discriminator — `provenanceRowSqlFromIds`, `provenanceRowSql`, and the TS
  twin `rowVisibleByProvenance` — so "one contract, N owners" is true rather than asserted.
- The two token-capable files may only **forward** `enforce.principal`. Deriving it from `tier` would
  relabel every token as a member; a guard fails the build on any other shape.
- **Member behaviour is unchanged.** The settled ENFB-2 hand-typed rule survives, and every
  member-only boundary threads `"member"` explicitly.

Not in scope: letting a token see hand-entered rows in projects it *is* granted. Those legs carry item
ids only; widening them is a product decision — **AUDITFIX-7**.

## What the loop caught, in order

**Four spec-review rounds, all BLOCKED, before any code existed.** They killed a required-field design
that had no runtime rule; killed a shared "member context" helper that *would have caused this leak*
(`matchingDecisions` is token-reachable and `nativeRetrieve` was dropping the discriminator); replaced
an AC that could not fail; and caught acceptance criteria that would have passed a fix closing only
the empty-scope case, leaving every realistically-scoped token leaking.

**Then the tiers found three things four review rounds did not:**

- The spec's consumer inventory said **7**; there are **9**. `app/api/v1/tasks/route.ts` and
  `app/t/[team]/people/[handle]/page.tsx` were unlisted, and omitting the discriminator there fails
  *closed* — a silent **member** regression. The tasks writeback feed dropped every UI-origin task.
- `visibleProjectCards` builds a **second** ctx for its counts. Nothing asserted it: the existing card
  test checks `visibleItems` only and never seeds an unsourced row.
- The guard scored my own code clean, because `enforce.ts` names the value in a constant.

**Fable's diff review — BLOCKED, and it defeated the guard in one line:**

```ts
const principal = "member" as ProvenancePrincipal;
const provCtx = { visibleItemIds, teamPosture, principal };
```

I planted that exact code and confirmed both halves: the guard passed **6/6**, and the same code
reddened the dm token tests on the real leak. Also found: `pulse.ts`'s fallback synthesised `"member"`
— the one thing the spec forbids; the allow-list honesty check named the wrong repair for a *lost*
literal; and AC7's sentence was false rather than its coverage.

**Codex's diff review — no BLOCKER, no HIGH.** It cleared the production fix, independently
re-derived the consumer inventory, and confirmed the SQL parameter numbering. Then it listed **six
more** guard evasions — a computed key, a spread override, `enforce!.principal = …`, `||=`,
`Reflect.set`, `Object.defineProperty` — plus brace-scanner and comment-stripping hazards.

That was the **third** review to defeat this guard, and the pattern was the finding: each defeat was a
new *spelling* of one act, and a text matcher can only enumerate spellings. **So the token-capable half
is now a TypeScript AST walk**, with all twelve historical evasions kept as negative controls. The
tree-wide scan stays regex and is relabelled as what it is — a coverage inventory, not a wall.

Codex also caught a footgun the type system endorsed: the three project-row helpers took a
`Principal` (whose `projectScope` makes it token-shaped) while asserting memberhood inside. They now
take `MemberPrincipal` (`projectScope?: never`) — a token-shaped value is a compile error, verified
both directions.

## Mutation testing — including one that survived

**24 mutations: 23 reddened only their intended test; 1 survived, was fixed, and now reddens.**

The survivor is the interesting one. Deleting retrieve's forward to `matchingDecisions` reddened
**nothing** — an absent discriminator closes the arm, so a token's outcome is unchanged and every token
assertion passes; what silently breaks is the *member's*, and no fixture separates that leg from the
recency window serving the same rows. The property moved into the guard: a ctx must **carry** the
discriminator, not merely be able to.

Two more came from probing the guard's own helpers after rewriting them: `codeOnly` was deleting
**generator methods** (a hiding place, fail-*open*), and the twin needle's `[\s\S]*?` escaped its own
statement. And Codex caught my rewritten truth table being mostly decoration — neither SQL string in
the `4 rows × 5 principals` loop referenced the row, and the trailing conditional re-asserted a
constant from the fixture table. A tautology reads exactly like coverage.

## Verification

| | |
|---|---|
| unit | **3,276 passed** / 0 failed |
| data-mechanics | **235/235 files · 1,337 passed** / 0 failed (`TZ=UTC`) |
| tsc · lint · docs-drift | clean (lint: 0 errors, 16 pre-existing warnings) |
| spec gate | `aios spec eval` → `SPEC_READY`, no findings |
| architecture map | updated — including correcting a sentence that was **false** |

`docs/ARCHITECTURE.md` claimed a delegated query is "ALWAYS attenuated". That was false for the
structured legs, and it is corrected rather than quietly amended.

**On the dm tier, stated plainly:** this machine's swap was exhausted (35.1/35.8 GB) throughout, and a
single full-tier run would not converge. The tier was run in **six batches covering all 235 files**,
plus the two files the rebase added. That is full coverage, assembled from six runs rather than one.

## Two things worth knowing

1. **Prod exposure today is zero** — 0 active agent tokens, and exactly 1 hand-entered task reachable
   by the arm. This is a contract violation on a shipped route, not current data loss. It becomes real
   the moment a token is minted, which is the operation the slice that introduced them exists for.
2. **This is slice 1 of 7.** The rest of the audit remediation: connector reconcile at ingest
   (AUDITFIX-2), system-project grant guard (-3), membership-writer error handling (-4), invite-default
   stranding (-5), sweep-vs-curation (-6, needs a product ruling), the MEDIUMs (-7).

## Review — Reviewed by Fable code-reviewer + Codex gpt-5.6-sol — verdict BLOCKED then no-BLOCKER/no-HIGH; every finding folded, 24 mutations run
