### PR TITLE
release: name the three branch roles, and make the workflows follow them (RELPTR-4)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,15 @@
 
 ## Work item
 
-<!-- Reference the brain task so aios-work-sync advances it to Done on merge (brain → Linear).
+<!-- Reference the brain task. What happens on merge depends on WHERE the row came from, and the
+     difference matters — this template used to promise the first case for both:
+
+       * a BRAIN-NATIVE row in this project resolves `applied` — aios-work-sync completes it and
+         projects it to Linear automatically;
+       * a row you pushed from the workspace (`3-log/tasks.md`) resolves `linked` — the event is
+         recorded and the task is DELIBERATELY left open, because completing on a team-wide match
+         would create duplicate Linear issues. For those, YOU close the row and `aios push`.
+
      No task yet, and this work should be tracked? Create one FIRST in the Team Brain dashboard
      (→ Tasks; it projects to Linear), then put its key here. Don't hand-edit the Linear issue —
      the brain is the source of truth, Linear is a one-way projection. -->

--- a/.github/workflows/aios-work-sync.yml
+++ b/.github/workflows/aios-work-sync.yml
@@ -1,9 +1,21 @@
 name: AIOS work sync
 
+# RELPTR-4 — BOTH the contribution base and the integration branch, deliberately, and landed BEFORE
+# the cutover rather than on the day. This fires on `pull_request` closed; today no pull request
+# targets `staging`, so adding it is near-inert — but the day contributions move, this workflow is
+# already right instead of being one more thing to remember while everything else is changing.
+#
+# THE ACCEPTED COST, stated rather than discovered: a MISTAKEN merge into `staging` (258 behind) now
+# emits a work event where before it emitted nothing. For a brain-native row in the pushed project
+# that resolves `applied`, i.e. it would complete a task and project it to Linear for work that is not
+# on trunk. Judged smaller than the risk of doing this on cutover day.
+#
+# The branch list is pinned by `test/guards/branch-roles.test.ts` as an EXACT SET — not "contains
+# both", because `[main, staging, "**"]` satisfies containment while silently widening to every branch.
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [main, staging]
 
 permissions:
   contents: read

--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -1,6 +1,7 @@
 name: scan-on-merge
 
-# Keep the codebase's agent-readiness fresh: on every merge to main, scan this repo with the
+# Keep the codebase's agent-readiness fresh: on every merge to the contribution base OR the
+# integration branch (RELPTR-4 — it was `main` only), scan this repo with the
 # ingestion scanner and push the result (full raw metrics + readiness) to the Team Brain.
 # The scan is read-only against the repo and idempotent on the brain (keyed by head_sha).
 #
@@ -18,8 +19,14 @@ name: scan-on-merge
 
 # RELPTR-4 — both branches. After the cutover `main` advances only by release fast-forward, so a
 # `[main]`-only trigger would silently drop codebase-readiness from per-merge to per-release freshness.
-# Widening carries no risk here: the scan is read-only against the repo and idempotent on the brain
-# (keyed by `head_sha`), so a push to either branch is safe to scan.
+# THE COST, stated rather than claimed away — an earlier version of this comment said "carries no
+# risk", and both reviewers showed that is false. `head_sha` idempotency only deduplicates the SAME
+# commit. A mistaken push to the 259-behind `staging` scans that stale tree and it becomes the
+# dashboard's CURRENT readiness, because `lib/metrics/codebases.ts` picks the newest point by
+# `scanned_at` (wall clock), not by ancestry — and `reconcile_codebase_findings` computes staleness the
+# same way, so findings fixed since staging's tip get reopened and findings introduced since get
+# resolved. It heals at the next merge to the contribution base. Accepted for the same reason as
+# `aios-work-sync`'s: cheaper than doing this on cutover day.
 on:
   push:
     branches: [main, staging]
@@ -30,8 +37,11 @@ permissions:
   pull-requests: read
 
 # One scan at a time; newer pushes supersede in-flight ones.
+# PER-REF, not one global group. With a single group a push to one branch CANCELS an in-flight scan
+# of the other (`cancel-in-progress: true`), so widening the trigger would have let a staging push kill
+# a main scan and leave the older snapshot as the latest. Codex found that.
 concurrency:
-  group: scan-on-merge
+  group: scan-on-merge-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -16,9 +16,13 @@ name: scan-on-merge
 # (These already exist for the aios-work-sync workflow; the scanner reads BRAIN_URL, mapped below.)
 # GITHUB_TOKEN is the built-in token (read access to this repo for stars/issues metadata).
 
+# RELPTR-4 — both branches. After the cutover `main` advances only by release fast-forward, so a
+# `[main]`-only trigger would silently drop codebase-readiness from per-merge to per-release freshness.
+# Widening carries no risk here: the scan is read-only against the repo and idempotent on the brain
+# (keyed by `head_sha`), so a push to either branch is safe to scan.
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
 
 permissions:
   contents: read

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -95,7 +95,7 @@ completeness.**
 |---|---|---|
 | 1 | A fast-forward push to `main` can be **rejected by a required check the candidate cannot acquire** — but this is **one context, not ten**. **MEASURED 2026-08-26** on the real merge commit `6dfddfc7` (a push to `main`): **9 of the 10 required contexts are present**, because `ci.yml` and `nda-gate.yml` both fire on `push`. The sole exception is **`PR records a diff review`**, emitted only on `pull_request` (`.github/workflows/pr-review-gate.yml`). The cutover therefore needs that one context **relocated** to the integration branch — not a release-actor bypass that defeats the other nine. *(A dated measurement, not an invariant: if protection gains an eleventh context, re-measure rather than trusting this row.)* | live protection on `main`; check-runs on `6dfddfc7` |
 | 2 | **Dependabot follows the default branch.** Three ecosystems, zero `target-branch` overrides (`.github/dependabot.yml`), so its PRs target the default; and security updates and alerts always follow the default branch, so a vulnerability introduced on the integration branch stays invisible until release. | `.github/dependabot.yml` |
-| 3 | **`aios-work-sync` breaks the day contributions move**, and cannot be deferred: it fires on a `pull_request` closed against `main` (`.github/workflows/aios-work-sync.yml`), so merges elsewhere emit nothing — and a release delivered by direct push emits nothing either. Decide whether *integration* or *release* closes a ticket before the first merge lands elsewhere. | `.github/workflows/aios-work-sync.yml` |
+| 3 | **PREPARED (RELPTR-4).** `aios-work-sync` fired on `pull_request` closed against `main` only, so merges elsewhere would have emitted nothing and **nothing would have closed a ticket**. It now fires on both `main` and `staging`, landed early because it is near-inert until contributions move. `scan-on-merge` was widened for the same reason — otherwise codebase readiness silently drops from per-merge to per-release. **The decision constraint 3 demanded is made: a ticket closes at INTEGRATION, not at release** (see §3.1b). **Still human at cutover:** nothing for this constraint. | `.github/workflows/aios-work-sync.yml` |
 | 4 | **`git diff origin/main...HEAD` is an operative instruction**, not documentation — the review gate and the attestation skills run it. The moment features branch elsewhere, that diff carries every unreleased commit. It must be updated *at* the cutover, not after. | `CLAUDE.md` §Review gate |
 | 5 | **`staging` is behind `main` and 0 ahead** (249 when slice 1 measured it; **257** on 2026-08-26 — it drifts further with every merge), and is branch-protected with its own (smaller) required set, so any strategy that gives it a new role begins with a fast-forward that protection has to be opened for. | `docs/CI-ARCHITECTURE.md` §Environments |
 | 6 | **Bare `gh pr create` targets the default branch** absent a `branch.<name>.gh-merge-base` override (none is set here), and this repo's own attestation skill calls it without `--base`. Whatever the default is, tooling will follow it. | `.agents/skills/pr-review-attestation/SKILL.md` |
@@ -132,6 +132,63 @@ in advance:
 the tag, wait for `Release candidate gate` to go green on that commit, *then* fast-forward `main`. A
 fast-forward attempted while the context is still pending is rejected.
 
+### 3.1b When a ticket closes, and what this repo's automation actually does
+
+**Decision (RELPTR-4): a ticket closes when its work merges to the CONTRIBUTION BASE — not when a
+release ships.** The work is done at integration; a release may be days later and batch dozens of
+tickets, and between `v0.10.0` and `v0.12.0` that was 23 days and ~170 commits. Release-closes would
+leave the board stale exactly when it is most useful.
+
+**Revert and abandonment:** a ticket closed at integration **stays closed** if the release is later
+reverted or never cut. That is identical to today's behaviour and is accepted — here "done" means
+**integrated**, not shipped. A separate shipped/released signal is follow-on work, not part of this.
+
+**What the automation actually does, which the PR template used to overstate:**
+
+| the row came from | resolution | what happens |
+|---|---|---|
+| brain-native, in this project | `applied` | completed **and** projected to Linear automatically |
+| pushed from the workspace (`3-log/tasks.md`) | `linked` | the event is recorded, the task is **deliberately left open** — completing on a team-wide match would create duplicate Linear issues. **You close it and `aios push`.** |
+
+**Known limitation, recorded rather than discovered later:** the work-sync payload carries only
+`pr.head.ref`. After the cutover the brain therefore **cannot tell which base a merge event came
+from** — every event looks the same whether it landed on the contribution base or the release branch.
+
+### 3.1c The cutover-day edits that a shared constant does NOT remove
+
+`scripts/branches.mjs` (RELPTR-4) names the three branch roles once, so the Node and instruction
+consumers move in one edit. **It is not "the cutover is one edit"**, and the difference is worth
+writing down before someone plans a day around the wrong number. These remain separate, and each is a
+file a human must change:
+
+1. **`.github/dependabot.yml` `target-branch`** — YAML cannot import a module, and unlike a workflow
+   `branches:` list there is no two-branch superset that is correct both before and after.
+2. **Prose that NAMES a branch** rather than pointing at the module — undetectable by any guard,
+   because `main` is a legitimate token everywhere.
+3. **Every branch-protection change** — the release actor, making `Release candidate gate` required,
+   relocating `PR records a diff review`.
+4. **The instruction corpus** — 31 operative `origin/main` command lines across 19 files. That is
+   **RELPTR-5**, deliberately its own slice; see §3.1d.
+
+### 3.1d Why the instruction corpus is its own slice
+
+Two independent pre-code reviews BLOCKED an attempt to fold it into RELPTR-4, both on the same defect:
+the corpus was undercounted (14 reported, **31 lines across 19 files** actual), so a guard built to
+that scope would have reddened on day one against files the scope never named — including
+`CONTRIBUTING.md`, the contributor entry point.
+
+Two properties make it a slice rather than a fold, and both must be settled **before** the guard is
+written rather than after:
+
+- **"Operative `origin/main`" is design vocabulary, not an observable.** It is implementable as a
+  *declared* heuristic — a line carrying a `git` invocation token plus the ref — which correctly
+  separates `branch-reconciliation/SKILL.md:30` from the historical prose in
+  `lib/graph/extraction-health.ts:297`. But it false-negatives on `adversarial-build`'s
+  "Branch from `origin/main`", which carries no `git` token.
+- **A past-tense rewrite does not exclude a quotation from a regex.** Constraint 4's row below quotes
+  the old instruction to explain itself; past-tenseness is invisible to a matcher. Either the literal
+  goes or the path is excluded — an earlier draft asked for both.
+
 ### 3.2 Ordering pairs that encode a hazard
 
 Not a total order — these are the adjacencies where getting it backwards causes the incident:
@@ -148,6 +205,8 @@ order:
   - workflow-on-main: before any new context is made required
   - tag-ruleset: before the release-candidate context is FIRST MINTED
   - fast-forward-staging: before any candidate tag is pushed
+  - work-sync-and-scan-widened: DONE (RELPTR-4), before contributions move
+  - dependabot-target-branch: at the cutover, never before (it would aim at a stale branch)
 ```
 
 The `workflow-on-main` pair is this repository's own scar tissue: `docs/CI-ARCHITECTURE.md` records that switching on

--- a/docs/design/cutover-prep-integration-branch.md
+++ b/docs/design/cutover-prep-integration-branch.md
@@ -19,8 +19,9 @@ instruction corpus) — no persistence and no HTTP surface
 
 **Deps:** RELPTR-3 merged (`5e2fe27f`). No code dependency.
 
-**Increment:** ONE PR = two named branch constants with one owner, `aios-work-sync` and
-`scan-on-merge` widened, the operative review instruction made base-relative, and guards for each.
+**Increment:** ONE PR = three named branch roles with one owner each, the release-candidate guard
+turned into a consumer, `aios-work-sync` and `scan-on-merge` widened, the PR template corrected, and
+guards for each. **The operative review instruction is NOT in this slice** — it is RELPTR-5.
 **No branch protection is changed, no release actor is created, `staging` is not fast-forwarded,
 Dependabot is not retargeted, and no required context is added or moved.**
 
@@ -30,7 +31,8 @@ Dependabot is not retargeted, and no required context is added or moved.**
 
 Option B moves contributions from `main` to an integration branch. `docs/RELEASING.md` §3.1 records
 **nine** constraints; several are repo-side code that breaks the moment contributions move, and **the
-failure mode of each is silence, not an error**:
+failure mode of each is silence, not an error**. Two of them are fixed here; the third — the operative
+`git diff` instruction — is described below and deferred to RELPTR-5:
 
 - **`aios-work-sync` fires on `pull_request` closed with `branches: [main]`.** The day work merges to
   `staging`, it emits nothing — **nothing closes a ticket**, and the board stops meaning anything.
@@ -93,7 +95,7 @@ to it.
 
 **The honest claim about cutover cost, restated because the first draft overclaimed it.** This does
 **not** make the cutover one edit. It makes the *Node and instruction* consumers one edit. These
-remain separate, enumerated, cutover-day edits, recorded in `docs/RELEASING.md` §3.2 so they cannot be
+remain separate, enumerated, cutover-day edits, recorded in `docs/RELEASING.md` §3.1c so they cannot be
 forgotten:
 
 - `.github/dependabot.yml` `target-branch` (YAML cannot import a module, and there is no two-branch
@@ -153,7 +155,7 @@ Two further problems make it a slice of its own rather than a fold:
 RELPTR-5 gets a complete per-file disposition (rewrite / exclude-as-history) decided BEFORE the guard
 is written, which is the opposite order from this attempt.
 
-**6. What this slice does NOT do**, each with its reason:
+**4. What this slice does NOT do**, each with its reason:
 
 - **Any branch-protection change**, the release actor, the `refs/tags/v*` ruleset, making
   `Release candidate gate` required, relocating `PR records a diff review` — outward-facing GitHub
@@ -176,7 +178,7 @@ is written, which is the opposite order from this attempt.
 `CONTRIBUTING.md`, `docs/agent-handoffs.md`, `docs/TODO.md`, `test-ci-wiring-audit`,
 `adversarial-build`, and the guard over them. Decision 3.
 
-**Cut:** everything in Decision 6.
+**Cut:** everything in Decision 4.
 
 ---
 
@@ -213,12 +215,12 @@ is written, which is the opposite order from this attempt.
    Presence-asserted, because stripping the sentence would satisfy a pure absence check.
 9. **unit** — a guard asserts `docs/RELEASING.md` records (a) the ticket-closing decision with its
    revert/abandonment policy and the `pr.head.ref`-only limitation, (b) that constraint 3 is PREPARED
-   with what remains human, and (c) the enumerated cutover-day edits from Decision 1 in §3.2.
+   with what remains human, and (c) the enumerated cutover-day edits from Decision 1 in §3.1c, including the branch-protection changes.
 
 ## What would falsify this
 
 - **A ticket that does not close after the cutover** — Decision 2 was wrong, or the widening was
-  re-narrowed by a condition criterion 6 failed to pin.
+  re-narrowed by a condition criterion 7 failed to pin — including one inside the run body.
 - **A reviewer handed every unreleased commit** — that is RELPTR-5's falsifier now, not this slice's;
   if it happens before RELPTR-5 lands, the split was the wrong call.
 - **Assertion C or D answering a different question after the cutover** — the refactor wired a ref to

--- a/docs/design/cutover-prep-integration-branch.md
+++ b/docs/design/cutover-prep-integration-branch.md
@@ -1,0 +1,231 @@
+# Cutover prep — the branch roles and the workflows that follow them (RELPTR-4)
+
+Status: **NARROWED after four blocking design verdicts across two models.** Round 1: Codex BLOCKED,
+Fable CLEAR-WITH-CONDITIONS — both on the same conceptual error. Round 2 on the rewrite: **Codex
+BLOCKED, Fable BLOCKED**, again independently, and again on the same thing — **the measured-terrain
+table was wrong a second time**, so a Scope derived from it would have reddened on day one against
+files it never mentioned. Rather than fold a third time, the slice is **split**: the instruction-corpus
+rewrite moves to **RELPTR-5**, and this slice keeps only what both reviewers said was right. Original
+status line follows.
+
+Previously: **rewritten after a pre-code design review returned BLOCKED.** Codex **BLOCKED**, Fable
+**CLEAR-WITH-CONDITIONS / build differently**, and both landed on the same conceptual error: the first
+draft proposed *one* declared "integration branch" reading `main` — while RELPTR-3's shipped guard
+**already** declares the integration ref as `staging` (`scripts/release-candidate-guard.mjs:169`).
+Those are two different concepts, they genuinely disagree before the cutover, and collapsing them
+would have destroyed assertion D's meaning. This document is the fold · Owner: chetan
+· Tier build-with: unit (the pure branch declarations + every guard over workflows and the active
+instruction corpus) — no persistence and no HTTP surface
+
+**Deps:** RELPTR-3 merged (`5e2fe27f`). No code dependency.
+
+**Increment:** ONE PR = two named branch constants with one owner, `aios-work-sync` and
+`scan-on-merge` widened, the operative review instruction made base-relative, and guards for each.
+**No branch protection is changed, no release actor is created, `staging` is not fast-forwarded,
+Dependabot is not retargeted, and no required context is added or moved.**
+
+---
+
+## Problem
+
+Option B moves contributions from `main` to an integration branch. `docs/RELEASING.md` §3.1 records
+**nine** constraints; several are repo-side code that breaks the moment contributions move, and **the
+failure mode of each is silence, not an error**:
+
+- **`aios-work-sync` fires on `pull_request` closed with `branches: [main]`.** The day work merges to
+  `staging`, it emits nothing — **nothing closes a ticket**, and the board stops meaning anything.
+- **`scan-on-merge` fires on `push: branches: [main]`.** After the cutover `main` moves only by
+  release fast-forward, so codebase-readiness metrics silently drop from per-merge to per-release.
+- **`git diff origin/main...HEAD` is an *operative* instruction** — the review gate quotes it,
+  `code-reviewer.md` runs it, the attestation skills execute it. Once features branch elsewhere that
+  diff carries **every unreleased commit**: the reviewer is handed hundreds of files and the review
+  becomes worthless without ever failing.
+
+### The conceptual error the review caught, and the model that replaces it
+
+The first draft declared one thing called the integration branch and set it to `main`. That is wrong
+in a way that matters, because **there are two branches with two different jobs**:
+
+| name | today | at cutover | who uses it |
+|---|---|---|---|
+| **contribution base** | `main` | becomes `staging` | the review-diff instruction; the branch PRs target |
+| **integration branch** | `staging` | `staging` (unchanged) | RELPTR-3's assertion D — *already shipped* |
+| **release branch** | `main` | `main` (unchanged) | assertion C; what installers deploy |
+
+`scripts/release-candidate-guard.mjs:169` already hardcodes `refs/remotes/origin/staging`, and its own
+comment explains why: assertion D asks whether a candidate crossed integration, and pointing it at
+`main` would make it answer a different question and destroy the deliberate pre-cutover red. So the
+integration branch is **already `staging` and fixed**; only the *contribution base* moves.
+
+That distinction is what makes the guards possible: a guard can pin `staging` **today**, from a
+constant that is `staging` today, instead of from one that only becomes `staging` on the day.
+
+### Measured terrain (live, read-only, 2026-08-27, against `main` `5e2fe27f`)
+
+| fact | value | why it matters |
+|---|---|---|
+| `aios-work-sync` trigger | `pull_request`, `types: [closed]`, **`branches: [main]`** | nothing closes a ticket once work moves |
+| `scan-on-merge` trigger | `push`, **`branches: [main]`** | readiness metrics degrade to per-release |
+| `ci.yml`, `nda-gate.yml` | already `[main, staging]` | **already cutover-ready**; no change needed |
+| files with the literal `origin/main...` | **14** | incl. `CLAUDE.md`, `scripts/pr-review-gate.mjs`, `.claude/agents/code-reviewer.md`, and `pr-review-attestation` across `.claude`/`.agents`/`.opencode`/`.cursor` |
+| operative `origin/main` in a git command | **31 lines across 19 files** — re-measured after the terrain table was wrong TWICE | far more than the 14 first counted, and it spans `CONTRIBUTING.md`, `docs/agent-handoffs.md` (×9), `docs/TODO.md`, `test-ci-wiring-audit` and `adversarial-build` — none of which the first two drafts scoped. **This is why the corpus rewrite is now RELPTR-5.** |
+| `.skill-runtimes.json` published | `connect`, `pr-review-attestation`, `railway-deploy-verify`, `setup-brain` | **`branch-reconciliation` is NOT mirrored** — the first draft said it was |
+| existing sync guard | `test/guards/skill-runtime-sync.test.ts` | mirror drift is ALREADY guarded; a new criterion for it would be green-by-construction |
+| hand-written runtime files | `sync-skill-runtimes.sh` leaves un-marked files alone (e.g. `.cursor/rules/codacy.mdc`) | neither generated nor sync-guarded, so the scan must cover them directly |
+| `staging` | **258 behind, 0 ahead**; `main` NOT an ancestor | a stale snapshot, not yet an integration branch |
+| open PRs targeting `staging` | **zero** | why widening is near-inert today — see Decision 2's caveat |
+
+**My recommendation to the operator narrowed while scoping, and both reviewers confirmed the
+narrowing was right** — `pr-review-gate` needs no code change (no `branches:` filter, so getting it off
+`main`'s required set is protection *config*); Dependabot cannot retarget to a 258-behind branch today;
+`gh pr create --base` has a different correct answer either side. But it also **missed** two things the
+review found: `scan-on-merge`, and the second declaration in `release-candidate-guard.mjs`.
+
+---
+
+## Decision
+
+**1. TWO named constants, one owner, and RELPTR-3's guard becomes a consumer.**
+`scripts/branches.mjs` exports `CONTRIBUTION_BASE` (`main` today), `INTEGRATION_BRANCH` (`staging`,
+fixed) and `RELEASE_BRANCH` (`main`, fixed). `scripts/release-candidate-guard.mjs` stops hardcoding
+its refs and imports them — removing the undeclared second owner rather than leaving a guard blind
+to it.
+
+**The honest claim about cutover cost, restated because the first draft overclaimed it.** This does
+**not** make the cutover one edit. It makes the *Node and instruction* consumers one edit. These
+remain separate, enumerated, cutover-day edits, recorded in `docs/RELEASING.md` §3.2 so they cannot be
+forgotten:
+
+- `.github/dependabot.yml` `target-branch` (YAML cannot import a module, and there is no two-branch
+  superset trick for Dependabot);
+- any prose that *names* a branch rather than pointing at the module;
+- every branch-protection change.
+
+**2. `aios-work-sync` and `scan-on-merge` widen to both branches now.**
+
+Widening is **near-inert today**: zero PRs target `staging`, and `aios-work-sync` is additionally
+gated on `merged == true`. The caveat, which the first draft omitted: a *mistaken* merge into the
+258-behind `staging` would now emit a work event where before it emitted nothing — and for a
+brain-native row in the pushed project that resolves `applied`, i.e. it would complete a task and
+project it to Linear for work that is not on trunk. That is an accepted, stated cost of landing early;
+the alternative is doing it on cutover day, when a mistake is far more likely. `scan-on-merge` carries
+no such risk — its scan is read-only and idempotent by `head_sha`.
+
+**Constraint 3's decision, stated: a ticket closes when its work merges to the CONTRIBUTION BASE, not
+when a release ships.** Reasons:
+
+- the work is done at integration — reviewed, merged, on trunk;
+- a release may be days later and batch dozens of tickets, so release-closes leaves the board stale
+  exactly when it is most useful. Between `v0.10.0` and `v0.12.0` that was 23 days and ~170 commits;
+- it preserves today's semantics ("merge to trunk closes") rather than inventing new machinery.
+
+**Corrections to the first draft's supporting argument**, both from review: `work_events` does **not**
+uniformly leave closing to a human — a workspace-pushed row resolves `linked` and is deliberately left
+open, while a brain-native row in the pushed project resolves **`applied`** and IS completed and
+projected automatically. And the payload carries only `pr.head.ref`, so **after the cutover the brain
+cannot tell which base a merge event came from** — a known limitation, recorded rather than papered
+over.
+
+**Revert and abandonment policy**, which the review said was missing: a ticket closed at integration
+stays closed if the release is later reverted or never cut. That is identical to today's behaviour and
+is accepted — "done" means **integrated**, not shipped. A separate shipped/released signal is
+explicitly out of scope and named as follow-on work.
+
+**3. The instruction-corpus rewrite is DEFERRED to RELPTR-5, and this is a scope decision forced by
+review.** Two independent BLOCKED verdicts landed on the same defect: the corpus was undercounted, so
+any guard built to the stated Scope would have reddened on day one against files the Scope never
+mentioned — `CONTRIBUTING.md:14` (the contributor entry point), `docs/agent-handoffs.md` (nine sites),
+`docs/TODO.md`, `test-ci-wiring-audit`, `adversarial-build`. Re-measured: **31 operative lines across
+19 files**, not the 14 first reported.
+
+Two further problems make it a slice of its own rather than a fold:
+
+- **"Operative `origin/main`" is design vocabulary, not an observable.** It *is* implementable as a
+  declared heuristic — a line carrying a `git` invocation token plus the ref — which correctly
+  separates `branch-reconciliation/SKILL.md:30` from `lib/graph/extraction-health.ts:297` on today's
+  corpus. But the heuristic has known error bars (it false-negatives on `adversarial-build`'s
+  "Branch from `origin/main`", which carries no `git` token), and a guard whose rule is not stated
+  cannot be reviewed.
+- **Decision 4 and criterion 13 contradicted each other**: excluding `docs/RELEASING.md`'s constraint-4
+  quotation "by rewriting it into past tense" does not work, because past-tenseness is invisible to a
+  regex. Either the literal goes or the path is excluded — the spec asked for both.
+
+RELPTR-5 gets a complete per-file disposition (rewrite / exclude-as-history) decided BEFORE the guard
+is written, which is the opposite order from this attempt.
+
+**6. What this slice does NOT do**, each with its reason:
+
+- **Any branch-protection change**, the release actor, the `refs/tags/v*` ruleset, making
+  `Release candidate gate` required, relocating `PR records a diff review` — outward-facing GitHub
+  configuration; human; recorded in `docs/RELEASING.md` §3.
+- **The `staging` fast-forward** — constraint 8, and the act that starts the cutover.
+- **Dependabot's `target-branch`** — would aim at a dead branch today.
+- **`gh pr create --base`** — different correct answer either side.
+- **A separate shipped/released signal** — Decision 2's revert policy names it as follow-on.
+
+---
+
+## Scope
+
+**In:** `scripts/branches.mjs`; `scripts/release-candidate-guard.mjs` (consumes it);
+`.github/workflows/aios-work-sync.yml`; `.github/workflows/scan-on-merge.yml`;
+`.github/pull_request_template.md`; `docs/RELEASING.md` §3; unit guards for all of it.
+
+**Deferred to RELPTR-5:** the whole instruction corpus — `CLAUDE.md` §Review gate,
+`.claude/agents/code-reviewer.md`, the attestation and branch-reconciliation skills and their mirrors,
+`CONTRIBUTING.md`, `docs/agent-handoffs.md`, `docs/TODO.md`, `test-ci-wiring-audit`,
+`adversarial-build`, and the guard over them. Decision 3.
+
+**Cut:** everything in Decision 6.
+
+---
+
+## Acceptance criteria
+
+1. **unit** — a guard asserts each of the three branch roles is declared EXACTLY ONCE across
+   `scripts/**`, so there is one owner per role and no undeclared second one. (The constants land in a
+   new module, `scripts/branches.mjs`.)
+2. **unit** — a guard asserts the release-candidate guard in `scripts/release-candidate-guard.mjs`
+   derives its integration ref from the INTEGRATION token and its release ref from the RELEASE token
+   **by name**, and contains no hardcoded `staging`/`main` ref literal.
+3. **unit** — the IDENTITY PIN, which both reviewers found missing: because `RELEASE_BRANCH` and
+   `CONTRIBUTION_BASE` are both `main` TODAY, wiring the release ref to the wrong one is invisible to
+   any value assertion. A test stubs `CONTRIBUTION_BASE` to a sentinel and asserts the release guard's
+   resolved refs are UNCHANGED — so the mistake reddens now instead of on cutover day, when assertion C
+   would silently become "is `staging` an ancestor of the candidate".
+4. **unit** — the release-candidate guard's behaviour is unchanged by the refactor, exercised against a
+   REAL git fixture through its production defaults (not only asserted about source text): integration
+   resolves to `staging`, release to `main`, and assertion C and D still consume the ref each is
+   documented to consume.
+5. **unit** — a guard over `.github/workflows/aios-work-sync.yml` asserts its `pull_request` `branches`
+   list equals EXACTLY the contribution base and the integration branch — an exact set, not "contains
+   both", since `[main, staging, "**"]` satisfies a containment check while silently widening the
+   trigger to every branch.
+6. **unit** — a guard over `.github/workflows/scan-on-merge.yml` asserts the same exact-set coverage
+   for its `push` trigger.
+7. **unit** — a guard asserts `aios-work-sync`'s job condition is exactly
+   `github.event.pull_request.merged == true`, AND that no STEP inside the job carries an `if:` — a
+   step-level `if: github.base_ref == 'main'` would suppress the emission while the job condition and
+   the trigger list both still pass.
+8. **unit** — a guard asserts `.github/pull_request_template.md` states the ACTUAL split rather than
+   deleting the claim: a merge completes a task automatically only for a brain-native row in the pushed
+   project (`applied`); a workspace-pushed row resolves `linked` and the human close is the only close.
+   Presence-asserted, because stripping the sentence would satisfy a pure absence check.
+9. **unit** — a guard asserts `docs/RELEASING.md` records (a) the ticket-closing decision with its
+   revert/abandonment policy and the `pr.head.ref`-only limitation, (b) that constraint 3 is PREPARED
+   with what remains human, and (c) the enumerated cutover-day edits from Decision 1 in §3.2.
+
+## What would falsify this
+
+- **A ticket that does not close after the cutover** — Decision 2 was wrong, or the widening was
+  re-narrowed by a condition criterion 6 failed to pin.
+- **A reviewer handed every unreleased commit** — that is RELPTR-5's falsifier now, not this slice's;
+  if it happens before RELPTR-5 lands, the split was the wrong call.
+- **Assertion C or D answering a different question after the cutover** — the refactor wired a ref to
+  `CONTRIBUTION_BASE` and criterion 3's identity pin failed to catch it.
+- **The guard reddening on a historical document** — the path exclusions are wrong, and the pressure
+  will be to weaken the guard rather than fix the paths.
+- **A cutover-day edit nobody remembered** — Decision 1's enumeration was incomplete, which is why it
+  lives in the runbook rather than only here.
+- **A tenth cutover constraint discovered at cutover time** — nine is what eight review rounds across
+  two models have found, not a proof of completeness.

--- a/scripts/branches.mjs
+++ b/scripts/branches.mjs
@@ -26,7 +26,7 @@
  * WHAT THIS DOES NOT BUY. It is NOT "the cutover is one edit". It makes the Node and instruction
  * consumers one edit. YAML cannot import a module, so `.github/dependabot.yml`'s `target-branch`,
  * prose that names a branch, and every branch-protection change remain separate cutover-day edits —
- * enumerated in `docs/RELEASING.md` §3.2 so they cannot be forgotten. The first draft overclaimed this
+ * enumerated in `docs/RELEASING.md` §3.1c so they cannot be forgotten. The first draft overclaimed this
  * and review corrected it.
  */
 
@@ -48,7 +48,10 @@ export const remoteRef = (branch) => `refs/remotes/origin/${branch}`;
 if (process.argv.includes("--print")) {
   const roles = { contribution: CONTRIBUTION_BASE, integration: INTEGRATION_BRANCH, release: RELEASE_BRANCH };
   const asked = process.argv[process.argv.indexOf("--print") + 1];
-  const value = roles[asked];
+  // `Object.hasOwn`, not truthiness: `roles["constructor"]` inherits a function from the prototype
+  // chain, which is truthy — so `--print constructor` would reach `stdout.write` and throw a
+  // TypeError instead of the intended diagnostic. Loud either way, but the wrong loud.
+  const value = Object.hasOwn(roles, asked ?? "") ? roles[asked] : undefined;
   if (!value) {
     process.stderr.write(`unknown role ${asked ?? "(none)"} — expected one of ${Object.keys(roles).join(", ")}\n`);
     process.exit(2);

--- a/scripts/branches.mjs
+++ b/scripts/branches.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * RELPTR-4 — the three branch ROLES this repository has, named once.
+ * Spec: `docs/design/cutover-prep-integration-branch.md` · runbook: `docs/RELEASING.md` §3
+ *
+ * WHY THREE AND NOT ONE. The first draft of this slice declared a single "integration branch" and set
+ * it to `main`. Two independent pre-code reviews killed it, because `scripts/release-candidate-guard.mjs`
+ * ALREADY declared the integration ref as `staging` — so there were two owners of one name holding
+ * disagreeing values, and unifying them would have pointed assertion D at `main`, making it ask a
+ * different question and destroying the deliberate pre-cutover red the guard exists to produce.
+ *
+ * They are three different jobs, and only ONE of them moves:
+ *
+ *   CONTRIBUTION_BASE   the branch pull requests target.  `main` TODAY → becomes `staging` at cutover.
+ *   INTEGRATION_BRANCH  where work accumulates before release.  `staging`, and ALREADY `staging`.
+ *   RELEASE_BRANCH      what installers deploy; advances only by fast-forward to a tagged commit.  `main`.
+ *
+ * ⚠️ TODAY `RELEASE_BRANCH === CONTRIBUTION_BASE === "main"`, AND THAT IS A TRAP. Wiring a consumer to
+ * the wrong one of those two is invisible to every value assertion — both reviewers found this, and
+ * neither a "resolves to main" test nor a "derives from the shared constants" test can see it. It would
+ * surface on cutover day, when `CONTRIBUTION_BASE` moves and the consumer silently follows it. The
+ * identity pin in `test/guards/branch-roles.test.ts` stubs `CONTRIBUTION_BASE` to a sentinel and
+ * asserts the release guard's refs do not move; that is the only thing standing between a one-token
+ * typo and a broken release check months from now.
+ *
+ * WHAT THIS DOES NOT BUY. It is NOT "the cutover is one edit". It makes the Node and instruction
+ * consumers one edit. YAML cannot import a module, so `.github/dependabot.yml`'s `target-branch`,
+ * prose that names a branch, and every branch-protection change remain separate cutover-day edits —
+ * enumerated in `docs/RELEASING.md` §3.2 so they cannot be forgotten. The first draft overclaimed this
+ * and review corrected it.
+ */
+
+/** The branch pull requests target. **This is the one that moves at the cutover.** */
+export const CONTRIBUTION_BASE = "main";
+
+/** Where work accumulates before a release. Fixed — RELPTR-3's assertion D already reads it. */
+export const INTEGRATION_BRANCH = "staging";
+
+/** What installers deploy. Fixed — assertion C reads it, and it must NOT follow CONTRIBUTION_BASE. */
+export const RELEASE_BRANCH = "main";
+
+/** `refs/remotes/origin/<branch>` — the form git comparison commands need. */
+export const remoteRef = (branch) => `refs/remotes/origin/${branch}`;
+
+// A printing CLI, so a shell instruction can embed a role by command substitution rather than
+// hardcoding a name. Prints the value ALONE with no banner: callers build a ref out of it, and a
+// stray line would corrupt the ref rather than fail loudly.
+if (process.argv.includes("--print")) {
+  const roles = { contribution: CONTRIBUTION_BASE, integration: INTEGRATION_BRANCH, release: RELEASE_BRANCH };
+  const asked = process.argv[process.argv.indexOf("--print") + 1];
+  const value = roles[asked];
+  if (!value) {
+    process.stderr.write(`unknown role ${asked ?? "(none)"} — expected one of ${Object.keys(roles).join(", ")}\n`);
+    process.exit(2);
+  }
+  process.stdout.write(value);
+}

--- a/scripts/release-candidate-guard.mjs
+++ b/scripts/release-candidate-guard.mjs
@@ -30,6 +30,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { INTEGRATION_BRANCH, RELEASE_BRANCH, remoteRef } from "./branches.mjs";
 
 /** A release tag is EXACTLY `vX.Y.Z`. No pre-release, no build metadata, no leading zeros. */
 const RELEASE_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
@@ -165,8 +166,14 @@ export function main({
   ref = process.env.GITHUB_REF,
   sha = process.env.GITHUB_SHA,
   remote = "origin",
-  mainRef = "refs/remotes/origin/main",
-  integrationRef = "refs/remotes/origin/staging",
+  // RELPTR-4: these were hardcoded here, which made this file an UNDECLARED SECOND OWNER of the
+  // integration branch — two names for one concept, holding different values. They now come from
+  // `scripts/branches.mjs`. Note WHICH role each takes: assertion C reads the RELEASE branch and
+  // assertion D the INTEGRATION branch, and today RELEASE_BRANCH and CONTRIBUTION_BASE are both
+  // `main`, so wiring C to the contribution base would be invisible until the cutover moved it.
+  // `test/guards/branch-roles.test.ts` pins that distinction with a sentinel.
+  mainRef = remoteRef(RELEASE_BRANCH),
+  integrationRef = remoteRef(INTEGRATION_BRANCH),
   cwd = undefined,
   log = console.log,
 } = {}) {

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { CONTRIBUTION_BASE, INTEGRATION_BRANCH, RELEASE_BRANCH, remoteRef } from "../../scripts/branches.mjs";
+
+/**
+ * RELPTR-4 — the three branch roles, and the workflows that follow them.
+ * Spec: `docs/design/cutover-prep-integration-branch.md` (criteria 1–9).
+ *
+ * THE DEFECT THIS FILE EXISTS FOR, which is not the obvious one. `scripts/release-candidate-guard.mjs`
+ * hardcoded `refs/remotes/origin/staging` — an UNDECLARED SECOND OWNER of the integration branch, while
+ * a first draft of this slice was declaring the same name as `main`. Two independent pre-code reviews
+ * killed that draft.
+ *
+ * But the sharper trap is what remains after the fix: **`RELEASE_BRANCH` and `CONTRIBUTION_BASE` are
+ * both `"main"` today.** A consumer wired to the wrong one passes every value assertion — "the release
+ * ref resolves to main" is true either way — and stays green until cutover day, when
+ * `CONTRIBUTION_BASE` moves to `staging` and assertion C silently becomes "is `staging` an ancestor of
+ * the candidate". That is the pre-cutover-green / post-cutover-silent shape this whole program exists
+ * to prevent, so it gets a test that can see it TODAY: the identity pin below.
+ */
+
+const ROOT = join(__dirname, "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+/** Loose on purpose — these guards inspect workflow shapes, including ones nobody would write. */
+type Step = { if?: unknown };
+type Job = { if?: unknown; steps?: Step[] };
+type Workflow = { on?: Record<string, { branches?: string[]; types?: string[]; push?: unknown }>; jobs?: Record<string, Job> };
+const workflow = (name: string) => parseYaml(read(`.github/workflows/${name}`)) as Workflow;
+
+describe("branch roles — one owner per role (criteria 1, 2)", () => {
+  it("the three roles hold the values the design says they hold", () => {
+    expect(CONTRIBUTION_BASE, "moves at the cutover").toBe("main");
+    expect(INTEGRATION_BRANCH, "already staging — RELPTR-3 reads it").toBe("staging");
+    expect(RELEASE_BRANCH, "what installers deploy").toBe("main");
+    expect(remoteRef("x")).toBe("refs/remotes/origin/x");
+  });
+
+  it("each role is DECLARED exactly once across scripts/**", () => {
+    // One owner per role, so moving the contribution base at cutover is one edit rather than a sweep.
+    const files = readdirSync(join(ROOT, "scripts")).filter((f) => f.endsWith(".mjs") || f.endsWith(".ts"));
+    for (const role of ["CONTRIBUTION_BASE", "INTEGRATION_BRANCH", "RELEASE_BRANCH"]) {
+      const declaring = files.filter((f) => new RegExp(`export const ${role}\\b`).test(read(`scripts/${f}`)));
+      expect(declaring, `${role} must have exactly one declaration`).toEqual(["branches.mjs"]);
+    }
+  });
+
+  it("the release-candidate guard no longer hardcodes a ref — it names the ROLES", () => {
+    // The second-owner defect, pinned so it cannot return. Asserted on the token, not the value,
+    // because the value is what makes the mistake invisible (see the identity pin below).
+    const src = read("scripts/release-candidate-guard.mjs");
+    expect(src, "must import the roles").toMatch(/from "\.\/branches\.mjs"/);
+    expect(src).toMatch(/mainRef = remoteRef\(RELEASE_BRANCH\)/);
+    expect(src).toMatch(/integrationRef = remoteRef\(INTEGRATION_BRANCH\)/);
+    expect(src, "no hardcoded remote ref may remain").not.toMatch(/"refs\/remotes\/origin\/(main|staging)"/);
+  });
+});
+
+describe("branch roles — the IDENTITY PIN (criterion 3)", () => {
+  it("the release ref follows RELEASE_BRANCH, NOT the contribution base", () => {
+    // BOTH REVIEWERS found this missing. Today RELEASE_BRANCH === CONTRIBUTION_BASE === "main", so
+    // `expect(mainRef).toBe("refs/remotes/origin/main")` passes whichever token the code used. The only
+    // way to tell them apart NOW is to make them differ: rewrite the module with a sentinel
+    // contribution base, re-import it, and assert the release guard's default did not move.
+    const src = read("scripts/branches.mjs");
+    const stubbed = src.replace('export const CONTRIBUTION_BASE = "main";', 'export const CONTRIBUTION_BASE = "SENTINEL-not-a-branch";');
+    expect(stubbed, "the sentinel substitution must actually apply").not.toBe(src);
+
+    const dir = mkdtempSync(join(tmpdir(), "roles-"));
+    try {
+      writeFileSync(join(dir, "branches.mjs"), stubbed);
+      // The guard's default expressions, evaluated against the stubbed module. If a future edit wires
+      // `mainRef` to CONTRIBUTION_BASE, this reddens immediately instead of on cutover day.
+      const out = execFileSync(
+        "node",
+        [
+          "--input-type=module",
+          "-e",
+          `import { CONTRIBUTION_BASE, RELEASE_BRANCH, INTEGRATION_BRANCH, remoteRef } from ${JSON.stringify(join(dir, "branches.mjs"))};
+           process.stdout.write(JSON.stringify({ base: CONTRIBUTION_BASE, main: remoteRef(RELEASE_BRANCH), integration: remoteRef(INTEGRATION_BRANCH) }));`,
+        ],
+        { encoding: "utf8" }
+      );
+      const got = JSON.parse(out);
+      expect(got.base, "the stub must have taken effect").toBe("SENTINEL-not-a-branch");
+      expect(got.main, "the release ref must NOT follow the contribution base").toBe("refs/remotes/origin/main");
+      expect(got.integration).toBe("refs/remotes/origin/staging");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is NON-VACUOUS: wiring the release ref to CONTRIBUTION_BASE would be caught", () => {
+    // Proves the pin above can fail — the mutation it is aimed at, executed directly.
+    const wrong = `export const CONTRIBUTION_BASE = "SENTINEL-not-a-branch";
+export const remoteRef = (b) => \`refs/remotes/origin/\${b}\`;
+export const mainRef = remoteRef(CONTRIBUTION_BASE);`;
+    const dir = mkdtempSync(join(tmpdir(), "roles-neg-"));
+    try {
+      writeFileSync(join(dir, "wrong.mjs"), wrong);
+      const out = execFileSync(
+        "node",
+        ["--input-type=module", "-e", `import { mainRef } from ${JSON.stringify(join(dir, "wrong.mjs"))}; process.stdout.write(mainRef);`],
+        { encoding: "utf8" }
+      );
+      expect(out, "the wrong wiring produces a different ref, so the pin discriminates").not.toBe("refs/remotes/origin/main");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("branch roles — the workflows that must follow the cutover (criteria 5, 6, 7)", () => {
+  it("aios-work-sync fires on EXACTLY the contribution base and the integration branch", () => {
+    // EXACT SET, not "contains both": `[main, staging, "**"]` satisfies a containment check while
+    // silently widening the trigger to every branch in the repository. Codex found that.
+    const on = workflow("aios-work-sync.yml").on!;
+    expect(on.pull_request!.branches).toEqual([CONTRIBUTION_BASE, INTEGRATION_BRANCH]);
+    expect(on.pull_request!.types).toEqual(["closed"]);
+    // …and INTEGRATION_BRANCH is `staging` TODAY, so this pins the widening now rather than
+    // collapsing to "contains main" until the cutover moves the value.
+    expect(on.pull_request!.branches).toContain("staging");
+  });
+
+  it("scan-on-merge fires on EXACTLY the same two branches", () => {
+    // After the cutover `main` advances only by release fast-forward, so a `[main]`-only trigger
+    // would drop codebase readiness from per-merge to per-release without any error.
+    const on = workflow("scan-on-merge.yml").on!;
+    expect((on.push as { branches?: string[] }).branches).toEqual([CONTRIBUTION_BASE, INTEGRATION_BRANCH]);
+  });
+
+  it("nothing INSIDE aios-work-sync re-narrows what the trigger widened", () => {
+    // The trigger list and the job condition can both be right while a STEP-level `if:` suppresses
+    // the emission for one branch — the widening undone one layer down, where criteria 5 cannot see
+    // it. Codex found this too. The job gate is pinned as an exact string; steps carry no `if:` at all.
+    const wf = workflow("aios-work-sync.yml");
+    const job = wf.jobs!["notify-brain"];
+    expect(job.if, "the job gate, exactly").toBe("github.event.pull_request.merged == true");
+    const stepIfs = (job.steps ?? []).filter((step) => step.if !== undefined);
+    expect(stepIfs, "no step may carry its own condition").toEqual([]);
+  });
+
+  it("is NON-VACUOUS: the parsed shapes are real, not empty reads", () => {
+    // A parse returning undefined would make every assertion above vacuously pass.
+    expect(workflow("aios-work-sync.yml").jobs!["notify-brain"].steps!.length).toBeGreaterThan(0);
+    expect(Object.keys(workflow("scan-on-merge.yml").jobs!).length).toBeGreaterThan(0);
+  });
+});
+
+describe("branch roles — the PR template states the split (criterion 8)", () => {
+  const TPL = () => read(".github/pull_request_template.md");
+
+  it("names BOTH outcomes, because the old text promised only the automatic one", () => {
+    // PRESENCE, not absence: stripping the sentence entirely would satisfy a "no longer claims
+    // automatic close" check while telling a contributor nothing. And the old claim was HALF true —
+    // a brain-native row in this project really does complete automatically — so the fix is to state
+    // the split, not to delete the promise.
+    const t = TPL();
+    expect(t, "the automatic case").toMatch(/brain-native/i);
+    expect(t).toMatch(/`applied`/);
+    expect(t, "the case where the human closes it").toMatch(/`linked`/);
+    expect(t).toMatch(/3-log\/tasks\.md/);
+    expect(t, "must say the workspace row is left open on purpose").toMatch(/DELIBERATELY left open/);
+  });
+
+  it("still asks for the work key at all", () => {
+    expect(TPL()).toMatch(/AIOS-Work:/);
+  });
+});
+
+describe("branch roles — the runbook records the decisions (criterion 9)", () => {
+  const RUNBOOK = () => read("docs/RELEASING.md");
+
+  it("§3.1b states the ticket-closing decision, its revert policy, and the applied/linked split", () => {
+    const r = RUNBOOK();
+    expect(r).toMatch(/a ticket closes when its work merges to the CONTRIBUTION BASE/);
+    expect(r, "the revert case must be decided, not left open").toMatch(/\*\*stays closed\*\* if the release is later\s*\n?reverted or never cut/);
+    expect(r).toMatch(/`applied`/);
+    expect(r).toMatch(/`linked`/);
+    // The limitation the review said was "recorded" with nowhere to record it.
+    expect(r, "the pr.head.ref limitation").toMatch(/carries only\s*\n?`pr\.head\.ref`/);
+  });
+
+  it("§3.1c enumerates the cutover-day edits a shared constant does NOT remove", () => {
+    // The first draft claimed "the cutover is one edit". It is not, and planning a day around the
+    // wrong number is the failure this section prevents.
+    const r = RUNBOOK();
+    expect(r).toMatch(/is not "the cutover is one edit"|not \*\*"the cutover is one edit"\*\*/);
+    expect(r).toMatch(/dependabot\.yml` `target-branch`/);
+    expect(r, "prose naming a branch is undetectable by a guard").toMatch(/Prose that NAMES a branch/);
+  });
+
+  it("constraint 3 is marked PREPARED with what remains human", () => {
+    const row3 = RUNBOOK().split("\n").find((l) => l.startsWith("| 3 |")) ?? "";
+    expect(row3, "constraint row 3 must exist").not.toBe("");
+    expect(row3).toMatch(/PREPARED \(RELPTR-4\)/);
+    expect(row3, "must say what is left for a human").toMatch(/Still human at cutover/);
+    expect(row3, "must not still describe it as unfixed").not.toMatch(/cannot be deferred/);
+  });
+
+  it("§3.2 carries the two new ordering pairs", () => {
+    const r = RUNBOOK();
+    expect(r).toMatch(/work-sync-and-scan-widened: DONE \(RELPTR-4\)/);
+    expect(r).toMatch(/dependabot-target-branch: at the cutover, never before/);
+  });
+
+  it("§3.1d records WHY the instruction corpus is deferred, with the real measurement", () => {
+    // The number was wrong twice. It is written down with its correction so a third attempt starts
+    // from the measurement rather than re-deriving it.
+    const r = RUNBOOK();
+    expect(r).toMatch(/31 lines across 19 files|\*\*31 lines across 19 files\*\*/);
+    expect(r, "and that the heuristic has known error bars").toMatch(/false-negatives/);
+  });
+});

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -41,7 +41,12 @@ describe("branch roles — one owner per role (criteria 1, 2)", () => {
 
   it("each role is DECLARED exactly once across scripts/**", () => {
     // One owner per role, so moving the contribution base at cutover is one edit rather than a sweep.
-    const files = readdirSync(join(ROOT, "scripts")).filter((f) => f.endsWith(".mjs") || f.endsWith(".ts"));
+    // RECURSIVE — criterion 1 says `scripts/**` and the first version read only `scripts/*`. Both
+    // reviewers found the same surviving mutation: declare a role in `scripts/setup/deploy-policy.mjs`
+    // and the undeclared-second-owner class this slice exists to kill returns one directory down.
+    const files = readdirSync(join(ROOT, "scripts"), { recursive: true })
+      .map(String)
+      .filter((f) => f.endsWith(".mjs") || f.endsWith(".ts"));
     for (const role of ["CONTRIBUTION_BASE", "INTEGRATION_BRANCH", "RELEASE_BRANCH"]) {
       const declaring = files.filter((f) => new RegExp(`export const ${role}\\b`).test(read(`scripts/${f}`)));
       expect(declaring, `${role} must have exactly one declaration`).toEqual(["branches.mjs"]);
@@ -55,7 +60,9 @@ describe("branch roles — one owner per role (criteria 1, 2)", () => {
     expect(src, "must import the roles").toMatch(/from "\.\/branches\.mjs"/);
     expect(src).toMatch(/mainRef = remoteRef\(RELEASE_BRANCH\)/);
     expect(src).toMatch(/integrationRef = remoteRef\(INTEGRATION_BRANCH\)/);
-    expect(src, "no hardcoded remote ref may remain").not.toMatch(/"refs\/remotes\/origin\/(main|staging)"/);
+    // Any quoting, not just double — a single-quoted or backticked literal would have evaded the
+    // first spelling of this assertion.
+    expect(src, "no hardcoded remote ref may remain").not.toMatch(/refs\/remotes\/origin\/(main|staging)/);
   });
 });
 
@@ -74,8 +81,23 @@ describe("branch roles — the IDENTITY PIN (criterion 3)", () => {
    * `mainRef` follows the contribution base, it resolves to a ref that does not exist, assertion C
    * goes false, and the verdict flips to FAIL. Behaviour, not text.
    */
+  // Isolated for every child process, git AND node. Both reviewers flagged that the RELPTR-3 twin in
+  // `release-candidate-gate.test.ts` already does this and this file did not: a machine with
+  // `tag.gpgSign = true` would make the annotated tag below attempt signing and the pin would red — or
+  // hang on a pinentry — for a reason that has nothing to do with the wiring under test. `vi.stubEnv`
+  // alone would not reach the spawned `node`, so the env is passed explicitly.
+  const ISOLATED = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_DIR: undefined,
+    GIT_WORK_TREE: undefined,
+    GIT_INDEX_FILE: undefined,
+  } as NodeJS.ProcessEnv;
+
   const git = (cwd: string, ...args: string[]) =>
-    execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+    execFileSync("git", args, { cwd, encoding: "utf8", env: ISOLATED }).trim();
 
   function scratchWithStub(stubValue: string | null) {
     const dir = mkdtempSync(join(tmpdir(), "roles-pin-"));
@@ -89,15 +111,28 @@ describe("branch roles — the IDENTITY PIN (criterion 3)", () => {
     git(dir, "init", "-q", "-b", "main");
     git(dir, "config", "user.email", "t@example.com");
     git(dir, "config", "user.name", "t");
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ version: "0.2.0" }));
+    git(dir, "add", "package.json");
+    git(dir, "commit", "-qm", "base");
+    const parent = git(dir, "rev-parse", "HEAD");
     writeFileSync(join(dir, "package.json"), JSON.stringify({ version: "0.3.0" }));
     git(dir, "add", "package.json");
     git(dir, "commit", "-qm", "release");
     const head = git(dir, "rev-parse", "HEAD");
-    // A valid candidate: main and staging both AT the tagged commit, so C and D both hold.
-    git(dir, "update-ref", "refs/remotes/origin/main", head);
+
+    // ASYMMETRIC ON PURPOSE — both reviewers found the first version degenerate. With `origin/main`,
+    // `origin/staging` and the tag all at ONE commit, C and D become indistinguishable: a full C↔D
+    // ref SWAP passes every behavioural test, leaving only a source-token regex holding the line —
+    // and this file's own header calls those evadable. Post-cutover a surviving swap would make D ask
+    // "reachable from main", turning the deliberate pre-cutover red green.
+    //
+    // So: release branch one commit BEHIND, integration branch AT the candidate. C still holds (the
+    // parent is an ancestor of head) and D still holds (head is reachable from staging) — but swap
+    // them and D asks whether head is reachable from the PARENT, which it is not. The swap now reds.
+    git(dir, "update-ref", "refs/remotes/origin/main", parent);
     git(dir, "update-ref", "refs/remotes/origin/staging", head);
     git(dir, "tag", "-a", "v0.3.0", "-m", "v0.3.0");
-    return { dir, head };
+    return { dir, head, parent };
   }
 
   /** Run the guard with its DEFAULT refs — the thing under test. */
@@ -112,7 +147,7 @@ describe("branch roles — the IDENTITY PIN (criterion 3)", () => {
            const r = main({ ref: "refs/tags/v0.3.0", sha: ${JSON.stringify(head)}, remote: ".", cwd: ${JSON.stringify(dir)}, log: () => {} });
            process.stdout.write(JSON.stringify(r));`,
         ],
-        { encoding: "utf8" }
+        { encoding: "utf8", env: ISOLATED }
       )
     );
 
@@ -142,6 +177,25 @@ describe("branch roles — the IDENTITY PIN (criterion 3)", () => {
       expect(r.facts.mainIsAncestor, "the sentinel ref does not exist, so C goes false").toBe(false);
       expect(r.verdict).toBe("FAIL");
       expect(r.failures.join(" ")).toMatch(/^C: |C: /);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is NON-VACUOUS on the OTHER axis: swapping the C and D refs makes this FAIL", () => {
+    // The mutation the asymmetric fixture exists for. Until the fixture stopped putting every ref on
+    // one commit, this swap was caught only by a source-token regex.
+    const { dir, head } = scratchWithStub(null);
+    try {
+      const guard = readFileSync(join(dir, "release-candidate-guard.mjs"), "utf8");
+      const swapped = guard
+        .replace("mainRef = remoteRef(RELEASE_BRANCH)", "mainRef = remoteRef(__TMP__)")
+        .replace("integrationRef = remoteRef(INTEGRATION_BRANCH)", "integrationRef = remoteRef(RELEASE_BRANCH)")
+        .replace("mainRef = remoteRef(__TMP__)", "mainRef = remoteRef(INTEGRATION_BRANCH)");
+      expect(swapped, "the swap must apply").not.toBe(guard);
+      writeFileSync(join(dir, "release-candidate-guard.mjs"), swapped);
+      const r = runWithDefaults(dir, head);
+      expect(r.verdict, "a C/D swap must be observable, not just readable").toBe("FAIL");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -187,6 +241,15 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     expect(stepIfs, "no step may carry its own condition").toEqual([]);
   });
 
+  it("the work-sync BODY never reads the base ref either", () => {
+    // Fable found the layer below the layer: criterion 7 pins the trigger and the job/step conditions,
+    // but the run body is free text. `if (pr.base.ref !== "main") process.exit(0)` inside it would keep
+    // every guard green while post-cutover staging merges emitted nothing — the exact silent failure
+    // constraint 3 describes. This also documents §3.1b's limitation: the payload is `pr.head.ref` only.
+    const body = read(".github/workflows/aios-work-sync.yml");
+    expect(body, "no base-ref branching in the body").not.toMatch(/base_ref|base\.ref/);
+  });
+
   it("is NON-VACUOUS: the parsed shapes are real, not empty reads", () => {
     // A parse returning undefined would make every assertion above vacuously pass.
     expect(workflow("aios-work-sync.yml").jobs!["notify-brain"].steps!.length).toBeGreaterThan(0);
@@ -203,9 +266,10 @@ describe("branch roles — the PR template states the split (criterion 8)", () =
     // a brain-native row in this project really does complete automatically — so the fix is to state
     // the split, not to delete the promise.
     const t = TPL();
-    expect(t, "the automatic case").toMatch(/brain-native/i);
-    expect(t).toMatch(/`applied`/);
-    expect(t, "the case where the human closes it").toMatch(/`linked`/);
+    // NOT existential: swapping `applied` and `linked` preserves both tokens while publishing the
+    // opposite guidance, so the MAPPING is asserted, not the vocabulary.
+    expect(t, "brain-native rows map to applied").toMatch(/BRAIN-NATIVE row[\s\S]{0,120}`applied`/);
+    expect(t, "workspace rows map to linked").toMatch(/pushed from the workspace[\s\S]{0,160}`linked`/);
     expect(t).toMatch(/3-log\/tasks\.md/);
     expect(t, "must say the workspace row is left open on purpose").toMatch(/DELIBERATELY left open/);
   });
@@ -235,6 +299,7 @@ describe("branch roles — the runbook records the decisions (criterion 9)", () 
     expect(r).toMatch(/is not "the cutover is one edit"|not \*\*"the cutover is one edit"\*\*/);
     expect(r).toMatch(/dependabot\.yml` `target-branch`/);
     expect(r, "prose naming a branch is undetectable by a guard").toMatch(/Prose that NAMES a branch/);
+    expect(r, "and the protection changes, which nothing in code can move").toMatch(/Every branch-protection change/);
   });
 
   it("constraint 3 is marked PREPARED with what remains human", () => {

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -241,6 +241,16 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     expect(stepIfs, "no step may carry its own condition").toEqual([]);
   });
 
+  it("scan-on-merge's concurrency group is PER-REF, so one branch cannot cancel the other", () => {
+    // Found by a mutation that SURVIVED: widening the trigger while leaving one global group means a
+    // push to either branch cancels an in-flight scan of the other (`cancel-in-progress: true`), so a
+    // staging push could kill a main scan and leave the older snapshot as the dashboard's latest.
+    // Changing the group without pinning it would have been a fix nothing held in place.
+    const wf = workflow("scan-on-merge.yml") as unknown as { concurrency?: { group?: string; "cancel-in-progress"?: boolean } };
+    expect(wf.concurrency?.group, "must vary by ref").toMatch(/\$\{\{\s*github\.ref\s*\}\}/);
+    expect(wf.concurrency?.["cancel-in-progress"], "still one scan at a time PER ref").toBe(true);
+  });
+
   it("the work-sync BODY never reads the base ref either", () => {
     // Fable found the layer below the layer: criterion 7 pins the trigger and the job/step conditions,
     // but the run body is free text. `if (pr.base.ref !== "main") process.exit(0)` inside it would keep

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -60,53 +60,97 @@ describe("branch roles — one owner per role (criteria 1, 2)", () => {
 });
 
 describe("branch roles — the IDENTITY PIN (criterion 3)", () => {
-  it("the release ref follows RELEASE_BRANCH, NOT the contribution base", () => {
-    // BOTH REVIEWERS found this missing. Today RELEASE_BRANCH === CONTRIBUTION_BASE === "main", so
-    // `expect(mainRef).toBe("refs/remotes/origin/main")` passes whichever token the code used. The only
-    // way to tell them apart NOW is to make them differ: rewrite the module with a sentinel
-    // contribution base, re-import it, and assert the release guard's default did not move.
-    const src = read("scripts/branches.mjs");
-    const stubbed = src.replace('export const CONTRIBUTION_BASE = "main";', 'export const CONTRIBUTION_BASE = "SENTINEL-not-a-branch";');
-    expect(stubbed, "the sentinel substitution must actually apply").not.toBe(src);
+  /**
+   * WHY THIS RUNS THE GUARD INSTEAD OF READING ITS SOURCE.
+   *
+   * A first version of this pin stubbed `CONTRIBUTION_BASE` and then asserted
+   * `remoteRef(RELEASE_BRANCH) === "refs/remotes/origin/main"` — which is TAUTOLOGICAL. It evaluates
+   * its own expression and never imports the release guard, so mis-wiring the guard could not redden
+   * it. Mutation-testing caught that: the mutation `mainRef = remoteRef(CONTRIBUTION_BASE)` reddened
+   * only the source-token assertion, and a source-token regex is evadable by an equivalent spelling.
+   *
+   * So this copies BOTH modules into a scratch tree with `CONTRIBUTION_BASE` set to a sentinel, builds
+   * a real repository where a valid candidate exists, and runs the guard through its DEFAULT refs. If
+   * `mainRef` follows the contribution base, it resolves to a ref that does not exist, assertion C
+   * goes false, and the verdict flips to FAIL. Behaviour, not text.
+   */
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 
-    const dir = mkdtempSync(join(tmpdir(), "roles-"));
-    try {
-      writeFileSync(join(dir, "branches.mjs"), stubbed);
-      // The guard's default expressions, evaluated against the stubbed module. If a future edit wires
-      // `mainRef` to CONTRIBUTION_BASE, this reddens immediately instead of on cutover day.
-      const out = execFileSync(
+  function scratchWithStub(stubValue: string | null) {
+    const dir = mkdtempSync(join(tmpdir(), "roles-pin-"));
+    const src = read("scripts/branches.mjs");
+    const branches =
+      stubValue === null ? src : src.replace('export const CONTRIBUTION_BASE = "main";', `export const CONTRIBUTION_BASE = ${JSON.stringify(stubValue)};`);
+    if (stubValue !== null) expect(branches, "the stub must apply").not.toBe(src);
+    writeFileSync(join(dir, "branches.mjs"), branches);
+    writeFileSync(join(dir, "release-candidate-guard.mjs"), read("scripts/release-candidate-guard.mjs"));
+
+    git(dir, "init", "-q", "-b", "main");
+    git(dir, "config", "user.email", "t@example.com");
+    git(dir, "config", "user.name", "t");
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ version: "0.3.0" }));
+    git(dir, "add", "package.json");
+    git(dir, "commit", "-qm", "release");
+    const head = git(dir, "rev-parse", "HEAD");
+    // A valid candidate: main and staging both AT the tagged commit, so C and D both hold.
+    git(dir, "update-ref", "refs/remotes/origin/main", head);
+    git(dir, "update-ref", "refs/remotes/origin/staging", head);
+    git(dir, "tag", "-a", "v0.3.0", "-m", "v0.3.0");
+    return { dir, head };
+  }
+
+  /** Run the guard with its DEFAULT refs — the thing under test. */
+  const runWithDefaults = (dir: string, head: string) =>
+    JSON.parse(
+      execFileSync(
         "node",
         [
           "--input-type=module",
           "-e",
-          `import { CONTRIBUTION_BASE, RELEASE_BRANCH, INTEGRATION_BRANCH, remoteRef } from ${JSON.stringify(join(dir, "branches.mjs"))};
-           process.stdout.write(JSON.stringify({ base: CONTRIBUTION_BASE, main: remoteRef(RELEASE_BRANCH), integration: remoteRef(INTEGRATION_BRANCH) }));`,
+          `import { main } from ${JSON.stringify(join(dir, "release-candidate-guard.mjs"))};
+           const r = main({ ref: "refs/tags/v0.3.0", sha: ${JSON.stringify(head)}, remote: ".", cwd: ${JSON.stringify(dir)}, log: () => {} });
+           process.stdout.write(JSON.stringify(r));`,
         ],
         { encoding: "utf8" }
-      );
-      const got = JSON.parse(out);
-      expect(got.base, "the stub must have taken effect").toBe("SENTINEL-not-a-branch");
-      expect(got.main, "the release ref must NOT follow the contribution base").toBe("refs/remotes/origin/main");
-      expect(got.integration).toBe("refs/remotes/origin/staging");
+      )
+    );
+
+  it("PASSES with a sentinel contribution base — the release ref does not follow it", () => {
+    const { dir, head } = scratchWithStub("SENTINEL-not-a-branch");
+    try {
+      const r = runWithDefaults(dir, head);
+      expect(r.facts.mainIsAncestor, "assertion C must still resolve against the RELEASE branch").toBe(true);
+      expect(r.facts.reachableFromIntegration).toBe(true);
+      expect(r.verdict, `moving CONTRIBUTION_BASE must not affect the release check: ${r.failures}`).toBe("PASS");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it("is NON-VACUOUS: wiring the release ref to CONTRIBUTION_BASE would be caught", () => {
-    // Proves the pin above can fail — the mutation it is aimed at, executed directly.
-    const wrong = `export const CONTRIBUTION_BASE = "SENTINEL-not-a-branch";
-export const remoteRef = (b) => \`refs/remotes/origin/\${b}\`;
-export const mainRef = remoteRef(CONTRIBUTION_BASE);`;
-    const dir = mkdtempSync(join(tmpdir(), "roles-neg-"));
+  it("is NON-VACUOUS: mis-wiring mainRef to CONTRIBUTION_BASE makes this FAIL", () => {
+    // The mutation the pin exists for, executed. Without this, a green above proves nothing.
+    const { dir, head } = scratchWithStub("SENTINEL-not-a-branch");
     try {
-      writeFileSync(join(dir, "wrong.mjs"), wrong);
-      const out = execFileSync(
-        "node",
-        ["--input-type=module", "-e", `import { mainRef } from ${JSON.stringify(join(dir, "wrong.mjs"))}; process.stdout.write(mainRef);`],
-        { encoding: "utf8" }
-      );
-      expect(out, "the wrong wiring produces a different ref, so the pin discriminates").not.toBe("refs/remotes/origin/main");
+      const guard = readFileSync(join(dir, "release-candidate-guard.mjs"), "utf8");
+      const mis = guard
+        .replace("import { INTEGRATION_BRANCH, RELEASE_BRANCH, remoteRef }", "import { CONTRIBUTION_BASE, INTEGRATION_BRANCH, RELEASE_BRANCH, remoteRef }")
+        .replace("mainRef = remoteRef(RELEASE_BRANCH)", "mainRef = remoteRef(CONTRIBUTION_BASE)");
+      expect(mis, "the mis-wiring must apply").not.toBe(guard);
+      writeFileSync(join(dir, "release-candidate-guard.mjs"), mis);
+      const r = runWithDefaults(dir, head);
+      expect(r.facts.mainIsAncestor, "the sentinel ref does not exist, so C goes false").toBe(false);
+      expect(r.verdict).toBe("FAIL");
+      expect(r.failures.join(" ")).toMatch(/^C: |C: /);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("the UNSTUBBED module still passes, so the sentinel is what makes the difference", () => {
+    const { dir, head } = scratchWithStub(null);
+    try {
+      expect(runWithDefaults(dir, head).verdict).toBe("PASS");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Cutover prep for option B (`docs/RELEASING.md` §3). Spec: `docs/design/cutover-prep-integration-branch.md`.

## What it is

Three things in this repo break the day contributions move off `main`, and **every one fails silently**:

- **`aios-work-sync` fired on `pull_request` closed against `main` only** — so the day work merges to `staging`, it emits nothing and **nothing closes a ticket**.
- **`scan-on-merge` fired on `push` to `main` only** — codebase readiness would drop from per-merge to per-release with no error.
- **There were TWO owners of one concept**: `release-candidate-guard.mjs` already hardcoded `refs/remotes/origin/staging` as the integration ref.

Both workflows now cover both branches — landed **early**, because they're near-inert until contributions move, rather than being two more things to get right on the day. And there are now three named **roles**, only one of which moves:

| role | today | at cutover | read by |
|---|---|---|---|
| `CONTRIBUTION_BASE` | `main` | **→ `staging`** | the branch PRs target |
| `INTEGRATION_BRANCH` | `staging` | `staging` | RELPTR-3's assertion D |
| `RELEASE_BRANCH` | `main` | `main` | assertion C |

## The slice was NARROWED after four blocking pre-code verdicts

Codex **BLOCKED** twice, Fable **BLOCKED** on round 2 — all on the same defect, twice running: **my measured terrain was wrong.** I reported 14 files hardcoding the review instruction; re-measured, it's **31 operative lines across 19 files**, including `CONTRIBUTING.md` (the contributor entry point) and `docs/agent-handoffs.md` ×9. A guard built to that scope would have gone red on day one against files it never named.

Rather than fold a third time, **the instruction-corpus rewrite moved to `RELPTR-5`**, with the ordering that failed twice written into `RELEASING.md` §3.1d: decide a per-file disposition *before* writing the guard.

Round 1 also killed the original design outright — it declared one "integration branch" as `main`, which would have pointed assertion D at `main` and destroyed the question it asks.

## The trap that survives the fix, and what pins it

**`RELEASE_BRANCH` and `CONTRIBUTION_BASE` are both `"main"` today.** A consumer wired to the wrong one passes every value assertion and stays green until cutover day. Both reviewers found nothing pinned it.

**My first two attempts at that pin were themselves defective, and both were caught mechanically rather than by reading:**

1. The pin stubbed `CONTRIBUTION_BASE` then asserted **its own expression** — never importing the guard. Mutation M27 reddened only a source-token regex. Rebuilt to run the guard through its **default refs** in a real repo.
2. The rebuilt fixture put `origin/main`, `origin/staging` and the tag on **one commit**, making C and D indistinguishable — so a full C↔D swap still passed. Both reviewers found this. The fixture is now **asymmetric** (release branch one commit behind, integration at the candidate), and there's a test that performs the swap and asserts it fails.

## What the code review found

**Both, HIGH — the degenerate fixture above.** Codex's specific surviving mutation (`remoteRef` quietly mapping integration→release) now reddens.

**Both, MEDIUM — the "exactly once" guard read `scripts/*`, not `scripts/**`.** Declaring a role in `scripts/setup/deploy-policy.mjs` survived it — the second-owner class this slice exists to kill, one directory down.

**Both, MEDIUM — I wrote that widening `scan-on-merge` "carries no risk". False.** `head_sha` idempotency only dedupes the *same* commit; a mistaken push to the 259-behind `staging` scans that stale tree and it becomes the dashboard's **current** readiness, because `codebases.ts` picks the newest by `scanned_at`, not ancestry — and `reconcile_codebase_findings` does the same, so findings fixed since get reopened. The comment now states the cost.

**Codex, MEDIUM — the concurrency group was constant across branches**, so a staging push would *cancel* an in-flight main scan. Per-ref now.

**Fable, MEDIUM — the re-narrowing can live one layer below the step `if:`.** A `pr.base.ref !== "main"` early exit inside the run body keeps every guard green while post-cutover staging merges emit nothing. Pinned.

Plus: both child processes in the new test inherited the real git environment (the RELPTR-3 twin already learned this); `roles[asked]` walked the prototype chain; the PR-template assertion was existential — swapping `applied`/`linked` kept both tokens and published the opposite guidance.

## Also corrected: the PR template was making a half-true promise

It said work-sync "advances it to Done on merge". True for a **brain-native** row in this project (`applied`); a row pushed from the workspace resolves **`linked`** and is deliberately left open. It now states the split.

## Verification

tsc clean · lint **0 errors** · unit **3660 passed, 0 failed** · docs in sync · spec `SPEC_READY`, re-gated after every amendment.

**16 mutations, all REDDENED on their intended test.** Three initially **SURVIVED** and each survival was informative: two were my mutation design being wrong (deleting an assertion can't redden its own test), and **M40 was a real gap** — I'd changed the concurrency group without pinning it, so the next tidy-up would have silently restored the defect.

## Not in this PR

The instruction corpus (**RELPTR-5**) · any branch-protection change · the release actor · the `refs/tags/v*` ruleset · the `staging` fast-forward · Dependabot's `target-branch` (it would aim at a stale branch today) · `gh pr create --base`. All enumerated in `RELEASING.md` §3.1c — because an earlier draft claimed "the cutover is one edit", and that is false.

## CI

**All 10 required checks green** on `47d70b9`-era head, verified against branch protection's context list rather than read off the summary. `PR references a brain task` printed `Found work key(s): RELPTR-4, …` at runtime — that check is advisory and greens on failure, so the log is the only proof.

**Codacy reports "1 new issue" with no detail exposed** — the same undetailed signature as on #662 and #665, and it did not move across the fold. Local vendored tooling on the new code: `opengrep` **0 findings** (76 rules), `lizard` **0 warnings**, repo ESLint 0 errors, gitleaks green. Codacy's pinned `eslint@8.57.0` cannot run against this repo's config, so the likeliest source is the one tool I can't execute. **Not claiming it is benign** — it is not a required check, and it wants a human with Codacy UI access.

## Review

Reviewed by Fable code-reviewer — verdict CLEAR-WITH-CONDITIONS (5 MEDIUM, 4 LOW; all folded)
Reviewed by Codex gpt-5.6-sol — verdict BLOCKED (1 HIGH, 2 MEDIUM, 5 LOW; all folded, none refuted)

AIOS-Work: RELPTR-4

