### PR TITLE
fix(deploy): the runner stage stops reading the build context (DOCKERPROD-2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,18 @@ EXPOSE 3000
 # root — where `-r` passes on a directory and on a zero-byte file, both of which still boot dead.
 # NOT `-x`: the ENTRYPOINT below invokes through `sh`, which reads the file rather than executing
 # it, and requiring the mode bit would re-couple what that form deliberately decouples.
+#
+# ⚠️ EACH TEST EXITS EXPLICITLY, and that is not style. The first version of this line was
+# `test -f "$f" && test -s "$f" && test -r "$f"` under `set -eu`, which DOES NOT FAIL: POSIX
+# ignores errexit for a command in an AND-OR list, so a missing file fell straight through and the
+# build went green. Measured — a build with bootstrap.mjs absent printed "BUILD PASSED WITH
+# bootstrap.mjs MISSING". An assertion that cannot fail is worse than none, because it reads as
+# coverage. `|| { …; exit 1; }` depends on no shell option at all, and names what is missing.
 RUN set -eu; \
     for f in /app/docker/entrypoint.sh /app/docker/bootstrap.mjs; do \
-      test -f "$f" && test -s "$f" && test -r "$f"; \
+      test -f "$f" || { echo "boot chain: $f is missing or not a regular file" >&2; exit 1; }; \
+      test -s "$f" || { echo "boot chain: $f is empty" >&2; exit 1; }; \
+      test -r "$f" || { echo "boot chain: $f is not readable" >&2; exit 1; }; \
     done; \
     /bin/sh -n /app/docker/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,10 @@ RUN set -eu; \
     done; \
     /bin/sh -n /app/docker/entrypoint.sh
 
-# Invoked through `sh` rather than as a bare path so the boot depends on nothing outside this file
-# — not the executable bit, not `/usr/bin/env`, not PATH. Same idiom as railway.json's
-# `sh scripts/railway-start.sh`.
+# Invoked through `sh` rather than as a bare path so INVOKING the entrypoint depends on nothing
+# outside this file — not the executable bit, not `/usr/bin/env`, not PATH. (The script's own line 5
+# still resolves `node` through PATH; that is unchanged and not what this form is about.) Same idiom
+# as railway.json's `sh scripts/railway-start.sh`.
 ENTRYPOINT ["/bin/sh", "/app/docker/entrypoint.sh"]
 # Load-bearing, not decoration: entrypoint.sh ends in `exec "$@"`, and POSIX `exec` with zero
 # arguments is a no-op — an empty CMD makes the script fall off the end and exit 0, which is a

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-# AIOS Team Brain — container image for the one-command local stack (`docker compose up`).
+# AIOS Team Brain — the container image.
 #
-# Scope, deliberately: this image exists so someone can evaluate the brain with Docker and
-# nothing else — no Node on the host, no Postgres, no accounts, no API keys. It is NOT wired
-# into the Railway deploy path, which still builds from the repo via the GitHub integration
-# (railway.json's preDeployCommand runs the schema). Nothing here changes how production ships.
+# Railway's GitHub integration auto-detects this root Dockerfile and BUILDS PRODUCTION with it.
+# Railway overrides this image's ENTRYPOINT/CMD with railway.json's startCommand, so the entrypoint below is the local `docker compose` path only.
+#
+# It also serves the one-command local stack (`docker compose up`), which is what the ENTRYPOINT is
+# for: evaluate the brain with Docker and nothing else — no Node on the host, no Postgres, no
+# accounts, no API keys.
 #
 # Why the runtime stage keeps dev dependencies: first boot seeds the demo team by running
 # `scripts/seed-demo.ts` and `scripts/admin.ts` through `tsx`, which is a devDependency. A
 # slimmer `--omit=dev` runtime would need `output: "standalone"` in next.config.ts and a
-# separate seeding image — worth doing for a production image, but that would change the
-# build output the live deploy already depends on, so it is out of scope here.
+# separate seeding image — that is DOCKERPROD-1, deliberately not this slice.
 
 FROM node:20-bookworm-slim AS base
 WORKDIR /app
@@ -29,15 +30,37 @@ COPY . .
 RUN npm run build
 
 # ── runtime ─────────────────────────────────────────────────────────────────
+# This stage reads NOTHING from the build context. The boot chain is already here — the build
+# stage's `COPY . .` put `docker/` under /app and the copy below brings it across — so a second
+# trip to the context would copy a file the image already has, from the one source that can fail
+# mid-build. That instruction failed two production deploys (DOCKERPROD-2).
 FROM base AS runner
 ENV NODE_ENV=production
 COPY --from=build /app ./
-COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # next start binds 0.0.0.0 by default in a container; be explicit so port-mapping is predictable.
 ENV PORT=3000 HOSTNAME=0.0.0.0
 EXPOSE 3000
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# TERMINAL boot-chain assertion — nothing below this line may touch the filesystem.
+#
+# Deleting the context COPY above would otherwise convert a BUILD failure into a RUNTIME one: a
+# build stage missing these files would produce a green image and a container that dies at boot.
+# This puts the failure back at build time. `-f`/`-s` and not `-r` alone, because the build runs as
+# root — where `-r` passes on a directory and on a zero-byte file, both of which still boot dead.
+# NOT `-x`: the ENTRYPOINT below invokes through `sh`, which reads the file rather than executing
+# it, and requiring the mode bit would re-couple what that form deliberately decouples.
+RUN set -eu; \
+    for f in /app/docker/entrypoint.sh /app/docker/bootstrap.mjs; do \
+      test -f "$f" && test -s "$f" && test -r "$f"; \
+    done; \
+    /bin/sh -n /app/docker/entrypoint.sh
+
+# Invoked through `sh` rather than as a bare path so the boot depends on nothing outside this file
+# — not the executable bit, not `/usr/bin/env`, not PATH. Same idiom as railway.json's
+# `sh scripts/railway-start.sh`.
+ENTRYPOINT ["/bin/sh", "/app/docker/entrypoint.sh"]
+# Load-bearing, not decoration: entrypoint.sh ends in `exec "$@"`, and POSIX `exec` with zero
+# arguments is a no-op — an empty CMD makes the script fall off the end and exit 0, which is a
+# green build and a container that vanishes at boot with no error anywhere.
 CMD ["npm", "start"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,9 +24,10 @@ supplies team and first-admin identity in Railway's form, including an `ADMIN_PA
 
 **Railway builds the repo-root `Dockerfile` for production.** Its GitHub integration auto-detects
 it, so the same image serves the one-command local stack (`docker compose up`) and the live deploy.
-The two paths differ in exactly one place: `railway.json`'s `startCommand` OVERRIDES the image's
-`ENTRYPOINT`/`CMD`, so `scripts/railway-start.sh` is production's entrypoint and
-`docker/entrypoint.sh` is the local one — both routing through the same `docker/bootstrap.mjs`. The
+They differ in more than one place — compose additionally supplies the database, volumes and
+environment — but the difference that matters here is the START: `railway.json`'s `startCommand`
+OVERRIDES the image's `ENTRYPOINT`/`CMD`, so `scripts/railway-start.sh` is production's entrypoint
+and `docker/entrypoint.sh` is the local one, both routing through the same `docker/bootstrap.mjs`. The
 runner stage reads nothing from the build context and asserts its boot chain at build time
 (`test/guards/dockerfile-runner-stage.test.ts`, DOCKERPROD-2); a second trip to the context there
 failed two production deploys.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,15 @@ secret functions generate `AUTH_SECRET`, `SECRETS_KEY`, and `GRAPH_LLM_PROXY_SEC
 supplies team and first-admin identity in Railway's form, including an `ADMIN_PASSWORD` of at least
 10 characters.
 
+**Railway builds the repo-root `Dockerfile` for production.** Its GitHub integration auto-detects
+it, so the same image serves the one-command local stack (`docker compose up`) and the live deploy.
+The two paths differ in exactly one place: `railway.json`'s `startCommand` OVERRIDES the image's
+`ENTRYPOINT`/`CMD`, so `scripts/railway-start.sh` is production's entrypoint and
+`docker/entrypoint.sh` is the local one — both routing through the same `docker/bootstrap.mjs`. The
+runner stage reads nothing from the build context and asserts its boot chain at build time
+(`test/guards/dockerfile-runner-stage.test.ts`, DOCKERPROD-2); a second trip to the context there
+failed two production deploys.
+
 On first start, `railway.json` runs the idempotent schema loader before release. The opt-in Railway
 startup wrapper then runs the shared bootstrap to ensure the real team and first admin from
 `TEAM_*` / `ADMIN_*`. Bootstrap runs on

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -220,6 +220,14 @@ Round 2 then broke my first version of it three ways, all folded above:
   `RUN test … && rm …` — passed round 1's wording, which is precisely the "rm after copying" hole the
   assertion exists to close. AC2(d) forbids any filesystem-touching instruction after it.
 
+⚠️ **The assertion is DEPTH-1, and "the two boot files" is not the whole chain.** `bootstrap.mjs`
+statically imports `../scripts/pg-load-schema.mjs` and two modules under `../scripts/setup/`, and the
+derivation only reads `entrypoint.sh` — so a `.dockerignore` line excluding `scripts/` would build
+green and boot dead. **Not a regression** (the old Dockerfile had the identical hole, and asserted
+nothing at all), and a complete check would mean resolving the ESM import graph at build time —
+`node -e "import(…)"` would do it but would also RUN bootstrap against no database, which is not a
+trade this slice should make. Named as a limit rather than left implied. Raised by the diff review.
+
 **Caching cannot stale this.** The `RUN`'s cache key includes its parent layer; `COPY --from=build
 /app ./` re-checksums the build stage's `/app`, so a changed tree invalidates the COPY and therefore
 the RUN. A cache hit implies a byte-identical tree, in which case the cached success is a true success.
@@ -350,6 +358,7 @@ if the deploy flow's prose is affected.
 | 11b | **`CMD ["true"]`** — non-empty, exec-form, serves nothing | **AC2(b)** |
 | 12 | assertion drops `/app/docker/bootstrap.mjs` | AC2(c) |
 | 13 | assertion weakens to `test -r` only (a dir or empty file would pass) | AC2(c) |
+| 13b | **assertion reverts to the `&&` AND-OR form** — the §2a-bis shape that cannot fail | **AC2(c)** |
 | 14 | **insert `RUN rm /app/docker/entrypoint.sh` AFTER the assertion** | **AC2(d)** |
 | 14b | **append `&& rm /app/docker/entrypoint.sh` INSIDE the assertion instruction** | **AC2(c)** |
 | 15 | `ENTRYPOINT` → `/app/scripts/railway-start.sh` — tracked and corresponds, but unasserted | AC2(e) |
@@ -427,8 +436,13 @@ password, then exits successfully having served nothing.
 | `entrypoint.sh` is a **directory** | FAIL | **FAILED** |
 | both present and valid (positive control) | PASS | **PASSED** |
 
-Each leg fires with its own message, so `-s` and `-r` are live rather than decorative. Against the
-FIRST version of the assertion, rows 1-4 all **PASSED** the build.
+`-f` and `-s` were each observed firing with their own message. ⚠️ **`-r` was NOT, and cannot be:**
+the build runs as root, where `access(2)` grants read regardless of mode — measured, `test -r` passes
+on a `chmod 000` file as root. It stays as belt, labelled untestable in this context rather than
+claimed live. *(An earlier draft of this line said "so `-s` and `-r` are live" — a leg no row
+exercises. That is the sweeping-claim habit this section exists to check, caught by the diff review.)*
+
+Against the FIRST version of the assertion, rows 1-4 all **PASSED** the build.
 
 **Code is written. AC1–AC3 are guarded in `test/guards/dockerfile-runner-stage.test.ts`; AC4 is the
 table above.**

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -1,0 +1,249 @@
+# The runner stage stops reading the build context — DOCKERPROD-2
+
+**Status:** spec, round 1 (both spec reviews folded). No code written.
+
+**Build with:** opus / high — it changes the image production boots from. The blast radius is small
+(one `COPY` deleted, one `ENTRYPOINT` changed, one build-time assertion added) but the failure mode is
+a container that builds green and cannot start, and the only roll-forward from that is another deploy.
+
+**Deps:** none. **Blocks:** DOCKERPROD-1, the standalone/production-image slice, which is deliberately
+NOT this one.
+
+---
+
+## What and why
+
+The repo-root `Dockerfile`'s runner stage re-reads the **build context** for a single file:
+
+```dockerfile
+FROM base AS runner
+COPY --from=build /app ./                                        # line 34
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh           # line 35  ← reads the CONTEXT
+RUN chmod +x /usr/local/bin/entrypoint.sh                        # line 36
+```
+
+**Line 35 copies a file the image already has.** The build stage's `COPY . .` (line 28) puts it at
+`/app/docker/entrypoint.sh`, and the runner's `COPY --from=build /app ./` (line 34) brings that in.
+That redundancy is the whole case for this slice, and it holds regardless of anything in §0b.
+
+**The motivation** — not the argument — is that this same instruction failed two Railway production
+builds, each time blocking a merged fix from reaching production for hours and each time needing a
+human dashboard re-trigger:
+
+| deployment | PR | date | failure |
+|---|---|---|---|
+| `4c842d11-3401-45da-ab28-6971c7e5d648` | #648 | 2026-08-23 | `lstat /docker/entrypoint.sh: no such file or directory` |
+| `1a210d5b-469b-4725-b60c-c6865e5073ad` | #658 | 2026-08-26 14:53 UTC | same |
+
+## 0. Terrain, measured before designing
+
+### 0a. The file is already in the image — measured, not traced
+
+I built a throwaway image over the real build context rather than reasoning about it:
+
+```
+$ docker build -f /tmp/probe/Dockerfile .      # FROM busybox; WORKDIR /app; COPY . .; RUN ls -l …
+-rwxr-xr-x    1 root     root           665 Jul 30 01:48 /app/docker/entrypoint.sh
+```
+
+So the context COPY lands the file at exactly the path the new `ENTRYPOINT` will name, **with its
+`100755` mode preserved**. Supporting reads:
+
+| claim | how checked | result |
+|---|---|---|
+| `.dockerignore` does not exclude `docker/` | read the file | excludes `node_modules`, `.next`, `.git`, `.github`, env files, dev noise — **nothing under `docker/`** |
+| the file is tracked, executable | `git ls-files -s docker/entrypoint.sh` | `100755 e940c8fa` |
+| nothing else consumes `/usr/local/bin/entrypoint.sh` | `grep -rn` across the repo | only the `Dockerfile`'s own `COPY`/`chmod`/`ENTRYPOINT` triple; both reviews confirmed independently |
+| the copy-through already works in production | `docker/entrypoint.sh:5` runs `node /app/docker/bootstrap.mjs` | the **sibling file** ships through this exact path today, and every compose boot proves it |
+
+### 0b. Why the flake is MOTIVATION and not EVIDENCE — a claim I withdrew
+
+Round 0 of this spec argued that the LATE context read is the vulnerable one, and offered the error's
+leading slash (`lstat /docker/…`) as proof that the daemon resolved the path against `/` rather than
+against the context. **Both reviewers rejected that, and they were right.** I tested it:
+
+```
+$ docker build .        # COPY definitely-not-here.sh /tmp/x   — a genuinely absent context file
+ERROR: failed to calculate checksum of ref …: "/definitely-not-here.sh": not found
+```
+
+A plainly context-relative miss **also prints a leading slash**, because the context root IS `/`. The
+slash discriminates nothing and that sentence is deleted. *(The message text does differ — `failed to
+calculate checksum … not found` here vs `lstat … no such file or directory` on Railway — but I am not
+going to build a second mechanism claim on one local buildkit version.)*
+
+What survives as fact: two failures at the identical instruction; the file present at both commits;
+`git diff` on `Dockerfile`, `.dockerignore` and `docker/` between the last success and the failure is
+**empty**; and in the #648 failure `npm run build` demonstrably EXECUTED (its full route table is in
+the build log), so the build stage was not a pure cache replay.
+
+**What remains a hypothesis, explicitly:** that the late context read is more exposed than the early
+one. ⚠️ **The honest no-improvement reading, which I accept:** if Railway/buildkit has an unreliable
+context session, deleting line 35 may just move the next failure onto `COPY . .`, leaving the total
+flake rate unchanged. **This slice does not promise a lower flake rate.** It removes an instruction
+that copies a file the image already carries — which is worth doing on its own, and is why the design
+does not rest on the mechanism at all.
+
+### 0c. On the production path, the entrypoint never runs
+
+`railway.json:5` sets `startCommand: "sh scripts/railway-start.sh"`, which replaces the image's
+`ENTRYPOINT`; `scripts/railway-start.sh:4-5` says so in its own comment and duplicates the bootstrap
+for that reason. So on Railway this file is **dead weight whose `COPY` can still fail the build**. Its
+only consumer is the local `docker compose` stack (`compose.yml`'s `app` service — `build: .`, no
+`entrypoint:` override).
+
+### 0d. The header sentence that made this look harmless is false
+
+```
+# It is NOT wired into the Railway deploy path, which still builds from the repo via the
+# GitHub integration
+```
+
+Railway's GitHub integration auto-detects a root `Dockerfile` and builds it — the build logs above are
+of its stages, by name. That sentence is why a local-demo `COPY` sat unexamined on the production
+critical path, so correcting it belongs to THIS slice: leaving a sentence I have just proven false, in
+the file I am editing, for the reason I am editing it, is its own defect. **Both reviewers agreed this
+is not DOCKERPROD-1 scope creep.**
+
+## 1. The rule
+
+> **The runner stage builds from earlier stages of this same Dockerfile and from nothing else — no
+> context, no named context, no external image. Anything it needs is already in the image, and it
+> asserts at BUILD time that what it points at is there.**
+
+## 2. The design
+
+### 2a. Delete the redundant copy; assert what replaces it; point `ENTRYPOINT` at it
+
+```dockerfile
+FROM base AS runner
+ENV NODE_ENV=production
+COPY --from=build /app ./
+RUN test -r /app/docker/entrypoint.sh          # ← fail CLOSED at build time
+...
+ENTRYPOINT ["/bin/sh", "/app/docker/entrypoint.sh"]
+```
+
+⚠️ **The `RUN test -r` is not belt-and-braces — it repairs a fail-open the deletion would otherwise
+introduce, and it is the sharpest thing either review found.** Today, if the file were ever absent
+from the build stage, line 35 **fails the build**. Delete line 35 and that same absence becomes:
+`COPY --from=build /app ./` succeeds, `next build` succeeds, the image is green, and the *container*
+dies at boot — a defect moved from build time to somebody's runtime. One `RUN` puts it back where it
+was.
+
+**Why `/bin/sh <path>` and not the bare path.** The two forms genuinely differ: the bare path makes
+the kernel read `#!/usr/bin/env sh` and resolve `sh` through `PATH` via `/usr/bin/env`, and it requires
+the executable bit; the explicit form depends on neither. `/bin/sh` is guaranteed on this Debian base
+(the upstream node image's own entrypoint uses `#!/bin/sh`, and this Dockerfile already relies on the
+default `/bin/sh -c` for its shell-form `RUN`s). It is also the idiom this repo already uses for the
+same script's production twin (`railway.json`: `sh scripts/railway-start.sh`).
+
+⚠️ *Round 0 justified this as removing a dependence on something "pinned by nothing." That was wrong
+and Fable caught it: the mode bit **is** pinned, by the git index at `100755`, which §0a verifies. The
+honest justification is narrower — the explicit form depends on nothing outside the Dockerfile, at
+zero cost. AC2 pins the form so a later bare-path edit cannot silently reintroduce the dependence.*
+
+Inside the script nothing changes: `$@` forwarding, `set -eu`, exit-code propagation, and the final
+`exec "$@"` are identical, and `sh` is the interim PID 1 in both forms.
+
+⚠️ *One correction to the existing comment at `docker/entrypoint.sh:15`, which says the exec makes
+"the server" PID 1: `exec "$@"` runs `npm start` (`package.json:9` → `next start`), so **npm** becomes
+PID 1, not Next. That is pre-existing and NOT changed by this slice; AC4 measures what PID 1 actually
+is and the finding is reported rather than fixed here.*
+
+### 2b. The header stops claiming it is off the deploy path
+
+Rewritten to state the two facts positively: Railway auto-detects and builds this root `Dockerfile`,
+and Railway's configured `startCommand` overrides the image's `ENTRYPOINT` — so the entrypoint is the
+local-compose path only. The devDependencies paragraph stays; it is still accurate and DOCKERPROD-1
+owns changing it.
+
+## 3. Scope
+
+**In:** `Dockerfile` (the runner lines + the header) · one guard, unit tier · `docs/ARCHITECTURE.md`
+if the deploy flow's prose is affected.
+
+**Out — all of it DOCKERPROD-1:**
+- `output: "standalone"`, `--omit=dev`, a traced runtime, splitting seeding out.
+- `railway.json`'s `preDeployCommand`, `scripts/railway-start.sh`, `next.config.ts`.
+- Moving the Dockerfile out of Railway's way — the operator's decision was to keep building it.
+- The `docker/entrypoint.sh:15` PID-1 comment (§2a): reported by AC4, corrected by neither slice yet.
+- Multi-arch, image signing, registry cache.
+
+## 4. Acceptance
+
+- **AC1 — the final stage reads nothing but declared earlier stages (guard, unit, ∀):** in the
+  Dockerfile's FINAL stage, (a) there is no `ADD`; (b) every `COPY` carries `--from=<name>` where
+  `<name>` is a stage declared by an earlier `FROM … AS <name>` **in this file**; (c) no
+  `RUN --mount=type=bind` without an explicit `from=<declared stage>`; and (d) — non-vacuity — at
+  least one `COPY --from=<declared stage>` exists. *Round 0 quantified over `COPY` alone, which both
+  reviewers broke three ways: `ADD` reads the context, `--from=` may name an external image or a named
+  context rather than a stage, and buildkit's default bind-mount source IS the context. A ∀ narrower
+  than the rule it claims to enforce is not a guard.*
+- **AC2 — the entrypoint is a build-asserted path in the invoked form (guard, unit):** the guard parses
+  `ENTRYPOINT`, and (a) **fails loudly on any shape it does not recognise** — shell form, `-c` string,
+  anything but `["/bin/sh", "<path>"]`; (b) requires the final stage to contain a `RUN` asserting that
+  exact `<path>` is readable; (c) requires `<path>` to correspond, under the image's `/app` root, to a
+  file tracked in the repo. *Round 0's version checked only (c) and called it proof the image carries
+  the file — Codex's counterexample: copy from the wrong stage, or `rm` after copying, and (c) still
+  passes. (b) is what actually observes the image, at build time. (a) exists because an ENTRYPOINT
+  shape the guard silently skips is a guard that passes on the defect.*
+- **AC3 — the header states the deploy contract positively (guard, unit):** the Dockerfile does not
+  contain the retired sentence, AND asserts both that Railway builds this Dockerfile and that its
+  `startCommand` overrides the image entrypoint. *Round 0 required only that the word "Railway" appear
+  — satisfied by "Railway never builds this Dockerfile," which is false. Asserting the contract is the
+  only version that cannot be satisfied by a differently-worded lie.*
+- **AC4 — the image builds, serves, and STOPS (manual, recorded):** `docker compose build app`
+  succeeds; a container from it boots through `entrypoint.sh` and answers an HTTP request;
+  `docker compose stop` terminates it within the grace period with no orphan; and `PID 1` is recorded
+  as observed (see §2a). ⚠️ *Manual and named as such — this repo has no container test tier and
+  claiming CI proves it would be false. The stop leg is here because the `ENTRYPOINT` form is the one
+  thing this slice changes about the running container.*
+
+| # | mutation | must redden |
+|---|---|---|
+| 1 | restore `COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh` in the runner | **AC1** (a context `COPY`) |
+| 2 | add `ADD package.json ./x` to the runner | **AC1** (the `ADD` leg) |
+| 3 | add `COPY --from=somectx package.json ./x` — a source that is not a declared stage | **AC1** (the undeclared-source leg) |
+| 4 | add `RUN --mount=type=bind,target=/ctx true` to the runner | **AC1** (the bind-mount leg) |
+| 5 | delete `COPY --from=build /app ./` entirely | **AC1** (the non-vacuity leg) |
+| 6 | `ENTRYPOINT` points at `/usr/local/bin/entrypoint.sh` | **AC2** (assertion/entrypoint divergence) |
+| 7 | `ENTRYPOINT` and the `RUN test` BOTH move to `/app/docker/nope.sh` | **AC2** (the repo-correspondence leg) |
+| 8 | delete the `RUN test -r` assertion | **AC2** (the build-assertion leg) |
+| 9 | `ENTRYPOINT /app/docker/entrypoint.sh` in **shell form** | **AC2** (ambiguity must fail, not skip) |
+| 10 | `ENTRYPOINT ["/app/docker/entrypoint.sh"]` — bare path, no `/bin/sh` | **AC2** (the invoked-form leg) |
+| 11 | restore the "NOT wired into the Railway deploy path" sentence | **AC3** |
+| 12 | header reads "Railway never builds this Dockerfile" — false, contains "Railway" | **AC3** (the round-0 bypass) |
+| 13 | header drops the `startCommand`-override statement | **AC3** (the second positive leg) |
+
+Each row changes exactly ONE condition, so a redden attributes to one criterion. Every row must redden
+the criterion NAMED, not merely something.
+
+## 5. Risks
+
+| risk | direction | mitigation |
+|---|---|---|
+| The file is absent from the build stage; the build goes green and the container dies at boot | **fail-open introduced by this very change** — the worst outcome here | §2a's `RUN test -r`, pinned by AC2(b) and mutation 8 |
+| Wrong entrypoint path or lost exec bit | an unbootable container | AC2(a)+(c); §2a removes the exec-bit dependence; AC4 boots a real container |
+| The guard reads the Dockerfile as prose | a guard with no failure mode is ceremony | it must parse stages and instructions; all 13 mutations must redden the NAMED criterion |
+| AC1 passes vacuously on a stage with no `COPY` at all | silently green | AC1(d), mutation 5 |
+| Someone reads this as "the flake is fixed" | a false claim in the map | §0b states the limit and the no-improvement reading; the PR body must repeat both |
+| Railway builds a different Dockerfile than the one guarded | the guard watches the wrong file | the build logs name these stages (`build`, `runner`) verbatim — §0b |
+
+## 6. Release condition
+
+**No staging gate — and the round-0 reason for that was false.** I wrote that the slice "does not
+change what the runtime contains." It does: `/usr/local/bin/entrypoint.sh` is gone and the `ENTRYPOINT`
+is different. What is actually true is narrower, and it is enough:
+
+- **Railway's runtime process is unchanged**, because `startCommand` overrides the image entrypoint
+  (§0c) — so the production path does not execute the thing this slice changes.
+- **Local compose is the path whose behaviour changes**, and AC4 exercises exactly that, in the real
+  container, including the stop path.
+- **One staging build could not demonstrate the absence of a stochastic flake anyway**, so invoking the
+  gate here would spend it on a question it cannot answer.
+
+That is a risk-based boundary, not an erosion of the gate DOCKERPROD-1 genuinely needs. Post-merge,
+the normal Railway deploy verification applies.
+
+**Nothing is built. No code exists for this slice.**

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -1,13 +1,14 @@
 # The runner stage stops reading the build context — DOCKERPROD-2
 
-**Status:** spec, round 1 (both spec reviews folded). No code written.
+**Status:** spec, round 2 (four model reviews folded: two rounds × two models). No code written.
 
-**Build with:** opus / high — it changes the image production boots from. The blast radius is small
-(one `COPY` deleted, one `ENTRYPOINT` changed, one build-time assertion added) but the failure mode is
-a container that builds green and cannot start, and the only roll-forward from that is another deploy.
+**Build with:** opus / high — it changes the image production boots from. The diff is small but the
+failure mode is a container that builds green and cannot start, and the only roll-forward from that is
+another deploy. Round 2 found **three** distinct ways to reach exactly that outcome while every
+round-1 criterion stayed green.
 
-**Deps:** none. **Blocks:** DOCKERPROD-1, the standalone/production-image slice, which is deliberately
-NOT this one.
+**Deps:** none. **Blocks:** DOCKERPROD-1, the standalone/production-image slice, deliberately NOT this
+one.
 
 ---
 
@@ -24,11 +25,10 @@ RUN chmod +x /usr/local/bin/entrypoint.sh                        # line 36
 
 **Line 35 copies a file the image already has.** The build stage's `COPY . .` (line 28) puts it at
 `/app/docker/entrypoint.sh`, and the runner's `COPY --from=build /app ./` (line 34) brings that in.
-That redundancy is the whole case for this slice, and it holds regardless of anything in §0b.
+That redundancy is the whole case for this slice and it holds independently of §0b.
 
-**The motivation** — not the argument — is that this same instruction failed two Railway production
-builds, each time blocking a merged fix from reaching production for hours and each time needing a
-human dashboard re-trigger:
+**The motivation** — not the argument — is that this instruction failed two Railway production builds,
+each time blocking a merged fix from production for hours and needing a human dashboard re-trigger:
 
 | deployment | PR | date | failure |
 |---|---|---|---|
@@ -46,51 +46,54 @@ $ docker build -f /tmp/probe/Dockerfile .      # FROM busybox; WORKDIR /app; COP
 -rwxr-xr-x    1 root     root           665 Jul 30 01:48 /app/docker/entrypoint.sh
 ```
 
-So the context COPY lands the file at exactly the path the new `ENTRYPOINT` will name, **with its
-`100755` mode preserved**. Supporting reads:
+The context COPY lands the file at exactly the path the new `ENTRYPOINT` names, with its `100755` mode
+preserved. Supporting reads:
 
 | claim | how checked | result |
 |---|---|---|
 | `.dockerignore` does not exclude `docker/` | read the file | excludes `node_modules`, `.next`, `.git`, `.github`, env files, dev noise — **nothing under `docker/`** |
 | the file is tracked, executable | `git ls-files -s docker/entrypoint.sh` | `100755 e940c8fa` |
-| nothing else consumes `/usr/local/bin/entrypoint.sh` | `grep -rn` across the repo | only the `Dockerfile`'s own `COPY`/`chmod`/`ENTRYPOINT` triple; both reviews confirmed independently |
+| nothing else consumes `/usr/local/bin/entrypoint.sh` | `grep -rn` across the repo | only the `Dockerfile`'s own `COPY`/`chmod`/`ENTRYPOINT` triple; both reviewers confirmed independently |
 | the copy-through already works in production | `docker/entrypoint.sh:5` runs `node /app/docker/bootstrap.mjs` | the **sibling file** ships through this exact path today, and every compose boot proves it |
 
 ### 0b. Why the flake is MOTIVATION and not EVIDENCE — a claim I withdrew
 
-Round 0 of this spec argued that the LATE context read is the vulnerable one, and offered the error's
-leading slash (`lstat /docker/…`) as proof that the daemon resolved the path against `/` rather than
-against the context. **Both reviewers rejected that, and they were right.** I tested it:
+Round 0 argued the LATE context read is the vulnerable one, offering the error's leading slash
+(`lstat /docker/…`) as proof the daemon resolved against `/` rather than the context. **Both reviewers
+rejected it and they were right.** Measured:
 
 ```
 $ docker build .        # COPY definitely-not-here.sh /tmp/x   — a genuinely absent context file
 ERROR: failed to calculate checksum of ref …: "/definitely-not-here.sh": not found
 ```
 
-A plainly context-relative miss **also prints a leading slash**, because the context root IS `/`. The
-slash discriminates nothing and that sentence is deleted. *(The message text does differ — `failed to
-calculate checksum … not found` here vs `lstat … no such file or directory` on Railway — but I am not
-going to build a second mechanism claim on one local buildkit version.)*
+A plainly context-relative miss **also prints a leading slash** — the context root IS `/`. The slash
+discriminates nothing; the sentence is deleted.
 
-What survives as fact: two failures at the identical instruction; the file present at both commits;
+**What survives as fact:** two failures at the identical instruction; the file present at both commits;
 `git diff` on `Dockerfile`, `.dockerignore` and `docker/` between the last success and the failure is
-**empty**; and in the #648 failure `npm run build` demonstrably EXECUTED (its full route table is in
-the build log), so the build stage was not a pure cache replay.
+**empty**; and in the #648 failure `npm run build` demonstrably EXECUTED (its route table is in the
+build log), so the build stage was not a pure cache replay — the same context session was read
+successfully minutes before the failing read. That is **consistent with** a late-read/session-longevity
+mechanism at n=2. It does not establish one.
 
-**What remains a hypothesis, explicitly:** that the late context read is more exposed than the early
-one. ⚠️ **The honest no-improvement reading, which I accept:** if Railway/buildkit has an unreliable
-context session, deleting line 35 may just move the next failure onto `COPY . .`, leaving the total
-flake rate unchanged. **This slice does not promise a lower flake rate.** It removes an instruction
-that copies a file the image already carries — which is worth doing on its own, and is why the design
-does not rest on the mechanism at all.
+**What this slice does and does not promise:**
+
+- ❌ **It does not promise a lower flake rate.** If Railway/buildkit has an unreliable context session,
+  the next failure may simply land on `COPY . .` instead. That reading is accepted.
+- ✅ **It provably cannot RAISE context exposure.** The change strictly removes one of the file's three
+  context reads and adds no new context dependency. Monotone, and free to state.
 
 ### 0c. On the production path, the entrypoint never runs
 
 `railway.json:5` sets `startCommand: "sh scripts/railway-start.sh"`, which replaces the image's
-`ENTRYPOINT`; `scripts/railway-start.sh:4-5` says so in its own comment and duplicates the bootstrap
-for that reason. So on Railway this file is **dead weight whose `COPY` can still fail the build**. Its
-only consumer is the local `docker compose` stack (`compose.yml`'s `app` service — `build: .`, no
-`entrypoint:` override).
+`ENTRYPOINT`; `scripts/railway-start.sh:4-5` says so and duplicates the bootstrap for that reason. On
+Railway this file is **dead weight whose `COPY` can still fail the build**. Its only consumer is the
+local `docker compose` stack (`compose.yml`'s `app` service — `build: .`, no `entrypoint:` override).
+
+⚠️ *That fact is load-bearing for §6, and it lives in `railway.json` — not in the Dockerfile. Deleting
+`deploy.startCommand` silently falsifies §0c AND §6 while every prose check still passes, which is why
+AC3(c) checks the file where the contract actually is.*
 
 ### 0d. The header sentence that made this look harmless is false
 
@@ -105,62 +108,121 @@ critical path, so correcting it belongs to THIS slice: leaving a sentence I have
 the file I am editing, for the reason I am editing it, is its own defect. **Both reviewers agreed this
 is not DOCKERPROD-1 scope creep.**
 
+### 0e. Two behaviours I measured because the reviewers disagreed or I was about to guess
+
+**`ONBUILD` fires inside a single Dockerfile.** Codex said it "does not execute in the current image
+build"; Fable said it bypasses the guard entirely. Fable is right, and the build log settles it — the
+context read is attributed to the *runner* stage while appearing in no runner-stage instruction:
+
+```
+FROM busybox AS base
+ONBUILD COPY leaked.txt /leaked.txt
+FROM base AS runner
+RUN ls -l /leaked.txt
+--------------------------------------------------------------------
+#6 [runner 1/2] ONBUILD COPY leaked.txt /leaked.txt
+#7 0.169 -rw-r--r--  1 root root  7 … /leaked.txt      ← the context, read inside runner
+```
+
+So AC1 must reject `ONBUILD` **anywhere in the file**, not just in the final stage.
+
+**An empty `CMD` is a silent, successful exit.** `docker/entrypoint.sh:17` ends in `exec "$@"`; POSIX
+`exec` with zero arguments is a no-op, so the script falls off the end and returns 0:
+
+```
+$ /bin/sh entrypoint-like.sh            # no args, i.e. CMD deleted
+bootstrap ran
+exit=0                                  ← green build, container exits at boot, no error anywhere
+```
+
+`CMD ["npm", "start"]` is therefore half the boot invocation and was pinned by nothing in round 1.
+
 ## 1. The rule
 
-> **The runner stage builds from earlier stages of this same Dockerfile and from nothing else — no
-> context, no named context, no external image. Anything it needs is already in the image, and it
-> asserts at BUILD time that what it points at is there.**
+> **The final stage's FILESYSTEM comes from earlier stages of this same Dockerfile and from nothing
+> else — no build context, no named context, no external image. Everything the boot chain needs is
+> already in the image, the stage ASSERTS that at build time, and that assertion is the last thing in
+> the stage that can touch the filesystem.**
+
+*Deliberately scoped to filesystem sources.* A final-stage `RUN` may still reach the network; policing
+that is a different rule and claiming it here would be claiming more than the guard checks.
 
 ## 2. The design
 
-### 2a. Delete the redundant copy; assert what replaces it; point `ENTRYPOINT` at it
+### 2a. Delete the redundant copy; assert the boot chain terminally; complete the invocation
 
 ```dockerfile
 FROM base AS runner
 ENV NODE_ENV=production
 COPY --from=build /app ./
-RUN test -r /app/docker/entrypoint.sh          # ← fail CLOSED at build time
-...
+ENV PORT=3000 HOSTNAME=0.0.0.0
+EXPOSE 3000
+
+# TERMINAL boot-chain assertion — nothing below this line may touch the filesystem.
+RUN set -eu; \
+    for f in /app/docker/entrypoint.sh /app/docker/bootstrap.mjs; do \
+      test -f "$f" && test -s "$f" && test -r "$f"; \
+    done; \
+    /bin/sh -n /app/docker/entrypoint.sh
+
 ENTRYPOINT ["/bin/sh", "/app/docker/entrypoint.sh"]
+CMD ["npm", "start"]
 ```
 
-⚠️ **The `RUN test -r` is not belt-and-braces — it repairs a fail-open the deletion would otherwise
-introduce, and it is the sharpest thing either review found.** Today, if the file were ever absent
-from the build stage, line 35 **fails the build**. Delete line 35 and that same absence becomes:
-`COPY --from=build /app ./` succeeds, `next build` succeeds, the image is green, and the *container*
-dies at boot — a defect moved from build time to somebody's runtime. One `RUN` puts it back where it
-was.
+⚠️ **The assertion repairs a fail-open the deletion would otherwise introduce — the sharpest finding of
+round 1.** Today, if the file were absent from the build stage, line 35 **fails the build**. Delete
+line 35 and that absence becomes: `COPY --from=build /app ./` succeeds, `next build` succeeds, the
+image is green, and the *container* dies at boot — a defect moved from build time to somebody's
+runtime. The `RUN` puts it back.
 
-**Why `/bin/sh <path>` and not the bare path.** The two forms genuinely differ: the bare path makes
-the kernel read `#!/usr/bin/env sh` and resolve `sh` through `PATH` via `/usr/bin/env`, and it requires
-the executable bit; the explicit form depends on neither. `/bin/sh` is guaranteed on this Debian base
-(the upstream node image's own entrypoint uses `#!/bin/sh`, and this Dockerfile already relies on the
-default `/bin/sh -c` for its shell-form `RUN`s). It is also the idiom this repo already uses for the
-same script's production twin (`railway.json`: `sh scripts/railway-start.sh`).
+Round 2 then broke my first version of it three ways, all folded above:
 
-⚠️ *Round 0 justified this as removing a dependence on something "pinned by nothing." That was wrong
-and Fable caught it: the mode bit **is** pinned, by the git index at `100755`, which §0a verifies. The
-honest justification is narrower — the explicit form depends on nothing outside the Dockerfile, at
-zero cost. AC2 pins the form so a later bare-path edit cannot silently reintroduce the dependence.*
+- **`test -r` alone is nearly `test -e`.** The build runs as root, where `access(2)` grants read on any
+  mode — and `-r` passes on a **directory** at that path and on a **zero-byte file**, both of which
+  still yield a green image and a container that exits without serving. Verified: `[ -r <dir> ]` is
+  true, `[ -f <dir> ]` is false. Hence `-f` + `-s` + `-r`, plus `sh -n` as a build-time parse of the
+  script. **Not `-x`** — that would re-couple the build to the very mode bit the `/bin/sh <path>` form
+  deliberately decouples from.
+- **It covered one of the two boot files.** `entrypoint.sh:5` runs `node /app/docker/bootstrap.mjs`;
+  any absence mechanism that can eat one can eat the other. Both are asserted.
+- **The assertion must be TERMINAL.** `RUN test …` followed by `RUN rm …` — or even
+  `RUN test … && rm …` — passed round 1's wording, which is precisely the "rm after copying" hole the
+  assertion exists to close. AC2(d) forbids any filesystem-touching instruction after it.
 
-Inside the script nothing changes: `$@` forwarding, `set -eu`, exit-code propagation, and the final
-`exec "$@"` are identical, and `sh` is the interim PID 1 in both forms.
+**Caching cannot stale this.** The `RUN`'s cache key includes its parent layer; `COPY --from=build
+/app ./` re-checksums the build stage's `/app`, so a changed tree invalidates the COPY and therefore
+the RUN. A cache hit implies a byte-identical tree, in which case the cached success is a true success.
+Both reviewers agree; recorded so the next one need not re-derive it.
 
-⚠️ *One correction to the existing comment at `docker/entrypoint.sh:15`, which says the exec makes
-"the server" PID 1: `exec "$@"` runs `npm start` (`package.json:9` → `next start`), so **npm** becomes
-PID 1, not Next. That is pre-existing and NOT changed by this slice; AC4 measures what PID 1 actually
-is and the finding is reported rather than fixed here.*
+**Why `/bin/sh <path>` and not the bare path.** The bare path makes the kernel read
+`#!/usr/bin/env sh`, resolve `sh` through `PATH` via `/usr/bin/env`, and require the executable bit;
+the explicit form depends on none of that. `/bin/sh` is guaranteed on this Debian base (the upstream
+node image's own entrypoint uses `#!/bin/sh`, and this Dockerfile already relies on the default
+`/bin/sh -c` for its shell-form `RUN`s), and it is the idiom this repo already uses for the same
+script's production twin (`railway.json`: `sh scripts/railway-start.sh`). Inside the script nothing
+changes: `$@` forwarding, `set -eu`, exit-code propagation and the final `exec "$@"` are identical.
 
-### 2b. The header stops claiming it is off the deploy path
+⚠️ *Round 0 justified this as removing a dependence on something "pinned by nothing." Wrong — the mode
+bit IS pinned, by the git index at `100755`, which §0a verifies. The honest justification is narrower:
+the explicit form depends on nothing outside the Dockerfile, at zero cost.*
 
-Rewritten to state the two facts positively: Railway auto-detects and builds this root `Dockerfile`,
-and Railway's configured `startCommand` overrides the image's `ENTRYPOINT` — so the entrypoint is the
-local-compose path only. The devDependencies paragraph stays; it is still accurate and DOCKERPROD-1
-owns changing it.
+⚠️ *One correction to `docker/entrypoint.sh:15`, which says the exec makes "the server" PID 1:
+`exec "$@"` runs `npm start` (`package.json:9` → `next start`), so **npm** becomes PID 1, not Next.
+Pre-existing and NOT changed here; AC4 records what PID 1 actually is and the finding is reported
+rather than fixed in this slice.*
+
+### 2b. The header states the deploy contract positively
+
+Two sentinel sentences, quoted here verbatim so the header and the guard cannot drift:
+
+> `Railway's GitHub integration auto-detects this root Dockerfile and BUILDS PRODUCTION with it.`
+> `Railway overrides this image's ENTRYPOINT/CMD with railway.json's startCommand, so the entrypoint below is the local `docker compose` path only.`
+
+The devDependencies paragraph stays — still accurate, and DOCKERPROD-1 owns changing it.
 
 ## 3. Scope
 
-**In:** `Dockerfile` (the runner lines + the header) · one guard, unit tier · `docs/ARCHITECTURE.md`
+**In:** `Dockerfile` (the runner stage + the header) · one guard, unit tier · `docs/ARCHITECTURE.md`
 if the deploy flow's prose is affected.
 
 **Out — all of it DOCKERPROD-1:**
@@ -172,63 +234,89 @@ if the deploy flow's prose is affected.
 
 ## 4. Acceptance
 
-- **AC1 — the final stage reads nothing but declared earlier stages (guard, unit, ∀):** in the
-  Dockerfile's FINAL stage, (a) there is no `ADD`; (b) every `COPY` carries `--from=<name>` where
-  `<name>` is a stage declared by an earlier `FROM … AS <name>` **in this file**; (c) no
-  `RUN --mount=type=bind` without an explicit `from=<declared stage>`; and (d) — non-vacuity — at
-  least one `COPY --from=<declared stage>` exists. *Round 0 quantified over `COPY` alone, which both
-  reviewers broke three ways: `ADD` reads the context, `--from=` may name an external image or a named
-  context rather than a stage, and buildkit's default bind-mount source IS the context. A ∀ narrower
-  than the rule it claims to enforce is not a guard.*
-- **AC2 — the entrypoint is a build-asserted path in the invoked form (guard, unit):** the guard parses
-  `ENTRYPOINT`, and (a) **fails loudly on any shape it does not recognise** — shell form, `-c` string,
-  anything but `["/bin/sh", "<path>"]`; (b) requires the final stage to contain a `RUN` asserting that
-  exact `<path>` is readable; (c) requires `<path>` to correspond, under the image's `/app` root, to a
-  file tracked in the repo. *Round 0's version checked only (c) and called it proof the image carries
-  the file — Codex's counterexample: copy from the wrong stage, or `rm` after copying, and (c) still
-  passes. (b) is what actually observes the image, at build time. (a) exists because an ENTRYPOINT
-  shape the guard silently skips is a guard that passes on the defect.*
-- **AC3 — the header states the deploy contract positively (guard, unit):** the Dockerfile does not
-  contain the retired sentence, AND asserts both that Railway builds this Dockerfile and that its
-  `startCommand` overrides the image entrypoint. *Round 0 required only that the word "Railway" appear
-  — satisfied by "Railway never builds this Dockerfile," which is false. Asserting the contract is the
-  only version that cannot be satisfied by a differently-worded lie.*
-- **AC4 — the image builds, serves, and STOPS (manual, recorded):** `docker compose build app`
-  succeeds; a container from it boots through `entrypoint.sh` and answers an HTTP request;
-  `docker compose stop` terminates it within the grace period with no orphan; and `PID 1` is recorded
-  as observed (see §2a). ⚠️ *Manual and named as such — this repo has no container test tier and
-  claiming CI proves it would be false. The stop leg is here because the `ENTRYPOINT` form is the one
-  thing this slice changes about the running container.*
+- **AC1 — the final stage's filesystem sources are earlier stages of this file, and nothing else
+  (guard, unit, ∀):** in the FINAL stage — defined as the last `FROM` in file order, i.e. the default
+  build target, which is what both `compose.yml:38` (`build: .`) and Railway build today —
+  **(a)** its own `FROM` names a stage declared earlier in this file; **(b)** there is no `ADD`;
+  **(c)** every `COPY` carries `--from=<name>` naming an earlier declared stage; **(d)** no `RUN`
+  carries any `--mount`; **(e)** no `ONBUILD` appears **anywhere in the file**; **(f)** the parser
+  fails LOUDLY rather than skipping — an unclassifiable instruction, a numeric or `ARG`-substituted
+  `--from`, a duplicate stage name, or a final stage with no instructions is a failure, not a pass.
+  *Round 1 quantified over `COPY` alone and round 2 broke it four ways: the stage's own `FROM` could
+  be `busybox` (green build, no `node`, dead boot); `--mount` with `type=` omitted defaults to bind
+  and `from=` omitted defaults to the context; `ONBUILD` in a parent stage executes inside this one
+  (§0e, measured); and "non-vacuity" was a parser property masquerading as a product criterion.
+  `--mount` is forbidden outright rather than allowlisted because modelling buildkit's mount defaults
+  is a bug surface and nothing here uses one.*
+- **AC2 — the boot invocation is complete, build-asserted, and terminal (guard, unit):**
+  **(a)** `ENTRYPOINT` is present and is exactly `["/bin/sh", "<path>"]` — absence, shell form, a bare
+  path, or any shape the parser does not recognise FAILS; **(b)** `CMD` is present, exec-form and
+  non-empty; **(c)** the final stage asserts, at build time, that **both** boot-chain files are
+  regular, non-empty and readable, and that the entrypoint parses; **(d)** that assertion is TERMINAL
+  — only `ENV`, `EXPOSE`, `LABEL`, `ARG`, `STOPSIGNAL`, `HEALTHCHECK`, `ENTRYPOINT`, `CMD` may follow
+  it (an allowlist, so an unknown instruction fails closed); **(e)** the `ENTRYPOINT` path is one of
+  the asserted paths; **(f)** the asserted paths correspond, under the image's `/app` root, to files
+  tracked in the repo. *(f) is the weakest leg and is labelled so: it observes the repo, not the
+  image — (c)+(d) are what observe the image. (b) exists because `exec "$@"` with an empty `$@` exits
+  0 silently (§0e), so an unpinned `CMD` reproduces this slice's stated worst case with nothing
+  noticing.*
+- **AC3 — the deploy contract is asserted where it is actually configured (guard, unit):**
+  **(a)** the Dockerfile does not contain the retired sentence; **(b)** it contains both §2b sentinel
+  sentences verbatim; **(c)** `railway.json` has a non-empty `deploy.startCommand`. *Round 1 required
+  only that the word "Railway" appear — satisfied by "Railway never builds this Dockerfile." And a
+  prose-only criterion cannot see the deletion of `deploy.startCommand`, which is what would actually
+  falsify §0c and §6.* ⚠️ **Stated limit:** a repo guard cannot see a Railway **dashboard**-set start
+  command or build target; that stays a deployment assumption, verified post-merge.
+- **AC4 — the image builds, serves, and STOPS (manual, recorded as observed):**
+  1. `docker compose build app` → exit 0.
+  2. `docker inspect -f '{{.Config.Entrypoint}} {{.Config.Cmd}}'` → `[/bin/sh /app/docker/entrypoint.sh] [npm start]`.
+  3. `docker compose logs app` contains bootstrap's own named startup line.
+  4. `curl -fsS http://localhost:3000/login` → exit 0.
+  5. `docker exec … cat /proc/1/cmdline` → recorded verbatim (expect `npm`, per §2a).
+  6. `docker compose stop app`; `docker inspect -f '{{.State.ExitCode}}'` → **143** (SIGTERM honoured),
+     NOT 137 (SIGKILL after the grace period); `docker compose ps` lists nothing running.
+  ⚠️ *Manual and named as such — this repo has no container test tier and claiming CI proves it would
+  be false. Round 1 said "boots through entrypoint.sh", "answers an HTTP request" and "no orphan",
+  all three of which are design vocabulary that would ship green: a 500 page answers a request, and
+  after `exec` there is no wrapper left to orphan. The numbers above are what a person can check.*
 
 | # | mutation | must redden |
 |---|---|---|
-| 1 | restore `COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh` in the runner | **AC1** (a context `COPY`) |
-| 2 | add `ADD package.json ./x` to the runner | **AC1** (the `ADD` leg) |
-| 3 | add `COPY --from=somectx package.json ./x` — a source that is not a declared stage | **AC1** (the undeclared-source leg) |
-| 4 | add `RUN --mount=type=bind,target=/ctx true` to the runner | **AC1** (the bind-mount leg) |
-| 5 | delete `COPY --from=build /app ./` entirely | **AC1** (the non-vacuity leg) |
-| 6 | `ENTRYPOINT` points at `/usr/local/bin/entrypoint.sh` | **AC2** (assertion/entrypoint divergence) |
-| 7 | `ENTRYPOINT` and the `RUN test` BOTH move to `/app/docker/nope.sh` | **AC2** (the repo-correspondence leg) |
-| 8 | delete the `RUN test -r` assertion | **AC2** (the build-assertion leg) |
-| 9 | `ENTRYPOINT /app/docker/entrypoint.sh` in **shell form** | **AC2** (ambiguity must fail, not skip) |
-| 10 | `ENTRYPOINT ["/app/docker/entrypoint.sh"]` — bare path, no `/bin/sh` | **AC2** (the invoked-form leg) |
-| 11 | restore the "NOT wired into the Railway deploy path" sentence | **AC3** |
-| 12 | header reads "Railway never builds this Dockerfile" — false, contains "Railway" | **AC3** (the round-0 bypass) |
-| 13 | header drops the `startCommand`-override statement | **AC3** (the second positive leg) |
+| 1 | final stage becomes `FROM busybox AS runner` | AC1(a) |
+| 2 | restore `COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh` | AC1(c) |
+| 3 | add `ADD package.json ./x` to the runner | AC1(b) |
+| 4 | add `COPY --from=somectx package.json ./x` — source is not a declared stage | AC1(c) |
+| 5 | add `RUN --mount=target=/ctx true` — type omitted ⇒ bind, from omitted ⇒ context | AC1(d) |
+| 6 | add `ONBUILD COPY . .` to the `base` stage | AC1(e) |
+| 7 | declare `AS build` twice | AC1(f) |
+| 8 | delete `ENTRYPOINT` entirely | AC2(a) |
+| 9 | `ENTRYPOINT` in shell form | AC2(a) |
+| 10 | `ENTRYPOINT ["/app/docker/entrypoint.sh"]` — bare path | AC2(a) |
+| 11 | **delete `CMD ["npm", "start"]`** | **AC2(b)** |
+| 12 | assertion drops `/app/docker/bootstrap.mjs` | AC2(c) |
+| 13 | assertion weakens to `test -r` only (a dir or empty file would pass) | AC2(c) |
+| 14 | **insert `RUN rm /app/docker/entrypoint.sh` AFTER the assertion** | **AC2(d)** |
+| 15 | `ENTRYPOINT` → `/app/scripts/railway-start.sh` — tracked and corresponds, but unasserted | AC2(e) |
+| 16 | assertion AND `ENTRYPOINT` both → `/app/docker/nope.sh` | AC2(f) |
+| 17 | restore the "NOT wired into the Railway deploy path" sentence | AC3(a) |
+| 18 | header reads "Railway never builds this Dockerfile" — false, contains "Railway" | AC3(b) |
+| 19 | **delete `deploy.startCommand` from `railway.json`** | **AC3(c)** |
 
-Each row changes exactly ONE condition, so a redden attributes to one criterion. Every row must redden
-the criterion NAMED, not merely something.
+Each row changes exactly ONE condition, so a redden attributes to one criterion, and every row must
+redden the criterion NAMED — not merely something. *These are unit-guard mutations; several would also
+fail AC4, which is manual and not part of the attribution.*
 
 ## 5. Risks
 
 | risk | direction | mitigation |
 |---|---|---|
-| The file is absent from the build stage; the build goes green and the container dies at boot | **fail-open introduced by this very change** — the worst outcome here | §2a's `RUN test -r`, pinned by AC2(b) and mutation 8 |
-| Wrong entrypoint path or lost exec bit | an unbootable container | AC2(a)+(c); §2a removes the exec-bit dependence; AC4 boots a real container |
-| The guard reads the Dockerfile as prose | a guard with no failure mode is ceremony | it must parse stages and instructions; all 13 mutations must redden the NAMED criterion |
-| AC1 passes vacuously on a stage with no `COPY` at all | silently green | AC1(d), mutation 5 |
-| Someone reads this as "the flake is fixed" | a false claim in the map | §0b states the limit and the no-improvement reading; the PR body must repeat both |
-| Railway builds a different Dockerfile than the one guarded | the guard watches the wrong file | the build logs name these stages (`build`, `runner`) verbatim — §0b |
+| The boot chain is absent; the build goes green and the container dies at boot | **fail-open introduced by this very change** | §2a's terminal assertion over both files, pinned by AC2(c)+(d), mutations 12–14 |
+| `CMD` is dropped and the container exits 0 at boot, silently | same outcome, no error anywhere (§0e) | AC2(b), mutation 11 |
+| `deploy.startCommand` is removed and §0c/§6 quietly become false | the release rationale evaporates unobserved | AC3(c), mutation 19 |
+| **Dropping the static `.dockerignore` leg trades pre-merge detection for at-Railway-build detection** | a PR adding `docker/` to `.dockerignore` passes ALL CI (this repo runs no docker build in CI), merges, and fails the Railway build — verbatim the incident class in this spec's own motivation table | Accepted, and it is **not a regression**: today's line 35 fails that same Railway build the same way. A third option was considered and declined — a battle-tested matcher library (`@balena/dockerignore`) is not hand-rolling — because a new production dependency to guard a one-line risk is out of proportion to this slice |
+| The guard reads the Dockerfile as prose | a guard with no failure mode is ceremony | it must parse stages and instructions; all 19 mutations must redden the NAMED criterion |
+| Railway builds a different Dockerfile, or a dashboard-set `--target`/start command diverges from the repo | the guard watches the wrong file | out of a repo guard's reach by construction; stated in AC3's limit; the build logs name these stages (`build`, `runner`) verbatim |
+| Someone reads this as "the flake is fixed" | a false claim in the map | §0b states the limit AND the monotone claim; the PR body must repeat both |
 
 ## 6. Release condition
 
@@ -237,13 +325,14 @@ change what the runtime contains." It does: `/usr/local/bin/entrypoint.sh` is go
 is different. What is actually true is narrower, and it is enough:
 
 - **Railway's runtime process is unchanged**, because `startCommand` overrides the image entrypoint
-  (§0c) — so the production path does not execute the thing this slice changes.
-- **Local compose is the path whose behaviour changes**, and AC4 exercises exactly that, in the real
+  (§0c) — so the production path does not execute the thing this slice changes. *Pinned by AC3(c),
+  because otherwise this bullet is prose that a one-line edit to `railway.json` can falsify.*
+- **Local compose is the path whose behaviour changes**, and AC4 exercises exactly that in a real
   container, including the stop path.
 - **One staging build could not demonstrate the absence of a stochastic flake anyway**, so invoking the
   gate here would spend it on a question it cannot answer.
 
-That is a risk-based boundary, not an erosion of the gate DOCKERPROD-1 genuinely needs. Post-merge,
-the normal Railway deploy verification applies.
+A risk-based boundary, not an erosion of the gate DOCKERPROD-1 genuinely needs. Post-merge, the normal
+Railway deploy verification applies.
 
 **Nothing is built. No code exists for this slice.**

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -445,5 +445,5 @@ exercises. That is the sweeping-claim habit this section exists to check, caught
 
 Against the FIRST version of the assertion, rows 1-4 all **PASSED** the build.
 
-**Code is written. AC1–AC3 are guarded in `test/guards/dockerfile-runner-stage.test.ts`; AC4 is the
-table above.**
+**Code is written. AC1–AC3 are guarded in `test/guards/dockerfile-runner-stage.test.ts`; AC4 and AC5
+are the tables above.**

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -1,6 +1,6 @@
 # The runner stage stops reading the build context — DOCKERPROD-2
 
-**Status:** spec, round 2 (four model reviews folded: two rounds × two models). No code written.
+**Status:** spec, round 3 (five model reviews folded). Code written against it.
 
 **Build with:** opus / high — it changes the image production boots from. The diff is small but the
 failure mode is a container that builds green and cannot start, and the only roll-forward from that is
@@ -250,9 +250,9 @@ if the deploy flow's prose is affected.
   is a bug surface and nothing here uses one.*
 - **AC2 — the boot invocation is complete, build-asserted, and terminal (guard, unit):**
   **(a)** `ENTRYPOINT` is present and is exactly `["/bin/sh", "<path>"]` — absence, shell form, a bare
-  path, or any shape the parser does not recognise FAILS; **(b)** `CMD` is present, exec-form and
-  non-empty; **(c)** the final stage asserts, at build time, that **both** boot-chain files are
-  regular, non-empty and readable, and that the entrypoint parses; **(d)** that assertion is TERMINAL
+  path, or any shape the parser does not recognise FAILS; **(b)** `CMD` is present, exec-form, and runs a
+  **script `package.json` actually defines**; **(c)** the final stage's boot-chain assertion is
+  EXACTLY the derived check — whole-instruction equality, not `contains`; **(d)** that assertion is TERMINAL
   — only `ENV`, `EXPOSE`, `LABEL`, `ARG`, `STOPSIGNAL`, `HEALTHCHECK`, `ENTRYPOINT`, `CMD` may follow
   it (an allowlist, so an unknown instruction fails closed); **(e)** the `ENTRYPOINT` path is one of
   the asserted paths; **(f)** the asserted paths correspond, under the image's `/app` root, to files
@@ -260,6 +260,15 @@ if the deploy flow's prose is affected.
   image — (c)+(d) are what observe the image. (b) exists because `exec "$@"` with an empty `$@` exits
   0 silently (§0e), so an unpinned `CMD` reproduces this slice's stated worst case with nothing
   noticing.*
+
+  ⚠️ **Two conditions that a round-3 confirmation pass added, both against the built guard rather
+  than the prose.** (i) `contains` was not enough for (c): `RUN <assertion> && rm <path>` asserts,
+  passes, and then destroys what it observed **inside one instruction**, where (d)'s look-ahead
+  cannot see it. Equality closes that, and has a second payoff — the Dockerfile line becomes a
+  DERIVED artifact, so adding a boot dependency to `docker/entrypoint.sh` reddens the guard until
+  the Dockerfile is updated to match. (ii) "non-empty `CMD`" was not the invariant either:
+  `CMD ["true"]` is non-empty and boots a container that exits 0 having served nothing. The
+  invariant is that `CMD` runs a script `package.json` defines — derived, not a pinned literal.
 - **AC3 — the deploy contract is asserted where it is actually configured (guard, unit):**
   **(a)** the Dockerfile does not contain the retired sentence; **(b)** it contains both §2b sentinel
   sentences verbatim; **(c)** `railway.json` has a non-empty `deploy.startCommand`. *Round 1 required
@@ -293,9 +302,11 @@ if the deploy flow's prose is affected.
 | 9 | `ENTRYPOINT` in shell form | AC2(a) |
 | 10 | `ENTRYPOINT ["/app/docker/entrypoint.sh"]` — bare path | AC2(a) |
 | 11 | **delete `CMD ["npm", "start"]`** | **AC2(b)** |
+| 11b | **`CMD ["true"]`** — non-empty, exec-form, serves nothing | **AC2(b)** |
 | 12 | assertion drops `/app/docker/bootstrap.mjs` | AC2(c) |
 | 13 | assertion weakens to `test -r` only (a dir or empty file would pass) | AC2(c) |
 | 14 | **insert `RUN rm /app/docker/entrypoint.sh` AFTER the assertion** | **AC2(d)** |
+| 14b | **append `&& rm /app/docker/entrypoint.sh` INSIDE the assertion instruction** | **AC2(c)** |
 | 15 | `ENTRYPOINT` → `/app/scripts/railway-start.sh` — tracked and corresponds, but unasserted | AC2(e) |
 | 16 | assertion AND `ENTRYPOINT` both → `/app/docker/nope.sh` | AC2(f) |
 | 17 | restore the "NOT wired into the Railway deploy path" sentence | AC3(a) |

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -360,6 +360,7 @@ if the deploy flow's prose is affected.
 | 13 | assertion weakens to `test -r` only (a dir or empty file would pass) | AC2(c) |
 | 13b | **assertion reverts to the `&&` AND-OR form** — the §2a-bis shape that cannot fail | **AC2(c)** |
 | 14 | **insert `RUN rm /app/docker/entrypoint.sh` AFTER the assertion** | **AC2(d)** |
+| 14c | **`ENV PATH=/nope` after the assertion** — green build, dead boot (`entrypoint.sh:5` resolves `node` via PATH) | **AC2(d)** |
 | 14b | **append `&& rm /app/docker/entrypoint.sh` INSIDE the assertion instruction** | **AC2(c)** |
 | 15 | `ENTRYPOINT` → `/app/scripts/railway-start.sh` — tracked and corresponds, but unasserted | AC2(e) |
 | 16 | assertion AND `ENTRYPOINT` both → `/app/docker/nope.sh` | AC2(f) |

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -282,8 +282,18 @@ if the deploy flow's prose is affected.
   3. `docker compose logs app` contains bootstrap's own named startup line.
   4. `curl -fsS http://localhost:3000/login` → exit 0.
   5. `docker exec … cat /proc/1/cmdline` → recorded verbatim (expect `npm`, per §2a).
-  6. `docker compose stop app`; `docker inspect -f '{{.State.ExitCode}}'` → **143** (SIGTERM honoured),
-     NOT 137 (SIGKILL after the grace period); `docker compose ps` lists nothing running.
+  6. `docker compose stop app` → stop latency **far under the 10s grace period** (SIGTERM honoured,
+     not a SIGKILL at the end of it), `docker compose ps` lists nothing running, and the exit code is
+     **UNCHANGED against the same image running `main`'s bare-path entrypoint** — an A/B, not a
+     predicted constant.
+
+  ⚠️ *Round 3 of this criterion said "exit code **143**, not 137." **Measured: it is 1, in both
+  forms.** `npm start` catches SIGTERM, forwards it, and exits 1 rather than 128+15 — so 143 was a
+  value I predicted instead of measured, written into an acceptance criterion where it would have
+  read as a regression in a change that causes none. The A/B is what discriminates: NEW
+  `["/bin/sh", "<path>"]` → exit 1 @ 1s; OLD bare path → exit 1 @ 2s; PID 1 is `npm start` in both.
+  Recorded rather than quietly corrected, because "the criterion named a number I had not observed"
+  is the finding.*
   ⚠️ *Manual and named as such — this repo has no container test tier and claiming CI proves it would
   be false. Round 1 said "boots through entrypoint.sh", "answers an HTTP request" and "no orphan",
   all three of which are design vocabulary that would ship green: a 500 page answers a request, and
@@ -346,4 +356,31 @@ is different. What is actually true is narrower, and it is enough:
 A risk-based boundary, not an erosion of the gate DOCKERPROD-1 genuinely needs. Post-merge, the normal
 Railway deploy verification applies.
 
-**Nothing is built. No code exists for this slice.**
+## 7. AC4, as observed
+
+Run against the real image built from this branch (`docker compose build app`, exit 0), on a real
+Postgres. Every line is a reading, not a claim.
+
+| # | observable | result |
+|---|---|---|
+| 1 | `docker compose build app` | **exit 0**; the runner stage is now 2 steps and **reads nothing from the context** — `#12 COPY --from=build /app ./`, `#13 RUN set -eu; …` |
+| 2 | `docker inspect -f '{{.Config.Entrypoint}} {{.Config.Cmd}}'` | `[/bin/sh /app/docker/entrypoint.sh]  [npm start]` |
+| 2b | the deleted copy is gone; the boot chain is present | `/usr/local/bin/entrypoint.sh`: **No such file or directory**; `/app/docker/entrypoint.sh` (665 b) and `/app/docker/bootstrap.mjs` (16,295 b) both `-rwxr-xr-x` |
+| 3 | booted THROUGH `entrypoint.sh` | `docker compose logs app` opens with bootstrap's own lines — `▶ generated AUTH_SECRET + SECRETS_KEY`, `▶ waiting for postgres…`, `▶ loading schema…` |
+| 4 | `curl -fsS http://localhost:3199/login` | **exit 0** |
+| 5 | `cat /proc/1/cmdline` | `npm start` — confirming §2a's correction: **npm** is PID 1, not Next |
+| 6 | stop | exit **1** @ **1s** (NEW) vs exit **1** @ **2s** (OLD bare path) — unchanged, and far under the 10s grace |
+
+**And the empty-`CMD` fail-open reproduced in a real container** — first by accident, because a compose
+`entrypoint:` override silently clears the image's `CMD`, then deliberately:
+
+| run | result |
+|---|---|
+| image defaults (`ENTRYPOINT` + `CMD`) | `Running=true` |
+| `CMD` removed | `Running=false`, **`ExitCode=0`**, last log line is the success banner's rule — **no error anywhere** |
+
+That is AC2(b)'s failure mode, observed rather than argued: a container that prints a login URL and a
+password, then exits successfully having served nothing.
+
+**Code is written. AC1–AC3 are guarded in `test/guards/dockerfile-runner-stage.test.ts`; AC4 is the
+table above.**

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -161,13 +161,44 @@ EXPOSE 3000
 # TERMINAL boot-chain assertion — nothing below this line may touch the filesystem.
 RUN set -eu; \
     for f in /app/docker/entrypoint.sh /app/docker/bootstrap.mjs; do \
-      test -f "$f" && test -s "$f" && test -r "$f"; \
+      test -f "$f" || { echo "boot chain: $f is missing or not a regular file" >&2; exit 1; }; \
+      test -s "$f" || { echo "boot chain: $f is empty" >&2; exit 1; }; \
+      test -r "$f" || { echo "boot chain: $f is not readable" >&2; exit 1; }; \
     done; \
     /bin/sh -n /app/docker/entrypoint.sh
 
 ENTRYPOINT ["/bin/sh", "/app/docker/entrypoint.sh"]
 CMD ["npm", "start"]
 ```
+
+### ⚠️ 2a-bis. The assertion I first wrote COULD NOT FAIL — measured, not reasoned
+
+The first version, under `set -eu`, was `for f in …; do test -f "$f" && test -s "$f" && test -r "$f"; done`.
+
+**It does not fail.** POSIX ignores `errexit` for a command in an AND-OR list, so a missing file falls
+straight through:
+
+```
+$ sh -c 'set -eu; for f in /nope; do test -f "$f" && test -s "$f"; done; echo REACHED'
+REACHED          exit=0     <- the && form
+$ sh -c 'set -eu; for f in /nope; do test -f "$f"; test -s "$f"; done; echo REACHED'
+                 exit=1     <- separate statements DO fire errexit
+```
+
+and end to end, which is the reading that matters — a real image build with `bootstrap.mjs` absent:
+
+```
+#8 [runner 3/3] RUN echo "!!! BUILD PASSED WITH bootstrap.mjs MISSING !!!"
+#8 0.113 !!! BUILD PASSED WITH bootstrap.mjs MISSING !!!
+```
+
+So the centrepiece repair of this slice — the thing that closes the fail-open — **was itself
+fail-open**, and all 21 static mutations still passed, because a static guard compares TEXT and the
+text looked right. Neither the spec reviews nor the mutation battery could have caught it; only
+building it could. Hence **AC5**: an assertion whose failure has never been observed is
+unfalsifiable, and unfalsifiable reads exactly like coverage.
+
+The shipped form exits explicitly, depends on no shell option, and names what is missing.
 
 ⚠️ **The assertion repairs a fail-open the deletion would otherwise introduce — the sharpest finding of
 round 1.** Today, if the file were absent from the build stage, line 35 **fails the build**. Delete
@@ -294,6 +325,10 @@ if the deploy flow's prose is affected.
   `["/bin/sh", "<path>"]` → exit 1 @ 1s; OLD bare path → exit 1 @ 2s; PID 1 is `npm start` in both.
   Recorded rather than quietly corrected, because "the criterion named a number I had not observed"
   is the finding.*
+- **AC5 — the assertion is FALSIFIABLE (manual, negative controls):** with each boot-chain file
+  removed, emptied, or replaced by a directory, `docker build` must **FAIL**; with all present it must
+  pass. *Without this, §2a-bis shipped: a decoration that every other criterion called green.*
+
   ⚠️ *Manual and named as such — this repo has no container test tier and claiming CI proves it would
   be false. Round 1 said "boots through entrypoint.sh", "answers an HTTP request" and "no orphan",
   all three of which are design vocabulary that would ship green: a 500 page answers a request, and
@@ -381,6 +416,19 @@ Postgres. Every line is a reading, not a claim.
 
 That is AC2(b)'s failure mode, observed rather than argued: a container that prints a login URL and a
 password, then exits successfully having served nothing.
+
+### AC5 — the negative controls, against the SHIPPED assertion
+
+| build | expected | result |
+|---|---|---|
+| `entrypoint.sh` missing | FAIL | **FAILED** |
+| `bootstrap.mjs` missing | FAIL | **FAILED** |
+| `bootstrap.mjs` present but **0 bytes** | FAIL | **FAILED** — `boot chain: /app/docker/bootstrap.mjs is empty` |
+| `entrypoint.sh` is a **directory** | FAIL | **FAILED** |
+| both present and valid (positive control) | PASS | **PASSED** |
+
+Each leg fires with its own message, so `-s` and `-r` are live rather than decorative. Against the
+FIRST version of the assertion, rows 1-4 all **PASSED** the build.
 
 **Code is written. AC1–AC3 are guarded in `test/guards/dockerfile-runner-stage.test.ts`; AC4 is the
 table above.**

--- a/docs/design/dockerprod2-deflake.md
+++ b/docs/design/dockerprod2-deflake.md
@@ -356,6 +356,8 @@ if the deploy flow's prose is affected.
 | 10 | `ENTRYPOINT ["/app/docker/entrypoint.sh"]` — bare path | AC2(a) |
 | 11 | **delete `CMD ["npm", "start"]`** | **AC2(b)** |
 | 11b | **`CMD ["true"]`** — non-empty, exec-form, serves nothing | **AC2(b)** |
+| 11c | **`CMD ["npm","start","--","--help"]`** — a defined script that prints help and exits 0 | **AC2(b)** |
+| 11d | **`CMD ["npm","build"]`** — in `package.json.scripts`, but npm answers `Unknown command` | **AC2(b)** |
 | 12 | assertion drops `/app/docker/bootstrap.mjs` | AC2(c) |
 | 13 | assertion weakens to `test -r` only (a dir or empty file would pass) | AC2(c) |
 | 13b | **assertion reverts to the `&&` AND-OR form** — the §2a-bis shape that cannot fail | **AC2(c)** |
@@ -367,10 +369,28 @@ if the deploy flow's prose is affected.
 | 17 | restore the "NOT wired into the Railway deploy path" sentence | AC3(a) |
 | 18 | header reads "Railway never builds this Dockerfile" — false, contains "Railway" | AC3(b) |
 | 19 | **delete `deploy.startCommand` from `railway.json`** | **AC3(c)** |
+| 19b | **`startCommand: "true"`** — non-empty, overrides the entrypoint, exits immediately | **AC3(c)** |
+| 20 | prepend a `` # escape=` `` parser directive — it changes what a backslash MEANS | parse test |
+| 21 | an instruction before the first `FROM` (only a global `ARG` is legal there) | parse test |
+| 22 | `COPY --from=2` — a numeric stage reference that cannot be statically resolved | AC1(c)+(f) |
+| 23 | **`node /app/docker/bootstrap.mjs?typo` in `docker/entrypoint.sh`** — the valid-PREFIX case | **AC2(c)** |
 
-Each row changes exactly ONE condition, so a redden attributes to one criterion, and every row must
-redden the criterion NAMED — not merely something. *These are unit-guard mutations; several would also
-fail AC4, which is manual and not part of the attribution.*
+Every row must redden the criterion NAMED — not merely something — and all 30 were **run**, not
+narrated. *These are unit-guard mutations; several would also fail AC4/AC5, which are manual.*
+
+⚠️ **Where isolation does NOT hold, stated rather than smoothed over.** Four rows (8, 9, 10, 15) also
+trip AC2(c), because the boot-chain expectation is DERIVED from the `ENTRYPOINT` by design — breaking
+the entrypoint necessarily breaks the derivation. Row 22 trips AC1(c) as well as (f). Rows 20/21 make
+the parse fail, which reddens the parse test and every test downstream of it by construction. In all
+of these the NAMED criterion is among the reddened; none is a case where the criterion under test
+stayed green.
+
+⚠️ **Row 23 SURVIVED on first run, and that is the point of running them.** `…/bootstrap.mjs?typo`
+yielded the valid PREFIX `/app/docker/bootstrap.mjs`, so the assertion covered a path node never
+requests and the guard reported everything fine. Closed by requiring a shell word boundary after the
+path. ⚠️ **Rows 20 and 21 first came back `REFUSING — ZERO tests ran`**: the parser threw at module
+scope, so vitest collected nothing, and zero-tests-ran is indistinguishable from all-green. A parse
+failure is now a red TEST rather than a collection error.
 
 ## 5. Risks
 

--- a/test/guards/dockerfile-runner-stage.test.ts
+++ b/test/guards/dockerfile-runner-stage.test.ts
@@ -287,9 +287,16 @@ describe("AC2 — the boot invocation is complete, build-asserted, and terminal"
     //
     // `-r` alone is nearly `-e` as root, and passes on a directory and on a zero-byte file — both of
     // which still build green and boot dead. Hence -f and -s too.
+    // Each test EXITS EXPLICITLY. The first version chained them with `&&` under `set -eu`, which
+    // does not fail: POSIX ignores errexit for a command in an AND-OR list, so a missing boot file
+    // fell through and the image built green. Pinning the exact text is what stops that shape
+    // coming back — a static guard cannot otherwise tell a working assertion from a decorative one.
+    const fail = (msg: string) => `|| { echo "boot chain: $f ${msg}" >&2; exit 1; }`;
     const expected =
       `set -eu; for f in ${bootPaths.join(" ")}; do ` +
-      `test -f "$f" && test -s "$f" && test -r "$f"; done; ` +
+      `test -f "$f" ${fail("is missing or not a regular file")}; ` +
+      `test -s "$f" ${fail("is empty")}; ` +
+      `test -r "$f" ${fail("is not readable")}; done; ` +
       `/bin/sh -n ${entrypointArgv?.[1]}`;
     expect(normalise(finalStage.instructions[assertionIndex].args)).toBe(normalise(expected));
   });

--- a/test/guards/dockerfile-runner-stage.test.ts
+++ b/test/guards/dockerfile-runner-stage.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * DOCKERPROD-2 — the runner stage's contract (spec: docs/design/dockerprod2-deflake.md).
+ *
+ * Railway's GitHub integration builds this root `Dockerfile` for PRODUCTION. Its runner stage used
+ * to re-read the BUILD CONTEXT for a single file (`COPY docker/entrypoint.sh /usr/local/bin/…`) that
+ * the image already carried via `COPY --from=build /app ./` — and that instruction failed two
+ * production deploys, each time blocking a merged fix for hours.
+ *
+ * Deleting it, on its own, would have traded a BUILD failure for a RUNTIME one: a build stage missing
+ * the boot chain would yield a green image and a container that dies at boot. So the contract this
+ * guard pins is three-part, and every part traces to a defect a reviewer actually produced against an
+ * earlier draft of the spec:
+ *
+ *   AC1  the final stage's FILESYSTEM comes from earlier stages of this file and nothing else
+ *   AC2  the boot invocation is complete (ENTRYPOINT *and* CMD), build-asserted, and TERMINAL
+ *   AC3  the deploy contract is asserted where it is actually configured (header + railway.json)
+ *
+ * The parser FAILS LOUDLY rather than skipping: an unclassifiable instruction, an unresolvable
+ * `--from`, a duplicate stage name or an empty final stage is a failure, not a pass. A guard that
+ * silently skips what it cannot classify passes on the defect.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const DOCKERFILE = readFileSync(join(ROOT, "Dockerfile"), "utf8");
+const ENTRYPOINT_SCRIPT = readFileSync(join(ROOT, "docker", "entrypoint.sh"), "utf8");
+const RAILWAY_JSON = readFileSync(join(ROOT, "railway.json"), "utf8");
+
+/** The image root every in-container path is resolved against (`WORKDIR /app` in the base stage). */
+const IMAGE_ROOT = "/app";
+
+/**
+ * Instructions that cannot change the filesystem, and may therefore follow the boot-chain assertion.
+ * An ALLOWLIST on purpose: an instruction nobody thought about fails closed rather than sneaking in
+ * behind the assertion the way `RUN rm …` would.
+ */
+const NON_FILESYSTEM_OPS = new Set([
+  "ENV",
+  "EXPOSE",
+  "LABEL",
+  "ARG",
+  "STOPSIGNAL",
+  "HEALTHCHECK",
+  "ENTRYPOINT",
+  "CMD",
+]);
+
+const KNOWN_OPS = new Set([
+  "FROM",
+  "RUN",
+  "CMD",
+  "LABEL",
+  "EXPOSE",
+  "ENV",
+  "ADD",
+  "COPY",
+  "ENTRYPOINT",
+  "VOLUME",
+  "USER",
+  "WORKDIR",
+  "ARG",
+  "ONBUILD",
+  "STOPSIGNAL",
+  "HEALTHCHECK",
+  "SHELL",
+  "MAINTAINER",
+]);
+
+type Instruction = { op: string; args: string; line: number };
+type Stage = { name: string | null; from: string; instructions: Instruction[]; line: number };
+
+/**
+ * A deliberately strict Dockerfile parser. Joins `\` continuations, drops comment lines (docker
+ * drops them mid-continuation too), and throws on anything it cannot classify.
+ */
+export function parseDockerfile(text: string): { stages: Stage[]; all: Instruction[] } {
+  const raw = text.split("\n");
+  const joined: Instruction[] = [];
+  let buffer = "";
+  let bufferLine = 0;
+
+  const flush = () => {
+    const trimmed = buffer.trim();
+    buffer = "";
+    if (!trimmed) return;
+    const m = trimmed.match(/^([A-Za-z]+)\s*([\s\S]*)$/);
+    if (!m) throw new Error(`Dockerfile line ${bufferLine}: cannot classify instruction: ${trimmed}`);
+    const op = m[1].toUpperCase();
+    if (!KNOWN_OPS.has(op)) {
+      throw new Error(`Dockerfile line ${bufferLine}: unknown instruction \`${op}\``);
+    }
+    joined.push({ op, args: m[2].trim(), line: bufferLine });
+  };
+
+  raw.forEach((lineText, i) => {
+    const lineNo = i + 1;
+    if (/^\s*#/.test(lineText)) return; // comment — dropped even mid-continuation
+    if (!buffer && !lineText.trim()) return;
+    if (!buffer) bufferLine = lineNo;
+    if (/\\\s*$/.test(lineText)) {
+      buffer += lineText.replace(/\\\s*$/, " ");
+      return;
+    }
+    buffer += lineText;
+    flush();
+  });
+  flush();
+
+  const stages: Stage[] = [];
+  for (const ins of joined) {
+    if (ins.op === "FROM") {
+      const m = ins.args.match(/^(\S+)(?:\s+[Aa][Ss]\s+(\S+))?\s*$/);
+      if (!m) throw new Error(`Dockerfile line ${ins.line}: cannot parse FROM: ${ins.args}`);
+      stages.push({ name: m[2] ?? null, from: m[1], instructions: [], line: ins.line });
+    } else {
+      if (stages.length === 0) continue; // pre-FROM ARG etc.
+      stages[stages.length - 1].instructions.push(ins);
+    }
+  }
+  if (stages.length === 0) throw new Error("Dockerfile declares no stages");
+  return { stages, all: joined };
+}
+
+const parsed = parseDockerfile(DOCKERFILE);
+/** FINAL = the last `FROM` in file order, i.e. the default build target — what compose and Railway build. */
+const finalStage = parsed.stages[parsed.stages.length - 1];
+const earlierStageNames = new Set(
+  parsed.stages.slice(0, -1).map((s) => s.name).filter((n): n is string => n !== null)
+);
+
+/** `--from=<value>` on a COPY/RUN-mount, or null when the flag is absent. */
+function fromFlag(args: string): string | null {
+  const m = args.match(/(?:^|\s)--from=(\S+)/);
+  return m ? m[1] : null;
+}
+
+/** The ENTRYPOINT's exec-form argv, or null if it is not a JSON array. */
+function execForm(args: string): string[] | null {
+  if (!args.trim().startsWith("[")) return null;
+  try {
+    const v = JSON.parse(args);
+    return Array.isArray(v) && v.every((x) => typeof x === "string") ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Collapse runs of whitespace so a multi-line `RUN` compares by content, not by formatting. */
+function normalise(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+function only(op: string): Instruction[] {
+  return finalStage.instructions.filter((i) => i.op === op);
+}
+
+describe("AC1 — the final stage's filesystem comes from earlier stages of this file, and nothing else", () => {
+  it("(a) the final stage's own FROM names an earlier declared stage", () => {
+    expect(
+      earlierStageNames.has(finalStage.from),
+      `The final stage is \`FROM ${finalStage.from}\`, which is not a stage declared earlier in this ` +
+        `Dockerfile (declared: ${[...earlierStageNames].join(", ")}). An external base here builds ` +
+        `green and boots dead — e.g. busybox has no \`node\` for docker/entrypoint.sh:5.`
+    ).toBe(true);
+  });
+
+  it("(b) the final stage contains no ADD — ADD reads the build context too", () => {
+    expect(only("ADD").map((i) => `line ${i.line}: ADD ${i.args}`)).toEqual([]);
+  });
+
+  it("(c) every final-stage COPY reads from an earlier declared stage", () => {
+    const offenders = only("COPY").map((i) => {
+      const from = fromFlag(i.args);
+      if (from === null) return `line ${i.line}: COPY with no --from= (reads the BUILD CONTEXT)`;
+      if (!earlierStageNames.has(from)) {
+        return `line ${i.line}: COPY --from=${from} — not a stage declared earlier in this file ` +
+          `(a named context or external image, not the build stage)`;
+      }
+      return null;
+    });
+    expect(offenders.filter(Boolean)).toEqual([]);
+  });
+
+  it("(d) no final-stage RUN carries a --mount of any kind", () => {
+    // Forbidden outright rather than allowlisted: with `type=` omitted buildkit defaults to bind and
+    // with `from=` omitted it defaults to the BUILD CONTEXT, so an allowlist would have to model
+    // those defaults correctly to be safe. Nothing here needs a mount.
+    const offenders = only("RUN")
+      .filter((i) => /(?:^|\s)--mount[=\s]/.test(i.args))
+      .map((i) => `line ${i.line}: RUN --mount…`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("(e) no ONBUILD anywhere in the file — it fires INSIDE the inheriting stage", () => {
+    // Measured, because the two spec reviewers disagreed about it (spec §0e): with
+    // `FROM busybox AS base / ONBUILD COPY x / FROM base AS runner`, buildkit prints
+    // `[runner 1/2] ONBUILD COPY x` — a context read attributed to the runner stage while appearing
+    // in no runner-stage instruction. A final-stage-only check cannot see it.
+    expect(parsed.all.filter((i) => i.op === "ONBUILD").map((i) => `line ${i.line}`)).toEqual([]);
+  });
+
+  it("(f) the final stage is non-empty and every stage name is unique — the parser must not pass vacuously", () => {
+    expect(finalStage.instructions.length).toBeGreaterThan(0);
+    const names = parsed.stages.map((s) => s.name).filter(Boolean);
+    expect(
+      names.filter((n, i) => names.indexOf(n) !== i),
+      "Duplicate stage name — docker resolves it last-wins, silently"
+    ).toEqual([]);
+    // An unresolvable --from must fail rather than be skipped.
+    const unresolvable = only("COPY")
+      .map((i) => fromFlag(i.args))
+      .filter((f): f is string => f !== null && (/^\d+$/.test(f) || f.includes("$")));
+    expect(unresolvable, "Numeric or ARG-substituted --from cannot be statically resolved").toEqual([]);
+  });
+});
+
+/**
+ * The paths the boot chain needs, derived rather than hardcoded: the ENTRYPOINT's own script, plus
+ * every absolute `/app/…` path that script goes on to execute. Adding a new boot dependency to
+ * `docker/entrypoint.sh` therefore extends what the image must assert, automatically.
+ */
+const entrypointArgv = (() => {
+  const ins = only("ENTRYPOINT");
+  return ins.length === 1 ? execForm(ins[0].args) : null;
+})();
+
+const bootPaths: string[] = (() => {
+  const script = entrypointArgv?.[1];
+  const referenced = [...ENTRYPOINT_SCRIPT.matchAll(/(\/app\/[A-Za-z0-9_./-]+)/g)].map((m) => m[1]);
+  return [...new Set([...(script ? [script] : []), ...referenced])];
+})();
+
+/** The final stage's boot-chain assertion: the RUN that tests the boot paths. */
+const assertionIndex = finalStage.instructions.findIndex(
+  (i) => i.op === "RUN" && /\btest\s+-f\b/.test(i.args)
+);
+
+describe("AC2 — the boot invocation is complete, build-asserted, and terminal", () => {
+  it("(a) ENTRYPOINT is present and is exactly [\"/bin/sh\", \"<path>\"]", () => {
+    const ins = only("ENTRYPOINT");
+    expect(ins.length, "exactly one ENTRYPOINT — absence is not a shape the guard may skip").toBe(1);
+    const argv = execForm(ins[0].args);
+    expect(argv, `ENTRYPOINT must be JSON exec form, got: ${ins[0].args}`).not.toBeNull();
+    expect(
+      argv,
+      "ENTRYPOINT must invoke through /bin/sh so the boot depends on nothing outside this file — " +
+        "not the executable bit, not /usr/bin/env, not PATH"
+    ).toHaveLength(2);
+    expect(argv?.[0]).toBe("/bin/sh");
+  });
+
+  it("(b) CMD is present, exec-form and non-empty — an empty CMD exits 0 at boot, silently", () => {
+    // docker/entrypoint.sh ends in `exec "$@"`, and POSIX `exec` with zero arguments is a NO-OP:
+    // the script falls off the end and returns 0. Green build, container gone, no error anywhere.
+    const ins = only("CMD");
+    expect(ins.length, "exactly one CMD").toBe(1);
+    const argv = execForm(ins[0].args);
+    expect(argv, `CMD must be JSON exec form, got: ${ins[0].args}`).not.toBeNull();
+    // Non-empty is NOT the invariant — `CMD ["true"]` is non-empty and boots a container that exits
+    // 0 having served nothing. What must hold is that CMD runs a DEFINED npm script of this package,
+    // derived from package.json rather than pinned to a literal.
+    expect(argv?.[0], "CMD must invoke npm").toBe("npm");
+    const scripts = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")).scripts ?? {};
+    expect(
+      Object.keys(scripts),
+      `CMD runs \`npm ${argv?.[1]}\`, which package.json does not define`
+    ).toContain(argv?.[1]);
+  });
+
+  it("(c) the assertion is EXACTLY the derived boot-chain check — no more, no less", () => {
+    expect(bootPaths.length, "derived boot paths must not be empty").toBeGreaterThan(0);
+    expect(assertionIndex, "no boot-chain assertion (`RUN … test -f …`) in the final stage").toBeGreaterThanOrEqual(0);
+    // WHOLE-INSTRUCTION equality, not `contains`. A `contains` check accepts
+    // `RUN <assertion> && rm /app/docker/entrypoint.sh` — the assertion runs, passes, and then
+    // destroys what it just observed, inside ONE instruction that AC2(d)'s look-ahead cannot see.
+    // Equality also makes the Dockerfile line a DERIVED artifact: add a boot dependency to
+    // docker/entrypoint.sh and this reddens until the Dockerfile is updated to match.
+    //
+    // `-r` alone is nearly `-e` as root, and passes on a directory and on a zero-byte file — both of
+    // which still build green and boot dead. Hence -f and -s too.
+    const expected =
+      `set -eu; for f in ${bootPaths.join(" ")}; do ` +
+      `test -f "$f" && test -s "$f" && test -r "$f"; done; ` +
+      `/bin/sh -n ${entrypointArgv?.[1]}`;
+    expect(normalise(finalStage.instructions[assertionIndex].args)).toBe(normalise(expected));
+  });
+
+  it("(d) the assertion is TERMINAL — nothing that can touch the filesystem follows it", () => {
+    // `RUN test -r X` followed by `RUN rm X` is exactly the rm-after-copy hole the assertion exists
+    // to close, and a "contains an assertion" check accepts it.
+    const after = finalStage.instructions.slice(assertionIndex + 1);
+    const offenders = after
+      .filter((i) => !NON_FILESYSTEM_OPS.has(i.op))
+      .map((i) => `line ${i.line}: ${i.op} — can invalidate what the assertion observed`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("(e) the ENTRYPOINT's script is one of the asserted paths", () => {
+    const body = finalStage.instructions[assertionIndex]?.args ?? "";
+    expect(body).toContain(entrypointArgv?.[1] ?? "<no entrypoint>");
+  });
+
+  it("(f) every asserted path corresponds, under /app, to a file tracked in the repo", () => {
+    // The WEAKEST leg, and labelled so: it observes the repo, not the image. (c)+(d) are what
+    // observe the image — a copy from the wrong stage passes this and fails those.
+    for (const p of bootPaths) {
+      expect(p.startsWith(`${IMAGE_ROOT}/`), `${p} is not under ${IMAGE_ROOT}`).toBe(true);
+      const repoPath = join(ROOT, p.slice(IMAGE_ROOT.length + 1));
+      expect(() => readFileSync(repoPath), `${p} has no counterpart at ${repoPath}`).not.toThrow();
+    }
+  });
+});
+
+/**
+ * The sentinel sentences, verbatim from spec §2b. Quoted in BOTH places on purpose: a prose guard
+ * that only requires the word "Railway" is satisfied by "Railway never builds this Dockerfile."
+ */
+const SENTINELS = [
+  "Railway's GitHub integration auto-detects this root Dockerfile and BUILDS PRODUCTION with it.",
+  "Railway overrides this image's ENTRYPOINT/CMD with railway.json's startCommand, so the entrypoint below is the local `docker compose` path only.",
+];
+const RETIRED = "It is NOT wired into the Railway deploy path";
+
+describe("AC3 — the deploy contract is asserted where it is actually configured", () => {
+  it("(a) the retired sentence is gone", () => {
+    expect(DOCKERFILE.includes(RETIRED), `Dockerfile still claims: "${RETIRED}" — it is false`).toBe(false);
+  });
+
+  it("(b) the header states both halves of the contract, verbatim", () => {
+    for (const s of SENTINELS) expect(DOCKERFILE, `header is missing: ${s}`).toContain(s);
+  });
+
+  it("(c) railway.json still carries a non-empty deploy.startCommand", () => {
+    // This is what makes the header's second sentence TRUE, and it lives in a different file.
+    // Delete it and Railway falls back to the image ENTRYPOINT — the spec's §0c and its
+    // no-staging-gate rationale both silently become false while every prose check still passes.
+    const cfg = JSON.parse(RAILWAY_JSON);
+    expect(typeof cfg?.deploy?.startCommand).toBe("string");
+    expect((cfg.deploy.startCommand as string).trim().length).toBeGreaterThan(0);
+  });
+});
+
+describe("the parser discriminates (non-vacuity)", () => {
+  it("throws on an unknown instruction rather than skipping it", () => {
+    expect(() => parseDockerfile("FROM a AS b\nFROBNICATE x\n")).toThrow(/unknown instruction/i);
+  });
+
+  it("joins line continuations into one instruction", () => {
+    const p = parseDockerfile("FROM a AS b\nRUN one \\\n  && two\n");
+    expect(p.stages[0].instructions).toHaveLength(1);
+    expect(p.stages[0].instructions[0].args).toMatch(/one\s+&&\s+two/);
+  });
+
+  it("drops comments, including mid-continuation", () => {
+    const p = parseDockerfile("FROM a AS b\nRUN one \\\n# a comment\n  && two\n");
+    expect(p.stages[0].instructions).toHaveLength(1);
+    expect(p.stages[0].instructions[0].args).not.toContain("comment");
+  });
+
+  it("reads --from and exec form", () => {
+    expect(fromFlag("--from=build /app ./")).toBe("build");
+    expect(fromFlag("/app ./")).toBeNull();
+    expect(execForm('["/bin/sh", "/x"]')).toEqual(["/bin/sh", "/x"]);
+    expect(execForm("npm start")).toBeNull(); // shell form is not a shape this guard may accept
+  });
+});

--- a/test/guards/dockerfile-runner-stage.test.ts
+++ b/test/guards/dockerfile-runner-stage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 /**
@@ -31,6 +32,17 @@ const RAILWAY_JSON = readFileSync(join(ROOT, "railway.json"), "utf8");
 
 /** The image root every in-container path is resolved against (`WORKDIR /app` in the base stage). */
 const IMAGE_ROOT = "/app";
+
+/**
+ * The EXACT command that serves. Not "any script package.json defines": measured,
+ * `npm start -- --help` exits 0 without serving, and `npm build` is not a valid invocation at all.
+ */
+const SERVING_CMD = ["npm", "start"];
+
+/** Files git actually tracks — `readFileSync` succeeding proves only that something is on disk. */
+const TRACKED = new Set(
+  execFileSync("git", ["ls-files"], { cwd: ROOT, encoding: "utf8" }).split("\n").filter(Boolean)
+);
 
 /**
  * Instructions that cannot change the filesystem, and may therefore follow the boot-chain assertion.
@@ -97,6 +109,14 @@ export function parseDockerfile(text: string): { stages: Stage[]; all: Instructi
     joined.push({ op, args: m[2].trim(), line: bufferLine });
   };
 
+  // A parser directive can change what a backslash MEANS. `# escape=\`` makes backslash an ordinary
+  // character, so every continuation below would be misread while the guard stayed green.
+  for (const line of raw.slice(0, 5)) {
+    if (/^\s*#\s*escape\s*=/i.test(line)) {
+      throw new Error(`Dockerfile: an \`escape\` parser directive changes continuation semantics — this guard does not model it`);
+    }
+  }
+
   raw.forEach((lineText, i) => {
     const lineNo = i + 1;
     if (/^\s*#/.test(lineText)) return; // comment — dropped even mid-continuation
@@ -118,7 +138,14 @@ export function parseDockerfile(text: string): { stages: Stage[]; all: Instructi
       if (!m) throw new Error(`Dockerfile line ${ins.line}: cannot parse FROM: ${ins.args}`);
       stages.push({ name: m[2] ?? null, from: m[1], instructions: [], line: ins.line });
     } else {
-      if (stages.length === 0) continue; // pre-FROM ARG etc.
+      if (stages.length === 0) {
+        // Docker permits ONLY a global `ARG` before the first `FROM`. Silently skipping anything
+        // else contradicts this parser's fail-loud contract.
+        if (ins.op !== "ARG") {
+          throw new Error(`Dockerfile line ${ins.line}: \`${ins.op}\` before the first FROM — only ARG is legal there`);
+        }
+        continue;
+      }
       stages[stages.length - 1].instructions.push(ins);
     }
   }
@@ -150,9 +177,21 @@ function execForm(args: string): string[] | null {
   }
 }
 
-/** Collapse runs of whitespace so a multi-line `RUN` compares by content, not by formatting. */
+/**
+ * Collapse runs of ASCII whitespace so a multi-line `RUN` compares by content, not by formatting.
+ *
+ * ASCII ONLY, and that is the point: JavaScript's `\s` matches U+00A0, so `set\u00A0-eu` would
+ * normalise equal to `set -eu` while dash reports `set -eu: command not found`. Whole-instruction
+ * "equality" that folds non-breaking spaces is not equality. `assertAscii` closes the rest.
+ */
 function normalise(s: string): string {
-  return s.replace(/\s+/g, " ").trim();
+  return s.replace(/[ \t\r\n]+/g, " ").trim();
+}
+
+/** Anything outside printable ASCII in a shell body is a homoglyph waiting to happen. */
+function assertAscii(s: string, what: string): void {
+  const bad = [...s].filter((c) => c.charCodeAt(0) < 0x20 || c.charCodeAt(0) > 0x7e);
+  expect(bad, `${what} contains non-ASCII characters: ${JSON.stringify(bad)}`).toEqual([]);
 }
 
 function only(op: string): Instruction[] {
@@ -220,9 +259,18 @@ describe("AC1 — the final stage's filesystem comes from earlier stages of this
 });
 
 /**
- * The paths the boot chain needs, derived rather than hardcoded: the ENTRYPOINT's own script, plus
- * every absolute `/app/…` path that script goes on to execute. Adding a new boot dependency to
- * `docker/entrypoint.sh` therefore extends what the image must assert, automatically.
+ * The paths the boot chain needs: the ENTRYPOINT's own script, plus every absolute `/app/…` LITERAL
+ * appearing in that script.
+ *
+ * ⚠️ This is a LITERAL SCAN, not a dependency analysis, and the difference matters:
+ *   - a path built from a variable (`node "$ROOT/bootstrap.mjs"`) or written relatively is invisible;
+ *   - `node /app/docker/bootstrap.mjs?typo` yields the valid PREFIX, so the assertion passes while
+ *     node requests a file that does not exist;
+ *   - an `/app/…` string inside a COMMENT manufactures a dependency that is not one;
+ *   - it is DEPTH-1 — `bootstrap.mjs` itself imports three modules under `scripts/` that nothing
+ *     here asserts (pre-existing; see the spec's §2a depth note).
+ * So it does NOT automatically extend when a dependency is added. It covers the shape the boot
+ * chain actually has today, and AC2(f) fails loudly if a scanned path is not a tracked file.
  */
 const entrypointArgv = (() => {
   const ins = only("ENTRYPOINT");
@@ -260,7 +308,7 @@ describe("AC2 — the boot invocation is complete, build-asserted, and terminal"
     expect(argv?.[0]).toBe("/bin/sh");
   });
 
-  it("(b) CMD is present, exec-form and non-empty — an empty CMD exits 0 at boot, silently", () => {
+  it("(b) CMD is exactly the serving command — an empty or non-serving CMD exits 0 at boot, silently", () => {
     // docker/entrypoint.sh ends in `exec "$@"`, and POSIX `exec` with zero arguments is a NO-OP:
     // the script falls off the end and returns 0. Green build, container gone, no error anywhere.
     const ins = only("CMD");
@@ -268,14 +316,19 @@ describe("AC2 — the boot invocation is complete, build-asserted, and terminal"
     const argv = execForm(ins[0].args);
     expect(argv, `CMD must be JSON exec form, got: ${ins[0].args}`).not.toBeNull();
     // Non-empty is NOT the invariant — `CMD ["true"]` is non-empty and boots a container that exits
-    // 0 having served nothing. What must hold is that CMD runs a DEFINED npm script of this package,
-    // derived from package.json rather than pinned to a literal.
-    expect(argv?.[0], "CMD must invoke npm").toBe("npm");
+    // 0 having served nothing. Nor is "a script package.json defines": measured,
+    // `npm start -- --help` prints help and exits 0 WITHOUT serving, and `npm build` is not even a
+    // valid invocation (npm answers `Unknown command: "build"` — arbitrary scripts need `npm run`).
+    // So the argv is pinned EXACTLY, and the script it names must exist.
+    //
+    // Pinning a literal is deliberate and fail-closed: DOCKERPROD-1 will want `["node","server.js"]`
+    // for the standalone image, and this reddens loudly and forces a conscious edit in that PR —
+    // which is the guard working, not the guard being brittle.
+    expect(argv, "CMD must be exactly the serving command").toEqual(SERVING_CMD);
     const scripts = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")).scripts ?? {};
-    expect(
-      Object.keys(scripts),
-      `CMD runs \`npm ${argv?.[1]}\`, which package.json does not define`
-    ).toContain(argv?.[1]);
+    expect(Object.keys(scripts), `package.json defines no \`${SERVING_CMD[1]}\` script`).toContain(
+      SERVING_CMD[1]
+    );
   });
 
   it("(c) the assertion is EXACTLY the derived boot-chain check — no more, no less", () => {
@@ -300,6 +353,7 @@ describe("AC2 — the boot invocation is complete, build-asserted, and terminal"
       `test -s "$f" ${fail("is empty")}; ` +
       `test -r "$f" ${fail("is not readable")}; done; ` +
       `/bin/sh -n ${entrypointArgv?.[1]}`;
+    assertAscii(finalStage.instructions[assertionIndex].args, "the boot-chain assertion");
     expect(normalise(finalStage.instructions[assertionIndex].args)).toBe(normalise(expected));
   });
 
@@ -323,8 +377,11 @@ describe("AC2 — the boot invocation is complete, build-asserted, and terminal"
     // observe the image — a copy from the wrong stage passes this and fails those.
     for (const p of bootPaths) {
       expect(p.startsWith(`${IMAGE_ROOT}/`), `${p} is not under ${IMAGE_ROOT}`).toBe(true);
-      const repoPath = join(ROOT, p.slice(IMAGE_ROOT.length + 1));
-      expect(() => readFileSync(repoPath), `${p} has no counterpart at ${repoPath}`).not.toThrow();
+      const rel = p.slice(IMAGE_ROOT.length + 1);
+      // `..` would escape the repo, and `readFileSync` succeeding proves only that SOMETHING is on
+      // disk — a generated or untracked file would pass while never entering the build context.
+      expect(rel.split("/").includes(".."), `${p} escapes ${IMAGE_ROOT}`).toBe(false);
+      expect(TRACKED.has(rel), `${p} maps to ${rel}, which git does not track`).toBe(true);
     }
   });
 });
@@ -354,7 +411,15 @@ describe("AC3 — the deploy contract is asserted where it is actually configure
     // no-staging-gate rationale both silently become false while every prose check still passes.
     const cfg = JSON.parse(RAILWAY_JSON);
     expect(typeof cfg?.deploy?.startCommand).toBe("string");
-    expect((cfg.deploy.startCommand as string).trim().length).toBeGreaterThan(0);
+    // Non-EMPTY is not the invariant: `startCommand: "true"` overrides the entrypoint and exits
+    // immediately, so §0c's claim ("Railway's runtime process is unchanged") would be false while
+    // this passed. What must hold is that it still runs the wrapper the claim names.
+    const wrapper = "scripts/railway-start.sh";
+    expect(
+      cfg.deploy.startCommand as string,
+      `railway.json's startCommand must still run ${wrapper}`
+    ).toContain(wrapper);
+    expect(TRACKED.has(wrapper), `${wrapper} is not tracked`).toBe(true);
   });
 });
 

--- a/test/guards/dockerfile-runner-stage.test.ts
+++ b/test/guards/dockerfile-runner-stage.test.ts
@@ -153,7 +153,19 @@ export function parseDockerfile(text: string): { stages: Stage[]; all: Instructi
   return { stages, all: joined };
 }
 
-const parsed = parseDockerfile(DOCKERFILE);
+/**
+ * Parsed EAGERLY but not THROWN eagerly. A throw at module scope makes vitest collect ZERO tests,
+ * and zero tests ran looks identical to all-green — the mutation harness refuses to call it a
+ * verdict, and rightly. A parse failure has to be a red TEST.
+ */
+let parseError: Error | null = null;
+let parsed: { stages: Stage[]; all: Instruction[] } = { stages: [], all: [] };
+try {
+  parsed = parseDockerfile(DOCKERFILE);
+} catch (e) {
+  parseError = e as Error;
+  parsed = { stages: [{ name: null, from: "<unparsed>", instructions: [], line: 0 }], all: [] };
+}
 /** FINAL = the last `FROM` in file order, i.e. the default build target — what compose and Railway build. */
 const finalStage = parsed.stages[parsed.stages.length - 1];
 const earlierStageNames = new Set(
@@ -199,6 +211,10 @@ function only(op: string): Instruction[] {
 }
 
 describe("AC1 — the final stage's filesystem comes from earlier stages of this file, and nothing else", () => {
+  it("the Dockerfile PARSES — an unmodellable directive or an illegal pre-FROM instruction fails here, not silently", () => {
+    expect(parseError?.message ?? null).toBeNull();
+  });
+
   it("(a) the final stage's own FROM names an earlier declared stage", () => {
     expect(
       earlierStageNames.has(finalStage.from),
@@ -279,7 +295,14 @@ const entrypointArgv = (() => {
 
 const bootPaths: string[] = (() => {
   const script = entrypointArgv?.[1];
-  const referenced = [...ENTRYPOINT_SCRIPT.matchAll(/(\/app\/[A-Za-z0-9_./-]+)/g)].map((m) => m[1]);
+  // The trailing lookahead is load-bearing: without it `node /app/docker/bootstrap.mjs?typo` yields
+  // the valid PREFIX `/app/docker/bootstrap.mjs`, so the assertion covers a path node never
+  // requests and the guard reports everything fine. Measured — that mutation SURVIVED until this
+  // boundary was added. Now the path simply does not match, the derived expectation loses it, and
+  // AC2(c) reddens loudly instead.
+  const referenced = [
+    ...ENTRYPOINT_SCRIPT.matchAll(/(\/app\/[A-Za-z0-9_./-]+)(?=["'`\s;)|&]|$)/gm),
+  ].map((m) => m[1]);
   return [...new Set([...(script ? [script] : []), ...referenced])];
 })();
 

--- a/test/guards/dockerfile-runner-stage.test.ts
+++ b/test/guards/dockerfile-runner-stage.test.ts
@@ -38,15 +38,17 @@ const IMAGE_ROOT = "/app";
  * behind the assertion the way `RUN rm …` would.
  */
 const NON_FILESYSTEM_OPS = new Set([
-  "ENV",
   "EXPOSE",
   "LABEL",
-  "ARG",
   "STOPSIGNAL",
-  "HEALTHCHECK",
   "ENTRYPOINT",
   "CMD",
 ]);
+// Deliberately NOT here: `ENV` (an `ENV PATH=…` after the assertion is a green build and a dead
+// boot — docker/entrypoint.sh:5 resolves `node` through PATH), `ARG` (feeds ENV substitution), and
+// `HEALTHCHECK` (runs a command). Nothing in this stage needs any of the three after the assertion,
+// and an allowlist that is wrong in the permissive direction is the failure this criterion exists
+// to prevent.
 
 const KNOWN_OPS = new Set([
   "FROM",

--- a/test/guards/dockerfile-runner-stage.test.ts
+++ b/test/guards/dockerfile-runner-stage.test.ts
@@ -233,9 +233,15 @@ const bootPaths: string[] = (() => {
   return [...new Set([...(script ? [script] : []), ...referenced])];
 })();
 
-/** The final stage's boot-chain assertion: the RUN that tests the boot paths. */
+/**
+ * The final stage's boot-chain assertion, located by its `set -eu` preamble.
+ *
+ * Located by PREAMBLE and not by content: keying on `test -f` made a mutation that WEAKENS the
+ * assertion (dropping `-f`) also unfindable, so it reddened (c), (d) and (e) at once and proved
+ * only whichever ran first. The preamble is stable under exactly the mutations (c) exists to catch.
+ */
 const assertionIndex = finalStage.instructions.findIndex(
-  (i) => i.op === "RUN" && /\btest\s+-f\b/.test(i.args)
+  (i) => i.op === "RUN" && /^set\s+-eu\b/.test(i.args.trim())
 );
 
 describe("AC2 — the boot invocation is complete, build-asserted, and terminal", () => {


### PR DESCRIPTION
## The runner stage stops reading the build context

The repo-root `Dockerfile` — which **Railway builds for production** — had its runner stage re-read
the **build context** for one file:

```dockerfile
COPY --from=build /app ./                                   # the whole build stage
COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh      # ← reads the CONTEXT again
RUN chmod +x /usr/local/bin/entrypoint.sh
```

**It copied a file the image already had.** Measured, not traced — I built a throwaway image over the
real context and the file lands at `/app/docker/entrypoint.sh`, mode `-rwxr-xr-x`, via the build
stage's `COPY . .`. Railway also overrides the image `ENTRYPOINT` with `railway.json`'s
`startCommand`, so on the production path it was **dead weight whose `COPY` could still fail the
build** — which it did, twice (`4c842d11` on #648, `1a210d5b` on #658), each time blocking a merged
fix for hours and needing a human dashboard re-trigger.

⚠️ **This does NOT promise a lower flake rate, and the spec says so.** If Railway/buildkit has an
unreliable context session, the next failure may land on `COPY . .` instead. What is provable: the
change strictly removes one of three context reads and adds none, so it **cannot raise** exposure.
*(Round 0 argued the leading slash in `lstat /docker/…` proved the daemon resolved against `/`. I
tested it — a plainly context-relative miss also prints a leading slash. Claim withdrawn.)*

## What ships

- The context `COPY` and its `chmod` are gone; `ENTRYPOINT` is `["/bin/sh", "/app/docker/entrypoint.sh"]`.
- A **terminal build-time boot-chain assertion**, because the deletion would otherwise convert a
  BUILD failure into a RUNTIME one.
- The header's false sentence (*"It is NOT wired into the Railway deploy path"*) is replaced by two
  sentinel sentences stating the real contract; `docs/ARCHITECTURE.md` now carries it too.
- One guard, `test/guards/dockerfile-runner-stage.test.ts` (AC1–AC3, 20 tests).

**Split from DOCKERPROD-1** (the `output: "standalone"` production image), which both spec reviews
returned BLOCKED on with the same prescription: ship the de-flake alone first. DOCKERPROD-1 is
`blocked` on the board with its findings recorded — a copy list that omitted `lib/`, `fixtures/` and
`tsconfig.json`, and that moving `tsx` to `dependencies` is a no-op because Next traces imports.

## ⚠️ The defect that matters most in this PR was mine, and the static battery was blind to it

My first assertion was `test -f "$f" && test -s "$f" && test -r "$f"` under `set -eu`.

**It could not fail.** POSIX ignores `errexit` for a command in an AND-OR list. An image built with
`bootstrap.mjs` deleted printed:

```
#8 [runner 3/3] RUN echo "!!! BUILD PASSED WITH bootstrap.mjs MISSING !!!"
#8 0.113 !!! BUILD PASSED WITH bootstrap.mjs MISSING !!!
```

**All 21 static mutations still passed**, because a static guard compares TEXT and the text looked
right. Five model review rounds on the spec could not have caught it either — only building it could.
So the repair that closes this slice's fail-open **was itself fail-open**, and it read as coverage.

Fixed: each test exits explicitly (`|| { echo …; exit 1; }`), depending on no shell option and naming
what is missing. The guard pins that exact text, so the `&&` shape cannot return (mutation 13b).

The durable outcome is **AC5 — negative controls**: an assertion whose failure has never been observed
is unfalsifiable, and unfalsifiable reads exactly like coverage.

| build | expected | result |
|---|---|---|
| `entrypoint.sh` missing | FAIL | **FAILED** |
| `bootstrap.mjs` missing | FAIL | **FAILED** |
| `bootstrap.mjs` present but 0 bytes | FAIL | **FAILED** — `boot chain: /app/docker/bootstrap.mjs is empty` |
| `entrypoint.sh` is a directory | FAIL | **FAILED** |
| both present and valid | PASS | **PASSED** |

Against the first version, rows 1–4 all **PASSED**.

## Verification

| tier | result |
|---|---|
| unit (`npm test`) | **3,569 passed**, 15 skipped |
| `npx tsc --noEmit` · `npm run lint` · `npm run check:docs` | clean (0 errors; 18 pre-existing warnings, none in this diff) |
| `aios spec eval` | `SPEC_READY`, exit 0 |
| mutations | **30 rows, all run**, each reddening its named criterion |

**AC4, measured against the real image** (`docker compose build app`, exit 0):

| observable | result |
|---|---|
| runner stage | 2 steps, **reads nothing from the context** |
| `docker inspect` Entrypoint/Cmd | `[/bin/sh /app/docker/entrypoint.sh]  [npm start]` |
| the deleted copy | `/usr/local/bin/entrypoint.sh`: **No such file or directory** |
| booted through `entrypoint.sh` | logs open with bootstrap's own `▶ generated AUTH_SECRET…` lines |
| `curl -fsS .../login` | **exit 0** |
| `/proc/1/cmdline` | `npm start` |
| stop | exit **1** @ **1s** vs **1** @ **2s** on `main`'s bare-path form — unchanged |

⚠️ **One red test, and it is not this diff.** `release-tag-policy` fails with `DEFAULT_TAGS is stale:
v0.12.0 is the newest release tag but is not in the upgrade set`. Tag `v0.12.0` was pushed
2026-08-26 22:09 by the release workstream; my diff touches neither that test nor `DEFAULT_TAGS`
(**0 lines**), so it fails identically on `origin/main` for anyone who has fetched tags. This is the
ordering hazard RELPTR-2 names, now live — **it will fail every open PR until v0.12.0 is added**, and
it belongs to that program, not here.

## Review — Reviewed by Fable code-reviewer and Codex gpt-5.6-sol — verdict Fable CLEAR-WITH-CONDITIONS (all folded), Codex BLOCKED on a HIGH that reproduced (folded, mutation-pinned)

Seven model rounds: three spec rounds each, then a diff round each. Both spec rounds returned
**BLOCKED** at least once. What each caught that the other did not:

**Fable — the `CMD` fail-open (HIGH).** `entrypoint.sh` ends in `exec "$@"`, and POSIX `exec` with
zero arguments is a **no-op** — delete `CMD` and the script falls off the end and exits **0**.
Reproduced in a real container: `Running=false`, `ExitCode=0`, last log line is the success banner
printing a login URL and password. Nothing indicates failure. Deleting that line passed all 13 of the
then-current mutations. *(I hit this by accident first: compose's `entrypoint:` override silently
clears the image `CMD`.)*

**Fable also independently reproduced the errexit defect above** before my fix landed — replication,
not agreement — and then found: my claim that "`-s` and `-r` are live" named a leg no control
exercises and root cannot falsify (`test -r` passes on `chmod 000` as root); `ENV` in my terminality
allowlist (an `ENV PATH=` after the assertion is a green build and a dead boot); and that the boot
chain is deeper than the two files I assert.

**Codex — a `CMD` that passes the guard and does not serve (HIGH, reproduced).** `["npm","start","--","--help"]`
satisfied "a script `package.json` defines" and exits 0 printing help; `["npm","build"]` satisfied it
while npm answers `Unknown command: "build"`. Also: `normalise()` folded **U+00A0** (JS `\s` matches
it), so `set -eu` compared equal while dash reports `command not found`; the parser ignored a
`# escape=` directive, which changes what a backslash *means*; instructions before the first `FROM`
were silently skipped, contradicting the fail-loud contract; AC2(f) said "tracked in the repo" and
only called `readFileSync`; and `startCommand: "true"` passed AC3(c) while falsifying the very claim
AC3 exists to protect.

**Two mutations misbehaved and are recorded as such, not smoothed over.** Codex's `?typo` case
**SURVIVED** — `node /app/docker/bootstrap.mjs?typo` yielded the valid PREFIX, so the assertion
covered a path node never requests. And rows 20/21 came back **`REFUSING — ZERO tests ran`**: the
parser threw at module scope, so vitest collected nothing, and zero-tests-ran is indistinguishable
from all-green. Both closed; both now redden.

**They disagreed on `ONBUILD`, so I built it** rather than picking a side. It **does** fire inside a
single Dockerfile — buildkit printed `#6 [runner 1/2] ONBUILD COPY leaked.txt`, a context read
attributed to a stage where the instruction does not appear. Fable right, Codex wrong; Codex retracted
on its diff pass. The guard rejects `ONBUILD` file-wide.

**And one criterion of mine named a number I never measured:** AC4 said the stop exit code would be
**143**. It is **1**, in both forms — npm's behaviour, not a regression. Corrected to an A/B.

⚠️ **Codacy — the one non-green check, and it is pre-existing.** It reports *"By not specifying a
`USER`, a program in the container may run as 'root'"* at `Dockerfile:72`. **`origin/main` has zero
`USER` instructions too** — it counts as "new" only because this diff touched the file. Not fixed
here, deliberately: `docker/bootstrap.mjs` writes `mode 0o600` secrets into the docker-managed
`appdata` volume at `/var/lib/aios`, so a non-root `USER` needs first-boot ownership handling — a
change that breaks a self-hoster's first five minutes if it is wrong, and one that belongs with
DOCKERPROD-1, where the runtime is already being reshaped. Filed there. Codacy is **not** a required
check on this repo.

**Deferred, with reasons:** the boot-chain assertion is **depth-1** (`bootstrap.mjs` imports three
modules under `scripts/` that nothing asserts) — pre-existing, and a complete ESM-graph check would
run bootstrap against no database. AC2(e) is logically implied by AC2(c). `docker/entrypoint.sh:15`'s
comment says the exec makes "the server" PID 1; it is **npm** — reported by AC4, corrected by neither
slice.

AIOS-Work: DOCKERPROD-2

