### PR TITLE
fix(nda): scan ranges beyond 100 commits (AIO-1061)

### DIFF
--- a/.github/workflows/nda-gate.yml
+++ b/.github/workflows/nda-gate.yml
@@ -86,7 +86,7 @@ jobs:
             exit 1
           fi
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
-            node scripts/nda-scan.mjs --tree "$MERGE_SHA" --range "$BASE_SHA..$HEAD_SHA"
+            node scripts/nda-scan.mjs --tree "$MERGE_SHA" --range "$BASE_SHA..$HEAD_SHA" --max-commits 500
           elif [ -n "${BASE_SHA:-}" ] && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
             node scripts/nda-scan.mjs --range "$BASE_SHA..$HEAD_SHA"
           else

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -824,6 +824,9 @@ guard enforces it, it's named.
   variants, every added commit-range path and content block (including merge commits), and commit
   messages. Backreferences are rejected and every matcher has a hard timeout. Push events scan their full
   `before..sha` range too, so add-then-scrub history cannot disappear behind a clean final tree.
+  Untrusted PR ranges carry an explicit 500-commit ceiling; exceeding it fails closed with a distinct,
+  actionable count/limit verdict, while the trusted recreated-protected-branch fallback remains an
+  uncapped full-history scan. The separate 2,000-path and 64 MiB range ceilings remain fail-closed.
   Matching uses one POSIX ERE engine throughout. Public CI emits only the unavoidable pass/fail bit:
   it never includes matching text, locations, counts, a term, an index, or the private list size;
   `--reveal` is disabled in CI. The gate **fails closed** whenever the list or scanner is unavailable,

--- a/scripts/nda-scan.mjs
+++ b/scripts/nda-scan.mjs
@@ -61,6 +61,28 @@ const rangeIdx = argv.indexOf("--range");
 const range = rangeIdx >= 0 ? argv[rangeIdx + 1] : null;
 const treeIdx = argv.indexOf("--tree");
 const tree = treeIdx >= 0 ? argv[treeIdx + 1] : null;
+const maxCommitsIdx = argv.indexOf("--max-commits");
+const maxCommitsRaw = maxCommitsIdx >= 0 ? argv[maxCommitsIdx + 1] : null;
+const parsedMaxCommits = maxCommitsRaw !== null && /^[1-9]\d*$/.test(maxCommitsRaw)
+  ? Number(maxCommitsRaw)
+  : null;
+const maxCommits = Number.isSafeInteger(parsedMaxCommits) ? parsedMaxCommits : null;
+
+class CommitRangeLimitError extends Error {
+  constructor(commitCount, limit) {
+    super(`commit range contains ${commitCount} commits, exceeding the configured limit of ${limit}; split or rebase the pull request`);
+    this.name = "CommitRangeLimitError";
+  }
+}
+
+function countRangeCommits(rangeSpec, cwd) {
+  const raw = runRedacted("git", ["rev-list", "--count", rangeSpec], { encoding: "utf8", cwd }) ?? "";
+  const value = raw.trim();
+  if (!/^(?:0|[1-9]\d*)$/.test(value)) throw new Error("confidential-pattern scan could not run");
+  const count = Number(value);
+  if (!Number.isSafeInteger(count)) throw new Error("confidential-pattern scan could not run");
+  return count;
+}
 
 // No path exclusions. This is a scan of the tracked tree, and a tracked lockfile, binary, symlink,
 // filename, or generated-looking directory is just as public as source code. `git grep` already
@@ -305,15 +327,25 @@ export function scan(terms, { revealLines = false, cwd = process.cwd(), treeish 
  * markers rather than file:line, because a patch hunk's "location" is a commit, and naming it is
  * enough to find it locally.
  */
-export function scanRange(terms, rangeSpec, { revealLines = false, cwd = process.cwd() } = {}) {
+export function scanRange(terms, rangeSpec, { revealLines = false, cwd = process.cwd(), maxCommits = null } = {}) {
   if (terms.length === 0) throw new Error("no active NDA terms — refusing to report a pass");
   assertSafeTerms(terms);
+  if (maxCommits !== null && (!Number.isSafeInteger(maxCommits) || maxCommits < 1)) {
+    throw new Error("confidential-pattern scan could not run");
+  }
+  if (maxCommits !== null) {
+    const commitCount = countRangeCommits(rangeSpec, cwd);
+    if (commitCount > maxCommits) throw new CommitRangeLimitError(commitCount, maxCommits);
+  }
   const res = [];
   const normalizedTerms = terms.map((term) => term.normalize("NFKC"));
-  const commits = (runRedacted("git", ["rev-list", "--reverse", rangeSpec], { encoding: "utf8", cwd }) ?? "")
+  const enumerationLimit = maxCommits === null ? [] : [`--max-count=${BigInt(maxCommits) + 1n}`];
+  const commits = (runRedacted("git", ["rev-list", "--reverse", ...enumerationLimit, rangeSpec], { encoding: "utf8", cwd }) ?? "")
     .split("\n")
     .filter(Boolean);
-  if (commits.length > 100) throw new Error("confidential-pattern scan could not run");
+  if (maxCommits !== null && commits.length > maxCommits) {
+    throw new CommitRangeLimitError(commits.length, maxCommits);
+  }
   let changedPathCount = 0;
   let scannedByteCount = 0;
 
@@ -472,6 +504,14 @@ function main() {
     console.error("NDA-GATE: BLOCKED — an option is missing its value.");
     process.exit(2);
   }
+  if (argv.filter((arg) => arg === "--max-commits").length > 1 || (maxCommitsIdx >= 0 && maxCommits === null)) {
+    console.error("NDA-GATE: BLOCKED — --max-commits requires one positive safe integer.");
+    process.exit(2);
+  }
+  if (maxCommits !== null && !range) {
+    console.error("NDA-GATE: BLOCKED — --max-commits requires --range.");
+    process.exit(2);
+  }
   const raw = termsFile ? readFileSync(termsFile, "utf8") : (process.env.NDA_TERMS ?? "");
   if (reveal && process.env.CI) {
     console.error("NDA-GATE: BLOCKED — reveal mode is disabled in CI.");
@@ -487,10 +527,10 @@ function main() {
   try {
     findings = scan(terms, { revealLines: reveal, treeish: tree });
     // The tree is what ships; the range is what becomes permanent history. Both, when given one.
-    if (range) findings = findings.concat(scanRange(terms, range, { revealLines: reveal }));
+    if (range) findings = findings.concat(scanRange(terms, range, { revealLines: reveal, maxCommits }));
   } catch (e) {
     console.error(`NDA-GATE: BLOCKED — ${e.message}`);
-    process.exit(2);
+    process.exit(e instanceof CommitRangeLimitError ? 3 : 2);
   }
   if (findings.length === 0) {
     console.log("NDA-GATE: clean (private patterns checked across the tracked tree)");

--- a/test/guards/nda-gate.test.ts
+++ b/test/guards/nda-gate.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFileSync, mkdtempSync, writeFileSync, rmSync, renameSync, symlinkSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  readFileSync,
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  renameSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseTerms, scan, scanRange } from "@/scripts/nda-scan.mjs";
@@ -17,9 +26,13 @@ const ROOT = join(import.meta.dirname, "..", "..");
 const SCRIPT = join(ROOT, "scripts", "nda-scan.mjs");
 
 /** Run the CLI and return its exit code + streams, without throwing on non-zero. */
-function run(env: Record<string, string>, args: string[] = []): { code: number; out: string; err: string } {
+function run(
+  env: Record<string, string>,
+  args: string[] = [],
+  cwd = ROOT
+): { code: number; out: string; err: string } {
   try {
-    const out = execFileSync("node", [SCRIPT, ...args], { cwd: ROOT, encoding: "utf8", env: { ...process.env, ...env } });
+    const out = execFileSync("node", [SCRIPT, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...env } });
     return { code: 0, out, err: "" };
   } catch (e) {
     const x = e as { status: number; stdout: string; stderr: string };
@@ -86,6 +99,25 @@ describe("guard: the NDA confidentiality gate", () => {
     const r = run({ NDA_TERMS: privatePattern, CI: "true" }, ["--reveal"]);
     expect(r.code).toBe(2);
     expect(`${r.out}\n${r.err}`).not.toContain(privatePattern);
+  });
+
+  it("validates the explicit commit limit without exposing configured patterns", () => {
+    const invalid = run(
+      { NDA_TERMS: "SYNTHETIC_NEVER_PRESENT", CI: "true" },
+      ["--range", "HEAD", "--max-commits", "0"]
+    );
+    expect(invalid.code).toBe(2);
+    expect(invalid.err).toMatch(/positive safe integer/i);
+
+    const unscoped = run(
+      { NDA_TERMS: "SYNTHETIC_NEVER_PRESENT", CI: "true" },
+      ["--max-commits", "500"]
+    );
+    expect(unscoped.code).toBe(2);
+    expect(unscoped.err).toMatch(/requires --range/i);
+    expect(`${invalid.out}\n${invalid.err}\n${unscoped.out}\n${unscoped.err}`).not.toContain(
+      "SYNTHETIC_NEVER_PRESENT"
+    );
   });
 
   it("still executes when invoked through a symlinked CLI path", () => {
@@ -192,6 +224,117 @@ describe("guard: the NDA confidentiality gate", () => {
       expect(scanRange(["SYNTHETICTERM"], `${removed}..${pathAdded}`, { cwd: dir }).length).toBeGreaterThan(0);
       expect(scanRange(["SYNTHETICTERM"], `${pathAdded}..${pathScrubbed}`, { cwd: dir })).toEqual([]);
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns real clean and blocked verdicts for ranges over 100 commits", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nda-gate-long-range-"));
+    const git = (...args: string[]) => execFileSync("git", args, { cwd: dir, encoding: "utf8" });
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.local");
+      git("config", "user.name", "t");
+      git("commit", "-qm", "base", "--allow-empty");
+      const base = git("rev-parse", "HEAD").trim();
+
+      for (let i = 1; i <= 101; i += 1) {
+        git("commit", "-qm", `synthetic clean commit ${i}`, "--allow-empty");
+      }
+      expect(scanRange(["SYNTHETICTERM"], `${base}..HEAD`, { cwd: dir })).toEqual([]);
+
+      git("commit", "-qm", "synthetic message contains SYNTHETICTERM", "--allow-empty");
+      expect(scanRange(["SYNTHETICTERM"], `${base}..HEAD`, { cwd: dir, maxCommits: 500 }).length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("fails an explicitly bounded range above 500 commits with a distinct actionable verdict", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nda-gate-pr-limit-"));
+    const git = (...args: string[]) => execFileSync("git", args, { cwd: dir, encoding: "utf8" });
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.local");
+      git("config", "user.name", "t");
+      git("commit", "-qm", "base", "--allow-empty");
+      const base = git("rev-parse", "HEAD").trim();
+
+      for (let i = 1; i <= 501; i += 1) {
+        git("commit", "-qm", `synthetic empty commit ${i}`, "--allow-empty");
+      }
+      const bounded = run(
+        { NDA_TERMS: "SYNTHETIC_NEVER_PRESENT", CI: "true" },
+        ["--range", `${base}..HEAD`, "--max-commits", "500"],
+        dir
+      );
+      expect(bounded.code).toBe(3);
+      expect(bounded.err).toMatch(/501 commits/);
+      expect(bounded.err).toMatch(/limit of 500/);
+      expect(bounded.err).toMatch(/split or rebase/i);
+      expect(`${bounded.out}\n${bounded.err}`).not.toContain("SYNTHETIC_NEVER_PRESENT");
+
+      const engineFailure = run(
+        { NDA_TERMS: "SYNTHETIC[", CI: "true" },
+        ["--range", `${base}..HEAD`],
+        dir
+      );
+      expect(engineFailure.code).toBe(2);
+      expect(`${engineFailure.out}\n${engineFailure.err}`).not.toContain("SYNTHETIC[");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it("counts a capped range before enumerating commit hashes and validates the count", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nda-gate-count-first-"));
+    const gitShim = join(dir, "git");
+    const enumerationMarker = join(dir, "enumerated");
+    const previousPath = process.env.PATH;
+    const previousCount = process.env.NDA_TEST_COMMIT_COUNT;
+    const previousMarker = process.env.NDA_TEST_ENUMERATION_MARKER;
+    try {
+      writeFileSync(
+        gitShim,
+        `#!/bin/sh
+if [ "$1" = "rev-list" ] && [ "$2" = "--count" ]; then
+  printf '%s\\n' "$NDA_TEST_COMMIT_COUNT"
+  exit 0
+fi
+if [ "$1" = "rev-list" ] && [ "$2" = "--reverse" ]; then
+  : > "$NDA_TEST_ENUMERATION_MARKER"
+  exit 97
+fi
+exit 98
+`
+      );
+      chmodSync(gitShim, 0o755);
+      process.env.PATH = `${dir}:${previousPath ?? ""}`;
+      process.env.NDA_TEST_ENUMERATION_MARKER = enumerationMarker;
+
+      process.env.NDA_TEST_COMMIT_COUNT = "not-a-count";
+      expect(() => scanRange(["SYNTHETICTERM"], "synthetic", { cwd: dir, maxCommits: 500 })).toThrow(
+        /scan could not run/i
+      );
+      expect(existsSync(enumerationMarker)).toBe(false);
+
+      process.env.NDA_TEST_COMMIT_COUNT = "9007199254740992";
+      expect(() => scanRange(["SYNTHETICTERM"], "synthetic", { cwd: dir, maxCommits: 500 })).toThrow(
+        /scan could not run/i
+      );
+      expect(existsSync(enumerationMarker)).toBe(false);
+
+      process.env.NDA_TEST_COMMIT_COUNT = "501";
+      expect(() => scanRange(["SYNTHETICTERM"], "synthetic", { cwd: dir, maxCommits: 500 })).toThrow(
+        /501 commits.*limit of 500/i
+      );
+      expect(existsSync(enumerationMarker)).toBe(false);
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousCount === undefined) delete process.env.NDA_TEST_COMMIT_COUNT;
+      else process.env.NDA_TEST_COMMIT_COUNT = previousCount;
+      if (previousMarker === undefined) delete process.env.NDA_TEST_ENUMERATION_MARKER;
+      else process.env.NDA_TEST_ENUMERATION_MARKER = previousMarker;
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -319,9 +462,12 @@ describe("guard: the NDA confidentiality gate", () => {
     expect(workflow).toContain("refs/pull/$PR_NUMBER/head:refs/nda-scan/pr-head");
     expect(workflow).toContain("refs/pull/$PR_NUMBER/merge:refs/nda-scan/pr-merge");
     expect(workflow).toContain('test "$(git show -s --format=%P "$MERGE_SHA")" = "$BASE_SHA $HEAD_SHA"');
-    expect(workflow).toContain('node scripts/nda-scan.mjs --tree "$MERGE_SHA" --range "$BASE_SHA..$HEAD_SHA"');
+    expect(workflow).toContain(
+      'node scripts/nda-scan.mjs --tree "$MERGE_SHA" --range "$BASE_SHA..$HEAD_SHA" --max-commits 500'
+    );
     expect(workflow).toContain('node scripts/nda-scan.mjs --range "$BASE_SHA..$HEAD_SHA"');
-    expect(workflow).toContain('node scripts/nda-scan.mjs --range "$HEAD_SHA"');
+    expect(workflow).toMatch(/node scripts\/nda-scan\.mjs --range "\$HEAD_SHA"\s*\n/);
+    expect(workflow.match(/--max-commits/g)).toHaveLength(1);
     expect(workflow).toContain("timeout-minutes: 10");
     expect(workflow).toContain("secrets.NDA_TERMS");
     expect(workflow).toContain("statuses: write");


### PR DESCRIPTION
## Summary

- remove the global 100-commit cliff so trusted protected-branch recreation can scan its full history
- cap untrusted `pull_request_target` ranges at 500 commits with an actionable count/limit verdict and distinct exit code 3
- count capped ranges before bounded hash enumeration, preserving existing path, byte, redaction, added-lines, and merge-parent protections
- document the trust-boundary split and add synthetic long-history, malformed-count, resource-limit, exit-code, and workflow-scoping coverage

## Frozen-base RED

- a synthetic 101-commit range hit the inherited generic scanner failure instead of returning a real clean or blocked verdict
- the first remediation left untrusted PR histories unbounded
- the second remediation enumerated the full revision list before checking the new ceiling, allowing very large ranges to lose the distinct verdict

## Verification

- focused NDA guard suite: 21/21 passed
- post-rebase serialized full unit suite: 3,390 passed, 15 skipped
- real local leak gate: passed with protected output suppressed
- ESLint: passed with the repository's existing warnings
- TypeScript typecheck: passed
- docs drift and `git diff --check`: passed
- exact-head GitHub NDA verification remains required after push

## Review — Reviewed by Codex CLI 0.149.1 — verdict Ready to merge; two resource-bound findings remediated; full writable test suite passed

Closes AIO-1061
