### PR TITLE
docs(codebases): name the debt page's population scanner-admitted, not all defects (AIO-1094)

### DIFF
--- a/components/codebases/debt-dashboard.tsx
+++ b/components/codebases/debt-dashboard.tsx
@@ -138,14 +138,19 @@ export function DebtMovement({ debt }: { debt: CodebaseDebtKpis }) {
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-tertiary">
-            Debt movement
+            Scanner-admitted debt
           </p>
           <h2
             id="debt-movement-heading"
             className="mt-1 font-display text-xl text-ink text-balance"
           >
-            Is the codebase paying debt down?
+            What has the deterministic health scanner admitted?
           </h2>
+          <p className="mt-2 max-w-3xl text-xs leading-5 text-ink-tertiary">
+            Every row below is a scanner-admitted finding — only what the
+            configured deterministic health scanner admitted into the ledger —
+            and is not a count of all defects in this codebase.
+          </p>
         </div>
         <p className="text-xs text-ink-tertiary">
           Stock as of {new Date(movement.asOf).toLocaleDateString()} · flow in
@@ -157,7 +162,7 @@ export function DebtMovement({ debt }: { debt: CodebaseDebtKpis }) {
         <div className="border-b border-border-subtle pb-5 lg:border-r lg:border-b-0 lg:pr-5 lg:pb-0">
           <dl className="grid grid-cols-2 gap-x-5">
             <Metric
-              label="Actionable"
+              label="Active scanner findings"
               value={movement.actionable}
               detail={`${movement.actionableOpen} open · ${movement.actionableReopened} reopened`}
               tone="arrival"
@@ -218,7 +223,7 @@ export function DebtMovement({ debt }: { debt: CodebaseDebtKpis }) {
             Open age
           </h3>
           <Distribution
-            label="Actionable findings by open-age bucket"
+            label="Active scanner findings by open-age bucket"
             rows={openAgeRows}
             total={movement.actionable}
             colorClass="bg-amber-500"
@@ -229,7 +234,7 @@ export function DebtMovement({ debt }: { debt: CodebaseDebtKpis }) {
             Current severity
           </h3>
           <Distribution
-            label="Actionable findings by current severity"
+            label="Active scanner findings by current severity"
             rows={severityRows}
             total={movement.actionable}
             colorClass="bg-red-500"
@@ -239,6 +244,13 @@ export function DebtMovement({ debt }: { debt: CodebaseDebtKpis }) {
             event-time snapshots.
           </p>
         </div>
+      </div>
+
+      <div className="mt-5">
+        <EvidenceGap
+          label="UltraHarden intake"
+          reason="candidate intake is not connected yet, so candidates that were rejected, deduplicated, or never filed do not appear here"
+        />
       </div>
     </section>
   );

--- a/components/codebases/debt-dashboard.tsx
+++ b/components/codebases/debt-dashboard.tsx
@@ -147,9 +147,10 @@ export function DebtMovement({ debt }: { debt: CodebaseDebtKpis }) {
             What has the deterministic health scanner admitted?
           </h2>
           <p className="mt-2 max-w-3xl text-xs leading-5 text-ink-tertiary">
-            Every row below is a scanner-admitted finding — only what the
-            configured deterministic health scanner admitted into the ledger —
-            and is not a count of all defects in this codebase.
+            This section is derived only from scanner-admitted findings and
+            their lifecycle events — what the configured deterministic health
+            scanner admitted into the ledger — and is not a count of all
+            defects in this codebase.
           </p>
         </div>
         <p className="text-xs text-ink-tertiary">

--- a/components/codebases/debt-patrol.tsx
+++ b/components/codebases/debt-patrol.tsx
@@ -169,8 +169,9 @@ export function DebtPatrol({
           ))}
         </dl>
         <p className="mt-2 text-xs text-ink-tertiary">
-          Recurring counts a repeated scanner observation of the same
-          fingerprint, not two distinct underlying defects.
+          Recurring counts active ranked findings whose fingerprint the
+          scanner observed more than once — not repeated observations, and not
+          distinct underlying defects.
         </p>
       </div>
 

--- a/components/codebases/debt-patrol.tsx
+++ b/components/codebases/debt-patrol.tsx
@@ -154,7 +154,7 @@ export function DebtPatrol({
             ["Recurring", patrol.rollups.recurring],
             ["Suppressed", patrol.rollups.suppressed],
             [
-              "Score coverage",
+              "Ranking evidence coverage",
               patrol.rollups.admission.meanCoveragePct == null
                 ? "n/a"
                 : `${patrol.rollups.admission.meanCoveragePct}%`,
@@ -168,6 +168,10 @@ export function DebtPatrol({
             </div>
           ))}
         </dl>
+        <p className="mt-2 text-xs text-ink-tertiary">
+          Recurring counts a repeated scanner observation of the same
+          fingerprint, not two distinct underlying defects.
+        </p>
       </div>
 
       {patrol.ranked.length === 0 ? (
@@ -243,7 +247,7 @@ export function DebtPatrol({
                   </div>
 
                   <p className="mt-2 font-mono text-[10px] text-ink-tertiary">
-                    fingerprint {finding.fingerprint} · score admission{" "}
+                    fingerprint {finding.fingerprint} · ranking evidence{" "}
                     {ranking.scoreCoveragePct}%
                   </p>
                   <DecisionSummary finding={finding} />

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -812,12 +812,14 @@ current state plus append-only `codebase_finding_events`; it does not persist so
 symbols, diagnostic prose, or source text. `lib/metrics/codebases.getCodebaseDetail` is the only
 read path and builds the report-only patrol with `lib/codebases/debt-ranking`.
 
-The dashboard population is **scanner-admitted only**: every row is a finding the configured
-deterministic health scanner admitted into the ledger, not a count of all defects in the codebase.
+The dashboard population is **scanner-admitted only**: the section is derived from findings the
+configured deterministic health scanner admitted into the ledger and from their lifecycle events,
+not from a count of all defects in the codebase. Arrivals, closures, and net flow are event counts,
+so one finding can contribute several of them.
 UltraHarden candidate intake is not connected, so candidates that were rejected, deduplicated, or
 never filed do not appear; the UI states that as a named evidence gap rather than implying
-completeness. `Recurring` counts a repeated scanner observation of the same fingerprint
-(`occurrence_count > 1`), not two distinct underlying defects.
+completeness. `Recurring` counts active ranked findings whose fingerprint was observed more than once
+(`occurrence_count > 1`) — a finding observed ten times contributes 1, not 9.
 
 Ranking method v1 is deterministic. Principal (severity plus explicitly unknown reachability) is
 reported separately from interest (recurrence, age, repository change pressure, and explicitly

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -812,11 +812,19 @@ current state plus append-only `codebase_finding_events`; it does not persist so
 symbols, diagnostic prose, or source text. `lib/metrics/codebases.getCodebaseDetail` is the only
 read path and builds the report-only patrol with `lib/codebases/debt-ranking`.
 
+The dashboard population is **scanner-admitted only**: every row is a finding the configured
+deterministic health scanner admitted into the ledger, not a count of all defects in the codebase.
+UltraHarden candidate intake is not connected, so candidates that were rejected, deduplicated, or
+never filed do not appear; the UI states that as a named evidence gap rather than implying
+completeness. `Recurring` counts a repeated scanner observation of the same fingerprint
+(`occurrence_count > 1`), not two distinct underlying defects.
+
 Ranking method v1 is deterministic. Principal (severity plus explicitly unknown reachability) is
 reported separately from interest (recurrence, age, repository change pressure, and explicitly
 unknown agent friction). Evidence confidence and remediation affordability are disclosed as
-separate factors. The score normalizes over known factor weight and always publishes admission
-coverage; unknown reachability, friction, or review cost is never converted to a measured zero.
+separate factors. The score normalizes over known factor weight and always publishes **ranking
+evidence coverage** — the share of factor weight actually evidenced (surfaced per finding and as a
+mean rollup); unknown reachability, friction, or review cost is never converted to a measured zero.
 North Star rollups are labelled `proxy` or `unknown`. The independently verified efficacy/cost
 report stays in the engineering harness and is not redefined by this dashboard.
 

--- a/test/guards/debt-patrol-ui.test.ts
+++ b/test/guards/debt-patrol-ui.test.ts
@@ -74,7 +74,7 @@ describe("debt patrol accessibility guard", () => {
     expect(html).toContain("Ranking evidence coverage");
     expect(html).toContain("ranking evidence");
     expect(html).toContain(
-      "Recurring counts a repeated scanner observation of the same fingerprint",
+      "Recurring counts active ranked findings whose fingerprint the scanner observed more than once",
     );
     expect(html).not.toContain("Record operator decision");
     expect(html).not.toContain("Score coverage");
@@ -100,13 +100,27 @@ describe("debt patrol accessibility guard", () => {
     );
     expect(html).toContain("scanner-admitted");
     expect(html).toContain("not a count of all defects");
-    expect(html).toContain("Active scanner findings");
     expect(html).toContain("UltraHarden intake");
     expect(html).toContain(
       "candidate intake is not connected yet, so candidates that were rejected, deduplicated, or never filed do not appear here",
     );
+
+    // The three "Active scanner findings" sites are asserted SEPARATELY on purpose. A bare
+    // toContain("Active scanner findings") is satisfied by either aria-label alone, so the metric
+    // label could regress to "Actionable" — or a chart could lose its accessible name — while the
+    // guard stayed green. That is a test passing for the wrong reason, which is worse than no test:
+    // it certifies copy nobody checked.
+    expect(html).toContain(">Active scanner findings</dt>");
+    expect(html).toContain(
+      'aria-label="Active scanner findings by open-age bucket"',
+    );
+    expect(html).toContain(
+      'aria-label="Active scanner findings by current severity"',
+    );
+
     expect(html).not.toContain("Debt movement");
     expect(html).not.toContain("Is the codebase paying debt down?");
+    expect(html).not.toContain(">Actionable</dt>");
     expect(html).not.toContain("Actionable findings by");
   });
 

--- a/test/guards/debt-patrol-ui.test.ts
+++ b/test/guards/debt-patrol-ui.test.ts
@@ -3,7 +3,9 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { DebtPatrol } from "@/components/codebases/debt-patrol";
+import { DebtMovement } from "@/components/codebases/debt-dashboard";
 import { buildDebtPatrol } from "@/lib/codebases/debt-ranking";
+import { deriveCodebaseDebtKpis } from "@/lib/codebases/debt-kpis";
 import type { CodebaseFinding } from "@/lib/metrics/codebases";
 
 const finding: CodebaseFinding = {
@@ -69,7 +71,43 @@ describe("debt patrol accessibility guard", () => {
     expect(html).toContain("unknown");
     expect(html).toContain("North Star reconciliation and admission gaps");
     expect(html).toContain('<th scope="row"');
+    expect(html).toContain("Ranking evidence coverage");
+    expect(html).toContain("ranking evidence");
+    expect(html).toContain(
+      "Recurring counts a repeated scanner observation of the same fingerprint",
+    );
     expect(html).not.toContain("Record operator decision");
+    expect(html).not.toContain("Score coverage");
+    expect(html).not.toContain("score admission");
+  });
+
+  it("names the scanner-admitted population and the absent UltraHarden intake", () => {
+    const debt = deriveCodebaseDebtKpis({
+      findings: [finding],
+      commits: [],
+      rangeStart: "2026-07-01T00:00:00.000Z",
+      rangeEnd: "2026-08-04T12:00:00.000Z",
+      asOf: "2026-08-04T12:00:00.000Z",
+      commitsWindow: 30,
+      scannerWindowDays: 90,
+    });
+    const html = renderToStaticMarkup(DebtMovement({ debt }));
+
+    expect(html).toContain('aria-labelledby="debt-movement-heading"');
+    expect(html).toContain("Scanner-admitted debt");
+    expect(html).toContain(
+      "What has the deterministic health scanner admitted?",
+    );
+    expect(html).toContain("scanner-admitted");
+    expect(html).toContain("not a count of all defects");
+    expect(html).toContain("Active scanner findings");
+    expect(html).toContain("UltraHarden intake");
+    expect(html).toContain(
+      "candidate intake is not connected yet, so candidates that were rejected, deduplicated, or never filed do not appear here",
+    );
+    expect(html).not.toContain("Debt movement");
+    expect(html).not.toContain("Is the codebase paying debt down?");
+    expect(html).not.toContain("Actionable findings by");
   });
 
   it("keeps movement before patrol and evidence after it", () => {


### PR DESCRIPTION
## Summary

The Codebases debt page reported two deterministic health findings under the heading
"Is the codebase paying debt down?" with the metric labelled **Actionable**. The derivation was
correct; the population label was not. An operator could read that page and conclude a repository
this size has two defects. It doesn't — it has two findings the configured deterministic health
scanner admitted.

This is UH3-1 of AIO-1093, and it is copy-only. No API, schema, read-model, lifecycle, or ranking
change. Every number on the page is byte-for-byte unchanged.

### What changed

`components/codebases/debt-dashboard.tsx`
- `Debt movement` → `Scanner-admitted debt`
- `Is the codebase paying debt down?` → `What has the deterministic health scanner admitted?`
- `Actionable` → `Active scanner findings` (and the two matching aria-labels)
- New population sentence naming the rows scanner-admitted and "not a count of all defects"
- New `EvidenceGap` — `UltraHarden intake` — stating candidate intake is not connected yet, so
  candidates rejected, deduplicated, or never filed do not appear here

`components/codebases/debt-patrol.tsx`
- `Score coverage` → `Ranking evidence coverage`, and the per-finding `score admission n%` →
  `ranking evidence n%` so one concept has one name
- New footnote: recurring counts a repeated scanner observation of the same fingerprint, not two
  distinct underlying defects

`docs/ARCHITECTURE.md` — the Durable-debt patrol prose follows the new vocabulary.

`test/guards/debt-patrol-ui.test.ts` — a new `DebtMovement` render guard plus negative guards on the
retired strings. `test/codebase-debt-kpis.test.ts` and `test/codebase-debt-ranking.test.ts` are
**unmodified and still pass** — that is the proof the numbers did not move.

## Verification

RED on the frozen base `1633e438711a1d0af712cf30821943864e7e3235`, before the source edits:

```
× renders an accessible, explainable, report-only ranking without hiding unknowns
  AssertionError: expected '<section aria-labelledby="debt-patrol…' to contain 'Ranking evidence coverage'
× names the scanner-admitted population and the absent UltraHarden intake
  AssertionError: expected '<section aria-labelledby="debt-moveme…' to contain 'Scanner-admitted debt'
Tests  2 failed | 2 passed (4)
```

GREEN on the head, run serially:

```
npm test -- test/guards/debt-patrol-ui.test.ts test/codebase-debt-ranking.test.ts test/codebase-debt-kpis.test.ts
  Test Files  3 passed (3) · Tests  16 passed (16)
npm test                  → 375 passed | 1 skipped (376 files), 3678 passed | 15 skipped
npm run typecheck         → exit 0, no output
npm run lint              → exit 0, 18 pre-existing warnings, 0 in touched files
npm run check:docs        → routes 64 · tables 85 · sources 8 in sync ✓
```

Visual evidence — a local instance seeded through the real `POST /api/v1/codebases` ingest path with
two open findings (OGR04 observed 3x, OGR11 observed 2x), screenshotted before and after at 1440,
768, and 390. Every value identical across the pair: Active/Actionable `2` (`2 open · 0 reopened`),
Suppressed `0`, Arrivals `2`, Closures `0`, Net flow `+2`, open-age `0/2/0/0`, severity
`0/1/1/0`, patrol rollups `2 / 2 / 0 / 83%`, ranks `66.3 / 73.3 / 55` and `49.4 / 40 / 42.5`,
fix-age `4/9/21/26/24/12`, `96/120` blamed at `80%`, fix share `50%`, fix-on-fix `18.8%`.

`Ranking evidence coverage` wraps to three lines inside its rollup cell at 768px and renders `83%`
in full — verified by crop, no clipping, dividers intact. The 390px cramping is pre-existing and
identical in the before shot; this slice does not change it.

## Scope fence

UH3-2 through UH3-11 are not authorized by this PR: the configured-check census, the finding
intake contract and producers, the Team Brain intake ledger, the funnel UI, and the backfill all
stay where AIO-1093 put them. This PR does not compensate for the missing intake with guessed
totals — it names the gap and stops.

AIOS-Work: AIO-1094

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and documentation only on report UI; no API, schema, or KPI derivation changes.
> 
> **Overview**
> Reframes the codebase **debt** page so operators do not read ledger counts as “all defects in the repo.” **Debt movement** becomes **Scanner-admitted debt**, the headline asks what the deterministic health scanner admitted, and **Actionable** metrics/distribution labels become **Active scanner findings**, with explicit copy that rows are scanner-admitted only.
> 
> Adds an **UltraHarden intake** `EvidenceGap` on the movement section stating candidate intake is not connected (rejected/deduplicated/unfiled candidates are absent). On **debt patrol**, **Score coverage** / **score admission** wording is unified to **ranking evidence coverage** / **ranking evidence**, plus a footnote that **Recurring** is repeated observations of the same fingerprint.
> 
> `docs/ARCHITECTURE.md` matches the new vocabulary; guard tests assert the new strings and reject retired labels. **No metric or ranking logic changes** — numbers stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 348dae6b40f73487de7f2af1bcca9e5ec92b0006. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review — Reviewed by Codex CLI (gpt-5.6-sol, reasoning high) — verdict two adversarial rounds bound to the exact head; round one raised two blocking copy-accuracy defects and one weak-assertion test defect, all fixed and mutation-checked; round two found no remaining defects
