### PR TITLE
docs: require Claude subscription access for coding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,7 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+## Anthropic coding authentication
+
+Never use an Anthropic API key for coding. Always use Claude through subscription-authenticated access, including delegated coding and builder fallbacks. If subscription access is unavailable or reaches a limit, do not switch to API-key billing; use an authorized alternative builder or report the blocker.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,6 +70,10 @@ pause for a GitHub fork or a post-deploy `--resume` command.
 
 ## Agent skill publication
 
+`AGENTS.md` requires subscription-authenticated Claude access for coding, including
+delegated work and builder fallbacks. Anthropic API-key billing is prohibited for
+coding even when subscription access is unavailable or reaches a limit.
+
 Repository-local agent skills are authored once under `.claude/skills/`. The explicit
 publication manifest `.skill-runtimes.json` selects which canonical skills are projected
 to `.agents/skills/`, `.opencode/skills/`, and `.cursor/rules/`; merely finding a generated


### PR DESCRIPTION
Require subscription-authenticated Claude access for coding in AGENTS.md, including delegated work and builder fallbacks. When subscription access is unavailable or limited, agents must use an authorized alternative builder or report the blocker; Anthropic API-key billing is prohibited.

Document the same policy in the architecture map.

Validation: `npm run check:docs`, `npm run check:skills`, and `git diff --check` passed. Documentation-only change.

## Review — Reviewed by Codex reviewer subagent — verdict clean, no actionable findings
