### PR TITLE
feat(admin): Agents — mint, list and revoke delegated agent tokens (AGENTUI-1)

### DIFF
--- a/app/t/[team]/admin/agents/actions.ts
+++ b/app/t/[team]/admin/agents/actions.ts
@@ -1,53 +1,93 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { adminClient } from "@/lib/db/admin";
 import { requireTeamAdmin as requireAdmin } from "@/lib/auth/guard";
 import { mintAgentToken, revokeAgentToken, type MintResult } from "@/lib/access/agent-tokens";
+import { validateMintRequest, type MintRequest } from "@/lib/access/agent-token-policy";
+import { visibleProjectRows } from "@/lib/access/enforce";
+
+/**
+ * Cache revalidation must never be able to discard an already-minted credential. `revalidatePath`
+ * runs AFTER the row is written, and the secret is returned exactly once — so if it throws, the
+ * caller sees a failure while a live token exists that nobody can ever read. A stale list is a
+ * cosmetic problem; an orphaned credential is a security one. Narrow by construction: it wraps only
+ * this one call, and only on the success path.
+ */
+function revalidateAgents(teamSlug: string): void {
+  try {
+    revalidatePath(`/t/${teamSlug}/admin/agents`);
+  } catch {
+    // Outside a request context (direct invocation in tests) or a revalidation fault — neither is a
+    // reason to lose the token the caller is about to be shown.
+  }
+}
 
 /**
  * Admin mint/revoke for delegated agent tokens (spec §10 QM slice — "mint/revoke admin
  * actions before any UI"). Thin admin-gated wrappers over the lib/access/agent-tokens single
- * writer; the §15.7 launcher screen builds on these later. The returned token string appears
- * exactly once, here — it is never stored, logged, or retrievable again.
+ * writer. The returned token string appears exactly once, here — it is never stored, logged, or
+ * retrievable again.
+ *
+ * AGENTUI-1: request policy moved OUT of this file into `lib/access/agent-token-policy`, and is
+ * applied here so it binds every caller. These are server actions — public HTTP endpoints — so a
+ * rule enforced only by the mint form binds only the people who use the form. The policy module is
+ * separate because a `"use server"` file may export nothing but async functions, and the form and
+ * this action have to share one lifetime cap.
  */
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export async function mintAgentTokenAction(
   teamSlug: string,
-  input: {
-    memberId: string;
-    onBehalfOf?: string | null;
-    /** null/undefined = unattenuated (spawn default); [] = sees nothing. */
-    projectScope?: string[] | null;
-    name?: string;
-    expiresAt?: string | null;
-  }
+  input: MintRequest
 ): Promise<MintResult> {
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
-  if (!UUID_RE.test(input.memberId)) return { ok: false, error: "memberId must be a member uuid" };
-  if (input.onBehalfOf != null && !UUID_RE.test(input.onBehalfOf)) {
-    return { ok: false, error: "onBehalfOf must be a member uuid" };
+
+  const policy = validateMintRequest(input, Date.now());
+  if (!policy.ok) return { ok: false, error: policy.error };
+
+  // SCOPE ⊆ WHAT THE ADMIN CAN SEE **AND** WHAT THE LAUNCHER CAN SEE. Two different properties,
+  // and Codex's diff review was right that checking only the first is not enough:
+  //   · the ADMIN check is authorization — you cannot grant reach you do not have yourself;
+  //   · the LAUNCHER check is meaning — the token reads AS that member, so a project they cannot
+  //     see would mint a scope that silently grants nothing (the oracle intersects live).
+  // They differ whenever the admin mints for someone else, which is the normal case. Fail-closed:
+  // a substrate error yields an empty set, so a scoped mint is refused rather than waved through.
+  // NOT race-free by construction — visibility can change between this read and the insert. That is
+  // acceptable because it is not the enforcement boundary: the oracle re-derives visibility on every
+  // request, so a stale grant here can only ever be narrower in effect, never wider.
+  if (input.projectScope != null) {
+    const db = adminClient();
+    const [adminVisible, launcherVisible] = await Promise.all([
+      visibleProjectRows(db, { teamId: ctx.teamId, memberId: ctx.memberId }),
+      visibleProjectRows(db, { teamId: ctx.teamId, memberId: input.memberId }),
+    ]);
+    if (input.projectScope.some((id) => !adminVisible.ids.has(id))) {
+      return { ok: false, error: "projectScope names project(s) you cannot see" };
+    }
+    if (input.projectScope.some((id) => !launcherVisible.ids.has(id))) {
+      return { ok: false, error: "projectScope names project(s) the launching member cannot see" };
+    }
   }
-  if (input.projectScope != null && input.projectScope.some((p) => !UUID_RE.test(p))) {
-    return { ok: false, error: "projectScope must contain project uuids" };
-  }
-  if (input.expiresAt != null && Number.isNaN(Date.parse(input.expiresAt))) {
-    return { ok: false, error: "expiresAt must be an ISO timestamp" };
-  }
-  return mintAgentToken(
+
+  const result = await mintAgentToken(
     adminClient(),
     ctx.teamId,
     {
       memberId: input.memberId,
-      onBehalfOf: input.onBehalfOf ?? null,
+      // Refused by policy above; passed as null so the shape stays explicit at the writer.
+      onBehalfOf: null,
       projectScope: input.projectScope ?? null,
       name: input.name?.slice(0, 200),
       expiresAt: input.expiresAt ?? null,
     },
     ctx.memberId
   );
+  // The list is server-rendered; without this it still shows the pre-mint state.
+  if (result.ok) revalidateAgents(teamSlug);
+  return result;
 }
 
 export async function revokeAgentTokenAction(
@@ -57,5 +97,7 @@ export async function revokeAgentTokenAction(
   const ctx = await requireAdmin(teamSlug);
   if (!ctx) return { ok: false, error: "admins only" };
   if (!UUID_RE.test(tokenRowId)) return { ok: false, error: "tokenRowId must be a uuid" };
-  return revokeAgentToken(adminClient(), ctx.teamId, tokenRowId, ctx.memberId);
+  const result = await revokeAgentToken(adminClient(), ctx.teamId, tokenRowId, ctx.memberId);
+  if (result.ok) revalidateAgents(teamSlug);
+  return result;
 }

--- a/app/t/[team]/admin/agents/page.tsx
+++ b/app/t/[team]/admin/agents/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { adminClient } from "@/lib/db/admin";
+import { requireTeamAdmin } from "@/lib/auth/guard";
+import { visibleProjectRows } from "@/lib/access/enforce";
+import { MintAgentToken, RevokeAgentTokenButton } from "@/components/admin/mint-agent-token";
+import { fmtDate, timeAgo } from "@/components/format";
+
+export const metadata: Metadata = { title: "Agents" };
+
+/**
+ * Admin → Agents (AGENTUI-1): mint / list / revoke delegated agent tokens.
+ *
+ * GATING: this page calls `requireTeamAdmin` ITSELF rather than leaning on the admin layout. Next's
+ * own guidance is that a layout check does not prevent a nested segment from running or from
+ * entering the RSC payload, and there is no RLS behind it (CLAUDE.md §5) — so the layout is defence
+ * in depth, not the control. `teamId` is taken from the gate's result, never from the slug.
+ *
+ * PROJECT READ: the picker is gated by `visibleProjectRows` (ENFB-2), not a raw team-wide select.
+ * Being an admin is authority to MANAGE, not a bypass of the access chain. The matching PROPERTY —
+ * an admin cannot scope a token to a project they cannot themselves see — is enforced in the ACTION
+ * (`mintAgentTokenAction`), not here: this picker only decides what is easy to choose.
+ * Fail-closed: on a substrate error the helper returns an empty set, so the picker offers nothing
+ * rather than everything.
+ *
+ * The select list deliberately EXCLUDES `token_hash`. The page has no use for it, and a server
+ * component holding hash material is one prop-pass from serializing it to the browser. (The keys
+ * page this is modelled on selects `key_id`, not `key_hash` — same discipline.)
+ */
+
+type TokenRow = {
+  id: string;
+  name: string;
+  member_id: string;
+  on_behalf_of: string | null;
+  project_scope: string[] | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+};
+
+/** `null` = inherit the launcher's projects · `[]` = sees nothing · array = restricted. */
+function describeScope(scope: string[] | null, names: Map<string, string>): string {
+  if (scope === null) return "inherits launcher";
+  if (scope.length === 0) return "sees nothing";
+  return scope.map((id) => names.get(id) ?? id.slice(0, 8)).join(", ");
+}
+
+export default async function AgentsAdminPage({ params }: { params: Promise<{ team: string }> }) {
+  const { team: teamSlug } = await params;
+
+  const ctx = await requireTeamAdmin(teamSlug);
+  if (!ctx) notFound();
+
+  const db = adminClient();
+  const visible = await visibleProjectRows(db, { teamId: ctx.teamId, memberId: ctx.memberId });
+
+  const [{ data: tokens }, { data: members }, { data: projects }] = await Promise.all([
+    db
+      .from("agent_tokens")
+      .select("id, name, member_id, on_behalf_of, project_scope, expires_at, last_used_at, revoked_at")
+      .eq("team_id", ctx.teamId)
+      .order("created_at", { ascending: false }),
+    // Resolved separately, not via an embedded `members(...)` select: the pg adapter has no
+    // `agent_tokens` relationship and the table has TWO member legs, so the embedded form fails.
+    db.from("members").select("id, display_name, actor_handle").eq("team_id", ctx.teamId).order("display_name"),
+    visible.ids.size > 0
+      ? db.from("projects").select("id, name, slug").eq("team_id", ctx.teamId).in("id", [...visible.ids]).order("name")
+      : Promise.resolve({ data: [] as { id: string; name: string; slug: string }[] }),
+  ]);
+
+  const memberList = (members ?? []) as { id: string; display_name: string; actor_handle: string }[];
+  const projectList = (projects ?? []) as { id: string; name: string; slug: string }[];
+  const memberNames = new Map(memberList.map((m) => [m.id, m.display_name]));
+  const projectNames = new Map(projectList.map((p) => [p.id, p.name || p.slug]));
+  const rows = (tokens ?? []) as TokenRow[];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="max-w-3xl text-sm text-ink-secondary">
+          <p>
+            Delegated tokens let an agent read the brain <em>as</em> a member, narrowed to chosen
+            projects and an expiry date. Unlike an API key, a delegated token creates no chat threads
+            — so agent queries stay out of that member&apos;s Query tab. Secrets are hashed at rest and
+            shown exactly once.
+          </p>
+          <p className="mt-2 text-ink-tertiary">
+            <strong className="text-ink-secondary">Read-only today.</strong> Delegated tokens work for{" "}
+            <code>aios query</code> and item reads. They are <em>not</em> accepted for writes, so{" "}
+            <code>aios push</code> with one returns 401 — an agent that pushes still needs its own API
+            key. Queries also count against the launching member&apos;s daily quota, so prefer minting
+            against a dedicated agent member rather than your own account.
+          </p>
+        </div>
+        <MintAgentToken teamSlug={teamSlug} members={memberList} projects={projectList} />
+      </div>
+
+      <div className="prism-card overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border-subtle text-left text-xs uppercase tracking-wide text-ink-tertiary">
+              <th className="px-4 py-3">Name</th>
+              <th className="px-4 py-3">Acts as</th>
+              <th className="px-4 py-3">Projects</th>
+              <th className="px-4 py-3">Expires</th>
+              <th className="px-4 py-3">Last used</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((t) => {
+              return (
+                <tr key={t.id} className="border-b border-border-subtle last:border-0">
+                  <td className="px-4 py-3 text-ink">{t.name || "—"}</td>
+                  <td className="px-4 py-3 text-ink-secondary">
+                    {memberNames.get(t.member_id) ?? "—"}
+                    {t.on_behalf_of ? ` → ${memberNames.get(t.on_behalf_of) ?? "?"}` : ""}
+                  </td>
+                  <td className="px-4 py-3 text-ink-secondary">
+                    {describeScope(t.project_scope, projectNames)}
+                  </td>
+                  <td className="px-4 py-3 text-ink-tertiary">
+                    {/* fmtDate, NOT timeAgo: timeAgo computes `Date.now() - then`, so a FUTURE date
+                        yields negative seconds and falls into its `secs < 60` branch — every live
+                        token would read "just now". Caught in review after an earlier version of
+                        this file claimed the opposite. */}
+                    {t.expires_at ? fmtDate(t.expires_at) : "never"}
+                  </td>
+                  <td className="px-4 py-3 text-ink-tertiary">
+                    {t.last_used_at ? timeAgo(t.last_used_at) : "never"}
+                  </td>
+                  <td className="px-4 py-3 text-xs">
+                    {/* No render-time clock read: React's purity rule forbids it, and evading the
+                        rule via a helper that calls Date.now() internally would be evasion. So this
+                        column reports only what is stored — revoked or not. Whether a token has
+                        LAPSED is read off the Expires column's absolute date, which is honest about
+                        requiring the reader to know today's date; claiming more than that is what
+                        the earlier version got wrong. */}
+                    {t.revoked_at ? (
+                      <span className="text-red-600">revoked</span>
+                    ) : (
+                      <span className="text-emerald-600">active</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {!t.revoked_at && <RevokeAgentTokenButton teamSlug={teamSlug} tokenRowId={t.id} />}
+                  </td>
+                </tr>
+              );
+            })}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-ink-tertiary">
+                  No agent tokens yet. Mint one to give an agent read access without handing over a
+                  member API key.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/admin-tabs.tsx
+++ b/components/admin/admin-tabs.tsx
@@ -9,6 +9,7 @@ const TABS = [
   { slug: "data", label: "Data" },
   { slug: "usage", label: "Usage" },
   { slug: "keys", label: "API keys" },
+  { slug: "agents", label: "Agents" },
   { slug: "integrations", label: "Integrations" },
   { slug: "pm-sync", label: "PM sync" },
   { slug: "policies", label: "Policies" },

--- a/components/admin/mint-agent-token.tsx
+++ b/components/admin/mint-agent-token.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Bot, Copy, Check } from "lucide-react";
+import { mintAgentTokenAction, revokeAgentTokenAction } from "@/app/t/[team]/admin/agents/actions";
+import {
+  DEFAULT_TOKEN_LIFETIME_DAYS,
+  MAX_TOKEN_LIFETIME_MS,
+  MAX_PROJECT_SCOPE,
+  canSubmitMint,
+  expiryInstantFor,
+  type ScopeChoice,
+} from "@/lib/access/agent-token-policy";
+
+type MemberOpt = { id: string; display_name: string; actor_handle: string };
+type ProjectOpt = { id: string; name: string; slug: string };
+
+/**
+ * AGENTUI-1 mint form.
+ *
+ * The rules below are ALSO enforced in `lib/access/agent-token-policy`, which the server action
+ * applies — this component makes the legal choices easy, it does not make them binding. That split
+ * is deliberate: a server action is a public endpoint, so a constraint that lives only here binds
+ * only people who use this page.
+ *
+ * SCOPE HAS NO DEFAULT. `null` (inherit) and a populated array are both legal, and they differ
+ * enormously in blast radius, so the admin must SAY which. An untouched control yields no
+ * submittable payload at all — never a silent `null` (which would inherit everything) and never a
+ * silent `[]` (which mints a token that reads nothing).
+ *
+ * The secret is rendered in a `<code>`, never an `<input>`: an input invites password-manager and
+ * autofill capture. It is held in state only until dismissed, and is never attached to an error —
+ * the admin error boundary reports to Sentry.
+ */
+
+function defaultExpiryValue(): string {
+  const d = new Date(Date.now() + DEFAULT_TOKEN_LIFETIME_DAYS * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+function maxExpiryValue(): string {
+  return new Date(Date.now() + MAX_TOKEN_LIFETIME_MS).toISOString().slice(0, 10);
+}
+
+function minExpiryValue(): string {
+  return new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+}
+
+/** The show-once reveal. Split out so `MintAgentToken` stays under the complexity ceiling and so
+ *  the secret's handling lives in one small, readable place. */
+function MintedPanel({
+  token,
+  onDone,
+}: {
+  token: string;
+  onDone: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState<string | null>(null);
+
+  return (
+    <div className="prism-card flex max-w-xl flex-col gap-3 border border-violet/40 p-4">
+      <p className="text-sm font-medium text-ink">
+        Token minted — copy it now. It is shown exactly once; only its hash is stored.
+      </p>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 overflow-x-auto rounded-lg bg-surface-overlay px-3 py-2 font-mono text-xs text-ink">
+          {token}
+        </code>
+        <button
+          onClick={() => {
+            // A rejection (no permission / insecure context) must not become an unhandled rejection
+            // with no feedback. The token stays on screen for manual copy either way.
+            navigator.clipboard.writeText(token).then(
+              () => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              },
+              () => setCopyError("Couldn't copy — select the token above and copy it manually.")
+            );
+          }}
+          className="rounded-lg border border-border-default p-2 text-ink-secondary hover:text-ink"
+          aria-label="Copy token"
+        >
+          {copied ? <Check className="size-4 text-violet" /> : <Copy className="size-4" />}
+        </button>
+      </div>
+      {copyError && <p className="text-xs text-red-600">{copyError}</p>}
+      <p className="text-xs text-ink-tertiary">
+        Set it as <code>AIOS_API_KEY</code> for the agent. Reads only — <code>aios push</code> with
+        this token returns 401.
+      </p>
+      <button onClick={onDone} className="self-start rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white">
+        Done — I copied it
+      </button>
+    </div>
+  );
+}
+
+export function MintAgentToken({
+  teamSlug,
+  members,
+  projects,
+}: {
+  teamSlug: string;
+  members: MemberOpt[];
+  projects: ProjectOpt[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [minted, setMinted] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const [memberId, setMemberId] = useState("");
+  const [name, setName] = useState("");
+  const [expiry, setExpiry] = useState(defaultExpiryValue);
+  const [scope, setScope] = useState<ScopeChoice>(null);
+  // Date bounds read the clock. A lazy `useState` initializer still runs during the FIRST render —
+  // so this is not "no clock read during render", it is "read once, then stable", which is what
+  // keeps re-renders pure. Stated accurately because an earlier comment overclaimed it. A server/
+  // client boundary crossing midnight UTC can therefore differ by a day; harmless, because the
+  // ACTION re-checks and clamps both bounds, so a stale bound can never widen what is minted.
+  const [expiryBounds] = useState(() => ({ min: minExpiryValue(), max: maxExpiryValue() }));
+
+  // The rule itself lives in the policy module so it is unit-testable without a DOM harness, and so
+  // the "untouched scope must not submit" hazard is pinned by an assertion rather than by this JSX.
+  const scopeChosen = canSubmitMint({ memberId: memberId || "x", expiry: expiry || "x", scope });
+  const canSubmit = canSubmitMint({ memberId, expiry, scope }) && !pending;
+
+  if (minted) {
+    return (
+      <MintedPanel
+        token={minted}
+        onDone={() => {
+          setMinted(null);
+          setOpen(false);
+          setScope(null);
+          setMemberId("");
+          setName("");
+          setExpiry(defaultExpiryValue());
+        }}
+      />
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="flex shrink-0 items-center gap-2 rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white"
+      >
+        <Bot className="size-4" /> Mint agent token
+      </button>
+    );
+  }
+
+  return (
+    <div className="prism-card flex w-full max-w-xl flex-col gap-3 p-4">
+      <label className="flex flex-col gap-1 text-xs text-ink-secondary">
+        Acts as
+        <select
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="rounded-lg border border-border-default bg-surface-card px-3 py-2 text-sm text-ink"
+        >
+          <option value="">Choose a member…</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.display_name} ({m.actor_handle})
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-ink-secondary">
+        Label
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. status-check agent"
+          className="rounded-lg border border-border-default bg-surface-card px-3 py-2 text-sm text-ink"
+        />
+      </label>
+
+      <fieldset className="flex flex-col gap-2 text-xs text-ink-secondary">
+        <legend className="mb-1">Projects this token can read</legend>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="scope"
+            checked={scope?.kind === "inherit"}
+            onChange={() => setScope({ kind: "inherit" })}
+          />
+          <span>Everything the member can see (inherits their access as it changes)</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="scope"
+            checked={scope?.kind === "restrict"}
+            onChange={() => setScope({ kind: "restrict", projectIds: [] })}
+          />
+          <span>Only the projects I choose</span>
+        </label>
+        {scope?.kind === "restrict" && (
+          <div className="ml-6 flex max-h-40 flex-col gap-1 overflow-y-auto">
+            {projects.length === 0 && (
+              <span className="text-ink-tertiary">
+                No projects available — choose the option above, or try again once projects load.
+              </span>
+            )}
+            {projects.map((p) => (
+              <label key={p.id} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={scope.projectIds.includes(p.id)}
+                  disabled={!scope.projectIds.includes(p.id) && scope.projectIds.length >= MAX_PROJECT_SCOPE}
+                  onChange={(e) =>
+                    setScope({
+                      kind: "restrict",
+                      // Capped here too: the action refuses more than MAX_PROJECT_SCOPE, and the
+                      // form must not be able to compose a request the action will reject.
+                      projectIds: e.target.checked
+                        ? [...scope.projectIds, p.id].slice(0, MAX_PROJECT_SCOPE)
+                        : scope.projectIds.filter((id) => id !== p.id),
+                    })
+                  }
+                />
+                <span>{p.name || p.slug}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </fieldset>
+
+      <label className="flex flex-col gap-1 text-xs text-ink-secondary">
+        Expires (required, max {Math.round(MAX_TOKEN_LIFETIME_MS / 86_400_000)} days)
+        <input
+          type="date"
+          value={expiry}
+          min={expiryBounds.min}
+          max={expiryBounds.max}
+          onChange={(e) => setExpiry(e.target.value)}
+          className="rounded-lg border border-border-default bg-surface-card px-3 py-2 text-sm text-ink"
+        />
+      </label>
+
+      {error && <p className="text-xs text-red-600">{error}</p>}
+
+      <div className="flex items-center gap-2">
+        <button
+          disabled={!canSubmit}
+          onClick={() =>
+            startTransition(async () => {
+              setError(null);
+              const res = await mintAgentTokenAction(teamSlug, {
+                memberId,
+                name,
+                // End of the chosen day, CLAMPED to the cap — picking the max offered date used to
+                // submit an instant ~12h past the exact 365-day limit, which the action then refused.
+                expiresAt: expiryInstantFor(expiry, Date.now()),
+                projectScope: scope?.kind === "restrict" ? scope.projectIds : null,
+              });
+              // Deliberately does NOT include res.token in any error path.
+              if (!res.ok || !res.token) {
+                setError(res.error || "mint failed");
+                return;
+              }
+              setMinted(res.token);
+            })
+          }
+          className="rounded-lg bg-violet px-4 py-2 text-sm font-medium text-white disabled:opacity-40"
+        >
+          {pending ? "Minting…" : "Mint token"}
+        </button>
+        <button
+          onClick={() => { setOpen(false); setError(null); }}
+          className="rounded-lg border border-border-default px-4 py-2 text-sm text-ink-secondary"
+        >
+          Cancel
+        </button>
+        {!scopeChosen && (
+          <span className="text-xs text-ink-tertiary">Choose what this token can read to continue.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function RevokeAgentTokenButton({
+  teamSlug,
+  tokenRowId,
+}: {
+  teamSlug: string;
+  tokenRowId: string;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      {/* Surfaced, not swallowed: a revoke that silently fails leaves a live credential looking dead. */}
+      {error && <span className="text-xs text-red-600">{error}</span>}
+      <button
+        disabled={pending}
+        onClick={() =>
+          startTransition(async () => {
+            setError(null);
+            const res = await revokeAgentTokenAction(teamSlug, tokenRowId);
+            if (!res.ok) setError(res.error || "revoke failed");
+          })
+        }
+        className="text-xs text-ink-tertiary hover:text-red-600 disabled:opacity-40"
+      >
+        {pending ? "Revoking…" : "Revoke"}
+      </button>
+    </span>
+  );
+}

--- a/docs/design/agent-tokens-admin-ui-v1.md
+++ b/docs/design/agent-tokens-admin-ui-v1.md
@@ -1,0 +1,341 @@
+---
+eval_tier: deterministic
+spec_gate: block
+safety: false
+type: issue-spec
+---
+
+# Admin → Agents — the surface that makes delegated tokens usable
+
+## What / why
+
+Delegated agent tokens are built, tested and enforced, and **no human can create one**.
+
+`lib/access/agent-tokens.ts` mints, hashes, verifies and revokes them; `lib/access/enforce.ts`
+attenuates every delegated read through a live triple intersection; `app/api/v1/query/route.ts` and
+`app/api/v1/items/route.ts` honor them; `app/t/[team]/admin/agents/actions.ts` exposes admin-gated
+`mintAgentTokenAction` / `revokeAgentTokenAction` server actions. What is missing is the page that
+calls them: that directory contains `actions.ts` and **no `page.tsx`**, nothing else in `app/`
+imports either action, no API route mints one, and **prod has 0 tokens ever minted**
+(`select count(*) from agent_tokens` → 0, measured read-only 2026-08-22).
+
+This is the same failure the Skills catalog had — a working, deployed capability with no way in.
+
+The motivating case: agent `aios query` traffic is written into the launching member's dashboard
+Query tab, because `/api/v1/query` creates a conversation for any member-scoped key. A delegated
+principal is **conversation-stateless** on that route and creates no conversation at all, so the
+noise disappears at the source.
+
+**"Stateless" means conversations ONLY, and an earlier draft overstated it.** A delegated request
+still writes: `last_used_at` plus an audit event at authentication (`lib/api/auth.ts`), a `query_log`
+row before streaming and an update on completion, and cost metering via `recordLlmUsage`
+(`app/api/v1/query/route.ts`). It also CONSUMES quota — the 10/min and 20/day buckets key on the
+LAUNCHING member (`route.ts:47`), so a token minted against a human member burns that human's daily
+allowance and can lock them out of their own dashboard. The page must therefore steer admins toward
+minting against a dedicated agent member row rather than against themselves, and say why. That is why the provenance-column alternative (`docs/design/query-provenance-v1.md`,
+QPROV-1) was declined after review: it filtered a symptom that two documented API calls could
+reproduce.
+
+**Measured constraint this page must state, because it decides whether a token is usable at all:
+delegated tokens are READ-ONLY today.** `GET /api/v1/items` honors them
+(`app/api/v1/items/route.ts:204` — "this is the ONE route that honors delegated agent tokens") and
+so does `/api/v1/query`, but `POST /api/v1/items` authenticates with `authenticateApiKey` only, so
+`aios push` presented with an `aiosd_` token gets 401. A query-only agent can switch today; an agent
+that also pushes cannot.
+
+**The CLI needs no change for reads.** It treats the credential as an opaque string and sends
+`Authorization: Bearer ${apiKey}`; there is no key-format validation anywhere in it. So the whole
+adoption step is: paste an `aiosd_` token where `AIOS_API_KEY` goes.
+
+## Outcomes
+
+- An admin can mint a delegated token from the dashboard and copy it once.
+- The page states the read-only limitation where it is read, not in a doc nobody opens.
+- Existing tokens are listable with their launcher, scope, expiry and last-used, and revocable.
+- A minted token immediately works for `aios query` with no CLI change — while the page states
+  plainly that the SAME agent's `aios push` will 401, so nobody swaps one credential and finds out
+  by breaking their ticket flow.
+- The page is REACHABLE — it appears in the admin tab bar, not only by typing the URL.
+
+## Interface / integration points
+
+- `app/t/[team]/admin/agents/actions.ts` — `mintAgentTokenAction(teamSlug, {memberId, onBehalfOf,
+  projectScope, name, expiresAt})` and `revokeAgentTokenAction(teamSlug, tokenRowId)`. Both already
+  call `requireAdmin`, validate UUID shape, and return `MintResult`. This slice adds a caller, and
+  changes neither.
+- `lib/access/agent-tokens.ts` — the single writer for `agent_tokens` (pinned by
+  `test/guards/access-single-writer.test.ts`). `MintResult.token` is returned exactly once and never
+  stored or logged; the page must honour that and not persist it.
+- `app/t/[team]/admin/keys/page.tsx` — the pattern this follows exactly: a server component that
+  lists credentials with a mint form and a revoke button.
+- `components/admin/issue-key.tsx` — `IssueKey` / `RevokeKeyButton`, the show-once + revoke client
+  components whose interaction shape is mirrored.
+- `components/admin/admin-tabs.tsx` — the `TABS` array (line 6). A new admin page that is not added
+  here is unreachable; `admin/access` is already in exactly that state and is NOT fixed by this
+  slice.
+- `app/t/[team]/admin/layout.tsx` — the admin shell, which already gates on `canAccessAdmin`.
+- `postgres/schema.sql` — `agent_tokens` already exists with every column this page reads
+  (`member_id, on_behalf_of, project_scope, name, expires_at, last_used_at, revoked_at`). **No
+  schema change, no migration.**
+- `components/format.ts` — `timeAgo`, used by the keys page for the same columns.
+- `lib/db/pg/relationships.ts` — the adapter's embedded-select relationship map. It has **no
+  `agent_tokens` entry**, and the table has TWO distinct member legs (`member_id`, `on_behalf_of`),
+  so the keys page's `members(...)` embedded select CANNOT be copied verbatim — it would fail at
+  runtime. The page resolves display names with a separate, team-scoped `members` read and joins in
+  memory. Found while scoping; this is the one place the "thin copy of the keys page" framing breaks.
+
+## New files to create
+
+Every path below is created by this slice; none exists yet.
+
+- new file: `app/t/[team]/admin/agents/page.tsx` — the server component: list + mint form.
+- new file: `components/admin/mint-agent-token.tsx` — the client component (form, show-once panel,
+  revoke button).
+- new file: `test/guards/admin-tabs-reachability.test.ts` — unit tier, the reachability pin.
+- new file: `test/datamechanics/agent-token-admin.datamechanics.test.ts` — real-Postgres tier, the
+  mint/revoke outcomes through the actions' own module boundary.
+
+## Contracts, named before implementation
+
+The page is a thin caller; the contract it must not break is the one the actions already define.
+
+```ts
+// Rendered per row. Read from agent_tokens, joined to members for display names.
+// NOTE: `token_hash` is deliberately absent — the page must not select it. The keys page it copies
+// selects `key_id`, not `key_hash`; an earlier draft of this spec deviated from that for a test's
+// convenience, which would have put hash material one careless prop-pass from the RSC payload.
+type AgentTokenRow = {
+  id: string;
+  name: string;
+  launcher: string;            // members.display_name for member_id
+  actingAs: string | null;     // members.display_name for on_behalf_of, null = self
+  scope: { kind: "inherit" } | { kind: "none" } | { kind: "restrict"; projectNames: string[] };
+  // Rendered as NAMES, not a count: an admin auditing a token must be able to see what it grants
+  // without dropping to SQL. `none` (the `[]` case) is rendered distinctly from `inherit`.
+  expiresAt: string | null;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+};
+```
+
+**`project_scope` has three states and the UI must not collapse them** — `null` is unattenuated
+(inherits the launcher's projects), `[]` sees NOTHING, and a populated array is a real scope.
+
+**The form must never DERIVE which of the three from an untouched control.** An earlier draft said
+"send `null` when nothing is picked", which is the fail-OPEN direction and both reviewers flagged it:
+the two failure modes are not symmetric. A `[]` token fails loud and closed — the agent reads
+nothing and someone notices in minutes. A `null` token minted because an admin meant to scope and
+forgot fails silent and open: it works everywhere, which looks exactly like success. So the form
+presents an EXPLICIT choice and has no default:
+
+```ts
+type ScopeChoice =
+  | { kind: "inherit" }                    // → projectScope: null, chosen deliberately
+  | { kind: "restrict"; projectIds: string[] };  // → projectScope: array, ≥1 required
+
+// Submit is DISABLED until a ScopeChoice exists. If the project list fails to load, the "restrict"
+// branch is unavailable but an EXPLICITLY confirmed "inherit" still mints: blocking every mint on a
+// transient read failure pushes an operator toward an ordinary API key, which is strictly worse
+// (write authority AND conversation persistence). Fail-closed applies to UNTOUCHED input, not to a
+// deliberate choice that needs no project list.
+```
+
+**Expiry is REQUIRED, bounded, and defaulted.** `mintAgentToken` stores `args.expiresAt ?? null`
+and a null expiry never expires (`lib/access/agent-tokens.ts:103`), while the action validates only
+that the string parses — so a past date mints an already-dead token. The form therefore: defaults to
+**90 days**, caps at **365**, refuses a past date, and does not offer "never".
+
+**`on_behalf_of` is NOT exposed in v1.** The action accepts it and the enforcement is sound (both
+legs intersect live), but it is impersonation-shaped: a delegated query answers in the represented
+person's first-person identity while quota, cost and audit attribute to the launcher, and there is
+no owner→agent authorization or represented-person consent model anywhere in the system. Shipping a
+dropdown for it would create that policy by accident. The mint form is self-only; the list still
+renders `actingAs` so a token minted by any other path is visible rather than hidden.
+
+### The server boundary — where the rules actually live
+
+`app/t/[team]/admin/agents/actions.ts` already validates shape (UUIDs, parseable date) in exactly
+this style; these are three more checks in the same file, applied to every caller:
+
+```ts
+// mintAgentTokenAction, after the existing UUID checks:
+if (input.onBehalfOf != null) return { ok: false, error: "acting-as is not available" };
+// ^ v1 mints self-only. Rejected server-side rather than merely omitted from the form, because
+//   "the UI doesn't offer it" is not a constraint on an HTTP endpoint.
+
+if (!input.expiresAt) return { ok: false, error: "expiresAt is required" };
+// ^ mintAgentToken stores `expiresAt ?? null` and a null expiry NEVER expires
+//   (lib/access/agent-tokens.ts). Absent must be refused, not defaulted silently.
+
+const ms = Date.parse(input.expiresAt);
+if (ms <= Date.now()) return { ok: false, error: "expiresAt must be in the future" };
+if (ms > Date.now() + MAX_TOKEN_LIFETIME_MS) return { ok: false, error: "expiresAt is beyond the 365-day maximum" };
+
+if (input.projectScope != null && input.projectScope.length === 0) {
+  return { ok: false, error: "projectScope must name at least one project, or be omitted to inherit" };
+}
+// ^ `[]` means "sees nothing" — a legal DB state, but never a legal REQUEST: it is only ever
+//   reachable by an empty multi-select, i.e. an accident. `null` (inherit) stays legal and explicit.
+```
+
+`MAX_TOKEN_LIFETIME_MS` is exported so the form and the action cannot disagree about the cap — one
+constant, two readers. The form's job is unchanged; it now simply cannot ask for something the action
+would refuse.
+
+## Dependencies
+
+Depends on: none. The token core, the actions, the table and the enforcement all shipped with PCCA
+Phase A. No AIOS CLI change is required for the read paths.
+
+## Scope
+
+**This is one reviewable PR.** One admin page, one client component, one tab entry, two tests. No
+schema change, no API route, no change to any existing enforcement path.
+
+**In:**
+
+- `app/t/[team]/admin/agents/page.tsx` listing the team's tokens and offering the mint form.
+- `components/admin/mint-agent-token.tsx` with the show-once reveal and copy.
+- `agents` added to `TABS` in `components/admin/admin-tabs.tsx`.
+- The read-only limitation stated on the page itself.
+- Tests: a reachability guard and a real-Postgres mint/revoke outcome test.
+
+**Deferred** (each its own issue, none blocking):
+
+- Extending delegated tokens to WRITE routes (`POST /api/v1/items`), which is what a push-capable
+  agent would need. A real limit, deliberately not widened here: widening an auth surface is its own
+  slice with its own review.
+- An `admin/access` page for groups and project grants — the sibling orphan found while scoping.
+- A per-member "my agents" view; this is admin-only, matching the actions' own gate.
+- Creating dedicated agent member rows from the admin UI, which is the prerequisite for the
+  quota-isolation advice above to be actionable at all.
+- Exposing `on_behalf_of` in the mint form. Deferred because it needs an owner→agent authorization
+  model and represented-person consent that do not exist anywhere yet — one reviewer declined the
+  whole slice over precisely this, and omitting the control from v1 is what makes building the rest
+  safe rather than deciding that policy by accident.
+- Any CLI change. None is needed for reads, and the write gap is the deferred item above.
+
+**Fenced out:** this slice raises one blanket constraint — **no change to
+`lib/access/agent-tokens.ts` or to any route that honors a delegated token.** The mint/hash/verify
+core and the enforcement paths are reviewed and tested; a UI slice must not edit them.
+
+**The fence deliberately does NOT cover `app/t/[team]/admin/agents/actions.ts`, and an earlier draft
+that fenced it out was wrong.** Round 2 of the spec review put it plainly: with the action excluded,
+every safety property in this spec lived only in a React form — and a server action is a public HTTP
+endpoint, so the form is a suggestion, not a boundary. `mintAgentTokenAction` would still have
+accepted `onBehalfOf`, a null (never-expiring) expiry, and any scope, from any caller who skipped the
+page. That is the "spec ruling silently unimplemented" failure by name. The rules therefore go where
+they hold: in the action, with the form as the ergonomic front end that makes the legal choices easy.
+
+What the fence still pushes out: the write-route gap (`POST /api/v1/items`) → its own slice; changes
+to scope SEMANTICS or to how a token is verified → out of scope entirely, this slice only constrains
+what may be REQUESTED, never what an existing token can do.
+
+## Acceptance criteria
+
+Each is independently satisfiable; none constrains a file another one requires changing.
+
+### Automated
+
+- `npm test` exits 0, including new `test/guards/admin-tabs-reachability.test.ts`, which pins BOTH
+  directions, because the page→tab direction alone is blind to the failure that motivated this slice:
+  (a) every admin directory with a `page.tsx` has a `TABS` entry, and (b) every admin directory with
+  an `actions.ts` has a caller — an orphaned capability is the actual repeated bug (Skills catalog,
+  `admin/agents` itself, `admin/access`). Direction (b) carries an explicit allowlist containing
+  the known orphans ONLY, so that debt is documented rather than invisible and a NEW orphan fails the
+  build. An earlier draft asserted only (a) and would not have caught its own motivating case.
+- `npm run test:datamechanics` exits 0 for coverage of the SERVER boundary in
+  `app/t/[team]/admin/agents/actions.ts`, calling the action directly (not through the form) and
+  asserting each refusal writes NO row: `onBehalfOf` set → refused; `expiresAt` absent → refused;
+  `expiresAt` in the past → refused; `expiresAt` beyond 365 days → refused; `projectScope: []` →
+  refused; and the legal cases (`projectScope: null`, and a populated array with a valid future
+  expiry) → accepted. These are the fail-open directions: each asserts the request is REJECTED, so a
+  removed check reddens rather than silently widening what can be minted.
+- `npm run db:test:up && npm run test:datamechanics` exits 0, including new
+  `test/datamechanics/agent-token-admin.datamechanics.test.ts`, which asserts against real Postgres:
+  minting writes exactly one `agent_tokens` row whose `token_hash` is not the returned token;
+  `project_scope` persists as NULL when no restriction is sent, and a populated array persists as
+  that array — an empty array is REFUSED by policy and therefore never written, so an earlier
+  draft's "persists as `{}`" asked for a row the design deliberately makes unreachable; a scope
+  naming a project the admin cannot see is refused AND writes no row; a revoked token sets
+  `revoked_at` and `verifyAgentToken` then returns null; and a non-admin caller mints nothing.
+- `npm test` exits 0, including unit coverage of the form's scope+expiry contract: an untouched
+  scope control yields NO submittable payload (not `null`, not `[]`); choosing "inherit" yields
+  `projectScope: null`; choosing "restrict" with zero projects is not submittable; the expiry
+  default is 90 days; a past expiry is refused; and there is no "never" option. These are the
+  fail-open directions both spec reviewers flagged, so each is asserted in the direction that would
+  silently mint an over-privileged credential.
+- `npx tsc --noEmit` is clean and `npm run lint` exits 0.
+- `npm test` exits 0 for a regression test asserting the page's `agent_tokens` select list does NOT
+  include `token_hash`, and that mint and revoke both call `revalidatePath` — the agents actions
+  currently have ZERO such calls while the keys actions have TWO (`app/t/[team]/admin/actions.ts:223`
+  and `:241`), so without it the list renders stale immediately after the action the admin just took.
+  (An earlier draft said "four" — that was a grep count including the import line, corrected here
+  rather than left as a plausible-looking number.)
+- `node scripts/mutate.mjs components/admin/admin-tabs.tsx` reddens the reachability guard when the
+  `agents` TABS entry is removed.
+- `node scripts/mutate.mjs app/t/[team]/admin/agents/actions.ts` reddens the INTENDED test for each
+  server-boundary check removed in turn — the acting-as refusal, the expiry-required refusal, the
+  max-lifetime refusal, and the empty-scope refusal. A check that survives its mutation is
+  decoration, and for this file that means an unenforced credential rule.
+
+### Manual
+
+- `psql "$DATABASE_TEST_URL" -c "select token_hash, project_scope from agent_tokens"` after a mint
+  shows a hash that does not equal the token string shown in the UI.
+
+### Visual
+
+- `/t/<team>/admin/agents` renders in the admin tab bar, lists existing tokens, and after minting
+  shows the token exactly once with a copy control and a warning that it will not be shown again.
+
+## Build-with
+
+Build-with: Fable 5, high effort. Small and UI-shaped, but it is the human interface to a security
+credential: a form that mis-sends `[]` for `null` mints a dead token, and one that logs or re-renders
+the secret breaks the show-once contract the token core is built on.
+
+## Tier safety
+
+Brain surfaces are touched: a new admin page reading `agent_tokens`, and a client component that
+handles a bearer secret.
+
+- **The PAGE must gate itself; the layout is not sufficient.** An earlier draft called this
+  "admin-gated twice" and that was wrong for the list read. Next's own guidance (see
+  `node_modules/next/dist/docs/`, the authentication guide) is explicit that a child page can execute
+  and land in the RSC payload despite a layout check — and with no RLS there is no backstop. So
+  `app/t/[team]/admin/agents/page.tsx` calls the admin gate itself and derives `teamId` from that
+  result, rather than trusting `app/t/[team]/admin/layout.tsx`. The MUTATIONS are separately safe:
+  both actions call the gate independently, which is the authoritative check for mint and revoke.
+- **The secret is show-once.** `MintResult.token` is rendered in component state and never written
+  to the DB, a log, an analytics call, or the URL. The list query selects `token_hash` for the test's
+  benefit only and must never render it.
+- **Team scoping.** Every read filters `team_id`; `agent_tokens` has composite FKs to
+  `members (team_id, id)` for both legs, so a cross-team row cannot exist to be listed.
+- **No widening.** This slice adds no route, no parameter, and no new principal type; it calls two
+  existing admin-gated actions. Enforcement of what a token can SEE is unchanged and remains the
+  oracle's live triple intersection.
+
+## Risk / rollback
+
+- **No schema change.** `agent_tokens` already exists in `postgres/schema.sql` with every column
+  used, so there is no migration, no replay risk, and nothing to undo in the database.
+- **Rollback is deleting the page** and removing one `TABS` entry. Any tokens minted before a
+  revert keep working — they are enforced server-side, independently of this UI — which is the
+  correct behaviour but worth stating: reverting the page does NOT revoke outstanding tokens, and
+  revocation would have to be done in SQL until the page returns.
+- **The irreversible act is minting**, not deploying. A minted token is a live credential until it
+  expires or is revoked; the page mitigates with a REQUIRED 90-day-default expiry (max 365, no
+  "never") and a one-click revoke on every row.
+- **Revocation takes effect on the NEXT request, not in-flight.** Verification happens once at
+  request start (`app/api/v1/query/route.ts`), so a streaming answer already running completes after
+  revoke. The page says so rather than implying a kill switch.
+- **The secret's exposure is wider than "show once" suggests.** Show-once describes BACKEND
+  retrievability — it is never stored or re-servable. It still crosses the wire in the Server Action
+  response, sits in React state until navigation, and is visible in network and React devtools and to
+  browser extensions; copying it puts it in clipboard history. The page therefore must not put it in
+  an `<input>` (autofill/password-manager capture) and must never attach it to an error — the admin
+  error boundary reports to Sentry. These are inherited properties of the pattern being copied, named
+  here rather than discovered later.
+- **Blast radius:** read-only against every existing surface. The one new write is an
+  `agent_tokens` insert through an already-tested single writer.

--- a/docs/design/query-provenance-v1.md
+++ b/docs/design/query-provenance-v1.md
@@ -1,0 +1,317 @@
+---
+eval_tier: deterministic
+spec_gate: block
+safety: false
+type: issue-spec
+status: DECLINED
+---
+
+> # ⛔ DECLINED — do not build this
+>
+> **QPROV-1 (AIO-1052) was declined in spec review on 2026-08-22 and is retained only as the record
+> of why.** Two adversarial rounds established that conversation-creation provenance cannot deliver
+> the property it promises: an agent holding a member-scoped key can `GET /api/v1/conversations`,
+> take a `dashboard` thread's id, and pass it to `POST /api/v1/query` — appending its question to a
+> human thread and bumping it to the top of the list. Two documented API calls defeat the whole
+> design, and the filter added to make it work is what enables the enumeration.
+>
+> The slice that replaced it is **AGENTUI-1** (`docs/design/agent-tokens-admin-ui-v1.md`): a
+> delegated principal is conversation-stateless, so agent traffic creates no threads at all and
+> there is nothing to filter.
+>
+> Everything below is the declined design, left unedited. Do not implement it.
+
+# Query provenance — the Query tab shows what a human typed, not what an agent asked
+
+## What / why
+
+`app/api/v1/query/route.ts` creates a conversation whenever the request's API key is
+member-scoped. `aios query "…"` uses exactly that key, so every query an agent runs from a
+terminal is written into that member's dashboard chat history and rendered by the Query tab as
+though the member had typed it. Nothing distinguishes the two: `conversations` carries no
+provenance at all.
+
+Measured in prod (read-only, 2026-08-22): **62 threads — Chetan 39, John Ellison 20, a third
+member 3**. Chetan's list is visibly dominated by agent close-gate reads — `what is the status of
+AUDITFIX-4`, `what does the AUDITFIX-6 ruling say about sweeps and human curation`, `status of
+task ENFB-3`, `status of task REVOKE-1` — none of which were typed into the dashboard. That is the
+report this slice answers.
+
+**Existing rows cannot be classified retroactively, and the spec does not pretend otherwise.**
+`chat_turn_runs` is written only by the dashboard path (`createRun`, called from
+`app/api/dashboard/query/route.ts`) and would be a perfect discriminator — except it shipped on
+2026-08-16 (#559), so only **4 of the 62** rows have one. Inferring provenance from its absence
+would relabel every pre-08-16 human thread as agent traffic, including all 20 of John's. So the
+backfill value is `unknown`, and `unknown` stays VISIBLE.
+
+## Outcomes
+
+- A member opening the Query tab sees NEWLY created threads only from where they typed them; agent
+  traffic created after this ships never appears. Threads that already exist are unaffected — see
+  the backlog note below, which is a real limit of this slice, not a hidden one.
+- Every conversation created from now on records which channel created it.
+- No existing thread disappears from anyone's history when this ships.
+- Agent queries keep being persisted and keep being attributed for cost — they are hidden from one
+  reading surface, not discarded.
+
+## Interface / integration points
+
+- `postgres/schema.sql` — the `conversations` table (`id, team_id, member_id, title, created_at,
+  updated_at, archived_at`) gains one column; mirrored for from-zero replay.
+- `postgres/migrations/README.md` — the additive-delta convention this follows: editing a
+  `create table if not exists` body is a no-op on a DB that already has the table, so the column
+  must arrive as an `alter table … add column if not exists` migration AND be mirrored into
+  `schema.sql`.
+- `lib/chat/store.ts` — the SOLE writer of `conversations` (pinned by
+  `test/guards/single-writer-chat.test.ts`). `createConversation` gains a required source argument;
+  `listConversations` and `searchConversations` gain a required `visibleTo` argument. The filter is
+  CALLER-SELECTED, never baked into the function — see the contract below for why.
+- `app/api/dashboard/query/route.ts` — the session-authenticated write path (a human typing in the
+  Query tab). Calls `createConversation` at one site.
+- `app/api/v1/query/route.ts` — the API-key write path (`aios query`, and Telegram-via-Hermes).
+  Calls `createConversation` at one site. Delegated `aiosd_` tokens are already stateless here and
+  create nothing, which this slice must not change.
+- `app/api/dashboard/conversations/route.ts` — the Query tab's list/search reader; the surface the
+  report is about.
+- `app/api/v1/conversations/route.ts` — the API's own list reader; passes `visibleTo: "all"` so the
+  CLI/Hermes can still list and resume the threads they created. It calls the SAME
+  `listConversations` as the dashboard, which is why the filter must be a parameter.
+- `lib/api/auth.ts` — `authenticateApiKey` / `authenticateAgentToken` / `isAgentBearer`, which is
+  what makes the two write paths distinguishable at all.
+- `lib/query/turn-runs.ts` — `createRun`, the dashboard-only marker whose ship date (#559) is the
+  evidence that retroactive classification is impossible.
+- `docs/ARCHITECTURE.md` — the Chat-history row (~line 111) states the cross-interface promise this
+  slice narrows; hand-maintained, NOT machine-guarded (see below), so updating it is on us.
+- `docs/CHAT-CLIENTS.md` — states the same promise in its opening paragraph; must be amended.
+- `scripts/check-docs-drift.mjs` — `deriveTables()` (line 50) extracts `create table` NAMES only, and
+  the block's accept regex rejects a dotted `table.column`. So `check:docs` can NOT enforce a new
+  COLUMN, and this spec does not pretend it can — an earlier draft claimed exactly that and the
+  criterion built on it would have enforced nothing.
+
+## New files to create
+
+Every path below is created by this slice; none exists yet.
+
+- new file: `postgres/migrations/20260822120000_conversations_source.sql` — adds the column.
+- new file: `test/datamechanics/conversation-source.datamechanics.test.ts` — real-Postgres tier,
+  persistence + the visibility filter in both directions.
+- new file: `test/guards/conversation-source-writers.test.ts` — unit tier, the writer/reader guard.
+
+## Contracts, named before implementation
+
+```ts
+/** The CHANNEL that created the conversation. Deliberately not a human/agent judgment. */
+export type ConversationSource = "dashboard" | "api" | "unknown";
+
+/** Sources the DASHBOARD Query tab renders. `unknown` is included: pre-migration rows are
+ *  unclassifiable, and hiding them would delete visible history. */
+export const HUMAN_VISIBLE_SOURCES: readonly ConversationSource[] = ["dashboard", "unknown"];
+
+/** WHICH reader wants which set. Required, no default — a new reader must choose deliberately,
+ *  and a compile error is the only thing that reliably makes that happen. */
+export type ConversationVisibility = "human" | "all";
+
+export async function createConversation(
+  db: DbClient,
+  owner: Owner,
+  title: string,
+  source: ConversationSource   // REQUIRED — no default, so a new call site cannot omit it
+): Promise<{ id: string } | null>;
+
+export async function listConversations(
+  db: DbClient, owner: Owner, visibleTo: ConversationVisibility, limit?: number
+): Promise<Conversation[]>;
+
+export async function searchConversations(
+  db: DbClient, owner: Owner, query: string, visibleTo: ConversationVisibility, limit?: number
+): Promise<Conversation[]>;
+```
+
+**The filter is a PARAMETER, not a property of the store function — this is the defect that killed
+the first draft.** `app/api/v1/conversations/route.ts` calls the same `listConversations` as the
+dashboard. A filter baked into the function would have silently stripped every `api` thread from the
+API's own list, so the CLI could no longer list the threads it just created — breaking the documented
+resume flow while the spec claimed that reader was "deliberately left unfiltered". Both reviewers
+caught it independently; it could not have been true as written.
+
+Storage: `conversations.source text not null default 'unknown' check (source in ('dashboard','api','unknown'))`.
+
+Text + `check` rather than a Postgres enum, matching the `teams.answering_provider` precedent in
+`postgres/schema.sql`: the value set will grow (telegram, mcp, cron are all plausible), an enum
+value can never be dropped, and this repo has been bitten twice by enum/constraint narrowing during
+`pg:schema` replay.
+
+**`source` records the channel, not an inference about who was typing.** The product rule is
+narrow and honest: the Query tab shows what was typed INTO the Query tab.
+
+**This DOES narrow a documented promise, and the narrowing is deliberate.** Three places state that
+threads created via the API show up in the member's web sidebar — `lib/chat/store.ts` (the module
+docstring: "the same history shows up across sessions and interfaces (web, mobile, CLI,
+Telegram/Hermes)"), `docs/CHAT-CLIENTS.md` (opening paragraph), and `docs/ARCHITECTURE.md`. All
+three are amended in this PR; leaving them would make the docs lie.
+
+Why the narrowing is safe TODAY, measured rather than assumed:
+
+- **Telegram-via-Hermes is not built.** `docs/CHAT-CLIENTS.md` says the server side is done and
+  "what remains is the client side"; there is no Telegram implementation anywhere in this repo.
+- **The CLI never resumes a thread.** `aios query` calls `streamQuery(question, null, …)` — it
+  passes `null` for `conversation_id` on every call, so it has never continued a thread.
+- **Nothing is exercising cross-interface resume.** 57 of the 62 prod conversations are single-turn;
+  the 5 multi-turn ones are dashboard chats.
+
+So the promise being narrowed has no live client. What this slice preserves is the MECHANISM:
+`/api/v1/conversations` still returns `api` threads, so a future Telegram client can list and resume
+them. What it loses is dashboard-sidebar visibility for those threads — which is precisely what was
+reported as the bug.
+
+**When Telegram does ship, the fix is one line**, and it is why `text + check` was chosen over an
+enum: Hermes declares `source: "telegram"`, and `telegram` joins `HUMAN_VISIBLE_SOURCES`. Treating a
+declared channel as a display tag is legitimate — visibility here is UX, not authorization, and a
+lying client can only mislabel its own key-owner's list. The earlier draft dismissed that option on
+a trust-boundary argument that does not apply, and that dismissal was wrong.
+
+## Dependencies
+
+Depends on: none. Self-contained in `aios-team-brain`; no AIOS CLI change, and `aios query` keeps
+working byte-identically — its threads simply stop appearing in the dashboard list.
+
+## Scope
+
+**This is one reviewable PR.** One column, two write sites that set it, two read sites (list and
+search) that filter on it, plus the schema/docs/tests that go with it.
+
+**In:**
+
+- `conversations.source` (migration + `schema.sql` mirror), defaulting to `unknown`.
+- `createConversation` takes `source` as a REQUIRED argument; both call sites pass their channel.
+- `listConversations` and `searchConversations` filter to `HUMAN_VISIBLE_SOURCES`.
+- `docs/ARCHITECTURE.md` drift block updated in the same PR.
+
+**Deferred** (each its own issue, none blocking):
+
+- A UI affordance to SEE hidden agent threads (a toggle or an "Agent activity" view). This slice
+  hides them from one list; it does not build the surface that shows them deliberately.
+- **Cleaning up the ~30 pre-existing agent threads.** They backfill to `unknown` and stay visible,
+  so the reported noise survives this slice. An earlier draft called retroactive classification
+  impossible; that was overclaimed — it rules out AUTOMATIC classification, not a one-off curated
+  pass over 62 rows (their titles are recognisable, and the member can already archive a thread from
+  the UI). Deferred because it is a data mutation on production content owned by two other people,
+  which is a decision, not a build step.
+- Filtering `app/api/v1/conversations/route.ts`. Left unfiltered on purpose — it is the API's own
+  view, and an agent listing threads has no reason to be shown a human-only subset. Revisit when
+  something actually consumes it.
+- The blank-thread defect: 9 of Chetan's 39 threads have a user message, no assistant message and
+  no `chat_turn_runs` row, and render as an empty `TEAM BRAIN` bubble with no error state. Real,
+  separate, and orthogonal — it affects dashboard threads too.
+- Delegated agent tokens for CLI use. **This is the terminal fix, and it is worth stating what that
+  makes this slice worth.** `aiosd_` tokens are ALREADY stateless on `app/api/v1/query/route.ts`:
+  a delegated principal creates no conversation at all. So pointing agents at delegated tokens would
+  solve the reported symptom for all future traffic with ZERO schema change. It is deferred by an
+  explicit product call, not because it would not work. What this slice adds over simply waiting is
+  therefore two things and no more: it covers the interim window, and it leaves a durable provenance
+  RECORD that a token swap would not — which is what a future "Agent activity" view, and any
+  per-channel analytics, would read.
+
+**Fenced out:** this slice raises one blanket constraint — **no change to what
+`app/api/v1/query/route.ts` persists, to `aios query`, or to cost/usage attribution.** Agent
+queries must keep creating conversations and keep metering, so nothing that reads
+`chat_messages`, `llm_usage` or `query_log` for attribution can regress. What the fence pushes out:
+*stopping* API-path persistence entirely → the delegated-token issue above, which is the correct
+mechanism for it; and any change to the Telegram-via-Hermes path → out of this epic, and untouched
+because it keeps the `api` value it would already get.
+
+## Acceptance criteria
+
+Each is independently satisfiable; none constrains a file another one requires changing.
+
+### Automated
+
+- `npm test` exits 0, including new `test/guards/conversation-source-writers.test.ts`, which pins
+  the ONE thing the compiler cannot: that the two DASHBOARD call sites (list and search in
+  `app/api/dashboard/conversations/route.ts`) both pass `visibleTo: "human"`, and that
+  `app/api/v1/conversations/route.ts` passes `"all"`. It deliberately does NOT assert that call
+  sites pass a source argument — a required parameter makes that a `tsc` error, and re-asserting it
+  in a grep guard is the ceremony CLAUDE.md §7 warns against.
+- `npm run db:test:up && npm run test:datamechanics` exits 0, including new
+  `test/datamechanics/conversation-source.datamechanics.test.ts`, which asserts against real
+  Postgres, in BOTH directions so it cannot pass by returning nothing: a `dashboard` conversation
+  IS listed and IS searchable; an `api` conversation is NOT listed and NOT searchable; an
+  `unknown` conversation IS listed (the no-history-vanishes guarantee); a row inserted with no
+  explicit source lands as `unknown`; and an out-of-domain value is rejected by the check
+  constraint.
+- `npm run test:migrate-from-existing` exits 0 — proves the additive migration exists and that
+  `schema.sql` mirrors it. This replaces a `check:docs` criterion from an earlier draft that was
+  VACUOUS: the drift guard extracts table names only and cannot see a new column at all.
+- `npm run lint` exits 0 and `npx tsc --noEmit` is clean — the required `source` argument means a
+  missed call site is a compile error, not a runtime surprise.
+- `node scripts/mutate.mjs lib/chat/store.ts` reddens the intended test for each of: removing the
+  filter from `listConversations`, removing it from `searchConversations`, and widening
+  `HUMAN_VISIBLE_SOURCES` to include `api`.
+
+### Manual
+
+- `psql "$DATABASE_TEST_URL" -c "\d conversations"` shows `source text not null default 'unknown'`
+  with the check constraint, after `npm run db:test:up` replays schema + migrations from zero.
+
+### Visual
+
+- The Query tab at `/t/<team>/query` does not show an agent thread created AFTER this ships (run
+  `aios query "probe"` and confirm it is absent), while a pre-migration thread IS still present.
+  Scoped to new threads deliberately: the ~30 existing agent threads backfill to `unknown` and stay
+  visible, so the tab does not look clean on ship day.
+
+## Build-with
+
+Build-with: Fable 5, high effort. Small in line count, but it changes a shared write contract and a
+tier-scoped read path, and a wrong default silently hides real user history.
+
+## Tier safety
+
+Brain surfaces are touched: a column on `conversations`, both query write paths, and the dashboard
+list/search read path.
+
+- **Ownership, not tiers, is the control here.** `conversations` is owner-scoped: every reader
+  already filters `team_id` + `member_id` (`ownsConversation`, `listConversations`,
+  `searchConversations`), so a member can only ever see their own threads. This slice narrows that
+  set further and cannot widen it — the filter is added to existing queries, never replacing an
+  owner predicate.
+- **Fail-closed direction:** an unrecognised or NULL source must be treated as NOT
+  human-visible-by-accident. The default is `unknown`, which IS visible — that is a deliberate
+  product choice (do not delete history), not an oversight, and it is asserted explicitly rather
+  than left implicit.
+- **No new cross-member or cross-tier read path** is introduced; no API route gains a new
+  parameter that could widen a result set.
+- **Hidden is NOT an access boundary, and the name must not imply otherwise.** A hidden thread stays
+  readable by its owner through the by-id detail routes (`app/api/dashboard/conversations/[id]`,
+  `app/api/v1/conversations/[id]`), which is deliberate: this is sidebar curation, not permission.
+  Owner scoping remains the only access control and is untouched.
+- **Residual, named rather than hidden:** source is set at CREATION, so an agent that passes an
+  existing `conversation_id` can still append turns to a `dashboard` thread
+  (`app/api/v1/query/route.ts` adopts any owned id). Accepted for this slice — no client does it
+  today (`aios query` always sends `null`) — and the durable fix is per-turn provenance or delegated
+  tokens, both named as follow-ups.
+
+## Risk / rollback
+
+- **Forward:** `postgres/migrations/20260822120000_conversations_source.sql` runs
+  `alter table conversations add column if not exists source text not null default 'unknown'`, then
+  adds a NAMED constraint `conversations_source_check` inside a guarded `do $$ … if not exists
+  (select 1 from pg_constraint where conname = …) … end $$` block — Postgres has no
+  `ADD CONSTRAINT IF NOT EXISTS`, and an earlier draft specified exactly that non-existent syntax.
+  The pattern is copied from `postgres/schema.sql` (the `teams_*_provider_check` block, ~line 186).
+  When the value set later widens, BOTH `schema.sql` and this migration's named constraint must be
+  updated together, or replay re-adds a constraint narrower than live data.
+- **From-zero replay alone does not prove the migration exists.** `npm run db:test:up` loads
+  `schema.sql` first, so a DB built from zero has the column whether or not the migration was
+  written — deleting the migration would leave every from-zero check green while PRODUCTION lacked
+  the column. `npm run test:migrate-from-existing` (`--mirror-check`) is the lane that catches it,
+  and it is an acceptance criterion below.
+- **Undo:** revert the app code and leave the column. A dropped column would lose the provenance
+  already recorded; an unused one costs nothing. The column is nullable-safe by virtue of its
+  default, so old code reading the table is unaffected.
+- **The one real hazard is the filter, not the column:** if `HUMAN_VISIBLE_SOURCES` were wrong, a
+  member's history would appear to vanish. That is why `unknown` is included and why the
+  data-mechanics test asserts an `unknown` row IS listed — the assertion exists specifically to
+  fail if someone later "tidies" the default to `api`.
+- **Blast radius:** no row's content changes, nothing is deleted, and the 62 existing conversations
+  keep rendering exactly as they do today until an agent creates a new one.

--- a/lib/access/agent-token-policy.ts
+++ b/lib/access/agent-token-policy.ts
@@ -1,0 +1,168 @@
+/**
+ * Mint-request policy for delegated agent tokens (AGENTUI-1) — PURE, no I/O, no framework.
+ *
+ * WHY THIS IS A SEPARATE MODULE, not three `if`s inside the server action:
+ *
+ *  1. A `"use server"` file may only export async functions, so the shared lifetime cap physically
+ *     cannot live there. The form and the action must agree on that number, and the only way to have
+ *     ONE constant with TWO readers is a plain module both import.
+ *  2. It makes the rules testable by calling them, rather than by reaching through a server action.
+ *
+ * WHY THE RULES ARE HERE AT ALL, rather than in the form: a server action is a public HTTP endpoint.
+ * A constraint that lives in a React component is a suggestion to anyone who uses the page and
+ * nothing whatsoever to anyone who does not. The spec review put it as "the safety folds currently
+ * exist only in client UX" — these are the same rules, moved to where they hold.
+ *
+ * SCOPE OF THIS MODULE: it constrains what may be REQUESTED. It says nothing about what an already
+ * minted token can DO — that is the oracle's live triple intersection, deliberately untouched.
+ */
+
+/** Hard ceiling on a token's lifetime. A credential with no horizon is the one nobody revokes. */
+export const MAX_TOKEN_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** Upper bound on a single token's scope list — a sanity cap, not a security control. */
+export const MAX_PROJECT_SCOPE = 200;
+
+/** What the mint form pre-fills. Short enough to force a renewal decision, long enough to be usable. */
+export const DEFAULT_TOKEN_LIFETIME_DAYS = 90;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+/** ISO-8601 instant, with Z or a numeric offset. Deliberately stricter than `Date.parse`. */
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})$/;
+
+export interface MintRequest {
+  memberId: string;
+  onBehalfOf?: string | null;
+  /** `null`/absent = inherit the launcher's projects. A populated array = restrict to those. */
+  projectScope?: string[] | null;
+  name?: string;
+  expiresAt?: string | null;
+}
+
+export type PolicyResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * `now` is a parameter, not `Date.now()`, so the expiry rules are testable at exact boundaries
+ * without the clock making the test flaky.
+ */
+/** Identity legs: the launcher, and the acting-as leg v1 refuses outright. */
+function checkIdentity(req: MintRequest): PolicyResult {
+  if (typeof req.memberId !== "string" || !UUID_RE.test(req.memberId)) {
+    return { ok: false, error: "memberId must be a member uuid" };
+  }
+  // ACTING-AS: refused server-side, not merely hidden. `on_behalf_of` makes a delegated query answer
+  // in the represented person's first-person identity while quota, cost and audit stay with the
+  // launcher, and no owner→agent authorization or consent model exists anywhere yet. Omitting the
+  // control from the form would leave this reachable by anyone posting to the action directly.
+  if (req.onBehalfOf != null) {
+    return { ok: false, error: "acting-as is not available in this version — tokens are self-only" };
+  }
+  if (req.name != null && typeof req.name !== "string") {
+    return { ok: false, error: "name must be a string" };
+  }
+  return { ok: true };
+}
+
+/**
+ * Scope: `null`/absent = inherit (legal, and the form makes it a deliberate choice). `[]` is a legal
+ * DB state ("sees nothing") but never a legal REQUEST — the only way to produce it is an empty
+ * multi-select, i.e. an accident that mints a token which silently reads nothing.
+ */
+function checkScope(req: MintRequest): PolicyResult {
+  if (req.projectScope == null) return { ok: true };
+  // A direct caller can send anything; without the array check a string throws inside `.some(...)`
+  // and the boundary returns an opaque 500 instead of a refusal.
+  if (!Array.isArray(req.projectScope)) {
+    return { ok: false, error: "projectScope must be an array of project uuids" };
+  }
+  if (req.projectScope.length === 0) {
+    return {
+      ok: false,
+      error: "projectScope must name at least one project, or be omitted to inherit the launcher's access",
+    };
+  }
+  if (req.projectScope.length > MAX_PROJECT_SCOPE) {
+    return { ok: false, error: `projectScope may name at most ${MAX_PROJECT_SCOPE} projects` };
+  }
+  if (new Set(req.projectScope).size !== req.projectScope.length) {
+    return { ok: false, error: "projectScope must not repeat a project" };
+  }
+  if (req.projectScope.some((p) => typeof p !== "string" || !UUID_RE.test(p))) {
+    return { ok: false, error: "projectScope must contain project uuids" };
+  }
+  return { ok: true };
+}
+
+/**
+ * Expiry: REQUIRED and bounded. `mintAgentToken` stores `expiresAt ?? null` and a null expiry never
+ * expires, so "absent" must be refused rather than quietly becoming forever.
+ */
+function checkExpiry(req: MintRequest, now: number): PolicyResult {
+  if (req.expiresAt == null || req.expiresAt === "") {
+    return { ok: false, error: "expiresAt is required" };
+  }
+  // `Date.parse` accepts plenty that is not ISO-8601 ("12/31/2026" parses) and coerces arrays, so
+  // require the shape before trusting the parse.
+  if (typeof req.expiresAt !== "string" || !ISO_RE.test(req.expiresAt)) {
+    return { ok: false, error: "expiresAt must be an ISO timestamp" };
+  }
+  const at = Date.parse(req.expiresAt);
+  if (Number.isNaN(at)) return { ok: false, error: "expiresAt must be an ISO timestamp" };
+  if (at <= now) return { ok: false, error: "expiresAt must be in the future" };
+  if (at > now + MAX_TOKEN_LIFETIME_MS) {
+    return { ok: false, error: "expiresAt is beyond the 365-day maximum" };
+  }
+  return { ok: true };
+}
+
+/**
+ * `now` is a parameter, not `Date.now()`, so the expiry rules are testable at exact boundaries
+ * without the clock making the test flaky. Split into three checks because a single chain of guard
+ * clauses crossed the complexity ceiling — the behaviour is unchanged and pinned by 35 tests.
+ */
+export function validateMintRequest(req: MintRequest, now: number): PolicyResult {
+  // A server action receives whatever the caller sends.
+  if (req == null || typeof req !== "object" || Array.isArray(req)) {
+    return { ok: false, error: "invalid request" };
+  }
+  for (const check of [checkIdentity(req), checkScope(req), checkExpiry(req, now)]) {
+    if (!check.ok) return check;
+  }
+  return { ok: true };
+}
+
+/**
+ * The mint form's submit rule, extracted as a pure function so it can be pinned by tests without a
+ * DOM harness — and so the "silent `null` inherits everything" hazard both spec reviewers flagged is
+ * covered by an assertion rather than by reading the JSX.
+ *
+ * `scope === null` means the admin has TOUCHED NOTHING. It must not be submittable: `null` would
+ * inherit the launcher's full visibility, which is the fail-open direction.
+ */
+export type ScopeChoice = null | { kind: "inherit" } | { kind: "restrict"; projectIds: string[] };
+
+export function canSubmitMint(input: {
+  memberId: string;
+  expiry: string;
+  scope: ScopeChoice;
+}): boolean {
+  if (!input.memberId) return false;
+  if (!input.expiry) return false;
+  if (input.scope === null) return false;
+  if (input.scope.kind === "restrict" && input.scope.projectIds.length === 0) return false;
+  return true;
+}
+
+/**
+ * The instant the form should submit for a chosen calendar date.
+ *
+ * WHY THIS EXISTS: the form offered `today + 365 days` as its max date and submitted it at
+ * 23:59:59Z — which is up to a day BEYOND the exact 365-day cap, so the action refused the very
+ * value its own picker allowed. The spec claims the form cannot request what the action refuses;
+ * this is what makes that true, and it lives beside the cap so the two cannot drift.
+ */
+export function expiryInstantFor(chosenDate: string, now: number): string {
+  const endOfDay = Date.parse(`${chosenDate}T23:59:59.000Z`);
+  const capped = Math.min(Number.isNaN(endOfDay) ? now : endOfDay, now + MAX_TOKEN_LIFETIME_MS);
+  return new Date(capped).toISOString();
+}

--- a/test/agent-token-policy.test.ts
+++ b/test/agent-token-policy.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  MAX_PROJECT_SCOPE,
+  canSubmitMint,
+  expiryInstantFor,
+  validateMintRequest,
+  MAX_TOKEN_LIFETIME_MS,
+  DEFAULT_TOKEN_LIFETIME_DAYS,
+  type MintRequest,
+} from "@/lib/access/agent-token-policy";
+
+/**
+ * AGENTUI-1 — the mint-request policy.
+ *
+ * Every assertion here is written in the FAIL-OPEN direction: it asserts a request is REFUSED. That
+ * is deliberate. Each rule exists because the permissive outcome is the dangerous one — an
+ * unattenuated token, a never-expiring token, a token that impersonates — and a test that only
+ * checked the happy path would stay green with every rule deleted.
+ */
+
+const NOW = Date.parse("2026-08-22T12:00:00.000Z");
+const MEMBER = "11111111-1111-4111-8111-111111111111";
+const PROJECT = "22222222-2222-4222-8222-222222222222";
+
+/** A request that is legal in every respect, so each test varies exactly one thing. */
+function legal(over: Partial<MintRequest> = {}): MintRequest {
+  return {
+    memberId: MEMBER,
+    expiresAt: new Date(NOW + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    ...over,
+  };
+}
+
+function errorFor(req: MintRequest): string {
+  const r = validateMintRequest(req, NOW);
+  return r.ok ? "(accepted)" : r.error;
+}
+
+describe("agent token mint policy", () => {
+  it("accepts the legal baseline (non-vacuity: if this fails, every refusal below proves nothing)", () => {
+    expect(validateMintRequest(legal(), NOW)).toEqual({ ok: true });
+  });
+
+  describe("acting-as is refused server-side, not merely hidden from the form", () => {
+    it("refuses onBehalfOf even when it is a well-formed member uuid", () => {
+      expect(errorFor(legal({ onBehalfOf: "33333333-3333-4333-8333-333333333333" }))).toMatch(/self-only/);
+    });
+
+    it("still accepts an explicit null (absent acting-as is the normal case)", () => {
+      expect(validateMintRequest(legal({ onBehalfOf: null }), NOW)).toEqual({ ok: true });
+    });
+  });
+
+  describe("scope: inherit is legal, 'sees nothing' is not a legal request", () => {
+    it("accepts an omitted scope (inherit the launcher's projects)", () => {
+      expect(validateMintRequest(legal(), NOW)).toEqual({ ok: true });
+    });
+
+    it("accepts an explicit null scope", () => {
+      expect(validateMintRequest(legal({ projectScope: null }), NOW)).toEqual({ ok: true });
+    });
+
+    it("REFUSES an empty array — the accidental 'reads nothing' token", () => {
+      expect(errorFor(legal({ projectScope: [] }))).toMatch(/at least one project/);
+    });
+
+    it("accepts a populated scope", () => {
+      expect(validateMintRequest(legal({ projectScope: [PROJECT] }), NOW)).toEqual({ ok: true });
+    });
+
+    it("refuses a scope containing a non-uuid", () => {
+      expect(errorFor(legal({ projectScope: [PROJECT, "not-a-uuid"] }))).toMatch(/project uuids/);
+    });
+  });
+
+  describe("expiry is required and bounded — a null expiry never expires", () => {
+    it("refuses an absent expiry", () => {
+      expect(errorFor({ memberId: MEMBER })).toMatch(/required/);
+    });
+
+    it("refuses an explicitly null expiry", () => {
+      expect(errorFor(legal({ expiresAt: null }))).toMatch(/required/);
+    });
+
+    it("refuses an empty-string expiry (an untouched date input, not a choice)", () => {
+      expect(errorFor(legal({ expiresAt: "" }))).toMatch(/required/);
+    });
+
+    it("refuses an unparseable expiry", () => {
+      expect(errorFor(legal({ expiresAt: "next tuesday" }))).toMatch(/ISO timestamp/);
+    });
+
+    it("refuses an expiry in the past — it would mint an already-dead credential", () => {
+      expect(errorFor(legal({ expiresAt: new Date(NOW - 1000).toISOString() }))).toMatch(/in the future/);
+    });
+
+    it("refuses an expiry exactly at now (boundary: <= now, not < now)", () => {
+      expect(errorFor(legal({ expiresAt: new Date(NOW).toISOString() }))).toMatch(/in the future/);
+    });
+
+    it("accepts an expiry exactly at the 365-day cap (boundary: <= max is legal)", () => {
+      expect(
+        validateMintRequest(legal({ expiresAt: new Date(NOW + MAX_TOKEN_LIFETIME_MS).toISOString() }), NOW)
+      ).toEqual({ ok: true });
+    });
+
+    it("refuses one millisecond beyond the cap", () => {
+      expect(
+        errorFor(legal({ expiresAt: new Date(NOW + MAX_TOKEN_LIFETIME_MS + 1).toISOString() }))
+      ).toMatch(/365-day maximum/);
+    });
+  });
+
+  it("refuses a malformed memberId", () => {
+    expect(errorFor(legal({ memberId: "nope" }))).toMatch(/member uuid/);
+  });
+
+  it("the form's default lifetime is inside the cap the action enforces (one constant, two readers)", () => {
+    expect(DEFAULT_TOKEN_LIFETIME_DAYS * 24 * 60 * 60 * 1000).toBeLessThan(MAX_TOKEN_LIFETIME_MS);
+  });
+});
+
+/**
+ * SPEC AC (agent-tokens-admin-ui-v1.md "Automated"): the form's scope+expiry contract. Extracted to
+ * a pure rule so it is pinned by assertions rather than by reading JSX — the "untouched scope
+ * silently inherits everything" hazard is the fail-open direction both spec reviewers flagged.
+ */
+describe("mint form submit rule", () => {
+  const base = { memberId: MEMBER, expiry: "2026-12-01" };
+
+  it("an UNTOUCHED scope is not submittable — never a silent inherit", () => {
+    expect(canSubmitMint({ ...base, scope: null })).toBe(false);
+  });
+
+  it("a deliberate inherit IS submittable", () => {
+    expect(canSubmitMint({ ...base, scope: { kind: "inherit" } })).toBe(true);
+  });
+
+  it("restrict with zero projects is not submittable — never a silent 'sees nothing'", () => {
+    expect(canSubmitMint({ ...base, scope: { kind: "restrict", projectIds: [] } })).toBe(false);
+  });
+
+  it("restrict with one project is submittable", () => {
+    expect(canSubmitMint({ ...base, scope: { kind: "restrict", projectIds: [PROJECT] } })).toBe(true);
+  });
+
+  it("a missing member or a cleared expiry blocks submit", () => {
+    expect(canSubmitMint({ memberId: "", expiry: "2026-12-01", scope: { kind: "inherit" } })).toBe(false);
+    expect(canSubmitMint({ memberId: MEMBER, expiry: "", scope: { kind: "inherit" } })).toBe(false);
+  });
+});
+
+/**
+ * SPEC AC: two source-level obligations the runtime tests cannot see.
+ */
+describe("agent-token admin surface obligations", () => {
+  const ROOT = join(import.meta.dirname, "..");
+  const page = readFileSync(join(ROOT, "app", "t", "[team]", "admin", "agents", "page.tsx"), "utf8");
+  const actions = readFileSync(join(ROOT, "app", "t", "[team]", "admin", "agents", "actions.ts"), "utf8");
+
+  it("the page never selects token_hash — checked per QUERY, not by mere absence of the word", () => {
+    // Occurrence checks were the weakness Codex named: a SECOND `.from("agent_tokens")` could add
+    // the hash while the first stayed clean. So pin the query count, then check each one.
+    const queries = [...page.matchAll(/\.from\("agent_tokens"\)([\s\S]*?)(?=\n\s*\]|\n\s*\);)/g)];
+    expect(queries.length, "exactly one agent_tokens query — add a test arm if a second is ever needed").toBe(1);
+    for (const q of queries) {
+      expect(q[1], "no agent_tokens query may select token_hash").not.toMatch(/token_hash/);
+      expect(q[1], "non-vacuity: the query body was actually captured").toMatch(/\.select\(/);
+    }
+  });
+
+  it("mint and revoke EACH revalidate — per function body, not a global count", () => {
+    // A global count of 2 stays green with both calls in mint and none in revoke (Codex).
+    const bodies = actions.split(/export async function /).slice(1);
+    const byName = new Map(bodies.map((b) => [b.slice(0, b.indexOf("(")), b]));
+    for (const fn of ["mintAgentTokenAction", "revokeAgentTokenAction"]) {
+      expect(byName.get(fn), `non-vacuity: ${fn} body was found`).toBeTruthy();
+      expect(byName.get(fn)!, `${fn} must revalidate on success`).toMatch(/revalidateAgents\(teamSlug\)/);
+    }
+    expect(actions, "revalidation must not be able to throw away a minted token").toMatch(/try \{[\s\S]*?revalidatePath/);
+  });
+
+  it("the expiry column uses fmtDate, not timeAgo (timeAgo renders every FUTURE date as 'just now')", () => {
+    expect(page).toMatch(/fmtDate\(t\.expires_at\)/);
+    expect(page, "a future expiry through timeAgo reads 'just now' for every live token").not.toMatch(/timeAgo\(t\.expires_at\)/);
+  });
+
+  it("the expiry instant offered by the form is always inside the cap the action enforces", () => {
+    const now = Date.parse("2026-08-22T12:00:00.000Z");
+    // The exact failure Codex found: the max date the picker offered, submitted at end-of-day,
+    // overshot the 365-day cap by ~12h and the action refused its own picker's value.
+    const maxDate = new Date(now + MAX_TOKEN_LIFETIME_MS).toISOString().slice(0, 10);
+    const instant = expiryInstantFor(maxDate, now);
+    expect(Date.parse(instant)).toBeLessThanOrEqual(now + MAX_TOKEN_LIFETIME_MS);
+    expect(validateMintRequest({ memberId: MEMBER, expiresAt: instant }, now)).toEqual({ ok: true });
+  });
+
+  it("a normal date is unchanged by the clamp (non-vacuity: it does not clamp everything)", () => {
+    const now = Date.parse("2026-08-22T12:00:00.000Z");
+    expect(expiryInstantFor("2026-09-20", now)).toBe("2026-09-20T23:59:59.000Z");
+  });
+});
+
+describe("policy hardening against malformed input (a public endpoint receives anything)", () => {
+  const NOW2 = Date.parse("2026-08-22T12:00:00.000Z");
+  const bad = (req: unknown) => validateMintRequest(req as never, NOW2);
+
+  it("refuses null/undefined/array requests instead of throwing", () => {
+    for (const r of [null, undefined, [], "nope"]) expect(bad(r).ok).toBe(false);
+  });
+
+  it("refuses an ARRAY memberId — RegExp.test coerces, so a type check must come first", () => {
+    expect(bad({ memberId: [MEMBER], expiresAt: "2026-09-20T00:00:00.000Z" })).toEqual({
+      ok: false,
+      error: "memberId must be a member uuid",
+    });
+  });
+
+  it("refuses a non-ISO date that Date.parse would happily accept", () => {
+    expect(bad({ memberId: MEMBER, expiresAt: "12/31/2026" }).ok).toBe(false);
+  });
+
+  it("accepts a numeric UTC offset (a legal ISO instant)", () => {
+    expect(bad({ memberId: MEMBER, expiresAt: "2026-09-20T10:00:00+02:00" })).toEqual({ ok: true });
+  });
+
+  it("refuses a non-array projectScope instead of throwing inside .some()", () => {
+    expect(bad({ memberId: MEMBER, expiresAt: "2026-09-20T00:00:00.000Z", projectScope: "x" }).ok).toBe(false);
+  });
+
+  it("refuses duplicates and over-cap scope lists", () => {
+    const dup = bad({ memberId: MEMBER, expiresAt: "2026-09-20T00:00:00.000Z", projectScope: [PROJECT, PROJECT] });
+    expect(dup.ok).toBe(false);
+    const many = Array.from({ length: MAX_PROJECT_SCOPE + 1 }, (_, i) => `${i}`.padStart(8, "0") + "-2222-4222-8222-222222222222");
+    expect(bad({ memberId: MEMBER, expiresAt: "2026-09-20T00:00:00.000Z", projectScope: many }).ok).toBe(false);
+  });
+
+  it("refuses a non-string name", () => {
+    expect(bad({ memberId: MEMBER, expiresAt: "2026-09-20T00:00:00.000Z", name: 5 }).ok).toBe(false);
+  });
+});

--- a/test/datamechanics/agent-token-admin.datamechanics.test.ts
+++ b/test/datamechanics/agent-token-admin.datamechanics.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db, seedTeam, type Seed } from "./helpers";
+
+vi.mock("@/lib/auth/guard", () => ({ requireTeamAdmin: vi.fn() }));
+
+import { requireTeamAdmin } from "@/lib/auth/guard";
+import { mintAgentTokenAction, revokeAgentTokenAction } from "@/app/t/[team]/admin/agents/actions";
+import { verifyAgentToken } from "@/lib/access/agent-tokens";
+import { addMemberToGroup, createGroup, grantProjectToGroup } from "@/lib/access/groups";
+
+/**
+ * AGENTUI-1 — the mint ACTION against real Postgres.
+ *
+ * The policy itself is unit-tested in `test/agent-token-policy.test.ts`. What this tier proves is
+ * the OUTCOME the unit tier structurally cannot: that a refused request leaves NO ROW behind. A
+ * policy that returns `{ok:false}` while the writer has already run would pass every unit test and
+ * still mint the credential it claimed to refuse.
+ */
+
+async function seedMember(seed: Seed, kind = "human"): Promise<string> {
+  const { data, error } = await db()
+    .from("members")
+    .insert({
+      team_id: seed.teamId,
+      email: `${randomUUID()}@test.local`,
+      display_name: `M-${randomUUID().slice(0, 6)}`,
+      actor_handle: `h-${randomUUID().slice(0, 10)}`,
+      role: "member",
+      tier: "team",
+      status: "active",
+      kind,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seed member failed: ${error?.message}`);
+  return data.id as string;
+}
+
+async function tokenCount(teamId: string): Promise<number> {
+  const { data } = await db().from("agent_tokens").select("id").eq("team_id", teamId);
+  return (data ?? []).length;
+}
+
+/** A project plus a group grant making it visible to `memberId` — the realistic admin setup. */
+async function grantedProject(seed: Seed, memberId: string): Promise<string> {
+  const { data, error } = await db()
+    .from("projects")
+    .insert({ team_id: seed.teamId, slug: `p-${randomUUID().slice(0, 6)}` })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seed project failed: ${error?.message}`);
+  const g = await createGroup(db(), seed.teamId, `g-${randomUUID().slice(0, 6)}`, "g", seed.memberId);
+  await addMemberToGroup(db(), seed.teamId, g.groupId!, memberId, seed.memberId);
+  await grantProjectToGroup(db(), seed.teamId, data.id as string, g.groupId!, seed.memberId);
+  return data.id as string;
+}
+
+/** A project with NO grant to anyone — visible to no admin. */
+async function ungrantedProject(seed: Seed): Promise<string> {
+  const { data, error } = await db()
+    .from("projects")
+    .insert({ team_id: seed.teamId, slug: `u-${randomUUID().slice(0, 6)}` })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seed project failed: ${error?.message}`);
+  return data.id as string;
+}
+
+function future(days: number): string {
+  return new Date(Date.now() + days * 86_400_000).toISOString();
+}
+
+describe("AGENTUI-1 — mintAgentTokenAction against real Postgres", () => {
+  beforeEach(() => vi.mocked(requireTeamAdmin).mockReset());
+
+  it("a legal request mints exactly one row, and the stored hash is not the returned token", async () => {
+    const seed = await seedTeam();
+    const agent = await seedMember(seed, "agent");
+    vi.mocked(requireTeamAdmin).mockResolvedValue({ teamId: seed.teamId, memberId: agent });
+
+    const before = await tokenCount(seed.teamId);
+    const res = await mintAgentTokenAction("any-slug", {
+      memberId: agent,
+      name: "status agent",
+      expiresAt: future(30),
+    });
+
+    expect(res.ok, res.error).toBe(true);
+    expect(res.token).toMatch(/^aiosd_/);
+    expect(await tokenCount(seed.teamId)).toBe(before + 1);
+
+    const { data } = await db()
+      .from("agent_tokens")
+      .select("token_hash, project_scope, on_behalf_of, expires_at")
+      .eq("id", res.tokenRowId!)
+      .single();
+    const row = data as { token_hash: string; project_scope: string[] | null; on_behalf_of: string | null };
+    expect(row.token_hash).not.toBe(res.token);
+    expect(row.project_scope, "omitted scope must persist as NULL (inherit), never []").toBeNull();
+    expect(row.on_behalf_of).toBeNull();
+  });
+
+  /**
+   * Each case asserts the ROW COUNT is unchanged. Asserting only `res.ok === false` would pass even
+   * if the writer had run — which is the failure this tier exists to catch.
+   */
+  const REFUSED: [name: string, input: () => Record<string, unknown>, match: RegExp][] = [
+    ["acting-as", () => ({ onBehalfOf: randomUUID(), expiresAt: future(30) }), /self-only/],
+    ["absent expiry", () => ({}), /required/],
+    ["null expiry", () => ({ expiresAt: null }), /required/],
+    ["past expiry", () => ({ expiresAt: new Date(Date.now() - 1000).toISOString() }), /in the future/],
+    ["expiry beyond the cap", () => ({ expiresAt: future(400) }), /365-day maximum/],
+    ["empty project scope", () => ({ projectScope: [], expiresAt: future(30) }), /at least one project/],
+  ];
+
+  for (const [label, extra, match] of REFUSED) {
+    it(`refuses ${label} AND writes no row`, async () => {
+      const seed = await seedTeam();
+      const agent = await seedMember(seed, "agent");
+      vi.mocked(requireTeamAdmin).mockResolvedValue({ teamId: seed.teamId, memberId: agent });
+
+      const before = await tokenCount(seed.teamId);
+      const res = await mintAgentTokenAction("any-slug", { memberId: agent, ...extra() } as never);
+
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(match);
+      expect(await tokenCount(seed.teamId), "a refused mint must not write").toBe(before);
+    });
+  }
+
+  it("a populated scope persists as the array it was given (distinguishable from NULL)", async () => {
+    const seed = await seedTeam();
+    const agent = await seedMember(seed, "agent");
+    vi.mocked(requireTeamAdmin).mockResolvedValue({ teamId: seed.teamId, memberId: agent });
+
+    const projectId = await grantedProject(seed, agent);
+
+    const res = await mintAgentTokenAction("any-slug", {
+      memberId: agent,
+      projectScope: [projectId],
+      expiresAt: future(30),
+    });
+    expect(res.ok, res.error).toBe(true);
+
+    const { data } = await db().from("agent_tokens").select("project_scope").eq("id", res.tokenRowId!).single();
+    expect((data as { project_scope: string[] }).project_scope).toEqual([projectId]);
+  });
+
+  /**
+   * The property the commit claims: an admin cannot scope a token to a project they cannot see.
+   * Enforced in the ACTION, not the picker — the picker is a web page and the action is a public
+   * endpoint. Asserted in BOTH directions so it cannot pass by refusing everything.
+   */
+  it("REFUSES a scope naming a project the admin cannot see, and writes no row", async () => {
+    const seed = await seedTeam();
+    const agent = await seedMember(seed, "agent");
+    vi.mocked(requireTeamAdmin).mockResolvedValue({ teamId: seed.teamId, memberId: agent });
+
+    const unseen = await ungrantedProject(seed);
+    const before = await tokenCount(seed.teamId);
+    const res = await mintAgentTokenAction("any-slug", {
+      memberId: agent,
+      projectScope: [unseen],
+      expiresAt: future(30),
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/cannot see/);
+    expect(await tokenCount(seed.teamId), "a refused scope must not write").toBe(before);
+  });
+
+  /**
+   * ADMIN and LAUNCHER are different identities, and the earlier test made them the same member —
+   * which hid the distinction entirely (Codex diff review). The token reads AS the launcher, so a
+   * project only the ADMIN can see would mint a scope that silently grants nothing.
+   */
+  it("REFUSES a project the admin can see but the LAUNCHING member cannot", async () => {
+    const seed = await seedTeam();
+    const adminM = await seedMember(seed, "human");
+    const launcher = await seedMember(seed, "agent");
+    vi.mocked(requireTeamAdmin).mockResolvedValue({ teamId: seed.teamId, memberId: adminM });
+
+    // Granted to the ADMIN only — the launcher is in no group that reaches it.
+    const adminOnly = await grantedProject(seed, adminM);
+
+    const before = await tokenCount(seed.teamId);
+    const res = await mintAgentTokenAction("any-slug", {
+      memberId: launcher,
+      projectScope: [adminOnly],
+      expiresAt: future(30),
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.error, "must name the LAUNCHER, not the admin").toMatch(/launching member cannot see/);
+    expect(await tokenCount(seed.teamId)).toBe(before);
+  });
+
+  it("ACCEPTS a project BOTH the admin and the launcher can see (non-vacuity for the pair)", async () => {
+    const seed = await seedTeam();
+    const adminM = await seedMember(seed, "human");
+    const launcher = await seedMember(seed, "agent");
+    vi.mocked(requireTeamAdmin).mockResolvedValue({ teamId: seed.teamId, memberId: adminM });
+
+    const shared = await grantedProject(seed, adminM);
+    await grantProjectToGroup(
+      db(),
+      seed.teamId,
+      shared,
+      (await createGroup(db(), seed.teamId, `g2-${randomUUID().slice(0, 6)}`, "g2", seed.memberId)).groupId!,
+      seed.memberId
+    );
+    // Put the launcher in a group that also reaches `shared`.
+    const g = await createGroup(db(), seed.teamId, `g3-${randomUUID().slice(0, 6)}`, "g3", seed.memberId);
+    await addMemberToGroup(db(), seed.teamId, g.groupId!, launcher, seed.memberId);
+    await grantProjectToGroup(db(), seed.teamId, shared, g.groupId!, seed.memberId);
+
+    const res = await mintAgentTokenAction("any-slug", {
+      memberId: launcher,
+      projectScope: [shared],
+      expiresAt: future(30),
+    });
+    expect(res.ok, res.error).toBe(true);
+  });
+
+  it("a non-admin caller mints nothing (pins the action's own gate, not the gate's internals)", async () => {
+    const seed = await seedTeam();
+    const agent = await seedMember(seed, "agent");
+    vi.mocked(requireTeamAdmin).mockResolvedValue(null);
+
+    const before = await tokenCount(seed.teamId);
+    const res = await mintAgentTokenAction("any-slug", { memberId: agent, expiresAt: future(30) });
+    expect(res).toEqual({ ok: false, error: "admins only" });
+    expect(await tokenCount(seed.teamId)).toBe(before);
+  });
+
+  /**
+   * REGRESSION (found by this tier): `revalidatePath` runs AFTER the row is written and throws
+   * outside a request context. Because the secret is returned exactly once, an exception there
+   * loses the token while the credential stays live — a stale list is cosmetic, an unreadable live
+   * credential is not. This test calls the action with no Next request context, which is exactly
+   * the condition that threw.
+   */
+  it("a mint still returns its token when cache revalidation cannot run", async () => {
+    const seed = await seedTeam();
+    const agent = await seedMember(seed, "agent");
+    vi.mocked(requireTeamAdmin).mockResolvedValue({ teamId: seed.teamId, memberId: agent });
+
+    const res = await mintAgentTokenAction("any-slug", { memberId: agent, expiresAt: future(30) });
+    expect(res.ok, res.error).toBe(true);
+    expect(res.token, "the secret must survive a revalidation fault — it is shown exactly once").toMatch(/^aiosd_/);
+    expect(await tokenCount(seed.teamId)).toBe(1);
+  });
+
+  it("revoke marks the row and verification then fails", async () => {
+    const seed = await seedTeam();
+    const agent = await seedMember(seed, "agent");
+    vi.mocked(requireTeamAdmin).mockResolvedValue({ teamId: seed.teamId, memberId: agent });
+
+    const minted = await mintAgentTokenAction("any-slug", { memberId: agent, expiresAt: future(30) });
+    expect(minted.ok, minted.error).toBe(true);
+    expect(await verifyAgentToken(db(), minted.token!)).not.toBeNull();
+
+    const rev = await revokeAgentTokenAction("any-slug", minted.tokenRowId!);
+    expect(rev.ok, rev.error).toBe(true);
+    expect(await verifyAgentToken(db(), minted.token!)).toBeNull();
+  });
+});

--- a/test/guards/admin-tabs-reachability.test.ts
+++ b/test/guards/admin-tabs-reachability.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+
+/**
+ * Admin surface reachability guard (AGENTUI-1).
+ *
+ * WHY THIS EXISTS — a repeated, observed bug. Three times now a capability has shipped with no way
+ * to reach it: the Skills catalog (built, deployed, 22 prod items, no nav entry for weeks),
+ * `admin/agents` (mint/revoke server actions, no page, 0 tokens ever minted), and `admin/access`
+ * (still in that state today). Nothing failed in any of the three, because nothing pinned them.
+ *
+ * TWO DIRECTIONS, because each catches a different half and the first alone is blind to the bug
+ * that motivated this file:
+ *   (a) a page with no tab   — built, but not linked;
+ *   (b) an actions.ts export with no caller — built, but nothing calls it. This is the actual
+ *       failure class, and a page→tab guard cannot see it.
+ *
+ * Direction (b) carries an explicit allowlist so known debt is documented rather than invisible, and
+ * the allowlist is asserted to be EXACTLY the known set — so it cannot quietly grow, and it fails
+ * once the debt is paid rather than lingering forever.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const ADMIN = join(ROOT, "app", "t", "[team]", "admin");
+const TABS_FILE = join(ROOT, "components", "admin", "admin-tabs.tsx");
+
+/**
+ * Known-orphaned admin exports, keyed at EXPORTED-SYMBOL level rather than by directory — a
+ * directory-level allowlist would exempt every other export in the same file, hiding the next
+ * orphan behind a known one. Both entries below were found by this guard on its first run and are
+ * pre-existing debt, deliberately not fixed by AGENTUI-1:
+ *   - access/*      : the PCCA access-chain admin UI was never built (sibling of the agents gap).
+ *   - linkMemberSlack: exported from members/actions.ts, referenced nowhere in app/, components/,
+ *     lib/ or scripts/ — surfaced by this guard's own first run; intent unknown, so not fixed here.
+ * Asserted to equal the real set EXACTLY, so a new orphan fails the build and a fixed one forces
+ * the entry to be removed rather than lingering as a lie.
+ */
+const ORPHAN_ALLOWLIST = [
+  "access/actions.ts :: runContextBackfillAction",
+  "members/actions.ts :: linkMemberSlack",
+] as const;
+
+function adminDirs(): string[] {
+  return readdirSync(ADMIN).filter((n) => statSync(join(ADMIN, n)).isDirectory());
+}
+
+function tabSlugs(): string[] {
+  // Comments are stripped first: a `// { slug: "agents" … }` line is NOT a shipped tab, and matching
+  // it would let someone comment an entry out of the nav with direction (a) still green — the exact
+  // "source text is not rendered output" hole this guard family keeps rediscovering.
+  const src = stripComments(readFileSync(TABS_FILE, "utf8"));
+  return [...src.matchAll(/\{\s*slug:\s*"([^"]+)"/g)].map((m) => m[1]);
+}
+
+/** Exported server-action names declared in a directory's actions.ts. */
+export function exportedActions(src: string): string[] {
+  return [...src.matchAll(/export\s+async\s+function\s+([A-Za-z0-9_]+)/g)].map((m) => m[1]);
+}
+
+/**
+ * Strip block AND line comments anywhere on a line — not just at line start. A trailing
+ * `const x = 0; // { slug: "agents" … }` kept direction (a) green when the live entry was removed
+ * (Codex diff review), which is the same "source text is not rendered output" hole in miniature.
+ */
+export function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+/** Every source file under the searched roots. A FILESYSTEM walk, deliberately not `git grep`:
+ *  git grep skips UNTRACKED files, so a brand-new caller in the same commit reads as absent and the
+ *  guard fails on the very change that fixes the orphan. (Observed on this file's first run.) */
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    let entries: string[];
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const name of entries) {
+      if (name === "node_modules" || name.startsWith(".")) continue;
+      const p = join(dir, name);
+      if (statSync(p).isDirectory()) walk(p);
+      else if (/\.(ts|tsx|mjs)$/.test(p)) out.push(p);
+    }
+  };
+  for (const r of ["app", "components", "lib", "scripts"]) walk(join(ROOT, r));
+  return out;
+}
+
+const SOURCES = sourceFiles();
+
+/** Is `name` referenced anywhere outside its own defining file? */
+function hasCaller(name: string, ownFile: string): boolean {
+  const re = new RegExp(`\\b${name}\\b`);
+  // Comments stripped here too: a commented-out invocation must not "pay" an orphan's debt.
+  return SOURCES.some((f) => f !== ownFile && re.test(stripComments(readFileSync(f, "utf8"))));
+}
+
+/** Every `dir/actions.ts :: exportName` in the admin tree that nothing references. */
+function orphanedExportKeys(): string[] {
+  const out: string[] = [];
+  for (const d of adminDirs()) {
+    const f = join(ADMIN, d, "actions.ts");
+    if (!existsSync(f)) continue;
+    for (const name of exportedActions(readFileSync(f, "utf8"))) {
+      if (!hasCaller(name, f)) out.push(`${d}/actions.ts :: ${name}`);
+    }
+  }
+  return out;
+}
+
+describe("admin surface reachability", () => {
+  it("sees a real admin tree and a real tab list (non-vacuity)", () => {
+    expect(adminDirs().length).toBeGreaterThanOrEqual(10);
+    expect(tabSlugs()).toContain("members");
+  });
+
+  it("(a) every admin page has a tab — a page nothing links to is unreachable", () => {
+    const slugs = new Set(tabSlugs());
+    const orphanPages = adminDirs()
+      .filter((d) => existsSync(join(ADMIN, d, "page.tsx")))
+      .filter((d) => !slugs.has(d));
+    expect(
+      orphanPages,
+      `Admin pages with no entry in components/admin/admin-tabs.tsx — reachable only by typing the URL:\n${orphanPages.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("(b) every admin server action has a caller — the Skills/agents failure class", () => {
+    const orphans: string[] = [];
+    for (const key of orphanedExportKeys()) {
+      if (!(ORPHAN_ALLOWLIST as readonly string[]).includes(key)) orphans.push(key);
+    }
+    expect(
+      orphans,
+      `Admin server actions nothing calls — built capability with no surface:\n${orphans.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("the orphan allowlist matches reality exactly, so paid-off debt cannot linger", () => {
+    expect(
+      orphanedExportKeys().sort(),
+      "ORPHAN_ALLOWLIST must equal the exports that are actually orphaned — no more (silent debt), no fewer (stale entry claiming debt that was paid)"
+    ).toEqual([...ORPHAN_ALLOWLIST].sort());
+  });
+
+  it("commented-out entries never count as shipped — including TRAILING comments (non-vacuity)", () => {
+    const slugsOf = (src: string) =>
+      [...stripComments(src).matchAll(/\{\s*slug:\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(slugsOf('  // { slug: "ghost" },\n  { slug: "real" },'), "leading comment").toEqual(["real"]);
+    expect(slugsOf('  const x = 0; // { slug: "ghost" }\n  { slug: "real" },'), "TRAILING comment").toEqual(["real"]);
+    expect(slugsOf('  /* { slug: "ghost" } */\n  { slug: "real" },'), "block comment").toEqual(["real"]);
+  });
+
+  it("the export parser discriminates (non-vacuity)", () => {
+    expect(exportedActions('export async function mintFoo(') ).toEqual(["mintFoo"]);
+    expect(exportedActions('async function notExported(')).toEqual([]);
+    expect(exportedActions('export const notAFunction = 1')).toEqual([]);
+  });
+});

--- a/test/guards/dashboard-tier-filter.test.ts
+++ b/test/guards/dashboard-tier-filter.test.ts
@@ -160,6 +160,12 @@ const TITLE_SURFACE_WIRING: [string, RegExp][] = [
   // the §2.1 resolution the round-2 BLOCKER-1 conflation would replace).
   ["app/t/[team]/tasks/page.tsx", /await visibleProjectRows\(adminClient\(\)/],
   ["app/t/[team]/decisions/page.tsx", /await visibleProjectRows\(adminClient\(\)/],
+  // AGENTUI-1: the agent-token mint form's project picker. An admin's authority is to MANAGE, not
+  // to bypass the access chain — so the scope options are the admin's OWN row-visible projects, and
+  // an admin cannot scope a token to a project they cannot see. Both pins: the resolution, and the
+  // `.in(...)` that applies it (the resolution alone shipped green once before — see M4 above).
+  ["app/t/[team]/admin/agents/page.tsx", /await visibleProjectRows\(db, \{ teamId: ctx\.teamId/],
+  ["app/t/[team]/admin/agents/page.tsx", /\.in\("id", \[\.\.\.visible\.ids\]\)/],
   // The adjacent WRITE routes (Fable diff HIGH 2): filing a hand-typed row into a container
   // un-hides it (§2.1 content arms), so both create actions gate on the same row visibility.
   ["app/actions/tasks.ts", /await canSeeProjectRow\(adminClient\(\)/],


### PR DESCRIPTION
## What this is

An **Admin → Agents** page that mints, lists and revokes delegated agent tokens — the surface that made an already-built capability usable.

The token core shipped with PCCA Phase A and is enforced: `aiosd_` wire format, hashed secret, live triple-intersection attenuation, fail-closed verification. What it never had was a way in. `app/t/[team]/admin/agents/` contained `actions.ts` and **no page**; nothing imported either action; no API route minted; **prod has 0 tokens ever minted**. Plumbing with no door — the same shape as the Skills catalog.

**Why it matters beyond the page:** a delegated principal is conversation-stateless on `/api/v1/query`, so agent traffic creates no chat threads at all. That removes agent `aios query` noise from a member's Query tab *at the source* — which is why the provenance-column alternative (**QPROV-1 / AIO-1052**) was **declined** in spec review: it filtered a symptom that two documented API calls could reproduce. That declined spec ships here with a `DECLINED` banner as the record of why.

## The point of the slice: the rules live on the server

Spec review round 2 returned BLOCKED on one sentence — *"the safety folds currently exist only in client UX."* A server action is a public HTTP endpoint, so a constraint enforced by a React form binds only the people who use the form.

`lib/access/agent-token-policy.ts` is a pure module the **action** applies to every caller:

| Rule | Why |
|---|---|
| **acting-as refused** | `on_behalf_of` makes a delegated query answer in the represented person's first-person identity while quota, cost and audit stay with the launcher — and no owner→agent authorization or consent model exists |
| **expiry required, ≤ 365 days** | `mintAgentToken` stores `expiresAt ?? null`, and a null expiry **never expires** |
| **`projectScope: []` refused** | a legal DB state ("sees nothing"), never a legal *request* — only reachable by an empty multi-select |
| **scope ⊆ admin's AND launcher's visible projects** | admin = authorization, launcher = meaning (the token reads *as* them) |

It's a separate module for a hard reason: a `"use server"` file can export nothing but async functions, so the shared lifetime cap physically cannot live in the action.

## Verification

`npx tsc --noEmit` clean · `npm run lint` **0 errors** · `npm run check:docs` ✓ · `npm test` **3410 passed**, 15 skipped · `npm run test:datamechanics` (this slice) **14 passed** · `aios spec eval` **SPEC_READY**.

**16 mutations, every one `REDDENED` with the intended test named** (verdicts from `node scripts/mutate.mjs`, not narrated):

| Mutation | Reddened |
|---|---|
| acting-as refusal removed | `refuses onBehalfOf even when it is a well-formed member uuid` |
| expiry-required removed | policy expiry suite |
| max-lifetime cap removed | policy expiry suite |
| empty-scope refusal removed | `REFUSES an empty array — the accidental 'reads nothing' token` |
| Agents tab removed | `(a) every admin page has a tab` |
| page's `.in(...)` oracle gate removed | `every title surface's application site is present` |
| scope-subset enforcement removed | `REFUSES a scope naming a project the admin cannot see` |
| Expires reverted to `timeAgo` | `the expiry column uses fmtDate, not timeAgo` |
| `token_hash` re-added to select | `the page never selects token_hash` |
| untouched-scope submit guard removed | `an UNTOUCHED scope is not submittable` |
| one `revalidateAgents` removed | `mint and revoke EACH revalidate` |
| ISO shape check removed | `refuses a non-ISO date that Date.parse would happily accept` |
| memberId type check removed | `refuses an ARRAY memberId` |
| expiry clamp removed | `the expiry instant offered by the form is always inside the cap` |
| trailing-comment stripping removed | `commented-out entries never count as shipped` |
| launcher-visibility check removed | `REFUSES a project the admin can see but the LAUNCHING member cannot` |

**Pre-existing failure, not mine:** `test/datamechanics/task-update-action` fails on this branch **and identically with my changes stashed** — verified on an isolated container. Untouched.

## Review

**Reviewed by Codex (gpt-5.6-sol) — verdict BLOCKED ×3 (2 spec rounds, 1 diff round), all findings folded.**
**Reviewed by Fable code-reviewer — verdict BLOCKED on the diff, CLEAR-WITH-CONDITIONS on the spec, all findings folded.**

Five adversarial rounds across two models before and during the build. The blocked-then-folded history *is* the value, so it's recorded rather than summarised away:

**Spec rounds (before any code).** The two reviewers **split** — Codex `DECLINE`, Fable `CLEAR-WITH-CONDITIONS`. Codex declined over `on_behalf_of` impersonation with no consent model; removing it from v1 satisfied both. Both independently caught that the scope default was **fail-open** (`null` when nothing picked inherits *everything*). Round 2 then returned BLOCKED on the client-only-safety point that reshaped the whole slice — and killed the fence I'd written that forbade touching the action.

**Diff rounds.** Fable found the **Expires column showed "just now" for every live token** — `timeAgo` computes `Date.now() - then`, so a future date falls into its `secs < 60` branch. Verified empirically (90-days → "just now"). Since I'd also removed the "expired" badge on purity grounds, no token's expiry was visible at all, defeating the point of forcing one. Codex then found that **my own commit message contained false claims**: two `str.replace()` calls with no assert had silently no-oped while the message described the intent. `git show --stat` proved that commit never touched the spec it claimed to amend. Every edit in the fold asserts its anchor and is grep-proven.

Also folded: scope checked only the admin, not the launcher (the dm test made them the same member, hiding it); malformed input threw or coerced (`["<uuid>"]` passes `RegExp.test`); source-level tests were occurrence checks a second query would defeat; the guard stripped only line-start comments; and "no render-time clock read" was false — a lazy `useState` initializer runs during the first render.

**The reachability guard found a third orphan on its first run**: `members/actions.ts :: linkMemberSlack`, exported and referenced nowhere. Allowlisted per-export (not per-directory, which would hide the next orphan behind a known one) and asserted to equal reality exactly.

The `aios spec eval` adversarial LLM layer did **not** run — `DEEPSEEK_API_KEY` is unset. The five model rounds above stood in for it; the deterministic layer passed.

## Stated limits, on the page itself

- **Read-only.** Honored on `GET /api/v1/items` and `/api/v1/query`; `POST /api/v1/items` uses `authenticateApiKey`, so `aios push` returns 401.
- **Quota is shared.** Queries count against the *launching* member's daily allowance — mint against a dedicated agent member, not your own account. That advice is currently unfollowable through the UI (no way to create a `kind='agent'` member without SQL), and the page says so rather than offering a remedy that doesn't exist.

## Deliberately not in this slice

- Delegated **writes** (`POST /api/v1/items`) — widening an auth surface is its own slice with its own review.
- An `admin/access` page for groups/grants — the sibling orphan found while scoping.
- Creating agent member rows from the UI — the prerequisite for the quota advice above.
- Exposing `on_behalf_of` — needs the owner→agent authorization model that one reviewer declined the whole slice over.

AIOS-Work: AGENTUI-1
