### PR TITLE
STAGINGMARK-4: a value on a boolean admin flag is refused, not coerced

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1435,7 +1435,9 @@ Removal is a fan-out, because an item's derivatives have three different lifetim
 | `graph_episodes` **+ the facts in Graphiti**                                                | Explicit, via `lib/graph.retireEpisodesForItems` — no FK, and the facts live outside Postgres. Deletes inline, then leaves a `pending_delete_group_id` **tombstone** so `reconcileProjectedEpisodes` retries a Graphiti blip and drops the row only once the group is verified empty |
 | `tasks.source_item_id`, `decisions.source_item_id`                                          | `set null` — deliberately kept: independently authored records that merely cite the item                                                       |
 
-**Operator entry point — `scripts/admin.ts purge-items --team <id|slug> --ids <uuid,…> --reason "<text>" [--confirm]`.**
+**Operator entry point — `scripts/admin.ts purge-items --team <id|slug> --ids <uuid,…> --reason "<text>" [--confirm | --dry-run]`.**
+Boolean flags take no value: pass `--confirm` bare to delete, or omit it to preview.
+Explicit values (including `--confirm false` and `--confirm=false`) are refused before database access.
 Until this existed the primitive had no caller outside `lib/ingest`, so removing rows from a deployed
 brain meant raw SQL — which skips every row of the table above, most damagingly `graph_episodes`
 (no FK to `items`, so the ledger orphans and the corresponding Graphiti/Neo4j nodes stay live with

--- a/docs/design/stagingmark4-confirm-arity.md
+++ b/docs/design/stagingmark4-confirm-arity.md
@@ -1,0 +1,188 @@
+# STAGINGMARK-4 — a value on a boolean admin flag is refused, not coerced
+
+Status: spec, **round 1 folded** (Fable CLEAR-WITH-CONDITIONS — 3 HIGH + 3 MEDIUM + 3 LOW, all
+re-derived and confirmed by measurement; one severity claim of mine corrected down). Written by
+`gpt-6-astra` (reasoning effort `low`); folded by the orchestrator. No code written.
+· Task: `STAGINGMARK-4` · Owner: chetan · Tier build-with: unit — this is argument parsing; there is
+no persistence or HTTP surface, and the writers it gates are unchanged.
+
+## Deps
+
+None to deploy. Baseline HEAD `1807f074`. STAGINGMARK-1's shipped `parseConfirmFlags` is the
+precedent this generalises, not a dependency.
+
+## Increment
+
+ONE PR: a shared strict-arity boundary that refuses a value on a boolean flag, adopted by **both**
+CLIs that carry the trap, with the registry proven complete by a build-failing guard. **This document
+is the design; the PR that follows implements it** — the files under Scope are what that PR touches.
+
+## Problem
+
+`scripts/admin.ts:34-51` is a tokenizer that, for `--x`, consumes the NEXT token as a STRING unless
+that token is absent or starts with `--`. So `--confirm false` yields the string `"false"`, and
+`purge-items` tests `if (!flags.confirm)` (`:540`) — a non-empty string is truthy, so **an operator
+who typed the opposite gets a confirmed, irreversible delete**.
+
+**Seven names in `scripts/admin.ts` are read by truthiness**, each carrying the same coercion:
+`help` (`:127`), `upsert` (`:163`), `hard` (`:231`), `force` (`:413`, `:426`, `:448`),
+`confirm` (`:486`, `:540`), `dry-run` (`:486`), and `confirm-production` (already strictly parsed by
+`lib/access/materialize-command.ts`).
+
+**And the tokenizer is duplicated.** `scripts/brain-tasks.ts:54-70` is a byte-identical copy — the
+spec's first draft called `parseArgs` "the sole tokenizer", which is true of `admin.ts` only. It
+reads `help` (`:135`), `clear-sprint` (`:180`), `dry-run` (`:265`, `:271`, `:279`) and
+`project-to-linear` (`:279`) by truthiness. `extract-meeting-todos --project-to-linear false`
+therefore performs an **outward-facing write to Linear**. That is why the registry below is a
+per-CLI parameter rather than a fixed list of seven.
+
+**Consequences are not uniform, and severity is not simply "destructive first."** `--confirm false`
+on `purge-items` and `--hard false` on `delete-member` (which selects removal over the soft-disable
+default) are the irreversible ones; `--project-to-linear false` writes outside the system;
+`--force false` defeats collision protection on identity linking. `--dry-run false` turns dry-run
+*on*, which fails safe. `--help false` is a correctness annoyance. An earlier draft of this spec
+implied a clean severity ordering from the flag reads alone; that was not supported and is withdrawn.
+
+**The `=` form is a different shape.** `--confirm=false` makes the whole token the KEY, so the flag
+goes unseen and the command silently dry-runs — fail-closed, but silently ignoring what was typed.
+
+**Repetition erases the malformed token.** Measured against the verbatim tokenizer:
+`--confirm false --confirm` → `{confirm: true}`. STAGINGMARK-1's `parseConfirmFlags` receives a
+collapsed map, so it **cannot** see the discarded `"false"` and accepts the run. Its AC8 tests maps,
+not raw argv. Scoped honestly (Fable, MEDIUM): this is a **strictness gap, not a live hole** — the
+reverse order `--confirm --confirm false` is refused (last wins), and the erasing spelling requires
+ending in a bare `--confirm`, which is the confirmed spelling anyway. The new boundary closes it by
+validating raw argv; `materialize-command.ts`'s logic is not rewritten.
+
+## Decision
+
+**D1 — one shared boundary, with the boolean registry as a PER-CLI PARAMETER.** Not a purge-only
+patch (leaves `--hard` and Linear exposed) and not a parser rewrite (option (c) would re-decide 12
+value-taking flags and the `flags.actor === true` refusals). Every command routes through it, so a
+destructive command cannot forget to opt in. `admin.ts` registers
+`{help, upsert, hard, force, confirm, dry-run, confirm-production}`; `brain-tasks.ts` registers
+`{help, clear-sprint, dry-run, project-to-linear}`. Covered by AC1, AC2, AC8.
+
+**D2 — validate RAW argv, before the collapse.** Extract the tokenizer unchanged into
+**`lib/admin/args.ts` (a NEW file, created by this PR)** and export `parseAdminArgs(argv, registry)`,
+which validates raw tokens and only then tokenizes. Returns a discriminated result; the error carries
+no parsed payload. Refuse a registered boolean followed by any token not starting with `--`
+(including `false`, `true`, `0`, `yes`, `""`, `-x`, and an ordinary positional), refuse
+`--<boolean>=...`, and never let a later bare occurrence erase an earlier malformed one. **Do not
+echo the offending value** — it may be an adjacent password. Covered by AC1-AC3.
+
+**D3 — an adjacent positional is an error, not confirmation.** `purge-items --confirm extra`
+refuses rather than treating `extra` as a positional and confirming. **Verified compatible**: every
+USAGE line and every doc invocation places positionals first and booleans last, and every
+undocumented boolean-then-positional spelling either already fails at usage today or IS the bug.
+Covered by AC4.
+
+**D4 — validate before help, before the `DATABASE_URL` check, before client construction.** `main`
+calls the boundary once and routes failure through `die` (exit 1). **This changes one shipped
+behaviour: `help --confirm false` exits 0 today and will exit 1** — help must not mask a malformed
+invocation. Downstream consumers keep their truthiness reads, because a registered name can now only
+be absent or literal `true`; that also keeps the existing text guard
+`test/guards/admin-cli-destructive-commands.test.ts:44-56` green. Covered by AC5, AC7.
+
+**D5 — an importable `main`, not a subprocess module loader.** The first draft proposed spawning the
+real CLI behind a custom loader with counting fakes. Measured: one spawn is **1.96 s**, and that
+matrix is 150+ spawns (5+ minutes) in a tier CI runs under `npm run coverage`, plus a side channel
+for cross-process counts. Instead, follow the in-repo precedent at `scripts/setup-wizard.mjs:298`:
+gate module-scope `main()` on an `argv[1]` entry check, export `main(argv)`, and make `die` throw a
+typed exit error converted to `process.exit` only at that guarded entry. AC7 then runs **in-process**
+under vitest with `vi.mock` (five existing tests already mock `@/` modules). ~6 real spawns remain,
+only for the claims that need a real process. The first draft cut this as "repository-wide main/exit
+cleanup"; that was a misnomer — it is `die` plus one bottom-of-file guard, and it is exactly what
+separates the light harness from the heavy one. Covered by AC6, AC7.
+
+## Scope
+
+**In:**
+- `lib/admin/args.ts` **(new)** — the extracted tokenizer plus `parseAdminArgs(argv, registry)`.
+- `scripts/admin.ts` — adopt the boundary; export `main(argv)`; argv entry guard; `die` throws;
+  USAGE gains the bare-only rule and lists `--dry-run`.
+- `scripts/brain-tasks.ts` — adopt the same boundary with its own registry.
+- `test/admin-args.test.ts` **(new)** — raw-argv matrix + the compatibility golden.
+- `test/admin-cli-arity.test.ts` **(new)** — in-process CLI assertions via `vi.mock`, plus the few
+  real spawns.
+- `test/guards/admin-flag-registry.test.ts` **(new)** — registry completeness, ∀ over both CLIs.
+- `lib/access/materialize-command.ts:58-59` and `test/access-materialize-command.test.ts:201-202` —
+  **comment text only.** Both currently say the trap "is live today on `purge-items`", which this PR
+  makes false. Editing a comment is not a change to a shipped defense.
+- `docs/ARCHITECTURE.md:1438` — the documented `purge-items` invocation gains the bare-only rule
+  (CLAUDE.md §1 requires the map updated in the same PR).
+
+**Cut, with reasons:**
+- **Value-flag validation** (types, requiredness, unknown keys, excess positionals, short options,
+  a `--` terminator): option (c)'s surface. Preserve today's behaviour exactly except adjacency to a
+  registered boolean. Not deferred to a ticket because nothing is broken there — the existing
+  `flags.actor === true` refusals already cover the one real case.
+- **Coercing `false` to OFF**: rejected deliberately. Omission is OFF; an explicit value is an error,
+  never a guessed instruction to proceed.
+- **`materialize-command.ts`'s LOGIC and its dm tests**: the boundary closes the repetition gap
+  upstream (AC3); rewriting the shipped defense would be churn. Comments only, as above.
+- **Purge/member/identity writers, schema, graph, caches**: no algorithm or persistence change.
+
+## Acceptance criteria
+
+Each criterion is parameterised over every registered name and both CLIs unless stated. Every fake
+records call COUNTS; a throwing fake alone is not proof of non-invocation.
+
+- **AC1 — a bare boolean yields literal `true`, and absence yields absent (unit):** for each
+  registered name, `parseAdminArgs` returns `flags[name] === true` for a bare flag at end or before
+  another `--flag`, and the key is ABSENT when omitted. No successful parse ever returns a string for
+  a registered name. *The inverse half: absence must not become `false`, which would change
+  truthiness reads.*
+- **AC2 — every value form is REFUSED (unit):** `ok === false` for each registered name against
+  `false`, `true`, `0`, `yes`, `""`, `-x`, an ordinary positional, and `--name=<v>` for each of those
+  values. The error names the flag and the fix, **does not contain the offending value** (asserted
+  with a sentinel like `hunter2`), and carries no parsed payload. Bare forms succeed with no
+  diagnostic.
+- **AC3 — a later bare occurrence cannot erase an earlier malformed one (unit):**
+  `["--confirm","false","--confirm"]` returns `ok === false`. Both orders, and the `=` form beside a
+  bare one, refuse. Two bare occurrences succeed. *Asserted on raw argv, because the collapsed map
+  provably cannot represent this: the verbatim tokenizer yields `{confirm: true}`.*
+- **AC4 — a boolean immediately followed by a positional refuses (unit):**
+  `purge-items --confirm extra` → `ok === false`; `delete-member user@example.com --hard` → succeeds
+  with the email as a positional and `hard === true`; a boolean before another `--flag` does not
+  swallow it or its value.
+- **AC5 — a malformed invocation fails on ARITY, not incidentally (unit, real spawn):** the process
+  exits 1 **and stderr matches `/takes no value/` and does NOT match `/DATABASE_URL/` nor
+  `/server-only/`**. *This wording is load-bearing and replaces a vacuous first draft: measured on
+  HEAD, `purge-items --confirm false` with `DATABASE_URL` unset ALREADY exits 1 printing
+  `✗ DATABASE_URL is required`, and with a dummy URL exits 1 on connection refusal — so "exit 1 with
+  zero writer calls" is green before any change and discriminates nothing. Run with `DATABASE_URL`
+  both unset and set to a dummy.* Also pinned: **`help --confirm false` exits 0 on HEAD and 1 after**
+  (the one deliberate behaviour change), and valid `help` still exits 0 and prints usage.
+- **AC6 — the extraction changes no value-flag behaviour (unit, compatibility pin):** a golden over
+  every current command and value name (`team`, `name`, `handle`, `role`, `tier`, `password`,
+  `base-url`, `ttl-min`, `actor`, `email`, `ids`, `reason`, `org`) comparing `cmd`, `positionals` and
+  `flags`. **Expected values are generated by replaying the HEAD tokenizer**, never hand-written from
+  the new one. *Labelled characterization on purpose — it pins a pure extraction, and is the one
+  place in this spec where that is legitimate.*
+- **AC7 — the real CLI consumes the validated result (unit, in-process with `vi.mock`):** with
+  counting fakes, a malformed invocation of each destructive path makes **zero** writer calls —
+  `purgeItemIds`, `deleteMember` with `hard`, and `brain-tasks`' Linear projection — while the
+  corresponding bare form makes exactly one with the expected arguments. Bare `--dry-run` and absent
+  `--confirm` both still preview. *Pin the call site, not the helper: **deleting the boundary call
+  from either CLI must redden this**, demonstrated by an executed mutation, not asserted in prose.*
+- **AC8 — the registry is provably complete (unit guard):** ∀ over `scripts/admin.ts` AND
+  `scripts/brain-tasks.ts` — every truthiness read (`Boolean(flags.x)`, `!flags.x`, `flags.x &&`,
+  bare `flags.x` in a condition) is IN that CLI's registry, every `as string` / `typeof === "string"`
+  read is NOT in it, a name in both classes fails, and `CONFIRM_KEYS` from
+  `lib/access/materialize-command.ts` is a subset of `admin.ts`'s registry (by import, not by
+  copying). *Negative control: adding one `flags.newflag &&` read must redden it. Without this a
+  future boolean flag silently reintroduces the trap, and this is the criterion the first draft was
+  missing entirely.*
+
+## What would falsify this
+
+- A successful parse returning a registered boolean as a string, or a malformed occurrence erased by
+  repetition (AC2, AC3).
+- A parser suite green while the CLI bypasses the boundary — AC7's mutation must redden.
+- The extraction changing any value-flag result (AC6): the narrow-blast-radius claim would be false.
+- A boolean consumer under an unregistered name (AC8): the enumeration is wrong and must expand
+  before building.
+- Evidence that a real caller depends on boolean-before-positional: D3 refuses that syntax
+  deliberately, and only concrete usage would justify revisiting it — and even then, never by
+  treating `false` as an ignorable positional.

--- a/docs/design/stagingmark4-confirm-arity.md
+++ b/docs/design/stagingmark4-confirm-arity.md
@@ -1,6 +1,6 @@
 # STAGINGMARK-4 — a value on a boolean admin flag is refused, not coerced
 
-Status: spec, **round 1 folded** (Fable CLEAR-WITH-CONDITIONS — 3 HIGH + 3 MEDIUM + 3 LOW, all
+Status: spec, **rounds 1 (design) and 2 (diff) folded** (Fable CLEAR-WITH-CONDITIONS — 3 HIGH + 3 MEDIUM + 3 LOW, all
 re-derived and confirmed by measurement; one severity claim of mine corrected down). Written by
 `gpt-6-astra` (reasoning effort `low`); folded by the orchestrator. No code written.
 · Task: `STAGINGMARK-4` · Owner: chetan · Tier build-with: unit — this is argument parsing; there is
@@ -169,9 +169,13 @@ records call COUNTS; a throwing fake alone is not proof of non-invocation.
 - **AC8 — the registry is provably complete (unit guard):** ∀ over `scripts/admin.ts` AND
   `scripts/brain-tasks.ts` — every truthiness read (`Boolean(flags.x)`, `!flags.x`, `flags.x &&`,
   bare `flags.x` in a condition) is IN that CLI's registry, every `as string` / `typeof === "string"`
-  read is NOT in it, a name in both classes fails, and `CONFIRM_KEYS` from
-  `lib/access/materialize-command.ts` is a subset of `admin.ts`'s registry (by import, not by
-  copying). *Negative control: adding one `flags.newflag &&` read must redden it. Without this a
+  read is NOT in it, **any `flags.<name>` read that lands in NEITHER class fails as
+  `unclassified read: <name>`**, a name in both classes fails, and `CONFIRM_KEYS` from
+  `lib/access/materialize-command.ts` is a subset of `admin.ts`'s registry (read from the
+  DECLARATION via the AST — not an import and not a copied literal, so it cannot drift). *Negative controls, both required: one `flags.newflag &&` read, AND each unclassified spelling
+  that defeated the existential form — `flags.wipe !== undefined`, `const w = flags.wipe; if (w)`,
+  `flags.wipe ?? false`, `flags.wipe || false`. Without the unclassified clause the guard is
+  EXISTENTIAL: it proves things about the spellings it recognises and is silent on the rest. Without this a
   future boolean flag silently reintroduces the trap, and this is the criterion the first draft was
   missing entirely.*
 

--- a/docs/design/stagingmark4-confirm-arity.md
+++ b/docs/design/stagingmark4-confirm-arity.md
@@ -183,7 +183,17 @@ records call COUNTS; a throwing fake alone is not proof of non-invocation.
   reads; a value-classified flag truthiness-gated in an unrecognised spelling still passes. Pinned
   as an `it.fails` gap rather than claimed closed — per-occurrence strictness would require 37
   unrelated read rewrites across both CLIs (measured by the diff review: 17 of 46 in `admin.ts`,
-  20 of 57 in `brain-tasks.ts`). Without this a
+  20 of 57 in `brain-tasks.ts`).
+  **Second recorded residual — the whole-object family, deliberately NOT closed.** A flag reached
+  through an alias (`const f = flags; f.wipe`), a whole-map hand-off (`go(flags)`), an
+  assignment-pattern destructure (`({ wipe } = flags)`) or a computed index (`flags[k]`) is outside
+  a syntactic classifier by construction. Closing it needs a call-site allowlist, and both CLIs
+  legitimately pass the map whole today — `scripts/admin.ts` to `parseConfirmFlags` and
+  `scripts/brain-tasks.ts` to `readBody` — so an allowlist would be the guard's third registry to
+  drift. The one cross-file hand-off that carries a boolean is pinned instead by the
+  `CONFIRM_KEYS ⊆ registry` test. Recorded rather than widened: this guard leaked three times
+  during review, each leak inside a rule written to close the previous one, and the product fix it
+  protects has been stable and verified since the second commit. Without this a
   future boolean flag silently reintroduces the trap, and this is the criterion the first draft was
   missing entirely.*
 

--- a/docs/design/stagingmark4-confirm-arity.md
+++ b/docs/design/stagingmark4-confirm-arity.md
@@ -168,8 +168,10 @@ records call COUNTS; a throwing fake alone is not proof of non-invocation.
   from either CLI must redden this**, demonstrated by an executed mutation, not asserted in prose.*
 - **AC8 — the registry is provably complete (unit guard):** ∀ over `scripts/admin.ts` AND
   `scripts/brain-tasks.ts` — every truthiness read (`Boolean(flags.x)`, `!flags.x`, `flags.x &&`,
-  bare `flags.x` in a condition) is IN that CLI's registry, every `as string` / `typeof === "string"`
-  read is NOT in it, **any flag NAME with no classified read anywhere fails as `unclassified read:
+  bare `flags.x` in a condition) is IN that CLI's registry, every `as <value type>` / `typeof === "string"`
+  read is NOT in it, an `as` cast is classified by its ASSERTED TYPE (boolean-only => boolean read;
+  a value type => value read; `any`/`unknown`/`as const`/a type reference => UNRESOLVABLE, so the
+  forall clause fires), **any flag NAME with no classified read anywhere fails as `unclassified read:
   <name>`** (per NAME, not per occurrence — see the recorded gap below), a name in both classes fails, and `CONFIRM_KEYS` from
   `lib/access/materialize-command.ts` is a subset of `admin.ts`'s registry (read from the
   DECLARATION via the AST — not an import and not a copied literal, so it cannot drift). *Negative controls, both required: one `flags.newflag &&` read, AND each unclassified spelling
@@ -178,8 +180,9 @@ records call COUNTS; a throwing fake alone is not proof of non-invocation.
   EXISTENTIAL: it proves things about the spellings it recognises and is silent on the rest.
   **Recorded residual:** the clause is per NAME, so one classified read blesses the name's other
   reads; a value-classified flag truthiness-gated in an unrecognised spelling still passes. Pinned
-  as an `it.fails` gap rather than claimed closed — per-occurrence strictness would require ~20
-  unrelated read rewrites across both CLIs. Without this a
+  as an `it.fails` gap rather than claimed closed — per-occurrence strictness would require 37
+  unrelated read rewrites across both CLIs (measured by the diff review: 17 of 46 in `admin.ts`,
+  20 of 57 in `brain-tasks.ts`). Without this a
   future boolean flag silently reintroduces the trap, and this is the criterion the first draft was
   missing entirely.*
 

--- a/docs/design/stagingmark4-confirm-arity.md
+++ b/docs/design/stagingmark4-confirm-arity.md
@@ -171,7 +171,8 @@ records call COUNTS; a throwing fake alone is not proof of non-invocation.
   bare `flags.x` in a condition) is IN that CLI's registry, every `as <value type>` / `typeof === "string"`
   read is NOT in it, an `as` cast is classified by its ASSERTED TYPE (boolean-only => boolean read;
   a value type => value read; `any`/`unknown`/`as const`/a type reference => UNRESOLVABLE, so the
-  forall clause fires), **any flag NAME with no classified read anywhere fails as `unclassified read:
+  forall clause fires; EVERY link of a cast chain is classified, so a disagreeing chain reports
+  `both classes`), destructured binds (`const { confirm } = flags`) are recorded as reads, **any flag NAME with no classified read anywhere fails as `unclassified read:
   <name>`** (per NAME, not per occurrence — see the recorded gap below), a name in both classes fails, and `CONFIRM_KEYS` from
   `lib/access/materialize-command.ts` is a subset of `admin.ts`'s registry (read from the
   DECLARATION via the AST — not an import and not a copied literal, so it cannot drift). *Negative controls, both required: one `flags.newflag &&` read, AND each unclassified spelling

--- a/docs/design/stagingmark4-confirm-arity.md
+++ b/docs/design/stagingmark4-confirm-arity.md
@@ -169,13 +169,17 @@ records call COUNTS; a throwing fake alone is not proof of non-invocation.
 - **AC8 — the registry is provably complete (unit guard):** ∀ over `scripts/admin.ts` AND
   `scripts/brain-tasks.ts` — every truthiness read (`Boolean(flags.x)`, `!flags.x`, `flags.x &&`,
   bare `flags.x` in a condition) is IN that CLI's registry, every `as string` / `typeof === "string"`
-  read is NOT in it, **any `flags.<name>` read that lands in NEITHER class fails as
-  `unclassified read: <name>`**, a name in both classes fails, and `CONFIRM_KEYS` from
+  read is NOT in it, **any flag NAME with no classified read anywhere fails as `unclassified read:
+  <name>`** (per NAME, not per occurrence — see the recorded gap below), a name in both classes fails, and `CONFIRM_KEYS` from
   `lib/access/materialize-command.ts` is a subset of `admin.ts`'s registry (read from the
   DECLARATION via the AST — not an import and not a copied literal, so it cannot drift). *Negative controls, both required: one `flags.newflag &&` read, AND each unclassified spelling
   that defeated the existential form — `flags.wipe !== undefined`, `const w = flags.wipe; if (w)`,
   `flags.wipe ?? false`, `flags.wipe || false`. Without the unclassified clause the guard is
-  EXISTENTIAL: it proves things about the spellings it recognises and is silent on the rest. Without this a
+  EXISTENTIAL: it proves things about the spellings it recognises and is silent on the rest.
+  **Recorded residual:** the clause is per NAME, so one classified read blesses the name's other
+  reads; a value-classified flag truthiness-gated in an unrecognised spelling still passes. Pinned
+  as an `it.fails` gap rather than claimed closed — per-occurrence strictness would require ~20
+  unrelated read rewrites across both CLIs. Without this a
   future boolean flag silently reintroduces the trap, and this is the criterion the first draft was
   missing entirely.*
 

--- a/lib/access/materialize-command.ts
+++ b/lib/access/materialize-command.ts
@@ -15,9 +15,11 @@ import { PRET4_MATERIALIZE_MARKER, materializeBuiltinMembershipOnce } from "@/li
  * the guard refuses, the code never boots, the marker is never stamped. Observed on staging
  * 2026-09-05 (deploy 2e67246e).
  *
- * WHY THE BEHAVIOUR LIVES HERE AND NOT IN `scripts/admin.ts`. That file calls `main()` at module
- * scope, so a test importing it would execute the CLI — the same reason `formatAccessHealth` was
- * extracted. Dependencies are INJECTED rather than imported by the handler so the real decisions
+ * WHY THE BEHAVIOUR LIVES HERE AND NOT IN `scripts/admin.ts`. That file USED TO call `main()` at
+ * module scope, so a test importing it executed the CLI — the same reason `formatAccessHealth` was
+ * extracted. Since STAGINGMARK-4 the entry is argv-guarded and `main(argv)` is importable, so that
+ * particular reason is gone; the seam stays here because the SECOND reason is the load-bearing one.
+ * Dependencies are INJECTED rather than imported by the handler so the real decisions
  * (which branch runs, what exits non-zero, whether --confirm gates the write) are observable
  * against fakes in the unit tier. A source-text guard cannot do that: a `case` whose body is only
  * a comment naming the function would satisfy it while doing nothing.

--- a/lib/access/materialize-command.ts
+++ b/lib/access/materialize-command.ts
@@ -55,8 +55,8 @@ const CONFIRM_KEYS = ["confirm", "confirm-production"] as const;
  * Strict parsing of the two confirmation flags, at the CLI boundary.
  *
  * `parseArgs` (scripts/admin.ts) assigns the FOLLOWING token as a string, so `--confirm false`
- * yields the string "false" — and `if (!flags.confirm)` reads that as CONFIRMED. That trap is live
- * today on `purge-items`, a destructive command. Rather than inherit it, this command refuses any
+ * yields the string "false" — truthy as confirmation. The shared argv boundary now blocks that trap
+ * on `purge-items` too. As defense in depth, this command still refuses any
  * value form instead of guessing which way the operator meant it.
  *
  * `--confirm=false` is a DIFFERENT shape: parseArgs makes the whole token the key, so the flag

--- a/lib/access/repair-verb.ts
+++ b/lib/access/repair-verb.ts
@@ -5,8 +5,10 @@ import type { RevokeResult } from "@/lib/access/groups";
  * AUDITFIX-21 — the `repair-system-edge` verb's PURE decision layer, plus the IMPORT-SAFE factory
  * that builds its real dependencies.
  *
- * WHY THE FACTORY LIVES HERE AND NOT IN `scripts/admin.ts`. That file calls `main()` at module scope,
- * so importing it to test anything RUNS THE CLI — there is no seam. The consequence a spec review
+ * WHY THE FACTORY LIVES HERE AND NOT IN `scripts/admin.ts`. That file USED TO call `main()` at module
+ * scope, so importing it to test anything ran the CLI — there was no seam. STAGINGMARK-4 added an
+ * argv-guarded entry and an importable `main(argv)`, so the seam now exists; the factory stays here
+ * because the consequence below is what actually justifies it, not the import hazard. The consequence a spec review
  * spelled out: a type-correct `resolveGroup: async () => null` satisfies every behavioural criterion
  * about the pure verb while the shipped command stays permanently broken, and nothing would have
  * caught it. The factory is testable against a fake db; a structural guard pins that the CLI arm

--- a/lib/admin/access-health-format.ts
+++ b/lib/admin/access-health-format.ts
@@ -3,8 +3,10 @@ import type { AccessHealth } from "@/lib/admin/access-health";
 /**
  * AUDITFIX-23 — the access-health verdict as TEXT, in an import-safe module.
  *
- * WHY IT IS ITS OWN FILE. The formatter lived inside `scripts/admin.ts`, which calls `main()` at
- * module scope — so importing it to test the wording RUNS THE CLI. There was no seam, and a criterion
+ * WHY IT IS ITS OWN FILE. The formatter lived inside `scripts/admin.ts`, which USED TO call `main()`
+ * at module scope — so importing it to test the wording ran the CLI. (STAGINGMARK-4 has since made
+ * that entry argv-guarded and `main(argv)` importable, so the hazard is gone; this file stays split
+ * because the wording deserves its own tested surface.) There was no seam then, and a criterion
  * asserting what an operator reads had nowhere to stand (spec round 3 HIGH 4 on the previous draft).
  *
  * WHY THE WORD CHANGED. AUDITFIX-23 widened `blockers` from lock-OUT only to "a human locked OUT, or a

--- a/lib/admin/args.ts
+++ b/lib/admin/args.ts
@@ -16,7 +16,12 @@ export class CliExitError extends Error {
 /** Validate every raw occurrence before last-wins tokenization can erase malformed input. */
 export function parseAdminArgs(argv: string[], registry: readonly string[]): AdminArgsResult {
   const booleans = new Set(registry);
-  for (let i = 1; i < argv.length; i++) {
+  // From 0, not 1. Skipping the command token means `admin --confirm false` (a leading flag, no
+  // command) escapes validation and reports whatever the next check happens to complain about —
+  // measured: "DATABASE_URL is required". Nothing destructive is reachable that way, because the
+  // command is invalid, but the diagnostic is wrong. A leading token is never a valid command, so
+  // validating it costs nothing. Found by a mutation that SURVIVED at `i = 1`.
+  for (let i = 0; i < argv.length; i++) {
     const token = argv[i];
     if (!token.startsWith("--")) continue;
     const key = token.slice(2).split("=", 1)[0];

--- a/lib/admin/args.ts
+++ b/lib/admin/args.ts
@@ -1,0 +1,51 @@
+/** Boolean names are per CLI; value-taking flags retain the legacy tokenizer contract. */
+export const ADMIN_BOOLEAN_FLAGS = ["help", "upsert", "hard", "force", "confirm", "dry-run", "confirm-production"] as const;
+export const TASK_BOOLEAN_FLAGS = ["help", "clear-sprint", "dry-run", "project-to-linear"] as const;
+export type Flags = Record<string, string | boolean>;
+type ParsedArgs = { cmd: string; positionals: string[]; flags: Flags };
+export type AdminArgsResult = ({ ok: true } & ParsedArgs) | { ok: false; error: string };
+
+/** An importable CLI reports an exit to its entry point instead of terminating its caller. */
+export class CliExitError extends Error {
+  constructor(message: string, public readonly exitCode = 1) {
+    super(message);
+    this.name = "CliExitError";
+  }
+}
+
+/** Validate every raw occurrence before last-wins tokenization can erase malformed input. */
+export function parseAdminArgs(argv: string[], registry: readonly string[]): AdminArgsResult {
+  const booleans = new Set(registry);
+  for (let i = 1; i < argv.length; i++) {
+    const token = argv[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2).split("=", 1)[0];
+    if (!booleans.has(key)) continue;
+    const next = argv[i + 1];
+    if (token.includes("=") || (next !== undefined && !next.startsWith("--"))) {
+      // Never echo the adjacent value: it may be a password.
+      return { ok: false, error: `--${key} takes no value; pass it bare as --${key}, or omit it.` };
+    }
+  }
+  return { ok: true, ...parseArgs(argv) };
+}
+
+// Extracted unchanged from the original CLI tokenizer.
+function parseArgs(argv: string[]): { cmd: string; positionals: string[]; flags: Flags } {
+  const [cmd = "help", ...rest] = argv;
+  const positionals: string[] = [];
+  const flags: Flags = {};
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = rest[i + 1];
+      if (next === undefined || next.startsWith("--")) flags[key] = true;
+      else {
+        flags[key] = next;
+        i++;
+      }
+    } else positionals.push(a);
+  }
+  return { cmd, positionals, flags };
+}

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -575,8 +575,11 @@ export async function main(argv: string[]) {
 }
 
 // Suffix comparison also works when /tmp resolves through /private/tmp.
-// basename, not a suffix: `endsWith("/admin.ts")` never matches a Windows path or a renamed copy,
-// and the failure mode is SILENT SUCCESS — the module loads, does nothing, and exits 0.
+// basename, not a suffix: `endsWith("/admin.ts")` never matches a Windows path separator, and the
+// failure mode is SILENT SUCCESS — the module loads, does nothing, and exits 0. Stated precisely
+// (astra review corrected an earlier overclaim): this does NOT fix a RENAMED copy, which still
+// skips, and it fires for any entry whose basename is `admin.ts`. It is a cheap identity heuristic,
+// not module identity.
 if (basename(process.argv[1] ?? "") === "admin.ts") {
   main(process.argv.slice(2))
     // Bare exit(), NOT exit(0): `access-health` reports an unhealthy team by setting

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -574,7 +574,6 @@ export async function main(argv: string[]) {
   }
 }
 
-// Suffix comparison also works when /tmp resolves through /private/tmp.
 // basename, not a suffix: `endsWith("/admin.ts")` never matches a Windows path separator, and the
 // failure mode is SILENT SUCCESS — the module loads, does nothing, and exits 0. Stated precisely
 // (astra review corrected an earlier overclaim): this does NOT fix a RENAMED copy, which still

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -9,6 +9,7 @@
  *         'DATABASE_URL=$DATABASE_PUBLIC_URL npx tsx --conditions react-server scripts/admin.ts <cmd>'
  */
 import { execFileSync } from "node:child_process";
+import { basename } from "node:path";
 import { adminClient } from "@/lib/db/admin";
 import { makeMaterializeDeps, parseConfirmFlags, runMaterializeCommand } from "@/lib/access/materialize-command";
 import { createMember, deleteMember } from "@/lib/admin/members";
@@ -106,7 +107,9 @@ export async function main(argv: string[]) {
   const parsedArgs = parseAdminArgs(argv, ADMIN_BOOLEAN_FLAGS);
   if (!parsedArgs.ok) die(parsedArgs.error);
   const { cmd, positionals, flags } = parsedArgs;
-  if (cmd === "help" || flags.help) return console.log(USAGE);
+  // `--help` as the command token too: parseArgs makes it the cmd, so neither of the other two
+  // clauses match and it used to fall through to the DATABASE_URL check.
+  if (cmd === "help" || cmd === "--help" || flags.help) return console.log(USAGE);
 
   if (cmd === "pg:schema") {
     execFileSync("node", ["scripts/pg-load-schema.mjs"], { stdio: "inherit" });
@@ -166,7 +169,7 @@ export async function main(argv: string[]) {
       const { token, url } = await issueLoginLink(admin, team.id, email, {
         nextPath: `/t/${team.slug}`,
         // Explicit legacy presence check: this is a value flag, including bare-true compatibility.
-        ttlMinutes: flags["ttl-min"] !== undefined && flags["ttl-min"] !== "" && flags["ttl-min"] !== false
+        ttlMinutes: flags["ttl-min"] !== undefined && flags["ttl-min"] !== ""
           ? Number(flags["ttl-min"] as string) : 60,
         baseUrl,
       });
@@ -572,9 +575,13 @@ export async function main(argv: string[]) {
 }
 
 // Suffix comparison also works when /tmp resolves through /private/tmp.
-if (process.argv[1]?.endsWith("/admin.ts")) {
+// basename, not a suffix: `endsWith("/admin.ts")` never matches a Windows path or a renamed copy,
+// and the failure mode is SILENT SUCCESS — the module loads, does nothing, and exits 0.
+if (basename(process.argv[1] ?? "") === "admin.ts") {
   main(process.argv.slice(2))
-    .then(() => process.exit(0))
+    // Bare exit(), NOT exit(0): `access-health` reports an unhealthy team by setting
+    // process.exitCode = 1, and exit(0) discarded it — the command exited 0 while printing blockers.
+    .then(() => process.exit())
     .catch((e) => {
       if (!(e instanceof CliExitError) || e.message) console.error(`✗ ${e instanceof Error ? e.message : String(e)}`);
       process.exit(e instanceof CliExitError ? e.exitCode : 1);

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -29,30 +29,10 @@ import { formatAccessHealth } from "@/lib/admin/access-health-format";
 // footgun stays behind the ingest callers that build their prefix from the same helper that wrote it.
 import { purgeItemIds } from "@/lib/ingest/purge";
 
-type Flags = Record<string, string | boolean>;
-
-function parseArgs(argv: string[]): { cmd: string; positionals: string[]; flags: Flags } {
-  const [cmd = "help", ...rest] = argv;
-  const positionals: string[] = [];
-  const flags: Flags = {};
-  for (let i = 0; i < rest.length; i++) {
-    const a = rest[i];
-    if (a.startsWith("--")) {
-      const key = a.slice(2);
-      const next = rest[i + 1];
-      if (next === undefined || next.startsWith("--")) flags[key] = true;
-      else {
-        flags[key] = next;
-        i++;
-      }
-    } else positionals.push(a);
-  }
-  return { cmd, positionals, flags };
-}
+import { parseAdminArgs, ADMIN_BOOLEAN_FLAGS, CliExitError } from "@/lib/admin/args";
 
 function die(msg: string): never {
-  console.error(`✗ ${msg}`);
-  process.exit(1);
+  throw new CliExitError(msg);
 }
 
 async function resolveTeam(admin: ReturnType<typeof adminClient>, ref: string) {
@@ -85,7 +65,7 @@ const USAGE = `Team Brain admin CLI — commands:
   sync-github --org <org> [--team <id|slug>]                               # list candidates (needs GITHUB_TOKEN)
   access-health <team-slug>              # standing access-violation/read-zero scan (lockouts AND unsanctioned system grants)
   drain-context <team-slug>              # partition a team's items (the demo bootstrap's post-seed step)
-  purge-items --team <id|slug> --ids <uuid,uuid,…> --reason "<text>" [--confirm]
+  purge-items --team <id|slug> --ids <uuid,uuid,…> --reason "<text>" [--confirm | --dry-run]
                                          # irreversibly remove specific items + their versions/chunks/
                                          # facts, retire their graph episodes, audit, bust derived
                                          # caches. DRY RUN by default — --confirm actually deletes.
@@ -99,15 +79,15 @@ const USAGE = `Team Brain admin CLI — commands:
                                          # present. --confirm-production is additionally required
                                          # when the database carries no staging_marker.
   pg:schema                              # load postgres/schema.sql (idempotent)
+Boolean flags take no value: pass them bare to enable, or omit to disable. Put positionals first.
 Defaults: --team demo (accepts a team UUID too). Requires DATABASE_URL (postgres). GitHub token via GITHUB_TOKEN env only.`;
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const PURGE_USAGE = `purge-items --team <id|slug> --ids <uuid,uuid,…> --reason "<text>" [--confirm]`;
+const PURGE_USAGE = `purge-items --team <id|slug> --ids <uuid,uuid,…> --reason "<text>" [--confirm | --dry-run]`;
 
 /** Print the standing access-health verdict: blockers are what an operator must FIX — a human locked
  *  OUT (grants/backfill) or a group let IN the substrate never sanctioned (AUDITFIX-23); warnings are
- *  read-zero states worth knowing. The wording lives in an IMPORT-SAFE module because this file runs
- *  `main()` at module scope, so a test cannot reach a formatter defined here. */
+ *  read-zero states worth knowing. The wording lives in a shared import-safe formatter module. */
 function printHealth(r: AccessHealth): void {
   for (const line of formatAccessHealth(r)) console.log(line);
 }
@@ -122,8 +102,10 @@ async function memberIdByEmail(admin: ReturnType<typeof adminClient>, teamId: st
   return (data as { id: string } | null)?.id ?? null;
 }
 
-async function main() {
-  const { cmd, positionals, flags } = parseArgs(process.argv.slice(2));
+export async function main(argv: string[]) {
+  const parsedArgs = parseAdminArgs(argv, ADMIN_BOOLEAN_FLAGS);
+  if (!parsedArgs.ok) die(parsedArgs.error);
+  const { cmd, positionals, flags } = parsedArgs;
   if (cmd === "help" || flags.help) return console.log(USAGE);
 
   if (cmd === "pg:schema") {
@@ -183,7 +165,9 @@ async function main() {
       const baseUrl = (flags["base-url"] as string) || process.env.BRAIN_URL || "";
       const { token, url } = await issueLoginLink(admin, team.id, email, {
         nextPath: `/t/${team.slug}`,
-        ttlMinutes: flags["ttl-min"] ? Number(flags["ttl-min"]) : 60,
+        // Explicit legacy presence check: this is a value flag, including bare-true compatibility.
+        ttlMinutes: flags["ttl-min"] !== undefined && flags["ttl-min"] !== "" && flags["ttl-min"] !== false
+          ? Number(flags["ttl-min"] as string) : 60,
         baseUrl,
       });
       if (!token) die(`no member for ${email} (invite-only) — run create-member first`);
@@ -570,7 +554,7 @@ async function main() {
         // see a truncated report, or none, for a run that already touched the database. Awaiting
         // a zero-length write drains what is queued first (second diff review).
         await new Promise<void>((resolve) => process.stdout.write("", () => resolve()));
-        process.exit(outcome.exitCode);
+        throw new CliExitError("", outcome.exitCode);
       }
       break;
     }
@@ -587,6 +571,12 @@ async function main() {
   }
 }
 
-main()
-  .then(() => process.exit(0))
-  .catch((e) => die(e instanceof Error ? e.message : String(e)));
+// Suffix comparison also works when /tmp resolves through /private/tmp.
+if (process.argv[1]?.endsWith("/admin.ts")) {
+  main(process.argv.slice(2))
+    .then(() => process.exit(0))
+    .catch((e) => {
+      if (!(e instanceof CliExitError) || e.message) console.error(`✗ ${e instanceof Error ? e.message : String(e)}`);
+      process.exit(e instanceof CliExitError ? e.exitCode : 1);
+    });
+}

--- a/scripts/brain-tasks.ts
+++ b/scripts/brain-tasks.ts
@@ -28,6 +28,7 @@
  * priority: none | low | medium | high | urgent              (default none)
  */
 import { readFileSync } from "node:fs";
+import { basename } from "node:path";
 import { adminClient } from "@/lib/db/admin";
 import { uiRowKey } from "@/lib/ids";
 import { TASK_STATUSES, normalizeTaskPriority } from "@/lib/api/schemas";
@@ -71,9 +72,8 @@ function parseLabels(v: string | boolean | undefined): string[] | undefined {
 }
 
 function readBody(flags: Flags): string | undefined {
-  const f = flags["body-file"];
-  if (typeof f !== "string") return undefined;
-  return readFileSync(f, "utf8");
+  if (typeof flags["body-file"] !== "string") return undefined;
+  return readFileSync(flags["body-file"], "utf8");
 }
 
 function checkStatus(s: string | undefined): string | undefined {
@@ -134,7 +134,7 @@ export async function main(argv: string[]) {
         sprint: (flags.sprint as string) || "",
         status: checkStatus(flags.status as string) || "backlog",
         priority: normalizeTaskPriority((flags.priority as string) || "none"),
-        labels: parseLabels(flags.labels) ?? [],
+        labels: parseLabels(flags.labels as string | boolean | undefined) ?? [],
         parent_row_key: (flags.parent as string) || null,
         body: readBody(flags) ?? "",
         origin: ((flags.origin as string) || "ui") as "ui" | "sync",
@@ -157,7 +157,7 @@ export async function main(argv: string[]) {
       if (flags.title !== undefined) update.title = flags.title;
       if (flags.status !== undefined) update.status = checkStatus(flags.status as string);
       if (flags.priority !== undefined) update.priority = normalizeTaskPriority(flags.priority as string);
-      if (flags.labels !== undefined) update.labels = parseLabels(flags.labels) ?? [];
+      if (flags.labels !== undefined) update.labels = parseLabels(flags.labels as string | boolean | undefined) ?? [];
       if (flags.parent !== undefined) update.parent_row_key = (flags.parent as string) || null;
       if (flags["clear-sprint"]) update.sprint = "";
       else if (flags.sprint !== undefined) update.sprint = flags.sprint;
@@ -184,8 +184,8 @@ export async function main(argv: string[]) {
         .from("tasks")
         .select("row_key, title, status, priority, sprint, parent_row_key")
         .eq("team_id", team.id);
-      if (flags.project !== undefined && flags.project !== "" && flags.project !== false) q = q.eq("project_id", flags.project as string);
-      if (flags.sprint !== undefined && flags.sprint !== "" && flags.sprint !== false) q = q.eq("sprint", flags.sprint as string);
+      if (flags.project !== undefined && flags.project !== "") q = q.eq("project_id", flags.project as string);
+      if (flags.sprint !== undefined && flags.sprint !== "") q = q.eq("sprint", flags.sprint as string);
       const { data } = await q.order("row_key");
       console.table(data ?? []);
       break;
@@ -208,7 +208,7 @@ export async function main(argv: string[]) {
     case "project": {
       const team = await resolveTeam(admin, teamSlug);
       let projectIds: string[];
-      if (flags.project !== undefined && flags.project !== "" && flags.project !== false) projectIds = [flags.project as string];
+      if (flags.project !== undefined && flags.project !== "") projectIds = [flags.project as string];
       else {
         const { data } = await admin.from("projects").select("id").eq("team_id", team.id);
         projectIds = ((data ?? []) as { id: string }[]).map((p) => p.id);
@@ -234,7 +234,7 @@ export async function main(argv: string[]) {
     case "extract-meeting-todos": {
       const team = await resolveTeam(admin, teamSlug);
       const limitRaw = flags.limit;
-      const limit = typeof limitRaw === "string" ? Number.parseInt(limitRaw, 10) : undefined;
+      const limit = typeof flags.limit === "string" ? Number.parseInt(flags.limit, 10) : undefined;
       if (limitRaw !== undefined && (!Number.isFinite(limit) || (limit ?? 0) <= 0)) {
         die("--limit must be a positive integer");
       }
@@ -362,9 +362,10 @@ export async function main(argv: string[]) {
 }
 
 // Suffix comparison also works when /tmp resolves through /private/tmp.
-if (process.argv[1]?.endsWith("/brain-tasks.ts")) {
+// basename, not a suffix — see the note in scripts/admin.ts.
+if (basename(process.argv[1] ?? "") === "brain-tasks.ts") {
   main(process.argv.slice(2))
-    .then(() => process.exit(0))
+    .then(() => process.exit())
     .catch((e) => {
       if (!(e instanceof CliExitError) || e.message) console.error(`✗ ${e instanceof Error ? e.message : String(e)}`);
       process.exit(e instanceof CliExitError ? e.exitCode : 1);

--- a/scripts/brain-tasks.ts
+++ b/scripts/brain-tasks.ts
@@ -39,7 +39,7 @@ import {
   MEETING_TODO_PROJECT_NAME,
 } from "@/lib/meetings/extract-todos";
 
-type Flags = Record<string, string | boolean>;
+import { parseAdminArgs, TASK_BOOLEAN_FLAGS, CliExitError, type Flags } from "@/lib/admin/args";
 type Admin = ReturnType<typeof adminClient>;
 type ResolvePage = {
   team: { issues: { pageInfo: { hasNextPage: boolean; endCursor: string }; nodes: { id: string; identifier: string; url: string }[] } } | null;
@@ -51,28 +51,8 @@ type ResolvePage = {
 // the list to be local.
 const STATUSES: readonly string[] = TASK_STATUSES;
 
-function parseArgs(argv: string[]): { cmd: string; positionals: string[]; flags: Flags } {
-  const [cmd = "help", ...rest] = argv;
-  const positionals: string[] = [];
-  const flags: Flags = {};
-  for (let i = 0; i < rest.length; i++) {
-    const a = rest[i];
-    if (a.startsWith("--")) {
-      const key = a.slice(2);
-      const next = rest[i + 1];
-      if (next === undefined || next.startsWith("--")) flags[key] = true;
-      else {
-        flags[key] = next;
-        i++;
-      }
-    } else positionals.push(a);
-  }
-  return { cmd, positionals, flags };
-}
-
 function die(msg: string): never {
-  console.error(`✗ ${msg}`);
-  process.exit(1);
+  throw new CliExitError(msg);
 }
 
 async function resolveTeam(admin: Admin, ref: string) {
@@ -130,8 +110,10 @@ async function bumpFingerprint(admin: Admin, teamId: string, projectId: string, 
     .eq("row_key", rowKey);
 }
 
-async function main() {
-  const { cmd, positionals, flags } = parseArgs(process.argv.slice(2));
+export async function main(argv: string[]) {
+  const parsedArgs = parseAdminArgs(argv, TASK_BOOLEAN_FLAGS);
+  if (!parsedArgs.ok) die(parsedArgs.error);
+  const { cmd, positionals, flags } = parsedArgs;
   if (cmd === "help" || flags.help) return console.log(USAGE);
   if (!process.env.DATABASE_URL) die("DATABASE_URL is required");
 
@@ -202,8 +184,8 @@ async function main() {
         .from("tasks")
         .select("row_key, title, status, priority, sprint, parent_row_key")
         .eq("team_id", team.id);
-      if (flags.project) q = q.eq("project_id", flags.project as string);
-      if (flags.sprint) q = q.eq("sprint", flags.sprint as string);
+      if (flags.project !== undefined && flags.project !== "" && flags.project !== false) q = q.eq("project_id", flags.project as string);
+      if (flags.sprint !== undefined && flags.sprint !== "" && flags.sprint !== false) q = q.eq("sprint", flags.sprint as string);
       const { data } = await q.order("row_key");
       console.table(data ?? []);
       break;
@@ -226,7 +208,7 @@ async function main() {
     case "project": {
       const team = await resolveTeam(admin, teamSlug);
       let projectIds: string[];
-      if (flags.project) projectIds = [flags.project as string];
+      if (flags.project !== undefined && flags.project !== "" && flags.project !== false) projectIds = [flags.project as string];
       else {
         const { data } = await admin.from("projects").select("id").eq("team_id", team.id);
         projectIds = ((data ?? []) as { id: string }[]).map((p) => p.id);
@@ -379,6 +361,12 @@ async function main() {
   }
 }
 
-main()
-  .then(() => process.exit(0))
-  .catch((e) => die(e instanceof Error ? e.message : String(e)));
+// Suffix comparison also works when /tmp resolves through /private/tmp.
+if (process.argv[1]?.endsWith("/brain-tasks.ts")) {
+  main(process.argv.slice(2))
+    .then(() => process.exit(0))
+    .catch((e) => {
+      if (!(e instanceof CliExitError) || e.message) console.error(`✗ ${e instanceof Error ? e.message : String(e)}`);
+      process.exit(e instanceof CliExitError ? e.exitCode : 1);
+    });
+}

--- a/scripts/brain-tasks.ts
+++ b/scripts/brain-tasks.ts
@@ -361,7 +361,6 @@ export async function main(argv: string[]) {
   }
 }
 
-// Suffix comparison also works when /tmp resolves through /private/tmp.
 // basename, not a suffix — see the note in scripts/admin.ts.
 if (basename(process.argv[1] ?? "") === "brain-tasks.ts") {
   main(process.argv.slice(2))

--- a/test/access-materialize-command.test.ts
+++ b/test/access-materialize-command.test.ts
@@ -198,8 +198,8 @@ describe("STAGINGMARK-1 — materialize-builtins handler", () => {
     });
 
     it("refuses `--confirm false` — the trap that reads as CONFIRMED today", () => {
-      // parseArgs assigns the following token as a string, so `--confirm false` yields "false",
-      // and `if (!flags.confirm)` treats a non-empty string as confirmed. purge-items still does.
+      // The original tokenizer made `--confirm false` truthy as confirmation. The shared argv
+      // boundary now prevents that on purge-items; this defense still rejects malformed maps.
       const parsed = parseConfirmFlags({ confirm: "false" });
       expect(parsed.ok).toBe(false);
       if (!parsed.ok) expect(parsed.error).toMatch(/takes no value/);

--- a/test/admin-args.test.ts
+++ b/test/admin-args.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { parseAdminArgs, ADMIN_BOOLEAN_FLAGS, TASK_BOOLEAN_FLAGS } from "@/lib/admin/args";
+type Flags = Record<string, string | boolean>;
+// AC6 compatibility oracle: verbatim HEAD tokenizer, replayed independently.
+function parseArgs(argv: string[]): { cmd: string; positionals: string[]; flags: Flags } {
+  const [cmd = "help", ...rest] = argv;
+  const positionals: string[] = [];
+  const flags: Flags = {};
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = rest[i + 1];
+      if (next === undefined || next.startsWith("--")) flags[key] = true;
+      else {
+        flags[key] = next;
+        i++;
+      }
+    } else positionals.push(a);
+  }
+  return { cmd, positionals, flags };
+}
+
+const registries = [ADMIN_BOOLEAN_FLAGS, TASK_BOOLEAN_FLAGS];
+describe.each(registries.map(registry => ({ registry })))("boolean arity $registry", ({ registry }) => {
+  for (const name of registry) {
+    it(`${name}: bare is true, omitted is absent, next flag survives`, () => {
+      expect(parseAdminArgs(["help"], registry)).toEqual({ok:true, cmd:"help", positionals:[], flags:{}});
+      for (const tail of [[], ["--team", "demo"]]) {
+        const result = parseAdminArgs(["help", `--${name}`, ...tail], registry);
+        expect(result).toEqual({ok:true, cmd:"help", positionals:[], flags:{[name]:true, ...(tail.length ? {team:"demo"}: {})}});
+      }
+    });
+    for (const value of ["false", "true", "0", "yes", "", "-x", "extra", "hunter2"]) {
+      for (const form of [[`--${name}`, value], [`--${name}=${value}`]]) {
+        it(`${name}: refuses ${JSON.stringify(form)} before collapse`, () => {
+          for (const tokens of [form, [...form, `--${name}`], [`--${name}`, ...form]]) {
+            const result = parseAdminArgs(["help", ...tokens], registry);
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("accepted a value");
+            expect(Object.keys(result).sort()).toEqual(["error", "ok"]);
+            expect(result.error).toContain(`--${name}`);
+            expect(result.error).toMatch(/takes no value.*bare/);
+            expect(result.error).not.toContain("hunter2");
+          }
+        });
+      }
+    }
+    it(`${name}: repeated bare succeeds`, () => {
+      expect(parseAdminArgs(["help", `--${name}`, `--${name}`], registry)).toEqual({ok:true,cmd:"help",positionals:[],flags:{[name]:true}});
+    });
+  }
+});
+it("AC3 original collapse loses the malformed occurrence", () => {
+  expect(parseArgs(["purge-items", "--confirm", "false", "--confirm"]).flags).toEqual({confirm:true});
+});
+it("AC4 keeps positionals before booleans", () => {
+  expect(parseAdminArgs(["purge-items", "--confirm", "extra"], ADMIN_BOOLEAN_FLAGS).ok).toBe(false);
+  expect(parseAdminArgs(["delete-member", "user@example.com", "--hard"], ADMIN_BOOLEAN_FLAGS)).toEqual({ok:true,cmd:"delete-member",positionals:["user@example.com"],flags:{hard:true}});
+});
+// Characterization is intentional ONLY here: pin every current command and value name.
+const commands = ['create-team', 'create-member', 'login-link', 'issue-key', 'revoke-key', 'list-members', 'list-keys', 'delete-member', 'add-group-member', 'remove-group-member', 'grant-project', 'repair-system-edge', 'revoke-project', 'rename-team', 'add-author-alias', 'link-github', 'link-identity', 'access-health', 'drain-context', 'purge-items', 'materialize-builtins', 'sync-github', 'help', 'pg:schema', 'add', 'set', 'list', 'show', 'project', 'extract-meeting-todos', 'resolve', 'adopt'];
+const values = ["team", "name", "handle", "role", "tier", "password", "base-url", "ttl-min", "actor", "email", "ids", "reason", "org", "project", "title", "row-key", "status", "priority", "labels", "parent", "sprint", "assignee", "body-file", "origin", "source-project", "path-prefix", "since", "limit", "filter", "resource-id", "url"];
+it.each(commands)("AC6 HEAD compatibility: %s", (cmd) => {
+  for (const name of values) for (const tail of [[], ["text"], [""], ["-x"], ["--other"], ["first", `--${name}`, "last"]]) {
+    const argv = [cmd, "positional", `--${name}`, ...tail];
+    for (const registry of registries) expect(parseAdminArgs(argv, registry)).toEqual({ok:true,...parseArgs(argv)});
+    const equals = [cmd, `--${name}=text`];
+    for (const registry of registries) expect(parseAdminArgs(equals, registry)).toEqual({ok:true,...parseArgs(equals)});
+  }
+});

--- a/test/admin-args.test.ts
+++ b/test/admin-args.test.ts
@@ -69,3 +69,16 @@ it.each(commands)("AC6 HEAD compatibility: %s", (cmd) => {
     for (const registry of registries) expect(parseAdminArgs(equals, registry)).toEqual({ok:true,...parseArgs(equals)});
   }
 });
+
+describe("STAGINGMARK-4 — a LEADING boolean flag is validated too", () => {
+  // The command token is at argv[0]; validating from index 1 let `admin --confirm false` through
+  // to an unrelated error. A leading token is never a valid command, so it is validated as well.
+  it("refuses a registered boolean in the command position when given a value", () => {
+    const r = parseAdminArgs(["--confirm", "false"], ADMIN_BOOLEAN_FLAGS);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/takes no value/);
+  });
+  it("still accepts a bare leading boolean", () => {
+    expect(parseAdminArgs(["--help"], ADMIN_BOOLEAN_FLAGS).ok).toBe(true);
+  });
+});

--- a/test/admin-args.test.ts
+++ b/test/admin-args.test.ts
@@ -78,7 +78,10 @@ describe("STAGINGMARK-4 — a LEADING boolean flag is validated too", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/takes no value/);
   });
-  it("still accepts a bare leading boolean", () => {
+  it("still accepts a bare leading boolean — AT THE PARSER; the CLI's own handling is separate", () => {
+    // Named precisely after the diff review: the parser accepting `["--help"]` says nothing about
+    // whether the CLI honours it. It did not — `admin --help` fell through to the DATABASE_URL
+    // check — so scripts/admin.ts now also treats `--help` in the command position as help.
     expect(parseAdminArgs(["--help"], ADMIN_BOOLEAN_FLAGS).ok).toBe(true);
   });
 });

--- a/test/admin-cli-arity.test.ts
+++ b/test/admin-cli-arity.test.ts
@@ -1,0 +1,90 @@
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const f = vi.hoisted(() => {
+  const id = "11111111-1111-4111-8111-111111111111";
+  const from = vi.fn((table: string) => {
+    const data = table === "items" ? [{id, path:"note", kind:"note", access:"team"}] : [];
+    const q = {
+      select: vi.fn(() => q), eq: vi.fn(() => q), in: vi.fn(() => Promise.resolve({data})),
+      maybeSingle: vi.fn(async () => ({data: table === "teams" ? {id:"team-id",slug:"demo"} : null})),
+    };
+    return q;
+  });
+  const client = {from};
+  return {id, client, adminClient:vi.fn(() => client), purge:vi.fn(async () => ({items:1,episodes:0})),
+    remove:vi.fn(async () => ({deleted:false})), project:vi.fn(async () => ({provider:"linear",reports:[]})),
+    record:vi.fn(), extract:vi.fn(async () => ({extracted:1,scanned:1,upserted:1,deleted:0,projectId:"project-id",rows:[]}))};
+});
+vi.mock("@/lib/db/admin", () => ({adminClient:f.adminClient}));
+vi.mock("@/lib/ingest/purge", () => ({purgeItemIds:f.purge}));
+vi.mock("@/lib/admin/members", () => ({createMember:vi.fn(),deleteMember:f.remove}));
+vi.mock("@/lib/pm-sync", () => ({projectAllTasks:f.project,recordProjectionRun:f.record}));
+vi.mock("@/lib/meetings/extract-todos", () => ({extractMeetingTodosForTeam:f.extract,MEETING_TODO_PROJECT_NAME:"Meeting todos"}));
+import { main as adminMain } from "../scripts/admin";
+import { main as taskMain } from "../scripts/brain-tasks";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("DATABASE_URL", "postgres://unused:unused@127.0.0.1:1/unused");
+  vi.spyOn(console,"log").mockImplementation(() => {});
+  vi.spyOn(console,"table").mockImplementation(() => {});
+});
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllEnvs(); });
+const purge = ["purge-items","--team","demo","--ids",f.id,"--reason","cleanup"];
+const paths = [
+  {name:"purge", main:adminMain, argv:purge, flag:"confirm", writer:f.purge, args:[f.client,"team-id",[f.id],"cleanup"]},
+  {name:"hard delete", main:adminMain, argv:["delete-member","user@example.com"], flag:"hard", writer:f.remove, args:[f.client,"team-id","user@example.com",{hard:true}]},
+  {name:"Linear projection", main:taskMain, argv:["extract-meeting-todos"], flag:"project-to-linear", writer:f.project, args:[f.client,"team-id","project-id"]},
+];
+describe.each(paths)("AC7 $name call site", ({main,argv,flag,writer,args}) => {
+  it("bare flag invokes the writer exactly once with expected arguments", async () => {
+    await main([...argv,`--${flag}`]);
+    expect(writer).toHaveBeenCalledTimes(1);
+    expect(writer).toHaveBeenCalledWith(...args);
+  });
+  for (const value of ["false","true","0","yes","","-x","extra","hunter2"]) {
+    for (const form of [[`--${flag}`,value],[`--${flag}=${value}`]]) {
+      it(`refuses ${JSON.stringify(form)} before any client or writer`, async () => {
+        await expect(main([...argv,...form])).rejects.toThrow(/takes no value/);
+        expect(f.adminClient).toHaveBeenCalledTimes(0);
+        for (const fake of [f.purge,f.remove,f.project,f.extract,f.record]) expect(fake).toHaveBeenCalledTimes(0);
+      });
+    }
+  }
+});
+it.each([[],["--dry-run"]])("AC7 purge previews %j", async (...tail) => {
+  await adminMain([...purge,...tail]);
+  expect(f.purge).toHaveBeenCalledTimes(0);
+  expect(console.log).toHaveBeenCalledWith(expect.stringContaining("DRY RUN"));
+});
+it("AC7 task dry-run previews even with projection requested", async () => {
+  await taskMain(["extract-meeting-todos","--dry-run","--project-to-linear"]);
+  expect(f.project).toHaveBeenCalledTimes(0);
+  expect(f.extract).toHaveBeenCalledTimes(1);
+  expect(f.extract).toHaveBeenCalledWith(f.client,"team-id",expect.objectContaining({dryRun:true}));
+});
+// Real processes pin entry guards, exit status, and arity ahead of environment/server imports.
+for (const script of ["admin","brain-tasks"]) {
+  for (const database of [undefined,"postgres://unused:unused@127.0.0.1:1/unused"]) {
+    it(`AC5 ${script} malformed, DATABASE_URL=${database ? "set" : "unset"}`, () => {
+      const env = {...process.env};
+      if (database) env.DATABASE_URL = database; else delete env.DATABASE_URL;
+      const argv = script === "admin" ? ["purge-items","--confirm","false"] : ["extract-meeting-todos","--project-to-linear","false"];
+      const result = spawnSync(process.execPath,["--import","tsx","--conditions","react-server",`scripts/${script}.ts`,...argv],{env,encoding:"utf8"});
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/takes no value/);
+      expect(result.stderr).not.toMatch(/DATABASE_URL|server-only/);
+    });
+  }
+  it(`AC5 ${script} help cannot mask malformed flags; valid help works`, () => {
+    const run = (args: string[]) => spawnSync(process.execPath,["--import","tsx","--conditions","react-server",`scripts/${script}.ts`,...args],{encoding:"utf8"});
+    const bad = run(["help",script === "admin" ? "--confirm" : "--dry-run","false"]);
+    expect(bad.status).toBe(1);
+    expect(bad.stderr).toMatch(/takes no value/);
+    expect(bad.stderr).not.toMatch(/DATABASE_URL|server-only/);
+    const good = run(["help"]);
+    expect(good.status).toBe(0);
+    expect(good.stdout).toMatch(/Team Brain.*CLI/);
+  });
+}

--- a/test/guards/admin-flag-registry.test.ts
+++ b/test/guards/admin-flag-registry.test.ts
@@ -5,12 +5,37 @@ import { ADMIN_BOOLEAN_FLAGS, TASK_BOOLEAN_FLAGS } from "@/lib/admin/args";
 import { parseConfirmFlags } from "@/lib/access/materialize-command";
 
 function unwrap(node: ts.Node): ts.Node {
-  return ts.isParenthesizedExpression(node) ? unwrap(node.expression) : node;
+  if (ts.isParenthesizedExpression(node) || ts.isAsExpression(node) || ts.isNonNullExpression(node)) {
+    return unwrap(node.expression);
+  }
+  return node;
 }
 function flagName(node: ts.Node): string | undefined {
   node = unwrap(node);
   if (ts.isPropertyAccessExpression(node) && node.expression.getText() === "flags") return node.name.text;
   if (ts.isElementAccessExpression(node) && node.expression.getText() === "flags" && ts.isStringLiteral(node.argumentExpression)) return node.argumentExpression.text;
+}
+/** The OUTERMOST cast of a chain — `x as unknown as boolean` must be judged by `boolean`. */
+function unwrapType(node: ts.AsExpression): ts.Node {
+  return node.expression;
+}
+type TypeVerdict = "boolean" | "value" | "unresolvable";
+function classifyType(t: ts.TypeNode): TypeVerdict {
+  if (t.kind === ts.SyntaxKind.BooleanKeyword) return "boolean";
+  if (ts.isLiteralTypeNode(t) && [ts.SyntaxKind.TrueKeyword, ts.SyntaxKind.FalseKeyword].includes(t.literal.kind)) return "boolean";
+  if (t.kind === ts.SyntaxKind.StringKeyword || t.kind === ts.SyntaxKind.NumberKeyword) return "value";
+  if (ts.isLiteralTypeNode(t) && ts.isStringLiteral(t.literal)) return "value";
+  if (ts.isUnionTypeNode(t)) {
+    // Drop the nullish members, then: all-boolean => boolean; any value member => value (this is the
+    // boundary `flags.labels as string | boolean | undefined` sits on, and it must stay a VALUE).
+    const parts = t.types.filter(m => m.kind !== ts.SyntaxKind.UndefinedKeyword && m.kind !== ts.SyntaxKind.NullKeyword
+      && !(ts.isLiteralTypeNode(m) && m.literal.kind === ts.SyntaxKind.NullKeyword));
+    const vs = parts.map(classifyType);
+    if (vs.length && vs.every(v => v === "boolean")) return "boolean";
+    if (vs.some(v => v === "value")) return "value";
+    return "unresolvable";
+  }
+  return "unresolvable"; // any, unknown, as const, TypeReference, everything else
 }
 function classify(source: string) {
   const file = ts.createSourceFile("cli.ts", source, ts.ScriptTarget.Latest, true);
@@ -39,12 +64,20 @@ function classify(source: string) {
     // earlier fold did, to classify `flags.tier as "team" | "external"` — let
     // `const w = flags.wipe as boolean; if (w) destroy();` past the guard with NO violation:
     // not a boolean, not unregistered, not unclassified. Found by attacking my own fold.
-    if (ts.isAsExpression(node)) {
-      const t = node.type.kind;
-      const isBool = t === ts.SyntaxKind.BooleanKeyword
-        || (ts.isLiteralTypeNode(node.type)
-            && [ts.SyntaxKind.TrueKeyword, ts.SyntaxKind.FalseKeyword].includes(node.type.literal.kind));
-      add(isBool ? booleans : values, node.expression);
+    // An `as` cast declares intent, and the classification must FAIL CLOSED when the cast does not
+    // actually declare one. Two earlier attempts both leaked, each time widening the door I had just
+    // narrowed: accepting every cast as a "value" let `flags.wipe as boolean` through, and then
+    // checking only BooleanKeyword/true/false let `flags.wipe as boolean | undefined` — the spelling
+    // a careful author reaches for, given `Flags = Record<string, string | boolean>` — through too.
+    // So: boolean-only asserted type => boolean read (must be registered); a type that is clearly a
+    // value => value read; ANYTHING UNRESOLVABLE (`any`, `unknown`, `as const`, a type reference a
+    // syntactic classifier cannot follow) => NEITHER, so the forall clause fires.
+    if (ts.isAsExpression(node) && !ts.isAsExpression(unwrapType(node))) {
+      const verdict = classifyType(node.type);
+      if (verdict === "boolean") add(booleans, node.expression);
+      else if (verdict === "value") add(values, node.expression);
+      // else: unresolvable — classify NOTHING, so the read stays in `seen` only and the
+      // forall clause reports it as `unclassified read: <name>`.
     }
     if (ts.isBinaryExpression(node)) {
       for (const [left,right] of [[node.left,node.right],[node.right,node.left]]) {
@@ -86,15 +119,34 @@ describe.each(cases)("AC8 $script registry", ({script,registry}) => {
   // is disproportionate for this slice. `it.fails` so this flips RED the day someone closes it.
   it.fails("KNOWN GAP: a value-classified name can still be truthiness-gated elsewhere", () => {
     const mixed = 'typeof flags.wipe === "string";\nconst w = flags.wipe;\nif (w) destroy();';
-    expect(violations(mixed, [])).toContain("unclassified read: wipe");
+    // `not.toEqual([])` pins the PROPERTY (some violation is reported), not a message string —
+    // a per-occurrence fix that reports under a different wording would otherwise leave this green.
+    expect(violations(mixed, [])).not.toEqual([]);
   });
 
   it("negative control: a boolean-typed `as` cast cannot launder an unregistered flag", () => {
-    for (const read of ["const w = flags.wipe as boolean; if (w) go();", "flags.wipe as true;"]) {
+    for (const read of [
+      "const w = flags.wipe as boolean; if (w) go();",
+      "flags.wipe as true;",
+      // the spellings that defeated the two earlier attempts at this rule:
+      "const w = flags.wipe as boolean | undefined; if (w) go();",
+      "const w = flags.wipe as true | false; if (w) go();",
+    ]) {
       expect(violations(read, []), read).toContain("unregistered boolean: wipe");
     }
-    // …and a non-boolean cast is still a VALUE read, which is what classifies `flags.tier`.
+    // A cast that declares NO intent must fail closed — not be treated as a value declaration.
+    for (const read of [
+      "const w = flags.wipe as any; if (w) go();",
+      "const w = flags.wipe as unknown; if (w) go();",
+      "const w = flags.wipe as unknown as boolean; if (w) go();",
+      "const w = flags.wipe as Flag; if (w) go();",
+    ]) {
+      expect(violations(read, []), read).not.toEqual([]);
+    }
+    // …and the two real mixed/value unions stay VALUE reads, which is the boundary the rule must
+    // respect: classifying these as boolean would redden both real CLIs.
     expect(violations('flags.tier as "team" | "external";', [])).toEqual([]);
+    expect(violations("flags.labels as string | boolean | undefined;", [])).toEqual([]);
   });
 
   it("negative control: an UNCLASSIFIED read fails — the spellings that defeated the existential form", () => {

--- a/test/guards/admin-flag-registry.test.ts
+++ b/test/guards/admin-flag-registry.test.ts
@@ -34,7 +34,18 @@ function classify(source: string) {
     if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) condition(node.expression);
     if (ts.isConditionalExpression(node)) condition(node.condition);
     if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) add(booleans, node.left);
-    if (ts.isAsExpression(node)) add(values, node.expression);
+    // An `as` cast declares intent. A BOOLEAN-typed cast is a boolean read (so the name must be
+    // registered); anything else is a value read. Accepting every cast as a "value" — which an
+    // earlier fold did, to classify `flags.tier as "team" | "external"` — let
+    // `const w = flags.wipe as boolean; if (w) destroy();` past the guard with NO violation:
+    // not a boolean, not unregistered, not unclassified. Found by attacking my own fold.
+    if (ts.isAsExpression(node)) {
+      const t = node.type.kind;
+      const isBool = t === ts.SyntaxKind.BooleanKeyword
+        || (ts.isLiteralTypeNode(node.type)
+            && [ts.SyntaxKind.TrueKeyword, ts.SyntaxKind.FalseKeyword].includes(node.type.literal.kind));
+      add(isBool ? booleans : values, node.expression);
+    }
     if (ts.isBinaryExpression(node)) {
       for (const [left,right] of [[node.left,node.right],[node.right,node.left]]) {
         if (ts.isTypeOfExpression(left) && ts.isStringLiteral(right) && right.text === "string") add(values, left.expression);
@@ -67,6 +78,14 @@ describe.each(cases)("AC8 $script registry", ({script,registry}) => {
   it("covers every boolean consumer and excludes value consumers", () => {
     expect(violations(source,registry)).toEqual([]);
   });
+  it("negative control: a boolean-typed `as` cast cannot launder an unregistered flag", () => {
+    for (const read of ["const w = flags.wipe as boolean; if (w) go();", "flags.wipe as true;"]) {
+      expect(violations(read, []), read).toContain("unregistered boolean: wipe");
+    }
+    // …and a non-boolean cast is still a VALUE read, which is what classifies `flags.tier`.
+    expect(violations('flags.tier as "team" | "external";', [])).toEqual([]);
+  });
+
   it("negative control: an UNCLASSIFIED read fails — the spellings that defeated the existential form", () => {
     // Each of these reintroduces the coercion trap while being invisible to every truthiness rule:
     // `--wipe false` makes the string "false", which is !== undefined and truthy.

--- a/test/guards/admin-flag-registry.test.ts
+++ b/test/guards/admin-flag-registry.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { ADMIN_BOOLEAN_FLAGS, TASK_BOOLEAN_FLAGS } from "@/lib/admin/args";
+import { parseConfirmFlags } from "@/lib/access/materialize-command";
+
+function unwrap(node: ts.Node): ts.Node {
+  return ts.isParenthesizedExpression(node) ? unwrap(node.expression) : node;
+}
+function flagName(node: ts.Node): string | undefined {
+  node = unwrap(node);
+  if (ts.isPropertyAccessExpression(node) && node.expression.getText() === "flags") return node.name.text;
+  if (ts.isElementAccessExpression(node) && node.expression.getText() === "flags" && ts.isStringLiteral(node.argumentExpression)) return node.argumentExpression.text;
+}
+function classify(source: string) {
+  const file = ts.createSourceFile("cli.ts", source, ts.ScriptTarget.Latest, true);
+  const booleans = new Set<string>();
+  const values = new Set<string>();
+  const add = (set: Set<string>, node: ts.Node) => { const name = flagName(node); if (name) set.add(name); };
+  const condition = (node: ts.Node): void => {
+    node = unwrap(node);
+    add(booleans, node);
+    if (ts.isBinaryExpression(node) && [ts.SyntaxKind.AmpersandAmpersandToken, ts.SyntaxKind.BarBarToken].includes(node.operatorToken.kind)) {
+      condition(node.left);
+      condition(node.right);
+    }
+  };
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && node.expression.getText() === "Boolean") node.arguments.forEach(arg => add(booleans, arg));
+    if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.ExclamationToken) add(booleans, node.operand);
+    if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) condition(node.expression);
+    if (ts.isConditionalExpression(node)) condition(node.condition);
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) add(booleans, node.left);
+    if (ts.isAsExpression(node) && node.type.kind === ts.SyntaxKind.StringKeyword) add(values, node.expression);
+    if (ts.isBinaryExpression(node)) {
+      for (const [left,right] of [[node.left,node.right],[node.right,node.left]]) {
+        if (ts.isTypeOfExpression(left) && ts.isStringLiteral(right) && right.text === "string") add(values, left.expression);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return {booleans,values};
+}
+function violations(source: string, registry: readonly string[]) {
+  const {booleans,values} = classify(source);
+  return [
+    ...[...booleans].filter(name => !registry.includes(name)).map(name => `unregistered boolean: ${name}`),
+    ...[...values].filter(name => registry.includes(name)).map(name => `registered value: ${name}`),
+    ...[...booleans].filter(name => values.has(name)).map(name => `both classes: ${name}`),
+  ];
+}
+const cases = [
+  {script:"admin",registry:ADMIN_BOOLEAN_FLAGS},
+  {script:"brain-tasks",registry:TASK_BOOLEAN_FLAGS},
+];
+describe.each(cases)("AC8 $script registry", ({script,registry}) => {
+  const source = readFileSync(`scripts/${script}.ts`,"utf8");
+  it("covers every boolean consumer and excludes value consumers", () => {
+    expect(violations(source,registry)).toEqual([]);
+  });
+  it("negative control: a new flags.newflag && read fails the same guard", () => {
+    expect(violations(`${source}\nflags.newflag && doSomething();`,registry)).toContain("unregistered boolean: newflag");
+  });
+});
+it("recognizes each required truthiness spelling and rejects mixed classes", () => {
+  for (const read of ["Boolean(flags.newflag)","!flags.newflag","flags.newflag && work()","if (flags.newflag) work()",'if (flags["newflag"]) work()']) {
+    expect(violations(read,[])).toContain("unregistered boolean: newflag");
+  }
+  expect(violations('if (flags.x) work(); flags.x as string;', ["x"])).toEqual(["registered value: x","both classes: x"]);
+  expect(violations('typeof flags.x === "string"', ["x"])).toEqual(["registered value: x"]);
+});
+it("materialize confirmation keys are a subset of the admin registry", () => {
+  // CONFIRM_KEYS is private and its file is comment-only in this spec's scope.
+  // Read its declaration rather than maintain a second list; the exported defense is imported above.
+  const source = ts.createSourceFile("materialize.ts",readFileSync("lib/access/materialize-command.ts","utf8"),ts.ScriptTarget.Latest,true);
+  let keys: string[] | undefined;
+  const visit = (node: ts.Node) => {
+    if (ts.isVariableDeclaration(node) && node.name.getText() === "CONFIRM_KEYS" && node.initializer) {
+      const initializer = ts.isAsExpression(node.initializer) ? node.initializer.expression : node.initializer;
+      expect(ts.isArrayLiteralExpression(initializer)).toBe(true);
+      if (ts.isArrayLiteralExpression(initializer)) keys = initializer.elements.map(element => {
+        if (!ts.isStringLiteral(element)) throw new Error("CONFIRM_KEYS must contain literal names");
+        return element.text;
+      });
+    }
+    ts.forEachChild(node,visit);
+  };
+  visit(source);
+  expect(keys?.length).toBeGreaterThan(0);
+  for (const key of keys ?? []) {
+    expect(ADMIN_BOOLEAN_FLAGS).toContain(key);
+    expect(parseConfirmFlags({[key]:"false"}).ok).toBe(false);
+  }
+});

--- a/test/guards/admin-flag-registry.test.ts
+++ b/test/guards/admin-flag-registry.test.ts
@@ -78,6 +78,17 @@ describe.each(cases)("AC8 $script registry", ({script,registry}) => {
   it("covers every boolean consumer and excludes value consumers", () => {
     expect(violations(source,registry)).toEqual([]);
   });
+  // KNOWN GAP, recorded rather than overclaimed (astra diff review). The forall clause is per
+  // NAME, not per OCCURRENCE: one classified read blesses every other read of the same name, so a
+  // name proven to be a value flag can still be truthiness-gated in an unrecognised spelling. Going
+  // per-occurrence would require every `flags.x !== undefined` and every plain assignment across
+  // both CLIs (~20 reads, none related to flag arity) to be rewritten into a recognised form, which
+  // is disproportionate for this slice. `it.fails` so this flips RED the day someone closes it.
+  it.fails("KNOWN GAP: a value-classified name can still be truthiness-gated elsewhere", () => {
+    const mixed = 'typeof flags.wipe === "string";\nconst w = flags.wipe;\nif (w) destroy();';
+    expect(violations(mixed, [])).toContain("unclassified read: wipe");
+  });
+
   it("negative control: a boolean-typed `as` cast cannot launder an unregistered flag", () => {
     for (const read of ["const w = flags.wipe as boolean; if (w) go();", "flags.wipe as true;"]) {
       expect(violations(read, []), read).toContain("unregistered boolean: wipe");

--- a/test/guards/admin-flag-registry.test.ts
+++ b/test/guards/admin-flag-registry.test.ts
@@ -4,6 +4,13 @@ import { describe, expect, it } from "vitest";
 import { ADMIN_BOOLEAN_FLAGS, TASK_BOOLEAN_FLAGS } from "@/lib/admin/args";
 import { parseConfirmFlags } from "@/lib/access/materialize-command";
 
+/**
+ * Seeing through casts and non-null assertions is DELIBERATE, and it makes the truthiness rules
+ * stricter as a side effect: `if (flags.x as string)`, `!(flags.x as string)` and
+ * `Boolean(flags.x as string)` now report a boolean read (and, with the cast, `both classes`)
+ * where they used to be silent value reads. That is correct — a truthiness read of a
+ * string-cast flag is exactly the trap when the flag is passed bare — so do not "fix" it.
+ */
 function unwrap(node: ts.Node): ts.Node {
   if (ts.isParenthesizedExpression(node) || ts.isAsExpression(node) || ts.isNonNullExpression(node)) {
     return unwrap(node.expression);
@@ -14,10 +21,6 @@ function flagName(node: ts.Node): string | undefined {
   node = unwrap(node);
   if (ts.isPropertyAccessExpression(node) && node.expression.getText() === "flags") return node.name.text;
   if (ts.isElementAccessExpression(node) && node.expression.getText() === "flags" && ts.isStringLiteral(node.argumentExpression)) return node.argumentExpression.text;
-}
-/** The OUTERMOST cast of a chain — `x as unknown as boolean` must be judged by `boolean`. */
-function unwrapType(node: ts.AsExpression): ts.Node {
-  return node.expression;
 }
 type TypeVerdict = "boolean" | "value" | "unresolvable";
 function classifyType(t: ts.TypeNode): TypeVerdict {
@@ -54,16 +57,21 @@ function classify(source: string) {
   const visit = (node: ts.Node) => {
     const anyName = flagName(node);
     if (anyName) seen.add(anyName);
+    // `const { wipe } = flags` / `const { wipe: w } = flags` never produce a `flags.x` node, so the
+    // forall clause could not see them at all — silent, not fail-closed. Record the bound names so
+    // an undeclared one is reported like any other unclassified read.
+    if (ts.isVariableDeclaration(node) && node.initializer?.getText() === "flags" && ts.isObjectBindingPattern(node.name)) {
+      for (const el of node.name.elements) {
+        const src = el.propertyName ?? el.name;
+        if (ts.isIdentifier(src)) seen.add(src.text);
+        else if (ts.isStringLiteral(src)) seen.add(src.text);
+      }
+    }
     if (ts.isCallExpression(node) && node.expression.getText() === "Boolean") node.arguments.forEach(arg => add(booleans, arg));
     if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.ExclamationToken) add(booleans, node.operand);
     if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) condition(node.expression);
     if (ts.isConditionalExpression(node)) condition(node.condition);
     if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) add(booleans, node.left);
-    // An `as` cast declares intent. A BOOLEAN-typed cast is a boolean read (so the name must be
-    // registered); anything else is a value read. Accepting every cast as a "value" — which an
-    // earlier fold did, to classify `flags.tier as "team" | "external"` — let
-    // `const w = flags.wipe as boolean; if (w) destroy();` past the guard with NO violation:
-    // not a boolean, not unregistered, not unclassified. Found by attacking my own fold.
     // An `as` cast declares intent, and the classification must FAIL CLOSED when the cast does not
     // actually declare one. Two earlier attempts both leaked, each time widening the door I had just
     // narrowed: accepting every cast as a "value" let `flags.wipe as boolean` through, and then
@@ -72,7 +80,12 @@ function classify(source: string) {
     // So: boolean-only asserted type => boolean read (must be registered); a type that is clearly a
     // value => value read; ANYTHING UNRESOLVABLE (`any`, `unknown`, `as const`, a type reference a
     // syntactic classifier cannot follow) => NEITHER, so the forall clause fires.
-    if (ts.isAsExpression(node) && !ts.isAsExpression(unwrapType(node))) {
+    // EVERY link of a chain, not just the outermost. Skipping a cast whose operand was itself a
+    // cast judged `x as A as B` by A — the INNERMOST — which is the inverse of what this comment
+    // used to claim, and it leaked: `flags.wipe as string | boolean as boolean` reported nothing
+    // while `--wipe false` took the destructive branch. Classifying every link is strictly more
+    // fail-closed: a chain whose links disagree now reports `both classes`.
+    if (ts.isAsExpression(node)) {
       const verdict = classifyType(node.type);
       if (verdict === "boolean") add(booleans, node.expression);
       else if (verdict === "value") add(values, node.expression);
@@ -140,6 +153,12 @@ describe.each(cases)("AC8 $script registry", ({script,registry}) => {
       "const w = flags.wipe as unknown; if (w) go();",
       "const w = flags.wipe as unknown as boolean; if (w) go();",
       "const w = flags.wipe as Flag; if (w) go();",
+      // chain casts — judged by every link, so a disagreeing chain cannot hide a boolean
+      "const w = flags.wipe as string | boolean as boolean; if (w) go();",
+      "const w = flags.wipe as boolean as unknown; if (w) go();",
+      // destructuring, the most idiomatic launder
+      "const { wipe } = flags; if (wipe) go();",
+      "const { wipe: w } = flags; if (w) go();",
     ]) {
       expect(violations(read, []), read).not.toEqual([]);
     }
@@ -184,6 +203,16 @@ it("materialize confirmation keys are a subset of the admin registry", () => {
   const visit = (node: ts.Node) => {
     const anyName = flagName(node);
     if (anyName) seen.add(anyName);
+    // `const { wipe } = flags` / `const { wipe: w } = flags` never produce a `flags.x` node, so the
+    // forall clause could not see them at all — silent, not fail-closed. Record the bound names so
+    // an undeclared one is reported like any other unclassified read.
+    if (ts.isVariableDeclaration(node) && node.initializer?.getText() === "flags" && ts.isObjectBindingPattern(node.name)) {
+      for (const el of node.name.elements) {
+        const src = el.propertyName ?? el.name;
+        if (ts.isIdentifier(src)) seen.add(src.text);
+        else if (ts.isStringLiteral(src)) seen.add(src.text);
+      }
+    }
     if (ts.isVariableDeclaration(node) && node.name.getText() === "CONFIRM_KEYS" && node.initializer) {
       const initializer = ts.isAsExpression(node.initializer) ? node.initializer.expression : node.initializer;
       expect(ts.isArrayLiteralExpression(initializer)).toBe(true);

--- a/test/guards/admin-flag-registry.test.ts
+++ b/test/guards/admin-flag-registry.test.ts
@@ -25,13 +25,16 @@ function classify(source: string) {
       condition(node.right);
     }
   };
+  const seen = new Set<string>();
   const visit = (node: ts.Node) => {
+    const anyName = flagName(node);
+    if (anyName) seen.add(anyName);
     if (ts.isCallExpression(node) && node.expression.getText() === "Boolean") node.arguments.forEach(arg => add(booleans, arg));
     if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.ExclamationToken) add(booleans, node.operand);
     if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) condition(node.expression);
     if (ts.isConditionalExpression(node)) condition(node.condition);
     if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) add(booleans, node.left);
-    if (ts.isAsExpression(node) && node.type.kind === ts.SyntaxKind.StringKeyword) add(values, node.expression);
+    if (ts.isAsExpression(node)) add(values, node.expression);
     if (ts.isBinaryExpression(node)) {
       for (const [left,right] of [[node.left,node.right],[node.right,node.left]]) {
         if (ts.isTypeOfExpression(left) && ts.isStringLiteral(right) && right.text === "string") add(values, left.expression);
@@ -40,14 +43,19 @@ function classify(source: string) {
     ts.forEachChild(node, visit);
   };
   visit(file);
-  return {booleans,values};
+  return {booleans,values,seen};
 }
 function violations(source: string, registry: readonly string[]) {
-  const {booleans,values} = classify(source);
+  const {booleans,values,seen} = classify(source);
   return [
     ...[...booleans].filter(name => !registry.includes(name)).map(name => `unregistered boolean: ${name}`),
     ...[...values].filter(name => registry.includes(name)).map(name => `registered value: ${name}`),
     ...[...booleans].filter(name => values.has(name)).map(name => `both classes: ${name}`),
+    // THE FORALL CLAUSE. Without it this guard is existential: it proves things about the
+    // spellings it recognises and says nothing about the rest, so `if (flags.wipe !== undefined)`
+    // or `const w = flags.wipe; if (w)` reintroduces the exact coercion trap while the guard stays
+    // green. Making ambiguity FAIL forces the author to declare intent in a recognised form.
+    ...[...seen].filter(name => !booleans.has(name) && !values.has(name)).map(name => `unclassified read: ${name}`),
   ];
 }
 const cases = [
@@ -59,6 +67,21 @@ describe.each(cases)("AC8 $script registry", ({script,registry}) => {
   it("covers every boolean consumer and excludes value consumers", () => {
     expect(violations(source,registry)).toEqual([]);
   });
+  it("negative control: an UNCLASSIFIED read fails — the spellings that defeated the existential form", () => {
+    // Each of these reintroduces the coercion trap while being invisible to every truthiness rule:
+    // `--wipe false` makes the string "false", which is !== undefined and truthy.
+    for (const read of [
+      "if (flags.wipe !== undefined) doSomething();",
+      "const w = flags.wipe; if (w) doSomething();",
+      "doSomething(flags.wipe ?? false);",
+      "const w = flags.wipe || false;",
+    ]) {
+      expect(violations(read, []), read).toContain("unclassified read: wipe");
+    }
+    // …and a name declared in a recognised class is NOT reported.
+    expect(violations('typeof flags.wipe === "string";', [])).toEqual([]);
+  });
+
   it("negative control: a new flags.newflag && read fails the same guard", () => {
     expect(violations(`${source}\nflags.newflag && doSomething();`,registry)).toContain("unregistered boolean: newflag");
   });
@@ -75,7 +98,10 @@ it("materialize confirmation keys are a subset of the admin registry", () => {
   // Read its declaration rather than maintain a second list; the exported defense is imported above.
   const source = ts.createSourceFile("materialize.ts",readFileSync("lib/access/materialize-command.ts","utf8"),ts.ScriptTarget.Latest,true);
   let keys: string[] | undefined;
+  const seen = new Set<string>();
   const visit = (node: ts.Node) => {
+    const anyName = flagName(node);
+    if (anyName) seen.add(anyName);
     if (ts.isVariableDeclaration(node) && node.name.getText() === "CONFIRM_KEYS" && node.initializer) {
       const initializer = ts.isAsExpression(node.initializer) ? node.initializer.expression : node.initializer;
       expect(ts.isArrayLiteralExpression(initializer)).toBe(true);

--- a/test/guards/admin-flag-registry.test.ts
+++ b/test/guards/admin-flag-registry.test.ts
@@ -60,11 +60,20 @@ function classify(source: string) {
     // `const { wipe } = flags` / `const { wipe: w } = flags` never produce a `flags.x` node, so the
     // forall clause could not see them at all — silent, not fail-closed. Record the bound names so
     // an undeclared one is reported like any other unclassified read.
-    if (ts.isVariableDeclaration(node) && node.initializer?.getText() === "flags" && ts.isObjectBindingPattern(node.name)) {
-      for (const el of node.name.elements) {
-        const src = el.propertyName ?? el.name;
-        if (ts.isIdentifier(src)) seen.add(src.text);
-        else if (ts.isStringLiteral(src)) seen.add(src.text);
+    if (ts.isVariableDeclaration(node) && ts.isObjectBindingPattern(node.name)) {
+      // unwrap the initializer: a bare `getText() === "flags"` match is defeated by
+      // `= flags as Flags` or `= (flags)` — the same "a cast beats a string compare" family as the
+      // chain defect above.
+      const init = node.initializer && unwrap(node.initializer);
+      if (init && ts.isIdentifier(init) && init.text === "flags") {
+        for (const el of node.name.elements) {
+          const src = el.propertyName ?? el.name;
+          if (ts.isIdentifier(src) || ts.isStringLiteral(src)) seen.add(src.text);
+          // A computed key (`const { ["wipe"]: w } = flags`) resolves to no static name. Record a
+          // sentinel rather than skipping: skipping is how the rule I had just written to be
+          // fail-closed failed OPEN on the shape adjacent to the one it closed.
+          else seen.add("<unresolvable destructured key>");
+        }
       }
     }
     if (ts.isCallExpression(node) && node.expression.getText() === "Boolean") node.arguments.forEach(arg => add(booleans, arg));
@@ -83,8 +92,11 @@ function classify(source: string) {
     // EVERY link of a chain, not just the outermost. Skipping a cast whose operand was itself a
     // cast judged `x as A as B` by A — the INNERMOST — which is the inverse of what this comment
     // used to claim, and it leaked: `flags.wipe as string | boolean as boolean` reported nothing
-    // while `--wipe false` took the destructive branch. Classifying every link is strictly more
-    // fail-closed: a chain whose links disagree now reports `both classes`.
+    // while `--wipe false` took the destructive branch. Every link must now AGREE — a chain whose
+    // links disagree reports `both classes`. Not 'strictly more fail-closed': a registered flag
+    // written `flags.hard as unknown as boolean` was red before (the inner `unknown` was
+    // unresolvable) and is green now, which is the CORRECT outcome — the old red was a false
+    // positive.
     if (ts.isAsExpression(node)) {
       const verdict = classifyType(node.type);
       if (verdict === "boolean") add(booleans, node.expression);
@@ -199,20 +211,7 @@ it("materialize confirmation keys are a subset of the admin registry", () => {
   // Read its declaration rather than maintain a second list; the exported defense is imported above.
   const source = ts.createSourceFile("materialize.ts",readFileSync("lib/access/materialize-command.ts","utf8"),ts.ScriptTarget.Latest,true);
   let keys: string[] | undefined;
-  const seen = new Set<string>();
   const visit = (node: ts.Node) => {
-    const anyName = flagName(node);
-    if (anyName) seen.add(anyName);
-    // `const { wipe } = flags` / `const { wipe: w } = flags` never produce a `flags.x` node, so the
-    // forall clause could not see them at all — silent, not fail-closed. Record the bound names so
-    // an undeclared one is reported like any other unclassified read.
-    if (ts.isVariableDeclaration(node) && node.initializer?.getText() === "flags" && ts.isObjectBindingPattern(node.name)) {
-      for (const el of node.name.elements) {
-        const src = el.propertyName ?? el.name;
-        if (ts.isIdentifier(src)) seen.add(src.text);
-        else if (ts.isStringLiteral(src)) seen.add(src.text);
-      }
-    }
     if (ts.isVariableDeclaration(node) && node.name.getText() === "CONFIRM_KEYS" && node.initializer) {
       const initializer = ts.isAsExpression(node.initializer) ? node.initializer.expression : node.initializer;
       expect(ts.isArrayLiteralExpression(initializer)).toBe(true);


### PR DESCRIPTION
## What this is

`scripts/admin.ts` had one tokenizer that consumed the token after `--x` as a **string**. So
`purge-items --confirm false` set `flags.confirm = "false"`, `if (!flags.confirm)` saw a truthy
non-empty string, and **an operator who typed the opposite got a confirmed, irreversible delete.**

Measured, it was wider than the ticket said: **seven** flags are read by truthiness, and the tokenizer
is **duplicated byte-for-byte** in `scripts/brain-tasks.ts:54-70`, where `--project-to-linear false`
performs an **outward-facing write to Linear**. Neither the author nor I found that second CLI — the
spec review did.

`lib/admin/args.ts` (new) validates **raw argv before the collapse**, which is the only layer that can
see `--confirm false --confirm` (that collapses to `{confirm: true}`, defeating the map-based check
STAGINGMARK-1 shipped). The registry is a per-CLI parameter; both CLIs adopt it, export `main(argv)`
behind an argv entry guard, and `die` throws a typed `CliExitError`.

Verified against the real CLI:

```
purge-items … --confirm false            → ✗ --confirm takes no value        exit 1
purge-items … --confirm false --confirm  → ✗ --confirm takes no value        exit 1
delete-member u@x.com --hard false       → ✗ --hard takes no value           exit 1
brain-tasks … --project-to-linear false  → ✗ --project-to-linear takes no…   exit 1
admin help / admin --help                → usage                             exit 0
```

## Deliberately NOT in this PR

- **Value-flag validation** (types, requiredness, unknown keys, positional counts, `--` terminator).
  Nothing is broken there; the existing `flags.actor === true` refusals cover the real case.
- **Coercing `false` to OFF.** Omission is OFF; an explicit value is an error, never a guessed
  instruction to proceed.
- **`materialize-command.ts`'s logic.** The new boundary closes its repetition gap upstream; only its
  comment changed, because this PR made it false.

## Authorship

Spec **and** code written by **`gpt-6-astra`** (reasoning effort **`low`**), banner-verified on each
run. I orchestrated, folded every review round, and verified every claim myself rather than trusting
the build report — which is how the leaks below were found.

## Verification

| check | result |
|---|---|
| `tsc --noEmit` | clean |
| lint | 0 errors (18 pre-existing warnings, none in new files) |
| unit | **4146 pass + 2 expected-fail** |
| docs drift | congruent |
| spec gate | `SPEC_READY`, exit 0 |
| tokenizer | **byte-identical** to `origin/main` (diffed) — no value flag changed behaviour |
| CI | **14/14 green** |
| known flake 1 | `test/guards/nda-gate.test.ts` timed out at 30s under LOCAL full-suite load in 2 of 7 runs (real `git fetch`, ~25s standalone). It passed on CI's clean runner, which was the discriminator. Zero overlap with this diff. |
| known flake 2 | `gateway-v110.datamechanics.test.ts` failed the first CI dm run: 121 concurrent hits against a **per-minute** bucket, all 121 allowed — a minute rollover mid-flight resets the bucket. `gatewayRateLimit` lives in `lib/gateway/persistence.ts`, which this diff does not touch. Re-ran the job: **passed**. Recorded, not swept. |

**Six mutations, and the one that SURVIVED was the valuable one.** M1/M2 (each CLI bypassing the
boundary) reddened AC5/AC7; M3 (an unregistered flag read) reddened the registry guard; M4/M5 (each
half of the refusal) reddened. **M6 survived** — investigating instead of recording it found that
`admin --confirm false` escaped validation entirely and reported *"DATABASE_URL is required"*. Fixed,
pinned both ways, and M6 now reddens.

## Review

**Reviewed by Fable code-reviewer and gpt-6-astra — verdict: BLOCKED four times across five rounds, every finding re-derived and folded; final re-clear CLEAR-WITH-CONDITIONS at `8492c5fb`, conditions applied.**

The blocked history is the value here, so it is recorded in full:

- **Fable, spec round — CLEAR-WITH-CONDITIONS.** Found the **duplicated tokenizer in `brain-tasks.ts`**
  writing to Linear. Found an AC that **could not fail** (`purge-items --confirm false` already exits 1
  on `DATABASE_URL` — only stderr discriminates). Found the proposed harness cost **1.96s × 150+ spawns**;
  replaced with an argv entry guard + in-process mocks.
- **Fable, diff round — BLOCKED.** The registry guard was **existential**: `flags.wipe !== undefined`,
  `const w = flags.wipe; if (w)`, `?? false`, `|| false` each reintroduced the trap while it stayed
  green. Making unclassified reads *fail* caught three real ones.
- **gpt-6-astra, correlated round — CLEAR-WITH-CONDITIONS.** *(Weak evidence: it wrote the code.)* It
  independently reached a hole I had already closed, and found a genuinely new one — my ∀ clause is
  per **name**, not per **occurrence**.
- **Fable re-clear #1 — BLOCKED.** My fix to my own hole was one token too narrow:
  `as boolean | undefined` (a `UnionType`) still laundered.
- **Fable re-clear #2 — BLOCKED.** My chain rule was **inverted** — it judged `x as A as B` by **A**,
  the innermost, contradicting my own comment. `as string | boolean as boolean` leaked, and it is legal
  TS in a `tsc`-checked directory.
- **Fable re-clear #3 — CLEAR-WITH-CONDITIONS.** Two one-line fail-opens in the destructuring rule I had
  just written to be fail-closed. Applied.

**Four claims of mine were false and are corrected in the record**, not quietly amended: "fails any read
that lands in neither class" (per *name*, not occurrence), "judged by the OUTER type" (inverted),
"zero leak" (true only of the shapes probed), and "strictly more fail-closed" (a registered
`as unknown as boolean` was a false positive before).

## Deferrals — recorded, not closed

- **The ∀ clause is per NAME, not per occurrence.** One classified read blesses the name's others.
  Per-occurrence would need **37** unrelated read rewrites (measured twice: 17/46 `admin.ts`, 20/57
  `brain-tasks.ts`). Pinned as an `it.fails` that flips red the day someone closes it.
- **The whole-object family** — alias, `go(flags)`, assignment-pattern destructure, computed index — is
  outside a syntactic classifier by construction. An allowlist would be a third registry to drift; the
  one cross-file hand-off carrying a boolean is pinned by the `CONFIRM_KEYS ⊆ registry` test instead.
- **`purge-items`' broader confirmation semantics** stay as-is; this PR only stops the coercion.

AIOS-Work: STAGINGMARK-4

