### PR TITLE
docs(skills): add /cut-release — the integration→release fast-forward, with its preconditions

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -2,162 +2,231 @@
 name: cut-release
 description: >
   Cut a release: declare the tag, bump the three version sites, date the
-  CHANGELOG, tag the commit on the integration branch, wait for the
-  release-candidate gate, then FAST-FORWARD the release branch onto that exact
-  tagged commit. Use when asked to "cut a release", "ship v0.13.0", "release
-  from staging", "tag a release", or /cut-release. The fast-forward is the step
-  that makes a tag a release — everything before it only produces a tag.
-  Verification-heavy and destructive-step-light: it never merges into the
-  release branch, never runs `pg:schema` against prod, and never touches
-  Railway.
+  CHANGELOG, verify the candidate LOCALLY, tag the commit on the integration
+  branch, wait for the release-candidate gate, then FAST-FORWARD the release
+  branch onto that exact tagged commit. Use when asked to "cut a release",
+  "ship v0.13.0", "release from staging", "tag a release", or /cut-release.
+  The fast-forward is the step that makes a tag a release — everything before
+  it only produces a tag. A pushed `v*` tag is PERMANENT (protected ruleset,
+  no bypass), so the local pre-push check is the last chance to be wrong
+  cheaply. Never merges into the release branch and never runs `pg:schema`
+  against prod.
 ---
 
 # Cut a release — integration branch → release branch
 
 The spine:
 
-> **check the preconditions → declare the tag → bump + date → tag the commit →
-> WAIT for the gate → fast-forward the release branch → publish → watch the
-> migration lane**
+> **preconditions → declare + bump + date → VERIFY LOCALLY → tag → wait for the
+> gate → fast-forward the release branch → verify the deploy → publish → watch
+> the migration lane**
 
-**Resolve the branch roles, never hardcode them** (`scripts/branches.mjs`):
+**Resolve the branch roles, never hardcode them.** Use the `$root` form so this
+works from any cwd — a bare relative path exits 1 with empty stdout from a nested
+directory, which turns precondition A into a false "diverged":
 
 ```bash
-INTEGRATION=$(node scripts/branches.mjs --print integration)   # staging
-RELEASE=$(node scripts/branches.mjs --print release)           # main
+root="$(git rev-parse --show-toplevel)"
+INTEGRATION="$(node "$root/scripts/branches.mjs" --print integration)"   # staging
+RELEASE="$(node "$root/scripts/branches.mjs" --print release)"           # main
 ```
 
-`docs/RELEASING.md` §2 is the runbook this skill executes; §3.1a explains the
-gate's four assertions. When the two disagree, the runbook wins and this file
-is stale — say so rather than following it.
+`docs/RELEASING.md` §2 is the runbook this executes; §3.1a explains the gate.
+When the two disagree, the runbook wins and this file is stale — say so rather
+than following it.
 
 ---
 
-## 0. Preconditions — three, and two of them have failed in practice
+## ⛔ The one irreversible step
 
-Check all three BEFORE touching a version number. Each is one command.
+**A pushed `v*` tag cannot be deleted or moved by anyone**, including admins:
+ruleset `22363258` is `active` over `refs/tags/v*` with `deletion`,
+`update` and `non_fast_forward`, and **zero bypass actors** (verified). If you
+push a tag and the gate reddens on A, B or C, that version number is **burned** —
+the recovery is to fix forward and cut the next patch number, not to re-tag.
+
+Everything before the tag push is cheap to get wrong. Everything after is not.
+That is why step 3 exists.
+
+---
+
+## 0. Preconditions — three, all `origin/` refs
+
+**Always compare remote refs.** Local branches in a worktree drift arbitrarily:
+measured in a real worktree, `main..staging` reported **221** commits while
+`origin/main..origin/staging` reported **6**. The local answer is not wrong-ish,
+it is unrelated.
+
+```bash
+git fetch origin --quiet
+```
 
 **A. The release branch must be an ANCESTOR of the integration branch.**
 
 ```bash
-git fetch origin --quiet
 git merge-base --is-ancestor "origin/$RELEASE" "origin/$INTEGRATION" \
   && echo "OK — ancestry holds" || echo "STOP — diverged"
 ```
 
-If it prints STOP, **no tag you cut can pass the gate**: assertion C wants the
-release branch to be an ancestor of the tagged commit and assertion D wants that
-commit reachable from the integration branch, and nothing satisfies both across
-a divergence. This is not theoretical — it happened **twice in one day** on
-2026-09-06 (repaired by #681 and #684), both times because a pull request landed
-on the release branch after the cutover.
+STOP means **no tag you cut can pass the gate**: assertion C wants the release
+branch to be an ancestor of the tagged commit and D wants that commit reachable
+from the integration branch, and nothing satisfies both across a divergence.
 
-The repair is a back-merge, and the merge method is load-bearing:
+This is not theoretical. It happened twice on 2026-09-06 — once as the planned
+pre-cutover reconcile (#681), and once **after** the cutover when #683 was opened
+against the release branch instead of the integration branch (repaired by #684).
+The post-cutover case is the one that will recur until RELPTR-8 lands, because an
+admin can still push to the release branch.
+
+Repair, and the merge method is load-bearing:
 
 ```bash
-gh pr create --base "$INTEGRATION" --head "$RELEASE" --title "reconcile: restore release ancestry"
-# merge it with a MERGE COMMIT, never --squash
+gh pr create --base "$INTEGRATION" --head "$RELEASE" \
+  --title "reconcile: restore release ancestry" \
+  --body "$(cat <<'EOF'
+Back-merge to restore ancestry so release candidates can pass assertions C and D.
+
+## Review — Reviewed by prior-PR review evidence (no new diff) — verdict every constituent commit was reviewed on its own PR; this back-merge adds no unreviewed code.
+
+The diff is exactly the release-branch-only commits and nothing else; a conflict
+would invalidate this line and a real review would be owed.
+EOF
+)"
 ```
 
-**A squash defeats the entire purpose** — it creates a new SHA, so the release
-branch is still not an ancestor. Land the reconcile, re-run the check, then
-continue.
+Two things that bite here:
 
-**B. Nothing unreleased is stranded.** `git log --oneline "$RELEASE".."$INTEGRATION"`
-should be exactly what you intend to ship. Read it; the CHANGELOG section you
-are about to write has to be true, and no check verifies that.
+- **Merge it with a MERGE COMMIT — not squash, not rebase.** Both of those mint
+  new SHAs, so the release branch is *still* not an ancestor. The repair that
+  looks like a fix and isn't. `gh pr merge <n> --merge`.
+- **The body needs the attestation line above.** The integration branch requires
+  `PR records a diff review`; a bare `gh pr create` produces a PR that cannot
+  merge.
 
-**C. The previous tag is declared.** `DEFAULT_TAGS` in
-`scripts/migrate-from-existing.mjs` must already contain every cut tag. If the
-newest cut tag is missing, fix that first — see step 1 for why.
+**B. Nothing unreleased is stranded.**
+
+```bash
+git log --oneline "origin/$RELEASE..origin/$INTEGRATION"
+```
+
+Read it — the CHANGELOG section you are about to write has to be true, and no
+check verifies that.
+
+**C. Every already-cut tag is declared.** `DEFAULT_TAGS` in
+`scripts/migrate-from-existing.mjs` must contain every tag that exists. Also
+worth a glance: GitHub *Releases* currently stop at `v0.10.0` while `v0.11.0` and
+`v0.12.0` exist as tags only — publishing (step 6) is the step that has been
+skipped before.
 
 ---
 
 ## 1. Declare the tag BEFORE cutting it
 
-Add the new tag to `DEFAULT_TAGS` in `scripts/migrate-from-existing.mjs` and land
-that pull request into the **integration** branch.
+One pull request into the **integration** branch, carrying three things:
 
-**Why this order and not the obvious one:** the migration lane runs in `ci.yml`
-on `pull_request`. Cutting a tag that `DEFAULT_TAGS` does not declare throws
-`DEFAULT_TAGS is stale` **on every open pull request in the repo** — not just
-yours. The lane deliberately *skips* a declared-but-uncut tag with a notice, and
-that pending slot is exactly the affordance that makes declare-then-cut safe.
+- **Add the new tag to `DEFAULT_TAGS`** in `scripts/migrate-from-existing.mjs`.
+  The migration lane runs in `ci.yml` on `pull_request`, and cutting a tag it
+  does not declare throws `DEFAULT_TAGS is stale` **on every open pull request in
+  the repo** — not just yours. The lane deliberately *skips* a declared-but-uncut
+  tag with a notice; that pending slot is what makes declare-then-cut safe.
+- **Bump all THREE version sites** — `package.json` `.version`,
+  `package-lock.json` `.version`, `package-lock.json` `.packages[""].version`.
+  Bumping one is a mistake already made here: the version sat at `0.10.0` for 23
+  days and two releases' worth of work. `test/guards/release-version-agreement.test.ts`
+  fails the build if the three disagree, or if the newest declared tag is not
+  `v${package.json.version}`.
+- **Move `CHANGELOG.md`'s `[Unreleased]` into `## [X.Y.Z] — YYYY-MM-DD`**, leaving
+  an empty `[Unreleased]`. The check reads the heading and verifies *presence*,
+  not truth.
 
-Same pull request, two more things:
-
-- **Bump the version at all THREE sites** — `package.json` `.version`,
-  `package-lock.json` `.version`, and `package-lock.json` `.packages[""].version`.
-  Bumping only the first is a mistake this repo has already made: the version sat
-  at `0.10.0` for 23 days and two releases' worth of work.
-  `test/guards/release-version-agreement.test.ts` fails the build if the three
-  disagree, or if the newest declared tag is not `v${package.json.version}`.
-- **Move `CHANGELOG.md`'s `[Unreleased]` into `## [X.Y.Z] — YYYY-MM-DD`** and
-  leave an empty `[Unreleased]` above it. A check reads the heading; it verifies
-  *presence*, not truth. Anything merged before you cut ships whether or not it
-  is listed.
+Land it. Then continue — and re-fetch, because the remote just moved.
 
 ---
 
-## 2. Tag the commit on the integration branch
+## 2. VERIFY LOCALLY — the last cheap moment
 
 ```bash
-git tag -a "v<X.Y.Z>" -m "v<X.Y.Z>" "origin/$INTEGRATION"
-git push origin "v<X.Y.Z>"
+git fetch origin --quiet
+CANDIDATE="$(git rev-parse "origin/$INTEGRATION")"
+VERSION="v$(git show "$CANDIDATE:package.json" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")"
+
+echo "candidate: $CANDIDATE"
+echo "version in the TAGGED TREE: $VERSION   (must equal the tag you are about to push)"
+git merge-base --is-ancestor "origin/$RELEASE" "$CANDIDATE" && echo "C ok" || echo "C FAILS"
+git merge-base --is-ancestor "$CANDIDATE" "origin/$INTEGRATION" && echo "D ok" || echo "D FAILS"
 ```
 
-**Annotated (`-a`), and exactly `vX.Y.Z`** — no pre-release suffix, no build
-metadata, no leading zeros. Assertion A rejects anything else.
+**This exists because the tag push is irreversible.** The failure it prevents is
+concrete and easy to walk into: fetch at precondition A, land the bump pull
+request at step 1, then tag `origin/$INTEGRATION` from the *stale* local ref — you
+tag the pre-bump commit, whose `package.json` still reads the old version,
+assertion **B** reddens, and the tag cannot be deleted. The version number is
+gone.
 
-Pushing the tag runs `.github/workflows/release-candidate.yml`. `ci.yml` fires on
-branches only, so **the tag push runs the gate and nothing else**.
+`$VERSION` must equal the tag you are about to push. If it does not, you are
+about to tag the wrong commit.
 
 ---
 
-## 3. WAIT for `Release candidate gate` — and know that nothing enforces the wait
+## 3. Tag the commit
 
 ```bash
-gh run list --repo <owner>/<repo> --workflow=release-candidate.yml --limit 1 \
-  --json status,conclusion,headSha
+git tag -a "$VERSION" -m "$VERSION" "$CANDIDATE"
+git push origin "$VERSION"
 ```
 
-Four assertions: **A** the tag is annotated and exactly `vX.Y.Z` · **B** the
-tagged tree's `package.json` matches the tag · **C** the release branch is an
-ancestor of the tagged commit · **D** the commit is reachable from the
-integration branch. A+B+C alone certify *"some descendant of the release
-branch"*; **D** is what makes it the right commit.
+**Annotated (`-a`), exactly `vX.Y.Z`** — no pre-release suffix, no build metadata,
+no leading zeros; assertion A rejects anything else. Tag `$CANDIDATE` (the SHA you
+just verified), not a branch name that may have moved since.
 
-⚠️ **THE WAIT IS HUMAN DISCIPLINE.** Measured 2026-09-06: `Release candidate
-gate` is **not** a required context on the release branch, `enforce_admins` is
-false, and there is no bypass allowance. So a non-admin's fast-forward is refused
-by "require a pull request" whatever the contexts say, and **an admin's push
-bypasses everything — including a pending or red gate.** Do not read a green
-branch-protection UI as having checked this for you. (RELPTR-8 tracks closing it.)
-
-**Do not fast-forward past a red assertion.** A red A/B/C means the tag itself is
-wrong — delete it, fix, re-tag. A red D after a green precondition A means
-something changed underneath you; re-check ancestry.
+`ci.yml` fires on branches only, so the tag push runs the release-candidate gate
+and nothing else.
 
 ---
 
-## 4. Fast-forward the release branch — the step that makes it a release
+## 4. Wait for the gate — nothing enforces this wait
 
 ```bash
-git push origin "v<X.Y.Z>^{commit}:$(node scripts/branches.mjs --print release)"
+gh run list --repo <owner>/<repo> --workflow=release-candidate.yml --limit 5 \
+  --json status,conclusion,headSha \
+  --jq ".[] | select(.headSha == \"$(git rev-parse "$VERSION^{commit}")\")"
+```
+
+Match on `headSha` — `--limit 1` can hand you another tag's run.
+
+Four assertions: **A** annotated and exactly `vX.Y.Z` · **B** the tagged tree's
+`package.json` matches the tag · **C** the release branch is an ancestor of the
+tagged commit · **D** the commit is reachable from the integration branch. A+B+C
+alone certify *"some descendant of the release branch"*; **D** is what makes it
+the right commit.
+
+⚠️ **THE WAIT IS HUMAN DISCIPLINE.** Measured 2026-09-06: `Release candidate gate`
+is **not** a required context on the release branch, `enforce_admins` is false,
+and there is no bypass allowance. A non-admin's fast-forward is refused by
+"require a pull request" whatever the contexts say; **an admin's push bypasses
+everything, including a pending or red gate.** Do not read a green
+branch-protection UI as having checked this. RELPTR-8 tracks closing it.
+
+**Red A/B/C means the tag is wrong — and you cannot re-tag** (see the ⛔ above).
+Fix forward on the integration branch and cut the next patch number.
+
+---
+
+## 5. Fast-forward the release branch — the step that makes it a release
+
+```bash
+git push origin "$VERSION^{commit}:$RELEASE"
 ```
 
 **Everything before this produces a tag; nothing before it moves what installers
 deploy.** This step was missing from the runbook entirely until a review caught
-that following §2 as written would leave installers on the pre-cutover release
-branch indefinitely, with every check green.
+that following §2 as written left installers on the old release branch
+indefinitely, with every check green.
 
-- `^{commit}` peels the annotated tag to the commit — pushing the tag object
-  itself would not advance a branch.
-- The destination resolves the ROLE. Hardcoding `main` here is the thing the
-  branch-roles module exists to prevent.
-- It is a **fast-forward, not a merge**. The release branch never gains a commit
-  that was not reviewed on the integration branch. If git refuses it as
-  non-fast-forward, ancestry broke — go back to precondition A.
+- `^{commit}` peels the annotated tag — pushing the tag object would not advance
+  a branch.
+- **Fast-forward only.** No `+`, no `--force`. If git refuses it as
+  non-fast-forward, ancestry broke after step 2 — return to precondition A.
 
 This push triggers the release deploy: Railway builds the release branch and runs
 `npm run pg:schema` as its `preDeployCommand`, **from the deployed artifact's
@@ -165,25 +234,34 @@ tree**.
 
 ⛔ **Never run `npm run pg:schema` against prod by hand.** It loads from *your*
 checkout (`loadSchema({ cwd = process.cwd() })`), and post-cutover your checkout
-is routinely AHEAD of the tag — so a manual run applies unreleased migrations to
-production. Verify the deploy's preDeploy step instead.
+is routinely ahead of the tag — a manual run applies unreleased migrations to
+production.
+
+**Then verify the deploy actually happened** — webhooks were dropped twice on
+2026-09-05. Use the `railway-deploy-verify` skill; do not assume.
 
 ---
 
-## 5. Publish, then watch the thing that actually tests the release
+## 6. Publish
 
-Publish the GitHub Release from the tag with the CHANGELOG section as its body.
+```bash
+gh release create "$VERSION" --title "$VERSION" --notes "<the CHANGELOG section>"
+```
 
-Then **watch the migration lane on the next pull request or branch push.** It
-exercises the previous-tag → new-tag upgrade against a real database, and it is
-the only evidence an existing install can upgrade. Read its output rather than
-assuming: on 2026-09-06 a staging refresh proved a v0.10-era database **could
-not** reach current in one deploy — the PRET-6 migration refused, correctly, and
-needed an intermediate step.
+Skipping this is a real habit here, not a hypothetical: Releases stop at
+`v0.10.0` while `v0.11.0` and `v0.12.0` exist as tags only.
 
 ---
 
-## 6. Close the loop
+## 7. Watch the thing that actually tests the release
+
+The migration lane on the next pull request or branch push exercises the
+previous-tag → new-tag upgrade against a real database. **It is the only evidence
+an existing install can upgrade.** Read its output: on 2026-09-06 a staging
+refresh proved a v0.10-era database could *not* reach current in one deploy — the
+PRET-6 migration refused, correctly, and needed an intermediate step.
+
+## 8. Close the loop
 
 Set the release row's `Status` to `done` in `3-log/tasks.md`, `aios push`
 (dry-run first), and **read the status back** — a push that reported `ok` is not
@@ -194,11 +272,12 @@ resolve `linked`, not `applied`.
 
 ## What this skill refuses to do
 
-- **Merge anything into the release branch.** It only ever fast-forwards.
-- **Run `pg:schema` against production**, for the reason in step 4.
-- **Touch Railway** beyond read-only verification — no `up`, `redeploy`, `down`,
-  `delete`.
-- **Cut the tag before the declare-and-bump pull request has landed.**
+- **Merge anything into the release branch.** It only fast-forwards.
+- **Run `pg:schema` against production.**
+- **Deploy via Railway** — `railway up` / `redeploy` / `down` / `delete` are never
+  run; verification is read-only.
+- **Push a tag before the local B/C/D check passes**, because that step is
+  irreversible.
 - **Fast-forward past a red or pending gate**, even though nothing stops it.
 
 ## Failure modes this sequence exists to catch
@@ -206,9 +285,14 @@ resolve `linked`, not `applied`.
 | Failure | Caught by |
 |---|---|
 | Release branch diverged; no candidate can pass | precondition A |
-| A back-merge squashed, so ancestry is still broken | precondition A's explicit merge-method note |
+| A back-merge squashed or rebased, so ancestry is still broken | precondition A's merge-method note |
+| The reconcile PR cannot merge (no attestation) | precondition A's PR body |
+| Local refs answering a different question | `origin/` everywhere + the 221-vs-6 note |
+| Tagging a stale ref → red B → **burned version number** | step 2 |
 | `DEFAULT_TAGS is stale` on every open PR | step 1's declare-then-cut order |
-| Version bumped at one site of three | step 1 + `release-version-agreement` guard |
-| A tag that is never actually released | step 4 existing at all |
-| Unreleased migrations applied to prod by hand | step 4's ⛔ |
-| A release nobody proved is installable | step 5's migration lane |
+| Version bumped at one site of three | step 1 + `release-version-agreement` |
+| A tag that is never actually released | step 5 existing at all |
+| Unreleased migrations applied to prod by hand | step 5's ⛔ |
+| A release that deployed nowhere | step 5's `railway-deploy-verify` routing |
+| A release nobody can find | step 6 |
+| A release nobody proved is installable | step 7 |

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: cut-release
+description: >
+  Cut a release: declare the tag, bump the three version sites, date the
+  CHANGELOG, tag the commit on the integration branch, wait for the
+  release-candidate gate, then FAST-FORWARD the release branch onto that exact
+  tagged commit. Use when asked to "cut a release", "ship v0.13.0", "release
+  from staging", "tag a release", or /cut-release. The fast-forward is the step
+  that makes a tag a release — everything before it only produces a tag.
+  Verification-heavy and destructive-step-light: it never merges into the
+  release branch, never runs `pg:schema` against prod, and never touches
+  Railway.
+---
+
+# Cut a release — integration branch → release branch
+
+The spine:
+
+> **check the preconditions → declare the tag → bump + date → tag the commit →
+> WAIT for the gate → fast-forward the release branch → publish → watch the
+> migration lane**
+
+**Resolve the branch roles, never hardcode them** (`scripts/branches.mjs`):
+
+```bash
+INTEGRATION=$(node scripts/branches.mjs --print integration)   # staging
+RELEASE=$(node scripts/branches.mjs --print release)           # main
+```
+
+`docs/RELEASING.md` §2 is the runbook this skill executes; §3.1a explains the
+gate's four assertions. When the two disagree, the runbook wins and this file
+is stale — say so rather than following it.
+
+---
+
+## 0. Preconditions — three, and two of them have failed in practice
+
+Check all three BEFORE touching a version number. Each is one command.
+
+**A. The release branch must be an ANCESTOR of the integration branch.**
+
+```bash
+git fetch origin --quiet
+git merge-base --is-ancestor "origin/$RELEASE" "origin/$INTEGRATION" \
+  && echo "OK — ancestry holds" || echo "STOP — diverged"
+```
+
+If it prints STOP, **no tag you cut can pass the gate**: assertion C wants the
+release branch to be an ancestor of the tagged commit and assertion D wants that
+commit reachable from the integration branch, and nothing satisfies both across
+a divergence. This is not theoretical — it happened **twice in one day** on
+2026-09-06 (repaired by #681 and #684), both times because a pull request landed
+on the release branch after the cutover.
+
+The repair is a back-merge, and the merge method is load-bearing:
+
+```bash
+gh pr create --base "$INTEGRATION" --head "$RELEASE" --title "reconcile: restore release ancestry"
+# merge it with a MERGE COMMIT, never --squash
+```
+
+**A squash defeats the entire purpose** — it creates a new SHA, so the release
+branch is still not an ancestor. Land the reconcile, re-run the check, then
+continue.
+
+**B. Nothing unreleased is stranded.** `git log --oneline "$RELEASE".."$INTEGRATION"`
+should be exactly what you intend to ship. Read it; the CHANGELOG section you
+are about to write has to be true, and no check verifies that.
+
+**C. The previous tag is declared.** `DEFAULT_TAGS` in
+`scripts/migrate-from-existing.mjs` must already contain every cut tag. If the
+newest cut tag is missing, fix that first — see step 1 for why.
+
+---
+
+## 1. Declare the tag BEFORE cutting it
+
+Add the new tag to `DEFAULT_TAGS` in `scripts/migrate-from-existing.mjs` and land
+that pull request into the **integration** branch.
+
+**Why this order and not the obvious one:** the migration lane runs in `ci.yml`
+on `pull_request`. Cutting a tag that `DEFAULT_TAGS` does not declare throws
+`DEFAULT_TAGS is stale` **on every open pull request in the repo** — not just
+yours. The lane deliberately *skips* a declared-but-uncut tag with a notice, and
+that pending slot is exactly the affordance that makes declare-then-cut safe.
+
+Same pull request, two more things:
+
+- **Bump the version at all THREE sites** — `package.json` `.version`,
+  `package-lock.json` `.version`, and `package-lock.json` `.packages[""].version`.
+  Bumping only the first is a mistake this repo has already made: the version sat
+  at `0.10.0` for 23 days and two releases' worth of work.
+  `test/guards/release-version-agreement.test.ts` fails the build if the three
+  disagree, or if the newest declared tag is not `v${package.json.version}`.
+- **Move `CHANGELOG.md`'s `[Unreleased]` into `## [X.Y.Z] — YYYY-MM-DD`** and
+  leave an empty `[Unreleased]` above it. A check reads the heading; it verifies
+  *presence*, not truth. Anything merged before you cut ships whether or not it
+  is listed.
+
+---
+
+## 2. Tag the commit on the integration branch
+
+```bash
+git tag -a "v<X.Y.Z>" -m "v<X.Y.Z>" "origin/$INTEGRATION"
+git push origin "v<X.Y.Z>"
+```
+
+**Annotated (`-a`), and exactly `vX.Y.Z`** — no pre-release suffix, no build
+metadata, no leading zeros. Assertion A rejects anything else.
+
+Pushing the tag runs `.github/workflows/release-candidate.yml`. `ci.yml` fires on
+branches only, so **the tag push runs the gate and nothing else**.
+
+---
+
+## 3. WAIT for `Release candidate gate` — and know that nothing enforces the wait
+
+```bash
+gh run list --repo <owner>/<repo> --workflow=release-candidate.yml --limit 1 \
+  --json status,conclusion,headSha
+```
+
+Four assertions: **A** the tag is annotated and exactly `vX.Y.Z` · **B** the
+tagged tree's `package.json` matches the tag · **C** the release branch is an
+ancestor of the tagged commit · **D** the commit is reachable from the
+integration branch. A+B+C alone certify *"some descendant of the release
+branch"*; **D** is what makes it the right commit.
+
+⚠️ **THE WAIT IS HUMAN DISCIPLINE.** Measured 2026-09-06: `Release candidate
+gate` is **not** a required context on the release branch, `enforce_admins` is
+false, and there is no bypass allowance. So a non-admin's fast-forward is refused
+by "require a pull request" whatever the contexts say, and **an admin's push
+bypasses everything — including a pending or red gate.** Do not read a green
+branch-protection UI as having checked this for you. (RELPTR-8 tracks closing it.)
+
+**Do not fast-forward past a red assertion.** A red A/B/C means the tag itself is
+wrong — delete it, fix, re-tag. A red D after a green precondition A means
+something changed underneath you; re-check ancestry.
+
+---
+
+## 4. Fast-forward the release branch — the step that makes it a release
+
+```bash
+git push origin "v<X.Y.Z>^{commit}:$(node scripts/branches.mjs --print release)"
+```
+
+**Everything before this produces a tag; nothing before it moves what installers
+deploy.** This step was missing from the runbook entirely until a review caught
+that following §2 as written would leave installers on the pre-cutover release
+branch indefinitely, with every check green.
+
+- `^{commit}` peels the annotated tag to the commit — pushing the tag object
+  itself would not advance a branch.
+- The destination resolves the ROLE. Hardcoding `main` here is the thing the
+  branch-roles module exists to prevent.
+- It is a **fast-forward, not a merge**. The release branch never gains a commit
+  that was not reviewed on the integration branch. If git refuses it as
+  non-fast-forward, ancestry broke — go back to precondition A.
+
+This push triggers the release deploy: Railway builds the release branch and runs
+`npm run pg:schema` as its `preDeployCommand`, **from the deployed artifact's
+tree**.
+
+⛔ **Never run `npm run pg:schema` against prod by hand.** It loads from *your*
+checkout (`loadSchema({ cwd = process.cwd() })`), and post-cutover your checkout
+is routinely AHEAD of the tag — so a manual run applies unreleased migrations to
+production. Verify the deploy's preDeploy step instead.
+
+---
+
+## 5. Publish, then watch the thing that actually tests the release
+
+Publish the GitHub Release from the tag with the CHANGELOG section as its body.
+
+Then **watch the migration lane on the next pull request or branch push.** It
+exercises the previous-tag → new-tag upgrade against a real database, and it is
+the only evidence an existing install can upgrade. Read its output rather than
+assuming: on 2026-09-06 a staging refresh proved a v0.10-era database **could
+not** reach current in one deploy — the PRET-6 migration refused, correctly, and
+needed an intermediate step.
+
+---
+
+## 6. Close the loop
+
+Set the release row's `Status` to `done` in `3-log/tasks.md`, `aios push`
+(dry-run first), and **read the status back** — a push that reported `ok` is not
+proof the row moved. Merge automation does not close workspace-pushed rows; they
+resolve `linked`, not `applied`.
+
+---
+
+## What this skill refuses to do
+
+- **Merge anything into the release branch.** It only ever fast-forwards.
+- **Run `pg:schema` against production**, for the reason in step 4.
+- **Touch Railway** beyond read-only verification — no `up`, `redeploy`, `down`,
+  `delete`.
+- **Cut the tag before the declare-and-bump pull request has landed.**
+- **Fast-forward past a red or pending gate**, even though nothing stops it.
+
+## Failure modes this sequence exists to catch
+
+| Failure | Caught by |
+|---|---|
+| Release branch diverged; no candidate can pass | precondition A |
+| A back-merge squashed, so ancestry is still broken | precondition A's explicit merge-method note |
+| `DEFAULT_TAGS is stale` on every open PR | step 1's declare-then-cut order |
+| Version bumped at one site of three | step 1 + `release-version-agreement` guard |
+| A tag that is never actually released | step 4 existing at all |
+| Unreleased migrations applied to prod by hand | step 4's ⛔ |
+| A release nobody proved is installable | step 5's migration lane |

--- a/RESOLVER.md
+++ b/RESOLVER.md
@@ -37,6 +37,7 @@ gates (AIOS hub, Tessera root) apply in addition.
 | Building a feature slice end-to-end ("build the next phase/slice", dual adversarial reviews) | `.claude/skills/adversarial-build/SKILL.md` — its steps 2–5 satisfy the Review gate; don't stack the attestation protocol on top |
 | About to push a PR branch / "did this get reviewed" / attest a PR | `.claude/skills/pr-review-attestation/SKILL.md` |
 | Just merged to main / "did the deploy go out" / check Railway | `.claude/skills/railway-deploy-verify/SKILL.md` |
+| Cut/ship a release, tag a version, promote staging → main | `.claude/skills/cut-release/SKILL.md` — a pushed `v*` tag is PERMANENT (no bypass), so its local pre-push check is the last cheap moment |
 | PM projection questions (brain→Linear) | `lib/pm-sync/` — the brain's tasks table is canonical, projection is one-way; reconcile reads live status surface-only |
 
 ## Agent Roles

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -167,8 +167,13 @@ in advance:
 > switch is thrown, not discovered during the first incident.
 
 **Operational note:** the tag push and the fast-forward are two acts, and the check needs time. Push
-the tag, wait for `Release candidate gate` to go green on that commit, *then* fast-forward `main`. A
-fast-forward attempted while the context is still pending is rejected.
+the tag, wait for `Release candidate gate` to go green on that commit, *then* fast-forward `main`.
+
+⚠️ **This paragraph used to end "a fast-forward attempted while the context is still pending is
+rejected", and that is FALSE for both actors** — §2 step 5 carries the measurement. The gate is not a
+required context on `main`, `enforce_admins` is false, and there is no bypass allowance: a non-admin
+is refused by "require a pull request" regardless of contexts, and an admin bypasses everything
+including a pending or red gate. The wait is discipline until RELPTR-8 lands.
 
 ### 3.1b When a ticket closes, and what this repo's automation actually does
 
@@ -300,7 +305,11 @@ order:
   - fast-forward-staging: before any candidate tag is pushed
   - work-sync-and-scan-widened: DONE (RELPTR-4), before contributions move
   - dependabot-target-branch: at the cutover, never before (it would aim at a stale branch)
-  - tag-ruleset-ENFORCEMENT-active: creating the ruleset is not enabling it   # shipped `disabled`
+  - tag-ruleset-ENFORCEMENT-active: DONE 2026-09-06   # shipped `disabled`; creating is not enabling
+  # CONSEQUENCE, now live: ruleset 22363258 over refs/tags/v* denies deletion, update and
+  # non-fast-forward with ZERO bypass actors — so a pushed `v*` tag is PERMANENT for everyone,
+  # admins included. A tag that reddens the gate burns that version number; fix forward to the next
+  # patch. `.claude/skills/cut-release` verifies B/C/D LOCALLY before the push for this reason.
 ```
 
 The `workflow-on-main` pair is this repository's own scar tissue: `docs/CI-ARCHITECTURE.md` records that switching on


### PR DESCRIPTION
## What

Adds **`/cut-release`** — the skill that walks a release from the integration branch to the release branch — plus three corrections to documents it depends on.

`docs/RELEASING.md` §2 describes the ritual but nothing walks it, and two of its steps are ones this repo has already got wrong:

- **§2 had no fast-forward step at all** until `RELPTR-7`'s review found it. Following the runbook as written produced a tag and left installers on the old release branch indefinitely, every check green.
- **The release branch diverged from the integration branch twice on 2026-09-06.** Either divergence makes *every* release candidate fail — assertion C wants the release branch to be an ancestor of the tagged commit and D wants it reachable from integration, and nothing satisfies both. So the skill leads with the ancestry precondition rather than the version bump.

## Also fixed here

- `docs/RELEASING.md` §3.1a still said a pending-gate fast-forward "is rejected" — **false for both actors**, and §2 step 5 had already measured and corrected it. The two sections contradicted each other.
- §3.2 still described the tag ruleset as shipped-`disabled`. It is `active` as of 2026-09-06, and the entry now records the consequence that makes it load-bearing (below).
- `RESOLVER.md` gained the routing row; `CLAUDE.md` says skill routing lives there.

## The finding that reshaped the skill

Fable reviewed the first draft and returned **BLOCKED** on three HIGHs that chain into one expensive outcome:

> tag a stale ref → the tagged tree's `package.json` still reads the old version → assertion **B** reddens → **and the tag cannot be deleted.**

Verified live: ruleset `22363258` over `refs/tags/v*` denies `deletion`, `update` and `non_fast_forward` with **zero bypass actors**. So a pushed `v*` tag is permanent for everyone, admins included — and the first draft's recovery instruction, *"delete it, fix, re-tag"*, is impossible against protection **this same session activated a few hours earlier**.

The draft also walked straight into the trigger: it fetched once in precondition A, then tagged `origin/<integration>` *after* landing the version-bump PR — i.e. the stale ref. That is precisely how you burn a version number.

**Fold:** a new step 2 verifies B/C/D **locally** before the irreversible push, after a re-fetch. Executed against the live repo just now — `version-in-tree=v0.12.0`, which is exactly the mismatch that would have caught a `v0.13.0` tag today.

Two more real defects in the draft:

- **Precondition B compared LOCAL refs** while everything else used `origin/`. In this worktree that is **221 commits vs 6** — not wrong-ish, unrelated.
- **`scripts/branches.mjs` was resolved relatively.** From a nested cwd node exits 1 with empty stdout, so precondition A printed `STOP — diverged` for a healthy repo. Now uses the `$root` form the instruction corpus pins; executed from `lib/access` to confirm.

Folded from the same review: "never squash" was half the rule (rebase mints new SHAs too); the reconcile PR needs an attestation body or it cannot merge into a branch requiring `PR records a diff review`; a **false history claim** (#684 is OPEN, and #681 was the *pre*-cutover reconcile, not a post-cutover mistake); deploy verification routed to `railway-deploy-verify`; `gh run list` matched on `headSha` rather than `--limit 1`; and step 6 gained the publish command, since Releases stop at `v0.10.0` while `v0.11.0` and `v0.12.0` exist as tags only.

## Verification

Instruction-corpus file, so the checks that matter are the corpus guards and the commands themselves.

| check | result |
|---|---|
| `npx tsc --noEmit` · `check:docs` · `check:instructions` · `check:skills` | green |
| `instruction-base` + `releasing-runbook` guards | 91 passed |
| full unit tier | 379 files passed; **1 known flake** — `nda-gate.test.ts > ranges over 100 commits`, which passes **21/21 in isolation** and has failed on unrelated PRs today |

**Every command in the skill was executed against the live repo**, not just read: role resolution (incl. from a nested cwd), precondition A (correctly reports `STOP` while #684 is unmerged), precondition B, and step 2's version extraction.

Canonical-only, matching `/adversarial-build` — publication to the runtime mirrors is opt-in and this is a Claude-operated runbook.

## Review — Reviewed by Fable 5.1 — verdict BLOCKED on three chained HIGHs (an irreversible tag whose stated recovery was impossible, a stale-ref tag path, and local-vs-origin refs); all folded, and each fold executed against the live repo rather than reasoned about.

Note what the review round was worth here: an instruction file's commands get pasted verbatim, so a wrong argument order or a missing fetch is not a style issue — it is the failure. The reviewer confirmed `merge-base --is-ancestor` argument order, the `^{commit}` peel, and that the fast-forward refspec carries no `+`/`--force`, in a scratch repo.

## Deliberately not here

- **RELPTR-8** (`AIO-1124`) — making `Release candidate gate` a required context and scoping a bypass allowance to the release actor. Until that lands, the skill's step 4 wait is discipline nothing enforces, which the skill says plainly rather than implying away.
- Publishing the skill to `.agents/`/`.opencode/`/`.cursor`.

AIOS-Work: RELPTR-8
