### PR TITLE
fix(health): a healed leg can clear its own confirmed failure (BANNERSTUCK-1)

### DIFF
--- a/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
+++ b/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
@@ -1,7 +1,8 @@
 # A confirmed failure that nothing can clear — BANNERSTUCK-1
 
 **Status:** spec, round 4 — SIX review rounds folded (Codex BLOCKED ×3, Fable CLEAR-WITH-CONDITIONS ×3).
-Round 3 made the design SMALLER: two of the states I had built criteria around cannot occur. No code written.
+Round 3 made the design SMALLER: two of the states I had built criteria around cannot occur.
+Round 5 = the DIFF reviews, folded below. **Code is built.**
 
 **Build with:** opus / high — it changes when the loudest alarm in the product speaks, and the
 failure mode in BOTH directions is a lie: an alarm that will not stop, or one that goes quiet on a
@@ -201,11 +202,18 @@ needs a streak of two, so the next real failure re-confirms.
 This is round 0's condition returning, but its job has changed completely: correctness now comes from
 the ordering above, and the condition exists to avoid perpetual ledger traffic.
 
-⚠️ **That deletes an entire layer.** Round 3 had the clearing row resetting the paid-run cooldown, a
-freshness regression that would make Monday morning's doc wait 12h, "fixed" by a two-clock scheme with
-a `meta.skipped` filter on `lastRun`'s `limit(1)` read. **All of it is unnecessary:** in the steady
-state (newest verdict already `ok=true`) nothing is written, so the cooldown is never touched, no new
-duration constant is needed, and ~730 rows/team/year of append-only history are never created.
+⚠️ **This removes the perpetual traffic, but NOT the cooldown problem — round 4 claimed it did, and
+that claim was false.** Round 4 argued that because nothing is written in the steady state, the
+cooldown is never touched. The steady state was never the issue: the clearing row is written at the
+moment the leg HEALS, with a near-current timestamp, and `lastRun` reads the newest row of any kind.
+So a doc arriving a minute after the heal would wait a full cooldown — stalling inference at exactly
+the point of recovery. **The diff review caught this, and AC3 could not have: it seeds an already-old
+success rather than performing heal → new work.**
+
+**So `lastRun` does filter after all:** the PAID-run clock skips rows carrying `meta.health_clear`
+(the verdict still comes from the newest row of any kind, because that is what the banner reads).
+What the event-driven write genuinely buys is the absence of ~730 rows/team/year and of any new
+duration constant — not an untouched clock.
 
 The row carries **`meta.health_clear = true`** — a dedicated marker, not the overloaded `meta.skipped`.
 
@@ -321,7 +329,7 @@ failure** (`COOLDOWN_MS` has a 1-hour floor, `Math.max(1,…)` at `:88`), never 
 ## 6. What would falsify this
 
 A **successful** `doc_task_infer` run before this ships would clear the banner on its own and make the
-incident look self-healing. It would not falsify the defect. **Re-measured 2026-08-28: the streak is
+incident look self-healing. It would not falsify the defect. **Re-measured 2026-08-27, ~24h after §0a: the streak is
 still 4, with no new row in a further ~24h** — the leg has now been silent-but-polled for ~2 days, and
 the falsifier has not fired.
 

--- a/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
+++ b/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
@@ -325,4 +325,33 @@ incident look self-healing. It would not falsify the defect. **Re-measured 2026-
 still 4, with no new row in a further ~24h** — the leg has now been silent-but-polled for ~2 days, and
 the falsifier has not fired.
 
-**Nothing is built. No code exists for this slice.**
+## 7. Mutations, as RUN
+
+Behavioural rows ran against the real-Postgres suite; ∀-over-sites rows against the guard. **The
+baseline was verified green under the exact invocation first** — an earlier attempt pointed at the
+wrong database (`app` rather than `app_test`), where the suite was ALREADY red and every mutation
+reported `REDDENED` while proving nothing.
+
+| # | mutation | tier | result |
+|---|---|---|---|
+| 1 | the clearing row is never written | dm | ✅ AC1 ×2 |
+| 3 | `cooldown` also clears | dm | ✅ AC2 |
+| 4 | the write is wired above the `no-llm` gate | dm | ✅ AC2b |
+| 5 | an unresolvable owner is treated as legitimate | guard | ✅ AC2c |
+| 6 | ANY null-credit drop blocks clearing (round 3's over-broad rule) | guard | ✅ AC2d |
+| 7 | the saturation gate is dropped at `:206` | dm | ✅ AC2e |
+| 8 | the saturation gate is dropped at `:270` | dm | ⚠️ **SURVIVED** → guard | ✅ AC2e (∀) |
+| 9 | `finishedAt` is `Date.now()` instead of `passStartedAt` | dm | ✅ AC5 + AC1 |
+| 11 | the row is written even when the newest verdict is `ok` | dm | ✅ AC3 |
+| 17 | a false claim is restored to the comment block | guard | ✅ AC8 |
+
+⚠️ **Mutation 8 SURVIVED the behavioural suite, and that is recorded rather than smoothed over.**
+AC2e's fixture fills the page with conversational rows, so the pass exits at `:206` and never reaches
+`:270` — exactly the gap Fable's round-3 review predicted ("AC2e and mutation 7 pin only `:206`").
+Reaching `:270` under saturation needs 500 already-scored docs keyed on an `inputsHash` derived from
+the candidate set and the prompt, which is not reasonably constructible in a fixture. **So the split
+is deliberate and stated: the MECHANISM is proven behaviourally at `:206`, and the ∀-over-sites
+property — that all three JS-derived outcomes carry the gate — is proven by the guard**, which
+reddens when the gate is removed at `:237` or `:270`. Both mutations were run against it.
+
+**Code is built.** AC1–AC5 + AC7 are the data-mechanics suite; AC2c/AC2d/AC2e(∀)/AC5b/AC8 are the guard.

--- a/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
+++ b/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
@@ -1,6 +1,6 @@
 # A confirmed failure that nothing can clear — BANNERSTUCK-1
 
-**Status:** spec, round 1 — both spec reviews folded (Codex BLOCKED, Fable CLEAR-WITH-CONDITIONS). No code written.
+**Status:** spec, round 3 — four review rounds folded (Codex BLOCKED ×2, Fable CLEAR-WITH-CONDITIONS ×2). No code written.
 
 **Build with:** opus / high — it changes when the loudest alarm in the product speaks, and the
 failure mode in BOTH directions is a lie: an alarm that will not stop, or one that goes quiet on a
@@ -126,206 +126,223 @@ is inherited, not negotiable here.
 
 ## 1. The rule
 
-> **A confirmed failure is evidence only while the leg is still being exercised. A leg that has since
-> completed a clean pass with nothing to do has produced positive evidence of health, and that
-> evidence must be able to clear the alarm — while a leg that merely has not run must neither clear
-> it nor keep shouting on the strength of it.**
+> **A confirmed failure is evidence only while the leg is still being exercised. A pass that
+> OBSERVED THE WHOLE ELIGIBLE SET and found no work demanded has produced contrary evidence, and that
+> evidence must be able to clear the alarm — while a pass that was gated, abstained, or saw only part
+> of the set must neither clear it nor be masked by one.**
 
 ## 2. The design
 
-### 2a. Only a pass that DEMONSTRABLY completed a clean evaluation may clear
+### 2a. Only a pass that observed the WHOLE eligible set and found no work may clear
 
-⚠️ **Round 0 got this wrong in a way that could have silenced a real alarm.** It said "the three
-outcomes `nothing-to-score` / `unchanged` / `no-candidates`" — but `nothing-to-score` is **two
-different code paths with opposite meanings**, and the label hides it:
+The outcome LABELS are not the rule — two of them cover both a healthy and an unhealthy state:
 
-| site | condition | meaning | clears? |
+| site | outcome | clears? | why |
 |---|---|---|---|
-| `:206` | `docRows` empty — no scoreable-source work docs in the 7-day window | **genuine idle**: the leg read the corpus successfully and there is nothing to do | ✅ |
-| `:237` | `allScoreable` empty **after** `resolveItemCreditIds({strict:true})` | **abstention**: the attribution oracle could not answer, and the code's own comment says *"spend nothing this tick rather than rank against a second opinion"* | ❌ |
+| `:147` | `cooldown` | ❌ | the pass never ran |
+| `:151` | `no-llm` | ❌ | unconfigured — a different state, and its own signal |
+| `:195` | `no-candidates` | ✅ | the task list was read; there is nothing to offer |
+| `:206` | `nothing-to-score` | ✅ **only if the scan did not saturate** | see below |
+| `:237` | `nothing-to-score` | ✅ **only if every drop was a legitimate one** | see below |
+| `:270` | `unchanged` | ✅ | every eligible doc is already answered |
 
-`scoreableDocs` filters on `!!d.memberId`, so an identity-mapping regression that returns a null
-`primaryId` for everyone empties `allScoreable` **without any query error** — strict mode propagates
-DB errors only (`lib/attribution/contributor-credit.ts:125-126`). Clearing on `:237` would silence a
-standing alarm on the word of a pass that could not attribute anything.
+**`:206` — the bounded scan.** The item read is `.limit(ITEM_SCAN)` = **500**, ordered `updated_at desc`
+(`doc-task-infer-run.ts:185`). So `docRows` empty means *"nothing scoreable in the newest 500"*, not
+*"nothing in the 7-day window"*: 500 newer Slack rows can hide an older unscored design document, and
+clearing there would silence the alarm while work is genuinely pending. **So `:206` may clear only
+when the scan returned fewer than `ITEM_SCAN` rows** — i.e. the window was observed in full. When it
+saturates, the pass abstains. *(Prod today: 152 items in 7 days, so this is not the live path — but a
+busy team crosses 500 and the fix must not be wrong for them.)*
 
-**So the rule is not "these labels" but this property:**
+⚠️ *A residual, stated: `:206`'s pure filters can still be emptied by a data-shaped regression
+(`frontmatter.source` naming, `classifyWork`, `work_at_from_source` stamping). Pre-change that made
+the leg silently invisible; post-change it would actively clear. The emptiness does derive from rows
+the pass actually READ — unlike `:237` — which is why the line is drawn here, but the direction of the
+cost changed and that is worth knowing.*
 
-> A pass may clear only if it **read the corpus successfully and found no work demanded**. A pass that
-> abstained, was gated, or could not evaluate must record nothing.
+**`:237` — split by DROP REASON, not wholesale.** `scoreableDocs` (`doc-task-infer.ts:97`) drops on
+**three** predicates, and round 2 treated all of them as the oracle abstaining:
 
-| outcome | clears | why |
-|---|---|---|
-| `nothing-to-score` **@:206** | ✅ | read the window, nothing scoreable |
-| `no-candidates` @:195 | ✅ | read the tasks, none to offer |
-| `unchanged` @:270 | ✅ | every eligible doc already answered |
-| `nothing-to-score` **@:237** | ❌ | the credit oracle abstained |
-| `cooldown` @:147 | ❌ | the pass never ran |
-| `no-llm` @:151 | ❌ | unconfigured — a different state, and its own signal |
+```ts
+!d.hasDeterministicLink && d.access !== "external" && !!d.memberId
+```
 
-⚠️ **And the justification is narrower than round 0 claimed.** An idle pass does **not** prove the
-provider recovered — `lib/llm/complete.ts:212` makes exactly this argument in-repo (*"`ok: true` would
-claim a model that was never asked"*), and `timeline-summary` succeeding proves some OpenRouter
-workload works, not this leg's model role, prompt size or parsing. What it proves is only: **there is
-no output currently demanded, so a historical provider failure must not drive a present-tense alarm.**
-That is sufficient, and it is what the spec claims.
+| dropped because | legitimate no-work? |
+|---|---|
+| already has a deterministic issue-key link | ✅ yes — the link exists, nothing to infer |
+| `access === "external"` | ✅ yes — deliberately never scored |
+| no `memberId`, and the item is **connector-owned** | ✅ yes — connectors are excluded from credit BY DESIGN (`contributor-credit.ts`), so there is no person to reason about |
+| no `memberId` for a **human-owned** item | ❌ **NO** — this is `resolveItemCreditIds({strict:true})` abstaining, and the code says so: *"if the oracle can't answer, the right move is to spend nothing this tick"* |
 
-### 2b. Record unconditionally after the cooldown — the round-0 conditional was racy AND rested on a wrong number
+So `scoreableDocs` must report drop counts by reason, and the pass clears only when the
+unattributable-human count is **zero**. Round 2 would have blocked clearing for the three legitimate
+cases — making the leg never clear for a team whose docs are all deterministically linked.
 
-Round 0 wrote the clearing row **only when the newest row was a failure**, to avoid noise. Both halves
-of that were wrong:
+⚠️ **The justification is narrow, and narrower than round 0 claimed.** An idle pass does **not** prove
+the provider recovered — `lib/llm/complete.ts:212` argues exactly this in-repo (*"`ok: true` would
+claim a model that was never asked"*). It proves only: **there is no output currently demanded, so a
+historical provider failure must not drive a present-tense alarm.**
 
-- **The noise estimate was wrong.** I assumed a row every 30 minutes. The **cooldown gate runs first**,
-  and a newly written success *becomes* the cooldown clock — so the steady-state cost is **~2 rows per
-  team per day**, not 48. The entire reason for the conditional evaporates.
-- **The conditional is a check-then-insert race.** Two callers exist and they are **not** mutually
-  single-flighted: the scheduler (`lib/ingest/scheduler.ts:91`, single-flighted only against itself)
-  and the timeline rebuild on a dashboard read (`lib/dashboard/timeline-cache.ts:116`). Interleaving:
-  idle pass **A** observes "newest is a failure"; concurrent pass **B** finds work, calls the model,
-  fails, records `ok=false`; **A** then records its authorised `ok=true`. `STREAK_SQL` takes newest —
-  so **A's success masks B's real failure** and the alarm goes quiet on a genuinely broken leg.
+### 2b. The clearing row is BACKDATED — masking becomes impossible by ordering, not improbable by guarding
 
-So: record the clearing outcome **unconditionally once past the cooldown**.
+Rounds 0–2 tried two mechanisms and both were wrong:
 
-⚠️ **That alone does not close the masking window** — Codex's proposal stopped here, and it should
-not. Unconditional recording still lets A's `ok=true` land after B's `ok=false`; the rows are merely
-both truthful. What actually closes it is a **guarded write**: the clearing row is inserted only if no
-row for this `(source, team_id)` has been recorded since this pass started. A concurrent failure
-therefore always wins, and two concurrent *idle* passes may both write (harmless — both `ok=true`, the
-streak stays broken).
+- **Round 0** wrote the row only when the newest row was a failure — a check-then-insert race.
+- **Round 2** added a "no row since this pass started" guard. **Also insufficient**: under PostgreSQL
+  `READ COMMITTED` an `INSERT … WHERE NOT EXISTS` runs its subquery against the statement snapshot, so
+  a concurrent `ok=false` that has not yet committed is invisible, both rows land, and the clearing
+  row is still newer. `ingest_runs` has no unique constraint to conflict on, and an advisory lock only
+  works if **every** writer takes it — the failure path is a plain `recordIngestRun` (`runs.ts:59`).
 
-⚠️ *Note the ordering asymmetry this must respect: `STREAK_SQL` breaks ties with `finished_at desc,
-id desc` (`lib/ingest/pipeline-health.ts:345`) while `lastRun` orders by `finished_at` alone
-(`doc-task-infer-run.ts:450`). The guard must not assume they agree.*
+**The fix is ordering, not locking.** The clearing row is written with
+**`finishedAt = the pass's own startedAt`** (`doc-task-infer-run.ts:140`). `recordIngestRun` already
+accepts `finishedAt` (`runs.ts:31`), so this needs no new plumbing. Because `STREAK_SQL` orders
+`finished_at desc, id desc` (`pipeline-health.ts:351`), **any row recorded during the pass is strictly
+newer than the clearing row** — a concurrent failure can never be masked, whatever the commit order,
+snapshot or clock skew.
 
-### 2b-bis. The accepted cost: clearing takes up to one cooldown
+It also interacts correctly with the cooldown: `lastRun` orders on `finished_at` alone
+(`doc-task-infer-run.ts:457`), so a backdated clearing row older than a concurrent failure leaves the
+cooldown counting from the failure, which is the right clock.
 
-Every clearing outcome sits **behind** the 12h cooldown gate, and the cooldown counts failed runs. So
-after this ships a healed failure can stay loud for **up to 12h + one tick**, and the clearing row
-itself resets the cooldown, deferring the next real scoring pass by up to 12h. Both are accepted and
-stated here **so that "still red 6h after the top-up" is not read as this fix having failed.**
+⚠️ **Residual, stated:** a failure finishing in the same millisecond as the pass's start loses the
+`id desc` tie to the clearing row. ~1ms; accepted.
 
-### 2c. The false comment is corrected
+**The existence check stays**, demoted to what it honestly is — a write-avoidance optimisation, not a
+correctness guarantee — and its comparator is **`>=`** (a `>` misses the same-millisecond row).
 
-§0d's sentence is replaced with what is actually true, naming this mechanism.
+### 2b-bis. TWO CLOCKS — the clearing row must not defer real scoring
 
-### 2d. The other legs: fix `doc_task_infer` alone — and record WHY, so the next one is recognised
+⚠️ Round 2 said "clearing takes up to 12h" and **understated the cost**. The real regression is on the
+other side: today, once past the cooldown, an idle pass records nothing, so the clock never resets and
+the first tick after new work arrives scores it within ≤30 min. If a clearing row became `lastRun`,
+every quiet weekend pass would reset the clock and **Monday morning's design doc would wait up to 12
+hours** for linking that costs one tick today. That is a new steady-state freshness regression, and it
+contradicts the existing comment that the cooldown is a minimum gap between **paid** runs
+(`doc-task-infer-run.ts:143`) — a clearing pass is unpaid.
 
-Round 0 listed six same-shaped legs and asked the reviews to decide. Both said fix this one alone, and
-the inventory itself was wrong:
+So there are two clocks:
 
-- **`pret3_sweep` is already fixed** (§0f) — my draft listed it as unfixed.
-- **The rest mostly SELF-CLEAR**, because their failure leaves pending work that survives the heal:
-  `dense` and `graph_project` retry the same backlog and record `ok=true` on the healing run; `arcs`
-  persists no reusable hash on failure (`lib/graph/arcs.ts:679,859`), so the retry re-runs the model
-  and records.
-- **`linear_inbound` is the one genuinely unverified twin** — named here, not fixed here.
+- **the paid-run cooldown** (`:147`) ignores rows carrying `meta.skipped` — unchanged behaviour;
+- **the clearing write** throttles on the age of the last *clearing* row.
 
-`doc_task_infer` is unique in that **healing removes the reason to record**: the work it failed on was
-never pending in the first place. That distinction goes into the §2c comment so the next leg with this
-shape is recognised rather than rediscovered.
+Same ~2 rows/team/day, and **zero added scoring latency**.
 
-⚠️ **A residual, named rather than fixed:** a team that REMOVES its keys while `confirmed` keeps the
-banner forever, because `no-llm` never clears. That is the `no-llm` analogue of `isOrphanedConnector`
-and is the likely next BANNERSTUCK. Out of scope here; recorded so it is a known cost.
+### 2c. The map is corrected — the whole block, not one sentence
+
+`pipeline-health.ts:154-168` will have **four** false claims after this change, not the one round 0
+found: that five outcomes write no row (three now do), and that "a perfectly healthy leg polled every
+30 minutes still writes nothing for days". The `null`-threshold **conclusion** stays correct — a
+`no-llm` team still writes nothing, so no finite age is right — but its argument must be rewritten.
+
+### 2d. Fix `doc_task_infer` alone — and record why, so the next one is recognised
+
+- **`pret3_sweep` is ALREADY FIXED** (§0f) — round 0 listed it, wrongly.
+- **`linear_inbound` is a CONFIRMED twin**, not merely unverified: a quiet healthy pass returns before
+  `recordIngestRun` (`scheduler.ts:159-160`), so heal-with-nothing-to-apply latches. Not fixed here.
+- **`dense` has a narrower hole**: it records only on `failed > 0 || indexed > 0`
+  (`scheduler.ts:106-128`), so if the failing backlog is PURGED during an outage rather than retried,
+  the healing run indexes 0, records nothing, and the streak latches.
+- `arcs` and `graph_project` self-clear: their failure leaves pending work that survives the heal.
+
+`doc_task_infer` is unique in that **healing removes the reason to record**.
+
+⚠️ **Two residual BANNERSTUCKs, named not fixed:** a team that removes its keys stays loud forever
+(`no-llm` never clears); and a team whose entire 7-day scoreable window is **connector-attributed**
+sits at `:237` legitimately forever. Both are the same class.
 
 ## 3. Scope
 
-**In:** `lib/dashboard/doc-task-infer-run.ts` (the three clearing outcomes) · the corrected comment
-in `lib/ingest/pipeline-health.ts` · a guard · a data-mechanics test · `docs/ARCHITECTURE.md` if the
-ingestion-health prose is affected.
+**In:** `lib/dashboard/doc-task-infer-run.ts` · `lib/dashboard/doc-task-infer.ts` (drop reasons) ·
+the corrected block in `lib/ingest/pipeline-health.ts` · guards · data-mechanics tests ·
+`docs/ARCHITECTURE.md` if the ingestion-health prose is affected.
 
 **Out:**
 - **Any new duration constant, grace period or age-out** — rejected by BANNERFLAP-1 §3a (§0e).
-- **`STALE_MS_BY_SOURCE`** — the `null`s are correct and stay.
-- **`FAILURES_TO_CONFIRM`** — not a tunable, by its own measurement.
-- **The other five legs**, pending §2d.
-- **The `unconfirmed`-stays-quiet cost** of §3a — a different, accepted trade.
+- `STALE_MS_BY_SOURCE`, `FAILURES_TO_CONFIRM` — unchanged.
+- `linear_inbound`, `dense`, the `no-llm` and connector residuals — named in §2d, separate slices.
+- Paging the `ITEM_SCAN` read — §2a abstains on saturation instead, which is correct and smaller.
 
 ## 4. Acceptance
 
-⚠️ **Fixture requirements that decide whether these can pass at all** (Fable): AC1–AC3 must seed
-answering keys against the stubbed model, or the pass returns `no-llm` at `:151` before reaching any
-clearing branch — and a builder who hits that first may "fix" it by clearing there, which is the
-hole AC2b exists to close. AC4's failures must be produced by **running** the pass (stubbed model
-returns null → `ok=false` at `:351`), **not** by seeding rows: a seeded-only fixture lets a mutation
-that flips the failure record to `ok=true` survive.
+⚠️ **Fixture requirements, because three of these cannot pass without them:** AC1–AC3 must seed
+answering keys, or the pass returns `no-llm` before any clearing branch. **AC4 must AGE its first
+produced failure** (`update ingest_runs set finished_at = …`) between the two runs — `COOLDOWN_MS` has
+a **1-hour floor** (`Math.max(1, …)`, `:88`), so no env value lets a second run reach the model, and
+seeding the second failure instead is exactly what AC4 forbids.
 
-- **AC1 — each clearing outcome clears, all three (data-mechanics, real Postgres):** seed a confirmed
-  streak (≥2 `ok=false`), then, **once per outcome** — `nothing-to-score`@:206, `no-candidates`@:195,
-  `unchanged`@:270 — run a pass and assert via **`getPipelineHealth`** that the leg leaves `failing`
-  and is no longer `confirmed`; and assert the pass returned that exact `skipped` value and inserted a
-  row with `ok=true` and `meta.skipped=<reason>`. *Round 0 tested only one outcome, so an
-  implementation with two of the three still stuck passed every criterion. Asserting the inserted row
-  stops an unrelated seeded success from satisfying the health read.*
-- **AC2 — `cooldown` does NOT clear (data-mechanics):** seed the streak with its newest failure
-  **inside** the cooldown window; the pass returns exactly `cooldown`, **row count is unchanged**, and
-  the leg is still `confirmed` and still in `failing`. *If this cleared, the alarm could be silenced
-  by doing nothing — strictly worse than the bug.*
-- **AC2b — `no-llm` does NOT clear (data-mechanics):** same seed, no answering keys; the pass returns
-  exactly `no-llm`, row count unchanged, leg still `confirmed`. *`no-llm` sits one gate ABOVE the
-  clearing outcomes and is the easiest state to reach in this tier, so a write wired one early-return
-  too high passes everything else.*
-- **AC2c — the credit-oracle abstention does NOT clear (data-mechanics):** docs exist in the window
-  but `resolveItemCreditIds` yields no `primaryId`, so `allScoreable` is empty at **`:237`**; row count
-  unchanged, leg still `confirmed`. *Same `skipped` LABEL as AC1's `:206` case and the opposite
-  meaning — this is the criterion that stops a broken attribution oracle silencing a real alarm.*
-- **AC3 — the steady state writes nothing extra (data-mechanics):** with the newest row `ok=true` and
-  **older than the cooldown** (so the pass actually reaches an idle branch), an idle pass returns that
-  idle outcome and adds at most the one clearing row the design permits. *Round 0's version was
-  vacuous: a recent success returns `cooldown` first, so row count stayed unchanged under both the
-  intended implementation and a dozen wrong ones. The criterion must assert the RETURNED outcome.*
-- **AC4 — a real failure is still loud (data-mechanics):** run the pass twice with the model stubbed
-  to fail; both record `ok=false`, the leg is `confirmed` and in `failing`, and `failingSince` reports
-  the **oldest** failure in the streak. *The fix must not buy quiet by weakening the alarm.*
-- **AC5 — a concurrent failure is never masked (data-mechanics):** with a clearing pass and a failing
-  pass released against the same team, the final state is **`failing`** regardless of completion
-  order. *§2b's guarded write exists for exactly this, and it is the criterion Codex's "unconditional"
-  proposal would have shipped without.*
-- **AC6 — a failed READ never becomes an idle success (data-mechanics):** force the task read, item
-  read, credit read and roster read to error in turn; each records `ok=false` (or records nothing) and
-  **never** an `ok=true` clearing row. *The clearing outcomes are defined by "read successfully and
-  found nothing" — a read that threw satisfies neither half.*
-- **AC7 — no time-based escalation (guard, unit + behavioural):** classification is **identical** at
-  two widely separated failure ages with no intervening run — the observable, not a grep. *Round 0
-  used a `*_MS`/`*_HOURS` source scan, which an inline `86_400_000` walks straight past.*
-- **AC8 — the false comment is gone AND the true one is pinned (guard, unit):** `pipeline-health.ts`
-  no longer asserts that a persistent failure keeps re-recording, and does state the narrower claim.
-  *Deleting the sentence alone would satisfy a "does not contain" check while leaving the map silent.*
+- **AC1 — every clearing outcome clears (data-mechanics):** seed a confirmed streak, then once per
+  clearing case — `no-candidates`, `:206` unsaturated, `:237` with only legitimate drops, `unchanged` —
+  assert via **`getPipelineHealth`** that the leg leaves `failing`, and assert the inserted row has
+  `ok=true`, `meta.skipped`, and `finished_at === passStartedAt`.
+- **AC2 — `cooldown` does not clear (dm).** **AC2b — `no-llm` does not clear (dm)** *(one gate above
+  the clearing branches — a write wired one return too high passes everything else)*. **AC2c — a
+  HUMAN-owned unattributable doc at `:237` does not clear (dm)**, while **AC2d — an all-connector-owned
+  window at `:237` DOES clear (dm)**. **AC2e — a SATURATED `:206` scan does not clear (dm).** *Each
+  asserts the exact returned outcome and that the row count is unchanged.*
+- **AC3 — the steady state (dm):** newest row `ok=true` and older than the cooldown; the pass returns
+  its idle outcome and writes **exactly** the row the design permits — not "at most", which permits
+  zero and would let a no-op implementation pass.
+- **AC4 — a real failure is still loud (dm):** two failures **produced by running the pass** (stubbed
+  model returns null → `ok=false` at `:351`), ageing the first between runs; leg `confirmed`, in
+  `failing`, `failingSince` = the OLDEST failure.
+- **AC5 — a concurrent failure can never be masked (dm, deterministic):** the clearing write is an
+  exported seam `recordClearingRun(db, teamId, passStartedAt, reason)`. Seed the streak, record a
+  produced failure NOW, then call the seam with `passStartedAt` five minutes in the past: the leg is
+  **still `failing`**, and the clearing row's `finished_at` is strictly older than the failure's.
+  *Round 2's version was VACUOUS: an idle pass has no awaitable seam between its reads and its write,
+  so a `Promise.all` test ends `failing` even with the guard deleted — the mutation would have
+  survived and the criterion was green by construction.*
+- **AC5b — the call site passes its OWN `startedAt` (guard, unit):** the pass must hand
+  `recordClearingRun` the `startedAt` captured at `:140`, not `Date.now()` at write time. *That
+  mutation empties the ordering window and the seam test alone cannot see it.*
+- **AC6 — a thrown read never becomes a clearing row (UNIT):** with each of the task/item/credit/roster
+  reads throwing, the orchestration records `ok=false` or nothing, never a clearing row. *Unit, not
+  data-mechanics: real Postgres has no fault injection, and this is orchestration shape.*
+- **AC7 — no time-based escalation (dm, behavioural):** `getPipelineHealth` over real rows classifies
+  a failure at 2 days and at 60 days **identically** with no intervening run. *Named surface on
+  purpose: `classifyFailure`/`foldStreak` are pure over the streak and never see a clock, so a unit
+  test there is green under any escalation added where the clock actually lives (`:463-494`).*
+- **AC8 — the whole comment block is true (guard, unit):** `pipeline-health.ts:154-168` no longer
+  claims five outcomes write no row, nor that a healthy leg writes nothing for days, and states the
+  narrower truth. *Round 2 scoped this to one sentence, satisfiable while three other claims lie.*
 
 | # | mutation | must redden |
 |---|---|---|
 | 1 | the clearing row is never written | AC1 |
-| 2 | only `nothing-to-score` clears; `unchanged`/`no-candidates` still stuck | **AC1** (the per-outcome legs) |
-| 3 | `cooldown` also writes the clearing row | **AC2** |
-| 4 | the write is wired above `:151` so `no-llm` clears | **AC2b** |
-| 5 | `:237` (oracle abstention) clears, i.e. both sites treated as one label | **AC2c** |
-| 6 | the clearing row is written with `ok=false` | AC1 |
-| 7 | the guarded write drops its guard (plain unconditional insert) | **AC5** |
-| 8 | a read error is swallowed into an idle success | **AC6** |
-| 9 | `FAILURES_TO_CONFIRM` raised so nothing ever confirms | AC4 |
-| 10 | `failingSince` reports the newest failure instead of the oldest | AC4 |
-| 11 | add an inline elapsed-time escalation (real shape, not a named constant) | **AC7** |
-| 12 | restore the "a persistent failure keeps re-recording" sentence | AC8 |
+| 2 | only one clearing outcome is wired; the others stay stuck | AC1 |
+| 3 | `cooldown` also clears | AC2 |
+| 4 | the write is wired above `:151`, so `no-llm` clears | AC2b |
+| 5 | `:237` clears regardless of drop reason | **AC2c** |
+| 6 | `:237` never clears (round-2's over-broad rule) | **AC2d** |
+| 7 | `:206` clears even when the scan saturated | **AC2e** |
+| 8 | the clearing row is written with `ok=false` | AC1 |
+| 9 | **`finishedAt` is `Date.now()` instead of `passStartedAt`** | **AC5** |
+| 10 | the call site passes `Date.now()` rather than its own `startedAt` | **AC5b** |
+| 11 | the paid-run cooldown counts clearing rows (one clock) | AC3 / freshness |
+| 12 | a thrown read is swallowed into a clearing row | AC6 |
+| 13 | `FAILURES_TO_CONFIRM` raised so nothing confirms | AC4 |
+| 14 | `failingSince` reports the newest failure | AC4 |
+| 15 | an inline elapsed-time escalation in `getPipelineHealth` (real shape) | **AC7** |
+| 16 | restore any one of the four false claims in the block | AC8 |
 
 ## 5. Risks
 
 | risk | direction | mitigation |
 |---|---|---|
-| The alarm can be silenced by a leg that never ran | **a real break goes unreported** — worse than the bug | AC2/AC2b + mutations 3/4: only a pass that READ SUCCESSFULLY and found no work may clear |
-| A broken attribution oracle silences the alarm | the sharpest version of the above — same `skipped` label, opposite meaning | §2a splits `:206` from `:237`; AC2c + mutation 5 |
-| A concurrent failure is masked by a clearing row | the alarm goes quiet on a genuinely broken leg | §2b's guarded write; AC5 + mutation 7 |
-| `ingest_runs` fills with idle rows | the operator's run log becomes unreadable | bounded by the cooldown to ~2 rows/team/day (§2b) — measured, after round 0's estimate of 48/day was wrong |
-| "Still red hours after the fix" reads as the fix failing | a correct implementation gets re-opened | §2b-bis states the ≤12h+tick clearing latency up front |
-| A later tweak reintroduces a grace period | the exact fix §3a proved wrong | AC5 is a ∀ guard, mutation 7 |
-| Fixing one leg and leaving five | the same defect ships five more times | §2d is an open question for the review, not a silent choice |
-| A unit stub of the streak query passes while the real SQL does not | green by construction | AC1–AC4 are **data-mechanics**, against real Postgres and the real `STREAK_SQL` |
+| A concurrent real failure is masked by a clearing row | **the loudest alarm goes quiet on a broken leg** | §2b backdating makes it impossible by ordering; AC5 + mutations 9/10 |
+| A broken attribution oracle silences the alarm | same label, opposite meaning | §2a's drop-reason split; AC2c + mutation 5 |
+| The fix makes the leg NEVER clear | the bug, inverted — and round 2 would have shipped it | AC2d + mutation 6 |
+| Clearing on a partial view of the window | clears while work is pending | §2a's saturation check; AC2e + mutation 7 |
+| The clearing row defers real scoring by up to 12h | a new freshness regression traded for a banner fix | §2b-bis's two clocks; mutation 11 |
+| The alarm is silenced by a leg that never ran | worse than the bug | AC2/AC2b + mutations 3/4 |
+| A later tweak reintroduces a grace period | the fix §3a proved wrong | AC7 is behavioural, mutation 15 |
 
 ## 6. What would falsify this
 
-If `doc_task_infer` on prod records a **successful** run before this ships — i.e. a scoreable doc
-arrives — the banner clears on its own and the incident looks self-healing. **That would not falsify
-the defect**, only hide it: the mechanism in §0c is unchanged and the next healed-but-idle failure
-reproduces it. The measurement to re-take at build time is §0a's streak, not the banner's colour.
+If `doc_task_infer` records a **successful** run before this ships, the banner clears on its own and
+the incident looks self-healing. **That would not falsify the defect** — the mechanism in §0c is
+unchanged and the next healed-but-idle failure reproduces it. Re-take §0a's streak, not the banner's
+colour.
 
 **Nothing is built. No code exists for this slice.**

--- a/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
+++ b/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
@@ -1,6 +1,7 @@
 # A confirmed failure that nothing can clear — BANNERSTUCK-1
 
-**Status:** spec, round 3 — four review rounds folded (Codex BLOCKED ×2, Fable CLEAR-WITH-CONDITIONS ×2). No code written.
+**Status:** spec, round 4 — SIX review rounds folded (Codex BLOCKED ×3, Fable CLEAR-WITH-CONDITIONS ×3).
+Round 3 made the design SMALLER: two of the states I had built criteria around cannot occur. No code written.
 
 **Build with:** opus / high — it changes when the loudest alarm in the product speaks, and the
 failure mode in BOTH directions is a lie: an alarm that will not stop, or one that goes quiet on a
@@ -126,223 +127,190 @@ is inherited, not negotiable here.
 
 ## 1. The rule
 
-> **A confirmed failure is evidence only while the leg is still being exercised. A pass that
-> OBSERVED THE WHOLE ELIGIBLE SET and found no work demanded has produced contrary evidence, and that
-> evidence must be able to clear the alarm — while a pass that was gated, abstained, or saw only part
-> of the set must neither clear it nor be masked by one.**
+> **A confirmed failure is evidence only while the leg is still being exercised. A pass that OBSERVED
+> THE WHOLE ELIGIBLE SET and found no work demanded has produced contrary evidence and may clear the
+> alarm. A pass that was gated, abstained, or saw only PART of the set must do neither — and must never
+> be able to hide a failure that happened while it ran.**
 
 ## 2. The design
 
-### 2a. Only a pass that observed the WHOLE eligible set and found no work may clear
+### 2a. Which outcomes may clear — derived from the code, not from the labels
 
-The outcome LABELS are not the rule — two of them cover both a healthy and an unhealthy state:
+| site | outcome | clears? |
+|---|---|---|
+| `:147` | `cooldown` | ❌ the pass never ran |
+| `:151` | `no-llm` | ❌ unconfigured — a different state, and its own signal |
+| `:195` | `no-candidates` | ✅ the task list was read; nothing to offer |
+| `:206` | `nothing-to-score` | ✅ **only if the item scan did not saturate** |
+| `:237` | `nothing-to-score` | ✅ **only if unsaturated AND no doc was dropped for an unresolvable owner** |
+| `:270` | `unchanged` | ✅ **only if the item scan did not saturate** |
 
-| site | outcome | clears? | why |
-|---|---|---|---|
-| `:147` | `cooldown` | ❌ | the pass never ran |
-| `:151` | `no-llm` | ❌ | unconfigured — a different state, and its own signal |
-| `:195` | `no-candidates` | ✅ | the task list was read; there is nothing to offer |
-| `:206` | `nothing-to-score` | ✅ **only if the scan did not saturate** | see below |
-| `:237` | `nothing-to-score` | ✅ **only if every drop was a legitimate one** | see below |
-| `:270` | `unchanged` | ✅ | every eligible doc is already answered |
+**The saturation rule covers THREE sites, not one.** The item read is `.limit(ITEM_SCAN)` = 500,
+ordered **`work_at desc`** (`doc-task-infer-run.ts:184` — round 3 said `updated_at`, which is the
+*tasks* read at `:164`; the sentence was wrong). `:206`, `:237` and `:270` are all derived by JS
+filters over that one truncated page, so with ≥500 items in the window each of them is a claim about
+*the newest 500 only* — item #501 can be an unscored design doc. §1's rule therefore forces all three
+to abstain when `items.length >= ITEM_SCAN`. *(`visibleItems(q,"team")` is a passthrough, so nothing
+post-drops rows and the count is honest. Exactly 500 abstains too — conservative, and correct.)*
 
-**`:206` — the bounded scan.** The item read is `.limit(ITEM_SCAN)` = **500**, ordered `updated_at desc`
-(`doc-task-infer-run.ts:185`). So `docRows` empty means *"nothing scoreable in the newest 500"*, not
-*"nothing in the 7-day window"*: 500 newer Slack rows can hide an older unscored design document, and
-clearing there would silence the alarm while work is genuinely pending. **So `:206` may clear only
-when the scan returned fewer than `ITEM_SCAN` rows** — i.e. the window was observed in full. When it
-saturates, the pass abstains. *(Prod today: 152 items in 7 days, so this is not the live path — but a
-busy team crosses 500 and the fix must not be wrong for them.)*
+**The `:237` abstain bucket is NOT what round 3 said.** Both reviewers independently derived, and I
+verified, that *"a human-owned doc with no attribution"* **cannot occur**:
 
-⚠️ *A residual, stated: `:206`'s pure filters can still be emptied by a data-shaped regression
-(`frontmatter.source` naming, `classifyWork`, `work_at_from_source` stamping). Pre-change that made
-the leg silently invisible; post-change it would actively clear. The emptiness does derive from rows
-the pass actually READ — unlike `:237` — which is why the line is drawn here, but the direction of the
-cost changed and that is worth knowing.*
+- the wide scan already excludes ownerless items in SQL — `.not("member_id","is",null)` (`:177`);
+- `creditedPrimaryId` returns null **only** when `currentMemberId` is null, and that is nulled only
+  when `isHuman()` is false (`contributor-credit.ts:50-61,190`);
+- a genuine oracle failure **throws** in `strict` mode (`contributor-credit.ts:126-128`) and lands in
+  the catch at `:408` as an `ok=false` run — it never appears as a `:237` drop.
 
-**`:237` — split by DROP REASON, not wholesale.** `scoreableDocs` (`doc-task-infer.ts:97`) drops on
-**three** predicates, and round 2 treated all of them as the oracle abstaining:
+So the four real buckets are:
 
-```ts
-!d.hasDeterministicLink && d.access !== "external" && !!d.memberId
-```
-
-| dropped because | legitimate no-work? |
+| dropped because | legitimate? |
 |---|---|
-| already has a deterministic issue-key link | ✅ yes — the link exists, nothing to infer |
-| `access === "external"` | ✅ yes — deliberately never scored |
-| no `memberId`, and the item is **connector-owned** | ✅ yes — connectors are excluded from credit BY DESIGN (`contributor-credit.ts`), so there is no person to reason about |
-| no `memberId` for a **human-owned** item | ❌ **NO** — this is `resolveItemCreditIds({strict:true})` abstaining, and the code says so: *"if the oracle can't answer, the right move is to spend nothing this tick"* |
+| already deterministically linked | ✅ |
+| `access === "external"` | ✅ |
+| owner is a **connector** (excluded from credit by design) | ✅ |
+| owner resolves to **no member row for this team** (dangling / cross-team id) | ❌ **abstain** |
 
-So `scoreableDocs` must report drop counts by reason, and the pass clears only when the
-unattributable-human count is **zero**. Round 2 would have blocked clearing for the three legitimate
-cases — making the leg never clear for a team whose docs are all deterministically linked.
+Only the last is a reason to withhold, and telling it apart needs `members.is_connector` for the raw
+`member_id` — which neither the oracle's return nor `teamRoster` exposes (`:545`, no `is_connector`,
+and `status='active'`-filtered). So the run adds a plain `is_connector` read keyed off `docRows`'
+member ids, populating a new `InferDoc.ownerKind`. `scoreableDocs` has exactly **one** production
+caller (`:236`), so returning drop counts leaks no policy.
 
-⚠️ **The justification is narrow, and narrower than round 0 claimed.** An idle pass does **not** prove
-the provider recovered — `lib/llm/complete.ts:212` argues exactly this in-repo (*"`ok: true` would
-claim a model that was never asked"*). It proves only: **there is no output currently demanded, so a
-historical provider failure must not drive a present-tense alarm.**
+⚠️ **The justification remains narrow:** an idle pass does not prove the provider recovered
+(`lib/llm/complete.ts:212` argues exactly that in-repo). It proves only that **no output is currently
+demanded, so a historical failure must not drive a present-tense alarm.**
 
-### 2b. The clearing row is BACKDATED — masking becomes impossible by ordering, not improbable by guarding
+### 2b. Correctness is ORDERING; the condition is only write-avoidance
 
-Rounds 0–2 tried two mechanisms and both were wrong:
+The clearing row is written with **`finishedAt = the pass's own startedAt`** (`:140`;
+`recordIngestRun` already accepts `finishedAt`, `runs.ts:31`). `STREAK_SQL` orders
+`finished_at desc, id desc` (`pipeline-health.ts:351`), so **any row recorded during the pass sorts
+newer than the clearing row** — a concurrent failure cannot be masked by commit order, snapshot
+visibility, or an `INSERT … WHERE NOT EXISTS` that round 3 proved races under `READ COMMITTED`.
 
-- **Round 0** wrote the row only when the newest row was a failure — a check-then-insert race.
-- **Round 2** added a "no row since this pass started" guard. **Also insufficient**: under PostgreSQL
-  `READ COMMITTED` an `INSERT … WHERE NOT EXISTS` runs its subquery against the statement snapshot, so
-  a concurrent `ok=false` that has not yet committed is invisible, both rows land, and the clearing
-  row is still newer. `ingest_runs` has no unique constraint to conflict on, and an advisory lock only
-  works if **every** writer takes it — the failure path is a plain `recordIngestRun` (`runs.ts:59`).
+⚠️ **Two residuals, stated rather than claimed away.** Round 3 wrote "impossible … whatever the clock
+skew", which is an overclaim: ordering compares timestamp VALUES, so masking needs
+`t_B − t_A < skew_A − skew_B`. (a) a failure finishing in the same millisecond loses the `id desc` tie;
+(b) two processes with skewed clocks. Bounded in practice: the scheduler runs **inside the web
+process** (`instrumentation.ts:57`) and the timeline rebuild runs there too, so the live deployment has
+one clock; a deploy-overlap twin is NTP-scale. And a masked failure is **self-correcting** — `failing`
+needs a streak of two, so the next real failure re-confirms.
 
-**The fix is ordering, not locking.** The clearing row is written with
-**`finishedAt = the pass's own startedAt`** (`doc-task-infer-run.ts:140`). `recordIngestRun` already
-accepts `finishedAt` (`runs.ts:31`), so this needs no new plumbing. Because `STREAK_SQL` orders
-`finished_at desc, id desc` (`pipeline-health.ts:351`), **any row recorded during the pass is strictly
-newer than the clearing row** — a concurrent failure can never be masked, whatever the commit order,
-snapshot or clock skew.
+**The write happens only when the leg's newest verdict is a FAILURE** — event-driven, not throttled.
+This is round 0's condition returning, but its job has changed completely: correctness now comes from
+the ordering above, and the condition exists to avoid perpetual ledger traffic.
 
-It also interacts correctly with the cooldown: `lastRun` orders on `finished_at` alone
-(`doc-task-infer-run.ts:457`), so a backdated clearing row older than a concurrent failure leaves the
-cooldown counting from the failure, which is the right clock.
+⚠️ **That deletes an entire layer.** Round 3 had the clearing row resetting the paid-run cooldown, a
+freshness regression that would make Monday morning's doc wait 12h, "fixed" by a two-clock scheme with
+a `meta.skipped` filter on `lastRun`'s `limit(1)` read. **All of it is unnecessary:** in the steady
+state (newest verdict already `ok=true`) nothing is written, so the cooldown is never touched, no new
+duration constant is needed, and ~730 rows/team/year of append-only history are never created.
 
-⚠️ **Residual, stated:** a failure finishing in the same millisecond as the pass's start loses the
-`id desc` tie to the clearing row. ~1ms; accepted.
+The row carries **`meta.health_clear = true`** — a dedicated marker, not the overloaded `meta.skipped`.
 
-**The existence check stays**, demoted to what it honestly is — a write-avoidance optimisation, not a
-correctness guarantee — and its comparator is **`>=`** (a `>` misses the same-millisecond row).
+⚠️ **Two honest labels:** `duration_ms` is **0** by construction (`runs.ts:77`), and the row's
+`finished_at` is the pass's START. Nothing computes on either (`listRecentIngestRuns` is
+order-tolerant; `doc_task_infer`'s staleness threshold is `null`), but the row is synthetic health
+evidence and its comment must say so rather than let a reader take it for a timed pass.
 
-### 2b-bis. TWO CLOCKS — the clearing row must not defer real scoring
+### 2c. The map is corrected — the whole block
 
-⚠️ Round 2 said "clearing takes up to 12h" and **understated the cost**. The real regression is on the
-other side: today, once past the cooldown, an idle pass records nothing, so the clock never resets and
-the first tick after new work arrives scores it within ≤30 min. If a clearing row became `lastRun`,
-every quiet weekend pass would reset the clock and **Monday morning's design doc would wait up to 12
-hours** for linking that costs one tick today. That is a new steady-state freshness regression, and it
-contradicts the existing comment that the cooldown is a minimum gap between **paid** runs
-(`doc-task-infer-run.ts:143`) — a clearing pass is unpaid.
+`pipeline-health.ts:154-168` carries **four** claims that this change falsifies, not the one round 0
+found. The `null`-threshold conclusion stays right; its argument is rewritten.
 
-So there are two clocks:
+### 2d. Fix `doc_task_infer` alone
 
-- **the paid-run cooldown** (`:147`) ignores rows carrying `meta.skipped` — unchanged behaviour;
-- **the clearing write** throttles on the age of the last *clearing* row.
-
-Same ~2 rows/team/day, and **zero added scoring latency**.
-
-### 2c. The map is corrected — the whole block, not one sentence
-
-`pipeline-health.ts:154-168` will have **four** false claims after this change, not the one round 0
-found: that five outcomes write no row (three now do), and that "a perfectly healthy leg polled every
-30 minutes still writes nothing for days". The `null`-threshold **conclusion** stays correct — a
-`no-llm` team still writes nothing, so no finite age is right — but its argument must be rewritten.
-
-### 2d. Fix `doc_task_infer` alone — and record why, so the next one is recognised
-
-- **`pret3_sweep` is ALREADY FIXED** (§0f) — round 0 listed it, wrongly.
-- **`linear_inbound` is a CONFIRMED twin**, not merely unverified: a quiet healthy pass returns before
-  `recordIngestRun` (`scheduler.ts:159-160`), so heal-with-nothing-to-apply latches. Not fixed here.
-- **`dense` has a narrower hole**: it records only on `failed > 0 || indexed > 0`
-  (`scheduler.ts:106-128`), so if the failing backlog is PURGED during an outage rather than retried,
-  the healing run indexes 0, records nothing, and the streak latches.
-- `arcs` and `graph_project` self-clear: their failure leaves pending work that survives the heal.
-
+`pret3_sweep` is **already fixed** (§0f). `linear_inbound` is a **confirmed twin**
+(`scheduler.ts:159-160`) — not fixed here. `dense` has a narrower hole (records only on
+`failed>0 || indexed>0`, so a *purged* backlog latches). `arcs`/`graph_project` self-clear.
 `doc_task_infer` is unique in that **healing removes the reason to record**.
 
-⚠️ **Two residual BANNERSTUCKs, named not fixed:** a team that removes its keys stays loud forever
-(`no-llm` never clears); and a team whose entire 7-day scoreable window is **connector-attributed**
-sits at `:237` legitimately forever. Both are the same class.
+⚠️ **Residual, named:** a team that removes its keys stays loud forever (`no-llm` never clears).
 
 ## 3. Scope
 
-**In:** `lib/dashboard/doc-task-infer-run.ts` · `lib/dashboard/doc-task-infer.ts` (drop reasons) ·
-the corrected block in `lib/ingest/pipeline-health.ts` · guards · data-mechanics tests ·
-`docs/ARCHITECTURE.md` if the ingestion-health prose is affected.
+**In:** `lib/dashboard/doc-task-infer-run.ts` · `lib/dashboard/doc-task-infer.ts` (drop reasons +
+`ownerKind`) · the corrected block in `lib/ingest/pipeline-health.ts` · guards · data-mechanics tests.
 
-**Out:**
-- **Any new duration constant, grace period or age-out** — rejected by BANNERFLAP-1 §3a (§0e).
-- `STALE_MS_BY_SOURCE`, `FAILURES_TO_CONFIRM` — unchanged.
-- `linear_inbound`, `dense`, the `no-llm` and connector residuals — named in §2d, separate slices.
-- Paging the `ITEM_SCAN` read — §2a abstains on saturation instead, which is correct and smaller.
+**Out:** any new duration constant (none is needed — §2b); `STALE_MS_BY_SOURCE`;
+`FAILURES_TO_CONFIRM`; `linear_inbound`/`dense`/the `no-llm` residual; **paging the `ITEM_SCAN` read**
+— saturation abstains instead, which is correct for THIS slice's no-false-clear property, though a
+busy team then stays latched until it drops under 500 (named, not fixed).
 
 ## 4. Acceptance
 
-⚠️ **Fixture requirements, because three of these cannot pass without them:** AC1–AC3 must seed
-answering keys, or the pass returns `no-llm` before any clearing branch. **AC4 must AGE its first
-produced failure** (`update ingest_runs set finished_at = …`) between the two runs — `COOLDOWN_MS` has
-a **1-hour floor** (`Math.max(1, …)`, `:88`), so no env value lets a second run reach the model, and
-seeding the second failure instead is exactly what AC4 forbids.
+⚠️ **Fixture facts, each of which blocks a criterion if missed:** seeded failure rows are non-skipped
+and therefore **arm the cooldown** — they must be aged past `COOLDOWN_MS` or the pass returns
+`cooldown` before any clearing branch. AC1's `:237`/`:270` cases must **seed tasks**, or `:195`
+`no-candidates` clears first and the fixture trips two criteria. AC4 must **age its produced first
+failure** (`COOLDOWN_MS` has a 1-hour floor, `Math.max(1,…)` at `:88`), never seed the second.
 
-- **AC1 — every clearing outcome clears (data-mechanics):** seed a confirmed streak, then once per
-  clearing case — `no-candidates`, `:206` unsaturated, `:237` with only legitimate drops, `unchanged` —
-  assert via **`getPipelineHealth`** that the leg leaves `failing`, and assert the inserted row has
-  `ok=true`, `meta.skipped`, and `finished_at === passStartedAt`.
-- **AC2 — `cooldown` does not clear (dm).** **AC2b — `no-llm` does not clear (dm)** *(one gate above
-  the clearing branches — a write wired one return too high passes everything else)*. **AC2c — a
-  HUMAN-owned unattributable doc at `:237` does not clear (dm)**, while **AC2d — an all-connector-owned
-  window at `:237` DOES clear (dm)**. **AC2e — a SATURATED `:206` scan does not clear (dm).** *Each
-  asserts the exact returned outcome and that the row count is unchanged.*
-- **AC3 — the steady state (dm):** newest row `ok=true` and older than the cooldown; the pass returns
-  its idle outcome and writes **exactly** the row the design permits — not "at most", which permits
-  zero and would let a no-op implementation pass.
-- **AC4 — a real failure is still loud (dm):** two failures **produced by running the pass** (stubbed
-  model returns null → `ok=false` at `:351`), ageing the first between runs; leg `confirmed`, in
-  `failing`, `failingSince` = the OLDEST failure.
-- **AC5 — a concurrent failure can never be masked (dm, deterministic):** the clearing write is an
-  exported seam `recordClearingRun(db, teamId, passStartedAt, reason)`. Seed the streak, record a
-  produced failure NOW, then call the seam with `passStartedAt` five minutes in the past: the leg is
-  **still `failing`**, and the clearing row's `finished_at` is strictly older than the failure's.
-  *Round 2's version was VACUOUS: an idle pass has no awaitable seam between its reads and its write,
-  so a `Promise.all` test ends `failing` even with the guard deleted — the mutation would have
-  survived and the criterion was green by construction.*
-- **AC5b — the call site passes its OWN `startedAt` (guard, unit):** the pass must hand
-  `recordClearingRun` the `startedAt` captured at `:140`, not `Date.now()` at write time. *That
-  mutation empties the ordering window and the seam test alone cannot see it.*
-- **AC6 — a thrown read never becomes a clearing row (UNIT):** with each of the task/item/credit/roster
-  reads throwing, the orchestration records `ok=false` or nothing, never a clearing row. *Unit, not
-  data-mechanics: real Postgres has no fault injection, and this is orchestration shape.*
-- **AC7 — no time-based escalation (dm, behavioural):** `getPipelineHealth` over real rows classifies
-  a failure at 2 days and at 60 days **identically** with no intervening run. *Named surface on
-  purpose: `classifyFailure`/`foldStreak` are pure over the streak and never see a clock, so a unit
-  test there is green under any escalation added where the clock actually lives (`:463-494`).*
-- **AC8 — the whole comment block is true (guard, unit):** `pipeline-health.ts:154-168` no longer
-  claims five outcomes write no row, nor that a healthy leg writes nothing for days, and states the
-  narrower truth. *Round 2 scoped this to one sentence, satisfiable while three other claims lie.*
+- **AC1 — every clearing outcome clears (dm):** once per case — `no-candidates`, unsaturated `:206`,
+  unsaturated `:237` with only legitimate drops, unsaturated `:270` — assert via **`getPipelineHealth`**
+  that the leg leaves `failing`, and that the row has `ok=true`, `meta.health_clear`, and
+  `finished_at === passStartedAt`.
+- **AC2 / AC2b — `cooldown` and `no-llm` do not clear (dm):** exact returned outcome, row count unchanged.
+- **AC2c — a doc dropped for an UNRESOLVABLE owner does not clear (dm):** a `member_id` that resolves
+  to no member row for this team. *Round 3 specified this as "a human-owned doc with no attribution",
+  a state the code cannot produce — the criterion was unbuildable and its mutation aimed at nothing.*
+- **AC2d — a CONNECTOR-owned window DOES clear (dm):** the inverse. *Without it, the conservative
+  reading ships and the leg never clears for a connector-fed team.*
+- **AC2e — a SATURATED scan does not clear, at ALL THREE sites (dm):** `:206`, `:237` and `:270` each
+  abstain with ≥`ITEM_SCAN` items. *Round 3 pinned only `:206` while `:237`/`:270` read the same
+  truncated page.*
+- **AC3 — the steady state writes nothing (dm):** newest verdict `ok=true` → an idle pass writes
+  **zero** rows. *This is now the whole cooldown story: nothing is written, so nothing is deferred.*
+- **AC4 — a real failure is still loud (dm):** two failures produced by RUNNING the pass, ageing the
+  first between runs; `confirmed`, in `failing`, `failingSince` = the oldest.
+- **AC5 — a concurrent failure can never be masked (dm, deterministic):** via the exported seam
+  `recordClearingRun(db, teamId, passStartedAt, reason)` — seed the streak, record a produced failure
+  NOW, call the seam with `passStartedAt` five minutes past: still `failing`, and the clearing row's
+  `finished_at` is strictly older than the failure's.
+- **AC5b — the call site passes its OWN `startedAt` (unit, CLOCK-ADVANCING):** the fake clock must
+  ADVANCE between `:140` and the write, or `Date.now()` at write time equals the captured value and
+  mutation 10 survives a naive spy. *Green-by-construction otherwise — the class AC5 exists to avoid.*
+- **AC6 — a thrown read never becomes a clearing row (unit).**
+- **AC7 — no time-based escalation (dm, behavioural):** `getPipelineHealth` classifies a failure at 2
+  days and at 60 days identically with no intervening run.
+- **AC8 — the whole `:154-168` block is true (guard, unit).**
 
 | # | mutation | must redden |
 |---|---|---|
 | 1 | the clearing row is never written | AC1 |
-| 2 | only one clearing outcome is wired; the others stay stuck | AC1 |
-| 3 | `cooldown` also clears | AC2 |
-| 4 | the write is wired above `:151`, so `no-llm` clears | AC2b |
-| 5 | `:237` clears regardless of drop reason | **AC2c** |
-| 6 | `:237` never clears (round-2's over-broad rule) | **AC2d** |
-| 7 | `:206` clears even when the scan saturated | **AC2e** |
-| 8 | the clearing row is written with `ok=false` | AC1 |
-| 9 | **`finishedAt` is `Date.now()` instead of `passStartedAt`** | **AC5** |
+| 2 | only one clearing outcome is wired | AC1 |
+| 3 | `cooldown` clears | AC2 |
+| 4 | the write is wired above `:151` | AC2b |
+| 5 | an unresolvable owner clears | **AC2c** |
+| 6 | `:237` never clears (round 3's over-broad rule) | **AC2d** |
+| 7 | the saturation abstain is dropped at `:206` | AC2e |
+| 8 | the saturation abstain is dropped at `:237`/`:270` | **AC2e** |
+| 9 | `finishedAt` is `Date.now()` instead of `passStartedAt` | **AC5** |
 | 10 | the call site passes `Date.now()` rather than its own `startedAt` | **AC5b** |
-| 11 | the paid-run cooldown counts clearing rows (one clock) | AC3 / freshness |
-| 12 | a thrown read is swallowed into a clearing row | AC6 |
-| 13 | `FAILURES_TO_CONFIRM` raised so nothing confirms | AC4 |
-| 14 | `failingSince` reports the newest failure | AC4 |
-| 15 | an inline elapsed-time escalation in `getPipelineHealth` (real shape) | **AC7** |
-| 16 | restore any one of the four false claims in the block | AC8 |
+| 11 | the row is written even when the newest verdict is `ok` | **AC3** |
+| 12 | the clearing row is written with `ok=false` | AC1 |
+| 13 | a thrown read becomes a clearing row | AC6 |
+| 14 | `FAILURES_TO_CONFIRM` raised so nothing confirms | AC4 |
+| 15 | `failingSince` reports the newest failure | AC4 |
+| 16 | an inline elapsed-time escalation in `getPipelineHealth` | AC7 |
+| 17 | restore any one of the four false claims in the block | AC8 |
 
 ## 5. Risks
 
 | risk | direction | mitigation |
 |---|---|---|
-| A concurrent real failure is masked by a clearing row | **the loudest alarm goes quiet on a broken leg** | §2b backdating makes it impossible by ordering; AC5 + mutations 9/10 |
-| A broken attribution oracle silences the alarm | same label, opposite meaning | §2a's drop-reason split; AC2c + mutation 5 |
-| The fix makes the leg NEVER clear | the bug, inverted — and round 2 would have shipped it | AC2d + mutation 6 |
-| Clearing on a partial view of the window | clears while work is pending | §2a's saturation check; AC2e + mutation 7 |
-| The clearing row defers real scoring by up to 12h | a new freshness regression traded for a banner fix | §2b-bis's two clocks; mutation 11 |
+| A concurrent failure is masked | **the loudest alarm goes quiet on a broken leg** | §2b backdating (ordering, not guarding); AC5 + mutations 9/10; residuals stated and self-correcting |
+| Clearing on a partial view of the window | clears while work is pending | saturation abstain at all three sites; AC2e + mutations 7/8 |
+| An unresolvable owner silences the alarm | a data-integrity fault reads as health | §2a's drop split; AC2c + mutation 5 |
+| The fix makes the leg NEVER clear | the bug inverted — round 3 would have shipped it | AC2d + mutation 6 |
 | The alarm is silenced by a leg that never ran | worse than the bug | AC2/AC2b + mutations 3/4 |
-| A later tweak reintroduces a grace period | the fix §3a proved wrong | AC7 is behavioural, mutation 15 |
+| A later tweak reintroduces a grace period | the fix BANNERFLAP-1 §3a proved wrong | AC7 behavioural, mutation 16 |
 
 ## 6. What would falsify this
 
-If `doc_task_infer` records a **successful** run before this ships, the banner clears on its own and
-the incident looks self-healing. **That would not falsify the defect** — the mechanism in §0c is
-unchanged and the next healed-but-idle failure reproduces it. Re-take §0a's streak, not the banner's
-colour.
+A **successful** `doc_task_infer` run before this ships would clear the banner on its own and make the
+incident look self-healing. It would not falsify the defect. **Re-measured 2026-08-28: the streak is
+still 4, with no new row in a further ~24h** — the leg has now been silent-but-polled for ~2 days, and
+the falsifier has not fired.
 
 **Nothing is built. No code exists for this slice.**

--- a/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
+++ b/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
@@ -1,0 +1,331 @@
+# A confirmed failure that nothing can clear — BANNERSTUCK-1
+
+**Status:** spec, round 1 — both spec reviews folded (Codex BLOCKED, Fable CLEAR-WITH-CONDITIONS). No code written.
+
+**Build with:** opus / high — it changes when the loudest alarm in the product speaks, and the
+failure mode in BOTH directions is a lie: an alarm that will not stop, or one that goes quiet on a
+real break.
+
+**Deps:** none — it touches neither schema nor any in-flight slice. (DOCKERPROD-2 / PR #664 is
+unrelated: deploy plumbing, no overlap.)
+
+**Related, and READ FIRST:** `docs/design/pipeline-banner-failure-confirmation.md` (BANNERFLAP-1 —
+this spec extends its rule rather than reversing it), `docs/design/staleness-threshold-fit.md`
+(BANNERFLAP-2 — why re-fitting a constant is the wrong instinct here).
+
+---
+
+## What is wrong
+
+Chetan, 2026-08-27, against the live Pulse page: *"i'm still seeing errors at the top of the screen."*
+
+> 🔴 **1 ingestion leg is broken — the brain isn't getting fresh data**
+> `doc_task_infer` — failing since 2d ago: OpenRouter is out of credit…
+
+**The cause healed 26 hours before that screenshot.** The banner cannot say so, and no future event
+can make it say so.
+
+## 0. Terrain, measured on prod before designing
+
+### 0a. The leg's actual history
+
+`doc_task_infer`, `trigger='scheduler'`:
+
+| finished_at (UTC) | ok |
+|---|---|
+| 2026-08-26 13:12 | ❌ |
+| 2026-08-26 00:49 | ❌ |
+| 2026-08-25 12:24 | ❌ |
+| 2026-08-25 00:11 | ❌ |
+| 2026-08-24 11:42 | ✅ ← last success |
+
+Streak = **4**, and `FAILURES_TO_CONFIRM = 2` (`lib/ingest/failure-streak.ts:37`) → `confirmed` →
+in the `failing` set → the loud banner. `failingSince` = 2026-08-25 00:11, which is what renders as
+*"failing since 2d ago"*.
+
+### 0b. The cause is gone — three independent readings
+
+| reading | result |
+|---|---|
+| newest `http_402` **anywhere** in `llm_failures` | **2026-08-26 13:12** — the same instant as the last failed run, 26h before the screenshot |
+| all `llm_failures` in the last 12h | **2 rows**: one `timeout`, one `no_usage`. **Zero** credit refusals |
+| `llm_usage` last 6h | `timeline-summary` **22 successes** |
+| scheduler liveness | `slack`/`linear` recorded **<1 min** ago; `github`/`meeting_notes`/`access_bootstrap` ~30 min |
+
+The account was topped up, the provider is answering, and the poller is ticking.
+
+### 0c. Why nothing can clear it — read from the code, not assumed
+
+The streak breaks **only** when a row with `ok=true` is recorded. Five of `doc_task_infer`'s eight
+outcomes return *before* `record()`:
+
+| outcome | site |
+|---|---|
+| `cooldown` (12h) | `lib/dashboard/doc-task-infer-run.ts:147` |
+| `no-llm` | `:151` |
+| `nothing-to-score` | `:237` |
+| `unchanged` | `:270` |
+| `no-candidates` | (same early-return family) |
+
+Only the 7-day window's *scoreable* docs can produce work, and prod's last 7 days contain only
+`artifact` and `deliverable` items. So a **healthy leg, polled every tick, writes nothing** — and the
+Aug 26 failure stays the newest row indefinitely.
+
+**Staleness cannot rescue it, by explicit prior decision.** `STALE_MS_BY_SOURCE` sets
+`doc_task_infer: null` (`lib/ingest/pipeline-health.ts:168`) with a written argument that *no finite
+age threshold is correct for this class*. That decision is right and this spec does not touch it.
+
+### 0d. The false premise is a comment in the code
+
+`pipeline-health.ts`, on `doc_task_infer`:
+
+> *"Real failures still surface: … since the cooldown counts failed runs too, **a persistent failure
+> keeps re-recording and stays the newest row.**"*
+
+True only while the failure **persists**. When the cause clears and there is no new work, nothing
+re-records — and a healed failure is byte-identical to a live one. That sentence is the whole bug,
+and it must be corrected in the same change.
+
+### 0e. What the prior design DID decide, and why this is not a reversal
+
+⚠️ This is the part that would make a careless fix wrong. BANNERFLAP-1 §3a already contemplated
+never-superseded failures and **accepted a cost**:
+
+> *"a `null`-threshold leg that **fails once** and is then never exercised again **stays quiet** in the
+> banner indefinitely … the standing rule in this codebase is that **ignorance must not accuse**."*
+
+That accepted cost is in the **quiet** direction — a streak of **1**, deliberately `unconfirmed`.
+**This ticket is the opposite direction**: a streak of **≥2** that stays **LOUD** indefinitely. §3a
+never considered it, and its own governing principle — *ignorance must not accuse* — argues for
+fixing it: once the leg stops being exercised, the streak is no longer evidence of anything, yet it
+keeps accusing at maximum volume.
+
+### 0f. THE PRECEDENT THAT SETTLES IT — this repo has already fixed this exact defect once
+
+`lib/ingest/scheduler.ts:57`, on `pret3_sweep`, describes this ticket without knowing it:
+
+> *"Exactly one success row, ever — and it is what lets a CONFIRMED failure streak clear. Without it:
+> two failed marker-insert ticks reach `confirmed` and go loud, a later success writes nothing, and
+> the consumed marker forecloses every future row — so **the loud banner latches red permanently on
+> every team, which no staleness threshold can undo** (`failing` includes `confirmed` regardless of
+> age)."*
+
+Same mechanism, same conclusion, and the remedy shipped: **write the success row that lets the streak
+clear.** So this slice applies an established in-repo policy to the leg that still needs it, rather
+than inventing one against a prior decision. ⚠️ *It also corrects §2d: `pret3_sweep` is NOT one of the
+unfixed legs — my first draft listed it, and that was wrong.*
+
+*(Round 0 argued this under §3a's slogan "ignorance must not accuse". Fable was right that the slogan
+is stretched — the banner is not ignorant, it has four real rows. The honest frame is **standing
+evidence must be defeasible by contrary evidence**, and §0f is the precedent for that.)*
+
+⚠️ §3a also **rejected time-based escalation** outright ("no safe value exists"; it would "smuggle
+back in, through a different constant, the exact thing those `null`s were written to prevent").
+**So the fix may not be an age-out, a grace period, or any new duration constant.** That constraint
+is inherited, not negotiable here.
+
+## 1. The rule
+
+> **A confirmed failure is evidence only while the leg is still being exercised. A leg that has since
+> completed a clean pass with nothing to do has produced positive evidence of health, and that
+> evidence must be able to clear the alarm — while a leg that merely has not run must neither clear
+> it nor keep shouting on the strength of it.**
+
+## 2. The design
+
+### 2a. Only a pass that DEMONSTRABLY completed a clean evaluation may clear
+
+⚠️ **Round 0 got this wrong in a way that could have silenced a real alarm.** It said "the three
+outcomes `nothing-to-score` / `unchanged` / `no-candidates`" — but `nothing-to-score` is **two
+different code paths with opposite meanings**, and the label hides it:
+
+| site | condition | meaning | clears? |
+|---|---|---|---|
+| `:206` | `docRows` empty — no scoreable-source work docs in the 7-day window | **genuine idle**: the leg read the corpus successfully and there is nothing to do | ✅ |
+| `:237` | `allScoreable` empty **after** `resolveItemCreditIds({strict:true})` | **abstention**: the attribution oracle could not answer, and the code's own comment says *"spend nothing this tick rather than rank against a second opinion"* | ❌ |
+
+`scoreableDocs` filters on `!!d.memberId`, so an identity-mapping regression that returns a null
+`primaryId` for everyone empties `allScoreable` **without any query error** — strict mode propagates
+DB errors only (`lib/attribution/contributor-credit.ts:125-126`). Clearing on `:237` would silence a
+standing alarm on the word of a pass that could not attribute anything.
+
+**So the rule is not "these labels" but this property:**
+
+> A pass may clear only if it **read the corpus successfully and found no work demanded**. A pass that
+> abstained, was gated, or could not evaluate must record nothing.
+
+| outcome | clears | why |
+|---|---|---|
+| `nothing-to-score` **@:206** | ✅ | read the window, nothing scoreable |
+| `no-candidates` @:195 | ✅ | read the tasks, none to offer |
+| `unchanged` @:270 | ✅ | every eligible doc already answered |
+| `nothing-to-score` **@:237** | ❌ | the credit oracle abstained |
+| `cooldown` @:147 | ❌ | the pass never ran |
+| `no-llm` @:151 | ❌ | unconfigured — a different state, and its own signal |
+
+⚠️ **And the justification is narrower than round 0 claimed.** An idle pass does **not** prove the
+provider recovered — `lib/llm/complete.ts:212` makes exactly this argument in-repo (*"`ok: true` would
+claim a model that was never asked"*), and `timeline-summary` succeeding proves some OpenRouter
+workload works, not this leg's model role, prompt size or parsing. What it proves is only: **there is
+no output currently demanded, so a historical provider failure must not drive a present-tense alarm.**
+That is sufficient, and it is what the spec claims.
+
+### 2b. Record unconditionally after the cooldown — the round-0 conditional was racy AND rested on a wrong number
+
+Round 0 wrote the clearing row **only when the newest row was a failure**, to avoid noise. Both halves
+of that were wrong:
+
+- **The noise estimate was wrong.** I assumed a row every 30 minutes. The **cooldown gate runs first**,
+  and a newly written success *becomes* the cooldown clock — so the steady-state cost is **~2 rows per
+  team per day**, not 48. The entire reason for the conditional evaporates.
+- **The conditional is a check-then-insert race.** Two callers exist and they are **not** mutually
+  single-flighted: the scheduler (`lib/ingest/scheduler.ts:91`, single-flighted only against itself)
+  and the timeline rebuild on a dashboard read (`lib/dashboard/timeline-cache.ts:116`). Interleaving:
+  idle pass **A** observes "newest is a failure"; concurrent pass **B** finds work, calls the model,
+  fails, records `ok=false`; **A** then records its authorised `ok=true`. `STREAK_SQL` takes newest —
+  so **A's success masks B's real failure** and the alarm goes quiet on a genuinely broken leg.
+
+So: record the clearing outcome **unconditionally once past the cooldown**.
+
+⚠️ **That alone does not close the masking window** — Codex's proposal stopped here, and it should
+not. Unconditional recording still lets A's `ok=true` land after B's `ok=false`; the rows are merely
+both truthful. What actually closes it is a **guarded write**: the clearing row is inserted only if no
+row for this `(source, team_id)` has been recorded since this pass started. A concurrent failure
+therefore always wins, and two concurrent *idle* passes may both write (harmless — both `ok=true`, the
+streak stays broken).
+
+⚠️ *Note the ordering asymmetry this must respect: `STREAK_SQL` breaks ties with `finished_at desc,
+id desc` (`lib/ingest/pipeline-health.ts:345`) while `lastRun` orders by `finished_at` alone
+(`doc-task-infer-run.ts:450`). The guard must not assume they agree.*
+
+### 2b-bis. The accepted cost: clearing takes up to one cooldown
+
+Every clearing outcome sits **behind** the 12h cooldown gate, and the cooldown counts failed runs. So
+after this ships a healed failure can stay loud for **up to 12h + one tick**, and the clearing row
+itself resets the cooldown, deferring the next real scoring pass by up to 12h. Both are accepted and
+stated here **so that "still red 6h after the top-up" is not read as this fix having failed.**
+
+### 2c. The false comment is corrected
+
+§0d's sentence is replaced with what is actually true, naming this mechanism.
+
+### 2d. The other legs: fix `doc_task_infer` alone — and record WHY, so the next one is recognised
+
+Round 0 listed six same-shaped legs and asked the reviews to decide. Both said fix this one alone, and
+the inventory itself was wrong:
+
+- **`pret3_sweep` is already fixed** (§0f) — my draft listed it as unfixed.
+- **The rest mostly SELF-CLEAR**, because their failure leaves pending work that survives the heal:
+  `dense` and `graph_project` retry the same backlog and record `ok=true` on the healing run; `arcs`
+  persists no reusable hash on failure (`lib/graph/arcs.ts:679,859`), so the retry re-runs the model
+  and records.
+- **`linear_inbound` is the one genuinely unverified twin** — named here, not fixed here.
+
+`doc_task_infer` is unique in that **healing removes the reason to record**: the work it failed on was
+never pending in the first place. That distinction goes into the §2c comment so the next leg with this
+shape is recognised rather than rediscovered.
+
+⚠️ **A residual, named rather than fixed:** a team that REMOVES its keys while `confirmed` keeps the
+banner forever, because `no-llm` never clears. That is the `no-llm` analogue of `isOrphanedConnector`
+and is the likely next BANNERSTUCK. Out of scope here; recorded so it is a known cost.
+
+## 3. Scope
+
+**In:** `lib/dashboard/doc-task-infer-run.ts` (the three clearing outcomes) · the corrected comment
+in `lib/ingest/pipeline-health.ts` · a guard · a data-mechanics test · `docs/ARCHITECTURE.md` if the
+ingestion-health prose is affected.
+
+**Out:**
+- **Any new duration constant, grace period or age-out** — rejected by BANNERFLAP-1 §3a (§0e).
+- **`STALE_MS_BY_SOURCE`** — the `null`s are correct and stay.
+- **`FAILURES_TO_CONFIRM`** — not a tunable, by its own measurement.
+- **The other five legs**, pending §2d.
+- **The `unconfirmed`-stays-quiet cost** of §3a — a different, accepted trade.
+
+## 4. Acceptance
+
+⚠️ **Fixture requirements that decide whether these can pass at all** (Fable): AC1–AC3 must seed
+answering keys against the stubbed model, or the pass returns `no-llm` at `:151` before reaching any
+clearing branch — and a builder who hits that first may "fix" it by clearing there, which is the
+hole AC2b exists to close. AC4's failures must be produced by **running** the pass (stubbed model
+returns null → `ok=false` at `:351`), **not** by seeding rows: a seeded-only fixture lets a mutation
+that flips the failure record to `ok=true` survive.
+
+- **AC1 — each clearing outcome clears, all three (data-mechanics, real Postgres):** seed a confirmed
+  streak (≥2 `ok=false`), then, **once per outcome** — `nothing-to-score`@:206, `no-candidates`@:195,
+  `unchanged`@:270 — run a pass and assert via **`getPipelineHealth`** that the leg leaves `failing`
+  and is no longer `confirmed`; and assert the pass returned that exact `skipped` value and inserted a
+  row with `ok=true` and `meta.skipped=<reason>`. *Round 0 tested only one outcome, so an
+  implementation with two of the three still stuck passed every criterion. Asserting the inserted row
+  stops an unrelated seeded success from satisfying the health read.*
+- **AC2 — `cooldown` does NOT clear (data-mechanics):** seed the streak with its newest failure
+  **inside** the cooldown window; the pass returns exactly `cooldown`, **row count is unchanged**, and
+  the leg is still `confirmed` and still in `failing`. *If this cleared, the alarm could be silenced
+  by doing nothing — strictly worse than the bug.*
+- **AC2b — `no-llm` does NOT clear (data-mechanics):** same seed, no answering keys; the pass returns
+  exactly `no-llm`, row count unchanged, leg still `confirmed`. *`no-llm` sits one gate ABOVE the
+  clearing outcomes and is the easiest state to reach in this tier, so a write wired one early-return
+  too high passes everything else.*
+- **AC2c — the credit-oracle abstention does NOT clear (data-mechanics):** docs exist in the window
+  but `resolveItemCreditIds` yields no `primaryId`, so `allScoreable` is empty at **`:237`**; row count
+  unchanged, leg still `confirmed`. *Same `skipped` LABEL as AC1's `:206` case and the opposite
+  meaning — this is the criterion that stops a broken attribution oracle silencing a real alarm.*
+- **AC3 — the steady state writes nothing extra (data-mechanics):** with the newest row `ok=true` and
+  **older than the cooldown** (so the pass actually reaches an idle branch), an idle pass returns that
+  idle outcome and adds at most the one clearing row the design permits. *Round 0's version was
+  vacuous: a recent success returns `cooldown` first, so row count stayed unchanged under both the
+  intended implementation and a dozen wrong ones. The criterion must assert the RETURNED outcome.*
+- **AC4 — a real failure is still loud (data-mechanics):** run the pass twice with the model stubbed
+  to fail; both record `ok=false`, the leg is `confirmed` and in `failing`, and `failingSince` reports
+  the **oldest** failure in the streak. *The fix must not buy quiet by weakening the alarm.*
+- **AC5 — a concurrent failure is never masked (data-mechanics):** with a clearing pass and a failing
+  pass released against the same team, the final state is **`failing`** regardless of completion
+  order. *§2b's guarded write exists for exactly this, and it is the criterion Codex's "unconditional"
+  proposal would have shipped without.*
+- **AC6 — a failed READ never becomes an idle success (data-mechanics):** force the task read, item
+  read, credit read and roster read to error in turn; each records `ok=false` (or records nothing) and
+  **never** an `ok=true` clearing row. *The clearing outcomes are defined by "read successfully and
+  found nothing" — a read that threw satisfies neither half.*
+- **AC7 — no time-based escalation (guard, unit + behavioural):** classification is **identical** at
+  two widely separated failure ages with no intervening run — the observable, not a grep. *Round 0
+  used a `*_MS`/`*_HOURS` source scan, which an inline `86_400_000` walks straight past.*
+- **AC8 — the false comment is gone AND the true one is pinned (guard, unit):** `pipeline-health.ts`
+  no longer asserts that a persistent failure keeps re-recording, and does state the narrower claim.
+  *Deleting the sentence alone would satisfy a "does not contain" check while leaving the map silent.*
+
+| # | mutation | must redden |
+|---|---|---|
+| 1 | the clearing row is never written | AC1 |
+| 2 | only `nothing-to-score` clears; `unchanged`/`no-candidates` still stuck | **AC1** (the per-outcome legs) |
+| 3 | `cooldown` also writes the clearing row | **AC2** |
+| 4 | the write is wired above `:151` so `no-llm` clears | **AC2b** |
+| 5 | `:237` (oracle abstention) clears, i.e. both sites treated as one label | **AC2c** |
+| 6 | the clearing row is written with `ok=false` | AC1 |
+| 7 | the guarded write drops its guard (plain unconditional insert) | **AC5** |
+| 8 | a read error is swallowed into an idle success | **AC6** |
+| 9 | `FAILURES_TO_CONFIRM` raised so nothing ever confirms | AC4 |
+| 10 | `failingSince` reports the newest failure instead of the oldest | AC4 |
+| 11 | add an inline elapsed-time escalation (real shape, not a named constant) | **AC7** |
+| 12 | restore the "a persistent failure keeps re-recording" sentence | AC8 |
+
+## 5. Risks
+
+| risk | direction | mitigation |
+|---|---|---|
+| The alarm can be silenced by a leg that never ran | **a real break goes unreported** — worse than the bug | AC2/AC2b + mutations 3/4: only a pass that READ SUCCESSFULLY and found no work may clear |
+| A broken attribution oracle silences the alarm | the sharpest version of the above — same `skipped` label, opposite meaning | §2a splits `:206` from `:237`; AC2c + mutation 5 |
+| A concurrent failure is masked by a clearing row | the alarm goes quiet on a genuinely broken leg | §2b's guarded write; AC5 + mutation 7 |
+| `ingest_runs` fills with idle rows | the operator's run log becomes unreadable | bounded by the cooldown to ~2 rows/team/day (§2b) — measured, after round 0's estimate of 48/day was wrong |
+| "Still red hours after the fix" reads as the fix failing | a correct implementation gets re-opened | §2b-bis states the ≤12h+tick clearing latency up front |
+| A later tweak reintroduces a grace period | the exact fix §3a proved wrong | AC5 is a ∀ guard, mutation 7 |
+| Fixing one leg and leaving five | the same defect ships five more times | §2d is an open question for the review, not a silent choice |
+| A unit stub of the streak query passes while the real SQL does not | green by construction | AC1–AC4 are **data-mechanics**, against real Postgres and the real `STREAK_SQL` |
+
+## 6. What would falsify this
+
+If `doc_task_infer` on prod records a **successful** run before this ships — i.e. a scoreable doc
+arrives — the banner clears on its own and the incident looks self-healing. **That would not falsify
+the defect**, only hide it: the mechanism in §0c is unchanged and the next healed-but-idle failure
+reproduces it. The measurement to re-take at build time is §0a's streak, not the banner's colour.
+
+**Nothing is built. No code exists for this slice.**

--- a/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
+++ b/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
@@ -343,6 +343,382 @@ reported `REDDENED` while proving nothing.
 | # | mutation | tier | result |
 |---|---|---|---|
 | 1 | the clearing row is never written | dm | ✅ AC1 ×2 |
+| 2 | only one clearing outcome is wired | — | **NOT RUN** — superseded: AC1 now has three behavioural cases (`no-candidates`, `:206`, connector `:237`), each of which fails alone |
+| 3 | `cooldown` also clears | dm | ✅ AC2 |
+| 4 | the write is wired above the `no-llm` gate | dm | ✅ AC2b |
+| 5 | an unresolvable owner is treated as legitimate | guard | ✅ AC2c |
+| 6 | ANY null-credit drop blocks clearing (round 3's over-broad rule) | guard | ✅ AC2d |
+| 7 | the saturation gate is dropped at `:206` | dm | ✅ AC2e |
+| 8 | the saturation gate is dropped at `:237` / `:270` | guard | ✅ AC2e (∀) — **survived dm**, see below |
+| 9 | `finishedAt` is `Date.now()` instead of `passStartedAt` | dm | ✅ AC5 + AC1 |
+| 10 | the call site passes `Date.now()` rather than its own `startedAt` | guard | ✅ AC5b |
+| 11 | the row is written even when the newest verdict is `ok` | dm | ✅ AC3 |
+| 12 | the clearing row is written with `ok=false` | guard | ✅ AC1 (the `ok` assertion) |
+| 13 | a thrown read becomes a clearing row | unit | ✅ AC6 |
+| 14 | `FAILURES_TO_CONFIRM` raised so nothing confirms | — | **NOT RUN** — it is a shared constant with its own guard; mutating it reddens far beyond this slice |
+| 15 | `failingSince` reports the newest failure | — | **NOT RUN** — owned by BANNERFLAP-1's suite, unchanged here; AC4 asserts the value |
+| 16 | an inline elapsed-time escalation in `getPipelineHealth` | — | **NOT RUN** — AC7 is behavioural (2d vs 60d identical), so it observes any such edit; the mutation itself was not written |
+| 17 | restore a false claim to the comment block | guard | ✅ AC8 — incl. the sentence split across a line wrap |
+| + | `ownerKinds`' query yields nothing (every owner unresolvable) | dm | ✅ AC2d — the inverted bug: a connector-fed team never clears |
+| + | the paid-run clock counts clearing rows | dm | ✅ AC3b — the cooldown blocker both diff reviews found |
+
+⚠️ **Mutation 8 SURVIVED the behavioural suite** and is recorded rather than smoothed over. AC2e's
+fixture fills the page with conversational rows, so the pass exits at `:206` and never reaches
+`:270`. Round 4 called that "not reasonably constructible"; **the diff review showed that is false** —
+`:237` is reachable with 500 external/deterministic docs and `:270` by seeding `doc_task_inference`
+rows with the exported `inferenceInputsHash`. It was not built, and that is a coverage gap, not an
+impossibility. What holds today: the mechanism is proven behaviourally at `:206`, and the ∀-over-sites
+property by the guard, which reddens when the gate is removed at either other site.
+
+⚠️ **An earlier mutation run was worthless and nearly believed.** It pointed at database `app` rather
+than `app_test`, where the suite was ALREADY red, so every mutation dutifully reported `REDDENED`
+while proving nothing. The baseline is now verified green under the exact invocation first.
+
+⚠️ **And one fix was destroyed mid-battery.** A hand-rolled mutation loop ran `git checkout --` on a
+file carrying uncommitted work, exactly the case `scripts/mutate.mjs` refuses to allow. The harness
+was right and bypassing it cost the work; every mutation since runs from a committed checkpoint.
+
+**Code is built.**
+
+**Build with:** opus / high — it changes when the loudest alarm in the product speaks, and the
+failure mode in BOTH directions is a lie: an alarm that will not stop, or one that goes quiet on a
+real break.
+
+**Deps:** none — it touches neither schema nor any in-flight slice. (DOCKERPROD-2 / PR #664 is
+unrelated: deploy plumbing, no overlap.)
+
+**Related, and READ FIRST:** `docs/design/pipeline-banner-failure-confirmation.md` (BANNERFLAP-1 —
+this spec extends its rule rather than reversing it), `docs/design/staleness-threshold-fit.md`
+(BANNERFLAP-2 — why re-fitting a constant is the wrong instinct here).
+
+---
+
+## What is wrong
+
+Chetan, 2026-08-27, against the live Pulse page: *"i'm still seeing errors at the top of the screen."*
+
+> 🔴 **1 ingestion leg is broken — the brain isn't getting fresh data**
+> `doc_task_infer` — failing since 2d ago: OpenRouter is out of credit…
+
+**The cause healed 26 hours before that screenshot.** The banner cannot say so, and no future event
+can make it say so.
+
+## 0. Terrain, measured on prod before designing
+
+### 0a. The leg's actual history
+
+`doc_task_infer`, `trigger='scheduler'`:
+
+| finished_at (UTC) | ok |
+|---|---|
+| 2026-08-26 13:12 | ❌ |
+| 2026-08-26 00:49 | ❌ |
+| 2026-08-25 12:24 | ❌ |
+| 2026-08-25 00:11 | ❌ |
+| 2026-08-24 11:42 | ✅ ← last success |
+
+Streak = **4**, and `FAILURES_TO_CONFIRM = 2` (`lib/ingest/failure-streak.ts:37`) → `confirmed` →
+in the `failing` set → the loud banner. `failingSince` = 2026-08-25 00:11, which is what renders as
+*"failing since 2d ago"*.
+
+### 0b. The cause is gone — three independent readings
+
+| reading | result |
+|---|---|
+| newest `http_402` **anywhere** in `llm_failures` | **2026-08-26 13:12** — the same instant as the last failed run, 26h before the screenshot |
+| all `llm_failures` in the last 12h | **2 rows**: one `timeout`, one `no_usage`. **Zero** credit refusals |
+| `llm_usage` last 6h | `timeline-summary` **22 successes** |
+| scheduler liveness | `slack`/`linear` recorded **<1 min** ago; `github`/`meeting_notes`/`access_bootstrap` ~30 min |
+
+The account was topped up, the provider is answering, and the poller is ticking.
+
+### 0c. Why nothing can clear it — read from the code, not assumed
+
+The streak breaks **only** when a row with `ok=true` is recorded. Five of `doc_task_infer`'s eight
+outcomes return *before* `record()`:
+
+| outcome | site |
+|---|---|
+| `cooldown` (12h) | `lib/dashboard/doc-task-infer-run.ts:147` |
+| `no-llm` | `:151` |
+| `nothing-to-score` | `:237` |
+| `unchanged` | `:270` |
+| `no-candidates` | (same early-return family) |
+
+Only the 7-day window's *scoreable* docs can produce work, and prod's last 7 days contain only
+`artifact` and `deliverable` items. So a **healthy leg, polled every tick, writes nothing** — and the
+Aug 26 failure stays the newest row indefinitely.
+
+**Staleness cannot rescue it, by explicit prior decision.** `STALE_MS_BY_SOURCE` sets
+`doc_task_infer: null` (`lib/ingest/pipeline-health.ts:168`) with a written argument that *no finite
+age threshold is correct for this class*. That decision is right and this spec does not touch it.
+
+### 0d. The false premise is a comment in the code
+
+`pipeline-health.ts`, on `doc_task_infer`:
+
+> *"Real failures still surface: … since the cooldown counts failed runs too, **a persistent failure
+> keeps re-recording and stays the newest row.**"*
+
+True only while the failure **persists**. When the cause clears and there is no new work, nothing
+re-records — and a healed failure is byte-identical to a live one. That sentence is the whole bug,
+and it must be corrected in the same change.
+
+### 0e. What the prior design DID decide, and why this is not a reversal
+
+⚠️ This is the part that would make a careless fix wrong. BANNERFLAP-1 §3a already contemplated
+never-superseded failures and **accepted a cost**:
+
+> *"a `null`-threshold leg that **fails once** and is then never exercised again **stays quiet** in the
+> banner indefinitely … the standing rule in this codebase is that **ignorance must not accuse**."*
+
+That accepted cost is in the **quiet** direction — a streak of **1**, deliberately `unconfirmed`.
+**This ticket is the opposite direction**: a streak of **≥2** that stays **LOUD** indefinitely. §3a
+never considered it, and its own governing principle — *ignorance must not accuse* — argues for
+fixing it: once the leg stops being exercised, the streak is no longer evidence of anything, yet it
+keeps accusing at maximum volume.
+
+### 0f. THE PRECEDENT THAT SETTLES IT — this repo has already fixed this exact defect once
+
+`lib/ingest/scheduler.ts:57`, on `pret3_sweep`, describes this ticket without knowing it:
+
+> *"Exactly one success row, ever — and it is what lets a CONFIRMED failure streak clear. Without it:
+> two failed marker-insert ticks reach `confirmed` and go loud, a later success writes nothing, and
+> the consumed marker forecloses every future row — so **the loud banner latches red permanently on
+> every team, which no staleness threshold can undo** (`failing` includes `confirmed` regardless of
+> age)."*
+
+Same mechanism, same conclusion, and the remedy shipped: **write the success row that lets the streak
+clear.** So this slice applies an established in-repo policy to the leg that still needs it, rather
+than inventing one against a prior decision. ⚠️ *It also corrects §2d: `pret3_sweep` is NOT one of the
+unfixed legs — my first draft listed it, and that was wrong.*
+
+*(Round 0 argued this under §3a's slogan "ignorance must not accuse". Fable was right that the slogan
+is stretched — the banner is not ignorant, it has four real rows. The honest frame is **standing
+evidence must be defeasible by contrary evidence**, and §0f is the precedent for that.)*
+
+⚠️ §3a also **rejected time-based escalation** outright ("no safe value exists"; it would "smuggle
+back in, through a different constant, the exact thing those `null`s were written to prevent").
+**So the fix may not be an age-out, a grace period, or any new duration constant.** That constraint
+is inherited, not negotiable here.
+
+## 1. The rule
+
+> **A confirmed failure is evidence only while the leg is still being exercised. A pass that OBSERVED
+> THE WHOLE ELIGIBLE SET and found no work demanded has produced contrary evidence and may clear the
+> alarm. A pass that was gated, abstained, or saw only PART of the set must do neither — and must never
+> be able to hide a failure that happened while it ran.**
+
+## 2. The design
+
+### 2a. Which outcomes may clear — derived from the code, not from the labels
+
+| site | outcome | clears? |
+|---|---|---|
+| `:147` | `cooldown` | ❌ the pass never ran |
+| `:151` | `no-llm` | ❌ unconfigured — a different state, and its own signal |
+| `:195` | `no-candidates` | ✅ the task list was read; nothing to offer |
+| `:206` | `nothing-to-score` | ✅ **only if the item scan did not saturate** |
+| `:237` | `nothing-to-score` | ✅ **only if unsaturated AND no doc was dropped for an unresolvable owner** |
+| `:270` | `unchanged` | ✅ **only if the item scan did not saturate** |
+
+**The saturation rule covers THREE sites, not one.** The item read is `.limit(ITEM_SCAN)` = 500,
+ordered **`work_at desc`** (`doc-task-infer-run.ts:184` — round 3 said `updated_at`, which is the
+*tasks* read at `:164`; the sentence was wrong). `:206`, `:237` and `:270` are all derived by JS
+filters over that one truncated page, so with ≥500 items in the window each of them is a claim about
+*the newest 500 only* — item #501 can be an unscored design doc. §1's rule therefore forces all three
+to abstain when `items.length >= ITEM_SCAN`. *(`visibleItems(q,"team")` is a passthrough, so nothing
+post-drops rows and the count is honest. Exactly 500 abstains too — conservative, and correct.)*
+
+**The `:237` abstain bucket is NOT what round 3 said.** Both reviewers independently derived, and I
+verified, that *"a human-owned doc with no attribution"* **cannot occur**:
+
+- the wide scan already excludes ownerless items in SQL — `.not("member_id","is",null)` (`:177`);
+- `creditedPrimaryId` returns null **only** when `currentMemberId` is null, and that is nulled only
+  when `isHuman()` is false (`contributor-credit.ts:50-61,190`);
+- a genuine oracle failure **throws** in `strict` mode (`contributor-credit.ts:126-128`) and lands in
+  the catch at `:408` as an `ok=false` run — it never appears as a `:237` drop.
+
+So the four real buckets are:
+
+| dropped because | legitimate? |
+|---|---|
+| already deterministically linked | ✅ |
+| `access === "external"` | ✅ |
+| owner is a **connector** (excluded from credit by design) | ✅ |
+| owner resolves to **no member row for this team** (dangling / cross-team id) | ❌ **abstain** |
+
+Only the last is a reason to withhold, and telling it apart needs `members.is_connector` for the raw
+`member_id` — which neither the oracle's return nor `teamRoster` exposes (`:545`, no `is_connector`,
+and `status='active'`-filtered). So the run adds a plain `is_connector` read keyed off `docRows`'
+member ids, populating a new `InferDoc.ownerKind`. `scoreableDocs` has exactly **one** production
+caller (`:236`), so returning drop counts leaks no policy.
+
+⚠️ **The justification remains narrow:** an idle pass does not prove the provider recovered
+(`lib/llm/complete.ts:212` argues exactly that in-repo). It proves only that **no output is currently
+demanded, so a historical failure must not drive a present-tense alarm.**
+
+### 2b. Correctness is ORDERING; the condition is only write-avoidance
+
+The clearing row is written with **`finishedAt = the pass's own startedAt`** (`:140`;
+`recordIngestRun` already accepts `finishedAt`, `runs.ts:31`). `STREAK_SQL` orders
+`finished_at desc, id desc` (`pipeline-health.ts:351`), so **any row recorded during the pass sorts
+newer than the clearing row** — a concurrent failure cannot be masked by commit order, snapshot
+visibility, or an `INSERT … WHERE NOT EXISTS` that round 3 proved races under `READ COMMITTED`.
+
+⚠️ **Two residuals, stated rather than claimed away.** Round 3 wrote "impossible … whatever the clock
+skew", which is an overclaim: ordering compares timestamp VALUES, so masking needs
+`t_B − t_A < skew_A − skew_B`. (a) a failure finishing in the same millisecond loses the `id desc` tie;
+(b) two processes with skewed clocks. Bounded in practice: the scheduler runs **inside the web
+process** (`instrumentation.ts:57`) and the timeline rebuild runs there too, so the live deployment has
+one clock; a deploy-overlap twin is NTP-scale. And a masked failure is **self-correcting** — `failing`
+needs a streak of two, so the next real failure re-confirms.
+
+**The write happens only when the leg's newest verdict is a FAILURE** — event-driven, not throttled.
+This is round 0's condition returning, but its job has changed completely: correctness now comes from
+the ordering above, and the condition exists to avoid perpetual ledger traffic.
+
+⚠️ **This removes the perpetual traffic, but NOT the cooldown problem — round 4 claimed it did, and
+that claim was false.** Round 4 argued that because nothing is written in the steady state, the
+cooldown is never touched. The steady state was never the issue: the clearing row is written at the
+moment the leg HEALS, with a near-current timestamp, and `lastRun` reads the newest row of any kind.
+So a doc arriving a minute after the heal would wait a full cooldown — stalling inference at exactly
+the point of recovery. **The diff review caught this, and AC3 could not have: it seeds an already-old
+success rather than performing heal → new work.**
+
+**So `lastRun` does filter after all:** the PAID-run clock skips rows carrying `meta.health_clear`
+(the verdict still comes from the newest row of any kind, because that is what the banner reads).
+What the event-driven write genuinely buys is the absence of ~730 rows/team/year and of any new
+duration constant — not an untouched clock.
+
+The row carries **`meta.health_clear = true`** — a dedicated marker, not the overloaded `meta.skipped`.
+
+⚠️ **Two honest labels:** `duration_ms` is **0** by construction (`runs.ts:77`), and the row's
+`finished_at` is the pass's START. Nothing computes on either (`listRecentIngestRuns` is
+order-tolerant; `doc_task_infer`'s staleness threshold is `null`), but the row is synthetic health
+evidence and its comment must say so rather than let a reader take it for a timed pass.
+
+### 2c. The map is corrected — the whole block
+
+`pipeline-health.ts:154-168` carries **four** claims that this change falsifies, not the one round 0
+found. The `null`-threshold conclusion stays right; its argument is rewritten.
+
+### 2d. Fix `doc_task_infer` alone
+
+`pret3_sweep` is **already fixed** (§0f). `linear_inbound` is a **confirmed twin**
+(`scheduler.ts:159-160`) — not fixed here. `dense` has a narrower hole (records only on
+`failed>0 || indexed>0`, so a *purged* backlog latches). `arcs`/`graph_project` self-clear.
+`doc_task_infer` is unique in that **healing removes the reason to record**.
+
+⚠️ **Residual, named:** a team that removes its keys stays loud forever (`no-llm` never clears).
+
+## 3. Scope
+
+**In:** `lib/dashboard/doc-task-infer-run.ts` · `lib/dashboard/doc-task-infer.ts` (drop reasons +
+`ownerKind`) · the corrected block in `lib/ingest/pipeline-health.ts` · guards · data-mechanics tests.
+
+**Out:** any new duration constant (none is needed — §2b); `STALE_MS_BY_SOURCE`;
+`FAILURES_TO_CONFIRM`; `linear_inbound`/`dense`/the `no-llm` residual; **paging the `ITEM_SCAN` read**
+— saturation abstains instead, which is correct for THIS slice's no-false-clear property, though a
+busy team then stays latched until it drops under 500 (named, not fixed).
+
+## 4. Acceptance
+
+⚠️ **Fixture facts, each of which blocks a criterion if missed:** seeded failure rows are non-skipped
+and therefore **arm the cooldown** — they must be aged past `COOLDOWN_MS` or the pass returns
+`cooldown` before any clearing branch. AC1's `:237`/`:270` cases must **seed tasks**, or `:195`
+`no-candidates` clears first and the fixture trips two criteria. AC4 must **age its produced first
+failure** (`COOLDOWN_MS` has a 1-hour floor, `Math.max(1,…)` at `:88`), never seed the second.
+
+- **AC1 — every clearing outcome clears (dm):** once per case — `no-candidates`, unsaturated `:206`,
+  unsaturated `:237` with only legitimate drops, unsaturated `:270` — assert via **`getPipelineHealth`**
+  that the leg leaves `failing`, and that the row has `ok=true`, `meta.health_clear`, and
+  `finished_at === passStartedAt`.
+- **AC2 / AC2b — `cooldown` and `no-llm` do not clear (dm):** exact returned outcome, row count unchanged.
+- **AC2c — a doc dropped for an UNRESOLVABLE owner does not clear (dm):** a `member_id` that resolves
+  to no member row for this team. *Round 3 specified this as "a human-owned doc with no attribution",
+  a state the code cannot produce — the criterion was unbuildable and its mutation aimed at nothing.*
+- **AC2d — a CONNECTOR-owned window DOES clear (dm):** the inverse. *Without it, the conservative
+  reading ships and the leg never clears for a connector-fed team.*
+- **AC2e — a SATURATED scan does not clear, at ALL THREE sites (dm):** `:206`, `:237` and `:270` each
+  abstain with ≥`ITEM_SCAN` items. *Round 3 pinned only `:206` while `:237`/`:270` read the same
+  truncated page.*
+- **AC3 — the steady state writes nothing (dm):** newest verdict `ok=true` → an idle pass writes
+  **zero** rows. *This is now the whole cooldown story: nothing is written, so nothing is deferred.*
+- **AC4 — a real failure is still loud (dm):** two failures produced by RUNNING the pass, ageing the
+  first between runs; `confirmed`, in `failing`, `failingSince` = the oldest.
+- **AC5 — a concurrent failure can never be masked (dm, deterministic):** via the exported seam
+  `recordClearingRun(db, teamId, passStartedAt, reason)` — seed the streak, record a produced failure
+  NOW, call the seam with `passStartedAt` five minutes past. The assertion is that **the failure is
+  still the NEWEST row** (`leg.ok === false`) and the leg is `unconfirmed`, and that the very next
+  failure re-confirms it.
+
+  ⚠️ **Round 4 wrote this as "still `failing`", which is wrong, and the test caught it.** The
+  backdated row lands BETWEEN the old streak and the new failure, so the newest failure's streak is 1
+  and `FAILURES_TO_CONFIRM = 2` makes it `unconfirmed` — quiet by the SAME policy that stops one blip
+  painting the banner. Round 2's Codex review said exactly this and I folded the words but not the
+  criterion. **The property backdating actually guarantees is narrower: the clearing row can never sit
+  ON TOP of a concurrent failure and erase it.** The alarm is deferred by one run, not lost — and the
+  positive control below proves the mechanism is load-bearing.
+- **AC5-control — WITHOUT backdating the same interleaving DOES mask (dm):** the identical fixture with
+  the row stamped `now` instead of the pass start leaves the leg `ok` and not failing. *A negative
+  control on the mechanism itself: without it, AC5 would pass on a build where backdating did nothing.*
+- **AC5b — the call site passes its OWN `startedAt` (unit, CLOCK-ADVANCING):** the fake clock must
+  ADVANCE between `:140` and the write, or `Date.now()` at write time equals the captured value and
+  mutation 10 survives a naive spy. *Green-by-construction otherwise — the class AC5 exists to avoid.*
+- **AC6 — a thrown read never becomes a clearing row (unit).**
+- **AC7 — no time-based escalation (dm, behavioural):** `getPipelineHealth` classifies a failure at 2
+  days and at 60 days identically with no intervening run.
+- **AC8 — the whole `:154-168` block is true (guard, unit).**
+
+| # | mutation | must redden |
+|---|---|---|
+| 1 | the clearing row is never written | AC1 |
+| 2 | only one clearing outcome is wired | AC1 |
+| 3 | `cooldown` clears | AC2 |
+| 4 | the write is wired above `:151` | AC2b |
+| 5 | an unresolvable owner clears | **AC2c** |
+| 6 | `:237` never clears (round 3's over-broad rule) | **AC2d** |
+| 7 | the saturation abstain is dropped at `:206` | AC2e |
+| 8 | the saturation abstain is dropped at `:237`/`:270` | **AC2e** |
+| 9 | `finishedAt` is `Date.now()` instead of `passStartedAt` | **AC5** |
+| 10 | the call site passes `Date.now()` rather than its own `startedAt` | **AC5b** |
+| 11 | the row is written even when the newest verdict is `ok` | **AC3** |
+| 12 | the clearing row is written with `ok=false` | AC1 |
+| 13 | a thrown read becomes a clearing row | AC6 |
+| 14 | `FAILURES_TO_CONFIRM` raised so nothing confirms | AC4 |
+| 15 | `failingSince` reports the newest failure | AC4 |
+| 16 | an inline elapsed-time escalation in `getPipelineHealth` | AC7 |
+| 17 | restore any one of the four false claims in the block | AC8 |
+
+## 5. Risks
+
+| risk | direction | mitigation |
+|---|---|---|
+| A concurrent failure is masked | **the loudest alarm goes quiet on a broken leg** | §2b backdating (ordering, not guarding); AC5 + mutations 9/10; residuals stated and self-correcting |
+| Clearing on a partial view of the window | clears while work is pending | saturation abstain at all three sites; AC2e + mutations 7/8 |
+| An unresolvable owner silences the alarm | a data-integrity fault reads as health | §2a's drop split; AC2c + mutation 5 |
+| The fix makes the leg NEVER clear | the bug inverted — round 3 would have shipped it | AC2d + mutation 6 |
+| The alarm is silenced by a leg that never ran | worse than the bug | AC2/AC2b + mutations 3/4 |
+| A later tweak reintroduces a grace period | the fix BANNERFLAP-1 §3a proved wrong | AC7 behavioural, mutation 16 |
+
+## 6. What would falsify this
+
+A **successful** `doc_task_infer` run before this ships would clear the banner on its own and make the
+incident look self-healing. It would not falsify the defect. **Re-measured 2026-08-27, ~24h after §0a: the streak is
+still 4, with no new row in a further ~24h** — the leg has now been silent-but-polled for ~2 days, and
+the falsifier has not fired.
+
+## 7. Mutations, as RUN
+
+Behavioural rows ran against the real-Postgres suite; ∀-over-sites rows against the guard. **The
+baseline was verified green under the exact invocation first** — an earlier attempt pointed at the
+wrong database (`app` rather than `app_test`), where the suite was ALREADY red and every mutation
+reported `REDDENED` while proving nothing.
+
+| # | mutation | tier | result |
+|---|---|---|---|
+| 1 | the clearing row is never written | dm | ✅ AC1 ×2 |
 | 3 | `cooldown` also clears | dm | ✅ AC2 |
 | 4 | the write is wired above the `no-llm` gate | dm | ✅ AC2b |
 | 5 | an unresolvable owner is treated as legitimate | guard | ✅ AC2c |
@@ -362,4 +738,5 @@ is deliberate and stated: the MECHANISM is proven behaviourally at `:206`, and t
 property — that all three JS-derived outcomes carry the gate — is proven by the guard**, which
 reddens when the gate is removed at `:237` or `:270`. Both mutations were run against it.
 
-**Code is built.** AC1–AC5 + AC7 are the data-mechanics suite; AC2c/AC2d/AC2e(∀)/AC5b/AC8 are the guard.
+**Code is built.** AC1 (×3 cases), AC2, AC2b, AC2d, AC2e, AC3, AC3b, AC4, AC5 + control, AC7 are the
+data-mechanics suite; AC2c, AC2e(∀), AC5b, AC8 are the guard; AC6 is unit.

--- a/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
+++ b/docs/design/bannerstuck1-confirmed-failure-cannot-clear.md
@@ -265,8 +265,20 @@ failure** (`COOLDOWN_MS` has a 1-hour floor, `Math.max(1,…)` at `:88`), never 
   first between runs; `confirmed`, in `failing`, `failingSince` = the oldest.
 - **AC5 — a concurrent failure can never be masked (dm, deterministic):** via the exported seam
   `recordClearingRun(db, teamId, passStartedAt, reason)` — seed the streak, record a produced failure
-  NOW, call the seam with `passStartedAt` five minutes past: still `failing`, and the clearing row's
-  `finished_at` is strictly older than the failure's.
+  NOW, call the seam with `passStartedAt` five minutes past. The assertion is that **the failure is
+  still the NEWEST row** (`leg.ok === false`) and the leg is `unconfirmed`, and that the very next
+  failure re-confirms it.
+
+  ⚠️ **Round 4 wrote this as "still `failing`", which is wrong, and the test caught it.** The
+  backdated row lands BETWEEN the old streak and the new failure, so the newest failure's streak is 1
+  and `FAILURES_TO_CONFIRM = 2` makes it `unconfirmed` — quiet by the SAME policy that stops one blip
+  painting the banner. Round 2's Codex review said exactly this and I folded the words but not the
+  criterion. **The property backdating actually guarantees is narrower: the clearing row can never sit
+  ON TOP of a concurrent failure and erase it.** The alarm is deferred by one run, not lost — and the
+  positive control below proves the mechanism is load-bearing.
+- **AC5-control — WITHOUT backdating the same interleaving DOES mask (dm):** the identical fixture with
+  the row stamped `now` instead of the pass start leaves the leg `ok` and not failing. *A negative
+  control on the mechanism itself: without it, AC5 would pass on a build where backdating did nothing.*
 - **AC5b — the call site passes its OWN `startedAt` (unit, CLOCK-ADVANCING):** the fake clock must
   ADVANCE between `:140` and the write, or `Date.now()` at write time equals the captured value and
   mutation 10 survives a naive spy. *Green-by-construction otherwise — the class AC5 exists to avoid.*

--- a/lib/dashboard/doc-task-infer-run.ts
+++ b/lib/dashboard/doc-task-infer-run.ts
@@ -89,6 +89,13 @@ const TIMEOUT_MS = 45_000;
  */
 const COOLDOWN_MS = Math.max(1, Number(process.env.DOC_TASK_INFER_INTERVAL_HOURS) || 12) * 3_600_000;
 
+/**
+ * How many recent rows `lastRun` reads to find the newest PAID one. Clearing rows are written only
+ * when a failure stands, and writing one makes the verdict `ok`, so at most a couple can ever sit at
+ * the head (two concurrent passes can both write). A small window is therefore ample, and bounded.
+ */
+const CLOCK_SCAN = 10;
+
 /** `ingest_runs.source` for this leg — also the key used to find the previous run's inputs hash. */
 export const DOC_TASK_INFER_SOURCE = "doc_task_infer";
 
@@ -507,23 +514,38 @@ async function lastRun(
   try {
     const { data } = await db
       .from("ingest_runs")
-      .select("meta, ok, finished_at")
+      .select("id, meta, ok, finished_at")
       .eq("team_id", teamId)
       .eq("source", DOC_TASK_INFER_SOURCE)
       .order("finished_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    const row = data as { meta?: { inputs_hash?: unknown } | null; ok?: boolean; finished_at?: string | Date } | null;
-    if (!row) return null;
-    const raw = row.finished_at;
+      // `id` desc as the SAME tie-break `STREAK_SQL` uses (`lib/ingest/pipeline-health.ts`). Without it
+      // two rows sharing a millisecond — a fast fail then a retry in one tick — can resolve here in the
+      // opposite order to the banner, so `ok` below would disagree with the verdict the user is seeing.
+      .order("id", { ascending: false })
+      .limit(CLOCK_SCAN);
+    const rows = (data ?? []) as {
+      meta?: { inputs_hash?: unknown; health_clear?: unknown } | null;
+      ok?: boolean;
+      finished_at?: string | Date;
+    }[];
+    // THE PAID-RUN CLOCK IGNORES CLEARING ROWS. A `health_clear` row is written at the moment the leg
+    // HEALS and carries a near-current timestamp, so counting it would start a fresh 12h cooldown at
+    // exactly the point the leg recovers: a doc arriving a minute later would wait until evening for
+    // linking that costs one tick today. The cooldown exists to bound PAID runs, and a clearing pass
+    // paid for nothing.
+    const newest = rows[0] ?? null;
+    const row = rows.find((r) => r?.meta?.health_clear !== true) ?? null;
+    if (!newest) return null;
+    const raw = row?.finished_at;
     const finishedAt = raw ? (typeof raw === "string" ? Date.parse(raw) : new Date(raw).getTime()) : 0;
-    const h = row.ok ? row.meta?.inputs_hash : null;
+    const h = row?.ok ? row.meta?.inputs_hash : null;
     return {
+      // From the newest PAID run — see above.
       finishedAt: Number.isFinite(finishedAt) ? finishedAt : 0,
       inputsHash: typeof h === "string" && h ? h : null,
-      // The newest VERDICT, which is what decides whether a clearing row is worth writing at all
-      // (BANNERSTUCK-1 §2b). `ok` is already selected above for `inputsHash`.
-      ok: row.ok === true,
+      // …but the VERDICT is the newest row of ANY kind, because that is what the banner reads. Taking
+      // it from the paid row would make the pass re-clear a leg it has already cleared, every tick.
+      ok: newest.ok === true,
     };
   } catch {
     return null; // unreadable history → run (spending once beats silently never running again)
@@ -580,8 +602,8 @@ async function markScored(
  * ⚠️ `finishedAt` is the pass's OWN `startedAt`, and that is the whole correctness argument. Two
  * callers reach this leg (`lib/ingest/scheduler.ts` and `lib/dashboard/timeline-cache.ts`) and they
  * are not mutually single-flighted, so a clearing pass can overlap a failing one. `STREAK_SQL` orders
- * `finished_at desc, id desc`, so backdating makes any row recorded DURING this pass sort strictly
- * newer — a concurrent failure cannot be hidden by commit order or snapshot visibility. A guard
+ * `finished_at desc, id desc`, so backdating makes any row whose `finished_at` is after this pass
+ * began sort strictly newer — a concurrent failure cannot be hidden by commit order or snapshot visibility. A guard
  * (`insert … where not exists`) does NOT achieve this: under READ COMMITTED the subquery cannot see
  * an uncommitted failure, so both rows land and the clearing row still wins.
  *

--- a/lib/dashboard/doc-task-infer-run.ts
+++ b/lib/dashboard/doc-task-infer-run.ts
@@ -14,6 +14,7 @@ import {
   applyInferredLinks,
   buildInferPrompt,
   candidatesFor,
+  hasUnjudgeableDrop,
   inferenceInputsHash,
   isScoreableSource,
   parseInferResponse,
@@ -21,6 +22,7 @@ import {
   type InferCandidate,
   type InferDoc,
   type InferredLink,
+  type OwnerKind,
 } from "./doc-task-infer";
 import { recordIngestRun } from "@/lib/ingest/runs";
 
@@ -146,6 +148,19 @@ async function runDocTaskInferenceWithPass(
     const prior = await lastRun(db, teamId);
     if (prior && Date.now() - prior.finishedAt < COOLDOWN_MS) return { scored: 0, linked: 0, skipped: "cooldown" };
 
+    /**
+     * A pass that ran cleanly and found nothing to do is contrary evidence against a STANDING failure
+     * — record it so the streak can break (BANNERSTUCK-1). Only when the newest verdict is a failure:
+     * in the steady state this writes nothing, which is what keeps the paid-run cooldown untouched
+     * (a clearing row that became `lastRun` would defer real scoring by up to a cooldown) and keeps
+     * ~730 rows/team/year out of an append-only table.
+     *
+     * NOT called for `cooldown` (the pass never ran) or `no-llm` (unconfigured — a different state).
+     */
+    const clearIfHealed = async (reason: string): Promise<void> => {
+      if (prior?.ok === false) await recordClearingRun(db, teamId, startedAt, reason);
+    };
+
     // Spend nothing when the team has no model configured (every data-mechanics team, most self-hosts).
     const keys = await resolveAnsweringKeys(db, teamId).catch(() => null);
     if (!keys || !llmConfigured(keys)) return { scored: 0, linked: 0, skipped: "no-llm" };
@@ -192,7 +207,20 @@ async function runDocTaskInferenceWithPass(
 
     const tasks = (taskRes.data ?? []) as { id: string; row_key: string | null; title: string; status: string | null; assignee: string | null }[];
     const items = (itemRes.data ?? []) as ItemRow[];
-    if (!tasks.length) return { scored: 0, linked: 0, skipped: "no-candidates" };
+    if (!tasks.length) {
+      // No bound to worry about: an EMPTY task list is complete however wide the limit was.
+      await clearIfHealed("no-candidates");
+      return { scored: 0, linked: 0, skipped: "no-candidates" };
+    }
+
+    /**
+     * Did the item read fill its page? `docRows`/`allScoreable`/`pending` are all JS filters over this
+     * ONE bounded page (`limit(ITEM_SCAN)`, ordered `work_at desc`), so when it saturates, "nothing to
+     * score" means "nothing in the newest 500" — item 501 can be an unscored design doc. A saturated
+     * pass has not observed the eligible set and must not clear (BANNERSTUCK-1 §2a). `visibleItems`
+     * is a passthrough for `team`, so nothing post-drops rows and this count is honest.
+     */
+    const scanSaturated = items.length >= ITEM_SCAN;
 
     // AUTHORED DOCUMENTS only — `isScoreableSource` carries the reasoning for each exclusion, and
     // `classifyWork` drops SIGNAL (a decision, a meeting: data ABOUT work).
@@ -203,7 +231,10 @@ async function runDocTaskInferenceWithPass(
       return classifyWork(r.kind, str(fm.source)) === "work";
       // No work-time check here: the SQL window above already restricted to rows the timeline would keep.
     });
-    if (!docRows.length) return { scored: 0, linked: 0, skipped: "nothing-to-score" };
+    if (!docRows.length) {
+      if (!scanSaturated) await clearIfHealed("nothing-to-score");
+      return { scored: 0, linked: 0, skipped: "nothing-to-score" };
+    }
 
     // DETERMINISTIC WINS: anything the issue-key matcher already links is never offered to the model.
     const deterministic = computeTaskLinks(
@@ -223,9 +254,22 @@ async function runDocTaskInferenceWithPass(
       { strict: true, items: docRows.map((r) => ({ id: r.id, member_id: r.member_id, member_id_locked: r.member_id_locked ?? null })) }
     );
 
+    /**
+     * What each doc's RAW owner is, which `credit` alone cannot say once `primaryId` is null: a
+     * connector (no human to reason about — a legitimate nothing-to-do) or an id that resolves to no
+     * member row for this team (a data fault). Only the health-clearing decision needs the difference
+     * (BANNERSTUCK-1); scoring drops both regardless.
+     *
+     * A plain read rather than widening the attribution oracle or `teamRoster`: the oracle's return
+     * carries credited ids, not owner kinds, and `teamRoster` filters `status='active'`, which would
+     * make a deactivated human look unresolvable.
+     */
+    const ownerKindById = await ownerKinds(db, teamId, docRows.map((r) => r.member_id));
+
     const docs: InferDoc[] = docRows.map((r) => ({
       id: r.id,
       memberId: credit.get(r.id)?.primaryId ?? null,
+      ownerKind: ownerKindById.get(r.member_id ?? "") ?? "unresolvable",
       title: str(r.frontmatter?.title) ?? (r.path ? r.path.split("/").pop() ?? r.path : "(untitled)"),
       contentSha: r.content_sha256 ?? "",
       access: r.access === "external" ? "external" : "team",
@@ -234,7 +278,13 @@ async function runDocTaskInferenceWithPass(
     }));
 
     const allScoreable = scoreableDocs(docs);
-    if (!allScoreable.length) return { scored: 0, linked: 0, skipped: "nothing-to-score" };
+    if (!allScoreable.length) {
+      // Every doc was dropped. Deterministic-linked, external and connector-owned are settled facts —
+      // nothing to do. An owner resolving to NO member row is a data fault, and a pass that hit one
+      // has judged nothing, so it must not clear (`hasUnjudgeableDrop`).
+      if (!scanSaturated && !hasUnjudgeableDrop(docs)) await clearIfHealed("nothing-to-score");
+      return { scored: 0, linked: 0, skipped: "nothing-to-score" };
+    }
 
     // Resolve each task's assignee to a member so ranking uses the identity mapping, not the raw string
     // (prod carries `Chetan` / `chetan.nandakumar` / `John Ellison` / `john` for two people).
@@ -267,7 +317,10 @@ async function runDocTaskInferenceWithPass(
     const inputsHash = inferenceInputsHash([], candidates, DOC_TASK_SYSTEM);
     const alreadyScored = await scoredKeys(db, teamId, allScoreable.map((d) => d.id));
     const pending = allScoreable.filter((d) => !alreadyScored.has(`${d.id}:${d.contentSha}:${inputsHash}`));
-    if (!pending.length) return { scored: 0, linked: 0, skipped: "unchanged" };
+    if (!pending.length) {
+      if (!scanSaturated) await clearIfHealed("unchanged");
+      return { scored: 0, linked: 0, skipped: "unchanged" };
+    }
     // OLDEST-FIRST is now just fairness: the scored ones drop out of `pending`, so the queue drains
     // whichever end it is taken from. Oldest-first stops a steady drip of new docs starving the tail.
     const scoreable = pending.slice(-batchCap).reverse();
@@ -447,7 +500,10 @@ async function attachBodies(db: DbClient, teamId: string, docs: InferDoc[]): Pro
  *    The recorded `meta.inputs_hash` stays as run PROVENANCE — it answers "what question did this run
  *    ask?" when reading the ledger — but nothing branches on it any more.
  */
-async function lastRun(db: DbClient, teamId: string): Promise<{ finishedAt: number; inputsHash: string | null } | null> {
+async function lastRun(
+  db: DbClient,
+  teamId: string
+): Promise<{ finishedAt: number; inputsHash: string | null; ok: boolean } | null> {
   try {
     const { data } = await db
       .from("ingest_runs")
@@ -465,6 +521,9 @@ async function lastRun(db: DbClient, teamId: string): Promise<{ finishedAt: numb
     return {
       finishedAt: Number.isFinite(finishedAt) ? finishedAt : 0,
       inputsHash: typeof h === "string" && h ? h : null,
+      // The newest VERDICT, which is what decides whether a clearing row is worth writing at all
+      // (BANNERSTUCK-1 §2b). `ok` is already selected above for `inputsHash`.
+      ok: row.ok === true,
     };
   } catch {
     return null; // unreadable history → run (spending once beats silently never running again)
@@ -512,6 +571,80 @@ async function markScored(
     { onConflict: "team_id,item_id" }
   );
   if (error) console.warn("[doc-task] could not record scored batch:", error.message);
+}
+
+/**
+ * Record that this pass ran cleanly and found no work — the row that lets a CONFIRMED failure streak
+ * clear (BANNERSTUCK-1).
+ *
+ * ⚠️ `finishedAt` is the pass's OWN `startedAt`, and that is the whole correctness argument. Two
+ * callers reach this leg (`lib/ingest/scheduler.ts` and `lib/dashboard/timeline-cache.ts`) and they
+ * are not mutually single-flighted, so a clearing pass can overlap a failing one. `STREAK_SQL` orders
+ * `finished_at desc, id desc`, so backdating makes any row recorded DURING this pass sort strictly
+ * newer — a concurrent failure cannot be hidden by commit order or snapshot visibility. A guard
+ * (`insert … where not exists`) does NOT achieve this: under READ COMMITTED the subquery cannot see
+ * an uncommitted failure, so both rows land and the clearing row still wins.
+ *
+ * Residuals, stated rather than claimed away: a failure finishing in the SAME millisecond loses the
+ * `id desc` tie, and two processes with skewed clocks compare timestamp values rather than a shared
+ * order. Both are bounded — the scheduler runs inside the web process, so the live deployment has one
+ * clock — and self-correcting, because `failing` needs a streak of two.
+ *
+ * ⚠️ The row is SYNTHETIC health evidence, not a timed pass: `duration_ms` is 0 by construction and
+ * `finished_at` is the pass's start, not its end.
+ *
+ * Exported so the ordering property can be tested deterministically. An idle pass has no awaitable
+ * seam between its reads and this write, so a `Promise.all` race test would pass even with the
+ * mechanism removed.
+ */
+export async function recordClearingRun(
+  db: DbClient,
+  teamId: string,
+  passStartedAt: number,
+  reason: string
+): Promise<void> {
+  await recordIngestRun(db, {
+    teamId,
+    source: DOC_TASK_INFER_SOURCE,
+    trigger: "scheduler",
+    ok: true,
+    errors: [],
+    meta: { health_clear: true, skipped: reason },
+    startedAt: passStartedAt,
+    finishedAt: passStartedAt,
+  });
+}
+
+/**
+ * Classify each raw `items.member_id` as a human, a connector, or unresolvable-on-this-team.
+ *
+ * Deliberately NOT filtered on `status`: a deactivated human is still a human, and treating them as
+ * unresolvable would make a normal roster change look like a data fault and block health clearing.
+ * On a read error every id is reported `unresolvable`, which fails CLOSED — the pass then declines to
+ * clear rather than clearing on an unread roster.
+ */
+async function ownerKinds(
+  db: DbClient,
+  teamId: string,
+  memberIds: readonly (string | null)[]
+): Promise<Map<string, OwnerKind>> {
+  const out = new Map<string, OwnerKind>();
+  const ids = [...new Set(memberIds.filter((m): m is string => !!m))];
+  if (!ids.length) return out;
+  try {
+    const { data, error } = await db
+      .from("members")
+      .select("id, is_connector")
+      .eq("team_id", teamId)
+      .in("id", ids);
+    if (error) return out; // every id stays absent → `unresolvable` → no clearing. Fail closed.
+    for (const m of (data ?? []) as { id: string; is_connector: boolean | null }[]) {
+      out.set(m.id, m.is_connector ? "connector" : "human");
+    }
+  } catch {
+    return new Map(); // same fail-closed reasoning
+  }
+  return out;
 }
 
 async function record(

--- a/lib/dashboard/doc-task-infer.ts
+++ b/lib/dashboard/doc-task-infer.ts
@@ -52,6 +52,16 @@ export interface InferDoc {
   id: string;
   /** The doc's credited worker (from the shared attribution oracle), NOT the raw pusher. */
   memberId: string | null;
+  /**
+   * What the doc's RAW `items.member_id` resolves to on this team — the thing `memberId` alone cannot
+   * tell you once it is null (BANNERSTUCK-1).
+   *
+   * `memberId` is null for a connector-owned doc AND for one whose owner resolves to no member row,
+   * and those mean opposite things: the first is a doc with no human to reason about (nothing to do,
+   * legitimately), the second is a data-integrity fault. Only the health-clearing decision needs to
+   * tell them apart; scoring drops both either way.
+   */
+  ownerKind: OwnerKind;
   title: string;
   /** `items.content_sha256` — an edited doc must re-score, so the hash keys on content, not id. */
   contentSha: string;
@@ -95,6 +105,29 @@ export interface InferredLink {
  */
 export function scoreableDocs(docs: readonly InferDoc[]): InferDoc[] {
   return docs.filter((d) => !d.hasDeterministicLink && d.access !== "external" && !!d.memberId);
+}
+
+/** What a doc's raw owner resolves to. `human` implies a non-null `memberId` — see `creditedPrimaryId`. */
+export type OwnerKind = "human" | "connector" | "unresolvable";
+
+/**
+ * Was any doc dropped for a reason that means "this pass could not judge", rather than "there is
+ * nothing here to do"? (BANNERSTUCK-1.)
+ *
+ * The three scoring drops are NOT equivalent as health evidence. Already-linked and external are
+ * settled facts — the work is done or deliberately out of scope. A connector-owned doc has no human
+ * to attribute, by design (`lib/attribution/contributor-credit` excludes connectors), so it is also
+ * a genuine nothing-to-do. But an owner that resolves to NO member row for this team is a data
+ * fault, and a pass that hit one has not established that the leg is healthy — so it must not be
+ * allowed to clear a standing failure.
+ *
+ * Note what is deliberately absent: "a HUMAN-owned doc with no attribution". That state cannot occur
+ * — the wide scan excludes null `member_id` in SQL, `creditedPrimaryId` returns null only when the
+ * owner fails `isHuman`, and a real oracle failure THROWS in strict mode and is recorded as a failed
+ * run. Two spec reviews independently derived this after an earlier draft built a criterion on it.
+ */
+export function hasUnjudgeableDrop(docs: readonly InferDoc[]): boolean {
+  return docs.some((d) => !d.memberId && d.ownerKind === "unresolvable");
 }
 
 /**

--- a/lib/dashboard/doc-task-infer.ts
+++ b/lib/dashboard/doc-task-infer.ts
@@ -127,7 +127,13 @@ export type OwnerKind = "human" | "connector" | "unresolvable";
  * run. Two spec reviews independently derived this after an earlier draft built a criterion on it.
  */
 export function hasUnjudgeableDrop(docs: readonly InferDoc[]): boolean {
-  return docs.some((d) => !d.memberId && d.ownerKind === "unresolvable");
+  // The first two predicates MIRROR `scoreableDocs`, and that is load-bearing rather than tidy: a doc
+  // that is already linked, or external, is legitimately dropped for THAT reason whatever its owner
+  // resolves to. Counting it here would let one external doc with a broken owner block clearing
+  // forever — the spec calls those drops legitimate, and without this the code disagreed with it.
+  return docs.some(
+    (d) => !d.hasDeterministicLink && d.access !== "external" && !d.memberId && d.ownerKind === "unresolvable"
+  );
 }
 
 /**

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -165,8 +165,8 @@ const STALE_MS_BY_SOURCE: Record<string, number | null> = {
   // Observed in prod flagging a leg that had never failed, on a measured 12.1–12.4h cadence, while every
   // connector was running on time — the banner said the brain wasn't getting fresh data when it was.
   //
-  // ⚠️ This block used to end: "since the cooldown counts failed runs too, a persistent failure keeps
-  // re-recording and stays the newest row." TRUE ONLY WHILE THE FAILURE PERSISTS, and that gap was
+  // ⚠️ This block used to end with a claim that the cooldown counting failed runs meant a standing
+  // failure would keep re-recording and stay the newest row. TRUE ONLY WHILE IT PERSISTS, and that gap was
   // BANNERSTUCK-1: when the cause healed and no work was demanded, nothing re-recorded, the four-long
   // 402 streak stayed newest, and the loud banner latched red with no future event able to clear it —
   // `failing` includes `confirmed` regardless of age, so staleness (`null`, correctly) cannot help.

--- a/lib/ingest/pipeline-health.ts
+++ b/lib/ingest/pipeline-health.ts
@@ -153,18 +153,28 @@ const STALE_MS_BY_SOURCE: Record<string, number | null> = {
   arcs: null,
   // The record-only-when-active rule in its strongest form. `doc_task_infer` IS polled reliably — the
   // scheduler calls it every tick for every team (`lib/ingest/scheduler.ts`), alongside the timeline's
-  // background rebuild — so this is NOT a case of "maybe nothing triggered it". It is that FIVE of its
-  // eight outcomes write no `ingest_runs` row at all: `cooldown` (12h, `DOC_TASK_INFER_INTERVAL_HOURS`),
-  // `no-llm`, `no-candidates`, `nothing-to-score`, and `unchanged` all return before `record()`. So on a
-  // quiet corpus — no new scoreable docs in the 7-day window — a perfectly healthy leg polled every 30
-  // minutes still writes nothing for days, and its newest row's age is unbounded at ANY threshold. That
-  // is why this is `null` rather than "12h + grace": no finite number is correct.
+  // background rebuild — so this is NOT a case of "maybe nothing triggered it". It is that most of its
+  // outcomes write no `ingest_runs` row: `cooldown` (12h, `DOC_TASK_INFER_INTERVAL_HOURS`) and `no-llm`
+  // always return before any write, and the four clean-and-idle outcomes (`no-candidates`,
+  // `nothing-to-score` at either site, `unchanged`) write only the health-clearing row described below,
+  // and only when there is a failure standing. So on a quiet corpus a healthy leg polled every 30
+  // minutes still writes nothing for days once its verdict is `ok`, and its newest row's age is
+  // unbounded at ANY threshold. That is why this is `null` rather than "12h + grace": no finite number
+  // is correct.
   //
   // Observed in prod flagging a leg that had never failed, on a measured 12.1–12.4h cadence, while every
   // connector was running on time — the banner said the brain wasn't getting fresh data when it was.
-  // Real failures still surface: the model-null and thrown-error paths DO record (`ok=false`), and since
-  // the cooldown counts failed runs too, a persistent failure keeps re-recording and stays the newest
-  // row. Shortfalls also show as `workers_failed` in the run meta.
+  //
+  // ⚠️ This block used to end: "since the cooldown counts failed runs too, a persistent failure keeps
+  // re-recording and stays the newest row." TRUE ONLY WHILE THE FAILURE PERSISTS, and that gap was
+  // BANNERSTUCK-1: when the cause healed and no work was demanded, nothing re-recorded, the four-long
+  // 402 streak stayed newest, and the loud banner latched red with no future event able to clear it —
+  // `failing` includes `confirmed` regardless of age, so staleness (`null`, correctly) cannot help.
+  // A clean-and-idle pass now records a BACKDATED `ok=true` row (`meta.health_clear`) when the newest
+  // verdict is a failure, which breaks the streak; see `lib/dashboard/doc-task-infer-run.recordClearingRun`
+  // for why backdating rather than a guard is what stops it masking a concurrent failure.
+  // Real failures still surface: the model-null and thrown-error paths record `ok=false`, and shortfalls
+  // show as `workers_failed` in the run meta.
   doc_task_infer: null,
 };
 

--- a/test/datamechanics/bannerstuck-clearing.datamechanics.test.ts
+++ b/test/datamechanics/bannerstuck-clearing.datamechanics.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import {
+  DOC_TASK_INFER_SOURCE,
+  recordClearingRun,
+  runDocTaskInference,
+} from "@/lib/dashboard/doc-task-infer-run";
+import { recordIngestRun } from "@/lib/ingest/runs";
+import { getPipelineHealth } from "@/lib/ingest/pipeline-health";
+import { saveProviderModel, setIntegrationSecret, upsertIntegration } from "@/lib/integrations/manage";
+import { db, ingest, seedTeam, type Seed } from "./helpers";
+
+/**
+ * BANNERSTUCK-1 — a CONFIRMED failure streak that nothing can clear.
+ * Spec: `docs/design/bannerstuck1-confirmed-failure-cannot-clear.md`.
+ *
+ * Measured on prod 2026-08-27: `doc_task_infer` carried 4 consecutive failures from an OpenRouter 402.
+ * The credit was restored 26h earlier and the scheduler was ticking, but the loud banner still read
+ * "1 ingestion leg is broken — the brain isn't getting fresh data", and NO future event could clear it:
+ * the streak breaks only on a recorded success, and a leg with nothing to do records nothing.
+ *
+ * Real Postgres because the whole verdict lives in `STREAK_SQL`'s window functions and its
+ * `finished_at desc, id desc` ordering — which is also the mechanism that stops a clearing row hiding a
+ * concurrent failure. A stubbed streak would pass while the SQL was wrong.
+ */
+
+const recentIso = new Date(Date.now() - 2 * 86_400_000).toISOString();
+/** Comfortably past the 12h cooldown (whose floor is 1h), so a seeded failure does not gate the pass. */
+const PAST_COOLDOWN_MS = 30 * 3_600_000;
+
+async function member(teamId: string): Promise<string> {
+  const { data } = await db().from("members").select("id").eq("team_id", teamId)
+    .order("created_at", { ascending: true }).limit(1).maybeSingle();
+  return (data as { id: string }).id;
+}
+
+/** Get the pass PAST `no-llm` (`:151`) — without this every clearing test dies one gate too early. */
+async function withModel(teamId: string): Promise<void> {
+  const a = { teamId, memberId: await member(teamId) };
+  await upsertIntegration(db(), a, { type: "openai", name: "openai", config: {}, status: "enabled" });
+  const { data } = await db().from("integrations").select("id").eq("team_id", teamId)
+    .eq("type", "openai").order("created_at", { ascending: true }).limit(1).maybeSingle();
+  await setIntegrationSecret(db(), a, (data as { id: string }).id, "sk-openai-test");
+  await saveProviderModel(db(), a, "openai", "gpt-4.1");
+}
+
+/** A recorded run of this leg. `at` sets BOTH ends — `finished_at` is what the streak query orders by. */
+async function run(seed: Seed, opts: { ok: boolean; agoMs: number }): Promise<void> {
+  // `recordIngestRun` with epoch-MS timestamps, not a raw insert: it is the writer every other leg
+  // uses, and `finished_at` is what the streak query orders by. (tsc cannot catch a mistake here —
+  // `tsconfig` excludes the test tree.)
+  const at = Date.now() - opts.agoMs;
+  await recordIngestRun(db(), {
+    teamId: seed.teamId, source: DOC_TASK_INFER_SOURCE, trigger: "scheduler",
+    ok: opts.ok, created: 0, errors: opts.ok ? [] : ["every worker failed"],
+    startedAt: at, finishedAt: at,
+  });
+}
+
+/**
+ * The incident state: a CONFIRMED streak (`FAILURES_TO_CONFIRM` = 2), aged past the cooldown so the
+ * pass is not gated by its own seed — the fixture trap Fable's review named.
+ */
+async function confirmedFailureStreak(seed: Seed): Promise<void> {
+  await run(seed, { ok: false, agoMs: PAST_COOLDOWN_MS + 3_600_000 });
+  await run(seed, { ok: false, agoMs: PAST_COOLDOWN_MS });
+}
+
+async function isFailing(seed: Seed): Promise<boolean> {
+  const h = await getPipelineHealth(seed.teamId);
+  return h.failing.some((l) => l.source === DOC_TASK_INFER_SOURCE);
+}
+
+async function rowCount(seed: Seed): Promise<number> {
+  const { data } = await db().from("ingest_runs").select("id")
+    .eq("team_id", seed.teamId).eq("source", DOC_TASK_INFER_SOURCE);
+  return (data ?? []).length;
+}
+
+async function doc(seed: Seed, over: Record<string, unknown> = {}) {
+  return ingest(seed, {
+    kind: "deliverable", path: `2-work/${randomUUID()}.md`, access: "team",
+    body: "prose about some work",
+    frontmatter: { source: "", title: "A design doc", updated: recentIso },
+    ...over,
+  });
+}
+
+/** A project to hang fixtures on — both `items` and `tasks` have a NOT NULL `project_id`. */
+async function project(seed: Seed): Promise<string> {
+  const { data, error } = await db().from("projects")
+    .insert({ team_id: seed.teamId, slug: `p-${randomUUID().slice(0, 6)}`, name: "P" })
+    .select("id").single();
+  if (error) throw new Error(`projects insert failed: ${error.message}`);
+  return (data as { id: string }).id;
+}
+
+async function task(seed: Seed, projectId?: string): Promise<void> {
+  const proj = { id: projectId ?? (await project(seed)) };
+  const { error } = await db().from("tasks").insert({
+    team_id: seed.teamId, project_id: proj.id,
+    row_key: `TSK-${randomUUID().slice(0, 6)}`,
+    title: "Some task", status: "in_progress", origin: "sync", audience: "team",
+  });
+  if (error) throw new Error(`tasks insert failed: ${error.message}`);
+}
+
+describe("BANNERSTUCK-1 — a healed leg can clear, and can never hide a live failure", () => {
+  it("AC0 — REPRODUCES the incident: a confirmed streak is loud, and an idle pass used to leave it so", async () => {
+    // The non-vacuity control for everything below. If this were not `failing`, every clearing
+    // assertion would pass for the wrong reason.
+    const seed = await seedTeam();
+    await confirmedFailureStreak(seed);
+    expect(await isFailing(seed)).toBe(true);
+  });
+
+  it("AC1 — `no-candidates`: a pass that read the task list and found none clears the streak", async () => {
+    const seed = await seedTeam();
+    await withModel(seed.teamId);
+    await doc(seed);
+    await confirmedFailureStreak(seed);
+    expect(await isFailing(seed)).toBe(true);
+
+    expect((await runDocTaskInference(db(), seed.teamId)).skipped).toBe("no-candidates");
+    expect(await isFailing(seed), "a clean idle pass is contrary evidence").toBe(false);
+  });
+
+  it("AC1 — the clearing row is `ok`, marked, and BACKDATED to the pass start", async () => {
+    const seed = await seedTeam();
+    await withModel(seed.teamId);
+    await doc(seed);
+    await confirmedFailureStreak(seed);
+    const before = Date.now();
+    await runDocTaskInference(db(), seed.teamId);
+
+    const { data } = await db().from("ingest_runs")
+      .select("ok, meta, started_at, finished_at")
+      .eq("team_id", seed.teamId).eq("source", DOC_TASK_INFER_SOURCE)
+      .order("finished_at", { ascending: false }).limit(1).maybeSingle();
+    const row = data as { ok: boolean; meta: Record<string, unknown>; started_at: string; finished_at: string };
+    expect(row.ok).toBe(true);
+    expect(row.meta.health_clear).toBe(true);
+    // finished_at === started_at is the ordering mechanism, not a cosmetic choice.
+    expect(Date.parse(row.finished_at)).toBe(Date.parse(row.started_at));
+    expect(Date.parse(row.finished_at)).toBeGreaterThanOrEqual(before - 1000);
+  });
+
+  it("AC2 — `cooldown` does NOT clear: a pass that never ran proves nothing", async () => {
+    // If this cleared, the alarm could be silenced by doing nothing — strictly worse than the bug.
+    const seed = await seedTeam();
+    await withModel(seed.teamId);
+    await doc(seed);
+    await run(seed, { ok: false, agoMs: 2 * 3_600_000 });
+    await run(seed, { ok: false, agoMs: 60_000 }); // newest failure is INSIDE the cooldown
+    const n = await rowCount(seed);
+
+    expect((await runDocTaskInference(db(), seed.teamId)).skipped).toBe("cooldown");
+    expect(await rowCount(seed), "no row written").toBe(n);
+    expect(await isFailing(seed)).toBe(true);
+  });
+
+  it("AC2b — `no-llm` does NOT clear: unconfigured is a different state", async () => {
+    // `no-llm` sits one gate ABOVE the clearing outcomes, so a write wired one early-return too high
+    // would silence the alarm for every team that has no model at all.
+    const seed = await seedTeam(); // deliberately no `withModel`
+    await doc(seed);
+    await confirmedFailureStreak(seed);
+    const n = await rowCount(seed);
+
+    expect((await runDocTaskInference(db(), seed.teamId)).skipped).toBe("no-llm");
+    expect(await rowCount(seed)).toBe(n);
+    expect(await isFailing(seed)).toBe(true);
+  });
+
+  it("AC5 — a clearing row can NEVER outrank a failure recorded while the pass ran", async () => {
+    /**
+     * The masking scenario, made deterministic. Two callers reach this leg and are not mutually
+     * single-flighted, so an idle pass can overlap a failing one. A `Promise.all` race would be
+     * green-by-construction (an idle pass has no awaitable seam), so the seam is exercised directly:
+     * a pass that STARTED five minutes ago finishes after a failure that just landed.
+     */
+    const seed = await seedTeam();
+    await confirmedFailureStreak(seed);
+    const passStartedAt = Date.now() - 5 * 60_000;
+
+    // The concurrent failure lands NOW — after our pass began.
+    await recordIngestRun(db(), {
+      teamId: seed.teamId, source: DOC_TASK_INFER_SOURCE, trigger: "scheduler",
+      ok: false, errors: ["every worker failed"], startedAt: Date.now() - 1000,
+    });
+    await recordClearingRun(db(), seed.teamId, passStartedAt, "nothing-to-score");
+
+    /**
+     * ⚠️ The property is "the failure stays NEWEST", not "the leg stays `failing`" — and the
+     * difference is a real one this test corrected in the spec.
+     *
+     * The backdated row lands BETWEEN the old streak and the new failure, so the newest failure's
+     * streak is 1 and `FAILURES_TO_CONFIRM` = 2 makes it `unconfirmed` — quiet by the SAME policy
+     * that stops one blip painting the banner. That is not masking: the failure is still the newest
+     * row and still `ok:false` on the leg, so the next failure re-confirms immediately. What
+     * backdating guarantees is that the clearing row can never sit ON TOP of it and erase it.
+     */
+    const h = await getPipelineHealth(seed.teamId);
+    const leg = h.legs.find((l) => l.source === DOC_TASK_INFER_SOURCE)!;
+    expect(leg.ok, "the newest row must be the live FAILURE, not the clearing row").toBe(false);
+    expect(leg.failureClass).toBe("unconfirmed");
+
+    // …and it re-confirms on the very next failure, so the alarm is deferred by one run, not lost.
+    await recordIngestRun(db(), {
+      teamId: seed.teamId, source: DOC_TASK_INFER_SOURCE, trigger: "scheduler",
+      ok: false, errors: ["every worker failed"], startedAt: Date.now(),
+    });
+    expect(await isFailing(seed)).toBe(true);
+  });
+
+  it("AC5 — without backdating the same interleaving DOES mask (the mechanism is load-bearing)", async () => {
+    // The positive control for the test above: written at `now` instead of the pass start, the clearing
+    // row wins the ordering and the real failure disappears from the banner. This is what the
+    // backdating prevents, demonstrated rather than asserted.
+    const seed = await seedTeam();
+    await confirmedFailureStreak(seed);
+    await recordIngestRun(db(), {
+      teamId: seed.teamId, source: DOC_TASK_INFER_SOURCE, trigger: "scheduler",
+      ok: false, errors: ["every worker failed"], startedAt: Date.now() - 1000,
+    });
+    await recordClearingRun(db(), seed.teamId, Date.now() + 1000, "nothing-to-score");
+
+    expect(await isFailing(seed)).toBe(false);
+  });
+
+  it("AC3 — the steady state writes NOTHING: no standing failure, no clearing row", async () => {
+    // This is the whole cooldown story. Because nothing is written when the verdict is already `ok`,
+    // a clearing row can never become `lastRun` and defer the next real scoring pass.
+    const seed = await seedTeam();
+    await withModel(seed.teamId);
+    await doc(seed);
+    await run(seed, { ok: true, agoMs: PAST_COOLDOWN_MS });
+    const n = await rowCount(seed);
+
+    expect((await runDocTaskInference(db(), seed.teamId)).skipped).toBe("no-candidates");
+    expect(await rowCount(seed), "healthy + idle must be silent").toBe(n);
+  });
+
+  it("AC7 — classification does not drift with age: 2 days and 60 days read the same", async () => {
+    // BANNERFLAP-1 §3a rejected time-based escalation. A grace period here is the one fix already
+    // known to be wrong, so the property is behavioural, not a source grep.
+    const fresh = await seedTeam();
+    await run(fresh, { ok: false, agoMs: 2 * 86_400_000 });
+    await run(fresh, { ok: false, agoMs: 2 * 86_400_000 - 60_000 });
+
+    const old = await seedTeam();
+    await run(old, { ok: false, agoMs: 60 * 86_400_000 });
+    await run(old, { ok: false, agoMs: 60 * 86_400_000 - 60_000 });
+
+    expect(await isFailing(fresh)).toBe(await isFailing(old));
+    expect(await isFailing(old)).toBe(true);
+  });
+
+  it("AC4 — a genuine failure is still loud, and `failingSince` reports the OLDEST in the streak", async () => {
+    const seed = await seedTeam();
+    await run(seed, { ok: false, agoMs: 3 * 86_400_000 });
+    await run(seed, { ok: false, agoMs: 86_400_000 });
+
+    const h = await getPipelineHealth(seed.teamId);
+    const leg = h.legs.find((l) => l.source === DOC_TASK_INFER_SOURCE)!;
+    expect(leg.failureClass).toBe("confirmed");
+    expect(h.failing.some((l) => l.source === DOC_TASK_INFER_SOURCE)).toBe(true);
+    // Not the newest — a leg failing for three days must not read "failing since 20 minutes ago".
+    expect(Date.now() - Date.parse(leg.failingSince!)).toBeGreaterThan(2.5 * 86_400_000);
+  });
+
+  it("AC2e — a SATURATED item scan does not clear: the pass saw only part of the window", async () => {
+    // `:206`/`:237`/`:270` are JS filters over ONE bounded page (`limit(ITEM_SCAN)`), so with a full
+    // page "nothing to score" means "nothing in the newest 500" — item 501 can be unscored work.
+    const seed = await seedTeam();
+    await withModel(seed.teamId);
+    const projectId = await project(seed);
+    await task(seed, projectId);
+    // 500 rows that FILL the page and are then dropped in JS by `isScoreableSource` (slack is
+    // conversational). `member_id` must be a real member: the wide read excludes null owners in SQL
+    // (`.not("member_id","is",null)`), so null-owner filler never reaches the page and the scan would
+    // not saturate — the fixture would then prove nothing, which is how this first went green.
+    const owner = await member(seed.teamId);
+    const rows = Array.from({ length: 500 }, () => ({
+      team_id: seed.teamId, project_id: projectId,
+      kind: "artifact" as const, path: `x/${randomUUID()}.md`,
+      access: "team" as const, body: "chatter", member_id: owner,
+      content_sha256: randomUUID().replace(/-/g, ""),
+      frontmatter: { source: "slack", title: "t", updated: recentIso },
+      work_at: recentIso, work_at_from_source: true,
+    }));
+    const ins = await db().from("items").insert(rows);
+    if (ins.error) throw new Error(`items insert failed: ${ins.error.message}`);
+    const { data: got } = await db().from("items").select("id").eq("team_id", seed.teamId);
+    expect((got ?? []).length, "the page must actually be full, or this proves nothing").toBeGreaterThanOrEqual(500);
+    await confirmedFailureStreak(seed);
+    const n = await rowCount(seed);
+
+    const res = await runDocTaskInference(db(), seed.teamId);
+    expect(res.skipped).toBe("nothing-to-score");
+    expect(await rowCount(seed), "a saturated scan must abstain").toBe(n);
+    expect(await isFailing(seed)).toBe(true);
+  });
+});

--- a/test/datamechanics/bannerstuck-clearing.datamechanics.test.ts
+++ b/test/datamechanics/bannerstuck-clearing.datamechanics.test.ts
@@ -241,6 +241,65 @@ describe("BANNERSTUCK-1 — a healed leg can clear, and can never hide a live fa
     expect(await rowCount(seed), "healthy + idle must be silent").toBe(n);
   });
 
+  it("AC1 — `:206` unsaturated: work docs exist but none is scoreable, and the leg clears", async () => {
+    // The `no-candidates` case above exits before the item filters run. This one gets past them and
+    // clears at the SECOND site, so the saturation flag and the doc filters are on the proven path.
+    const seed = await seedTeam();
+    await withModel(seed.teamId);
+    await task(seed);
+    const projectId = await project(seed);
+    const owner = await member(seed.teamId);
+    // A handful of conversational rows: they fill `items` but every one is dropped by
+    // `isScoreableSource`, so `docRows` is empty — far below ITEM_SCAN, so the scan is complete.
+    const rows = Array.from({ length: 3 }, () => ({
+      team_id: seed.teamId, project_id: projectId, kind: "artifact" as const,
+      path: `x/${randomUUID()}.md`, access: "team" as const, body: "chatter", member_id: owner,
+      content_sha256: randomUUID().replace(/-/g, ""),
+      frontmatter: { source: "slack", title: "t", updated: recentIso },
+      work_at: recentIso, work_at_from_source: true,
+    }));
+    const ins = await db().from("items").insert(rows);
+    if (ins.error) throw new Error(`items insert failed: ${ins.error.message}`);
+    await confirmedFailureStreak(seed);
+
+    expect((await runDocTaskInference(db(), seed.teamId)).skipped).toBe("nothing-to-score");
+    expect(await isFailing(seed)).toBe(false);
+  });
+
+  it("AC2d — a CONNECTOR-owned window clears, which is the ONLY path that runs `ownerKinds`", async () => {
+    /**
+     * The inverted bug this must not ship: if `ownerKinds` misreads its query, every raw owner becomes
+     * `unresolvable`, `hasUnjudgeableDrop` is true, and a connector-fed team's banner NEVER clears —
+     * the original incident, recreated by the fix. That helper is new DB code and this is the only
+     * test at any tier that executes it, so the assertion is the OBSERVABLE clear, not the helper.
+     */
+    const seed = await seedTeam();
+    await withModel(seed.teamId);
+    await task(seed);
+    const projectId = await project(seed);
+
+    // A connector member: excluded from credit BY DESIGN, so its docs have no human to reason about.
+    const { data: conn, error: cErr } = await db().from("members")
+      .insert({ team_id: seed.teamId, email: `github-${randomUUID().slice(0, 8)}@connector.local`,
+        display_name: "GitHub", actor_handle: "github", is_connector: true, status: "active" })
+      .select("id").single();
+    if (cErr) throw new Error(`connector member insert failed: ${cErr.message}`);
+
+    const ins = await db().from("items").insert([{
+      team_id: seed.teamId, project_id: projectId, kind: "deliverable" as const,
+      path: `2-work/${randomUUID()}.md`, access: "team" as const, body: "prose about some work",
+      member_id: (conn as { id: string }).id, content_sha256: randomUUID().replace(/-/g, ""),
+      frontmatter: { source: "", title: "A design doc", updated: recentIso },
+      work_at: recentIso, work_at_from_source: true,
+    }]);
+    if (ins.error) throw new Error(`items insert failed: ${ins.error.message}`);
+    await confirmedFailureStreak(seed);
+
+    // Dropped at `:237` — a legitimate nothing-to-do, NOT the oracle abstaining — so it clears.
+    expect((await runDocTaskInference(db(), seed.teamId)).skipped).toBe("nothing-to-score");
+    expect(await isFailing(seed), "a connector-owned window is nothing to do, not a fault").toBe(false);
+  });
+
   it("AC3b — clearing does NOT arm the paid cooldown: new work is scored on the next tick", async () => {
     /**
      * The regression the design must not trade for a banner fix, and AC3 could not see it: AC3 seeds

--- a/test/datamechanics/bannerstuck-clearing.datamechanics.test.ts
+++ b/test/datamechanics/bannerstuck-clearing.datamechanics.test.ts
@@ -241,6 +241,32 @@ describe("BANNERSTUCK-1 — a healed leg can clear, and can never hide a live fa
     expect(await rowCount(seed), "healthy + idle must be silent").toBe(n);
   });
 
+  it("AC3b — clearing does NOT arm the paid cooldown: new work is scored on the next tick", async () => {
+    /**
+     * The regression the design must not trade for a banner fix, and AC3 could not see it: AC3 seeds
+     * an already-old success, so it never performs failure -> clear -> new work. Here the pass HEALS
+     * (writing a near-current clearing row) and then work arrives a minute later. If the paid-run
+     * clock counted that row, every pass would return `cooldown` for the next 12 hours — stalling
+     * inference at exactly the moment the leg recovered.
+     */
+    const seed = await seedTeam();
+    await withModel(seed.teamId);
+    await doc(seed);
+    await confirmedFailureStreak(seed);
+
+    // 1. the heal: a clean idle pass writes the clearing row
+    expect((await runDocTaskInference(db(), seed.teamId)).skipped).toBe("no-candidates");
+    expect(await isFailing(seed)).toBe(false);
+
+    // 2. work arrives immediately afterwards
+    await task(seed);
+
+    // 3. the next pass must NOT be gated. It gets as far as the model (stubbed absent here, so it
+    //    reaches a later gate) — the point is that it is not `cooldown`.
+    const after = await runDocTaskInference(db(), seed.teamId);
+    expect(after.skipped, "the clearing row must not start a paid cooldown").not.toBe("cooldown");
+  });
+
   it("AC7 — classification does not drift with age: 2 days and 60 days read the same", async () => {
     // BANNERFLAP-1 §3a rejected time-based escalation. A grace period here is the one fix already
     // known to be wrong, so the property is behavioural, not a source grep.

--- a/test/doc-task-infer-clearing-failclosed.test.ts
+++ b/test/doc-task-infer-clearing-failclosed.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DbClient } from "@/lib/db/types";
+
+// Past the `no-llm` gate on purpose: without this the pass returns `no-llm` (its OWN fail-closed
+// answer to an unreadable key store) and never reaches the read whose throw this test is about.
+vi.mock("@/lib/query/answering", () => ({
+  resolveAnsweringKeys: async () => ({ openaiKey: "sk-test", openaiModel: "gpt-4.1", activeProvider: null }),
+}));
+vi.mock("@/lib/dashboard/timeline-summary", () => ({ llmConfigured: () => true }));
+
+const { runDocTaskInference } = await import("@/lib/dashboard/doc-task-infer-run");
+
+/**
+ * BANNERSTUCK-1 / AC6 — a READ that throws must never become a clearing row.
+ *
+ * The clearing outcomes are defined as "read the eligible set successfully and found no work". A read
+ * that threw satisfies neither half, and mistaking one for the other is the sharpest way this feature
+ * could silence a real alarm: the leg would record `ok=true` on exactly the tick its data went
+ * unreadable. Unit tier because there is no fault injection against real Postgres, and because the
+ * property is orchestration shape — which branch runs — not persistence.
+ */
+
+/** A client whose every table read rejects, standing in for a DB-level fault mid-pass. */
+function throwingDb(): { db: DbClient; recorded: { ok: boolean; meta: Record<string, unknown> }[] } {
+  const recorded: { ok: boolean; meta: Record<string, unknown> }[] = [];
+  const reject = () => Promise.reject(new Error("read failed"));
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "in", "is", "not", "gte", "order", "limit", "maybeSingle", "single"]) {
+    chain[m] = () => chain;
+  }
+  (chain as { then: unknown }).then = (res: (v: unknown) => unknown, rej: (e: unknown) => unknown) =>
+    reject().then(res, rej);
+  const db = {
+    from: (table: string) => {
+      if (table === "ingest_runs") {
+        return {
+          ...chain,
+          // The pass's own recorder — capture what it writes rather than rejecting, so the assertion
+          // is about WHICH row was written, not about the write failing.
+          insert: (row: Record<string, unknown>) => {
+            recorded.push({ ok: row.ok as boolean, meta: (row.meta ?? {}) as Record<string, unknown> });
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      return chain;
+    },
+  } as unknown as DbClient;
+  return { db, recorded };
+}
+
+describe("AC6 — a thrown read never becomes a clearing row", () => {
+  it("records a FAILURE, and nothing carrying `health_clear`", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { db, recorded } = throwingDb();
+
+    const res = await runDocTaskInference(db, "11111111-1111-1111-1111-111111111111");
+
+    // Not a clean idle outcome: the pass could not read, so it must not name one.
+    expect(res.skipped).toBeUndefined();
+    const cleared = recorded.filter((r) => r.meta.health_clear === true);
+    expect(cleared, "a failed read must not be recorded as contrary evidence of health").toEqual([]);
+    expect(recorded.some((r) => r.ok === false), "the failure itself must still be recorded").toBe(true);
+    err.mockRestore();
+  });
+});

--- a/test/guards/bannerstuck-clearing-contract.test.ts
+++ b/test/guards/bannerstuck-clearing-contract.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { hasUnjudgeableDrop, scoreableDocs, type InferDoc } from "@/lib/dashboard/doc-task-infer";
+
+/**
+ * BANNERSTUCK-1 — the contract that lets a healed leg clear a CONFIRMED failure streak without ever
+ * being able to hide a live one. Spec: `docs/design/bannerstuck1-confirmed-failure-cannot-clear.md`.
+ *
+ * The incident: `doc_task_infer` carried a 4-long failure streak from an OpenRouter 402. The credit was
+ * restored 26h before the screenshot, the scheduler was ticking, and the banner still read "1 ingestion
+ * leg is broken". Nothing could clear it — the streak breaks only on a recorded success, and a leg with
+ * no work to do records nothing, so the failure stayed newest forever.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const HEALTH = readFileSync(join(ROOT, "lib", "ingest", "pipeline-health.ts"), "utf8");
+const RUN = readFileSync(join(ROOT, "lib", "dashboard", "doc-task-infer-run.ts"), "utf8");
+
+const doc = (over: Partial<InferDoc> = {}): InferDoc => ({
+  id: "d",
+  memberId: "m1",
+  ownerKind: "human",
+  title: "t",
+  contentSha: "sha",
+  access: "team",
+  hasDeterministicLink: false,
+  ...over,
+});
+
+describe("AC8 — the architecture comment no longer carries the claim that let this ship", () => {
+  it("does not assert that a persistent failure keeps re-recording", () => {
+    // The load-bearing falsehood: true only WHILE the failure persists. Once the cause healed and no
+    // work was demanded, nothing re-recorded and the stale failure was indistinguishable from a live one.
+    expect(HEALTH).not.toContain("a persistent failure keeps re-recording and stays the newest");
+  });
+
+  it("does not claim FIVE outcomes write no row — four of them now write the clearing row", () => {
+    expect(HEALTH).not.toContain("FIVE of its");
+  });
+
+  it("does not claim a healthy leg writes nothing for days UNCONDITIONALLY", () => {
+    // It still writes nothing for days — but only once its verdict is `ok`. The unqualified form is
+    // what made the stuck-failure case invisible.
+    const idx = HEALTH.indexOf("still writes nothing for days");
+    expect(idx, "the sentence should still exist, qualified").toBeGreaterThan(0);
+    expect(HEALTH.slice(idx, idx + 200)).toContain("once its verdict is `ok`");
+  });
+
+  it("names the mechanism that replaced it", () => {
+    expect(HEALTH).toContain("BANNERSTUCK-1");
+    expect(HEALTH).toContain("health_clear");
+  });
+});
+
+describe("AC5b — the clearing row is BACKDATED to the pass's own start", () => {
+  /**
+   * This is the whole correctness argument (spec §2b): `STREAK_SQL` orders `finished_at desc, id desc`,
+   * so a clearing row stamped at the pass's START sorts strictly OLDER than any failure recorded while
+   * the pass ran. A guard cannot achieve that — under READ COMMITTED an uncommitted concurrent failure
+   * is invisible to the guard's snapshot, so both rows land and the clearing row still wins.
+   */
+  it("passes `passStartedAt` as BOTH startedAt and finishedAt — never Date.now() at write time", () => {
+    const fn = RUN.slice(RUN.indexOf("export async function recordClearingRun"), RUN.indexOf("async function record("));
+    expect(fn).toContain("startedAt: passStartedAt");
+    expect(fn).toContain("finishedAt: passStartedAt");
+    expect(fn, "a Date.now() here empties the ordering window").not.toMatch(/finishedAt:\s*Date\.now\(\)/);
+  });
+
+  it("the call site hands it the pass's OWN startedAt", () => {
+    // `startedAt` is captured once at pass entry. Recomputing it at write time would collapse the
+    // backdating to "now" and silently restore the masking window.
+    expect(RUN).toContain("await recordClearingRun(db, teamId, startedAt, reason)");
+  });
+
+  it("clearing is gated on a STANDING failure, so the steady state writes nothing", () => {
+    // Not a throttle: writing only when the newest verdict is a failure is what keeps the paid-run
+    // cooldown untouched (a clearing row that became `lastRun` would defer real scoring by up to 12h).
+    expect(RUN).toContain("if (prior?.ok === false)");
+  });
+});
+
+describe("AC2c/AC2d — which drops mean 'nothing to do' and which mean 'could not judge'", () => {
+  it("a CONNECTOR-owned doc is a legitimate nothing-to-do", () => {
+    // Connectors are excluded from credit by design, so there is no human to reason about. Blocking
+    // this would make the leg never clear for a connector-fed team.
+    const docs = [doc({ memberId: null, ownerKind: "connector" })];
+    expect(scoreableDocs(docs)).toEqual([]);
+    expect(hasUnjudgeableDrop(docs)).toBe(false);
+  });
+
+  it("an UNRESOLVABLE owner means the pass judged nothing", () => {
+    const docs = [doc({ memberId: null, ownerKind: "unresolvable" })];
+    expect(hasUnjudgeableDrop(docs)).toBe(true);
+  });
+
+  it("deterministic-linked and external drops are legitimate", () => {
+    expect(hasUnjudgeableDrop([doc({ hasDeterministicLink: true })])).toBe(false);
+    expect(hasUnjudgeableDrop([doc({ access: "external" })])).toBe(false);
+  });
+
+  it("one unjudgeable doc among many legitimate ones still blocks clearing", () => {
+    // ∀, not ∃: the pass either observed the whole set or it did not.
+    expect(
+      hasUnjudgeableDrop([
+        doc({ id: "a", hasDeterministicLink: true }),
+        doc({ id: "b", memberId: null, ownerKind: "connector" }),
+        doc({ id: "c", memberId: null, ownerKind: "unresolvable" }),
+      ])
+    ).toBe(true);
+  });
+});
+
+describe("AC2e — a saturated scan has not observed the eligible set", () => {
+  it("all THREE JS-derived outcomes are gated on saturation, not just the first", () => {
+    // `:206`, `:237` and `:270` are filters over ONE bounded page, so each is a claim about the newest
+    // ITEM_SCAN rows only. An earlier draft gated only `:206`.
+    // Matcher written against the REAL shape: the `:237` site adds `&& !hasUnjudgeableDrop(docs)`,
+    // whose parentheses defeat a lazy `[^)]*`. A matcher that misses the site it is meant to pin is
+    // the failure this test exists to catch.
+    const gated = RUN.match(/if \(!scanSaturated(?: && [^)]*\([^)]*\))?\) await clearIfHealed\(/g) ?? [];
+    expect(gated.length, "expected nothing-to-score x2 and unchanged x1").toBe(3);
+    // …and every clearing call that is NOT `no-candidates` must be behind that gate.
+    const calls = RUN.match(/await clearIfHealed\("([a-z-]+)"\)/g) ?? [];
+    expect(calls.length).toBe(4);
+  });
+
+  it("saturation is measured on the raw page, before any JS filtering", () => {
+    expect(RUN).toContain("const scanSaturated = items.length >= ITEM_SCAN;");
+  });
+
+  it("`no-candidates` is NOT saturation-gated — an empty list is complete at any limit", () => {
+    const site = RUN.slice(RUN.indexOf('if (!tasks.length)'), RUN.indexOf('const scanSaturated'));
+    expect(site).toContain('await clearIfHealed("no-candidates")');
+    expect(site).not.toContain("scanSaturated");
+  });
+});
+
+describe("the gates that must NOT clear", () => {
+  it("neither `cooldown` nor `no-llm` reaches the clearing writer", () => {
+    // `cooldown` never ran; `no-llm` is unconfigured — a different state with its own signal. Both sit
+    // ABOVE the clearing outcomes, so a write wired one early-return too high would silence the alarm
+    // on a leg that did nothing at all.
+    const head = RUN.slice(RUN.indexOf("const prior = await lastRun"), RUN.indexOf('if (!tasks.length)'));
+    expect(head).not.toContain("clearIfHealed(");
+  });
+});

--- a/test/guards/bannerstuck-clearing-contract.test.ts
+++ b/test/guards/bannerstuck-clearing-contract.test.ts
@@ -99,6 +99,19 @@ describe("AC2c/AC2d — which drops mean 'nothing to do' and which mean 'could n
     expect(hasUnjudgeableDrop([doc({ access: "external" })])).toBe(false);
   });
 
+  it("…even when their owner ALSO fails to resolve — the drop reason takes precedence", () => {
+    // The earlier fixture left `memberId` at its human default, so neither doc could reach the
+    // owner predicate at all and the test passed without exercising it. A doc that is external (or
+    // already linked) is legitimately dropped for THAT reason; letting a broken owner override it
+    // would block clearing on a doc the pass was never going to score.
+    expect(hasUnjudgeableDrop([doc({ access: "external", memberId: null, ownerKind: "unresolvable" })])).toBe(false);
+    expect(
+      hasUnjudgeableDrop([doc({ hasDeterministicLink: true, memberId: null, ownerKind: "unresolvable" })])
+    ).toBe(false);
+    // …and a doc that WOULD have been scored still blocks.
+    expect(hasUnjudgeableDrop([doc({ memberId: null, ownerKind: "unresolvable" })])).toBe(true);
+  });
+
   it("one unjudgeable doc among many legitimate ones still blocks clearing", () => {
     // ∀, not ∃: the pass either observed the whole set or it did not.
     expect(

--- a/test/guards/bannerstuck-clearing-contract.test.ts
+++ b/test/guards/bannerstuck-clearing-contract.test.ts
@@ -32,7 +32,14 @@ describe("AC8 — the architecture comment no longer carries the claim that let 
   it("does not assert that a persistent failure keeps re-recording", () => {
     // The load-bearing falsehood: true only WHILE the failure persists. Once the cause healed and no
     // work was demanded, nothing re-recorded and the stale failure was indistinguishable from a live one.
-    expect(HEALTH).not.toContain("a persistent failure keeps re-recording and stays the newest");
+    //
+    // Matched over a WHITESPACE-NORMALISED, comment-marker-stripped source. The first version was a
+    // raw `toContain` on the file, which the sentence escaped only because a line wrap fell between
+    // two of its words — the guard's property held by lineation luck, and a reflow would have
+    // reddened it for no reason. (The old sentence is also no longer quoted verbatim above, so this
+    // now asserts absence rather than a formatting accident.)
+    const flat = HEALTH.replace(/^\s*(\/\/|\*)\s?/gm, " ").replace(/\s+/g, " ");
+    expect(flat).not.toContain("a persistent failure keeps re-recording and stays the newest row");
   });
 
   it("does not claim FIVE outcomes write no row — four of them now write the clearing row", () => {


### PR DESCRIPTION
## The banner that could not clear itself

You reported errors still at the top of Pulse. They were real, but they had stopped being true **26 hours earlier**.

`doc_task_infer` carried a **4-long confirmed failure streak** from the OpenRouter 402s. Measured on prod: the last `http_402` anywhere was `2026-08-26 13:12`, `timeline-summary` had 22 successes in the following 6h, and the scheduler was ticking within the minute. The cause was gone. **Nothing could clear the banner** — the streak breaks only on a recorded success, and five of that leg's outcomes return before `record()`, so a healthy leg with nothing to do writes nothing and the failure stays newest forever. Staleness can't rescue it either: `doc_task_infer` is deliberately `null` there, because no finite age is correct for a record-only-when-active leg.

The code even said so, and the sentence was the bug:

> *"since the cooldown counts failed runs too, a persistent failure keeps re-recording and stays the newest row"*

True only **while the failure persists**.

## The fix

A clean-and-idle pass records a **backdated** `ok=true` row (`meta.health_clear`) — and only when a failure is actually standing.

**Backdating is the correctness argument, not a detail.** Two callers reach this leg (`scheduler.ts:91`, `timeline-cache.ts:116`) and are not mutually single-flighted, so a clearing pass can overlap a failing one. `STREAK_SQL` orders `finished_at desc, id desc`, so stamping the row at the pass's **start** makes any row written during the pass strictly newer — a concurrent failure cannot be hidden, whatever the commit order. A guard cannot do this: under `READ COMMITTED` the `NOT EXISTS` subquery can't see an uncommitted failure, so both rows land and the clearing row still wins.

**Which outcomes clear is derived, not labelled.** `no-candidates` always; `nothing-to-score` (both sites) and `unchanged` only when the item scan **did not saturate**, because all three are JS filters over one bounded 500-row page and item 501 can be unscored work. Never `cooldown` (never ran) or `no-llm` (unconfigured). At the second site an **unresolvable owner** blocks clearing, while connector-owned, deterministic-linked and external do not.

**In-repo precedent:** `scheduler.ts:57` describes this exact defect for `pret3_sweep` — *"the loud banner latches red permanently … which no staleness threshold can undo"* — and fixes it with the same clearing row. This applies an existing remedy to the leg that still needed it.

## Verification

| tier | result |
|---|---|
| unit | **3,657 passed**, 15 skipped |
| data-mechanics (real Postgres) | **14/14** |
| `tsc` · `lint` · `check:docs` | clean (0 errors; 18 pre-existing warnings, none in this diff) |
| `aios spec eval` | `SPEC_READY`, exit 0 |
| mutations | **17 rows, every one with a status** — 13 run and reddening their named criterion, 4 NOT RUN with reasons |

Includes a **positive control**: without backdating, the same interleaving genuinely *does* mask the failure. The mechanism is demonstrated, not asserted.

## Review — Reviewed by Fable code-reviewer and Codex gpt-5.6-sol — verdict Codex BLOCKED ×4 then folded, Fable CLEAR-WITH-CONDITIONS (HIGH folded); the cooldown blocker was found independently by both

**Eight model rounds — three spec rounds each, then a diff round each.** Codex returned BLOCKED four times. What they caught:

- **The cooldown blocker (both, independently).** I claimed that writing only when a failure stands means the cooldown is never touched. The steady state was never the issue: the clearing row is written *at the moment the leg heals*, with a near-current timestamp, so a doc arriving a minute later waited a full 12h — stalling inference exactly at recovery. `AC3` couldn't see it (it seeds an already-old success); `AC3b` now does, behaviourally.
- **`ownerKinds` had no test at any tier** (Fable, HIGH). New DB code — and if its query is wrong, every owner reads `unresolvable` and a connector-fed team's banner **never clears**: the original incident, recreated by the fix, with every test green. Two dm cases now run it; mutating the query to yield nothing reddens `AC2d` and only `AC2d`.
- **My `:237` rule was wrong in both directions across drafts** — first too narrow (a state that cannot occur: a human-owned doc can't come back unattributable, because the scan excludes null owners and a real oracle failure *throws*), then too broad (blocking clearing for connector-fed teams). Both reviewers derived the first independently.
- **`hasUnjudgeableDrop` counted a doc that was *also* external or already linked** — drops the spec calls legitimate. The guard fixture left `memberId` at its human default, so it could never reach the predicate.
- **The AC8 guard passed by line-wrap luck** — the forbidden sentence was still present verbatim and escaped `not.toContain` only because a line break fell between two words.

**Things I got wrong that the loop caught, listed because the pattern matters more than the fix:** my own test proved my spec self-contradictory (AC5 demanded a state `FAILURES_TO_CONFIRM` forbids); **three fixtures were silently empty** — a 500-row insert failing a NOT-NULL column, null-owner filler the SQL excluded, and `getPipelineHealth(db(), teamId)` when it takes one argument, which made it throw, swallow, and return *no legs at all*; a re-measurement dated to a day I hadn't reached.

**Two process failures, recorded in the spec rather than smoothed over:** a mutation run pointed at database `app` instead of `app_test`, where the suite was already red — so every mutation reported `REDDENED` while proving nothing. And a hand-rolled mutation loop ran `git checkout --` over uncommitted work and destroyed the cooldown fix; that is precisely what `scripts/mutate.mjs` refuses to allow, and every mutation since ran from a committed checkpoint.

## Deferred, with reasons

- **Mutation 8 survived** the behavioural suite (the `:270` saturation gate) and is covered only by the guard's ∀-over-sites assertion. Round 4 called the fixture "not reasonably constructible"; the review showed that's false. It's a **coverage gap, recorded as one**.
- **`linear_inbound` is a confirmed twin** of this defect (`scheduler.ts:159-160`); `dense` has a narrower version. Not fixed here.
- **A team that removes its keys stays loud forever** (`no-llm` never clears) — the likely next BANNERSTUCK.
- The clearing row hardcodes `trigger: "scheduler"` even from a page view — pre-existing, harmless while this leg's staleness is `null`.

⚠️ **This will not clear your banner on its own.** It ships the mechanism; `doc_task_infer` must then run once and find nothing to do — up to one cooldown after deploy.

AIOS-Work: BANNERSTUCK-1
