### PR TITLE
AUDITFIX-7: a delegated token reads hand-entered rows in projects it holds

### DIFF
--- a/app/api/v1/query/route.ts
+++ b/app/api/v1/query/route.ts
@@ -135,10 +135,13 @@ export async function POST(req: NextRequest) {
   try {
     const { visibleItemIds, delegatedVisibleItemIds } = await import("@/lib/access/enforce");
     if (agent) {
-      const { ids } = await delegatedVisibleItemIds(db, agent);
+      const { ids, projectIds } = await delegatedVisibleItemIds(db, agent);
       // QMIR-1: a delegated token is `principal: "token"` — the org-structural mirror legs stay
       // absolutely omitted for it, tier-independent (the round-3 Codex Critical posture).
-      enforce = { visibleItemIds: ids, principal: "token" };
+      // AUDITFIX-7: `tokenProjectIds` is the token's EFFECTIVE project set and gates the hand-typed
+      // arm. It is forwarded from the value `delegatedVisibleItemIds` returned — never recomputed
+      // here, which would be a second oracle read free to disagree with the first.
+      enforce = { visibleItemIds: ids, principal: "token", tokenProjectIds: projectIds };
     } else {
       // PRET-6: enforcing is the only behavior — the member arm is unconditional.
       const { ids, projectIds } = await visibleItemIds(db, { teamId, memberId: auth!.memberId });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,15 +254,33 @@ rejects the prefix; `aios_*` member keys are byte-for-byte unchanged.
 > `visibleItemIds` — and every valid token is team-tier by construction, so an empty-scoped token
 > received every hand-entered task and decision in the team. Reproduced against real Postgres; found
 > by the Phase A audit, not by the suite (the existing token test asserted `ctx.sources` only).
-> **The rule now:** the hand-typed arm is emitted only on the POSITIVE test
-> `principal === "member" && teamPosture === true` (`lib/access/provenance-sql.admitsUnsourced`), so
-> a token, an absent value and any foreign value all close. All THREE owners of the contract take the
-> discriminator — `provenanceRowSqlFromIds`, `provenanceRowSql`, and the TS twin
-> `rowVisibleByProvenance`. The two token-capable consumers (`lib/query/retrieve.ts`,
-> `lib/query/structured-extras.ts`) may only FORWARD `enforce.principal`; deriving it from `tier` or
-> posture would relabel every token as a member, and `test/guards/provenance-principal-callsites.test.ts`
-> fails the build on a member literal in either file. A token still cannot see hand-entered rows in
-> projects it IS granted — those legs carry item ids only, and widening them is AUDITFIX-7.
+> **The rule now (AUDITFIX-7 made it three-valued):** `lib/access/provenance-sql.unsourcedAdmission`
+> returns `{kind:"all"}` for a member at team posture, `{kind:"projects"}` for a TOKEN whose effective
+> project set is non-empty, and `{kind:"closed"}` for everything else — an absent value, a foreign
+> value, and a token with an empty or absent set. All THREE owners consume it —
+> `provenanceRowSqlFromIds`, `provenanceRowSql`, and the TS twin `rowVisibleByProvenance` — and each
+> `switch`es EXHAUSTIVELY with a `never` check, because a union does not enforce itself: a consumer
+> branching on `kind !== "closed"` reads `"projects"` as `"all"` and hands a scoped token the corpus.
+> **AUDITFIX-7 deliberately reversed AUDITFIX-1's "a token never sees a hand-typed row"**, under an
+> explicit product ruling: an agent granted a project reads what a person typed into it. The
+> protection AUDITFIX-1 actually added is kept — the arm is GATED on the token's authority
+> (`effectiveVisibleProjects`) rather than closed — and the claim it rested on ("a null-source row
+> cannot be tested against that scope") was **false**: such rows carry `project_id`, written by the
+> dashboard create actions in the same insert as `created_by`, and both leg queries already join
+> `projects`. ⚠️ `projectScope: null` is NOT the empty set — the oracle attenuates only when the scope
+> is non-null, so an unscoped token's authority is its launcher's granted projects; returning `[]`
+> there would silently blind every unscoped agent while every scoped test stayed green.
+> The two token-capable consumers (`lib/query/retrieve.ts`, `lib/query/structured-extras.ts`) may only
+> FORWARD `enforce.principal` **and `enforce.tokenProjectIds`**; deriving either would relabel or
+> re-derive authority, and `test/guards/provenance-principal-callsites.test.ts` fails the build on a
+> member literal in either file **and on a ctx that omits either field** — an omitted forward closes
+> the arm, which is indistinguishable from the fail-closed default and so reddens nothing on its own.
+> On the TS owner the token path requires `project_id: string` STATICALLY (an overload): the column is
+> `NOT NULL`, so an absent field means the CALLER did not select it, and denying quietly there turns a
+> one-line wiring defect into a legitimate-looking empty result. **Making a project reachable by an
+> agent still requires an operator GRANT** — measured 2026-08-22, prod has 2 granted projects of 19
+> and zero delegated tokens, so this changed nothing on that fleet. Requiring a scope at mint is
+> **AUDITFIX-19**; the agents admin page is **AUDITFIX-20**.
 
 Brain API 1.18 was ADDITIVE: delegated agent tokens (`aiosd_*`, spec §10) on the Phase A surface
 only — `GET /api/v1/items` accepts them oracle-filtered, everything else rejects the prefix;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -272,8 +272,10 @@ rejects the prefix; `aios_*` member keys are byte-for-byte unchanged.
 > there would silently blind every unscoped agent while every scoped test stayed green.
 > The two token-capable consumers (`lib/query/retrieve.ts`, `lib/query/structured-extras.ts`) may only
 > FORWARD `enforce.principal` **and `enforce.tokenProjectIds`**; deriving either would relabel or
-> re-derive authority, and `test/guards/provenance-principal-callsites.test.ts` fails the build on a
-> member literal in either file **and on a ctx that omits either field** — an omitted forward closes
+> re-derive authority — a recomputed project set is a SECOND oracle read free to disagree with the
+> first — and `test/guards/provenance-principal-callsites.test.ts` fails the build on a member literal
+> in either file, on a ctx that OMITS either field, and on either field being anything other than the
+> exact `enforce?.…` forward — an omitted forward closes
 > the arm, which is indistinguishable from the fail-closed default and so reddens nothing on its own.
 > On the TS owner the token path requires `project_id: string` STATICALLY (an overload): the column is
 > `NOT NULL`, so an absent field means the CALLER did not select it, and denying quietly there turns a

--- a/docs/design/auditfix7-token-hand-entered-rows.md
+++ b/docs/design/auditfix7-token-hand-entered-rows.md
@@ -1,0 +1,176 @@
+# A delegated token sees hand-entered rows in projects it holds — AUDITFIX-7
+
+**Status:** spec, round 0. No code written.
+**Build with:** opus / high — it changes what a delegated agent may read, on the access path.
+
+**Deps:** none. **Sequence it BEFORE TIERRET-1**, which rewrites the same function
+(`admitsUnsourced`'s `teamPosture` conjunct is a tier input and dies with it), so the predicate is
+rewritten once rather than twice.
+
+---
+
+## What and why
+
+**What:** a delegated `aiosd_` token may read a task or decision a human typed by hand, when that row
+sits in a project the token's own authority covers. Member behaviour is unchanged.
+
+**Why:** today it may read **none of them**. `admitsUnsourced` (`lib/access/provenance-sql.ts:56-58`)
+omits the unsourced arm entirely for a token, so an agent gets everything synced from
+Linear/meetings/pushes and nothing hand-typed — a confidently incomplete answer with no error.
+
+**RULING (Chetan, 2026-08-22):** an agent granted a project *should* be able to read what a person
+typed into it by hand.
+
+## 0. Terrain, measured on production before designing (read-only, 2026-08-22)
+
+⚠️ **The measurements changed what this slice can honestly claim. Leading with them.**
+
+| | |
+|---|---|
+| hand-entered **tasks** (`source_item_id is null`) | **136 of 1,254 (11 %)** |
+| hand-entered **decisions** | **0 of 83** |
+| do hand-entered tasks carry a `project_id`? | **yes — 136/136**, the premise the design rests on |
+| how many distinct projects hold them? | **1** — `aios-team-brain`, `kind='source'` |
+| is that project **granted** to any group? | **NO** |
+| projects on the fleet | **19** total, **2 granted** (`general`, `external-shared` — both system) |
+| **delegated tokens in existence** | **0** |
+
+**Three consequences, stated rather than discovered in review:**
+
+1. **The decision case is theoretical.** The New Decision button exists
+   (`components/decisions/new-decision-button.tsx`, Decisions page, admins/leads only) but nobody uses
+   it; decisions are curated through the CLI (`decision-log.md` → `aios push`), which gives them a
+   `source_item_id` and so they were never blocked. **The live class is tasks from the Kanban board**
+   (`components/kanban/new-task-dialog.tsx`). Neither surface is Pulse; there is no third-party create
+   path (`/api/v1/tasks` and `/api/v1/decisions` are GET-only).
+2. **This fix will admit ZERO additional rows on this fleet, and that is CORRECT.** The 136 rows live
+   in a project no group is granted, so no token's authority covers it — under the ruling, an agent
+   without access to `aios-team-brain` *should not* see tasks typed into it. The inertness is the rule
+   working, not the fix failing. **Nobody should expect a behaviour change from merging this.**
+3. **The defect is fully latent: there are no delegated tokens.** So this is closing a class before
+   agents are used, plus correcting a false justification in the code — not repairing a live
+   complaint. Said plainly because the ticket's framing implied otherwise.
+
+## 1. The false claim this slice removes
+
+`lib/access/provenance-sql.ts:42-44` justifies the exclusion:
+
+> *"A delegated token's authority is its attenuated scope; a row with no `source_item_id` cannot be
+> tested against that scope, so it can never be shown to one."*
+
+**"Cannot be tested" is false.** Hand-entered rows carry a project:
+`app/actions/tasks.ts:98` (`project_id: input.projectId`), `app/actions/decisions.ts:57` — written in
+the same insert as `created_by`. Both token-reachable leg queries already `left join projects`
+(`lib/query/retrieve.ts:668`, `:691`).
+
+And the plumbing is **half-built**: `visibleItemIds` already returns `projectIds` alongside the ids
+(`lib/access/enforce.ts:128-135`, added because "recomputing the oracle a second time would be a
+disagreement surface"), while the token path `delegatedVisibleItemIds` (`:145-151`) computes
+`effectiveVisibleProjects` and **discards it**.
+
+Whatever is decided, that docstring must stop asserting something untrue — a posture defended by a
+false argument will not survive the next reviewer, and this program has now been bitten three times by
+prose nobody re-derived.
+
+## 2. The rule
+
+> **The unsourced arm admits a row for a MEMBER at team posture (unchanged), and for a TOKEN when the
+> row's `project_id` is in that token's EFFECTIVE project set. Everything else closes.**
+
+Expressed **positively**, for the reason AUDITFIX-1 records: `principal !== "token"` would admit
+`undefined`, `null` and any foreign value, and those are real runtime states because `tsconfig.json`
+excludes `test/`.
+
+**The member arm is NOT narrowed.** Members today see every hand-entered row at team posture; adding a
+project conjunct there would be a silent regression, and the ruling is about agents.
+
+### 2a. Why `project_id` is a sound access input HERE and not in general
+
+⚠️ `lib/access/enforce.ts:179` states, deliberately: *"`tasks.project_id` is the INGEST project, not
+an access-control project."* That is true **for ingested rows**, where the column records which
+connector project the content arrived through and nothing re-points it when content is re-partitioned.
+
+**For an unsourced row it is a different fact**: there is no ingest, so `project_id` is exactly the box
+a human chose in the UI at creation. The conjunct is therefore scoped to the arm where the column means
+what the rule needs it to mean, and the sourced arm keeps gating on item membership.
+
+**The residual, named:** nothing re-points a hand-entered row's `project_id` afterwards, and there is no
+UI to move one. If a curation surface ever ships, this becomes a column that must be kept honest — that
+obligation belongs to the curation slice and is recorded here, not silently inherited.
+
+## 3. The design
+
+`ProvenancePrincipal` stays a two-value discriminator. What changes is that the policy needs a project
+set for the token case, so `admitsUnsourced` is replaced by a function returning the **SQL fragment**
+for the unsourced arm, or `null` when the arm closes:
+
+```ts
+unsourcedArmSql(alias, p, ctx): string | null
+//  member + teamPosture     -> "<alias>.source_item_id is null and <alias>.created_by is not null"
+//  token  + tokenProjectIds -> the same, AND "<alias>.project_id = any($n::uuid[])"
+//  anything else            -> null
+```
+
+- **An empty token project set closes the arm** — `= any('{}')` is false for every row, which is the
+  correct fail-closed outcome, but the function returns `null` explicitly rather than relying on that,
+  so the closed case is a decision rather than an emergent property of SQL.
+- `delegatedVisibleItemIds` returns `projectIds` alongside the id set, exactly as `visibleItemIds`
+  already does — the same one-substrate-read reason.
+- `app/api/v1/query/route.ts:141` forwards it into `enforce` beside `principal`.
+
+### 3a. The guard must move with it
+
+`test/guards/provenance-principal-callsites.test.ts` is an AST walk that pins "every object literal
+carrying `visibleItemIds` also carries `principal`" — the M13 property, added because deleting a
+forward reddened nothing. **A token project set is now equally load-bearing and equally deletable**:
+drop the forward and the arm silently closes for every token, which looks exactly like today's
+behaviour and no token test would notice. The guard gains the same carry-it requirement for the new
+field, with the historical evasions kept as negative controls.
+
+## 4. Scope
+
+**In:** `lib/access/provenance-sql.ts` (the policy + the arm) · `lib/access/enforce.ts`
+(`delegatedVisibleItemIds` returns the project set) · `lib/query/retrieve.ts` +
+`lib/query/structured-extras.ts` (forward it) · `app/api/v1/query/route.ts` (supply it) ·
+`test/guards/provenance-principal-callsites.test.ts` · `docs/ARCHITECTURE.md`.
+
+**Out:** narrowing the member arm (§2) · moving hand-entered rows into the unit/membership substrate
+(the durable answer, and a different slice — it would make this predicate unnecessary rather than
+correct) · granting any project (an operator action; it is what would make this fix observable).
+
+## 5. Acceptance
+
+⚠️ **AUDITFIX-1's scar governs this list: an empty-scope test passes trivially.** Every criterion below
+uses a **non-empty** token scope, and the pair that matters asserts both directions.
+
+- **AC1 — a hand-entered row in an IN-SCOPE project is VISIBLE to a token (dm):** token scoped to
+  project P; a task with `source_item_id is null`, `created_by` set, `project_id = P`. It appears in
+  the token's structured results. *This is the behaviour the ruling asks for.*
+- **AC2 — a hand-entered row in an OUT-OF-SCOPE project stays INVISIBLE (dm):** same token, same
+  shape, `project_id = Q ∉ scope`. Absent. **Without AC2, AC1 is satisfied by deleting the arm's
+  gate entirely** — which is the AUDITFIX-1 failure repeated.
+- **AC3 — an EMPTY-scope token sees no hand-entered rows (dm):** the fail-closed floor, and the
+  criterion that must NOT be the only one.
+- **AC4 — a row with `created_by` null stays invisible to a token even in scope (dm):** the existing
+  authorship conjunct is not weakened by the new one.
+- **AC5 — MEMBER behaviour is unchanged (dm):** a member at team posture still sees a hand-entered row
+  whose project is in NO granted set — the exact rows prod holds today (136 in an ungranted project).
+  *This is the regression this slice is most likely to cause.*
+- **AC6 — the SOURCED arm is untouched (dm):** a token still sees an ingested row via `visibleItemIds`
+  and still cannot see one outside its item set, with the new field present.
+- **AC7 — the forward is CARRIED, not merely available (unit guard):** deleting the token project set
+  from a ctx literal fails the build. Mutation-verified, because the M13 lesson is that an absent
+  forward closes the arm and therefore reddens nothing.
+- **AC8 — the arm closes on an absent/foreign principal (unit):** `undefined`, `null` and a foreign
+  string each yield `null` from `unsourcedArmSql`. The positive-policy property AUDITFIX-1 shipped.
+
+**What no criterion claims:** that any row becomes visible on this fleet. §0 measures why none will.
+
+## 6. Risks
+
+| risk | direction | mitigation |
+|---|---|---|
+| The member arm is narrowed by accident | 136 rows vanish for every human | AC5 asserts it directly, on the real shape |
+| The new forward is added but not carried | every token silently keeps today's behaviour | AC7 + the AST guard; an absent forward reddens nothing on its own |
+| `project_id` drifts from what a human chose | a stale row becomes visible or invisible | §2a: no writer re-points it today, and the obligation is recorded for the curation slice |
+| Someone reads this as fixing a live complaint | wasted expectation | §0 states there are zero tokens and zero in-scope rows |

--- a/docs/design/auditfix7-token-hand-entered-rows.md
+++ b/docs/design/auditfix7-token-hand-entered-rows.md
@@ -23,33 +23,52 @@ typed into it by hand.
 
 ## 0. Terrain, measured on production before designing (read-only, 2026-08-22)
 
-⚠️ **The measurements changed what this slice can honestly claim. Leading with them.**
+⚠️ **Round 1 showed my first measurement was the wrong predicate, and the corrected number is 136×
+smaller. Leading with that.**
+
+I counted `source_item_id is null` and called it "hand-entered". The arm the code actually admits is
+`source_item_id is null` **AND `created_by is not null`** (`lib/access/provenance.ts:28`), and
+"unsourced" does not imply "typed by a human":
+
+- **`ON DELETE SET NULL`** turns a formerly-sourced row back into a null-source row when its item is
+  purged (`lib/ingest/purge.ts:25`) — deliberately, so "a UI-authored task must not vanish because its
+  evidence was purged".
+- **`scripts/brain-tasks.ts:143`** inserts unsourced rows with no `created_by` at all.
+
+| | first count (wrong predicate) | **corrected** |
+|---|---|---|
+| tasks, `source_item_id is null` | 136 | 136 |
+| **tasks, unsourced AND authored** — the population the arm admits | *(claimed 136)* | **1** |
+| decisions, unsourced AND authored | 0 | **0** |
+
+**The rest of the 136, broken down (`origin`):** 69 are `sync` — the purge lifecycle above. **66 are
+`ui`** but carry no `created_by`, all created in a single historical window (2026-06-28 → 07-01);
+`createTaskAction` sets `created_by: me.id` today (`app/actions/tasks.ts:106`), so this is legacy data,
+not a live writer defect. ⚠️ **Those 66 fail the authorship conjunct and are therefore invisible to
+EVERY principal — member and token alike — on provenance-gated surfaces.** That is a real finding, it
+is **not** this slice's, and it is recorded here rather than folded in silently.
 
 | | |
 |---|---|
-| hand-entered **tasks** (`source_item_id is null`) | **136 of 1,254 (11 %)** |
-| hand-entered **decisions** | **0 of 83** |
-| do hand-entered tasks carry a `project_id`? | **yes — 136/136**, the premise the design rests on |
-| how many distinct projects hold them? | **1** — `aios-team-brain`, `kind='source'` |
-| is that project **granted** to any group? | **NO** |
+| does the one authored row carry a `project_id`? | **yes** — the premise holds |
+| which project? | `aios-team-brain`, `kind='source'` |
+| is it **granted** to any group? | **NO** |
 | projects on the fleet | **19** total, **2 granted** (`general`, `external-shared` — both system) |
 | **delegated tokens in existence** | **0** |
 
-**Three consequences, stated rather than discovered in review:**
+**What this slice can honestly claim:**
 
-1. **The decision case is theoretical.** The New Decision button exists
-   (`components/decisions/new-decision-button.tsx`, Decisions page, admins/leads only) but nobody uses
-   it; decisions are curated through the CLI (`decision-log.md` → `aios push`), which gives them a
-   `source_item_id` and so they were never blocked. **The live class is tasks from the Kanban board**
-   (`components/kanban/new-task-dialog.tsx`). Neither surface is Pulse; there is no third-party create
-   path (`/api/v1/tasks` and `/api/v1/decisions` are GET-only).
-2. **This fix will admit ZERO additional rows on this fleet, and that is CORRECT.** The 136 rows live
-   in a project no group is granted, so no token's authority covers it — under the ruling, an agent
-   without access to `aios-team-brain` *should not* see tasks typed into it. The inertness is the rule
-   working, not the fix failing. **Nobody should expect a behaviour change from merging this.**
-3. **The defect is fully latent: there are no delegated tokens.** So this is closing a class before
-   agents are used, plus correcting a false justification in the code — not repairing a live
-   complaint. Said plainly because the ticket's framing implied otherwise.
+1. **It admits ZERO additional rows on this fleet, and that is faithful to the ruling.**
+   `effectiveVisibleProjects` is the delegated authority — launcher grants ∩ represented-member grants
+   ∩ token scope (`lib/access/oracle.ts:127-143`). No token's authority covers `aios-team-brain`, so an
+   agent should not see what was typed into it. **Making that project useful to an agent requires an
+   OPERATOR GRANT, not a code change.** Round 1 confirmed this independently.
+2. **The defect is fully latent** — zero tokens exist. This closes a class before agents are used.
+3. **The live class is tasks, not decisions.** The New Decision button exists
+   (`components/decisions/new-decision-button.tsx`, Decisions page, admins/leads only) but decisions
+   are curated through the CLI, which gives them a `source_item_id`. The task surface is
+   `components/kanban/new-task-dialog.tsx`. Neither is Pulse; `/api/v1/tasks` and `/api/v1/decisions`
+   are GET-only, so there is no third-party create path.
 
 ## 1. The false claim this slice removes
 
@@ -58,111 +77,144 @@ typed into it by hand.
 > *"A delegated token's authority is its attenuated scope; a row with no `source_item_id` cannot be
 > tested against that scope, so it can never be shown to one."*
 
-**"Cannot be tested" is false.** Hand-entered rows carry a project:
-`app/actions/tasks.ts:98` (`project_id: input.projectId`), `app/actions/decisions.ts:57` — written in
-the same insert as `created_by`. Both token-reachable leg queries already `left join projects`
+**"Cannot be tested" is false.** Hand-entered rows carry a project: `app/actions/tasks.ts:98`
+(`project_id: input.projectId`), `app/actions/decisions.ts:57` — written in the same insert as
+`created_by`. Both token-reachable leg queries already `left join projects`
 (`lib/query/retrieve.ts:668`, `:691`).
 
 And the plumbing is **half-built**: `visibleItemIds` already returns `projectIds` alongside the ids
-(`lib/access/enforce.ts:128-135`, added because "recomputing the oracle a second time would be a
-disagreement surface"), while the token path `delegatedVisibleItemIds` (`:145-151`) computes
+(`lib/access/enforce.ts:128-135`), while `delegatedVisibleItemIds` (`:145-151`) computes
 `effectiveVisibleProjects` and **discards it**.
-
-Whatever is decided, that docstring must stop asserting something untrue — a posture defended by a
-false argument will not survive the next reviewer, and this program has now been bitten three times by
-prose nobody re-derived.
 
 ## 2. The rule
 
-> **The unsourced arm admits a row for a MEMBER at team posture (unchanged), and for a TOKEN when the
-> row's `project_id` is in that token's EFFECTIVE project set. Everything else closes.**
+> **The unsourced arm admits a row when it is AUTHORED (`created_by is not null`) and either the
+> principal is a MEMBER at team posture (unchanged), or the principal is a TOKEN whose EFFECTIVE
+> project set contains the row's `project_id`. Everything else closes.**
 
-Expressed **positively**, for the reason AUDITFIX-1 records: `principal !== "token"` would admit
-`undefined`, `null` and any foreign value, and those are real runtime states because `tsconfig.json`
-excludes `test/`.
+Expressed **positively**, for AUDITFIX-1's reason: `principal !== "token"` would admit `undefined`,
+`null` and any foreign value, and those are real runtime states because `tsconfig.json` excludes
+`test/`.
 
-**The member arm is NOT narrowed.** Members today see every hand-entered row at team posture; adding a
-project conjunct there would be a silent regression, and the ruling is about agents.
+**The member arm is NOT narrowed.** Adding a project conjunct there would be a silent regression.
 
-### 2a. Why `project_id` is a sound access input HERE and not in general
+### 2a. Why `project_id` is a sound access input on THIS arm — restated, because round 1 broke my first version
 
-⚠️ `lib/access/enforce.ts:179` states, deliberately: *"`tasks.project_id` is the INGEST project, not
-an access-control project."* That is true **for ingested rows**, where the column records which
-connector project the content arrived through and nothing re-points it when content is re-partitioned.
+⚠️ My first argument was *"unsourced means exactly the box a human chose in the UI"*. **That is false**
+(§0): the purge lifecycle and the task CLI both produce unsourced rows that no human typed.
 
-**For an unsourced row it is a different fact**: there is no ingest, so `project_id` is exactly the box
-a human chose in the UI at creation. The conjunct is therefore scoped to the arm where the column means
-what the rule needs it to mean, and the sourced arm keeps gating on item membership.
+The argument that survives rests on the **combined** predicate. A row that is `source_item_id is null`
+**and** `created_by is not null` was written by a dashboard create action — the only writer that sets
+`created_by` (`lib/access/provenance.ts:8-10` states this, and `app/actions/tasks.ts:105-106` /
+`app/actions/decisions.ts:57` are the writers). For exactly that row, `project_id` is the box a person
+chose, not an ingest artifact — which is what makes `lib/access/enforce.ts:179` (*"`tasks.project_id`
+is the INGEST project, not an access-control project"*) true of sourced rows and inapplicable here.
 
-**The residual, named:** nothing re-points a hand-entered row's `project_id` afterwards, and there is no
-UI to move one. If a curation surface ever ships, this becomes a column that must be kept honest — that
-obligation belongs to the curation slice and is recorded here, not silently inherited.
+**Two residuals, named rather than buried.** A purged-source row keeps whatever `project_id` the
+ingest gave it — it is excluded by the authorship conjunct, so it never reaches the project test, and
+that ordering is load-bearing. And nothing re-points a hand-entered row's `project_id` afterwards; if
+a curation surface ships, keeping that column honest becomes its obligation.
 
 ## 3. The design
 
-`ProvenancePrincipal` stays a two-value discriminator. What changes is that the policy needs a project
-set for the token case, so `admitsUnsourced` is replaced by a function returning the **SQL fragment**
-for the unsourced arm, or `null` when the arm closes:
+### 3a. THREE owners, not two — the BLOCKER round 1 found
+
+AUDITFIX-1 established *"one contract, three owners"*. My scope listed two. The third is
+**`lib/access/provenance.ts`**, which imports `admitsUnsourced` (`:2`) and calls it (`:28`) — and whose
+row type does not carry `project_id` at all. Implementing this spec literally would either fail
+compilation or leave the TS owner enforcing a different policy than the SQL owners, which is precisely
+the divergence AUDITFIX-1 exists to prevent.
+
+So the policy stays **one function**, in a form both a SQL builder and a TS row-check can consume:
 
 ```ts
-unsourcedArmSql(alias, p, ctx): string | null
-//  member + teamPosture     -> "<alias>.source_item_id is null and <alias>.created_by is not null"
-//  token  + tokenProjectIds -> the same, AND "<alias>.project_id = any($n::uuid[])"
-//  anything else            -> null
+type UnsourcedAdmission =
+  | { kind: "closed" }
+  | { kind: "all" }                                  // member @ team posture
+  | { kind: "projects"; projectIds: readonly string[] }; // token, scoped
+
+export function unsourcedAdmission(ctx: {
+  principal?: ProvenancePrincipal;
+  teamPosture: boolean;
+  tokenProjectIds?: readonly string[];
+}): UnsourcedAdmission;
 ```
 
-- **An empty token project set closes the arm** — `= any('{}')` is false for every row, which is the
-  correct fail-closed outcome, but the function returns `null` explicitly rather than relying on that,
-  so the closed case is a decision rather than an emergent property of SQL.
-- `delegatedVisibleItemIds` returns `projectIds` alongside the id set, exactly as `visibleItemIds`
-  already does — the same one-substrate-read reason.
-- `app/api/v1/query/route.ts:141` forwards it into `enforce` beside `principal`.
+A **discriminated union, not `string | null`** — round 1's point that a nullable SQL fragment invites a
+caller to read `null` as "no filter". Each owner consumes it in its own idiom:
 
-### 3a. The guard must move with it
+| owner | consumes |
+|---|---|
+| `provenanceRowSqlFromIds` (id-array SQL) | `"all"` → the bare arm; `"projects"` → the arm `AND project_id = any($n)`; `"closed"` → omit |
+| `provenanceRowSql` (semijoin SQL) | same |
+| `rowVisibleByProvenance` (TS) | `"all"` → true; `"projects"` → `projectIds.includes(row.project_id)`; `"closed"` → false |
 
-`test/guards/provenance-principal-callsites.test.ts` is an AST walk that pins "every object literal
-carrying `visibleItemIds` also carries `principal`" — the M13 property, added because deleting a
-forward reddened nothing. **A token project set is now equally load-bearing and equally deletable**:
-drop the forward and the arm silently closes for every token, which looks exactly like today's
-behaviour and no token test would notice. The guard gains the same carry-it requirement for the new
-field, with the historical evasions kept as negative controls.
+`rowVisibleByProvenance`'s row type gains `project_id?: string | null`, and **its callers are
+inventoried in the spec and asserted by the guard** — a `"projects"` admission against a row whose
+`project_id` was never selected must **close**, not silently pass, so an un-updated caller fails
+closed rather than leaking.
+
+An **empty** `tokenProjectIds` returns `{kind:"closed"}` explicitly, rather than relying on
+`= any('{}')` being false — the closed case is a decision, not an emergent property of SQL.
+
+### 3b. The route carry, pinned where it actually happens
+
+`app/api/v1/query/route.ts:138` destructures the delegated result to `{ ids }`, and the existing AST
+guard analyses only `lib/query/retrieve.ts` and `lib/query/structured-extras.ts`
+(`test/guards/provenance-principal-callsites.test.ts:47`). So a dm test that calls retrieval directly
+can pass **while the real route omits the project set entirely**. `delegatedVisibleItemIds` returns
+`projectIds` (as `visibleItemIds` already does), the route forwards it, and both a **minted-token HTTP
+test** and a **structural guard on the route file** pin that it forwards the value that function
+returned rather than a same-named property.
 
 ## 4. Scope
 
-**In:** `lib/access/provenance-sql.ts` (the policy + the arm) · `lib/access/enforce.ts`
-(`delegatedVisibleItemIds` returns the project set) · `lib/query/retrieve.ts` +
-`lib/query/structured-extras.ts` (forward it) · `app/api/v1/query/route.ts` (supply it) ·
-`test/guards/provenance-principal-callsites.test.ts` · `docs/ARCHITECTURE.md`.
+**In:** `lib/access/provenance-sql.ts` (the policy + both SQL owners) · **`lib/access/provenance.ts`
+(the TS owner + its row type)** · `lib/access/enforce.ts` (`delegatedVisibleItemIds` returns the
+project set) · `lib/query/retrieve.ts` + `lib/query/structured-extras.ts` ·
+`app/api/v1/query/route.ts` · `test/guards/provenance-principal-callsites.test.ts` ·
+`docs/ARCHITECTURE.md`.
 
-**Out:** narrowing the member arm (§2) · moving hand-entered rows into the unit/membership substrate
-(the durable answer, and a different slice — it would make this predicate unnecessary rather than
-correct) · granting any project (an operator action; it is what would make this fix observable).
+**Out:** narrowing the member arm (§2) · **the 66 author-less UI tasks** (§0 — real, invisible to
+everyone, and a data/backfill question, not this predicate's) · moving hand-entered rows into the
+unit/membership substrate (the durable answer; it would make this predicate unnecessary rather than
+correct) · granting `aios-team-brain` (an **operator action**, and the thing that would make this fix
+observable).
 
 ## 5. Acceptance
 
-⚠️ **AUDITFIX-1's scar governs this list: an empty-scope test passes trivially.** Every criterion below
-uses a **non-empty** token scope, and the pair that matters asserts both directions.
+⚠️ **Two scars govern this list.** AUDITFIX-1's: an empty-scope test passes trivially, so every
+criterion uses a **non-empty** scope. And round 1's: my first draft seeded only a **task**, so an
+implementation could gate alias `t` and leave alias `d` open and still pass everything.
 
-- **AC1 — a hand-entered row in an IN-SCOPE project is VISIBLE to a token (dm):** token scoped to
-  project P; a task with `source_item_id is null`, `created_by` set, `project_id = P`. It appears in
-  the token's structured results. *This is the behaviour the ruling asks for.*
-- **AC2 — a hand-entered row in an OUT-OF-SCOPE project stays INVISIBLE (dm):** same token, same
-  shape, `project_id = Q ∉ scope`. Absent. **Without AC2, AC1 is satisfied by deleting the arm's
-  gate entirely** — which is the AUDITFIX-1 failure repeated.
-- **AC3 — an EMPTY-scope token sees no hand-entered rows (dm):** the fail-closed floor, and the
-  criterion that must NOT be the only one.
-- **AC4 — a row with `created_by` null stays invisible to a token even in scope (dm):** the existing
-  authorship conjunct is not weakened by the new one.
-- **AC5 — MEMBER behaviour is unchanged (dm):** a member at team posture still sees a hand-entered row
-  whose project is in NO granted set — the exact rows prod holds today (136 in an ungranted project).
-  *This is the regression this slice is most likely to cause.*
-- **AC6 — the SOURCED arm is untouched (dm):** a token still sees an ingested row via `visibleItemIds`
-  and still cannot see one outside its item set, with the new field present.
-- **AC7 — the forward is CARRIED, not merely available (unit guard):** deleting the token project set
-  from a ctx literal fails the build. Mutation-verified, because the M13 lesson is that an absent
-  forward closes the arm and therefore reddens nothing.
-- **AC8 — the arm closes on an absent/foreign principal (unit):** `undefined`, `null` and a foreign
-  string each yield `null` from `unsourcedArmSql`. The positive-policy property AUDITFIX-1 shipped.
+- **AC1 — in-scope authored rows are VISIBLE to a token, BOTH row types (dm):** in one non-empty-scope
+  invocation, an authored task **and** an authored decision with `project_id ∈ scope` both appear.
+- **AC2 — out-of-scope authored rows stay INVISIBLE, BOTH row types (dm):** same invocation, same
+  shapes, `project_id ∉ scope`. Absent. **Without AC2, AC1 is satisfied by deleting the gate.**
+- **AC3 — the SOURCED arm is a positive control in the same invocation (dm):** an ingested row inside
+  `visibleItemIds` is still visible, and one outside it still is not.
+- **AC4 — an EMPTY-scope token sees no unsourced rows (dm):** the fail-closed floor, never the only
+  criterion.
+- **AC5 — `created_by` null closes even in scope (dm):** the authorship conjunct is not weakened by the
+  project conjunct, and the ordering in §2a holds.
+- **AC6 — MEMBER behaviour is unchanged across ALL THREE owners (dm + unit):** a member at team
+  posture still sees an authored row in an **ungranted** project — asserted through the id-array SQL
+  owner, the **semijoin** owner (`visibleProjectRows` / project-card counts,
+  `lib/access/enforce.ts:281,351`), **and** `rowVisibleByProvenance`. *Round 1: a retrieval-only
+  fixture passes while the semijoin owner silently narrows members.*
+- **AC7 — the three owners agree on ONE truth table (unit):** every (principal, posture, scope, row)
+  combination yields the same admit/deny from all three. This is what makes "one contract, three
+  owners" a fact rather than a claim.
+- **AC8 — the route forwards the real project set (http + unit guard):** a minted-token
+  `POST /api/v1/query` returns an in-scope authored row and not an out-of-scope one; and a structural
+  guard asserts `app/api/v1/query/route.ts` forwards what `delegatedVisibleItemIds` returned.
+- **AC9 — the forward is CARRIED, not merely available (unit guard):** deleting the project set from a
+  ctx literal fails the build. Mutation-verified — the M13 lesson is that an absent forward closes the
+  arm and therefore reddens nothing on its own.
+- **AC10 — the arm closes on an absent/foreign principal (unit):** `undefined`, `null` and a foreign
+  string each yield `{kind:"closed"}`.
+- **AC11 — a `"projects"` admission with no `project_id` on the row CLOSES (unit):** the fail-closed
+  behaviour for a TS caller that has not been updated to select the column.
 
 **What no criterion claims:** that any row becomes visible on this fleet. §0 measures why none will.
 
@@ -170,7 +222,25 @@ uses a **non-empty** token scope, and the pair that matters asserts both directi
 
 | risk | direction | mitigation |
 |---|---|---|
-| The member arm is narrowed by accident | 136 rows vanish for every human | AC5 asserts it directly, on the real shape |
-| The new forward is added but not carried | every token silently keeps today's behaviour | AC7 + the AST guard; an absent forward reddens nothing on its own |
-| `project_id` drifts from what a human chose | a stale row becomes visible or invisible | §2a: no writer re-points it today, and the obligation is recorded for the curation slice |
-| Someone reads this as fixing a live complaint | wasted expectation | §0 states there are zero tokens and zero in-scope rows |
+| The member arm is narrowed on an owner the tests do not cover | authored rows vanish for humans | AC6 asserts all three owners explicitly |
+| A TS caller is not updated to select `project_id` | a token sees an out-of-scope row | AC11 — the missing column CLOSES |
+| The route never forwards the set | every token keeps today's behaviour, invisibly | AC8 + AC9; an absent forward reddens nothing on its own |
+| Someone reads the merge as fixing a live complaint | wasted expectation | §0: zero tokens, one qualifying row, in an ungranted project |
+| `project_id` drifts from the human's choice | a stale row becomes visible | §2a; the obligation is recorded for the curation slice |
+
+---
+
+## 7. Round 1 — BLOCKED, and it corrected my measurement by 136×
+
+| # | finding | outcome |
+|---|---|---|
+| **B1** | the design removes `admitsUnsourced`, but **`lib/access/provenance.ts` is a third owner** that imports and calls it, and its row type has no `project_id` — literal implementation fails compilation or forks the policy | **CONFIRMED.** The third owner is in scope; the policy became a discriminated union both idioms consume; AC7 asserts one truth table (§3a) |
+| **H1** | acceptance seeded only a **task**, so an implementation could gate alias `t` and leave alias `d` open and pass everything — leaking an out-of-scope decision through both legs | **CONFIRMED.** AC1/AC2 now assert both row types in one invocation, plus a sourced positive control |
+| **H2** | AC5 could pass while members were narrowed on the **semijoin** owner (`visibleProjectRows`, project-card counts) | **CONFIRMED.** AC6 covers all three owners |
+| **H3** | the route destructures to `{ ids }` and the AST guard does not analyse it, so a direct-retrieval test passes while the real route omits the set | **CONFIRMED.** AC8 adds a minted-token HTTP test and a structural guard on the route |
+| **M1** | the central inference is right: `effectiveVisibleProjects` IS the delegated authority, and gating on `visibleProjectRows` would let visible content bootstrap access to an ungranted container | **CONFIRMED** — and it says plainly what §0 now says: an operator grant is what makes this useful |
+| **M2** | §2a overstated — `source_item_id is null` does not mean "typed by a human" (purge `SET NULL`; the task CLI writes no `created_by`), so the 136 figure was unproven | **CONFIRMED, and the correction is large:** the qualifying population is **1**, not 136. §2a now rests on the combined predicate |
+| **M3** | `string \| null` invites a caller to read `null` as "no filter" | **CONFIRMED.** Discriminated union |
+| **M4** | build it, do not decline — it establishes correct latent behaviour before tokens exist, and sequencing before TIERRET-1 avoids touching the policy twice | **ACCEPTED** |
+
+**Nothing is built. No code exists for this slice.**

--- a/docs/design/auditfix7-token-hand-entered-rows.md
+++ b/docs/design/auditfix7-token-hand-entered-rows.md
@@ -98,123 +98,167 @@ Expressed **positively**, for AUDITFIX-1's reason: `principal !== "token"` would
 
 **The member arm is NOT narrowed.** Adding a project conjunct there would be a silent regression.
 
-### 2a. Why `project_id` is a sound access input on THIS arm — restated, because round 1 broke my first version
+### 2a. Why `project_id` is a sound access input on THIS arm
 
-⚠️ My first argument was *"unsourced means exactly the box a human chose in the UI"*. **That is false**
-(§0): the purge lifecycle and the task CLI both produce unsourced rows that no human typed.
+⚠️ **Round 1 broke my first argument and round 2 broke my second. This is the third, and both
+corrections are recorded rather than quietly replaced.**
 
-The argument that survives rests on the **combined** predicate. A row that is `source_item_id is null`
-**and** `created_by is not null` was written by a dashboard create action — the only writer that sets
-`created_by` (`lib/access/provenance.ts:8-10` states this, and `app/actions/tasks.ts:105-106` /
-`app/actions/decisions.ts:57` are the writers). For exactly that row, `project_id` is the box a person
-chose, not an ingest artifact — which is what makes `lib/access/enforce.ts:179` (*"`tasks.project_id`
-is the INGEST project, not an access-control project"*) true of sourced rows and inapplicable here.
+**v1 (wrong):** *"unsourced means exactly the box a human chose in the UI."* False — the purge
+lifecycle (`ON DELETE SET NULL`, `lib/ingest/purge.ts:25`) and the task CLI
+(`scripts/brain-tasks.ts:143`) both produce unsourced rows no human typed.
 
-**Two residuals, named rather than buried.** A purged-source row keeps whatever `project_id` the
-ingest gave it — it is excluded by the authorship conjunct, so it never reaches the project test, and
-that ordering is load-bearing. And nothing re-points a hand-entered row's `project_id` afterwards; if
-a curation surface ships, keeping that column honest becomes its obligation.
+**v2 (also wrong):** *"the authorship conjunct excludes purged-source rows, so they never reach the
+project test — the ordering is load-bearing."* Also false, and round 2 showed why: a dashboard row
+retains `created_by`, and a later **sync upsert sets `source_item_id` while omitting `created_by`**
+(`lib/ingest/tasks.ts:161`, `lib/ingest/decisions.ts:15` — verified: neither upsert row includes the
+column, so the original value survives). If that item is later purged, `source_item_id` returns to
+`null` while `created_by` is still set. **Such a row DOES reach the project test.**
+
+**v3, which survives:** the combined predicate (`source_item_id is null AND created_by is not null`)
+proves **dashboard authorship** — not that the row was never subsequently sourced. The full lifecycle
+is *dashboard create → writeback/sync → purge*, and the project it carries at the end is **still the
+human's**: the sync upsert conflicts on `(team_id, project_id, row_key)`, so it cannot move the row to
+a different project — it can only rewrite the row that already sits in that one.
+
+That is what makes `project_id` an access input here while `lib/access/enforce.ts:179` (*"`tasks.project_id`
+is the INGEST project, not an access-control project"*) remains true of genuinely sourced rows.
+
+**The residual, named:** nothing re-points a hand-entered row's `project_id` afterwards, and there is
+no UI to move one. If a curation surface ships, keeping that column honest becomes its obligation.
 
 ## 3. The design
 
-### 3a. THREE owners, not two — the BLOCKER round 1 found
+### 3a. THREE owners, and the union must be exhaustively consumed
 
-AUDITFIX-1 established *"one contract, three owners"*. My scope listed two. The third is
-**`lib/access/provenance.ts`**, which imports `admitsUnsourced` (`:2`) and calls it (`:28`) — and whose
-row type does not carry `project_id` at all. Implementing this spec literally would either fail
-compilation or leave the TS owner enforcing a different policy than the SQL owners, which is precisely
-the divergence AUDITFIX-1 exists to prevent.
+AUDITFIX-1 established *"one contract, three owners"*. Round 1 found my scope listed two — the third
+is `lib/access/provenance.ts`, which imports `admitsUnsourced` (`:2`) and calls it (`:28`), and whose
+row type carries no `project_id`.
 
-So the policy stays **one function**, in a form both a SQL builder and a TS row-check can consume:
+The policy stays **one function** returning a discriminated union:
 
 ```ts
 type UnsourcedAdmission =
   | { kind: "closed" }
-  | { kind: "all" }                                  // member @ team posture
-  | { kind: "projects"; projectIds: readonly string[] }; // token, scoped
-
-export function unsourcedAdmission(ctx: {
-  principal?: ProvenancePrincipal;
-  teamPosture: boolean;
-  tokenProjectIds?: readonly string[];
-}): UnsourcedAdmission;
+  | { kind: "all" }                                       // member @ team posture
+  | { kind: "projects"; projectIds: readonly string[] };  // token, gated on its effective set
 ```
 
-A **discriminated union, not `string | null`** — round 1's point that a nullable SQL fragment invites a
-caller to read `null` as "no filter". Each owner consumes it in its own idiom:
+⚠️ **Round 2's HIGH 1: a union alone does not prevent the widening it was chosen to prevent.** A
+consumer can treat every non-`closed` result as the bare arm, silently reading `"projects"` as
+`"all"`. So all three consumers **must `switch` exhaustively with a `never` check** — the compiler,
+not a convention, is what makes a missed branch impossible.
 
 | owner | consumes |
 |---|---|
-| `provenanceRowSqlFromIds` (id-array SQL) | `"all"` → the bare arm; `"projects"` → the arm `AND project_id = any($n)`; `"closed"` → omit |
+| `provenanceRowSqlFromIds` (id-array SQL) | `"all"` → bare arm · `"projects"` → arm `AND <alias>.project_id = any($n)` · `"closed"` → omit |
 | `provenanceRowSql` (semijoin SQL) | same |
-| `rowVisibleByProvenance` (TS) | `"all"` → true; `"projects"` → `projectIds.includes(row.project_id)`; `"closed"` → false |
+| `rowVisibleByProvenance` (TS) | `"all"` → true · `"projects"` → `projectIds.includes(row.project_id)` · `"closed"` → false |
 
-`rowVisibleByProvenance`'s row type gains `project_id?: string | null`, and **its callers are
-inventoried in the spec and asserted by the guard** — a `"projects"` admission against a row whose
-`project_id` was never selected must **close**, not silently pass, so an un-updated caller fails
-closed rather than leaking.
-
-An **empty** `tokenProjectIds` returns `{kind:"closed"}` explicitly, rather than relying on
+**An empty `tokenProjectIds` returns `{kind:"closed"}` explicitly**, rather than relying on
 `= any('{}')` being false — the closed case is a decision, not an emergent property of SQL.
 
-### 3b. The route carry, pinned where it actually happens
+### 3b. SQL aliases vs materialised rows — a distinction round 2 forced
 
-`app/api/v1/query/route.ts:138` destructures the delegated result to `{ ids }`, and the existing AST
-guard analyses only `lib/query/retrieve.ts` and `lib/query/structured-extras.ts`
-(`test/guards/provenance-principal-callsites.test.ts:47`). So a dm test that calls retrieval directly
-can pass **while the real route omits the project set entirely**. `delegatedVisibleItemIds` returns
+The two are **not** the same obligation, and conflating them is how a caller silently drops rows:
+
+- **SQL owners** need only that the alias exposes the column. `tasks.project_id` and
+  `decisions.project_id` are `not null` in the schema (`postgres/schema.sql:1068,1187`), so
+  `<alias>.project_id` always resolves. **No SQL caller needs to change.**
+- **The TS owner** operates on a materialised row, so the column must have been **selected**. Two
+  production callers do not select it — the project-detail decisions query
+  (`app/t/[team]/projects/[project]/page.tsx:77`) and the timeline decisions query
+  (`lib/dashboard/work-timeline.ts:372`). Both are member-only today, so `"all"` never needs the
+  column; a future token reuse would compile and silently drop rows.
+
+**So the fail-closed rule needs a static partner (round 2's HIGH 2).** Because `project_id` is
+`NOT NULL` in the database, a missing field on a materialised row means *the caller forgot to select
+it* — never *the record has no project*. Returning `false` quietly turns a wiring defect into an
+apparently legitimate empty result, which is data-loss-shaped.
+
+Therefore: **the `"projects"` path requires `project_id: string` STATICALLY** (an overload, or a
+row/context pair that only type-checks when the column is present), **and** a runtime absence still
+denies **and emits a loud diagnostic**. Security direction unchanged; the programmer error stops being
+silent.
+
+### 3c. The full caller inventory
+
+Recorded because §3a claimed one and did not contain it.
+
+| owner | production callers |
+|---|---|
+| `provenanceRowSql` (semijoin) | `lib/access/enforce.ts:281`, `:351` (project rows + card counts) |
+| `provenanceRowSqlFromIds` | `lib/query/retrieve.ts:670` · `lib/query/structured-extras.ts:75` · `lib/access/structured-windows.ts:30` · `lib/sync/decisions.ts:53` · `lib/identity/context.ts:223` · `lib/metrics/pulse.ts:221` · `lib/dashboard/work-timeline.ts:376` |
+| `rowVisibleByProvenance` (TS) | `app/t/[team]/decisions/page.tsx:70` · `app/t/[team]/tasks/page.tsx:93` · `app/t/[team]/projects/[project]/page.tsx:97` · `lib/dashboard/work-timeline.ts:670` |
+
+### 3d. The route carry, pinned where it happens
+
+`app/api/v1/query/route.ts:138` destructures the delegated result to `{ ids }`, and the AST guard
+analyses only `lib/query/retrieve.ts` and `lib/query/structured-extras.ts`
+(`test/guards/provenance-principal-callsites.test.ts:47`). So a dm test calling retrieval directly can
+pass **while the real route omits the project set entirely**. `delegatedVisibleItemIds` returns
 `projectIds` (as `visibleItemIds` already does), the route forwards it, and both a **minted-token HTTP
-test** and a **structural guard on the route file** pin that it forwards the value that function
-returned rather than a same-named property.
+test** and a **structural guard on the route file** pin that it forwards what that function returned
+rather than a same-named property.
 
 ## 4. Scope
 
-**In:** `lib/access/provenance-sql.ts` (the policy + both SQL owners) · **`lib/access/provenance.ts`
-(the TS owner + its row type)** · `lib/access/enforce.ts` (`delegatedVisibleItemIds` returns the
-project set) · `lib/query/retrieve.ts` + `lib/query/structured-extras.ts` ·
-`app/api/v1/query/route.ts` · `test/guards/provenance-principal-callsites.test.ts` ·
-`docs/ARCHITECTURE.md`.
+**In:** `lib/access/provenance-sql.ts` · **`lib/access/provenance.ts`** · `lib/access/enforce.ts`
+(`delegatedVisibleItemIds` returns the project set) · `lib/query/retrieve.ts` +
+`lib/query/structured-extras.ts` · `app/api/v1/query/route.ts` ·
+`test/guards/provenance-principal-callsites.test.ts` · `docs/ARCHITECTURE.md`.
 
-**Out:** narrowing the member arm (§2) · **the 66 author-less UI tasks** (§0 — real, invisible to
-everyone, and a data/backfill question, not this predicate's) · moving hand-entered rows into the
-unit/membership substrate (the durable answer; it would make this predicate unnecessary rather than
-correct) · granting `aios-team-brain` (an **operator action**, and the thing that would make this fix
-observable).
+**Not split.** Round 2: *"the slice is cohesive enough not to split — policy, authority carry, both
+token query legs, route wiring, and guards form one authorization change."*
+
+**Out:** narrowing the member arm · the **66 author-less UI tasks** (§0 — invisible to everyone, a
+data/backfill question; AC5 pins that this slice neither repairs nor worsens them) · moving
+hand-entered rows into the unit/membership substrate (the durable answer; a different slice) ·
+**requiring an explicit scope at mint (AUDITFIX-19)** and **the agents admin page (AUDITFIX-20)** —
+both filed, and together they are what make scoping usable rather than merely enforceable.
 
 ## 5. Acceptance
 
-⚠️ **Two scars govern this list.** AUDITFIX-1's: an empty-scope test passes trivially, so every
-criterion uses a **non-empty** scope. And round 1's: my first draft seeded only a **task**, so an
-implementation could gate alias `t` and leave alias `d` open and still pass everything.
+⚠️ **Three scars govern this list.** AUDITFIX-1's: an empty-scope test passes trivially. Round 1's: I
+seeded only a **task**, so an implementation could gate tasks and leave decisions open. Round 2's:
+every positive used an **explicit non-empty scope**, so an implementation that returns `[]` for a
+`null` scope passes everything while silently blinding every unscoped token.
 
-- **AC1 — in-scope authored rows are VISIBLE to a token, BOTH row types (dm):** in one non-empty-scope
-  invocation, an authored task **and** an authored decision with `project_id ∈ scope` both appear.
+- **AC1 — in-scope authored rows are VISIBLE to a token, BOTH row types (dm):** one non-empty-scope
+  invocation; an authored task **and** an authored decision with `project_id ∈ scope` both appear.
 - **AC2 — out-of-scope authored rows stay INVISIBLE, BOTH row types (dm):** same invocation, same
-  shapes, `project_id ∉ scope`. Absent. **Without AC2, AC1 is satisfied by deleting the gate.**
-- **AC3 — the SOURCED arm is a positive control in the same invocation (dm):** an ingested row inside
-  `visibleItemIds` is still visible, and one outside it still is not.
-- **AC4 — an EMPTY-scope token sees no unsourced rows (dm):** the fail-closed floor, never the only
-  criterion.
-- **AC5 — `created_by` null closes even in scope (dm):** the authorship conjunct is not weakened by the
-  project conjunct, and the ordering in §2a holds.
-- **AC6 — MEMBER behaviour is unchanged across ALL THREE owners (dm + unit):** a member at team
-  posture still sees an authored row in an **ungranted** project — asserted through the id-array SQL
-  owner, the **semijoin** owner (`visibleProjectRows` / project-card counts,
-  `lib/access/enforce.ts:281,351`), **and** `rowVisibleByProvenance`. *Round 1: a retrieval-only
-  fixture passes while the semijoin owner silently narrows members.*
-- **AC7 — the three owners agree on ONE truth table (unit):** every (principal, posture, scope, row)
-  combination yields the same admit/deny from all three. This is what makes "one contract, three
-  owners" a fact rather than a claim.
-- **AC8 — the route forwards the real project set (http + unit guard):** a minted-token
-  `POST /api/v1/query` returns an in-scope authored row and not an out-of-scope one; and a structural
-  guard asserts `app/api/v1/query/route.ts` forwards what `delegatedVisibleItemIds` returned.
-- **AC9 — the forward is CARRIED, not merely available (unit guard):** deleting the project set from a
-  ctx literal fails the build. Mutation-verified — the M13 lesson is that an absent forward closes the
-  arm and therefore reddens nothing on its own.
-- **AC10 — the arm closes on an absent/foreign principal (unit):** `undefined`, `null` and a foreign
+  shapes, `project_id ∉ scope`. **Without AC2, AC1 is satisfied by deleting the gate.**
+- **AC3 — an UNSCOPED token (`projectScope: null`) sees its launcher's projects, not nothing (dm):**
+  launcher granted P; authored task and decision in P and in Q. **P appears, Q does not.** Explicitly
+  asserts `null → the launcher/represented intersection` while `[] → closed`. *Round 2's BLOCKER: the
+  implementation that returns `[]` for a null scope passes AC1–AC2 and silently narrows every
+  unscoped token.*
+- **AC4 — an EMPTY scope (`[]`) closes (dm):** the fail-closed floor, and distinct from AC3.
+- **AC5 — `created_by` null closes even in scope (dm):** seeded as `origin='ui'`,
+  `source_item_id=null`, `created_by=null`, project **in scope** — the exact shape of the 66 legacy
+  rows, making it explicit that project scope alone does not rehabilitate them.
+- **AC6 — the SOURCED arm is a positive control in the same invocation (dm).**
+- **AC7 — MEMBER behaviour is unchanged across ALL THREE owners (dm + unit):** a member at team
+  posture still sees an authored row in an **ungranted** project — through the id-array SQL owner, the
+  **semijoin** owner (`lib/access/enforce.ts:281,351`), and `rowVisibleByProvenance`.
+- **AC8 — the three owners agree on ONE truth table, EXECUTABLY (unit + dm):** ⚠️ *Round 2's HIGH 1:
+  the owners return different types, so "compare their outputs" is not a mechanism.* Three parts:
+  (i) the policy function's exact union result is unit-asserted for every (principal, posture, scope)
+  input; (ii) all three consumers `switch` exhaustively with a `never` check, so a missed branch is a
+  compile error; (iii) **both SQL forms are executed against the same dm fixture truth table** as the
+  TS owner, and all three admit/deny identically.
+- **AC9 — the route forwards the real project set (http + unit guard):** a minted-token
+  `POST /api/v1/query` returns an in-scope authored row and not an out-of-scope one; a structural
+  guard asserts the route forwards what `delegatedVisibleItemIds` returned.
+- **AC10 — the forward is CARRIED, not merely available (unit guard):** deleting the project set from
+  a ctx literal fails the build. The M13 lesson: an absent forward closes the arm and reddens nothing.
+- **AC11 — the arm closes on an absent/foreign principal (unit):** `undefined`, `null` and a foreign
   string each yield `{kind:"closed"}`.
-- **AC11 — a `"projects"` admission with no `project_id` on the row CLOSES (unit):** the fail-closed
-  behaviour for a TS caller that has not been updated to select the column.
+- **AC12 — a missing `project_id` DENIES and is LOUD, and cannot compile on the token path (unit +
+  types):** runtime absence denies **and** emits a diagnostic; and a `"projects"` admission against a
+  row type without `project_id: string` **fails typecheck**. Pins both *no leak* and *not silent*.
+
+**Mutations required** (round 2): flipping the `"projects"` branch to the bare arm **independently in
+each SQL owner** must redden — one mutation per owner, so a shared fixture cannot mask either.
 
 **What no criterion claims:** that any row becomes visible on this fleet. §0 measures why none will.
 
@@ -222,25 +266,38 @@ implementation could gate alias `t` and leave alias `d` open and still pass ever
 
 | risk | direction | mitigation |
 |---|---|---|
-| The member arm is narrowed on an owner the tests do not cover | authored rows vanish for humans | AC6 asserts all three owners explicitly |
-| A TS caller is not updated to select `project_id` | a token sees an out-of-scope row | AC11 — the missing column CLOSES |
-| The route never forwards the set | every token keeps today's behaviour, invisibly | AC8 + AC9; an absent forward reddens nothing on its own |
-| Someone reads the merge as fixing a live complaint | wasted expectation | §0: zero tokens, one qualifying row, in an ungranted project |
-| `project_id` drifts from the human's choice | a stale row becomes visible | §2a; the obligation is recorded for the curation slice |
+| An unscoped token is silently blinded | every `null`-scope agent loses authored rows | AC3 — the round-2 BLOCKER |
+| A consumer reads `"projects"` as `"all"` | a token sees out-of-scope rows | exhaustive `switch` + `never` (§3a); per-owner mutations |
+| A TS caller does not select `project_id` | rows silently dropped | AC12: static requirement + loud runtime denial |
+| The member arm is narrowed on an untested owner | authored rows vanish for humans | AC7 across all three owners |
+| The route never forwards the set | every token keeps today's behaviour, invisibly | AC9 + AC10 |
+| Someone reads the merge as fixing a live complaint | wasted expectation | §0: zero tokens, one qualifying row, ungranted project |
 
 ---
 
-## 7. Round 1 — BLOCKED, and it corrected my measurement by 136×
+## 7. Round 1 — BLOCKED: a missed owner, and a measurement wrong by 136×
 
 | # | finding | outcome |
 |---|---|---|
-| **B1** | the design removes `admitsUnsourced`, but **`lib/access/provenance.ts` is a third owner** that imports and calls it, and its row type has no `project_id` — literal implementation fails compilation or forks the policy | **CONFIRMED.** The third owner is in scope; the policy became a discriminated union both idioms consume; AC7 asserts one truth table (§3a) |
-| **H1** | acceptance seeded only a **task**, so an implementation could gate alias `t` and leave alias `d` open and pass everything — leaking an out-of-scope decision through both legs | **CONFIRMED.** AC1/AC2 now assert both row types in one invocation, plus a sourced positive control |
-| **H2** | AC5 could pass while members were narrowed on the **semijoin** owner (`visibleProjectRows`, project-card counts) | **CONFIRMED.** AC6 covers all three owners |
-| **H3** | the route destructures to `{ ids }` and the AST guard does not analyse it, so a direct-retrieval test passes while the real route omits the set | **CONFIRMED.** AC8 adds a minted-token HTTP test and a structural guard on the route |
-| **M1** | the central inference is right: `effectiveVisibleProjects` IS the delegated authority, and gating on `visibleProjectRows` would let visible content bootstrap access to an ungranted container | **CONFIRMED** — and it says plainly what §0 now says: an operator grant is what makes this useful |
-| **M2** | §2a overstated — `source_item_id is null` does not mean "typed by a human" (purge `SET NULL`; the task CLI writes no `created_by`), so the 136 figure was unproven | **CONFIRMED, and the correction is large:** the qualifying population is **1**, not 136. §2a now rests on the combined predicate |
-| **M3** | `string \| null` invites a caller to read `null` as "no filter" | **CONFIRMED.** Discriminated union |
-| **M4** | build it, do not decline — it establishes correct latent behaviour before tokens exist, and sequencing before TIERRET-1 avoids touching the policy twice | **ACCEPTED** |
+| **B1** | `lib/access/provenance.ts` is a THIRD owner that imports and calls the function being replaced | **CONFIRMED.** In scope; policy became a union; §3c inventories every caller |
+| **H1** | acceptance seeded only a task — an implementation could gate `t` and leave `d` open | **CONFIRMED.** AC1/AC2 assert both row types in one invocation |
+| **H2** | AC5 could pass while members were narrowed on the **semijoin** owner | **CONFIRMED.** AC7 covers all three |
+| **H3** | the route destructures to `{ ids }` and the AST guard does not analyse it | **CONFIRMED.** AC9 |
+| **M1** | the central inference is right — `effectiveVisibleProjects` IS the delegated authority | **CONFIRMED**; an operator grant is what makes it useful (§0) |
+| **M2** | the 136 figure was the wrong predicate | **CONFIRMED.** Qualifying population is **1** |
+| **M3** | `string \| null` invites "null = no filter" | **CONFIRMED.** Discriminated union |
+| **M4** | build it, do not decline | **ACCEPTED** |
+
+## 8. Round 2 — BLOCKED: the unscoped token, and a union that does not enforce itself
+
+| # | finding | outcome |
+|---|---|---|
+| **B1** | **no criterion pinned `projectScope: null`.** An implementation returning `[]` for a null scope passes every folded positive and silently blinds every unscoped token — the exact narrowing the ruling forbids | **CONFIRMED. AC3 added**, asserting `null → launcher/represented intersection` and `[] → closed` as distinct outcomes |
+| **H1** | AC7 claimed three-owner parity with **no executable mechanism** — the owners return different types, and `{kind:"all"}` stays vulnerable to a consumer treating every non-closed result as the bare arm | **CONFIRMED.** AC8 is now three parts (union unit-asserted · exhaustive `switch` + `never` · both SQL forms executed against the TS owner's fixture table), plus per-owner mutations |
+| **H2** | AC11's fail-closed was right on security but data-loss-shaped: `project_id` is `NOT NULL`, so a missing field means the CALLER forgot to select it. Two TS callers omit it today | **CONFIRMED.** AC12 requires it **statically** on the token path and makes the runtime denial loud |
+| **M1** | the caller inventory was claimed but absent; and "SQL alias exposes a column" ≠ "TS row selected it" | **CONFIRMED.** §3b draws the distinction, §3c is the inventory. **No SQL caller needs to change** |
+| **M2** | §2a's residual was **false** — a sync upsert preserves `created_by`, so a dashboard→sync→purge row DOES reach the project test | **CONFIRMED**, verified in `lib/ingest/tasks.ts:161`. §2a v3 rests on dashboard authorship, and on the upsert conflicting on `(team_id, project_id, row_key)` so the project stays the human's |
+| **M3** | the 66 legacy rows are separable, but acceptance should say so | **CONFIRMED.** AC5 seeds their exact shape |
+| — | the slice is cohesive enough not to split | **ACCEPTED** |
 
 **Nothing is built. No code exists for this slice.**

--- a/docs/design/auditfix7-token-hand-entered-rows.md
+++ b/docs/design/auditfix7-token-hand-entered-rows.md
@@ -1,6 +1,9 @@
 # A delegated token sees hand-entered rows in projects it holds — AUDITFIX-7
 
-**Status:** spec, round 0. No code written.
+**Status:** **BUILT.** Two BLOCKED spec rounds (§7, §8), then two diff reviews — Fable CLEAR, Codex
+CLEAR-WITH-CONDITIONS — both folded (§9). ⚠️ *This line said "spec, round 0. No code written" after
+the code had landed; the second diff review caught it, which is the same class of stale claim this
+slice has now been caught by four times.*
 **Build with:** opus / high — it changes what a delegated agent may read, on the access path.
 
 **Deps:** none. **Sequence it BEFORE TIERRET-1**, which rewrites the same function
@@ -162,7 +165,7 @@ not a convention, is what makes a missed branch impossible.
 The two are **not** the same obligation, and conflating them is how a caller silently drops rows:
 
 - **SQL owners** need only that the alias exposes the column. `tasks.project_id` and
-  `decisions.project_id` are `not null` in the schema (`postgres/schema.sql:1068,1187`), so
+  `decisions.project_id` are `not null` in the schema (`postgres/schema.sql:1220` (tasks) and `:1394` (decisions) — ⚠️ *the first version of this cited 1068/1187, which are unrelated tables; a diff review caught it*), so
   `<alias>.project_id` always resolves. **No SQL caller needs to change.**
 - **The TS owner** operates on a materialised row, so the column must have been **selected**. Two
   production callers do not select it — the project-detail decisions query
@@ -302,11 +305,31 @@ each SQL owner** must redden — one mutation per owner, so a shared fixture can
 | # | finding | outcome |
 |---|---|---|
 | **B1** | **no criterion pinned `projectScope: null`.** An implementation returning `[]` for a null scope passes every folded positive and silently blinds every unscoped token — the exact narrowing the ruling forbids | **CONFIRMED. AC3 added**, asserting `null → launcher/represented intersection` and `[] → closed` as distinct outcomes |
-| **H1** | AC7 claimed three-owner parity with **no executable mechanism** — the owners return different types, and `{kind:"all"}` stays vulnerable to a consumer treating every non-closed result as the bare arm | **CONFIRMED.** AC8 is now three parts (union unit-asserted · exhaustive `switch` + `never` · both SQL forms executed against the TS owner's fixture table), plus per-owner mutations |
+| **H1** | AC7 claimed three-owner parity with **no executable mechanism** — the owners return different types, and `{kind:"all"}` stays vulnerable to a consumer treating every non-closed result as the bare arm | **CONFIRMED.** AC8 is now three parts (union unit-asserted · exhaustive `switch` + `never` · both SQL forms executed against the TS owner's fixture table), plus per-owner mutations. ⚠️ *This row still said "both SQL forms executed against the TS owner's fixture table" after AC8 was corrected — a diff review caught the contradiction.* |
 | **H2** | AC11's fail-closed was right on security but data-loss-shaped: `project_id` is `NOT NULL`, so a missing field means the CALLER forgot to select it. Two TS callers omit it today | **CONFIRMED.** AC12 requires it **statically** on the token path and makes the runtime denial loud |
 | **M1** | the caller inventory was claimed but absent; and "SQL alias exposes a column" ≠ "TS row selected it" | **CONFIRMED.** §3b draws the distinction, §3c is the inventory. **No SQL caller needs to change** |
 | **M2** | §2a's residual was **false** — a sync upsert preserves `created_by`, so a dashboard→sync→purge row DOES reach the project test | **CONFIRMED**, verified in `lib/ingest/tasks.ts:161`. §2a v3 rests on dashboard authorship, and on the upsert conflicting on `(team_id, project_id, row_key)` so the project stays the human's |
 | **M3** | the 66 legacy rows are separable, but acceptance should say so | **CONFIRMED.** AC5 seeds their exact shape |
 | — | the slice is cohesive enough not to split | **ACCEPTED** |
 
-**Nothing is built. No code exists for this slice.**
+**BUILT** — see the PR. (This line said "nothing is built" after the code landed; a diff review caught it.)
+
+## 9. The two diff reviews — Fable CLEAR, Codex CLEAR-WITH-CONDITIONS
+
+Neither could construct a token that reads an out-of-scope hand-entered row. Both found real defects
+anyway, and each found things the other did not — which is the whole argument for two models.
+
+| # | reviewer | finding | outcome |
+|---|---|---|---|
+| **M1** | Fable | **a false coverage claim I wrote**: the test header said both SQL forms were EXECUTED against a dm fixture table. Only the id-array form is; the semijoin `"projects"` branch is production-dead (its three callers are `MemberPrincipal`-typed) | **CONFIRMED.** Comment + spec corrected, along with AC4/AC5/AC9 tier labels that overstated their tiers |
+| **M2** | Fable | the token arm ignores `teamPosture` deliberately, and that is only safe because `verifyAgentToken` refuses external-tier delegation. The coupling was written nowhere | **CONFIRMED.** Recorded at the pin and **guarded from both ends** — deleting either reddens |
+| **M3** | **Codex** | **the carry was not required by the TYPE.** `tokenProjectIds` was optional, so `{ visibleItemIds, principal: "token" }` type-checked and silently restored pre-slice behaviour — and `lib/query/provider.ts` restated the shape while omitting the field entirely | **CONFIRMED.** `RetrieveEnforce` is a **discriminated union**; the provider reuses it instead of restating it. Verified with a probe: the unsafe shape is now a compile error |
+| **M4** | **Codex** | **the AST guard had a mutation bypass**: it forbade assignment to `.principal` but not `.tokenProjectIds`, so a ctx could be built correctly and then mutated. `Object.assign` escaped too | **CONFIRMED.** Both fields are now one `AUTHORITY_FIELDS` set across the assignment, `Reflect.set`, `defineProperty` and `Object.assign` rules |
+| **L1** | Fable | guard rule (6) was presence-only, asymmetric with rule (1) | **CONFIRMED.** `tokenProjectIds` must be exactly `enforce?.tokenProjectIds`; a recomputed set is a second oracle read free to disagree |
+| **L2** | Fable | on a substrate read error, an empty id set was returned WITH a populated project set — wider than the same failure before this slice | **CONFIRMED.** Gated on `!items.error`. ⚠️ *Its mutation SURVIVED until I wrote a test: I fixed it and pinned nothing, the fourth time in two slices* |
+| **L3** | **Codex** | four claims still false after the M1 fold — the status line, §8's row, a test comment, and a schema citation pointing at unrelated tables | **CONFIRMED**, all four corrected |
+
+**A note on the type change.** Making `RetrieveEnforce` a union put `principal: "member"` in a TYPE
+position, which the tree-wide guard layer flags — it cannot distinguish a type annotation from a value
+assignment by text. Rather than weaken the guard, the discriminants are **derived**
+(`Extract<ProvenancePrincipal, "member">`), so no new literal exists anywhere.

--- a/docs/design/auditfix7-token-hand-entered-rows.md
+++ b/docs/design/auditfix7-token-hand-entered-rows.md
@@ -232,8 +232,11 @@ every positive used an **explicit non-empty scope**, so an implementation that r
   asserts `null → the launcher/represented intersection` while `[] → closed`. *Round 2's BLOCKER: the
   implementation that returns `[]` for a null scope passes AC1–AC2 and silently narrows every
   unscoped token.*
-- **AC4 — an EMPTY scope (`[]`) closes (dm):** the fail-closed floor, and distinct from AC3.
-- **AC5 — `created_by` null closes even in scope (dm):** seeded as `origin='ui'`,
+- **AC4 — an EMPTY scope (`[]`) closes (unit + dm, piecewise):** the unit tier proves `[] → closed`
+  from the policy; the dm leak suite independently proves an empty effective set. ⚠️ *Labelled "dm"
+  before the diff review; it is proven in two places, not one end-to-end fixture.*
+- **AC5 — `created_by` null closes even in scope (unit):** ⚠️ *labelled "dm" before the diff review;
+  it is asserted on the TS owner, not seeded through the route.* Shaped as `origin='ui'`,
   `source_item_id=null`, `created_by=null`, project **in scope** — the exact shape of the 66 legacy
   rows, making it explicit that project scope alone does not rehabilitate them.
 - **AC6 — the SOURCED arm is a positive control in the same invocation (dm).**
@@ -244,9 +247,15 @@ every positive used an **explicit non-empty scope**, so an implementation that r
   the owners return different types, so "compare their outputs" is not a mechanism.* Three parts:
   (i) the policy function's exact union result is unit-asserted for every (principal, posture, scope)
   input; (ii) all three consumers `switch` exhaustively with a `never` check, so a missed branch is a
-  compile error; (iii) **both SQL forms are executed against the same dm fixture truth table** as the
-  TS owner, and all three admit/deny identically.
-- **AC9 — the route forwards the real project set (http + unit guard):** a minted-token
+  compile error; (iii) each SQL form is asserted SEPARATELY with its OWN mutation, so a shared fixture
+  cannot mask either owner. ⚠️ *Corrected after the diff review: I had written "both SQL forms are
+  EXECUTED against the same dm fixture truth table". Only the id-array form is — the semijoin form's
+  `"projects"` branch is production-dead (all three callers are `MemberPrincipal`-typed, so no token
+  reaches it) and is string-asserted plus mutation-pinned rather than executed. Claiming coverage the
+  tests do not contain is the exact failure this slice has now been caught by three times.*
+- **AC9 — the route forwards the real project set (in-process route + unit guard):** ⚠️ *labelled
+  "http" before the diff review; the test imports the route handler and calls `POST` directly with
+  `streamAnswer` mocked — the real enforcement path, but not the wire tier.* a minted-token
   `POST /api/v1/query` returns an in-scope authored row and not an out-of-scope one; a structural
   guard asserts the route forwards what `delegatedVisibleItemIds` returned.
 - **AC10 — the forward is CARRIED, not merely available (unit guard):** deleting the project set from

--- a/lib/access/enforce.ts
+++ b/lib/access/enforce.ts
@@ -156,7 +156,13 @@ export async function delegatedVisibleItemIds(
   // non-null (`lib/access/oracle.ts:106-110`), so an unscoped token's authority is its launcher's
   // granted projects. Returning `[]` here would silently blind every unscoped token while every
   // scoped test stayed green — spec round 2's BLOCKER, and the reason AC3 exists.
-  return { ...items, projectIds: [...projects] };
+  // ⚠️ ERROR-PATH SYMMETRY (Fable diff review, LOW). `visibleItemIdsForProjects` sets `error: true`
+  // when the substrate read failed, and the id set is then an ERROR-derived empty rather than a
+  // genuine one. Returning the project set anyway would make a failed request serve hand-typed rows
+  // while every SOURCED row was error-suppressed — a strictly WIDER answer than the same failure
+  // produced before AUDITFIX-7. "Substrate error → serve nothing" is the posture everywhere else
+  // here, so the project set is gated on it too.
+  return { ...items, projectIds: items.error ? [] : [...projects] };
 }
 
 /**

--- a/lib/access/enforce.ts
+++ b/lib/access/enforce.ts
@@ -145,9 +145,18 @@ export async function visibleItemIds(
 export async function delegatedVisibleItemIds(
   db: DbClient,
   token: { teamId: string; memberId: string; onBehalfOf: string | null; projectScope: string[] | null }
-): Promise<VisibleItemIds> {
+): Promise<VisibleItemIds & { projectIds: string[] }> {
   const projects = await effectiveVisibleProjects(db, token);
-  return visibleItemIdsForProjects(db, token.teamId, projects);
+  const items = await visibleItemIdsForProjects(db, token.teamId, projects);
+  // AUDITFIX-7: RETURN the effective project set instead of discarding it. It is the token's
+  // authority, and the hand-typed arm needs it — recomputing the oracle a second time downstream
+  // would be a disagreement surface, which is the same reason `visibleItemIds` already returns it.
+  //
+  // ⚠️ `projectScope: null` is NOT the empty set: the oracle attenuates only when the scope is
+  // non-null (`lib/access/oracle.ts:106-110`), so an unscoped token's authority is its launcher's
+  // granted projects. Returning `[]` here would silently blind every unscoped token while every
+  // scoped test stayed green — spec round 2's BLOCKER, and the reason AC3 exists.
+  return { ...items, projectIds: [...projects] };
 }
 
 /**

--- a/lib/access/provenance-sql.ts
+++ b/lib/access/provenance-sql.ts
@@ -49,6 +49,18 @@ export function newSqlParams(initial: readonly unknown[] = []): SqlParams {
 export type ProvenancePrincipal = "member" | "token" | undefined;
 
 /**
+ * The two discriminant tags, DERIVED rather than re-spelled.
+ *
+ * ⚠️ Written this way for a specific reason: `test/guards/provenance-principal-callsites.test.ts`'s
+ * tree-wide layer flags a bare `"member"` literal outside a listed member-only boundary, and it
+ * cannot distinguish a TYPE annotation (`principal: "member";`) from a value assignment by text —
+ * the two are textually identical. `Extract` gives the discriminated `RetrieveEnforce` union its
+ * arms without introducing a literal the guard would have to be weakened to permit.
+ */
+export type MemberTag = Extract<ProvenancePrincipal, "member">;
+export type TokenTag = Extract<ProvenancePrincipal, "token">;
+
+/**
  * THE POLICY, in one place, expressed POSITIVELY (AUDITFIX-1) — now three-valued (AUDITFIX-7).
  *
  * Positive on purpose: `principal !== "token"` would admit `undefined`, `null` and any foreign value

--- a/lib/access/provenance-sql.ts
+++ b/lib/access/provenance-sql.ts
@@ -40,21 +40,54 @@ export function newSqlParams(initial: readonly unknown[] = []): SqlParams {
  * WHO is asking. The unsourced (hand-typed) arm is admitted for a MEMBER at team posture and for
  * nobody else — see `admitsUnsourced`.
  *
- * A delegated token's authority is its attenuated scope; a row with no `source_item_id` cannot be
- * tested against that scope, so it can never be shown to one. Absent/foreign values close.
+ * ⚠️ THIS USED TO SAY a row with no `source_item_id` "cannot be tested against that scope, so it can
+ * never be shown to one". **The premise was false** (AUDITFIX-7): hand-entered rows carry
+ * `project_id`, written by the dashboard create actions in the same insert as `created_by`, and both
+ * token-reachable leg queries already join `projects`. A token now sees such a row when its EFFECTIVE
+ * project set contains that project. Absent/foreign values still close.
  */
 export type ProvenancePrincipal = "member" | "token" | undefined;
 
 /**
- * THE POLICY, in one place, expressed POSITIVELY (AUDITFIX-1).
+ * THE POLICY, in one place, expressed POSITIVELY (AUDITFIX-1) — now three-valued (AUDITFIX-7).
  *
  * Positive on purpose: `principal !== "token"` would admit `undefined`, `null` and any foreign value
  * — and those are real runtime states here, because `tsconfig.json` excludes `test/`, so an omitted
- * discriminator never fails typecheck. Written this way, everything that is not an explicit member at
- * team posture closes.
+ * discriminator never fails typecheck. Everything that is not an explicit member at team posture, or
+ * an explicit token with a project set, closes.
+ *
+ * ⚠️ A UNION IS NOT SELF-ENFORCING. A consumer that branches on `kind !== "closed"` reads `"projects"`
+ * as `"all"` and hands a scoped token the whole corpus — the very widening the union was chosen to
+ * prevent (spec round 2, HIGH 1). Every consumer therefore switches EXHAUSTIVELY with a `never`
+ * check, so a missed branch is a COMPILE error rather than a policy decision nobody made.
  */
-export function admitsUnsourced(ctx: { principal?: ProvenancePrincipal; teamPosture: boolean }): boolean {
-  return ctx.principal === "member" && ctx.teamPosture === true;
+export type UnsourcedAdmission =
+  | { kind: "closed" }
+  | { kind: "all" }
+  | { kind: "projects"; projectIds: readonly string[] };
+
+/** Exhaustiveness helper — the compile error a missed union branch must produce. */
+export function assertNeverAdmission(x: never): never {
+  throw new Error(`unhandled UnsourcedAdmission: ${JSON.stringify(x)}`);
+}
+
+export function unsourcedAdmission(ctx: {
+  principal?: ProvenancePrincipal;
+  teamPosture: boolean;
+  /** The token's EFFECTIVE project set (`effectiveVisibleProjects`). Absent closes. */
+  tokenProjectIds?: readonly string[];
+}): UnsourcedAdmission {
+  if (ctx.principal === "member" && ctx.teamPosture === true) return { kind: "all" };
+  if (ctx.principal === "token") {
+    const ids = ctx.tokenProjectIds;
+    // An EMPTY set closes EXPLICITLY rather than relying on `= any('{}')` being false: the closed
+    // case is a decision, not an emergent property of SQL. Absent closes for the same reason a
+    // missing discriminator does — a permissive default obtainable by saying nothing is the defect
+    // AUDITFIX-1 exists to have removed.
+    if (ids === undefined || ids.length === 0) return { kind: "closed" };
+    return { kind: "projects", projectIds: ids };
+  }
+  return { kind: "closed" };
 }
 
 export interface ProvenanceSqlCtx {
@@ -66,6 +99,8 @@ export interface ProvenanceSqlCtx {
   grantedProjectIds: readonly string[];
   /** True when the viewer is team posture — the hand-typed arm's audience wall. */
   teamPosture: boolean;
+  /** AUDITFIX-7: a TOKEN's effective project set, gating the hand-typed arm. Absent closes it. */
+  tokenProjectIds?: readonly string[];
 }
 
 /**
@@ -104,12 +139,23 @@ export function itemVisibleSql(expr: string, p: SqlParams, ctx: ProvenanceSqlCtx
  */
 export function provenanceRowSql(alias: string, p: SqlParams, ctx: ProvenanceSqlCtx): string {
   const sourced = `(${alias}.source_item_id is not null and ${itemVisibleSql(`${alias}.source_item_id`, p, ctx)})`;
-  // The arm is OMITTED, not parameterised false — a token's SQL simply has no hand-typed disjunct.
-  if (!admitsUnsourced(ctx)) return `(${sourced})`;
-  return `(
-    ${sourced}
-    or (${alias}.source_item_id is null and ${alias}.created_by is not null)
-  )`;
+  const authored = `${alias}.source_item_id is null and ${alias}.created_by is not null`;
+  const admission = unsourcedAdmission(ctx);
+  switch (admission.kind) {
+    // The arm is OMITTED, not parameterised false — a closed principal's SQL simply has no disjunct.
+    case "closed":
+      return `(${sourced})`;
+    case "all":
+      return `(\n    ${sourced}\n    or (${authored})\n  )`;
+    case "projects": {
+      // `alias.project_id` always resolves: both columns are NOT NULL in the schema, so a SQL caller
+      // never has to select anything extra (spec §3b — the distinction from the TS owner).
+      const scope = p.add([...admission.projectIds]);
+      return `(\n    ${sourced}\n    or (${authored} and ${alias}.project_id = any(${scope}::uuid[]))\n  )`;
+    }
+    default:
+      return assertNeverAdmission(admission);
+  }
 }
 
 /**
@@ -128,13 +174,28 @@ export function provenanceRowSql(alias: string, p: SqlParams, ctx: ProvenanceSql
 export function provenanceRowSqlFromIds(
   alias: string,
   p: SqlParams,
-  ctx: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean; principal?: ProvenancePrincipal }
+  ctx: {
+    visibleItemIds: ReadonlySet<string>;
+    teamPosture: boolean;
+    principal?: ProvenancePrincipal;
+    /** AUDITFIX-7: the token's effective project set. Absent closes the arm for a token. */
+    tokenProjectIds?: readonly string[];
+  }
 ): string {
   const ids = p.add([...ctx.visibleItemIds]);
   const sourced = `(${alias}.source_item_id is not null and ${alias}.source_item_id = any(${ids}::uuid[]))`;
-  if (!admitsUnsourced(ctx)) return `(${sourced})`;
-  return `(
-    ${sourced}
-    or (${alias}.source_item_id is null and ${alias}.created_by is not null)
-  )`;
+  const authored = `${alias}.source_item_id is null and ${alias}.created_by is not null`;
+  const admission = unsourcedAdmission(ctx);
+  switch (admission.kind) {
+    case "closed":
+      return `(${sourced})`;
+    case "all":
+      return `(\n    ${sourced}\n    or (${authored})\n  )`;
+    case "projects": {
+      const scope = p.add([...admission.projectIds]);
+      return `(\n    ${sourced}\n    or (${authored} and ${alias}.project_id = any(${scope}::uuid[]))\n  )`;
+    }
+    default:
+      return assertNeverAdmission(admission);
+  }
 }

--- a/lib/access/provenance-sql.ts
+++ b/lib/access/provenance-sql.ts
@@ -79,6 +79,16 @@ export function unsourcedAdmission(ctx: {
 }): UnsourcedAdmission {
   if (ctx.principal === "member" && ctx.teamPosture === true) return { kind: "all" };
   if (ctx.principal === "token") {
+    // ⚠️ THE TOKEN ARM DOES NOT CONSULT `teamPosture`, AND THAT IS ONLY SAFE BECAUSE OF ONE LINE
+    // ELSEWHERE (Fable diff review, MEDIUM). A token's wall is its project authority, not posture —
+    // but if `verifyAgentToken`'s Phase-A refusal of external-tier delegation
+    // (`lib/access/agent-tokens.ts:170`, `if (effectiveTier === "external") return null`) is ever
+    // lifted, an external-posture token would get `{kind:"projects"}` while its own external LAUNCHER
+    // gets `{kind:"closed"}` — the token EXCEEDING its launcher, which `lib/access/enforce.ts:39`
+    // states can never happen. The per-leg `audience = 'external'` conjuncts would be the only
+    // remaining wall, and those are per-leg, not the central policy.
+    // `test/guards/provenance-principal-callsites.test.ts` reddens if that refusal is deleted while
+    // this pin stands, so the coupling cannot be broken silently from either end.
     const ids = ctx.tokenProjectIds;
     // An EMPTY set closes EXPLICITLY rather than relying on `= any('{}')` being false: the closed
     // case is a decision, not an emergent property of SQL. Absent closes for the same reason a

--- a/lib/access/provenance.ts
+++ b/lib/access/provenance.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { admitsUnsourced, type ProvenancePrincipal } from "@/lib/access/provenance-sql";
+import { unsourcedAdmission, assertNeverAdmission, type ProvenancePrincipal } from "@/lib/access/provenance-sql";
 
 /**
  * The settled PROVENANCE rule for structured rows (tasks/decisions) on body-serving surfaces —
@@ -8,8 +8,9 @@ import { admitsUnsourced, type ProvenancePrincipal } from "@/lib/access/provenan
  *   - a SOURCED row gates on its source item's membership visibility;
  *   - a NULL-SOURCE row survives only when HAND-TYPED (`created_by` — written solely by the
  *     dashboard create actions, never by sync, so a purged restricted basis stays dropped)
- *     AND the viewer is team posture (no membership axis exists for a hand-typed row, so the
- *     audience wall survives on exactly this branch).
+ *     AND EITHER the viewer is a member at team posture, OR the viewer is a TOKEN whose effective
+ *     project set contains the row's `project_id` (AUDITFIX-7 — the claim that a hand-typed row
+ *     "cannot be tested against a token's scope" was false; it carries a project).
  * Fail-closed: a missing visibility set denies sourced rows.
  *
  * `principal` (AUDITFIX-1) is the THIRD owner of this contract taking the same discriminator as the
@@ -18,13 +19,69 @@ import { admitsUnsourced, type ProvenancePrincipal } from "@/lib/access/provenan
  * all close. It is REQUIRED rather than defaulted: a default would be the permissive value, and this
  * whole slice exists because a permissive default was obtainable by saying nothing.
  */
+export interface ProvenanceRow {
+  source_item_id?: string | null;
+  created_by?: string | null;
+  /** Required on the TOKEN path — see the overloads below. */
+  project_id?: string | null;
+}
+
+/**
+ * ⚠️ THE TOKEN OVERLOAD REQUIRES `project_id: string` STATICALLY (AUDITFIX-7, spec round 2 HIGH 2).
+ *
+ * `tasks.project_id` and `decisions.project_id` are NOT NULL in the schema, so a materialised row
+ * that lacks the field means THE CALLER DID NOT SELECT IT — never that the record has no project.
+ * Denying quietly in that case is correct for access and wrong for everything else: it turns a
+ * one-line wiring defect into an apparently legitimate empty result, which nobody diagnoses. Two
+ * production callers omit the column today and are member-only; a future token reuse must not
+ * compile rather than silently drop rows.
+ *
+ * So: a token call whose row type cannot promise `project_id` is a TYPE ERROR, and a row that
+ * nonetheless arrives without one at runtime is denied AND logged.
+ */
 export function rowVisibleByProvenance(
-  row: { source_item_id?: string | null; created_by?: string | null },
+  row: ProvenanceRow & { project_id: string },
   visibleItemIds: ReadonlySet<string> | null,
   tier: "team" | "external",
-  principal: ProvenancePrincipal
+  principal: "token",
+  tokenProjectIds: readonly string[]
+): boolean;
+export function rowVisibleByProvenance(
+  row: ProvenanceRow,
+  visibleItemIds: ReadonlySet<string> | null,
+  tier: "team" | "external",
+  principal: Exclude<ProvenancePrincipal, "token">
+): boolean;
+export function rowVisibleByProvenance(
+  row: ProvenanceRow,
+  visibleItemIds: ReadonlySet<string> | null,
+  tier: "team" | "external",
+  principal: ProvenancePrincipal,
+  tokenProjectIds?: readonly string[]
 ): boolean {
   const source = row.source_item_id ?? null;
   if (source !== null) return visibleItemIds != null && visibleItemIds.has(source);
-  return (row.created_by ?? null) !== null && admitsUnsourced({ principal, teamPosture: tier === "team" });
+  if ((row.created_by ?? null) === null) return false;
+
+  const admission = unsourcedAdmission({ principal, teamPosture: tier === "team", tokenProjectIds });
+  switch (admission.kind) {
+    case "closed":
+      return false;
+    case "all":
+      return true;
+    case "projects": {
+      const projectId = row.project_id ?? null;
+      if (projectId === null) {
+        // Denied, but NOT silently: the column is NOT NULL, so this is a caller that forgot to
+        // select it. The overloads make it a compile error; this is the runtime backstop.
+        console.error(
+          "[access] rowVisibleByProvenance: token admission with no project_id on the row — the caller did not select it; denying"
+        );
+        return false;
+      }
+      return admission.projectIds.includes(projectId);
+    }
+    default:
+      return assertNeverAdmission(admission);
+  }
 }

--- a/lib/query/provider.ts
+++ b/lib/query/provider.ts
@@ -57,7 +57,10 @@ export interface RetrievalRequest {
    *  public entry throws without it, and this seam (independently callable) yields
    *  `principal: undefined`, which CLOSES the hand-typed structured arm (AUDITFIX-1 §2d).
    *  Never synthesise "member" here: that is the sentence that would reopen the leak. */
-  enforce?: { visibleItemIds: ReadonlySet<string>; graphProjectIds?: readonly string[]; principal: "member" | "token" } | null;
+  /** AUDITFIX-7: reuses `RetrieveEnforce` rather than restating its shape. The restated version
+   *  omitted `tokenProjectIds` entirely, so this seam could construct a token enforce that silently
+   *  closed the hand-typed arm — the drift a duplicated type invites (Codex diff review). */
+  enforce?: import("@/lib/query/retrieve").RetrieveEnforce | null;
 }
 
 /** A context layer. Swap the default by implementing this and selecting via CONTEXT_PROVIDER. */

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -149,6 +149,10 @@ export type RetrieveEnforce = {
   visibleItemIds: ReadonlySet<string>;
   graphProjectIds?: readonly string[];
   principal: "member" | "token";
+  /** AUDITFIX-7: a TOKEN's effective project set — the authority that gates the hand-typed arm.
+   *  Absent closes that arm, so this must be CARRIED, not merely available: an omitted forward
+   *  looks exactly like today's behaviour and reddens nothing on its own (the M13 lesson). */
+  tokenProjectIds?: readonly string[];
 };
 
 /** The wire half of the graph leg, injectable for tests (the client was previously constructed
@@ -604,6 +608,10 @@ async function nativeRetrieve(
         // discriminator is the only thing standing between a scoped token and every hand-typed
         // decision in the team. Deriving it here from `tier` would say "member" for every token.
         principal: enforce?.principal,
+        // AUDITFIX-7: this leg is the SECOND token-reachable path to a hand-typed decision. Round 1
+        // of the spec review found acceptance that seeded only a TASK — which would have gated the
+        // task leg correctly and left THIS one open. Forwarded on the same terms.
+        tokenProjectIds: enforce?.tokenProjectIds,
       })
     : Promise.resolve([]);
 
@@ -654,6 +662,10 @@ async function nativeRetrieve(
     visibleItemIds: visibleIds ?? new Set<string>(),
     teamPosture: tier === "team",
     principal: enforce?.principal,
+    // AUDITFIX-7: FORWARDED, never derived. Absent closes the hand-typed arm for a token, which is
+    // the fail-closed direction and also today's behaviour — so a deleted forward reddens nothing on
+    // its own. That is why the guard requires this to be CARRIED alongside `principal`.
+    tokenProjectIds: enforce?.tokenProjectIds,
   };
   const dParams = newSqlParams();
   const dTeam = dParams.add(teamId);

--- a/lib/query/retrieve.ts
+++ b/lib/query/retrieve.ts
@@ -4,7 +4,7 @@ import { GraphitiClient, type GraphFact } from "@/lib/graph/graphiti-client";
 import { selectEnforcedGraphPartitions } from "@/lib/graph/partition-read";
 import { isRestrictedTier } from "@/lib/auth/visibility";
 import { runSql } from "@/lib/db/pg/pool";
-import { newSqlParams, provenanceRowSqlFromIds } from "@/lib/access/provenance-sql";
+import { newSqlParams, provenanceRowSqlFromIds, type MemberTag, type TokenTag } from "@/lib/access/provenance-sql";
 import {
   selectedProviderName,
   type RetrievalProvider,
@@ -145,15 +145,32 @@ const GRAPH_QUERY_TIMEOUT_MS = Number(process.env.GRAPH_QUERY_TIMEOUT_MS ?? 4000
  * (default-deny; the serve test is the POSITIVE `=== "member"`, guard-pinned). Routes assign it;
  * a caller never chooses its own arm.
  */
-export type RetrieveEnforce = {
-  visibleItemIds: ReadonlySet<string>;
-  graphProjectIds?: readonly string[];
-  principal: "member" | "token";
-  /** AUDITFIX-7: a TOKEN's effective project set — the authority that gates the hand-typed arm.
-   *  Absent closes that arm, so this must be CARRIED, not merely available: an omitted forward
-   *  looks exactly like today's behaviour and reddens nothing on its own (the M13 lesson). */
-  tokenProjectIds?: readonly string[];
-};
+/**
+ * ⚠️ A DISCRIMINATED UNION, so the token's authority is REQUIRED BY THE TYPE (Codex diff review).
+ *
+ * It was an optional field first, which meant `{ visibleItemIds, principal: "token" }` type-checked
+ * and silently restored pre-AUDITFIX-7 behaviour — the arm closes, no test reddens, and it looks
+ * exactly like the shipped default. An AST guard caught it in the two files it analyses; the type
+ * system now catches it everywhere, including the provider seam that omitted the field entirely.
+ *
+ * `tokenProjectIds` MAY be empty — an empty set closes the arm, which is the correct fail-closed
+ * outcome for a token with no reachable projects. What it may not be is ABSENT.
+ */
+export type RetrieveEnforce =
+  | {
+      visibleItemIds: ReadonlySet<string>;
+      graphProjectIds?: readonly string[];
+      principal: MemberTag;
+      tokenProjectIds?: undefined;
+    }
+  | {
+      visibleItemIds: ReadonlySet<string>;
+      graphProjectIds?: readonly string[];
+      principal: TokenTag;
+      /** The token's effective project set. REQUIRED: an omitted forward looks exactly like the
+       *  fail-closed default and so reddens nothing on its own (the M13 lesson). */
+      tokenProjectIds: readonly string[];
+    };
 
 /** The wire half of the graph leg, injectable for tests (the client was previously constructed
  *  inline, making the partition wiring unpinnable). */

--- a/lib/query/structured-extras.ts
+++ b/lib/query/structured-extras.ts
@@ -66,7 +66,13 @@ export async function matchingDecisions(
   // ENFB-2 §2.2: the provenance predicate compiles into THIS window too (the keyword leg was
   // one of the deferred post-LIMIT sites). Absent ctx (a caller with no enforcement view)
   // fails CLOSED: an empty visible set admits only nothing-sourced… i.e. no sourced rows.
-  enforce?: { visibleItemIds: ReadonlySet<string>; teamPosture: boolean; principal?: ProvenancePrincipal }
+  enforce?: {
+    visibleItemIds: ReadonlySet<string>;
+    teamPosture: boolean;
+    principal?: ProvenancePrincipal;
+    /** AUDITFIX-7: a token's effective project set; absent closes the hand-typed arm. */
+    tokenProjectIds?: readonly string[];
+  }
 ): Promise<DecisionMatch[]> {
   if (!orQuery.trim()) return [];
   try {
@@ -78,6 +84,8 @@ export async function matchingDecisions(
       // Absent enforcement closes the hand-typed arm (undefined), preserving this function's
       // existing fail-closed default rather than synthesising a member (AUDITFIX-1 §2d).
       principal: enforce?.principal,
+      // AUDITFIX-7: forwarded on the same terms — absent closes.
+      tokenProjectIds: enforce?.tokenProjectIds,
     });
     const params: unknown[] = p.values;
     const sql = `

--- a/test/access-delegated-error-path.test.ts
+++ b/test/access-delegated-error-path.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * AUDITFIX-7, Fable diff review (LOW) — the substrate-error path must not WIDEN the answer.
+ *
+ * `visibleItemIdsForProjects` fails closed on a read error and flags it (`error: true`), so the id
+ * set is an ERROR-derived empty rather than a genuine one. `delegatedVisibleItemIds` also returns the
+ * token's project set now — and returning it on that path would serve hand-typed rows while every
+ * SOURCED row was error-suppressed, i.e. a strictly wider answer than the same failure produced
+ * before this slice. "Substrate error → serve nothing" is the posture everywhere else.
+ *
+ * The mutation removing that gate SURVIVED until this test existed: the fix had no pin, which is the
+ * failure mode this slice has been caught by repeatedly.
+ */
+vi.mock("@/lib/access/oracle", () => ({
+  effectiveVisibleProjects: async () => new Set(["p1", "p2"]),
+  visibleProjects: async () => ({ projectIds: new Set<string>(), groupIds: new Set<string>() }),
+}));
+
+const TOKEN = { teamId: "t1", memberId: "m1", onBehalfOf: null, projectScope: null };
+
+/** A DbClient stub whose substrate read fails — the only thing under test. */
+function erroringDb(fail: boolean) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "in", "is", "not", "order", "limit", "gt"]) {
+    chain[m] = () => chain;
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    resolve(fail ? { data: null, error: { message: "substrate read failed" } } : { data: [], error: null });
+  return { from: () => chain } as never;
+}
+
+describe("delegatedVisibleItemIds — the error path must not widen", () => {
+  it("a substrate READ ERROR yields NO project set, so the hand-typed arm closes too", async () => {
+    const { delegatedVisibleItemIds } = await import("@/lib/access/enforce");
+    const r = await delegatedVisibleItemIds(erroringDb(true), TOKEN);
+    expect(r.error, "the read failure is still flagged").toBe(true);
+    expect(r.ids.size).toBe(0);
+    expect(
+      r.projectIds,
+      "returning the authority here would serve hand-typed rows while every sourced row was suppressed"
+    ).toEqual([]);
+  });
+
+  it("a clean read still returns the effective project set", async () => {
+    const { delegatedVisibleItemIds } = await import("@/lib/access/enforce");
+    const r = await delegatedVisibleItemIds(erroringDb(false), TOKEN);
+    expect(r.error).toBeUndefined();
+    expect([...r.projectIds].sort(), "the happy path is unchanged — this gate must not close it").toEqual(["p1", "p2"]);
+  });
+});

--- a/test/access-provenance-principal.test.ts
+++ b/test/access-provenance-principal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { admitsUnsourced, newSqlParams, provenanceRowSql, provenanceRowSqlFromIds } from "@/lib/access/provenance-sql";
+import { unsourcedAdmission, newSqlParams, provenanceRowSql, provenanceRowSqlFromIds } from "@/lib/access/provenance-sql";
 import { rowVisibleByProvenance } from "@/lib/access/provenance";
 
 /**
@@ -21,16 +21,23 @@ const PRINCIPALS = [
   ["administrator" as unknown as undefined, false],
 ] as const;
 
-describe("admitsUnsourced — the one policy, positively expressed", () => {
+/**
+ * ⚠️ AUDITFIX-7 made the policy THREE-VALUED. It returns `{kind:"closed"|"all"|"projects"}` instead
+ * of a boolean, because a token is no longer always-closed — it is closed UNLESS the row's project is
+ * in the token's effective set. These assertions are converted, not deleted: every principal that
+ * closed here still closes, and the token rows now say WHY (no project set supplied → closed), which
+ * is the same fail-closed default expressed in the richer type.
+ */
+describe("unsourcedAdmission — the one policy, positively expressed", () => {
   for (const [principal, admitted] of PRINCIPALS) {
     it(`principal=${String(principal)} at team posture → ${admitted ? "admits" : "closes"}`, () => {
-      expect(admitsUnsourced({ principal, teamPosture: true })).toBe(admitted);
+      expect(unsourcedAdmission({ principal, teamPosture: true }).kind).toBe(admitted ? "all" : "closed");
     });
   }
 
   it("a member at EXTERNAL posture still closes — posture is the other conjunct", () => {
     // The audience wall predates this slice and must survive it: this is not a token rule only.
-    expect(admitsUnsourced({ principal: "member", teamPosture: false })).toBe(false);
+    expect(unsourcedAdmission({ principal: "member", teamPosture: false })).toEqual({ kind: "closed" });
   });
 });
 

--- a/test/access-unsourced-admission.test.ts
+++ b/test/access-unsourced-admission.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   unsourcedAdmission,
   provenanceRowSqlFromIds,
+  provenanceRowSql,
   newSqlParams,
   type UnsourcedAdmission,
 } from "@/lib/access/provenance-sql";
@@ -111,5 +112,33 @@ describe("AC8(iii, SQL half) — the id-array owner emits the project conjunct o
     const p = newSqlParams();
     const sql = provenanceRowSqlFromIds("t", p, { visibleItemIds: ids, teamPosture: true, principal: "token" });
     expect(sql, "the arm is OMITTED, not parameterised false").not.toContain("created_by");
+  });
+});
+
+describe("AC8(iii, SQL half) — the SEMIJOIN owner, asserted SEPARATELY", () => {
+  // ⚠️ A mutation dropping the project conjunct from THIS owner SURVIVED the first version of this
+  // file, because every SQL assertion targeted the id-array owner. The spec had already said it —
+  // "one mutation per SQL owner, so a shared fixture cannot mask either" — and I under-implemented
+  // it. Two owners, two sets of assertions, two mutations.
+  const base = { teamId: "t1", grantedProjectIds: ["g1"], teamPosture: true } as const;
+
+  it("member → the bare authored arm, with NO project filter", () => {
+    const sql = provenanceRowSql("t", newSqlParams(), { ...base, principal: "member" });
+    expect(sql).toContain("created_by is not null");
+    expect(sql, "a member's arm must not be project-gated here either").not.toContain("t.project_id");
+  });
+
+  it("token with a set → the authored arm AND a project filter on the ALIAS", () => {
+    const p = newSqlParams();
+    const sql = provenanceRowSql("t", p, { ...base, principal: "token", tokenProjectIds: ["p1"] });
+    expect(sql).toContain("created_by is not null");
+    expect(sql, "the alias column resolves without the caller selecting anything").toContain("t.project_id = any(");
+    expect(p.values.at(-1)).toEqual(["p1"]);
+  });
+
+  it("token with no set → NO authored arm at all", () => {
+    const sql = provenanceRowSql("t", newSqlParams(), { ...base, principal: "token" });
+    expect(sql).not.toContain("created_by");
+    expect(sql, "closing the arm must not blank the sourced half").toContain("source_item_id is not null");
   });
 });

--- a/test/access-unsourced-admission.test.ts
+++ b/test/access-unsourced-admission.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  unsourcedAdmission,
+  provenanceRowSqlFromIds,
+  newSqlParams,
+  type UnsourcedAdmission,
+} from "@/lib/access/provenance-sql";
+import { rowVisibleByProvenance } from "@/lib/access/provenance";
+
+/**
+ * AUDITFIX-7 AC8 — the THREE OWNERS agree, executably.
+ *
+ * ⚠️ A spec round killed the first version of this criterion: it said "every combination yields the
+ * same admit/deny from all three", which is not a mechanism — the owners return different TYPES (a
+ * boolean vs SQL fragments), so "compare their outputs" cannot be written. The parity is pinned in
+ * three separable parts instead:
+ *   (i)  the policy function's EXACT union result, here;
+ *   (ii) exhaustive `switch` + `never` in all three consumers, so a missed branch is a COMPILE error
+ *        (that one is enforced by tsc, not by a test);
+ *   (iii) both SQL forms executed against the same fixture truth table as the TS owner, in the
+ *        data-mechanics tier where real rows exist.
+ * This file is (i), plus the TS owner's half of (iii).
+ */
+
+const P = ["p1", "p2"] as const;
+
+describe("AC8(i) — the policy function's exact union result", () => {
+  const cases: { name: string; ctx: Parameters<typeof unsourcedAdmission>[0]; want: UnsourcedAdmission }[] = [
+    { name: "member @ team posture → all", ctx: { principal: "member", teamPosture: true }, want: { kind: "all" } },
+    { name: "member @ external posture → closed", ctx: { principal: "member", teamPosture: false }, want: { kind: "closed" } },
+    { name: "token with a non-empty set → projects", ctx: { principal: "token", teamPosture: true, tokenProjectIds: P }, want: { kind: "projects", projectIds: P } },
+    // The empty and absent cases are DISTINCT inputs with the same correct outcome, and both are
+    // decided explicitly rather than left to `= any('{}')` being false.
+    { name: "token with an EMPTY set → closed", ctx: { principal: "token", teamPosture: true, tokenProjectIds: [] }, want: { kind: "closed" } },
+    { name: "token with NO set → closed", ctx: { principal: "token", teamPosture: true }, want: { kind: "closed" } },
+    { name: "token @ external posture with a set → projects (posture is not the token's wall)", ctx: { principal: "token", teamPosture: false, tokenProjectIds: P }, want: { kind: "projects", projectIds: P } },
+    // AUDITFIX-1's positive-policy property: everything that is not an explicit principal closes.
+    { name: "undefined principal → closed", ctx: { teamPosture: true }, want: { kind: "closed" } },
+    { name: "null principal → closed", ctx: { principal: null as never, teamPosture: true }, want: { kind: "closed" } },
+    { name: "foreign principal → closed", ctx: { principal: "admin" as never, teamPosture: true }, want: { kind: "closed" } },
+  ];
+  it.each(cases)("$name", ({ ctx, want }) => {
+    expect(unsourcedAdmission(ctx)).toEqual(want);
+  });
+});
+
+describe("AC8(iii, TS half) + AC12 — rowVisibleByProvenance consumes the union", () => {
+  const authored = { source_item_id: null, created_by: "u1", project_id: "p1" };
+
+  it("a member at team posture sees an authored row in ANY project — including an ungranted one", () => {
+    expect(rowVisibleByProvenance({ ...authored, project_id: "not-granted" }, new Set(), "team", "member")).toBe(true);
+  });
+
+  it("a token sees an authored row IN its project set", () => {
+    expect(rowVisibleByProvenance(authored, new Set(), "team", "token", ["p1", "p2"])).toBe(true);
+  });
+
+  it("a token does NOT see an authored row OUTSIDE its project set", () => {
+    expect(rowVisibleByProvenance({ ...authored, project_id: "p9" }, new Set(), "team", "token", ["p1"])).toBe(false);
+  });
+
+  it("a token with an EMPTY project set sees nothing authored", () => {
+    expect(rowVisibleByProvenance(authored, new Set(), "team", "token", [])).toBe(false);
+  });
+
+  it("an unauthored row (created_by null) closes even inside the project set", () => {
+    // The 66 legacy `origin='ui'` rows on prod have exactly this shape. Project scope alone must not
+    // rehabilitate them — this slice neither repairs nor worsens their invisibility.
+    expect(rowVisibleByProvenance({ ...authored, created_by: null }, new Set(), "team", "token", ["p1"])).toBe(false);
+  });
+
+  it("AC12 — a token admission with NO project_id on the row DENIES, and says so", () => {
+    // `project_id` is NOT NULL in the schema, so its absence means the CALLER did not select it.
+    // Denying is right; denying SILENTLY would turn a one-line wiring defect into a legitimate-
+    // looking empty result. The overload makes it a compile error; this is the runtime backstop.
+    const errors: unknown[] = [];
+    const spy = console.error;
+    console.error = (...a: unknown[]) => void errors.push(a);
+    try {
+      const row = { source_item_id: null, created_by: "u1" } as { source_item_id: null; created_by: string; project_id: string };
+      expect(rowVisibleByProvenance(row, new Set(), "team", "token", ["p1"])).toBe(false);
+    } finally {
+      console.error = spy;
+    }
+    expect(errors.length, "the denial must be LOUD, not silent").toBe(1);
+    expect(String(errors[0])).toMatch(/did not select it/);
+  });
+
+  it("the SOURCED arm is untouched by any of this", () => {
+    const sourced = { source_item_id: "i1", created_by: null, project_id: "p9" };
+    expect(rowVisibleByProvenance(sourced, new Set(["i1"]), "team", "token", ["p1"])).toBe(true);
+    expect(rowVisibleByProvenance({ ...sourced, source_item_id: "i2" }, new Set(["i1"]), "team", "token", ["p1"])).toBe(false);
+  });
+});
+
+describe("AC8(iii, SQL half) — the id-array owner emits the project conjunct only for a token", () => {
+  const ids = new Set(["i1"]);
+  it("member → the bare authored arm, with NO project filter", () => {
+    const p = newSqlParams();
+    const sql = provenanceRowSqlFromIds("t", p, { visibleItemIds: ids, teamPosture: true, principal: "member" });
+    expect(sql).toContain("created_by is not null");
+    expect(sql, "a member's arm must not be project-gated — that would silently narrow members").not.toContain("project_id");
+  });
+  it("token with a set → the authored arm AND a project filter", () => {
+    const p = newSqlParams();
+    const sql = provenanceRowSqlFromIds("t", p, { visibleItemIds: ids, teamPosture: true, principal: "token", tokenProjectIds: ["p1"] });
+    expect(sql).toContain("t.project_id = any(");
+    expect(p.values.at(-1), "the scope binds as ONE parameter").toEqual(["p1"]);
+  });
+  it("token with no set → NO authored arm at all", () => {
+    const p = newSqlParams();
+    const sql = provenanceRowSqlFromIds("t", p, { visibleItemIds: ids, teamPosture: true, principal: "token" });
+    expect(sql, "the arm is OMITTED, not parameterised false").not.toContain("created_by");
+  });
+});

--- a/test/access-unsourced-admission.test.ts
+++ b/test/access-unsourced-admission.test.ts
@@ -18,9 +18,16 @@ import { rowVisibleByProvenance } from "@/lib/access/provenance";
  *   (i)  the policy function's EXACT union result, here;
  *   (ii) exhaustive `switch` + `never` in all three consumers, so a missed branch is a COMPILE error
  *        (that one is enforced by tsc, not by a test);
- *   (iii) both SQL forms executed against the same fixture truth table as the TS owner, in the
- *        data-mechanics tier where real rows exist.
- * This file is (i), plus the TS owner's half of (iii).
+ *   (iii) each SQL form asserted SEPARATELY, with its own mutation, so a shared fixture cannot mask
+ *        either owner.
+ *
+ * ⚠️ AN EARLIER VERSION OF THIS COMMENT CLAIMED (iii) meant "both SQL forms EXECUTED against the same
+ * fixture truth table in the data-mechanics tier". That was false and a diff review caught it: only
+ * the ID-ARRAY form is ever executed against real Postgres (through the route dm tests). The SEMIJOIN
+ * form's `"projects"` branch is production-dead today — all three of its callers are typed
+ * `MemberPrincipal`, so a token cannot reach it — and it is therefore STRING-asserted here plus
+ * mutation-pinned, not executed. Stating coverage the tests do not contain is the failure mode this
+ * whole slice keeps being caught by; the claim is now what is true.
  */
 
 const P = ["p1", "p2"] as const;

--- a/test/datamechanics/token-structured-route.datamechanics.test.ts
+++ b/test/datamechanics/token-structured-route.datamechanics.test.ts
@@ -6,6 +6,17 @@ import { db, ingest, seedTeam, type Seed } from "./helpers";
 /**
  * AUDITFIX-1 AC5 — the leak proof at the ROUTE, not at the library.
  *
+ * ⚠️ AUDITFIX-7 DELIBERATELY REVERSED HALF OF THIS FILE'S ORIGINAL ASSERTION, under an explicit
+ * product ruling (Chetan, 2026-08-22): an agent granted a project SHOULD read what a person typed
+ * into that project by hand. AUDITFIX-1 closed the hand-typed arm for EVERY token because scope was
+ * being ignored entirely — an empty-scoped token received the whole team's hand-typed rows. The arm
+ * is now GATED on the token's effective project set rather than closed, so:
+ *   IN-scope hand-entered rows are SERVED (the ruling), and
+ *   OUT-OF-scope hand-entered rows are still ABSENT (AUDITFIX-1's actual protection, kept).
+ * The original test seeded its hand-entered rows INSIDE the token's scope, so it could only ever
+ * express the closed rule. It is converted, not deleted: the leak it proves is still proven, by the
+ * out-of-scope half.
+ *
  * Everything else in this slice calls `retrieve`/`matchingDecisions` directly and hands them a
  * `principal` the test itself chose. That proves the predicate, and proves nothing about whether the
  * shipped route reaches it: the reproduced CRITICAL was a real `POST /api/v1/query` disclosure, and
@@ -89,7 +100,7 @@ describe("AUDITFIX-1 AC5: the real POST /api/v1/query attenuates a delegated tok
     captured.structured = [];
   });
 
-  it("a NON-EMPTY-scoped aiosd_ token is served its in-scope sourced rows and NO hand-entered rows", async () => {
+  it("a NON-EMPTY-scoped aiosd_ token is served IN-scope hand-entered rows and never OUT-of-scope ones", async () => {
     const seed = await seedTeam();
     const { backfillTeamContext } = await import("@/lib/projects/context/backfill");
     const { mintAgentToken } = await import("@/lib/access/agent-tokens");
@@ -102,20 +113,28 @@ describe("AUDITFIX-1 AC5: the real POST /api/v1/query attenuates a delegated tok
     const bySlug = new Map(((projects ?? []) as { id: string; slug: string }[]).map((p) => [p.slug, p.id]));
     await curateInto(seed, inScope.id, bySlug.get("rproj")!);
 
-    // A hand-entered task and decision — no source item, so no membership axis to test a scope
-    // against. These are the rows the reproduced defect handed to every token in the team.
+    // Hand-entered rows — no source item, so the ONLY thing that can gate them is the project the
+    // author chose. Seeded in BOTH directions in one invocation, because a spec round found that
+    // seeding only the in-scope half lets an implementation pass by deleting the gate outright, and
+    // seeding only a TASK lets it gate the task leg while leaving the decision leg open.
+    const inScopeTask = `INSCOPETASK-${randomUUID().slice(0, 8)}`;
+    const inScopeDecision = `INSCOPEDECISION-${randomUUID().slice(0, 8)} ${TERM}`;
     const secretTask = `SECRETTASK-${randomUUID().slice(0, 8)}`;
     const secretDecision = `SECRETDECISION-${randomUUID().slice(0, 8)} ${TERM}`;
-    const t = await db().from("tasks").insert({
-      team_id: seed.teamId, row_key: `RT-${randomUUID().slice(0, 6)}`, title: secretTask, status: "in_progress",
-      source_item_id: null, created_by: seed.memberId, audience: "team", project_id: bySlug.get("rproj")!, origin: "ui",
-    });
-    if (t.error) throw new Error(`task seed failed: ${t.error.message}`);
-    const d = await db().from("decisions").insert({
-      team_id: seed.teamId, row_key: `RD-${randomUUID().slice(0, 6)}`, title: secretDecision, decided_by: "x",
-      still_valid: true, source_item_id: null, created_by: seed.memberId, audience: "team", project_id: bySlug.get("rproj")!,
-    });
-    if (d.error) throw new Error(`decision seed failed: ${d.error.message}`);
+    const handEntered = async (title: string, decisionTitle: string, projectSlug: string) => {
+      const t = await db().from("tasks").insert({
+        team_id: seed.teamId, row_key: `RT-${randomUUID().slice(0, 6)}`, title, status: "in_progress",
+        source_item_id: null, created_by: seed.memberId, audience: "team", project_id: bySlug.get(projectSlug)!, origin: "ui",
+      });
+      if (t.error) throw new Error(`task seed failed: ${t.error.message}`);
+      const d = await db().from("decisions").insert({
+        team_id: seed.teamId, row_key: `RD-${randomUUID().slice(0, 6)}`, title: decisionTitle, decided_by: "x",
+        still_valid: true, source_item_id: null, created_by: seed.memberId, audience: "team", project_id: bySlug.get(projectSlug)!,
+      });
+      if (d.error) throw new Error(`decision seed failed: ${d.error.message}`);
+    };
+    await handEntered(inScopeTask, inScopeDecision, "rproj");
+    await handEntered(secretTask, secretDecision, "otherproj");
 
     // A SOURCED task on the in-scope item — the survival half. Without it, a route that returned
     // an empty structured digest for every token would pass this test while breaking the feature.
@@ -147,7 +166,57 @@ describe("AUDITFIX-1 AC5: the real POST /api/v1/query attenuates a delegated tok
     expect(captured.structured.length, "streamAnswer must have run — otherwise nothing was asserted").toBe(1);
     const structured = captured.structured[0];
     expect(structured, "the token's in-scope SOURCED task is still served").toContain(sourcedTask);
-    expect(structured, "a hand-entered TASK must never reach a token's prompt").not.toContain(secretTask);
-    expect(structured, "a hand-entered DECISION must never reach a token's prompt").not.toContain(secretDecision);
+    // The RULING (AUDITFIX-7): an agent granted a project reads what a person typed into it.
+    expect(structured, "an IN-SCOPE hand-entered TASK is served to the token").toContain(inScopeTask);
+    expect(structured, "an IN-SCOPE hand-entered DECISION is served to the token").toContain(inScopeDecision);
+    // AUDITFIX-1's protection, kept: the gate is a scope, not an open door.
+    expect(structured, "an OUT-OF-SCOPE hand-entered TASK must never reach a token's prompt").not.toContain(secretTask);
+    expect(structured, "an OUT-OF-SCOPE hand-entered DECISION must never reach a token's prompt").not.toContain(secretDecision);
+  });
+
+  it("an UNSCOPED token (projectScope: null) gets its launcher's projects — NOT nothing, NOT everything", async () => {
+    // Spec round 2's BLOCKER. The oracle attenuates only when the scope is NON-NULL, so `null` means
+    // "the launcher's granted projects" while `[]` means "sees nothing". Every other criterion here
+    // uses an explicit non-empty scope, so an implementation returning `[]` for a null scope would
+    // pass all of them and silently blind every unscoped agent — which is the exact narrowing the
+    // ruling forbids, and it would look identical to today's behaviour.
+    const seed = await seedTeam();
+    const { backfillTeamContext } = await import("@/lib/projects/context/backfill");
+    const { mintAgentToken } = await import("@/lib/access/agent-tokens");
+    const { addMemberToGroup, createGroup, grantProjectToGroup } = await import("@/lib/access/groups");
+
+    await ingest(seed, { path: "u/in.md", body: `in ${TERM}`, access: "team", project: "uproj" });
+    await ingest(seed, { path: "u/out.md", body: `out ${TERM}`, access: "team", project: "uother" });
+    await backfillTeamContext(db(), seed.teamId);
+    const { data: projects } = await db().from("projects").select("id, slug").eq("team_id", seed.teamId);
+    const bySlug = new Map(((projects ?? []) as { id: string; slug: string }[]).map((p) => [p.slug, p.id]));
+
+    const reachable = `UNSCOPEDREACHABLE-${randomUUID().slice(0, 8)}`;
+    const unreachable = `UNSCOPEDUNREACHABLE-${randomUUID().slice(0, 8)}`;
+    for (const [title, slug] of [[reachable, "uproj"], [unreachable, "uother"]] as const) {
+      const r = await db().from("tasks").insert({
+        team_id: seed.teamId, row_key: `UT-${randomUUID().slice(0, 6)}`, title, status: "in_progress",
+        source_item_id: null, created_by: seed.memberId, audience: "team", project_id: bySlug.get(slug)!, origin: "ui",
+      });
+      if (r.error) throw new Error(`task seed failed: ${r.error.message}`);
+    }
+
+    // The agent is granted ONLY uproj. The token names NO scope at all.
+    const agent = await seedMember(seed, { kind: "agent" });
+    const g = await createGroup(db(), seed.teamId, `ut-${randomUUID().slice(0, 6)}`, "G", seed.memberId);
+    await addMemberToGroup(db(), seed.teamId, g.groupId!, agent, seed.memberId);
+    await grantProjectToGroup(db(), seed.teamId, bySlug.get("uproj")!, g.groupId!, seed.memberId);
+    const minted = await mintAgentToken(db(), seed.teamId, { memberId: agent, projectScope: null }, seed.memberId);
+    expect(minted.ok, minted.error).toBe(true);
+
+    const { POST: queryPOST } = await import("@/app/api/v1/query/route");
+    const res = await queryPOST(queryReq(minted.token!, `tell me about ${TERM}`));
+    expect(res.status).toBe(200);
+    await drain(res);
+
+    expect(captured.structured.length, "streamAnswer must have run").toBe(1);
+    const structured = captured.structured[0];
+    expect(structured, "an unscoped token still reaches its launcher's granted project").toContain(reachable);
+    expect(structured, "an unscoped token is NOT unattenuated — an ungranted project stays closed").not.toContain(unreachable);
   });
 });

--- a/test/guards/enforce-retrieve-callsites.test.ts
+++ b/test/guards/enforce-retrieve-callsites.test.ts
@@ -109,10 +109,16 @@ describe("delegated query wiring in app/api/v1/query/route.ts (Phase B slice 3)"
     // QMIR-1 widened the pin: the agent arm must ALSO carry `principal: "token"` — the
     // org-structural mirror legs key on the positive member test, so losing the discriminant
     // here silently costs nothing today but is the field a future refactor must not drop.
+    // AUDITFIX-7 widened it again, for the SAME reason and it is worth stating twice: the arm must
+    // destructure `projectIds` from what `delegatedVisibleItemIds` returned and forward it as
+    // `tokenProjectIds`. Dropping it closes every token's hand-typed arm — which is EXACTLY the
+    // pre-AUDITFIX-7 behaviour, so no test would redden and no user would report it. The regex
+    // requires the forwarded name to be the destructured one, so a recomputed or same-named
+    // substitute does not satisfy it.
     // Comment lines between the resolve and the assignment are permitted; code is not.
     expect(src).toMatch(
       // PRET-6: the member arm is the unconditional ELSE (the flag read retired).
-      /if\s*\(agent\)\s*\{\s*const\s*\{\s*ids\s*\}\s*=\s*await\s+delegatedVisibleItemIds\(\s*db\s*,\s*agent\s*\)\s*;\s*(?:\/\/[^\n]*\n\s*)*enforce\s*=\s*\{\s*visibleItemIds:\s*ids\s*,\s*principal:\s*"token"\s*\}\s*;\s*\}\s*else\s*\{/
+      /if\s*\(agent\)\s*\{\s*const\s*\{\s*ids\s*,\s*projectIds\s*\}\s*=\s*await\s+delegatedVisibleItemIds\(\s*db\s*,\s*agent\s*\)\s*;\s*(?:\/\/[^\n]*\n\s*)*enforce\s*=\s*\{\s*visibleItemIds:\s*ids\s*,\s*principal:\s*"token"\s*,\s*tokenProjectIds:\s*projectIds\s*\}\s*;\s*\}\s*else\s*\{/
     );
     // No bare `enforce = null` assignment may exist anywhere (Codex B3 Low: the sequence regex
     // above survives a later re-null). The typed declaration (`let enforce: … | null = null`)

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -126,6 +126,10 @@ function filesUnder(dir: string): string[] {
  * arms. Read this guard as the fast build-failing layer over a tier that independently proves the
  * outcome — not as the only thing between a token and the hand-typed rows.
  */
+/** The two fields that carry a principal's AUTHORITY. Both are forward-only, and both are equally
+ *  deletable-without-reddening, so every rule below treats them identically. */
+const AUTHORITY_FIELDS = new Set(["principal", "tokenProjectIds"]);
+
 function astViolations(code: string, rel = "inline.ts"): string[] {
   const src = ts.createSourceFile(rel, code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
   const bad: string[] = [];
@@ -156,23 +160,29 @@ function astViolations(code: string, rel = "inline.ts"): string[] {
   };
 
   const visit = (node: ts.Node): void => {
-    // (3) an assignment INTO a `.principal` property, in any assignment operator (`=`, `||=`, `??=`).
+    // (3) an assignment INTO an authority property, in any assignment operator (`=`, `||=`, `??=`).
+    // ⚠️ BOTH FIELDS, symmetrically (Codex diff review). This checked `principal` only, so the
+    // literal could be built correctly and then mutated:
+    //     const ctx = { …, tokenProjectIds: enforce?.tokenProjectIds };
+    //     ctx.tokenProjectIds = ["out-of-scope-project"];
+    // — which passed the object-literal rule and admitted that project. A carry rule that inspects
+    // only construction is a rule about the first line, not about the value.
     if (
       ts.isBinaryExpression(node) &&
       ts.isPropertyAccessExpression(node.left) &&
-      node.left.name.text === "principal" &&
+      AUTHORITY_FIELDS.has(node.left.name.text) &&
       node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
       node.operatorToken.kind <= ts.SyntaxKind.LastAssignment
     ) {
-      bad.push(`${at(node)} assigns to .principal — this file may only FORWARD it`);
+      bad.push(`${at(node)} assigns to .${node.left.name.text} — this file may only FORWARD it`);
     }
 
     // (4) reaching it reflectively.
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
       const callee = `${node.expression.expression.getText(src)}.${node.expression.name.text}`;
-      if (callee === "Reflect.set" || callee === "Object.defineProperty") {
-        if (node.arguments.some((a) => ts.isStringLiteralLike(a) && a.text === "principal")) {
-          bad.push(`${at(node)} sets .principal via ${callee}`);
+      if (callee === "Reflect.set" || callee === "Object.defineProperty" || callee === "Object.assign") {
+        if (node.arguments.some((a) => ts.isStringLiteralLike(a) && AUTHORITY_FIELDS.has(a.text))) {
+          bad.push(`${at(node)} sets an authority field via ${callee}`);
         }
       }
     }

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -138,6 +138,13 @@ function astViolations(code: string, rel = "inline.ts"): string[] {
     return ts.isIdentifier(inner.expression) && inner.expression.text === "enforce" && inner.name.text === "principal";
   };
 
+  /** The ONE permitted initialiser for the token project set: `enforce?.tokenProjectIds`. */
+  const isForwardedProjects = (e: ts.Expression): boolean => {
+    const inner = ts.isNonNullExpression(e) ? e.expression : e;
+    if (!ts.isPropertyAccessExpression(inner)) return false;
+    return ts.isIdentifier(inner.expression) && inner.expression.text === "enforce" && inner.name.text === "tokenProjectIds";
+  };
+
   /** A property's name, resolving a literal COMPUTED key — the spelling Codex demonstrated. */
   const nameOf = (p: ts.ObjectLiteralElementLike): string | null => {
     if (ts.isSpreadAssignment(p)) return null;
@@ -197,6 +204,18 @@ function astViolations(code: string, rel = "inline.ts"): string[] {
         // put `principal` here: an absent forward is indistinguishable from the fail-closed default.
         if (!names.includes("tokenProjectIds")) {
           bad.push(`${at(node)} provenance ctx omits tokenProjectIds — a token's hand-typed arm closes silently`);
+        } else {
+          // Fable diff review, LOW: presence alone was ASYMMETRIC with rule (1), which requires
+          // `principal` to be initialised to exactly `enforce?.principal`. `tokenProjectIds: undefined`
+          // or a locally recomputed set satisfied mere presence — and recomputing the authority is a
+          // second oracle read free to disagree with the first, which is the whole reason
+          // `delegatedVisibleItemIds` returns it. Same rule, same shape, both fields.
+          const prop = node.properties[names.indexOf("tokenProjectIds")];
+          if (prop && ts.isPropertyAssignment(prop) && !isForwardedProjects(prop.initializer)) {
+            bad.push(`${at(prop)} tokenProjectIds is \`${prop.initializer.getText(src)}\`, not enforce?.tokenProjectIds`);
+          } else if (prop && ts.isShorthandPropertyAssignment(prop)) {
+            bad.push(`${at(prop)} shorthand \`{ tokenProjectIds }\` — forwarding cannot be spelled that way`);
+          }
         }
       }
     }
@@ -250,13 +269,17 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     // Each of these passed the regex guard at some point in this slice's history. They are kept as
     // negative controls so a future simplification of the walk reddens here rather than silently
     // reopening the hole.
-    const FORWARD = "const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: enforce?.principal };";
+    const FORWARD = "const ctx = { visibleItemIds, teamPosture, tokenProjectIds: enforce?.tokenProjectIds, principal: enforce?.principal };";
     const EVASIONS: [string, string][] = [
-      ["literal", 'const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: "member" };'],
-      ["named constant", "const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: MEMBER_ONLY_SURFACE };"],
+      ["literal", 'const ctx = { visibleItemIds, teamPosture, tokenProjectIds: enforce?.tokenProjectIds, principal: "member" };'],
+      ["named constant", "const ctx = { visibleItemIds, teamPosture, tokenProjectIds: enforce?.tokenProjectIds, principal: MEMBER_ONLY_SURFACE };"],
       [
         "local binding + shorthand (Fable's HIGH)",
-        'const principal = "member" as ProvenancePrincipal;\nconst ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal };',
+        'const principal = "member" as ProvenancePrincipal;\nconst ctx = { visibleItemIds, teamPosture, tokenProjectIds: enforce?.tokenProjectIds, principal };',
+      ],
+      [
+        "AUDITFIX-7: tokenProjectIds RECOMPUTED rather than forwarded (a second oracle read free to disagree)",
+        "const ctx = { visibleItemIds, teamPosture, tokenProjectIds: await recomputeProjects(), principal: enforce?.principal };",
       ],
       [
         "AUDITFIX-7: tokenProjectIds omitted (closes every token's hand-typed arm SILENTLY)",
@@ -265,13 +288,13 @@ describe("guard: a token can never acquire member provenance semantics", () => {
       ["computed key", 'const ctx = { visibleItemIds, teamPosture, tokenProjectIds, ["principal"]: "member" };'],
       [
         "spread override",
-        'const o = { principal: "member" };\nconst ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: enforce?.principal, ...o };',
+        'const o = { principal: "member" };\nconst ctx = { visibleItemIds, teamPosture, tokenProjectIds: enforce?.tokenProjectIds, principal: enforce?.principal, ...o };',
       ],
       ["direct assignment", `${FORWARD}\nenforce!.principal = "member";`],
       ["logical-or assignment", `${FORWARD}\nenforce!.principal ||= "member";`],
       ["Reflect.set", `${FORWARD}\nReflect.set(enforce, "principal", "member");`],
       ["defineProperty", `${FORWARD}\nObject.defineProperty(enforce, "principal", { value: "member" });`],
-      ["derived from tier", 'const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: tier === "team" ? "member" : "token" };'],
+      ["derived from tier", 'const ctx = { visibleItemIds, teamPosture, tokenProjectIds: enforce?.tokenProjectIds, principal: tier === "team" ? "member" : "token" };'],
       ["omitted entirely (M13)", "const ctx = { visibleItemIds, teamPosture };"],
       ["as-const literal", 'const ctx = { visibleItemIds, principal: "member" as const };'],
     ];
@@ -281,7 +304,7 @@ describe("guard: a token can never acquire member provenance semantics", () => {
 
     // …and it must ACCEPT the one legal shape, or it is a check that always fails.
     expect(astViolations(FORWARD), "forwarding must pass").toEqual([]);
-    expect(astViolations("const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: enforce.principal };")).toEqual([]);
+    expect(astViolations("const ctx = { visibleItemIds, teamPosture, tokenProjectIds: enforce?.tokenProjectIds, principal: enforce.principal };")).toEqual([]);
     // The three shapes that broke the hand-rolled scanner, all now handled by the parser.
     expect(
       astViolations('interface E { visibleItemIds: ReadonlySet<string>; principal?: "member" | "token" }'),
@@ -289,7 +312,7 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     ).toEqual([]);
     expect(astViolations("const { visibleItemIds } = enforce;"), "destructuring is not a construction").toEqual([]);
     expect(
-      astViolations('const s = "{ visibleItemIds }";\nconst ctx = { visibleItemIds, tokenProjectIds, principal: enforce?.principal };'),
+      astViolations('const s = "{ visibleItemIds }";\nconst ctx = { visibleItemIds, tokenProjectIds: enforce?.tokenProjectIds, principal: enforce?.principal };'),
       "a brace inside a string no longer misleads anything"
     ).toEqual([]);
   });
@@ -335,5 +358,27 @@ describe("guard: a token can never acquire member provenance semantics", () => {
         "hand-typed arm — OR the file genuinely no longer needs the entry. Check which before " +
         "deleting the allow-list line."
     ).toEqual([]);
+  });
+
+  it("AUDITFIX-7: the token arm's posture-free pin stays coupled to the external-delegation refusal", () => {
+    // Fable diff review, MEDIUM. `unsourcedAdmission`'s token branch deliberately does NOT consult
+    // `teamPosture` — a token's wall is its project authority. That is only SAFE because
+    // `verifyAgentToken` refuses external-tier delegation outright, so no live token is ever at
+    // external posture. If that refusal is lifted while the pin stands, an external-posture TOKEN
+    // would be admitted where its own external LAUNCHER is closed — the token exceeding its
+    // launcher, which lib/access/enforce.ts states can never happen.
+    //
+    // The coupling was written in a comment and enforced by nothing. Now deleting either end reddens.
+    const tokens = read("lib/access/agent-tokens.ts");
+    expect(
+      tokens,
+      "verifyAgentToken must still refuse external-tier delegation — the token arm's posture-free pin depends on it"
+    ).toMatch(/if\s*\(\s*effectiveTier\s*===\s*"external"\s*\)\s*return\s+null\s*;/);
+
+    const policy = read("lib/access/provenance-sql.ts");
+    expect(
+      policy,
+      "if the token arm ever DOES consult teamPosture, this guard has outlived its premise — delete it deliberately"
+    ).toMatch(/if \(ctx\.principal === "token"\) \{[\s\S]{0,1200}?const ids = ctx\.tokenProjectIds;/);
   });
 });

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -180,9 +180,23 @@ function astViolations(code: string, rel = "inline.ts"): string[] {
     // (4) reaching it reflectively.
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
       const callee = `${node.expression.expression.getText(src)}.${node.expression.name.text}`;
-      if (callee === "Reflect.set" || callee === "Object.defineProperty" || callee === "Object.assign") {
+      if (callee === "Reflect.set" || callee === "Object.defineProperty") {
+        // These name the field as a STRING ARGUMENT.
         if (node.arguments.some((a) => ts.isStringLiteralLike(a) && AUTHORITY_FIELDS.has(a.text))) {
           bad.push(`${at(node)} sets an authority field via ${callee}`);
+        }
+      }
+      if (callee === "Object.assign") {
+        // ⚠️ DIFFERENT SHAPE, and the first version of this rule missed it: `Object.assign` names the
+        // field as a KEY INSIDE an object-literal argument, not as a string argument. Reusing the
+        // string-argument test read as coverage and provided none — caught by its own mutation
+        // surviving.
+        for (const a of node.arguments) {
+          if (!ts.isObjectLiteralExpression(a)) continue;
+          for (const prop of a.properties) {
+            const n = nameOf(prop);
+            if (n && AUTHORITY_FIELDS.has(n)) bad.push(`${at(prop)} sets .${n} via Object.assign`);
+          }
         }
       }
     }
@@ -301,6 +315,14 @@ describe("guard: a token can never acquire member provenance semantics", () => {
         'const o = { principal: "member" };\nconst ctx = { visibleItemIds, teamPosture, tokenProjectIds: enforce?.tokenProjectIds, principal: enforce?.principal, ...o };',
       ],
       ["direct assignment", `${FORWARD}\nenforce!.principal = "member";`],
+      // ⚠️ Codex's diff review demonstrated this exact bypass: build the literal CORRECTLY, then
+      // mutate it one line later. The object-literal rule inspects construction; it says nothing
+      // about the value. Both authority fields, all three reflective shapes.
+      ["post-construction mutation of tokenProjectIds", `${FORWARD}\nctx.tokenProjectIds = ["out-of-scope"];`],
+      ["post-construction mutation of principal", `${FORWARD}\nctx.principal = "member";`],
+      ["Object.assign over tokenProjectIds", `${FORWARD}\nObject.assign(ctx, { "tokenProjectIds": ["out-of-scope"] });`],
+      ["Object.assign over principal", `${FORWARD}\nObject.assign(ctx, { "principal": "member" });`],
+      ["Reflect.set over tokenProjectIds", `${FORWARD}\nReflect.set(ctx, "tokenProjectIds", ["out-of-scope"]);`],
       ["logical-or assignment", `${FORWARD}\nenforce!.principal ||= "member";`],
       ["Reflect.set", `${FORWARD}\nReflect.set(enforce, "principal", "member");`],
       ["defineProperty", `${FORWARD}\nObject.defineProperty(enforce, "principal", { value: "member" });`],

--- a/test/guards/provenance-principal-callsites.test.ts
+++ b/test/guards/provenance-principal-callsites.test.ts
@@ -110,7 +110,8 @@ function filesUnder(dir: string): string[] {
  *   2. no object literal carrying `visibleItemIds` may contain a SPREAD, which could overwrite it;
  *   3. nothing ASSIGNS to a `.principal` property, in any assignment operator;
  *   4. `Reflect.set` / `Object.defineProperty` may not target `principal`;
- *   5. every object literal carrying `visibleItemIds` also carries `principal` — the M13 property,
+ *   5. every object literal carrying `visibleItemIds` also carries `principal` AND `tokenProjectIds`
+ *      (AUDITFIX-7) — the M13 property,
  *      which exists because deleting a forward reddened nothing: it fails closed for a token and
  *      silently drops a MEMBER's hand-typed rows, and no fixture separates that leg from its twin.
  *
@@ -190,6 +191,13 @@ function astViolations(code: string, rel = "inline.ts"): string[] {
         if (spread) bad.push(`${at(spread)} spread into a provenance ctx can overwrite principal`);
         // (5) the M13 property — carry it, don't merely be able to.
         if (!names.includes("principal")) bad.push(`${at(node)} provenance ctx omits principal`);
+        // (6) AUDITFIX-7: the token's project set is equally load-bearing and equally deletable.
+        // Deleting the forward closes the hand-typed arm for every token — which is EXACTLY today's
+        // behaviour, so no token test would notice and no mutation would redden. Same reasoning that
+        // put `principal` here: an absent forward is indistinguishable from the fail-closed default.
+        if (!names.includes("tokenProjectIds")) {
+          bad.push(`${at(node)} provenance ctx omits tokenProjectIds — a token's hand-typed arm closes silently`);
+        }
       }
     }
     ts.forEachChild(node, visit);
@@ -242,24 +250,28 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     // Each of these passed the regex guard at some point in this slice's history. They are kept as
     // negative controls so a future simplification of the walk reddens here rather than silently
     // reopening the hole.
-    const FORWARD = "const ctx = { visibleItemIds, teamPosture, principal: enforce?.principal };";
+    const FORWARD = "const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: enforce?.principal };";
     const EVASIONS: [string, string][] = [
-      ["literal", 'const ctx = { visibleItemIds, teamPosture, principal: "member" };'],
-      ["named constant", "const ctx = { visibleItemIds, teamPosture, principal: MEMBER_ONLY_SURFACE };"],
+      ["literal", 'const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: "member" };'],
+      ["named constant", "const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: MEMBER_ONLY_SURFACE };"],
       [
         "local binding + shorthand (Fable's HIGH)",
-        'const principal = "member" as ProvenancePrincipal;\nconst ctx = { visibleItemIds, teamPosture, principal };',
+        'const principal = "member" as ProvenancePrincipal;\nconst ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal };',
       ],
-      ["computed key", 'const ctx = { visibleItemIds, teamPosture, ["principal"]: "member" };'],
+      [
+        "AUDITFIX-7: tokenProjectIds omitted (closes every token's hand-typed arm SILENTLY)",
+        "const ctx = { visibleItemIds, teamPosture, principal: enforce?.principal };",
+      ],
+      ["computed key", 'const ctx = { visibleItemIds, teamPosture, tokenProjectIds, ["principal"]: "member" };'],
       [
         "spread override",
-        'const o = { principal: "member" };\nconst ctx = { visibleItemIds, teamPosture, principal: enforce?.principal, ...o };',
+        'const o = { principal: "member" };\nconst ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: enforce?.principal, ...o };',
       ],
       ["direct assignment", `${FORWARD}\nenforce!.principal = "member";`],
       ["logical-or assignment", `${FORWARD}\nenforce!.principal ||= "member";`],
       ["Reflect.set", `${FORWARD}\nReflect.set(enforce, "principal", "member");`],
       ["defineProperty", `${FORWARD}\nObject.defineProperty(enforce, "principal", { value: "member" });`],
-      ["derived from tier", 'const ctx = { visibleItemIds, teamPosture, principal: tier === "team" ? "member" : "token" };'],
+      ["derived from tier", 'const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: tier === "team" ? "member" : "token" };'],
       ["omitted entirely (M13)", "const ctx = { visibleItemIds, teamPosture };"],
       ["as-const literal", 'const ctx = { visibleItemIds, principal: "member" as const };'],
     ];
@@ -269,7 +281,7 @@ describe("guard: a token can never acquire member provenance semantics", () => {
 
     // …and it must ACCEPT the one legal shape, or it is a check that always fails.
     expect(astViolations(FORWARD), "forwarding must pass").toEqual([]);
-    expect(astViolations("const ctx = { visibleItemIds, teamPosture, principal: enforce.principal };")).toEqual([]);
+    expect(astViolations("const ctx = { visibleItemIds, teamPosture, tokenProjectIds, principal: enforce.principal };")).toEqual([]);
     // The three shapes that broke the hand-rolled scanner, all now handled by the parser.
     expect(
       astViolations('interface E { visibleItemIds: ReadonlySet<string>; principal?: "member" | "token" }'),
@@ -277,7 +289,7 @@ describe("guard: a token can never acquire member provenance semantics", () => {
     ).toEqual([]);
     expect(astViolations("const { visibleItemIds } = enforce;"), "destructuring is not a construction").toEqual([]);
     expect(
-      astViolations('const s = "{ visibleItemIds }";\nconst ctx = { visibleItemIds, principal: enforce?.principal };'),
+      astViolations('const s = "{ visibleItemIds }";\nconst ctx = { visibleItemIds, tokenProjectIds, principal: enforce?.principal };'),
       "a brace inside a string no longer misleads anything"
     ).toEqual([]);
   });


### PR DESCRIPTION
## What this is

A delegated `aiosd_` token could read **no** hand-entered tasks or decisions — anything a person typed
into a project through the dashboard. An agent got everything synced from Linear or meetings and
nothing typed, so it answers *"there's no task about that"* when you wrote one down.

**RULING (Chetan, 2026-08-22):** an agent granted a project should read what a person typed into it.

The arm is now **gated on the token's effective project set** instead of closed. In-scope hand-entered
rows are served; out-of-scope ones are not. **Member behaviour is unchanged.**

## This deliberately reverses part of AUDITFIX-1

AUDITFIX-1 states a token "never" sees such rows. That closure existed because scope was being ignored
*entirely* — an empty-scoped token received the whole team's hand-typed content. **The protection it
actually added is kept**: the arm is gated on authority, not reopened. And the claim it rested on —
*"a null-source row cannot be tested against that scope"* — was **false**: those rows carry
`project_id`, written by the dashboard create actions in the same insert as `created_by`, and both leg
queries already join `projects`. The token path computed the project set and **discarded it**.

The route test that encoded the old rule is **converted, not deleted** — it seeded its hand-entered
rows *inside* the token's scope, so it could only ever express "closed for every token". It now
asserts both halves.

## Measured on production first (read-only, 2026-08-22)

⚠️ **A spec round corrected my measurement by 136×, and the corrected number is what matters.**

I counted `source_item_id is null` and called it "hand-entered". The arm also requires
`created_by is not null` — and *unsourced* does not imply *typed by a human*: `ON DELETE SET NULL`
turns purged-source rows back into null-source rows, and the task CLI writes no author.

| | |
|---|---|
| tasks, `source_item_id is null` | 136 |
| **tasks, unsourced AND authored** — the population the arm admits | **1** |
| decisions, unsourced AND authored | **0** |
| the project holding it | `aios-team-brain` — **not granted to any group** |
| projects on the fleet | 19 total, **2 granted** |
| **delegated tokens in existence** | **0** |

**This admits zero additional rows on this fleet, and that is correct** — no token's authority covers
that project, so under the ruling an agent should not see what was typed into it. **Nobody should
expect a behaviour change from merging this.** Making that project reachable by an agent requires an
**operator grant**, not a code change.

**Also found, not fixed here:** 66 `origin='ui'` tasks carry no `created_by` (one window,
2026-06-28→07-01; `createTaskAction` sets it today). They fail the authorship conjunct and are
invisible to **every** principal. AC5 pins that this slice neither repairs nor worsens them.

## Deliberately not in this slice

**AUDITFIX-19** — requiring a project scope at mint. `project_scope: args.projectScope ?? null` makes
the *lazy* path the *permissive* one, which is the shape the previous slice existed to remove.
**AUDITFIX-20** — the agents admin page; there is none today, which is why zero tokens exist.

## Verification

| | |
|---|---|
| unit (`npm run coverage`, what CI runs) | **3,369 passed** |
| data-mechanics, affected | **6 passed** |
| tsc · lint · docs-drift | clean (lint 0 errors, 16 pre-existing warnings) |
| spec gate | `SPEC_READY`, no findings |

**Mutations — verdicts pasted from `scripts/mutate.mjs`, not narrated:**

| mutation | reddens |
|---|---|
| M1 token admission widens to `"all"` | union · TS owner · both SQL owners |
| M2 an empty token set stops closing explicitly | `token with an EMPTY set → closed` |
| M3 semijoin owner drops the project conjunct | its own SQL assertion |
| M4 TS owner stops checking set membership | out-of-scope TS case |
| M5 the loud denial goes silent | AC12 |
| M6 the route carry is dropped | the route wiring guard |
| M7 `delegatedVisibleItemIds` returns `[]` when unscoped | **the unscoped route test** |
| M8 the carry property leaves the AST walk | guard non-vacuity |
| M9 the external-delegation refusal is deleted | the coupling guard |
| M10 the forward-shape rule is removed | guard non-vacuity |
| M11 the error-path gate is removed | the error-path test |
| M12 assignment rule reverts to `principal`-only | guard non-vacuity |
| M13 the `Object.assign` arm is removed | guard non-vacuity |

**Four mutations SURVIVED during the build and were fixed.** M3 because I asserted only one of the two
SQL owners — the spec had already said "one mutation per owner" and I under-implemented it. M11, M12
and M13 because **I applied a review fix and wrote nothing that fails when it is removed.**

## Known-flaky, proven NOT this diff

`graph-cdc`, `nda-gate`, `neo4j-tier-wiring` and `mutation-flow` fail non-deterministically in full
`npm run coverage` runs — all spawn processes and race under parallel load. **I checked out untouched
`origin/main` and reproduced it there: 8 failures in a full run, against 5 on this branch.** All four
pass in isolation here.

## Review — Reviewed by Fable code-reviewer + Codex gpt-5.6-sol — verdict CLEAR and CLEAR-WITH-CONDITIONS after two BLOCKED spec rounds; neither could construct a token reading an out-of-scope row, and each found defects the other missed

**Spec rounds (Codex, before any code): BLOCKED, then BLOCKED on the fold.** Round 1 found I had missed
a **third owner** of this contract — the compiler named it the instant the old function was removed —
and corrected the measurement above. Round 2 found **no criterion pinned an unscoped token**
(`projectScope: null` is not `[]`): an implementation returning `[]` there passes every scoped test and
**silently blinds every unscoped agent**. It also showed a discriminated union does not enforce itself,
and that fail-closed on a missing `project_id` is *data-loss-shaped* because that column is `NOT NULL`.

**Fable (diff): CLEAR.** Could construct no out-of-scope read; verified the compile-time claims with a
real probe file. Found **a false coverage claim I had written** — my comment said both SQL forms were
executed against a real database; only one is. Found a **safety coupling written nowhere**: the token
arm skips a posture check, safe only because a *different* file refuses external-tier agents. Now
guarded from both ends. And an **error path that widened**: on a substrate read failure my change
served hand-typed rows while suppressing everything else.

**Codex (diff): CLEAR-WITH-CONDITIONS**, and it found two things Fable did not. **The carry was not
required by the type** — `{ visibleItemIds, principal: "token" }` type-checked and silently restored
pre-slice behaviour, and the provider seam restated the shape while omitting the field. It is a
**discriminated union** now, verified by probe that the unsafe shape is a compile error. And the **AST
guard had a mutation bypass** — build the literal correctly, mutate it one line later. Closing that
exposed a further defect in my own fix: the `Object.assign` arm reused the string-argument test, which
read as coverage and provided none.

AIOS-Work: AUDITFIX-7
