### PR TITLE
fix(ci): stop aios-work-sync exfiltrating brain secrets on an unmerged PR close

### DIFF
--- a/.github/workflows/aios-work-sync.yml
+++ b/.github/workflows/aios-work-sync.yml
@@ -1,70 +1,179 @@
 name: AIOS work sync
 
-# RELPTR-4 — BOTH the contribution base and the integration branch, deliberately, and landed BEFORE
-# the cutover rather than on the day. This fires on `pull_request` closed; today no pull request
-# targets `staging`, so adding it is near-inert — but the day contributions move, this workflow is
-# already right instead of being one more thing to remember while everything else is changing.
+# ─────────────────────────────────────────────────────────────────────────────────────────
+# ⛔ THIS RUNS `pull_request_target` AND MUST NEVER CHECK OUT, FETCH, BUILD, INSTALL, IMPORT
+#    OR EXECUTE ANYTHING FROM THE PULL REQUEST'S HEAD.
 #
-# THE ACCEPTED COST, stated rather than discovered: a MISTAKEN merge into `staging` (258 behind) now
-# emits a work event where before it emitted nothing. For a brain-native row in the pushed project
-# that resolves `applied`, i.e. it would complete a task and project it to Linear for work that is not
-# on trunk. Judged smaller than the risk of doing this on cutover day.
+# THE DEFECT THIS SHAPE REPLACES, and it was live in this file. The trigger was `pull_request`
+# with `types: [closed]`. On `pull_request` GitHub takes the WORKFLOW FILE ITSELF from the pull
+# request's head, and `actions/checkout`'s default ref is `refs/pull/N/merge` — the pull
+# request's own tree. This job holds a TEAM-tier `AIOS_API_KEY` plus `AIOS_BRAIN_URL` and
+# `AIOS_TEAM`, and it `await import`ed `scripts/pr-work-keys.mjs` out of that checkout.
 #
-# The branch list is pinned by `test/guards/branch-roles.test.ts` as an EXACT SET — not "contains
-# both", because `[main, staging, "**"]` satisfies containment while silently widening to every branch.
+# The `merged == true` gate was the only thing standing in front of that, and IT LIVED IN THE
+# REWRITABLE FILE. So the attack needed no merge and no approval: push a branch, edit this
+# file to drop the gate and print the three values, open a pull request, then CLOSE IT
+# UNMERGED. `closed` fires on any close. One same-repository branch — which is how every agent
+# and every maintainer here works — exfiltrated a durable brain credential.
+#
+# Forks were never the population that mattered. GitHub does withhold secrets from fork pull
+# requests; a same-repository branch gets the full set. That is the same one-branch-short
+# reasoning `pr-task-link.yml` shipped with, fixed in #672, and repeated here.
+#
+# WHAT MAKES THIS SHAPE SAFE — four properties, all of them load-bearing:
+#
+#   1. `pull_request_target` runs the BASE branch's copy of this file and of the checkout below.
+#      Every line that executes is reviewed `main` code that no pull request can edit. The gate
+#      on the job is therefore trusted again, which is the whole point.
+#   2. NOTHING from the pull request's head is checked out, fetched, installed, built or run.
+#      The checkout below carries NO `ref:` — on this trigger the default is the base branch.
+#      Adding `ref:`, a `git fetch`/`git checkout` of a pull ref, an `npm ci` (lifecycle scripts
+#      are contributor-authored code), or an artifact download is the textbook pwn-request, and
+#      `test/guards/pr-task-link-credential-isolation.test.ts` fails the build on each of them.
+#   3. Every contributor-controlled value reaches the program through `env:` and is read with
+#      `process.env`. No `github.event.*` expression is interpolated into a `run:` body: an
+#      interpolated pull request TITLE is substituted before the shell parses the script, which
+#      is a command-injection primitive in a job holding a durable credential.
+#   4. The job is scoped to SAME-REPOSITORY pull requests. Under `pull_request` a fork run got
+#      no secrets and skipped harmlessly; `pull_request_target` would newly hand the brain
+#      credentials to a run an outside contributor can start, so the gate restores that.
+#      `permissions:` stays `contents: read` — no `statuses: write`, no `checks: write`.
+#
+# WHAT `environment: trusted-automation` IS, AND WHAT IT IS NOT. It is a repository Environment
+# whose deployment branch policy allows `main` only. It is a BLAST-RADIUS control over WHICH
+# WORKFLOWS in this repository may reach `AIOS_API_KEY` / `AIOS_BRAIN_URL` / `AIOS_TEAM`. It is
+# NOT a boundary against forks, and reading it as one would repeat the mistake above in a new
+# place: on `pull_request_target` the run's ref is ALWAYS the base branch, so a fork pull
+# request satisfies a `main`-only policy exactly as easily as a maintainer's branch does. Point
+# 4 is what excludes forks; points 1-3 are what protect the credential. Measured, not assumed —
+# the same measurement is recorded in `pr-task-link.yml`'s header.
+#
+# The three values still exist as plain REPOSITORY secrets, which GitHub hands to every job
+# whether or not it names an environment (an environment secret SHADOWS a same-named repository
+# secret; it does not revoke access to one). Naming the environment here is the last of the
+# three `AIOS_*` consumers to enrol — `pr-task-link.yml` and `scan-on-merge.yml` are the other
+# two — which is what makes DELETING the repository-level copies possible. That deletion is a
+# manual step for a repository admin and is deliberately NOT part of this change. Until it
+# happens this job reads the repository-level values and really does post the work event.
+#
+# ─────────────────────────────────────────────────────────────────────────────────────────
+# RELPTR-4 — BOTH the contribution base and the integration branch, deliberately, and landed
+# BEFORE the cutover rather than on the day. Today no pull request targets `staging`, so the
+# second entry is near-inert.
+#
+# THE ACCEPTED COST, stated rather than discovered: a MISTAKEN merge into `staging` (258 behind)
+# now emits a work event where before it emitted nothing. For a brain-native row in the pushed
+# project that resolves `applied`, i.e. it would complete a task and project it to Linear for
+# work that is not on trunk. Judged smaller than the risk of doing this on cutover day.
+#
+# THE SECOND COST, NEW WITH `pull_request_target` AND NOT INERT AT CUTOVER: the run's ref is the
+# pull request's target branch, and `trusted-automation` permits `main` only. A merge into
+# `staging` would be REFUSED the environment and the job would go red having run zero steps —
+# loud, not silent, but a work event that never posts. That is fine while nothing targets
+# `staging`; at cutover the environment's branch policy and this trigger list have to move
+# together, exactly as `pr-task-link.yml`'s do. `docs/RELEASING.md` §3.1c carries the entry.
+#
+# The branch list is pinned by `test/guards/branch-roles.test.ts` as an EXACT SET — not
+# "contains both", because `[main, staging, "**"]` satisfies containment while silently
+# widening to every branch.
+# ─────────────────────────────────────────────────────────────────────────────────────────
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main, staging]
 
+# `contents: read` and nothing else, forever. `statuses: write`/`checks: write` would let this
+# PR-reachable workflow mint a required context on an arbitrary SHA — see
+# `test/guards/workflow-permissions.test.ts`.
 permissions:
   contents: read
 
 jobs:
   notify-brain:
-    if: github.event.pull_request.merged == true
+    # Both halves matter. `merged == true` is the original semantics, now enforced from
+    # base-branch code instead of from a file the pull request could rewrite. The second
+    # clause is new: it keeps fork pull requests away from the credential, which the old
+    # `pull_request` trigger achieved only as a side effect of GitHub withholding secrets.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # A blast-radius control over which WORKFLOWS reach the credential — not a trust boundary
+    # against untrusted authors. See the header: a fork pull request satisfies this policy too.
+    environment: trusted-automation
     env:
       AIOS_BRAIN_URL: ${{ secrets.AIOS_BRAIN_URL }}
+      # MUST be a TEAM-tier key — `/api/v1/work-events` writes team-tier task state.
       AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
       AIOS_TEAM: ${{ secrets.AIOS_TEAM }}
       AIOS_PROJECT: aios-team-brain
     steps:
-      - uses: actions/checkout@v7
+      # NO `ref:`. On `pull_request_target` the default is the base branch — the trusted copy.
+      # Adding `ref: ${{ github.event.pull_request.head.sha }}` here is precisely the
+      # vulnerability this workflow was rewritten to close.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Post merged work event
+        env:
+          # Contributor-controlled pull request metadata, passed as DATA. Never inlined into the
+          # script body — see point 3 in the header.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HTML_URL: ${{ github.event.pull_request.html_url }}
+          PR_MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
         run: |
           node <<'NODE'
           // Async IIFE so the shared ESM helper can be `await import`ed from this CommonJS heredoc.
           (async () => {
-          const fs = require("node:fs");
-          // ONE matcher, shared with pr-task-link.yml (`scripts/pr-work-keys.mjs`) and unit-tested. These
-          // were two inline copies: the advisory check could clear a PR whose keys THIS step — the one
-          // that actually closes tickets — then read differently.
+          // BASE-BRANCH CODE. `./scripts/…` resolves inside the checkout above, which on
+          // `pull_request_target` is the base branch, not the pull request.
+          //
+          // ONE matcher, shared with pr-task-link.yml (`scripts/pr-work-keys.mjs`) and unit-tested.
+          // These were two inline copies: the advisory check could clear a PR whose keys THIS step —
+          // the one that actually closes tickets — then read differently.
           const { extractWorkKeys } = await import("./scripts/pr-work-keys.mjs");
 
           const brain = process.env.AIOS_BRAIN_URL;
           const key = process.env.AIOS_API_KEY;
           const team = process.env.AIOS_TEAM;
           if (!brain || !key || !team) {
+            // Reachable only in one window: the repository-level copies have been deleted and the
+            // trusted-automation environment has not been given the values yet. A branch-policy
+            // mismatch is NOT this case — it fails the job before any step runs. NAMES ONLY; printing
+            // a value would publish the credential this rewrite exists to protect.
             console.log("AIOS work sync skipped: AIOS_BRAIN_URL, AIOS_API_KEY, or AIOS_TEAM is not configured.");
             process.exit(0);
           }
 
-          const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
-          const pr = event.pull_request;
+          // Read ONLY through these env vars — this workflow no longer parses GITHUB_EVENT_PATH, so
+          // the exact set of pull request fields it trusts is visible in the YAML above rather than
+          // implied by a whole-payload read.
+          const pr = {
+            title: process.env.PR_TITLE || "",
+            body: process.env.PR_BODY || "",
+            head: { ref: process.env.PR_HEAD_REF || "" },
+          };
           const workKeys = extractWorkKeys(pr);
 
           const payload = {
             project: process.env.AIOS_PROJECT,
             event_kind: "merged",
-            repo: event.repository.full_name,
-            merged_sha: pr.merge_commit_sha || event.after || pr.head.sha,
-            pr_url: pr.html_url,
+            // Runner-provided, not contributor-controlled — the same value the event payload's
+            // `repository.full_name` carried.
+            repo: process.env.GITHUB_REPOSITORY,
+            merged_sha: process.env.PR_MERGE_COMMIT_SHA || process.env.PR_HEAD_SHA || "",
+            pr_url: process.env.PR_HTML_URL || "",
             pr_title: pr.title,
-            pr_body: pr.body || "",
-            branch: pr.head?.ref || "",
+            pr_body: pr.body,
+            branch: pr.head.ref,
             work_keys: workKeys,
-            actor: pr.merged_by?.login || pr.user?.login || "",
+            actor: process.env.PR_MERGED_BY || process.env.PR_USER || "",
           };
 
           const url = `${brain.replace(/\/$/, "")}/api/v1/work-events`;

--- a/.github/workflows/scan-on-merge.yml
+++ b/.github/workflows/scan-on-merge.yml
@@ -49,6 +49,22 @@ jobs:
     name: codebase readiness scan → brain
     runs-on: ubuntu-latest
     if: github.repository == 'aiosbrain/aios-team-brain'
+    # ENROLMENT, NOT ISOLATION. `trusted-automation` is a repository Environment whose deployment
+    # branch policy allows `main` only. Naming it here is a BLAST-RADIUS control: it declares which
+    # workflows in this repository may reach AIOS_BRAIN_URL / AIOS_TEAM / AIOS_API_KEY. It is not a
+    # trust boundary of any kind, and it does not make the credentials environment-scoped on its own —
+    # an environment secret only SHADOWS a same-named repository secret. This job is the third and
+    # last of the three `AIOS_*` consumers to enrol (`pr-task-link.yml` and `aios-work-sync.yml` are
+    # the others), which is what makes deleting the repository-level copies possible; that deletion is
+    # a manual admin step, deliberately not part of the change that added this line.
+    #
+    # WHY THE POLICY ACCEPTS THIS JOB: the trigger is `push`, so the run's ref is the pushed branch.
+    # For `main` that is `refs/heads/main` and the policy allows it. For `staging` — the RELPTR-4
+    # second entry above — it does NOT: such a push would be refused the environment and the job
+    # would go red having run zero steps, loud rather than silent, with no scan posted. Nothing has
+    # pushed `staging` since 2026-07-25, so that is inert today; at cutover the environment's branch
+    # policy and this trigger list move together. `docs/RELEASING.md` §3.1c carries the entry.
+    environment: trusted-automation
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/docs/CI-ARCHITECTURE.md
+++ b/docs/CI-ARCHITECTURE.md
@@ -94,11 +94,24 @@ strict only about SUBSTANCE, because a gate that rejects honest attestations get
 inside fenced blocks and HTML comments is ignored, so quoting the template neither satisfies nor poisons
 the check. Reads only the event payload — no secrets, no network. See CLAUDE.md §"Review gate".
 
-### `aios-work-sync.yml` — fires on merge to `main`
+### `aios-work-sync.yml` — fires on a merged PR into `main` or `staging`
 
 Extracts work keys from the PR **title, body and branch ref** and POSTs a merge event to `/api/v1/work-events`. This closes the matching issue in the team's primary PM tool automatically — currently **Linear** (the brain projects the merge event to whichever provider `teams.primary_pm_provider` names; the sync path itself is provider-neutral).
 
 **Required secrets:** `AIOS_BRAIN_URL`, `AIOS_API_KEY`, `AIOS_TEAM`
+
+**⛔ It runs on `pull_request_target`, and every line of code it executes comes from the base branch** — the same shape, and for the same reason, as `pr-task-link.yml` below. The trigger used to be `pull_request: types: [closed]`, and on `pull_request` GitHub takes the **workflow file itself** from the PR head. So the `merged == true` guard was contributor-editable, and the attack needed no merge and no approval: push a branch, edit this file to delete the guard and print the three secrets, open a PR, then **close it unmerged** — `closed` fires on any close. Same class as `pr-task-link.yml`'s defect, one step worse, because the thing that was supposed to limit it lived inside the rewritable file.
+
+What makes the current shape safe, in the order the properties matter:
+
+- **Base-branch code only.** `actions/checkout` takes no `ref:` — on `pull_request_target` the default is the base branch — and nothing from the PR head is fetched, installed, built or executed. The PR contributes **data only**: title, body, branch ref, head SHA, merge-commit SHA, html URL, author and merger, each passed through the step's `env:` and read with `process.env`. No `github.event.*` expression appears in a `run:` body, because interpolation happens before the shell parses and a PR title is therefore a command-injection primitive next to a durable credential.
+- **`branches: [main, staging]` is not decoration.** Under `pull_request_target` the "base" is whatever branch the PR targets, so without an explicit filter a collaborator pushes `evil`, opens `evil2 → evil`, and the trusted base-branch code **is their own tree**. The filter is what makes "base branch" mean a reviewed branch.
+- **Same-repository condition.** `github.event.pull_request.head.repo.full_name == github.repository`, alongside `merged == true`. Under `pull_request` a fork run received no secrets and skipped harmlessly; `pull_request_target` would newly hand the brain credentials to a run an outside contributor can start, so the condition restores what the old trigger gave for free.
+- **`permissions: contents: read` only**, and `environment: trusted-automation` — a blast-radius control, **not** a fork boundary; see the identical note under `pr-task-link.yml`.
+
+`test/guards/pr-task-link-credential-isolation.test.ts` pins every one of those as parsed YAML, and its `KNOWN_GAPS` list is now **empty**: no PR-reachable workflow in this repo is excused from the rule.
+
+**One cost, inert today and not at the RELPTR-4 cutover.** The environment's deployment branch policy allows `main` only, and on `pull_request_target` the run's ref is the PR's target branch. A merge into `staging` would be **refused the environment** and the job would go red having run zero steps — loud rather than silent, but with no work event posted. No PR targets `staging` today; at the cutover the branch policy and the trigger list move together. `docs/RELEASING.md` §3.1c carries the entry.
 
 ### Work-key extraction — `scripts/pr-work-keys.mjs` (ONE copy)
 
@@ -124,7 +137,7 @@ What makes the current shape safe:
 
   So the only thing protecting this key is the rule above: **base-branch code only, no PR-head checkout/fetch/import/execute, no attacker-controlled value interpolated into a `run:` body.** Treat it as load-bearing, because it is the entire defence.
 
-  The environment is also **not connected yet**: `AIOS_API_KEY`, `AIOS_BRAIN_URL` and `AIOS_TEAM` still exist as plain repository secrets, and GitHub gives those to every job whether or not it names an environment — an environment secret only *shadows* a same-named repository secret, it does not revoke access to one. Connecting it means entering the values there **and deleting the repository-level copies**, which is blocked on rewriting `aios-work-sync.yml` (its `pull_request: closed` runs have ref `refs/pull/N/merge`, which a `main`-only policy would refuse). The trigger is pinned to `branches: [main]` so the run's ref always matches the policy; if the contribution base moves (RELPTR-4) the trigger list and the branch policy move together — `docs/RELEASING.md` §3.1c carries that entry.
+  The environment is also **not connected yet**: `AIOS_API_KEY`, `AIOS_BRAIN_URL` and `AIOS_TEAM` still exist as plain repository secrets, and GitHub gives those to every job whether or not it names an environment — an environment secret only *shadows* a same-named repository secret, it does not revoke access to one. Connecting it means entering the values there **and deleting the repository-level copies**. That deletion used to be blocked on `aios-work-sync.yml`, whose `pull_request: closed` runs had ref `refs/pull/N/merge` that a `main`-only policy would refuse; it no longer is. **All three `AIOS_*` consumers — this file, `aios-work-sync.yml` and `scan-on-merge.yml` — now name the environment**, which `test/guards/pr-task-link-credential-isolation.test.ts` asserts by enumerating every job with one of the three secrets in scope rather than by naming the three files. So the deletion is unblocked and is a **repository-admin action**, not a code change. The trigger here is pinned to `branches: [main]` so the run's ref always matches the policy; if the contribution base moves (RELPTR-4) the trigger list and the branch policy move together — `docs/RELEASING.md` §3.1c carries that entry.
 
   **A mismatched branch policy fails loudly**, not silently: `Branch "x" is not allowed to deploy to trusted-automation`, job failed, zero steps run. It never arrives as an empty secret.
 - **`permissions: contents: read` only.** No `statuses: write` / `checks: write` — a PR-reachable workflow with either can mint a required context on an arbitrary SHA (`test/guards/workflow-permissions.test.ts`).
@@ -138,7 +151,7 @@ The soft-skip path — `brain credentials not configured (missing: …) — only
 
 Runs the Python codebase scanner over this repo and POSTs the result to `/api/v1/codebases`, so the Codebases dashboard's agent-readiness figures for `aios-team-brain` stay fresh. It runs `npm run coverage` first purely as a **metrics source** for the scanner's `_read_coverage()` (`|| true` — the coverage _gate_ stays in `ci.yml`), then `python -m aios_ingest.cli scan`. Concurrency group `scan-on-merge` with `cancel-in-progress: true`, and the job is pinned to `if: github.repository == 'aiosbrain/aios-team-brain'` so a fork never scans into someone else's brain.
 
-**Required secrets — the SAME three as `aios-work-sync.yml`:** `AIOS_BRAIN_URL`, `AIOS_TEAM`, `AIOS_API_KEY`.
+**Required secrets — the SAME three as `aios-work-sync.yml`:** `AIOS_BRAIN_URL`, `AIOS_TEAM`, `AIOS_API_KEY`. The job names `environment: trusted-automation` for the same reason the other two do — enrolment, so the repository-level copies can be deleted; it is not a boundary of any kind here, since this workflow is not PR-reachable at all. Its trigger is `push`, so the run's ref is the pushed branch: `main` satisfies the `main`-only branch policy, and a push to `staging` would be refused it and fail with zero steps run. Nothing has pushed `staging` since 2026-07-25.
 
 Three things about them are easy to get wrong, and each fails in a way that does not look like a failure:
 
@@ -259,8 +272,11 @@ integration auto-deploys `main` → `production` and `staging` → `staging`. Th
 deploy job, and the Railway CLI stays read-only in this repo (see `CLAUDE.md` §6).
 
 `ci.yml` runs on PRs and pushes to **both** `main` and `staging`, so `staging` carries the same
-required-check bar. `aios-work-sync.yml` stays scoped to `main` only — a staging merge must not
-close Linear issues.
+required-check bar. This paragraph used to say `aios-work-sync.yml` "stays scoped to `main` only —
+a staging merge must not close Linear issues"; **RELPTR-4 reversed that decision** and widened both
+`aios-work-sync.yml` and `scan-on-merge.yml` to `[main, staging]` ahead of the cutover, with the
+accepted cost written into each workflow's header. See `docs/RELEASING.md` §3.1b for the
+ticket-closing decision and §3.1c for what still moves on cutover day.
 
 ### Staging variable boundary
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -167,16 +167,37 @@ file a human must change:
    because `main` is a legitimate token everywhere.
 3. **Every branch-protection change** — the release actor, making `Release candidate gate` required,
    relocating `PR records a diff review`.
-4. **`pr-task-link.yml`'s `branches:` list AND the `trusted-automation` environment's deployment
-   branch policy, together.** This one is unlike `aios-work-sync` and `scan-on-merge`, which were
-   deliberately pre-widened to both branches so cutover day would not have to remember them.
-   `pr-task-link` **cannot** be pre-widened: it runs on `pull_request_target`, so the run's ref is the
-   PR's base branch, and once the environment holds the credentials a `staging`-based run would be
-   refused a `main`-only policy and go red — on an advisory check that is never allowed to go red.
-   Leaving the trigger at `[main]` instead makes it go **dark** for `staging` PRs, which is the safer
-   failure but is still a loss nobody would notice. So both move in one edit, and
-   `test/guards/pr-task-link-credential-isolation.test.ts` pins the trigger to exactly `["main"]` so
-   the widening has to be deliberate rather than accidental.
+4. **The `trusted-automation` environment's deployment branch policy — `main` only today — and it now
+   gates all three `AIOS_*` consumers.** This entry has grown, and the earlier version of it is now
+   wrong in a way worth naming: it said `aios-work-sync` and `scan-on-merge` "were deliberately
+   pre-widened to both branches so cutover day would not have to remember them". The trigger lists
+   still are. The **environment** is not, and after the credential-isolation fix all three workflows
+   name it, so the policy is a cutover-day edit for every one of them:
+
+   - **`pr-task-link.yml`** — the trigger list AND the policy move together. It runs on
+     `pull_request_target`, so the run's ref is the pull request's target branch; once the environment
+     holds the credentials a `staging`-based run would be refused a `main`-only policy and go red — on
+     an advisory check that is never allowed to go red. Leaving its trigger at `[main]` instead makes
+     it go **dark** for `staging` pull requests: the safer failure, still a loss nobody would notice.
+     `test/guards/pr-task-link-credential-isolation.test.ts` pins that trigger to exactly `["main"]`
+     so the widening has to be deliberate.
+   - **`aios-work-sync.yml`** — trigger already `[main, staging]`, but it moved from `pull_request` to
+     `pull_request_target` to close the credential hole (the `merged == true` gate used to live in a
+     file the pull request could rewrite). Same consequence: the run's ref is the target branch, so a
+     `staging` merge would be refused the environment and go red having run zero steps, and **no work
+     event would post**. Loud, not silent — and inert only while nothing targets `staging`.
+   - **`scan-on-merge.yml`** — trigger already `[main, staging]`, on `push`, so the run's ref is the
+     pushed branch. A `staging` push would be refused the environment the same way. Nothing has pushed
+     `staging` since 2026-07-25.
+
+   So the cutover-day edit is one policy change (add `staging` to the environment's branch policy)
+   plus `pr-task-link.yml`'s trigger list. Do the policy **first**: widening it is inert until a
+   branch is actually used, whereas doing it late means red merge automation on the day.
+
+   A related manual step, **not** a cutover item and **not** to be done in the pull request that
+   enrolled these workflows: the three values still exist as repository-level secrets, which GitHub
+   hands to every job regardless of `environment:`. Only deleting the repository copies makes the
+   environment load-bearing, and that is a repository-admin action.
 5. **The instruction corpus** — 31 operative `origin/main` command lines across 19 files. That is
    **RELPTR-5**, deliberately its own slice; see §3.1d.
 

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -215,12 +215,21 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
   it("aios-work-sync fires on EXACTLY the contribution base and the integration branch", () => {
     // EXACT SET, not "contains both": `[main, staging, "**"]` satisfies a containment check while
     // silently widening the trigger to every branch in the repository. Codex found that.
+    //
+    // `pull_request_target`, not `pull_request` — the credential-isolation fix. Under `pull_request`
+    // the workflow FILE comes from the pull request's head, so the `merged == true` gate was
+    // contributor-editable and an unmerged close fired the job with three brain secrets in scope.
+    // The branch filter is doubly load-bearing on this trigger: without it the "base" is whatever
+    // branch a pull request targets, so a collaborator can make their own tree the trusted one.
+    // `test/guards/pr-task-link-credential-isolation.test.ts` owns the security half; this owns the
+    // RELPTR-4 half, and both must move together.
     const on = workflow("aios-work-sync.yml").on!;
-    expect(on.pull_request!.branches).toEqual([CONTRIBUTION_BASE, INTEGRATION_BRANCH]);
-    expect(on.pull_request!.types).toEqual(["closed"]);
+    expect(Object.keys(on), "the trigger itself is part of criterion 5 now").toEqual(["pull_request_target"]);
+    expect(on.pull_request_target!.branches).toEqual([CONTRIBUTION_BASE, INTEGRATION_BRANCH]);
+    expect(on.pull_request_target!.types).toEqual(["closed"]);
     // …and INTEGRATION_BRANCH is `staging` TODAY, so this pins the widening now rather than
     // collapsing to "contains main" until the cutover moves the value.
-    expect(on.pull_request!.branches).toContain("staging");
+    expect(on.pull_request_target!.branches).toContain("staging");
   });
 
   it("scan-on-merge fires on EXACTLY the same two branches", () => {
@@ -236,7 +245,13 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // it. Codex found this too. The job gate is pinned as an exact string; steps carry no `if:` at all.
     const wf = workflow("aios-work-sync.yml");
     const job = wf.jobs!["notify-brain"];
-    expect(job.if, "the job gate, exactly").toBe("github.event.pull_request.merged == true");
+    // Exact string, both clauses. `merged == true` is the merge semantics (`closed` fires on ANY
+    // close); the same-repository clause is the credential fix keeping fork pull requests away from
+    // secrets that `pull_request` used to withhold for us. NEITHER of them narrows by BRANCH, which
+    // is what criterion 5 is protecting here.
+    expect(job.if, "the job gate, exactly").toBe(
+      "github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository"
+    );
     const stepIfs = (job.steps ?? []).filter((step) => step.if !== undefined);
     expect(stepIfs, "no step may carry its own condition").toEqual([]);
   });

--- a/test/guards/pr-task-link-credential-isolation.test.ts
+++ b/test/guards/pr-task-link-credential-isolation.test.ts
@@ -225,16 +225,22 @@ export function credentialExposures(file: string, doc: Workflow): Finding[] {
 }
 
 /**
- * The ONE documented exception, and it is a different vulnerability with a different fix.
+ * EMPTY, and that is the claim this file now makes: every PR-reachable workflow in this repository
+ * is asserted clean, with no exception.
  *
- * `aios-work-sync.yml` runs on `pull_request: [closed]` gated by `merged == true`, so its default
- * checkout is PR-controlled code running with the same three brain secrets. It is NOT closed here
- * for two reasons: it fires only AFTER a merge (so it costs a reviewer's approval, not just an
- * `edited` event), and rewriting it is Phase 0 item 5 of the leak-gate remediation plan — a separate
- * change with its own test evidence. Removing it from this list without fixing the workflow is the
- * only wrong move: the entry is here so the hole is counted, not so it is forgotten.
+ * It held `aios-work-sync.yml` until Phase 0 item 5 of the leak-gate remediation plan. That workflow
+ * ran on `pull_request: [closed]` gated by `merged == true` — and the gate lived in the same file,
+ * which on `pull_request` GitHub takes from the pull request's head. So the gate was not a gate: a
+ * same-repository branch could delete it, print the three brain secrets, and CLOSE ITS OWN UNMERGED
+ * pull request to fire the job. `closed` fires on any close. It is now `pull_request_target` with a
+ * same-repository condition, base-branch code only, and `environment: trusted-automation`; the
+ * `aios-work-sync.yml specifically` block below pins each of those.
+ *
+ * A name added back to this list is a new hole. A name left on it after its workflow was fixed makes
+ * the list lie about what is outstanding — which is why the assertion below is an exact-set equality
+ * in both directions rather than a subset check.
  */
-const KNOWN_GAPS = new Set(["aios-work-sync.yml"]);
+const KNOWN_GAPS = new Set<string>([]);
 
 describe("guard: no PR-reachable job runs PR-controlled code with a credential", () => {
   it("finds a non-trivial set of workflows, so a rename cannot empty this guard", () => {
@@ -251,13 +257,29 @@ describe("guard: no PR-reachable job runs PR-controlled code with a credential",
     expect(offenders, `these hand a durable credential to code a pull request can edit:\n${offenders.join("\n")}`).toEqual([]);
   });
 
-  it("the gap list is EXACTLY the documented one, and every entry still really trips the detector", () => {
+  it("the gap list is EMPTY — no workflow here is excused from the rule", () => {
     // Two failure modes, both real. A new name silently added to the list is a new hole; a name left
     // on the list after its workflow was fixed makes the list lie about what is outstanding.
-    expect([...KNOWN_GAPS]).toEqual(["aios-work-sync.yml"]);
+    expect([...KNOWN_GAPS]).toEqual([]);
     for (const f of KNOWN_GAPS) {
       expect(credentialExposures(f, load(f)), `${f} no longer trips this — remove it from KNOWN_GAPS`).not.toEqual([]);
     }
+  });
+
+  it("the exclusion is still WIRED, so emptying the list did not disarm the filter", () => {
+    // With no entries the `for` loop above is inert and the `.filter(…)` in the sweep is a no-op, so
+    // neither can any longer show that KNOWN_GAPS does anything. Without this, someone could delete
+    // the mechanism entirely and every assertion in this file would stay green — and the NEXT hole
+    // would be waved through by a list that no longer exists. Proven by exercising the filter over a
+    // known-dirty file name instead of by reading the source.
+    const dirty = "aios-work-sync-preimage.yml";
+    const preimage = parseYaml(
+      "on:\n  pull_request:\n    types: [closed]\njobs:\n  a:\n    env:\n      K: ${{ secrets.AIOS_API_KEY }}\n    steps:\n      - uses: actions/checkout@abc\n"
+    ) as Workflow;
+    expect(credentialExposures(dirty, preimage), "the pre-fix shape must still be a finding").not.toEqual([]);
+    const gaps = new Set([dirty]);
+    expect([dirty].filter((f) => !gaps.has(f)), "a listed name is excluded from the sweep").toEqual([]);
+    expect([dirty].filter((f) => !KNOWN_GAPS.has(f)), "an unlisted name is not").toEqual([dirty]);
   });
 
   it("`nda-gate.yml` stays clean: fetching PR objects as DATA is not an exposure", () => {
@@ -509,5 +531,208 @@ describe("guard: pr-task-link.yml specifically", () => {
       // this catches it, and the bright line is cheaper to hold than the taxonomy.
       expect(run, "a `run:` block in this job must contain no workflow expression whatsoever").not.toContain("${{");
     }
+  });
+});
+
+/**
+ * The file with every COMMENT removed — YAML `#` lines and the JavaScript `//` lines inside the
+ * heredoc alike.
+ *
+ * These workflows describe the vulnerability they close, at length and on purpose, because the
+ * control that failed here was a header that reasoned about the wrong threat. A guard that cannot
+ * tell the warning from the practice would push the next person to delete the warning, so the
+ * "must not contain X" assertions read this view rather than the raw text.
+ */
+const executable = (f: string): string =>
+  text(f)
+    .split("\n")
+    .filter((l) => !/^\s*(#|\/\/)/.test(l))
+    .join("\n");
+
+describe("guard: aios-work-sync.yml specifically", () => {
+  const FILE = "aios-work-sync.yml";
+  const doc = () => load(FILE);
+  const job = () => doc().jobs!["notify-brain"];
+
+  it("has no credential exposure of any kind — this is what leaving KNOWN_GAPS means", () => {
+    expect(credentialExposures(FILE, doc())).toEqual([]);
+    // Belt and braces on the exact regression, over the executable lines only.
+    const code = executable(FILE);
+    expect(code).not.toMatch(/ref:\s*\$\{\{[^}]*github\.event\.pull_request\.head/);
+    expect(code).not.toMatch(/ref:\s*\$\{\{[^}]*github\.head_ref/);
+  });
+
+  it("the comment stripper is NON-VACUOUS — it removes comments and keeps code", () => {
+    // Otherwise `executable()` could silently return "" and every not-toContain assertion above
+    // would pass by reading nothing at all.
+    const code = executable(FILE);
+    expect(code, "the checkout is code and must survive").toContain("actions/checkout@");
+    expect(code, "so must the step env").toContain("PR_TITLE:");
+    expect(code, "a YAML comment must not").not.toContain("pwn-request");
+    expect(code, "nor a JS comment inside the heredoc").not.toContain("BASE-BRANCH CODE");
+  });
+
+  it("runs ONLY on pull_request_target — an added `pull_request` trigger restores the whole hole", () => {
+    // Not "includes pull_request_target". Declaring BOTH would run the pull request's own copy of
+    // this file with the same three secrets, and every other assertion here would still pass. That
+    // is not hypothetical: `pull_request` IS the trigger this workflow shipped with, and on it the
+    // `merged == true` gate below is contributor-editable, so an unmerged close fires the job.
+    expect(triggers(doc())).toEqual(["pull_request_target"]);
+  });
+
+  it("carries an explicit branch filter — without one, a contributor picks the base", () => {
+    // MANDATORY, and it is the non-obvious half of the fix. `pull_request_target` alone means the
+    // "base" is whatever branch the pull request targets, so a collaborator pushes `evil`, opens
+    // `evil2 -> evil`, and the trusted base-branch code IS their own tree. The filter is what makes
+    // "base branch" mean a reviewed branch. Asserted as an EXACT SET, matching branch-roles.test.ts:
+    // `[main, staging, "**"]` satisfies containment while widening to every branch in the repository.
+    const on = doc().on as Record<string, { branches?: unknown; types?: unknown }>;
+    expect(on.pull_request_target.branches).toEqual(["main", "staging"]);
+    expect(on.pull_request_target.types).toEqual(["closed"]);
+  });
+
+  it("keeps `merged == true`, and adds the same-repository condition forks used to get for free", () => {
+    // `closed` fires on ANY close, so `merged == true` is the whole of the merge semantics — it is
+    // preserved, but now it lives in base-branch code where a pull request cannot delete it. The
+    // second clause is new: under `pull_request` a fork run received no secrets and skipped
+    // harmlessly, and `pull_request_target` would newly hand the brain credentials to a run an
+    // outside contributor can start. Asserted as an exact string so dropping either half reds.
+    expect(job().if).toBe(
+      "github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository"
+    );
+  });
+
+  it("takes its credentials from the `trusted-automation` environment", () => {
+    // The third and last `AIOS_*` consumer to enrol, which is what unblocks deleting the
+    // repository-level copies. NOT a fork boundary: on pull_request_target the ref is always the
+    // base branch, so a fork pull request satisfies a `main`-only policy too. See the file header.
+    expect(job().environment).toBe("trusted-automation");
+    expect(secretRefs(job())).toEqual(["AIOS_API_KEY", "AIOS_BRAIN_URL", "AIOS_TEAM"]);
+  });
+
+  it("requests `contents: read` and NOTHING else", () => {
+    expect((doc() as { permissions?: unknown }).permissions).toEqual({ contents: "read" });
+    expect(job().permissions, "no job-level widening either").toBeUndefined();
+  });
+
+  it("checks out the BASE branch: a checkout with no `ref:`, pinned by full commit SHA", () => {
+    const checkouts = asSteps(job()).filter(isCheckout);
+    expect(checkouts.length, "no checkout found — the ref assertion would be vacuous").toBe(1);
+    expect(stepRef(checkouts[0]), "any `ref:` at all is the pwn-request").toBeUndefined();
+    const uses = asSteps(job()).map(usesId).filter(Boolean);
+    expect(uses.length, "no actions found — this assertion would be vacuous").toBeGreaterThan(0);
+    for (const u of uses) expect(u, `${u} is not pinned by SHA`).toMatch(/@[0-9a-f]{40}$/);
+  });
+
+  it("reads pull request metadata from `env:`, never as a `run:` interpolation", () => {
+    // Interpolation is substituted before the shell parses, so a pull request TITLE is a
+    // command-injection primitive in a job that holds a durable credential.
+    const steps = asSteps(job());
+    const runs = steps.map((s) => (typeof s.run === "string" ? s.run : ""));
+    expect(runs.filter(Boolean).length, "no run blocks found — this would be vacuous").toBeGreaterThan(0);
+    for (const run of runs) {
+      // NO INTERPOLATION AT ALL, not "no dangerous interpolation" — GitHub scans a `run:` block for
+      // expressions with no idea that JavaScript has comments, so even a commented-out one is
+      // evaluated for real. `actionlint` caught that in the sibling workflow; the bright line is
+      // cheaper to hold than the taxonomy.
+      expect(run, "a `run:` block in this job must contain no workflow expression whatsoever").not.toContain("${{");
+    }
+    // …and the values really do arrive, so the rule above did not simply delete the feature.
+    const stepEnv = steps.flatMap((s) => Object.entries(((s as { env?: Record<string, string> }).env ?? {})));
+    const fromPr = stepEnv.filter(([, v]) => String(v).includes("github.event.pull_request."));
+    expect(fromPr.map(([k]) => k).sort()).toEqual([
+      "PR_BODY",
+      "PR_HEAD_REF",
+      "PR_HEAD_SHA",
+      "PR_HTML_URL",
+      "PR_MERGED_BY",
+      "PR_MERGE_COMMIT_SHA",
+      "PR_TITLE",
+      "PR_USER",
+    ]);
+    const body = text(FILE);
+    for (const [name] of fromPr) expect(body, `${name} must be read with process.env`).toContain(`process.env.${name}`);
+    // The enumerated set above is the POINT: a whole-payload read would make the trusted field list
+    // implied rather than visible, so the workflow must not go back to parsing the event file.
+    // EXECUTABLE LINES ONLY — both the YAML header and the inline JS say the words "no longer parses
+    // GITHUB_EVENT_PATH" on purpose, and a guard that cannot tell the explanation from the practice
+    // would push the next person to delete the explanation.
+    expect(executable(FILE), "no whole-payload read").not.toContain("GITHUB_EVENT_PATH");
+  });
+
+  it("STILL posts the merged work event through the ONE shared matcher", () => {
+    // The regression most likely to be lost in a security rewrite: this is the only step that closes
+    // a task. `scripts/pr-work-keys.mjs` is shared with pr-task-link.yml precisely because two inline
+    // copies disagreed once — the advisory check cleared a PR whose keys this step read differently.
+    const body = text(FILE);
+    expect(body).toContain("scripts/pr-work-keys.mjs");
+    expect(body).toContain("extractWorkKeys");
+    expect(body).toContain("/api/v1/work-events");
+    expect(body, "the pushed project decides applied-vs-linked").toContain("AIOS_PROJECT: aios-team-brain");
+  });
+
+  it("fails LOUDLY — it is the only thing that closes a task", () => {
+    // The opposite requirement to pr-task-link.yml, which is advisory and `continue-on-error: true`.
+    // A silent skip here leaves the board wrong with a green tick next to it.
+    expect(job()["continue-on-error"], "must not be excused from failing").toBeUndefined();
+    expect(text(FILE)).toContain("process.exit(1)");
+  });
+});
+
+/**
+ * ENROLMENT COMPLETENESS — the precondition for deleting the repository-level secrets.
+ *
+ * `AIOS_API_KEY` / `AIOS_BRAIN_URL` / `AIOS_TEAM` exist twice over: as repository secrets, which
+ * GitHub hands to EVERY job, and (once entered) as `trusted-automation` environment secrets, which
+ * only jobs naming that environment can read. An environment secret merely SHADOWS a same-named
+ * repository secret — so the environment becomes load-bearing only when the repository copies are
+ * DELETED, and deleting them breaks any consumer that has not enrolled.
+ *
+ * So the guard is not "these three files name the environment", which a rename would empty. It is:
+ * every job anywhere in this repository that reads one of the three MUST name the environment. A new
+ * consumer added without it is caught here rather than by a red workflow after the deletion.
+ *
+ * STATED LIMIT, because this is exactly where an overstated guard would do harm: naming the
+ * environment does NOT scope the credential, and a green result here is not evidence that the
+ * repository-level copies are gone. That deletion is a repository-admin action this file cannot see.
+ */
+describe("guard: every AIOS_* credential consumer is enrolled in `trusted-automation`", () => {
+  const BRAIN_SECRETS = ["AIOS_API_KEY", "AIOS_BRAIN_URL", "AIOS_TEAM"];
+
+  /** [file, jobId] for every job with one of the three brain secrets in scope. */
+  const consumers = (): [string, string][] =>
+    files().flatMap((f) => {
+      const doc = load(f);
+      const wf = secretRefs(doc?.env);
+      return Object.entries(doc?.jobs ?? {})
+        .filter(([, job]) => [...wf, ...secretRefs(job)].some((s) => BRAIN_SECRETS.includes(s)))
+        .map(([id]) => [f, id] as [string, string]);
+    });
+
+  it("finds exactly the three known consumers — a rename cannot empty this", () => {
+    // Enumerated, so a fourth consumer appearing is a deliberate decision rather than a silent one.
+    expect(consumers().map(([f, j]) => `${f}:${j}`).sort()).toEqual([
+      "aios-work-sync.yml:notify-brain",
+      "pr-task-link.yml:work-key",
+      "scan-on-merge.yml:scan",
+    ]);
+  });
+
+  it("every one of them names the environment", () => {
+    const unenrolled = consumers()
+      .filter(([f, j]) => load(f).jobs![j].environment !== "trusted-automation")
+      .map(([f, j]) => `${f} [job:${j}]`);
+    expect(
+      unenrolled,
+      `these read a brain secret without naming trusted-automation, so deleting the repository-level copies would break them:\n${unenrolled.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("is NON-VACUOUS: an unenrolled consumer is detected", () => {
+    const doc = parseYaml(
+      "on:\n  push:\njobs:\n  a:\n    env:\n      K: ${{ secrets.AIOS_API_KEY }}\n    steps:\n      - run: 'true'\n"
+    ) as Workflow;
+    expect(doc.jobs!["a"].environment, "the fixture must really lack it").toBeUndefined();
+    expect(secretRefs(doc.jobs!["a"]).some((s) => BRAIN_SECRETS.includes(s))).toBe(true);
   });
 });


### PR DESCRIPTION
> ## ⚠️ One thing only John can do — and it must NOT be done in this PR
>
> **Delete the repository-level `AIOS_API_KEY` / `AIOS_BRAIN_URL` / `AIOS_TEAM` secrets — after entering them into the `trusted-automation` environment.** This PR enrols the last two consumers, which is what *unblocks* that deletion; it does not perform it. GitHub secrets are write-only, so I cannot read the existing values to copy them, and deleting the repository copies before the environment holds the values would break all three workflows at once. Sequence: enter the values in the environment → confirm one green run of each → then delete the repository copies.
>
> Still outstanding from #672: **rotate `AIOS_API_KEY`.** The exfiltration path described below was open for the life of the key.

## Review — Reviewed by Fable code-reviewer (subagent, model fable) — verdict Ready: no residual secret-exfiltration route found, no payload regression (the dropped `event.after` was already dead code on a PR payload), guards non-vacuous with no green-surviving mutation of the security properties, environment claims accurate and not overstated

Two informational notes from that review, neither a blocker:

1. **The divergence from workspace #664 is deliberate** (checkout + shared matcher vs no checkout + inlined regex) and the checkout is the guard's explicitly-allowed safe shape.
2. **`staging` is a permitted `pull_request_target` base**, and base-branch trust therefore extends to a branch 258 commits behind and less protected than `main`. Exploiting it needs repository write access plus a merge to `staging` — already credential-equivalent trust — and it is inert today. Noted for awareness; the cutover doc already couples the trigger list and the branch policy.

## What & Why

`.github/workflows/aios-work-sync.yml` handed a **durable TEAM-tier brain credential to code a pull request could edit**, and the guard meant to limit it lived in the file the pull request rewrites.

**The exact exfiltration path closed:**

1. The trigger was `pull_request: types: [closed]`. On `pull_request`, GitHub takes the **workflow file itself** from the PR head.
2. So a contributor pushes a branch, edits this file to delete the `if: merged == true` gate and print `AIOS_API_KEY`, `AIOS_BRAIN_URL`, `AIOS_TEAM`, opens a PR, and **closes it unmerged**. `closed` fires on any close.
3. There is also no merge needed for the second route: the bare `actions/checkout@v7` was `refs/pull/N/merge` — the PR's own tree — and the `run:` block `await import`ed `./scripts/pr-work-keys.mjs` from it.

No merge, no approval, no review. Same class as `pr-task-link.yml` (#672), one step worse: there the gate was outside the attacker's reach, here it was inside it.

Implements **Phase 0 items 4 and 5** of `leak-gate-remediation-plan.md` (§2 item 4, §5.1 Team Brain item 2). Mirrors the fix already merged for the identical workspace workflow (`aios-workspace` #664, `80ef98eb`) and the in-repo house style set by `pr-task-link.yml` (#672).

## The fix

`pull_request_target`, so the workflow file **and** every line of code it executes come from the base branch.

| Property | Why it is load-bearing |
| --- | --- |
| `branches: [main, staging]` | **Mandatory, and the non-obvious half.** Under `pull_request_target` the "base" is whatever branch the PR targets — without a filter a collaborator pushes `evil`, opens `evil2 → evil`, and the trusted base-branch code *is their own tree*. This exact bug was caught by a reviewer on workspace #664. |
| No `ref:` on the checkout | On this trigger the default is the base branch. Nothing from the PR head is fetched, installed, built, or executed. |
| Every PR value via step `env:`, read with `process.env` | No `github.event.*` expression anywhere in a `run:` body. Interpolation is substituted before the shell parses, so a PR title is a command-injection primitive next to a durable credential. |
| `merged == true` kept, plus a same-repository condition | The merge semantics are preserved but now enforced from base-branch code. The fork condition restores what `pull_request` gave for free (GitHub withholds secrets from fork runs; `pull_request_target` does not). |
| `permissions: contents: read` | No `statuses: write`, no `checks: write` — either can mint a required context on an arbitrary SHA. |
| Actions pinned by full commit SHA | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`. |

**Deliberate divergence from the workspace version:** workspace dropped `actions/checkout` entirely and inlined the key regex. Here the checkout stays (base-branch only) so the workflow keeps importing `scripts/pr-work-keys.mjs` — the **one** matcher shared with `pr-task-link.yml`. Two inline copies is a defect this repo already had: the advisory check cleared a PR whose keys the merge step then read differently. Inlining it again to save a checkout would trade a closed hole for a reopened one.

## The environment is a blast-radius control, NOT a fork boundary

Stated identically in the workflow header, `docs/CI-ARCHITECTURE.md`, and here, because this is the claim most likely to be misread later.

`environment: trusted-automation` limits **which workflows in this repository** can reach the credential. It does **not** keep the credential away from untrusted **authors**: on `pull_request_target` the run's ref is always the base branch, so a fork PR satisfies a `main`-only deployment branch policy exactly as easily as a maintainer's branch does. (Measured in #672, not assumed.)

**Base-branch-code-only is the actual defence.** The environment is enrolment plumbing.

## Environment enrolment — what this completes

`scan-on-merge.yml` gains `environment: trusted-automation` and nothing else. It runs on `push`, so `GITHUB_REF` is `refs/heads/main` and the `main`-only policy accepts it.

With `pr-task-link.yml` (already enrolled in #672), **all three `AIOS_*` consumers are now enrolled** — which is the precondition for deleting the repository-level copies. The new guard asserts this by *enumerating every job with one of the three secrets in scope*, not by naming three files, so a fourth consumer added without enrolling reddens.

## Tests

`test/guards/pr-task-link-credential-isolation.test.ts`:

- **`KNOWN_GAPS` is now empty.** `aios-work-sync.yml` was its only entry; the list is asserted as an exact set in both directions.
- Emptying it makes the `for` loop and the sweep's `.filter()` inert, so a new test proves the exclusion mechanism is still **wired** — otherwise someone could delete it and every assertion here would stay green while the next hole was waved through.
- New `aios-work-sync.yml specifically` block: no credential exposure; trigger is *exactly* `["pull_request_target"]` (declaring both triggers restores the whole hole and would pass every other assertion); exact branch set; the job gate as an exact string; the environment; a checkout with no `ref:` and SHA-pinned; no `${{` in any `run:`; the enumerated `PR_*` env set each read with `process.env`; and the behaviour that must survive a security rewrite — the shared matcher, `/api/v1/work-events`, and failing loudly.
- New enrolment block over all three consumers.

`test/guards/branch-roles.test.ts` — RELPTR-4 criteria 5/7 updated for the new trigger and job condition, still pinning the branch list as an exact set.

### Mutation testing

Baseline **102 passed** across the three guard files. Each defect reintroduced one at a time:

| Mutation | Result |
| --- | --- |
| Trigger back to `pull_request` (the live defect) | **5 failed / 94 passed** |
| `branches:` filter deleted (`evil2 → evil`) | **2 failed / 97 passed** |
| `ref: ${{ github.event.pull_request.head.sha }}` added to the checkout | **3 failed / 96 passed** |
| Same-repository condition removed | **2 failed / 97 passed** |
| `environment:` removed from `aios-work-sync.yml` | **1 failed / 98 passed** |
| PR title interpolated into the `run:` body | **3 failed / 96 passed** |
| `environment:` removed from `scan-on-merge.yml` | **1 failed / 60 passed** (that file alone) |

Restored → **102 passed**.

## What was verified

- `npm test` — **3746 passed, 15 skipped, 377 files passed / 1 skipped, 0 failed.** Note: `test/guards/single-writer-company-graph.test.ts`, which #672 reported as a local path-length failure, **passed** here (4/4) — this worktree path is short enough. Nothing was hidden.
- `npm run lint` — 0 errors, 18 pre-existing warnings (all unused-var warnings in files this PR does not touch).
- `npm run typecheck` — clean.
- `npm run check:docs` — routes 64, tables 85, sources 8, all in sync.
- `actionlint` — exit 0 across all workflows, and exit 0 on the two changed files specifically.
- Payload equivalence checked field by field against `git show origin/main:.github/workflows/aios-work-sync.yml`, and `extractWorkKeys` run over both the old whole-payload shape and the new env-built shape on the same fixture → identical output.
- Environment readback: `deployment-branch-policies` → `[{name: "main", type: "branch"}]`, total 1.

## Residual risks — stated, not waved away

- **`staging` merges would now go red rather than post an event.** Under `pull_request_target` the run's ref is the PR's target branch, and the environment allows `main` only. This is loud (job fails with zero steps run, `Branch "staging" is not allowed to deploy to trusted-automation`), not silent. **Inert today** — no PR targets `staging` — but it is a real cutover-day item, and `docs/RELEASING.md` §3.1c now says so. The same applies to `scan-on-merge.yml` on a `staging` push; nothing has pushed `staging` since 2026-07-25.
- **§3.1c's previous text was wrong and is corrected.** It said `aios-work-sync` and `scan-on-merge` "were deliberately pre-widened so cutover day would not have to remember them". Their *triggers* still are; the *environment branch policy* is not, and now gates all three. The cutover-day edit is one policy change plus `pr-task-link.yml`'s trigger list — and the policy change should go **first**, since widening it is inert until a branch is used.
- **The guard reads files, not configuration.** It cannot see secret configuration, environment protection rules, or branch protection. A green result here is not evidence that the credential is environment-scoped — only deleting the repository copies makes that true.
- **`docs/CI-ARCHITECTURE.md` line ~262 was already stale** on `main` (it still claimed `aios-work-sync` is `main`-only, which RELPTR-4 reversed). Corrected here rather than left, since this PR touches the adjacent claim.

## The NDA gate is deliberately untouched

`nda-gate.yml`, `NDA_TERMS`, `scripts/nda-scan.mjs` and every leak/NDA scanning path are **not modified** — the diff is six files and none of them is one of those. `NDA_TERMS` was **not** added to the environment. No repository secret is deleted. Removing existing protection before its replacement exists is explicitly forbidden by the remediation plan, and the guard continues to assert `nda-gate.yml` stays clean precisely so this change can never be read as an argument for weakening it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how durable brain API credentials are exposed in PR-reachable automation; incorrect regression would re-open secret exfiltration or break merge-time task closure.
> 
> **Overview**
> Closes a **same-repo pwn-request** on merge automation: `aios-work-sync.yml` used `pull_request` with a contributor-editable `merged == true` gate, default checkout of the PR merge ref, and `import` of `scripts/pr-work-keys.mjs` while **TEAM-tier** `AIOS_*` secrets were in scope—so closing an **unmerged** PR could exfiltrate credentials.
> 
> The workflow is rewritten to match `pr-task-link.yml`: **`pull_request_target`** with **`branches: [main, staging]`**, base-branch checkout (no `ref:`), PR fields only via step **`env:`** / `process.env` (no `${{` in `run:`), **`merged == true` plus same-repository** job `if`, `permissions: contents: read`, SHA-pinned checkout, and **`environment: trusted-automation`**.
> 
> **`scan-on-merge.yml`** only adds that environment (third `AIOS_*` consumer enrolled). Docs in **`CI-ARCHITECTURE.md`** and **`RELEASING.md`** document the threat model, that the environment is blast-radius not fork protection, and that **`staging` merges/pushes will fail the `main`-only policy** until cutover widens it.
> 
> Guards: **`KNOWN_GAPS` is empty**; new pins for `aios-work-sync.yml` and an enrolment sweep for all brain-secret jobs; **`branch-roles.test.ts`** expects `pull_request_target` and the expanded job condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4f562e0888b83e9c2595822bdce2563383a4e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->