### PR TITLE
STAGINGMARK-1: a wedged fleet can stamp the PRET-4 marker without booting

### DIFF
--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -764,7 +764,7 @@ fleet — upgrade through the prior release first (see docs/RELEASE-NOTES-pret6.
 
 **This happened to staging on 2026-09-05** (deploy `2e67246e`). It means the database has teams but no
 `pret4_builtin_materialize` marker. **The refusal is safe, and the running version keeps serving** — it
-raises before the column drop, so no access state is changed. Be precise about what "safe" means here:
+raises before the column drop, so the PRET-6 block changes nothing. Be precise about the rest:
 `scripts/pg-load-schema.mjs` replays `postgres/schema.sql` and then each migration in filename order
 with **no wrapping transaction**, so `schema.sql` and every migration sorting before
 `20260818210000_pret6_retire_access_enforcement.sql` HAVE already applied (idempotently), and the ones

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -752,3 +752,48 @@ legs go stale in staging, but that alarm is *thresholded* and *true*).
   starts billing real extraction. Three non-test entrypoints reach it — the scheduler, the admin
   button, and `scripts/graph-window-battery/run-projection.ts`.
 - Staging is **disposable**: anything created there is destroyed by the next refresh.
+
+### If a deploy refuses with "the PRET-4 builtin materialization has not completed"
+
+The exact failure, as it appears in the Railway build log — the deploy stops at `preDeploy`, before
+anything is applied:
+
+```
+schema load failed: PRET-6 refused: the PRET-4 builtin materialization has not completed on this
+fleet — upgrade through the prior release first (see docs/RELEASE-NOTES-pret6.md)
+```
+
+**This happened to staging on 2026-09-05** (deploy `2e67246e`). It means the database has teams but no
+`pret4_builtin_materialize` marker. **The refusal is safe** — it raises before the column drop, nothing
+is half-applied, and the previously-deployed version keeps serving.
+
+It is also a **deadlock**, which is why it needs a command rather than a retry: the marker is written
+only by application code (`instrumentation.ts` at boot, and the scheduler tick), and both of those are
+downstream of a deploy that succeeded. Redeploying the same commit will refuse again, forever.
+
+**The fix — stamp the marker directly:**
+
+```bash
+DATABASE_URL="<the wedged database's URL>" npm run admin -- materialize-builtins
+```
+
+That is a **dry run**: it reports which fleet it believes it is pointed at, whether the marker is
+absent, and how many teams would be reconciled. Nothing is written. Re-run with `--confirm` to do it.
+
+⚠️ **Run it from a checked-out tree of the release you are trying to deploy** — not from the running
+old image, which does not contain the command. Any machine with the repo and network access to the
+database works.
+
+⚠️ **`--confirm-production` is additionally required when the target carries no `staging_marker`**, i.e.
+when it may be production. The command tells you which case you are in before it does anything. Team
+identity deliberately is **not** used for this: staging is a restore of production and holds the same
+team row, so a team slug matches both databases equally.
+
+The command is a **no-op when the marker is already present** — it reads and exits without writing —
+so running it against a healthy fleet is harmless.
+
+**The alternative, if you would rather not run a command against the database:** roll back to the
+previous release in the Railway dashboard (never `railway up` — see §"Railway is read-only here"). That
+release boots, its startup materialization stamps the marker, and the blocked deploy then applies. This
+is what `docs/RELEASE-NOTES-pret6.md` describes; the command above exists because a self-hoster has no
+dashboard to roll back in.

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -755,8 +755,7 @@ legs go stale in staging, but that alarm is *thresholded* and *true*).
 
 ### If a deploy refuses with "the PRET-4 builtin materialization has not completed"
 
-The exact failure, as it appears in the Railway build log — the deploy stops at `preDeploy`, before
-anything is applied:
+The exact failure, as it appears in the Railway build log — the deploy stops at `preDeploy`:
 
 ```
 schema load failed: PRET-6 refused: the PRET-4 builtin materialization has not completed on this
@@ -764,8 +763,13 @@ fleet — upgrade through the prior release first (see docs/RELEASE-NOTES-pret6.
 ```
 
 **This happened to staging on 2026-09-05** (deploy `2e67246e`). It means the database has teams but no
-`pret4_builtin_materialize` marker. **The refusal is safe** — it raises before the column drop, nothing
-is half-applied, and the previously-deployed version keeps serving.
+`pret4_builtin_materialize` marker. **The refusal is safe, and the running version keeps serving** — it
+raises before the column drop, so no access state is changed. Be precise about what "safe" means here:
+`scripts/pg-load-schema.mjs` replays `postgres/schema.sql` and then each migration in filename order
+with **no wrapping transaction**, so `schema.sql` and every migration sorting before
+`20260818210000_pret6_retire_access_enforcement.sql` HAVE already applied (idempotently), and the ones
+sorting after it have not. The release is stopped part-way through an idempotent replay, which the next
+successful deploy completes — not an all-or-nothing abort.
 
 It is also a **deadlock**, which is why it needs a command rather than a retry: the marker is written
 only by application code (`instrumentation.ts` at boot, and the scheduler tick), and both of those are
@@ -779,21 +783,23 @@ DATABASE_URL="<the wedged database's URL>" npm run admin -- materialize-builtins
 
 That is a **dry run**: it reports which fleet it believes it is pointed at, whether the marker is
 absent, and how many teams would be reconciled. Nothing is written. Re-run with `--confirm` to do it.
+The dry run is where you check the fleet line — on a confirmed run the output prints after the work,
+so read it here, before committing to it.
 
 ⚠️ **Run it from a checked-out tree of the release you are trying to deploy** — not from the running
 old image, which does not contain the command. Any machine with the repo and network access to the
 database works.
 
 ⚠️ **`--confirm-production` is additionally required when the target carries no `staging_marker`**, i.e.
-when it may be production. The command tells you which case you are in before it does anything. Team
-identity deliberately is **not** used for this: staging is a restore of production and holds the same
-team row, so a team slug matches both databases equally.
+when it may be production. The dry run tells you which case you are in. Team identity deliberately is
+**not** used for this: staging is a restore of production and holds the same team row, so a team slug
+matches both databases equally.
 
 The command is a **no-op when the marker is already present** — it reads and exits without writing —
 so running it against a healthy fleet is harmless.
 
 **The alternative, if you would rather not run a command against the database:** roll back to the
-previous release in the Railway dashboard (never `railway up` — see §"Railway is read-only here"). That
-release boots, its startup materialization stamps the marker, and the blocked deploy then applies. This
+previous release in the Railway dashboard (never `railway up` — the Railway CLI is read-only here;
+see §4 "Railway deploy safety"). That release boots, its startup materialization stamps the marker, and the blocked deploy then applies. This
 is what `docs/RELEASE-NOTES-pret6.md` describes; the command above exists because a self-hoster has no
 dashboard to roll back in.

--- a/docs/RELEASE-NOTES-pret6.md
+++ b/docs/RELEASE-NOTES-pret6.md
@@ -44,13 +44,18 @@ still serving — in exactly two cases, each named in the raised error:
 
   **Or stamp it directly, without booting anything** (STAGINGMARK-1) —
   `DATABASE_URL=<the wedged database> npm run admin -- materialize-builtins`, dry-run by default.
-  This is the only route a self-hoster has, since "boot the prior release" assumes a dashboard to
-  roll back in. Full runbook, including which machine to run it from:
+  Usually the shorter route: "boot the prior release" is also open to a self-hoster (check out the
+  previous tag and start it), but it means finding and running an older build, where this is one
+  command against the database. Full runbook, including which machine to run it from:
   `docs/OPS.md` §11 "If a deploy refuses …".
 
-A refused deploy is **safe**: the guard runs before the drop, nothing is half-applied, and the
-running version keeps serving. Replaying the migration after a successful drop is a clean
-no-op, and a from-zero install never sees the guard fire (a fresh DB has no teams).
+A refused deploy is **safe**: the guard raises before the drop, so no access state changes, and the
+running version keeps serving. It is **not** an all-or-nothing abort, and this note used to say so
+wrongly: `scripts/pg-load-schema.mjs` applies `postgres/schema.sql` and then each migration in
+filename order with no wrapping transaction, so everything sorting before this migration HAS already
+replayed (idempotently) and everything after it has not. The next successful deploy completes the
+replay. Replaying the migration after a successful drop is a clean no-op, and a from-zero install
+never sees the guard fire (a fresh DB has no teams).
 
 ## What changes for operators
 

--- a/docs/RELEASE-NOTES-pret6.md
+++ b/docs/RELEASE-NOTES-pret6.md
@@ -42,6 +42,12 @@ still serving — in exactly two cases, each named in the raised error:
   restored-from-backup DB or a skipped release. Boot the prior release once (its startup runs
   the materialization), then take this one.
 
+  **Or stamp it directly, without booting anything** (STAGINGMARK-1) —
+  `DATABASE_URL=<the wedged database> npm run admin -- materialize-builtins`, dry-run by default.
+  This is the only route a self-hoster has, since "boot the prior release" assumes a dashboard to
+  roll back in. Full runbook, including which machine to run it from:
+  `docs/OPS.md` §11 "If a deploy refuses …".
+
 A refused deploy is **safe**: the guard runs before the drop, nothing is half-applied, and the
 running version keeps serving. Replaying the migration after a successful drop is a clean
 no-op, and a from-zero install never sees the guard fire (a fresh DB has no teams).

--- a/docs/design/stagingmark1-materialize-oneshot.md
+++ b/docs/design/stagingmark1-materialize-oneshot.md
@@ -125,7 +125,9 @@ cannot carry it to prod. So:
 | carries `staging_marker` | `--confirm` |
 | does **not** carry it (may be production) | `--confirm` **and** `--confirm-production` |
 
-Both paths print which fleet they believe they are pointed at before doing anything.
+Both paths report which fleet they believe they are pointed at. Precisely: the **dry run** is where an
+operator reads that line and can still change course — on a confirmed run the handler returns its lines
+after the write, so the output is a record, not a prompt. There is no interactive abort, by design.
 
 **Behaviour lives in an import-safe module with injected dependencies** —
 `lib/access/materialize-command.ts` **(new file)**, exporting `runMaterializeCommand(deps, opts)`.

--- a/docs/design/stagingmark1-materialize-oneshot.md
+++ b/docs/design/stagingmark1-materialize-oneshot.md
@@ -1,0 +1,271 @@
+# A wedged fleet can stamp the PRET-4 marker without booting — STAGINGMARK-1
+
+**Status:** spec, **rounds 1 and 2 folded** (Codex `gpt-5.6-sol`: round 1 CLEAR-WITH-CONDITIONS, round 2 **BLOCKED** on the rewrite — 2 HIGH + 2 MEDIUM + 1 LOW accepted, and round 2's proposed remedy for its own HIGH-1 REFUTED by measurement). No code written.
+
+**Build with:** unit (an import-safe command handler with injected dependencies + one call-site pin)
+and data-mechanics (the real migration guard against a real Postgres) — the materialization itself is
+shipped and dm-pinned by PRET-4; this slice adds an entry point, not an algorithm.
+
+**Deps:** PRET-4 (marker live on prod), PRET-6 (the refusing guard). No schema change, no migration.
+
+---
+
+## What and why
+
+**What:** deploys run `npm run pg:schema` as Railway's `preDeployCommand`. That replays
+`postgres/migrations/20260818210000_pret6_retire_access_enforcement.sql`, whose guard raises when a
+database has teams but no `pret4_builtin_materialize` marker:
+
+```sql
+if exists (select 1 from teams)
+   and not exists (select 1 from migration_markers where name = 'pret4_builtin_materialize') then
+  raise exception 'PRET-6 refused: the PRET-4 builtin materialization has not completed on this fleet …';
+```
+
+The marker has exactly **one writer** — `lib/access/groups.ts:274-276`, inside
+`materializeBuiltinMembershipOnce`. Verified by enumeration: no migration and no bootstrap path writes
+it (`pparc3_g_wipe` and `pret3_post_activation_sweep` are written elsewhere; this one is not). That
+function has exactly **two** invokers, `instrumentation.ts:45-53` (boot) and
+`lib/ingest/scheduler.ts:66-80` (tick). Both are downstream of a deploy that succeeded. So:
+
+> teams + no marker → preDeploy refuses → the new code never boots → the marker is never stamped → refuses forever
+
+**Why now:** staging deployment `2e67246e` failed **2026-09-05 16:05** with exactly that message. The
+staging database was the July demo-seed instance: it had a team and had never run the PRET-4 release.
+It was unwedged only by restoring a full production dump.
+
+**Why the refusal stays:** it protects the fleet from the H-VANISH hazard, and a refused deploy is
+safe — it raises before the column drop and the running version keeps serving. This slice does not
+touch it. The gap is that the documented recovery, "boot the prior release once"
+(`docs/RELEASE-NOTES-pret6.md:40-43`), means a Railway dashboard rollback, or for a self-hoster
+hunting an older image. No command simply does the thing.
+
+## 0. Terrain, measured before designing
+
+Read-only, 2026-09-05.
+
+| fact | measurement |
+|---|---|
+| prod marker | `pret4_builtin_materialize \| 2026-08-18 22:29:17.371595+00` |
+| staging marker | same row, **byte-identical timestamp** |
+| prod teams / staging teams | 1 / 1 |
+| `migration_markers` in the dump exclusion list? | **No** |
+| staging `INGEST_POLL_ENABLED` | **UNSET** — not `false` as `docs/OPS.md:702` expects |
+| `scripts/` entries invoking the materialization | **none** |
+| writers of `pret4_builtin_materialize` | **one** (`lib/access/groups.ts:276`) |
+
+**What is NOT measured:** how many self-hosted installs are currently wedged. The class is reachable
+by construction; its population is unknown and this spec claims no number for it.
+
+### Why the originally-proposed refresh assertion is NOT built (round-1 correction)
+
+The first draft proposed asserting the marker inside `scripts/staging-refresh.sh` between the restore
+and the schema replay, justified by "it could never fire." **That justification was too strong and is
+withdrawn** — it generalised from one populated production to an invariant. The precise position:
+
+- **Populated source (today's prod):** the marker travels in the dump, so after a refresh it is
+  present. And in the case where it were absent, `pg:schema` at `staging-refresh.sh:208` **already
+  refuses** — the assertion would only move the same failure five lines earlier. Diagnostic, not
+  protective.
+- **Zero-team source — the case round 1 raised as reachable — is REFUTED.** The marker upsert at
+  `lib/access/groups.ts:274-276` sits **after** the per-team loop and is **unconditional**: a fleet
+  with zero teams runs an empty loop and still stamps the marker. So a zero-team restore deploys
+  (PRET-6's predicate requires `exists (select 1 from teams)`), boots, and stamps the marker before
+  any team can be created. It cannot become wedged later.
+- **Markerless populated source** would mean production itself had lost the marker — in which case
+  production is wedged on its own next deploy, which a staging-side assertion does not address.
+
+So the fence excludes exactly one thing — a duplicate of a refusal that already exists — and it lands
+nowhere because there is nothing left to build. Recorded rather than deferred.
+
+## 1. The rule
+
+**An operator holding a `DATABASE_URL` must be able to complete the PRET-4 materialization without
+booting the application; on an already-materialized fleet that must be a read-only no-op; and the
+fleet-rewriting case must require explicit confirmation.**
+
+## 2. The design
+
+**One new admin command**, `materialize-builtins`, in the existing CLI (`scripts/admin.ts`, run as
+`npm run admin -- materialize-builtins`).
+
+It calls the **shipped** `materializeBuiltinMembershipOnce`. It does not reimplement it, copy its
+predicate, or add a second writer — the manual path and the boot path are the same function, so they
+cannot drift.
+
+**`--confirm` is REQUIRED to write; dry-run is the default** (round-1 finding, accepted). The
+asymmetry with `purge-items`, which already dry-runs by default in this same CLI, was not defensible:
+this command is fleet-wide, can create groups, can add memberships, can **delete** deliberately-edited
+builtin memberships, and runs against whatever `DATABASE_URL` the shell happens to hold. The concrete
+wrong outcome it prevents: an operator believes the URL is staging, it is production, production's
+marker is absent mid-recovery, and a member deliberately removed from `everyone` is silently restored
+by a reconcile from the retired tier predicate.
+
+**`--confirm` is parsed STRICTLY as a bare flag** (round-2 HIGH, accepted). `parseArgs`
+(`scripts/admin.ts:37-48`) assigns the following token as a string, so `--confirm false` yields the
+string `"false"`, and `if (!flags.confirm)` treats that as **confirmed**. This command therefore
+accepts only the bare form and **refuses** `--confirm <value>` and `--confirm=<value>` rather than
+guessing. *(The same trap exists today in `purge-items` at `scripts/admin.ts:531` — a real latent
+defect in a destructive command, out of scope here — see §3.)*
+
+**Fleet identity comes from `staging_marker`, not from team identity** (round-2 HIGH, accepted — but
+with the proposed remedy REFUTED and replaced). Round 2 proposed binding confirmation to the team
+slug/UUID. **Measured, and it does not discriminate:** staging is a restore of production, so both
+databases hold the *same* team — `73409b20-c11d-4b35-8ce4-e0a53eb219b5 | aios` — and a
+`--confirm-team aios` would match production exactly as well as staging. A hash of the ordered team
+UUID set fails identically, for the same reason.
+
+The primitive that *does* discriminate already exists and was purpose-built for this question:
+`to_regclass('public.staging_marker')` is **`t` on staging and `f` on production** (measured), because
+the table is deliberately absent from `postgres/schema.sql` and every migration so a `--clean` restore
+cannot carry it to prod. So:
+
+| database | to write |
+|---|---|
+| carries `staging_marker` | `--confirm` |
+| does **not** carry it (may be production) | `--confirm` **and** `--confirm-production` |
+
+Both paths print which fleet they believe they are pointed at before doing anything.
+
+**Behaviour lives in an import-safe module with injected dependencies** —
+`lib/access/materialize-command.ts` **(new file)**, exporting `runMaterializeCommand(deps, opts)`.
+Two reasons, the second from round 1:
+
+1. `scripts/admin.ts` calls `main()` at module scope, so a test that imports it executes the CLI. The
+   file already solved this once for `formatAccessHealth` (`scripts/admin.ts:98-104`).
+2. A static source-text guard is **not behavioural coverage**: `case "materialize-builtins": { /* materializeBuiltinMembershipOnce */ break; }`
+   would satisfy it while doing nothing. Injecting `{ readState, materialize }` makes the real
+   decisions — which branch runs, what exits non-zero, whether `--confirm` gates the write —
+   observable in the unit tier against fakes.
+
+```ts
+type FleetState = { marker: boolean; teams: number; stagingMarker: boolean };
+type MaterializeDeps = {
+  readState: () => Promise<FleetState>;                                  // READ-ONLY by construction
+  materialize: () => Promise<{ ok: boolean; ran?: boolean; error?: string }>;
+};
+type Opts = { confirm: boolean; confirmProduction: boolean };
+runMaterializeCommand(deps, opts): Promise<{ lines: string[]; exitCode: number }>
+```
+
+**Every reachable outcome has a contract** (round-2 MEDIUM, accepted — the first draft's table omitted
+four of these):
+
+| state | effect | exit |
+|---|---|---|
+| `readState` rejects or errors | reports the read failure; `materialize` **never called** | **non-zero** |
+| marker present | reports already-materialized; `materialize` **never called** | 0 |
+| marker absent, not confirmed | reports fleet identity + team count + what it would do; **no write** | 0 |
+| marker absent, confirmed, no `staging_marker`, no `--confirm-production` | **refuses**, naming the missing flag | **non-zero** |
+| marker absent, confirmed, `materialize` → `{ok:true, ran:true}`, teams > 0 | reports N teams reconciled | 0 |
+| marker absent, confirmed, `{ok:true, ran:true}`, teams = 0 | reports **marker stamped, zero teams reconciled** — distinct wording | 0 |
+| marker absent, confirmed, `{ok:true, ran:false}` | **the race**: boot/tick stamped it between the read and the call (the materializer re-reads at `lib/access/groups.ts:205-211`). Reports *already completed concurrently* — a success, not a lie about having run | 0 |
+| marker absent, confirmed, `{ok:false, error}` | reports the error; marker NOT stamped | **non-zero** |
+| marker absent, confirmed, `materialize` **throws** | caught and reported like `ok:false` (boot/tick already anticipate throws — `lib/ingest/scheduler.ts:71-75`) | **non-zero** |
+
+The non-zero exit is load-bearing: an operator recovering a wedged deploy needs to know whether to
+redeploy, and a command that prints an error and exits 0 reads as success to a human in a hurry and to
+any wrapper script.
+
+**Safety envelope, stated precisely** (round-1 narrowing): when the marker is present the function
+performs one read and zero writes, because the marker read at `lib/access/groups.ts:205` returns at
+`:211` before every write (`:217` groups, `:250` adds, `:257` deletes, `:267` audit, `:273` marker).
+That makes an accidental run against a **healthy** production harmless. It does **not** make an
+accidental run against a markerless production harmless — which is precisely why `--confirm` exists.
+
+**The wiring pin extends the existing guard.** `test/guards/access-bootstrap-callsites.test.ts`
+already pins this function's call sites and states the repo's recurring failure mode in its header.
+The new dispatch is pinned there, not in a parallel file.
+
+## 3. Scope
+
+**In:** one command in `scripts/admin.ts`; `lib/access/materialize-command.ts` (new); unit tests over
+the handler; one call-site pin added to the existing guard; a dm test executing the real migration
+guard; the USAGE line; the runbook section.
+
+**Out, deliberately:**
+- **The PRET-6 migration is not modified.** Making it self-materialize would either reproduce a
+  TypeScript reconcile in SQL (a second implementation, drift risk) or invoke application code from
+  schema replay (materially expanding the deployment contract). **Recorded here as follow-up work; no ticket filed yet** (STAGINGMARK-2 when opened) —
+  named rather than left as "a better end state."
+- **`scripts/staging-refresh.sh` is not touched** — §0 states the corrected reason.
+- **No Railway automation.** Nothing here sets a variable or triggers a deploy.
+- **The `docs/OPS.md:702` drift** (`INGEST_POLL_ENABLED` documented `false`, live UNSET) is recorded
+  in §0 and **not fixed here**: it concerns a different table, and changing live staging variables is
+  outward-facing and needs its own decision. **Recorded here; no ticket filed yet** (STAGINGMARK-3 when opened).
+- **`purge-items`' own `--confirm` trap** (`scripts/admin.ts:531` — `--confirm false` reads as
+  confirmed, so a destructive command proceeds) is a **pre-existing defect found by this slice's
+  round-2 review**, not introduced by it. Fixing a destructive command's confirmation deserves its own
+  spec and reviews rather than a drive-by edit here. **Recorded here; no ticket filed yet** (STAGINGMARK-4 when opened).
+
+## 4. Acceptance
+
+- **AC1 — an already-materialized fleet never calls the materializer (unit):** with
+  `readState → {marker:true, teams:1}` and a `materialize` fake that throws if invoked,
+  `runMaterializeCommand` resolves, `exitCode === 0`, and the fake was **not called**. *This is the
+  property that makes a slip against healthy production harmless; asserting the call did not happen is
+  stronger than asserting the row did not change.*
+- **AC2 — without `--confirm` a markerless fleet is not written (unit):** with
+  `readState → {marker:false, teams:3}` and `confirm:false`, the materializer fake is **not called**,
+  `exitCode === 0`, and the output names the team count and how to proceed.
+- **AC3 — with `--confirm` it runs (unit):** same state, `confirm:true`, materializer returns
+  `{ok:true, ran:true}` → it **was** called once, `exitCode === 0`, output distinct from AC1's.
+- **AC4 — a failure exits non-zero (unit):** materializer returns `{ok:false, error:"boom"}` →
+  `exitCode !== 0` and the output contains `boom`. *An error printed with exit 0 is read as success.*
+- **AC5 — the three outcomes are distinguishable (unit):** the `lines` from AC1, AC3 and AC4 are
+  pairwise different, and only AC4's matches `/fail/i`. *An operator who cannot tell whether the
+  command did anything has to guess whether to redeploy.*
+- **AC6 — the remaining non-success states exit non-zero, and two of them never write (unit):** three
+  cases beyond AC4 — (a) `readState` rejects; (b) marker absent, `confirm:true`,
+  `stagingMarker:false`, `confirmProduction:false` (the production refusal); (c) `materialize`
+  **throws** rather than returning `{ok:false}`. All give `exitCode !== 0`; in (a) and (b) a
+  `materialize` fake that throws if invoked is **never called**. *Round 2 found the first draft's
+  table silent on all three; boot/tick already anticipate a throw (`lib/ingest/scheduler.ts:71-75`),
+  so the handler must too.*
+- **AC7 — the two success-but-did-not-run states are not reported as a run (unit):** with the
+  materializer returning `{ok:true, ran:false}` (the boot/tick race) the output says *already
+  completed*, `exitCode === 0`, and does **not** claim it ran; with `{ok:true, ran:true}` and
+  `teams:0` the output distinguishes *marker stamped, zero teams reconciled* from AC3's substantive
+  wording. *The first draft would have printed "it ran" for a call that did nothing.*
+- **AC8 — `--confirm` is a bare flag, and a value is REFUSED (unit):** the CLI-boundary parser accepts
+  `--confirm`; for `--confirm false`, `--confirm=false` and a duplicated `--confirm`, it **refuses**
+  with a message rather than treating the string as truthy. *Verified at the parse boundary, not
+  through the handler, because `parseArgs` (`scripts/admin.ts:37-48`) is exactly where
+  `"false"` becomes truthy — AC1–AC5 take an already-normalised boolean and structurally cannot catch
+  this.*
+- **AC9 — the dispatch is pinned by SHAPE, and there is no second writer (unit guard):**
+  `test/guards/access-bootstrap-callsites.test.ts` asserts (a) `scripts/admin.ts` calls
+  `runMaterializeCommand(` , (b) `USAGE` lists `materialize-builtins`, and (c) `scripts/admin.ts`
+  does **not** reference `materializeBuiltinMembershipOnce` directly. *(c) is the load-bearing half:
+  without it the CLI could call the handler AND invoke the materializer itself, leaving AC1 green
+  while the real command writes. The file already pins call shape rather than names at `:83-100`.
+  Must be mutation-proven to redden when the dispatch is deleted.*
+- **AC10 — the real migration guard stops refusing (dm):** against a real Postgres with one
+  non-permissive team, builtin groups and **no** marker: extract the `do $$ … $$` block **verbatim
+  from `postgres/migrations/20260818210000_pret6_retire_access_enforcement.sql`** (read from the file,
+  never retyped) and execute it **inside `begin … rollback`** — it **raises** with the marker message.
+  Run `materializeBuiltinMembershipOnce`, execute the same block the same way — it **does not raise**.
+  *Round 2 HIGH, accepted: the block's second half drops `teams.access_enforcement` and
+  `autoflip_hold` (`:36-43`), and dm isolation truncates rows but not DDL
+  (`test/datamechanics/setup.ts:66-76`) — running it bare would corrupt the shared schema for every
+  later test, which is exactly the hazard CLAUDE.md records. Postgres DDL is transactional, so the
+  rollback keeps the execution verbatim AND leaves no trace. The claim stays scoped to the marker
+  refusal; the permissive condition at `:36` is not addressed by this slice.*
+- **AC11 — a partial reconcile leaves the marker unstamped (dm):** construct a team where
+  `ensureBuiltins` performs a convergent write and then fails, so the function returns before the
+  marker upsert. Assert **both** that the partial write landed **and** that `migration_markers` holds
+  no `pret4_builtin_materialize` row. *Round 2 LOW, accepted: a failure induced before any write would
+  leave the marker absent trivially and prove nothing about marker-last ordering.*
+- **AC12 — the runbook names the recovery, runnably (docs + unit guard):** `docs/OPS.md` §11 gains a
+  subsection containing the refusal message **verbatim**, the command in `npm run admin -- …` form,
+  where it is run from (a checked-out tree of the candidate release with `DATABASE_URL` set — **not**
+  the still-running old image, which does not contain the command), and the dashboard-rollback
+  alternative. The existing guard forbidding bare `npx tsx scripts/admin.ts` in docs
+  (`test/guards/release-tag-policy.test.ts:238`) must stay green. *Verbatim so an operator pasting the
+  error into a search lands here.*
+
+## 5. What would falsify this
+
+If `materializeBuiltinMembershipOnce` wrote anything before its marker read, the read-only claim would
+be false and the marker-present path would need confirmation too. AC1 is written to catch that by
+asserting the materializer is never invoked, against fakes rather than by reading the function.

--- a/docs/design/stagingmark1-materialize-oneshot.md
+++ b/docs/design/stagingmark1-materialize-oneshot.md
@@ -228,11 +228,14 @@ guard; the USAGE line; the runbook section.
   `teams:0` the output distinguishes *marker stamped, zero teams reconciled* from AC3's substantive
   wording. *The first draft would have printed "it ran" for a call that did nothing.*
 - **AC8 — `--confirm` is a bare flag, and a value is REFUSED (unit):** the CLI-boundary parser accepts
-  `--confirm`; for `--confirm false`, `--confirm=false` and a duplicated `--confirm`, it **refuses**
-  with a message rather than treating the string as truthy. *Verified at the parse boundary, not
-  through the handler, because `parseArgs` (`scripts/admin.ts:37-48`) is exactly where
-  `"false"` becomes truthy — AC1–AC5 take an already-normalised boolean and structurally cannot catch
-  this.*
+  the bare forms; for `--confirm false`, `--confirm-production <value>` and `--confirm=false` it
+  **refuses** with a message rather than treating the string as truthy or silently ignoring it.
+  *Verified at the parse boundary, not through the handler, because `parseArgs`
+  (`scripts/admin.ts:37-48`) is exactly where `"false"` becomes truthy — AC1–AC5 take an
+  already-normalised boolean and structurally cannot catch this. Round 2 also asked for a duplicated
+  `--confirm` to be refused; that is **not built and the criterion does not claim it**, because
+  `parseArgs` collapses `--confirm --confirm` to the same `true` before this layer sees it, making the
+  two spellings indistinguishable by construction — and they mean the same thing.*
 - **AC9 — the dispatch is pinned by SHAPE, and there is no second writer (unit guard):**
   `test/guards/access-bootstrap-callsites.test.ts` asserts (a) `scripts/admin.ts` calls
   `runMaterializeCommand(` , (b) `USAGE` lists `materialize-builtins`, and (c) `scripts/admin.ts`

--- a/lib/access/materialize-command.ts
+++ b/lib/access/materialize-command.ts
@@ -1,0 +1,202 @@
+import "server-only";
+import type { DbClient } from "@/lib/db/types";
+import { runSql } from "@/lib/db/pg/pool";
+import { PRET4_MATERIALIZE_MARKER, materializeBuiltinMembershipOnce } from "@/lib/access/groups";
+
+/**
+ * STAGINGMARK-1 — the operator entry point for PRET-4's one-time builtin materialization.
+ * Spec: docs/design/stagingmark1-materialize-oneshot.md.
+ *
+ * WHY THIS EXISTS. The PRET-6 preDeploy guard refuses a fleet that has teams but no
+ * `pret4_builtin_materialize` marker, and that marker has exactly ONE writer
+ * (`materializeBuiltinMembershipOnce`) reachable from exactly TWO call sites — boot
+ * (`instrumentation.ts`) and the scheduler tick — both of which are downstream of a deploy that
+ * SUCCEEDED. A fleet in that state therefore cannot get the marker by any amount of redeploying:
+ * the guard refuses, the code never boots, the marker is never stamped. Observed on staging
+ * 2026-09-05 (deploy 2e67246e).
+ *
+ * WHY THE BEHAVIOUR LIVES HERE AND NOT IN `scripts/admin.ts`. That file calls `main()` at module
+ * scope, so a test importing it would execute the CLI — the same reason `formatAccessHealth` was
+ * extracted. Dependencies are INJECTED rather than imported by the handler so the real decisions
+ * (which branch runs, what exits non-zero, whether --confirm gates the write) are observable
+ * against fakes in the unit tier. A source-text guard cannot do that: a `case` whose body is only
+ * a comment naming the function would satisfy it while doing nothing.
+ */
+
+export type FleetState = {
+  /** the PRET-4 marker — present means the fleet is already materialized */
+  marker: boolean;
+  teams: number;
+  /** `staging_marker` is the repo's purpose-built staging/production discriminator. It is
+   *  deliberately absent from schema.sql and every migration, so a `--clean` restore cannot carry
+   *  it to production. Measured 2026-09-05: `t` on staging, `f` on prod. Team identity does NOT
+   *  discriminate — staging is a restore of prod and holds the SAME team row. */
+  stagingMarker: boolean;
+};
+
+export type MaterializeResult = { ok: boolean; ran?: boolean; error?: string };
+
+export type MaterializeDeps = {
+  readState: () => Promise<FleetState>;
+  materialize: () => Promise<MaterializeResult>;
+};
+
+export type MaterializeOpts = { confirm: boolean; confirmProduction: boolean };
+
+export type MaterializeOutcome = { lines: string[]; exitCode: number };
+
+export type ConfirmParse =
+  | { ok: true; confirm: boolean; confirmProduction: boolean }
+  | { ok: false; error: string };
+
+const CONFIRM_KEYS = ["confirm", "confirm-production"] as const;
+
+/**
+ * Strict parsing of the two confirmation flags, at the CLI boundary.
+ *
+ * `parseArgs` (scripts/admin.ts) assigns the FOLLOWING token as a string, so `--confirm false`
+ * yields the string "false" — and `if (!flags.confirm)` reads that as CONFIRMED. That trap is live
+ * today on `purge-items`, a destructive command. Rather than inherit it, this command refuses any
+ * value form instead of guessing which way the operator meant it.
+ *
+ * `--confirm=false` is a DIFFERENT shape: parseArgs makes the whole token the key, so the flag
+ * would simply go unseen and the command would dry-run (fail-closed, but silently ignoring what the
+ * operator typed). It is refused explicitly so the mistake is reported rather than absorbed.
+ *
+ * A repeated `--confirm --confirm` is NOT detectable here and is not treated as an error: parseArgs
+ * collapses both to the same `true`, so the two spellings are indistinguishable by construction and
+ * mean the same thing.
+ */
+export function parseConfirmFlags(flags: Record<string, string | boolean>): ConfirmParse {
+  for (const key of Object.keys(flags)) {
+    const equalsForm = /^(confirm|confirm-production)=/.exec(key);
+    if (equalsForm) {
+      return { ok: false, error: `--${key} uses '='; pass the flag bare: --${equalsForm[1]}` };
+    }
+  }
+  for (const key of CONFIRM_KEYS) {
+    const value = flags[key];
+    if (value === undefined) continue;
+    if (value !== true) {
+      return { ok: false, error: `--${key} takes no value (got '${String(value)}'); pass the flag bare: --${key}` };
+    }
+  }
+  return {
+    ok: true,
+    confirm: flags.confirm === true,
+    confirmProduction: flags["confirm-production"] === true,
+  };
+}
+
+/**
+ * The real dependencies. `readState` is read-only by construction — three reads, no write — and
+ * `materialize` is the SHIPPED function, passed in rather than reached for, so the manual path and
+ * the boot path cannot drift apart.
+ */
+export function makeMaterializeDeps(db: DbClient): MaterializeDeps {
+  return {
+    readState: async () => {
+      const marker = await runSql<{ present: boolean }>(
+        "select exists (select 1 from migration_markers where name = $1) as present",
+        [PRET4_MATERIALIZE_MARKER]
+      );
+      const teams = await runSql<{ n: string }>("select count(*)::text as n from teams", []);
+      const staging = await runSql<{ present: boolean }>(
+        "select to_regclass('public.staging_marker') is not null as present",
+        []
+      );
+      return {
+        marker: marker.rows[0]?.present === true,
+        teams: Number(teams.rows[0]?.n ?? "0"),
+        stagingMarker: staging.rows[0]?.present === true,
+      };
+    },
+    materialize: () => materializeBuiltinMembershipOnce(db),
+  };
+}
+
+const errText = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+const fleetLine = (state: FleetState): string =>
+  state.stagingMarker
+    ? "fleet: this database carries `staging_marker` — a STAGING database."
+    : "fleet: this database does NOT carry `staging_marker` — it may be PRODUCTION.";
+
+/**
+ * Every reachable outcome has a contract. The ones that are easy to omit, and were: a failing
+ * `readState`; a `materialize` that THROWS rather than returning `{ok:false}` (boot and tick both
+ * anticipate that); the race where boot/tick stamps the marker between our read and our call, so
+ * the materializer re-reads and returns `ran:false` — reporting that as "it ran" would be a lie;
+ * and a zero-team fleet, where the marker is stamped but nothing was reconciled.
+ */
+export async function runMaterializeCommand(
+  deps: MaterializeDeps,
+  opts: MaterializeOpts
+): Promise<MaterializeOutcome> {
+  let state: FleetState;
+  try {
+    state = await deps.readState();
+  } catch (err) {
+    return { lines: [`✗ could not read the fleet state: ${errText(err)}`], exitCode: 1 };
+  }
+
+  const fleet = fleetLine(state);
+
+  if (state.marker) {
+    return {
+      lines: [fleet, `✓ already materialized — '${PRET4_MATERIALIZE_MARKER}' is present. Nothing to do.`],
+      exitCode: 0,
+    };
+  }
+
+  if (!opts.confirm) {
+    const extra = state.stagingMarker ? "--confirm" : "--confirm --confirm-production";
+    return {
+      lines: [
+        fleet,
+        `'${PRET4_MATERIALIZE_MARKER}' is ABSENT — this fleet refuses PRET-6 at preDeploy.`,
+        `${state.teams} team(s) would have their builtin group membership reconciled.`,
+        `DRY RUN — nothing written. Re-run with ${extra} to materialize.`,
+      ],
+      exitCode: 0,
+    };
+  }
+
+  if (!state.stagingMarker && !opts.confirmProduction) {
+    return {
+      lines: [
+        fleet,
+        "✗ refusing: this may be production and it would rewrite builtin group membership fleet-wide.",
+        "  If that is genuinely what you intend, pass --confirm-production as well.",
+      ],
+      exitCode: 1,
+    };
+  }
+
+  let result: MaterializeResult;
+  try {
+    result = await deps.materialize();
+  } catch (err) {
+    return { lines: [fleet, `✗ materialization threw: ${errText(err)} — the marker is NOT stamped.`], exitCode: 1 };
+  }
+
+  if (!result.ok) {
+    return {
+      lines: [fleet, `✗ materialization failed: ${result.error ?? "unknown error"} — the marker is NOT stamped.`],
+      exitCode: 1,
+    };
+  }
+  if (!result.ran) {
+    return {
+      lines: [fleet, "✓ already completed concurrently — a boot or scheduler tick stamped the marker first."],
+      exitCode: 0,
+    };
+  }
+  if (state.teams === 0) {
+    return { lines: [fleet, "✓ marker stamped; zero teams reconciled."], exitCode: 0 };
+  }
+  return {
+    lines: [fleet, `✓ materialization ran — ${state.teams} team(s) reconciled and the marker is stamped.`],
+    exitCode: 0,
+  };
+}

--- a/lib/access/materialize-command.ts
+++ b/lib/access/materialize-command.ts
@@ -123,6 +123,13 @@ const fleetLine = (state: FleetState): string =>
     : "fleet: this database does NOT carry `staging_marker` — it may be PRODUCTION.";
 
 /**
+ * WORDING DISCIPLINE, from the second diff review. Two claims this must NOT make:
+ *   • a failure cannot say "the marker is NOT stamped" — it is never re-read, and a concurrent boot
+ *     or tick may have stamped it after our read. It says what this RUN did instead.
+ *   • success cannot report `state.teams` as the number reconciled — that count came from the
+ *     pre-write read, and the materializer re-reads teams itself (lib/access/groups.ts:213), so a
+ *     team created in between is reconciled but uncounted. The count is labelled as of the check.
+ *
  * Every reachable outcome has a contract. The ones that are easy to omit, and were: a failing
  * `readState`; a `materialize` that THROWS rather than returning `{ok:false}` (boot and tick both
  * anticipate that); the race where boot/tick stamps the marker between our read and our call, so
@@ -177,12 +184,12 @@ export async function runMaterializeCommand(
   try {
     result = await deps.materialize();
   } catch (err) {
-    return { lines: [fleet, `✗ materialization threw: ${errText(err)} — the marker is NOT stamped.`], exitCode: 1 };
+    return { lines: [fleet, `✗ materialization threw: ${errText(err)} — this run did not stamp the marker.`], exitCode: 1 };
   }
 
   if (!result.ok) {
     return {
-      lines: [fleet, `✗ materialization failed: ${result.error ?? "unknown error"} — the marker is NOT stamped.`],
+      lines: [fleet, `✗ materialization failed: ${result.error ?? "unknown error"} — this run did not stamp the marker.`],
       exitCode: 1,
     };
   }
@@ -196,7 +203,7 @@ export async function runMaterializeCommand(
     return { lines: [fleet, "✓ marker stamped; zero teams reconciled."], exitCode: 0 };
   }
   return {
-    lines: [fleet, `✓ materialization ran — ${state.teams} team(s) reconciled and the marker is stamped.`],
+    lines: [fleet, `✓ materialization ran and the marker is stamped (${state.teams} team(s) at the time of the check).`],
     exitCode: 0,
   };
 }

--- a/postgres/migrations/20260818210000_pret6_retire_access_enforcement.sql
+++ b/postgres/migrations/20260818210000_pret6_retire_access_enforcement.sql
@@ -26,8 +26,15 @@
 -- pg:schema, Railway's preDeploy halts the release, and the old code keeps serving. The fix
 -- is in the release notes (docs/RELEASE-NOTES-pret6.md): upgrade through the prior release,
 -- let auto-flip converge, flip warned teams manually, verify zero permissive teams remain.
--- (A restored-from-backup fleet on THIS release self-heals: the surviving scheduler
--- materialization slot re-stamps the marker within a tick, after which deploys pass.)
+-- (A restored-from-backup fleet whose app is ALREADY RUNNING this release self-heals: the
+-- scheduler materialization slot re-stamps the marker within a tick, after which deploys pass.
+-- CORRECTED 2026-09-05, STAGINGMARK-1 — this used to say "a restored fleet on THIS release
+-- self-heals" without that qualifier, and it is false for the case that actually bites: a fleet
+-- that has teams and has NEVER booted this release cannot self-heal at all, because the refusal
+-- below stops the deploy, so the code that would stamp the marker never runs. Staging deploy
+-- 2e67246e died in exactly that loop. Recovery is `npm run admin -- materialize-builtins`
+-- (docs/OPS.md §11) or booting the prior release once. COMMENT ONLY — no behaviour is changed
+-- by this edit; the guard below is byte-for-byte what shipped.)
 do $$ begin
   if exists (select 1 from teams)
      and not exists (select 1 from migration_markers where name = 'pret4_builtin_materialize') then

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -564,7 +564,14 @@ async function main() {
       if (!parsed.ok) die(parsed.error);
       const outcome = await runMaterializeCommand(makeMaterializeDeps(admin), parsed);
       for (const line of outcome.lines) console.log(line);
-      if (outcome.exitCode !== 0) process.exit(outcome.exitCode);
+      if (outcome.exitCode !== 0) {
+        // FLUSH BEFORE EXITING. `console.log` to a PIPE is asynchronous, and `process.exit()`
+        // does not wait for it — so a wrapper or CI job capturing this command's output could
+        // see a truncated report, or none, for a run that already touched the database. Awaiting
+        // a zero-length write drains what is queued first (second diff review).
+        await new Promise<void>((resolve) => process.stdout.write("", () => resolve()));
+        process.exit(outcome.exitCode);
+      }
       break;
     }
     case "sync-github": {

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -10,6 +10,7 @@
  */
 import { execFileSync } from "node:child_process";
 import { adminClient } from "@/lib/db/admin";
+import { makeMaterializeDeps, parseConfirmFlags, runMaterializeCommand } from "@/lib/access/materialize-command";
 import { createMember, deleteMember } from "@/lib/admin/members";
 import { syncMemberActor, removeMemberActor } from "@/lib/graph/company-actors";
 import { issueApiKey, revokeApiKey } from "@/lib/admin/keys";
@@ -89,6 +90,14 @@ const USAGE = `Team Brain admin CLI — commands:
                                          # facts, retire their graph episodes, audit, bust derived
                                          # caches. DRY RUN by default — --confirm actually deletes.
                                          # Explicit ids only; there is no path-prefix form here.
+  materialize-builtins [--confirm] [--confirm-production]
+                                         # STAGINGMARK-1: complete PRET-4's one-time builtin
+                                         # materialization WITHOUT booting the app — the recovery for
+                                         # a fleet wedged on "PRET-6 refused: the PRET-4 builtin
+                                         # materialization has not completed on this fleet".
+                                         # DRY RUN by default. No-op when the marker is already
+                                         # present. --confirm-production is additionally required
+                                         # when the database carries no staging_marker.
   pg:schema                              # load postgres/schema.sql (idempotent)
 Defaults: --team demo (accepts a team UUID too). Requires DATABASE_URL (postgres). GitHub token via GITHUB_TOKEN env only.`;
 
@@ -543,6 +552,19 @@ async function main() {
         "• derived caches: work_timeline_cache + arc_cache bust requested via bustTeamLearningCaches —\n" +
           "  best-effort, so if a bust failed the error is printed above and those surfaces self-heal on TTL."
       );
+      break;
+    }
+    case "materialize-builtins": {
+      // STAGINGMARK-1. The behaviour, and every outcome's exit code, live in
+      // lib/access/materialize-command.ts so they are testable — this case is wiring only. It
+      // reaches the underlying materialization ONLY through makeMaterializeDeps: a direct second
+      // caller here would leave the handler's tests green while the real command still wrote, and
+      // test/guards/access-bootstrap-callsites.test.ts fails the build if one appears.
+      const parsed = parseConfirmFlags(flags);
+      if (!parsed.ok) die(parsed.error);
+      const outcome = await runMaterializeCommand(makeMaterializeDeps(admin), parsed);
+      for (const line of outcome.lines) console.log(line);
+      if (outcome.exitCode !== 0) process.exit(outcome.exitCode);
       break;
     }
     case "sync-github": {

--- a/test/access-materialize-command.test.ts
+++ b/test/access-materialize-command.test.ts
@@ -86,7 +86,7 @@ describe("STAGINGMARK-1 — materialize-builtins handler", () => {
     );
     expect(out.exitCode).not.toBe(0);
     expect(out.lines.join("\n")).toContain("boom");
-    expect(out.lines.join("\n")).toMatch(/NOT stamped/);
+    expect(out.lines.join("\n")).toMatch(/this run did not stamp the marker/i);
   });
 
   it("AC5 — the three outcomes are pairwise distinguishable, and only the failure reads as failure", async () => {
@@ -159,7 +159,9 @@ describe("STAGINGMARK-1 — materialize-builtins handler", () => {
       );
       expect(out.exitCode).not.toBe(0);
       expect(out.lines.join("\n")).toContain("pool exhausted");
-      expect(out.lines.join("\n")).toMatch(/NOT stamped/);
+      expect(out.lines.join("\n")).toMatch(/this run did not stamp the marker/i);
+      // …and it must NOT assert the marker is absent, which this run never re-read.
+      expect(out.lines.join("\n")).not.toMatch(/marker is NOT stamped/i);
     });
   });
 

--- a/test/access-materialize-command.test.ts
+++ b/test/access-materialize-command.test.ts
@@ -16,12 +16,13 @@ import {
  * while doing nothing.
  */
 
-/** A materializer that FAILS THE TEST if it is ever invoked — the sharp end of AC1/AC2/AC6. */
-const forbidden = () => {
-  throw new Error("materialize must not be called in this state");
-};
-
-function spy(result: MaterializeResult | (() => never)) {
+/**
+ * A counting fake. "Was it called?" is asserted with `calls`, NEVER by having the fake throw:
+ * the diff review caught that a throwing fake proves nothing here, because the handler CATCHES a
+ * thrown materializer by design (AC6c) and turns it into exit 1 — so a "must not be called" fake
+ * that throws is silently absorbed and its test can still pass for the wrong reason.
+ */
+function spy(result: MaterializeResult) {
   let calls = 0;
   return {
     get calls() {
@@ -29,8 +30,7 @@ function spy(result: MaterializeResult | (() => never)) {
     },
     fn: async () => {
       calls++;
-      if (typeof result === "function") result();
-      return result as MaterializeResult;
+      return result;
     },
   };
 }
@@ -46,10 +46,12 @@ const staging = (over: Partial<FleetState> = {}) => async () => state(over);
 
 describe("STAGINGMARK-1 — materialize-builtins handler", () => {
   it("AC1 — an already-materialized fleet never calls the materializer", async () => {
+    const m = spy({ ok: true, ran: true });
     const out = await runMaterializeCommand(
-      { readState: staging({ marker: true }), materialize: forbidden as never },
+      { readState: staging({ marker: true }), materialize: m.fn },
       { confirm: true, confirmProduction: true }
     );
+    expect(m.calls, "the marker-present path must perform zero writes").toBe(0);
     expect(out.exitCode).toBe(0);
     expect(out.lines.join("\n")).toMatch(/already materialized/i);
   });
@@ -89,7 +91,7 @@ describe("STAGINGMARK-1 — materialize-builtins handler", () => {
 
   it("AC5 — the three outcomes are pairwise distinguishable, and only the failure reads as failure", async () => {
     const done = await runMaterializeCommand(
-      { readState: staging({ marker: true }), materialize: forbidden as never },
+      { readState: staging({ marker: true }), materialize: spy({ ok: true, ran: true }).fn },
       { confirm: true, confirmProduction: true }
     );
     const ran = await runMaterializeCommand(
@@ -108,15 +110,17 @@ describe("STAGINGMARK-1 — materialize-builtins handler", () => {
 
   describe("AC6 — the remaining non-success states exit non-zero", () => {
     it("(a) a failing readState never reaches the materializer", async () => {
+      const m = spy({ ok: true, ran: true });
       const out = await runMaterializeCommand(
         {
           readState: async () => {
             throw new Error("connection refused");
           },
-          materialize: forbidden as never,
+          materialize: m.fn,
         },
         { confirm: true, confirmProduction: true }
       );
+      expect(m.calls, "a failed state read must not reach the materializer").toBe(0);
       expect(out.exitCode).not.toBe(0);
       expect(out.lines.join("\n")).toContain("connection refused");
     });

--- a/test/access-materialize-command.test.ts
+++ b/test/access-materialize-command.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseConfirmFlags,
+  runMaterializeCommand,
+  type FleetState,
+  type MaterializeResult,
+} from "@/lib/access/materialize-command";
+
+/**
+ * STAGINGMARK-1 acceptance, AC1–AC8. Spec: docs/design/stagingmark1-materialize-oneshot.md.
+ *
+ * These are BEHAVIOURAL, against injected fakes, because the thing worth pinning is which branch
+ * runs and what it exits with — not that a source file mentions a function name. The design review
+ * killed an earlier source-text-only criterion by pointing out that
+ * `case "materialize-builtins": { /* materializeBuiltinMembershipOnce *\/ break; }` would satisfy it
+ * while doing nothing.
+ */
+
+/** A materializer that FAILS THE TEST if it is ever invoked — the sharp end of AC1/AC2/AC6. */
+const forbidden = () => {
+  throw new Error("materialize must not be called in this state");
+};
+
+function spy(result: MaterializeResult | (() => never)) {
+  let calls = 0;
+  return {
+    get calls() {
+      return calls;
+    },
+    fn: async () => {
+      calls++;
+      if (typeof result === "function") result();
+      return result as MaterializeResult;
+    },
+  };
+}
+
+const state = (over: Partial<FleetState> = {}): FleetState => ({
+  marker: false,
+  teams: 1,
+  stagingMarker: true,
+  ...over,
+});
+
+const staging = (over: Partial<FleetState> = {}) => async () => state(over);
+
+describe("STAGINGMARK-1 — materialize-builtins handler", () => {
+  it("AC1 — an already-materialized fleet never calls the materializer", async () => {
+    const out = await runMaterializeCommand(
+      { readState: staging({ marker: true }), materialize: forbidden as never },
+      { confirm: true, confirmProduction: true }
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.lines.join("\n")).toMatch(/already materialized/i);
+  });
+
+  it("AC2 — without --confirm a markerless fleet is not written", async () => {
+    const m = spy({ ok: true, ran: true });
+    const out = await runMaterializeCommand(
+      { readState: staging({ marker: false, teams: 3 }), materialize: m.fn },
+      { confirm: false, confirmProduction: false }
+    );
+    expect(m.calls).toBe(0);
+    expect(out.exitCode).toBe(0);
+    expect(out.lines.join("\n")).toContain("3 team(s)");
+    expect(out.lines.join("\n")).toMatch(/DRY RUN/);
+  });
+
+  it("AC3 — with --confirm it runs", async () => {
+    const m = spy({ ok: true, ran: true });
+    const out = await runMaterializeCommand(
+      { readState: staging({ marker: false, teams: 2 }), materialize: m.fn },
+      { confirm: true, confirmProduction: false }
+    );
+    expect(m.calls).toBe(1);
+    expect(out.exitCode).toBe(0);
+    expect(out.lines.join("\n")).toMatch(/materialization ran/i);
+  });
+
+  it("AC4 — a failure exits non-zero and surfaces the error", async () => {
+    const out = await runMaterializeCommand(
+      { readState: staging(), materialize: async () => ({ ok: false, error: "boom" }) },
+      { confirm: true, confirmProduction: false }
+    );
+    expect(out.exitCode).not.toBe(0);
+    expect(out.lines.join("\n")).toContain("boom");
+    expect(out.lines.join("\n")).toMatch(/NOT stamped/);
+  });
+
+  it("AC5 — the three outcomes are pairwise distinguishable, and only the failure reads as failure", async () => {
+    const done = await runMaterializeCommand(
+      { readState: staging({ marker: true }), materialize: forbidden as never },
+      { confirm: true, confirmProduction: true }
+    );
+    const ran = await runMaterializeCommand(
+      { readState: staging(), materialize: async () => ({ ok: true, ran: true }) },
+      { confirm: true, confirmProduction: true }
+    );
+    const failed = await runMaterializeCommand(
+      { readState: staging(), materialize: async () => ({ ok: false, error: "boom" }) },
+      { confirm: true, confirmProduction: true }
+    );
+    const texts = [done, ran, failed].map((o) => o.lines.join("\n"));
+    expect(new Set(texts).size).toBe(3);
+    expect(texts.filter((t) => /fail/i.test(t))).toHaveLength(1);
+    expect(texts[2]).toMatch(/fail/i);
+  });
+
+  describe("AC6 — the remaining non-success states exit non-zero", () => {
+    it("(a) a failing readState never reaches the materializer", async () => {
+      const out = await runMaterializeCommand(
+        {
+          readState: async () => {
+            throw new Error("connection refused");
+          },
+          materialize: forbidden as never,
+        },
+        { confirm: true, confirmProduction: true }
+      );
+      expect(out.exitCode).not.toBe(0);
+      expect(out.lines.join("\n")).toContain("connection refused");
+    });
+
+    it("(b) a database with no staging_marker refuses without --confirm-production", async () => {
+      const m = spy({ ok: true, ran: true });
+      const out = await runMaterializeCommand(
+        { readState: staging({ stagingMarker: false }), materialize: m.fn },
+        { confirm: true, confirmProduction: false }
+      );
+      expect(m.calls).toBe(0);
+      expect(out.exitCode).not.toBe(0);
+      expect(out.lines.join("\n")).toContain("--confirm-production");
+      expect(out.lines.join("\n")).toMatch(/may be PRODUCTION/);
+    });
+
+    it("(b') …and proceeds once --confirm-production is given", async () => {
+      const m = spy({ ok: true, ran: true });
+      const out = await runMaterializeCommand(
+        { readState: staging({ stagingMarker: false }), materialize: m.fn },
+        { confirm: true, confirmProduction: true }
+      );
+      expect(m.calls).toBe(1);
+      expect(out.exitCode).toBe(0);
+    });
+
+    it("(c) a materializer that THROWS is caught and exits non-zero", async () => {
+      const out = await runMaterializeCommand(
+        {
+          readState: staging(),
+          materialize: async () => {
+            throw new Error("pool exhausted");
+          },
+        },
+        { confirm: true, confirmProduction: true }
+      );
+      expect(out.exitCode).not.toBe(0);
+      expect(out.lines.join("\n")).toContain("pool exhausted");
+      expect(out.lines.join("\n")).toMatch(/NOT stamped/);
+    });
+  });
+
+  describe("AC7 — success states that did not reconcile are not reported as a run", () => {
+    it("the boot/tick race (ran:false) reports 'already completed', not a run", async () => {
+      const out = await runMaterializeCommand(
+        { readState: staging(), materialize: async () => ({ ok: true, ran: false }) },
+        { confirm: true, confirmProduction: true }
+      );
+      expect(out.exitCode).toBe(0);
+      expect(out.lines.join("\n")).toMatch(/already completed concurrently/i);
+      expect(out.lines.join("\n")).not.toMatch(/materialization ran/i);
+    });
+
+    it("a zero-team fleet says the marker was stamped and nothing reconciled", async () => {
+      const out = await runMaterializeCommand(
+        { readState: staging({ teams: 0 }), materialize: async () => ({ ok: true, ran: true }) },
+        { confirm: true, confirmProduction: true }
+      );
+      expect(out.exitCode).toBe(0);
+      expect(out.lines.join("\n")).toMatch(/zero teams reconciled/i);
+    });
+  });
+
+  describe("AC8 — --confirm is a bare flag and a value is refused", () => {
+    it("accepts the bare forms", () => {
+      expect(parseConfirmFlags({})).toEqual({ ok: true, confirm: false, confirmProduction: false });
+      expect(parseConfirmFlags({ confirm: true })).toEqual({ ok: true, confirm: true, confirmProduction: false });
+      expect(parseConfirmFlags({ confirm: true, "confirm-production": true })).toEqual({
+        ok: true,
+        confirm: true,
+        confirmProduction: true,
+      });
+    });
+
+    it("refuses `--confirm false` — the trap that reads as CONFIRMED today", () => {
+      // parseArgs assigns the following token as a string, so `--confirm false` yields "false",
+      // and `if (!flags.confirm)` treats a non-empty string as confirmed. purge-items still does.
+      const parsed = parseConfirmFlags({ confirm: "false" });
+      expect(parsed.ok).toBe(false);
+      if (!parsed.ok) expect(parsed.error).toMatch(/takes no value/);
+    });
+
+    it("refuses `--confirm-production <value>` too", () => {
+      const parsed = parseConfirmFlags({ confirm: true, "confirm-production": "yes" });
+      expect(parsed.ok).toBe(false);
+    });
+
+    it("refuses the `=` form rather than silently ignoring it", () => {
+      // parseArgs makes the whole token the KEY, so this would otherwise go unseen and dry-run.
+      const parsed = parseConfirmFlags({ "confirm=false": true });
+      expect(parsed.ok).toBe(false);
+      if (!parsed.ok) expect(parsed.error).toMatch(/bare/);
+    });
+  });
+});

--- a/test/datamechanics/stagingmark-materialize.datamechanics.test.ts
+++ b/test/datamechanics/stagingmark-materialize.datamechanics.test.ts
@@ -1,0 +1,131 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { db, seedTeam } from "./helpers";
+import { getPool } from "@/lib/db/pg/pool";
+import { ensureBuiltins, materializeBuiltinMembershipOnce } from "@/lib/access/groups";
+
+/**
+ * STAGINGMARK-1 acceptance AC10–AC11, against a real Postgres.
+ * Spec: docs/design/stagingmark1-materialize-oneshot.md.
+ *
+ * AC10 executes the PRET-6 migration's OWN TEXT rather than a paraphrase of its predicate. An
+ * earlier draft asserted the predicate by hand and the design review killed it: re-typing the
+ * `select` proves only that inserting a row changes a query you wrote to notice that row, and it
+ * would keep passing if the real migration's condition drifted.
+ *
+ * WHY begin/ROLLBACK, and why this matters more than it looks. The migration's second half DROPS
+ * `teams.access_enforcement` and `teams.autoflip_hold`. The data-mechanics harness truncates ROWS
+ * between tests, not DDL — so running this file's statement bare would permanently change the
+ * shared test schema for every later test in the run, which is precisely the PRET-6 hazard
+ * CLAUDE.md records against `db:test:up`. Postgres DDL is transactional, so a rollback keeps the
+ * execution verbatim AND leaves no trace. The block is run on ONE pinned client, because `runSql`
+ * goes through the pool and a `begin` there could land on a different connection than the
+ * `rollback`.
+ */
+
+const MIGRATION = readFileSync(
+  join(import.meta.dirname, "..", "..", "postgres", "migrations", "20260818210000_pret6_retire_access_enforcement.sql"),
+  "utf8"
+);
+
+const MARKER = "pret4_builtin_materialize";
+
+/**
+ * Run the migration verbatim in a transaction that ALWAYS rolls back; return the raised error, or
+ * null when it applied cleanly. The teams are normalised to non-permissive first (also rolled
+ * back) so a `permissive` row left by another test cannot make this raise the OTHER PRET-6
+ * message and read like a marker failure.
+ */
+async function runMigrationRolledBack(): Promise<string | null> {
+  const client = await getPool().connect();
+  try {
+    await client.query("begin");
+    await client.query(`do $$ begin
+      if exists (select 1 from information_schema.columns
+                 where table_schema = current_schema() and table_name = 'teams' and column_name = 'access_enforcement') then
+        update teams set access_enforcement = 'enforcing';
+      end if;
+    end $$;`);
+    try {
+      await client.query(MIGRATION);
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  } finally {
+    await client.query("rollback").catch(() => {});
+    client.release();
+  }
+}
+
+beforeEach(async () => {
+  // The marker is one-time PER FLEET and the shared test DB carries it across files.
+  await db().from("migration_markers").delete().eq("name", MARKER);
+});
+
+describe("STAGINGMARK-1 — the wedged fleet, against the real migration", () => {
+  it("AC10 — the real PRET-6 guard refuses before materialization and applies after", async () => {
+    const seed = await seedTeam();
+    await ensureBuiltins(db(), seed.teamId);
+
+    // BEFORE: teams exist, marker absent → the migration's own text refuses.
+    const before = await runMigrationRolledBack();
+    expect(before, "the migration must refuse a markerless fleet").not.toBeNull();
+    expect(before).toContain("PRET-4 builtin materialization has not completed");
+
+    // The one-shot's effect — the same function the CLI handler is given.
+    const result = await materializeBuiltinMembershipOnce(db());
+    expect(result.ok).toBe(true);
+    expect((result as { ran?: boolean }).ran).toBe(true);
+
+    const { data: marker } = await db().from("migration_markers").select("name").eq("name", MARKER).maybeSingle();
+    expect(marker, "the marker must be stamped").not.toBeNull();
+
+    // AFTER: the same verbatim text no longer refuses.
+    const after = await runMigrationRolledBack();
+    expect(after, `the migration must apply once materialized, got: ${after}`).toBeNull();
+  });
+
+  it("AC10b — the rolled-back run leaves the schema intact (the column drop did not persist)", async () => {
+    // Negative control for the isolation the whole AC depends on. If begin/rollback were not
+    // holding, the migration's `alter table teams drop column` would have changed the shared
+    // schema and this assertion is where that shows up.
+    const seed = await seedTeam();
+    await ensureBuiltins(db(), seed.teamId);
+    await materializeBuiltinMembershipOnce(db());
+    await runMigrationRolledBack();
+
+    const { rows } = await getPool().query<{ present: boolean }>(
+      "select to_regclass('public.teams') is not null as present"
+    );
+    expect(rows[0]?.present).toBe(true);
+    // The team row itself survives the rolled-back `update teams set access_enforcement`.
+    const { data: team } = await db().from("teams").select("id").eq("id", seed.teamId).maybeSingle();
+    expect(team).not.toBeNull();
+  });
+
+  it("AC11 — a reconcile that fails partway leaves the marker UNSTAMPED", async () => {
+    const seed = await seedTeam();
+    await ensureBuiltins(db(), seed.teamId);
+
+    // Break the fleet AFTER this team: a second team whose builtin slug is occupied by a
+    // non-builtin group, so `ensureBuiltins` fails for it. The loop returns before the marker
+    // upsert, which is the marker-LAST discipline this criterion exists to pin.
+    const { data: other, error } = await db()
+      .from("teams")
+      .insert({ slug: `t-${randomUUID().slice(0, 8)}`, name: "partial" })
+      .select("id")
+      .single();
+    if (error || !other) throw new Error(`seed second team failed: ${error?.message}`);
+    const otherId = (other as { id: string }).id;
+    await db().from("groups").insert({ team_id: otherId, slug: "everyone", name: "squatter", is_builtin: false });
+
+    const result = await materializeBuiltinMembershipOnce(db());
+    expect(result.ok, "a fleet with an unbuildable team must not report success").toBe(false);
+
+    const { data: marker } = await db().from("migration_markers").select("name").eq("name", MARKER).maybeSingle();
+    expect(marker, "a partial reconcile must NOT stamp the marker — a retry has to be able to finish").toBeNull();
+  });
+});

--- a/test/datamechanics/stagingmark-materialize.datamechanics.test.ts
+++ b/test/datamechanics/stagingmark-materialize.datamechanics.test.ts
@@ -104,30 +104,54 @@ describe("STAGINGMARK-1 — the wedged fleet, against the real migration", () =>
     await ensureBuiltins(db(), seed.teamId);
     await materializeBuiltinMembershipOnce(db());
 
-    const snapshot = async () => {
-      const col = await getPool().query<{ present: boolean }>(
-        `select exists (select 1 from information_schema.columns
-           where table_schema = current_schema() and table_name = 'teams'
-             and column_name = 'access_enforcement') as present`
+    const columnsPresent = async () => {
+      const { rows } = await getPool().query<{ c: string }>(
+        `select column_name as c from information_schema.columns
+          where table_schema = current_schema() and table_name = 'teams'
+            and column_name in ('access_enforcement', 'autoflip_hold')
+          order by column_name`
       );
-      const present = col.rows[0]?.present === true;
-      if (!present) return { present, value: null as string | null };
-      const val = await getPool().query<{ v: string | null }>(
-        "select access_enforcement::text as v from teams where id = $1",
-        [seed.teamId]
-      );
-      return { present, value: val.rows[0]?.v ?? null };
+      return rows.map((r) => r.c);
     };
 
-    const before = await snapshot();
-    await runMigrationRolledBack();
-    const after = await snapshot();
+    // ESTABLISH the pre-PRET-6 column shape first. The second diff review caught that without
+    // this the control cannot fail: on the normal post-PRET-6 database the columns are already
+    // gone, the migration's existence gate at :36 is false, so it performs no UPDATE and no DROP —
+    // and `before === after` holds even with `begin`/`rollback` deleted outright. The rollback is
+    // only observable against a schema that actually has something to drop.
+    await getPool().query("alter table teams add column if not exists access_enforcement text not null default 'enforcing'");
+    await getPool().query("alter table teams add column if not exists autoflip_hold boolean not null default false");
+    try {
+      const before = await columnsPresent();
+      expect(before, "precondition: both columns must exist for this control to mean anything").toEqual([
+        "access_enforcement",
+        "autoflip_hold",
+      ]);
+      const beforeValue = (
+        await getPool().query<{ v: string }>("select access_enforcement::text as v from teams where id = $1", [
+          seed.teamId,
+        ])
+      ).rows[0]?.v;
 
-    expect(after.present, "the migration's column drop must not survive the rollback").toBe(before.present);
-    expect(after.value, "the normalisation UPDATE must not survive the rollback").toBe(before.value);
-    // Recorded honestly: when the column is already absent on this database (the post-PRET-6
-    // shape), `present` is false both times and this control only proves the UPDATE did not leak.
-    // It is still the strongest observation available, and it reddens whenever the column exists.
+      const raised = await runMigrationRolledBack();
+      expect(raised, `the migration should apply once materialized, got: ${raised}`).toBeNull();
+
+      // BOTH drops must have been rolled back — the earlier version never observed autoflip_hold.
+      expect(await columnsPresent(), "the migration's column drops must not survive the rollback").toEqual([
+        "access_enforcement",
+        "autoflip_hold",
+      ]);
+      const afterValue = (
+        await getPool().query<{ v: string }>("select access_enforcement::text as v from teams where id = $1", [
+          seed.teamId,
+        ])
+      ).rows[0]?.v;
+      expect(afterValue, "the normalisation UPDATE must not survive the rollback").toBe(beforeValue);
+    } finally {
+      // Leave the shared schema exactly as found.
+      await getPool().query("alter table teams drop column if exists access_enforcement");
+      await getPool().query("alter table teams drop column if exists autoflip_hold");
+    }
   });
 
   it("AC11 — a reconcile that fails partway leaves the marker UNSTAMPED", async () => {

--- a/test/datamechanics/stagingmark-materialize.datamechanics.test.ts
+++ b/test/datamechanics/stagingmark-materialize.datamechanics.test.ts
@@ -55,8 +55,13 @@ async function runMigrationRolledBack(): Promise<string | null> {
       return err instanceof Error ? err.message : String(err);
     }
   } finally {
-    await client.query("rollback").catch(() => {});
-    client.release();
+    // release(true) DESTROYS the connection when the rollback itself failed, rather than returning
+    // a client with a possibly-open aborted transaction to the shared pool (diff-review LOW).
+    let rolledBack = true;
+    await client.query("rollback").catch(() => {
+      rolledBack = false;
+    });
+    client.release(rolledBack ? undefined : true);
   }
 }
 
@@ -88,31 +93,53 @@ describe("STAGINGMARK-1 — the wedged fleet, against the real migration", () =>
     expect(after, `the migration must apply once materialized, got: ${after}`).toBeNull();
   });
 
-  it("AC10b — the rolled-back run leaves the schema intact (the column drop did not persist)", async () => {
-    // Negative control for the isolation the whole AC depends on. If begin/rollback were not
-    // holding, the migration's `alter table teams drop column` would have changed the shared
-    // schema and this assertion is where that shows up.
+  it("AC10b — the rolled-back run leaks neither the column drop nor the enforcement update", async () => {
+    // NEGATIVE CONTROL for the isolation the whole AC depends on — rewritten after the diff review
+    // showed the first version could not fail: it asserted `to_regclass('public.teams')`, but the
+    // migration drops COLUMNS, never the table, so that assertion was green in the leaked world
+    // too. It now observes the two things the transaction actually changes: the presence of
+    // `teams.access_enforcement` (dropped by the migration's second half) and the value the
+    // normalisation writes.
     const seed = await seedTeam();
     await ensureBuiltins(db(), seed.teamId);
     await materializeBuiltinMembershipOnce(db());
-    await runMigrationRolledBack();
 
-    const { rows } = await getPool().query<{ present: boolean }>(
-      "select to_regclass('public.teams') is not null as present"
-    );
-    expect(rows[0]?.present).toBe(true);
-    // The team row itself survives the rolled-back `update teams set access_enforcement`.
-    const { data: team } = await db().from("teams").select("id").eq("id", seed.teamId).maybeSingle();
-    expect(team).not.toBeNull();
+    const snapshot = async () => {
+      const col = await getPool().query<{ present: boolean }>(
+        `select exists (select 1 from information_schema.columns
+           where table_schema = current_schema() and table_name = 'teams'
+             and column_name = 'access_enforcement') as present`
+      );
+      const present = col.rows[0]?.present === true;
+      if (!present) return { present, value: null as string | null };
+      const val = await getPool().query<{ v: string | null }>(
+        "select access_enforcement::text as v from teams where id = $1",
+        [seed.teamId]
+      );
+      return { present, value: val.rows[0]?.v ?? null };
+    };
+
+    const before = await snapshot();
+    await runMigrationRolledBack();
+    const after = await snapshot();
+
+    expect(after.present, "the migration's column drop must not survive the rollback").toBe(before.present);
+    expect(after.value, "the normalisation UPDATE must not survive the rollback").toBe(before.value);
+    // Recorded honestly: when the column is already absent on this database (the post-PRET-6
+    // shape), `present` is false both times and this control only proves the UPDATE did not leak.
+    // It is still the strongest observation available, and it reddens whenever the column exists.
   });
 
   it("AC11 — a reconcile that fails partway leaves the marker UNSTAMPED", async () => {
     const seed = await seedTeam();
     await ensureBuiltins(db(), seed.teamId);
 
-    // Break the fleet AFTER this team: a second team whose builtin slug is occupied by a
-    // non-builtin group, so `ensureBuiltins` fails for it. The loop returns before the marker
-    // upsert, which is the marker-LAST discipline this criterion exists to pin.
+    // Squat the SECOND builtin slug, not the first. The diff review caught that squatting
+    // `everyone` makes this vacuous: `ensureBuiltins` iterates [everyone, external]
+    // (lib/access/groups.ts:110-113) and refuses on the squatter BEFORE inserting anything, so no
+    // partial write exists and the absent marker proves nothing. Squatting `external` means
+    // `everyone` IS inserted — the convergent write — and the refusal lands after it, in either
+    // team-iteration order (the `select id from teams` at :213 has no ORDER BY).
     const { data: other, error } = await db()
       .from("teams")
       .insert({ slug: `t-${randomUUID().slice(0, 8)}`, name: "partial" })
@@ -120,11 +147,22 @@ describe("STAGINGMARK-1 — the wedged fleet, against the real migration", () =>
       .single();
     if (error || !other) throw new Error(`seed second team failed: ${error?.message}`);
     const otherId = (other as { id: string }).id;
-    await db().from("groups").insert({ team_id: otherId, slug: "everyone", name: "squatter", is_builtin: false });
+    await db().from("groups").insert({ team_id: otherId, slug: "external", name: "squatter", is_builtin: false });
 
     const result = await materializeBuiltinMembershipOnce(db());
     expect(result.ok, "a fleet with an unbuildable team must not report success").toBe(false);
 
+    // BOTH halves, per the spec: the partial write landed …
+    const { data: partial } = await db()
+      .from("groups")
+      .select("id")
+      .eq("team_id", otherId)
+      .eq("slug", "everyone")
+      .eq("is_builtin", true)
+      .maybeSingle();
+    expect(partial, "the convergent write must have landed — otherwise this proves nothing about ordering").not.toBeNull();
+
+    // … and the marker did NOT.
     const { data: marker } = await db().from("migration_markers").select("name").eq("name", MARKER).maybeSingle();
     expect(marker, "a partial reconcile must NOT stamp the marker — a retry has to be able to finish").toBeNull();
   });

--- a/test/guards/access-bootstrap-callsites.test.ts
+++ b/test/guards/access-bootstrap-callsites.test.ts
@@ -57,6 +57,15 @@ describe("PRET-4 explicit builtin-state call sites", () => {
       admin,
       "scripts/admin.ts must not call materializeBuiltinMembershipOnce directly — go through runMaterializeCommand"
     ).not.toMatch(/materializeBuiltinMembershipOnce/);
+    // (d) …and not reach AROUND the function either. The diff review found (c) defeated by the
+    //     shape that actually matters: a case that calls the handler and THEN stamps the marker
+    //     itself (`admin.from("migration_markers").upsert({ name: PRET4_MATERIALIZE_MARKER })`)
+    //     passes (a), (b) and (c) while claiming a fleet was reconciled when it was not. The
+    //     marker is the thing PRET-6 trusts, so the CLI must never write it by any spelling.
+    expect(
+      admin,
+      "scripts/admin.ts must not write the PRET-4 marker itself — the marker is stamped only by the shipped materialization"
+    ).not.toMatch(/migration_markers|PRET4_MATERIALIZE_MARKER/);
   });
 
   it("team creation bootstraps the access topology", () => {

--- a/test/guards/access-bootstrap-callsites.test.ts
+++ b/test/guards/access-bootstrap-callsites.test.ts
@@ -41,6 +41,24 @@ describe("PRET-4 explicit builtin-state call sites", () => {
     expect(downstreamIdx).toBeGreaterThan(matIdx);
   });
 
+  it("STAGINGMARK-1: the admin CLI reaches the materialization ONLY through the tested handler", () => {
+    const admin = read("scripts/admin.ts");
+    // (a) the dispatch exists, pinned by CALL SHAPE rather than a bare name — a comment naming
+    //     the handler must not satisfy this.
+    expect(admin).toMatch(/runMaterializeCommand\s*\(/);
+    expect(admin).toMatch(/makeMaterializeDeps\s*\(/);
+    // (b) the command is discoverable.
+    expect(admin).toMatch(/materialize-builtins/);
+    // (c) THE LOAD-BEARING HALF. Without it the CLI could call the handler *and* invoke the
+    //     materializer directly, leaving every behavioural test in
+    //     test/access-materialize-command.test.ts green while the real command still wrote —
+    //     the second-writer shape this file exists to prevent.
+    expect(
+      admin,
+      "scripts/admin.ts must not call materializeBuiltinMembershipOnce directly — go through runMaterializeCommand"
+    ).not.toMatch(/materializeBuiltinMembershipOnce/);
+  });
+
   it("team creation bootstraps the access topology", () => {
     expect(read("lib/admin/teams.ts")).toMatch(/ensureAccessBootstrap\s*\(/);
   });

--- a/test/guards/access-bootstrap-callsites.test.ts
+++ b/test/guards/access-bootstrap-callsites.test.ts
@@ -61,7 +61,11 @@ describe("PRET-4 explicit builtin-state call sites", () => {
     //     shape that actually matters: a case that calls the handler and THEN stamps the marker
     //     itself (`admin.from("migration_markers").upsert({ name: PRET4_MATERIALIZE_MARKER })`)
     //     passes (a), (b) and (c) while claiming a fleet was reconciled when it was not. The
-    //     marker is the thing PRET-6 trusts, so the CLI must never write it by any spelling.
+    //     marker is the thing PRET-6 trusts, so the CLI must never write it itself.
+    //     SCOPE, stated honestly (second review): this is a SUBSTRING check, not a proof. A split
+    //     literal ("migration_" + "markers") or an imported helper would pass it. It is aimed at
+    //     the idiom that actually appears in this repo, and it is the cheapest thing that reddens
+    //     on the realistic regression; a general answer needs import/AST analysis and is not here.
     expect(
       admin,
       "scripts/admin.ts must not write the PRET-4 marker itself — the marker is stamped only by the shipped materialization"


### PR DESCRIPTION
## What this is

The PRET-6 preDeploy guard refuses a database that has teams but no `pret4_builtin_materialize`
marker. That marker has exactly **one writer** (`materializeBuiltinMembershipOnce`,
`lib/access/groups.ts:274-276`) reachable from exactly **two** call sites — `instrumentation.ts` at
boot and the scheduler tick — and **both are downstream of a deploy that succeeded**. So a fleet in
that state is deadlocked: the guard refuses → the code never boots → the marker is never stamped →
it refuses forever.

**This is not hypothetical.** Staging deploy `2e67246e` died in exactly that loop on 2026-09-05, and
was only unwedged by restoring a full production dump.

This adds `npm run admin -- materialize-builtins`: it invokes the **shipped** function without
booting the app, so the manual path and the boot path cannot drift. Dry-run by default.

| database | to write |
|---|---|
| carries `staging_marker` | `--confirm` |
| does **not** carry it (may be production) | `--confirm` **and** `--confirm-production` |

Plus a runbook section (`docs/OPS.md` §11) and a pointer from `docs/RELEASE-NOTES-pret6.md`, which is
where the raised error actually sends operators.

## Deliberately NOT in this PR

- **The PRET-6 migration's behaviour is unchanged.** Making it self-materialize is the better end
  state but would either reproduce a TypeScript reconcile in SQL or invoke app code from schema
  replay. Named in the spec §3 as follow-up; no ticket filed yet.
- **A comment in that migration IS corrected** — it claimed a restored fleet "self-heals", which is
  false for the fleet that has never booted this release, and is the misconception behind the whole
  bug. **Comment-only, proven by diffing the non-comment lines before/after: byte-identical.**
- **`scripts/staging-refresh.sh` is untouched.** The originally-proposed assertion there is dropped —
  see spec §0 for the corrected reasoning (my first justification, "it could never fire", was too
  strong and is withdrawn).
- **`purge-items` has the same `--confirm` parsing trap** (`--confirm false` reads as confirmed on a
  destructive command). Found by review here, **not fixed** — a destructive command's confirmation
  deserves its own spec. Spec §3.
- **`docs/OPS.md:702` documents `INGEST_POLL_ENABLED=false` but staging has it UNSET** (measured).
  Recorded in spec §0; changing live staging variables is outward-facing and needs its own decision.

## Verification

| tier | result |
|---|---|
| `tsc --noEmit` | clean |
| lint | 0 errors (18 pre-existing warnings, none in the new files) |
| unit | **3843 passed / 0 failed**, 379 files |
| docs drift | congruent |
| spec gate | `SPEC_READY`, exit 0 |
| **data-mechanics (AC10, AC10b, AC11)** | ✅ **VERIFIED IN CI** — `Data-mechanics tests (real Postgres)`: SUCCESS, `stagingmark-materialize.datamechanics.test.ts (3 tests)` passed, 244 dm files passed / 2 skipped. NOT run locally: Docker's daemon was wedged on this machine (process up, socket present, `docker version` never returned), so CI is the only place these three ran. |

### Mutations — 11, every one reddening its INTENDED test

| # | mutation | result |
|---|---|---|
| M1 | delete the CLI dispatch | REDDENED (wiring guard) |
| M2 | reintroduce a direct second writer | REDDENED (guard c) |
| M3 | remove the marker-present early return | REDDENED (AC1) |
| M4 | remove the dry-run gate | REDDENED (AC2) |
| M5 | remove the production refusal | REDDENED (AC6b) |
| M6 | relax `--confirm` to truthiness | REDDENED (AC8) |
| M7 | remove the `ran:false` race branch | REDDENED (AC7) |
| M8 | remove the thrown-materializer catch | REDDENED (AC6c) |
| M9 | reach around with a direct marker write | REDDENED (guard d) |
| M4′, M8′ | re-run after fold 2 | REDDENED |

Note: M1 originally reddened on my own **comment** containing the function name — the guard caught
its author before it caught anything else.

## Review

**Reviewed by Fable code-reviewer and Codex gpt-5.6-sol — verdict BLOCKED by both, every finding re-derived and folded; two reviewer claims refuted with measurement.**

Four rounds, and the blocked history is the point:

- **Codex, spec round 1 — CLEAR-WITH-CONDITIONS.** Forced `--confirm` (dry-run default); moved
  behaviour into an import-safe handler with injected deps after showing a source-text criterion
  would pass on a `case` whose body is only a comment; killed an AC claiming the fleet "becomes
  deployable" (the guard has a second condition this slice doesn't address).
- **Codex, spec round 2 — BLOCKED.** Found `--confirm false` parses as the string `"false"` and reads
  as confirmed. Found my AC would have **corrupted the shared dm schema** — the migration's second
  half drops columns and dm isolation restores rows, not DDL. Proposed binding confirmation to team
  identity; **REFUTED by measurement** — staging is a restore of prod and holds the same team
  (`73409b20-…|aios`), so `--confirm-team` matches production equally well. Replaced with
  `staging_marker` (`t` on staging, `f` on prod).
- **Fable, diff round — BLOCKED (1 HIGH).** AC11 was vacuous: it squatted `everyone`, but
  `ensureBuiltins` iterates `[everyone, external]` and refuses before writing anything, so no partial
  write existed. Also caught three false claims in the docs and a `forbidden` test fake that a
  `catch` silently absorbs.
- **Codex, diff round — BLOCKED (2 HIGH).** AC10b was **still** unable to fail after the first fold.
  And I had corrected "nothing is half-applied" in OPS.md while leaving the identical sentence in
  RELEASE-NOTES-pret6.md — then written "docs congruent" in the commit message.

Also refuted: round 1's zero-team-source case — the marker upsert is unconditional after the team
loop, so a zero-team fleet stamps at first boot and cannot wedge later.

## Deferrals

- dm tier could not run locally (Docker wedged); it ran in CI and passed. Recorded rather than quietly dropped, because "green" here rests entirely on the CI job, not on anything I observed on this machine.
- Guard (d) is a substring check, not a proof; a split literal or imported helper defeats it. Scope
  recorded in the test rather than overclaimed.
- The three follow-ups above are recorded in the spec, not filed as tickets.

AIOS-Work: STAGINGMARK-1

