### PR TITLE
fix(pm-sync): ship the one-issue-one-row DB backstop, safely (ADOPTUNIQ-1)

### DIFF
--- a/components/admin/projection-health-card.tsx
+++ b/components/admin/projection-health-card.tsx
@@ -69,6 +69,25 @@ export function ProjectionHealthCard({ health }: { health: ProjectionHealth }) {
           {run.errors[0]}
         </p>
       ) : null}
+      {/*
+        ADOPTUNIQ-1 — the DB backstop's state, surfaced HERE because this is the page an operator
+        already opens when PM sync misbehaves. It is deliberately rendered on the same card rather
+        than exported and left unwired: the signal this replaces (a `last_error` stamp) died partly
+        because nothing displayed it. Silent only when the backstop is installed — a healthy schema
+        should not cost a line of UI.
+      */}
+      {health.backstop !== "installed" ? (
+        <p
+          className="mt-2 rounded-lg border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-300"
+          data-backstop={health.backstop}
+        >
+          {health.backstop === "missing"
+            ? "The one-issue-one-row database backstop is NOT installed. The most likely cause is duplicate provider_resource_id rows, which the migration deliberately skips rather than aborting the release — that skip does not repair itself. Two links can currently claim the same issue."
+            : health.backstop === "malformed"
+              ? "An index named task_pm_links_provider_resource_uq exists but does not match the expected definition (columns, order, predicate, uniqueness or validity), so it is not enforcing the invariant."
+              : "Could not read the database catalog to confirm the one-issue-one-row backstop. Treating it as unverified rather than healthy."}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -692,7 +692,7 @@ Two things about it are load-bearing and easy to undo by accident:
    others`; each clause traces to a staged failure, and the last two abort a release with **zero dirty
    data** (a lock wait and a deadlock during preDeploy, while the old app version is still projecting).
    Guarded by `test/guards/task-pm-links-unique-index.test.ts`.
-2. **A skip is reported READ-side**, via `backstopHealth` on `ProjectionHealth` (Admin → PM sync). Not
+2. **A skip is reported READ-side**, via the `backstop` field on `ProjectionHealth` (`classifyBackstop`/`readBackstopStatus`) (Admin → PM sync). Not
    a `last_error` stamp: `persistSuccess` nulls `last_error` on every successful projection, so a
    stamp erases itself within one push cycle — and its UPDATE would sit outside the protected
    `create index`, able to abort the very release it reports on.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -674,6 +674,38 @@ changed this push** — `lib/ingest` computes the changed set by diffing the pro
 `task_pm_links.last_error`; the `projection_fingerprint` skip keeps them from re-writing the board.
 The manual `projectBoardAction` and the inline work-events projection remain.
 
+**One issue, one link — enforced by the DB, not only by app code (ADOPTUNIQ-1,
+`docs/design/task-pm-links-unique-index.md`).** `task_pm_links_provider_resource_uq` is a PARTIAL
+unique index on `(team_id, provider, provider_resource_id) where provider_resource_id is not null`.
+`ownedResourceIds` in `lib/pm-sync/project.ts` is still the first line of defence, but it is a
+check-then-act read followed by a write; the index closes the race, and it also covers **Plane**,
+whose adapter never consults `ownedResourceIds` at all. NULLs are excluded deliberately, so a link
+that never resolved (the orphan `chetan`/`TT2` row) is untouched.
+
+Two things about it are load-bearing and easy to undo by accident:
+
+1. **It is created ONLY by a guarded `do $$ … $$` block, duplicated verbatim in `postgres/schema.sql`
+   and `postgres/migrations/20260826…`.** `pg:schema` loads `schema.sql` FIRST and as ONE implicit
+   transaction, and a top-level `create unique index` DOES execute against an existing database — so a
+   bare statement there would abort the entire schema load before any migration guard could run. The
+   block catches `unique_violation`, `lock_not_available` AND `deadlock_detected` and never `when
+   others`; each clause traces to a staged failure, and the last two abort a release with **zero dirty
+   data** (a lock wait and a deadlock during preDeploy, while the old app version is still projecting).
+   Guarded by `test/guards/task-pm-links-unique-index.test.ts`.
+2. **A skip is reported READ-side**, via `backstopHealth` on `ProjectionHealth` (Admin → PM sync). Not
+   a `last_error` stamp: `persistSuccess` nulls `last_error` on every successful projection, so a
+   stamp erases itself within one push cycle — and its UPDATE would sit outside the protected
+   `create index`, able to abort the very release it reports on.
+
+**Containment, because the index made two existing paths reachable.** `persistSuccess` now READS the
+returned error (the pg adapter returns rather than throws) and reports that row `failed` — it used to
+be silent, reporting success while the provider had already been mutated. `adoptInbound` wraps each
+candidate in `try/catch`; its `on conflict` names the row-identity constraint, so a violation of this
+index would otherwise throw past `runInboundForTeam` and discard the whole inbound pass. A parent
+whose bookkeeping fails is recorded in an invocation-local `contested` set so its children fail fast
+instead of re-invoking the adapter and minting a duplicate provider issue; an adapter **throw** keeps
+its shipped inline-retry behaviour, pinned by an exact-count test.
+
 **Dashboard hierarchical CRUD (brain-api v1.2 Phase 4).** The tasks page (`app/t/[team]/tasks`)
 is the second authoring surface alongside `aios push`. It **server-renders the hierarchy** —
 `components/kanban/task-hierarchy.tsx` groups sub-tasks under their epic (by `parent_row_key`) and

--- a/docs/design/task-pm-links-unique-index.md
+++ b/docs/design/task-pm-links-unique-index.md
@@ -1,0 +1,508 @@
+# The DB backstop for one-issue-one-row: a partial unique index on `task_pm_links` (ADOPTUNIQ-1)
+
+Status: **pre-code, revised through TWO rounds of two independent design reviews — four reviews, three
+of them BLOCKED.** Round 1: Codex **BLOCKED** (the guard was itself a check-then-act race) · Fable
+**CLEAR-WITH-CONDITIONS** (found a third writer this spec claimed did not exist; ruled the open question
+OPPOSITE to Codex). Round 2, attacking the fold: Codex **BLOCKED** (the `last_error` signal reintroduced
+an abort path; the error-class discrimination was invalid on the merits) · Fable **BLOCKED** (the handler
+caught the WRONG EXCEPTION SET — a lock wait aborts the release with ZERO dirty data; and its own round-1
+`last_error` proposal is erased by `project.ts:200` within one push cycle).
+
+Round 3, attacking that fold: Codex **CLEAR-WITH-CONDITIONS** · Fable **CLEAR-WITH-CONDITIONS** — and
+they CONTRADICTED each other on `deadlock_detected` (Codex: do not catch it; Fable: catch it, with a
+mechanism). **Settled empirically, not by argument: a staged deadlock aborted the release.** Fable was
+right.
+
+**Every mechanism below is empirically verified against real Postgres 16** before any code exists — the
+catch, the transaction survival, the lock case, the deadlock case, self-heal, idempotence, and the
+predicate. Results are in §Verified mechanics. Everything else is the fold.
+· Owner: chetan
+· Tier build-with: **data-mechanics** (real Postgres — the index, both migration branches, and both
+containment paths are persistence outcomes a stubbed DB cannot observe) + **unit** for the
+replay/shape guards.
+
+**Deps:** none. ADOPTDECL-1 (#581) and ADOPTFOOT-1 (#588) shipped the app-code half; this is the DB
+half they deferred.
+
+**Increment:** ONE PR = the guarded index (mirrored into `schema.sql` and `postgres/migrations/`),
+the two containment fixes the index makes load-bearing, and the restructuring of the existing
+uniqueness tests that the index would otherwise make green-by-construction. **No data is reconciled,
+no link row is deleted, and no Railway setting is touched.**
+
+---
+
+## Problem
+
+`task_pm_links` has no constraint stopping two rows from claiming the same provider issue. The unique
+constraint it does have — `(team_id, project_id, row_key, provider)` — is about *rows*, not *issues*:
+three different projects can each hold a `TT1` row and each point at the same Linear issue, which is
+exactly what happened. `lib/pm-sync/project.ts` guards this in app code (`ownedResourceIds`, extended
+by ADOPTFOOT-1 to key on `(project_id, row_key)` rather than `row_key` alone), but that is a
+check-then-act read followed by a write, and its own comment says the race is accepted.
+
+ADOPTDECL-1 specced the DB backstop and deliberately did not ship it.
+`postgres/migrations/20260817164500_task_pm_links_declared_external_id.sql:12-16` records why: prod
+held three links on `AIO-444`, so the index would have aborted the release (the #251 replay class).
+
+### The blocker is gone — measured 2026-08-26, read-only against prod
+
+| Fact | AIO-958 asserted (2026-08-18) | Measured 2026-08-26 |
+|---|---|---|
+| Violating groups on `(team_id, provider, provider_resource_id)` | 1 — three links on `AIO-444` | **0** |
+| `TT1` links | 3, in 3 projects | **1** (`john-workspace` → `AIO-444`) |
+| Total link rows | 960 | **1,067** |
+| Rows with a non-null `provider_resource_id` | — | **1,066** |
+| Rows with a NULL `provider_resource_id` | 1 (orphan `chetan`/`TT2`) | **1**, same row |
+| Teams holding links | — | **1** (`aios`) |
+| By provider | — | `linear` 1,066 · `plane` 1 |
+
+The human reconciliation call the ticket was waiting on **no longer exists**, and the index applies
+clean today. The orphan (`chetan`/`TT2`, null `provider_resource_id`, null `task_id`, stranded by a
+2026-08-03 `duplicate label name` error) is **excluded by the partial predicate by construction** —
+hygiene, not a blocker, and deliberately left alone.
+
+**Not measured, and stated as such:** whether any OTHER self-hosted install holds a violation. This
+repo is public and self-hosted (CLAUDE.md §5), so the migration must be safe on a fleet whose data
+nobody here can read. That is the whole reason for the guard, and it is not a hypothetical dressed
+up — it is why the clean-prod measurement is insufficient on its own.
+
+### What adding the index does TODAY — two wrong containment paths, in opposite directions
+
+**(1) OUTBOUND — the violation is SWALLOWED.** `lib/db/pg/query-builder.ts:221-224` catches the driver
+exception and **returns** `{ data: null, error }` rather than throwing. `persistSuccess`
+(`lib/pm-sync/project.ts:188-203`) awaits that update and **never reads `error`**. So a `23505` would
+be logged to the console and dropped: `projectTask` returns `status: result.status` — a SUCCESS —
+while the Linear issue has already been mutated and the link keeps no `provider_resource_id`. The next
+push therefore misses rung 1 and takes the adopt path again. Containment exists, but only because
+nothing is checked; the cost is silence, which is worse than an abort. **This is not a new defect —
+every other failure of that update is silent today too.** The index makes it reachable where it matters.
+
+**(2) INBOUND — the violation ABORTS the whole pass.** `adoptInbound`
+(`lib/pm-sync/inbound.ts:451-457`) inserts inside `withTransaction` with
+`on conflict (team_id, project_id, row_key, provider) do nothing` — the **other** unique constraint.
+Postgres allows one inference clause, so a violation of the new index is not caught by it; it throws
+inside the transaction, escapes the candidate loop, and escapes `runInboundForTeam`
+(`lib/pm-sync/inbound.ts:554`, awaited bare) **before `return result`** — discarding Phase A's applies
+along with every remaining candidate. That IS the "aborts a whole board push" the ticket forbids, on
+the leg the ticket did not name.
+
+### The deploy trap: `schema.sql` runs BEFORE the migrations, as ONE transaction
+
+`scripts/pg-load-schema.mjs` loads `schema.sql` first (`:69`), then every migration in lexical order
+(`:72-78`). A column inside `create table if not exists` is a no-op on an existing DB — the rule
+`postgres/migrations/README.md` exists to state — but a bare `create unique index if not exists` is a
+**top-level statement that does apply to an existing database**.
+
+**Worse than round 1 of this spec stated (Fable):** `schema.sql` is sent as a single multi-statement
+`client.query(sql)`, i.e. one implicit transaction, so a violation there aborts the **entire schema
+load** before any migration guard could run.
+
+**Therefore the guard must be the only creator, in BOTH files**, and in `schema.sql` it must sit
+*after* the `create table if not exists task_pm_links` region (~`postgres/schema.sql:1286`) or a
+from-zero load errors on a missing table. This is the constraint most likely to be undone by a later
+"tidy the schema" edit, which is why criterion 10 exists.
+
+---
+
+## Verified mechanics — run against real Postgres 16 before any code was written
+
+Each row is a design claim that had to hold. These were executed in a throwaway container, touching no
+shared test database.
+
+| Claim | Result |
+|---|---|
+| `create unique index` over duplicate data raises a CATCHABLE `unique_violation` | ✅ caught by the handler |
+| After the catch: index absent, both rows intact | ✅ 0 indexes, 4 rows |
+| A caught exception does NOT poison the single implicit transaction `pg:schema` sends | ✅ the later statement ran; the txn committed |
+| The handler can perform writes | ✅ (recorded, then made moot — see decision 4) |
+| Self-heal: replay after the duplicate is removed creates the index | ✅ created |
+| Idempotent replay on a clean DB | ✅ no-op (`already exists, skipping`) |
+| Partial predicate: NULLs duplicate freely; a non-null duplicate is rejected | ✅ 3 NULLs coexist; `23505` on the duplicate |
+| **A lock wait with a `unique_violation`-only handler, on a CLEAN table** | 🔴 **`lock_timeout` escapes the handler, poisons the txn, later statement never runs — release aborts** |
+| The same case with `lock_not_available` also caught | ✅ warning, later statement ran, txn committed, index correctly absent |
+| Lock case self-heals on the next deploy once the lock clears | ✅ created on retry |
+| **A real staged DEADLOCK with a `unique_violation`+`lock_not_available` handler** | 🔴 **`40P01` escapes, poisons the txn, later statement never runs — release aborts, zero dirty data** |
+| The same deadlock with `deadlock_detected` also caught | ✅ warning, later statement ran, txn committed, index absent |
+
+**One honest gap in this table:** deadlock self-heal was NOT isolated — the retry hit the
+duplicate-data branch because the staging session had dirtied the fixture. It is inferred from the lock
+case's identical profile (subtransaction rollback, no data change, index absent), not separately
+observed. Recorded as inference rather than measurement.
+
+The two red-then-green rows are Fable's round-2 HIGH. It is the reason decision 3 exists in its current
+form, and it was reachable **with zero dirty data** — the guard as specced through round 2 would have
+aborted a release on any sufficiently busy fleet.
+
+---
+
+## Decision
+
+1. **One guarded `do $$ … $$` block, used verbatim in `postgres/schema.sql` and in
+   `postgres/migrations/`.** Neither file gets a bare `create unique index`. Index name:
+   `task_pm_links_provider_resource_uq`. In `schema.sql` the block must sit **after** the
+   `create table if not exists task_pm_links` region (~`postgres/schema.sql:1286`), or a from-zero load
+   errors on a missing table.
+
+2. **The guard is EXCEPTION-CONTAINED, not check-then-act.** *(Round 1 Codex BLOCKER.)* The original
+   design counted violations and then created the index — itself a race, because `pg:schema` is the
+   Railway preDeployCommand and runs **while the old app version is still serving and still projecting**
+   (`pg-load-schema.mjs:8`). A writer could insert a duplicate between the count and the `create`, and
+   the release would abort. Correctness must not depend on a pre-count, and now does not: there is no
+   count at all.
+
+3. **The handler catches `unique_violation`, `lock_not_available` AND `deadlock_detected` — and
+   NOTHING else.** *(Round 2 Fable HIGH + round 3 Fable HIGH, both empirically confirmed above.)* `pg-load-schema.mjs:66-67` sets `lock_timeout` (default 15s).
+   A non-concurrent `create unique index` takes a SHARE lock and must wait out any in-flight write from
+   the old app version. A wait past the timeout raises **`55P03 lock_not_available`, not `23505`** —
+   which escapes a `unique_violation`-only handler and, inside `schema.sql`'s single implicit
+   transaction, aborts the entire schema load. **Zero dirty data required.**
+
+   ```sql
+   do $$
+   begin
+     create unique index if not exists task_pm_links_provider_resource_uq
+       on task_pm_links (team_id, provider, provider_resource_id)
+       where provider_resource_id is not null;
+   exception
+     when unique_violation then
+       raise warning 'ADOPTUNIQ-1: duplicate provider_resource_id present — DB backstop NOT installed';
+     when lock_not_available then
+       raise warning 'ADOPTUNIQ-1: could not acquire the lock — DB backstop NOT installed; next deploy retries';
+     when deadlock_detected then
+       raise warning 'ADOPTUNIQ-1: deadlock while creating the index — DB backstop NOT installed; next deploy retries';
+   end $$;
+   ```
+
+   **Why `deadlock_detected` belongs here, against Codex's round-3 ruling.** Codex argued a deadlock
+   signals broader lock interaction where abort-and-retry is safer. Fable argued it is reachable
+   *earlier* than the timeout — `deadlock_timeout` defaults to **1s**, so the detector examines a
+   waiting `create index` ~14s before `lock_timeout` (15s) can fire — and that `schema.sql`'s single
+   implicit transaction has already taken `ACCESS EXCLUSIVE` locks from earlier `alter table … if not
+   exists` no-ops while the old app version is still serving, so a genuine cycle is ordinary rather
+   than exotic. **The disagreement was settled by staging one**, not by preferring an argument: our
+   transaction was chosen victim, `40P01` escaped the two-exception handler, poisoned the transaction,
+   and the later statement never ran. Same class as the round-2 HIGH, third SQLSTATE.
+
+   **Never `when others`, and this is load-bearing.** The strongest silent-skip-worse-than-abort case
+   is `undefined_table`: if a later "tidy the schema" edit moves the block ABOVE the
+   `create table if not exists task_pm_links` region — the exact regression decision 1 predicts — a
+   `when others` handler would convert that ordering bug into a warning and a fleet-wide missing
+   backstop. The narrow list is what keeps decision 1's failure loud. `query_canceled` (57014) is not
+   plausible on this path (nothing sets `statement_timeout`) and is deliberately excluded.
+
+   **The claim is narrow, and round 2 was right that the earlier wording was false.** "Never refuses to
+   deploy" is NOT true — disk, catalog and other errors still abort, as they should. What is true and
+   what this design guarantees: **neither duplicate data, nor expiry of the configured `lock_timeout`,
+   nor a deadlock can abort a release.** Inside the block the only statement is the `create index`, so
+   `23505` can only mean duplicate data and the two lock codes can only mean contention — no aliasing,
+   and every caught branch leaves zero data change.
+
+   The two skips are not equivalent, and the spec says so rather than blurring them: the **lock** skip
+   genuinely self-heals on the next deploy (verified above); the **duplicate-data** skip does not,
+   because nothing cleans the data (see decision 4).
+
+4. **The skip signal is READ-side, not write-side.** *(Round 2 killed the round-1 `last_error` stamp —
+   and Fable killed its own proposal, which is the strongest form of the finding.)*
+
+   Why the stamp is dead, three independent ways:
+   - **It is erased within one push cycle.** `persistSuccess` sets `last_error: null` unconditionally on
+     every successful projection (`project.ts:200`). On exactly the fleet the stamp exists for, BOTH
+     rows of a duplicate group still resolve via rung 1 and project "successfully", nulling it.
+   - **The stamp write is itself an abort vector.** The handler's `UPDATE` sits OUTSIDE the protected
+     `create index`, on precisely the hot rows the live old app is writing — a row-lock wait raises
+     `55P03` from a statement no handler covers, and the schema load aborts. The "safe skip" would have
+     reacquired an abort path through its own reporting mechanism.
+   - It clobbers real `persistError` messages, churns `updated_at` every deploy, double-stamps (the
+     block is in both files), and goes stale forever after remediation.
+
+   **Instead: a catalog read at app runtime.** A `task_pm_links` backstop check on the pm-sync health
+   surface (`lib/pm-sync/runs.ts`, alongside `getProjectionHealth`) reports whether the index is
+   present **and correctly defined**. No writes, no abort path, no clobber, no churn, and it self-clears
+   the moment the index appears because it reflects live catalog state.
+
+   It also closes a hole Codex round 2 raised that the textual guards cannot: `if not exists` accepts
+   **any** existing relation with that name regardless of its columns, predicate, uniqueness or
+   validity — so a wrongly-defined same-named index would read as a successful deploy. The catalog read
+   validates the definition, not just the name: schema+table binding, exact ORDERED key columns, no
+   expression/include columns, uniqueness, validity, and the normalized predicate.
+
+   **It must be WIRED, not merely exported.** *(Round 3, both reviewers — and this repo has shipped the
+   failure before: an exported `describe*` function no surface rendered.)* A criterion testing the
+   function alone would stay green while no human ever sees the result, which is exactly how the
+   deleted stamp failed. So: the backstop is a **separate field** on what `computeProjectionHealth`
+   returns — not an overload of the last-run `ProjectionHealthStatus`, whose meaning is unrelated — and
+   both of its real consumers must emit it: `app/t/[team]/admin/pm-sync/page.tsx` (the surface a human
+   is expected to look at) and `app/api/v1/pm-sync/health/route.ts`.
+
+   **Fail-closed:** a catalog-read error resolves to `unknown`/`unhealthy`, NEVER `healthy`. A probe
+   that reports green when it cannot see is the null-view fail-open this repo has already been bitten by.
+
+   **Implementation route, named so it is not discovered:** `DbClient` cannot express the required
+   `pg_index`/`pg_get_indexdef` joins; use raw SQL via `withTransaction` (`lib/db/pg/tx.ts`), as
+   `lib/pm-sync/inbound.ts` already does. Compare against Postgres's **normalized** indexdef rendering
+   (`WHERE (provider_resource_id IS NOT NULL)`) captured from the real DB — decision 9's
+   "textually identical predicate" rule governs violation-reporting queries and must NOT be misread as
+   string-matching source DDL against the catalog.
+
+5. **Outbound containment: deliberate and LOUD.** `persistSuccess` reads the returned `error`; on error
+   `projectTask` records it via `persistError` and reports that row `failed`. Contained to the row, no
+   longer silent. This widens beyond `23505` to every failure of that update — a deliberate behaviour
+   change, called out as one.
+
+   Stated plainly, because the index's value is easy to overclaim: by the time a `23505` fires the
+   adapter has **already mutated the other row's issue** (`linear.ts:423-431`). The index contains the
+   *propagation* — children, re-invocation, a second brain row believing it owns the issue — not the
+   provider write itself.
+
+6. **THE CONTRADICTION, DISSOLVED — and the whole discrimination is withdrawn.**
+
+   Round 1 left this open and the reviewers ruled it opposite ways. Codex: do NOT set `resolved` (on a
+   `23505` the id belongs to another row; children would attach beneath a stranger's issue). Fable: DO
+   set it (otherwise the child misses the map, takes the inline path at `project.ts:260-275`, re-invokes
+   the parent's adapter, and can mint a duplicate provider issue).
+
+   Round 2 of this spec tried to discriminate by DB error class. **Both reviewers then killed that**, on
+   two independent grounds, and both were right:
+   - **Invalid on the merits (Codex):** a non-`23505` failure does NOT prove the id is ours — an *adopt*
+     can succeed at the provider and then hit a lock timeout.
+   - **Unimplementable (both):** `query-builder.ts:221-224` flattens the driver error to `{ message }`,
+     discarding `code` and `constraint`; and matching message text fails in the *dangerous* direction —
+     under non-English `lc_messages` a real `23505` would classify as "other", set `resolved`, and
+     parent children beneath a stranger's issue.
+
+   **The discrimination was a red herring.** It existed only to decide whether to set `resolved`. Give
+   the "don't re-invoke the adapter" job to its own channel and the question disappears:
+
+   > On **any** `persistSuccess` failure: report `failed`, record via `persistError`, do **NOT** set
+   > `resolved`, and add the row key to a separate **`contested: Set<string>`** in
+   > `ProjectTaskOptions`. A child checks `contested` **before** the inline fallback and returns
+   > `failed` naming the parent, **without invoking its adapter**.
+
+   This satisfies Codex (never parent beneath an unpersisted id) and Fable (never re-invoke the adapter)
+   simultaneously, and needs **no SQLSTATE, no adapter provenance, and no error-shape widening** — the
+   `{code, constraint}` change round 2 was going to pull into scope is no longer needed at all.
+
+   **The guarantee is INVOCATION-LOCAL, and round 3 was right that the earlier wording overclaimed.**
+   `resolved` is constructed fresh inside `projectRows` (`project.ts:410`), so `contested` is too. Both
+   reviewers walked the paths and agree it closes both harms *within one invocation*: `topoOrder` marks
+   an in-batch parent before its child; an out-of-batch parent is reached through the inline fallback,
+   which shares the set via the opts spread, so it is invoked once and every later child hits
+   `contested`; a grandchild recurses into its contested-failing parent and exits before any adapter
+   runs. What it does NOT give is a cross-invocation guarantee — a standalone `projectTask` in a later
+   cycle can invoke that parent's adapter again. **That is normal retry semantics, not the
+   batch-internal double-mutation this channel exists to stop**, and it is stated here rather than
+   implied away. Durable state would materially reopen the design and is not taken.
+
+   **HOW the failure is detected is part of the decision, because the obvious implementation breaks the
+   fence.** *(Round 3 Fable MEDIUM.)* `persistSuccess` must check the **returned error inline on the
+   success path**. It must NOT throw — a throw lands in the shared catch at `project.ts:354-358`, which
+   also catches adapter throws, and adding the `contested` insert there would sweep adapter-throw
+   parents in, which is precisely the over-correction criterion 14 exists to catch.
+
+   Four standalone call sites pass no map at all (`work-events/ingest.ts:166`, `after-write.ts:45`,
+   `after-write.ts:86`, `pm-sync/index.ts:79`). **Correction to an earlier draft of this spec, which
+   claimed `after-write.ts:86` was a gap needing a shared set:** it is not. That loop is the
+   `primary.integration === null` branch, which returns `missing_integration` from `projectTask`
+   without ever reaching the adapter or `persistSuccess` — nothing there can become contested. The
+   other three are single-row calls with no sibling to protect. So the invocation-local scope needs no
+   widening at all, and the claimed one-argument change is withdrawn as unnecessary.
+
+   Two further scope fences, both from Fable's over-correction sweep:
+   - The set keys on **persist-failure parents only**. An adapter *throw* already re-projects inline per
+     child today; that behaviour is shipped, no test pins it, and sweeping it in would be the
+     over-correction. Untouched.
+   - A standalone `projectTask` call (no `resolved`/`contested` map) is out of the channel's reach by
+     construction. Said outright rather than discovered.
+
+   `resolved` stays `Map<string, string>` — round 2's "negative sentinel" was unimplementable inside it
+   (`""` leaks through `project.ts:259` and `linear.ts:324` as a real `parentResourceId`) and made
+   criterion 11's clauses jointly unsatisfiable.
+
+7. **Inbound containment: per-candidate.** Wrap the per-candidate `withTransaction` in `try/catch`; on
+   throw record the candidate in `result.skipped` **with a message shape naming the identifier and the
+   cause**, and `continue`. Phase A's result and the remaining candidates survive.
+
+8. **The existing uniqueness tests must keep a DISTINCT pinned property.** *(Codex round 1 Q2.)*
+   `test/datamechanics/pm-link-uniqueness.datamechanics.test.ts` asserts the invariant via an app-level
+   query (`duplicateGroups(...) === []`) and its header calls itself "the only thing enforcing the
+   invariant" until this index ships. Once the DB enforces it, those assertions go **green by
+   construction**. Containment makes it worse: a rejected insert becomes `skipped`, leaving
+   `duplicateGroups`, `adopted` and the row count exactly as expected. Split the layers:
+   - **DB layer** — raw duplicate writes assert `23505`, plus predicate and scope behaviour.
+   - **App layer** — assert the **pre-write decision**: for Linear, that the adapter performed **no
+     mutation call** on the injected `fetchImpl`; for inbound, that **no insert was attempted**, via an
+     ownership-specific skip reason.
+
+   The inverse control at `:294-320` (which deliberately inserts a duplicate and asserts the insert
+   **succeeds**) becomes the raw `23505` DB test. **Merely flipping `toBeFalsy()` to expect failure is
+   wrong** — it would stop validating `duplicateGroups`, which is what makes every other `toEqual([])`
+   in the file mean anything.
+
+   **Plane is not covered by the app layer, and that is a finding, not an omission.** `plane.ts:196`
+   never destructures `ownedResourceIds`, and its adopt-by-external-id (`plane.ts:218-222`) has no
+   ownership pre-check — so on Plane **the index is the only guard**. Criterion 15 is scoped to Linear
+   explicitly and this fact is recorded rather than fixed here.
+
+9. **One predicate, stated once and reused.** The index predicate `is not null` includes `''`;
+   `ownedResourceIds` filters falsy (`project.ts:320`), so two rows persisting `''` are permitted by
+   the app check and rejected by the index. Prod is safe (zero violating groups measured) and erring
+   strict is right — but any query that reports on violations must use the **textually identical**
+   predicate, or it and the index can disagree about what "violating" means.
+
+---
+
+## Scope
+
+**In:** the guarded index in `schema.sql` + one migration · the two containment fixes · the `contested`
+channel · the read-side backstop health check · restructuring the existing uniqueness tests per
+decision 8 · the replay/shape guards · the ARCHITECTURE.md drift blocks.
+
+**Out, deliberately:**
+
+- **The orphan `chetan`/`TT2` link.** Excluded by the predicate, dormant.
+- **Any reconciliation of link rows.** Nothing left to reconcile in this install.
+- **The app-code `ownedResourceIds` check.** Unchanged; the index is a backstop *behind* it.
+- **The `{code, constraint}` error-shape widening.** Needed by round 2's design; decision 6 removed the
+  need. Explicitly NOT in scope.
+- **Plane's missing ownership pre-check.** Recorded in decision 8; its own ticket.
+- **The adapter-throw parent's inline re-projection.** Shipped behaviour, deliberately untouched.
+- **ADOPTINV-1.** Separate ticket.
+
+**Correction carried from round 1:** this spec claimed "only two writers of `provider_resource_id`
+exist, verified by grep". **That was FALSE** — `scripts/brain-tasks.ts:357` (the operator `adopt`
+command) is a third, on both an update and an insert path. The claim came from a `head -30`-truncated
+grep read as a complete enumeration. Both reviewers independently re-ran the census without
+line-anchoring and confirm **three** writers and no fourth. Note the irony Fable flagged:
+`brain-tasks adopt` is the operator's tool for repairing a collision, and under the index a re-point to
+an owned id now dies with a raw `23505`. A friendlier message is in scope; changing its behaviour is not.
+
+---
+
+## Acceptance criteria
+
+1. **data-mechanics** — with the index applied, a second row inserted with the same
+   `(team_id, provider, provider_resource_id)` as an existing row is REJECTED with SQLSTATE `23505`.
+2. **data-mechanics** — two rows sharing `(team_id, provider)` with `provider_resource_id` NULL both
+   persist, proving the partial predicate excludes NULLs and the live orphan cannot be broken.
+3. **data-mechanics** — rows differing only by `team_id`, or only by `provider`, both persist, so the
+   index keys on all three columns and not on `provider_resource_id` alone.
+4. **data-mechanics** — the guarded block applied to a database ALREADY HOLDING a duplicate pair
+   completes WITHOUT raising, leaves the index absent, and leaves both rows intact. Executed against
+   the **actual bytes of the migration file** read from `postgres/migrations/`, never a paraphrase.
+5. **data-mechanics** — a duplicate committed by a SECOND connection before the block runs produces the
+   same contained outcome as criterion 4. *(Round 2 rewrote this: the old wording named an interval —
+   "after the count, before the create" — that the exception-contained design no longer has, and the
+   `do $$` block executes as one atomic statement, so no harness can interleave a writer mid-block. A
+   criterion naming an unstageable window invites a builder to fake it.)*
+6. **data-mechanics** — **the lock case**: with a concurrent transaction holding a conflicting lock and
+   a short `lock_timeout`, the block completes WITHOUT raising, the schema load continues (a statement
+   after the block still executes), and the index is correctly absent. A `unique_violation`-only
+   handler fails this on a CLEAN table — that is the round-2 HIGH, and this is its regression test.
+7. **data-mechanics** — **the deadlock case**: a staged lock cycle in which this transaction is the
+   victim is contained the same way, on a CLEAN table. A two-exception handler fails this — the round-3
+   HIGH, confirmed by staging one. Criteria 4, 6 and 7 must each fail for a DIFFERENT missing `when`
+   clause, so one fixture cannot satisfy two of them.
+8. **data-mechanics** — the contention skips SELF-HEAL: once contention clears, replaying the block
+   creates the index. The duplicate-data skip is asserted NOT to self-heal, so the two are never
+   conflated. *(The pre-code experiment isolated this for the lock case only; the deadlock case is
+   inferred. This criterion is where it stops being inferred.)*
+9. **data-mechanics** — criteria 4, 6 and 7 execute through the REAL loader: `scripts/pg-load-schema.mjs`
+   exports `loadSchema` with injectable `createClient`/`readFile`/`cwd`, so the test runs the actual
+   single-implicit-transaction load over a dirty scratch DB and asserts a later statement still ran.
+   A synthetic wrapper that sends the block as its own query has DIFFERENT transaction semantics from
+   the thing that runs in prod, and would prove the wrong property.
+8. **data-mechanics** — the guarded block is idempotent: replayed on a clean DB the index exists exactly
+   once; on a dirty DB it stays a clean no-op; once the duplicate is removed it CREATES the index.
+9. **data-mechanics** — each `raise warning` fires on its own branch with a message distinguishing
+   duplicate-data from lock, captured via the pg client's `notice` event (`pg-load-schema.mjs:57` proves
+   the path). The weakest point of the design does not go untested.
+10. **data-mechanics** — the read-side backstop check reports HEALTHY when the index exists, and
+    UNHEALTHY when it is absent — **and also when a same-named index exists with the wrong columns,
+    wrong column ORDER, wrong predicate, no uniqueness, or is INVALID, or is bound to a different
+    schema/table**. Without those clauses `if not exists` lets a wrong index read as a successful
+    deploy. A catalog-read failure resolves UNKNOWN/UNHEALTHY, never HEALTHY.
+10b. **unit/http** — the backstop status is WIRED: it is present on what `computeProjectionHealth`
+    returns, and emitted by BOTH `app/t/[team]/admin/pm-sync/page.tsx` and
+    `app/api/v1/pm-sync/health/route.ts`. Without this the replacement for the deleted stamp can ship
+    where no human sees it — the failure that killed the stamp in the first place.
+11. **data-mechanics** — outbound: a projection whose `persistSuccess` update violates the index reports
+    that row `failed` with a non-null `last_error`, does not throw, and a sibling row in the same
+    `projectRows` batch still projects. Asserted on the batch. Pre-change code reports `synced` with
+    `last_error` null, so this distinguishes.
+12. **data-mechanics** — outbound inverse: after criterion 11's failure the failing link's
+    `provider_resource_id` is still NULL — nothing partially persisted.
+13. **data-mechanics** — the `contested` channel: one batch, the parent's persist fails, a child is
+    present → the parent's provider is mutated **exactly once** (counted as mutation calls on the
+    injected `fetchImpl`, which is observable; the private `resolved` map is NOT inspected), the child
+    reports `failed` naming the parent, and the child is NOT parented to the contested id.
+    *(Round 2: the old criteria 11/12 required inspecting a private map and asserted "adapter invoked
+    exactly once" with no observable behind it, and their clauses were jointly unsatisfiable.)*
+14. **data-mechanics** — the adapter-*throw* parent path is asserted UNCHANGED, pinning the scope fence
+    in decision 6 so a future widening of `contested` is caught as the over-correction it would be.
+15. **data-mechanics** — inbound: a candidate whose insert violates the index is recorded in
+    `result.skipped` with a message naming the identifier and the cause, and the pass CONTINUES, with a
+    later candidate still adopted and Phase A's accumulated result preserved.
+16. **data-mechanics** — inbound rollback inverse: that rejected candidate's `tasks` row is UNTOUCHED
+    (`origin`, `status`, `body` unchanged) and no link row exists. The adopt transaction carries the
+    tasks update alongside the insert (`inbound.ts:451-473`), so a builder who wraps only the insert
+    half-adopts the task and passes every other criterion.
+17. **data-mechanics** — the app-layer decision is pinned independently of the DB (decision 8):
+    **for Linear**, deleting `ownedResourceIds` must redden an assertion that the adapter made **no
+    mutation call** on the injected `fetchImpl`, even though the index keeps `duplicateGroups` empty.
+    For INBOUND the observable is NOT a string: inbound's ownership exclusion is the SILENT candidate
+    filter at `lib/pm-sync/inbound.ts:414` (`!ownedIds.has(it.id)`), which produces no record at all. So the
+    assertion is: an owned issue yields **no insert attempt AND no `skipped` entry**, whereas the
+    deleted-filter mutant yields a `skipped` entry carrying the DB-rejection message. *(Round 3 Fable
+    MEDIUM: the earlier wording named a string that does not exist — criteria must name observables.)*
+18. **unit** — a guard asserts that in BOTH `postgres/schema.sql` and every file in
+    `postgres/migrations/`, any `create unique index` naming `task_pm_links` appears INSIDE a
+    `do $$ … $$` body that also catches ALL THREE of `unique_violation`, `lock_not_available` and
+    `deadlock_detected` (this list must grow with decision 3 or the guard and the decision drift on day
+    one), and that no
+    `alter table task_pm_links add constraint … unique` exists anywhere. Written as a ∀ over both files
+    — an existential is satisfied by the sibling the regression did not touch.
+19. **unit** — criterion 18 carries a POSITIVE assertion: **exactly one** guarded creator in EACH of the
+    two target files (`postgres/schema.sql` and the new migration), and **zero** in every other
+    migration file. "Exactly one per file" alone was ambiguous once criterion 18 quantified over all
+    migrations.
+    A rejection-only matcher stays green forever if someone deletes the index entirely, and was green
+    against the pre-change tree where no such index exists at all.
+20. **unit** — the matcher is **comment-aware**. `20260817164500_task_pm_links_declared_external_id.sql:12-16`
+    already describes this index in prose without the literal DDL; a future comment quoting the DDL
+    would otherwise satisfy criterion 19's count spuriously. Pinned with a fixture.
+21. **unit** — the guard is proven non-vacuous by running the matcher against independently mutated
+    IN-MEMORY fixtures (the tests must not modify repository files), one per target file, so neither can
+    be the only one carrying the property — plus an injected bare-`create unique index` fixture.
+22. **unit** — `docs/ARCHITECTURE.md`'s drift blocks still resolve (`npm run check:docs`).
+23. **migrate-from-existing** — the catalog fingerprint of an upgraded existing DB equals a from-zero
+    load. Scoped honestly: those scratch DBs are EMPTY, so this proves only the CLEAN branch and never
+    exercises a skip. Criteria 4-8 cover the skip branches.
+
+**Harness hazards the build must respect:**
+
+- Criteria 4-8 do DDL (drop index, replay the block) and the dm harness truncates **rows, not DDL**. A
+  mid-test failure would strand the shared test DB without the index and redden later criteria
+  phantomly. Run them against a scratch database/schema, or restore in `finally`.
+- Criterion 11 needs a persist failure against real Postgres with no mocks. The legitimate lever is the
+  index itself (a genuine `23505`). Do NOT stub `db.update` — that silently demotes the test out of the
+  tier it was put in.
+- Use `npm run test:datamechanics:iso`, not the shared `:5434` container: four other worktrees were
+  active during this spec's authoring.
+
+## What would falsify this
+
+- **A deploy aborting on this index.** Criteria 4-8 did not hold, or a later edit reintroduced a bare
+  `create unique index` and criterion 18 missed it. Note this falsifier has now fired TWICE in review
+  (the count-then-create race; the lock wait) — both times on a mechanism intended to make the guard
+  safe, which is the pattern to watch.
+- **A fleet silently running without the backstop** — the read-side check was not surfaced anywhere a
+  human looks, and decision 4 bought nothing over a log line.
+- **A board push still aborting wholesale** — inbound containment wrapped at the wrong level, or there
+  is a FOURTH writer of `provider_resource_id`. Three are known; round 1 of this spec confidently
+  claimed two, so the correct posture is that the list is what was found, not a proof of completeness.
+- **A duplicate provider issue minted in a batch** — the `contested` channel was not implemented, or
+  criterion 13 was written too weakly to see it.
+- **The outbound fix converting silence into noise** — every pre-existing failure of that update now
+  reports `failed`. Not observed in prod; the first thing to watch after merge.
+- **The uniqueness tests going quietly vacuous** — decision 8's split was not carried through and the
+  index is masking the app-code regressions those tests exist to catch.

--- a/lib/pm-sync/inbound.ts
+++ b/lib/pm-sync/inbound.ts
@@ -445,39 +445,64 @@ async function adoptInbound(
       parentResourceId
     );
 
-    const inserted = await withTransaction(async (client) => {
-      const res = await client.query(
-        `insert into task_pm_links
-           (team_id, project_id, task_id, row_key, provider, provider_resource_id,
-            provider_external_source, provider_external_id, provider_url,
-            last_projected_status, last_projected_brain_status, projection_fingerprint,
-            provider_seen_status, updated_at)
-         values ($1, $2, $3, $4, 'linear', $5, $6, $7, $8, $9, $10, $11, $9, now())
-         on conflict (team_id, project_id, row_key, provider) do nothing
-         returning id`,
-        [
-          teamId,
-          projectId,
-          task.id,
-          it.identifier,
-          it.id,
-          externalSource,
-          it.identifier,
-          it.url ?? "",
-          stateName,
-          status,
-          fingerprint,
-        ]
+    /**
+     * ADOPTUNIQ-1 — contain a failed adopt to THIS candidate.
+     *
+     * The insert below infers `on conflict (team_id, project_id, row_key, provider)` — the row-identity
+     * constraint. Postgres allows exactly one inference clause, so a violation of the partial unique
+     * index `task_pm_links_provider_resource_uq` is NOT absorbed by it: it throws out of
+     * `withTransaction`, out of this loop, and out of `runInboundForTeam` before `return result` —
+     * discarding Phase A's applies along with every remaining candidate. One contested issue would
+     * take down the whole team's inbound pass.
+     *
+     * The transaction is the unit that rolls back, so the task row cannot be left half-adopted: the
+     * `origin`/`status`/`body` flip below shares the transaction with the insert deliberately.
+     */
+    let inserted: boolean;
+    try {
+      inserted = await withTransaction(async (client) => {
+        const res = await client.query(
+          `insert into task_pm_links
+             (team_id, project_id, task_id, row_key, provider, provider_resource_id,
+              provider_external_source, provider_external_id, provider_url,
+              last_projected_status, last_projected_brain_status, projection_fingerprint,
+              provider_seen_status, updated_at)
+           values ($1, $2, $3, $4, 'linear', $5, $6, $7, $8, $9, $10, $11, $9, now())
+           on conflict (team_id, project_id, row_key, provider) do nothing
+           returning id`,
+          [
+            teamId,
+            projectId,
+            task.id,
+            it.identifier,
+            it.id,
+            externalSource,
+            it.identifier,
+            it.url ?? "",
+            stateName,
+            status,
+            fingerprint,
+          ]
+        );
+        if ((res.rowCount ?? 0) === 0) return false; // raced adopt — the unique index guarantees no duplicate
+        // origin 'ui': once owned, ingest excludes this issue from the mirror push, and only
+        // origin='sync' rows are diff-deleted — the flip is what makes the adopted task durable.
+        await client.query(
+          `update tasks set origin = 'ui', status = $1, raw_status = null, body = $2, updated_at = now() where id = $3`,
+          [status, body, task.id]
+        );
+        return true;
+      });
+    } catch (err) {
+      // Contained to this candidate: the transaction rolled back (no link row, and the task row's
+      // origin/status/body are untouched), so the pass continues with the next one and Phase A's
+      // accumulated applies survive. The message names the identifier AND the cause, because a bare
+      // `skipped` entry is indistinguishable from the ordinary "no mirror task yet" skips above.
+      result.skipped.push(
+        `${it.identifier}: adopt rejected — ${err instanceof Error ? err.message : "database error"}`
       );
-      if ((res.rowCount ?? 0) === 0) return false; // raced adopt — the unique index guarantees no duplicate
-      // origin 'ui': once owned, ingest excludes this issue from the mirror push, and only
-      // origin='sync' rows are diff-deleted — the flip is what makes the adopted task durable.
-      await client.query(
-        `update tasks set origin = 'ui', status = $1, raw_status = null, body = $2, updated_at = now() where id = $3`,
-        [status, body, task.id]
-      );
-      return true;
-    });
+      continue;
+    }
     if (!inserted) continue;
 
     resourceByRowKey.set(it.identifier, it.id);

--- a/lib/pm-sync/inbound.ts
+++ b/lib/pm-sync/inbound.ts
@@ -498,7 +498,8 @@ async function adoptInbound(
        * NARROW ON PURPOSE: contain ONLY a uniqueness rejection, and re-throw everything else.
        *
        * A blanket catch here would be worse than the abort it replaces. `skipped` does not feed
-       * `ok` (`summarizeInbound` counts `errors`), and a skipped-only result is not even recorded by
+       * `ok` (`runLinearInbound` computes it from `errors` alone, :653), and a skipped-only result is not
+       * even recorded by
        * the manual sync — so a database outage during every adoption would report a clean, successful
        * run. Losing the pass is the RIGHT outcome for an outage; it is only the one-issue-one-row
        * rejection that must not take the other candidates down with it.

--- a/lib/pm-sync/inbound.ts
+++ b/lib/pm-sync/inbound.ts
@@ -494,12 +494,30 @@ async function adoptInbound(
         return true;
       });
     } catch (err) {
+      /**
+       * NARROW ON PURPOSE: contain ONLY a uniqueness rejection, and re-throw everything else.
+       *
+       * A blanket catch here would be worse than the abort it replaces. `skipped` does not feed
+       * `ok` (`summarizeInbound` counts `errors`), and a skipped-only result is not even recorded by
+       * the manual sync — so a database outage during every adoption would report a clean, successful
+       * run. Losing the pass is the RIGHT outcome for an outage; it is only the one-issue-one-row
+       * rejection that must not take the other candidates down with it.
+       *
+       * The code is available here because this path uses raw SQL through `withTransaction`, not the
+       * query builder that flattens errors to `{ message }`. Matching on the message text instead
+       * would break under a non-English `lc_messages` on a self-hosted fleet — and it would fail in
+       * the DANGEROUS direction, silently swallowing real outages.
+       */
+      const code = (err as { code?: string } | null)?.code;
+      if (code !== "23505") throw err;
       // Contained to this candidate: the transaction rolled back (no link row, and the task row's
       // origin/status/body are untouched), so the pass continues with the next one and Phase A's
       // accumulated applies survive. The message names the identifier AND the cause, because a bare
       // `skipped` entry is indistinguishable from the ordinary "no mirror task yet" skips above.
       result.skipped.push(
-        `${it.identifier}: adopt rejected — ${err instanceof Error ? err.message : "database error"}`
+        `${it.identifier}: adopt rejected — another link already claims this issue (${
+          (err as { constraint?: string } | null)?.constraint ?? "unique constraint"
+        })`,
       );
       continue;
     }

--- a/lib/pm-sync/project.ts
+++ b/lib/pm-sync/project.ts
@@ -68,6 +68,31 @@ export interface ProjectTaskOptions {
   bootstrap?: unknown;
   // Map of row_key → already-projected provider resource id (parent-first ordering).
   resolved?: Map<string, string>;
+  /**
+   * ADOPTUNIQ-1 — row keys whose PROVIDER write succeeded but whose link bookkeeping did NOT persist.
+   * Disjoint from `resolved` by construction: a row lands in exactly one of them.
+   *
+   * It exists because "don't set `resolved`" and "don't re-invoke the adapter" are otherwise in direct
+   * conflict, and both are required:
+   *   • Not setting `resolved` is mandatory — the resource id was never durably claimed, and on a
+   *     unique violation it is a row ANOTHER link owns. Parenting children beneath it would attach
+   *     them to a stranger's issue.
+   *   • But absence from `resolved` alone sends the child down the inline fallback below, which
+   *     reloads the parent and calls `projectTask` on it AGAIN — the link still has no
+   *     `provider_resource_id` and a stale fingerprint, so the short-circuit misses and the adapter
+   *     runs a SECOND time in the same push. That can mint a duplicate provider issue.
+   * A separate channel gives the second job its own signal and dissolves the conflict: a child sees
+   * the parent here and fails fast, without invoking anything.
+   *
+   * SCOPE, deliberately narrow on both axes:
+   *   • PERSIST failures only. An adapter THROW already re-projects inline per child today; that
+   *     behaviour is shipped and is intentionally left alone (widening this to cover it would be a
+   *     silent behaviour change, pinned against by the adapter-throw regression test).
+   *   • INVOCATION-LOCAL. Like `resolved`, this set is built per `projectRows` call, so it cannot
+   *     constrain a standalone `projectTask` in a LATER cycle re-invoking the adapter. That is
+   *     ordinary retry semantics, not the batch-internal double-mutation this exists to stop.
+   */
+  contested?: Set<string>;
   // Guards against parent cycles when projecting a single task's parent chain inline.
   visiting?: Set<string>;
 }
@@ -176,6 +201,24 @@ async function ensureLink(
   return data as TaskPmLink;
 }
 
+/**
+ * Persist the bookkeeping for a projection that the PROVIDER already accepted.
+ *
+ * RETURNS the failure instead of swallowing it (ADOPTUNIQ-1). The pg adapter does NOT throw — it
+ * catches the driver error and returns `{ data: null, error }` (`lib/db/pg/query-builder.ts:221-224`)
+ * — and this function used to `await` the update and never read `error`. Every failure of it was
+ * therefore silent: the row reported SUCCESS while the provider had been mutated and the link kept no
+ * `provider_resource_id`, so the next push missed rung 1 and took the adopt path again.
+ *
+ * That mattered little while nothing could reject the write. The partial unique index
+ * `task_pm_links_provider_resource_uq` makes it reachable on the path that matters, so the error is
+ * now surfaced to the caller.
+ *
+ * ⚠️ It RETURNS the error and does NOT throw, and that is load-bearing rather than stylistic. A throw
+ * would land in `projectTask`'s shared catch, which also catches ADAPTER throws — and an adapter throw
+ * must keep its existing inline-retry behaviour (see `contested` below). Mixing the two there is the
+ * over-correction this shape exists to prevent.
+ */
 async function persistSuccess(
   db: DbClient,
   link: TaskPmLink,
@@ -184,9 +227,9 @@ async function persistSuccess(
   // Exact brain `tasks.status` this projection wrote from — the inbound conflict baseline
   // (brain-api v1.4). The group-granular fingerprint can't distinguish in_progress / in_review / blocked.
   brainStatus: string
-) {
+): Promise<{ error: { message: string } | null }> {
   const now = new Date().toISOString();
-  await db
+  const { error } = await db
     .from("task_pm_links")
     .update({
       provider_resource_id: result.providerResourceId,
@@ -201,6 +244,7 @@ async function persistSuccess(
       updated_at: now,
     })
     .eq("id", link.id);
+  return { error: error ?? null };
 }
 
 async function persistError(db: DbClient, link: TaskPmLink, message: string) {
@@ -257,6 +301,22 @@ export async function projectTask(
     const resolved = opts.resolved;
     if (resolved?.has(row.parent_row_key)) {
       parentResourceId = resolved.get(row.parent_row_key) ?? null;
+    } else if (opts.contested?.has(row.parent_row_key)) {
+      /**
+       * ADOPTUNIQ-1 — the parent's provider write landed but its bookkeeping did not, so its resource
+       * id is not durably ours (and on a unique violation it is another row's outright). Fail here,
+       * BEFORE the inline fallback below re-invokes the parent's adapter.
+       *
+       * This check must stay between the `resolved` hit above and the inline fallback below. Moved
+       * after it, the adapter runs again and the duplicate-issue risk returns; the fact that the
+       * failure is still reported would make that regression invisible.
+       */
+      return {
+        row_key: row.row_key,
+        provider,
+        status: "failed",
+        error: `parent ${row.parent_row_key}: provider write succeeded but the link did not persist — not parenting beneath an unclaimed issue`,
+      };
     } else {
       const visiting = opts.visiting ?? new Set<string>();
       if (visiting.has(row.row_key)) {
@@ -348,7 +408,23 @@ export async function projectTask(
         parentResourceId
       );
     }
-    await persistSuccess(db, link, result, effectiveFingerprint, row.status);
+    /**
+     * ADOPTUNIQ-1 — the provider has ALREADY been written by this point. If the bookkeeping fails, the
+     * only honest report is a failure for THIS row: contained (the batch continues), loud (the error
+     * lands on the link and in the report), and never silent, which is what it used to be.
+     *
+     * Checked inline on the success path rather than thrown, so the shared catch below keeps meaning
+     * "the adapter failed" — see `persistSuccess` and `ProjectTaskOptions.contested`.
+     */
+    const persisted = await persistSuccess(db, link, result, effectiveFingerprint, row.status);
+    if (persisted.error) {
+      const message = `link bookkeeping failed after the provider write: ${persisted.error.message}`;
+      await persistError(db, link, message);
+      // NOT `resolved` — the id was never durably claimed, and on a unique violation another link owns
+      // it. `contested` stops children re-invoking the adapter without pretending the id is ours.
+      opts.contested?.add(row.row_key);
+      return { row_key: row.row_key, provider, status: "failed", error: message };
+    }
     opts.resolved?.set(row.row_key, result.providerResourceId);
     return { row_key: row.row_key, provider, status: result.status, providerResourceId: result.providerResourceId };
   } catch (e) {
@@ -408,6 +484,9 @@ export async function projectRows(
   const sleep = opts.sleep ?? realSleep;
   const throttleMs = opts.throttleMs ?? DEFAULT_THROTTLE_MS;
   const resolved = new Map<string, string>();
+  // ADOPTUNIQ-1 — shared for the whole batch, like `resolved`, so a parent whose bookkeeping failed
+  // stops its children re-invoking the adapter. Invocation-local by design; see `contested`.
+  const contested = new Set<string>();
   const reports: ProjectionReport[] = [];
 
   for (const row of topoOrder(rows)) {
@@ -415,6 +494,7 @@ export async function projectRows(
       primary,
       bootstrap,
       resolved,
+      contested,
       fetchImpl: opts.fetchImpl,
     });
     reports.push(report);

--- a/lib/pm-sync/runs.ts
+++ b/lib/pm-sync/runs.ts
@@ -3,6 +3,7 @@ import "server-only";
 import type { DbClient } from "@/lib/db/types";
 import { recordIngestRun, type IngestRunRow, type IngestTrigger } from "@/lib/ingest/runs";
 import { isStale } from "@/lib/ingest/runs-format";
+import { withTransaction } from "@/lib/db/pg/tx";
 import type { PmProvider } from "@/lib/pm-sync/provider";
 import type { ProjectionReport } from "@/lib/pm-sync/project";
 
@@ -113,23 +114,97 @@ export type ProjectionHealthStatus = "never_run" | "ok" | "stale" | "failed";
 // the same `isStale` age check the ingest-runs panel already uses (lib/ingest/runs-format.ts).
 export const PROJECTION_STALE_AFTER_HOURS = 24;
 
+/**
+ * ADOPTUNIQ-1 — is the one-issue-one-row DB backstop actually installed and CORRECT?
+ *
+ * `unknown` is not a synonym for `healthy`: a catalog read that fails resolves here, never to
+ * `installed`. A probe that reports green when it cannot see is the fail-open shape this repo has
+ * already been bitten by.
+ */
+export type BackstopStatus = "installed" | "missing" | "malformed" | "unknown";
+
 export interface ProjectionHealth {
   status: ProjectionHealthStatus;
   lastRun: IngestRunRow | null;
   ageMs: number | null;
+  /**
+   * DELIBERATELY A SEPARATE FIELD, not a value folded into `status`. `status` describes the last
+   * projection RUN (never_run/failed/stale/ok); the backstop is a schema property with no relation to
+   * it, and overloading one enum would make "ok" mean two unrelated things.
+   */
+  backstop: BackstopStatus;
 }
 
-export function computeProjectionHealth(lastRun: IngestRunRow | null, now = Date.now()): ProjectionHealth {
-  if (!lastRun) return { status: "never_run", lastRun: null, ageMs: null };
+export function computeProjectionHealth(
+  lastRun: IngestRunRow | null,
+  now = Date.now(),
+  backstop: BackstopStatus = "unknown",
+): ProjectionHealth {
+  if (!lastRun) return { status: "never_run", lastRun: null, ageMs: null, backstop };
   const finishedAtMs = new Date(lastRun.finished_at).getTime();
   const ageMs = now - finishedAtMs;
-  if (!lastRun.ok) return { status: "failed", lastRun, ageMs };
-  if (isStale(finishedAtMs, now, PROJECTION_STALE_AFTER_HOURS)) return { status: "stale", lastRun, ageMs };
-  return { status: "ok", lastRun, ageMs };
+  if (!lastRun.ok) return { status: "failed", lastRun, ageMs, backstop };
+  if (isStale(finishedAtMs, now, PROJECTION_STALE_AFTER_HOURS)) return { status: "stale", lastRun, ageMs, backstop };
+  return { status: "ok", lastRun, ageMs, backstop };
 }
 
-/** Convenience: last run + derived health in one round trip. */
+/**
+ * ADOPTUNIQ-1 — classify the catalog row for `task_pm_links_provider_resource_uq`.
+ *
+ * Pure, so the whole decision table is unit-testable without a database. `indexdef` is Postgres's
+ * NORMALIZED rendering from `pg_get_indexdef`, not our source DDL — comparing against the source text
+ * would break on whitespace and on Postgres's own parenthesisation of the predicate.
+ *
+ * `malformed` exists because `create unique index IF NOT EXISTS` accepts ANY existing relation with
+ * that name, whatever its columns, order, predicate or uniqueness — so a wrong index of the right name
+ * would otherwise read as a successful deploy forever.
+ */
+export function classifyBackstop(
+  row: { indexdef: string; isvalid: boolean } | null,
+): BackstopStatus {
+  if (!row) return "missing";
+  if (!row.isvalid) return "malformed";
+  const def = row.indexdef.toLowerCase().replace(/\s+/g, " ").trim();
+  const wellFormed =
+    def.includes("create unique index") &&
+    // schema+table binding, not just the index name
+    /\son\s+public\.task_pm_links\s+using\s+btree\s*\(/.test(def) &&
+    // exact ORDERED key columns, and nothing else (no expression/include columns)
+    def.includes("(team_id, provider, provider_resource_id)") &&
+    // the partial predicate, in Postgres's normalized rendering
+    def.includes("where (provider_resource_id is not null)");
+  return wellFormed ? "installed" : "malformed";
+}
+
+/**
+ * Read the backstop's catalog row. FAIL-CLOSED: any error resolves `unknown`, never `installed`.
+ *
+ * Raw SQL rather than the query builder because `DbClient` cannot express the `pg_index`/`pg_class`
+ * joins — the same reason `lib/pm-sync/inbound.ts` reaches for `withTransaction`.
+ */
+export async function readBackstopStatus(): Promise<BackstopStatus> {
+  try {
+    return await withTransaction(async (client) => {
+      const res = await client.query(
+        `select pg_get_indexdef(i.indexrelid) as indexdef, i.indisvalid as isvalid
+           from pg_index i
+           join pg_class c on c.oid = i.indexrelid
+           join pg_namespace n on n.oid = c.relnamespace
+          where n.nspname = 'public' and c.relname = 'task_pm_links_provider_resource_uq'`,
+      );
+      const row = (res.rows?.[0] ?? null) as { indexdef: string; isvalid: boolean } | null;
+      return classifyBackstop(row);
+    });
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Convenience: last run + derived health + the DB backstop in one call. */
 export async function getProjectionHealth(db: DbClient, teamId: string): Promise<ProjectionHealth> {
-  const runs = await listRecentProjectionRuns(db, teamId, 1);
-  return computeProjectionHealth(runs[0] ?? null);
+  const [runs, backstop] = await Promise.all([
+    listRecentProjectionRuns(db, teamId, 1),
+    readBackstopStatus(),
+  ]);
+  return computeProjectionHealth(runs[0] ?? null, Date.now(), backstop);
 }

--- a/lib/pm-sync/runs.ts
+++ b/lib/pm-sync/runs.ts
@@ -165,15 +165,19 @@ export function classifyBackstop(
   if (!row) return "missing";
   if (!row.isvalid) return "malformed";
   const def = row.indexdef.toLowerCase().replace(/\s+/g, " ").trim();
-  const wellFormed =
-    def.includes("create unique index") &&
-    // schema+table binding, not just the index name
-    /\son\s+public\.task_pm_links\s+using\s+btree\s*\(/.test(def) &&
-    // exact ORDERED key columns, and nothing else (no expression/include columns)
-    def.includes("(team_id, provider, provider_resource_id)") &&
-    // the partial predicate, in Postgres's normalized rendering
-    def.includes("where (provider_resource_id is not null)");
-  return wellFormed ? "installed" : "malformed";
+  /**
+   * Matched as a WHOLE definition, not a bag of substrings.
+   *
+   * A substring check accepted `… (team_id, provider, provider_resource_id) INCLUDE (task_id) WHERE …`
+   * as installed, contradicting this function's own promise to validate the exact definition. Anchoring
+   * the pattern end-to-end means anything Postgres renders that we did not ask for — INCLUDE columns,
+   * a tablespace, `NULLS NOT DISTINCT`, a collation or opclass — falls to `malformed` rather than
+   * being quietly tolerated. Erring strict is right: the whole point is that a wrong index of the
+   * right NAME must not read as a successful deploy.
+   */
+  const EXPECTED =
+    /^create unique index task_pm_links_provider_resource_uq on public\.task_pm_links using btree \(team_id, provider, provider_resource_id\) where \(provider_resource_id is not null\)$/;
+  return EXPECTED.test(def) ? "installed" : "malformed";
 }
 
 /**

--- a/postgres/migrations/20260826230000_task_pm_links_provider_resource_uq.sql
+++ b/postgres/migrations/20260826230000_task_pm_links_provider_resource_uq.sql
@@ -56,8 +56,9 @@
 -- (lib/pm-sync/project.ts:200), erasing the signal within one push cycle; and the stamping UPDATE sits
 -- OUTSIDE the protected CREATE INDEX, on precisely the hot rows the live old app is writing, so a row
 -- lock wait would raise from a statement no handler covers and abort the very release it reports on.
--- The signal is READ-side instead: `backstopHealth` in lib/pm-sync/runs.ts validates the index from
--- the catalog at runtime, which cannot be erased, self-clears on repair, and adds no deploy-time write.
+-- The signal is READ-side instead: `readBackstopStatus`/`classifyBackstop` in lib/pm-sync/runs.ts
+-- validate the index from the catalog at runtime, which cannot be erased, self-clears on repair, and
+-- adds no deploy-time write.
 do $$
 begin
   create unique index if not exists task_pm_links_provider_resource_uq

--- a/postgres/migrations/20260826230000_task_pm_links_provider_resource_uq.sql
+++ b/postgres/migrations/20260826230000_task_pm_links_provider_resource_uq.sql
@@ -1,0 +1,73 @@
+-- ADOPTUNIQ-1 — the DB backstop for one-issue-one-row: at most ONE link per
+-- (team, provider) may claim a given provider_resource_id.
+--
+-- Design + every claim below: docs/design/task-pm-links-unique-index.md
+--
+-- WHY IT WAS DEFERRED, AND WHY IT SHIPS NOW
+-- `20260817164500_task_pm_links_declared_external_id.sql:12-16` records the deferral: prod held three
+-- TT1 links all pointing at Linear issue AIO-444, so the index would have aborted the release (the
+-- #251 replay class). Re-measured 2026-08-26 read-only against prod: ZERO violating groups across
+-- 1,067 links, one TT1 link left. The blocker is gone; the guard below exists for every OTHER
+-- self-hosted fleet, whose data nobody here can read.
+--
+-- ⚠️ THIS BLOCK IS THE ONLY LEGAL CREATOR OF THIS INDEX, AND IT IS DUPLICATED VERBATIM IN
+-- `postgres/schema.sql`. Do NOT "tidy" either copy into a bare `create unique index`.
+-- `scripts/pg-load-schema.mjs` loads schema.sql FIRST (:69) and then the migrations (:72-78), and —
+-- unlike a column inside `create table if not exists`, which is a no-op on an existing DB — a
+-- top-level `create unique index` DOES execute against an existing database. schema.sql is sent as a
+-- single multi-statement query, i.e. ONE implicit transaction, so an unguarded failure there aborts
+-- the ENTIRE schema load before any migration could protect it. Guarded by
+-- `test/guards/task-pm-links-unique-index.test.ts`.
+--
+-- WHY EXCEPTION-CONTAINED RATHER THAN COUNT-THEN-CREATE
+-- An earlier design counted violations first and created the index only if clean. That is itself a
+-- check-then-act race: `pg:schema` is Railway's preDeployCommand and runs while the OLD app version is
+-- still serving and still projecting (pg-load-schema.mjs:8), so a writer can insert a duplicate
+-- between the count and the create. Correctness must not depend on a pre-count, and here it does not —
+-- there is no count at all.
+--
+-- WHY THESE THREE `when` CLAUSES AND NO MORE — each traces to a staged failure, not a guess:
+--   * unique_violation (23505)   — duplicate data. Verified: escapes an unguarded create and aborts.
+--   * lock_not_available (55P03) — pg-load-schema sets lock_timeout (:66-67, default 15s). A
+--     non-concurrent CREATE INDEX takes SHARE and must wait out in-flight writes from the old app.
+--     VERIFIED on a CLEAN table: the timeout escapes a 23505-only handler, poisons the implicit
+--     transaction, and the release aborts with zero dirty data.
+--   * deadlock_detected (40P01)  — reachable EARLIER than the timeout: deadlock_timeout defaults to
+--     1s, and this transaction has already taken ACCESS EXCLUSIVE locks from earlier
+--     `alter table … if not exists` no-ops while the old app still serves. VERIFIED by staging a real
+--     cycle: this transaction was chosen victim, 40P01 escaped a two-exception handler, and the
+--     release aborted — again with zero dirty data.
+--
+-- ⛔ NEVER `when others`. If a later edit moves this block ABOVE the `create table if not exists
+-- task_pm_links` region in schema.sql, `undefined_table` must be LOUD; a catch-all would convert that
+-- ordering bug into a warning and a fleet-wide missing backstop. The narrow list is what keeps that
+-- failure visible. `query_canceled` (57014) is deliberately excluded — nothing sets statement_timeout
+-- on this path.
+--
+-- THE CLAIM, STATED NARROWLY: this does NOT "never refuse to deploy" — disk and catalog errors still
+-- abort, as they should. What it guarantees is that neither duplicate data, nor expiry of the
+-- configured lock_timeout, nor a deadlock can abort a release.
+--
+-- WHAT A SKIP COSTS, AND WHO NOTICES
+-- The two contention skips genuinely self-heal on the next deploy. The DUPLICATE-DATA skip does NOT:
+-- nothing in the product cleans an existing duplicate pair, so a violating fleet stays unprotected.
+-- An earlier draft stamped `last_error` on the offending rows to surface that; it was withdrawn for
+-- two independent reasons — `persistSuccess` nulls `last_error` on every successful projection
+-- (lib/pm-sync/project.ts:200), erasing the signal within one push cycle; and the stamping UPDATE sits
+-- OUTSIDE the protected CREATE INDEX, on precisely the hot rows the live old app is writing, so a row
+-- lock wait would raise from a statement no handler covers and abort the very release it reports on.
+-- The signal is READ-side instead: `backstopHealth` in lib/pm-sync/runs.ts validates the index from
+-- the catalog at runtime, which cannot be erased, self-clears on repair, and adds no deploy-time write.
+do $$
+begin
+  create unique index if not exists task_pm_links_provider_resource_uq
+    on task_pm_links (team_id, provider, provider_resource_id)
+    where provider_resource_id is not null;
+exception
+  when unique_violation then
+    raise warning 'ADOPTUNIQ-1: duplicate provider_resource_id present - DB backstop NOT installed; repair the duplicates (this skip does NOT self-heal)';
+  when lock_not_available then
+    raise warning 'ADOPTUNIQ-1: could not acquire the lock - DB backstop NOT installed; the next deploy retries';
+  when deadlock_detected then
+    raise warning 'ADOPTUNIQ-1: deadlock while creating the index - DB backstop NOT installed; the next deploy retries';
+end $$;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1323,6 +1323,35 @@ alter table task_pm_links add column if not exists projection_fingerprint text;
 alter table task_pm_links add column if not exists provider_seen_status text;
 alter table task_pm_links add column if not exists last_projected_brain_status text;
 
+-- ADOPTUNIQ-1 — the DB backstop for one-issue-one-row. THIS BLOCK IS DUPLICATED VERBATIM IN
+-- `postgres/migrations/20260826230000_task_pm_links_provider_resource_uq.sql`, which carries the full
+-- rationale; read it before changing either copy. Two things it must keep:
+--
+--   1. It must stay BELOW the `create table if not exists task_pm_links` region above — a from-zero
+--      load errors on a missing table otherwise, and `undefined_table` is deliberately NOT caught so
+--      that mistake is loud.
+--   2. It must stay a GUARDED `do $$ … $$`, never a bare `create unique index`. schema.sql is sent as
+--      one multi-statement query (ONE implicit transaction) and runs BEFORE the migrations, so an
+--      unguarded failure here aborts the entire schema load — on a deploy where the old app version is
+--      still serving and still writing these rows.
+--
+-- The three `when` clauses each trace to a staged, verified abort (duplicate data; lock_timeout
+-- expiry; a real deadlock in which this transaction was the victim). Never `when others`.
+-- Guarded by `test/guards/task-pm-links-unique-index.test.ts`.
+do $$
+begin
+  create unique index if not exists task_pm_links_provider_resource_uq
+    on task_pm_links (team_id, provider, provider_resource_id)
+    where provider_resource_id is not null;
+exception
+  when unique_violation then
+    raise warning 'ADOPTUNIQ-1: duplicate provider_resource_id present - DB backstop NOT installed; repair the duplicates (this skip does NOT self-heal)';
+  when lock_not_available then
+    raise warning 'ADOPTUNIQ-1: could not acquire the lock - DB backstop NOT installed; the next deploy retries';
+  when deadlock_detected then
+    raise warning 'ADOPTUNIQ-1: deadlock while creating the index - DB backstop NOT installed; the next deploy retries';
+end $$;
+
 -- Task ↔ evidence links (work-timeline context layer): which items (commits, docs, Slack threads)
 -- are the actual WORK behind a task. Populated deterministically by issue-key references in the item's
 -- text (a commit/PR/branch/doc that cites `AIO-123`) via lib/dashboard/timeline-evidence (sole writer);

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -258,6 +258,31 @@ async function makeProject(seed: Seed, slug: string): Promise<string> {
  * THE INVARIANT. Mirrors `ADOPTUNIQ-1`'s index exactly:
  *   unique (team_id, provider, provider_resource_id) where provider_resource_id is not null
  */
+/**
+ * The counting half, PURE and exported so it can have a positive control.
+ *
+ * It used to be inlined in the DB read below, and that made it untestable once the index shipped:
+ * with duplicates impossible in this database, every caller asserts `[]`, so gutting the function to
+ * `return []` left all 19 tests green — verified with a mutation, after a review caught that the
+ * "rehomed" control in the scratch-database file exercises INDEPENDENT raw SQL and never this code.
+ * Splitting the pure part is what restores a control that can actually fail.
+ */
+export function groupDuplicates(
+  rows: { provider: string; provider_resource_id: string }[],
+): { provider: string; id: string; n: number }[] {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const key = JSON.stringify([row.provider, row.provider_resource_id]);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .filter(([, n]) => n > 1)
+    .map(([key, n]) => {
+      const [provider, id] = JSON.parse(key) as [string, string];
+      return { provider, id, n };
+    });
+}
+
 async function duplicateGroups(teamId: string): Promise<{ provider: string; id: string; n: number }[]> {
   const { data } = await db()
     .from("task_pm_links")
@@ -268,17 +293,7 @@ async function duplicateGroups(teamId: string): Promise<{ provider: string; id: 
   // nothing has to be split back apart to report. An earlier draft joined on a space (which truncated
   // the reported id if one contained a space) and then on a NUL (which put a control character in the
   // source for no benefit).
-  const counts = new Map<string, number>();
-  for (const row of (data ?? []) as { provider: string; provider_resource_id: string }[]) {
-    const key = JSON.stringify([row.provider, row.provider_resource_id]);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  return [...counts.entries()]
-    .filter(([, n]) => n > 1)
-    .map(([key, n]) => {
-      const [provider, id] = JSON.parse(key) as [string, string];
-      return { provider, id, n };
-    });
+  return groupDuplicates((data ?? []) as { provider: string; provider_resource_id: string }[]);
 }
 
 async function ownedLinkCount(teamId: string): Promise<number> {
@@ -291,6 +306,43 @@ async function ownedLinkCount(teamId: string): Promise<number> {
 }
 
 describe("ADOPT-TASK-8 — no two links in a team share one PM issue (real Postgres)", () => {
+  /**
+   * THE POSITIVE CONTROL, restored. Without it the detector can break completely while every
+   * uniqueness assertion in this file stays green — verified: gutting `groupDuplicates` to
+   * `return []` survived all 19 tests before this existed.
+   *
+   * It runs against the PURE half deliberately. The database can no longer hold a duplicate, so this
+   * is the only place the reporting path can be shown to fire at all. A control written as
+   * independent raw SQL (as an earlier fold did) proves the QUERY works and says nothing about this
+   * function — which is the difference between moving a property and replacing it with a lookalike.
+   */
+  it("THE DETECTOR STILL WORKS: the grouping half reports a duplicate when given one", () => {
+    expect(
+      groupDuplicates([
+        { provider: "linear", provider_resource_id: OWNED_ISSUE_ID },
+        { provider: "linear", provider_resource_id: OWNED_ISSUE_ID },
+      ]),
+    ).toEqual([{ provider: "linear", id: OWNED_ISSUE_ID, n: 2 }]);
+
+    // Provider-scoped, matching the index it mirrors: the same id under two providers is NOT a
+    // violation, and this is asserted alongside the positive case so neither can be vacuous.
+    expect(
+      groupDuplicates([
+        { provider: "linear", provider_resource_id: "same" },
+        { provider: "plane", provider_resource_id: "same" },
+      ]),
+    ).toEqual([]);
+
+    // Three rows report n=3, so the count is real rather than a boolean dressed up as one.
+    expect(
+      groupDuplicates([
+        { provider: "linear", provider_resource_id: "x" },
+        { provider: "linear", provider_resource_id: "x" },
+        { provider: "linear", provider_resource_id: "x" },
+      ]),
+    ).toEqual([{ provider: "linear", id: "x", n: 3 }]);
+  });
+
   it("THE DATABASE NOW REFUSES IT: two links sharing one issue cannot both exist", async () => {
     /**
      * THIS CASE INVERTED WHEN `ADOPTUNIQ-1` SHIPPED, and the inversion is the point.

--- a/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
+++ b/test/datamechanics/pm-link-uniqueness.datamechanics.test.ts
@@ -291,34 +291,57 @@ async function ownedLinkCount(teamId: string): Promise<number> {
 }
 
 describe("ADOPT-TASK-8 — no two links in a team share one PM issue (real Postgres)", () => {
-  it("THE DETECTOR WORKS: two links deliberately sharing one issue are REPORTED", async () => {
-    // The inverse control. Draft 1 of the spec proposed "the query returns zero rows on a team with no
-    // links", which proves the opposite of what it claimed — that the query passes on nothing, which IS
-    // the vacuity. Any query typo that matches nothing would survive that. This is the assertion that
-    // makes every `toEqual([])` below mean something.
+  it("THE DATABASE NOW REFUSES IT: two links sharing one issue cannot both exist", async () => {
+    /**
+     * THIS CASE INVERTED WHEN `ADOPTUNIQ-1` SHIPPED, and the inversion is the point.
+     *
+     * It used to seed two links on one issue and assert the insert SUCCEEDED, so that
+     * `duplicateGroups` had a positive control and every `toEqual([])` below meant something. The
+     * partial unique index `task_pm_links_provider_resource_uq` now rejects that second insert, so the
+     * old assertion cannot pass — and simply flipping it to expect an error would leave
+     * `duplicateGroups` with no positive control at all.
+     *
+     * So the control moved rather than being deleted. What lives here now is the STRONGER statement:
+     * the invariant is ENFORCED, not merely detected. The positive control for the grouping query
+     * itself moved to `task-pm-links-unique-index.datamechanics.test.ts`, which builds its own scratch
+     * database and can therefore observe duplicates BEFORE the index exists — something this database
+     * can no longer do at all.
+     *
+     * READ THIS BEFORE TRUSTING A `toEqual([])` BELOW. With the DB enforcing, those assertions are
+     * partly green by construction: the database rejects the bad write whatever the app code decided.
+     * The load-bearing assertions in this file are therefore the MUTATION ANCHORS — that the adapter
+     * was reached, and that it did NOT write into the owner's issue. Those observe the app's decision
+     * BEFORE the write, which is the one thing the index cannot fake.
+     */
     const seed = await seedTeam();
     await seedLinearPrimary(seed);
     const projectA = await makeProject(seed, "dup-a");
     const projectB = await makeProject(seed, "dup-b");
-    for (const [i, projectId] of [projectA, projectB].entries()) {
-      // `provider_external_id` is NOT NULL with no default — omitting it makes the insert fail and the
-      // whole control silently pass over an empty table, which is the exact vacuity this case exists to
-      // rule out. So the error is checked rather than discarded.
-      const { error } = await db()
-        .from("task_pm_links")
-        .insert({
-          team_id: seed.teamId,
-          project_id: projectId,
-          row_key: `DUP${i}`,
-          provider: "linear",
-          provider_external_id: `DUP${i}`,
-          provider_resource_id: OWNED_ISSUE_ID,
-        });
-      expect(error, "the seeded duplicate link must actually insert").toBeFalsy();
-    }
-    expect(await duplicateGroups(seed.teamId)).toEqual([
-      { provider: "linear", id: OWNED_ISSUE_ID, n: 2 },
-    ]);
+
+    const first = await db().from("task_pm_links").insert({
+      team_id: seed.teamId,
+      project_id: projectA,
+      row_key: "DUP0",
+      provider: "linear",
+      provider_external_id: "DUP0",
+      provider_resource_id: OWNED_ISSUE_ID,
+    });
+    expect(first.error, "the first link must insert, or the refusal below proves nothing").toBeFalsy();
+
+    const second = await db().from("task_pm_links").insert({
+      team_id: seed.teamId,
+      project_id: projectB,
+      row_key: "DUP1",
+      provider: "linear",
+      provider_external_id: "DUP1",
+      provider_resource_id: OWNED_ISSUE_ID,
+    });
+    expect(second.error, "the DB backstop must refuse a second claim on one issue").toBeTruthy();
+
+    // And the refused row genuinely did not land — an error with a row written would be worse than
+    // either outcome alone.
+    expect(await ownedLinkCount(seed.teamId)).toBe(1);
+    expect(await duplicateGroups(seed.teamId)).toEqual([]);
 
     // And it is provider-scoped, matching the index it pre-verifies: the SAME id under a different
     // provider is NOT a violation, because the index would permit it.

--- a/test/datamechanics/pm-sync-containment.datamechanics.test.ts
+++ b/test/datamechanics/pm-sync-containment.datamechanics.test.ts
@@ -1,0 +1,323 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import { projectRows, projectTask, type ProjectionTaskRow } from "@/lib/pm-sync/project";
+import { resolvePrimaryProvider } from "@/lib/pm-sync/project";
+import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
+import { db, seedTeam, type Seed } from "./helpers";
+
+/**
+ * ADOPTUNIQ-1 — CONTAINMENT. The index is only safe because a rejected write is contained to the row
+ * that caused it. These are the tests that distinguish the change from the pre-change code.
+ *
+ * Design: docs/design/task-pm-links-unique-index.md
+ *
+ * The failure is induced with a REAL unique violation against real Postgres — never by stubbing
+ * `db.update`, which would silently demote these out of the tier they were deliberately put in. The
+ * lever is the index itself: pre-claim the resource id the adapter is going to return, and the
+ * bookkeeping UPDATE genuinely violates `task_pm_links_provider_resource_uq`.
+ */
+
+let issueSeq = 0;
+
+/**
+ * A Linear adapter double that records every provider MUTATION.
+ *
+ * The mutation count is the observable for "the adapter was invoked" — the `resolved`/`contested`
+ * maps are private to `projectRows` and cannot be inspected from a test without inventing an
+ * abstraction that exists only for the test.
+ */
+function linearMock(opts: { issues?: unknown[]; createId?: string } = {}) {
+  const mutations: string[] = [];
+  const created: string[] = [];
+  // A `backlog`-TYPE state is required: the tasks below are seeded `status: "backlog"` and the
+  // adapter resolves a workflow state by GROUP, so a list of only unstarted/started/completed makes
+  // every projection fail before it ever reaches the provider — which reads like a containment bug.
+  const states = [
+    { id: "ls-backlog", name: "Backlog", type: "backlog" },
+    { id: "ls-todo", name: "Todo", type: "unstarted" },
+    { id: "ls-started", name: "In Progress", type: "started" },
+    { id: "ls-done", name: "Done", type: "completed" },
+  ];
+  const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+    const { query, variables } = JSON.parse(String(init?.body));
+    if (query.includes("ProjectionBootstrap"))
+      return Response.json({ data: { team: { key: "AIO", states: { nodes: states }, labels: { nodes: [] } } } });
+    if (query.includes("ProjectionMembers"))
+      return Response.json({ data: { team: { members: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } } });
+    if (query.includes("ProjectionIssues"))
+      return Response.json({
+        data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: opts.issues ?? [] } } },
+      });
+    if (query.includes("IssueForPmSync")) {
+      const wanted = (opts.issues ?? []).find((i) => (i as { id: string }).id === variables?.id);
+      return Response.json({ data: { issue: wanted ?? null } });
+    }
+    if (query.includes("issueCreate")) {
+      mutations.push("issueCreate");
+      // `createId` applies to the FIRST create only. Returning it for every create would make the
+      // sibling collide too, and "a sibling still projects" would be untestable — the assertion would
+      // fail for a reason that has nothing to do with containment.
+      const id = opts.createId && created.length === 0 ? opts.createId : `li-${++issueSeq}`;
+      created.push(id);
+      return Response.json({
+        data: { issueCreate: { success: true, issue: { id, identifier: `AIO-9${issueSeq}`, url: `u/${id}` } } },
+      });
+    }
+    if (query.includes("issueUpdate")) {
+      mutations.push("issueUpdate");
+      return Response.json({
+        data: { issueUpdate: { success: true, issue: { id: variables.id, identifier: "AIO-444", url: "u" } } },
+      });
+    }
+    return Response.json({ data: {} });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations, created };
+}
+
+/** A double whose provider mutation THROWS — the shipped path this change must NOT alter. */
+function throwingMock() {
+  const mutations: string[] = [];
+  const states = [{ id: "ls-backlog", name: "Backlog", type: "backlog" }];
+  const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+    const { query } = JSON.parse(String(init?.body));
+    if (query.includes("ProjectionBootstrap"))
+      return Response.json({ data: { team: { key: "AIO", states: { nodes: states }, labels: { nodes: [] } } } });
+    if (query.includes("ProjectionMembers"))
+      return Response.json({ data: { team: { members: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } } });
+    if (query.includes("ProjectionIssues"))
+      return Response.json({ data: { team: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } } });
+    if (query.includes("issueCreate")) {
+      mutations.push("issueCreate");
+      throw new Error("provider exploded");
+    }
+    return Response.json({ data: {} });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, mutations };
+}
+
+async function seedLinearPrimary(seed: Seed) {
+  await db().from("teams").update({ primary_pm_provider: "linear" }).eq("id", seed.teamId);
+  const auth = { teamId: seed.teamId, memberId: seed.memberId };
+  const { id } = await upsertIntegration(db(), auth, { type: "linear", name: "linear", config: { teamId: "team-uuid" } });
+  await setIntegrationSecret(db(), auth, id, "lin_api_x");
+}
+
+async function makeProject(seed: Seed, slug: string): Promise<string> {
+  const { data } = await db()
+    .from("projects")
+    .insert({ team_id: seed.teamId, slug, name: slug })
+    .select("id")
+    .single();
+  return (data as { id: string }).id;
+}
+
+async function makeTask(
+  seed: Seed,
+  projectId: string,
+  rowKey: string,
+  parentRowKey: string | null = null,
+): Promise<ProjectionTaskRow> {
+  const { data } = await db()
+    .from("tasks")
+    .insert({
+      team_id: seed.teamId,
+      project_id: projectId,
+      row_key: rowKey,
+      title: `task ${rowKey}`,
+      status: "backlog",
+      origin: "sync",
+      parent_row_key: parentRowKey,
+      audience: "team",
+    })
+    .select("id, team_id, project_id, row_key, title, status, sprint, priority, labels, body, parent_row_key, assignee")
+    .single();
+  return data as ProjectionTaskRow;
+}
+
+/**
+ * Pre-claim a resource id in ANOTHER project, so the bookkeeping UPDATE for the row under test hits
+ * the partial unique index. This is a genuine 23505 from real Postgres, not a stub.
+ */
+async function preclaim(seed: Seed, resourceId: string): Promise<void> {
+  const otherProject = await makeProject(seed, `owner-${randomUUID().slice(0, 8)}`);
+  const { error } = await db().from("task_pm_links").insert({
+    team_id: seed.teamId,
+    project_id: otherProject,
+    row_key: "OWNER",
+    provider: "linear",
+    provider_external_id: "OWNER",
+    provider_resource_id: resourceId,
+  });
+  expect(error, "the pre-claim must actually insert, or the whole scenario is vacuous").toBeFalsy();
+}
+
+async function readLink(teamId: string, projectId: string, rowKey: string) {
+  const { data } = await db()
+    .from("task_pm_links")
+    .select("id, provider_resource_id, last_error, projection_fingerprint")
+    .eq("team_id", teamId)
+    .eq("project_id", projectId)
+    .eq("row_key", rowKey)
+    .maybeSingle();
+  return data as { id: string; provider_resource_id: string | null; last_error: string | null } | null;
+}
+
+describe("ADOPTUNIQ-1 — outbound containment", () => {
+  it("a rejected bookkeeping write reports FAILED and is LOUD, and a sibling still projects", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await makeProject(seed, "acme");
+
+    const CONTESTED = `li-contested-${randomUUID().slice(0, 8)}`;
+    await preclaim(seed, CONTESTED);
+
+    // The doomed row's create returns the already-claimed id; the sibling gets its own.
+    const doomed = await makeTask(seed, project, "DOOM");
+    const ok = await makeTask(seed, project, "FINE");
+
+    const mock = linearMock({ createId: CONTESTED });
+    const primary = await resolvePrimaryProvider(db(), seed.teamId);
+    const reports = await projectRows(db(), primary as never, [doomed, ok], {
+      fetchImpl: mock.fetchImpl,
+      throttleMs: 0,
+    });
+
+    const byKey = Object.fromEntries(reports.map((r) => [r.row_key, r]));
+
+    // PRE-CHANGE BEHAVIOUR WAS `synced` WITH A NULL last_error — the update failed and nothing read
+    // the error. That is what makes this assertion distinguishing rather than green-by-construction.
+    expect(byKey.DOOM.status).toBe("failed");
+    expect(byKey.DOOM.error).toMatch(/bookkeeping/i);
+    const doomedLink = await readLink(seed.teamId, project, "DOOM");
+    expect(doomedLink?.last_error, "the failure must land on the link, not just the report").toBeTruthy();
+
+    // CONTAINED: the batch continued.
+    expect(byKey.FINE.status).toBe("synced");
+  });
+
+  it("INVERSE: nothing is partially persisted — the failing link's resource id is still NULL", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await makeProject(seed, "acme");
+    const CONTESTED = `li-inv-${randomUUID().slice(0, 8)}`;
+    await preclaim(seed, CONTESTED);
+
+    const doomed = await makeTask(seed, project, "DOOM");
+    const mock = linearMock({ createId: CONTESTED });
+    const primary = await resolvePrimaryProvider(db(), seed.teamId);
+    await projectRows(db(), primary as never, [doomed], { fetchImpl: mock.fetchImpl, throttleMs: 0 });
+
+    const link = await readLink(seed.teamId, project, "DOOM");
+    // Asserting the survivor's content is not enough — the removed half has to be asserted absent.
+    expect(link?.provider_resource_id).toBeNull();
+  });
+});
+
+describe("ADOPTUNIQ-1 — the `contested` channel", () => {
+  it("a child does NOT re-invoke the parent's adapter and is NOT parented to the contested id", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await makeProject(seed, "acme");
+
+    const CONTESTED = `li-parent-${randomUUID().slice(0, 8)}`;
+    await preclaim(seed, CONTESTED);
+
+    const parent = await makeTask(seed, project, "P1");
+    const child = await makeTask(seed, project, "C1", "P1");
+
+    const mock = linearMock({ createId: CONTESTED });
+    const primary = await resolvePrimaryProvider(db(), seed.teamId);
+    const reports = await projectRows(db(), primary as never, [parent, child], {
+      fetchImpl: mock.fetchImpl,
+      throttleMs: 0,
+    });
+    const byKey = Object.fromEntries(reports.map((r) => [r.row_key, r]));
+
+    expect(byKey.P1.status).toBe("failed");
+    expect(byKey.C1.status, "the child must fail rather than attach beneath an unclaimed issue").toBe("failed");
+    expect(byKey.C1.error).toMatch(/P1/);
+
+    // THE POINT. Without `contested`, the child misses `resolved`, takes the inline fallback, and
+    // re-projects the parent — a SECOND provider mutation in the same push, which is how a duplicate
+    // provider issue gets minted. Exactly one mutation is the whole guarantee.
+    expect(mock.mutations, `expected one provider mutation, got ${JSON.stringify(mock.mutations)}`).toHaveLength(1);
+
+    // And the child never got a link pointing at the contested id.
+    const childLink = await readLink(seed.teamId, project, "C1");
+    expect(childLink?.provider_resource_id ?? null).toBeNull();
+  });
+
+  it("a GRANDCHILD also completes with no further adapter invocations", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await makeProject(seed, "acme");
+    const CONTESTED = `li-gp-${randomUUID().slice(0, 8)}`;
+    await preclaim(seed, CONTESTED);
+
+    const gp = await makeTask(seed, project, "GP");
+    const p = await makeTask(seed, project, "P", "GP");
+    const c = await makeTask(seed, project, "C", "P");
+
+    const mock = linearMock({ createId: CONTESTED });
+    const primary = await resolvePrimaryProvider(db(), seed.teamId);
+    const reports = await projectRows(db(), primary as never, [gp, p, c], {
+      fetchImpl: mock.fetchImpl,
+      throttleMs: 0,
+    });
+    const byKey = Object.fromEntries(reports.map((r) => [r.row_key, r]));
+
+    expect(byKey.GP.status).toBe("failed");
+    expect(byKey.P.status).toBe("failed");
+    expect(byKey.C.status).toBe("failed");
+    expect(mock.mutations, "the failure must not fan out into N provider writes").toHaveLength(1);
+  });
+
+  /**
+   * THE SCOPE FENCE. `contested` covers PERSIST failures only. An adapter THROW already re-projects
+   * inline per child today; that behaviour is shipped and is deliberately untouched. Sweeping it in
+   * would be the over-correction, and this is the test that would catch it — so the baseline is
+   * written down exactly rather than asserted as a vague "unchanged".
+   */
+  it("the adapter-THROW path is UNCHANGED: the parent is still retried inline per child", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await makeProject(seed, "acme");
+
+    const parent = await makeTask(seed, project, "TP");
+    const child = await makeTask(seed, project, "TC", "TP");
+
+    const mock = throwingMock();
+    const primary = await resolvePrimaryProvider(db(), seed.teamId);
+    const reports = await projectRows(db(), primary as never, [parent, child], {
+      fetchImpl: mock.fetchImpl,
+      throttleMs: 0,
+    });
+    const byKey = Object.fromEntries(reports.map((r) => [r.row_key, r]));
+
+    expect(byKey.TP.status).toBe("failed");
+    expect(byKey.TC.status).toBe("failed");
+    // EXACTLY TWO: the parent's own attempt, plus the inline retry the child triggers. If a future
+    // change routes adapter throws through `contested` this drops to 1 and this test reddens — which
+    // is the entire point of pinning the number rather than the word "unchanged".
+    expect(mock.mutations, "shipped behaviour: the child re-projects the throwing parent inline").toHaveLength(2);
+  });
+
+  it("a STANDALONE projectTask has no contested channel, and that boundary is deliberate", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await makeProject(seed, "acme");
+    const CONTESTED = `li-solo-${randomUUID().slice(0, 8)}`;
+    await preclaim(seed, CONTESTED);
+
+    const row = await makeTask(seed, project, "SOLO");
+    const mock = linearMock({ createId: CONTESTED });
+    const report = await projectTask(db(), row, { fetchImpl: mock.fetchImpl });
+
+    // Contained and loud even without the map — the channel only ever existed to stop SIBLINGS
+    // re-invoking, and a standalone call has no siblings. A later cycle re-invoking is ordinary
+    // retry semantics, not the batch-internal double-mutation this guards.
+    expect(report.status).toBe("failed");
+    expect(mock.mutations).toHaveLength(1);
+  });
+});

--- a/test/datamechanics/pm-sync-containment.datamechanics.test.ts
+++ b/test/datamechanics/pm-sync-containment.datamechanics.test.ts
@@ -4,7 +4,15 @@ import { describe, expect, it, vi } from "vitest";
 import { projectRows, projectTask, type ProjectionTaskRow } from "@/lib/pm-sync/project";
 import { resolvePrimaryProvider } from "@/lib/pm-sync/project";
 import { upsertIntegration, setIntegrationSecret } from "@/lib/integrations/manage";
+import { withTransaction } from "@/lib/db/pg/tx";
 import { db, seedTeam, type Seed } from "./helpers";
+
+/** Raw DDL against the tier's database — the query builder cannot express triggers. */
+async function rawExec(sql: string): Promise<void> {
+  await withTransaction(async (c) => {
+    await c.query(sql);
+  });
+}
 
 /**
  * ADOPTUNIQ-1 — CONTAINMENT. The index is only safe because a rejected write is contained to the row
@@ -319,5 +327,64 @@ describe("ADOPTUNIQ-1 — the `contested` channel", () => {
     // retry semantics, not the batch-internal double-mutation this guards.
     expect(report.status).toBe("failed");
     expect(mock.mutations).toHaveLength(1);
+  });
+});
+
+describe("ADOPTUNIQ-1 — inbound containment is NARROW", () => {
+  /**
+   * The containment must swallow a uniqueness rejection and NOTHING else.
+   *
+   * A blanket catch would be worse than the abort it replaced: `skipped` does not feed `ok`
+   * (`summarizeInbound` counts `errors`), and a skipped-only result is not recorded by the manual
+   * sync at all — so a database outage during every adoption would report a clean, successful run.
+   * Losing the pass is the CORRECT outcome for an outage.
+   *
+   * Staged with a temporary trigger raising a NON-23505 error, because that is the only way to make
+   * the adopt transaction fail for a reason that is not a constraint the schema already enforces.
+   * Installed and dropped inside this test; `finally` runs even on assertion failure, since a
+   * surviving trigger would poison every later test against this database.
+   */
+  it("a NON-uniqueness database failure PROPAGATES rather than being reported as a clean run", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const project = await makeProject(seed, "acme");
+    const row = await makeTask(seed, project, "BOOM");
+
+    await db().from("task_pm_links").insert({
+      team_id: seed.teamId,
+      project_id: project,
+      row_key: "BOOM",
+      provider: "linear",
+      provider_external_id: "BOOM",
+    });
+
+    await rawExec(`
+      create or replace function adoptuniq_boom() returns trigger as $fn$
+      begin
+        if new.row_key = 'BOOM' then
+          raise exception 'simulated outage' using errcode = '08006';
+        end if;
+        return new;
+      end $fn$ language plpgsql;
+      create trigger adoptuniq_boom_trg before update on task_pm_links
+        for each row execute function adoptuniq_boom();
+    `);
+    try {
+      const mock = linearMock();
+      const primary = await resolvePrimaryProvider(db(), seed.teamId);
+      // The outbound path is the reachable one for this trigger, and it exercises the same rule:
+      // a non-uniqueness persist failure must be reported, never silently treated as success.
+      const reports = await projectRows(db(), primary as never, [row], {
+        fetchImpl: mock.fetchImpl,
+        throttleMs: 0,
+      });
+      expect(reports[0].status, "an outage-shaped failure must not read as synced").toBe("failed");
+      expect(reports[0].error).toMatch(/simulated outage/i);
+    } finally {
+      await rawExec(`
+        drop trigger if exists adoptuniq_boom_trg on task_pm_links;
+        drop function if exists adoptuniq_boom();
+      `);
+    }
   });
 });

--- a/test/datamechanics/pm-sync-containment.datamechanics.test.ts
+++ b/test/datamechanics/pm-sync-containment.datamechanics.test.ts
@@ -335,7 +335,7 @@ describe("ADOPTUNIQ-1 — inbound containment is NARROW", () => {
    * The containment must swallow a uniqueness rejection and NOTHING else.
    *
    * A blanket catch would be worse than the abort it replaced: `skipped` does not feed `ok`
-   * (`summarizeInbound` counts `errors`), and a skipped-only result is not recorded by the manual
+   * (`runLinearInbound` computes it from `errors` alone), and a skipped-only result is not recorded by the manual
    * sync at all — so a database outage during every adoption would report a clean, successful run.
    * Losing the pass is the CORRECT outcome for an outage.
    *

--- a/test/datamechanics/pm-sync-inbound.datamechanics.test.ts
+++ b/test/datamechanics/pm-sync-inbound.datamechanics.test.ts
@@ -520,8 +520,8 @@ describe("inbound adopt — Linear-native issues become owned team-tier tasks (r
    *
    * `adoptInbound` now catches around its `withTransaction` so that one contested issue cannot take
    * down the whole pass. That catch swallows ONLY SQLSTATE 23505 and re-throws everything else, and
-   * the re-throw is the load-bearing half: `skipped` does not feed `ok` (`summarizeInbound` counts
-   * `errors`), and a skipped-only result is not recorded by the manual sync at all — so a blanket
+   * the re-throw is the load-bearing half: `skipped` does not feed `ok` (`runLinearInbound` computes it from `errors`
+   * alone), and a skipped-only result is not recorded by the manual sync at all — so a blanket
    * catch would turn a database outage during every adoption into a clean, successful run. Losing
    * the pass is the CORRECT outcome for an outage.
    *

--- a/test/datamechanics/pm-sync-inbound.datamechanics.test.ts
+++ b/test/datamechanics/pm-sync-inbound.datamechanics.test.ts
@@ -515,6 +515,55 @@ describe("inbound adopt — Linear-native issues become owned team-tier tasks (r
     return (data as { id: string }).id;
   }
 
+  /**
+   * ADOPTUNIQ-1 — the per-candidate containment must be NARROW.
+   *
+   * `adoptInbound` now catches around its `withTransaction` so that one contested issue cannot take
+   * down the whole pass. That catch swallows ONLY SQLSTATE 23505 and re-throws everything else, and
+   * the re-throw is the load-bearing half: `skipped` does not feed `ok` (`summarizeInbound` counts
+   * `errors`), and a skipped-only result is not recorded by the manual sync at all — so a blanket
+   * catch would turn a database outage during every adoption into a clean, successful run. Losing
+   * the pass is the CORRECT outcome for an outage.
+   *
+   * Staged with a temporary trigger raising a non-23505 error; dropped in `finally`, because a
+   * surviving trigger would poison every later test against this database.
+   */
+  it("a NON-uniqueness failure during adopt PROPAGATES — an outage must not read as a clean pass", async () => {
+    const seed = await seedTeam();
+    await seedLinearPrimary(seed);
+    const mirror = await seedProject(seed.teamId, "linear-eng");
+    await seedMirrorTask(seed, mirror, "ENG-9");
+
+    await runSql(`
+        create or replace function adoptuniq_inbound_boom() returns trigger as $fn$
+        begin
+          if new.row_key = 'ENG-9' then
+            raise exception 'simulated outage' using errcode = '08006';
+          end if;
+          return new;
+        end $fn$ language plpgsql;
+        create trigger adoptuniq_inbound_boom_trg before insert on task_pm_links
+          for each row execute function adoptuniq_inbound_boom();
+    `);
+    try {
+      const native = issue("li-n9", "ls-started", {
+        identifier: "ENG-9",
+        title: "Native ENG-9",
+        description: "A Linear-authored description",
+        url: "https://linear.app/li-n9",
+      });
+      const mock = linearMock([native]);
+      await expect(
+        runInboundForTeam(db(), seed.teamId, { fetchImpl: mock.fetchImpl }),
+      ).rejects.toThrow(/simulated outage/i);
+    } finally {
+      await runSql(`
+        drop trigger if exists adoptuniq_inbound_boom_trg on task_pm_links;
+        drop function if exists adoptuniq_inbound_boom();
+      `);
+    }
+  });
+
   it("adopts: backfills the link + footer, flips origin to 'ui', seeds body, and never duplicates", async () => {
     const seed = await seedTeam();
     await seedLinearPrimary(seed);

--- a/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
+++ b/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
@@ -1,0 +1,321 @@
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+import { describe, expect, it } from "vitest";
+
+import { classifyBackstop, readBackstopStatus } from "@/lib/pm-sync/runs";
+import { db, seedTeam, type Seed } from "./helpers";
+
+/**
+ * ADOPTUNIQ-1 — the partial unique index, and the three ways its migration must REFUSE TO CREATE
+ * rather than abort a release.
+ *
+ * Design: docs/design/task-pm-links-unique-index.md
+ *
+ * WHY THESE RUN ON THEIR OWN SCRATCH DATABASE. Every test here does DDL — dropping the index,
+ * replaying the guarded block, installing a deliberately wrong one. The dm harness truncates ROWS,
+ * not DDL, so a mid-test failure against the shared test database would strand it without the index
+ * and redden unrelated tests phantomly (and the shared `:5434` container is contended by other
+ * worktrees). Each of these opens its own database instead, created and dropped here.
+ *
+ * The one exception is the LIVE-schema assertion at the end, which reads the catalog of the database
+ * the tier itself loaded — that is the only test that can prove the block in `postgres/schema.sql`
+ * actually ran during `db:test:up`.
+ */
+
+const INDEX = "task_pm_links_provider_resource_uq";
+
+/** The guarded block, byte-identical to the shipped migration — read from disk, never paraphrased. */
+async function guardedBlock(): Promise<string> {
+  const { readFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  return readFileSync(
+    join(__dirname, "..", "..", "postgres", "migrations", "20260826230000_task_pm_links_provider_resource_uq.sql"),
+    "utf8",
+  );
+}
+
+function adminUrl(): string {
+  const url = process.env.DATABASE_TEST_URL;
+  if (!url) throw new Error("DATABASE_TEST_URL required");
+  return url;
+}
+
+/** A throwaway database with just enough of the real shape to exercise the index. */
+async function withScratchDb<T>(fn: (c: Client, name: string) => Promise<T>): Promise<T> {
+  const name = `adoptuniq_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const admin = new Client({ connectionString: adminUrl() });
+  await admin.connect();
+  await admin.query(`create database ${name}`);
+  await admin.end();
+
+  const target = new URL(adminUrl());
+  target.pathname = `/${name}`;
+  const c = new Client({ connectionString: target.toString() });
+  await c.connect();
+  try {
+    // Minimal shape: the index only needs these four columns, and a full schema load per test would
+    // dominate the runtime without testing anything extra.
+    await c.query(`
+      create table task_pm_links (
+        id uuid primary key default gen_random_uuid(),
+        team_id uuid not null,
+        provider text not null,
+        provider_resource_id text,
+        row_key text not null
+      );
+    `);
+    return await fn(c, name);
+  } finally {
+    await c.end().catch(() => {});
+    const cleanup = new Client({ connectionString: adminUrl() });
+    await cleanup.connect();
+    await cleanup.query(`drop database if exists ${name} with (force)`).catch(() => {});
+    await cleanup.end().catch(() => {});
+  }
+}
+
+const TEAM_A = "11111111-1111-1111-1111-111111111111";
+const TEAM_B = "22222222-2222-2222-2222-222222222222";
+
+async function insertLink(
+  c: Client,
+  over: { team?: string; provider?: string; rid?: string | null; key?: string } = {},
+) {
+  return c.query(
+    `insert into task_pm_links (team_id, provider, provider_resource_id, row_key) values ($1,$2,$3,$4)`,
+    [over.team ?? TEAM_A, over.provider ?? "linear", over.rid === undefined ? "issue-1" : over.rid, over.key ?? randomUUID().slice(0, 8)],
+  );
+}
+
+async function indexCount(c: Client): Promise<number> {
+  const r = await c.query(`select count(*)::int as n from pg_indexes where indexname = $1`, [INDEX]);
+  return r.rows[0].n as number;
+}
+
+describe("ADOPTUNIQ-1 — what the index enforces once installed", () => {
+  it("REJECTS a second link claiming the same issue, with SQLSTATE 23505", async () => {
+    await withScratchDb(async (c) => {
+      await c.query(await guardedBlock());
+      expect(await indexCount(c)).toBe(1);
+
+      await insertLink(c, { rid: "issue-444" });
+      const err = await insertLink(c, { rid: "issue-444" }).catch((e) => e);
+      // The CODE, not the message — a message match would pass on an unrelated failure and would
+      // break under a non-English lc_messages on a self-hosted fleet.
+      expect(err.code).toBe("23505");
+      expect(err.constraint).toBe(INDEX);
+    });
+  });
+
+  it("PERMITS unlimited NULL resource ids — the live orphan row cannot be broken by this", async () => {
+    await withScratchDb(async (c) => {
+      await c.query(await guardedBlock());
+      await insertLink(c, { rid: null });
+      await insertLink(c, { rid: null });
+      await insertLink(c, { rid: null });
+      const n = await c.query(`select count(*)::int as n from task_pm_links where provider_resource_id is null`);
+      expect(n.rows[0].n).toBe(3);
+    });
+  });
+
+  it("keys on ALL THREE columns — same id under a different team or provider is allowed", async () => {
+    await withScratchDb(async (c) => {
+      await c.query(await guardedBlock());
+      await insertLink(c, { rid: "shared", team: TEAM_A, provider: "linear" });
+      // different team
+      await expect(insertLink(c, { rid: "shared", team: TEAM_B, provider: "linear" })).resolves.toBeDefined();
+      // different provider
+      await expect(insertLink(c, { rid: "shared", team: TEAM_A, provider: "plane" })).resolves.toBeDefined();
+      // and the actual duplicate still rejects, so the permissive cases above aren't vacuous
+      await expect(insertLink(c, { rid: "shared", team: TEAM_A, provider: "linear" })).rejects.toMatchObject({ code: "23505" });
+    });
+  });
+});
+
+describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () => {
+  it("DIRTY DATA: completes without raising, index absent, both rows intact", async () => {
+    await withScratchDb(async (c) => {
+      await insertLink(c, { rid: "dup" });
+      await insertLink(c, { rid: "dup" });
+
+      // A statement AFTER the block, in the same transaction, is what proves the schema load survived
+      // the caught exception — the property the whole design rests on.
+      await c.query(`begin`);
+      await c.query(await guardedBlock());
+      await c.query(`create table later_ran (x int)`);
+      await c.query(`commit`);
+
+      expect(await indexCount(c), "index must NOT be installed on dirty data").toBe(0);
+      const later = await c.query(`select count(*)::int as n from pg_tables where tablename = 'later_ran'`);
+      expect(later.rows[0].n, "the schema load must continue past the skip").toBe(1);
+      const rows = await c.query(`select count(*)::int as n from task_pm_links`);
+      expect(rows.rows[0].n, "no row may be touched by the skip").toBe(2);
+    });
+  });
+
+  it("DIRTY DATA committed by a SECOND connection is contained identically", async () => {
+    await withScratchDb(async (c, name) => {
+      const url = new URL(adminUrl());
+      url.pathname = `/${name}`;
+      const other = new Client({ connectionString: url.toString() });
+      await other.connect();
+      try {
+        await other.query(
+          `insert into task_pm_links (team_id, provider, provider_resource_id, row_key) values ($1,'linear','x','A'),($1,'linear','x','B')`,
+          [TEAM_A],
+        );
+      } finally {
+        await other.end();
+      }
+      await c.query(await guardedBlock());
+      expect(await indexCount(c)).toBe(0);
+    });
+  });
+
+  it("SELF-HEAL asymmetry: the duplicate-data skip does NOT heal until the data is repaired", async () => {
+    await withScratchDb(async (c) => {
+      await insertLink(c, { rid: "dup", key: "A" });
+      await insertLink(c, { rid: "dup", key: "B" });
+
+      await c.query(await guardedBlock());
+      expect(await indexCount(c), "still dirty -> still absent").toBe(0);
+
+      // Replaying against unchanged data must stay a clean no-op, not accumulate damage.
+      await c.query(await guardedBlock());
+      expect(await indexCount(c)).toBe(0);
+
+      // Only repairing the DATA installs it. This is the asymmetry the migration's warning states:
+      // unlike the contention skips, this one has no actor and will never self-heal on its own.
+      await c.query(`delete from task_pm_links where row_key = 'B'`);
+      await c.query(await guardedBlock());
+      expect(await indexCount(c), "repaired -> installed on the next deploy").toBe(1);
+    });
+  });
+
+  it("is IDEMPOTENT on a clean database — replay does not raise or duplicate", async () => {
+    await withScratchDb(async (c) => {
+      await c.query(await guardedBlock());
+      await c.query(await guardedBlock());
+      await c.query(await guardedBlock());
+      expect(await indexCount(c)).toBe(1);
+    });
+  });
+
+  /**
+   * THE ROUND-2 REGRESSION TEST. `pg-load-schema.mjs:66-67` sets `lock_timeout`. A non-concurrent
+   * CREATE INDEX takes SHARE and must wait out in-flight writes from the old app version, which is
+   * still serving during preDeploy. Before `when lock_not_available` was added, the timeout escaped
+   * the handler, poisoned the implicit transaction, and aborted the release — ON A CLEAN TABLE.
+   */
+  it("LOCK WAIT on a CLEAN table: contained, and the schema load continues", async () => {
+    await withScratchDb(async (c, name) => {
+      const url = new URL(adminUrl());
+      url.pathname = `/${name}`;
+      const holder = new Client({ connectionString: url.toString() });
+      await holder.connect();
+      try {
+        await holder.query(`begin`);
+        await holder.query(`insert into task_pm_links (team_id, provider, provider_resource_id, row_key) values ($1,'linear','held','H')`, [TEAM_A]);
+
+        await c.query(`set lock_timeout = 1000`);
+        await c.query(`begin`);
+        await c.query(await guardedBlock());
+        await c.query(`create table later_ran (x int)`);
+        await c.query(`commit`);
+
+        expect(await indexCount(c), "could not lock -> not installed").toBe(0);
+        const later = await c.query(`select count(*)::int as n from pg_tables where tablename = 'later_ran'`);
+        expect(later.rows[0].n, "the release must NOT abort on a lock wait").toBe(1);
+      } finally {
+        await holder.query(`rollback`).catch(() => {});
+        await holder.end().catch(() => {});
+      }
+    });
+  });
+
+  it("the LOCK skip DOES self-heal once the lock clears", async () => {
+    await withScratchDb(async (c, name) => {
+      const url = new URL(adminUrl());
+      url.pathname = `/${name}`;
+      const holder = new Client({ connectionString: url.toString() });
+      await holder.connect();
+      await holder.query(`begin`);
+      await holder.query(`insert into task_pm_links (team_id, provider, provider_resource_id, row_key) values ($1,'linear','held','H')`, [TEAM_A]);
+
+      await c.query(`set lock_timeout = 1000`);
+      await c.query(await guardedBlock());
+      expect(await indexCount(c)).toBe(0);
+
+      await holder.query(`rollback`);
+      await holder.end();
+
+      await c.query(await guardedBlock());
+      expect(await indexCount(c), "contention cleared -> installed, no operator step").toBe(1);
+    });
+  });
+});
+
+describe("ADOPTUNIQ-1 — the read-side backstop signal", () => {
+  it("reports `installed` against the tier's OWN live schema", async () => {
+    // The only assertion here that proves the block in postgres/schema.sql actually executed during
+    // `db:test:up`. If someone deletes the schema.sql copy, the guard test still passes (it reads
+    // files) but THIS reddens.
+    expect(await readBackstopStatus()).toBe("installed");
+  });
+
+  it("reports `missing` when the index is absent, and `malformed` for a wrong same-named index", async () => {
+    await withScratchDb(async (c) => {
+      const read = async () => {
+        const r = await c.query(
+          `select pg_get_indexdef(i.indexrelid) as indexdef, i.indisvalid as isvalid
+             from pg_index i join pg_class cl on cl.oid = i.indexrelid
+             join pg_namespace n on n.oid = cl.relnamespace
+            where n.nspname='public' and cl.relname=$1`,
+          [INDEX],
+        );
+        return classifyBackstop((r.rows[0] ?? null) as { indexdef: string; isvalid: boolean } | null);
+      };
+
+      expect(await read()).toBe("missing");
+
+      // The exact hole `create unique index IF NOT EXISTS` leaves open: it matches on NAME alone, so a
+      // wrong index of the right name makes every future deploy a silent no-op.
+      await c.query(`create index ${INDEX} on task_pm_links (team_id, provider, provider_resource_id) where provider_resource_id is not null`);
+      expect(await read(), "non-unique index of the right name must NOT read as installed").toBe("malformed");
+
+      await c.query(`drop index ${INDEX}`);
+      await c.query(await guardedBlock());
+      expect(await read()).toBe("installed");
+    });
+  });
+});
+
+describe("ADOPTUNIQ-1 — the live schema really carries the constraint", () => {
+  it("rejects a duplicate through the ordinary app client, not just raw SQL", async () => {
+    // Seeded INSIDE the test, not in beforeAll: the harness truncates between files, so a beforeAll
+    // seed is gone by the time the assertion runs and the FK failure reads like a product bug.
+    const seed: Seed = await seedTeam();
+    const { data: project } = await db()
+      .from("projects")
+      .insert({ team_id: seed.teamId, slug: `p-${randomUUID().slice(0, 8)}`, name: "p" })
+      .select("id")
+      .single();
+    const projectId = (project as { id: string }).id;
+    const rid = `issue-${randomUUID().slice(0, 8)}`;
+
+    const base = {
+      team_id: seed.teamId,
+      project_id: projectId,
+      provider: "linear",
+      provider_external_id: "X",
+      provider_resource_id: rid,
+    };
+    const first = await db().from("task_pm_links").insert({ ...base, row_key: "K1" });
+    expect(first.error, "the first link must insert").toBeFalsy();
+
+    // The pg adapter returns errors rather than throwing, which is exactly why the outbound path had
+    // to start READING them (lib/pm-sync/project.ts persistSuccess).
+    const second = await db().from("task_pm_links").insert({ ...base, row_key: "K2" });
+    expect(second.error, "a second link on the same issue must be refused by the DB").toBeTruthy();
+  });
+});

--- a/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
+++ b/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
@@ -361,6 +361,12 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
         expect(await indexCount(c), "deadlocked -> not installed").toBe(0);
         const later = await c.query(`select count(*)::int as n from pg_tables where tablename = 'later_ran'`);
         expect(later.rows[0].n, "the release must NOT abort on a deadlock").toBe(1);
+
+        // SELF-HEAL, asserted rather than inferred from the lock case's identical profile. The
+        // pre-code experiment could not isolate this (its fixture went dirty), so without this line
+        // the claim would rest on an analogy.
+        await c.query(await guardedBlock());
+        expect(await indexCount(c), "contention cleared -> installed on the next deploy").toBe(1);
       } finally {
         await old.query(`rollback`).catch(() => {});
         await old.end().catch(() => {});
@@ -388,6 +394,123 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       expect(await indexCount(c), "contention cleared -> installed, no operator step").toBe(1);
     });
   });
+});
+
+describe("ADOPTUNIQ-1 — the skip is AUDIBLE, and survives the real loader", () => {
+  it("each branch RAISES ITS OWN WARNING, delivered through the notice channel", async () => {
+    // `pg-load-schema.mjs:57` installs a `notice` listener precisely so RAISE WARNING reaches the
+    // deploy log. That log line is the only signal a skipped fleet gets at deploy time, and an
+    // untested warning is a signal nobody has ever seen fire.
+    await withScratchDb(async (c, name) => {
+      const url = new URL(adminUrl());
+      url.pathname = `/${name}`;
+      const listening = new Client({ connectionString: url.toString() });
+      const notices: string[] = [];
+      listening.on("notice", (n) => notices.push(String(n.message)));
+      await listening.connect();
+      try {
+        await listening.query(
+          `insert into task_pm_links (team_id, provider, provider_resource_id, row_key) values ($1,'linear','dup','A'),($1,'linear','dup','B')`,
+          [TEAM_A],
+        );
+        await listening.query(await guardedBlock());
+        expect(
+          notices.some((m) => /duplicate provider_resource_id/i.test(m)),
+          `expected a duplicate-data warning, got ${JSON.stringify(notices)}`,
+        ).toBe(true);
+        // And it names the consequence, not just the condition — a fleet reading this needs to know
+        // the backstop is absent and that THIS skip will not repair itself.
+        expect(notices.join(" ")).toMatch(/NOT installed/i);
+        expect(notices.join(" ")).toMatch(/does NOT self-heal/i);
+      } finally {
+        await listening.end().catch(() => {});
+      }
+    });
+  });
+
+  it("THE REAL LOADER survives a dirty upgrade — schema.sql AND every migration still apply", async () => {
+    /**
+     * The other cases execute the guarded block directly. This one runs `loadSchema` itself — the
+     * actual Railway preDeployCommand — so the property under test is the real one: schema.sql is
+     * sent as ONE implicit transaction, and a caught exception inside it must not poison the rest of
+     * the load.
+     *
+     * Staged as a genuine UPGRADE: load once (clean, index created), drop the index, dirty the data,
+     * then load again exactly as a deploy would.
+     */
+    const { pathToFileURL } = await import("node:url");
+    const { join: joinPath } = await import("node:path");
+    // Imported by file URL: the module is a plain .mjs outside the "@/" alias root, and it must be
+    // the REAL one — a re-implementation here would test a paraphrase of the deploy path.
+    const { loadSchema } = await import(
+      pathToFileURL(joinPath(__dirname, "..", "..", "scripts", "pg-load-schema.mjs")).href
+    );
+    const name = `adoptuniq_loader_${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const admin = new Client({ connectionString: adminUrl() });
+    await admin.connect();
+    await admin.query(`create database ${name}`);
+    await admin.end();
+    const url = new URL(adminUrl());
+    url.pathname = `/${name}`;
+
+    const c = new Client({ connectionString: url.toString() });
+    await c.connect();
+    try {
+      await loadSchema({ databaseUrl: url.toString(), logger: { log: () => {} } });
+      expect(await indexCount(c), "a clean from-zero load installs it").toBe(1);
+
+      await c.query(`drop index ${INDEX}`);
+      // Staged UNCONDITIONALLY. An earlier version used an `insert … select` over teams/projects with
+      // a `.catch()` fallback — but the select matched ZERO rows rather than erroring, so the catch
+      // never fired, no duplicate existed, and the test passed over an empty table while asserting
+      // nothing. The rows are checked in.
+      /**
+       * The marker is stamped because the moment this test inserts a `teams` row it becomes a
+       * NON-EMPTY fleet, and `20260818210000_pret6_retire_access_enforcement.sql` REFUSES to replay
+       * against one that has not completed the PRET-4 builtin materialization — aborting the load
+       * with P0001 for a reason that has nothing to do with this index. A real fleet stamps this at
+       * boot; emulating that is what makes the reload below exercise the branch under test rather
+       * than an unrelated precondition.
+       */
+      await c.query(
+        `insert into migration_markers (name) values ('pret4_builtin_materialize') on conflict (name) do nothing`,
+      );
+      const { rows: tr } = await c.query(`insert into teams (slug, name) values ('dirty','d') returning id`);
+      const { rows: pr } = await c.query(
+        `insert into projects (team_id, slug, name) values ($1,'dp','dp') returning id`,
+        [tr[0].id],
+      );
+      for (const k of ["A", "B"]) {
+        await c.query(
+          `insert into task_pm_links (team_id, project_id, row_key, provider, provider_external_id, provider_resource_id)
+           values ($1,$2,$3,'linear',$3,'dup')`,
+          [tr[0].id, pr[0].id, k],
+        );
+      }
+      const dupes = await c.query(
+        `select count(*)::int as n from task_pm_links where provider_resource_id = 'dup'`,
+      );
+      expect(dupes.rows[0].n, "the duplicate must actually exist or this proves nothing").toBe(2);
+
+      // THE ASSERTION: a deploy over dirty data completes. Before the guard, this threw and Railway
+      // halted the release.
+      await expect(
+        loadSchema({ databaseUrl: url.toString(), logger: { log: () => {} } }),
+      ).resolves.toBeUndefined();
+      expect(await indexCount(c), "dirty -> skipped, and the rest of the load still applied").toBe(0);
+
+      // Prove the load really did continue rather than stopping early at the block: a table created
+      // by a LATER migration must exist.
+      const later = await c.query(`select count(*)::int as n from pg_tables where tablename = 'connector_cursors'`);
+      expect(later.rows[0].n, "statements after the guarded block must still have applied").toBe(1);
+    } finally {
+      await c.end().catch(() => {});
+      const cleanup = new Client({ connectionString: adminUrl() });
+      await cleanup.connect();
+      await cleanup.query(`drop database if exists ${name} with (force)`).catch(() => {});
+      await cleanup.end().catch(() => {});
+    }
+  }, 120_000);
 });
 
 describe("ADOPTUNIQ-1 — the read-side backstop signal", () => {

--- a/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
+++ b/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
@@ -515,9 +515,9 @@ describe("ADOPTUNIQ-1 — the skip is AUDIBLE, and survives the real loader", ()
 
 describe("ADOPTUNIQ-1 — the read-side backstop signal", () => {
   it("reports `installed` against the tier's OWN live schema", async () => {
-    // The only assertion here that proves the block in postgres/schema.sql actually executed during
-    // `db:test:up`. If someone deletes the schema.sql copy, the guard test still passes (it reads
-    // files) but THIS reddens.
+    // The distinct property here is EXECUTION, not existence: the unit guard reads the files and would
+    // also redden if the schema.sql copy were deleted, but only this can show the block actually RAN
+    // during `db:test:up` and produced a real catalog object.
     expect(await readBackstopStatus()).toBe("installed");
   });
 

--- a/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
+++ b/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
@@ -43,10 +43,31 @@ function adminUrl(): string {
 /** A throwaway database with just enough of the real shape to exercise the index. */
 async function withScratchDb<T>(fn: (c: Client, name: string) => Promise<T>): Promise<T> {
   const name = `adoptuniq_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
-  const admin = new Client({ connectionString: adminUrl() });
-  await admin.connect();
-  await admin.query(`create database ${name}`);
-  await admin.end();
+  /**
+   * RETRIED, because it flaked once in a full parallel run and a 1-in-N test is a liability.
+   *
+   * `create database` takes a short exclusive lock and can transiently fail while other files in the
+   * tier are creating or dropping their own scratch databases. The failure surfaced as a bare
+   * assertion mismatch in an unrelated-looking case, which is precisely how infrastructure contention
+   * gets misread as a product bug. Bounded, and it rethrows rather than silently proceeding against a
+   * database that does not exist.
+   */
+  let created = false;
+  let lastErr: unknown = null;
+  for (let attempt = 0; attempt < 5 && !created; attempt++) {
+    const admin = new Client({ connectionString: adminUrl() });
+    try {
+      await admin.connect();
+      await admin.query(`create database ${name}`);
+      created = true;
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 100 * (attempt + 1)));
+    } finally {
+      await admin.end().catch(() => {});
+    }
+  }
+  if (!created) throw new Error(`could not create scratch database ${name}: ${String(lastErr)}`);
 
   const target = new URL(adminUrl());
   target.pathname = `/${name}`;
@@ -171,6 +192,46 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       expect(later.rows[0].n, "the schema load must continue past the skip").toBe(1);
       const rows = await c.query(`select count(*)::int as n from task_pm_links`);
       expect(rows.rows[0].n, "no row may be touched by the skip").toBe(2);
+    });
+  });
+
+  /**
+   * THE POSITIVE CONTROL FOR THE INVARIANT QUERY, rehomed from
+   * `pm-link-uniqueness.datamechanics.test.ts`.
+   *
+   * That file used to prove its `duplicateGroups` detector non-vacuous by inserting a real duplicate
+   * and asserting the query REPORTED it. The index makes that impossible in the tier's shared
+   * database — nothing can be duplicated there any more — so the control would have been silently
+   * lost, leaving every `toEqual([])` in that file green by construction with nothing proving the
+   * query can ever return a non-empty result.
+   *
+   * Here it still works, because this scratch database has no index until the block runs.
+   */
+  it("the invariant QUERY can still report a duplicate — the control the index would have deleted", async () => {
+    await withScratchDb(async (c) => {
+      await insertLink(c, { rid: "dup", key: "A" });
+      await insertLink(c, { rid: "dup", key: "B" });
+      // Same shape as pm-link-uniqueness's `duplicateGroups`: grouped by (provider, resource id),
+      // NULLs excluded by the identical predicate the index uses.
+      const groups = await c.query(
+        `select provider, provider_resource_id, count(*)::int as n
+           from task_pm_links
+          where provider_resource_id is not null
+          group by provider, provider_resource_id
+         having count(*) > 1`,
+      );
+      expect(groups.rows).toEqual([{ provider: "linear", provider_resource_id: "dup", n: 2 }]);
+
+      // And it is provider-scoped, matching the index it mirrors: the same id under a different
+      // provider is NOT a violation.
+      await insertLink(c, { rid: "solo", provider: "linear", key: "C" });
+      await insertLink(c, { rid: "solo", provider: "plane", key: "D" });
+      const after = await c.query(
+        `select provider_resource_id from task_pm_links
+          where provider_resource_id is not null
+          group by provider, provider_resource_id having count(*) > 1`,
+      );
+      expect(after.rows.map((r) => r.provider_resource_id)).toEqual(["dup"]);
     });
   });
 

--- a/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
+++ b/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
@@ -24,6 +24,16 @@ import { db, seedTeam, type Seed } from "./helpers";
 
 const INDEX = "task_pm_links_provider_resource_uq";
 
+/**
+ * Every scratch-database case needs far more than the tier's 5s default, and the reason is real work
+ * rather than a slow assertion: each one CREATEs a database (Postgres copies `template1`), connects,
+ * runs DDL, and DROPs it — and under the full tier a dozen files do that concurrently. Two of three
+ * full runs timed out here at 5s while passing standalone in ~2s, which is the signature of
+ * contention, not of a hang. Raising it is the honest fix; the alternative is a test that reddens for
+ * reasons that have nothing to do with the index.
+ */
+const SCRATCH_TIMEOUT = 60_000;
+
 /** The guarded block, byte-identical to the shipped migration — read from disk, never paraphrased. */
 async function guardedBlock(): Promise<string> {
   const { readFileSync } = await import("node:fs");
@@ -147,7 +157,7 @@ describe("ADOPTUNIQ-1 — what the index enforces once installed", () => {
       expect(err.code).toBe("23505");
       expect(err.constraint).toBe(INDEX);
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   it("PERMITS unlimited NULL resource ids — the live orphan row cannot be broken by this", async () => {
     await withScratchDb(async (c) => {
@@ -158,7 +168,7 @@ describe("ADOPTUNIQ-1 — what the index enforces once installed", () => {
       const n = await c.query(`select count(*)::int as n from task_pm_links where provider_resource_id is null`);
       expect(n.rows[0].n).toBe(3);
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   it("keys on ALL THREE columns — same id under a different team or provider is allowed", async () => {
     await withScratchDb(async (c) => {
@@ -171,7 +181,7 @@ describe("ADOPTUNIQ-1 — what the index enforces once installed", () => {
       // and the actual duplicate still rejects, so the permissive cases above aren't vacuous
       await expect(insertLink(c, { rid: "shared", team: TEAM_A, provider: "linear" })).rejects.toMatchObject({ code: "23505" });
     });
-  });
+  }, SCRATCH_TIMEOUT);
 });
 
 describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () => {
@@ -193,7 +203,7 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       const rows = await c.query(`select count(*)::int as n from task_pm_links`);
       expect(rows.rows[0].n, "no row may be touched by the skip").toBe(2);
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   /**
    * THE POSITIVE CONTROL FOR THE INVARIANT QUERY, rehomed from
@@ -233,7 +243,7 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       );
       expect(after.rows.map((r) => r.provider_resource_id)).toEqual(["dup"]);
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   it("DIRTY DATA committed by a SECOND connection is contained identically", async () => {
     await withScratchDb(async (c, name) => {
@@ -252,7 +262,7 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       await c.query(await guardedBlock());
       expect(await indexCount(c)).toBe(0);
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   it("SELF-HEAL asymmetry: the duplicate-data skip does NOT heal until the data is repaired", async () => {
     await withScratchDb(async (c) => {
@@ -272,7 +282,7 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       await c.query(await guardedBlock());
       expect(await indexCount(c), "repaired -> installed on the next deploy").toBe(1);
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   it("is IDEMPOTENT on a clean database — replay does not raise or duplicate", async () => {
     await withScratchDb(async (c) => {
@@ -281,7 +291,7 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       await c.query(await guardedBlock());
       expect(await indexCount(c)).toBe(1);
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   /**
    * THE ROUND-2 REGRESSION TEST. `pg-load-schema.mjs:66-67` sets `lock_timeout`. A non-concurrent
@@ -313,7 +323,7 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
         await holder.end().catch(() => {});
       }
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   /**
    * THE ROUND-3 REGRESSION TEST, and it exists because the mutation SURVIVED without it.
@@ -372,7 +382,7 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
         await old.end().catch(() => {});
       }
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   it("the LOCK skip DOES self-heal once the lock clears", async () => {
     await withScratchDb(async (c, name) => {
@@ -393,7 +403,7 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       await c.query(await guardedBlock());
       expect(await indexCount(c), "contention cleared -> installed, no operator step").toBe(1);
     });
-  });
+  }, SCRATCH_TIMEOUT);
 });
 
 describe("ADOPTUNIQ-1 — the skip is AUDIBLE, and survives the real loader", () => {
@@ -426,7 +436,7 @@ describe("ADOPTUNIQ-1 — the skip is AUDIBLE, and survives the real loader", ()
         await listening.end().catch(() => {});
       }
     });
-  });
+  }, SCRATCH_TIMEOUT);
 
   it("THE REAL LOADER survives a dirty upgrade — schema.sql AND every migration still apply", async () => {
     /**
@@ -545,7 +555,7 @@ describe("ADOPTUNIQ-1 — the read-side backstop signal", () => {
       await c.query(await guardedBlock());
       expect(await read()).toBe("installed");
     });
-  });
+  }, SCRATCH_TIMEOUT);
 });
 
 describe("ADOPTUNIQ-1 — the live schema really carries the constraint", () => {

--- a/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
+++ b/test/datamechanics/task-pm-links-unique-index.datamechanics.test.ts
@@ -63,6 +63,11 @@ async function withScratchDb<T>(fn: (c: Client, name: string) => Promise<T>): Pr
         provider_resource_id text,
         row_key text not null
       );
+      -- A second relation, so a DEADLOCK cycle can be staged: the deploy transaction locks this one
+      -- first (standing in for the ACCESS EXCLUSIVE locks schema.sql accumulates from its earlier
+      -- alter-table-if-not-exists no-ops), while the old app version waits on it.
+      create table other_rel (x int);
+      insert into other_rel values (1);
     `);
     return await fn(c, name);
   } finally {
@@ -85,6 +90,22 @@ async function insertLink(
     `insert into task_pm_links (team_id, provider, provider_resource_id, row_key) values ($1,$2,$3,$4)`,
     [over.team ?? TEAM_A, over.provider ?? "linear", over.rid === undefined ? "issue-1" : over.rid, over.key ?? randomUUID().slice(0, 8)],
   );
+}
+
+/** Block until some backend is actually WAITING on `rel` — polling beats a fixed sleep, which would
+ *  either flake on a slow machine or silently stage no contention at all. */
+async function waitForWaiter(c: Client, rel: string): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    const r = await c.query(
+      `select count(*)::int as n from pg_locks l
+         join pg_class cl on cl.oid = l.relation
+        where cl.relname = $1 and not l.granted`,
+      [rel],
+    );
+    if ((r.rows[0].n as number) > 0) return;
+    await new Promise((res) => setTimeout(res, 50));
+  }
+  throw new Error(`no backend ever waited on ${rel} — the deadlock was never staged`);
 }
 
 async function indexCount(c: Client): Promise<number> {
@@ -229,6 +250,59 @@ describe("ADOPTUNIQ-1 — the block SKIPS rather than aborting the release", () 
       } finally {
         await holder.query(`rollback`).catch(() => {});
         await holder.end().catch(() => {});
+      }
+    });
+  });
+
+  /**
+   * THE ROUND-3 REGRESSION TEST, and it exists because the mutation SURVIVED without it.
+   *
+   * `deadlock_timeout` defaults to 1s — well before the 15s `lock_timeout` — and by the time this
+   * block runs, `schema.sql` has already taken ACCESS EXCLUSIVE locks from its earlier
+   * `alter table … if not exists` no-ops while the old app version is still serving. So a genuine
+   * cycle is ordinary, not exotic. Staged and confirmed: this transaction is chosen victim, and
+   * without `when deadlock_detected` the 40P01 escapes, poisons the implicit transaction, and aborts
+   * the release — on a CLEAN table, with zero dirty data.
+   */
+  it("DEADLOCK on a CLEAN table: contained, and the schema load continues", async () => {
+    await withScratchDb(async (c, name) => {
+      const url = new URL(adminUrl());
+      url.pathname = `/${name}`;
+      const old = new Client({ connectionString: url.toString() });
+      await old.connect();
+      try {
+        await c.query(`set deadlock_timeout = '100ms'`);
+        await c.query(`set lock_timeout = 30000`);
+
+        // 1. The old app takes ROW EXCLUSIVE on task_pm_links — the relation we are about to index.
+        await old.query(`begin`);
+        await old.query(
+          `insert into task_pm_links (team_id, provider, provider_resource_id, row_key) values ($1,'linear','held','H')`,
+          [TEAM_A],
+        );
+
+        // 2. The deploy transaction takes ACCESS EXCLUSIVE on the other relation.
+        await c.query(`begin`);
+        await c.query(`lock table other_rel in access exclusive mode`);
+
+        // 3. The old app now requests the relation we hold -> it waits on us. NOT awaited: it blocks.
+        const blocked = old.query(`update other_rel set x = x + 1`).catch(() => undefined);
+        await waitForWaiter(c, "other_rel");
+
+        // 4. We request the relation IT holds -> cycle. One of us is the victim.
+        await c.query(await guardedBlock());
+        await c.query(`create table later_ran (x int)`);
+        await c.query(`commit`);
+
+        await old.query(`rollback`).catch(() => {});
+        await blocked;
+
+        expect(await indexCount(c), "deadlocked -> not installed").toBe(0);
+        const later = await c.query(`select count(*)::int as n from pg_tables where tablename = 'later_ran'`);
+        expect(later.rows[0].n, "the release must NOT abort on a deadlock").toBe(1);
+      } finally {
+        await old.query(`rollback`).catch(() => {});
+        await old.end().catch(() => {});
       }
     });
   });

--- a/test/guards/task-pm-links-unique-index.test.ts
+++ b/test/guards/task-pm-links-unique-index.test.ts
@@ -1,0 +1,212 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { classifyBackstop } from "@/lib/pm-sync/runs";
+
+/**
+ * ADOPTUNIQ-1 — the partial unique index on `task_pm_links` may only ever be created by a GUARDED
+ * `do $$ … $$` block, and that block must catch all three demonstrated abort codes.
+ *
+ * WHY A BUILD-FAILING GUARD RATHER THAN A COMMENT. `scripts/pg-load-schema.mjs` loads
+ * `postgres/schema.sql` FIRST (:69) and then the migrations (:72-78), and — unlike a column inside
+ * `create table if not exists`, which is a no-op on an existing DB — a top-level
+ * `create unique index` DOES execute against an existing database. `schema.sql` is sent as a single
+ * multi-statement query, i.e. ONE implicit transaction, so an unguarded failure there aborts the
+ * ENTIRE schema load on a deploy where the old app version is still serving and still writing these
+ * rows. "Someone tidies the guarded block into a plain create index" is the regression this exists to
+ * make impossible, and it is exactly the kind of edit that looks like cleanup in review.
+ *
+ * Every `when` clause below traces to a STAGED failure against real Postgres 16, not a guess:
+ *   • unique_violation (23505)   — duplicate data.
+ *   • lock_not_available (55P03) — `pg-load-schema.mjs:66-67` sets `lock_timeout`; a lock wait past it
+ *     escaped a 23505-only handler on a CLEAN table and aborted the release.
+ *   • deadlock_detected (40P01)  — `deadlock_timeout` defaults to 1s, well before the 15s
+ *     `lock_timeout`; a staged cycle picked this transaction as victim and aborted the release, again
+ *     with zero dirty data.
+ */
+
+const ROOT = join(__dirname, "..", "..");
+const SCHEMA = join(ROOT, "postgres", "schema.sql");
+const MIGRATIONS_DIR = join(ROOT, "postgres", "migrations");
+const MIGRATION = join(MIGRATIONS_DIR, "20260826230000_task_pm_links_provider_resource_uq.sql");
+
+const INDEX_NAME = "task_pm_links_provider_resource_uq";
+
+/**
+ * Strip SQL line comments before matching.
+ *
+ * NOT cosmetic: `20260817164500_task_pm_links_declared_external_id.sql:12-16` already DESCRIBES this
+ * index in prose, and this migration's own header quotes the DDL repeatedly. A comment-blind matcher
+ * would count those as creators and the "exactly one creator" assertion below would pass for the
+ * wrong reason — the guard would then survive the deletion of the real statement.
+ */
+export function stripSqlComments(sql: string): string {
+  return sql
+    .split("\n")
+    .map((line) => {
+      const i = line.indexOf("--");
+      return i === -1 ? line : line.slice(0, i);
+    })
+    .join("\n");
+}
+
+/** Count real `create unique index` statements naming this index (comments excluded). */
+export function countCreators(sql: string): number {
+  const code = stripSqlComments(sql).toLowerCase();
+  return (code.match(new RegExp(`create\\s+unique\\s+index[^;]*${INDEX_NAME}`, "g")) ?? []).length;
+}
+
+/**
+ * Is every creator in this file inside a `do $$ … $$` body that catches all three codes?
+ *
+ * Written as a ∀ over the file's DO blocks containing a creator: an existential ("some block has the
+ * handlers") is satisfied by a sibling block the regression never touched, which is precisely the
+ * failure mode that makes a guard decorative.
+ */
+export function creatorsAreGuarded(sql: string): boolean {
+  const code = stripSqlComments(sql).toLowerCase();
+  const blocks = code.match(/do\s+\$\$[\s\S]*?end\s*\$\$/g) ?? [];
+  const creatorsInBlocks = blocks.reduce((n, b) => n + countCreators(b), 0);
+  if (creatorsInBlocks !== countCreators(code)) return false; // a creator outside any DO block
+  return blocks
+    .filter((b) => countCreators(b) > 0)
+    .every(
+      (b) =>
+        b.includes("when unique_violation") &&
+        b.includes("when lock_not_available") &&
+        b.includes("when deadlock_detected"),
+    );
+}
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .map((f) => join(MIGRATIONS_DIR, f));
+}
+
+describe("ADOPTUNIQ-1 — the unique index has exactly one guarded creator per target file", () => {
+  it("BOTH target files carry exactly ONE real creator", () => {
+    // POSITIVE, not merely a rejection. A rejection-only matcher ("no bare create") stays green
+    // forever if someone deletes the index entirely — and was green against the pre-change tree,
+    // where no such index existed at all.
+    expect(countCreators(readFileSync(SCHEMA, "utf8")), "postgres/schema.sql").toBe(1);
+    expect(countCreators(readFileSync(MIGRATION, "utf8")), "the ADOPTUNIQ-1 migration").toBe(1);
+  });
+
+  it("EVERY other migration file carries ZERO creators", () => {
+    for (const f of migrationFiles()) {
+      if (f === MIGRATION) continue;
+      expect(countCreators(readFileSync(f, "utf8")), f).toBe(0);
+    }
+  });
+
+  it("every creator in both files is inside a DO block catching all THREE codes", () => {
+    for (const f of [SCHEMA, MIGRATION]) {
+      expect(creatorsAreGuarded(readFileSync(f, "utf8")), f).toBe(true);
+    }
+  });
+
+  it("no file reaches the same invariant via `alter table … add constraint … unique`", () => {
+    // The index is not the only way to add this constraint, and a UNIQUE CONSTRAINT cannot be
+    // partial — it would reject the NULL-resource-id orphan rows the predicate deliberately permits,
+    // and it has no `if not exists`, so it would abort every replay. Forbidden outright.
+    const forbidden = /alter\s+table[^;]*task_pm_links[^;]*add\s+constraint[^;]*unique/i;
+    for (const f of [SCHEMA, ...migrationFiles()]) {
+      expect(forbidden.test(stripSqlComments(readFileSync(f, "utf8"))), f).toBe(false);
+    }
+  });
+});
+
+describe("ADOPTUNIQ-1 — the guard is non-vacuous (in-memory fixtures, repo files untouched)", () => {
+  const GUARDED = `do $$
+begin
+  create unique index if not exists ${INDEX_NAME}
+    on task_pm_links (team_id, provider, provider_resource_id)
+    where provider_resource_id is not null;
+exception
+  when unique_violation then raise warning 'x';
+  when lock_not_available then raise warning 'y';
+  when deadlock_detected then raise warning 'z';
+end $$;`;
+
+  it("accepts the real shape", () => {
+    expect(countCreators(GUARDED)).toBe(1);
+    expect(creatorsAreGuarded(GUARDED)).toBe(true);
+  });
+
+  it("REJECTS a bare create outside any DO block — the tidy-up regression", () => {
+    const bare = `create unique index if not exists ${INDEX_NAME} on task_pm_links (team_id, provider, provider_resource_id) where provider_resource_id is not null;`;
+    expect(countCreators(bare)).toBe(1);
+    expect(creatorsAreGuarded(bare)).toBe(false);
+  });
+
+  /**
+   * One condition per fixture: each mutant drops exactly ONE `when` clause, so a fixture cannot pass
+   * by tripping a different term than the one it targets.
+   */
+  it.each([
+    ["unique_violation", "when unique_violation then raise warning 'x';"],
+    ["lock_not_available", "when lock_not_available then raise warning 'y';"],
+    ["deadlock_detected", "when deadlock_detected then raise warning 'z';"],
+  ])("REJECTS a block missing `when %s`", (_name, clause) => {
+    const mutant = GUARDED.replace(`  ${clause}\n`, "");
+    expect(mutant, "the mutation must actually change the fixture").not.toBe(GUARDED);
+    expect(creatorsAreGuarded(mutant)).toBe(false);
+  });
+
+  it("is COMMENT-AWARE: prose quoting the DDL is not a creator", () => {
+    // 20260817164500 already describes this index in prose; without this, that file would count as a
+    // creator and the per-file counts above would be satisfied by a comment.
+    const prose = `-- create unique index if not exists ${INDEX_NAME} on task_pm_links (...)
+-- (deliberately not shipped here)
+select 1;`;
+    expect(countCreators(prose)).toBe(0);
+  });
+
+  it("a commented-out creator does not satisfy the exactly-one count", () => {
+    const commentedOnly = GUARDED.split("\n").map((l) => `-- ${l}`).join("\n");
+    expect(countCreators(commentedOnly)).toBe(0);
+  });
+});
+
+describe("ADOPTUNIQ-1 — backstop classification fails CLOSED", () => {
+  const GOOD =
+    "CREATE UNIQUE INDEX task_pm_links_provider_resource_uq ON public.task_pm_links USING btree (team_id, provider, provider_resource_id) WHERE (provider_resource_id IS NOT NULL)";
+
+  it("a correct, valid index is `installed`", () => {
+    expect(classifyBackstop({ indexdef: GOOD, isvalid: true })).toBe("installed");
+  });
+
+  it("an absent index is `missing`, never `installed`", () => {
+    expect(classifyBackstop(null)).toBe("missing");
+  });
+
+  it("an INVALID index of the right shape is `malformed`", () => {
+    // A failed CREATE INDEX CONCURRENTLY leaves an invalid index that enforces nothing.
+    expect(classifyBackstop({ indexdef: GOOD, isvalid: false })).toBe("malformed");
+  });
+
+  /**
+   * These are the cases `create unique index IF NOT EXISTS` silently accepts: it matches on NAME
+   * alone, so any same-named relation makes the deploy look successful while enforcing nothing (or
+   * the wrong thing). One condition per fixture.
+   */
+  it.each([
+    ["not unique", GOOD.replace("CREATE UNIQUE INDEX", "CREATE INDEX")],
+    ["wrong column order", GOOD.replace("(team_id, provider, provider_resource_id)", "(provider, team_id, provider_resource_id)")],
+    ["missing a key column", GOOD.replace("(team_id, provider, provider_resource_id)", "(team_id, provider_resource_id)")],
+    ["no partial predicate", GOOD.replace(" WHERE (provider_resource_id IS NOT NULL)", "")],
+    ["wrong predicate", GOOD.replace("IS NOT NULL", "IS NULL")],
+    ["wrong table", GOOD.replace("public.task_pm_links", "public.tasks")],
+    ["wrong schema", GOOD.replace("public.task_pm_links", "other.task_pm_links")],
+  ])("a same-named index that is %s reads as `malformed`", (_name, indexdef) => {
+    expect(indexdef, "the mutation must actually change the fixture").not.toBe(GOOD);
+    expect(classifyBackstop({ indexdef, isvalid: true })).toBe("malformed");
+  });
+
+  it("whitespace-normalises rather than string-matching our source DDL", () => {
+    const noisy = GOOD.replace(/ /g, "  ").replace("USING", "\n  USING");
+    expect(classifyBackstop({ indexdef: noisy, isvalid: true })).toBe("installed");
+  });
+});

--- a/test/guards/task-pm-links-unique-index.test.ts
+++ b/test/guards/task-pm-links-unique-index.test.ts
@@ -51,10 +51,17 @@ export function stripSqlComments(sql: string): string {
     .join("\n");
 }
 
-/** Count real `create unique index` statements naming this index (comments excluded). */
+/**
+ * Count real `create unique index` statements ON `task_pm_links` (comments excluded).
+ *
+ * Matched on the TABLE, not on our index NAME. Keying on the name let a bare equivalent index under
+ * any other spelling escape the guard entirely and restore the preDeploy abort path this whole file
+ * exists to prevent — the invariant is "no unguarded unique index on this table", not "no unguarded
+ * index called X".
+ */
 export function countCreators(sql: string): number {
   const code = stripSqlComments(sql).toLowerCase();
-  return (code.match(new RegExp(`create\\s+unique\\s+index[^;]*${INDEX_NAME}`, "g")) ?? []).length;
+  return (code.match(/create\s+unique\s+index[^;]*?\btask_pm_links\b/g) ?? []).length;
 }
 
 /**
@@ -155,6 +162,14 @@ end $$;`;
     expect(creatorsAreGuarded(mutant)).toBe(false);
   });
 
+  it("REJECTS an equivalent unique index under a DIFFERENT name", () => {
+    // Keying the matcher on our index NAME let this through, and a bare create on this table is the
+    // preDeploy abort path regardless of what it is called.
+    const aliased = `create unique index if not exists some_other_name on task_pm_links (team_id, provider, provider_resource_id) where provider_resource_id is not null;`;
+    expect(countCreators(aliased)).toBe(1);
+    expect(creatorsAreGuarded(aliased)).toBe(false);
+  });
+
   it("is COMMENT-AWARE: prose quoting the DDL is not a creator", () => {
     // 20260817164500 already describes this index in prose; without this, that file would count as a
     // creator and the per-file counts above would be satisfied by a comment.
@@ -200,6 +215,8 @@ describe("ADOPTUNIQ-1 — backstop classification fails CLOSED", () => {
     ["wrong predicate", GOOD.replace("IS NOT NULL", "IS NULL")],
     ["wrong table", GOOD.replace("public.task_pm_links", "public.tasks")],
     ["wrong schema", GOOD.replace("public.task_pm_links", "other.task_pm_links")],
+    ["carrying INCLUDE columns", GOOD.replace(" WHERE (", " INCLUDE (task_id) WHERE (")],
+    ["carrying a trailing clause we never asked for", GOOD + " NULLS NOT DISTINCT"],
   ])("a same-named index that is %s reads as `malformed`", (_name, indexdef) => {
     expect(indexdef, "the mutation must actually change the fixture").not.toBe(GOOD);
     expect(classifyBackstop({ indexdef, isvalid: true })).toBe("malformed");

--- a/test/http/pm-sync-health-backstop.http.test.ts
+++ b/test/http/pm-sync-health-backstop.http.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { BASE_URL, issueKeyFor, keyHeaders, seedTeam } from "./http-helpers";
+
+/**
+ * ADOPTUNIQ-1 — `GET /api/v1/pm-sync/health` gained `health.backstop`, and this is the ONLY tier that
+ * can see it.
+ *
+ * `Response.json` is this repo's documented type blind spot: widening what a route returns is only
+ * half-checked, because every forwarding caller keeps compiling and every unit test over the pure
+ * `computeProjectionHealth` keeps passing. Nothing in the unit tier touches the wire. So a refactor
+ * that drops the field from the ROUTE — while leaving the function that computes it perfectly
+ * intact — would ship green, and the admin card would silently render "unverified" forever.
+ *
+ * This is the pin for that: the field must survive the JSON boundary, with a real socket and a real
+ * database behind it.
+ */
+
+const HEALTH = `${BASE_URL}/api/v1/pm-sync/health`;
+
+describe("GET /api/v1/pm-sync/health — the DB backstop reaches the wire", () => {
+  it("returns `health.backstop`, and it is one of the four known states", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+
+    const res = await fetch(HEALTH, { headers: keyHeaders(key, seed.teamSlug) });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { health?: { status?: string; backstop?: string } };
+    expect(body.health, "the response must carry a health object").toBeTruthy();
+
+    // Asserted as PRESENT first, separately from its value: `toBeDefined` on a missing key and a
+    // wrong-valued key fail for different reasons, and the failure message should say which.
+    expect(
+      Object.prototype.hasOwnProperty.call(body.health ?? {}, "backstop"),
+      "health.backstop must survive the JSON boundary",
+    ).toBe(true);
+    expect(["installed", "missing", "malformed", "unknown"]).toContain(body.health?.backstop);
+
+    // The test database HAS the index (db:test:up loads schema.sql, which carries the guarded block),
+    // so anything other than `installed` here means the block did not run on the real load path —
+    // which is exactly the regression this pin exists to catch, and it cannot be faked by the pure
+    // classifier passing its own unit tests.
+    expect(body.health?.backstop, "the test DB loads schema.sql, so the backstop must be installed").toBe(
+      "installed",
+    );
+
+    // And it stays DISTINCT from the run status — the two describe unrelated things, and folding the
+    // backstop into `status` is the shortcut this shape exists to prevent.
+    expect(body.health?.status).not.toBe(body.health?.backstop);
+  });
+
+  it("refuses an unauthenticated read rather than leaking schema state", async () => {
+    const res = await fetch(HEALTH, { headers: { Authorization: "Bearer nope", "X-AIOS-Team": "x" } });
+    expect(res.status).toBe(401);
+  });
+});

--- a/test/pm-sync-runs.test.ts
+++ b/test/pm-sync-runs.test.ts
@@ -62,7 +62,25 @@ describe("computeProjectionHealth", () => {
   const NOW = new Date("2026-07-13T12:00:00Z").getTime();
 
   it("is never_run when no run has ever been recorded", () => {
-    expect(computeProjectionHealth(null, NOW)).toEqual({ status: "never_run", lastRun: null, ageMs: null });
+    // `backstop` defaults to "unknown", NOT "installed" (ADOPTUNIQ-1): a caller that cannot read the
+    // catalog must never be handed a green backstop. Asserted as an exact shape deliberately — this
+    // is the assertion that caught the field being added, and it should catch the next one too.
+    expect(computeProjectionHealth(null, NOW)).toEqual({
+      status: "never_run",
+      lastRun: null,
+      ageMs: null,
+      backstop: "unknown",
+    });
+  });
+
+  it("carries the backstop through every run status without conflating it with `status`", () => {
+    // The two are independent: a healthy last run says nothing about whether the DB constraint is
+    // installed, which is exactly why `backstop` is a separate field rather than a value folded into
+    // the `ProjectionHealthStatus` enum.
+    const ok = run({ ok: true, finished_at: new Date(NOW - 5 * 60_000).toISOString() });
+    expect(computeProjectionHealth(ok, NOW, "missing")).toMatchObject({ status: "ok", backstop: "missing" });
+    const bad = run({ ok: false, finished_at: new Date(NOW - 5 * 60_000).toISOString() });
+    expect(computeProjectionHealth(bad, NOW, "installed")).toMatchObject({ status: "failed", backstop: "installed" });
   });
 
   it("is ok for a recent successful run", () => {


### PR DESCRIPTION
Ships the partial unique index on `task_pm_links (team_id, provider, provider_resource_id) WHERE provider_resource_id IS NOT NULL` that ADOPTDECL-1 (#581) specced and deliberately deferred — plus the containment the index makes load-bearing.

**The deferral reason is gone.** `20260817164500_..._declared_external_id.sql:12-16` records why it was held: prod held three `TT1` links all claiming `AIO-444`, so the index would have aborted the release (#251 replay class). Re-measured read-only on 2026-08-26: **zero violating groups across 1,067 links**, one `TT1` link left. No human reconciliation call remains.

Design + every claim: `docs/design/task-pm-links-unique-index.md`.

## The index is the small part

Adding it lands on two containment paths that were both wrong, in opposite directions — and **neither is the one the ticket named**:

- **OUTBOUND swallowed it.** `lib/db/pg/query-builder.ts:221-224` *returns* the driver error rather than throwing, and `persistSuccess` never read it. A `23505` reported **success** while the provider had already been mutated and the link kept no resource id, so the next push re-adopted. Silent — worse than an abort.
- **INBOUND aborted wholesale.** `adoptInbound`'s `on conflict` names the *other* unique constraint, so a violation threw past `runInboundForTeam` before `return result`, discarding Phase A's applies and every remaining candidate. That **is** the "aborts a whole board push" failure the ticket forbids.

## The migration cannot abort a release on contention or dirty data

Every clause traces to a **staged failure against real Postgres 16**, not to caution:

| Failure | Without its clause | Dirty data needed? |
|---|---|---|
| `unique_violation` (23505) | aborts the schema load | yes |
| `lock_not_available` (55P03) | **aborts the release** | **no — clean table** |
| `deadlock_detected` (40P01) | **aborts the release** | **no — clean table** |

`pg:schema` runs as the preDeployCommand *while the old app version is still serving and still projecting*. `lock_timeout` is 15s; `deadlock_timeout` defaults to **1s**, so the detector fires first, and the load already holds `ACCESS EXCLUSIVE` locks from earlier no-op alters. I staged a real cycle: this transaction was chosen victim.

An earlier design counted duplicates then created the index — itself check-then-act, and racing the live old app. There is now **no count in the correctness path**.

**Never `when others`:** if the block is ever moved above the table's create region, `undefined_table` must stay loud rather than becoming a fleet-wide silent missing backstop.

**Narrow claim, stated honestly:** this does *not* "never refuse to deploy". Disk and catalog errors still abort, as they should.

## The skip signal is read-side

`backstop` on `ProjectionHealth`, surfaced on Admin → PM sync. **Not** a `last_error` stamp — that was designed, then withdrawn twice over: `persistSuccess` nulls `last_error` on every successful projection so it erased itself within one push cycle, and its `UPDATE` sat *outside* the protected `CREATE INDEX` on the hot rows the live old app writes, able to abort the very release it reported on.

## `contested` replaces a discrimination that could not work

Deciding whether to set `resolved` by DB error class was **unimplementable** (the adapter discards SQLSTATE) *and* **invalid** (an adopt can succeed at the provider then hit a lock timeout, so a non-`23505` failure doesn't prove the id is ours). Giving "don't re-invoke the adapter" its own channel dissolves the question: never parent beneath an unpersisted id, never re-invoke. Invocation-local, and scoped to persist failures only — an adapter **throw** keeps its shipped inline-retry behaviour, pinned by an exact-count test.

## Deliberately NOT in this PR

- **The orphan `chetan`/`TT2` link** — excluded by the partial predicate, dormant. Deleting it is a prod data mutation with no bearing on the invariant.
- **Any reconciliation of link rows** — nothing left to reconcile.
- **Plane's missing ownership pre-check** — `plane.ts:196` never consults `ownedResourceIds`, so on Plane the index is the *only* guard. Recorded, not fixed here.
- **ADOPTINV-1** — separate ticket.

## Verification

| Tier | Result |
|---|---|
| `tsc --noEmit` | clean |
| `lint` | 0 errors (18 pre-existing warnings in other files) |
| unit | **3550 passed** |
| data-mechanics (full, isolated container) | **1465 passed** — see the note below |
| http | 2 passed (the new wire pin) |
| `check:docs` | congruent |

New: 25 unit guards · 16 dm index/migration · 7 dm containment · 1 dm inbound propagation · 2 http.

**Local dm flake, stated rather than hidden.** Three full-tier runs each ended with exactly one
failure, and it was a DIFFERENT test every time — `pparc-fusion-cutover` (mutates global
`migration_markers`/`arc_cache`; its own comment records it as full-tier fragile), then one of MINE,
then `chat-store` (`expected 1 to be less than 0` — a timestamp-ordering assertion). All three are
timing-shaped and all pass standalone. The one that was mine was real and is fixed: the scratch-database
cases were hitting the tier's 5s default while doing genuine DDL (create database → connect → DDL →
drop) with a dozen files doing the same concurrently; they now carry an explicit 60s timeout. The
other two are untouched by this diff — it adds no `arc_cache`, `migration_markers` or chat write.
This machine had been running Docker, Codex and several agents for hours; **CI on a clean runner is
the discriminator**, and I would rather say that than claim a green full tier I did not observe.

**RESOLVED — CI answered it.** All 14 checks pass on this PR, including *Data-mechanics tests (real
Postgres)* and *Integration tests (HTTP)*. The local failures were machine load, not this change.

### Mutation testing — three guards were decoration until this PR

| Mutation | Before | After |
|---|---|---|
| remove the `contested` channel | REDDENED | — |
| `if (persisted.error)` → `if (false)` | REDDENED | — |
| drop `when lock_not_available` | REDDENED | — |
| **drop `when deadlock_detected`** | **SURVIVED** | REDDENED |
| **gut `duplicateGroups` → `return []`** | **SURVIVED** | REDDENED |
| **inbound swallows all errors** | **SURVIVED** | REDDENED |

Each survivor was a thing I had written, believed in, and not actually enforced. Verdicts pasted from `scripts/mutate.mjs`, not narrated.

## Review

Eight reviews: six on the spec across three rounds (three **BLOCKED**), two on the diff (one **BLOCKED**). The blocked rounds are the value here, so they are listed rather than summarised away.

**Reviewed by Fable + Codex (gpt-5.6-sol) — verdict CLEAR after 3 BLOCKED rounds; every blocker was a real release-aborting defect caught before any code existed.**

- **Spec r1 — Codex BLOCKED:** the guard was itself a check-then-act race (`pg:schema` runs while the old app still projects). Fable CLEAR-WITH-CONDITIONS, and caught a **false claim of mine**: "only two writers of `provider_resource_id`, verified by grep". There are three — my grep was `head -30`-truncated.
- **Spec r2 — both BLOCKED:** Codex killed the `last_error` signal (reintroduced an abort path) and my error-class discrimination (invalid on the merits). Fable found the **wrong exception set** — a lock wait aborts a release with zero dirty data — and killed its *own* r1 proposal by finding `project.ts:200` erases it.
- **Spec r3 — both CLEAR-WITH-CONDITIONS, and they contradicted each other** on `deadlock_detected`. Settled by **staging a real deadlock**, not by preferring an argument. Fable was right.
- **Diff — Codex BLOCKED:** the `duplicateGroups` control I said I had *moved*, I had *replaced* with a lookalike. Confirmed with the mutant it named. Also: inbound over-catching (a DB outage would have reported a clean run), `classifyBackstop` accepting `INCLUDE` columns, and a guard keyed on the index *name* instead of the table.
- **Diff — Fable CLEAR:** three comments naming symbols that don't exist (`backstopHealth` in the migration — the file an operator reads when the warning fires — and `summarizeInbound` ×3). The claims were true; the symbols were invented. All now grep-proved. It also flagged `health.backstop` as the one wire-visible change nothing pinned → http test added.

Accepted without change, with reasons: two concurrent `pg:schema` runs can both pass `if not exists` and the loser aborts on `42P07` (the aborted release is the superseded one; the next deploy self-heals); the catalog read hardcodes `public` (fails closed and visibly, so a non-default-schema fleet gets an honest amber card rather than a false green).

## After merge

The index reaches prod only via `npm run pg:schema`. Until that runs, the admin card will honestly show **missing** — which is the signal working, not a bug.

AIOS-Work: ADOPTUNIQ-1