### PR TITLE
fix(guards): the branch-role pins survive the cutover (RELPTR-6 PR A)

### DIFF
--- a/docs/design/cutover-execution.md
+++ b/docs/design/cutover-execution.md
@@ -101,10 +101,22 @@ The real justifications differ per workflow and must be stated separately rather
 - **`scan-on-merge` (push):** keeping `main` buys release-time retry/reconciliation, at the cost of
   normally re-scanning a SHA already scanned on `staging`. Storage is keyed by `head_sha`, so the
   open question — no-op or duplicate compute — must be answered and tested, not assumed.
-- **`aios-work-sync` (`pull_request_target: closed`):** the pair is a **security allowlist of trusted
-  PR bases**, not "the branches that receive contributions". A release fast-forward to `main` emits no
-  `pull_request_target` event at all, so `main`'s entry exists only for in-flight or exceptional pull
-  requests — a policy that must be stated explicitly or the entry is unnecessary exposure.
+- **`aios-work-sync` (`pull_request_target: closed`):** a release fast-forward to `main` emits no
+  `pull_request_target` event at all, so `main`'s entry serves in-flight and exceptional pull requests
+  into the release branch.
+
+  **REFUTED by Fable's diff review, recorded rather than deleted:** a draft called this pair a
+  *security allowlist of trusted PR bases*. It is not one. On `pull_request_target` the workflow file
+  — `on:` filter included — is read from the pull request's BASE branch, and a same-repo collaborator
+  can push a branch and control that copy, which is exactly the population the workflow's own header
+  names as the threat. The real blast-radius control is the `trusted-automation` environment's
+  deployment branch policy, which lives in repository settings, not in the file.
+
+  **What actually justifies the pair, in both workflows, is elimination:** the trigger needs two
+  DISTINCT branches. `[CONTRIBUTION_BASE, RELEASE_BRANCH]` collapses today (both `main`);
+  `[CONTRIBUTION_BASE, INTEGRATION_BRANCH]` collapses after the cutover (both `staging`);
+  `[RELEASE_BRANCH, INTEGRATION_BRANCH]` is distinct in both worlds. That is checkable, and it is
+  what the guard now asserts.
 
 **This correction is value-invariant today** (`RELEASE_BRANCH === CONTRIBUTION_BASE === "main"`), so
 it can be verified before the flip and carries no behavioural risk. It is the identity trap the
@@ -150,7 +162,8 @@ occurrences) follows without further edits. `INTEGRATION_BRANCH` and `RELEASE_BR
 release branch and the integration branch; the contribution base is one of them, not a third thing.
 
 **Decision 3 — sentinels must not be real branch names.** D2 and D3 both come from fixtures keyed on
-a real value. Both become sentinels that no role can ever equal (`__NOT-A-BRANCH__`), and the stub is
+a real value. Both become sentinels that no role can ever equal (`contribution-sentinel` and
+`release-sentinel` — an earlier draft of this line said `__NOT-A-BRANCH__`, which is not what shipped), and the stub is
 applied by a regex over the declaration rather than an exact-literal replace.
 
 **Decision 4 — SUPERSEDED BY REVIEW. `.github/workflows/pr-task-link.yml` stays at `[main]`, and its guard keeps the
@@ -204,6 +217,7 @@ have the fix. Reviewer should rule.
 | `test/guards/pr-task-link-credential-isolation.test.ts` | trigger pin `["main"]` → `["main", "staging"]` |
 | `.github/dependabot.yml` | `target-branch: "staging"` on all three ecosystems |
 | `.github/workflows/pr-task-link.yml` | `branches: [main, staging]` + header prose corrected |
+| `.github/workflows/aios-work-sync.yml`, `.github/workflows/scan-on-merge.yml` | HEADER COMMENTS ONLY — both still describe their trigger as "the contribution base and the integration branch", which reads as "staging and staging" after the flip. The guard already asserts release+integration; this is the identity trap surviving in prose. Assigned here by Fable's diff review, which found them unowned by either half |
 | `.claude/skills/{adversarial-build,adversarial-build-astra,branch-reconciliation,pr-review-attestation,test-ci-wiring-audit}/**` | `currently \`main\`` → `currently \`staging\`` |
 | `.agents/**`, `.opencode/**`, `.cursor/**` | REGENERATED ONLY, by `scripts/sync-skill-runtimes.sh` |
 | `docs/RELEASING.md` | §3 cutover status, constraint rows 1/4/5/7/8, §3.2 ordering pairs |
@@ -215,12 +229,18 @@ A change to any file not in this table is a finding, not a tidy-up.
 
 ## Acceptance criteria
 
+**PARTITIONED BY PR — the split in the Status block reached only that block, which Fable's diff
+review caught.** **PR A (the value-invariant hardening) is criteria 2, 3, 4, 5, 6 and 15.** Every
+other criterion belongs to the **held cutover change set** and is not satisfiable, or even
+meaningful, until `CONTRIBUTION_BASE` moves.
+
+
 1. `scripts/branches.mjs` exports `CONTRIBUTION_BASE === "staging"` — asserted in unit tier `test/guards/branch-roles.test.ts`.
-2. `test/guards/branch-roles.test.ts` asserts `.github/workflows/aios-work-sync.yml`'s trigger equals `[RELEASE_BRANCH, INTEGRATION_BRANCH]` and NOT `[CONTRIBUTION_BASE, …]` — the source token is pinned, so a revert to the old pair reddens.
-3. `test/guards/branch-roles.test.ts` asserts `.github/workflows/scan-on-merge.yml`'s push trigger equals `[RELEASE_BRANCH, INTEGRATION_BRANCH]` — same pin.
+2. `test/guards/branch-roles.test.ts` asserts `.github/workflows/aios-work-sync.yml`'s trigger equals `[RELEASE_BRANCH, INTEGRATION_BRANCH]`, AND a source-token assertion forbids `[CONTRIBUTION_BASE, INTEGRATION_BRANCH]` while counting both surviving `RELEASE_BRANCH` sites — mutation: reverting either site must redden. **This sentence was FALSE when first written** and Fable's diff review measured it: the value assertion alone cannot see the revert, because the two pairs are the same value today, and both revert mutations SURVIVED. A source regex is evadable and is the only instrument that works here; the pin was added in the fold, and the same two mutations now REDDEN.
+3. `test/guards/branch-roles.test.ts` asserts `.github/workflows/scan-on-merge.yml`'s push trigger equals `[RELEASE_BRANCH, INTEGRATION_BRANCH]` — covered by the same source-token pin as criterion 2.
 4. `test/guards/branch-roles.test.ts`'s stub applies via a regex over `export const CONTRIBUTION_BASE = "<any>"`, so it survives any future value — mutation: change the declared value, the stub must still apply.
 5. `test/guards/instruction-base.test.ts`'s scratch module uses a sentinel base that **no** role equals — asserted by importing all three roles and requiring the sentinel differs from each.
-6. `test/guards/instruction-base.test.ts` is NON-VACUOUS after the flip: hardcoding `origin/staging` in the instruction under test must redden it (negative control, executed).
+6. `test/guards/instruction-base.test.ts` is NON-VACUOUS: the negative control rewrites `scripts/pr-review-gate.mjs`'s `origin/${CONTRIBUTION_BASE}...HEAD` to a hardcoded `origin/main...HEAD` and asserts the rendered message loses the sentinel (executed, in-test). `origin/main` rather than `origin/staging` because it is the equivalent mutation against a sentinel base and proves the same property identically before and after the cutover — an earlier draft of this criterion named `origin/staging`, which is not what the code does.
 7. `.github/dependabot.yml` sets `target-branch: "staging"` on all three ecosystems — asserted by a unit guard that parses the YAML and requires the count to equal the ecosystem count.
 8. `.github/workflows/pr-task-link.yml` fires on exactly `[main, staging]` — asserted in `test/guards/pr-task-link-credential-isolation.test.ts` as an EXACT array, not containment.
 9. `.github/workflows/pr-task-link.yml`'s header no longer claims the `[main]` pin is what keeps it advisory, and states the environment-policy precondition instead — presence assertion.
@@ -230,7 +250,7 @@ A change to any file not in this table is a finding, not a tidy-up.
 13. `docs/RELEASING.md` records what the fast-forward MEASURED: `scan-on-merge` red with zero steps, and Railway staging not auto-deploying — both are new facts, not predictions.
 14. `npm run check:instructions` stays green and its partial-scan blind-spot message is unchanged — Decision 6.
 15. `npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run check:docs` all pass.
-16. The PR body states the merge preconditions (environment policy widened first; default branch moved; `PR records a diff review` relocated) and is opened as a DRAFT.
+16. **(Held set only.)** The cutover PR body states the merge preconditions (environment policy widened first; default branch moved; `PR records a diff review` relocated) and is opened as a DRAFT. **PR A is deliberately NOT a draft** — it is value-invariant and meant to merge; an earlier version of this criterion applied the draft rule to both halves.
 
 ## What would falsify this design
 
@@ -273,9 +293,9 @@ satisfied without the thing it names being true:
    environment branch policies, the default branch, the tag ruleset, the release actor's push ability,
    the required-context sets, the deployed staging SHA, and a successful pre-deploy schema hook.
 5. **There is no criterion for the Railway staging runtime at all** — see below.
-6. **`test/guards/branch-roles.test.ts:232`'s `toContain("staging")` loses its meaning** once `staging`
-   is both the contribution and integration value. Remove it as redundant after the exact role-pair
-   correction, or recast it explicitly as an integration-role assertion.
+6. ~~**`test/guards/branch-roles.test.ts:232`'s `toContain("staging")` loses its meaning**~~ —
+   **RESOLVED in PR A.** Removed; it was implied by the `toEqual` above it, and replaced by an
+   assertion that the two roles in the pair can never be the same branch.
 
 ## The prerequisite this spec wrongly called out of scope
 

--- a/docs/design/cutover-execution.md
+++ b/docs/design/cutover-execution.md
@@ -1,0 +1,298 @@
+# The cutover, executed — `staging` becomes the contribution base (RELPTR-6)
+
+Status: **round 1 BLOCKED by Codex (gpt-5.6-sol), 2026-09-05 — folded into a SPLIT.** The reviewer's
+ruling: the value-invariant guard hardening is sound and should merge now; the branch flip, the
+Dependabot retarget and the `pr-task-link` trigger must NOT sit in a mergeable precursor, because the
+runbook's ordering pairs (`dependabot-target-branch: at the cutover, never before`) and the
+`pr-task-link` header's own argument both forbid it. Round 2 is pending on the criteria rewrite
+listed under "Open findings". Owner: chetan
+· Tier build-with: **unit** (`test/guards/branch-roles.test.ts`, `test/guards/instruction-base.test.ts`,
+`test/guards/pr-task-link-credential-isolation.test.ts`) — no persistence, no HTTP, no model.
+
+**Deps:** RELPTR-4 (`1633e438`, `scripts/branches.mjs`) and RELPTR-5 (`c76e66af`, the instruction
+corpus resolves the base) are both merged. `staging` was fast-forwarded to `c76e66af` on 2026-09-05
+(see Measured terrain), which is the §3.2 pair `fast-forward-staging: before retargeting any
+contribution flow`.
+
+**Increment — SPLIT after review, two change sets, not one:**
+
+- **PR A (mergeable now):** the three value-invariant guard fixes, D1/D2/D3 below. No branch flip, no
+  Dependabot edit, no workflow trigger edit, no cutover-status prose. Every fix is correct **today**
+  and each is a latent defect that only surfaces on cutover day, so leaving it in an unmerged branch
+  means the repository does not have the fix.
+- **The cutover change set (held for the coordinated window):** the `CONTRIBUTION_BASE` flip, the
+  instruction prose + regenerated mirrors, the Dependabot `target-branch` overrides and the
+  `pr-task-link` trigger — applied **alongside** the verified environment-policy and branch-protection
+  changes, with the Railway staging prerequisite verified before contributions reopen.
+
+Every branch protection change, the `trusted-automation` environment branch policy, the tag ruleset,
+the release actor and the GitHub default branch are **human admin steps and are in neither PR**.
+
+---
+
+## Problem
+
+`docs/RELEASING.md` §3 records a cutover that has been designed, prepared across four slices, and
+never executed. RELPTR-4 made the Node consumers follow a single declared role; RELPTR-5 made the
+instruction corpus resolve that role at run time. What remains in code is the one-line flip plus the
+sites that a shared constant provably does **not** cover — §3.1c enumerates them, and this slice is
+the enumeration turned into a diff.
+
+The slice exists as its own row because the flip is **not** safe to write casually: today
+`RELEASE_BRANCH === CONTRIBUTION_BASE === "main"`, so several assertions that look like they pin a
+value are today satisfied by *either* role, and moving the contribution base is the event that tells
+them apart. Three of those are latent defects this slice found by reading, not by running.
+
+---
+
+## Measured terrain — live, 2026-09-05
+
+Everything below was read from the live GitHub API, the live Railway project, and the repository at
+`c76e66af`. Nothing here is inferred.
+
+| fact | measurement |
+|---|---|
+| `staging` before | `05a771ff` (2026-07-25), **0 ahead / 267 behind** `main` |
+| `staging` after | fast-forwarded to `c76e66af`; **0 ahead / 0 behind** — constraints 5 and 8 now hold |
+| the push | required an **admin bypass** (`staging` requires a pull request at 0 approvals); `enforce_admins: false` on `staging` made that possible |
+| `scan-on-merge` on that push | **red in 3s having run ZERO steps** — the `trusted-automation` environment's branch policy is `main` only |
+| `trusted-automation` policy | exactly one branch policy: `main` (API-confirmed) |
+| repository rulesets | **zero**; `repos/.../tags/protection` → **404** (constraint 7 still false) |
+| `main` protection | 10 required contexts, `enforce_admins: true`, `strict: true`, **no push restrictions** — so no actor can push to `main` at all (constraint 1/the release actor: still false) |
+| `staging` protection | 7 required contexts, **no** `PR records a diff review`, push restricted to `chetan-guevara` + `johnellison`, `enforce_admins: false` |
+| `.github/dependabot.yml` | 3 ecosystems (npm, pip, github-actions), **zero** `target-branch` overrides |
+| `.github/workflows/pr-task-link.yml` | `on.pull_request_target.branches: [main]`; guard pins it to exactly `["main"]` |
+| `.github/workflows/aios-work-sync.yml` / `.github/workflows/scan-on-merge.yml` | already `[main, staging]` |
+| Railway staging | **did not auto-deploy** the fast-forward; latest deployment still 2026-07-25 08:36. Staging Postgres carries the July-25 schema (**70** tables vs `main`'s **85**; `members.handle` absent) |
+
+**What is NOT measured:** whether Railway's staging service has a GitHub source connected at all, or
+whether the webhook was merely dropped. Distinguishing those needs the Railway dashboard, which is a
+human read; the CLI is read-only here and cannot show service source settings.
+
+---
+
+## The three latent defects the flip exposes
+
+These are the reason this is a spec and not a one-line commit. Each is green today and each fails —
+or worse, silently stops testing anything — the moment `CONTRIBUTION_BASE` moves.
+
+### D1 — the workflow triggers are wired to the wrong role, invisibly
+
+`test/guards/branch-roles.test.ts:228,239` assert:
+
+```ts
+expect(on.pull_request_target!.branches).toEqual([CONTRIBUTION_BASE, INTEGRATION_BRANCH]);
+expect((on.push as { branches?: string[] }).branches).toEqual([CONTRIBUTION_BASE, INTEGRATION_BRANCH]);
+```
+
+Today that evaluates to `["main", "staging"]` and matches both files. After the flip it evaluates to
+`["staging", "staging"]` and the guard goes **red against a correct file**.
+
+The correct role pair is `[RELEASE_BRANCH, INTEGRATION_BRANCH]`.
+
+**REFUTED, and the refutation is recorded rather than quietly dropped:** a first draft of this spec
+justified keeping `main` by claiming that dropping it would reduce codebase readiness to per-release.
+Codex disproved that — post-cutover every merge lands on `staging`, so `staging`-only scanning is
+still per-merge. RELPTR-4's original failure was the mirror image (a `main`-ONLY trigger after
+contributions moved), and reversing it is not an argument for this pair.
+
+The real justifications differ per workflow and must be stated separately rather than under one slogan:
+
+- **`scan-on-merge` (push):** keeping `main` buys release-time retry/reconciliation, at the cost of
+  normally re-scanning a SHA already scanned on `staging`. Storage is keyed by `head_sha`, so the
+  open question — no-op or duplicate compute — must be answered and tested, not assumed.
+- **`aios-work-sync` (`pull_request_target: closed`):** the pair is a **security allowlist of trusted
+  PR bases**, not "the branches that receive contributions". A release fast-forward to `main` emits no
+  `pull_request_target` event at all, so `main`'s entry exists only for in-flight or exceptional pull
+  requests — a policy that must be stated explicitly or the entry is unnecessary exposure.
+
+**This correction is value-invariant today** (`RELEASE_BRANCH === CONTRIBUTION_BASE === "main"`), so
+it can be verified before the flip and carries no behavioural risk. It is the identity trap the
+`scripts/branches.mjs` header warns about, found in a second place.
+
+### D2 — the identity pin's stub is keyed on the literal being replaced
+
+`test/guards/branch-roles.test.ts:106` builds its sentinel by string-replacing
+`'export const CONTRIBUTION_BASE = "main";'`. After the flip that literal no longer exists.
+
+This one fails **loudly** — line 107's `expect(branches, "the stub must apply").not.toBe(src)` catches
+it — so it is a maintenance defect, not a silent one. It is listed because the fix must not be "update
+the literal to `staging`", which would reintroduce the same coupling one cutover later.
+
+### D3 — the instruction-base sentinel stops being a sentinel (silent)
+
+`test/guards/instruction-base.test.ts:182` writes a scratch module:
+
+```ts
+writeFileSync(join(dir, "branches.mjs"), 'export const CONTRIBUTION_BASE = "staging"; export const RELEASE_BRANCH = "release-sentinel";');
+```
+
+`"staging"` is chosen precisely because it is **not** the real value — that is what makes the test
+prove the instruction resolves the base rather than hardcoding it. After the flip, `"staging"` **is**
+the real value, and the test can no longer distinguish "resolved the base" from "hardcoded `staging`".
+It stays green while proving nothing.
+
+This is the dangerous one: no assertion reddens, so nothing announces the loss. It is the
+[measured-one-state-claimed-an-invariant] shape — a fixture whose discriminating power depends on a
+value that this very PR changes.
+
+---
+
+## Decisions
+
+**Decision 1 — the flip is one line, and the roles absorb the rest.**
+`CONTRIBUTION_BASE = "staging"` in `scripts/branches.mjs`. Every Node consumer
+(`scripts/pr-review-gate.mjs`) and every instruction site (RELPTR-5's 22 path + 4 refspec
+occurrences) follows without further edits. `INTEGRATION_BRANCH` and `RELEASE_BRANCH` do not move.
+
+**Decision 2 — express "both live branches" as `[RELEASE_BRANCH, INTEGRATION_BRANCH]`, not
+`[CONTRIBUTION_BASE, INTEGRATION_BRANCH]`.** See D1. Post-cutover the two live branches are the
+release branch and the integration branch; the contribution base is one of them, not a third thing.
+
+**Decision 3 — sentinels must not be real branch names.** D2 and D3 both come from fixtures keyed on
+a real value. Both become sentinels that no role can ever equal (`__NOT-A-BRANCH__`), and the stub is
+applied by a regex over the declaration rather than an exact-literal replace.
+
+**Decision 4 — SUPERSEDED BY REVIEW. `.github/workflows/pr-task-link.yml` stays at `[main]`, and its guard keeps the
+exact `["main"]` pin, until the environment policy is observably widened.** The original decision
+widened the trigger and relied on a PR-body precondition to stop an early merge; the reviewer's
+objection is that a stated precondition is not enforcement, and the failure it permits is concrete:
+merge the widening while the policy is `main`-only → the first pull request targeting `staging` starts
+`pr-task-link` → the environment refuses it with zero steps → an advisory check is red, hidden only by
+`continue-on-error`, which the file's own header says must never be relied on for that. The edit moves
+into the cutover change set. Original reasoning follows. §3.1c is explicit: the environment's branch policy must be widened
+**first**. Widening the trigger while the policy is `main`-only makes a `staging` pull request's run
+get refused the environment and go red — on a check whose whole contract is that it never goes red.
+`continue-on-error: true` masks it, which the file's own header calls out as *"relying on this line to
+hide a broken job, which is not what it is for"*. The PR therefore lands the widening but the merge is
+gated on the policy change, and this is written into the PR body as a merge precondition.
+
+**Decision 5 — the prose parentheticals flip, the mirrors are regenerated, never hand-edited.**
+Six canonical files carry `the contribution base (currently \`main\`, declared in
+\`scripts/branches.mjs\`)`; `.claude/skills/adversarial-build-astra/SKILL.md` carries a `today \`main\``
+variant. All become `staging`. `.agents/`, `.opencode/` and `.cursor/` copies are regenerated with
+`scripts/sync-skill-runtimes.sh`.
+
+**Decision 6 — `scripts/instruction-base.mjs` does NOT change.** It matches the literals
+`origin/(main|staging)` deliberately, never the resolved base, so that post-cutover it still sees a
+reintroduced `origin/main` — the likeliest regression. RELPTR-5 records this as a decision; this slice
+must not "fix" it into following the role.
+
+### Open question for review — one PR or two?
+
+D1, D2 and D3 are **correct today and value-invariant**: they can merge before the cutover and stop
+being latent. The flip itself must not merge until the admin steps are done. Two shapes:
+
+- **A (one PR, draft):** everything together, held unmerged. Simple, but it rots against a moving
+  `main`, and the three hardening fixes stay latent for however long the admin steps take.
+- **B (two PRs, stacked):** PR A = D1+D2+D3 hardening, mergeable immediately; PR B = the flip +
+  dependabot + trigger + prose, draft. More coordination; removes the latency.
+
+The operator asked for one PR. **Recommendation: B**, because the whole point of D3 is that it is a
+guard which silently stops working, and leaving it in an unmerged branch means the repository does not
+have the fix. Reviewer should rule.
+
+---
+
+## Scope — every file this PR may touch
+
+| file | change |
+|---|---|
+| `scripts/branches.mjs` | `CONTRIBUTION_BASE` → `"staging"`; header prose updated to describe the post-cutover world |
+| `test/guards/branch-roles.test.ts` | role-pair fix (D1), sentinel de-coupling (D2), value assertion `"staging"` |
+| `test/guards/instruction-base.test.ts` | sentinel de-vacuity (D3), `prose` const → `currently \`staging\`` |
+| `test/guards/pr-task-link-credential-isolation.test.ts` | trigger pin `["main"]` → `["main", "staging"]` |
+| `.github/dependabot.yml` | `target-branch: "staging"` on all three ecosystems |
+| `.github/workflows/pr-task-link.yml` | `branches: [main, staging]` + header prose corrected |
+| `.claude/skills/{adversarial-build,adversarial-build-astra,branch-reconciliation,pr-review-attestation,test-ci-wiring-audit}/**` | `currently \`main\`` → `currently \`staging\`` |
+| `.agents/**`, `.opencode/**`, `.cursor/**` | REGENERATED ONLY, by `scripts/sync-skill-runtimes.sh` |
+| `docs/RELEASING.md` | §3 cutover status, constraint rows 1/4/5/7/8, §3.2 ordering pairs |
+| `docs/design/cutover-execution.md` | this spec |
+
+A change to any file not in this table is a finding, not a tidy-up.
+
+---
+
+## Acceptance criteria
+
+1. `scripts/branches.mjs` exports `CONTRIBUTION_BASE === "staging"` — asserted in unit tier `test/guards/branch-roles.test.ts`.
+2. `test/guards/branch-roles.test.ts` asserts `.github/workflows/aios-work-sync.yml`'s trigger equals `[RELEASE_BRANCH, INTEGRATION_BRANCH]` and NOT `[CONTRIBUTION_BASE, …]` — the source token is pinned, so a revert to the old pair reddens.
+3. `test/guards/branch-roles.test.ts` asserts `.github/workflows/scan-on-merge.yml`'s push trigger equals `[RELEASE_BRANCH, INTEGRATION_BRANCH]` — same pin.
+4. `test/guards/branch-roles.test.ts`'s stub applies via a regex over `export const CONTRIBUTION_BASE = "<any>"`, so it survives any future value — mutation: change the declared value, the stub must still apply.
+5. `test/guards/instruction-base.test.ts`'s scratch module uses a sentinel base that **no** role equals — asserted by importing all three roles and requiring the sentinel differs from each.
+6. `test/guards/instruction-base.test.ts` is NON-VACUOUS after the flip: hardcoding `origin/staging` in the instruction under test must redden it (negative control, executed).
+7. `.github/dependabot.yml` sets `target-branch: "staging"` on all three ecosystems — asserted by a unit guard that parses the YAML and requires the count to equal the ecosystem count.
+8. `.github/workflows/pr-task-link.yml` fires on exactly `[main, staging]` — asserted in `test/guards/pr-task-link-credential-isolation.test.ts` as an EXACT array, not containment.
+9. `.github/workflows/pr-task-link.yml`'s header no longer claims the `[main]` pin is what keeps it advisory, and states the environment-policy precondition instead — presence assertion.
+10. Every canonical instruction file that carried `currently \`main\`` carries `currently \`staging\`` and **no** `currently \`main\`` — per-site presence AND absence, per RELPTR-5 criterion 14.
+11. `.agents/`, `.opencode/` and `.cursor/` copies match a fresh `scripts/sync-skill-runtimes.sh` run — asserted by `npm run check:skills`. This fence excludes nothing: no hand-authored content lives in those trees, and any file there that is not regenerable is an orphan the same check already reports (it did so in this worktree, for an untracked local skill stub).
+12. `docs/RELEASING.md` §3.2 no longer says `cutover: pending`, and rows 5 and 8 record the fast-forward as done with its date and sha.
+13. `docs/RELEASING.md` records what the fast-forward MEASURED: `scan-on-merge` red with zero steps, and Railway staging not auto-deploying — both are new facts, not predictions.
+14. `npm run check:instructions` stays green and its partial-scan blind-spot message is unchanged — Decision 6.
+15. `npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run check:docs` all pass.
+16. The PR body states the merge preconditions (environment policy widened first; default branch moved; `PR records a diff review` relocated) and is opened as a DRAFT.
+
+## What would falsify this design
+
+- If widening `.github/workflows/pr-task-link.yml`'s trigger before the environment policy does **not** produce a red
+  job — then Decision 4's ordering is unnecessary and the runbook overstates it. (Observable: the
+  `scan-on-merge` failure measured today is the same mechanism, so this is already evidenced once.)
+- If `[RELEASE_BRANCH, INTEGRATION_BRANCH]` is the wrong pair because post-cutover `main` should stop
+  receiving `scan-on-merge` entirely — that would be a product decision reversing RELPTR-4, and would
+  make D1 a scope change rather than a bug fix.
+- If the repository intends the default branch to stay `main` (contributions retargeted by tooling
+  rather than by default), constraint 6 changes shape and Decision 1 is insufficient on its own.
+
+## Out of scope, named
+
+Branch protection changes of any kind · the release actor · the `refs/tags/v*` ruleset · moving the
+GitHub default branch · widening the `trusted-automation` environment branch policy · making
+`Release candidate gate` a required context · relocating `PR records a diff review` · re-triggering
+the Railway staging deploy · anything touching the staging database.
+
+
+---
+
+## Open findings from round 1 — the criteria rewrite round 2 must clear
+
+Recorded verbatim rather than silently folded, because every one of them is a criterion that can be
+satisfied without the thing it names being true:
+
+1. **Criterion 7 is existential in aggregate.** "target-branch count equals ecosystem count" is
+   satisfied by one ecosystem carrying two keys and another carrying none. Parse every `updates`
+   entry and require **exactly one** `target-branch: staging` per entry, universally.
+2. **Criterion 9 has no inverse.** It requires the new prose to be present and never requires the old
+   claim — that the `[main]` pin is what prevents environment refusal — to be absent.
+3. **Criterion 10 is per-FILE where per-SITE is required.** Several canonical files carry more than one
+   `currently \`main\`` site; a per-file existential passes after deleting one of them. Reuse RELPTR-5's
+   per-site enumeration (`test/guards/instruction-base.test.ts:23`) with site-level presence AND
+   old-value absence — the identical defect that BLOCKED RELPTR-5 twice.
+4. **Criteria 12, 13 and 16 test documentation, not the world.** A prose edit removing `cutover:
+   pending` satisfies criterion 12 while constraints 1 and 7 (release actor, tag ruleset) remain
+   measurably false. Replace them with API-observable predicates: exact branch protections, exact
+   environment branch policies, the default branch, the tag ruleset, the release actor's push ability,
+   the required-context sets, the deployed staging SHA, and a successful pre-deploy schema hook.
+5. **There is no criterion for the Railway staging runtime at all** — see below.
+6. **`test/guards/branch-roles.test.ts:232`'s `toContain("staging")` loses its meaning** once `staging`
+   is both the contribution and integration value. Remove it as redundant after the exact role-pair
+   correction, or recast it explicitly as an integration-role assertion.
+
+## The prerequisite this spec wrongly called out of scope
+
+Round 1's third blocker, accepted: **the staging runtime is a cutover prerequisite, not an unrelated
+operational annoyance.** The branch advanced; the service did not. The app is serving July code
+against a 70-table July schema while the branch it tracks expects 85 tables. After the cutover every
+merge lands on `staging` — and if its runtime neither deploys nor migrates, the integration branch has
+lost the operational feedback that is the entire reason to have one. Worse, because the service's
+source connection is **unmeasured**, the next merge is not evidence that deployment will recover.
+
+Before contributions reopen, these must be observed rather than assumed:
+
+- the staging service's source is connected to this repository and to the `staging` branch;
+- a deployment of the current `staging` SHA succeeds;
+- the pre-deploy schema step (`npm run pg:schema`) runs and exits zero;
+- the deployed SHA equals the branch tip;
+- a health check exercises the current build against the migrated staging database.
+
+Re-triggering a deploy is a Railway **dashboard** action and stays a human step. Verifying the
+resulting state is an acceptance criterion of the cutover.

--- a/docs/design/cutover-execution.md
+++ b/docs/design/cutover-execution.md
@@ -169,11 +169,35 @@ applied by a regex over the declaration rather than an exact-literal replace.
 **Decision 4 — SUPERSEDED BY REVIEW. `.github/workflows/pr-task-link.yml` stays at `[main]`, and its guard keeps the
 exact `["main"]` pin, until the environment policy is observably widened.** The original decision
 widened the trigger and relied on a PR-body precondition to stop an early merge; the reviewer's
-objection is that a stated precondition is not enforcement, and the failure it permits is concrete:
-merge the widening while the policy is `main`-only → the first pull request targeting `staging` starts
-`pr-task-link` → the environment refuses it with zero steps → an advisory check is red, hidden only by
-`continue-on-error`, which the file's own header says must never be relied on for that. The edit moves
-into the cutover change set. Original reasoning follows. §3.1c is explicit: the environment's branch policy must be widened
+objection is that a stated precondition is not enforcement. **The conclusion stands; the SCENARIO
+that was given for it does not, and the correction changes the cutover ordering.**
+
+The scenario said: merge the widening while the policy is `main`-only → a pull request targeting
+`staging` runs `pr-task-link` → the environment refuses it with zero steps → an advisory check goes
+red. gpt-6-astra's cold review found this rests on **pre-2025-12-08 `pull_request_target` semantics**,
+and the primary source confirms it — GitHub's 2025-11-07 changelog, effective **2025-12-08**: *"The
+workflow file and checkout commit will always be taken from the repository's default branch,
+regardless of the pull request's base branch"*, and *"For `pull_request_target`, environment rules
+evaluate against the default branch."*
+
+**So, with the default branch still `main`:** a pull request based on `staging` evaluates the
+environment against `main`, the `main`-only policy ALLOWS it, and nothing goes red. Widening the
+trigger early is not the hazard that was claimed.
+
+**The real hazard moves to the DEFAULT-BRANCH MOVE, and it is bigger.** Once the default branch
+becomes `staging`, every `pull_request_target` workflow — `.github/workflows/pr-task-link.yml` AND `.github/workflows/aios-work-sync.yml`
+— evaluates the `trusted-automation` policy against `staging`. A `main`-only policy then refuses
+**all of them**, so the advisory check goes red on every pull request and no work event posts on any
+merge. The ordering pair is therefore **widen the environment policy BEFORE moving the default
+branch**, not before widening a trigger.
+
+**What is unaffected:** the `scan-on-merge` failure measured on 2026-09-05 was a **`push`** event,
+whose `GITHUB_REF` is the pushed branch. That evaluated against `staging`, was refused, and ran zero
+steps. That measurement stands and is untouched by the `pull_request_target` change.
+
+The edit still moves into the cutover change set — a trigger widening with no branch to serve is
+churn, and it belongs with the policy and default-branch changes it is ordered against. Original
+reasoning follows, and is superseded by the paragraphs above. §3.1c is explicit: the environment's branch policy must be widened
 **first**. Widening the trigger while the policy is `main`-only makes a `staging` pull request's run
 get refused the environment and go red — on a check whose whole contract is that it never goes red.
 `continue-on-error: true` masks it, which the file's own header calls out as *"relying on this line to
@@ -296,6 +320,17 @@ satisfied without the thing it names being true:
 6. ~~**`test/guards/branch-roles.test.ts:232`'s `toContain("staging")` loses its meaning**~~ —
    **RESOLVED in PR A.** Removed; it was implied by the `toEqual` above it, and replaced by an
    assertion that the two roles in the pair can never be the same branch.
+
+7. **`docs/RELEASING.md` §3.1c carries the same pre-2025-12-08 `pull_request_target` model** and must
+   be corrected with Decision 4 — it argues that a `staging`-based run "would be refused a `main`-only
+   policy and go red", which is false while the default branch is `main` and understates what happens
+   once it is not. Left to the held change set rather than expanded into PR A, because it is
+   cutover-planning prose, not a guard; flagged here so it is not discovered on the day.
+8. **Both reviewers were wrong about this, in opposite directions, and neither could have settled it
+   alone.** Fable refuted a claim using the old event model; gpt-6-astra refuted the refutation but
+   had no network to check its own citation. The primary source decided it. Recorded because the
+   lesson generalises: a reviewer's confident mechanism claim about a third-party platform is a
+   hypothesis until the vendor's own changelog is read.
 
 ## The prerequisite this spec wrongly called out of scope
 

--- a/docs/design/cutover-execution.md
+++ b/docs/design/cutover-execution.md
@@ -4,8 +4,12 @@ Status: **round 1 BLOCKED by Codex (gpt-5.6-sol), 2026-09-05 — folded into a S
 ruling: the value-invariant guard hardening is sound and should merge now; the branch flip, the
 Dependabot retarget and the `pr-task-link` trigger must NOT sit in a mergeable precursor, because the
 runbook's ordering pairs (`dependabot-target-branch: at the cutover, never before`) and the
-`pr-task-link` header's own argument both forbid it. Round 2 is pending on the criteria rewrite
-listed under "Open findings". Owner: chetan
+`pr-task-link` header's own argument both forbid it. Round 2 ran: Fable reviewed the DIFF
+(CLEAR-WITH-CONDITIONS), gpt-6-astra reviewed it cold (BLOCKED — it caught a false premise in Fable's
+own refutation), and Fable re-cleared the post-fold diff (CLEAR-WITH-CONDITIONS, prose only). PR A's
+criteria (2–6, 15) are folded and satisfied. **The HELD set's criteria — 1, 7–14, 16 — remain in their
+round-1 form and still carry the open findings listed at the end of this document; they are not
+review-clean and must not be treated as such when the cutover PR is written.** Owner: chetan
 · Tier build-with: **unit** (`test/guards/branch-roles.test.ts`, `test/guards/instruction-base.test.ts`,
 `test/guards/pr-task-link-credential-isolation.test.ts`) — no persistence, no HTTP, no model.
 
@@ -278,9 +282,14 @@ meaningful, until `CONTRIBUTION_BASE` moves.
 
 ## What would falsify this design
 
-- If widening `.github/workflows/pr-task-link.yml`'s trigger before the environment policy does **not** produce a red
-  job — then Decision 4's ordering is unnecessary and the runbook overstates it. (Observable: the
-  `scan-on-merge` failure measured today is the same mechanism, so this is already evidenced once.)
+- **(Rewritten — the original was met by this spec and left standing, which Fable's re-clear caught.)**
+  It said: *if widening `pr-task-link`'s trigger before the environment policy does not produce a red
+  job, Decision 4's ordering is unnecessary*, and cited the `scan-on-merge` failure as the same
+  mechanism. Decision 4 now asserts that exact outcome — no red while the default branch is `main` —
+  and says `scan-on-merge` was a `push`, a **different** mechanism. The live falsifier is the new
+  hazard: **if, after the default branch moves to `staging` under a `main`-only `trusted-automation`
+  policy, `pull_request_target` runs are NOT refused, then the widen-policy-before-default-branch
+  ordering pair is unnecessary.**
 - If `[RELEASE_BRANCH, INTEGRATION_BRANCH]` is the wrong pair because post-cutover `main` should stop
   receiving `scan-on-merge` entirely — that would be a product decision reversing RELPTR-4, and would
   make D1 a scope change rather than a bug fix.
@@ -321,11 +330,20 @@ satisfied without the thing it names being true:
    **RESOLVED in PR A.** Removed; it was implied by the `toEqual` above it, and replaced by an
    assertion that the two roles in the pair can never be the same branch.
 
-7. **`docs/RELEASING.md` §3.1c carries the same pre-2025-12-08 `pull_request_target` model** and must
-   be corrected with Decision 4 — it argues that a `staging`-based run "would be refused a `main`-only
-   policy and go red", which is false while the default branch is `main` and understates what happens
-   once it is not. Left to the held change set rather than expanded into PR A, because it is
-   cutover-planning prose, not a guard; flagged here so it is not discovered on the day.
+7. **FOUR files carry the superseded pre-2025-12-08 `pull_request_target` model**, not one. An
+   earlier version of this finding named only the first, and Fable's re-clear enumerated the rest:
+   - `docs/RELEASING.md` §3.1c (~:178–190) — argues a `staging`-based run "would be refused a
+     `main`-only policy and go red": false while the default branch is `main`, and it understates
+     what happens once it is not;
+   - `.github/workflows/aios-work-sync.yml` (:25, :29, :46, **:69–71**, :112, :135) — the "SECOND
+     COST" paragraph is now false, and it sits ten lines above the trigger this PR's new test pins;
+   - `.github/workflows/pr-task-link.yml` (:28, :49, :71–75, :121, :134);
+   - `test/guards/pr-task-link-credential-isolation.test.ts` (:471–472, :608) — the **assertion**
+     (`["main"]`) still holds; only its stated rationale is stale.
+
+   All four are held-set corrections, not PR A's: they are cutover-planning and rationale prose, and
+   widening PR A to chase them would break its value-invariant story. Flagged so they are not
+   discovered on the day.
 8. **Both reviewers were wrong about this, in opposite directions, and neither could have settled it
    alone.** Fable refuted a claim using the old event model; gpt-6-astra refuted the refutation but
    had no network to check its own citation. The primary source decided it. Recorded because the

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -262,13 +262,21 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // the default branch". (github.blog/changelog/2025-11-07-actions-pull_request_target-and-
     // environment-branch-protections-changes/)
     //
-    // So the base branch controls neither the workflow file nor the environment evaluation, and this
-    // `branches:` filter is a plain event filter — not a security control in either direction. The
-    // blast-radius control is the `trusted-automation` environment policy, evaluated against the
-    // DEFAULT branch, which is repository settings and not this file.
+    // So the base branch controls neither the workflow file nor the environment evaluation. But
+    // "therefore the filter is not a security control" — a first version of this comment — is the
+    // over-correction, and Fable's re-clear caught it. The filter is not a CREDENTIAL boundary; it is
+    // the INTEGRITY control over which merges count. With `branches: ["**"]` a collaborator opens a
+    // pull request into their own unprotected branch, merges it themselves, satisfies
+    // `merged == true && same-repo` from trusted default-branch code, and `notify-brain` posts a work
+    // event that can resolve `applied` and close a task. Under the verified model the filter is MORE
+    // load-bearing, not less, because a same-repo branch can no longer edit it. The separate
+    // blast-radius control over the CREDENTIAL is the `trusted-automation` environment policy,
+    // evaluated against the DEFAULT branch — repository settings, not this file.
     //
-    // What IS true and worth keeping: a release fast-forward to `main` emits no
-    // `pull_request_target` at all, so `main`'s entry serves in-flight and exceptional pull
+    // What IS true and worth keeping: a release fast-forward is a PUSH, so it does not by itself
+    // raise `pull_request_target`. ("emits none at all" was too strong — if a `staging`→`main` pull
+    // request is open when the push lands, GitHub marks it merged and `closed` fires with
+    // `merged == true`.) `main`'s entry serves exactly those in-flight and exceptional pull
     // requests into the release branch.
     const on = workflow("aios-work-sync.yml").on!;
     expect(Object.keys(on), "the trigger itself is part of criterion 5 now").toEqual(["pull_request_target"]);
@@ -293,15 +301,18 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // WHY A SOURCE REGEX, WHICH THIS FILE'S OWN HEADER CALLS EVADABLE: today
     // `RELEASE_BRANCH === CONTRIBUTION_BASE === "main"`, so the two role pairs are the SAME VALUE
     // and no value or behavioural assertion can tell them apart. Measured, not assumed — reverting
-    // either `toEqual` below to `[CONTRIBUTION_BASE, INTEGRATION_BRANCH]` leaves all 41 tests in
-    // this file green (`scripts/mutate.mjs` verdict: SURVIVED, twice). Fable's diff review found
+    // either `toEqual` below to `[CONTRIBUTION_BASE, INTEGRATION_BRANCH]` leaves EVERY test in this
+    // file green (`scripts/mutate.mjs` verdict: SURVIVED, twice). Fable's diff review found
     // exactly that gap, and this test exists because of it. An evadable pin beats no pin; the
     // alternative was a fix nothing held in place until cutover day made it loud.
     // COMMENT LINES ARE STRIPPED FIRST. gpt-6-astra's cold review found the hole in the first
     // version: prefixing either assertion with `//` leaves both regex checks satisfied — the string
     // is still in the file — while removing its execution entirely, so the count certified coverage
-    // that no longer runs. Stated limit, because a guard's blind spots belong in the guard: this
-    // strips LINE comments only, so a `/* … */` block around an assertion would still evade it.
+    // that no longer runs. Stated limits, because a guard's blind spots belong in the guard: this
+    // strips LINE comments only, so a `/* … */` block around an assertion evades it — and so does
+    // disabling the test that contains it (`it.skip`, `describe.skip`, `xit`, `it.todo`), which
+    // leaves the source text and therefore the count untouched. Same class, same acceptance: these
+    // are deliberate edits by someone reading this comment, not silent drift.
     const src = read("test/guards/branch-roles.test.ts")
       .split("\n")
       .filter((line) => !line.trim().startsWith("//"))

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -222,7 +222,7 @@ describe("branch roles — the IDENTITY PIN (criterion 3)", () => {
 });
 
 describe("branch roles — the workflows that must follow the cutover (criteria 5, 6, 7)", () => {
-  it("aios-work-sync fires on EXACTLY the contribution base and the integration branch", () => {
+  it("aios-work-sync fires on EXACTLY the release branch and the integration branch", () => {
     // EXACT SET, not "contains both": `[main, staging, "**"]` satisfies a containment check while
     // silently widening the trigger to every branch in the repository. Codex found that.
     //

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -241,11 +241,23 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // `CONTRIBUTION_BASE` becomes `staging`, the old expectation COLLAPSES to
     // `["staging", "staging"]`, and this guard reddens against a workflow file that is correct.
     //
-    // Why RELEASE and not CONTRIBUTION is the right role here: this trigger is a SECURITY
-    // ALLOWLIST of trusted pull-request bases, not "the branches that receive contributions". A
-    // release fast-forward to `main` emits no `pull_request_target` at all, so `main`'s entry
-    // exists for in-flight and exceptional pull requests into the release branch — stated here
-    // rather than left implicit, because if that is NOT the policy the entry is pure exposure.
+    // WHY RELEASE AND NOT CONTRIBUTION — by elimination, which is the only argument that holds in
+    // both worlds. The trigger needs two DISTINCT branches. `[CONTRIBUTION_BASE, RELEASE_BRANCH]`
+    // collapses today (both `main`); `[CONTRIBUTION_BASE, INTEGRATION_BRANCH]` collapses after the
+    // cutover (both `staging`); `[RELEASE_BRANCH, INTEGRATION_BRANCH]` is distinct in both. That is
+    // the whole justification and it is checkable.
+    //
+    // A REFUTED VERSION, kept so it is not re-derived: a draft called this pair a SECURITY
+    // ALLOWLIST of trusted pull-request bases. Fable disproved it — on `pull_request_target` the
+    // workflow file, `on:` filter included, is read from the pull request's BASE branch, and a
+    // same-repo collaborator can push a branch and control that copy. The filter cannot allowlist
+    // against the population this workflow's own header names as the threat. The real blast-radius
+    // control is the `trusted-automation` environment's deployment branch policy, which lives in
+    // repository settings, not in this file.
+    //
+    // What IS true and worth keeping: a release fast-forward to `main` emits no
+    // `pull_request_target` at all, so `main`'s entry serves in-flight and exceptional pull
+    // requests into the release branch.
     const on = workflow("aios-work-sync.yml").on!;
     expect(Object.keys(on), "the trigger itself is part of criterion 5 now").toEqual(["pull_request_target"]);
     expect(on.pull_request_target!.branches).toEqual([RELEASE_BRANCH, INTEGRATION_BRANCH]);
@@ -257,10 +269,27 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // that stopped meaning anything once `staging` could be BOTH values. `[RELEASE_BRANCH,
     // INTEGRATION_BRANCH]` is a two-branch allowlist by construction; `[CONTRIBUTION_BASE,
     // INTEGRATION_BRANCH]` is only a two-branch allowlist by accident of today's values.
+    //
+    // ONE assertion, not two. A first version followed this with
+    // `expect([A,B]).toHaveLength(new Set([A,B]).size)` and a comment claiming it pinned the
+    // COLLAPSE of the old pair. For a 2-tuple that is the same predicate respelled, and it never
+    // mentioned `CONTRIBUTION_BASE` — a comment describing a third thing neither line did.
     expect(RELEASE_BRANCH, "a collapsed pair is a one-branch trigger wearing a two-branch shape").not.toBe(INTEGRATION_BRANCH);
-    // …and the pair that WAS used does collapse, which is the whole finding, pinned so the
-    // regression is a red test rather than a rediscovery on cutover day.
-    expect([RELEASE_BRANCH, INTEGRATION_BRANCH]).toHaveLength(new Set([RELEASE_BRANCH, INTEGRATION_BRANCH]).size);
+  });
+
+  it("the workflow triggers are pinned to the RELEASE role, not the contribution base", () => {
+    // WHY A SOURCE REGEX, WHICH THIS FILE'S OWN HEADER CALLS EVADABLE: today
+    // `RELEASE_BRANCH === CONTRIBUTION_BASE === "main"`, so the two role pairs are the SAME VALUE
+    // and no value or behavioural assertion can tell them apart. Measured, not assumed — reverting
+    // either `toEqual` below to `[CONTRIBUTION_BASE, INTEGRATION_BRANCH]` leaves all 41 tests in
+    // this file green (`scripts/mutate.mjs` verdict: SURVIVED, twice). Fable's diff review found
+    // exactly that gap, and this test exists because of it. An evadable pin beats no pin; the
+    // alternative was a fix nothing held in place until cutover day made it loud.
+    const src = read("test/guards/branch-roles.test.ts");
+    expect(src, "the trigger assertions must name RELEASE_BRANCH").not.toMatch(/toEqual\(\[CONTRIBUTION_BASE, INTEGRATION_BRANCH\]\)/);
+    // NON-VACUOUS: forbidding a shape proves nothing unless the shape it REPLACED is present.
+    // Both trigger sites, counted — deleting one would otherwise satisfy the line above.
+    expect(src.match(/toEqual\(\[RELEASE_BRANCH, INTEGRATION_BRANCH\]\)/g), "both trigger sites").toHaveLength(2);
   });
 
   it("scan-on-merge fires on EXACTLY the same two branches", () => {

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -247,13 +247,25 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // cutover (both `staging`); `[RELEASE_BRANCH, INTEGRATION_BRANCH]` is distinct in both. That is
     // the whole justification and it is checkable.
     //
-    // A REFUTED VERSION, kept so it is not re-derived: a draft called this pair a SECURITY
-    // ALLOWLIST of trusted pull-request bases. Fable disproved it — on `pull_request_target` the
-    // workflow file, `on:` filter included, is read from the pull request's BASE branch, and a
-    // same-repo collaborator can push a branch and control that copy. The filter cannot allowlist
-    // against the population this workflow's own header names as the threat. The real blast-radius
-    // control is the `trusted-automation` environment's deployment branch policy, which lives in
-    // repository settings, not in this file.
+    // TWO REFUTED VERSIONS, both kept so neither is re-derived. This is the one claim in this slice
+    // that three passes disagreed about, so the evidence is written down rather than the conclusion.
+    //
+    //   (1) A draft called this pair a SECURITY ALLOWLIST of trusted pull-request bases.
+    //   (2) Fable's diff review disproved (1) by arguing that on `pull_request_target` the workflow
+    //       file — `on:` filter included — is read from the pull request's BASE branch, which a
+    //       same-repo collaborator controls.
+    //
+    // (2) IS ALSO WRONG, AND IS THE OLDER MODEL. gpt-6-astra caught it and it was verified against
+    // the primary source: GitHub changed `pull_request_target` effective 2025-12-08 —
+    // "The workflow file and checkout commit will always be taken from the repository's default
+    // branch, regardless of the pull request's base branch", and "environment rules evaluate against
+    // the default branch". (github.blog/changelog/2025-11-07-actions-pull_request_target-and-
+    // environment-branch-protections-changes/)
+    //
+    // So the base branch controls neither the workflow file nor the environment evaluation, and this
+    // `branches:` filter is a plain event filter — not a security control in either direction. The
+    // blast-radius control is the `trusted-automation` environment policy, evaluated against the
+    // DEFAULT branch, which is repository settings and not this file.
     //
     // What IS true and worth keeping: a release fast-forward to `main` emits no
     // `pull_request_target` at all, so `main`'s entry serves in-flight and exceptional pull
@@ -285,11 +297,20 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // this file green (`scripts/mutate.mjs` verdict: SURVIVED, twice). Fable's diff review found
     // exactly that gap, and this test exists because of it. An evadable pin beats no pin; the
     // alternative was a fix nothing held in place until cutover day made it loud.
-    const src = read("test/guards/branch-roles.test.ts");
+    // COMMENT LINES ARE STRIPPED FIRST. gpt-6-astra's cold review found the hole in the first
+    // version: prefixing either assertion with `//` leaves both regex checks satisfied — the string
+    // is still in the file — while removing its execution entirely, so the count certified coverage
+    // that no longer runs. Stated limit, because a guard's blind spots belong in the guard: this
+    // strips LINE comments only, so a `/* … */` block around an assertion would still evade it.
+    const src = read("test/guards/branch-roles.test.ts")
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"))
+      .join("\n");
     expect(src, "the trigger assertions must name RELEASE_BRANCH").not.toMatch(/toEqual\(\[CONTRIBUTION_BASE, INTEGRATION_BRANCH\]\)/);
     // NON-VACUOUS: forbidding a shape proves nothing unless the shape it REPLACED is present.
-    // Both trigger sites, counted — deleting one would otherwise satisfy the line above.
-    expect(src.match(/toEqual\(\[RELEASE_BRANCH, INTEGRATION_BRANCH\]\)/g), "both trigger sites").toHaveLength(2);
+    // Both trigger sites, counted — deleting or commenting out one would otherwise satisfy the
+    // line above while removing the assertion it exists to protect.
+    expect(src.match(/toEqual\(\[RELEASE_BRANCH, INTEGRATION_BRANCH\]\)/g), "both trigger sites, uncommented").toHaveLength(2);
   });
 
   it("scan-on-merge fires on EXACTLY the same two branches", () => {
@@ -301,8 +322,15 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // `main` by claiming its removal would reduce readiness to per-release. Codex disproved it —
     // post-cutover every merge lands on `staging`, so `staging`-only scanning is still per-merge.
     // `main`'s entry buys release-time retry/reconciliation, at the cost of normally re-scanning a
-    // SHA already scanned on `staging` (the workflow keys stored results by `head_sha`, so that is
-    // duplicate compute rather than a wrong result). Same role correction as above, same reason.
+    // SHA already scanned on `staging`.
+    //
+    // A FIRST VERSION CALLED THAT "duplicate compute rather than a wrong result". Too strong, and
+    // gpt-6-astra produced the counterexample; re-derived here before folding. `lib/codebases/ingest.ts`
+    // upserts on `(codebase_id, head_sha)` and REFRESHES `scanned_at`, while
+    // `lib/metrics/codebases.ts` picks the latest scan by ORDERING ON `scanned_at`. So: staging
+    // scans A then B; a later release fast-forward re-scans A; A now carries the newest timestamp
+    // and wins "latest" despite B being newer by ancestry. That is a pre-existing operational risk
+    // this slice neither introduces nor fixes — recorded so the reassurance is not repeated.
     const on = workflow("scan-on-merge.yml").on!;
     expect((on.push as { branches?: string[] }).branches).toEqual([RELEASE_BRANCH, INTEGRATION_BRANCH]);
   });

--- a/test/guards/branch-roles.test.ts
+++ b/test/guards/branch-roles.test.ts
@@ -99,11 +99,21 @@ describe("branch roles — the IDENTITY PIN (criterion 3)", () => {
   const git = (cwd: string, ...args: string[]) =>
     execFileSync("git", args, { cwd, encoding: "utf8", env: ISOLATED }).trim();
 
+  // RELPTR-6 D2 — match the DECLARATION, not the value it currently holds. The first version
+  // replaced the literal string `export const CONTRIBUTION_BASE = "main";`, so the day the cutover
+  // moves that value the substitution silently stops matching. It fails loudly today (the
+  // `not.toBe(src)` below), which is why this is brittleness rather than a false green — but
+  // "update the literal to `staging`" would reintroduce the identical coupling one cutover later.
+  // Global + count-checked: a SECOND declaration would otherwise leave one copy unstubbed, and the
+  // stub would test a module that still resolves the real branch.
+  const CONTRIBUTION_BASE_DECL = /export const CONTRIBUTION_BASE = "[^"]*";/g;
+
   function scratchWithStub(stubValue: string | null) {
     const dir = mkdtempSync(join(tmpdir(), "roles-pin-"));
     const src = read("scripts/branches.mjs");
+    expect(src.match(CONTRIBUTION_BASE_DECL), "exactly one declaration to stub").toHaveLength(1);
     const branches =
-      stubValue === null ? src : src.replace('export const CONTRIBUTION_BASE = "main";', `export const CONTRIBUTION_BASE = ${JSON.stringify(stubValue)};`);
+      stubValue === null ? src : src.replace(CONTRIBUTION_BASE_DECL, `export const CONTRIBUTION_BASE = ${JSON.stringify(stubValue)};`);
     if (stubValue !== null) expect(branches, "the stub must apply").not.toBe(src);
     writeFileSync(join(dir, "branches.mjs"), branches);
     writeFileSync(join(dir, "release-candidate-guard.mjs"), read("scripts/release-candidate-guard.mjs"));
@@ -223,20 +233,49 @@ describe("branch roles — the workflows that must follow the cutover (criteria 
     // branch a pull request targets, so a collaborator can make their own tree the trusted one.
     // `test/guards/pr-task-link-credential-isolation.test.ts` owns the security half; this owns the
     // RELPTR-4 half, and both must move together.
+    //
+    // RELPTR-6 D1 — THE PAIR IS `[RELEASE_BRANCH, INTEGRATION_BRANCH]`, AND IT USED TO BE
+    // `[CONTRIBUTION_BASE, INTEGRATION_BRANCH]`. Today those evaluate identically (`["main",
+    // "staging"]`), which is exactly why the mis-wiring was invisible — the same identity trap
+    // `scripts/branches.mjs`'s header names, found in a second place. On cutover day
+    // `CONTRIBUTION_BASE` becomes `staging`, the old expectation COLLAPSES to
+    // `["staging", "staging"]`, and this guard reddens against a workflow file that is correct.
+    //
+    // Why RELEASE and not CONTRIBUTION is the right role here: this trigger is a SECURITY
+    // ALLOWLIST of trusted pull-request bases, not "the branches that receive contributions". A
+    // release fast-forward to `main` emits no `pull_request_target` at all, so `main`'s entry
+    // exists for in-flight and exceptional pull requests into the release branch — stated here
+    // rather than left implicit, because if that is NOT the policy the entry is pure exposure.
     const on = workflow("aios-work-sync.yml").on!;
     expect(Object.keys(on), "the trigger itself is part of criterion 5 now").toEqual(["pull_request_target"]);
-    expect(on.pull_request_target!.branches).toEqual([CONTRIBUTION_BASE, INTEGRATION_BRANCH]);
+    expect(on.pull_request_target!.branches).toEqual([RELEASE_BRANCH, INTEGRATION_BRANCH]);
     expect(on.pull_request_target!.types).toEqual(["closed"]);
-    // …and INTEGRATION_BRANCH is `staging` TODAY, so this pins the widening now rather than
-    // collapsing to "contains main" until the cutover moves the value.
-    expect(on.pull_request_target!.branches).toContain("staging");
+  });
+
+  it("the two roles in that pair can never be the same branch", () => {
+    // The property the old pair lacked, asserted directly instead of via a `toContain("staging")`
+    // that stopped meaning anything once `staging` could be BOTH values. `[RELEASE_BRANCH,
+    // INTEGRATION_BRANCH]` is a two-branch allowlist by construction; `[CONTRIBUTION_BASE,
+    // INTEGRATION_BRANCH]` is only a two-branch allowlist by accident of today's values.
+    expect(RELEASE_BRANCH, "a collapsed pair is a one-branch trigger wearing a two-branch shape").not.toBe(INTEGRATION_BRANCH);
+    // …and the pair that WAS used does collapse, which is the whole finding, pinned so the
+    // regression is a red test rather than a rediscovery on cutover day.
+    expect([RELEASE_BRANCH, INTEGRATION_BRANCH]).toHaveLength(new Set([RELEASE_BRANCH, INTEGRATION_BRANCH]).size);
   });
 
   it("scan-on-merge fires on EXACTLY the same two branches", () => {
-    // After the cutover `main` advances only by release fast-forward, so a `[main]`-only trigger
-    // would drop codebase readiness from per-merge to per-release without any error.
+    // RELPTR-4's original failure: a `[main]`-ONLY push trigger after contributions moved would
+    // drop codebase readiness from per-merge to per-release without any error. That is why the
+    // trigger was widened, and it is still why `staging` must be here.
+    //
+    // RELPTR-6 D1, and a REFUTATION worth keeping: a draft of that slice justified retaining
+    // `main` by claiming its removal would reduce readiness to per-release. Codex disproved it —
+    // post-cutover every merge lands on `staging`, so `staging`-only scanning is still per-merge.
+    // `main`'s entry buys release-time retry/reconciliation, at the cost of normally re-scanning a
+    // SHA already scanned on `staging` (the workflow keys stored results by `head_sha`, so that is
+    // duplicate compute rather than a wrong result). Same role correction as above, same reason.
     const on = workflow("scan-on-merge.yml").on!;
-    expect((on.push as { branches?: string[] }).branches).toEqual([CONTRIBUTION_BASE, INTEGRATION_BRANCH]);
+    expect((on.push as { branches?: string[] }).branches).toEqual([RELEASE_BRANCH, INTEGRATION_BRANCH]);
   });
 
   it("nothing INSIDE aios-work-sync re-narrows what the trigger widened", () => {

--- a/test/guards/instruction-base.test.ts
+++ b/test/guards/instruction-base.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { isOperativeLine, scanInventory, trackedInventory, report } from "../../scripts/instruction-base.mjs";
+import { CONTRIBUTION_BASE, INTEGRATION_BRANCH, RELEASE_BRANCH } from "../../scripts/branches.mjs";
 
 // Assertions derive from RELPTR-5 criteria 1–16 and its named disposition, not scan output.
 const ROOT = join(import.meta.dirname, "../..");
@@ -178,13 +179,59 @@ describe("observable shell and role identity (11, 15)", () => {
     expect(output).toContain("+feature");
     expect(output).not.toContain("+advanced");
   }));
+  /**
+   * RELPTR-6 D3 — THE SENTINEL MUST BE A VALUE NO ROLE HOLDS, and this test used to violate that.
+   *
+   * It stubbed `CONTRIBUTION_BASE = "staging"` and asserted the rendered message says
+   * `origin/staging...HEAD`. That discriminates ONLY because `staging` is not the real contribution
+   * base: if `pr-review-gate.mjs` hardcoded the branch instead of importing the role, the output
+   * would say `origin/main` and the assertions would redden. The cutover makes `staging` the REAL
+   * value — at which point a hardcoded `origin/staging` renders exactly what a correct
+   * implementation renders, all three assertions still pass, and the test proves nothing. Nothing
+   * reddens to announce the loss, which makes this the silent member of the D1/D2/D3 set.
+   *
+   * The fix is a sentinel drawn from no role's value-space, checked against every role rather than
+   * against a remembered one, plus an executed negative control below — because a stub that cannot
+   * fail is the same failure in a new spelling.
+   */
+  const BASE_SENTINEL = "contribution-sentinel";
+  const RELEASE_SENTINEL = "release-sentinel";
+  const stubbedRoles = `export const CONTRIBUTION_BASE = ${JSON.stringify(BASE_SENTINEL)}; export const RELEASE_BRANCH = ${JSON.stringify(RELEASE_SENTINEL)};`;
+  const renderMissing = (dir: string) =>
+    execFileSync("node", ["--input-type=module", "-e", `import { FAIL_MESSAGE } from ${JSON.stringify(pathToFileURL(join(dir, "pr-review-gate.mjs")).href)}; console.log(FAIL_MESSAGE.missing);`], { env: isolated, encoding: "utf8" });
+
+  it("the sentinels are values NO branch role holds, now and after the cutover", () => {
+    // Asserted, not asserted-about-in-a-comment: this is the property the whole fixture rests on,
+    // and the only thing standing between it and the vacuity it just came out of.
+    for (const role of [CONTRIBUTION_BASE, INTEGRATION_BRANCH, RELEASE_BRANCH]) {
+      expect(BASE_SENTINEL, "a sentinel equal to a real role cannot discriminate").not.toBe(role);
+      expect(RELEASE_SENTINEL).not.toBe(role);
+    }
+  });
+
   it("runtime gate follows contribution, independently of release", () => scratch(dir => {
-    writeFileSync(join(dir, "branches.mjs"), 'export const CONTRIBUTION_BASE = "staging"; export const RELEASE_BRANCH = "release-sentinel";');
+    writeFileSync(join(dir, "branches.mjs"), stubbedRoles);
     writeFileSync(join(dir, "pr-review-gate.mjs"), read("scripts/pr-review-gate.mjs"));
-    const output = execFileSync("node", ["--input-type=module", "-e", `import { FAIL_MESSAGE } from ${JSON.stringify(pathToFileURL(join(dir, "pr-review-gate.mjs")).href)}; console.log(FAIL_MESSAGE.missing);`], { env: isolated, encoding: "utf8" });
-    expect(output).toContain("origin/staging...HEAD");
-    expect(output).not.toContain("origin/main");
-    expect(output).not.toContain("release-sentinel");
+    const output = renderMissing(dir);
+    expect(output).toContain(`origin/${BASE_SENTINEL}...HEAD`);
+    // Every REAL role name must be absent — not just `main`. A gate hardcoding the post-cutover
+    // value is the regression this now catches and previously would not have.
+    for (const role of [CONTRIBUTION_BASE, INTEGRATION_BRANCH, RELEASE_BRANCH]) expect(output).not.toContain(`origin/${role}`);
+    expect(output).not.toContain(RELEASE_SENTINEL);
+  }));
+
+  it("is NON-VACUOUS: a gate that hardcodes the base instead of importing the role FAILS", () => scratch(dir => {
+    // The negative control, executed. Without it the assertions above are a claim about a mutation
+    // nobody ran — and D3 is precisely the case where the assertions kept passing against a broken
+    // implementation. Mutating to the literal `main` proves the same thing pre- and post-cutover.
+    writeFileSync(join(dir, "branches.mjs"), stubbedRoles);
+    const src = read("scripts/pr-review-gate.mjs");
+    const hardcoded = src.replace("origin/${CONTRIBUTION_BASE}...HEAD", "origin/main...HEAD");
+    expect(hardcoded, "the mutation must apply").not.toBe(src);
+    writeFileSync(join(dir, "pr-review-gate.mjs"), hardcoded);
+    const output = renderMissing(dir);
+    expect(output, "the mutant renders a hardcoded ref").toContain("origin/main...HEAD");
+    expect(output, "…and NOT the resolved role, which is what the test above pins").not.toContain(`origin/${BASE_SENTINEL}...HEAD`);
   }));
   it("fails loudly when a tracked file cannot be read", () => scratch(dir => {
     git(dir, "init", "-q");


### PR DESCRIPTION
## What this is

**PR A of RELPTR-6** — the cutover's **value-invariant guard hardening**, and nothing else. Three latent defects that are green today and fire the day `CONTRIBUTION_BASE` moves. Only two test guards and one design doc change; **no production behaviour changes now or later.**

Spec: `docs/design/cutover-execution.md` (in this diff, `SPEC_READY`, exit 0).

| | defect | how it fails at cutover |
|---|---|---|
| **`D1`** | the workflow triggers were pinned to `[CONTRIBUTION_BASE, INTEGRATION_BRANCH]` | both become `staging` → the pair collapses and the guard **reddens against a correct file** |
| **`D2`** | the identity pin's stub string-replaced the literal `"main"` | the substitution stops matching — loud, but the obvious fix reintroduces the coupling |
| **`D3`** | `instruction-base` used `"staging"` as a sentinel *because it was not the real base* | the cutover makes it real: the test **stays green while proving nothing** — the silent one |

## Deliberately NOT in this PR

The whole cutover change set is **held for the coordinated window**: the `CONTRIBUTION_BASE` flip, the Dependabot `target-branch` overrides, the `pr-task-link.yml` trigger, the instruction prose and regenerated mirrors. Codex blocked bundling them — `docs/RELEASING.md` §3.2 says `dependabot-target-branch: at the cutover, never before`, and a stated PR-body precondition is not enforcement. The spec's acceptance criteria are now **partitioned**: PR A is criteria 2–6 and 15; criteria 1, 7–14 and 16 belong to the held set and are explicitly *not* review-clean yet.

## Who wrote it

**Claude authored the spec and the code.** This ran under `/adversarial-build-astra`, whose default is that gpt-6-astra authors — it did not here, and the skill's own rule is never to describe a model as the author when it wasn't. One consequence worth stating: astra's round is therefore **not** the correlated one that skill assumes, but a genuinely independent second pass.

## Verification

| check | result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npm run lint` | 0 errors (36 pre-existing warnings) |
| `npm run check:docs` | green |
| `npm run check:instructions` | green (partial-scan blind spots unchanged — `RELPTR-5` Decision 6) |
| the two guard files | **101 passed** |
| full unit tier | 3822 passed. 4 failures isolated to an **untracked local skill stub** in my worktree — parking it makes that guard 14/14 green. Not from this diff. |

**Mutation table — verdicts pasted from `scripts/mutate.mjs`, not narrated. All 9 REDDENED, each on its intended test.**

| # | mutation | verdict |
|---|---|---|
| `M1` | `branches.mjs` `INTEGRATION_BRANCH` `staging`→`main` | REDDENED |
| `M2` | `aios-work-sync.yml` `[main, staging]`→`[main]` | REDDENED |
| `M3` | `scan-on-merge.yml` `[main, staging]`→`[main]` | REDDENED |
| `M4` | `BASE_SENTINEL`→`"staging"` | REDDENED |
| `M5` | `pr-review-gate.mjs` hardcodes `origin/main` | REDDENED |
| `M7`/`M8` | revert the `D1` pair, both sites | REDDENED *(SURVIVED before the fold — see below)* |
| `M9` | weaken a trigger site to `toBeDefined()` | REDDENED |
| `M10` | comment out a trigger assertion | REDDENED *(SURVIVED before the fold)* |

**Cutover simulation** (`CONTRIBUTION_BASE` stubbed to `staging`): the **old** guards go red on 5 tests; the **new** ones on exactly 1 — `expect(CONTRIBUTION_BASE).toBe("main")`, which belongs to the held PR. `D3`'s old test stayed *green* under the simulation, which is precisely the claim that it is the silent defect.

## Review

Three rounds, and the two reviewers **contradicted each other on the load-bearing claim** — that disagreement is the most useful thing in this PR, so it is recorded in full rather than summarised into a CLEAR.

- **Fable (round 1, diff) — CLEAR-WITH-CONDITIONS.** Found a **HIGH the mutation table had missed**: the `D1` fix was *unpinned*. Because both role pairs are the same value today, reverting the fix left everything green — I re-ran it and confirmed **SURVIVED, twice**. The spec's claim "the source token is pinned, so a revert reddens" was **false when written**. Folded: a source-token pin; both reverts now REDDEN.
- **gpt-6-astra (round 2, cold, independent) — BLOCKED.** Caught that **Fable's own refutation used pre-2025-12-08 `pull_request_target` semantics**. Verified against the primary source (GitHub changelog 2025-11-07, effective 2025-12-08): *"The workflow file and checkout commit will always be taken from the repository's default branch, regardless of the pull request's base branch"*, and *"environment rules evaluate against the default branch."* This **changes the cutover ordering**: widening a trigger early is *not* the hazard — the hazard is the **default-branch move**, after which a `main`-only `trusted-automation` policy refuses every `pull_request_target` run. Also found a real evasion (commenting out an assertion preserved the pin's count) and refuted a "duplicate compute rather than a wrong result" claim with a `scanned_at` counterexample I re-derived and confirmed.
- **Fable (round 3, re-clear of the post-fold diff) — CLEAR-WITH-CONDITIONS, prose only.** Fetched the changelog itself and confirmed astra was right and it had been wrong. Three Mediums + four Lows, all wording, all folded: an over-claim that the `branches:` filter is "not a security control" (it is not a *credential* boundary, but it **is** the integrity control over which merges count), the spec's own falsifier bullet which had been met by the spec and left standing, and three further files still carrying the superseded model. The final fold was **comment-and-prose only**, so §7's re-clear requirement is satisfied.

## Review — Reviewed by Fable 5.1 (diff, 2 rounds: CLEAR-WITH-CONDITIONS, then re-clear CLEAR-WITH-CONDITIONS) and gpt-6-astra (cold, BLOCKED then folded) — verdict all findings folded; astra caught a false premise in Fable's refutation, verified against GitHub's changelog, and it moved the cutover ordering from the trigger widening to the default-branch move.

## Deferred, with reasons

- **Four files still carry the superseded `pull_request_target` model** (`docs/RELEASING.md` §3.1c, `aios-work-sync.yml`, `pr-task-link.yml`, `pr-task-link-credential-isolation.test.ts`). Held-set corrections: they are cutover-planning and rationale prose, and chasing them here would break this PR's value-invariant story. Enumerated in the spec's open finding 7 so they are not discovered on the day. **The credential-isolation assertion itself still holds; only its stated rationale is stale.**
- **The pin's blind spots are stated in the guard**: it strips line comments, so a `/* … */` block or `it.skip`/`xit`/`it.todo` still evades the count. Accepted — those are deliberate edits by someone reading the comment, not silent drift.

AIOS-Work: RELPTR-6
