### PR TITLE
release: prepare v0.12.0 — declare, bump, date, and guard the three that must agree (RELPTR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,60 @@ line go stale while the code moved on, so it is not restated.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-08-26
+
+### Removed
+
+- **PRET-6 — the permissive access mode is deleted.** `teams.access_enforcement` and
+  `teams.autoflip_hold` are dropped; membership is the only thing that decides what a member reads.
+  There is no flag to flip back, and `set-access-enforcement` is gone from the admin CLI.
+
+  **⚠️ You may not upgrade to this release directly from anything older than `v0.11.0`.** The
+  migration refuses:
+
+  ```
+  PRET-6 refused: the PRET-4 builtin materialization has not completed on this fleet
+  ```
+
+  Both refusal conditions must be cleared first — the PRET-4 marker present, and zero teams left
+  `permissive`. Run `v0.11.0` (the `release/v0.11.0` branch), let it boot, let auto-flip converge,
+  flip anything it could not, and verify with the query in [`docs/RELEASING.md`](docs/RELEASING.md)
+  §3.4. A successful deploy is not the gate; the query is. Full detail:
+  `docs/RELEASE-NOTES-pret6.md`.
+
+  **One-way.** At least one migration in this range adds an enum value, which Postgres cannot drop.
+  Roll forward, not back.
+
+### Added
+
+### Changed
+
+### Added
+
+- **Coverage arrives with its denominator (AIO-995, Brain API 1.22).** `test_coverage_pct` was a
+  bare percentage carrying 40% of `health_score` and 25% of `agentic_score`, so a repo measuring
+  436 lines and one measuring 10,647 were indistinguishable in every composite. The scan payload
+  gains six optional, nullable raw measures — `test_coverage_lines_total` /
+  `test_coverage_lines_covered` (the denominator) and `tests_total` / `tests_passed` /
+  `tests_skipped` / `tests_failed` (run integrity) — and the brain derives, persists and displays
+  `coverage_breadth_pct`. Coverage now renders with its scope (`99% (436 / 3,140 lines)`), a
+  narrow measurement is visually distinct, and a run with skipped or failed cases is flagged
+  partial. **No score changes**: breadth is disclosed, not weighted, because every pre-1.22 row
+  has a null denominator and a factor applied today would rank re-scanned repos against
+  un-rescanned ones under two different formulas. Null means unknown throughout — never zero,
+  never full scope.
+
+> This section lists the changes that were written down. The interval also contains work that was
+> never itemised here — it is not an exhaustive record of 168 commits, and is not presented as one.
+
+## [0.11.0] — 2026-08-18
+
+**The convergence release.** Upgrading through it is mandatory for any installation older than it;
+see the `v0.12.0` entry above. It also carries **PRET-4** (the tier-wall teardown, #594) and
+**PRET-5** (the external-member proof, #606), which write the explicit built-in membership rows and
+the boot materialization the retirement requires — named here because the entries below predate them
+and this release's identity depends on them.
+
 ### Changed
 
 - **PRET-3 — every arcs panel is now the fused per-project panel.** External members and
@@ -32,19 +86,6 @@ line go stale while the code moved on, so it is not restated.
   `admin.ts set-access-enforcement --dry-run`, and the flip stays a manual decision.
 
 ### Added
-
-- **Coverage arrives with its denominator (AIO-995, Brain API 1.22).** `test_coverage_pct` was a
-  bare percentage carrying 40% of `health_score` and 25% of `agentic_score`, so a repo measuring
-  436 lines and one measuring 10,647 were indistinguishable in every composite. The scan payload
-  gains six optional, nullable raw measures — `test_coverage_lines_total` /
-  `test_coverage_lines_covered` (the denominator) and `tests_total` / `tests_passed` /
-  `tests_skipped` / `tests_failed` (run integrity) — and the brain derives, persists and displays
-  `coverage_breadth_pct`. Coverage now renders with its scope (`99% (436 / 3,140 lines)`), a
-  narrow measurement is visually distinct, and a run with skipped or failed cases is flagged
-  partial. **No score changes**: breadth is disclosed, not weighted, because every pre-1.22 row
-  has a null denominator and a factor applied today would rank re-scanned repos against
-  un-rescanned ones under two different formulas. Null means unknown throughout — never zero,
-  never full scope.
 
 - **Code Maintenance Loop Phase 0 (AIO-610)** — Brain API 1.17 accepts the backward-compatible
   codebase-health v2 snapshot with repository profile identity, explicit evidence completeness,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,35 @@ line go stale while the code moved on, so it is not restated.
   PRET-6 refused: the PRET-4 builtin materialization has not completed on this fleet
   ```
 
-  Both refusal conditions must be cleared first — the PRET-4 marker present, and zero teams left
-  `permissive`. Run `v0.11.0` (the `release/v0.11.0` branch), let it boot, let auto-flip converge,
-  flip anything it could not, and verify with the query in [`docs/RELEASING.md`](docs/RELEASING.md)
-  §3.4. A successful deploy is not the gate; the query is. Full detail:
-  `docs/RELEASE-NOTES-pret6.md`.
+  **The upgrade, in full — inlined deliberately.** The `v0.11.0` tree predates these docs, so an
+  operator pinned there cannot open them:
+
+  1. Point the service at the **`release/v0.11.0`** branch and deploy it. (Railway's connected source
+     is a branch; there is no supported fleet-wide way to select a tag.)
+  2. Let it **boot** — the PRET-4 marker is written by the running application, not by a migration,
+     so applying the schema alone does not satisfy the precondition.
+  3. Let auto-flip converge, then flip anything it could not, using the command that release carries:
+
+     ```bash
+     npm run admin -- set-access-enforcement <team-slug> enforcing
+     ```
+
+  4. **Verify both conditions directly. This query is the gate — a successful deploy is not:**
+
+     ```sql
+     select exists (select 1 from migration_markers where name = 'pret4_builtin_materialize') as marker_ok,
+            (select count(*) from teams where access_enforcement = 'permissive') as permissive_left;
+     ```
+
+     Proceed only on `marker_ok = t` and `permissive_left = 0`. Both the command above and this
+     column are **deleted by this release**, so run them while still on `v0.11.0`.
+  5. Point the service back at `main` and deploy.
+
+  Fuller background: [`docs/RELEASING.md`](docs/RELEASING.md) §3.4 and `docs/RELEASE-NOTES-pret6.md`
+  (both present from this release onward).
 
   **One-way.** At least one migration in this range adds an enum value, which Postgres cannot drop.
   Roll forward, not back.
-
-### Added
-
-### Changed
 
 ### Added
 
@@ -52,10 +69,18 @@ line go stale while the code moved on, so it is not restated.
   un-rescanned ones under two different formulas. Null means unknown throughout — never zero,
   never full scope.
 
-> This section lists the changes that were written down. The interval also contains work that was
-> never itemised here — it is not an exhaustive record of 168 commits, and is not presented as one.
+> This section lists the changes that were written down. The interval also contains a great deal of
+> work that was never itemised here — it is not an exhaustive record, and is not presented as one.
+> (An earlier draft claimed a precise commit count; it was measured days before the release and was
+> already wrong by the time it was written down.)
 
 ## [0.11.0] — 2026-08-18
+
+> **Read this date as the content boundary, not the cut date.** `v0.11.0` was branched from
+> `803122ff` (authored 2026-08-18) and tagged on 2026-08-26 — the eight days between are this
+> repo's own work on the release path, none of which is in the release. Every other entry in this
+> file was cut the day its content landed, so this one is the exception and is labelled rather than
+> silently normalised. The tagged tree carries this same heading, unchanged.
 
 **The convergence release.** Upgrading through it is mandatory for any installation older than it;
 see the `v0.12.0` entry above. It also carries **PRET-4** (the tier-wall teardown, #594) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ line go stale while the code moved on, so it is not restated.
   un-rescanned ones under two different formulas. Null means unknown throughout — never zero,
   never full scope.
 
+- **One issue, one row — a DB backstop for PM links (ADOPTUNIQ-1).** A unique index now enforces that
+  at most one `task_pm_links` row per `(team, provider)` may claim a given `provider_resource_id`.
+  **It declines rather than aborting**: the migration is exception-contained, so on a fleet that
+  already holds duplicates the index is *not* created and the release still succeeds — the log line is
+  the only signal. If you want the backstop, de-duplicate and re-run `pg:schema`. Nothing is deleted
+  and no data is rewritten either way.
+
 > This section lists the changes that were written down. The interval also contains a great deal of
 > work that was never itemised here — it is not an exhaustive record, and is not presented as one.
 > (An earlier draft claimed a precise commit count; it was measured days before the release and was

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,11 +39,20 @@ runs, today and at every future rebuild — and that branch is trunk.
 1. **Declare the release before you cut it.** Add the new tag to `DEFAULT_TAGS` in
    `scripts/migrate-from-existing.mjs` and land that PR. The lane skips a declared-but-uncut tag with
    a notice, so this is green *before* the tag exists — that is exactly what the change bought.
-2. **Bump `package.json`'s `version`** to the release version, in the same PR.
-3. **Move `CHANGELOG.md`'s `[Unreleased]` into a dated `## [X.Y.Z] — YYYY-MM-DD` section.** It is the
-   only human-readable record of what a pinned user is running. **No automated check reads this
-   heading today** — an earlier draft of this file claimed one did, which is exactly the kind of
-   invented-check claim the rest of this PR corrects.
+2. **Bump the version at all THREE sites**, in the same PR — `package.json` `.version`,
+   `package-lock.json` `.version`, and `package-lock.json` `.packages[""].version`. Bumping only the
+   first is the mistake this repo has already made: the version sat at `0.10.0` for 23 days and two
+   releases' worth of work. `test/guards/release-version-agreement.test.ts` now fails the build if the
+   three disagree, or if the newest **declared** tag is not `v${package.json.version}`.
+3. **Move `CHANGELOG.md`'s `[Unreleased]` into a dated `## [X.Y.Z] — YYYY-MM-DD` section**, and leave
+   an empty `## [Unreleased]` above it. It is the only human-readable record of what a pinned user is
+   running. **A check now reads this heading** (RELPTR-2): the build fails if there is no section for
+   the version being shipped, or if no `[Unreleased]` heading is left for the next cycle. It checks
+   *presence*, not contents — and it ignores headings inside fenced code blocks, so an illustration
+   cannot stand in for a missing section. Note what it still cannot check: whether the section is
+   TRUE. Anything merged before you cut the tag ships in the release whether or not it is listed.
+   (An earlier draft of this file claimed a check existed when none did; this line is accurate as of
+   the guard, not aspirational.)
 4. **Cut the tag on the release commit** and push it. **Pushing a tag triggers nothing** —
    `ci.yml` fires on `pull_request` and `push` to branches only, so there is no tag-triggered run to
    watch. The migration lane picks the new tag up on the **next** PR or branch push, and that is the

--- a/docs/design/release-pret6-upgrade-path.md
+++ b/docs/design/release-pret6-upgrade-path.md
@@ -162,7 +162,7 @@ asserts only that the declared list is in a **legal** state, which is true mid-p
 entirely — the deleted permissive mode, the mandatory ordered upgrade, and the deployment refusal
 (`docs/RELEASE-NOTES-pret6.md:31-55`). Publishing that as `v0.12.0`'s notes would hide the one thing a
 pinned operator must act on. This slice adds a pointer to the PRET-6 release notes and the upgrade
-order; it does **not** editorialise 168 commits it did not review.
+order; it does **not** editorialise the interval's commits it did not review.
 
 ## Scope
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aios-team-brain",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aios-team-brain",
-      "version": "0.10.0",
+      "version": "0.12.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aios-alpha/design": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-team-brain",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "scripts": {

--- a/scripts/migrate-from-existing.mjs
+++ b/scripts/migrate-from-existing.mjs
@@ -66,7 +66,8 @@ const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
  * `nextTagPolicy` for why that exception exists and how narrow it is.
  */
 export const DEFAULT_TAGS = ["v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0", "v0.11.0", "v0.12.0"];
-// `v0.11.0` is DECLARED BEFORE IT IS CUT, on purpose (RELPTR-2). Cutting it first would fail
+// The NEWEST entry is DECLARED BEFORE IT IS CUT, on purpose (RELPTR-2) — `v0.12.0` today, `v0.11.0`
+// when that line was written. Cutting first would fail
 // `DEFAULT_TAGS is stale` on every open PR — the freeze `nextTagPolicy` exists to prevent. Its
 // pending slot is exactly this affordance: declare, then cut, and nothing reddens in between.
 

--- a/scripts/migrate-from-existing.mjs
+++ b/scripts/migrate-from-existing.mjs
@@ -65,7 +65,7 @@ const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
  * Every one must exist in git — EXCEPT the newest, which may be a release being prepared. See
  * `nextTagPolicy` for why that exception exists and how narrow it is.
  */
-export const DEFAULT_TAGS = ["v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0", "v0.11.0"];
+export const DEFAULT_TAGS = ["v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0", "v0.11.0", "v0.12.0"];
 // `v0.11.0` is DECLARED BEFORE IT IS CUT, on purpose (RELPTR-2). Cutting it first would fail
 // `DEFAULT_TAGS is stale` on every open PR — the freeze `nextTagPolicy` exists to prevent. Its
 // pending slot is exactly this affordance: declare, then cut, and nothing reddens in between.

--- a/test/guards/release-tag-policy.test.ts
+++ b/test/guards/release-tag-policy.test.ts
@@ -23,12 +23,12 @@ import { DEFAULT_TAGS, nextTagPolicy } from "../../scripts/migrate-from-existing
  */
 
 const ROOT = join(__dirname, "..", "..");
-const REAL_TAGS = ["v0.10.0", "v0.9.0", "v0.8.0", "v0.7.0"]; // newest-first, as git reports them
+const REAL_TAGS = ["v0.11.0", "v0.10.0", "v0.9.0", "v0.8.0", "v0.7.0"]; // newest-first, as git reports them
 
 /** A fully-CUT declared list, for policy semantics. Deliberately NOT `DEFAULT_TAGS`: the live list
  *  legitimately carries a declared-but-uncut release during preparation, and assertions that assumed
  *  otherwise turned red the moment a release was declared. */
-const CUT_FIXTURE = ["v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0"];
+const CUT_FIXTURE = ["v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0", "v0.11.0"];
 
 /**
  * Does THIS checkout have the release tags?
@@ -83,9 +83,15 @@ describe("release tag policy — the prepared release (criteria 1, 2, 5)", () =>
   it("picks the exempt tag by VERSION, not by list position", () => {
     // `v0.9.0` > `v0.10.0` under string sort. A list written out of order must not change which tag
     // is allowed to be missing, or the exemption moves under a harmless reformat.
-    const res = nextTagPolicy(["v0.11.0", "v0.7.0", "v0.8.0", "v0.9.0", "v0.10.0"], REAL_TAGS);
-    expect(res.pending).toBe("v0.11.0");
-    expect(() => nextTagPolicy(["v0.11.0", "v0.9.5", "v0.10.0"], [...REAL_TAGS, "v0.11.0"])).toThrow(
+    // SYNTHETIC versions on purpose. These fixtures originally used `v0.11.0` as "the uncut one" — and
+    // broke the day v0.11.0 was actually cut. A fixture that borrows a plausible real version rots into
+    // a false failure the moment the project reaches it.
+    // Derived from CUT_FIXTURE (with the synthetic pending tag pushed to the FRONT) rather than
+    // hand-listed: a hand-listed copy silently omits the newest cut release and trips the staleness
+    // rule instead of testing the ordering it claims to.
+    const res = nextTagPolicy(["v9.9.9", ...CUT_FIXTURE], REAL_TAGS);
+    expect(res.pending).toBe("v9.9.9");
+    expect(() => nextTagPolicy(["v9.9.9", "v0.9.5", ...CUT_FIXTURE], [...REAL_TAGS, "v9.9.9"])).toThrow(
       /unknown git tag: v0\.9\.5/
     );
   });
@@ -93,7 +99,9 @@ describe("release tag policy — the prepared release (criteria 1, 2, 5)", () =>
 
 describe("release tag policy — the anti-rot rule survives (criteria 3, 4, 5)", () => {
   it("THROWS when a tag EXISTS that is newer than everything declared", () => {
-    expect(() => nextTagPolicy(["v0.7.0", "v0.8.0"], REAL_TAGS)).toThrow(/DEFAULT_TAGS is stale: v0\.10\.0/);
+    // The newest EXISTING tag is whatever REAL_TAGS says today — asserted by name so the message is
+    // pinned, and updated deliberately when a release is cut (it was v0.10.0 before v0.11.0 existed).
+    expect(() => nextTagPolicy(["v0.7.0", "v0.8.0"], REAL_TAGS)).toThrow(/DEFAULT_TAGS is stale: v0\.11\.0/);
   });
 
   it("is NON-VACUOUS in both directions against the SHIPPED list", () => {

--- a/test/guards/release-tag-policy.test.ts
+++ b/test/guards/release-tag-policy.test.ts
@@ -60,8 +60,8 @@ describe("release tag policy — the prepared release (criteria 1, 2, 5)", () =>
     // moment a release was DECLARED (`pending` stops being null, `usable` stops equalling the list)
     // they went red — the guard that exists to make releases possible would have blocked one. Policy
     // semantics are tested against fixtures; the live list gets its own legal-state check below.
-    const res = nextTagPolicy([...CUT_FIXTURE, "v9.9.9"], REAL_TAGS);
-    expect(res.pending).toBe("v9.9.9");
+    const res = nextTagPolicy([...CUT_FIXTURE, "v0.100.0"], REAL_TAGS);
+    expect(res.pending).toBe("v0.100.0");
     expect(res.usable).toEqual(CUT_FIXTURE);
     expect(res.notice).toMatch(/declared but not yet cut/);
   });
@@ -83,15 +83,19 @@ describe("release tag policy — the prepared release (criteria 1, 2, 5)", () =>
   it("picks the exempt tag by VERSION, not by list position", () => {
     // `v0.9.0` > `v0.10.0` under string sort. A list written out of order must not change which tag
     // is allowed to be missing, or the exemption moves under a harmless reformat.
-    // SYNTHETIC versions on purpose. These fixtures originally used `v0.11.0` as "the uncut one" — and
-    // broke the day v0.11.0 was actually cut. A fixture that borrows a plausible real version rots into
-    // a false failure the moment the project reaches it.
+    // SYNTHETIC, and specifically `v0.100.0`: it string-sorts BELOW `v0.9.0` while being numerically the
+    // newest, so a string-sorting exemption pick fails this test. The previous fixture (`v9.9.9`) was the
+    // maximum under both orderings and had silently stopped discriminating — review caught that.
+    // These fixtures originally used `v0.11.0` as "the uncut one" and broke the day it was cut; a fixture
+    // borrowing a plausible real version rots the moment the project reaches it. ROT HORIZON: 88 more
+    // minor releases. If the project ever reaches v0.100.0, move these to the next version that sorts
+    // below the newest real one as text — the property being tested is that disagreement, not the number.
     // Derived from CUT_FIXTURE (with the synthetic pending tag pushed to the FRONT) rather than
     // hand-listed: a hand-listed copy silently omits the newest cut release and trips the staleness
     // rule instead of testing the ordering it claims to.
-    const res = nextTagPolicy(["v9.9.9", ...CUT_FIXTURE], REAL_TAGS);
-    expect(res.pending).toBe("v9.9.9");
-    expect(() => nextTagPolicy(["v9.9.9", "v0.9.5", ...CUT_FIXTURE], [...REAL_TAGS, "v9.9.9"])).toThrow(
+    const res = nextTagPolicy(["v0.100.0", ...CUT_FIXTURE], REAL_TAGS);
+    expect(res.pending).toBe("v0.100.0");
+    expect(() => nextTagPolicy(["v0.100.0", "v0.9.5", ...CUT_FIXTURE], [...REAL_TAGS, "v0.100.0"])).toThrow(
       /unknown git tag: v0\.9\.5/
     );
   });
@@ -167,7 +171,7 @@ describe("release tag policy — the anti-rot rule survives (criteria 3, 4, 5)",
 
   it("each outcome fires ALONE for an input that triggers only it", () => {
     expect(nextTagPolicy(CUT_FIXTURE, REAL_TAGS)).toEqual({ usable: CUT_FIXTURE, pending: null, notice: null });
-    expect(nextTagPolicy([...CUT_FIXTURE, "v9.9.9"], REAL_TAGS).pending).toBe("v9.9.9");
+    expect(nextTagPolicy([...CUT_FIXTURE, "v0.100.0"], REAL_TAGS).pending).toBe("v0.100.0");
     expect(() => nextTagPolicy(["v0.7.0", "v0.8.5", "v0.10.0"], REAL_TAGS)).toThrow(/unknown git tag/);
     expect(() => nextTagPolicy(["v0.7.0"], REAL_TAGS)).toThrow(/stale/);
   });

--- a/test/guards/release-version-agreement.test.ts
+++ b/test/guards/release-version-agreement.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DEFAULT_TAGS } from "../../scripts/migrate-from-existing.mjs";
+
+/**
+ * RELPTR-2 — the three things a release must agree about, checked against each other.
+ * Spec: `docs/design/release-pret6-upgrade-path.md`, Decision 5.
+ *
+ * WHY THESE THREE. A "half-cut release" is the failure: the version the app reports, the tag a user
+ * pins, and the CHANGELOG heading disagreeing. Each is written by hand at a different moment, and
+ * nothing pinned them to each other — `package.json` sat at `0.10.0` for 168 commits and 23 days
+ * without a single check noticing.
+ *
+ * WHY THEY PARSE JSON RATHER THAN MATCH TEXT. Measured: a grep for `0.10.0` matches **eight**
+ * unrelated `"node": ">=0.10.0"` engine constraints inside `package-lock.json`. A text-matching guard
+ * would have been noise on its first run, and noise is how a guard gets deleted.
+ */
+
+const ROOT = join(__dirname, "..", "..");
+const readJson = (rel: string) => JSON.parse(readFileSync(join(ROOT, rel), "utf8"));
+
+/** Every place the Node application's version is written. NOT `ingestion/pyproject.toml`: that is a
+ *  separately packaged sidecar with its own versioning (`ingestion/NOTICE`), and forcing it to match
+ *  would be inventing a coupling that does not exist. */
+function versionSites(): { where: string; version: unknown }[] {
+  const pkg = readJson("package.json");
+  const lock = readJson("package-lock.json");
+  return [
+    { where: "package.json .version", version: pkg.version },
+    { where: "package-lock.json .version", version: lock.version },
+    { where: 'package-lock.json .packages[""].version', version: lock.packages?.[""]?.version },
+  ];
+}
+
+/** `vX.Y.Z` ordered by number, never by string — `v0.9.0` sorts after `v0.10.0` as text. */
+function newestDeclared(tags: readonly string[]): string {
+  const rank = (t: string) => t.slice(1).split(".").map(Number);
+  return [...tags]
+    .filter((t) => /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(t))
+    .sort((a, b) => {
+      const [ax, ay, az] = rank(a);
+      const [bx, by, bz] = rank(b);
+      return ax - bx || ay - by || az - bz;
+    })
+    .at(-1)!;
+}
+
+/** Does the changelog carry a section for this version? Tolerant of the file's real punctuation —
+ *  the headings use an EM DASH (`## [0.10.0] — 2026-08-03`), which a naive `- ` pattern misses. */
+function changelogHasVersion(md: string, version: string): boolean {
+  return new RegExp(`^## \\[${version.replace(/\./g, "\\.")}\\]`, "m").test(md);
+}
+
+describe("release agreement — the version's three sites (criteria 1, 2)", () => {
+  it("all three agree", () => {
+    const sites = versionSites();
+    const distinct = new Set(sites.map((s) => String(s.version)));
+    expect([...distinct], sites.map((s) => `${s.where}=${s.version}`).join(" | ")).toHaveLength(1);
+  });
+
+  it("each site is READ, so none can go missing and pass as agreement", () => {
+    // A site that returns `undefined` would collapse into a single distinct value with the others only
+    // if they were all undefined — but an absent lockfile path silently reading `undefined` while the
+    // other two agree is exactly the shape that makes an equality check look green. Pin presence too.
+    for (const s of versionSites()) {
+      expect(s.version, `${s.where} must exist`).toMatch(/^\d+\.\d+\.\d+$/);
+    }
+  });
+
+  it("is NON-VACUOUS: a disagreement at ANY single site is caught", () => {
+    // Each site failing ALONE, against a synthetic pair — the real files are green, so without this
+    // the assertion above proves only that today happens to be fine.
+    const agree = ["0.12.0", "0.12.0", "0.12.0"];
+    for (let i = 0; i < 3; i += 1) {
+      const broken = [...agree];
+      broken[i] = "0.11.0";
+      expect(new Set(broken).size, `site ${i} must be detectable alone`).toBeGreaterThan(1);
+    }
+    expect(new Set(agree).size).toBe(1);
+  });
+
+  it("does NOT match text: the lockfile's engine constraints must not be mistaken for our version", () => {
+    // The reason this guard parses. `"node": ">=0.10.0"` appears several times in package-lock.json.
+    const lockText = readFileSync(join(ROOT, "package-lock.json"), "utf8");
+    const engineHits = [...lockText.matchAll(/">=0\.10\.0"/g)].length;
+    expect(engineHits, "the trap this guard exists to avoid should still be present").toBeGreaterThan(1);
+    // …and none of them is a version site.
+    expect(versionSites().every((s) => s.version !== ">=0.10.0")).toBe(true);
+  });
+});
+
+describe("release agreement — the declared tag and the changelog (criteria 3, 4, 5)", () => {
+  it("the newest DECLARED tag matches the version this tree ships as", () => {
+    const version = readJson("package.json").version as string;
+    expect(newestDeclared(DEFAULT_TAGS)).toBe(`v${version}`);
+  });
+
+  it("compares by SEMVER, not array position — a reordered list gives the same answer", () => {
+    // `.at(-1)` on the raw array would let a harmless reordering disagree with `nextTagPolicy`, which
+    // picks the semver maximum. Then the guard and the policy would name different pending releases.
+    expect(newestDeclared(["v0.12.0", "v0.10.0", "v0.11.0"])).toBe("v0.12.0");
+    expect(newestDeclared(["v0.9.0", "v0.10.0"])).toBe("v0.10.0"); // string sort would say v0.9.0
+  });
+
+  it("CHANGELOG.md carries a section for the version being shipped", () => {
+    const version = readJson("package.json").version as string;
+    const md = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
+    expect(changelogHasVersion(md, version), `no "## [${version}]" section`).toBe(true);
+  });
+
+  it("is NON-VACUOUS, and tolerates the file's real em-dash headings", () => {
+    const md = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
+    expect(changelogHasVersion(md, "0.11.0"), "a version that IS there").toBe(true);
+    expect(changelogHasVersion(md, "0.99.0"), "a version that is NOT").toBe(false);
+    // The real heading punctuation, which a `] - ` pattern would miss.
+    expect(md).toMatch(/^## \[0\.11\.0\] — /m);
+  });
+
+  it("keeps an empty [Unreleased] heading for the next cycle (criterion 6)", () => {
+    // Dating a section without leaving one behind means the next contributor invents a new heading,
+    // and the guard above starts passing against a section nobody is adding to.
+    const md = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
+    expect(md).toMatch(/^## \[Unreleased\]$/m);
+  });
+
+  it("reads the version from package.json, not a literal — so next release needs no edit here", () => {
+    const src = readFileSync(join(__dirname, "release-version-agreement.test.ts"), "utf8");
+    // The assertions must not hardcode the shipping version; `0.11.0`/`0.99.0` above are fixtures for
+    // the non-vacuity check, and `0.12.0` appears only in the synthetic triple.
+    expect(src).toMatch(/readJson\("package\.json"\)\.version/);
+  });
+});

--- a/test/guards/release-version-agreement.test.ts
+++ b/test/guards/release-version-agreement.test.ts
@@ -9,12 +9,15 @@ import { DEFAULT_TAGS } from "../../scripts/migrate-from-existing.mjs";
  *
  * WHY THESE THREE. A "half-cut release" is the failure: the version the app reports, the tag a user
  * pins, and the CHANGELOG heading disagreeing. Each is written by hand at a different moment, and
- * nothing pinned them to each other — `package.json` sat at `0.10.0` for 168 commits and 23 days
- * without a single check noticing.
+ * nothing pinned them to each other — `package.json` sat at `0.10.0` for 23 days and the entire
+ * v0.11.0+v0.12.0 interval without a single check noticing. (No commit count here: the first draft
+ * said 168, measured days earlier, and it was 172 by the time it was written.)
  *
- * WHY THEY PARSE JSON RATHER THAN MATCH TEXT. Measured: a grep for `0.10.0` matches **eight**
- * unrelated `"node": ">=0.10.0"` engine constraints inside `package-lock.json`. A text-matching guard
- * would have been noise on its first run, and noise is how a guard gets deleted.
+ * WHY THEY PARSE JSON RATHER THAN MATCH TEXT. Measured: a grep for `">=0.10.0"` matches **14**
+ * unrelated dependency engine constraints inside `package-lock.json` (an earlier draft of this comment
+ * said eight — counted by eye rather than by grep, which is the exact habit these guards exist to
+ * replace). A text-matching guard would have been noise on its first run, and noise is how a guard
+ * gets deleted.
  */
 
 const ROOT = join(__dirname, "..", "..");
@@ -23,21 +26,32 @@ const readJson = (rel: string) => JSON.parse(readFileSync(join(ROOT, rel), "utf8
 /** Every place the Node application's version is written. NOT `ingestion/pyproject.toml`: that is a
  *  separately packaged sidecar with its own versioning (`ingestion/NOTICE`), and forcing it to match
  *  would be inventing a coupling that does not exist. */
-function versionSites(): { where: string; version: unknown }[] {
-  const pkg = readJson("package.json");
-  const lock = readJson("package-lock.json");
+type PkgLike = { version?: unknown };
+type LockLike = { version?: unknown; packages?: Record<string, { version?: unknown } | undefined> };
+
+/** The READ, split from the FILES so a test can perturb the inputs and prove each label reads the
+ *  field it names. `versionSites()` below is the only production-shaped caller. */
+function versionSitesFrom(pkg: PkgLike, lock: LockLike): { where: string; version: unknown }[] {
   return [
-    { where: "package.json .version", version: pkg.version },
-    { where: "package-lock.json .version", version: lock.version },
-    { where: 'package-lock.json .packages[""].version', version: lock.packages?.[""]?.version },
+    { where: "package.json .version", version: pkg?.version },
+    { where: "package-lock.json .version", version: lock?.version },
+    { where: 'package-lock.json .packages[""].version', version: lock?.packages?.[""]?.version },
   ];
+}
+
+function versionSites(): { where: string; version: unknown }[] {
+  return versionSitesFrom(readJson("package.json"), readJson("package-lock.json"));
 }
 
 /** `vX.Y.Z` ordered by number, never by string — `v0.9.0` sorts after `v0.10.0` as text. */
 function newestDeclared(tags: readonly string[]): string {
+  const CORE = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+  // REJECT, don't filter. Silently dropping a malformed declaration (a `v0.13.0-rc.1`) would let it sit
+  // in DEFAULT_TAGS while this guard cheerfully agreed about a different tag — review found that hole.
+  const malformed = tags.filter((t) => !CORE.test(t));
+  if (malformed.length > 0) throw new Error(`DEFAULT_TAGS carries a non-release tag: ${malformed.join(", ")}`);
   const rank = (t: string) => t.slice(1).split(".").map(Number);
   return [...tags]
-    .filter((t) => /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(t))
     .sort((a, b) => {
       const [ax, ay, az] = rank(a);
       const [bx, by, bz] = rank(b);
@@ -49,7 +63,40 @@ function newestDeclared(tags: readonly string[]): string {
 /** Does the changelog carry a section for this version? Tolerant of the file's real punctuation —
  *  the headings use an EM DASH (`## [0.10.0] — 2026-08-03`), which a naive `- ` pattern misses. */
 function changelogHasVersion(md: string, version: string): boolean {
-  return new RegExp(`^## \\[${version.replace(/\./g, "\\.")}\\]`, "m").test(md);
+  // Anchored on what may FOLLOW the bracket too: `## [0.12.0]garbage` is not a release heading, and the
+  // first spelling accepted it. Either end-of-line or a date delimiter.
+  //
+  // ANY dash, not just this file's em dash. Keep-a-Changelog's own spelling is an ASCII hyphen, so a
+  // contributor writing `## [0.13.0] - 2026-09-01` would have reddened a guard for being conventional.
+  // Widening costs nothing — `\]` still does the anti-collision work, so `0.1` never matches `[0.12.0]`.
+  //
+  // FENCED BLOCKS ARE NOT THE DOCUMENT. A `## [0.12.0]` line inside a ``` example is prose about a
+  // heading, not a heading; accepting it would let the guard pass on a release whose real section had
+  // been deleted, while an illustration stood in for it. Codex found that.
+  return new RegExp(`^## \\[${version.replace(/\./g, "\\.")}\\](?:\\s*$|[ \\t]*[—–-])`, "m").test(
+    stripFences(md)
+  );
+}
+
+/** Blank out ``` / ~~~ fenced regions, preserving line count so `^`/`$` anchors keep their meaning. */
+function stripFences(md: string): string {
+  let inFence: string | null = null;
+  return md
+    .split("\n")
+    .map((line) => {
+      const open = /^\s*(```+|~~~+)/.exec(line);
+      if (inFence === null && open) {
+        inFence = open[1][0];
+        return "";
+      }
+      if (inFence !== null) {
+        const close = /^\s*(```+|~~~+)/.exec(line);
+        if (close && close[1][0] === inFence) inFence = null;
+        return "";
+      }
+      return line;
+    })
+    .join("\n");
 }
 
 describe("release agreement — the version's three sites (criteria 1, 2)", () => {
@@ -68,16 +115,46 @@ describe("release agreement — the version's three sites (criteria 1, 2)", () =
     }
   });
 
-  it("is NON-VACUOUS: a disagreement at ANY single site is caught", () => {
-    // Each site failing ALONE, against a synthetic pair — the real files are green, so without this
-    // the assertion above proves only that today happens to be fine.
-    const agree = ["0.12.0", "0.12.0", "0.12.0"];
-    for (let i = 0; i < 3; i += 1) {
-      const broken = [...agree];
-      broken[i] = "0.11.0";
-      expect(new Set(broken).size, `site ${i} must be detectable alone`).toBeGreaterThan(1);
+  it("pins WHICH three sites are read — dropping one must not read as agreement", () => {
+    // Both reviewers found this: the previous non-vacuity test asserted Set semantics over hardcoded
+    // literals and shared no code path with versionSites(). Delete a site from the array and every
+    // assertion stayed green while that lockfile field drifted freely. Pin the identities and the count.
+    expect(versionSites().map((s) => s.where)).toEqual([
+      "package.json .version",
+      "package-lock.json .version",
+      'package-lock.json .packages[""].version',
+    ]);
+  });
+
+  it("each label reads the field it NAMES — perturb the input, not the output", () => {
+    // BOTH REVIEWERS, round 2. The previous two attempts pinned the wrong thing: one compared label
+    // strings, the other perturbed the reader's OUTPUT — so aliasing a site to a different field while
+    // keeping its label (`version: pkg.version` under the `.packages[""]` label) survived every test,
+    // and the lockfile field it claims to watch could then drift freely. That is precisely the
+    // half-cut release this guard exists to prevent, so the perturbation has to go in the INPUT and
+    // come out at the matching label.
+    const site = (sites: { where: string; version: unknown }[], where: string) =>
+      sites.find((s) => s.where === where)?.version;
+    const pkg = { version: "1.0.0" };
+    const lock = { version: "2.0.0", packages: { "": { version: "3.0.0" } } };
+    const sites = versionSitesFrom(pkg, lock);
+    expect(site(sites, "package.json .version")).toBe("1.0.0");
+    expect(site(sites, "package-lock.json .version")).toBe("2.0.0");
+    expect(site(sites, 'package-lock.json .packages[""].version')).toBe("3.0.0");
+    // Three DISTINCT values, so no two sites can be aliased to each other and still pass.
+    expect(new Set(sites.map((s) => s.version)).size).toBe(3);
+    // …and a site that goes missing surfaces as undefined rather than borrowing a neighbour's value.
+    expect(site(versionSitesFrom(pkg, { version: "2.0.0" }), 'package-lock.json .packages[""].version')).toBeUndefined();
+  });
+
+  it("is NON-VACUOUS: each real site, broken alone, breaks agreement", () => {
+    const real = versionSites().map((s) => String(s.version));
+    expect(new Set(real).size, "the repo itself must agree").toBe(1);
+    for (let i = 0; i < real.length; i += 1) {
+      const broken = [...real];
+      broken[i] = "9.9.9";
+      expect(new Set(broken).size, `${versionSites()[i].where} must be detectable alone`).toBeGreaterThan(1);
     }
-    expect(new Set(agree).size).toBe(1);
   });
 
   it("does NOT match text: the lockfile's engine constraints must not be mistaken for our version", () => {
@@ -94,6 +171,19 @@ describe("release agreement — the declared tag and the changelog (criteria 3, 
   it("the newest DECLARED tag matches the version this tree ships as", () => {
     const version = readJson("package.json").version as string;
     expect(newestDeclared(DEFAULT_TAGS)).toBe(`v${version}`);
+  });
+
+  it("REJECTS a non-release tag rather than filtering it away", () => {
+    // Fable, round 2: reverting this to the old silent `.filter` kept all 38 tests green — the fold's
+    // own fix was pinned by nothing. The exposure is concrete: with `v0.13.0-rc.1` sitting in
+    // DEFAULT_TAGS, a filtering reader agrees cheerfully about v0.12.0 while an undeclared-but-listed
+    // tag rides along, and the live-list legality check that would otherwise catch it is tag-gated and
+    // SKIPS on CI's tagless checkout. This assertion is the only always-running check on that path.
+    expect(() => newestDeclared(["v0.12.0", "v0.13.0-rc.1"])).toThrow(/non-release tag/);
+    expect(() => newestDeclared(["v0.12.0", "0.13.0"])).toThrow(/non-release tag/);
+    expect(() => newestDeclared(["v0.12.0", "v01.0.0"])).toThrow(/non-release tag/);
+    // …and it names the offender, so the failure is actionable rather than a bare throw.
+    expect(() => newestDeclared(["v0.12.0", "v0.13.0-rc.1"])).toThrow(/v0\.13\.0-rc\.1/);
   });
 
   it("compares by SEMVER, not array position — a reordered list gives the same answer", () => {
@@ -113,11 +203,26 @@ describe("release agreement — the declared tag and the changelog (criteria 3, 
     const md = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
     expect(changelogHasVersion(md, "0.11.0"), "a version that IS there").toBe(true);
     expect(changelogHasVersion(md, "0.99.0"), "a version that is NOT").toBe(false);
+    // …and a heading that only looks like one.
+    expect(changelogHasVersion("## [0.12.0]garbage", "0.12.0"), "malformed heading").toBe(false);
+    expect(changelogHasVersion("## [0.1] — x\n", "0.1"), "a real short heading still matches").toBe(true);
+    // An ASCII-hyphen heading is Keep-a-Changelog's own spelling — it must not red the guard.
+    expect(changelogHasVersion("## [0.13.0] - 2026-09-01\n", "0.13.0"), "ASCII hyphen").toBe(true);
+    // …but a heading that is only an EXAMPLE inside a fence is not a section (Codex, round 2).
+    expect(
+      changelogHasVersion("# Changelog\n\n```md\n## [0.12.0] — example\n```\n", "0.12.0"),
+      "a fenced illustration is not a section"
+    ).toBe(false);
+    // …and the fence stripper must not eat the document around it.
+    expect(
+      changelogHasVersion("```md\n## [0.9.9] — example\n```\n\n## [0.12.0] — 2026-08-26\n", "0.12.0"),
+      "a real heading after a fence still matches"
+    ).toBe(true);
     // The real heading punctuation, which a `] - ` pattern would miss.
     expect(md).toMatch(/^## \[0\.11\.0\] — /m);
   });
 
-  it("keeps an empty [Unreleased] heading for the next cycle (criterion 6)", () => {
+  it("keeps an [Unreleased] HEADING for the next cycle — presence, not emptiness (criterion 6)", () => {
     // Dating a section without leaving one behind means the next contributor invents a new heading,
     // and the guard above starts passing against a section nobody is adding to.
     const md = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
@@ -126,8 +231,11 @@ describe("release agreement — the declared tag and the changelog (criteria 3, 
 
   it("reads the version from package.json, not a literal — so next release needs no edit here", () => {
     const src = readFileSync(join(__dirname, "release-version-agreement.test.ts"), "utf8");
-    // The assertions must not hardcode the shipping version; `0.11.0`/`0.99.0` above are fixtures for
-    // the non-vacuity check, and `0.12.0` appears only in the synthetic triple.
+    // The assertions must not hardcode the shipping version. `0.11.0`/`0.99.0`/`0.13.0` above are
+    // changelog fixtures, and the `v0.12.0` literals are ordering/reject fixtures — none of them is the
+    // value under test. (An earlier draft of this comment cited "the synthetic triple", which a later
+    // fold had already deleted; a comment describing code that is gone is the drift these guards exist
+    // to catch, one level up.)
     expect(src).toMatch(/readJson\("package\.json"\)\.version/);
   });
 });


### PR DESCRIPTION
Step 3 of four. `v0.11.0` is cut (tag `735bad4f` → commit `336210f4`), so declaring a second pending tag is now legal — the sequence `nextTagPolicy` enforces.

## What's in it

- **`v0.12.0` declared** in `DEFAULT_TAGS` (pending), and the version bumped to `0.12.0` at **all three sites** — `package.json` `.version`, `package-lock.json` `.version`, `package-lock.json` `.packages[""].version`.
- **The changelog now tells both stories.** `[Unreleased]` had accumulated ~168 commits across two releases, so it's split by what actually carried each entry: PRET-2, PRET-3 and Code Maintenance Loop Phase 0 were in `[Unreleased]` **at `803122ff`**, so they belong to `v0.11.0`; the coverage/AIO-995 work (migration dated 2026-08-20) is new, so it belongs to `v0.12.0`.
- **`v0.12.0`'s entry leads with the refusal**, because that's what a pinned operator has to act on: permissive is deleted, upgrading directly from anything older than `v0.11.0` is refused, both conditions must be cleared first, and the range is one-way.
- **Three agreement guards** (`test/guards/release-version-agreement.test.ts`).

## The guards, and why each is shaped the way it is

| guard | the failure it exists for |
|---|---|
| the version's three sites agree | `package.json` sat at `0.10.0` for **168 commits and 23 days** with nothing noticing |
| newest **declared** tag == `v${package.json.version}` | a half-cut release: the version the app reports, the tag a user pins, and the changelog heading disagreeing |
| `CHANGELOG.md` has a section for that version | shipping a version whose contents nobody can read |

They **parse JSON paths** rather than matching text — a grep for `0.10.0` hits **eight** unrelated `"node": ">=0.10.0"` engine constraints in the lockfile, and noise is how a guard gets deleted. The tag comparison is by **semver**, not array position: `.at(-1)` on the raw array would let a reordering make the guard and `nextTagPolicy` name different pending releases.

## Fixtures that rotted the moment a release became real

Three assertions in `release-tag-policy.test.ts` used `v0.11.0` as their hypothetical *not-yet-cut* tag — and broke the day it was cut. They now use an obviously synthetic `v9.9.9` and derive the rest from `CUT_FIXTURE`, so a real release can't turn them red again. A fixture that borrows a plausible future version is a time bomb with a date on it.

## Verification

tsc clean · lint 0 errors · unit **3533 passed** · docs in sync

Policy state after this change — exactly as designed:

```
usable:  [v0.7.0, v0.8.0, v0.9.0, v0.10.0, v0.11.0]
pending: v0.12.0
```

**4 mutations, all REDDENED on their intended test:**

| # | mutation | reddened |
|---|---|---|
| 12 | lockfile version drifts from `package.json` | "all three agree" |
| 13 | declared tag stops matching the shipped version | "the newest DECLARED tag matches the version this tree ships as" |
| 14 | changelog loses the shipped version's section | "CHANGELOG.md carries a section for the version being shipped" |
| — | *(first M12 attempt refused: needle appeared twice — re-run with a unique multi-line needle)* | |

`nda-gate.test.ts` fails under a full-suite run and passes standalone (21/21) — 102 `git commit` subprocesses inside a 30-second budget. Known, untouched by this diff, and reported rather than hidden.

## Checked myself, before review

- **The two `v0.11.0` changelog sections agree.** Main's and the tagged release tree's were written separately; diffed them — same substance, no contradiction.
- **No prefix collision** in the changelog matcher: `0.1` and `0.12` do not match `## [0.12.0]`, because `\]` anchors the end.

## Round 2 — what the reviewers found, and the fold

Both returned **CLEAR-WITH-CONDITIONS**, no BLOCKER and no HIGH, and both landed on the same thing: **round 1's own fixes were the unpinned artifacts.**

**MEDIUM (both, independently) — the site-identity pin pinned a LABEL, not the read.** Aliasing the `.packages[""].version` site to `pkg.version` while keeping its label survived every test: the identity test compared label strings, and the "REAL reader" test perturbed the reader's *output*, so it inherited the same broken read. After that one-line typo the lockfile field the guard claims to watch could drift freely — the exact half-cut release it exists for. Now the read is split from the files (`versionSitesFrom(pkg, lock)`), and the non-vacuity test perturbs the **input objects** and asserts the perturbation comes out at the matching label, with three distinct values so no two sites can alias each other and pass.

**MEDIUM (Fable) — the fold's own "reject, don't filter" throw was pinned by nothing.** Reverting it to the old silent `.filter` kept all 38 tests green. Codex read the same code and concluded the throw *does* reach an assertion — both are true and it's the distinction that matters: the throw fires if `DEFAULT_TAGS` is already malformed, but the *reject-vs-filter choice* was untested, so it could be silently undone. The exposure is concrete: with `v0.13.0-rc.1` in `DEFAULT_TAGS`, a filtering reader agrees cheerfully about `v0.12.0` while the live-list legality check that would catch it is tag-gated and **skips on CI's tagless checkout**. One assertion now pins it, and pins that the message names the offender.

**MEDIUM (Codex) — `changelogHasVersion()` accepted a heading inside a fenced code block.** Verified by running it. A release whose real section had been deleted could pass with an illustration standing in for it. Fences are blanked before matching, line count preserved so the `^`/`$` anchors keep their meaning — and the *call site* and the *helper* are mutated separately, because pinning only the function leaves the wiring deletable.

**LOW (Codex) — the matcher rejected `## [0.13.0] - 2026-09-01`,** which is Keep-a-Changelog's own spelling. A contributor would have reddened a guard for being conventional. Any dash now matches; `\]` still does the anti-collision work, so `0.1` still never matches `## [0.12.0]`.

**LOW (both) — `## [0.11.0] — 2026-08-18` is not the cut date.** The tag was created 2026-08-26 from a 2026-08-18 base. I checked `v0.9.0` and `v0.10.0`: tag date == commit date == heading date, so the file's convention is *release date* and this entry is the exception. I labelled it rather than normalising it — changing the heading would break its agreement with the immutable tagged tree, which is a real invariant. **Stated as a residual, not closed.**

Also folded: the empty `### Changed` scaffold under a dated release; a comment citing "the synthetic triple" that a previous fold had already deleted; and the `168 commits` figure removed from the spec doc for the same reason it left the guard comment — measured days early, already wrong.

**Not folded, with reasons:** `CORE` accepting `v9007199254740992.0.0` and rejecting `v1.2.3+build.1` (LOW) — the repo's tag policy is stable core-only `vX.Y.Z`, and `nextTagPolicy` shares that assumption; inventing full-semver here would create a coupling that doesn't exist. `v0.100.0` as a future-rot fixture (LOW) — real but 88 minor releases out, and the rot horizon plus what to change is now written next to it.

## Round-2 mutations — 9, all REDDENED on their intended test

| # | mutation | intended test |
|---|---|---|
| M15 | alias the `.packages[""]` site to `pkg.version`, keep its label | each label reads the field it NAMES |
| M16 | drop the third version site entirely | pins WHICH three sites are read |
| M17 | revert the reject to the old silent `.filter` | REJECTS a non-release tag rather than filtering |
| M18 | throw without naming the offending tag | (same test, the actionability half) |
| M19 | call site: match raw `md` instead of `stripFences(md)` | a fenced illustration is not a section |
| M20 | `stripFences` itself becomes a no-op | (same property, the other layer) |
| M21 | drop the ASCII hyphen from the dash class | ASCII-hyphen heading still matches |
| M22 | drop the follow-anchor: any bracket is a heading | malformed heading rejected |
| M23 | rename the shipped version's CHANGELOG heading | CHANGELOG carries a section for the shipped version |

M15 and M16 were **re-run** after `versionSitesFrom` was retyped, because a mutation is only evidence against the code as it now stands.

**Verification after the fold:** tsc clean · lint **0 errors** · unit **3537 passed, 0 failed** · docs in sync. (The `nda-gate` full-run timeout did not reproduce this run; it is load-dependent, untouched by this diff, and passes standalone 21/21.)

## After the reviews: a rebase, and one entry the reviewers did not see

The `NDA confidentiality gate` failed **closed** on the previous head — not on content. It fetches `refs/pull/662/merge` and asserts its parents are exactly `BASE_SHA HEAD_SHA`; `main` advanced (#661, #663) between the workflow capturing `BASE_SHA=0e5a5667` and GitHub recomputing the merge ref against `c00b8142`, so the equality failed. Confirmed by reading the merge ref's parents directly rather than assuming a flake. Rebased onto current `main` (0 behind), which resolves it.

**That rebase pulled #663 (ADOPTUNIQ-1) into the release this PR is dating**, so `v0.12.0` now names it. Its migration is exception-contained: on a fleet already holding duplicate `task_pm_links` rows the unique index is **silently not created** and the release still succeeds — the exact thing an operator cannot infer from a green deploy, so it earns a line rather than the section's non-exhaustive disclaimer. I verified that behaviour against the migration's own source, not its PR description.

**Scope note this raises:** anything merged before the tag is cut ships in `v0.12.0`. The section is a snapshot as of the merge, and says so.

**Delta since the two reviews: one prose paragraph in `CHANGELOG.md`.** No code, no guard, no test changed — stated rather than folded into the attestation below, which describes what the reviewers actually read. Re-verified after the rebase: tsc clean · lint **0 errors** · unit **3566 passed, 0 failed** · docs in sync · the release guards green alongside #663's new one (65 tests across the three files).

## CI, and the one check I could not see into

**All 10 required checks are green** on `71e550ec` (`Docs drift · Static checks · gitleaks · Brain unit · Integration HTTP · Ingestion pytest · PR records a diff review · NDA gate · Data-mechanics · Graph Neo4j`), verified against branch protection's context list rather than by eye. `mergeStateStatus` is `UNSTABLE`, and that is **Codacy only, which is not a required context**.

**Codacy reports "1 new issue (0 max.)" and exposes no detail** — no rule, no file, no line, through either the check-run output or the commit-status API. It passes on #660, #661 and #663, so it is specific to this diff rather than a global outage. I tried to reproduce it with the repo's own vendored Codacy CLI:

- `opengrep` (631 rules): **0 findings** — but it skipped both test files under `.semgrepignore`, so its silence covers only `scripts/migrate-from-existing.mjs`.
- `lizard`: **0 warnings**, no threshold exceeded across all three code files.
- Codacy's pinned `eslint@8.57.0` **cannot run here at all** (`TypeError` loading `@typescript-eslint/no-unused-expressions` against this repo's config), so the tool most likely to be the source is exactly the one I could not execute.
- The repo's own ESLint: 0 errors. `gitleaks`: green. The diff is docs, a changelog, two test files and a three-site version bump — no runtime code and no credential-shaped strings.

**So: I do not know what it says, and I am explicitly not claiming it is benign.** It wants a human with Codacy UI access. Noting the shape of the honest answer because a previous PR in this program published a confident triage of a Codacy count that turned out to be wrong.

## Review

Reviewed by Fable code-reviewer — verdict CLEAR-WITH-CONDITIONS (2 MEDIUM, 2 LOW; both MEDIUMs folded)
Reviewed by Codex gpt-5.6-sol — verdict CLEAR-WITH-CONDITIONS (2 MEDIUM, 4 LOW; both MEDIUMs folded)

## Not in this PR

Tagging `v0.12.0` (step 4, after merge) · publishing either GitHub Release (outward-facing; yours) · the sandbox verification `docs/RAILWAY-TEMPLATE.md` requires per release · `ingestion/pyproject.toml`, a separately-versioned sidecar · the option-B branch cutover (RELPTR-3).

AIOS-Work: RELPTR-2



