### PR TITLE
fix(instructions): resolve the contribution base (RELPTR-5)

### DIFF
--- a/.agents/skills/pr-review-attestation/SKILL.md
+++ b/.agents/skills/pr-review-attestation/SKILL.md
@@ -53,13 +53,15 @@ genuinely done.
 
 ## Steps
 
-1. **Get the diff — against a fresh `origin/main`.**
+1. **Get the diff — against a fresh remote ref for the contribution base (currently `main`, declared in `scripts/branches.mjs`).**
    ```bash
-   git fetch origin main
-   git diff origin/main...HEAD
+   root="$(git rev-parse --show-toplevel)"
+   base="$(node "$root/scripts/branches.mjs" --print contribution)"
+   git -C "$root" fetch origin "$base"
+   git -C "$root" diff "origin/$base...HEAD"
    ```
    The fetch is not optional. PRs merge fast in this repo, so a checkout whose
-   `origin/main` ref is a few hours stale produces a diff carrying other
+   remote contribution-base ref is a few hours stale produces a diff carrying other
    people's already-merged commits — the reviewer then raises HIGH findings on
    code that isn't yours, and step 3 burns a skeptic pass per phantom finding.
    If the diff is empty, stop — there's nothing to review or attest.

--- a/.agents/skills/pr-review-attestation/evals/evals.json
+++ b/.agents/skills/pr-review-attestation/evals/evals.json
@@ -3,10 +3,10 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Attest this PR before I push it. The branch diff (git diff origin/main...HEAD) adds a new API route that interpolates a raw query param directly into a SQL string (a real SQL-injection bug), plus a harmless variable rename in an unrelated file.",
+      "prompt": "Attest this PR before I push it. The branch diff (root=\"$(git rev-parse --show-toplevel)\"\nbase=\"$(node \"$root/scripts/branches.mjs\" --print contribution)\"\ngit -C \"$root\" fetch origin \"$base\"\ngit -C \"$root\" diff \"origin/$base...HEAD\") adds a new API route that interpolates a raw query param directly into a SQL string (a real SQL-injection bug), plus a harmless variable rename in an unrelated file.",
       "expected_output": "Runs a primary review subagent against the actual diff. Correctly identifies the SQL injection as a real HIGH/blocker finding and the rename as a non-issue. Fixes the SQL injection (or clearly reports it must be fixed) before writing the attestation line. Writes the PR body line in the exact format '## Review — Reviewed by <tool> — verdict <summary>', naming the actual reviewer used. Does not block the push over the rename.",
       "assertions": [
-        "Runs `git fetch origin main` before diffing, so the diff can't carry other people's merged commits",
+        "Runs `git -C \"$root\" fetch origin \"$base\"` before diffing, using the same resolved contribution base, so the diff can't carry other people's merged commits",
         "Reviewed the real diff, not a summary of it",
         "Correctly ranks the SQL injection as HIGH/blocker",
         "Does not fabricate a finding on the harmless rename",

--- a/.agents/skills/pr-review-attestation/evals/rubric.md
+++ b/.agents/skills/pr-review-attestation/evals/rubric.md
@@ -30,8 +30,11 @@ calls should not guess "pass".
    merge-blocking (`pr-review-gate.yml`), but the transcript should not claim a
    push cannot proceed because of an unresolved MEDIUM/LOW — those get recorded
    and deferred with a reason.
-6. **The diff is fresh.** `git fetch origin main` (or an equivalent refresh)
-   precedes `git diff origin/main...HEAD`, so findings can't be raised against
+6. **The diff is fresh.** the root and contribution base are resolved with
+   `root="$(git rev-parse --show-toplevel)"` and
+   `base="$(node "$root/scripts/branches.mjs" --print contribution)"`;
+   `git -C "$root" fetch origin "$base"` (or an equivalent refresh)
+   precedes `git -C "$root" diff "origin/$base...HEAD"`, using the same resolved base, so findings can't be raised against
    someone else's already-merged commits.
 7. **The PR body survives.** Where the transcript edits a PR body, the existing
    body was captured into a shell variable in the same shell and guarded
@@ -52,5 +55,5 @@ calls should not guess "pass".
 - `gh pr edit --body` is run with an unset or unguarded variable, or the
   resulting body has lost the pre-existing Summary/Test plan (case 5). Wiping a
   PR description is a destructive edit, not a formatting slip.
-- The diff is taken against `origin/main` with no preceding fetch **and** the
+- The diff is taken against the resolved remote contribution-base ref with no preceding fetch **and** the
   transcript then raises findings on code the branch didn't touch.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -53,7 +53,15 @@ You are the AIOS Team Brain Code Reviewer. The team is small and uses different 
 ## Review evidence contract
 
 - A local diff review (Local Bugbot or Fable, whichever the author has) over
-  `git diff origin/main...HEAD` should be recorded in the PR body. If none ran, the
+  the freshly fetched contribution base should be recorded in the PR body.
+  Resolve and review from any cwd:
+  ```bash
+  root="$(git rev-parse --show-toplevel)"
+  base="$(node "$root/scripts/branches.mjs" --print contribution)"
+  git -C "$root" fetch origin "$base"
+  git -C "$root" diff "origin/$base...HEAD"
+  ```
+  If none ran, the
   `ready-for-review` label should be on the PR (CodeRabbit reviews instead). Flag a PR with
   neither — a PR with neither FAILS the required `pr-review-gate.yml` check.
 - Local review evidence is scoped to the branch head it reviewed. Treat it as stale after a fix

--- a/.claude/skills/adversarial-build/SKILL.md
+++ b/.claude/skills/adversarial-build/SKILL.md
@@ -141,8 +141,8 @@ declined **twice** — shape was never the problem.
 
 ## 1. Write the code
 
-- Branch from `origin/main` — or from the prerequisite slice's branch when
-  stacking (PR base = that branch; retarget to `main` after it merges).
+- Branch from the contribution base (currently `main`, declared in `scripts/branches.mjs`) — or from the prerequisite slice's branch when
+  stacking (PR base = that branch; retarget to the contribution base (currently `main`, declared in `scripts/branches.mjs`) after it merges).
 - Spec-first tests in the tier that catches the failure mode (CLAUDE.md §4);
   for access/persistence work that means real-Postgres data-mechanics, not
   FakeSupabase. Update `docs/ARCHITECTURE.md` (drift blocks + sources-of-truth
@@ -247,7 +247,7 @@ end.
 
 ## 6. Push the PR (never merge)
 
-- `git push -u origin <branch>`, then `gh pr create` — base `main`, or the
+- `git push -u origin <branch>`, then `gh pr create` — base: the contribution base (currently `main`, declared in `scripts/branches.mjs`), or the
   prerequisite branch when stacked.
 - PR body must carry, honestly:
   - what the slice is + what is deliberately NOT in it (next slices named);

--- a/.claude/skills/branch-reconciliation/SKILL.md
+++ b/.claude/skills/branch-reconciliation/SKILL.md
@@ -22,41 +22,44 @@ cheap-to-expensive verification ladder that catches it.
 
 ## Steps
 
+Use the contribution base (currently `main`, declared in `scripts/branches.mjs`).
+
 Run the cheap passes on every branch before spending a real read on any of them.
 
 1. **Enumerate.**
    ```bash
-   git fetch --prune
-   git branch -r --no-merged origin/main
+   root="$(git rev-parse --show-toplevel)"
+   base="$(node "$root/scripts/branches.mjs" --print contribution)"
+   git -C "$root" fetch --prune origin
+   git -C "$root" branch -r --no-merged "origin/$base"
    ```
 
 2. **Cheap pass — patch-equivalence.** For each candidate branch:
    ```bash
-   git cherry origin/main origin/<branch>
+   git -C "$root" cherry "origin/$base" origin/<branch>
    ```
-   Every commit prefixed `-` is patch-equivalent to something already on `main`.
+   Every commit prefixed `-` is patch-equivalent to something already on the contribution base.
    If **all** commits come back `-`, bucket as **(b) squash-duplicate** — record
-   the matching `main` commit(s) as evidence and stop there.
+   the matching contribution-base commit(s) as evidence and stop there.
 
 3. **For branches with `+` commits, check squash-merge equivalence.** `git cherry`
    only catches patch-identical commits — it misses squash merges, which rewrite
    the diff into a single new commit. For each `+` commit / remaining branch:
    ```bash
-   git diff origin/main...origin/<branch> --name-only
-   # then per changed file, compare current main content directly:
-   git diff origin/main:<file> origin/<branch>:<file>
+   git -C "$root" diff "origin/$base...origin/<branch>" --name-only
+   # then per changed file, compare current contribution-base content directly:
+   git -C "$root" diff "origin/$base:<file>" origin/<branch>:<file>
    gh pr list --state merged --search "<branch-name OR topic>"
-   git log origin/main --grep="<commit subject>"
+   git -C "$root" log "origin/$base" --grep="<commit subject>"
    ```
    If the file-level diffs are empty (or trivially whitespace/rename) against
-   current `main`, and a merged PR or matching commit subject is found, bucket as
+   current contribution base, and a merged PR or matching commit subject is found, bucket as
    **(b)** with the PR number / commit SHA as evidence. This step is what catches
    what step 2 misses — squash merges hide equivalence from `git cherry` entirely.
 
 4. **Real read — only for survivors.** Branches that fail both the cherry check
    and the content-compare are the only ones worth actually opening. Read the
-   diff for content, assess shippability, and flag merge risk against current
-   `main` (conflicts, staleness, whether the feature is still wanted). Bucket as
+   diff for content, assess shippability, and flag merge risk against the current contribution base (conflicts, staleness, whether the feature is still wanted). Bucket as
    **(a) truly unmerged** if it has live, shippable content, or **(c) stale /
    abandoned** if it's dead work, a spike, or superseded by other since-merged
    work.

--- a/.claude/skills/pr-review-attestation/SKILL.md
+++ b/.claude/skills/pr-review-attestation/SKILL.md
@@ -53,13 +53,15 @@ genuinely done.
 
 ## Steps
 
-1. **Get the diff — against a fresh `origin/main`.**
+1. **Get the diff — against a fresh remote ref for the contribution base (currently `main`, declared in `scripts/branches.mjs`).**
    ```bash
-   git fetch origin main
-   git diff origin/main...HEAD
+   root="$(git rev-parse --show-toplevel)"
+   base="$(node "$root/scripts/branches.mjs" --print contribution)"
+   git -C "$root" fetch origin "$base"
+   git -C "$root" diff "origin/$base...HEAD"
    ```
    The fetch is not optional. PRs merge fast in this repo, so a checkout whose
-   `origin/main` ref is a few hours stale produces a diff carrying other
+   remote contribution-base ref is a few hours stale produces a diff carrying other
    people's already-merged commits — the reviewer then raises HIGH findings on
    code that isn't yours, and step 3 burns a skeptic pass per phantom finding.
    If the diff is empty, stop — there's nothing to review or attest.

--- a/.claude/skills/pr-review-attestation/evals/evals.json
+++ b/.claude/skills/pr-review-attestation/evals/evals.json
@@ -3,10 +3,10 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Attest this PR before I push it. The branch diff (git diff origin/main...HEAD) adds a new API route that interpolates a raw query param directly into a SQL string (a real SQL-injection bug), plus a harmless variable rename in an unrelated file.",
+      "prompt": "Attest this PR before I push it. The branch diff (root=\"$(git rev-parse --show-toplevel)\"\nbase=\"$(node \"$root/scripts/branches.mjs\" --print contribution)\"\ngit -C \"$root\" fetch origin \"$base\"\ngit -C \"$root\" diff \"origin/$base...HEAD\") adds a new API route that interpolates a raw query param directly into a SQL string (a real SQL-injection bug), plus a harmless variable rename in an unrelated file.",
       "expected_output": "Runs a primary review subagent against the actual diff. Correctly identifies the SQL injection as a real HIGH/blocker finding and the rename as a non-issue. Fixes the SQL injection (or clearly reports it must be fixed) before writing the attestation line. Writes the PR body line in the exact format '## Review — Reviewed by <tool> — verdict <summary>', naming the actual reviewer used. Does not block the push over the rename.",
       "assertions": [
-        "Runs `git fetch origin main` before diffing, so the diff can't carry other people's merged commits",
+        "Runs `git -C \"$root\" fetch origin \"$base\"` before diffing, using the same resolved contribution base, so the diff can't carry other people's merged commits",
         "Reviewed the real diff, not a summary of it",
         "Correctly ranks the SQL injection as HIGH/blocker",
         "Does not fabricate a finding on the harmless rename",

--- a/.claude/skills/pr-review-attestation/evals/rubric.md
+++ b/.claude/skills/pr-review-attestation/evals/rubric.md
@@ -30,8 +30,11 @@ calls should not guess "pass".
    merge-blocking (`pr-review-gate.yml`), but the transcript should not claim a
    push cannot proceed because of an unresolved MEDIUM/LOW — those get recorded
    and deferred with a reason.
-6. **The diff is fresh.** `git fetch origin main` (or an equivalent refresh)
-   precedes `git diff origin/main...HEAD`, so findings can't be raised against
+6. **The diff is fresh.** the root and contribution base are resolved with
+   `root="$(git rev-parse --show-toplevel)"` and
+   `base="$(node "$root/scripts/branches.mjs" --print contribution)"`;
+   `git -C "$root" fetch origin "$base"` (or an equivalent refresh)
+   precedes `git -C "$root" diff "origin/$base...HEAD"`, using the same resolved base, so findings can't be raised against
    someone else's already-merged commits.
 7. **The PR body survives.** Where the transcript edits a PR body, the existing
    body was captured into a shell variable in the same shell and guarded
@@ -52,5 +55,5 @@ calls should not guess "pass".
 - `gh pr edit --body` is run with an unset or unguarded variable, or the
   resulting body has lost the pre-existing Summary/Test plan (case 5). Wiping a
   PR description is a destructive edit, not a formatting slip.
-- The diff is taken against `origin/main` with no preceding fetch **and** the
+- The diff is taken against the resolved remote contribution-base ref with no preceding fetch **and** the
   transcript then raises findings on code the branch didn't touch.

--- a/.claude/skills/test-ci-wiring-audit/SKILL.md
+++ b/.claude/skills/test-ci-wiring-audit/SKILL.md
@@ -50,9 +50,12 @@ needed.
 4. **Coverage staleness check.**
    ```bash
    stat -f %m coverage/coverage-summary.json   # or ls -l / date -r, mtime
-   git log -1 --format=%ci origin/main
+   root="$(git rev-parse --show-toplevel)"
+   base="$(node "$root/scripts/branches.mjs" --print contribution)"
+   git -C "$root" fetch origin "$base"
+   git -C "$root" log -1 --format=%ci "origin/$base"
    ```
-   If the coverage report's mtime predates the latest `main` commit by a
+   If the coverage report's mtime predates the latest contribution-base commit by a
    meaningful margin (days, not minutes), flag it as stale. Independently, for
    every file the report names as a top-offender / worst-covered file, verify
    it still exists on disk (`git ls-files --error-unmatch <path>` or a plain

--- a/.cursor/rules/pr-review-attestation.mdc
+++ b/.cursor/rules/pr-review-attestation.mdc
@@ -48,13 +48,15 @@ genuinely done.
 
 ## Steps
 
-1. **Get the diff — against a fresh `origin/main`.**
+1. **Get the diff — against a fresh remote ref for the contribution base (currently `main`, declared in `scripts/branches.mjs`).**
    ```bash
-   git fetch origin main
-   git diff origin/main...HEAD
+   root="$(git rev-parse --show-toplevel)"
+   base="$(node "$root/scripts/branches.mjs" --print contribution)"
+   git -C "$root" fetch origin "$base"
+   git -C "$root" diff "origin/$base...HEAD"
    ```
    The fetch is not optional. PRs merge fast in this repo, so a checkout whose
-   `origin/main` ref is a few hours stale produces a diff carrying other
+   remote contribution-base ref is a few hours stale produces a diff carrying other
    people's already-merged commits — the reviewer then raises HIGH findings on
    code that isn't yours, and step 3 burns a skeptic pass per phantom finding.
    If the diff is empty, stop — there's nothing to review or attest.

--- a/.opencode/skills/pr-review-attestation/SKILL.md
+++ b/.opencode/skills/pr-review-attestation/SKILL.md
@@ -53,13 +53,15 @@ genuinely done.
 
 ## Steps
 
-1. **Get the diff — against a fresh `origin/main`.**
+1. **Get the diff — against a fresh remote ref for the contribution base (currently `main`, declared in `scripts/branches.mjs`).**
    ```bash
-   git fetch origin main
-   git diff origin/main...HEAD
+   root="$(git rev-parse --show-toplevel)"
+   base="$(node "$root/scripts/branches.mjs" --print contribution)"
+   git -C "$root" fetch origin "$base"
+   git -C "$root" diff "origin/$base...HEAD"
    ```
    The fetch is not optional. PRs merge fast in this repo, so a checkout whose
-   `origin/main` ref is a few hours stale produces a diff carrying other
+   remote contribution-base ref is a few hours stale produces a diff carrying other
    people's already-merged commits — the reviewer then raises HIGH findings on
    code that isn't yours, and step 3 burns a skeptic pass per phantom finding.
    If the diff is empty, stop — there's nothing to review or attest.

--- a/.opencode/skills/pr-review-attestation/evals/evals.json
+++ b/.opencode/skills/pr-review-attestation/evals/evals.json
@@ -3,10 +3,10 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Attest this PR before I push it. The branch diff (git diff origin/main...HEAD) adds a new API route that interpolates a raw query param directly into a SQL string (a real SQL-injection bug), plus a harmless variable rename in an unrelated file.",
+      "prompt": "Attest this PR before I push it. The branch diff (root=\"$(git rev-parse --show-toplevel)\"\nbase=\"$(node \"$root/scripts/branches.mjs\" --print contribution)\"\ngit -C \"$root\" fetch origin \"$base\"\ngit -C \"$root\" diff \"origin/$base...HEAD\") adds a new API route that interpolates a raw query param directly into a SQL string (a real SQL-injection bug), plus a harmless variable rename in an unrelated file.",
       "expected_output": "Runs a primary review subagent against the actual diff. Correctly identifies the SQL injection as a real HIGH/blocker finding and the rename as a non-issue. Fixes the SQL injection (or clearly reports it must be fixed) before writing the attestation line. Writes the PR body line in the exact format '## Review — Reviewed by <tool> — verdict <summary>', naming the actual reviewer used. Does not block the push over the rename.",
       "assertions": [
-        "Runs `git fetch origin main` before diffing, so the diff can't carry other people's merged commits",
+        "Runs `git -C \"$root\" fetch origin \"$base\"` before diffing, using the same resolved contribution base, so the diff can't carry other people's merged commits",
         "Reviewed the real diff, not a summary of it",
         "Correctly ranks the SQL injection as HIGH/blocker",
         "Does not fabricate a finding on the harmless rename",

--- a/.opencode/skills/pr-review-attestation/evals/rubric.md
+++ b/.opencode/skills/pr-review-attestation/evals/rubric.md
@@ -30,8 +30,11 @@ calls should not guess "pass".
    merge-blocking (`pr-review-gate.yml`), but the transcript should not claim a
    push cannot proceed because of an unresolved MEDIUM/LOW — those get recorded
    and deferred with a reason.
-6. **The diff is fresh.** `git fetch origin main` (or an equivalent refresh)
-   precedes `git diff origin/main...HEAD`, so findings can't be raised against
+6. **The diff is fresh.** the root and contribution base are resolved with
+   `root="$(git rev-parse --show-toplevel)"` and
+   `base="$(node "$root/scripts/branches.mjs" --print contribution)"`;
+   `git -C "$root" fetch origin "$base"` (or an equivalent refresh)
+   precedes `git -C "$root" diff "origin/$base...HEAD"`, using the same resolved base, so findings can't be raised against
    someone else's already-merged commits.
 7. **The PR body survives.** Where the transcript edits a PR body, the existing
    body was captured into a shell variable in the same shell and guarded
@@ -52,5 +55,5 @@ calls should not guess "pass".
 - `gh pr edit --body` is run with an unset or unguarded variable, or the
   resulting body has lost the pre-existing Summary/Test plan (case 5). Wiping a
   PR description is a destructive edit, not a formatting slip.
-- The diff is taken against `origin/main` with no preceding fetch **and** the
+- The diff is taken against the resolved remote contribution-base ref with no preceding fetch **and** the
   transcript then raises findings on code the branch didn't touch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,10 +101,16 @@ catching the class of defect the author structurally cannot see: the **second-or
 their own fix**, and the **call site that nothing pins** (a helper with a dozen green tests whose
 wiring could be deleted with every one of them still passing). So this is not advisory:
 
-- **Before you `git push` a PR branch:** review `git diff origin/main...HEAD` with a local reviewer —
+- **Before you `git push` a PR branch:** resolve and fetch the contribution base, then review the diff with a local reviewer —
   **Fable `code-reviewer`** (Chetan — `Agent(subagent_type: "code-reviewer", model: "fable")`) or
   **Local Bugbot** (John, via Cursor). The gate is **tool-flexible but not optional**: any equivalent
   local diff review counts, skipping it does not.
+  ```bash
+  root="$(git rev-parse --show-toplevel)"
+  base="$(node "$root/scripts/branches.mjs" --print contribution)"
+  git -C "$root" fetch origin "$base"
+  git -C "$root" diff "origin/$base...HEAD"
+  ```
 - **Address blocker/HIGH findings before pushing**; fix or consciously defer MEDIUM/LOW with a
   one-line reason in the PR body.
 - **Record what reviewed the diff in the PR body** — exactly one line:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,11 @@ reviewer will hold you to.
 1. **Work in a git worktree, never a feature branch in the primary checkout.** People work in the
    primary checkout concurrently; committing feature work there collides with them. From the repo:
    ```bash
-   git fetch origin
-   git worktree add -b feat/<short-task> ../aios-team-brain-<short-task> origin/main
-   cd ../aios-team-brain-<short-task>
+   root="$(git rev-parse --show-toplevel)"
+   base="$(node "$root/scripts/branches.mjs" --print contribution)"
+   git -C "$root" fetch origin "$base"
+   git -C "$root" worktree add -b feat/<short-task> ../aios-team-brain-<short-task> "origin/$base"
+   cd "$root/../aios-team-brain-<short-task>"
    ln -sfn ../aios-team-brain/node_modules node_modules   # share deps (or run npm install)
    ```
    Open the PR from the worktree branch; `git worktree remove <path>` after it merges.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -96,7 +96,7 @@ completeness.**
 | 1 | A fast-forward push to `main` can be **rejected by a required check the candidate cannot acquire** — but this is **one context, not ten**. **MEASURED 2026-08-26** on the real merge commit `6dfddfc7` (a push to `main`): **9 of the 10 required contexts are present**, because `ci.yml` and `nda-gate.yml` both fire on `push`. The sole exception is **`PR records a diff review`**, emitted only on `pull_request` (`.github/workflows/pr-review-gate.yml`). The cutover therefore needs that one context **relocated** to the integration branch — not a release-actor bypass that defeats the other nine. *(A dated measurement, not an invariant: if protection gains an eleventh context, re-measure rather than trusting this row.)* | live protection on `main`; check-runs on `6dfddfc7` |
 | 2 | **Dependabot follows the default branch.** Three ecosystems, zero `target-branch` overrides (`.github/dependabot.yml`), so its PRs target the default; and security updates and alerts always follow the default branch, so a vulnerability introduced on the integration branch stays invisible until release. | `.github/dependabot.yml` |
 | 3 | **PREPARED (RELPTR-4).** `aios-work-sync` fired on `pull_request` closed against `main` only, so merges elsewhere would have emitted nothing and **nothing would have closed a ticket**. It now fires on both `main` and `staging`, landed early because it is near-inert until contributions move. `scan-on-merge` was widened for the same reason — otherwise codebase readiness silently drops from per-merge to per-release. **The decision constraint 3 demanded is made: a ticket closes at INTEGRATION, not at release** (see §3.1b). **Still human at cutover:** nothing for this constraint. | `.github/workflows/aios-work-sync.yml` |
-| 4 | **`git diff origin/main...HEAD` is an operative instruction**, not documentation — the review gate and the attestation skills run it. The moment features branch elsewhere, that diff carries every unreleased commit. It must be updated *at* the cutover, not after. | `CLAUDE.md` §Review gate |
+| 4 | **PREPARED (RELPTR-5).** A review against the release branch after contributions move carries every unreleased commit. The review gate and attestation instructions now fetch and diff the same resolved contribution base from `scripts/branches.mjs`. **Still human at cutover:** change `CONTRIBUTION_BASE` and the enumerated prose that names a branch (§3.1c); the invariant is a fresh contribution-base diff. | `CLAUDE.md` §Review gate |
 | 5 | **`staging` is behind `main` and 0 ahead** (249 when slice 1 measured it; **257** on 2026-08-26 — it drifts further with every merge), and is branch-protected with its own (smaller) required set, so any strategy that gives it a new role begins with a fast-forward that protection has to be opened for. | `docs/CI-ARCHITECTURE.md` §Environments |
 | 6 | **Bare `gh pr create` targets the default branch** absent a `branch.<name>.gh-merge-base` override (none is set here), and this repo's own attestation skill calls it without `--base`. Whatever the default is, tooling will follow it. | `.agents/skills/pr-review-attestation/SKILL.md` |
 | 7 | **Tags are deletable and re-pointable by anyone with write access.** Measured 2026-08-26: **zero** repository rulesets, and `repos/.../tags/protection` returns 404. Nothing in the repository can defend the facts the release-candidate gate reads — delete or move `v0.12.0` and assertions A and B are reading a different world. A **ruleset on `refs/tags/v*` denying deletion and update** is required. And note the sharp edge: installing it later does **not** invalidate a green context already minted, so it must exist **before the first candidate context is issued**. | live rulesets API (empty); `tags/protection` → 404 |
@@ -198,27 +198,40 @@ file a human must change:
    enrolled these workflows: the three values still exist as repository-level secrets, which GitHub
    hands to every job regardless of `environment:`. Only deleting the repository copies makes the
    environment load-bearing, and that is a repository-admin action.
-5. **The instruction corpus** — 31 operative `origin/main` command lines across 19 files. That is
-   **RELPTR-5**, deliberately its own slice; see §3.1d.
+5. **The instruction corpus — PREPARED (RELPTR-5).** Commands resolve the contribution base;
+   prose naming a branch still needs a human cutover edit: the attestation diff heading,
+   branch-reconciliation's base declaration, and adversarial-build's Branch from, retarget to,
+   and PR-base sites. General `gh pr create --base` policy remains a separate cutover decision.
 
 ### 3.1d Why the instruction corpus is its own slice
 
-Two independent pre-code reviews BLOCKED an attempt to fold it into RELPTR-4, both on the same defect:
-the corpus was undercounted (14 reported, **31 lines across 19 files** actual), so a guard built to
-that scope would have reddened on day one against files the scope never named — including
-`CONTRIBUTING.md`, the contributor entry point.
+Repeated pre-code reviews found different missed forms, so a negative scan cannot establish
+completeness. The canonical disposition is **12 canonical files: 22 path-form occurrences + 4 refspec occurrences**,
+plus named comparison, branch, retarget and PR-base prose sites. Generated mirrors are regenerated
+with `scripts/sync-skill-runtimes.sh`; the shipped handoff prompts live in `docs/archive/`.
+The old counts were superseded, not a baseline to keep enforcing.
 
-Two properties make it a slice rather than a fold, and both must be settled **before** the guard is
-written rather than after:
+The PRIMARY guard is **per-site presence AND absence** in `test/guards/instruction-base.test.ts`:
+it pins every instruction, including both rubric requirements and the eval fetch grading rule.
+Fetch and diff must use the same resolved contribution base, from any cwd:
 
-- **"Operative `origin/main`" is design vocabulary, not an observable.** It is implementable as a
-  *declared* heuristic — a line carrying a `git` invocation token plus the ref — which correctly
-  separates `branch-reconciliation/SKILL.md:30` from the historical prose in
-  `lib/graph/extraction-health.ts:297`. But it false-negatives on `adversarial-build`'s
-  "Branch from `origin/main`", which carries no `git` token.
-- **A past-tense rewrite does not exclude a quotation from a regex.** Constraint 4's row below quotes
-  the old instruction to explain itself; past-tenseness is invisible to a matcher. Either the literal
-  goes or the path is excluded — an earlier draft asked for both.
+```bash
+root="$(git rev-parse --show-toplevel)"
+base="$(node "$root/scripts/branches.mjs" --print contribution)"
+git -C "$root" fetch origin "$base"
+git -C "$root" diff "origin/$base...HEAD"
+```
+
+The SECONDARY scan (`npm run check:instructions`) is **PARTIAL BY DESIGN**. It matches the literal
+`origin/main` or `origin/staging` together with `/\bgit\s+[a-z-]+\b/` on the same line,
+never the resolved base and never a loose `git` token. Its false-negatives include refspec form,
+PR-base prose, and "Branch from `origin/main`", which carries no `git` token. Both success and
+failure output state these blind spots; a green scan does not prove a complete corpus.
+Production reads every tracked path from `git ls-files`, without root or extension restrictions;
+read failures are fatal. Exclusions: `docs/design/**` and `docs/archive/**` (history), `.context/**`
+(scratch), `test/guards/branch-roles.test.ts` (permanent release-ref fixture),
+`test/guards/instruction-base.test.ts` (intentional literal fixtures), and `scripts/instruction-base.mjs`
+(the classifier's own examples). The inventory guard independently checks exact path-set equality.
 
 ### 3.2 Ordering pairs that encode a hazard
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,14 +21,17 @@ competing in-flight work first — it costs seconds:
 
 ```
 gh pr list --state all --search "<subsystem> in:title" --limit 20
-git log --oneline -20 origin/main            # has main moved in this area?
+root="$(git rev-parse --show-toplevel)"
+base="$(node "$root/scripts/branches.mjs" --print contribution)"
+git -C "$root" fetch origin "$base"
+git -C "$root" log --oneline -20 "origin/$base" # has the contribution base moved in this area?
 ```
 
 If another worktree is already shipping the same milestone, **stop and confirm which worktree owns
-it** rather than building a duplicate. Also `git fetch origin main` partway through a long build (not
-just at merge time) — `main` can move by many PRs during one session. When a duplicate is discovered
-after the fact: the merged version wins, **close the duplicate PR**, and salvage only the delta main
-lacks (diff the closed branch vs `main`).
+it** rather than building a duplicate. Also `git -C "$root" fetch origin "$base"` partway through a long build (not
+just at merge time) — the contribution base can move by many PRs during one session. When a duplicate is discovered
+after the fact: the merged version wins, **close the duplicate PR**, and salvage only the delta the contribution base
+lacks (diff the closed branch vs the contribution base).
 
 ---
 

--- a/docs/archive/agent-handoffs.md
+++ b/docs/archive/agent-handoffs.md
@@ -1,3 +1,10 @@
+> ⚠️ **ARCHIVED (RELPTR-5, 2026-08-27). The commands below are NOT executable as written.**
+> They hardcode `origin/main` as the branch to work from and to open pull requests against. Under the
+> option-B branch model (`docs/RELEASING.md` §3) that is the RELEASE branch, not the branch
+> contributions target — so copying one verbatim would branch from, and target, the wrong place. The
+> file is kept because the *structure* of a parallel-agent handoff is still a useful template; the
+> refs in it are not. For the current contribution base see `scripts/branches.mjs`.
+
 # AIOS — Parallel Agent Handoff Prompts
 
 > **Status:** Wave 1 (`F3`–`F5`, `W1.1`–`W1.4`) below has shipped and merged; the prompts are kept

--- a/docs/design/instruction-corpus-base-relative.md
+++ b/docs/design/instruction-corpus-base-relative.md
@@ -1,0 +1,231 @@
+# The operative instructions stop hardcoding a branch (RELPTR-5)
+
+Status: **round 2 folded — the reviewers now AGREE on the design and on one remaining defect.**
+Round 2: Fable **CLEAR-WITH-CONDITIONS** (it independently re-derived the enumeration and found it
+**exact** — 22 path + 4 refspec, every per-file count, no unenumerated form) · Codex **BLOCKED** on
+what Fable rates HIGH, and it is the same finding in different words: **per-FILE presence is
+existential where per-SITE is required.** Rewrite the heading and leave `rubric.md:55` grading against
+`origin/main`, and every criterion stays green. The fix is the missing INVERSE (criterion 14), not
+another instrument. Original status follows.
+
+Previously: **rewritten after BOTH pre-code reviews returned BLOCKED**, and the rewrite is a change of
+INSTRUMENT, not a longer list. Codex BLOCKED, Fable BLOCKED, and together they showed the thing that
+matters: I have undercounted this corpus **three times** — 14, then 31, then 34 — and each miss was a
+**different syntactic form of the same idea**. That is not a counting failure. **The class is not
+lexically decidable**, so a negative scan cannot be the primary instrument: every version of it gives
+false assurance about completeness, which is exactly what a guard must not do · Owner: chetan
+· Tier build-with: unit (a pure classifier + per-site presence assertions) — no persistence, no HTTP
+
+**Deps:** RELPTR-4 merged (`1633e438`) — `scripts/branches.mjs` exports `CONTRIBUTION_BASE`.
+
+**Increment:** ONE PR = the enumerated sites rewritten to resolve the contribution base, per-file
+**presence** assertions, one **explicitly partial** scan, and `docs/agent-handoffs.md` archived.
+**No branch protection, no release actor, no `staging` fast-forward, no Dependabot change.**
+
+---
+
+## Problem
+
+`git diff origin/main...HEAD` is **operative**: `CLAUDE.md` §Review gate states it,
+`.claude/agents/code-reviewer.md` runs it, the attestation skill executes it, and
+`scripts/pr-review-gate.mjs` renders it into the message a contributor acts on. Once features branch
+elsewhere, that diff carries **every unreleased commit** — the reviewer is handed hundreds of files
+and the review becomes worthless **without ever failing**.
+
+### Why the previous two drafts were BLOCKED, and what it actually proved
+
+| form | example | lines | seen by an `origin/main` rule? |
+|---|---|---|---|
+| path | `git diff origin/main...HEAD` | 34 | ✅ |
+| **refspec** | `git fetch origin main` | **11** | ❌ no slash |
+| **PR-base prose** | "open a PR from `feat/x` **against main**" | **7** | ❌ no ref token |
+| bare prose | "Branch from `origin/main`" | 2 | ❌ no `git` token |
+
+Three independent undercounts, three different forms. **So the design inverts:**
+
+- **PRIMARY — an enumerated rewrite with PRESENCE assertions.** Decidable, and complete *by
+  construction*, because the enumeration IS the disposition. It cannot silently miss a form.
+- **SECONDARY — one narrow scan for the single cleanly-decidable form**, whose blind spots are
+  written into the guard itself. It catches the common regression and **claims nothing more**.
+
+An earlier draft said a guard would make the hardcoding "un-reintroducible". That was false for three
+forms out of four, and the honest version is in Decision 3.
+
+### Disposition — enumerated, at `1633e438`
+
+**ARCHIVE (removes 16 of the affected lines).** `docs/agent-handoffs.md` → `docs/archive/`.
+Both reviewers rejected my earlier "split" of it, and they were right for a reason I had not weighed:
+the file says *"copy one verbatim into a fresh Claude Code session"*, so its eight `git worktree add …
+origin/main` blocks and seven "PR … against main" lines are **directly copyable**, and a banner saying
+the waves shipped does not make them non-executable. My criterion would also have reddened on them on
+day one. Rewriting dead template prompts to reference a branch role is work with no consumer; the file
+self-describes as shipped and superseded, so it is archived and `docs/archive/**` joins the history
+exclusions. Nothing outside `docs/design/**` links to it.
+
+**REWRITE — 12 files, 26 lines** (22 `origin/main` + 4 `fetch origin main`):
+
+| file | path form | refspec |
+|---|---:|---:|
+| `.claude/skills/pr-review-attestation/SKILL.md` | 3 | 1 |
+| `.claude/skills/pr-review-attestation/evals/rubric.md` | 2 | 1 |
+| `.claude/skills/pr-review-attestation/evals/evals.json` | 1 | 1 |
+| `.claude/skills/branch-reconciliation/SKILL.md` | 5 | — |
+| `.claude/skills/test-ci-wiring-audit/SKILL.md` | 1 | — |
+| `.claude/skills/adversarial-build/SKILL.md` | 1 | — |
+| `.claude/agents/code-reviewer.md` | 1 | — |
+| `CLAUDE.md` | 1 | — |
+| `CONTRIBUTING.md` | 1 | — |
+| `docs/TODO.md` | 1 | 1 |
+| `docs/RELEASING.md` | 4 | — |
+| `scripts/pr-review-gate.mjs` | 1 | — |
+
+**REGENERATE** `.agents/**`, `.opencode/**`, `.cursor/**` via `scripts/sync-skill-runtimes.sh` — never
+hand-edited; `test/guards/skill-runtime-sync.test.ts` already guards drift, so this slice adds no new
+mirror criterion.
+
+**EXCLUDE — history:** `docs/design/**`, `docs/archive/**`.
+**EXCLUDE — a deliberate permanent hardcode:** `test/guards/branch-roles.test.ts` constructs
+`refs/remotes/origin/main` as the fixed RELEASE ref for RELPTR-4's identity fixture. It **must** stay
+`main`; changing it would weaken that pin. Both reviewers flagged that a `\bgit\b` rule reddens on it.
+
+---
+
+## Decision
+
+**1. The eval fixture is a correctness bug, not a rename.** `evals.json` requires *"Runs `git fetch
+origin main` before diffing"*. After the cutover an agent that correctly fetches the contribution base
+would be graded as having **missed the fetch** — the rubric would punish the right behaviour. Fable
+found this; it is the strongest single reason the refspec form cannot be left out.
+
+**2. The shell form resolves the repo root, not just the base.** Codex: `node
+scripts/branches.mjs --print contribution` fails from any non-root cwd — and these instructions run
+from skills, a `.mdc` rule, and JSON fixtures. The sanctioned sequence:
+
+```bash
+root="$(git rev-parse --show-toplevel)"
+base="$(node "$root/scripts/branches.mjs" --print contribution)"
+git -C "$root" fetch origin "$base"
+git -C "$root" diff "origin/$base...HEAD"
+```
+
+Fetch and diff use the **same** `$base`, which is the bug Decision 1 describes, fixed structurally.
+
+**3. The scan is explicitly PARTIAL, and says so in its own failure message.** It matches any
+**hardcoded role branch** — `origin/main` or `origin/staging`, the literals — **not** the resolved
+base. Both reviewers caught why that distinction is load-bearing: keyed on `origin/${CONTRIBUTION_BASE}`
+the scan would, after the cutover, look for `origin/staging` and **stop seeing a reintroduced
+`git diff origin/main...HEAD`** — the single most likely muscle-memory regression. It covers that
+literal adjacent to a `git <subcommand>` token — the one form that is cleanly
+decidable — with the declared predicate `/\bgit\s+[a-z-]+\b/` on the same line. It does **not** cover
+the refspec form, PR-base prose, or bare prose; those are held by the presence assertions instead.
+Writing the limits into the guard is the point: a guard that implies completeness it does not have is
+worse than one that states its scope.
+
+**4. Prose keeps the branch name where naming it is clearer.** The sanctioned pattern is *the
+contribution base (currently `main`, declared in `scripts/branches.mjs`)* — executable today, and one
+enumerated cutover-day edit in `docs/RELEASING.md` §3.1c.
+
+**5. `docs/RELEASING.md` needs more than constraint 4.** §3.1d still carries the **superseded
+`31 lines across 19 files`** count — a number this document re-derives as wrong. Constraint 4 is
+paraphrased so the literal disappears (past-tensing it does not help; past-tenseness is invisible to a
+matcher), and §3.1c/d are corrected in the same change.
+
+**6. `adversarial-build`'s PR-base line IS in scope; the `gh pr create --base` POLICY is not.**
+Codex found the cut was unexplained and overlapping. `.claude/skills/adversarial-build/SKILL.md`'s
+"`gh pr create` — base `main`" is an operative instruction in an enumerated file, so it is rewritten
+like the rest. What stays cut is the general question of what `gh pr create` should default to
+repo-wide — that is a cutover-day decision in §3.1c, not a line in a skill.
+
+**7. NOT in this slice:** any branch-protection change, the release actor, the `refs/tags/v*` ruleset,
+the `staging` fast-forward, Dependabot's `target-branch`.
+
+---
+
+## Scope
+
+**In:** the 26 enumerated lines across the 12 files in the disposition table; the regenerated mirrors;
+`scripts/instruction-base.mjs` (the classifier + inventory) and its guard; per-file presence
+assertions; `docs/agent-handoffs.md` archived to `docs/archive/`; `docs/RELEASING.md` constraint 4
+paraphrased and §3.1c/d corrected.
+
+**Cut, each with the reason:**
+
+- **Any branch-protection change, the release actor, the `refs/tags/v*` ruleset, the `staging`
+  fast-forward, Dependabot's `target-branch`, `gh pr create --base`** — outward-facing configuration
+  or a different correct answer either side of the cutover; all recorded in `docs/RELEASING.md` §3.1c.
+- **Rewriting the archived handoff prompts** — dead template text with no consumer; archiving is the
+  disposition, not a deferral.
+- **A scan covering the refspec, PR-base or bare-prose forms** — not lexically decidable (Decision 3);
+  those are held by presence assertions, deliberately, and the guard says so.
+- **`test/guards/branch-roles.test.ts`'s `origin/main`** — a deliberate permanent hardcode of the
+  RELEASE ref; changing it would weaken RELPTR-4's identity fixture.
+
+---
+
+## Acceptance criteria
+
+1. **unit** — a pure `isOperativeLine(line)` implements the DECLARED predicate exactly
+   (`/\bgit\s+[a-z-]+\b/` on the same line as `origin/<base>`), with fixtures from the real corpus in
+   both directions: `git branch -r --no-merged origin/main` is operative;
+   `lib/graph/extraction-health.ts`'s "`origin/main` kept that state loud" is not.
+2. **unit** — `isOperativeLine` is asserted NOT to fire on the two lines a looser `\bgit\b` rule would
+   falsely catch — `docs/RELEASING.md`'s sentence discussing the "`git` token", and
+   `test/guards/branch-roles.test.ts`'s `git(dir, "update-ref", "refs/remotes/origin/main", …)` — so
+   the predicate's precision is pinned, not assumed.
+3. **unit** — a separate `scanInventory(records)` takes an INJECTED list of `{path, content}`, so
+   coverage is provable with fixtures; production obtains its inventory from `git ls-files`.
+4. **unit** — the production inventory is asserted EQUAL to `git ls-files` minus the documented
+   exclusions — path-set equality, not "contains a known file from each root", which an inventory that
+   silently dropped everything else would still satisfy.
+5. **unit** — the scan finds NO operative path-form line outside the exclusions.
+6. **unit** — PRESENCE, per rewritten file, for all 12: each still contains a base-resolved
+   instruction. This is the primary instrument, so it is asserted per file rather than in aggregate —
+   deleting an instruction must not satisfy criterion 5.
+7. **unit** — the REFSPEC form is pinned by presence too: the attestation SKILL, its rubric, its
+   `evals.json`, and `docs/TODO.md` are asserted to fetch the RESOLVED base, and asserted NOT to
+   contain the literal `fetch origin main` — the form the scan cannot see.
+8. **unit** — `evals.json`'s required behaviour is asserted to describe fetching the resolved base, so
+   the rubric cannot grade a correct post-cutover run as a miss (Decision 1).
+9. **unit** — the bare-prose sites are pinned by name: `adversarial-build/SKILL.md` (both the
+   "Branch from" line and the "retarget to" line) and the attestation SKILL's prose headings carry the
+   sanctioned phrasing, because the scan provably cannot see them.
+10. **unit** — the guard's own failure message states what it does NOT cover, so a reader cannot infer
+    completeness from a green run.
+11. **unit** — the full shell sequence from Decision 2 is EXECUTED in a temporary git fixture from a
+    NESTED cwd, under both a `main` and a `staging` base, and produces a valid diff range — criterion
+    10 of the previous draft tested only the CLI's stdout and inferred the rest.
+12. **unit** — `docs/agent-handoffs.md` is absent from its old path, present under `docs/archive/`,
+    and `docs/archive/**` is in the guard's exclusions; the archived copy is NOT required to be
+    rewritten.
+13. **unit** — `docs/RELEASING.md` constraint 4 is paraphrased without the literal AND retains the
+    failure it names, the invariant, its PREPARED status, and what remains human; **§3.1c AND §3.1d**
+    no longer carry the superseded `31 lines across 19 files` count.
+14. **unit — THE INVERSE, and the one both reviewers converged on.** Each of the rewritten files
+    contains **NO** `origin/main` literal afterwards, asserted per file. Without it, per-file presence
+    is existential: rewriting `SKILL.md`'s heading while leaving line 62 ("a stale `origin/main` ref
+    produces a diff carrying other people's commits") and `rubric.md:55` ("the diff is taken against
+    `origin/main`") passes criteria 5–9 — both are scan-blind, and criterion 9 names only the
+    headings. Named exceptions, and only these: `docs/RELEASING.md`'s meta-prose ABOUT the guard
+    (§3.1d describes the predicate and its false negative, so it must quote them).
+15. **unit** — criterion 11's fixture carries a **stub `scripts/branches.mjs`** (because
+    `git rev-parse --show-toplevel` resolves to the FIXTURE root, where the real module does not
+    exist) and a **path remote** (a unit test must not reach the network), and the remote base is
+    **advanced after checkout** so a stale `origin/$base` cannot produce a valid range without the
+    fetch having refreshed it — a false green Codex named specifically.
+16. **unit** — criterion 4's expected set is derived from its OWN `git ls-files` call and its OWN
+    exclusion literals, never from the module under test, which would make the equality
+    green-by-construction.
+
+---
+
+## What would falsify this
+
+- **A reviewer handed every unreleased commit after the cutover** — a site was missed *and* its
+  presence assertion did not exist, which is now two independent failures rather than one.
+- **The rubric grading a correct run as a miss** — Decision 1 was not carried into `evals.json`.
+- **The scan reddening on history or on the deliberate fixture** — the exclusions are wrong, and the
+  pressure will be to weaken the guard rather than fix the paths.
+- **Someone reading the scan as complete** — criterion 10's message failed to say otherwise.
+- **The shell sequence failing from a skill's cwd** — criterion 11 did not actually execute it.
+- **A rewritten file still containing `origin/main`** — criterion 14's inverse was dropped, and
+  per-file presence went back to being satisfiable by one line out of three.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
+    "check:instructions": "node scripts/instruction-base.mjs --run",
     "check:docs": "node scripts/check-docs-drift.mjs",
     "check:skills": "bash scripts/sync-skill-runtimes.sh --check",
     "check:skills:fix": "bash scripts/sync-skill-runtimes.sh --all",

--- a/scripts/instruction-base.mjs
+++ b/scripts/instruction-base.mjs
@@ -28,6 +28,7 @@
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 /** Both role-branch literals. Not the resolved base — see the header. */
 export const ROLE_REFS = /origin\/(main|staging)\b/;
@@ -47,6 +48,7 @@ export const EXCLUSIONS = [
   "docs/archive/", // archived, and banner-marked non-executable
   ".context/", // untracked scratch; listed so a future fs-walk cannot pick it up
   "test/guards/branch-roles.test.ts", // the fixed RELEASE ref in RELPTR-4's identity fixture
+  "test/guards/instruction-base.test.ts", // intentional literal regression fixtures
   "scripts/instruction-base.mjs", // this file documents the forms it hunts
 ];
 
@@ -78,12 +80,13 @@ export function scanInventory(records) {
 
 /** Every tracked file, as the scan's production inventory. */
 export function trackedInventory(cwd = undefined) {
-  const files = execFileSync("git", ["ls-files"], { encoding: "utf8", cwd }).trim().split("\n").filter(Boolean);
-  return files.flatMap((path) => {
+  const root = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8", cwd }).replace(/\n$/, "");
+  const files = execFileSync("git", ["ls-files", "-z"], { encoding: "utf8", cwd: root }).split("\0").filter(Boolean);
+  return [...new Set(files)].filter((path) => !isExcluded(path)).map((path) => {
     try {
-      return [{ path, content: readFileSync(path, "utf8") }];
-    } catch {
-      return []; // binary or unreadable — nothing to scan
+      return { path, content: readFileSync(join(root, path), "utf8") };
+    } catch (cause) {
+      throw new Error(`Cannot read tracked instruction inventory path ${path}`, { cause });
     }
   });
 }
@@ -102,6 +105,7 @@ export function report(hits) {
     `${hits.length} instruction(s) hardcode a role branch in a git command:`,
     ...hits.map((h) => `  ${h.path}:${h.line}  ${h.text}`),
     "Resolve the contribution base instead — see scripts/branches.mjs and docs/RELEASING.md §3.1d.",
+    "PARTIAL BY DESIGN: does not cover refspec form, PR-base prose, or bare refs without a git subcommand. Use the per-site presence and absence assertions too.",
   ].join("\n");
 }
 

--- a/scripts/instruction-base.mjs
+++ b/scripts/instruction-base.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * RELPTR-5 — the scan for instructions that hardcode a branch role.
+ * Spec: `docs/design/instruction-corpus-base-relative.md` · runbook: `docs/RELEASING.md` §3.1d
+ *
+ * ⚠️ THIS SCAN IS DELIBERATELY PARTIAL, AND THAT IS THE DESIGN. Read this before trusting a green run.
+ *
+ * WHY IT IS PARTIAL. Three attempts at this slice were blocked pre-code because the corpus was
+ * undercounted — 14, then 31, then 34 — and each miss was a DIFFERENT SYNTACTIC FORM of one idea:
+ *
+ *     path form      git diff origin/main...HEAD          ← this scan sees it
+ *     refspec form   git fetch origin main                ← INVISIBLE (no slash)
+ *     PR-base prose  "open a PR from feat/x against main" ← INVISIBLE (no ref token)
+ *     bare prose     "Branch from `origin/main`"          ← INVISIBLE (no git token)
+ *
+ * The class is not lexically decidable, so a scan cannot be the primary instrument: every version of
+ * one gives false assurance about completeness, which is exactly what a guard must not do. The PRIMARY
+ * instrument is the enumerated rewrite with per-site presence AND absence assertions in
+ * `test/guards/instruction-base.test.ts`. This scan is the secondary net for the one form that IS
+ * cleanly decidable, and its failure message says so out loud.
+ *
+ * WHY IT MATCHES THE LITERALS AND NOT THE RESOLVED BASE. Both reviewers caught this. Keyed on
+ * `origin/${CONTRIBUTION_BASE}`, the scan would after the cutover look for `origin/staging` and stop
+ * seeing a reintroduced `git diff origin/main...HEAD` — the single most likely muscle-memory
+ * regression, invisible at exactly the moment it starts mattering. So it matches the ROLE BRANCH
+ * LITERALS, both of them, always.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+/** Both role-branch literals. Not the resolved base — see the header. */
+export const ROLE_REFS = /origin\/(main|staging)\b/;
+
+/**
+ * A `git` SUBCOMMAND invocation on the same line. Declared verbatim because a guard whose rule is not
+ * stated cannot be reviewed, and because the `\s+` is load-bearing: it is what keeps this from firing
+ * on `git(dir, "update-ref", "refs/remotes/origin/main", …)` in `test/guards/branch-roles.test.ts` —
+ * a JS helper call, and a DELIBERATE permanent hardcode of the release ref — and on prose that says
+ * "carries no `git` token". Both were named by reviewers as false positives a looser `\bgit\b` causes.
+ */
+export const GIT_INVOCATION = /\bgit\s+[a-z-]+\b/;
+
+/** Paths whose hardcoded refs are correct and must stay. Each entry has a reason. */
+export const EXCLUSIONS = [
+  "docs/design/", // history: a design doc recording what an instruction USED to say is correct
+  "docs/archive/", // archived, and banner-marked non-executable
+  ".context/", // untracked scratch; listed so a future fs-walk cannot pick it up
+  "test/guards/branch-roles.test.ts", // the fixed RELEASE ref in RELPTR-4's identity fixture
+  "scripts/instruction-base.mjs", // this file documents the forms it hunts
+];
+
+/** Is this line an operative, hardcoded role-branch reference? The declared predicate, exactly. */
+export function isOperativeLine(line) {
+  return ROLE_REFS.test(line) && GIT_INVOCATION.test(line);
+}
+
+export const isExcluded = (path) => EXCLUSIONS.some((e) => (e.endsWith("/") ? path.startsWith(e) : path === e));
+
+/**
+ * Scan an INJECTED inventory of `{ path, content }`. Injected rather than read from disk so the roots
+ * can be proven covered with fixtures — production supplies the real inventory below, and the test
+ * asserts THAT separately, because a fixture written to disk would not be tracked and so could never
+ * appear in a `git ls-files` scan.
+ */
+export function scanInventory(records) {
+  const hits = [];
+  for (const { path, content } of records) {
+    if (isExcluded(path)) continue;
+    String(content)
+      .split("\n")
+      .forEach((line, i) => {
+        if (isOperativeLine(line)) hits.push({ path, line: i + 1, text: line.trim() });
+      });
+  }
+  return hits;
+}
+
+/** Every tracked file, as the scan's production inventory. */
+export function trackedInventory(cwd = undefined) {
+  const files = execFileSync("git", ["ls-files"], { encoding: "utf8", cwd }).trim().split("\n").filter(Boolean);
+  return files.flatMap((path) => {
+    try {
+      return [{ path, content: readFileSync(path, "utf8") }];
+    } catch {
+      return []; // binary or unreadable — nothing to scan
+    }
+  });
+}
+
+/** The failure text. It states the scan's LIMITS, so nobody can read a green run as completeness. */
+export function report(hits) {
+  if (hits.length === 0) {
+    return (
+      "no hardcoded role-branch git commands found.\n" +
+      "NOTE: this scan is PARTIAL BY DESIGN. It does not see `git fetch origin main` (refspec form), " +
+      "PR-base prose, or a bare `origin/main` with no git subcommand. Those are held by the per-site " +
+      "presence and absence assertions in test/guards/instruction-base.test.ts, not by this scan."
+    );
+  }
+  return [
+    `${hits.length} instruction(s) hardcode a role branch in a git command:`,
+    ...hits.map((h) => `  ${h.path}:${h.line}  ${h.text}`),
+    "Resolve the contribution base instead — see scripts/branches.mjs and docs/RELEASING.md §3.1d.",
+  ].join("\n");
+}
+
+if (process.argv.includes("--run")) {
+  const hits = scanInventory(trackedInventory());
+  console.log(report(hits));
+  process.exit(hits.length === 0 ? 0 : 1);
+}

--- a/scripts/pr-review-gate.mjs
+++ b/scripts/pr-review-gate.mjs
@@ -1,3 +1,5 @@
+import { CONTRIBUTION_BASE } from "./branches.mjs";
+
 /**
  * The pre-push review gate, as a check (CLAUDE.md §"Review gate").
  *
@@ -121,7 +123,7 @@ export function evaluatePr(pr) {
 // pastes this whole message into the PR body while fixing it doesn't lock themselves out.
 export const FAIL_MESSAGE = {
   missing:
-    "This PR records no diff review. Per CLAUDE.md, review `git diff origin/main...HEAD` with a local " +
+    `This PR records no diff review. Per CLAUDE.md, fetch the contribution base and review \`git diff origin/${CONTRIBUTION_BASE}...HEAD\` with a local ` +
     "reviewer (Fable `code-reviewer`, Local Bugbot, or equivalent), then add ONE line to the PR body:\n" +
     "```\n## Review — Reviewed by <the reviewer you ran> — verdict <what it found>\n```\n" +
     `If no local reviewer was available, say so and add the \`${CODERABBIT_LABEL}\` label so CodeRabbit reviews it instead.`,

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -341,11 +341,12 @@ describe("branch roles — the runbook records the decisions (criterion 9)", () 
     expect(r).toMatch(/dependabot-target-branch: at the cutover, never before/);
   });
 
-  it("§3.1d records WHY the instruction corpus is deferred, with the real measurement", () => {
-    // The number was wrong twice. It is written down with its correction so a third attempt starts
-    // from the measurement rather than re-deriving it.
-    const r = RUNBOOK();
-    expect(r).toMatch(/31 lines across 19 files|\*\*31 lines across 19 files\*\*/);
+  it("§3.1d records the instruction corpus disposition and the scan's limits", () => {
+    // RELPTR-5 replaces the undercount with a per-site disposition. Keep the release-role
+    // identity fixture above fixed; only this superseded runbook assertion changes.
+    const r = RUNBOOK().split("### 3.1d")[1].split("### 3.2")[0];
+    expect(r).toContain("12 canonical files: 22 path-form occurrences + 4 refspec occurrences");
+    expect(r).toContain("per-site presence AND absence");
     expect(r, "and that the heuristic has known error bars").toMatch(/false-negatives/);
   });
 });

--- a/test/guards/instruction-base.test.ts
+++ b/test/guards/instruction-base.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { isOperativeLine, scanInventory, trackedInventory, report } from "../../scripts/instruction-base.mjs";
+
+// Assertions derive from RELPTR-5 criteria 1–16 and its named disposition, not scan output.
+const ROOT = join(import.meta.dirname, "../..");
+const read = (path: string) => readFileSync(join(ROOT, path), "utf8");
+const skill = (name: string) => `.claude/skills/${name}/SKILL.md`;
+const att = skill("pr-review-attestation");
+const rubric = ".claude/skills/pr-review-attestation/evals/rubric.md";
+const evals = ".claude/skills/pr-review-attestation/evals/evals.json";
+const resolution = 'root="$(git rev-parse --show-toplevel)"\nbase="$(node "$root/scripts/branches.mjs" --print contribution)"';
+const fetch = 'git -C "$root" fetch origin "$base"';
+const diff = 'git -C "$root" diff "origin/$base...HEAD"';
+const sequence = `${resolution}\n${fetch}\n${diff}`;
+const prose = 'the contribution base (currently `main`, declared in `scripts/branches.mjs`)';
+const normalized = (path: string) => read(path).replace(/^ +/gm, "");
+
+// Each entry is a SITE, including scan-blind grading/prose. Deleting any site must fail.
+const sites: [string, string][] = [
+  [att, `Get the diff — against a fresh remote ref for ${prose}`],
+  [att, sequence],
+  [att, 'remote contribution-base ref is a few hours stale'],
+  [rubric, '**The diff is fresh.**'],
+  [rubric, '`base="$(node "$root/scripts/branches.mjs" --print contribution)"`;'],
+  [rubric, fetch],
+  [rubric, diff],
+  [rubric, 'The diff is taken against the resolved remote contribution-base ref with no preceding fetch'],
+  [skill("branch-reconciliation"), `${resolution}\n git -C "$root" fetch --prune origin`.replace("\n git", "\ngit")],
+  [skill("branch-reconciliation"), 'git -C "$root" branch -r --no-merged "origin/$base"'],
+  [skill("branch-reconciliation"), 'git -C "$root" cherry "origin/$base" origin/<branch>'],
+  [skill("branch-reconciliation"), 'git -C "$root" diff "origin/$base...origin/<branch>" --name-only'],
+  [skill("branch-reconciliation"), 'git -C "$root" diff "origin/$base:<file>" origin/<branch>:<file>'],
+  [skill("branch-reconciliation"), 'git -C "$root" log "origin/$base" --grep="<commit subject>"'],
+  [skill("branch-reconciliation"), 'patch-equivalent to something already on the contribution base'],
+  [skill("branch-reconciliation"), 'matching contribution-base commit(s) as evidence'],
+  [skill("branch-reconciliation"), 'compare current contribution-base content directly'],
+  [skill("branch-reconciliation"), 'current contribution base, and a merged PR'],
+  [skill("branch-reconciliation"), 'merge risk against the current contribution base'],
+  [skill("test-ci-wiring-audit"), resolution],
+  [skill("test-ci-wiring-audit"), 'git -C "$root" log -1 --format=%ci "origin/$base"'],
+  [skill("test-ci-wiring-audit"), "latest contribution-base commit"],
+  [skill("adversarial-build"), `Branch from ${prose}`],
+  [skill("adversarial-build"), `retarget to ${prose} after it merges`],
+  [skill("adversarial-build"), `gh pr create\` — base: ${prose}`],
+  [".claude/agents/code-reviewer.md", sequence],
+  ["CLAUDE.md", sequence],
+  ["CONTRIBUTING.md", `${resolution}\n${fetch}`],
+  ["CONTRIBUTING.md", 'cd "$root/../aios-team-brain-<short-task>"'],
+  ["CONTRIBUTING.md", 'git -C "$root" worktree add -b feat/<short-task> ../aios-team-brain-<short-task> "origin/$base"'],
+  ["docs/TODO.md", resolution],
+  ["docs/TODO.md", 'git -C "$root" log --oneline -20 "origin/$base"'],
+  ["docs/TODO.md", fetch],
+  ["docs/TODO.md", `Also \`${fetch}\` partway through a long build`],
+  ["docs/TODO.md", "diff the closed branch vs the contribution base"],
+  [skill("branch-reconciliation"), `Use ${prose}.`],
+  ["docs/RELEASING.md", sequence],
+  ["scripts/pr-review-gate.mjs", 'from "./branches.mjs"'],
+];
+
+describe("primary per-site disposition (6–9, 13–14)", () => {
+  it.each(sites)("%s retains site %s", (path, expected) => {
+    expect(normalized(path)).toContain(expected);
+  });
+  const canonical = [...new Set([...sites.map(([path]) => path), evals])];
+  it("covers exactly twelve canonical files", () => expect(canonical).toHaveLength(12));
+  it.each(canonical)("%s has no residual hardcoded instruction", (path) => {
+    const text = path === "docs/RELEASING.md"
+      ? read(path).split("\n").filter(line => ![
+          "`origin/main` or `origin/staging` together with `/\\bgit\\s+[a-z-]+\\b/` on the same line,",
+          'PR-base prose, and "Branch from `origin/main`", which carries no `git` token. Both success and',
+        ].includes(line)).join("\n") : read(path);
+    expect(text).not.toMatch(/origin\/(main|staging)\b/);
+    expect(text).not.toMatch(/fetch origin (main|staging)\b/);
+  });
+  it("eval prompt and fetch requirement grade the resolved base (7–8)", () => {
+    const first = JSON.parse(read(evals)).evals.find((e: { id: number }) => e.id === 1);
+    expect(first.prompt).toContain(sequence);
+    expect(first.assertions).toContain(`Runs \`${fetch}\` before diffing, using the same resolved contribution base, so the diff can't carry other people's merged commits`);
+  });
+  it("runbook retains the hazard, preparation, human work and corrected inventory (13)", () => {
+    const text = read("docs/RELEASING.md");
+    const row = text.split("\n").find(l => l.startsWith("| 4 |"))!;
+    for (const phrase of ["PREPARED (RELPTR-5)", "every unreleased commit", "same resolved contribution base", "Still human at cutover"]) expect(row).toContain(phrase);
+    const sections = text.slice(text.indexOf("### 3.1c"), text.indexOf("### 3.2"));
+    expect(sections).not.toMatch(/31 (?:operative .*?command )?lines across 19 files/);
+    expect(sections).toContain("12 canonical files");
+    expect(sections).toContain("22 path-form occurrences + 4 refspec occurrences");
+    expect(sections).toContain("per-site presence AND absence");
+    expect(sections).toContain("trusted-automation");
+    expect(sections).toContain("Do the policy **first**");
+  });
+});
+
+describe("deliberately partial scan (1–5, 10, 12, 16)", () => {
+  it.each([
+    ["git branch -r --no-merged origin/main", true],
+    ["git diff origin/staging...HEAD", true],
+    ["git diff origin/topic...HEAD", false],
+    ['`origin/main` kept that state loud', false],
+    ['"Branch from `origin/main`", which carries no `git` token.', false],
+    ['git(dir, "update-ref", "refs/remotes/origin/main", parent)', false],
+    ["git fetch origin main", false],
+    ["open a PR against main", false],
+    ["Branch from origin/staging", false],
+    ["git  diff origin/main", true],
+    ["git origin/main", true],
+    ["git DIFF origin/main", false],
+    ["git diff origin/mainland", false],
+    ["git\tdiff origin/staging", true],
+  ])("classifies %s as %s", (line, expected) => expect(isOperativeLine(line)).toBe(expected));
+  it("scans injected paths regardless of root or extension and respects history", () => {
+    const records = ["odd/place.bin", "rootfile", ".cursor/rules/new.mdc", "docs/archive/old.md", "docs/design/old.md", "test/guards/instruction-base.test.ts"]
+      .map(path => ({ path, content: "intro\ngit diff origin/main...HEAD\n" }));
+    expect(scanInventory(records)).toEqual(records.slice(0, 3).map(({ path }) => ({ path, line: 2, text: "git diff origin/main...HEAD" })));
+  });
+  it("inventory equals an independent git ls-files minus independently specified exclusions, also from nested cwd", () => {
+    const expected = execFileSync("git", ["ls-files", "-z"], { cwd: ROOT, encoding: "utf8" }).split("\0").filter(Boolean)
+      .filter(p => !["docs/design/", "docs/archive/", ".context/"].some(prefix => p.startsWith(prefix)))
+      .filter(p => !["test/guards/branch-roles.test.ts", "test/guards/instruction-base.test.ts", "scripts/instruction-base.mjs"].includes(p));
+    for (const cwd of [ROOT, join(ROOT, ".claude/skills")]) {
+      expect(new Set(trackedInventory(cwd).map((r: { path: string }) => r.path))).toEqual(new Set(expected));
+    }
+  });
+  it("has no operative path-form regression (mirrors must be generated)", () => expect(scanInventory(trackedInventory(ROOT))).toEqual([]));
+  it.each([{ hits: [] }, { hits: [{ path: "x", line: 1, text: "git diff origin/main" }] }])("both report outcomes state blind spots", ({ hits }) => {
+    const message = report(hits);
+    for (const phrase of ["PARTIAL", "refspec", "PR-base prose", "bare", "per-site"]) expect(message).toContain(phrase);
+  });
+  it("archives handoff prompts (12)", () => {
+    expect(existsSync(join(ROOT, "docs/agent-handoffs.md"))).toBe(false);
+    expect(read("docs/archive/agent-handoffs.md")).toMatch(/archiv/i);
+    expect(scanInventory([{ path: "docs/archive/agent-handoffs.md", content: "git diff origin/main" }])).toEqual([]);
+  });
+});
+
+// Pure local fixtures: no network, secrets, hooks, signing, index, or checkout mutations.
+const isolated = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))) as NodeJS.ProcessEnv;
+Object.assign(isolated, { GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null", GIT_CONFIG_NOSYSTEM: "1", GIT_TERMINAL_PROMPT: "0" });
+const git = (cwd: string, ...args: string[]) => execFileSync("git", args, { cwd, env: isolated, encoding: "utf8" }).trim();
+function scratch(run: (dir: string) => void) {
+  const dir = mkdtempSync(join(tmpdir(), "instruction base 'fixture-"));
+  try { run(dir); } finally { rmSync(dir, { recursive: true, force: true }); }
+}
+function advance(cwd: string, branch: string, name: string, parent?: string) {
+  // fast-import creates a real commit and advances the fixture ref without add/commit/update-ref.
+  const input = `commit refs/heads/${branch}\ncommitter Test <test@example.invalid> 1000000000 +0000\ndata ${name.length}\n${name}\n${parent ? `from ${parent}\n` : ""}M 100644 inline ${name}.txt\ndata ${name.length}\n${name}\n\ndone\n`;
+  execFileSync("git", ["fast-import", "--quiet"], { cwd, env: isolated, input, stdio: ["pipe", "pipe", "pipe"] });
+  return git(cwd, "rev-parse", `refs/heads/${branch}`);
+}
+describe("observable shell and role identity (11, 15)", () => {
+  it.each(["main", "staging"])("executes the sanctioned sequence with fresh %s from nested cwd", base => scratch(dir => {
+    const remote = join(dir, "path remote");
+    const work = join(dir, "working copy");
+    mkdirSync(remote);
+    git(remote, "init", "--bare", "-q", `--initial-branch=${base}`);
+    const old = advance(remote, base, "initial");
+    git(dir, "clone", "-q", remote, work);
+    mkdirSync(join(work, "scripts"));
+    writeFileSync(join(work, "scripts/branches.mjs"), `if (process.argv.slice(2).join(" ") !== "--print contribution") throw Error("wrong role"); process.stdout.write(${JSON.stringify(base)});`);
+    const head = advance(work, "feature", "feature", old);
+    git(work, "symbolic-ref", "HEAD", "refs/heads/feature");
+    const fresh = advance(remote, base, "advanced", old);
+    expect(git(work, "rev-parse", `origin/${base}`)).toBe(old);
+    expect(old).not.toBe(fresh);
+    const nested = join(work, "nested/deeper");
+    mkdirSync(nested, { recursive: true });
+    // Execute the actual documented block, also pinned independently to Decision 2 above.
+    const documented = normalized(att).match(/```bash\n([\s\S]*?)\n```/)![1];
+    expect(documented).toBe(sequence);
+    const output = execFileSync("bash", ["-eu", "-c", documented], { cwd: nested, env: isolated, encoding: "utf8" });
+    expect(git(work, "rev-parse", `origin/${base}`)).toBe(fresh);
+    expect(git(work, "rev-parse", "HEAD")).toBe(head);
+    expect(output).toContain("+feature");
+    expect(output).not.toContain("+advanced");
+  }));
+  it("runtime gate follows contribution, independently of release", () => scratch(dir => {
+    writeFileSync(join(dir, "branches.mjs"), 'export const CONTRIBUTION_BASE = "staging"; export const RELEASE_BRANCH = "release-sentinel";');
+    writeFileSync(join(dir, "pr-review-gate.mjs"), read("scripts/pr-review-gate.mjs"));
+    const output = execFileSync("node", ["--input-type=module", "-e", `import { FAIL_MESSAGE } from ${JSON.stringify(pathToFileURL(join(dir, "pr-review-gate.mjs")).href)}; console.log(FAIL_MESSAGE.missing);`], { env: isolated, encoding: "utf8" });
+    expect(output).toContain("origin/staging...HEAD");
+    expect(output).not.toContain("origin/main");
+    expect(output).not.toContain("release-sentinel");
+  }));
+  it("fails loudly when a tracked file cannot be read", () => scratch(dir => {
+    git(dir, "init", "-q");
+    advance(dir, "main", "missing");
+    // Populate the fixture index without checking files out; tracked missing content must throw.
+    git(dir, "read-tree", "refs/heads/main");
+    expect(() => trackedInventory(dir)).toThrow(/missing\.txt/);
+  }));
+});


### PR DESCRIPTION
## What & Why

When contributions move off `main`, hardcoded review ranges include unrelated unreleased commits, and the attestation eval rejects agents that fetch the correct base. Resolve the repository root and contribution base for the enumerated commands, prose, and eval requirements; the runtime review-gate message follows `CONTRIBUTION_BASE` too.

The primary guard pins individual instruction sites with presence and absence checks across 12 canonical files. The secondary scan deliberately covers only literal role refs alongside a Git subcommand and states its blind spots in both outcomes. Archive shipped handoff prompts, regenerate runtime mirrors, and update the cutover runbook while preserving its credential-isolation requirements. Branch roles and external cutover configuration do not change.

`GPT-6 Astra` authored the implementation from the supplied, already-approved spec. The orchestrator generated mirrors after the author sandbox refused `.agents` writes and updated the existing runbook-count assertion that required the superseded count. The fixed release-ref identity fixture is unchanged. The unrelated Astra skill and local discovery wrappers are outside this PR.

## Work item

AIOS-Work: RELPTR-5

## Validation

- `npx tsc --noEmit`: passed.
- `npm run lint`: passed, 18 warnings and no errors.
- `npm test`: 378 files passed, 1 skipped; 3,823 tests passed, 15 skipped.
- `npm run check:docs`: passed (64 routes, 85 tables, 8 sources).
- `npm run check:instructions`: zero operative hits across 1,649 tracked paths after documented exclusions.
- `bash scripts/sync-skill-runtimes.sh --check`: passed.
- Restored guard tests: 125 passed, including the 77 new instruction tests.
- All 13 mutation probes returned `mutate: REDDENED`; the intended assertions failed, and the checkpoint was restored cleanly. Nested-cwd local Git fixtures exercise both contribution bases and require refresh of an advanced remote. No persistence or Python behavior changed.

<details>
<summary>Mutation evidence (actual tool verdicts)</summary>

**bare-retarget-regression**

```text
mutate: REDDENED
  red: primary per-site disposition (6–9, 13–14) .claude/skills/adversarial-build/SKILL.md retains site retarget to the contribution base (currently `main`, declared in `scripts/branches.mjs`) after it merges
  tests run: 77
```

**classifier-disabled**

```text
mutate: REDDENED
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git branch -r --no-merged origin/main as true
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git diff origin/staging...HEAD as true
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git  diff origin/main as true
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git origin/main as true
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git	diff origin/staging as true
  red: deliberately partial scan (1–5, 10, 12, 16) scans injected paths regardless of root or extension and respects history
  tests run: 77
```

**drops-main-literal**

```text
mutate: REDDENED
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git branch -r --no-merged origin/main as true
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git  diff origin/main as true
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git origin/main as true
  red: deliberately partial scan (1–5, 10, 12, 16) scans injected paths regardless of root or extension and respects history
  tests run: 77
```

**eval-fetch-main**

```text
mutate: REDDENED
  red: primary per-site disposition (6–9, 13–14) .claude/skills/pr-review-attestation/evals/evals.json has no residual hardcoded instruction
  red: primary per-site disposition (6–9, 13–14) eval prompt and fetch requirement grade the resolved base (7–8)
  tests run: 77
```

**failure-overclaims**

```text
mutate: REDDENED
  red: deliberately partial scan (1–5, 10, 12, 16) both report outcomes state blind spots
  tests run: 77
```

**gate-follows-release**

```text
mutate: REDDENED
  red: observable shell and role identity (11, 15) runtime gate follows contribution, independently of release
  tests run: 77
```

**inventory-drops-root**

```text
mutate: REDDENED
  red: deliberately partial scan (1–5, 10, 12, 16) inventory equals an independent git ls-files minus independently specified exclusions, also from nested cwd
  tests run: 77
```

**inventory-swallows-missing**

```text
mutate: REDDENED
  red: observable shell and role identity (11, 15) fails loudly when a tracked file cannot be read
  tests run: 77
```

**loose-git-token**

```text
mutate: REDDENED
  red: deliberately partial scan (1–5, 10, 12, 16) classifies "Branch from `origin/main`", which carries no `git` token. as false
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git(dir, "update-ref", "refs/remotes/origin/main", parent) as false
  red: deliberately partial scan (1–5, 10, 12, 16) classifies git DIFF origin/main as false
  red: deliberately partial scan (1–5, 10, 12, 16) has no operative path-form regression (mirrors must be generated)
  tests run: 77
```

**rubric-scan-blind-hardcode**

```text
mutate: REDDENED
  red: primary per-site disposition (6–9, 13–14) .claude/skills/pr-review-attestation/evals/rubric.md retains site The diff is taken against the resolved remote contribution-base ref with no preceding fetch
  red: primary per-site disposition (6–9, 13–14) .claude/skills/pr-review-attestation/evals/rubric.md has no residual hardcoded instruction
  tests run: 77
```

**rubric-site-deleted**

```text
mutate: REDDENED
  red: primary per-site disposition (6–9, 13–14) .claude/skills/pr-review-attestation/evals/rubric.md retains site The diff is taken against the resolved remote contribution-base ref with no preceding fetch
  tests run: 77
```

**success-overclaims**

```text
mutate: REDDENED
  red: deliberately partial scan (1–5, 10, 12, 16) both report outcomes state blind spots
  tests run: 77
```

**todo-midbuild-fetch-deleted**

```text
mutate: REDDENED
  red: primary per-site disposition (6–9, 13–14) docs/TODO.md retains site Also `git -C "$root" fetch origin "$base"` partway through a long build
  tests run: 77
```

</details>

## Review summary

## Review — Reviewed by code-reviewer (Fable 5.1) — verdict CLEAR; no Critical/High findings, six LOW notes deferred below

The independent review covered `9d472c2a` against `origin/main` at `4656ef1b`. Fable independently reproduced the baseline enumeration, checked the per-site assertions and shell fixtures, and ran the partial scan and mirror check. It did not run Vitest; the orchestrator's runs are reported above.

## Review — Reviewed by `GPT-6 Astra` (fresh read-only session, correlated with the author) — verdict CLEAR-WITH-CONDITIONS; no new actionable findings, verify CI and stored PR metadata

Astra reviewed the same `9d472c2a` head in a fresh read-only session, re-derived the baseline and inventory, and inspected all 16 criteria. It did not execute the shell fixtures or Vitest. Its sandbox could not run `diff` against stdin in the mirror checker; it independently compared generated content instead. The orchestrator's unrestricted mirror check passed. This correlated pass does not substitute for Fable's independent CLEAR. No code changed after either review.

Deferred Fable notes (all LOW unless marked INFO):

- Eval prompt formatting: retain the explicit four-line sequence that the tests execute; readability-only change.
- Rubric sentence capitalization: cosmetic, no grading behavior changes.
- Repeated contribution-base parentheticals: preserve the sanctioned wording pinned by criterion 9.
- Archive banner date: retain the date supplied with the already-prepared archive move.
- Extra test pin for the cutover-day prose enumeration: optional coverage beyond the approved criteria; the required runbook hazard and per-site rewrite guards pass.
- String normalization expression in the branch-reconciliation assertion: style-only simplification deferred.
- INFO, ambient `GIT_*` variables in production inventory: this slice adds no hook invocation; fixture processes already isolate Git configuration.


## CI result

All CI checks passed on the reviewed commit `9d472c2a`. The first Postgres attempt failed only the unchanged timeline-cache stale-mark test: an unawaited background refresh appears to have overwritten the stale timestamp (the after value was 10 ms newer). The test and cache implementation are identical to the base. [Retrying only that job](https://github.com/aiosbrain/aios-team-brain/actions/runs/33983342629/job/101355670736) passed without code changes, including the migration-from-existing step. The initial failure is retained here as a timing-flake observation, not a fix claimed by this slice.

The stored PR body preserves both review verdicts. The brain-task runtime log confirmed `Found work key(s): RELPTR-5`. Astra's CI and metadata conditions are satisfied. This PR remains unmerged.
