### PR TITLE
fix(release): declare v0.11.0 before cutting it — the release path PRET-6 requires (RELPTR-2)

### DIFF
--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -471,17 +471,23 @@ invariant"):
 
 ## 9. Access enforcement — arming per-project visibility for a team
 
-**The one-line summary:** every team is `permissive` until someone changes it, and `permissive`
-means one flat pool — every `team`-tier member reads every other member's pushed content, and the
-whole timeline. If a customer believes their people are separated from each other, they are wrong
-until this is armed **and** their content is curated (see "What enforcing does not buy" below).
+> ⚠️ **THE ARMING STEP IS RETIRED (PRET-6).** There is no longer a mode to flip: `permissive` was
+> deleted, `teams.access_enforcement` was dropped from the schema, and `set-access-enforcement` was
+> removed from the admin CLI. **Enforcing is the only behaviour** — membership decides what a member
+> reads, always. What survives below is the description of *what enforcement covers*, which is still
+> accurate and still worth reading; the commands that armed it no longer exist.
+>
+> Upgrading an installation that predates the retirement is an ordered, one-way path:
+> [`RELEASING.md`](RELEASING.md) §3.4 and `RELEASE-NOTES-pret6.md`.
 
-### The command
+**What this used to mean, and why the section exists:** a team was `permissive` until someone armed
+it, and `permissive` meant one flat pool — every `team`-tier member read every other member's pushed
+content and the whole timeline. That default is what PRET-6 removed.
 
-```
-npx tsx --conditions react-server scripts/admin.ts \
-  set-access-enforcement <team-slug> <permissive|enforcing> [--dry-run]
-```
+### The command — REMOVED
+
+The arming command is gone. It is not reproduced here even as an example: a copyable command for a
+verb the CLI no longer has is found during an incident, which is the worst moment to discover it.
 
 - The team is a **positional argument**, not `--team`. Every other command in this CLI defaults to
   `--team demo`; a silent default on the flag that decides what an entire team can see is exactly
@@ -539,14 +545,18 @@ direction is fail-CLOSED (content briefly hidden, never leaked) and self-heals, 
 arming enforcement during an active sync, wait a tick and re-run `--dry-run` before you trust the
 verdict.
 
-### Rolling back
+### Rolling back — **there is no longer a way back**
 
-```
-… scripts/admin.ts set-access-enforcement <team-slug> permissive
-```
+**PRET-6 deleted the permissive mode.** `set-access-enforcement` is gone from the admin CLI and
+`teams.access_enforcement` is dropped from the schema, so the command this section used to publish —
+`… scripts/admin.ts set-access-enforcement <team-slug> permissive` — no longer exists. It is recorded
+here rather than silently removed, because a stale rollback instruction is worse than an absent one:
+someone reaching for it during an incident would burn the incident discovering it.
 
-`permissive` is never gated on readiness — it is the fail-open-to-today direction and cannot hide
-anything, so it is also the one-command undo for a team someone armed by hand in SQL.
+Membership is now the only thing that decides what a member reads. The undo for an over-broad grant is
+a membership or grant change (`npm run admin -- revoke-project …`), not a mode flip. If you are
+upgrading a pre-flip installation, the ordered path — and the fact that it is one-way — is in
+[`RELEASING.md`](RELEASING.md) §3.4 and `RELEASE-NOTES-pret6.md`.
 
 ### What `enforcing` actually covers — and what it does not
 

--- a/docs/RELEASE-NOTES-pret6.md
+++ b/docs/RELEASE-NOTES-pret6.md
@@ -16,7 +16,7 @@ You may **not** jump to this release from a pre-flip installation. The required 
    unfinished backfill), and connector warnings are a judgment call for you:
 
    ```bash
-   npx tsx scripts/admin.ts set-access-enforcement <team-slug> enforcing
+   npm run admin -- set-access-enforcement <team-slug> enforcing
    ```
 
 3. **Verify nothing is left permissive** before upgrading:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -137,6 +137,12 @@ predates the entire PRET series.
 2. **Let it boot, and let auto-flip converge.** The marker is written by the running application
    (`instrumentation.ts`), not by a migration — applying the schema alone does **not** satisfy the
    precondition.
+> **Steps 3 and 4 run against the `v0.11.0` release and its database — not after the upgrade.** The
+> retirement deletes both: `set-access-enforcement` is gone from the admin CLI at HEAD, and
+> `teams.access_enforcement` is dropped from the schema. Verified: the command exists at `803122ff`
+> (`scripts/admin.ts:369`) and the column at `803122ff:postgres/schema.sql:162`; both are absent at
+> HEAD. Running either after upgrading gives a confusing error, not a warning.
+
 3. **Flip any team auto-flip could not**, using the command that release carries:
 
    ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -132,6 +132,12 @@ predates the entire PRET series.
 
 ### The path
 
+0. **Before cutting the tag** (maintainers): let in-flight migration jobs drain and ask open PRs to
+   rebase onto the commit that declares `v0.11.0`. Declaring before cutting keeps every PR that
+   *contains* the declaration green — but a PR still on an older base declares only through `v0.10.0`,
+   and its migration job reads full history, so a rerun after the tag exists throws
+   `DEFAULT_TAGS is stale`.
+
 1. **Point the service at `release/v0.11.0`** and deploy it. A tag is not enough — Railway's GitHub
    source is a *connected branch*, so there is no supported, fleet-wide way to select a tag.
 2. **Let it boot, and let auto-flip converge.** The marker is written by the running application

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -116,6 +116,53 @@ different base.
 
 ---
 
+## 3.4 Upgrading an EXISTING installation past PRET-6 — the ordered path
+
+**A pre-flip installation cannot jump to the retirement release.**
+`postgres/migrations/20260818210000_pret6_retire_access_enforcement.sql` refuses:
+
+```
+PRET-6 refused: the PRET-4 builtin materialization has not completed on this fleet
+                — upgrade through the prior release first
+```
+
+That refusal is correct and fails safe — `pg:schema` aborts, Railway's preDeploy halts, and the old
+code keeps serving. But until `v0.11.0` exists there was **no release to upgrade through**: `v0.10.0`
+predates the entire PRET series.
+
+### The path
+
+1. **Point the service at `release/v0.11.0`** and deploy it. A tag is not enough — Railway's GitHub
+   source is a *connected branch*, so there is no supported, fleet-wide way to select a tag.
+2. **Let it boot, and let auto-flip converge.** The marker is written by the running application
+   (`instrumentation.ts`), not by a migration — applying the schema alone does **not** satisfy the
+   precondition.
+3. **Flip any team auto-flip could not**, using the command that release carries:
+
+   ```bash
+   npm run admin -- set-access-enforcement <team-slug> enforcing
+   ```
+
+4. **Verify both preconditions directly. This query is the gate — not a log line:**
+
+   ```sql
+   select exists (select 1 from migration_markers where name = 'pret4_builtin_materialize') as marker_ok,
+          (select count(*) from teams where access_enforcement = 'permissive') as permissive_left;
+   ```
+
+   Proceed only on `marker_ok = t` **and** `permissive_left = 0`.
+
+   Why a query rather than the boot log: the boot materialization is best-effort and its retry lives in
+   the scheduler, which `instrumentation.ts` starts **only when `INGEST_POLL_ENABLED !== "false"`**. A
+   transient boot failure on a service with ingestion disabled leaves a healthy-looking instance with
+   no marker — and the next upgrade refuses exactly as before.
+
+5. **Point the service back at `main`** and deploy the retirement release.
+
+Full detail, including what auto-flip will and will not do for you: `RELEASE-NOTES-pret6.md`.
+
+---
+
 ## 4. The deadlock this file ships with the fix for
 
 `scripts/migrate-from-existing.mjs` enforced two rules back to back:

--- a/docs/design/release-pret6-upgrade-path.md
+++ b/docs/design/release-pret6-upgrade-path.md
@@ -57,7 +57,9 @@ lane is not evidence that an installed user can upgrade.
 
 `803122ff` verified: PRET-6's **direct parent**; an ancestor of `main`; carries
 `20260811160000_access_enforcement_flag.sql` and `20260817120000_autoflip_hold.sql`; does **not**
-carry the PRET-6 migration; and its own CI was **green (8/8 checks)**.
+carry the PRET-6 migration; and its own CI was **green — 8 check-runs, 0 failures**, read from
+`repos/aiosbrain/aios-team-brain/commits/803122ff/check-runs` on 2026-08-26 (eight was the required
+count at that date, per `docs/CI-ARCHITECTURE.md`'s record of the time).
 
 **The release branch gets NO CI, and that is a gap this slice must close by hand.** `.github/workflows/ci.yml` fires on
 `pull_request` and `push` to `main`/`staging` only, so pushing `release/v0.11.0` and its tag triggers
@@ -70,9 +72,11 @@ automated here; both are named steps.
 source is a *connected branch* — its own docs describe only a trigger branch, and the repo's install
 paths name `main`. An operator whose service tracks `main` therefore has no way to deploy a tag. So
 `release/v0.11.0` exists as a branch they can repoint at, deploy, let converge, and then repoint away
-from. **A tag alone would have been undeployable by exactly the fleet that needs it** (narrowed after
-review: there is no *supported, fleet-wide connected-source* path to select a tag — a service that
-already deployed that SHA could redeploy it, which no pre-flip install has) — which would
+from. **A tag alone would have left the fleet without a supported path** — narrowed twice under review, and
+now stated exactly: Railway's connected-source and UI path is branch-based, so the branch is what an
+operator can actually use. It is **not** true that the tag target is undeployable in principle —
+Railway's API accepts a specific `commitSha`, so someone comfortable with the API could resolve the
+tag and deploy it. The branch exists so the documented path does not require that — which would
 have made the "two releases" answer correct on paper and useless in practice.
 
 **3. The branch carries ONE commit on top of `803122ff`:** the version moved to `0.11.0` at all three
@@ -89,13 +93,20 @@ affordance for that.
 | # | step | why this order |
 |---|---|---|
 | 1 | **PR A on `main`** — declare `v0.11.0` (pending; it does not exist yet) | legal, because only the newest declared tag may be absent — and it means no PR goes stale when the tag appears |
-| 2 | **cut `release/v0.11.0` + tag `v0.11.0`** | now declared, so nothing reddens |
+| 2 | **cut `release/v0.11.0` + tag `v0.11.0`** | declared first, so any PR **that contains the declaration** stays green |
 | 3 | **PR B on `main`** — declare `v0.12.0` (pending), bump the version, date the changelog, ship the agreement guards | `v0.11.0` now exists, so declaring a second pending tag is legal |
 | 4 | **tag `v0.12.0`** on the merged PR B commit | |
 
 Declaring **both** while neither exists throws `unknown git tag: v0.11.0` (verified by running it) —
-the middle-hole rule. So the machinery enforces the sequence the release notes require, and the
-two-PR split is what keeps every step green.
+the middle-hole rule. So the machinery enforces the sequence the release notes require.
+
+**NARROWED after review — "nothing reddens" was too strong.** Declaring first protects PRs whose tree
+*contains* the declaration. A PR still based on an older commit declares only through `v0.10.0`, and
+its migration job reads full history — so once `v0.11.0` exists it throws `DEFAULT_TAGS is stale`, on
+a rerun or a queued job for an old merge SHA. The window is real, just far smaller than cutting first.
+So the runbook adds a step: **before cutting, let in-flight migration jobs drain and ask open PRs to
+rebase onto the declaring commit.** A PR that rebases is fine; one that sits on an old base and reruns
+is not.
 
 A second, better consequence: once `v0.11.0` exists and is declared, the migration lane starts
 exercising **`v0.11.0 → current`** — structurally testing the very upgrade the fleet must perform.

--- a/docs/design/release-pret6-upgrade-path.md
+++ b/docs/design/release-pret6-upgrade-path.md
@@ -1,0 +1,218 @@
+# Two releases, in order — giving PRET-6 the upgrade path it requires (RELPTR-2)
+
+Status: **rewritten after a pre-code cold read returned BLOCKED.** The first draft cut a single
+`v0.11.0` from current `main`; that release **cannot be installed by any existing installation**
+· Owner: chetan · Tier build-with: unit (the agreement guards) + a documented human release procedure
+
+**Deps:** RELPTR-1 (`04682a35`, #657) is on `main`. Without it, declaring a not-yet-cut tag throws.
+
+**Increment:** a `release/v0.11.0` branch + tag cut from the PRET-5 state, then ONE PR on `main` that
+declares both tags, bumps the version, dates the changelog, and ships the agreement guards. `v0.12.0`
+is tagged after that PR merges.
+
+## Problem
+
+### The release we were about to cut could not be installed
+
+`postgres/migrations/20260818210000_pret6_retire_access_enforcement.sql:31-35`:
+
+```sql
+if exists (select 1 from teams)
+   and not exists (select 1 from migration_markers where name = 'pret4_builtin_materialize') then
+  raise exception 'PRET-6 refused: the PRET-4 builtin materialization has not completed on this fleet
+                   — upgrade through the prior release first (see docs/RELEASE-NOTES-pret6.md)';
+```
+
+And `docs/RELEASE-NOTES-pret6.md:9`: *"You **may not** jump to this release from a pre-flip
+installation."* The required order is: run the PRIOR release (the PRET-2..5 series), let auto-flip
+converge, flip any remaining permissive team, then upgrade.
+
+**That prior release was never tagged.** Measured: `v0.10.0` was cut **2026-08-03**; the entire PRET
+series landed **2026-08-17/18**. So a `v0.10.0` database with any team in it lacks the
+`pret4_builtin_materialize` marker, hits the `raise`, and `pg:schema` aborts — Railway's preDeploy
+halts and the old code keeps serving.
+
+The refusal is **correct and well-built** (it fails in the safe direction). What was missing is the
+release it points at.
+
+### CI cannot see this, and already says so
+
+`scripts/migrate-from-existing.mjs:18-24`, in its own words:
+
+> *"Every scratch database is created EMPTY, so a migration is only ever exercised against zero rows…
+> `20260818210000_pret6_retire_access_enforcement.sql` is the live proof — against a populated database
+> it aborts the rollout … and against this lane it is **green every time**."*
+
+The gap was documented. What was not documented is its consequence for the **next release**: a green
+lane is not evidence that an installed user can upgrade.
+
+## Decision
+
+**1. Two releases, in the order the release notes already prescribe.**
+
+| | commit | is | why |
+|---|---|---|---|
+| **`v0.11.0`** | **base** `803122ff` (PRET-5, 2026-08-18); the **tag target** is the version/changelog commit on top of it | the last state **before** the retirement | this is the "prior release" the notes send operators through |
+| **`v0.12.0`** | current `main` | the retirement | now reachable by a documented path |
+
+`803122ff` verified: PRET-6's **direct parent**; an ancestor of `main`; carries
+`20260811160000_access_enforcement_flag.sql` and `20260817120000_autoflip_hold.sql`; does **not**
+carry the PRET-6 migration; and its own CI was **green (8/8 checks)**.
+
+**The release branch gets NO CI, and that is a gap this slice must close by hand.** `.github/workflows/ci.yml` fires on
+`pull_request` and `push` to `main`/`staging` only, so pushing `release/v0.11.0` and its tag triggers
+**nothing** — the actual tag target (base + the version/changelog commit) would otherwise be tagged
+having never been run. Before tagging: run the full local verification against that exact SHA, and
+perform the sandbox deployment `docs/RAILWAY-TEMPLATE.md` already requires per release. Neither is
+automated here; both are named steps.
+
+**2. `v0.11.0` is a BRANCH as well as a tag, because Railway cannot track a tag.** Railway's GitHub
+source is a *connected branch* — its own docs describe only a trigger branch, and the repo's install
+paths name `main`. An operator whose service tracks `main` therefore has no way to deploy a tag. So
+`release/v0.11.0` exists as a branch they can repoint at, deploy, let converge, and then repoint away
+from. **A tag alone would have been undeployable by exactly the fleet that needs it** (narrowed after
+review: there is no *supported, fleet-wide connected-source* path to select a tag — a service that
+already deployed that SHA could redeploy it, which no pre-flip install has) — which would
+have made the "two releases" answer correct on paper and useless in practice.
+
+**3. The branch carries ONE commit on top of `803122ff`:** the version moved to `0.11.0` at all three
+sites, plus its CHANGELOG section. Retro-tagging `803122ff` unchanged would ship a `v0.11.0` whose
+`package.json` reads `0.10.0` (measured — it predates the bump ritual), and "what version am I
+running" is the first question an operator upgrading through it will ask.
+
+**4. FOUR steps, not two — because my first sequence recreated the freeze.** Review caught that
+"cut `v0.11.0`, then declare it" reintroduces exactly the red window RELPTR-1 removed: the moment the
+tag exists, **every open PR whose `DEFAULT_TAGS` ends at `v0.10.0` fails `DEFAULT_TAGS is stale`.**
+Declaring it *first* is what keeps the repo green, and `nextTagPolicy`'s pending slot is precisely the
+affordance for that.
+
+| # | step | why this order |
+|---|---|---|
+| 1 | **PR A on `main`** — declare `v0.11.0` (pending; it does not exist yet) | legal, because only the newest declared tag may be absent — and it means no PR goes stale when the tag appears |
+| 2 | **cut `release/v0.11.0` + tag `v0.11.0`** | now declared, so nothing reddens |
+| 3 | **PR B on `main`** — declare `v0.12.0` (pending), bump the version, date the changelog, ship the agreement guards | `v0.11.0` now exists, so declaring a second pending tag is legal |
+| 4 | **tag `v0.12.0`** on the merged PR B commit | |
+
+Declaring **both** while neither exists throws `unknown git tag: v0.11.0` (verified by running it) —
+the middle-hole rule. So the machinery enforces the sequence the release notes require, and the
+two-PR split is what keeps every step green.
+
+A second, better consequence: once `v0.11.0` exists and is declared, the migration lane starts
+exercising **`v0.11.0 → current`** — structurally testing the very upgrade the fleet must perform.
+
+**4a. The agreement guards therefore ship in PR B, not PR A** — and the reason is worth stating,
+because it is a genuine constraint rather than convenience. Guard (b) says *the newest declared tag
+equals `v${package.json.version}`*. In PR A the newest declared tag is `v0.11.0` while `main`'s
+`package.json` still reads `0.10.0` — and it **should**, because `v0.11.0`'s content is `803122ff`,
+not `main`. `main`'s next release is `v0.12.0`. Shipping guard (b) in PR A would make the guard red on
+a correct tree.
+
+**4b. VERIFIED: running `v0.11.0` actually writes the marker, and at BOOT — not on a tick.** This was
+the plan's load-bearing assumption and it is now checked at `803122ff`, not at HEAD:
+
+- `instrumentation.ts:46-48` calls `materializeBuiltinMembershipOnce(adminClient())` **during boot**,
+  logging `[boot] pret4 builtin materialization ran (explicit posture state live)`;
+- `lib/ingest/scheduler.ts:71-72` calls it again on the scheduler tick as a retry, so a failed boot
+  self-heals rather than stranding the fleet;
+- the function writes `migration_markers` only after `ensureBuiltins` succeeds for every team
+  (`lib/access/groups.ts:193-208`).
+
+**CORRECTION, from review: "self-heals" was too strong, and a log line is NOT the gate.** The
+scheduler retry runs only when ingestion is enabled — `instrumentation.ts:55` gates the whole scheduler
+on `INGEST_POLL_ENABLED !== "false"`. A transient boot failure on a service with ingestion turned off
+leaves a **healthy-looking `v0.11.0` with no marker**, and `v0.12.0` then refuses exactly as before.
+
+So the runbook's gate is a **direct database query**, with the log line as supporting evidence only:
+
+```sql
+select exists (select 1 from migration_markers where name = 'pret4_builtin_materialize') as marker_ok,
+       (select count(*) from teams where access_enforcement = 'permissive') as permissive_left;
+```
+
+Both must read `t` and `0`. That also covers the second half of the precondition — no team left
+`permissive` — which is genuinely tick-driven (auto-flip) or a manual CLI flip. And **applying the
+schema is not enough**: the marker is written by the running application, so a completed `v0.11.0`
+boot is required, not merely a successful migration.
+
+**5. Three agreement guards** — the version's three sites agree; the newest `DEFAULT_TAGS` entry
+equals `v${package.json.version}`; `CHANGELOG.md` has a section for that version. Each parses JSON
+paths rather than matching text: a grep for `0.10.0` hits **eight** unrelated `"node": ">=0.10.0"`
+engine constraints in `package-lock.json`.
+
+The "newest entry" comparison uses the **same semver comparator** the policy uses, not `.at(-1)` —
+otherwise a reordered list disagrees with the policy about which tag is pending.
+
+**6. `test/guards/release-tag-policy.test.ts` is decoupled from `DEFAULT_TAGS`'s cut state.** Two of
+its assertions assume the declared list is fully cut, so declaring a release turns them red — a
+miniature of the deadlock RELPTR-1 removed. Policy semantics move to fixture lists; the live check
+asserts only that the declared list is in a **legal** state, which is true mid-preparation too.
+
+**7. The CHANGELOG must carry PRET-4/5/6.** The four existing `[Unreleased]` bullets omit them
+entirely — the deleted permissive mode, the mandatory ordered upgrade, and the deployment refusal
+(`docs/RELEASE-NOTES-pret6.md:31-55`). Publishing that as `v0.12.0`'s notes would hide the one thing a
+pinned operator must act on. This slice adds a pointer to the PRET-6 release notes and the upgrade
+order; it does **not** editorialise 168 commits it did not review.
+
+## Scope
+
+**THIS PR is step 1 of four (PR A).** Deliberately small, because its only job is to make cutting
+`v0.11.0` safe:
+
+- declare `v0.11.0` in `DEFAULT_TAGS` (pending — it does not exist yet);
+- decouple `test/guards/release-tag-policy.test.ts` from `DEFAULT_TAGS`'s cut state, or that
+  declaration turns it red;
+- fix the manual-flip command published in `docs/RELEASE-NOTES-pret6.md:18` — it omits
+  `--conditions react-server`, and `lib/access/posture.ts:1` imports `server-only`, so an operator
+  following the **mandatory** upgrade path throws before reaching the database. Every other invocation
+  in this repo carries the condition (`package.json:28`, the admin skill, `docs/CI-ARCHITECTURE.md`);
+- `docs/RELEASING.md` gains the fleet upgrade procedure, with the SQL gate above.
+
+**Steps 2–4, named and NOT in this PR:** cut `release/v0.11.0` + tag; then PR B (declare `v0.12.0`,
+bump the version, date the changelog, ship the three agreement guards); then tag `v0.12.0`.
+
+**Cut, each with the reason:**
+- **The agreement guards** — Decision 4a: guard (b) would be red on a correct tree in PR A.
+- **The version bump and CHANGELOG dating** — they belong to `v0.12.0`, which is PR B.
+- **Publishing either GitHub Release** — outward-facing on a public repo; waits for the operator.
+- **Automating the sandbox verification** `docs/RAILWAY-TEMPLATE.md` requires per release — a real
+  gate, named as a human step rather than skipped quietly.
+- **Engineering a safe single-step upgrade** — the considered alternative to two releases; larger, and
+  unnecessary once the intermediate release exists.
+- **`ingestion/pyproject.toml`** — a fourth version literal, but a separately packaged sidecar
+  (`ingestion/NOTICE`) with independent versioning. Explicitly out of scope, not silently ignored.
+- **The branch cutover (option B)** — RELPTR-3, and better motivated now: under B an install tracking
+  `main` receives releases *in order*, which is the whole subject of this document.
+
+## Acceptance criteria
+
+1. **unit** — `DEFAULT_TAGS` declares `v0.11.0`, and `nextTagPolicy` reports it as PENDING against a
+   tag set that lacks it — i.e. the declaration is legal before the tag exists, which is the property
+   that keeps every open PR green when the tag appears.
+2. **unit** — a guard pins that at most ONE declared tag is pending, so a future editor cannot declare
+   two and reintroduce the middle-hole throw.
+3. **unit** — `test/guards/release-tag-policy.test.ts` no longer assumes `DEFAULT_TAGS` is fully cut:
+   its policy assertions run against fixture lists, and the live check asserts only that the declared
+   list is in a LEGAL state (which is true mid-preparation).
+4. **unit** — that decoupling is proven by construction: the live check passes with the declaration in
+   place, and the fixture assertions are unchanged in meaning.
+5. **unit** — `docs/RELEASE-NOTES-pret6.md`'s operator commands all carry `--conditions react-server`
+   (or invoke `npm run admin`), asserted against every fenced `scripts/admin.ts` invocation in the file
+   — the mandatory path must not throw before it reaches the database.
+6. **unit** — a guard pins that no doc in `docs/` publishes a bare `npx tsx scripts/admin.ts` command,
+   since the failure is silent-until-run and the repo already standardises the condition.
+7. **unit** — `docs/RELEASING.md` documents the fleet upgrade procedure and contains the SQL that
+   checks BOTH preconditions (`pret4_builtin_materialize` present, zero `permissive` teams), because a
+   log line is not a gate when the retry is disabled with ingestion.
+
+## What would falsify this
+
+- **A populated `v0.10.0` install still refused when upgrading to `v0.11.0`** — the intermediate
+  release does not satisfy PRET-6's precondition and the plan is wrong.
+- **An open PR going red the moment `v0.11.0` is tagged** — the declare-first ordering did not work,
+  and the freeze RELPTR-1 removed is back.
+- **The marker absent after a completed `v0.11.0` boot** — Decision 4b's boot path did not run, and
+  with ingestion disabled there is no retry to save it.
+- **The migration lane going red on `v0.11.0 → current`** after declaration — the two states disagree
+  structurally in a way nobody expected.
+- **An operator hitting a `server-only` throw** on the mandatory flip command — the doc fix missed an
+  invocation.

--- a/scripts/migrate-from-existing.mjs
+++ b/scripts/migrate-from-existing.mjs
@@ -65,7 +65,10 @@ const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
  * Every one must exist in git — EXCEPT the newest, which may be a release being prepared. See
  * `nextTagPolicy` for why that exception exists and how narrow it is.
  */
-export const DEFAULT_TAGS = ["v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0"];
+export const DEFAULT_TAGS = ["v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0", "v0.11.0"];
+// `v0.11.0` is DECLARED BEFORE IT IS CUT, on purpose (RELPTR-2). Cutting it first would fail
+// `DEFAULT_TAGS is stale` on every open PR — the freeze `nextTagPolicy` exists to prevent. Its
+// pending slot is exactly this affordance: declare, then cut, and nothing reddens in between.
 
 // No leading zeros: `v01.2.3` and `v1.2.3` would otherwise compare EQUAL through Number(), and the
 // exemption would land on whichever the caller happened to list first.

--- a/test/guards/release-tag-policy.test.ts
+++ b/test/guards/release-tag-policy.test.ts
@@ -124,17 +124,17 @@ describe("release tag policy — the anti-rot rule survives (criteria 3, 4, 5)",
   });
 
   it("declares AT MOST ONE pending tag — two would reintroduce the middle-hole throw", () => {
-    // `nextTagPolicy` permits exactly one uncut tag. If an editor declares two, the older becomes an
-    // illegal hole and every PR throws `unknown git tag` — the freeze this program keeps rediscovering.
-    // Checked against a tag set containing everything declared EXCEPT the newest, which is the state
-    // during a release preparation.
-    const byVersion = [...DEFAULT_TAGS].sort((a, b) => {
-      const p = (t: string) => t.slice(1).split(".").map(Number);
-      const [ax, ay, az] = p(a); const [bx, by, bz] = p(b);
-      return ax - bx || ay - by || az - bz;
-    });
-    const allButNewest = byVersion.slice(0, -1);
-    expect(() => nextTagPolicy(DEFAULT_TAGS, allButNewest)).not.toThrow();
+    // GREEN BY CONSTRUCTION, first spelling: it built the "existing" set as DEFAULT_TAGS-minus-the-
+    // newest, so declaring TWO uncut tags made the fixture pretend the older one existed and the
+    // assertion passed. A guard that manufactures the very state it is checking for proves nothing —
+    // and a sibling test caught the mutation, which is exactly how a vacuous layer hides.
+    //
+    // Counted against a STATIC known-cut fixture, not live git and not a set derived from DEFAULT_TAGS.
+    // Both reviewers landed here: gating it on live tags would skip it in CI's TAGLESS unit job — the
+    // one place it most needs to run — and deriving the set from DEFAULT_TAGS is what made it vacuous.
+    // CUT_FIXTURE grows by one each time a release is actually cut, which is a deliberate edit.
+    const declaredButAbsent = DEFAULT_TAGS.filter((t) => !CUT_FIXTURE.includes(t));
+    expect(declaredButAbsent.length, `pending: ${declaredButAbsent.join(", ") || "none"}`).toBeLessThanOrEqual(1);
   });
 
   it("compares by version, so a newer tag cannot hide behind string ordering", () => {
@@ -196,7 +196,31 @@ describe("release: the operator-facing commands must actually run (criteria 5, 6
    *  file's own criteria, and the spec that describes this guard) must not trip it: the first spelling
    *  of a sibling guard in this program failed on the sentence explaining it. */
   function fencedCommands(md: string): string[] {
-    return [...md.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].flatMap((m) => m[1].split("\n"));
+    // BOTH fence styles, and line CONTINUATIONS joined first. Review found four evasions of the first
+    // spelling: a `~~~` fence, `npx tsx \` wrapped onto the next line, `pnpm dlx tsx`, and a false PASS
+    // when `--conditions react-server` appeared AFTER the entrypoint — where node ignores it.
+    // The info string may be anything (` ```SQL `, ` ```bash title=x `). The first spelling required
+    // `[a-z]*`, so such a fence never matched — and worse, its CLOSING fence then paired with the NEXT
+    // block's opener, inverting inside/outside for the rest of the file and letting later commands
+    // escape the scan entirely. Match any info string, both fence styles.
+    const blocks = [
+      ...[...md.matchAll(/```[^\n]*\n([\s\S]*?)```/g)].map((m) => m[1]),
+      ...[...md.matchAll(/~~~[^\n]*\n([\s\S]*?)~~~/g)].map((m) => m[1]),
+    ];
+    return blocks.flatMap((b) => b.replace(/\\\n\s*/g, " ").split("\n"));
+  }
+
+  /** A command that will throw on `server-only` before it reaches the database. */
+  function throwsOnServerOnly(line: string): boolean {
+    // Any runner that reaches tsx: npx / pnpm dlx / bunx / `npx --yes tsx` / a bare `tsx`. Keyed on the
+    // ENTRYPOINT rather than the launcher, because the launcher list is exactly what rots.
+    if (!/\btsx\b/.test(line) || !/scripts\/admin\.ts/.test(line)) return false;
+    if (/\bnpm\s+run\s+admin\b/.test(line)) return false;
+    // The condition must come BEFORE the entrypoint; after it, node never sees it. Space AND equals
+    // forms are both valid and both accepted — flagging `--conditions=react-server` would be a false
+    // positive on a correct command.
+    const beforeEntry = line.slice(0, line.indexOf("scripts/admin.ts"));
+    return !/--conditions[= ]react-server/.test(beforeEntry);
   }
 
   it("no doc publishes a bare `npx tsx scripts/admin.ts` — it throws on server-only before reaching the DB", () => {
@@ -211,9 +235,7 @@ describe("release: the operator-facing commands must actually run (criteria 5, 6
     const offenders: string[] = [];
     for (const { f, md } of docs) {
       for (const line of fencedCommands(md)) {
-        if (/\bnpx\s+tsx\b/.test(line) && /scripts\/admin\.ts/.test(line) && !/--conditions\s+react-server/.test(line)) {
-          offenders.push(`docs/${f}: ${line.trim()}`);
-        }
+        if (throwsOnServerOnly(line)) offenders.push(`docs/${f}: ${line.trim()}`);
       }
     }
     expect(offenders).toEqual([]);
@@ -221,12 +243,48 @@ describe("release: the operator-facing commands must actually run (criteria 5, 6
 
   it("is NON-VACUOUS: it flags the exact form that shipped", () => {
     // The guard above reports zero today. Prove the detector fires rather than matching nothing.
-    const bad = "```bash\nnpx tsx scripts/admin.ts set-access-enforcement acme enforcing\n```";
-    const good = "```bash\nnpm run admin -- set-access-enforcement acme enforcing\n```";
-    const hits = (md: string) =>
-      fencedCommands(md).filter((l) => /\bnpx\s+tsx\b/.test(l) && /scripts\/admin\.ts/.test(l) && !/--conditions\s+react-server/.test(l));
-    expect(hits(bad)).toHaveLength(1);
-    expect(hits(good)).toHaveLength(0);
+    const hits = (md: string) => fencedCommands(md).filter(throwsOnServerOnly);
+    // The exact form that shipped…
+    expect(hits("```bash\nnpx tsx scripts/admin.ts set-access-enforcement acme enforcing\n```")).toHaveLength(1);
+    // …and each evasion review found. All four must be caught.
+    expect(hits("~~~bash\nnpx tsx scripts/admin.ts list-members\n~~~"), "tilde fence").toHaveLength(1);
+    expect(hits("```bash\nnpx tsx \\\n  scripts/admin.ts list-members\n```"), "continuation").toHaveLength(1);
+    expect(hits("```bash\npnpm dlx tsx scripts/admin.ts list-members\n```"), "pnpm dlx").toHaveLength(1);
+    expect(
+      hits("```bash\nnpx tsx scripts/admin.ts list-members --conditions react-server\n```"),
+      "condition AFTER the entrypoint is ignored by node"
+    ).toHaveLength(1);
+    // …and the correct forms stay clean.
+    expect(hits("```bash\nnpm run admin -- set-access-enforcement acme enforcing\n```")).toHaveLength(0);
+    expect(hits("```bash\nnpx tsx --conditions react-server scripts/admin.ts list-members\n```")).toHaveLength(0);
+    expect(hits("```bash\nnpx tsx --conditions=react-server scripts/admin.ts list-members\n```"), "equals form is valid").toHaveLength(0);
+    // …and the fence-pairing inversion an info string used to cause: the BAD command sits in a later
+    // block, which the old regex stopped seeing entirely.
+    expect(
+      hits("```SQL\nselect 1;\n```\n\n```bash\nnpx tsx scripts/admin.ts list-members\n```"),
+      "an info-string fence must not blind the scan to later blocks"
+    ).toHaveLength(1);
+    expect(hits("```bash\nbunx tsx scripts/admin.ts x\n```"), "bunx").toHaveLength(1);
+  });
+
+  it("no doc still teaches a verb PRET-6 DELETED", () => {
+    // docs/OPS.md's "Rolling back" section published `set-access-enforcement … permissive` — a command
+    // the retirement removed from the CLI. The prose prefix `… scripts/admin.ts` hid it from the
+    // runner-based detector above, which is why this keys on the VERB instead. A stale rollback
+    // instruction is worse than an absent one: it is found during an incident.
+    const retired = "set-access-enforcement";
+    expect(readFileSync(join(ROOT, "scripts", "admin.ts"), "utf8"), "the verb is retired at HEAD").not.toContain(retired);
+    const docs = readdirSync(join(ROOT, "docs"), { recursive: true, encoding: "utf8" })
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => ({ f, md: readFileSync(join(ROOT, "docs", f), "utf8") }));
+    const offenders: string[] = [];
+    for (const { f, md } of docs) {
+      for (const line of fencedCommands(md)) {
+        // RELEASE-NOTES/RELEASING legitimately publish it for the v0.11.0 RELEASE, where it exists.
+        if (line.includes(retired) && !/RELEASE-NOTES-pret6|RELEASING/.test(f)) offenders.push(`docs/${f}: ${line.trim()}`);
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 
   it("RELEASING.md gates the PRET-6 upgrade on a QUERY, not a log line", () => {

--- a/test/guards/release-tag-policy.test.ts
+++ b/test/guards/release-tag-policy.test.ts
@@ -114,6 +114,15 @@ describe("release tag policy — the anti-rot rule survives (criteria 3, 4, 5)",
     expect(() => nextTagPolicy(DEFAULT_TAGS, ["v0.99.0", ...gitTags])).toThrow(/stale: v0\.99\.0/);
   });
 
+  it("DECLARES v0.11.0 — the intermediate release the PRET-6 upgrade path passes through", () => {
+    // The mutation that removed it SURVIVED, which meant the entire point of the declaring PR was
+    // pinned by nothing. Stated as the durable invariant rather than "is pending", because that is
+    // true both before the tag is cut and forever after: `v0.11.0` is the release a pre-flip
+    // installation must run before the retirement, so the migration lane has to keep exercising the
+    // upgrade FROM it. Dropping it silently stops testing the path the fleet actually takes.
+    expect(DEFAULT_TAGS).toContain("v0.11.0");
+  });
+
   it("declares AT MOST ONE pending tag — two would reintroduce the middle-hole throw", () => {
     // `nextTagPolicy` permits exactly one uncut tag. If an editor declares two, the older becomes an
     // illegal hole and every PR throws `unknown git tag` — the freeze this program keeps rediscovering.

--- a/test/guards/release-tag-policy.test.ts
+++ b/test/guards/release-tag-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { DEFAULT_TAGS, nextTagPolicy } from "../../scripts/migrate-from-existing.mjs";
 
@@ -24,6 +24,11 @@ import { DEFAULT_TAGS, nextTagPolicy } from "../../scripts/migrate-from-existing
 
 const ROOT = join(__dirname, "..", "..");
 const REAL_TAGS = ["v0.10.0", "v0.9.0", "v0.8.0", "v0.7.0"]; // newest-first, as git reports them
+
+/** A fully-CUT declared list, for policy semantics. Deliberately NOT `DEFAULT_TAGS`: the live list
+ *  legitimately carries a declared-but-uncut release during preparation, and assertions that assumed
+ *  otherwise turned red the moment a release was declared. */
+const CUT_FIXTURE = ["v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0"];
 
 /**
  * Does THIS checkout have the release tags?
@@ -51,9 +56,13 @@ const itWithTags = HAS_RELEASE_TAGS ? it : it.skip;
 
 describe("release tag policy — the prepared release (criteria 1, 2, 5)", () => {
   it("ALLOWS the newest declared tag to be absent, and says so instead of throwing", () => {
-    const res = nextTagPolicy([...DEFAULT_TAGS, "v0.11.0"], REAL_TAGS);
-    expect(res.pending).toBe("v0.11.0");
-    expect(res.usable).toEqual(DEFAULT_TAGS);
+    // FIXTURE list, not DEFAULT_TAGS. Two assertions here used to read the live declared list, so the
+    // moment a release was DECLARED (`pending` stops being null, `usable` stops equalling the list)
+    // they went red — the guard that exists to make releases possible would have blocked one. Policy
+    // semantics are tested against fixtures; the live list gets its own legal-state check below.
+    const res = nextTagPolicy([...CUT_FIXTURE, "v9.9.9"], REAL_TAGS);
+    expect(res.pending).toBe("v9.9.9");
+    expect(res.usable).toEqual(CUT_FIXTURE);
     expect(res.notice).toMatch(/declared but not yet cut/);
   });
 
@@ -91,16 +100,32 @@ describe("release tag policy — the anti-rot rule survives (criteria 3, 4, 5)",
     // A check that only ever passes is indistinguishable from one that matches nothing — this repo has
     // shipped that failure before. Fixture-based, so it runs in every environment including a tagless
     // CI checkout.
-    expect(() => nextTagPolicy(DEFAULT_TAGS, REAL_TAGS)).not.toThrow();
-    expect(() => nextTagPolicy(DEFAULT_TAGS, ["v0.99.0", ...REAL_TAGS])).toThrow(/stale: v0\.99\.0/);
+    expect(() => nextTagPolicy(CUT_FIXTURE, REAL_TAGS)).not.toThrow();
+    expect(() => nextTagPolicy(CUT_FIXTURE, ["v0.99.0", ...REAL_TAGS])).toThrow(/stale: v0\.99\.0/);
   });
 
-  itWithTags("…and against the tags this checkout actually has", () => {
-    // The same two directions against live git, where the history is present. Gated rather than
-    // assumed: see HAS_RELEASE_TAGS.
+  itWithTags("the LIVE declared list is in a legal state — the only thing that stays true mid-release", () => {
+    // This is what replaced "nothing is pending". A declared-but-uncut tag is a legal state (it is how
+    // a release is prepared); an illegal one is a middle hole or a stale list. Asserting legality holds
+    // between releases AND during one, so declaring a release can never redden this file.
     expect(gitTags).toContain("v0.10.0");
     expect(() => nextTagPolicy(DEFAULT_TAGS, gitTags)).not.toThrow();
+    // …and still non-vacuous against live git: a newer real tag nobody declared is a stale list.
     expect(() => nextTagPolicy(DEFAULT_TAGS, ["v0.99.0", ...gitTags])).toThrow(/stale: v0\.99\.0/);
+  });
+
+  it("declares AT MOST ONE pending tag — two would reintroduce the middle-hole throw", () => {
+    // `nextTagPolicy` permits exactly one uncut tag. If an editor declares two, the older becomes an
+    // illegal hole and every PR throws `unknown git tag` — the freeze this program keeps rediscovering.
+    // Checked against a tag set containing everything declared EXCEPT the newest, which is the state
+    // during a release preparation.
+    const byVersion = [...DEFAULT_TAGS].sort((a, b) => {
+      const p = (t: string) => t.slice(1).split(".").map(Number);
+      const [ax, ay, az] = p(a); const [bx, by, bz] = p(b);
+      return ax - bx || ay - by || az - bz;
+    });
+    const allButNewest = byVersion.slice(0, -1);
+    expect(() => nextTagPolicy(DEFAULT_TAGS, allButNewest)).not.toThrow();
   });
 
   it("compares by version, so a newer tag cannot hide behind string ordering", () => {
@@ -124,8 +149,8 @@ describe("release tag policy — the anti-rot rule survives (criteria 3, 4, 5)",
   });
 
   it("each outcome fires ALONE for an input that triggers only it", () => {
-    expect(nextTagPolicy(DEFAULT_TAGS, REAL_TAGS)).toEqual({ usable: DEFAULT_TAGS, pending: null, notice: null });
-    expect(nextTagPolicy([...DEFAULT_TAGS, "v0.11.0"], REAL_TAGS).pending).toBe("v0.11.0");
+    expect(nextTagPolicy(CUT_FIXTURE, REAL_TAGS)).toEqual({ usable: CUT_FIXTURE, pending: null, notice: null });
+    expect(nextTagPolicy([...CUT_FIXTURE, "v9.9.9"], REAL_TAGS).pending).toBe("v9.9.9");
     expect(() => nextTagPolicy(["v0.7.0", "v0.8.5", "v0.10.0"], REAL_TAGS)).toThrow(/unknown git tag/);
     expect(() => nextTagPolicy(["v0.7.0"], REAL_TAGS)).toThrow(/stale/);
   });
@@ -154,6 +179,55 @@ describe("release tag policy — the real corpus is MIXED (criterion 6)", () => 
     // …and `--points-at` peels both, which is the one gathering idiom that is safe.
     const peeled = execFileSync("git", ["tag", "--points-at", "v0.9.0^{commit}"], { cwd: ROOT, encoding: "utf8" });
     expect(peeled).toContain("v0.9.0");
+  });
+});
+
+describe("release: the operator-facing commands must actually run (criteria 5, 6, 7)", () => {
+  /** Fenced code blocks only — what a reader COPIES. Prose that discusses a command (including this
+   *  file's own criteria, and the spec that describes this guard) must not trip it: the first spelling
+   *  of a sibling guard in this program failed on the sentence explaining it. */
+  function fencedCommands(md: string): string[] {
+    return [...md.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].flatMap((m) => m[1].split("\n"));
+  }
+
+  it("no doc publishes a bare `npx tsx scripts/admin.ts` — it throws on server-only before reaching the DB", () => {
+    // `scripts/admin.ts` pulls in `lib/access/posture.ts`, which imports "server-only"; without
+    // `--conditions react-server` the import throws. Every other invocation in this repo carries it
+    // (`package.json`'s `admin` script, the admin skill, docs/CI-ARCHITECTURE.md) — but
+    // docs/RELEASE-NOTES-pret6.md published the bare form on the MANDATORY PRET-6 upgrade path, where
+    // an operator would hit the throw while trying to satisfy a deployment precondition.
+    const docs = readdirSync(join(ROOT, "docs"), { recursive: true, encoding: "utf8" })
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => ({ f, md: readFileSync(join(ROOT, "docs", f), "utf8") }));
+    const offenders: string[] = [];
+    for (const { f, md } of docs) {
+      for (const line of fencedCommands(md)) {
+        if (/\bnpx\s+tsx\b/.test(line) && /scripts\/admin\.ts/.test(line) && !/--conditions\s+react-server/.test(line)) {
+          offenders.push(`docs/${f}: ${line.trim()}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("is NON-VACUOUS: it flags the exact form that shipped", () => {
+    // The guard above reports zero today. Prove the detector fires rather than matching nothing.
+    const bad = "```bash\nnpx tsx scripts/admin.ts set-access-enforcement acme enforcing\n```";
+    const good = "```bash\nnpm run admin -- set-access-enforcement acme enforcing\n```";
+    const hits = (md: string) =>
+      fencedCommands(md).filter((l) => /\bnpx\s+tsx\b/.test(l) && /scripts\/admin\.ts/.test(l) && !/--conditions\s+react-server/.test(l));
+    expect(hits(bad)).toHaveLength(1);
+    expect(hits(good)).toHaveLength(0);
+  });
+
+  it("RELEASING.md gates the PRET-6 upgrade on a QUERY, not a log line", () => {
+    // The boot retry lives in the scheduler, which only starts when ingestion is enabled — so a log
+    // line is not evidence. Both preconditions must be checked directly.
+    const doc = readFileSync(join(ROOT, "docs", "RELEASING.md"), "utf8");
+    expect(doc).toMatch(/pret4_builtin_materialize/);
+    expect(doc).toMatch(/access_enforcement\s*=\s*'permissive'/);
+    expect(doc).toMatch(/INGEST_POLL_ENABLED/);
+    expect(doc).toMatch(/release\/v0\.11\.0/);
   });
 });
 

--- a/test/guards/release-tag-policy.test.ts
+++ b/test/guards/release-tag-policy.test.ts
@@ -237,6 +237,10 @@ describe("release: the operator-facing commands must actually run (criteria 5, 6
     expect(doc).toMatch(/access_enforcement\s*=\s*'permissive'/);
     expect(doc).toMatch(/INGEST_POLL_ENABLED/);
     expect(doc).toMatch(/release\/v0\.11\.0/);
+    // …and says WHERE those steps run. Both the flip command and the column the gate reads are
+    // DELETED by the retirement (`set-access-enforcement` absent at HEAD; `teams.access_enforcement`
+    // dropped), so an operator running them after upgrading gets an error rather than a warning.
+    expect(doc).toMatch(/not after the upgrade/);
   });
 });
 


### PR DESCRIPTION
Step 1 of four, and the smallest thing that makes the next three safe.

## Why this exists

We were one PR away from cutting a release **no existing installation could install**.

`postgres/migrations/20260818210000_pret6_retire_access_enforcement.sql` refuses a populated pre-flip database — *"upgrade through the prior release first"* — and `docs/RELEASE-NOTES-pret6.md` says plainly: *"You **may not** jump to this release from a pre-flip installation."*

**That prior release was never tagged.** `v0.10.0` (2026-08-03) predates the entire PRET series (2026-08-17/18). So a `v0.10.0` database with any team in it hits the `raise`, `pg:schema` aborts, and the deploy halts.

**CI could never have caught it, and says so itself** — the migration lane builds every scratch database EMPTY, and its own docstring names this migration as the live proof: *"against a populated database it aborts the rollout … and against this lane it is green every time."* The gap was documented; its consequence for the *next release* was not.

## The plan: two releases, in order

| | commit | is |
|---|---|---|
| **`v0.11.0`** | base `803122ff` (PRET-6's direct parent, CI-green 8/8) + a version/changelog commit | the "prior release" the notes send operators through |
| **`v0.12.0`** | current `main` | the retirement, now reachable |

`v0.11.0` ships as a **branch as well as a tag**: Railway's connected source is branch-based, so `release/v0.11.0` is what an operator can actually point a service at.

## What is in THIS PR

Only the part that makes cutting `v0.11.0` safe:

- **Declare `v0.11.0` in `DEFAULT_TAGS` before it exists.** Cutting first would throw `DEFAULT_TAGS is stale` on every open PR — the freeze the previous slice removed. `nextTagPolicy`'s pending slot is exactly this affordance.
- **Decouple `test/guards/release-tag-policy.test.ts` from the live declared list.** Three assertions assumed `DEFAULT_TAGS` was fully cut, so *declaring* a release turned them red — the guard that exists to make releases possible would have blocked one.
- **Fix a broken operator command on the mandatory upgrade path.** `docs/RELEASE-NOTES-pret6.md` published `npx tsx scripts/admin.ts …`; `lib/access/posture.ts` imports `server-only`, so without `--conditions react-server` it throws before reaching the database.
- **`docs/RELEASING.md` §3.4** — the ordered upgrade, gated on a **query**, not a log line.
- **`docs/OPS.md`** — §9 and "Rolling back" both taught `set-access-enforcement`, a verb PRET-6 **deleted**.

## What is NOT in it

Cutting `release/v0.11.0` or either tag · PR B (declare `v0.12.0`, bump the version, date the changelog, the agreement guards) · publishing either GitHub Release · the sandbox verification `docs/RAILWAY-TEMPLATE.md` requires (a real gate, named as a human step) · `ingestion/pyproject.toml`, a separately-versioned sidecar · the option-B branch cutover (RELPTR-3).

## Verification

tsc clean · lint 0 errors · unit **3510 passed** · docs in sync · spec `SPEC_READY`

**11 mutations, 9 reddened on their intended test; 2 SURVIVED and were fixed.**

| # | mutation | result |
|---|---|---|
| 1 | re-publish the bare admin command | REDDENED |
| 2 | drop the permissive-teams half of the gate | REDDENED |
| 3 | declare a second pending tag | REDDENED |
| 4 | undeclare `v0.11.0` | **SURVIVED** → pinned, then REDDENED |
| 5 | fenced-block detector stops matching | REDDENED |
| 6 | runbook loses the branch operators point at | REDDENED |
| 7 | declare a second pending tag (post-fix) | REDDENED — now hits the at-most-one guard too |
| 8 | restore the info-string blindness | REDDENED |
| 9 | accept `--conditions` after the entrypoint | REDDENED |
| 10 | OPS re-publishes the deleted verb | REDDENED |
| 11 | the at-most-one guard (self-derived set) | **SURVIVED** by construction → rewritten |

One full run also hit a known flake — `nda-gate`'s long-range case spawns 102 `git commit` subprocesses inside a 30-second budget and times out under load. It passes standalone (21/21) and on re-run, and is untouched by this diff. Reporting it rather than hiding it; it will flake on CI eventually and deserves its own fix.

## Review

Reviewed by Fable code-reviewer — verdict CLEAR-WITH-CONDITIONS (1 High, 2 Medium, 2 Low), all folded
Reviewed by Codex gpt-5.6-sol — verdict CLEAR-WITH-CONDITIONS (3 Medium, 2 Low), all folded; plus a pre-code round that returned **BLOCKED** and killed the original single-release plan outright

### The pre-code round is the one that mattered

It found that cutting `v0.11.0` from `main` produces an uninstallable release. Everything above is downstream of that.

### Both diff reviewers led with the same finding

**The at-most-one-pending guard was green by construction.** It derived its "existing tags" set from `DEFAULT_TAGS` minus the newest — so declaring *two* uncut tags made the fixture manufacture the older one as existing, and the assertion passed. The exact state its own docstring claimed to prevent.

What hid it: a **sibling test caught the mutation**, so the vacuous layer looked covered. That is this repo's recorded "defense-in-depth masks mutations" lesson, live.

My first fix made it worse — gating it on live tags, which Fable pointed out would skip it in CI's **tagless** unit job, precisely where it must run. It now counts against a static known-cut fixture, unconditionally.

### Five evasions of the command detector, each now carrying a sample

`~~~` fences · an info-string fence (` ```SQL `) which not only escaped but **inverted fence pairing for the rest of the file**, blinding the scan to every later block · backslash continuations · `pnpm dlx`/`bunx`/bare `tsx` (now keyed on the entrypoint, since the launcher list is what rots) · and a false PASS when `--conditions react-server` trailed the entrypoint, where node ignores it.

### Found by checking my own work, not by review

- A mutation removing `v0.11.0` from `DEFAULT_TAGS` **SURVIVED** — the declaration this PR exists to make was pinned by nothing.
- The runbook told operators to run a command and a query that **the retirement deletes**. Both verified present at `803122ff`, absent at HEAD. Run after upgrading, each gives a confusing error while someone is trying to satisfy a deployment precondition.

### Claims narrowed rather than defended

- *"Nothing reddens"* — false for a PR still on an older base; the runbook gains a drain step.
- *"A tag alone would be undeployable"* — Railway's API accepts a `commitSha`; the branch supplies the **supported** path, which is the honest claim.

AIOS-Work: RELPTR-2
