### PR TITLE
feat(nav): restore the Skills entry — the shared-skills catalog is reachable again (SKILLNAV-1)

### DIFF
--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { CircleAlert } from "lucide-react";
 import { activateInvitedMembership } from "@/lib/auth/pg-login";
 import { resolveTeamContext } from "@/lib/auth/team-context";
-import { TeamNav, type NavEntry, type NavLeaf } from "@/components/team-nav";
+import { TeamNav } from "@/components/team-nav";
+import { buildNavItems } from "@/lib/dashboard/nav-items";
 import { SignOutButton } from "@/components/account/sign-out-button";
 
 function NoTeamScreen({ slug }: { slug: string }) {
@@ -45,31 +46,7 @@ export default async function TeamLayout({
 
   const base = `/t/${team.slug}`;
 
-  // Settings groups the low-frequency config surfaces; Admin is appended only for admins.
-  // "Team tools" (/team-tools) removed from the nav (2026-07-13, product call) — route still resolves.
-  const settingsChildren: NavLeaf[] = [
-    { icon: "account", label: "Account", href: `${base}/account` },
-  ];
-  if (me.role === "admin") {
-    settingsChildren.push({ icon: "admin", label: "Admin", href: `${base}/admin` });
-  }
-
-  // Lean primary IA (2026-07-10, product call). Removed from the left nav — routes still resolve by
-  // direct URL, only the nav entry was cut: "Tasks" (/tasks), "Maturity" (/maturity), "Decisions"
-  // (/decisions, empty + unused). "Data" moved under Admin → Data (verification/debug view, now
-  // admin-gated). The "Work" group is dropped (nothing left in it; Projects stays commented out).
-  // "Meetings" stays a top-level entry — a new, actively-used surface, not part of the trim.
-  // "Pulse" (home) is now the flagship narrative surface: it absorbed the old "Learning" tab (arcs +
-  // timeline + facts/events), so that entry was removed and `/learning` redirects here. The Brain icon
-  // fronts Pulse to signal it's the synthesized-understanding surface, not a generic dashboard home.
-  const items: NavEntry[] = [
-    { icon: "learning", label: "Pulse", href: base, exact: true },
-    { icon: "codebases", label: "Codebases", href: `${base}/codebases` },
-    { icon: "meetings", label: "Meetings", href: `${base}/meetings` },
-    { icon: "query", label: "Query", href: `${base}/query` },
-  ];
-  // "Social" removed from the left nav (product call) — the /social route still resolves by direct URL.
-  items.push({ label: "Settings", children: settingsChildren });
+  const items = buildNavItems({ base, role: me.role });
 
   return (
     <div className="flex min-h-dvh flex-1 bg-surface-raised">

--- a/lib/dashboard/nav-items.ts
+++ b/lib/dashboard/nav-items.ts
@@ -1,0 +1,60 @@
+import type { NavEntry, NavLeaf } from "@/components/team-nav";
+
+/**
+ * The team dashboard's left-nav contents — a PURE function of the team slug and the viewer's role.
+ *
+ * WHY THIS IS EXTRACTED (SKILLNAV-1). The nav used to be built inline in the layout's server
+ * component, which made it unreachable to tests: a guard could only grep the source. Grep cannot
+ * tell a rendered entry from one inside a block comment, and cannot see that an entry moved behind
+ * `if (role === "admin")` — so a guard built on it stays green while the nav is broken for real
+ * users. That is not hypothetical: it is how the Skills entry disappeared unnoticed once already.
+ * A pure builder lets the guard CALL the thing and assert on what it actually returns, per role.
+ *
+ * Keep this free of I/O and React so it stays trivially callable from the unit tier.
+ */
+export function buildNavItems({ base, role }: { base: string; role: string }): NavEntry[] {
+  // Settings groups the low-frequency config surfaces; Admin is appended only for admins.
+  // "Team tools" (/team-tools) removed from the nav (2026-07-13, product call) — route still resolves.
+  const settingsChildren: NavLeaf[] = [
+    { icon: "account", label: "Account", href: `${base}/account` },
+  ];
+  if (role === "admin") {
+    settingsChildren.push({ icon: "admin", label: "Admin", href: `${base}/admin` });
+  }
+
+  // Lean primary IA (2026-07-10, product call). Removed from the left nav — routes still resolve by
+  // direct URL, only the nav entry was cut: "Tasks" (/tasks), "Maturity" (/maturity), "Decisions"
+  // (/decisions, empty + unused). "Data" moved under Admin → Data (verification/debug view, now
+  // admin-gated). The "Work" group is dropped (nothing left in it; Projects stays commented out).
+  // "Meetings" stays a top-level entry — a new, actively-used surface, not part of the trim.
+  // "Pulse" (home) is now the flagship narrative surface: it absorbed the old "Learning" tab (arcs +
+  // timeline + facts/events), so that entry was removed and `/learning` redirects here. The Brain icon
+  // fronts Pulse to signal it's the synthesized-understanding surface, not a generic dashboard home.
+  const items: NavEntry[] = [
+    { icon: "learning", label: "Pulse", href: base, exact: true },
+    { icon: "codebases", label: "Codebases", href: `${base}/codebases` },
+    { icon: "meetings", label: "Meetings", href: `${base}/meetings` },
+    { icon: "query", label: "Query", href: `${base}/query` },
+    // SKILLNAV-1: "Skills" is back as a top-level entry. The catalog at /library/skills has been
+    // built, authenticated and serving real data throughout — 22 published skills in prod. It lost
+    // its way in over two commits, neither of which meant to remove it:
+    //   3feb311  ships the page WITH a top-level nav entry;
+    //   5138047  removes that entry, because the Library PAGE gained a kind-chip linking to it
+    //            ("Skills folds into Library … not a top-level peer") — reachable, but only via
+    //            one link on one page;
+    //   5509ca9  (#213) turns library/page.tsx into a redirect to /admin/data, destroying that
+    //            chip — and with it the last path in. Its comment still asserts skills are "linked
+    //            from arc evidence, query citations, etc."; grep finds no such link anywhere.
+    // So the lesson is not "don't trim the nav" — it is that reachability delegated to ONE link on
+    // ANOTHER page dies silently when that page changes. Hence: top-level, and guarded by
+    // test/guards/nav-reachability.test.ts. Do not re-trim without checking the catalog is empty.
+    { icon: "skills", label: "Skills", href: `${base}/library/skills` },
+  ];
+  // "Social" removed from the left nav (product call) — the /social route still resolves by direct URL.
+  items.push({ label: "Settings", children: settingsChildren });
+  // FROZEN (Fable review, round 3): the guard asserts what this function RETURNS and that the layout
+  // renders it, but neither sees an in-place edit between the two — `const items` blocks reassignment,
+  // not `items.splice(...)`. Freezing turns that silent drop into a runtime throw. Shallow is enough:
+  // the failure mode is removing an entry, not mutating one's fields.
+  return Object.freeze(items) as NavEntry[];
+}

--- a/test/guards/nav-reachability.test.ts
+++ b/test/guards/nav-reachability.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildNavItems } from "@/lib/dashboard/nav-items";
+import type { NavEntry, NavLeaf } from "@/components/team-nav";
+
+/**
+ * Nav reachability guard (SKILLNAV-1).
+ *
+ * WHY THIS EXISTS — an observed bug, not a hypothetical. The shared-skills catalog
+ * (`/t/<team>/library/skills`) shipped with a top-level nav entry (3feb311). `5138047` then REMOVED
+ * that entry, because the Library PAGE had gained a kind-chip linking to it; `5509ca9` (#213) turned
+ * library/page.tsx into a redirect, destroying the chip and the last path in. (Corrected here in
+ * round 3 — an earlier draft blamed #213 for cutting the nav entry, which `git show 5138047`
+ * disproves. The account in lib/dashboard/nav-items.ts is the one to trust.) The only remaining
+ * reference is `app/t/[team]/skills/page.tsx`, a bare redirect ALIAS — reachable if you already know
+ * the old URL, discoverable by no one. So the catalog stayed authenticated, deployed and holding 22
+ * published skills while being unreachable. Nothing failed, because nothing pinned it.
+ *
+ * The guard CALLS `buildNavItems` rather than grepping the layout. That distinction is the whole
+ * point: a source-text guard cannot tell a rendered entry from one sitting inside a block comment,
+ * and cannot see an entry that moved behind `if (role === "admin")` — both leave the nav broken for
+ * real users while the guard stays green. An earlier draft of this file had exactly that hole; the
+ * adversarial review broke it with a two-line probe.
+ *
+ * Two invariants, one per direction of the failure:
+ *   1. NO DEAD LINKS — every nav href resolves to a real route file.
+ *   2. NO ORPHANED CATALOGS — browsable surfaces must appear in the nav, for every role that may see
+ *      them. This is the one that actually happened.
+ */
+
+const PAGES = join(import.meta.dirname, "..", "..", "app", "t", "[team]");
+const BASE = "/t/acme";
+
+/** Every role whose nav must be checked; an entry hidden from some roles is still a regression. */
+const ROLES = ["member", "lead", "admin"] as const;
+
+function isSection(e: NavEntry): e is { label: string; children: NavLeaf[] } {
+  return (e as { children?: unknown }).children !== undefined;
+}
+
+/** Flatten primary entries + section children into the leaves a user can actually click. */
+export function leaves(items: NavEntry[]): NavLeaf[] {
+  return items.flatMap((e) => (isSection(e) ? e.children : [e]));
+}
+
+/**
+ * Route path → the page file that serves it. `/t/acme` (the base itself) is the index page.
+ * Every page under `app/t/[team]` is `.tsx` today; the other extensions are accepted so a routine
+ * rename cannot turn this guard into a false blocker. Route groups `(x)` and parallel slots `@x`
+ * are NOT modelled — none exist under this subtree, and inventing support for them would be
+ * untested code in a guard.
+ */
+const PAGE_EXTS = ["tsx", "ts", "jsx", "js"] as const;
+function routeFile(href: string): string | null {
+  const dir = join(PAGES, href.slice(BASE.length).replace(/^\//, ""));
+  return PAGE_EXTS.map((e) => join(dir, `page.${e}`)).find(existsSync) ?? null;
+}
+function routeExists(href: string): boolean {
+  return routeFile(href) !== null;
+}
+
+/** Surfaces that exist to be browsed. Add a row when one ships — that is the point. */
+const MUST_BE_REACHABLE: [label: string, path: string][] = [["Skills", "/library/skills"]];
+
+describe("nav reachability", () => {
+  it("the builder returns a real nav (non-vacuity: an empty nav must not pass anything below)", () => {
+    const l = leaves(buildNavItems({ base: BASE, role: "member" }));
+    expect(l.length, "buildNavItems returned almost nothing — every assertion below would be vacuous").toBeGreaterThanOrEqual(5);
+    expect(l.map((x) => x.label)).toContain("Pulse");
+  });
+
+  it("the builder is role-sensitive, and the guard sees that (non-vacuity)", () => {
+    const admin = leaves(buildNavItems({ base: BASE, role: "admin" })).map((x) => x.label);
+    const member = leaves(buildNavItems({ base: BASE, role: "member" })).map((x) => x.label);
+    expect(admin, "admin should get the Admin entry").toContain("Admin");
+    expect(member, "a non-admin must NOT get the Admin entry — if this fails the role arg is ignored").not.toContain("Admin");
+  });
+
+  for (const role of ROLES) {
+    it(`every nav href resolves to a real route file — role: ${role} (no dead links)`, () => {
+      const dead = leaves(buildNavItems({ base: BASE, role }))
+        .filter((n) => !routeExists(n.href))
+        .map((n) => `${n.label} → ${n.href}`);
+      expect(dead, `Nav entries pointing at routes that do not exist:\n${dead.join("\n")}`).toEqual([]);
+    });
+
+    it(`browsable catalogs appear in the nav — role: ${role}`, () => {
+      const hrefs = new Set(leaves(buildNavItems({ base: BASE, role })).map((n) => n.href));
+      const orphaned = MUST_BE_REACHABLE.filter(([, p]) => !hrefs.has(`${BASE}${p}`)).map(([l, p]) => `${l} (${p})`);
+      expect(
+        orphaned,
+        `Built, deployed, data-bearing surfaces with NO way in from the nav for role "${role}":\n` +
+          `${orphaned.join("\n")}\n` +
+          `This is the SKILLNAV-1 regression: /library/skills sat unreachable for weeks while holding\n` +
+          `22 published skills. If a catalog is genuinely retired, delete its route AND its row here.`
+      ).toEqual([]);
+    });
+  }
+
+  it("the route resolver discriminates (non-vacuity: a fabricated route must NOT resolve)", () => {
+    expect(routeExists(`${BASE}/query`)).toBe(true);
+    expect(routeExists(`${BASE}/definitely-not-a-route`)).toBe(false);
+  });
+
+  it("every must-be-reachable catalog actually exists on disk (the list can't rot)", () => {
+    const missing = MUST_BE_REACHABLE.filter(([, p]) => !routeExists(`${BASE}${p}`)).map(([l]) => l);
+    expect(missing, `listed as must-be-reachable but has no route file: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  /**
+   * ROUND-2 FOLD (call-site pin). The assertions above prove what `buildNavItems` RETURNS. They say
+   * nothing about whether the layout renders it: `<TeamNav items={items.filter(e => e.label !==
+   * "Skills")} />` removes Skills for every user with all of the above still green. This pins the
+   * DISTINCT property — the wiring — so the two layers cannot mask each other's mutations.
+   */
+  it("the layout renders the builder's nav unmodified (call-site pin)", () => {
+    const src = readFileSync(join(PAGES, "layout.tsx"), "utf8");
+    expect(src, "layout must build its nav via buildNavItems").toMatch(/const\s+items\s*=\s*buildNavItems\(/);
+    expect(
+      src,
+      "layout must pass the built nav to TeamNav UNMODIFIED — any .filter/.slice/.map between the\n" +
+        "builder and the render is a way to drop an entry while the builder-level assertions stay green"
+    ).toMatch(/<TeamNav\s+items=\{items\}\s*\/>/);
+  });
+
+  it("the call-site pin rejects a transformed nav (non-vacuity)", () => {
+    const pass = /<TeamNav\s+items=\{items\}\s*\/>/;
+    expect(pass.test("<TeamNav items={items} />")).toBe(true);
+    expect(pass.test('<TeamNav items={items.filter((e) => e.label !== "Skills")} />')).toBe(false);
+  });
+
+  /**
+   * ROUND-3 FOLD (Fable). The pin above proves the good render EXISTS somewhere in the file — not
+   * that it is the one that runs. That reopens, one level up, the exact hole the builder extraction
+   * closed: `{/* <TeamNav items={items} /> *[/]}` next to a real `<TeamNav items={pruned} />`
+   * satisfies the regex, and so does a conditional `{flag && <TeamNav items={items} />}`. Both were
+   * confirmed with a direct probe. Requiring EXACTLY ONE occurrence makes the matched render the
+   * rendered one; the in-place `items.splice(...)` variant is additionally blocked at runtime by
+   * `Object.freeze` in the builder.
+   */
+  it("the layout renders TeamNav exactly once (a second copy makes the pin meaningless)", () => {
+    const src = readFileSync(join(PAGES, "layout.tsx"), "utf8");
+    const occurrences = src.match(/<TeamNav\b/g) ?? [];
+    expect(
+      occurrences.length,
+      "layout.tsx must contain exactly ONE <TeamNav ...>. A second occurrence — even commented out —\n" +
+        "lets the pin match a render that never runs while a different, transformed one does."
+    ).toBe(1);
+  });
+
+  it("the layout does not mutate the nav in place between builder and render", () => {
+    const src = readFileSync(join(PAGES, "layout.tsx"), "utf8");
+    const mutators = src.match(/\bitems\.(splice|push|pop|shift|unshift|sort|reverse|fill|copyWithin)\s*\(|\bitems\.length\s*=/g) ?? [];
+    expect(
+      mutators,
+      `In-place mutation of the nav in layout.tsx: ${mutators.join(", ")}. \`const\` blocks reassignment,\n` +
+        `not mutation — and the builder-level assertions call buildNavItems() fresh, so they cannot see it.`
+    ).toEqual([]);
+  });
+
+  it("the once-only and mutation pins discriminate (non-vacuity)", () => {
+    const once = (src: string) => (src.match(/<TeamNav\b/g) ?? []).length;
+    expect(once("<TeamNav items={items} />")).toBe(1);
+    expect(once('{/* <TeamNav items={items} /> */}\n<TeamNav items={pruned} />'), "a commented-out copy must break the once-only pin").toBe(2);
+    const mut = /\bitems\.(splice|push|pop|shift|unshift|sort|reverse|fill|copyWithin)\s*\(|\bitems\.length\s*=/g;
+    expect("items.splice(4, 1);".match(mut)).not.toEqual(null);
+    expect("const items = buildNavItems({ base, role: me.role });".match(mut)).toEqual(null);
+  });
+
+  it("the builder's return is frozen, so an in-place drop throws instead of silently passing", () => {
+    const nav = buildNavItems({ base: BASE, role: "member" });
+    expect(Object.isFrozen(nav), "buildNavItems must return a frozen array").toBe(true);
+    expect(() => (nav as NavEntry[]).splice(0, 1)).toThrow();
+  });
+
+  /**
+   * ROUND-2 FOLD (redirect stub). A route FILE existing does not mean the surface renders: make
+   * SkillsPage `redirect(...)` immediately and every existence check still passes. Scoped to
+   * browsable catalogs deliberately — `admin/page.tsx` is a legitimate redirect stub, so a blanket
+   * rule here would be a false blocker.
+   */
+  it("browsable catalogs render content — not a redirect stub", () => {
+    const stubs = MUST_BE_REACHABLE.filter(([, p]) => {
+      const f = routeFile(`${BASE}${p}`);
+      // `return redirect(...)`, `permanentRedirect`, and `notFound()` all render nothing and were
+      // all missed by the original bare-`redirect(` matcher (Fable review, round 3).
+      return f !== null && /^\s*(?:return\s+)?(?:permanentR|r)edirect\(|^\s*(?:return\s+)?notFound\(/m.test(readFileSync(f, "utf8"));
+    }).map(([l]) => l);
+    expect(
+      stubs,
+      `Catalogs whose page immediately redirects — reachable in the nav, but there is nothing to\n` +
+        `reach: ${stubs.join(", ")}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this is

The shared-skills catalog at `/t/<team>/library/skills` gets its nav entry back. The page has been built, authenticated and serving real data throughout — **22 published skill items in prod, all of which resolve through the membership oracle** (verified by replaying `visibleItemIds`' exact predicate against production: member → groups → projects → current include memberships → active item-grain units → 22/22 visible). What it lacked was a way in.

## How it was lost

Verified against the commits — my first draft of this history was wrong and the review caught it:

| Commit | Effect |
|---|---|
| `3feb311` | ships the Skills page **with** a top-level nav entry |
| `5138047` | **removes** that entry — deliberately, because the Library *page* gained a kind-chip linking to `/library/skills` ("Skills folds into Library … not a top-level peer") |
| `5509ca9` (#213) | turns `library/page.tsx` into a redirect to `/admin/data`, destroying that chip — the last path in |

`#213`'s own comment still asserts skills are *"linked from arc evidence, query citations, etc."* Grep finds no such link anywhere in `app/`, `components/`, or `lib/`. The comment asserting reachability was the bug's alibi.

The lesson isn't "don't trim the nav" — it's that **reachability delegated to one link on another page dies silently when that page changes.** Hence: restored top-level, and guarded.

## What ships

- **`lib/dashboard/nav-items.ts`** — the nav becomes a pure builder, `buildNavItems({ base, role })`. Extracted so it is testable *at all*: inline in a server component, a guard could only grep source, and grep cannot tell a rendered entry from one inside a block comment or one moved behind `if (role === "admin")`. Behaviour identical to `main` — same order, icons, hrefs, `exact`, admin condition, Settings last.
- **`app/t/[team]/layout.tsx`** — now just `const items = buildNavItems({ base, role: me.role })`.
- **`test/guards/nav-reachability.test.ts`** — 13 assertions across three layers, each pinning a **distinct** property so they can't mask each other's mutations:
  1. *builder output*, per role — no orphaned catalogs, no dead links;
  2. *the call site* — the layout must pass the nav to `TeamNav` unmodified (`items.filter(...)` at the render site drops an entry with layer 1 green);
  3. *the target* — a browsable catalog must not be a redirect stub (a page **file** existing ≠ the surface renders). Scoped to catalogs deliberately: `admin/page.tsx` is a legitimate redirect stub, so a blanket rule would false-block.

## Verification

`npx tsc --noEmit` clean · `npm run lint` 0 errors (16 pre-existing warnings, none in touched files) · `npm run check:docs` ✓ · `npm test` **3289 passed**, 15 skipped.

Mutation-verified — each reddens the **intended** test and no other:

| Mutation | Red |
|---|---|
| block-comment the Skills entry | 3 |
| hide it behind `role === "admin"` | 2 (member + lead) |
| builder ignores its `role` arg | 1 |
| point a non-Skills href at a missing route | 3 |
| `items.filter(...)` at the render site | 1 |
| make the Skills page `redirect(...)` | 1 |

Data-mechanics and http tiers **not run** — this change adds no DB read/write and no route; the unit tier is where its failure modes live (CLAUDE.md §4).

## Review

**Reviewed by Fable code-reviewer — verdict CLEAR (2 MEDIUM + 1 LOW, all folded).**
**Reviewed by Codex (gpt-5.6-sol, 2 adversarial rounds) — verdict BLOCKED→BLOCKED, all 6 findings folded.**

Three rounds, two models, nine findings — every one confirmed against the code before folding, none refuted.

**Codex round 1 (BLOCKED)** — HIGH: the guard was green-by-construction, text-parsing `layout.tsx`; a block-comment wrap and an `if (role === "admin")` move both bypassed it (reproduced with a direct parser probe). MEDIUM: the same parser ignored multiline/reordered entries. LOW: false history in the comment. *Folded* by replacing the parser with the pure builder the guard now **calls**, per role.

**Codex round 2 (BLOCKED, attacking the folds)** — HIGH: the guard proved builder output but not rendered nav; `<TeamNav items={items.filter(...)} />` bypassed it. MEDIUM: `routeFile()` accepted a redirecting page and rejected non-`.tsx` pages. LOW: the false history still stood in the first commit's message. *Folded* via a call-site pin, redirect-stub detection, multi-extension resolution, and squashing to one commit.

**Fable round 3 (CLEAR)** — found three things two Codex rounds missed:
- **MEDIUM** — the round-2 call-site pin *reopened the round-1 hole one level up*. Asserting `<TeamNav items={items} />` appears **somewhere** doesn't make it the render that runs: a commented-out copy beside a real `<TeamNav items={pruned} />` passes, as does an in-place `items.splice(...)` (`const` blocks reassignment, not mutation). Both confirmed by probe. *Folded*: exactly-one-`<TeamNav>` assertion, a no-in-place-mutation assertion, and `Object.freeze` on the builder's return so the splice variant throws.
- **MEDIUM** — the redirect-stub matcher `/^\s*redirect\(/m` missed `return redirect(...)`, `permanentRedirect(...)` and `notFound()` — 3 of the 4 common Next idioms. *Folded*: broadened.
- **LOW** — the corrected history was applied to three of four sites; the **guard file's own header still blamed #213**, contradicting the module it imports. *Folded*, plus a clause noting `app/t/[team]/skills/page.tsx` is a redirect **alias**, not a discoverable link.

Fable also independently verified the layers pin genuinely distinct properties (deleting any one leaves a mutation only it catches — no decoration layer), behaviour parity with `main`, the fail-closed access path, and the mutation counts claimed above.

Four further mutations were added for the round-3 folds; all redden the intended test and no other.

## Not in scope

No change to the skills page, the access path, the `skill` item kind, or the CLI. The harness epic (**HARNESS-1..7 / AIO-837..843**) owns discovery-beyond-nav, the authoring on-ramp, the eval gate, and telemetry. Deliberately separated so 22 stranded skills don't wait on a permission re-architecture.

Note for that epic: **AIO-838's spec is stale** — it was written against `visibleItems`/`access`-tier before PCCA landed, and its tier-safety section needs rewriting against the oracle before anyone builds from it.

AIOS-Work: SKILLNAV-1

