### PR TITLE
fix(health): the per-task bullet reads the diagnosis too (LLMCREDIT-4)

### DIFF
--- a/components/admin/generation-health-banner.tsx
+++ b/components/admin/generation-health-banner.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import type { LlmHealth } from "@/lib/query/llm-health";
+import { legDetail } from "@/lib/ingest/leg-detail";
 
 /**
  * LOUD, hard-to-miss banner on Pulse when GENERATION is degraded — the answering model has stopped
@@ -73,28 +74,29 @@ export function GenerationHealthBanner({ health, href }: { health: LlmHealth; hr
               <li key={t.task} className="list-disc text-xs">
                 <span className="font-medium">{labelOf(t.task)}</span>
                 {t.model ? <span className="text-red-600/80 dark:text-red-300/80"> · {t.model}</span> : null}
-                {/* LLMCREDIT-4: THE DIAGNOSIS LEADS HERE TOO. LLMCREDIT-3 gave the summary paragraph
-                    below its plain-English reading but left THIS bullet rendering the provider's raw
-                    JSON — and the bullet is the most prominent red text on the page, so the operator
-                    still met four hundred characters of `{"error":{"message":…` first. `diagnosis` is
-                    computed SERVER-side (see LlmTaskHealth) because this is a client component and
-                    the classifier reaches a `server-only` module. Null when unrecognised, and then
-                    this is exactly the old rendering. */}
-                {t.diagnosis ? (
-                  <>
-                    <span className="text-red-700 dark:text-red-200">
-                      {" "}
-                      — {t.diagnosis.headline} {t.diagnosis.action}
-                    </span>
-                    {t.lastError ? (
-                      <span className="mt-0.5 block text-[11px] text-red-600/60 dark:text-red-300/60">
-                        {t.lastError.length > 160 ? `${t.lastError.slice(0, 160)}…` : t.lastError}
-                      </span>
-                    ) : null}
-                  </>
-                ) : t.lastError ? (
-                  <span className="text-red-600/80 dark:text-red-300/80"> — {t.lastError}</span>
-                ) : null}
+                {/* LLMCREDIT-4: THE DIAGNOSIS LEADS HERE TOO. LLMCREDIT-3 gave the summary
+                    paragraph below its plain-English reading but left THIS bullet rendering the
+                    provider's raw JSON — and the bullet renders FIRST, above the note, carrying ~470
+                    unclipped characters, so that is what the operator met.
+                    Composed by `legDetail`, the pure client-safe helper extracted during LLMCREDIT-3
+                    for exactly this: it owns the lead/raw split AND the clip length, so this banner
+                    and the ingestion one cannot drift, and a revert to raw JSON is catchable by a
+                    guard rather than invisible. `diagnosis` is computed SERVER-side (see
+                    LlmTaskHealth) because this is a client component and the classifier reaches a
+                    `server-only` module. */}
+                {(() => {
+                  const d = legDetail({ error: t.lastError, diagnosis: t.diagnosis });
+                  if (!d.lead)
+                    return d.raw ? <span className="text-red-600/80 dark:text-red-300/80"> — {d.raw}</span> : null;
+                  return (
+                    <>
+                      <span className="text-red-700 dark:text-red-200"> — {d.lead}</span>
+                      {d.raw ? (
+                        <span className="block pl-6 text-[11px] text-red-600/60 dark:text-red-300/60">{d.raw}</span>
+                      ) : null}
+                    </>
+                  );
+                })()}
               </li>
             ))}
           </ul>

--- a/components/admin/generation-health-banner.tsx
+++ b/components/admin/generation-health-banner.tsx
@@ -73,7 +73,26 @@ export function GenerationHealthBanner({ health, href }: { health: LlmHealth; hr
               <li key={t.task} className="list-disc text-xs">
                 <span className="font-medium">{labelOf(t.task)}</span>
                 {t.model ? <span className="text-red-600/80 dark:text-red-300/80"> · {t.model}</span> : null}
-                {t.lastError ? (
+                {/* LLMCREDIT-4: THE DIAGNOSIS LEADS HERE TOO. LLMCREDIT-3 gave the summary paragraph
+                    below its plain-English reading but left THIS bullet rendering the provider's raw
+                    JSON — and the bullet is the most prominent red text on the page, so the operator
+                    still met four hundred characters of `{"error":{"message":…` first. `diagnosis` is
+                    computed SERVER-side (see LlmTaskHealth) because this is a client component and
+                    the classifier reaches a `server-only` module. Null when unrecognised, and then
+                    this is exactly the old rendering. */}
+                {t.diagnosis ? (
+                  <>
+                    <span className="text-red-700 dark:text-red-200">
+                      {" "}
+                      — {t.diagnosis.headline} {t.diagnosis.action}
+                    </span>
+                    {t.lastError ? (
+                      <span className="mt-0.5 block text-[11px] text-red-600/60 dark:text-red-300/60">
+                        {t.lastError.length > 160 ? `${t.lastError.slice(0, 160)}…` : t.lastError}
+                      </span>
+                    ) : null}
+                  </>
+                ) : t.lastError ? (
                   <span className="text-red-600/80 dark:text-red-300/80"> — {t.lastError}</span>
                 ) : null}
               </li>

--- a/docs/design/llmcredit4-banner-bullet-diagnosis.md
+++ b/docs/design/llmcredit4-banner-bullet-diagnosis.md
@@ -1,0 +1,81 @@
+# The bullet reads the diagnosis too — LLMCREDIT-4
+
+**Status:** spec, written AFTER the code, and that is the defect this document also records. ⚠️ The
+Codex spec round is skipped (a copy fix inside LLMCREDIT-3's own stated scope); the Fable diff review
+is not — it returned **BLOCKED** and is folded below.
+
+**Build with:** opus / high — it is the sentence an operator reads first.
+
+**Deps:** LLMCREDIT-3 (merged, deployed) — this finishes what §2c of that spec claimed.
+
+---
+
+## What and why
+
+LLMCREDIT-3 said the diagnosis would be *"consumed at both surfaces"*. It reached the generation
+banner's summary **paragraph** (`degradedNote`) and not the per-task **bullet** above it, which kept
+rendering `{t.lastError}` — the provider's raw JSON, unclipped, **rendered first**.
+
+The operator reported it against the shipped build: *"Even after the merge I'm still getting the same
+error message on the pulse screen."* He was right about what he saw. The screenshot shows the
+ingestion banner correctly leading with *"OpenRouter is out of credit — … Top up the account"*, and
+the generation banner's bullet still opening with `{"error":{"message":"This request requires more
+credits…`.
+
+⚠️ *Not "the most prominent red text on the page" — an earlier draft of this claim said that and a
+review disproved it from the classNames. It is `text-xs` at `text-red-600/80`. What makes it the thing
+he saw is that it renders FIRST and carried ~470 unclipped characters.*
+
+## 1. The rule
+
+> **No surface renders the provider's raw error as its own message. The composition belongs to one
+> shared helper, and reverting to raw must turn a test red.**
+
+## 2. The design
+
+- `LlmTaskHealth` gains `diagnosis`, computed **server-side** in `deriveTaskHealth`.
+  ⚠️ Server-side because the banner is `"use client"` and `diagnoseProviderFault` reaches
+  `lib/query/claude`, which is `server-only`: a value import there breaks `next build` while `tsc` and
+  the whole unit tier stay green. That exact mistake shipped once on this lane and CI caught it.
+- The bullet composes through **`legDetail`** — the pure, client-safe helper already extracted during
+  LLMCREDIT-3 for precisely this — so both banners share the lead/raw split AND the clip length.
+- `diagnosis` keeps `kind`, so `degradedNote` reads the field instead of re-deriving the same answer
+  from the same string.
+
+## 3. Scope
+
+**In:** `lib/query/llm-health.ts` · `components/admin/generation-health-banner.tsx` ·
+`test/generation-health-banner.test.ts` · `test/provider-fault-diagnosis.test.ts` ·
+`test/llm-health.test.ts`.
+
+**Out:** the underlying faults (still an empty provider balance), the classifier itself (LLMCREDIT-3),
+and any new fault kind.
+
+## 4. Acceptance
+
+- **AC1 — the raw provider error is NEVER interpolated into the markup (guard, unit):** ∀ over the JSX
+  region — no `{t.lastError` occurrence — and `legDetail({ error: t.lastError` is present, so it
+  cannot pass by rendering nothing.
+- **AC2 — the client component imports `llm-health` as a TYPE only (guard, unit):** every matching
+  import line carries `type`. *The hazard was documented three times in this lane and guarded zero.*
+- **AC3 — every task with an in-window failure carries its own diagnosis (unit):** `deriveTaskHealth`
+  populates it from the error TEXT; an unrecognised error yields `null` and the bullet falls back to
+  the raw string.
+
+| # | mutation | must redden |
+|---|---|---|
+| 1 | revert the whole component to `origin/main` (the bullet back to raw `{t.lastError}`) | **AC1** |
+| 2 | make the `llm-health` import a value import | AC2 |
+| 3 | `deriveTaskHealth` stops populating `diagnosis` | AC3 |
+
+## 5. Risks
+
+| risk | direction | mitigation |
+|---|---|---|
+| A value import creeps back into the client component | `next build` breaks; tsc + unit tier stay green | AC2 |
+| The bullet quietly reverts to raw JSON | the reported defect, again | AC1 — ∀, and mutation 1 is the reviewer's own surviving mutation |
+| Two diagnoses for one error disagree | the paragraph and the bullet contradict each other | `kind` retained; `degradedNote` reads the field |
+
+## 6. What this does NOT fix
+
+The account is still out of credit. This changes what the operator READS, not what failed.

--- a/lib/query/llm-health.ts
+++ b/lib/query/llm-health.ts
@@ -73,6 +73,16 @@ export interface LlmTaskHealth {
    *  rest the query model, so a leg-level model name would send an operator to the wrong picker. */
   model: string | null;
   lastError: string | null;
+  /**
+   * The operator-facing reading of `lastError` (LLMCREDIT-3/-4), or null when nothing confident can be
+   * said — in which case the surface falls back to the raw text.
+   *
+   * ⚠️ COMPUTED SERVER-SIDE AND PASSED DOWN, exactly as `PipelineLeg.diagnosis` is. The banner is a
+   * CLIENT component and `diagnoseProviderFault` reaches `lib/query/claude`, which is `server-only`, so
+   * importing it there would break `next build` while `tsc` and every unit test stayed green — the
+   * failure CI caught once already on this lane.
+   */
+  diagnosis: { headline: string; action: string } | null;
   lastFailedAt: string | null;
   lastOkAt: string | null;
 }
@@ -216,6 +226,7 @@ export function deriveTaskHealth(runsNewestFirst: readonly LlmRun[] | null, nowM
       // retry's model sends an operator to the wrong picker.
       model: state === "healthy" ? newest.model : (newestFailure?.model ?? newest.model),
       lastError: newestFailure?.error ?? null,
+      diagnosis: faultOfTask(newestFailure?.error ?? null),
       lastFailedAt: newestFailure?.finishedAt ?? null,
       lastOkAt: newestOk?.finishedAt ?? null,
     });
@@ -250,6 +261,12 @@ export function deriveLlmState(tasks: readonly LlmTaskHealth[]): LlmHealthState 
 const RAW_ERROR_CLIP = 160;
 function clipError(e: string): string {
   return e.length <= RAW_ERROR_CLIP ? e : `${e.slice(0, RAW_ERROR_CLIP)}…`;
+}
+
+/** The diagnosis for one task's own recorded error, or null when nothing confident can be said. */
+function faultOfTask(error: string | null): { headline: string; action: string } | null {
+  const f = diagnoseProviderFault(error);
+  return f ? { headline: f.headline, action: f.action } : null;
 }
 
 export function degradedNote(tasks: readonly LlmTaskHealth[]): string {

--- a/lib/query/llm-health.ts
+++ b/lib/query/llm-health.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { runSql } from "@/lib/db/pg/pool";
 import { classifyFailure, foldStreak, FAILURES_TO_CONFIRM } from "@/lib/ingest/failure-streak";
 import { diagnoseProviderFault } from "@/lib/llm/provider-fault";
+import { RAW_ERROR_CLIP } from "@/lib/ingest/leg-detail";
 
 /**
  * Answering-model health for the admin dashboard. Non-streaming LLM tasks funnel through
@@ -82,7 +83,7 @@ export interface LlmTaskHealth {
    * importing it there would break `next build` while `tsc` and every unit test stayed green — the
    * failure CI caught once already on this lane.
    */
-  diagnosis: { headline: string; action: string } | null;
+  diagnosis: { kind: string; headline: string; action: string } | null;
   lastFailedAt: string | null;
   lastOkAt: string | null;
 }
@@ -257,16 +258,20 @@ export function deriveLlmState(tasks: readonly LlmTaskHealth[]): LlmHealthState 
  * was false in both directions: it named a feature the leg had never observed, and it named only two
  * when more could be failing. Pure and exported so the sentence is testable without a database.
  */
-/** The provider's own words, kept available but never allowed to BE the message (LLMCREDIT-3). */
-const RAW_ERROR_CLIP = 160;
+/** The provider's own words, kept available but never allowed to BE the message (LLMCREDIT-3).
+ *  ⚠️ `RAW_ERROR_CLIP` is IMPORTED, not re-declared: `leg-detail` calls itself "ONE constant", and a
+ *  local copy here made that sentence false the moment it was written. A review counted three. */
 function clipError(e: string): string {
   return e.length <= RAW_ERROR_CLIP ? e : `${e.slice(0, RAW_ERROR_CLIP)}…`;
 }
 
-/** The diagnosis for one task's own recorded error, or null when nothing confident can be said. */
-function faultOfTask(error: string | null): { headline: string; action: string } | null {
+/** The diagnosis for one task's own recorded error, or null when nothing confident can be said.
+ *  ⚠️ `kind` is KEPT. The first version projected it away, which forced `degradedNote` to re-derive
+ *  the same answer from the same string — two independently-computed diagnoses on one object, free to
+ *  disagree for any task not built by `deriveTaskHealth`. A review caught it; there is one answer now. */
+function faultOfTask(error: string | null): { kind: string; headline: string; action: string } | null {
   const f = diagnoseProviderFault(error);
-  return f ? { headline: f.headline, action: f.action } : null;
+  return f ? { kind: f.kind, headline: f.headline, action: f.action } : null;
 }
 
 export function degradedNote(tasks: readonly LlmTaskHealth[]): string {
@@ -297,7 +302,9 @@ export function degradedNote(tasks: readonly LlmTaskHealth[]): string {
   // concurrently, both tasks of this banner. That version would have filed one under the other, and
   // WHICH one led depended on Map insertion order, so the diagnosis could change between page loads.
   // A misattributed diagnosis is the thing this whole slice exists to avoid.
-  const diagnosed = failing.map((t) => ({ task: t, fault: diagnoseProviderFault(t.lastError) }));
+  // Reads the FIELD rather than re-deriving it — see `faultOfTask`. A task built without one (an old
+  // fixture, a future producer) still derives, so this cannot go silently blank.
+  const diagnosed = failing.map((t) => ({ task: t, fault: t.diagnosis ?? diagnoseProviderFault(t.lastError) }));
   const kinds = new Set(diagnosed.map((d) => d.fault?.kind).filter(Boolean));
   const fault = kinds.size === 1 ? diagnosed.find((d) => d.fault)!.fault! : null;
   const lead = fault

--- a/test/generation-health-banner.test.ts
+++ b/test/generation-health-banner.test.ts
@@ -43,6 +43,37 @@ describe("guard: the reason is specific — feature, model, error", () => {
     expect(SRC).toContain("t.lastError");
   });
 
+  it("LLMCREDIT-4: the raw provider error is NEVER rendered directly — it goes through legDetail", () => {
+    // ⚠️ THIS GUARD EXISTS BECAUSE THE DIFF REVIEW RAN THE MUTATION AND IT SURVIVED. Reverting this
+    // component to `{t.lastError}` — the exact defect LLMCREDIT-4 removes — left the whole unit tier
+    // green, because the criterion pinned the SERVER field while the JSX was what changed. That is
+    // the pin-the-call-site failure, one ticket after the same finding was folded on LLMCREDIT-3.
+    //
+    // ∀, not ∃: the property is that NO rendered interpolation of the raw error exists, not that a
+    // good one exists somewhere. Scoped to the JSX region for the reason the sibling guard above
+    // learned — the dismissal signature legitimately reads `t.lastError` in a template literal above
+    // the return.
+    const jsx = SRC.slice(SRC.indexOf("  return ("));
+    const rendered = [...jsx.matchAll(/\{\s*t\.lastError\b/g)];
+    expect(
+      rendered.map((m) => jsx.slice(Math.max(0, m.index - 40), m.index + 40)),
+      "the provider's raw JSON must not be interpolated into the markup — compose it with legDetail()"
+    ).toEqual([]);
+    // …and the composition that replaced it is actually present, so this cannot pass by the bullet
+    // rendering nothing at all.
+    expect(jsx).toContain("legDetail({ error: t.lastError");
+  });
+
+  it("LLMCREDIT-4: the client component imports llm-health as a TYPE only", () => {
+    // The hazard is documented three times in this lane and was guarded zero times. `llm-health`
+    // reaches `provider-fault` → `lib/query/claude`, which is `server-only`: a VALUE import here
+    // breaks `next build` while tsc and the whole unit tier stay green. That mistake shipped once on
+    // this lane and CI caught it; a comment is not a check.
+    for (const m of SRC.matchAll(/^import\s+(type\s+)?\{[^}]*\}\s+from\s+"@\/lib\/query\/llm-health";/gm)) {
+      expect(m[1], `value import of llm-health in a client component: ${m[0]}`).toBeTruthy();
+    }
+  });
+
   it("names features through a label map, never a raw slug", () => {
     expect(SRC).toMatch(/labelOf\(t\.task\)/);
     // A bare slug in the RENDERED MARKUP is the defect. Scoped to the JSX region (from the component's

--- a/test/llm-health.test.ts
+++ b/test/llm-health.test.ts
@@ -242,6 +242,7 @@ describe("pickReportedFailure — the singular fields must not describe a HEALED
     state,
     model,
     lastError: failedAgo === null ? null : "err",
+    diagnosis: null,
     lastFailedAt: failedAgo === null ? null : ago(failedAgo),
     lastOkAt: null,
   });

--- a/test/provider-fault-diagnosis.test.ts
+++ b/test/provider-fault-diagnosis.test.ts
@@ -206,6 +206,43 @@ describe("LLMCREDIT-3: the two surfaces, not just the classifier", () => {
     expect(diagnosisForLeg(null)).toBeNull();
   });
 
+  it("AC9: every FAILING task carries its own diagnosis, computed server-side", async () => {
+    // ⚠️ LLMCREDIT-3 fixed the summary paragraph and LEFT THIS — the per-task bullet, which is the
+    // most prominent red text on the page, so the operator still met the raw JSON first. It is
+    // computed SERVER-side and passed down because the banner is a client component and the
+    // classifier reaches `lib/query/claude`, which is `server-only`: importing it there breaks
+    // `next build` while tsc and every unit test stay green. That exact mistake shipped once on this
+    // lane and CI caught it, so the criterion pins the SERVER field rather than the JSX.
+    const { deriveTaskHealth } = await import("@/lib/query/llm-health");
+    const now = Date.now();
+    const run = (task: string, ok: boolean, error: string | null) => ({
+      task,
+      ok,
+      error,
+      model: "qwen/qwen3.7-max",
+      finishedAt: new Date(now - 60_000).toISOString(),
+      calls: 1,
+      failures: ok ? 0 : 1,
+    });
+    const tasks = deriveTaskHealth(
+      [
+        run("doc-task-infer", false, OUT_OF_CREDIT),
+        run("doc-task-infer", false, OUT_OF_CREDIT),
+      ] as never,
+      now
+    );
+    const t = tasks.find((x) => x.task === "doc-task-infer")!;
+    expect(t.diagnosis?.headline).toContain("OpenRouter");
+    expect(t.diagnosis?.action.toLowerCase()).toMatch(/top up/);
+
+    // An unrecognised error yields null, so the bullet falls back to the provider's own words.
+    const other = deriveTaskHealth(
+      [run("arcs", false, "connection reset"), run("arcs", false, "connection reset")] as never,
+      now
+    );
+    expect(other.find((x) => x.task === "arcs")!.diagnosis).toBeNull();
+  });
+
   it("AC8: the banner's line LEADS with the diagnosis and keeps the raw text underneath", () => {
     // ⚠️ PINNING THE CALL SITE, NOT THE CLASSIFIER. The component itself is unreachable from this tier
     // (the unit config includes only `*.test.ts` and there is no DOM harness), so the composition was

--- a/test/provider-fault-diagnosis.test.ts
+++ b/test/provider-fault-diagnosis.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { diagnoseProviderFault, faultSentence, providerNameFrom } from "@/lib/llm/provider-fault";
-import { degradedNote, type LlmTaskHealth } from "@/lib/query/llm-health";
+import { degradedNote, deriveTaskHealth, type LlmTaskHealth } from "@/lib/query/llm-health";
 import { diagnosisForLeg } from "@/lib/ingest/pipeline-health";
 import { legDetail, RAW_ERROR_CLIP } from "@/lib/ingest/leg-detail";
 
@@ -207,28 +207,30 @@ describe("LLMCREDIT-3: the two surfaces, not just the classifier", () => {
   });
 
   it("AC9: every FAILING task carries its own diagnosis, computed server-side", async () => {
-    // ⚠️ LLMCREDIT-3 fixed the summary paragraph and LEFT THIS — the per-task bullet, which is the
-    // most prominent red text on the page, so the operator still met the raw JSON first. It is
+    // ⚠️ LLMCREDIT-3 fixed the summary paragraph and LEFT THIS — the per-task bullet, which renders
+    // FIRST, above the note, carrying ~470 unclipped characters, so that is what the operator met.
+    // (An earlier version of this comment called it "the most prominent red text on the page". A
+    // review disproved that from the classNames — it was `text-red-600/80` at `text-xs`, i.e. the
+    // LEAST prominent. The true fact — rendered first, unclipped — carries the point on its own.) It is
     // computed SERVER-side and passed down because the banner is a client component and the
     // classifier reaches `lib/query/claude`, which is `server-only`: importing it there breaks
     // `next build` while tsc and every unit test stay green. That exact mistake shipped once on this
     // lane and CI caught it, so the criterion pins the SERVER field rather than the JSX.
-    const { deriveTaskHealth } = await import("@/lib/query/llm-health");
     const now = Date.now();
+    // No `calls`/`failures` here: neither exists on `LlmRun`, and carrying them forced an `as never`
+    // that switched OFF all argument checking rather than just tolerating the extras (review LOW-3).
     const run = (task: string, ok: boolean, error: string | null) => ({
       task,
       ok,
       error,
       model: "qwen/qwen3.7-max",
       finishedAt: new Date(now - 60_000).toISOString(),
-      calls: 1,
-      failures: ok ? 0 : 1,
     });
     const tasks = deriveTaskHealth(
       [
         run("doc-task-infer", false, OUT_OF_CREDIT),
         run("doc-task-infer", false, OUT_OF_CREDIT),
-      ] as never,
+      ] as Parameters<typeof deriveTaskHealth>[0],
       now
     );
     const t = tasks.find((x) => x.task === "doc-task-infer")!;
@@ -237,7 +239,9 @@ describe("LLMCREDIT-3: the two surfaces, not just the classifier", () => {
 
     // An unrecognised error yields null, so the bullet falls back to the provider's own words.
     const other = deriveTaskHealth(
-      [run("arcs", false, "connection reset"), run("arcs", false, "connection reset")] as never,
+      [run("arcs", false, "connection reset"), run("arcs", false, "connection reset")] as Parameters<
+        typeof deriveTaskHealth
+      >[0],
       now
     );
     expect(other.find((x) => x.task === "arcs")!.diagnosis).toBeNull();


### PR DESCRIPTION
## You were right — the fix was half-applied

LLMCREDIT-3 said the diagnosis would be *"consumed at both surfaces."* It reached the generation
banner's summary **paragraph** and not the per-task **bullet above it**, which kept rendering the
provider's raw JSON — unclipped, and **rendered first**. So on the shipped build the ingestion banner
correctly said *"OpenRouter is out of credit — top up the account"* while the bullet two inches above
still opened with `{"error":{"message":"This request requires more credits…`.

That is what "still getting the same error message" was. The report was accurate.

⚠️ *Not "the most prominent red text on the page" — an earlier version of this claim said that and the
review disproved it from the classNames (it is `text-xs` at `text-red-600/80`, the least prominent).
What makes it the thing you saw is that it renders FIRST and carried ~470 unclipped characters.*

## What ships

- `LlmTaskHealth` gains `diagnosis`, computed **server-side** in `deriveTaskHealth`.
- The bullet composes through **`legDetail`** — the pure, client-safe helper already extracted during
  LLMCREDIT-3 for exactly this — so both banners now share the lead/raw split *and* the clip length.
- `diagnosis` keeps `kind`, so `degradedNote` reads the field instead of re-deriving the same answer.

⚠️ **Server-side, and that is not incidental.** The banner is `"use client"` and the classifier reaches
`lib/query/claude`, which is `server-only`. A value import there breaks `next build` while `tsc` and
the entire unit tier stay green — that exact mistake shipped once on this lane and CI caught it. This
time I checked the boundary before writing the import, and there is now a guard for it.

## Verification

| tier | result |
|---|---|
| unit (`npm test`) | **3,518 passed**, 15 skipped |
| `npm run build` | **exit 0** — the check that catches the boundary, run locally |
| `npx tsc --noEmit` · `npm run lint` · `npm run check:docs` | clean (0 errors; 18 pre-existing warnings, none in this diff) |
| `aios spec eval` | `SPEC_READY`, exit 0 |

Three tests fail under full-suite load — `nda-gate` (×2) and `release-tag-policy`. **All three are
pre-existing**: I stashed this diff and reproduced them on `origin/main`.

### Mutations

| # | mutation | verdict |
|---|---|---|
| 1 | **revert the whole component to `origin/main`** — the reviewer's own surviving mutation | REDDENED — AC1 |
| 2 | make the `llm-health` import a value import | REDDENED — AC2 |
| 3 | `deriveTaskHealth` stops populating `diagnosis` | REDDENED — AC3 |

## Review — Reviewed by Fable code-reviewer — verdict BLOCKED, one HIGH + three MEDIUM + four LOW, all folded

**It ran the mutation itself and it survived.** Reverting this component to `origin/main` — the exact
defect this ticket removes — left **40/40 green**, because my criterion pinned the *server field*
while the *JSX* was what changed. That is the pin-the-call-site failure, one ticket after I folded
that same finding on LLMCREDIT-3. Worse, the answer was already in the tree: `legDetail`, which I had
extracted during LLMCREDIT-3 for precisely this reason and then declined to use here.

The fold is the reviewer's own one-sentence prescription: compose through `legDetail`, and add a **∀**
guard that the raw error is never interpolated into the markup. Mutation 1 is its mutation, and it now
reddens.

Also folded:

- **Five type errors in a shipped test helper, invisible to CI.** Widening `LlmTaskHealth` broke
  `test/llm-health.test.ts`'s `T` helper — and `tsconfig` excludes `test/`, so `npm run typecheck`
  never sees it. The sibling helper hid the same error behind an `as unknown as` cast.
- **Two independently-derived diagnoses on one object.** `degradedNote` re-derived from the string
  what was now a field, free to disagree for any task not built by `deriveTaskHealth`. `kind` is
  retained and the field is read.
- **A third copy of the 160-char clip**, which falsified `leg-detail`'s own "ONE constant" comment.
  Imported now.
- **A false superlative attached to a true finding** (LOW-1 above), plus test hygiene: an `as never`
  that switched off all argument checking rather than tolerating two cargo-culted fields.

**Deferred:** nothing.

AIOS-Work: LLMCREDIT-4
