### PR TITLE
fix(ingest): harden status lookup tables (AIO-993)

### DIFF
--- a/lib/ingest/sources/linear-normalize.ts
+++ b/lib/ingest/sources/linear-normalize.ts
@@ -95,13 +95,14 @@ export function linearMirrorProject(teamKey: string): string {
 }
 
 // Linear state.type → brain status. Linear uses "canceled" (one l); both terminal states → done.
-const TYPE_TO_STATUS: Record<string, string> = {
+// Match ClickUp's null-prototype table: provider JSON keys must never resolve Object.prototype.
+const TYPE_TO_STATUS: Record<string, string> = Object.assign(Object.create(null), {
   backlog: "backlog",
   unstarted: "ready",
   started: "in_progress",
   completed: "done",
   canceled: "done",
-};
+} as Record<string, string>);
 
 /**
  * Strict variant for the inbound apply (brain-api v1.4): a state whose name doesn't match a brain

--- a/lib/ingest/sources/plane-normalize.ts
+++ b/lib/ingest/sources/plane-normalize.ts
@@ -94,13 +94,14 @@ function safeSegment(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
-const GROUP_TO_STATUS: Record<string, string> = {
+// Match ClickUp's null-prototype table: provider JSON keys must never resolve Object.prototype.
+const GROUP_TO_STATUS: Record<string, string> = Object.assign(Object.create(null), {
   backlog: "backlog",
   unstarted: "ready",
   started: "in_progress",
   completed: "done",
   cancelled: "done", // terminal/closed; the brain has no distinct "cancelled"
-};
+} as Record<string, string>);
 
 /** A state literally NAMED like a brain status wins (e.g. a "Blocked" state in the started group); else map by group. */
 function planeStatus(stateName: string | undefined, group: string | undefined): string {

--- a/test/ingest-linear-normalize.test.ts
+++ b/test/ingest-linear-normalize.test.ts
@@ -260,6 +260,13 @@ describe("linearStatus — 'In Review' (brain-api v1.21)", () => {
     expect(linearStatus("Peer Feedback", "wat")).toBe("backlog");
   });
 
+  it("never resolves a Linear state type through Object.prototype", () => {
+    for (const hostile of ["constructor", "__proto__", "toString", "hasOwnProperty", "valueOf"]) {
+      expect(linearStatus("Marinating", hostile)).toBe("backlog");
+      expect(linearStatusOrNull("Marinating", hostile)).toBeNull();
+    }
+  });
+
   it("still lets a state literally named like another brain status win over its type", () => {
     expect(linearStatus("Blocked", "started")).toBe("blocked");
     expect(linearStatus("Done", "started")).toBe("done");

--- a/test/ingest-plane-normalize.test.ts
+++ b/test/ingest-plane-normalize.test.ts
@@ -176,6 +176,54 @@ describe("normalizePlaneProject", () => {
     expect((p.rows as Record<string, unknown>[])[0].status).toBe("blocked");
   });
 
+  it("never resolves a Plane state group through Object.prototype", () => {
+    const hostileGroups = ["constructor", "__proto__", "toString", "hasOwnProperty", "valueOf"];
+    const p = normalizePlaneProject({
+      ...base,
+      states: hostileGroups.map((group, index) => ({
+        id: `s-hostile-${index}`,
+        name: `Native state ${index}`,
+        group,
+      })),
+      items: hostileGroups.map((_, index) => ({
+        id: `wi-hostile-${index}`,
+        sequence_id: 100 + index,
+        name: `Hostile group ${index}`,
+        state: `s-hostile-${index}`,
+      })),
+    });
+
+    expect((p.rows as Record<string, unknown>[]).map((row) => row.status)).toEqual([
+      "backlog",
+      "backlog",
+      "backlog",
+      "backlog",
+      "backlog",
+    ]);
+  });
+
+  it("preserves every configured Plane group mapping", () => {
+    const groups = ["backlog", "unstarted", "started", "completed", "cancelled"];
+    const p = normalizePlaneProject({
+      ...base,
+      states: groups.map((group, index) => ({ id: `s-group-${index}`, name: `Native ${index}`, group })),
+      items: groups.map((_, index) => ({
+        id: `wi-group-${index}`,
+        sequence_id: 200 + index,
+        name: `Known group ${index}`,
+        state: `s-group-${index}`,
+      })),
+    });
+
+    expect((p.rows as Record<string, unknown>[]).map((row) => row.status)).toEqual([
+      "backlog",
+      "ready",
+      "in_progress",
+      "done",
+      "done",
+    ]);
+  });
+
   it("serializes projectable fields into the body so a changed field shifts content_sha256", () => {
     const mk = (status: string) =>
       normalizePlaneProject({

--- a/test/pm-sync-inbound-status.test.ts
+++ b/test/pm-sync-inbound-status.test.ts
@@ -35,6 +35,12 @@ describe("linearStatusOrNull / linearStatus", () => {
     expect(linearStatusOrNull(undefined, undefined)).toBeNull();
   });
 
+  it("treats inherited Object.prototype names as unknown types on the strict inbound path", () => {
+    for (const hostile of ["constructor", "__proto__", "toString", "hasOwnProperty", "valueOf"]) {
+      expect(linearStatusOrNull("Weird", hostile)).toBeNull();
+    }
+  });
+
   it("linearStatus keeps the ingest default (backlog) for unresolvable states", () => {
     expect(linearStatus("Weird", "mystery")).toBe("backlog");
     expect(linearStatus("Blocked", "started")).toBe("blocked");


### PR DESCRIPTION
## Summary

- make Linear and Plane status lookup tables prototype-safe using the established ClickUp null-prototype pattern
- add hostile-key regression coverage across Linear ingest, strict inbound reconciliation, and Plane ingest
- preserve every configured type/group mapping and the existing name-first semantics

## Frozen-base RED

`npx vitest run test/ingest-linear-normalize.test.ts test/pm-sync-inbound-status.test.ts test/ingest-plane-normalize.test.ts`

- 3 test files failed; 3 tests failed and 42 passed
- Linear returned inherited `Object.prototype` functions instead of `backlog`/`null`
- Plane returned inherited prototype members for all five hostile keys

## Verification

- focused Vitest: 3 files passed, 45 tests passed
- serialized full unit suite: 3,386 passed, 15 skipped
- allowlisted ESLint: passed
- TypeScript typecheck: passed
- docs drift: passed (64 routes, 85 tables, 8 sources)
- architecture map re-checked; no truth change

## Review — Reviewed by Codex CLI 0.149.1 — verdict Ready to merge; no blocking findings; executable tests passed in the writable builder/orchestrator runs

Closes AIO-993

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive change to status lookup tables with regression tests; no auth, data migration, or API contract changes beyond fixing incorrect status resolution for prototype property names.
> 
> **Overview**
> **Hardens PM ingest status mapping** so untrusted provider `type`/`group` strings cannot hit inherited `Object.prototype` keys (e.g. `constructor`, `__proto__`).
> 
> `TYPE_TO_STATUS` in **linear-normalize** and `GROUP_TO_STATUS` in **plane-normalize** now use the same **null-prototype** table pattern as ClickUp (`Object.assign(Object.create(null), …)`). Legitimate mappings and name-first semantics are unchanged; hostile keys fall through to **backlog** on ingest and **null** on strict inbound (`linearStatusOrNull`).
> 
> Regression tests cover hostile keys on Linear unit tests, Plane normalize (plus an explicit check that all configured group mappings still hold), and pm-sync inbound status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f86d614e2ab0ff346dc691e2dd6473279d18f03f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->