### PR TITLE
feat(staging): say so — an unmistakable banner on every staging page (STGENV-1)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Instrument_Serif, Instrument_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
+import { StagingBanner } from "@/components/layout/staging-banner";
 
 const instrumentSerif = Instrument_Serif({
   variable: "--font-instrument-serif",
@@ -38,6 +39,9 @@ export default function RootLayout({
       className={`${instrumentSerif.variable} ${instrumentSans.variable} ${jetbrainsMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-surface-base">
+        {/* STGENV-1: outside <Providers> and above everything, so it cannot be hidden by a
+            page-level layout and renders even if a provider below it throws. */}
+        <StagingBanner />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,18 @@ const jetbrainsMono = JetBrains_Mono({
   weight: ["400", "500", "600"],
 });
 
+/**
+ * STGENV-1 — never prerender anything under this layout.
+ *
+ * MEASURED: with this absent, `npm run build` bakes the staging banner's decision into the prerendered
+ * `/_not-found` route — built with `RAILWAY_ENVIRONMENT_NAME=staging` the 404 page carries the banner,
+ * built without it the page carries none, and neither answer changes at runtime. Every data-bearing
+ * page is dynamic by construction (cookies, DB, searchParams), so the prod-data hazard is not reached
+ * today — but "a banner on every page" is false for that one route, and the mechanism widens silently
+ * the day a page stops touching a request API.
+ */
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: { default: "Team Brain", template: "%s · Team Brain" },
   description: "Shared memory and coordination for AIOS teams.",
@@ -39,8 +51,9 @@ export default function RootLayout({
       className={`${instrumentSerif.variable} ${instrumentSans.variable} ${jetbrainsMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-surface-base">
-        {/* STGENV-1: outside <Providers> and above everything, so it cannot be hidden by a
-            page-level layout and renders even if a provider below it throws. */}
+        {/* STGENV-1: above and outside the providers so no page-level layout can cover it, and so it
+            survives a PAGE crash (app/t/[team]/error.tsx keeps this layout). It does NOT survive a
+            provider throw — global-error.tsx replaces the whole document, banner included. */}
         <StagingBanner />
         <Providers>{children}</Providers>
       </body>

--- a/app/t/[team]/layout.tsx
+++ b/app/t/[team]/layout.tsx
@@ -50,7 +50,13 @@ export default async function TeamLayout({
 
   return (
     <div className="flex min-h-dvh flex-1 bg-surface-raised">
-      <aside className="frosted sticky top-0 flex h-dvh w-60 shrink-0 flex-col border-r border-border-subtle px-4 py-6">
+      {/* `data-staging-offset`: on staging the banner publishes `--staging-banner-h` and this shifts
+          down by exactly that, so the sidebar's footer stays on screen. Off staging the var is unset
+          and the fallback `0px` keeps today's behaviour byte-for-byte. */}
+      <aside
+        data-staging-offset
+        className="frosted sticky top-[var(--staging-banner-h,0px)] flex h-[calc(100dvh-var(--staging-banner-h,0px))] w-60 shrink-0 flex-col border-r border-border-subtle px-4 py-6"
+      >
         {/* No AIOS lockup here on purpose. This is the team's workspace, so the team name is
             the subject and AIOS is the tool it runs on — the mark lives in the favicon, the way
             Slack keeps its own logo out of a workspace sidebar. If this sidebar ever gains a

--- a/components/layout/staging-banner.tsx
+++ b/components/layout/staging-banner.tsx
@@ -1,0 +1,32 @@
+import { isStagingDeployment } from "@/lib/env/deployment";
+
+/**
+ * STGENV-1 — the "this is not production" band.
+ *
+ * WHY IT SAYS WHAT IT SAYS. Staging runs a COPY of production's data (`scripts/staging-refresh.sh`),
+ * so every name, meeting and decision on screen is real. That is the whole hazard: the thing that makes
+ * staging useful is exactly what makes it easy to mistake for production. So the banner names the
+ * environment AND the reason it looks convincing, rather than a bare "staging" chip that reads as
+ * decoration after a day.
+ *
+ * Server component: `isStagingDeployment` reads a server-only variable and this never ships to the
+ * client bundle. Renders nothing at all off staging — see the module header for why that asymmetry is
+ * the right way round.
+ */
+export function StagingBanner() {
+  if (!isStagingDeployment()) return null;
+  return (
+    <div
+      role="status"
+      aria-label="Staging environment"
+      data-testid="staging-banner"
+      className="sticky top-0 z-50 flex items-center justify-center gap-2 border-b border-amber-500/40 bg-amber-500/15 px-4 py-1.5 text-center text-xs font-medium text-amber-900 dark:text-amber-200"
+    >
+      <span aria-hidden="true">⚠️</span>
+      <span>
+        <strong className="font-semibold">STAGING</strong> — a copy of production data. Changes here do
+        not reach production, and production is never written from here.
+      </span>
+    </div>
+  );
+}

--- a/components/layout/staging-banner.tsx
+++ b/components/layout/staging-banner.tsx
@@ -9,6 +9,13 @@ import { isStagingDeployment } from "@/lib/env/deployment";
  * environment AND the reason it looks convincing, rather than a bare "staging" chip that reads as
  * decoration after a day.
  *
+ * WHAT IT DELIBERATELY DOES NOT CLAIM. An earlier draft added "production is never written from here".
+ * That is a property of `DATABASE_URL`, and this key knows only the ENVIRONMENT NAME. Point staging's
+ * `DATABASE_URL` at production — the exact careless `railway variables --set` this design cites — and
+ * the banner would have been affirming a safety property above every write that reached production.
+ * The repo's real discriminator for that is the `staging_marker` table; cross-checking it is follow-on
+ * work (STGENV-3/4), and until then this claims only what it can prove.
+ *
  * Server component: `isStagingDeployment` reads a server-only variable and this never ships to the
  * client bundle. Renders nothing at all off staging — see the module header for why that asymmetry is
  * the right way round.
@@ -20,12 +27,17 @@ export function StagingBanner() {
       role="status"
       aria-label="Staging environment"
       data-testid="staging-banner"
-      className="sticky top-0 z-50 flex items-center justify-center gap-2 border-b border-amber-500/40 bg-amber-500/15 px-4 py-1.5 text-center text-xs font-medium text-amber-900 dark:text-amber-200"
+      // `--staging-banner-h` lets sticky descendants offset by exactly this band. Without it the
+      // team sidebar (`app/t/[team]/layout.tsx`, `sticky top-0 h-dvh`) sits UNDER the banner at
+      // z-50: its "Sign out" footer falls below the fold on every staging page, and once scrolled
+      // the banner covers the sidebar header instead. Fable measured that.
+      style={{ ["--staging-banner-h" as string]: "2rem" }}
+      className="sticky top-0 z-50 flex h-8 items-center justify-center gap-2 border-b border-amber-500/40 bg-amber-500/15 px-4 text-center text-xs font-medium text-amber-900 dark:text-amber-200 [&~*_[data-staging-offset]]:top-[var(--staging-banner-h)]"
     >
       <span aria-hidden="true">⚠️</span>
       <span>
-        <strong className="font-semibold">STAGING</strong> — a copy of production data. Changes here do
-        not reach production, and production is never written from here.
+        <strong className="font-semibold">STAGING</strong> — this environment serves a copy of
+        production data.
       </span>
     </div>
   );

--- a/lib/env/deployment.ts
+++ b/lib/env/deployment.ts
@@ -2,11 +2,15 @@
  * STGENV-1 — which deployment am I? Server-side only.
  *
  * WHY A PLATFORM VARIABLE AND NOT ONE OF OURS. Railway injects `RAILWAY_ENVIRONMENT_NAME` into every
- * deploy, and application code cannot forge it — it is the same trust basis `scripts/service-guard.mjs`
- * already relies on for `RAILWAY_PROJECT_ID` / `RAILWAY_SERVICE_NAME` when it refuses a schema load on
- * a service that is not AIOS's. A banner keyed on a variable we set ourselves would be one careless
- * `railway variables --set` away from lying in the direction that matters (production silently claiming
- * to be staging, or worse, staging claiming to be production).
+ * deploy, so application code cannot forge it. A banner keyed on a variable we set ourselves would be
+ * one careless `railway variables --set` away from lying in the direction that matters.
+ *
+ * BUT IT IS A WEAKER GUARANTEE THAN `service-guard.mjs`'s, and an earlier draft of this comment
+ * overstated it by calling them "the same trust basis". That module's argument for `RAILWAY_PROJECT_ID`
+ * is that the id is IMMUTABLE and cannot be forgotten into absence. An environment NAME is
+ * operator-chosen and renameable — the opposite property. What the two genuinely share is only
+ * "platform-injected, not settable by the app". Rename the environment and this silently stops
+ * matching, which is why the guard tests pin the exact name rather than a pattern.
  *
  * WHY NOT `NEXT_PUBLIC_*`. The only consumer is a SERVER component (`app/layout.tsx`), so the value
  * never needs to reach the client bundle. Exposing it would add a second, client-side copy that can

--- a/lib/env/deployment.ts
+++ b/lib/env/deployment.ts
@@ -1,0 +1,40 @@
+/**
+ * STGENV-1 — which deployment am I? Server-side only.
+ *
+ * WHY A PLATFORM VARIABLE AND NOT ONE OF OURS. Railway injects `RAILWAY_ENVIRONMENT_NAME` into every
+ * deploy, and application code cannot forge it — it is the same trust basis `scripts/service-guard.mjs`
+ * already relies on for `RAILWAY_PROJECT_ID` / `RAILWAY_SERVICE_NAME` when it refuses a schema load on
+ * a service that is not AIOS's. A banner keyed on a variable we set ourselves would be one careless
+ * `railway variables --set` away from lying in the direction that matters (production silently claiming
+ * to be staging, or worse, staging claiming to be production).
+ *
+ * WHY NOT `NEXT_PUBLIC_*`. The only consumer is a SERVER component (`app/layout.tsx`), so the value
+ * never needs to reach the client bundle. Exposing it would add a second, client-side copy that can
+ * drift from the server's answer, for no benefit.
+ *
+ * THE DEFAULT IS "NOT STAGING", DELIBERATELY. Off Railway — local dev, `npm test`, CI — the variable is
+ * unset, and an unset variable must not paint a staging banner across every developer's screen. But note
+ * the asymmetry this creates and why it is the right way round: a staging deploy that somehow loses the
+ * variable shows NO banner, which is a real failure mode (see `isStagingDeployment`'s guard test). It is
+ * still preferable to the inverse, because a banner that cries wolf on localhost is a banner people
+ * learn to ignore — and then it is worth nothing on the day it matters.
+ */
+
+/** The platform's name for this deployment's environment, or null off-platform. */
+export function deploymentEnvironment(env: NodeJS.ProcessEnv = process.env): string | null {
+  const raw = env.RAILWAY_ENVIRONMENT_NAME ?? env.RAILWAY_ENVIRONMENT ?? null;
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Is this the staging deployment?
+ *
+ * Compared case-insensitively against the exact name, not a prefix or a substring: `staging` matches,
+ * `Staging` matches, and `staging-2`/`prestaging` do NOT. A substring test would make a future
+ * environment called `staging-experiments` inherit the banner silently, and — the direction that
+ * actually bites — nothing named like production could ever be mistaken for it either way round.
+ */
+export function isStagingDeployment(env: NodeJS.ProcessEnv = process.env): boolean {
+  return deploymentEnvironment(env)?.toLowerCase() === "staging";
+}

--- a/test/guards/staging-banner.test.ts
+++ b/test/guards/staging-banner.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { deploymentEnvironment, isStagingDeployment } from "../../lib/env/deployment";
+import { StagingBanner } from "../../components/layout/staging-banner";
 
 /**
  * STGENV-1 — the staging banner, pinned in BOTH directions.
@@ -50,6 +53,35 @@ describe("staging banner — the environment decision (STGENV-1)", () => {
   });
 });
 
+describe("staging banner — what it RENDERS (STGENV-1)", () => {
+  /**
+   * THE ASSERTION THIS FILE WAS MISSING, and the reason it matters more than all the source-text
+   * pinning below. Fable ran the obvious mutation — inverting `if (!isStagingDeployment())` to
+   * `if (isStagingDeployment())` — and ALL TEN of the original guards stayed green. That mutant paints
+   * "STAGING — a copy of production data" across PRODUCTION and shows nothing on staging, with the
+   * suite passing. Source-text guards cannot see it; only rendering can.
+   */
+  afterEach(() => vi.unstubAllEnvs());
+  const markup = () => renderToStaticMarkup(createElement(StagingBanner));
+
+  it("RENDERS the banner on staging", () => {
+    vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "staging");
+    const html = markup();
+    expect(html).toContain('data-testid="staging-banner"');
+    expect(html).toMatch(/copy of production data/i);
+  });
+
+  it("renders NOTHING on production", () => {
+    vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "production");
+    expect(markup()).toBe("");
+  });
+
+  it("renders NOTHING off-platform", () => {
+    vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "");
+    expect(markup()).toBe("");
+  });
+});
+
 describe("staging banner — it is actually WIRED (STGENV-1)", () => {
   it("is mounted in the ROOT layout, so no page can be reached without it", () => {
     // Pinning the call site, not just the component: a banner nothing renders is decoration, and this
@@ -75,7 +107,10 @@ describe("staging banner — it is actually WIRED (STGENV-1)", () => {
 
   it("is a SERVER component — the env read must not reach the client bundle", () => {
     const src = read("components/layout/staging-banner.tsx");
-    expect(src, 'a "use client" directive would ship the env read to the browser').not.toMatch(/["']use client["']/);
+    // NOT because the value would be inlined into the bundle — non-`NEXT_PUBLIC_` vars never are.
+    // The real failure is a HYDRATION MISMATCH: the server paints the banner, the client computes
+    // `null` from an env it cannot see, and the banner VANISHES after hydration on staging.
+    expect(src, 'a "use client" directive would make the banner disappear on hydration').not.toMatch(/["']use client["']/);
     expect(src).toMatch(/isStagingDeployment\(\)/);
   });
 
@@ -84,13 +119,51 @@ describe("staging banner — it is actually WIRED (STGENV-1)", () => {
     // a copy of production — so the text has to say that, or the banner does not do its job.
     const src = read("components/layout/staging-banner.tsx");
     expect(src).toMatch(/STAGING/);
-    expect(src).toMatch(/copy of production data/i);
+    expect(src).toMatch(/copy of\s+\n?\s*\*?\s*production data/i);
   });
 
-  it("does not read the env anywhere else, so there is ONE owner of the answer", () => {
-    // A second reader is a second answer that can drift. `lib/env/deployment.ts` is the only place
-    // allowed to consult the platform variable.
-    const banner = read("components/layout/staging-banner.tsx");
-    expect(banner, "the component must ask the module, not process.env").not.toMatch(/process\.env/);
+  it("does NOT claim a database property it cannot prove", () => {
+    // The key knows the ENVIRONMENT NAME. "production is never written from here" is a claim about
+    // DATABASE_URL — and if staging's URL were ever pointed at prod, the banner would have been
+    // asserting safety above every write that reached production.
+    const src = read("components/layout/staging-banner.tsx");
+    const rendered = src.slice(src.indexOf("<div"));
+    expect(rendered, "must not assert a write-safety property").not.toMatch(/never written from here/);
+  });
+
+  it("offsets sticky descendants so it cannot cover the team sidebar", () => {
+    expect(read("components/layout/staging-banner.tsx")).toMatch(/--staging-banner-h/);
+    const team = read("app/t/[team]/layout.tsx");
+    expect(team, "the sidebar must opt in").toMatch(/data-staging-offset/);
+    expect(team, "and fall back to 0px off staging").toMatch(/var\(--staging-banner-h,\s*0px\)/);
+  });
+
+  it("lib/env/deployment.ts is the ONLY reader of the platform variable in app code", () => {
+    // The first spelling checked one file while its name claimed the repo. Walk the app surface: a
+    // second reader is a second answer that can drift from the banner's.
+    const roots = ["app", "components", "lib"];
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const e of readdirSync(join(ROOT, dir), { withFileTypes: true })) {
+        const rel = `${dir}/${e.name}`;
+        if (e.isDirectory()) walk(rel);
+        else if (/\.(ts|tsx)$/.test(e.name) && rel !== "lib/env/deployment.ts") {
+          // Match a READ (`process.env.RAILWAY_ENVIRONMENT…`), not a mention. This is the SECOND
+          // needle in this file to match prose instead of code — the first found `<Providers>` inside
+          // a comment. Here a comment in `app/layout.tsx` explaining the variable tripped it.
+          if (/process\.env\.RAILWAY_ENVIRONMENT/.test(read(rel))) offenders.push(rel);
+        }
+      }
+    };
+    roots.forEach(walk);
+    expect(offenders, `only lib/env/deployment.ts may read it; also found: ${offenders.join(", ")}`).toEqual([]);
+  });
+
+  it("the root layout is never PRERENDERED, so the banner is decided per request", () => {
+    // MEASURED by Fable: built this branch twice. `_not-found.html` contained the banner when the env
+    // was set AT BUILD TIME and not when it wasn't — the decision was frozen at `npm run build` for
+    // that route. Every data-bearing page is dynamic by construction today, so the hazard is not
+    // reached, but it widens silently the day a page stops touching a request API.
+    expect(read("app/layout.tsx")).toMatch(/export const dynamic = "force-dynamic"/);
   });
 });

--- a/test/guards/staging-banner.test.ts
+++ b/test/guards/staging-banner.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { deploymentEnvironment, isStagingDeployment } from "../../lib/env/deployment";
+
+/**
+ * STGENV-1 — the staging banner, pinned in BOTH directions.
+ *
+ * WHY BOTH. A banner that never appears is the obvious failure, and it is the one people write a test
+ * for. The one they forget is a banner that appears EVERYWHERE — on localhost, in CI, and eventually on
+ * production — because that is not a louder warning, it is a warning nobody reads. The asymmetry
+ * assertions below exist so neither can regress silently, and the production case is asserted by NAME
+ * rather than by "not staging", so a future environment cannot inherit the banner by accident.
+ */
+
+const ROOT = join(__dirname, "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+describe("staging banner — the environment decision (STGENV-1)", () => {
+  it("is TRUE only for the staging environment", () => {
+    expect(isStagingDeployment({ RAILWAY_ENVIRONMENT_NAME: "staging" } as NodeJS.ProcessEnv)).toBe(true);
+    // Case-insensitive: the platform's casing is not something this should depend on.
+    expect(isStagingDeployment({ RAILWAY_ENVIRONMENT_NAME: "Staging" } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isStagingDeployment({ RAILWAY_ENVIRONMENT: "staging" } as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it("is FALSE on production — asserted by name, not merely as 'not staging'", () => {
+    expect(isStagingDeployment({ RAILWAY_ENVIRONMENT_NAME: "production" } as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("is FALSE off-platform, where the variable is unset or blank", () => {
+    // Local dev, `npm test`, CI. A banner across every developer's screen is a banner people learn to
+    // ignore, and then it is worth nothing on the day it matters.
+    expect(isStagingDeployment({} as NodeJS.ProcessEnv)).toBe(false);
+    expect(isStagingDeployment({ RAILWAY_ENVIRONMENT_NAME: "" } as NodeJS.ProcessEnv)).toBe(false);
+    expect(isStagingDeployment({ RAILWAY_ENVIRONMENT_NAME: "   " } as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("matches the environment EXACTLY — no prefix or substring inheritance", () => {
+    // `staging-experiments` must not silently inherit the banner, and nothing production-shaped may
+    // ever match. A `startsWith`/`includes` implementation passes the tests above and fails these.
+    for (const name of ["staging-2", "prestaging", "staging-experiments", "not-staging", "production-staging"]) {
+      expect(isStagingDeployment({ RAILWAY_ENVIRONMENT_NAME: name } as NodeJS.ProcessEnv), name).toBe(false);
+    }
+  });
+
+  it("reports the raw environment name, trimmed, for anything else that needs it", () => {
+    expect(deploymentEnvironment({ RAILWAY_ENVIRONMENT_NAME: " staging " } as NodeJS.ProcessEnv)).toBe("staging");
+    expect(deploymentEnvironment({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+});
+
+describe("staging banner — it is actually WIRED (STGENV-1)", () => {
+  it("is mounted in the ROOT layout, so no page can be reached without it", () => {
+    // Pinning the call site, not just the component: a banner nothing renders is decoration, and this
+    // repo has a recorded case of exporting a describe* function and never mounting it.
+    const layout = read("app/layout.tsx");
+    expect(layout).toMatch(/import \{ StagingBanner \}/);
+    expect(layout).toMatch(/<StagingBanner \/>/);
+  });
+
+  it("renders ABOVE and OUTSIDE the providers", () => {
+    // So it survives a provider below it throwing, and cannot be covered by a page-level layout.
+    const layout = read("app/layout.tsx");
+    // Match the ELEMENT, not the bare tag name: an earlier spelling searched for `<Providers>` and
+    // found it inside a comment that happened to mention it, which put the "banner is first"
+    // assertion the wrong way round and failed on correct code. A needle that can match prose is
+    // not a needle.
+    const banner = layout.indexOf("<StagingBanner />");
+    const providers = layout.indexOf("<Providers>{children}</Providers>");
+    expect(banner, "the banner element must be present").toBeGreaterThan(-1);
+    expect(providers, "the providers element must be present").toBeGreaterThan(-1);
+    expect(banner, "banner must render before the providers element").toBeLessThan(providers);
+  });
+
+  it("is a SERVER component — the env read must not reach the client bundle", () => {
+    const src = read("components/layout/staging-banner.tsx");
+    expect(src, 'a "use client" directive would ship the env read to the browser').not.toMatch(/["']use client["']/);
+    expect(src).toMatch(/isStagingDeployment\(\)/);
+  });
+
+  it("names the environment AND why it looks convincing", () => {
+    // A bare "staging" chip reads as decoration after a day. The hazard is that the data is REAL —
+    // a copy of production — so the text has to say that, or the banner does not do its job.
+    const src = read("components/layout/staging-banner.tsx");
+    expect(src).toMatch(/STAGING/);
+    expect(src).toMatch(/copy of production data/i);
+  });
+
+  it("does not read the env anywhere else, so there is ONE owner of the answer", () => {
+    // A second reader is a second answer that can drift. `lib/env/deployment.ts` is the only place
+    // allowed to consult the platform variable.
+    const banner = read("components/layout/staging-banner.tsx");
+    expect(banner, "the component must ask the module, not process.env").not.toMatch(/process\.env/);
+  });
+});


### PR DESCRIPTION
Staging serves a **copy of production data**, so every name, meeting and decision on screen is real. That is exactly what makes it easy to mistake for production. This puts an unmistakable band on every staging page.

Keyed on **`RAILWAY_ENVIRONMENT_NAME`** — platform-injected, app code can't forge it. Measured: the staging service really carries `staging`, production carries `production`. Server component in `RootLayout`, above and outside `Providers`, so no page-level layout can cover it. No `NEXT_PUBLIC`.

**Pinned in both directions.** The failure people forget is the banner that shows *everywhere* — on localhost and in CI — because that is a warning people learn to ignore. So: false on production **by name**, false off-platform, and exact-match so a future `staging-experiments` cannot inherit it silently.

## What the review found

Fable returned CLEAR-WITH-CONDITIONS, and three of its four findings were **measured, not reasoned**.

**HIGH — nothing pinned that the banner RENDERS.** It ran the obvious mutation — inverting the condition — and **all ten guards stayed green**. That mutant paints `STAGING` across **production** and shows nothing on staging, with the suite passing. Source-text guards cannot see it. There are now render assertions, and the same mutation reddens three of them.

**MEDIUM — build-time baking is real.** It built the branch twice: `_not-found.html` carried the banner when built with the env set and not when it wasn't, with neither answer changing at runtime. Every data-bearing page is dynamic by construction, so the prod-data hazard isn't reached today — but "a banner on every page" was false for that route, and it widens the day a page stops touching a request API. `export const dynamic = "force-dynamic"`, pinned by a guard.

**MEDIUM — the banner fought the team sidebar.** The aside is `sticky top-0 h-dvh`; the banner at `z-50` wins, so **"Sign out" fell below the fold on every staging page**, and once scrolled the banner covered the sidebar header instead. The banner now publishes `--staging-banner-h` and the sidebar offsets by it, with a `0px` fallback that leaves off-staging rendering byte-for-byte identical.

**MEDIUM — the text claimed a database property from an environment-name key.** *"production is never written from here"* is a fact about `DATABASE_URL`. Point staging's URL at prod — the exact careless `railway variables --set` this design cites — and the banner would have been asserting safety above every write reaching production. It now claims only what the key proves.

## Three claims of mine that were wrong, corrected in place

- A `"use client"` directive would **not** leak the value to the browser — non-`NEXT_PUBLIC_` vars are never inlined. The real failure is a **hydration mismatch** that makes the banner vanish on staging.
- The banner does **not** survive a provider throw — `global-error.tsx` replaces the whole document. What the placement buys is surviving a *page* crash.
- *"The same trust basis as `service-guard.mjs`"* overstated it. That module's argument is **immutability**; an environment name is operator-renameable. They share only "platform-injected".

## And two needles that matched prose

Both caught by running rather than reading: one searched for the bare tag `<Providers>` and found it inside a **comment**, inverting an ordering check so it failed on correct code; the other flagged `app/layout.tsx` as a second env reader because a comment there **mentions** the variable. A needle that can match prose is not a needle.

## Verification

tsc clean · lint 0 errors · unit **3859 passed** · docs in sync.

**Mutation:** the inverted-condition mutation — the one that survived all ten original guards — now REDDENS three render assertions.

## Not in this PR

`STGENV-2` (stop staging CI writing to the prod brain — a live leak), `STGENV-3` (bolt-to-bolt graph copy), `STGENV-4` (refresh cron + dispatch button). Deferred with a reason: cross-checking the `staging_marker` table so the banner could assert a *database* property belongs with the refresh work in STGENV-3/4.

**After deploy, one check settles the prerender question:** `curl -s https://aios-team-brain-staging.up.railway.app/definitely-not-a-route | grep -c staging-banner` must print `1`.

## Review

Reviewed by Fable code-reviewer — verdict CLEAR-WITH-CONDITIONS (1 HIGH, 4 MEDIUM, 5 LOW; all folded)

AIOS-Work: STGENV-1
