### PR TITLE
AIO-1109: add disposable Brain HTTP support for MCP authorization acceptance

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,6 +14,13 @@ portable: plain SQL migrations, Postgres-backed rate limiting, no Vercel-only de
 
 ## First-install deployment flow
 
+Test-only MCP acceptance (`vitest.mcp.config.ts`) reuses the production HTTP harness
+and real Postgres helpers. `test/http/mcp-tier-safety.acceptance.ts` provisions synthetic
+ingestion, keys, and project memberships, then launches the Workspace-owned stdio
+outcome suite over a private parent/child IPC channel. It exposes no HTTP control route
+and changes no production authorization. The caller owns the isolated database and
+disposable build; fixture cleanup is asserted before server/database teardown.
+
 The canonical hosted-install entry point is `https://aiosbrain.dev/deploy/team-brain/`. It resolves
 to the official Railway template described in [`RAILWAY-TEMPLATE.md`](RAILWAY-TEMPLATE.md): Team
 Brain, Postgres, Graphiti, and Neo4j. Railway reference variables keep Graphiti and Neo4j on the

--- a/test/http/global-setup.ts
+++ b/test/http/global-setup.ts
@@ -34,13 +34,21 @@ export default async function setup(): Promise<() => Promise<void>> {
   }
 
   const nextBin = resolve("node_modules/.bin/next");
+  // The MCP outer runner owns a detached Vitest process group. Keep its server
+  // inside that group so an outer timeout also closes every inherited pipe.
+  const detached = process.env.MCP_HTTP_ATTACHED !== "1";
   const server: ChildProcess = spawn(nextBin, ["start", "-p", PORT], {
     // Inherit the backend/secret env pinned in vitest.http.config.ts; PORT is also
     // honored by `next start`. detached so we can kill the whole process group.
     env: { ...process.env, PORT },
     stdio: ["ignore", "inherit", "inherit"],
-    detached: true,
+    detached,
   });
+  const stop = (signal: NodeJS.Signals) => {
+    if (!server.pid) return;
+    if (detached) process.kill(-server.pid, signal);
+    else server.kill(signal);
+  };
 
   server.on("error", (err) => {
     throw new Error(`HTTP tier: failed to spawn next start — ${err.message}`);
@@ -51,7 +59,7 @@ export default async function setup(): Promise<() => Promise<void>> {
   } catch (e) {
     if (server.pid) {
       try {
-        process.kill(-server.pid, "SIGKILL");
+        stop("SIGKILL");
       } catch {
         /* already gone */
       }
@@ -63,13 +71,14 @@ export default async function setup(): Promise<() => Promise<void>> {
     if (server.pid && server.exitCode === null && server.signalCode === null) {
       const exited = once(server, "exit");
       const timeout = setTimeout(() => {
-        try { process.kill(-server.pid!, "SIGKILL"); } catch { /* exit raced */ }
+        try { stop("SIGKILL"); } catch { /* exit raced */ }
       }, 5000);
       try {
-        process.kill(-server.pid, "SIGTERM");
+        stop("SIGTERM");
         await exited;
         if (server.signalCode === "SIGKILL") throw new Error("HTTP server required forced termination");
       } finally { clearTimeout(timeout); }
     }
+    console.log("HTTP_SERVER_CLEANUP_OK");
   };
 }

--- a/test/http/global-setup.ts
+++ b/test/http/global-setup.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { once } from "node:events";
 import { BASE_URL, HTTP_TEST_PORT as PORT } from "./server-url";
 
 // One production Next.js server for the whole HTTP suite. We boot `next start`
@@ -14,7 +15,7 @@ async function waitForReady(): Promise<void> {
   // the route runtime is live. Poll until then (≤30s).
   for (let i = 0; i < 30; i++) {
     try {
-      const res = await fetch(`${BASE_URL}/api/v1/items`);
+      const res = await fetch(`${BASE_URL}/api/v1/items`, { signal: AbortSignal.timeout(1000) });
       if (res.status === 401) return;
     } catch {
       // connection refused while the server is still binding — keep polling
@@ -59,12 +60,16 @@ export default async function setup(): Promise<() => Promise<void>> {
   }
 
   return async () => {
-    if (server.pid) {
+    if (server.pid && server.exitCode === null && server.signalCode === null) {
+      const exited = once(server, "exit");
+      const timeout = setTimeout(() => {
+        try { process.kill(-server.pid!, "SIGKILL"); } catch { /* exit raced */ }
+      }, 5000);
       try {
         process.kill(-server.pid, "SIGTERM");
-      } catch {
-        /* already gone */
-      }
+        await exited;
+        if (server.signalCode === "SIGKILL") throw new Error("HTTP server required forced termination");
+      } finally { clearTimeout(timeout); }
     }
   };
 }

--- a/test/http/mcp-tier-safety.acceptance.ts
+++ b/test/http/mcp-tier-safety.acceptance.ts
@@ -1,0 +1,86 @@
+// AIO-1109 companion: test-only IPC provisioning for the workspace-owned wire assertions.
+import { it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { Client } from "pg";
+import { db, seedTeam, ingest, externalMember } from "../datamechanics/helpers";
+import { BASE_URL, convergeTeam } from "./http-helpers";
+import { issueApiKey } from "@/lib/admin/keys";
+import { createGroup, addMemberToGroup, removeMemberFromGroup, grantProjectToGroup, revokeProjectFromGroup } from "@/lib/access/groups";
+
+it("runs the actual workspace MCP process against disposable Brain fixtures", async () => {
+  const workspace = process.env.MCP_WORKSPACE_DIR;
+  if (!workspace) throw new Error("MCP_WORKSPACE_DIR is required");
+  const seed = await seedTeam();
+  try {
+    const admin = db();
+    const promoted = await admin.from("members").update({ role: "admin" }).eq("id", seed.memberId);
+    expect(promoted.error).toBeNull();
+    const external = await externalMember(seed);
+    const boardMember = await externalMember(seed);
+    const { data: everyone } = await admin.from("groups").select("id").eq("team_id", seed.teamId).eq("slug", "everyone").single();
+    expect((await addMemberToGroup(admin, seed.teamId, everyone!.id, boardMember, seed.memberId)).ok).toBe(true);
+    const visible = "4-shared/mcp-visible.md";
+    const granted = "2-work/mcp-grant-only.md";
+    await ingest(seed, { path: visible, body: "Synthetic public lighthouse", access: "external" });
+    const x = await ingest(seed, { path: granted, body: "Synthetic granted juniper", access: "team" });
+    await ingest(seed, { path: "2-work/mcp-hidden.md", body: "Synthetic hidden obsidian", access: "team" });
+    await convergeTeam(seed);
+    // Same fixture topology as the Brain's membership leak suite: an ingested item
+    // is assigned to a restricted initiative, not its General backfill membership.
+    const { data: project, error } = await admin.from("projects").insert({
+      team_id: seed.teamId, slug: `mcp-${randomUUID().slice(0, 8)}`, name: "MCP grant fixture", kind: "initiative",
+    }).select("id").single();
+    expect(error).toBeNull();
+    const { data: unit } = await admin.from("project_context_units").select("id").eq("source_item_id", x.id).single();
+    expect(unit).toBeTruthy();
+    expect((await admin.from("project_context_memberships").update({ valid_to: new Date().toISOString() }).eq("context_unit_id", unit!.id)).error).toBeNull();
+    expect((await admin.from("project_context_memberships").insert({ team_id: seed.teamId, project_id: project!.id, context_unit_id: unit!.id, method: "manual" })).error).toBeNull();
+    const group = await createGroup(admin, seed.teamId, "mcp-grantees", "MCP grantees", seed.memberId);
+    expect(group.ok, group.error).toBe(true);
+    expect((await addMemberToGroup(admin, seed.teamId, group.groupId!, external, seed.memberId)).ok).toBe(true);
+    const { key: teamKey } = await issueApiKey(admin, seed.teamId, boardMember, "MCP stale-list test");
+    const { key: externalKey } = await issueApiKey(admin, seed.teamId, external, "MCP external test");
+    const child = spawn(process.execPath, [resolve(workspace, "test/brain-mcp-tier-safety.test.mjs")], {
+      cwd: workspace,
+      env: { PATH: process.env.PATH, MCP_SAFETY_FIXTURE: JSON.stringify({ url: BASE_URL, team: seed.teamSlug, teamKey, externalKey, visible, granted }) },
+      stdio: ["ignore", "inherit", "inherit", "ipc"],
+    });
+    let chain = Promise.resolve();
+    child.on("message", (message: { id: number; command: string }) => {
+      chain = chain.then(async () => {
+        try {
+          let result;
+          if (message.command === "demote") result = await removeMemberFromGroup(admin, seed.teamId, everyone!.id, boardMember, seed.memberId);
+          else if (message.command === "grant") result = await grantProjectToGroup(admin, seed.teamId, project!.id, group.groupId!, seed.memberId);
+          else if (message.command === "revoke") result = await revokeProjectFromGroup(admin, seed.teamId, project!.id, group.groupId!, { kind: "member", memberId: seed.memberId });
+          else throw new Error("unknown fixture command");
+          if (!result.ok) throw new Error(result.error);
+          if (child.connected) child.send({ id: message.id, result });
+        } catch (error) {
+          if (child.connected) child.send({ id: message.id, error: String(error) });
+        }
+      });
+    });
+    const timer = setTimeout(() => child.kill("SIGKILL"), 150000);
+    try {
+      const code = await new Promise((resolve, reject) => { child.once("error", reject); child.once("close", resolve); });
+      await chain;
+      expect(code, "workspace MCP outcome suite failed").toBe(0);
+    } finally { clearTimeout(timer); }
+  } finally {
+    // Explicit principal/key/fixture cleanup, in addition to outer container removal.
+    const client = new Client({ connectionString: process.env.DATABASE_TEST_URL });
+    await client.connect();
+    try {
+      await client.query("DELETE FROM teams WHERE id = $1", [seed.teamId]);
+      for (const table of ["teams", "members", "api_keys", "items", "projects"]) {
+        const column = table === "teams" ? "id" : "team_id";
+        const result = await client.query(`SELECT count(*)::int AS n FROM ${table} WHERE ${column} = $1`, [seed.teamId]);
+        expect(result.rows[0].n, `cleanup ${table}`).toBe(0);
+      }
+      console.log("MCP_FIXTURE_CLEANUP_OK");
+    } finally { await client.end(); }
+  }
+}, 180000);

--- a/test/http/mcp-tier-safety.acceptance.ts
+++ b/test/http/mcp-tier-safety.acceptance.ts
@@ -12,8 +12,8 @@ import { createGroup, addMemberToGroup, removeMemberFromGroup, grantProjectToGro
 it("runs the actual workspace MCP process against disposable Brain fixtures", async () => {
   const workspace = process.env.MCP_WORKSPACE_DIR;
   if (!workspace) throw new Error("MCP_WORKSPACE_DIR is required");
-  const seed = await seedTeam();
   try {
+    const seed = await seedTeam();
     const admin = db();
     const promoted = await admin.from("members").update({ role: "admin" }).eq("id", seed.memberId);
     expect(promoted.error).toBeNull();
@@ -74,10 +74,11 @@ it("runs the actual workspace MCP process against disposable Brain fixtures", as
     const client = new Client({ connectionString: process.env.DATABASE_TEST_URL });
     await client.connect();
     try {
-      await client.query("DELETE FROM teams WHERE id = $1", [seed.teamId]);
+      // Same dedicated-DB cleanup primitive as datamechanics/setup.ts. Row
+      // DELETE would correctly hit the audit log's append-only trigger.
+      await client.query("TRUNCATE teams RESTART IDENTITY CASCADE");
       for (const table of ["teams", "members", "api_keys", "items", "projects"]) {
-        const column = table === "teams" ? "id" : "team_id";
-        const result = await client.query(`SELECT count(*)::int AS n FROM ${table} WHERE ${column} = $1`, [seed.teamId]);
+        const result = await client.query(`SELECT count(*)::int AS n FROM ${table}`);
         expect(result.rows[0].n, `cleanup ${table}`).toBe(0);
       }
       console.log("MCP_FIXTURE_CLEANUP_OK");

--- a/vitest.mcp.config.ts
+++ b/vitest.mcp.config.ts
@@ -1,7 +1,8 @@
-import { mergeConfig } from "vitest/config";
+import { defineConfig } from "vitest/config";
 import httpConfig from "./vitest.http.config";
 
 // Opt-in only: normal HTTP and offline suites remain independent of Workspace.
-export default mergeConfig(httpConfig, {
-  test: { include: ["test/http/mcp-tier-safety.acceptance.ts"] },
+export default defineConfig({
+  ...httpConfig,
+  test: { ...httpConfig.test, include: ["test/http/mcp-tier-safety.acceptance.ts"] },
 });

--- a/vitest.mcp.config.ts
+++ b/vitest.mcp.config.ts
@@ -1,0 +1,7 @@
+import { mergeConfig } from "vitest/config";
+import httpConfig from "./vitest.http.config";
+
+// Opt-in only: normal HTTP and offline suites remain independent of Workspace.
+export default mergeConfig(httpConfig, {
+  test: { include: ["test/http/mcp-tier-safety.acceptance.ts"] },
+});


### PR DESCRIPTION
AIO-1109 needs the Workspace MCP process to prove authorization against the production Brain HTTP server and real Postgres. This test-only companion reuses the HTTP harness, canonical key issuance, ingestion, and group grant/revocation helpers, and exposes fixture control solely through parent/child IPC. No production authorization code changes.

The separate `vitest.mcp.config.ts` runs the Workspace-owned assertions from `MCP_WORKSPACE_DIR`. Fixtures include nonempty visible and hidden content, a team-to-external demotion after MCP initialization, and explicit grants followed by revocation. Dedicated-database cleanup verifies principals, keys, items and projects are gone.

Validation: docs drift check and changed-file ESLint pass. Frozen local acceptance passed: baseline exit 0; project-denial and item-visibility mutations each exit 1 at their intended MCP assertion. Fixture, both MCP processes, HTTP server and database cleanup are verified in every run. Evidence manifest SHA256: 1be4ae3c6a955ffef1b73d203ce0081afd14f632044345e432f5e860ac1fd82c; full logs and digests recorded on AIO-1109. This companion alone does not close AIO-1109.

## Review — Reviewed by Codex independent review subagent — verdict no outstanding findings at 1a2ca61fd39003f3a72b5cdf4beb39ae5dfe32f7

AIOS-Work: AIO-1109

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test harness, fixture IPC, and documentation; no production authorization or API surface changes.
> 
> **Overview**
> Adds an **opt-in MCP acceptance path** (`vitest.mcp.config.ts`) that runs a single HTTP integration test against a real `next start` server and dedicated test Postgres, without pulling Workspace into the default HTTP suite.
> 
> The new **`mcp-tier-safety.acceptance.ts`** seeds synthetic teams, keys, ingestion, and project/group grants, then spawns the Workspace-owned MCP outcome suite from `MCP_WORKSPACE_DIR` with fixture details over env and **parent/child IPC** for demote/grant/revoke steps mid-run. Teardown **truncates** the test DB and asserts core tables are empty.
> 
> **`global-setup.ts`** is adjusted for MCP runners: `MCP_HTTP_ATTACHED=1` keeps the Next process in the same group as a detached Vitest parent; readiness polling uses fetch timeouts; shutdown waits for exit with a SIGKILL fallback and logs **`HTTP_SERVER_CLEANUP_OK`**.
> 
> **`ARCHITECTURE.md`** documents this test-only flow and states it does not add HTTP control routes or change production authorization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2ca61fd39003f3a72b5cdf4beb39ae5dfe32f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added acceptance coverage for MCP tier-safety scenarios, including role changes, access restrictions, external members, API keys, and fixture cleanup.
  * Added dedicated test configuration for running the MCP safety acceptance flow.
  * Improved HTTP test server startup, readiness checks, graceful shutdown, and cleanup verification.

* **Documentation**
  * Documented the test-only MCP acceptance flow, including its isolated fixtures and private communication channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Review follow-up: the MCP command is intentionally owned by the Workspace companion. Its pinned `scripts/test-mcp-tier-safety.mjs` passes `MCP_HTTP_ATTACHED: "1"` to Vitest (https://github.com/aiosbrain/aios-workspace/pull/675), so the reported missing-variable path does not occur in acceptance. The ordinary Brain HTTP command retains its existing self-owned detached-server lifecycle. Live baseline and both mutation runs verified HTTP shutdown.
