### PR TITLE
fix(scan): honor fixed-window rate-limit retries

### DIFF
--- a/app/api/v1/codebases/route.ts
+++ b/app/api/v1/codebases/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { adminClient } from "@/lib/db/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
-import { rateLimit } from "@/lib/api/rate-limit";
+import { rateLimitWithReset } from "@/lib/api/rate-limit";
 import { codebaseScanPayloadSchema, errorResponse } from "@/lib/api/schemas";
 import { ingestCodebaseScan } from "@/lib/codebases/ingest";
 import { recordIngestRun, type IngestTrigger } from "@/lib/ingest/runs";
@@ -23,8 +23,11 @@ export async function POST(req: NextRequest) {
   }
 
   const db = adminClient();
-  if (!(await rateLimit(db, `${auth.apiKeyId}:codebases:post`, 60))) {
-    return errorResponse("rate_limited", "60 scans/min per key", 429);
+  const rateLimitDecision = await rateLimitWithReset(db, `${auth.apiKeyId}:codebases:post`, 60);
+  if (!rateLimitDecision.allowed) {
+    const response = errorResponse("rate_limited", "60 scans/min per key", 429);
+    response.headers.set("Retry-After", String(rateLimitDecision.retryAfterSeconds));
+    return response;
   }
 
   const len = parseInt(req.headers.get("content-length") || "0", 10);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -529,6 +529,16 @@ flowchart LR
   ST[("sqlite: cursors + watch channels")] -.-> T2
 ```
 
+The codebase-scan path has an exact fixed-window retry handshake. When
+`POST /api/v1/codebases` exhausts its authenticated team-tier bucket
+(`apiKeyId:codebases:post`, 60/min), the 429 carries a decimal-integer `Retry-After` from the
+same clock sample used to select that minute window: 60 at its start and 1 just before reset.
+`BrainClient.push_codebase_scan` makes at most six attempts (the initial call plus five retries),
+uses valid server delta-seconds within that 1–60-second contract, and otherwise waits
+2 + 4 + 8 + 16 + 32 seconds before the final attempt. Jitter is additive and bounded to one second
+per wait, so it cannot erode the fallback's 62-second floor; the terminal response keeps its actual
+429/5xx error class and is never followed by another sleep.
+
 ### PM progression loop — merged work → done in the primary PM tool (Linear)
 
 ```mermaid

--- a/ingestion/aios_ingest/brain_client.py
+++ b/ingestion/aios_ingest/brain_client.py
@@ -8,10 +8,12 @@ backing off on 429. It is the only thing in the sidecar that talks to the brain.
 from __future__ import annotations
 
 import asyncio
+import math
 import os
+import random
 import time
 from dataclasses import dataclass
-from typing import Literal
+from typing import Awaitable, Callable, Literal
 
 import httpx
 
@@ -22,6 +24,7 @@ IngestStatus = Literal["created", "updated", "unchanged"]
 # Brain limit is 120/min/key; stay safely under it. Tokens refill continuously.
 _DEFAULT_MAX_PER_MIN = 100
 _MAX_RETRIES = 5
+_SCAN_RATE_LIMIT_WINDOW_SECONDS = 60
 # A codebase scan push is the heaviest single request: the brain projects every recent commit into
 # searchable items (with embeddings) synchronously before responding, which can far exceed the 30s
 # default. The scan runs in CI (latency-insensitive) and the endpoint is idempotent, so we give this
@@ -82,6 +85,8 @@ class BrainClient:
         *,
         max_per_min: int = _DEFAULT_MAX_PER_MIN,
         timeout: float = 30.0,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        random_fn: Callable[[], float] = random.random,
     ):
         if not api_key.startswith("aios_"):
             raise ValueError("api_key must look like aios_<key_id>_<secret>")
@@ -93,6 +98,8 @@ class BrainClient:
         }
         self._limiter = _RateLimiter(max_per_min)
         self._client = httpx.AsyncClient(timeout=timeout)
+        self._sleep = sleep
+        self._random = random_fn
 
     async def __aenter__(self) -> "BrainClient":
         return self
@@ -140,20 +147,38 @@ class BrainClient:
 
     async def push_codebase_scan(self, payload: dict) -> dict:
         """POST one codebase scan (RAW metrics) to /api/v1/codebases. The brain computes
-        scores, audits, and upserts idempotently. Same retry policy as push(); a longer
+        scores, audits, and upserts idempotently. Uses the codebase-specific six-attempt
+        fixed-window retry policy and a longer
         read timeout (_SCAN_TIMEOUT) because the server projects commits→items synchronously."""
         url = f"{self._base}/api/v1/codebases"
-        for attempt in range(_MAX_RETRIES):
+        for attempt in range(_MAX_RETRIES + 1):
             await self._limiter.acquire()
             resp = await self._client.post(url, json=payload, headers=self._headers, timeout=_SCAN_TIMEOUT)
             if resp.status_code in (200, 201):
                 return resp.json()
             if resp.status_code == 429 or resp.status_code >= 500:
-                backoff = _retry_after(resp) or min(2**attempt, 30)
-                await asyncio.sleep(backoff)
+                if attempt == _MAX_RETRIES:
+                    raise BrainError(resp.status_code, *_error_fields(resp))
+                server_delay = _retry_after_delta_seconds(resp) if resp.status_code == 429 else None
+                backoff = server_delay or min(2 ** (attempt + 1), 32)
+                await self._sleep(backoff + _bounded_jitter(self._random()))
                 continue
             raise BrainError(resp.status_code, *_error_fields(resp))
-        raise BrainError(429, "rate_limited", f"gave up after {_MAX_RETRIES} retries")
+        raise AssertionError("unreachable retry loop")
+
+
+def _retry_after_delta_seconds(resp: httpx.Response) -> int | None:
+    raw = resp.headers.get("retry-after")
+    if not raw or not raw.isascii() or not raw.isdecimal():
+        return None
+    seconds = int(raw)
+    return seconds if 1 <= seconds <= _SCAN_RATE_LIMIT_WINDOW_SECONDS else None
+
+
+def _bounded_jitter(value: float) -> float:
+    if not math.isfinite(value):
+        return 0.0
+    return min(1.0, max(0.0, value))
 
 
 def _retry_after(resp: httpx.Response) -> float | None:

--- a/ingestion/tests/test_brain_client.py
+++ b/ingestion/tests/test_brain_client.py
@@ -101,3 +101,161 @@ async def test_fetch_integration_selections_raises_on_definitive_4xx():
         with pytest.raises(BrainError) as ei:
             await c.fetch_integration_selections()
     assert ei.value.status_code == 403
+
+
+def _scan_client(
+    transport: httpx.MockTransport,
+    sleeps: list[float],
+    *,
+    random_value: float = 0.0,
+) -> BrainClient:
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    c = BrainClient(
+        "http://brain",
+        "aios_abc_def",
+        "demo",
+        max_per_min=10_000,
+        sleep=sleep,
+        random_fn=lambda: random_value,
+    )
+    c._client = httpx.AsyncClient(transport=transport)
+    return c
+
+
+async def test_codebase_scan_honors_valid_retry_after_then_succeeds():
+    calls = 0
+    sleeps: list[float] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                429,
+                headers={"retry-after": "17"},
+                json={"error": {"code": "rate_limited", "message": "wait"}},
+            )
+        return httpx.Response(201, json={"status": "ok"})
+
+    async with _scan_client(httpx.MockTransport(handler), sleeps, random_value=0.25) as c:
+        result = await c.push_codebase_scan({"scan": "payload"})
+
+    assert result == {"status": "ok"}
+    assert calls == 2
+    assert sleeps == [17.25]
+
+
+@pytest.mark.parametrize(
+    "retry_after",
+    [None, "", "garbage", "-1", "0", "1.5", "NaN", "61", "600000"],
+)
+async def test_codebase_scan_invalid_or_missing_retry_after_uses_conservative_fallback(retry_after):
+    calls = 0
+    sleeps: list[float] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls <= 5:
+            headers = {} if retry_after is None else {"retry-after": retry_after}
+            return httpx.Response(
+                429,
+                headers=headers,
+                json={"error": {"code": "rate_limited", "message": "wait"}},
+            )
+        return httpx.Response(201, json={"status": "ok"})
+
+    async with _scan_client(httpx.MockTransport(handler), sleeps) as c:
+        result = await c.push_codebase_scan({"scan": "payload"})
+
+    assert result == {"status": "ok"}
+    assert calls == 6
+    assert sleeps == [2, 4, 8, 16, 32]
+    assert sum(sleeps) > 60
+
+
+async def test_codebase_scan_adds_at_most_one_second_of_jitter_per_wait():
+    calls = 0
+    sleeps: list[float] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls <= 2:
+            return httpx.Response(429, json={"error": {"code": "rate_limited", "message": "wait"}})
+        return httpx.Response(201, json={"status": "ok"})
+
+    async with _scan_client(httpx.MockTransport(handler), sleeps, random_value=1.0) as c:
+        await c.push_codebase_scan({"scan": "payload"})
+
+    assert sleeps == [3, 5]
+
+
+async def test_codebase_scan_persistent_429_caps_at_six_attempts_without_terminal_sleep():
+    calls = 0
+    sleeps: list[float] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            429,
+            headers={"retry-after": "7"},
+            json={"error": {"code": "rate_limited", "message": "still limited"}},
+        )
+
+    async with _scan_client(httpx.MockTransport(handler), sleeps) as c:
+        with pytest.raises(BrainError) as exc:
+            await c.push_codebase_scan({"scan": "payload"})
+
+    assert calls == 6
+    assert sleeps == [7, 7, 7, 7, 7]
+    assert exc.value.status_code == 429
+    assert exc.value.code == "rate_limited"
+    assert "still limited" in str(exc.value)
+
+
+async def test_codebase_scan_terminal_5xx_keeps_actual_final_error_class():
+    calls = 0
+    sleeps: list[float] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            503,
+            json={"error": {"code": "upstream_unavailable", "message": "brain unavailable"}},
+        )
+
+    async with _scan_client(httpx.MockTransport(handler), sleeps) as c:
+        with pytest.raises(BrainError) as exc:
+            await c.push_codebase_scan({"scan": "payload"})
+
+    assert calls == 6
+    assert sleeps == [2, 4, 8, 16, 32]
+    assert exc.value.status_code == 503
+    assert exc.value.code == "upstream_unavailable"
+
+
+async def test_codebase_scan_non_429_4xx_is_immediate_and_never_sleeps():
+    calls = 0
+    sleeps: list[float] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            422,
+            json={"error": {"code": "invalid_payload", "message": "bad scan"}},
+        )
+
+    async with _scan_client(httpx.MockTransport(handler), sleeps) as c:
+        with pytest.raises(BrainError) as exc:
+            await c.push_codebase_scan({"scan": "payload"})
+
+    assert calls == 1
+    assert sleeps == []
+    assert exc.value.status_code == 422
+    assert exc.value.code == "invalid_payload"

--- a/lib/api/rate-limit.ts
+++ b/lib/api/rate-limit.ts
@@ -3,7 +3,8 @@ import type { DbClient } from "@/lib/db/types";
 
 /**
  * Postgres fixed-window rate limiting (no Vercel KV — self-host portable).
- * Window = 1 minute. Returns true if the call is allowed.
+ * Window = 1 minute. Existing callers receive a boolean; callers that need to tell a client when
+ * the same fixed window resets can use rateLimitWithReset().
  */
 
 // In-process fixed-window fallback used ONLY when the DB rate-limit RPC errors (audit M3). Previously
@@ -31,12 +32,33 @@ export async function rateLimit(
   bucket: string,
   limitPerMinute: number
 ): Promise<boolean> {
-  const windowStart = new Date();
+  return (await rateLimitWithReset(db, bucket, limitPerMinute)).allowed;
+}
+
+export type RateLimitDecision = {
+  allowed: boolean;
+  retryAfterSeconds: number;
+};
+
+export async function rateLimitWithReset(
+  db: DbClient,
+  bucket: string,
+  limitPerMinute: number,
+  now = new Date(),
+): Promise<RateLimitDecision> {
+  const windowStart = new Date(now);
   windowStart.setSeconds(0, 0);
   const { data, error } = await db.rpc("rate_limit_hit", {
     p_bucket: bucket,
     p_window_start: windowStart.toISOString(),
   });
-  if (error) return fallbackAllow(bucket, limitPerMinute, windowStart.getTime()); // degrade, don't open
-  return (data as number) <= limitPerMinute;
+  const allowed = error
+    ? fallbackAllow(bucket, limitPerMinute, windowStart.getTime()) // degrade, don't open
+    : (data as number) <= limitPerMinute;
+  const resetAtMs = windowStart.getTime() + 60_000;
+  const retryAfterSeconds = Math.min(
+    60,
+    Math.max(1, Math.ceil((resetAtMs - now.getTime()) / 1_000)),
+  );
+  return { allowed, retryAfterSeconds };
 }

--- a/test/codebases-rate-limit.test.ts
+++ b/test/codebases-rate-limit.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const h = vi.hoisted(() => ({
+  auth: null as null | {
+    teamId: string;
+    memberId: string;
+    apiKeyId: string;
+    memberTier: "team" | "external";
+  },
+  rateLimitWithReset: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db/admin", () => ({ adminClient: () => ({}) }));
+vi.mock("@/lib/api/auth", () => ({ authenticateApiKey: async () => h.auth }));
+vi.mock("@/lib/api/rate-limit", () => ({ rateLimitWithReset: h.rateLimitWithReset }));
+vi.mock("@/lib/codebases/ingest", () => ({ ingestCodebaseScan: vi.fn() }));
+vi.mock("@/lib/ingest/runs", () => ({ recordIngestRun: vi.fn() }));
+
+const { POST } = await import("@/app/api/v1/codebases/route");
+
+function request(): NextRequest {
+  return new Request("https://brain.example.com/api/v1/codebases", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer aios_key-1_secret",
+      "Content-Type": "application/json",
+    },
+    body: "{}",
+  }) as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  h.auth = {
+    teamId: "team-1",
+    memberId: "member-1",
+    apiKeyId: "key-1",
+    memberTier: "team",
+  };
+  h.rateLimitWithReset.mockReset().mockResolvedValue({
+    allowed: false,
+    retryAfterSeconds: 60,
+  });
+});
+
+describe("POST /api/v1/codebases rate-limit response", () => {
+  it.each([60, 1])("returns a decimal-integer Retry-After boundary of %i", async (seconds) => {
+    h.rateLimitWithReset.mockResolvedValue({ allowed: false, retryAfterSeconds: seconds });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe(String(seconds));
+    expect(response.headers.get("Retry-After")).toMatch(/^[1-9][0-9]*$/);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "rate_limited" } });
+    expect(h.rateLimitWithReset).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      "key-1:codebases:post",
+      60,
+    );
+  });
+
+  it("does not rate-limit or disclose reset guidance before authentication", async () => {
+    h.auth = null;
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(401);
+    expect(response.headers.has("Retry-After")).toBe(false);
+    expect(h.rateLimitWithReset).not.toHaveBeenCalled();
+  });
+
+  it("preserves the team-tier wall before rate limiting", async () => {
+    h.auth = { ...h.auth!, memberTier: "external" };
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(403);
+    expect(response.headers.has("Retry-After")).toBe(false);
+    expect(h.rateLimitWithReset).not.toHaveBeenCalled();
+  });
+});

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { rateLimit } from "@/lib/api/rate-limit";
+import { rateLimit, rateLimitWithReset } from "@/lib/api/rate-limit";
 import type { DbClient } from "@/lib/db/types";
 
 /**
@@ -33,5 +33,47 @@ describe("rateLimit degraded mode (audit M3)", () => {
   it("allows normally when the DB is healthy and under the limit", async () => {
     const bucket = `test-healthy-${Math.random().toString(36).slice(2)}`;
     expect(await rateLimit(healthyDb, bucket, 60)).toBe(true);
+  });
+});
+
+describe("fixed-window reset guidance", () => {
+  it.each([
+    ["2026-08-31T12:34:00.000Z", 60],
+    ["2026-08-31T12:34:59.999Z", 1],
+  ])("returns an integer boundary for %s", async (nowIso, expectedSeconds) => {
+    const result = await rateLimitWithReset(
+      healthyDb,
+      `test-reset-${nowIso}`,
+      0,
+      new Date(nowIso),
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterSeconds).toBe(expectedSeconds);
+    expect(Number.isInteger(result.retryAfterSeconds)).toBe(true);
+    expect(result.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+    expect(result.retryAfterSeconds).toBeLessThanOrEqual(60);
+  });
+
+  it("uses the same sampled window start for the database decision and reset", async () => {
+    const calls: Array<{ p_bucket: string; p_window_start: string }> = [];
+    const db = {
+      rpc: async (_name: string, args: { p_bucket: string; p_window_start: string }) => {
+        calls.push(args);
+        return { data: 61, error: null };
+      },
+    } as unknown as DbClient;
+
+    const result = await rateLimitWithReset(
+      db,
+      "key-1:codebases:post",
+      60,
+      new Date("2026-08-31T12:34:17.250Z"),
+    );
+
+    expect(calls).toEqual([
+      { p_bucket: "key-1:codebases:post", p_window_start: "2026-08-31T12:34:00.000Z" },
+    ]);
+    expect(result).toEqual({ allowed: false, retryAfterSeconds: 43 });
   });
 });


### PR DESCRIPTION
## What

Implements the producer half of AIO-992's already-pinned fixed-window rate-limit contract.

- Sends a decimal-integer `Retry-After` (1–60 seconds) on the existing authenticated,
  team-tier-only `POST /api/v1/codebases` 429 response, derived from the same fixed-window clock
  sample used for the database bucket.
- Keeps the existing boolean rate-limit surface for all other callers.
- Makes the sidecar scan client honor valid server guidance; missing, malformed, zero, negative,
  fractional, or out-of-window guidance falls back to 2+4+8+16+32 seconds plus bounded additive
  jitter. It caps at six attempts and preserves terminal 429/5xx classification.

## Scope and exclusions

No database/schema change, API-version bump, auth/tier/bucket weakening, live-endpoint oracle,
credential change, or unrelated contract repair. Workspace's immutable scanner pin is intentionally
the follow-on consumer PR after this producer deploy verifies.

## Verification

- `npm test` — 3,684 passed, 15 skipped (376 passed, 1 skipped files)
- `npm run lint` — pass; 18 existing untouched-file warnings
- `npm run typecheck` — pass
- `npm run check:docs` — 64 routes, 85 tables, 8 sources congruent
- `cd ingestion && uv run pytest -q` — 147 passed, 14 skipped
- Read-only pinned-contract conformance:
  `brain-api-conformance-aio-992-team-brain-final-d8d3c0b3.md`

## Review — Reviewed by OpenCode (opencode/deepseek-v4-pro) — verdict no Critical/High; exact head `d8d3c0b31cbab197e39b43d28fc3c64cdb167503`

The final exact-head review found three Low, non-blocking items: the lack of a live cross-language
test (deterministic boundaries are covered), negligible decision calculation for boolean callers,
and the intentional documented 5xx fallback horizon. Round 1's stale docstring finding was fixed
and re-reviewed; round artifacts are retained at the hub root.

AIOS-Work: AIO-992

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to scan ingest throttling and client backoff; auth/tier ordering is preserved and boolean rate limiting behavior for other routes is unchanged.
> 
> **Overview**
> Implements the **producer–consumer contract** for codebase scan rate limits (AIO-992): when `POST /api/v1/codebases` returns 429, the response now includes a **decimal-integer `Retry-After` (1–60s)** tied to the same one-minute fixed window used for the `apiKeyId:codebases:post` bucket.
> 
> `rateLimitWithReset()` extends the Postgres fixed-window limiter with reset guidance; existing **`rateLimit()` callers keep a boolean** and delegate internally. Auth and team-tier checks still run **before** rate limiting, so unauthenticated or external-tier requests do not get `Retry-After`.
> 
> The ingestion **`BrainClient.push_codebase_scan`** path is updated separately from generic `push()`: up to **six attempts**, waits on valid `Retry-After` for 429s, otherwise uses **2+4+8+16+32s** plus at most **1s jitter**, and surfaces the **terminal 429/5xx** without an extra sleep. Architecture docs and Vitest/Pytest cover boundaries and invalid header handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d3c0b31cbab197e39b43d28fc3c64cdb167503. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->