### PR TITLE
AUDITFIX-17: bound codebase scan request admission

### DIFF
--- a/app/api/v1/codebases/route.ts
+++ b/app/api/v1/codebases/route.ts
@@ -2,6 +2,11 @@ import { NextRequest } from "next/server";
 import { adminClient } from "@/lib/db/admin";
 import { authenticateApiKey } from "@/lib/api/auth";
 import { rateLimitWithReset } from "@/lib/api/rate-limit";
+import { readBoundedJson } from "@/lib/api/bounded-json";
+import {
+  MAX_SCAN_BODY_BYTES,
+  SCAN_BODY_LIMIT_MESSAGE,
+} from "@/lib/api/codebase-request-limits";
 import { codebaseScanPayloadSchema, errorResponse } from "@/lib/api/schemas";
 import { ingestCodebaseScan } from "@/lib/codebases/ingest";
 import { recordIngestRun, type IngestTrigger } from "@/lib/ingest/runs";
@@ -10,8 +15,6 @@ import { recordIngestRun, type IngestTrigger } from "@/lib/ingest/runs";
 const KNOWN_TRIGGERS = new Set<IngestTrigger>(["scheduler", "manual", "merge", "cli", "api"]);
 
 export const runtime = "nodejs";
-
-const MAX_PAYLOAD = 2_000_000; // 2 MB — scans carry per-author/day rollups + issues
 
 export async function POST(req: NextRequest) {
   const auth = await authenticateApiKey(req);
@@ -30,17 +33,19 @@ export async function POST(req: NextRequest) {
     return response;
   }
 
-  const len = parseInt(req.headers.get("content-length") || "0", 10);
-  if (len > MAX_PAYLOAD * 1.2) return errorResponse("payload_too_large", "max 2 MB", 413);
-
-  let json: unknown;
-  try {
-    json = await req.json();
-  } catch {
-    return errorResponse("invalid_payload", "body must be JSON", 422);
+  // Bounded body read — AFTER auth/tier/rate limiting, so 401/403/429 keep their precedence and
+  // none of them consumes the body. An oversized body then outranks malformed JSON and every
+  // schema issue, because admission is decided before anything is parsed. Nothing below this
+  // line is reached on rejection, so no scan-domain write happens: no `ingestCodebaseScan`, no
+  // projected commits, no `codebase.scanned` audit row and no `ingest_runs` row.
+  const body = await readBoundedJson(req, MAX_SCAN_BODY_BYTES);
+  if (!body.ok) {
+    return body.failure === "payload_too_large"
+      ? errorResponse("payload_too_large", SCAN_BODY_LIMIT_MESSAGE, 413)
+      : errorResponse("invalid_payload", "body must be JSON", 422);
   }
 
-  const parsed = codebaseScanPayloadSchema.safeParse(json);
+  const parsed = codebaseScanPayloadSchema.safeParse(body.value);
   if (!parsed.success) {
     return errorResponse("invalid_payload", parsed.error.issues[0]?.message ?? "invalid", 422);
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -262,6 +262,24 @@ field stayed producer-only, so catching up needed no version bump). That version
 `test/fixtures/contract/brain-contract.json` (regenerated in lockstep with the canonical
 copy in `aios-workspace/docs/contract/`) — bump all of them together on a contract change.
 
+**The member API version is NOT the whole contract.** AUDITFIX-17 adds a **separately versioned
+request-admission supplement** for `POST /api/v1/codebases` — canonical
+`aios-workspace/docs/contract/codebase-request-limits-v1.json`, vendored and sha256-pinned at
+`test/fixtures/contract/codebase-request-limits-v1.json`, carrying its own `revision: 1` and
+`appliesFromMemberApiVersion: "1.23"`. The effective contract is therefore *the published payload
+shape plus this admission supplement*, and the two move independently. `BRAIN_API_VERSION` stays
+**1.23** deliberately: the canonical doc is at member 1.24, whose scanner-identity semantics this
+server does not implement, so bumping to 1.25 to advertise a size limit would claim 1.24's
+semantics by implication. A limit is a **resource-admission** change, and the canonical change
+policy names that as an explicit exception to "breaking semantics go to /v2" — precedent: the 1.20
+`rows` cap and the dated 2026-06-19 same-route full-metrics tightening. (That exception and the
+supplement are part of the same coordinated change and land in the workspace repo **first**; a
+rollback reverses the order — withdraw or supersede the canonical revision before the server stops
+enforcing, so a live normative cap never outlives the enforcement.) It is an intentional
+narrowing for oversized direct callers, not a claim that every previously accepted request still
+succeeds; every historical *valid* payload fixture is still accepted, and
+`test/guards/codebase-request-limits-contract.test.ts` proves that alongside the boundary itself.
+
 Brain API 1.19 opens `POST /api/v1/query` to delegated `aiosd_*` tokens (Phase B slice 3, spec
 §10/§17-B), retiring 1.18's 403 `delegation_not_supported` on that route. A delegated query is
 ALWAYS attenuated — retrieval filters to the token's live triple-intersection effective set and
@@ -550,6 +568,35 @@ uses valid server delta-seconds within that 1–60-second contract, and otherwis
 2 + 4 + 8 + 16 + 32 seconds before the final attempt. Jitter is additive and bounded to one second
 per wait, so it cannot erode the fallback's 62-second floor; the terminal response keeps its actual
 429/5xx error class and is never followed by another sleep.
+
+**Bounded admission on that path (AUDITFIX-17).** `POST /api/v1/codebases` is the only production
+caller of `ingestCodebaseScan`, which writes the codebase and the metrics snapshot and then
+projects **every** `metrics.recent_commits` element through `ingestItem`, one synchronous write
+each. The scanner itself stops at 20 recent commits, but the HTTP boundary did not, and its only
+size gate read `Content-Length` — a header a chunked request never sends. Both are now bounded,
+inclusively, at the seam:
+
+| Boundary | Limit | Failure |
+|---|---:|---|
+| `metrics.recent_commits` (counted on the raw wire array, before normalization/dedup) | 100 elements | `422 invalid_payload`, naming the field, the ceiling and the recovery |
+| bytes exposed by `Request.body` (JSON syntax, whitespace and unknown fields included) | 2,400,000 | `413 payload_too_large`, same posture |
+
+The order is **authenticate → team-tier → rate limit → bounded body read → JSON parse → schema →
+ingest → run record**, so 401/403/429 keep their precedence and their `Retry-After` and none of
+them consumes the body. `lib/api/bounded-json.readBoundedJson` sums each chunk's `byteLength`
+*before* retaining it and returns as soon as the total crosses the cap — it never calls `json()`,
+keeps the crossing chunk, or parses the oversized prefix, and it **releases** the reader lock
+rather than cancelling (unread-body cleanup is the runtime's). A `Content-Length` above the cap is
+an optimization that refuses without reading; a missing, unusable or misleadingly low one is
+ignored and the counter decides. At EOF it decodes the concatenated bytes the way `Request.json()`
+does (non-fatal UTF-8, BOM stripped), so a multibyte character split across chunks round-trips and
+no new strict-decoder rejection appears. Rejection is whole-request — never a silent truncation,
+never a retry — and reaches **no scan-domain write**: no `ingestCodebaseScan`, no projected
+commits, no `codebase.scanned` audit row and no scan-source `ingest_runs` row. Authentication's
+`api_keys.last_used_at` touch and the rate-limit bucket write still happen, as they do on every
+request. The bounds and both operator-facing messages live in
+`lib/api/codebase-request-limits.ts`; the wire limits are published in the admission supplement
+described above.
 
 ### PM progression loop — merged work → done in the primary PM tool (Linear)
 
@@ -1316,7 +1363,7 @@ PR as the code change, or the [drift guard](#docs-drift-guard) fails.
 - `GET /api/v1/conversations/:id` — API-key read of a thread's messages (owner-only)
 - `GET /api/v1/okf-bundle` — OKF link graph (tier-filtered, link redaction)
 - `POST /api/v1/actions` — request a policy-gated action (Organ 4)
-- `POST /api/v1/codebases` — ingest a codebase scan (raw metrics + scanner-scored AEM agent-readiness, persisted verbatim; team-tier key only, audited)
+- `POST /api/v1/codebases` — ingest a codebase scan (raw metrics + scanner-scored AEM agent-readiness, persisted verbatim; team-tier key only, audited; admission-bounded at 100 recent commits / 2,400,000 measured body bytes — AUDITFIX-17)
 - `GET /api/v1/integrations` — API-key read of a team's enabled integration selections; NON-SECRET only (no secret/secret_ciphertext), team-scoped, audited
 - `POST /api/v1/metrics` — ingest an AEM individual maturity daily snapshot (team-tier key only; brain recomputes canonical scores; audited)
 - `POST /api/v1/costs` — ingest external AI provider daily spend (Cursor dashboard + session-log estimates; team-tier key only; audited)

--- a/docs/design/auditfix17-request-bounds.md
+++ b/docs/design/auditfix17-request-bounds.md
@@ -185,10 +185,12 @@ revisions until explicitly superseded/withdrawn, not `/api/v2`; do not use a fin
 or a non-URI `$schema`. Include independent boundary cases: count 0/20/100 admitted, 101 rejected;
 byte limit/exceeded behavior. Cases assume other payload constraints pass.
 
-The canonical brain-api doc receives a dated AUDITFIX-17 revision entry, the resource-hardening
-policy exception and endpoint limits/recovery, explicitly naming this separately versioned
-supplement. Preserve historical schemas/fixtures in their owning repos; Brain currently vendors
-and pins only the 1.23 payload artifacts. The effective contract is the existing payload shape
+The canonical brain-api doc advances its **document revision to 1.25** and receives a dated
+AUDITFIX-17 revision entry, the resource-hardening policy exception and endpoint limits/recovery,
+explicitly naming this separately versioned supplement. Document revision 1.25 is metadata:
+canonical member API remains **1.24**, Brain API remains **1.23**, and supplement revision remains
+**1**. Preserve historical schemas/fixtures in their owning repos; Brain currently vendors and pins
+only the 1.23 payload artifacts. The effective contract is the existing payload shape
 plus this admission supplement; old valid fixtures must still pass. Keep server
 `BRAIN_API_VERSION=1.23`, existing `test/fixtures/contract/brain-contract.json`, and canonical member
 feature version 1.24 honest; no parallel negotiation header or runtime version switch.
@@ -202,6 +204,13 @@ reviewed locally before server implementation; merge the canonical contract befo
 The canonical companion PR targets `aios-workspace` main, as explicitly approved by the user;
 the brain PR targets staging. Merge the canonical companion first. Do not require canonical merge
 before local code work.
+
+**Per-instance activation:** these admission limits become active on an instance only when a
+Brain build containing AUDITFIX-17 is deployed to that instance. Canonical contract publication
+alone does not activate enforcement, and a reported member API version of 1.23 alone does not
+prove the patch is present. The supplement's version range describes the supported API range;
+older instances retain their previous admission behavior until upgraded. This is a deployment
+notice, not a feature flag or a new negotiation mechanism.
 
 ## Acceptance matrix
 

--- a/docs/design/auditfix17-request-bounds.md
+++ b/docs/design/auditfix17-request-bounds.md
@@ -17,9 +17,9 @@ high performs final code review. The CLI gate is explicitly deterministic
 
 **Deps:** Lane A PR #694 is already merged into staging. Before server implementation, prepare
 and review the canonical contract edit and supplement in the isolated companion worktree; a
-companion merge is not required before local implementation. Canonical contract merges to staging
-before the brain merges to staging. Companion remote staging setup is a publication prerequisite
-owned by the coordinator, not a blocker to local spec/contract preparation.
+companion merge is not required before local implementation. The user explicitly approved merging
+the canonical companion contract to `aios-workspace` main before merging the brain to staging.
+No companion staging branch setup is required.
 
 ## Scope and outcomes
 
@@ -199,8 +199,9 @@ expected 100/101 cases and the pinned supplement, and reader/route tests must ex
 Update `docs/ARCHITECTURE.md` in this PR to describe the admission supplement and bounded codebase
 flow. Do not imply a full member-version upgrade. Companion contract edits must exist and be
 reviewed locally before server implementation; merge the canonical contract before the brain.
-All PR targets/merges are staging; companion remote staging setup gates publication only and is
-coordinator-owned. Do not require canonical merge before local code work.
+The canonical companion PR targets `aios-workspace` main, as explicitly approved by the user;
+the brain PR targets staging. Merge the canonical companion first. Do not require canonical merge
+before local code work.
 
 ## Acceptance matrix
 
@@ -267,8 +268,9 @@ never run shared destructive DB reset during parallel work. One HTTP suite provi
 proof here; an extra FakeSupabase or duplicate data-mechanics suite is unnecessary.
 
 No schema migration, new writes, background jobs, timeout promise, or request concurrency policy.
-Merge the companion contract first and brain enforcement second, both to staging. Review staging
-before any later promotion; never merge directly to main. A complete rollback is coordinated:
+Merge the companion contract to `aios-workspace` main first, as explicitly approved by the user,
+then merge brain enforcement to staging. Review Brain staging before any later promotion; this
+approval does not authorize a Brain main merge. A complete rollback is coordinated:
 first publish an explicit withdrawal/superseding resource revision and canonical doc update that
 removes this supplement's normative applicability, accepting the temporary stricter-server period;
 then revert server enforcement and update its vendored supplement/pin to the withdrawn/superseding

--- a/docs/design/auditfix17-request-bounds.md
+++ b/docs/design/auditfix17-request-bounds.md
@@ -1,0 +1,286 @@
+---
+eval_tier: deterministic
+spec_gate: block
+---
+
+# AUDITFIX-17 — bound codebase scan requests
+
+Status: accepted, 2026-09-07. Brain task **AUDITFIX-17**;
+projected Linear ticket **AIO-1136**. Phase A remediation Lane B item 17 only.
+Baseline: `0006d51f798deebdd008855767de9498ab88b048` (`origin/staging`, after Lane A PR #694).
+Governing parent: `docs/specs/project-context-classification-v1.md` (internally V2) and
+`docs/design/phase-a-remediation-plan.md`. Implementation follows accepted spec and SPEC_READY.
+
+**Build-with:** Opus / high. Astra owns spec decisions; Fable reviews spec and code; fresh Astra /
+high performs final code review. The CLI gate is explicitly deterministic
+(`--no-llm`); substantive Astra/Fable reviews run separately and remain required.
+
+**Deps:** Lane A PR #694 is already merged into staging. Before server implementation, prepare
+and review the canonical contract edit and supplement in the isolated companion worktree; a
+companion merge is not required before local implementation. Canonical contract merges to staging
+before the brain merges to staging. Companion remote staging setup is a publication prerequisite
+owned by the coordinator, not a blocker to local spec/contract preparation.
+
+## Scope and outcomes
+
+Bound admission at `POST /api/v1/codebases`, preserve ordinary scans and existing auth/rate behavior,
+and prove whole-request rejection before scan writes. Deliver the reader, schema cap, focused
+boundary/HTTP/sidecar tests, canonical admission supplement and architecture documentation.
+
+Deferred: Lane B items 14/18, scheduler/reconcile hooks, access semantics, other ingestion loops,
+and a fleet concurrency allocation. A named **Wave 3 cross-route request-admission follow-up
+(unfiled)** owns the same header-only pattern in `app/api/v1/items/route.ts`,
+`app/api/v1/metrics/route.ts`, `app/api/v1/costs/route.ts`, and
+`app/api/v1/subscriptions/route.ts`; coordinator records that destination in the remediation plan.
+No existing AUDITFIX key is assumed for that follow-up. Do not retrofit those routes here.
+
+## Re-derived problem and precedents
+
+The scanner is bounded: `ingestion/aios_ingest/analyzers/codebase.py:309` appends only while
+`len(recent) < 20`. The old line-159 citation is stale. Changing the scanner is unnecessary.
+The HTTP boundary is not bounded equivalently: `lib/api/schemas.ts:348` accepts an arbitrary
+`metrics.recent_commits` array. `app/api/v1/codebases/route.ts` is the only production caller of
+`ingestCodebaseScan`; a valid team-posture API key can bypass the scanner. The ingest owner
+writes the codebase and metrics before projecting each commit through `ingestItem` synchronously
+(`lib/codebases/ingest.ts`, `lib/codebases/commits-to-items.ts`). This is an admitted-work issue,
+not evidence that the scanner emits unlimited commits or a measured denial-of-service incident.
+
+The route currently rejects only `parseInt(Content-Length) > 2_000_000 * 1.2` and then calls
+`req.json()`. Its effective declared-length ceiling is **2,400,000 bytes**, despite saying
+“max 2 MB.” Missing length defaults to zero, so a chunked body can pass the check without a
+body bound. Both gaps remain at this baseline. Contributions and issues already have separate
+5,000-element caps; their algorithms are outside this slice.
+
+Precedents constrain this decision:
+
+- `lib/gateway/http.ts:readGatewayJson` counts stream `Uint8Array.byteLength` before parsing.
+  Reuse the technique, not its gateway-specific status codes, strict UTF-8 or encoding policy.
+  The installed Next route guide confirms Route Handlers use the standard Web Request API;
+  Pages Router `bodyParser` configuration is inapplicable.
+- `lib/api/item-payload-schema.ts` puts a diagnosable wire count limit before storage work.
+  Its 1.20 change narrowed formerly accepted requests while remaining on `/api/v1`.
+- `docs/design/auditfix2-writer-inventory-guard.md:213` records 205 historical pushes and a
+  maximum of 100 “items,” but its original measurement query/producer is not established here;
+  the route's run `updated` field counts contributions, not recent commits. Do not treat that
+  historical number as proven recent-commit cardinality. Choose **100** as explicit engineering
+  headroom, five times the current scanner's 20, while making direct-client amplification finite.
+  Current scanner compatibility is supported; arbitrary direct-client compatibility and safe
+  runtime duration are not measured. This is not a fleet concurrency allocation.
+- The same document §6b deliberately declined post-response reconciliation. This fix does not
+  reopen it. Items 14/18, new reconcile hooks, scheduler behavior, writer inventory, and access
+  semantics remain separate work.
+
+## Decision and wire behavior
+
+Scope is `POST /api/v1/codebases` only. Use named immutable constants for the two bounds and
+one small bounded-JSON reader under `lib/api/` (or route-local equivalent). Do not retrofit
+other endpoints or alter the shared gateway reader.
+
+| Boundary | Inclusive limit | Failure |
+|---|---:|---|
+| `metrics.recent_commits` | 100 array elements, counted before normalization/deduplication | `422 invalid_payload` |
+| Request body exposed by `Request.body` | 2,400,000 bytes, including JSON syntax, whitespace and unknown fields | `413 payload_too_large` |
+
+The commit array remains required and accepts zero elements. Existing commit-object validation,
+optional analytical fields, unknown-field behavior, and the rest of the payload remain unchanged.
+Count all elements, including duplicate SHAs or objects without a usable SHA: downstream skipping
+must not be an input-budget escape. Reject the entire request; never silently truncate it.
+Apply the count cap to `codeMetricsSchema.recent_commits`, which is consumed by the HTTP payload
+schema. There is no production in-process reparse requiring the separate wire/storage factory
+used by `/items`; do not introduce one without a demonstrated caller.
+
+Use the existing error envelope. Specify these messages so the route's first-issue-only response
+still identifies the field, ceiling and recovery:
+
+- Count: `metrics.recent_commits: at most 100 entries per scan; send a complete scan with a smaller recent-commit window; do not split a snapshot across pushes`
+- Bytes: `body: at most 2400000 bytes per scan; reduce the scan payload and retry; do not split a snapshot across pushes`
+- Invalid JSON, empty body, or body-read failure: existing `422 invalid_payload` / `body must be JSON`.
+
+The exact count message is required when count is the payload's only schema violation. If an
+array element or another field also violates the existing schema, the existing first-issue message
+may win; the request still returns `422 invalid_payload` before ingest. Do not add a duplicate
+raw-array precheck just to reorder multiple validation errors.
+
+The complete scan and full aggregate metrics remain required. Reducing recent-commit detail must
+not change full-window aggregate counts or remove required metrics. Do not offer batching as
+recovery: the same `(codebase_id, head_sha)` upsert replaces the metrics snapshot. For oversized
+non-commit detail, the producer must reduce optional detail or source scope coherently and retry
+one complete snapshot. Neither 413 nor 422 is transient; the existing sidecar already raises
+`BrainError` without retrying these statuses. Preserve its 429/5xx retry behavior.
+
+## Stream algorithm, precedence, and side effects
+
+Preserve this order: authenticate → team-posture check → existing rate limit → bounded body
+read → JSON parse → complete schema validation → ingest → scan-run recording. Thus 401, 403,
+and 429 retain precedence, existing rate bucket and `Retry-After`; do not consume the body on
+those paths. An oversized body takes precedence over malformed JSON/count validation once
+body admission begins.
+
+A syntactically decimal, nonnegative Content-Length greater than the cap MUST reject early.
+It is only an optimization. Missing, invalid, or misleading low declarations cannot bypass the
+stream counter; ignore an unusable declaration at application level and measure actual bytes.
+Do not add a new Content-Length syntax error contract. HTTP parsers may reject malformed wire
+framing themselves; unit Requests, not contradictory real-socket framing, test spoofed headers.
+
+Read chunks once, sum each chunk's **byteLength before storing/decoding it**, and stop when the
+sum exceeds the cap. Never call `req.json()`, `text()`, or `arrayBuffer()` first and check later.
+On overflow, stop application reads, release the reader lock, and return 413 without cancelling
+the request body or waiting for EOF. Release the lock on success/read failure too. Do not retain
+the crossing chunk in the accumulator or JSON-parse the oversized prefix. The HTTP runtime owns
+unread-body/connection cleanup and may drain remaining bytes; the application reader does not.
+A chunk may already be larger than the cap when supplied by the platform; this bounds application
+retention, not upstream allocation, total bytes sent, or the size of one delivered chunk.
+
+This release-only choice removes unnecessary cancellation lifecycle handling. Adapter-level
+loopback diagnostics using the installed NextRequestAdapter on Node 20 and 25 returned JSON 413
+for awaited cancellation, unawaited cancellation and release-only variants. Node's stream destroyer
+detaches a server request's socket before destroying it. These observations cover the adapter
+path; AC17-06 still proves the full `next start` response path and must not be replaced by the
+adapter diagnostic.
+
+Currently `proxy.ts` excludes `/api/`, so Next middleware's clone/prebuffer path does not run for
+this endpoint. If that matcher changes, the installed Next clone-size truncation behavior must
+be considered and the real-socket 413 test retained. The app cap is below the current default
+10 MB clone ceiling. Production proxy limits/buffering remain unmeasured.
+
+At EOF within the cap, combine/decode using Web Request JSON-compatible UTF-8 behavior and
+parse once. Count raw bytes, not JavaScript character count or decoded/re-encoded text; split
+multibyte characters across chunks must round-trip. Preserve ordinary `Request.json()` decoding
+semantics (including UTF-8 replacement behavior and BOM handling), avoiding an unrelated new
+strict-decoder rejection. Empty/read-failed/invalid JSON returns the existing 422. No new request
+compression feature or Content-Encoding policy is introduced: count the bytes the platform
+exposes, and invalid compressed JSON follows the existing malformed-body path.
+
+“No writes on rejection” means **no scan-domain writes**: do not enter `ingestCodebaseScan`,
+project commits, reconcile finding state, emit `codebase.scanned`, or call `recordIngestRun` for
+body/count rejection. This preserves the current pre-validation boundary. It is not a claim of
+zero database mutations: authentication already marks `api_keys.last_used_at` and can audit
+failures, and rate limiting already writes its bucket. Preserve those operations. Rejection is
+diagnosed to the caller through 413/422 and leaves no scan-source `ingest_runs` row; that existing
+operational visibility limitation is deliberate and new rejection telemetry is out of scope.
+
+## Contract seam and compatibility decision
+
+The primary workspace checkout is dirty and stale (doc 1.14). The authoritative read-only
+snapshot of its remote main at `f3c5f764715c3b803d8cfc7c9c0891e3e3122c18` says member API 1.24,
+whereas this brain implements/pins 1.23. Revision 1.24 adds scanner identity semantics outside
+this slice. Do not silently claim those semantics by bumping `BRAIN_API_VERSION` to 1.25.
+
+A new count cap changes accepted requests; documenting only an implementation tweak would be
+false. The canonical policy broadly asks for `/v2` for breaking semantics, but the published
+1.20 row-cap tightening is a directly relevant exception in practice. The canonical 2026-06-19
+same-route full-metrics requirement is an even closer dated tightening without a version bump.
+Make the exception explicit:
+a versioned, diagnosed resource-admission limit may harden an existing v1 endpoint while keeping
+its successful payload/response semantics. This is an intentional narrowing for oversized direct
+callers, not a claim that every old request still succeeds.
+
+Minimal cross-repo change: create canonical
+`aios-workspace/docs/contract/codebase-request-limits-v1.json` (new file) and vendor identical bytes
+as `test/fixtures/contract/codebase-request-limits-v1.json` (new file), with a SHA-256 pin.
+Use `kind: aios-codebase-request-limits`, supplement `revision: 1`, method/path,
+`memberApiMajor: 1`, `appliesFromMemberApiVersion: "1.23"`, `maxBodyBytes: 2400000`,
+`maxRecentCommits: 100`, and error statuses/codes/messages. This covers subsequent member 1.x
+revisions until explicitly superseded/withdrawn, not `/api/v2`; do not use a finite version list
+or a non-URI `$schema`. Include independent boundary cases: count 0/20/100 admitted, 101 rejected;
+byte limit/exceeded behavior. Cases assume other payload constraints pass.
+
+The canonical brain-api doc receives a dated AUDITFIX-17 revision entry, the resource-hardening
+policy exception and endpoint limits/recovery, explicitly naming this separately versioned
+supplement. Preserve historical schemas/fixtures in their owning repos; Brain currently vendors
+and pins only the 1.23 payload artifacts. The effective contract is the existing payload shape
+plus this admission supplement; old valid fixtures must still pass. Keep server
+`BRAIN_API_VERSION=1.23`, existing `test/fixtures/contract/brain-contract.json`, and canonical member
+feature version 1.24 honest; no parallel negotiation header or runtime version switch.
+
+A conformance guard must run the actual schema against generated boundary payloads using literal
+expected 100/101 cases and the pinned supplement, and reader/route tests must exercise literal
+2,400,000/2,400,001-byte inputs. Comparing exported constants to themselves is insufficient.
+Update `docs/ARCHITECTURE.md` in this PR to describe the admission supplement and bounded codebase
+flow. Do not imply a full member-version upgrade. Companion contract edits must exist and be
+reviewed locally before server implementation; merge the canonical contract before the brain.
+All PR targets/merges are staging; companion remote staging setup gates publication only and is
+coordinator-owned. Do not require canonical merge before local code work.
+
+## Acceptance matrix
+
+These IDs are stable. Tests are written from these outcomes before implementation, and the
+regression tests must fail against baseline for the intended reason. No database/test execution
+is claimed by this specification.
+
+- **AC17-01 — commit count:** Valid 0, 20 and 100 element arrays are accepted; 101 otherwise
+  valid elements return the exact named count 422. Duplicate/skip-worthy elements still count.
+  A separate schema violation may supply the first error message but still returns 422 before
+  ingest. Prove through pure schema boundary tests and supplement conformance; retain analytics
+  validation tests.
+- **AC17-02 — bytes:** Exactly 2,400,000 bytes are admitted; 2,400,001 returns the exact 413.
+  Missing/low length cannot bypass; high valid declaration rejects without consuming the body.
+  Prove with reader/route tests using UTF-8 byte-sized valid JSON, including whitespace padding.
+- **AC17-03 — early return:** Overflow stops application reads, does not parse/retain the
+  crossing chunk, releases the reader lock and returns 413 without waiting for EOF or cancelling.
+  Reader tests use remaining queued data and a source that stays open after crossing the limit;
+  observe response completion/read calls and unlocked stream. Runtime cleanup may read/drain.
+- **AC17-04 — decoding:** Multibyte UTF-8 split across chunks round-trips; byte count wins over
+  character count; ordinary replacement/BOM behavior is preserved; malformed/empty/read-failed
+  body returns existing 422. Prove with reader tests against Web Request.json reference behavior
+  and literal byte boundaries, including lock release on read failure.
+- **AC17-05 — existing outcomes:** 401/403/429 preserve precedence, no body reads or ingest,
+  and 429 Retry-After; accepted requests retain the 201 envelope. Route tests may mock auth,
+  rate limiting and ingest for orchestration; existing rate-limit tests remain green.
+- **AC17-06 — real rejection:** An authenticated real-socket chunked body above the byte limit
+  receives application JSON 413; a bounded 101-valid-commit request receives named 422. Neither
+  creates/changes scan-domain state. Use production `next start` and isolated real Postgres,
+  Node HTTP chunks without Content-Length, and the scoped before/after inventory below.
+- **AC17-07 — recovery and persistence:** A corrected complete scan succeeds after rejection;
+  all 100 unique valid commits persist as items and in the recent_commits snapshot; prior accepted
+  state survives invalid replacement. Same HTTP/DB suite: accepted seed → rejected replacement →
+  unchanged exact rows → corrected new scan; verify item paths/snapshot and no partial success.
+- **AC17-08 — contract:** Shared supplement/pinned bytes agree with actual acceptance behavior;
+  historical valid fixtures remain accepted; API versions remain truthful. Contract guards and
+  companion tests check digest plus literal boundary behavior, not constants-only equality.
+  Canonical documentation includes the coordinated rollback procedure below.
+- **AC17-09 — caller recovery:** Sidecar 413/422 retain the new status/code/message without retry;
+  existing 429/5xx behavior survives. Use focused MockTransport error cases and existing retry
+  tests. Scanner max20 is premise evidence only, not a lasting acceptance cap or a new temp-git
+  test requirement; a future scanner can widen within the admitted100.
+
+For AC17-06/07, use a fresh seeded team, real API key, unique repo slugs/commit SHAs, and snapshot
+before/after rows scoped to that team/codebase: `codebases`, `code_metrics`, `code_contributions`,
+`github_issues`, `codebase_findings`, `codebase_finding_events`, `items`/`item_versions`, and scan-source
+`ingest_runs`. Include transitive commit ingestion state: team `projects` (including
+`last_synced_at` and `graph_group_id`), `project_context_units`, `project_context_memberships`,
+`codebase.scanned` audit rows and target-scoped `item.*` audit rows. When no target IDs existed
+before rejection, scope by the dedicated test team's item audit actions so unexpected new IDs
+cannot escape the comparison. Include both rejected new slug and existing
+snapshot replacement; the accepted control proves the DB assertions are not vacuous. Route spy
+tests prove ingest/run functions are never entered; real DB equality proves persisted outcome.
+Use allowed auth/rate mutations as explicit exceptions, not a failing whole-database snapshot.
+
+## Verification and rollout limits
+
+Implement and test only after the accepted Astra/Fable spec review and SPEC_READY, with canonical
+contract edits prepared/reviewed first locally. Required verification: targeted
+unit/contract tests; focused Python tests; real-socket HTTP cases backed by isolated Postgres;
+TypeScript/lint and docs drift checks appropriate to touched files. The current HTTP harness boots
+`next start` against a prebuilt `.next`; configure this worktree's test DB/port independently and
+never run shared destructive DB reset during parallel work. One HTTP suite provides persistence
+proof here; an extra FakeSupabase or duplicate data-mechanics suite is unnecessary.
+
+No schema migration, new writes, background jobs, timeout promise, or request concurrency policy.
+Merge the companion contract first and brain enforcement second, both to staging. Review staging
+before any later promotion; never merge directly to main. A complete rollback is coordinated:
+first publish an explicit withdrawal/superseding resource revision and canonical doc update that
+removes this supplement's normative applicability, accepting the temporary stricter-server period;
+then revert server enforcement and update its vendored supplement/pin to the withdrawn/superseding
+canonical state. Do not silently rewrite revision1 history or leave a live normative100 cap while
+the server accepts101. A standalone emergency brain revert is temporary contract non-conformance,
+not completed rollback; record and repair it. Removing enforcement reopens the resource exposure;
+no data repair is needed for requests rejected before ingest. Existing accepted scan failures
+remain non-transactional behavior outside this admission fix.
+
+Unmeasured: current fleet payload/count distribution, peak memory and latency at100 commits,
+production proxy prebuffering/upstream limits, and concurrency across keys. Current Next adapter
+behavior and proxy matcher have source/diagnostic evidence above; real-socket full-server tests
+remain required and do not prove Railway proxy behavior. Report any runtime rejection earlier
+than the application as such. Neither historical ambiguous max100 nor the chosen headroom is a
+benchmark, timeout guarantee or bound on total fleet work.

--- a/docs/design/phase-a-remediation-plan.md
+++ b/docs/design/phase-a-remediation-plan.md
@@ -64,6 +64,25 @@ and part of -7's predicate.
 
 **Wave 3 — re-triage** `5`, `6`, `16` against the smaller codebase.
 
+**Wave 3 also owns the cross-route request-admission follow-up — UNFILED, no key.** AUDITFIX-17
+bounded `POST /api/v1/codebases` only. Four sibling write routes still admit a request on the
+header-only pattern it replaced — `parseInt(Content-Length)` with a missing header defaulting to
+zero, so a chunked body passes ungated:
+
+- `app/api/v1/items/route.ts`
+- `app/api/v1/metrics/route.ts`
+- `app/api/v1/costs/route.ts`
+- `app/api/v1/subscriptions/route.ts`
+
+`lib/api/bounded-json.readBoundedJson` is deliberately generic and is the intended reuse, but each
+route needs its own decided ceiling, its own diagnosable message, and its own answer to whether the
+narrowing is publishable on `/api/v1` — none of which AUDITFIX-17 decided for them. **Do not
+retrofit them under -17's key**, and do not assume an existing AUDITFIX number covers this: no
+ticket exists yet, and this entry is the record of that, not an implementation plan. Whoever
+picks it up files it first (a row in `3-log/tasks.md` → `aios push`) and specs the ceilings
+against measured payloads rather than inheriting -17's 2,400,000, which was that route's own
+pre-existing number.
+
 ## Standing rules this pass produced
 
 1. **A ticket premise is a hypothesis.** Re-derive before speccing. 4-of-5 were wrong.

--- a/ingestion/tests/test_brain_client.py
+++ b/ingestion/tests/test_brain_client.py
@@ -259,3 +259,80 @@ async def test_codebase_scan_non_429_4xx_is_immediate_and_never_sleeps():
     assert sleeps == []
     assert exc.value.status_code == 422
     assert exc.value.code == "invalid_payload"
+
+
+# ——— AUDITFIX-17 / AIO-1136, AC17-09: the two admission rejections reach the operator ———
+#
+# The brain now bounds POST /api/v1/codebases at 100 `metrics.recent_commits` (422) and
+# 2,400,000 request bytes (413). Neither is transient: a retry of the identical scan fails
+# identically, so retrying only delays the operator seeing a message they must act on.
+#
+# The scanner appends at most 20 recent commits (analyzers/codebase.py), so it cannot itself
+# trip the count bound today — these cases are about what a caller DOES with the rejection, not
+# about characterizing the scanner. A future scanner may widen its window inside the admitted
+# 100 without touching this behaviour.
+#
+# These assert PRESERVED behaviour and are expected green at the AUDITFIX-17 baseline. Their job
+# is to fail if the enforcement work, or a later retry-policy change, turns a diagnosis the
+# operator needs into silent backoff — or drops the ceiling out of the message.
+
+_COUNT_MESSAGE = (
+    "metrics.recent_commits: at most 100 entries per scan; send a complete scan with a "
+    "smaller recent-commit window; do not split a snapshot across pushes"
+)
+_BYTES_MESSAGE = (
+    "body: at most 2400000 bytes per scan; reduce the scan payload and retry; do not split "
+    "a snapshot across pushes"
+)
+
+
+@pytest.mark.parametrize(
+    "status,code,message",
+    [
+        (422, "invalid_payload", _COUNT_MESSAGE),
+        (413, "payload_too_large", _BYTES_MESSAGE),
+    ],
+)
+async def test_codebase_scan_admission_rejection_surfaces_verbatim_without_retry(
+    status, code, message
+):
+    calls = 0
+    sleeps: list[float] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status, json={"error": {"code": code, "message": message}})
+
+    async with _scan_client(httpx.MockTransport(handler), sleeps) as c:
+        with pytest.raises(BrainError) as exc:
+            await c.push_codebase_scan({"scan": "payload"})
+
+    # One attempt, no backoff: the recovery is a smaller complete scan, not patience.
+    assert calls == 1
+    assert sleeps == []
+    assert exc.value.status_code == status
+    assert exc.value.code == code
+    # The ceiling and the recovery must survive into what the operator reads. A BrainError that
+    # says only "422" tells them nothing they can act on.
+    assert message in str(exc.value)
+
+
+async def test_codebase_scan_retry_behaviour_survives_the_new_admission_statuses():
+    """A 413 must not join the retryable set that 429/5xx are in — and they must stay in it."""
+    attempts: list[int] = []
+    sleeps: list[float] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        attempts.append(len(attempts) + 1)
+        if len(attempts) == 1:
+            return httpx.Response(
+                503, json={"error": {"code": "upstream_unavailable", "message": "down"}}
+            )
+        return httpx.Response(201, json={"status": "ok"})
+
+    async with _scan_client(httpx.MockTransport(handler), sleeps) as c:
+        assert await c.push_codebase_scan({"scan": "payload"}) == {"status": "ok"}
+
+    assert len(attempts) == 2
+    assert sleeps == [2]

--- a/lib/api/bounded-json.ts
+++ b/lib/api/bounded-json.ts
@@ -1,0 +1,108 @@
+/**
+ * A bounded JSON body reader for untrusted HTTP input (AUDITFIX-17 / AIO-1136).
+ *
+ * WHY NOT `req.json()` PLUS A SIZE CHECK: by the time `json()`, `text()` or `arrayBuffer()`
+ * resolves, the whole body has already been buffered and decoded — checking afterwards bounds
+ * nothing. WHY NOT `Content-Length`: a chunked request does not send one, so a gate that trusts
+ * the header is not a bound at all. This counts each chunk's `byteLength` BEFORE retaining it and
+ * stops the moment the running total crosses the cap.
+ *
+ * Technique borrowed from `lib/gateway/http.readGatewayJson`, deliberately NOT its policy: the
+ * gateway has its own status codes, its own 415 content-encoding rule and a strict (`fatal: true`)
+ * decoder. This reader reports an outcome and lets the caller own the envelope, and it decodes the
+ * way `Request.json()` does so bounding a body cannot smuggle in a new rejection class.
+ *
+ * ON CANCELLATION — this reader RELEASES the reader lock and never cancels. Cancelling a server
+ * request body is a lifecycle the application does not need to own: the HTTP runtime owns
+ * unread-body and connection cleanup and may drain the remainder. Releasing on every path
+ * (overflow, success, read failure) leaves the stream unlocked for whatever the runtime does next.
+ *
+ * The installed Next route guide confirms Route Handlers use the standard Web `Request` API and
+ * that Pages Router `bodyParser` configuration is inapplicable, so `Request.body` is the whole
+ * surface there is to bound here.
+ */
+
+export type BoundedJsonFailure = "payload_too_large" | "unreadable_body";
+
+export type BoundedJsonResult =
+  | { readonly ok: true; readonly value: unknown }
+  | { readonly ok: false; readonly failure: BoundedJsonFailure };
+
+const TOO_LARGE: BoundedJsonResult = Object.freeze({
+  ok: false,
+  failure: "payload_too_large",
+});
+const UNREADABLE: BoundedJsonResult = Object.freeze({
+  ok: false,
+  failure: "unreadable_body",
+});
+
+/**
+ * True when the caller DECLARED more than the cap in a syntactically usable way.
+ *
+ * This is an optimization and nothing more: it lets an oversized push be refused without reading
+ * a single byte. It is never the measurement. A missing, non-decimal or misleadingly low
+ * declaration is simply ignored at application level — unusable input gets no new error contract
+ * of its own, and the stream counter below is what actually decides.
+ */
+function declaredLengthExceeds(headers: Headers, maxBytes: number): boolean {
+  const declared = headers.get("content-length");
+  return declared !== null && /^\d+$/.test(declared) && Number(declared) > maxBytes;
+}
+
+/**
+ * Read `req.body` up to an INCLUSIVE `maxBytes` and parse it as JSON.
+ *
+ * - exactly `maxBytes` is admitted; `maxBytes + 1` is `payload_too_large`;
+ * - the crossing chunk is never retained and the oversized prefix is never parsed;
+ * - an absent body, a read failure and malformed JSON are all `unreadable_body`, which the caller
+ *   maps onto its existing invalid-body response rather than a new one.
+ */
+export async function readBoundedJson(
+  req: Request,
+  maxBytes: number,
+): Promise<BoundedJsonResult> {
+  if (declaredLengthExceeds(req.headers, maxBytes)) return TOO_LARGE;
+
+  const body = req.body;
+  if (!body) return UNREADABLE;
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      // Count the chunk BEFORE storing it, so retention is bounded by the cap rather than by the
+      // cap plus one chunk. (A single delivered chunk may already exceed the cap; that is the
+      // platform's allocation, not this reader's.)
+      total += value.byteLength;
+      if (total > maxBytes) return TOO_LARGE;
+      chunks.push(value);
+    }
+  } catch {
+    return UNREADABLE;
+  } finally {
+    // Every read above is awaited, so no read is ever pending here and this cannot throw.
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  try {
+    // `Request.json()` is "UTF-8 decode, then JSON.parse". A default `TextDecoder` is exactly that
+    // decode: non-fatal (invalid sequences become U+FFFD, they do not reject) and BOM-stripping.
+    // Decoding the CONCATENATED bytes is what makes a multibyte character split across two chunks
+    // round-trip; per-chunk decoding would replace both halves.
+    return { ok: true, value: JSON.parse(new TextDecoder().decode(bytes)) };
+  } catch {
+    return UNREADABLE;
+  }
+}

--- a/lib/api/codebase-request-limits.ts
+++ b/lib/api/codebase-request-limits.ts
@@ -1,0 +1,49 @@
+/**
+ * Request-admission bounds for `POST /api/v1/codebases` (AUDITFIX-17 / AIO-1136).
+ *
+ * WHY A COUNT BOUND AND NOT ONLY A TRANSPORT ONE. `lib/codebases/ingest` writes the codebase and
+ * the metrics snapshot and then projects EVERY element of `metrics.recent_commits` through
+ * `ingestItem`, one synchronous write each. The Python scanner is already bounded — it appends
+ * only while `len(recent) < 20` (`ingestion/aios_ingest/analyzers/codebase.py`) — but the HTTP
+ * boundary was not, so a valid team-tier key could hand the ingest owner an arbitrary number of
+ * commits. This is an admitted-work bound; it is not a claim that the scanner ever emitted more.
+ *
+ * WHY 100. Explicit engineering headroom: five times the scanner's current 20, which keeps every
+ * scan this fleet produces comfortably inside the ceiling while making direct-client
+ * amplification finite. It is NOT a benchmark, a latency guarantee, or a fleet concurrency
+ * allocation — none of those are measured. A future scanner may widen its window within it.
+ *
+ * WHY 2,400,000 BYTES. It is the ceiling the route already had: the old gate compared
+ * `Content-Length` against `2_000_000 * 1.2` while reporting "max 2 MB". The number is unchanged
+ * and now honest — what changed is that it is MEASURED off the body rather than believed from a
+ * header a chunked request never sends.
+ *
+ * Both bounds are INCLUSIVE, and both are published in the shared admission supplement
+ * (canonical: `aios-workspace/docs/contract/codebase-request-limits-v1.json`; vendored at
+ * `test/fixtures/contract/codebase-request-limits-v1.json`). The supplement is versioned on its
+ * own `revision` and deliberately does NOT bump the member API version — see
+ * `test/guards/codebase-request-limits-contract.test.ts`, which runs the published boundary cases
+ * through the real schema rather than comparing these constants to themselves.
+ */
+
+/** Inclusive ceiling on `metrics.recent_commits`, counted BEFORE normalization/deduplication. */
+export const MAX_RECENT_COMMITS = 100;
+
+/**
+ * Inclusive ceiling on the bytes exposed by `Request.body`, including JSON syntax, whitespace and
+ * unknown fields. Raw bytes — not decoded character count.
+ */
+export const MAX_SCAN_BODY_BYTES = 2_400_000;
+
+/**
+ * `route.ts` answers with `issues[0].message` verbatim and drops the issue `path`, so the field,
+ * the ceiling and the recovery all have to be inside the message or the 422 is undiagnosable.
+ *
+ * The advice is a SMALLER WINDOW, never two pushes: `code_metrics` upserts on
+ * `(codebase_id, head_sha)` and REPLACES the row, so a second push of the same snapshot would
+ * silently discard the first half rather than append to it.
+ */
+export const RECENT_COMMITS_LIMIT_MESSAGE = `metrics.recent_commits: at most ${MAX_RECENT_COMMITS} entries per scan; send a complete scan with a smaller recent-commit window; do not split a snapshot across pushes`;
+
+/** Same posture for the transport bound: name the ceiling and the recovery, never just "too big". */
+export const SCAN_BODY_LIMIT_MESSAGE = `body: at most ${MAX_SCAN_BODY_BYTES} bytes per scan; reduce the scan payload and retry; do not split a snapshot across pushes`;

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  MAX_RECENT_COMMITS,
+  RECENT_COMMITS_LIMIT_MESSAGE,
+} from "./codebase-request-limits";
 
 export {
   decisionRowSchema,
@@ -345,7 +349,15 @@ export const codeMetricsSchema = z.object({
   // Brain API 1.23 adds optional, versioned commit observations. The surrounding commit object
   // stays open so legacy and additive scanner fields remain compatible; the two analytical
   // objects are deliberately closed to keep paths and source text out of the boundary.
-  recent_commits: z.array(recentCommitSchema),
+  //
+  // AUDITFIX-17: bounded at MAX_RECENT_COMMITS. The array stays REQUIRED and zero elements stay
+  // legal — this is an admission ceiling, not a new minimum. The count is taken here, on the RAW
+  // wire array, so duplicate SHAs and elements with no usable sha still count: `normalizeCommit`
+  // drops the latter and the upsert dedups the former, but only after the ingest owner has
+  // already done the work, so downstream skipping must not buy extra input budget.
+  recent_commits: z
+    .array(recentCommitSchema)
+    .max(MAX_RECENT_COMMITS, RECENT_COMMITS_LIMIT_MESSAGE),
   // explicit scaffolding inputs (required)
   has_claude_md: z.boolean(),
   has_agents_md: z.boolean(),

--- a/test/bounded-json-reader.test.ts
+++ b/test/bounded-json-reader.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, it } from "vitest";
+import { readBoundedJson, type BoundedJsonResult } from "@/lib/api/bounded-json";
+import { MAX_SCAN_BODY_BYTES } from "@/lib/api/codebase-request-limits";
+
+/**
+ * AUDITFIX-17 / AIO-1136 — AC17-03 (early return, no retention, lock release) and AC17-04
+ * (decoding), plus the reader half of AC17-02 (the literal byte boundary and the
+ * `Content-Length` rules). Spec: docs/design/auditfix17-request-bounds.md.
+ *
+ * WHY THIS TIER. These are properties of the READ, not of the response: how many times the
+ * application called `read()`, whether the crossing chunk was kept, whether the lock came back,
+ * whether the answer arrived before EOF. A real socket cannot see any of them — the HTTP tier
+ * (test/http/codebases-request-bounds.http.test.ts) proves the wire outcome and that a rejected
+ * scan writes nothing; this file proves the algorithm underneath it.
+ *
+ * The `Request` doubles below expose exactly what the reader consumes — `headers` and a `body`
+ * with `getReader()` — so a read count is an APPLICATION read count. Driving a platform
+ * `Request` instead would fold in whatever undici prefetches, which is not the thing under test.
+ * The two real-`ReadableStream` cases exist for the one property a double cannot honestly
+ * report: `stream.locked`.
+ *
+ * Every case that could hang if the reader kept going is wrapped in `within()`, which REJECTS
+ * with a diagnostic rather than stalling the suite — "awaited EOF" must be a visible failure,
+ * not a timeout somebody later marks flaky.
+ */
+
+const encoder = new TextEncoder();
+const encode = (text: string) => encoder.encode(text);
+
+/** A bounded wait that fails loudly. An absent answer is the exact bug these cases rule out. */
+async function within<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${what}: nothing settled within ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface ReaderProbe {
+  /** `read()` calls the APPLICATION made. */
+  reads: number;
+  releases: number;
+  cancels: number;
+}
+
+/**
+ * A `Request` double whose reader is instrumented.
+ *
+ * `afterQueue: "stay-open"` models a client that has crossed the limit and is still sending: the
+ * read after the queue never settles, so an implementation that waited for EOF would never
+ * answer — and `within()` turns that into a named failure.
+ */
+function stubRequest(options: {
+  chunks: readonly Uint8Array[];
+  headers?: Record<string, string>;
+  afterQueue?: "close" | "stay-open";
+  failAtRead?: number;
+}): { req: Request; probe: ReaderProbe } {
+  const { chunks, headers = {}, afterQueue = "close", failAtRead } = options;
+  const probe: ReaderProbe = { reads: 0, releases: 0, cancels: 0 };
+  let next = 0;
+
+  const reader = {
+    read(): Promise<{ done: boolean; value?: Uint8Array }> {
+      const nth = probe.reads++;
+      if (failAtRead !== undefined && nth === failAtRead) {
+        return Promise.reject(new Error("connection reset"));
+      }
+      if (next < chunks.length) {
+        return Promise.resolve({ done: false, value: chunks[next++] });
+      }
+      if (afterQueue === "stay-open") return new Promise<never>(() => {});
+      return Promise.resolve({ done: true, value: undefined });
+    },
+    releaseLock(): void {
+      probe.releases++;
+    },
+    cancel(): Promise<void> {
+      probe.cancels++;
+      return Promise.resolve();
+    },
+  };
+
+  const req = {
+    headers: new Headers(headers),
+    body: { getReader: () => reader },
+  } as unknown as Request;
+  return { req, probe };
+}
+
+/** A REAL stream, for the one thing a double cannot report honestly: `locked`. */
+function realStreamRequest(chunks: readonly Uint8Array[], close: boolean) {
+  const cancelled = { called: false };
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      if (close) controller.close();
+    },
+    cancel() {
+      cancelled.called = true;
+    },
+  });
+  const req = { headers: new Headers(), body: stream } as unknown as Request;
+  return { req, stream, cancelled };
+}
+
+/** Split `bytes` into fixed-size chunks so a body genuinely streams. */
+function chunked(bytes: Uint8Array, size: number): Uint8Array[] {
+  const out: Uint8Array[] = [];
+  for (let i = 0; i < bytes.byteLength; i += size) out.push(bytes.slice(i, i + size));
+  return out;
+}
+
+/** Valid ASCII JSON of EXACTLY `targetBytes`, padded with insignificant whitespace. */
+function jsonOfExactBytes(payload: unknown, targetBytes: number): string {
+  const base = JSON.stringify(payload);
+  const padding = targetBytes - base.length;
+  if (padding < 0) throw new Error(`payload is already ${base.length} B > ${targetBytes} B`);
+  const body = `{${" ".repeat(padding)}${base.slice(1)}`;
+  if (Buffer.byteLength(body, "utf8") !== targetBytes) {
+    throw new Error(`padding failed: ${Buffer.byteLength(body, "utf8")} != ${targetBytes}`);
+  }
+  return body;
+}
+
+/** What `Request.json()` — the behaviour this reader must not diverge from — does with `bytes`. */
+async function requestJsonOutcome(
+  bytes: Uint8Array,
+): Promise<{ ok: true; value: unknown } | { ok: false }> {
+  try {
+    const reference = new Request("https://brain.example.com/api/v1/codebases", {
+      method: "POST",
+      body: bytes as unknown as BodyInit,
+    });
+    return { ok: true, value: await reference.json() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+const value = (result: BoundedJsonResult) => (result.ok ? result.value : undefined);
+
+describe("AC17-02 (reader) — the literal byte boundary", () => {
+  // The route's cap and the number these cases use are the same number, asserted rather than
+  // assumed. The cases below then use the LITERAL, so this file cannot drift into comparing an
+  // exported constant with itself.
+  it("the scan cap is 2,400,000 bytes", () => {
+    expect(MAX_SCAN_BODY_BYTES).toBe(2_400_000);
+  });
+
+  it("admits a chunked body of exactly 2,400,000 bytes", async () => {
+    const body = jsonOfExactBytes({ scan: "at-the-ceiling" }, 2_400_000);
+    const { req } = stubRequest({ chunks: chunked(encode(body), 64_000) });
+
+    const result = await within(readBoundedJson(req, 2_400_000), 10_000, "at-the-ceiling read");
+
+    expect(result.ok).toBe(true);
+    expect(value(result)).toEqual({ scan: "at-the-ceiling" });
+  });
+
+  it("rejects a chunked body of 2,400,001 bytes", async () => {
+    const body = jsonOfExactBytes({ scan: "one-over" }, 2_400_001);
+    const { req } = stubRequest({ chunks: chunked(encode(body), 64_000) });
+
+    const result = await within(readBoundedJson(req, 2_400_000), 10_000, "one-over read");
+
+    expect(result).toEqual({ ok: false, failure: "payload_too_large" });
+  });
+
+  it("rejects a Content-Length above the cap without reading a single byte", async () => {
+    const { req, probe } = stubRequest({
+      chunks: [encode("{}")],
+      headers: { "content-length": String(2_400_001) },
+    });
+
+    const result = await readBoundedJson(req, 2_400_000);
+
+    expect(result).toEqual({ ok: false, failure: "payload_too_large" });
+    // The declaration is an OPTIMIZATION: its whole value is that the body is never consumed.
+    expect(probe.reads).toBe(0);
+  });
+
+  it("a declared length AT the cap is admitted — the bound is inclusive", async () => {
+    const body = jsonOfExactBytes({ scan: "declared-at-limit" }, 2_400_000);
+    const { req } = stubRequest({
+      chunks: chunked(encode(body), 64_000),
+      headers: { "content-length": String(2_400_000) },
+    });
+
+    const result = await within(readBoundedJson(req, 2_400_000), 10_000, "declared-at-limit read");
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("a misleadingly LOW declaration cannot buy admission", async () => {
+    // The header says 10 bytes; the stream delivers 2,400,001. The counter is the measurement,
+    // so the request is refused on what actually arrived.
+    const body = jsonOfExactBytes({ scan: "lying-header" }, 2_400_001);
+    const { req } = stubRequest({
+      chunks: chunked(encode(body), 64_000),
+      headers: { "content-length": "10" },
+    });
+
+    const result = await within(readBoundedJson(req, 2_400_000), 10_000, "low-declaration read");
+
+    expect(result).toEqual({ ok: false, failure: "payload_too_large" });
+  });
+
+  // NOT included: a value with surrounding whitespace. `Headers` normalises that away before the
+  // reader ever sees it, so "2400001 " is a USABLE declaration, not an unusable one.
+  it.each(["", "abc", "-1", "+2400001", "2,400,001", "0x10", "2.4e6"])(
+    "ignores the unusable Content-Length %j and measures instead",
+    async (declared) => {
+      // No new Content-Length syntax contract: an unusable declaration is not an error of its
+      // own, it is simply not evidence. A small valid body must still be admitted.
+      const { req } = stubRequest({
+        chunks: [encode('{"ok":true}')],
+        headers: { "content-length": declared },
+      });
+
+      const result = await readBoundedJson(req, 2_400_000);
+
+      expect(result).toEqual({ ok: true, value: { ok: true } });
+    },
+  );
+});
+
+describe("AC17-03 — the reader stops at the crossing chunk and lets go", () => {
+  it("stops reading the moment the running total crosses the cap", async () => {
+    // Eight chunks of 10 bytes against a 25-byte cap: the third crosses it (30 > 25). Chunks
+    // four through eight are still queued and must never be read.
+    const chunks = Array.from({ length: 8 }, () => encode("0123456789"));
+    const { req, probe } = stubRequest({ chunks });
+
+    const result = await within(readBoundedJson(req, 25), 5_000, "overflow read");
+
+    expect(result).toEqual({ ok: false, failure: "payload_too_large" });
+    expect(probe.reads).toBe(3);
+    expect(probe.releases).toBe(1);
+    // Release-only. Cancelling a server request body is the runtime's business, not this
+    // reader's — see the module header.
+    expect(probe.cancels).toBe(0);
+  });
+
+  it("never parses the oversized prefix, even when the prefix is a complete document", async () => {
+    // The first chunk is EXACTLY the cap and is valid JSON on its own; the second chunk is one
+    // trailing byte. A reader that answered from what it had already accumulated would return
+    // that document. The whole request is rejected instead — no silent truncation.
+    const prefix = jsonOfExactBytes({ truncated: "would-be-accepted" }, 64);
+    const { req, probe } = stubRequest({ chunks: [encode(prefix), encode(" ")] });
+
+    const result = await within(readBoundedJson(req, 64), 5_000, "prefix read");
+
+    expect(result).toEqual({ ok: false, failure: "payload_too_large" });
+    expect(probe.reads).toBe(2);
+  });
+
+  it("answers without waiting for EOF on a source that stays open", async () => {
+    // The client crossed the limit and is still sending: after the queued chunks, `read()` never
+    // settles. The 413 must not be hostage to the client finishing.
+    const { req, probe } = stubRequest({
+      chunks: [encode("0".repeat(20)), encode("0".repeat(20))],
+      afterQueue: "stay-open",
+    });
+
+    const result = await within(
+      readBoundedJson(req, 25),
+      3_000,
+      "413 on a still-open source (the reader awaited EOF)",
+    );
+
+    expect(result).toEqual({ ok: false, failure: "payload_too_large" });
+    expect(probe.reads).toBe(2);
+    expect(probe.releases).toBe(1);
+    expect(probe.cancels).toBe(0);
+  });
+
+  it("leaves a real stream UNLOCKED and uncancelled after an overflow", async () => {
+    // A double can only report that `releaseLock()` was called. `locked` is the actual property
+    // the runtime cares about, so one case asserts it against a real ReadableStream — one that
+    // is deliberately never closed, so the reader must stop on its own.
+    const { req, stream, cancelled } = realStreamRequest(
+      [encode("0".repeat(20)), encode("0".repeat(20))],
+      false,
+    );
+
+    const result = await within(readBoundedJson(req, 25), 3_000, "real-stream overflow");
+
+    expect(result).toEqual({ ok: false, failure: "payload_too_large" });
+    expect(stream.locked).toBe(false);
+    expect(cancelled.called).toBe(false);
+  });
+
+  it("leaves a real stream unlocked after a SUCCESSFUL read too", async () => {
+    const { req, stream } = realStreamRequest(chunked(encode('{"ok":true}'), 3), true);
+
+    const result = await within(readBoundedJson(req, 2_400_000), 3_000, "real-stream success");
+
+    expect(result).toEqual({ ok: true, value: { ok: true } });
+    expect(stream.locked).toBe(false);
+  });
+
+  it("releases the lock when the read itself fails, and reports an unreadable body", async () => {
+    const { req, probe } = stubRequest({
+      chunks: [encode('{"ok":')],
+      failAtRead: 1,
+    });
+
+    const result = await within(readBoundedJson(req, 2_400_000), 3_000, "failed read");
+
+    // A dropped connection is not a payload-size verdict: it takes the existing invalid-body
+    // path, which the route answers as 422.
+    expect(result).toEqual({ ok: false, failure: "unreadable_body" });
+    expect(probe.releases).toBe(1);
+  });
+});
+
+describe("AC17-04 — decoding matches Request.json()", () => {
+  /** Our result and `Request.json()`'s must be the same OUTCOME on the same bytes. */
+  async function expectMatchesRequestJson(bytes: Uint8Array, chunkSize = 1) {
+    const reference = await requestJsonOutcome(bytes);
+    const { req } = stubRequest({ chunks: chunked(bytes, chunkSize) });
+    const mine = await within(readBoundedJson(req, 2_400_000), 5_000, "decode read");
+
+    expect(mine.ok, `Request.json() ${reference.ok ? "parsed" : "threw"}`).toBe(reference.ok);
+    if (mine.ok && reference.ok) expect(mine.value).toEqual(reference.value);
+    return { mine, reference };
+  }
+
+  it("round-trips multibyte characters split across chunk boundaries", async () => {
+    // One byte per chunk, so EVERY multibyte character is split. Decoding per chunk would turn
+    // each half into U+FFFD; decoding the concatenation is what makes this work.
+    const document = { note: "héllo — café 🚀 日本語", tail: "ok" };
+    const bytes = encode(JSON.stringify(document));
+    expect(bytes.byteLength).toBeGreaterThan(JSON.stringify(document).length);
+
+    const { mine } = await expectMatchesRequestJson(bytes, 1);
+
+    // Non-vacuity: the reference agreeing is worth nothing if both simply failed.
+    expect(mine.ok).toBe(true);
+    expect(value(mine)).toEqual(document);
+  });
+
+  it("counts BYTES, not characters", async () => {
+    // 16 characters, 24 bytes — built rather than typed, so the two counts below are exact by
+    // construction. Under a 20-byte cap a CHARACTER count would admit this document.
+    const accented = "é".repeat(8);
+    const body = `{"s":"${accented}"}`;
+    const bytes = encode(body);
+    expect(body.length).toBe(16);
+    expect(bytes.byteLength).toBe(24);
+
+    const over = stubRequest({ chunks: chunked(bytes, 5) });
+    expect(await within(readBoundedJson(over.req, 20), 3_000, "byte-count read")).toEqual({
+      ok: false,
+      failure: "payload_too_large",
+    });
+
+    // Same document, a cap equal to its true byte length: admitted. Without this half the case
+    // above would pass against a reader that rejected everything.
+    const exact = stubRequest({ chunks: chunked(bytes, 5) });
+    const admitted = await within(readBoundedJson(exact.req, 24), 3_000, "byte-count read");
+    expect(admitted.ok).toBe(true);
+    expect(value(admitted)).toEqual({ s: accented });
+  });
+
+  it("handles a UTF-8 BOM exactly as Request.json() does", async () => {
+    const bom = Uint8Array.from([0xef, 0xbb, 0xbf]);
+    const json = encode('{"a":1}');
+    const bytes = new Uint8Array(bom.byteLength + json.byteLength);
+    bytes.set(bom, 0);
+    bytes.set(json, bom.byteLength);
+
+    await expectMatchesRequestJson(bytes, 2);
+  });
+
+  it("applies ordinary replacement to invalid UTF-8, rather than a new strict rejection", async () => {
+    // A lone 0xFF inside a JSON string. The gateway reader's `fatal: true` decoder would reject
+    // this; the platform's would not, and bounding a body must not smuggle in a new error class.
+    const bytes = Uint8Array.from([
+      ...encode('{"s":"'),
+      0xff,
+      ...encode('"}'),
+    ]);
+
+    const { mine } = await expectMatchesRequestJson(bytes, 3);
+
+    const REPLACEMENT = String.fromCharCode(0xfffd);
+    expect(mine.ok).toBe(true);
+    expect(value(mine)).toEqual({ s: REPLACEMENT });
+  });
+
+  it.each([
+    ["malformed JSON", '{"a":'],
+    ["a bare fragment", "not json at all"],
+    ["an empty body", ""],
+  ])("reports %s as an unreadable body", async (label, text) => {
+    const { req } = stubRequest({ chunks: text ? [encode(text)] : [] });
+
+    const result = await within(readBoundedJson(req, 2_400_000), 3_000, "invalid-body read");
+
+    expect(result, label).toEqual({ ok: false, failure: "unreadable_body" });
+  });
+
+  it("reports an absent body as unreadable, not as an empty object", async () => {
+    const req = { headers: new Headers(), body: null } as unknown as Request;
+
+    expect(await readBoundedJson(req, 2_400_000)).toEqual({
+      ok: false,
+      failure: "unreadable_body",
+    });
+  });
+});

--- a/test/codebase-request-bounds.test.ts
+++ b/test/codebase-request-bounds.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
+import { fullMetrics } from "./fixtures/codebase-scan";
+
+/**
+ * AUDITFIX-17 / AIO-1136 — AC17-01, the `metrics.recent_commits` count bound at the
+ * POST /api/v1/codebases payload schema.
+ *
+ * Spec: docs/design/auditfix17-request-bounds.md. Canonical supplement:
+ * aios-workspace/docs/contract/codebase-request-limits-v1.json (vendored at
+ * test/fixtures/contract/codebase-request-limits-v1.json).
+ *
+ * WHY THIS TIER. The count bound is a property of the payload schema, and the route reports
+ * only the FIRST schema issue, so the wire behaviour a caller sees is decided entirely by what
+ * `codebaseScanPayloadSchema` produces here. The real-socket proof that a rejected scan writes
+ * nothing lives in test/http/codebases-request-bounds.http.test.ts; this file is the pure
+ * boundary and the exact operator-facing message.
+ *
+ * WHAT THIS IS RED FOR AT BASELINE (0006d51f): `lib/api/schemas.ts` accepts an arbitrary
+ * `metrics.recent_commits` array, so 101 valid commits parse successfully today. That is the
+ * admitted-work gap AUDITFIX-17 closes — a valid team-tier key can hand the ingest owner an
+ * unbounded number of commits to project through `ingestItem`, one synchronous write each.
+ */
+
+// Verbatim from the canonical supplement. Written out rather than imported so a hand-edit to
+// the vendored artifact cannot quietly re-point what "the exact message" means; the guard
+// test/guards/codebase-request-limits-contract.test.ts is what ties the two together.
+const COUNT_MESSAGE =
+  "metrics.recent_commits: at most 100 entries per scan; send a complete scan with a smaller recent-commit window; do not split a snapshot across pushes";
+
+const CODEBASE = { slug: "bounds-repo", full_name: "acme/bounds-repo", provider: "github" };
+
+/** `n` distinct, schema-valid commit objects. */
+function commits(n: number): Record<string, unknown>[] {
+  return Array.from({ length: n }, (_, i) => ({
+    sha: i.toString(16).padStart(40, "0"),
+    author: "Jo <jo@example.com>",
+    author_email: "jo@example.com",
+    message: `commit ${i}`,
+    committed_at: "2026-09-01T10:00:00Z",
+    ai: false,
+    additions: 3,
+    deletions: 1,
+  }));
+}
+
+function scan(recent_commits: unknown[]) {
+  return { codebase: CODEBASE, metrics: fullMetrics({ recent_commits }) };
+}
+
+/** The first issue's message, which is exactly what the route puts on the wire. */
+function firstIssue(payload: unknown): string | null {
+  const parsed = codebaseScanPayloadSchema.safeParse(payload);
+  return parsed.success ? null : (parsed.error.issues[0]?.message ?? "");
+}
+
+describe("AC17-01 — metrics.recent_commits count bound", () => {
+  // The array stays REQUIRED and empty stays legal: this is an admission ceiling, not a new
+  // minimum. A scan of a repo with no commits in the window is an ordinary scan.
+  it.each([0, 20, 100])("admits %i commits (0, the scanner's 20, and the ceiling)", (n) => {
+    expect(firstIssue(scan(commits(n)))).toBeNull();
+  });
+
+  it("rejects 101 otherwise-valid commits with the exact named message", () => {
+    expect(firstIssue(scan(commits(101)))).toBe(COUNT_MESSAGE);
+  });
+
+  // The count is taken BEFORE normalization/deduplication. `normalizeCommit` drops a commit
+  // with no usable sha and re-pushing an identical sha dedups to a no-op, so if the bound were
+  // applied to what survives, a caller could buy unlimited input budget with junk the brain
+  // throws away — the work of validating and normalizing it has already been done by then.
+  it("counts duplicate SHAs — deduplication downstream is not an input-budget escape", () => {
+    const duplicated = Array.from({ length: 101 }, () => commits(1)[0]);
+    expect(firstIssue(scan(duplicated))).toBe(COUNT_MESSAGE);
+  });
+
+  it("counts commits with no usable sha — skipping downstream is not an escape either", () => {
+    const unusable = Array.from({ length: 101 }, () => ({ author: "Jo", message: "no sha" }));
+    expect(firstIssue(scan(unusable))).toBe(COUNT_MESSAGE);
+  });
+
+  // Precedence, stated so the exact-message assertion above is not read as a promise the route
+  // cannot keep: the response is first-issue-only. When an ELEMENT is also invalid, whichever
+  // message wins, the outcome is still a schema rejection — which is what "returns 422 before
+  // ingest" depends on. The spec explicitly declines a duplicate raw-array precheck just to
+  // reorder these two.
+  it("still rejects when an element ALSO violates the schema (message may differ)", () => {
+    const withBadElement = commits(101);
+    withBadElement[0] = {
+      ...withBadElement[0],
+      fix_analysis: {
+        method: "first-parent-line-blame-v1",
+        candidate_parent_lines: 1,
+        blamed_parent_lines: 1,
+        age_buckets: { "0_1d": 1, "2_7d": 0, "8_30d": 0, "31_90d": 0, "91_365d": 0, "366d_plus": 0 },
+        prior_fix_parent_lines: 0,
+      },
+    };
+    expect(codebaseScanPayloadSchema.safeParse(scan(withBadElement)).success).toBe(false);
+  });
+
+  // Non-vacuity for the message assertion: the ceiling must be what rejects 101, not some
+  // unrelated property of the generated fixtures. 100 of the SAME objects must parse.
+  it("is the count that rejects — 100 of the identical objects parse", () => {
+    const hundred = Array.from({ length: 100 }, () => commits(1)[0]);
+    expect(firstIssue(scan(hundred))).toBeNull();
+  });
+});

--- a/test/codebases-request-admission.test.ts
+++ b/test/codebases-request-admission.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+import { fullMetrics } from "./fixtures/codebase-scan";
+
+/**
+ * AUDITFIX-17 / AIO-1136 — AC17-05 (401/403/429 keep their precedence and read no body; an
+ * accepted scan keeps its 201 envelope) and the route half of "reject before ingest": the two
+ * functions that own every scan-domain write, `ingestCodebaseScan` and `recordIngestRun`, are
+ * never ENTERED on a rejection.
+ *
+ * Spec: docs/design/auditfix17-request-bounds.md. Sibling of test/codebases-rate-limit.test.ts,
+ * which owns the Retry-After contract itself and stays green untouched.
+ *
+ * WHY THIS TIER, AND NOT THE HTTP ONE. Two claims here are unobservable over a socket:
+ *   - "429 does not consume the body" — the body is instrumented, so a read is COUNTED. Tripping
+ *     the real bucket would need 60 requests a minute against a shared server and still would not
+ *     show whether the handler read anything.
+ *   - "ingest was never entered" — a spy proves the call did not happen. Real rows prove only that
+ *     nothing was written, which is the complementary claim and lives in the HTTP tier
+ *     (test/http/codebases-request-bounds.http.test.ts).
+ */
+
+const h = vi.hoisted(() => ({
+  auth: null as null | {
+    teamId: string;
+    memberId: string;
+    apiKeyId: string;
+    memberTier: "team" | "external";
+  },
+  rateLimitWithReset: vi.fn(),
+  ingestCodebaseScan: vi.fn(),
+  recordIngestRun: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db/admin", () => ({ adminClient: () => ({}) }));
+vi.mock("@/lib/api/auth", () => ({ authenticateApiKey: async () => h.auth }));
+vi.mock("@/lib/api/rate-limit", () => ({ rateLimitWithReset: h.rateLimitWithReset }));
+vi.mock("@/lib/codebases/ingest", () => ({ ingestCodebaseScan: h.ingestCodebaseScan }));
+vi.mock("@/lib/ingest/runs", () => ({ recordIngestRun: h.recordIngestRun }));
+
+const { POST } = await import("@/app/api/v1/codebases/route");
+
+// Verbatim from the canonical admission supplement (vendored at
+// test/fixtures/contract/codebase-request-limits-v1.json). Spelled out as literals so this file
+// states the wire contract; test/guards/codebase-request-limits-contract.test.ts ties the strings
+// to the shared artifact.
+const BYTES_MESSAGE =
+  "body: at most 2400000 bytes per scan; reduce the scan payload and retry; do not split a snapshot across pushes";
+const COUNT_MESSAGE =
+  "metrics.recent_commits: at most 100 entries per scan; send a complete scan with a smaller recent-commit window; do not split a snapshot across pushes";
+
+const encoder = new TextEncoder();
+
+function commits(n: number): Record<string, unknown>[] {
+  return Array.from({ length: n }, (_, i) => ({
+    sha: i.toString(16).padStart(40, "0"),
+    author: "Jo <jo@example.com>",
+    author_email: "jo@example.com",
+    message: `commit ${i}`,
+    committed_at: "2026-09-01T10:00:00Z",
+    ai: false,
+  }));
+}
+
+const scanPayload = (recent_commits: unknown[]) => ({
+  codebase: { slug: "admission-repo", full_name: "acme/admission-repo", provider: "github" },
+  metrics: fullMetrics({ recent_commits }),
+});
+
+/**
+ * A request whose body READS ARE COUNTED. `chunks` are served in order; after them the stream
+ * closes. `declaredLength` sets `Content-Length` without changing what is delivered.
+ */
+function request(options: {
+  chunks?: string[];
+  declaredLength?: number;
+  headers?: Record<string, string>;
+} = {}): { req: NextRequest; probe: { reads: number } } {
+  const { chunks = ["{}"], declaredLength, headers = {} } = options;
+  const probe = { reads: 0 };
+  let next = 0;
+  const reader = {
+    read(): Promise<{ done: boolean; value?: Uint8Array }> {
+      probe.reads++;
+      return next < chunks.length
+        ? Promise.resolve({ done: false, value: encoder.encode(chunks[next++]) })
+        : Promise.resolve({ done: true });
+    },
+    releaseLock() {},
+    cancel: () => Promise.resolve(),
+  };
+
+  const headerInit: Record<string, string> = {
+    Authorization: "Bearer aios_key-1_secret",
+    "Content-Type": "application/json",
+    ...headers,
+  };
+  if (declaredLength !== undefined) headerInit["Content-Length"] = String(declaredLength);
+
+  return {
+    req: {
+      headers: new Headers(headerInit),
+      body: { getReader: () => reader },
+    } as unknown as NextRequest,
+    probe,
+  };
+}
+
+const jsonRequest = (payload: unknown) => request({ chunks: [JSON.stringify(payload)] });
+
+async function errorOf(response: Response): Promise<{ code: string; message: string }> {
+  return ((await response.json()) as { error: { code: string; message: string } }).error;
+}
+
+/** Nothing in the scan domain was entered. */
+function expectNoScanWork() {
+  expect(h.ingestCodebaseScan).not.toHaveBeenCalled();
+  expect(h.recordIngestRun).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  h.auth = { teamId: "team-1", memberId: "member-1", apiKeyId: "key-1", memberTier: "team" };
+  h.rateLimitWithReset.mockReset().mockResolvedValue({ allowed: true, retryAfterSeconds: 0 });
+  h.ingestCodebaseScan.mockReset().mockResolvedValue({ contributions: 1, issues: 0 });
+  h.recordIngestRun.mockReset().mockResolvedValue(undefined);
+});
+
+describe("POST /api/v1/codebases — admission precedence (AC17-05)", () => {
+  it("401 outranks an oversized body, and reads none of it", async () => {
+    h.auth = null;
+    const { req, probe } = request({ chunks: ["x".repeat(3_000_000)] });
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(401);
+    expect(probe.reads).toBe(0);
+    expect(h.rateLimitWithReset).not.toHaveBeenCalled();
+    expectNoScanWork();
+  });
+
+  it("403 outranks an oversized body, and reads none of it", async () => {
+    h.auth = { ...h.auth!, memberTier: "external" };
+    const { req, probe } = request({ chunks: ["x".repeat(3_000_000)] });
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(403);
+    expect((await errorOf(response)).code).toBe("forbidden_tier");
+    expect(probe.reads).toBe(0);
+    expect(h.rateLimitWithReset).not.toHaveBeenCalled();
+    expectNoScanWork();
+  });
+
+  it("429 keeps its Retry-After and consumes no body", async () => {
+    // The bound sits AFTER the rate limiter, so an exhausted key is told to come back rather than
+    // being handed a size verdict — and the request body is never read to decide that.
+    h.rateLimitWithReset.mockResolvedValue({ allowed: false, retryAfterSeconds: 42 });
+    const { req, probe } = request({ chunks: ["x".repeat(3_000_000)] });
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("42");
+    expect((await errorOf(response)).code).toBe("rate_limited");
+    expect(probe.reads).toBe(0);
+    expectNoScanWork();
+  });
+
+  it("an oversized body is refused with the named 413, before any scan work", async () => {
+    // Three 1,000,000-byte chunks: the third crosses 2,400,000, and the reader stops there.
+    const { req, probe } = request({ chunks: Array.from({ length: 3 }, () => "x".repeat(1_000_000)) });
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(413);
+    expect(await errorOf(response)).toMatchObject({
+      code: "payload_too_large",
+      message: BYTES_MESSAGE,
+    });
+    expect(probe.reads).toBe(3);
+    expectNoScanWork();
+  });
+
+  it("a Content-Length above the ceiling is refused without reading the body", async () => {
+    const { req, probe } = request({ chunks: ['{"a":1}'], declaredLength: 2_400_001 });
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(413);
+    expect((await errorOf(response)).message).toBe(BYTES_MESSAGE);
+    expect(probe.reads).toBe(0);
+    expectNoScanWork();
+  });
+
+  it("101 commits are refused with the named 422, before any scan work", async () => {
+    const { req } = jsonRequest(scanPayload(commits(101)));
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(422);
+    expect(await errorOf(response)).toMatchObject({
+      code: "invalid_payload",
+      message: COUNT_MESSAGE,
+    });
+    expectNoScanWork();
+  });
+
+  it("a malformed body keeps the existing 422, not a new error class", async () => {
+    const { req } = request({ chunks: ['{"codebase":'] });
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(422);
+    expect(await errorOf(response)).toMatchObject({
+      code: "invalid_payload",
+      message: "body must be JSON",
+    });
+    expectNoScanWork();
+  });
+
+  it("an ordinary scan at the ceiling still ingests and returns the 201 envelope", async () => {
+    // Non-vacuity for every `expectNoScanWork()` above: the spies DO fire when a request is
+    // admitted, so their silence elsewhere means the request was refused, not that the route was
+    // never exercised.
+    const { req } = jsonRequest(scanPayload(commits(100)));
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({ status: "ok", contributions: 1 });
+    expect(h.ingestCodebaseScan).toHaveBeenCalledOnce();
+    expect(h.recordIngestRun).toHaveBeenCalledOnce();
+    const scan = h.ingestCodebaseScan.mock.calls[0][2] as {
+      metrics: { recent_commits: unknown[] };
+    };
+    expect(scan.metrics.recent_commits).toHaveLength(100);
+    expect(h.recordIngestRun.mock.calls[0][1]).toMatchObject({ source: "scan", ok: true });
+  });
+});

--- a/test/fixtures/contract/codebase-request-limits-v1.json
+++ b/test/fixtures/contract/codebase-request-limits-v1.json
@@ -1,0 +1,55 @@
+{
+  "kind": "aios-codebase-request-limits",
+  "revision": 1,
+  "method": "POST",
+  "path": "/api/v1/codebases",
+  "maxBodyBytes": 2400000,
+  "maxRecentCommits": 100,
+  "bodyMeasurement": "Bytes supplied by Request.body, including JSON syntax and whitespace; inclusive limit; Content-Length is not authoritative",
+  "errors": {
+    "body": {
+      "status": 413,
+      "code": "payload_too_large",
+      "message": "body: at most 2400000 bytes per scan; reduce the scan payload and retry; do not split a snapshot across pushes"
+    },
+    "recentCommits": {
+      "status": 422,
+      "code": "invalid_payload",
+      "message": "metrics.recent_commits: at most 100 entries per scan; send a complete scan with a smaller recent-commit window; do not split a snapshot across pushes"
+    }
+  },
+  "boundaryCases": {
+    "recentCommits": [
+      {
+        "count": 0,
+        "admitted": true
+      },
+      {
+        "count": 20,
+        "admitted": true
+      },
+      {
+        "count": 100,
+        "admitted": true
+      },
+      {
+        "count": 101,
+        "admitted": false
+      }
+    ],
+    "body": [
+      {
+        "bytes": 2400000,
+        "admitted": true
+      },
+      {
+        "bytes": 2400001,
+        "admitted": false
+      }
+    ]
+  },
+  "memberApiMajor": 1,
+  "appliesFromMemberApiVersion": "1.23",
+  "applicability": "POST /api/v1/codebases for member API major 1 from 1.23 onward until explicitly superseded or withdrawn; not /api/v2",
+  "boundaryCasePrecondition": "All other existing payload constraints pass; another schema violation may supply the first invalid_payload message"
+}

--- a/test/guards/codebase-request-limits-contract.test.ts
+++ b/test/guards/codebase-request-limits-contract.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { BRAIN_API_VERSION } from "@/lib/api/version";
+import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
+import { fullMetrics } from "../fixtures/codebase-scan";
+
+/**
+ * AUDITFIX-17 / AIO-1136 — AC17-08. Server-side conformance guard for the codebase
+ * request-admission supplement (canonical home:
+ * aios-workspace/docs/contract/codebase-request-limits-v1.json, vendored here).
+ *
+ * Sibling of test/guards/codebase-payload-contract.test.ts, which pins the payload SHAPE
+ * contract. This one pins the ADMISSION contract, and the two are deliberately separate
+ * artifacts: the supplement is versioned on its own `revision` and does NOT bump the member
+ * API, so a shape revision and an admission revision can move independently.
+ *
+ * The load-bearing assertion is the last block: the supplement's published boundary cases are
+ * run through the ACTUAL `codebaseScanPayloadSchema`, using the literal counts the file
+ * publishes. Comparing an exported constant to itself would pass no matter what the schema
+ * does; comparing published behaviour to real behaviour is what makes the shared artifact
+ * mean something to a client that reads it.
+ *
+ * RED AT BASELINE (0006d51f) for the count cases: the schema accepts an unbounded
+ * `metrics.recent_commits`, so the supplement's `count: 101, admitted: false` case is a
+ * statement the server does not yet honour. The byte half of the supplement
+ * (`boundaryCases.body`) is a TRANSPORT bound and cannot be observed through the schema at
+ * all — it is proven over a real socket in test/http/codebases-request-bounds.http.test.ts,
+ * and this guard only checks its published shape.
+ */
+
+const CONTRACT_DIR = join(import.meta.dirname, "..", "fixtures", "contract");
+const SUPPLEMENT_FILE = "codebase-request-limits-v1.json";
+
+const raw = readFileSync(join(CONTRACT_DIR, SUPPLEMENT_FILE), "utf8");
+const supplement = JSON.parse(raw) as {
+  readonly kind: string;
+  readonly revision: number;
+  readonly method: string;
+  readonly path: string;
+  readonly maxBodyBytes: number;
+  readonly maxRecentCommits: number;
+  readonly bodyMeasurement: string;
+  readonly memberApiMajor: number;
+  readonly appliesFromMemberApiVersion: string;
+  readonly errors: Record<string, { status: number; code: string; message: string }>;
+  readonly boundaryCases: {
+    readonly recentCommits: readonly { count: number; admitted: boolean }[];
+    readonly body: readonly { bytes: number; admitted: boolean }[];
+  };
+};
+
+/**
+ * sha256 of the canonical revision-1 bytes, in the same posture as the `PINNED` map in the
+ * sibling `codebase-payload-contract.test.ts` and `brain-contract.json`'s contentHash: the
+ * vendored copy is guarded against out-of-band edits, and refreshing it from the canonical home
+ * means updating this digest in the same change.
+ *
+ * A digest says only THAT something drifted, so it is deliberately not the only pin here — the
+ * literal-value and literal-behaviour cases below say WHAT the artifact has to mean.
+ */
+const PINNED_SHA256 = "85fac3ea83a706bc5b51c80d233f7d2259e60549045f0aed861e46c6933666fb";
+
+/**
+ * The two ceilings and the count message, spelled out INDEPENDENTLY of the file under guard.
+ * Reading them from the supplement and then asserting the supplement matches would pass for any
+ * pair of numbers; a third-party client codes against these literals, so the guard states them.
+ */
+const LITERAL_MAX_RECENT_COMMITS = 100;
+const LITERAL_OVER_RECENT_COMMITS = 101;
+const LITERAL_MAX_BODY_BYTES = 2_400_000;
+const LITERAL_COUNT_MESSAGE =
+  "metrics.recent_commits: at most 100 entries per scan; send a complete scan with a smaller recent-commit window; do not split a snapshot across pushes";
+
+const CODEBASE = { slug: "contract-repo", full_name: "acme/contract-repo", provider: "github" };
+
+function scanWithCommits(n: number) {
+  const recent_commits = Array.from({ length: n }, (_, i) => ({
+    sha: i.toString(16).padStart(40, "0"),
+    author: "Jo <jo@example.com>",
+    author_email: "jo@example.com",
+    message: `commit ${i}`,
+    committed_at: "2026-09-01T10:00:00Z",
+    ai: false,
+  }));
+  return { codebase: CODEBASE, metrics: fullMetrics({ recent_commits }) };
+}
+
+describe("codebase request-admission supplement (revision 1)", () => {
+  it("the vendored copy is byte-identical to the pinned canonical revision", () => {
+    const bytes = readFileSync(join(CONTRACT_DIR, SUPPLEMENT_FILE));
+    expect(createHash("sha256").update(bytes).digest("hex"), SUPPLEMENT_FILE).toBe(PINNED_SHA256);
+  });
+
+  it("publishes the literal ceilings this server enforces", () => {
+    // Independent of the digest: a byte pin cannot tell 100 from 1000, only that the file moved.
+    expect(supplement.kind).toBe("aios-codebase-request-limits");
+    expect(supplement.revision).toBe(1);
+    expect(supplement.maxRecentCommits).toBe(LITERAL_MAX_RECENT_COMMITS);
+    expect(supplement.maxBodyBytes).toBe(LITERAL_MAX_BODY_BYTES);
+    expect(supplement.errors.recentCommits.message).toBe(LITERAL_COUNT_MESSAGE);
+  });
+
+  it("adopting the supplement does not bump the member API version", () => {
+    // The supplement carries its own `revision` and applies from 1.23 onward. Bumping
+    // BRAIN_API_VERSION to 1.25 would claim the canonical 1.24 scanner-identity semantics
+    // this server does not implement; leaving it at 1.23 is the honest declaration.
+    expect(BRAIN_API_VERSION).toBe("1.23");
+    // "applies from 1.23 ONWARD" — so the running server must be at or above that, not equal
+    // to it. Pinning equality here would turn a legitimate future minor bump into a red guard.
+    const [supMajor, supMinor] = supplement.appliesFromMemberApiVersion.split(".").map(Number);
+    const [srvMajor, srvMinor] = BRAIN_API_VERSION.split(".").map(Number);
+    expect(supplement.memberApiMajor).toBe(supMajor);
+    expect(srvMajor).toBe(supMajor);
+    expect(srvMinor).toBeGreaterThanOrEqual(supMinor);
+  });
+
+  it("names the endpoint it bounds", () => {
+    expect(supplement.method).toBe("POST");
+    expect(supplement.path).toBe("/api/v1/codebases");
+  });
+
+  // ——— the part that can actually be wrong ———
+
+  it("every published recent_commits boundary case matches the real schema's verdict", () => {
+    for (const boundaryCase of supplement.boundaryCases.recentCommits) {
+      const parsed = codebaseScanPayloadSchema.safeParse(scanWithCommits(boundaryCase.count));
+      expect(
+        parsed.success,
+        `supplement publishes count ${boundaryCase.count} as ` +
+          `${boundaryCase.admitted ? "admitted" : "rejected"}; the schema ` +
+          `${parsed.success ? "accepted" : "rejected"} it`
+      ).toBe(boundaryCase.admitted);
+    }
+  });
+
+  it("the LITERAL 100/101 boundary behaves as published, whatever the file says", () => {
+    // The case above is driven by the artifact, so an artifact that published the wrong pair
+    // could still agree with a wrong schema. This one hard-codes the boundary: 100 in, 101 out,
+    // with the exact operator-facing message. Both halves are required — asserting only the
+    // rejection would pass against a schema that rejected everything.
+    expect(
+      codebaseScanPayloadSchema.safeParse(scanWithCommits(LITERAL_MAX_RECENT_COMMITS)).success,
+    ).toBe(true);
+    const over = codebaseScanPayloadSchema.safeParse(
+      scanWithCommits(LITERAL_OVER_RECENT_COMMITS),
+    );
+    expect(over.success).toBe(false);
+    if (over.success) return;
+    expect(over.error.issues[0]?.message).toBe(LITERAL_COUNT_MESSAGE);
+  });
+
+  it("the published 422 message is what a caller actually receives", () => {
+    // The route answers with `parsed.error.issues[0].message`, so the supplement's promise is
+    // only kept if the count violation is BOTH the rejection reason and the first issue.
+    const over = supplement.boundaryCases.recentCommits.find((c) => !c.admitted);
+    expect(over, "the supplement publishes no rejected count case").toBeDefined();
+    const parsed = codebaseScanPayloadSchema.safeParse(scanWithCommits(over!.count));
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.error.issues[0]?.message).toBe(supplement.errors.recentCommits.message);
+    expect(supplement.errors.recentCommits.status).toBe(422);
+    expect(supplement.errors.recentCommits.code).toBe("invalid_payload");
+  });
+
+  it("historical valid payload fixtures are still accepted (the narrowing is bounded)", () => {
+    // AC17-08: an admission limit must not retroactively invalidate the published payload
+    // shape. Every canonical 1.23 valid fixture must survive this change untouched.
+    const fixtures = JSON.parse(
+      readFileSync(join(CONTRACT_DIR, "codebase-payload-1.23-fixtures.json"), "utf8")
+    ) as { valid: readonly { name: string; payload: unknown }[] };
+    expect(fixtures.valid.length).toBeGreaterThanOrEqual(3);
+    for (const entry of fixtures.valid) {
+      const res = codebaseScanPayloadSchema.safeParse(entry.payload);
+      expect(res.success, `${entry.name}: ${res.success ? "" : res.error.issues[0]?.message}`).toBe(
+        true
+      );
+    }
+  });
+
+  it("the byte bound is published as a transport bound, proven in the HTTP tier", () => {
+    // Not testable here by construction: the schema never sees the wire. This asserts only
+    // that the published contract says the right thing about HOW the bytes are measured —
+    // Content-Length is an optimization, never the measurement — so the HTTP tier's
+    // chunked-body case is testing the documented rule and not an invented one.
+    expect(supplement.maxBodyBytes).toBe(2_400_000);
+    expect(supplement.errors.body.status).toBe(413);
+    expect(supplement.errors.body.code).toBe("payload_too_large");
+    expect(supplement.bodyMeasurement).toContain("Content-Length is not authoritative");
+    expect(supplement.boundaryCases.body.map((c) => c.bytes)).toEqual([2_400_000, 2_400_001]);
+    expect(supplement.boundaryCases.body.map((c) => c.admitted)).toEqual([true, false]);
+  });
+});

--- a/test/http/codebases-request-bounds.http.test.ts
+++ b/test/http/codebases-request-bounds.http.test.ts
@@ -1,0 +1,452 @@
+import { request as httpRequest } from "node:http";
+import { describe, expect, it } from "vitest";
+import { BASE_URL, db, issueKeyFor, keyHeaders, seedTeam, type Seed } from "./http-helpers";
+import { HTTP_TEST_PORT } from "./server-url";
+import { fullMetrics } from "../fixtures/codebase-scan";
+
+/**
+ * AUDITFIX-17 / AIO-1136 — AC17-02, AC17-05, AC17-06, AC17-07 for POST /api/v1/codebases,
+ * over a REAL socket against `next start` + the isolated test Postgres.
+ *
+ * Spec: docs/design/auditfix17-request-bounds.md. This is the only tier that can prove the two
+ * things this change is actually about:
+ *
+ *   1. The BYTE bound is a transport property. The schema never sees the wire, and the route's
+ *      current gate reads `Content-Length` — which a chunked request simply does not send. An
+ *      in-process test that hands a route handler a `Request` built from a string cannot
+ *      reproduce that, because it has a length. Only a real Node client that writes chunks
+ *      without declaring a length does.
+ *   2. "No writes on rejection" is a claim about persisted state. A spy proves the ingest
+ *      function was not CALLED; only real rows prove nothing was written. Both matter, and this
+ *      file owns the second.
+ *
+ * RED AT BASELINE (0006d51f), for the intended reasons:
+ *   - a chunked 2,400,001-byte body has no `Content-Length`, so `parseInt(null || "0")` is 0,
+ *     the gate does not fire, `req.json()` parses the whole thing and the scan is INGESTED;
+ *   - `metrics.recent_commits` has no cardinality bound, so 101 commits are accepted and each
+ *     one is projected through `ingestItem`;
+ *   - the declared-length rejection answers `413 "max 2 MB"`, which names neither the real
+ *     2,400,000-byte ceiling nor any recovery.
+ *
+ * NOT PROVEN HERE, deliberately: AC17-03 (the reader stops early, retains no crossing chunk and
+ * releases the lock) and AC17-04 (multibyte round-trip, decoder semantics). Those are properties
+ * of the bounded reader, observable only by driving a stream directly, and their tests land with
+ * the reader. A real socket cannot see whether the application read one chunk or all of them.
+ */
+
+const CODEBASES_URL = `${BASE_URL}/api/v1/codebases`;
+const MAX_BODY_BYTES = 2_400_000;
+
+// Verbatim from the canonical supplement (aios-workspace docs/contract/, vendored at
+// test/fixtures/contract/codebase-request-limits-v1.json). Spelled out here so this file states
+// the wire contract it is asserting; test/guards/codebase-request-limits-contract.test.ts is
+// what proves these strings still match the shared artifact.
+const BYTES_MESSAGE =
+  "body: at most 2400000 bytes per scan; reduce the scan payload and retry; do not split a snapshot across pushes";
+const COUNT_MESSAGE =
+  "metrics.recent_commits: at most 100 entries per scan; send a complete scan with a smaller recent-commit window; do not split a snapshot across pushes";
+
+let slugCounter = 0;
+const uniqueSlug = (label: string) => `af17-${label}-${Date.now().toString(36)}-${slugCounter++}`;
+
+/** `n` distinct, schema-valid commits with unique SHAs (so none dedups away). */
+function commits(n: number, saltHex = "0"): Record<string, unknown>[] {
+  return Array.from({ length: n }, (_, i) => ({
+    sha: `${saltHex}${i.toString(16)}`.padStart(40, "f"),
+    author: "Jo Committer <jo@example.com>",
+    author_email: "jo@example.com",
+    message: `bounded scan commit ${i}`,
+    committed_at: "2026-09-01T10:00:00Z",
+    ai: false,
+    additions: 2,
+    deletions: 1,
+  }));
+}
+
+function scanPayload(slug: string, headSha: string, recent_commits: unknown[]) {
+  return {
+    codebase: { slug, full_name: `acme/${slug}`, provider: "github" },
+    metrics: fullMetrics({ head_sha: headSha, recent_commits }),
+  };
+}
+
+/**
+ * Serialize `payload` to EXACTLY `targetBytes` of valid JSON by padding with insignificant
+ * whitespace immediately after the opening brace. ASCII-only, so byte length == string length,
+ * and the padding is part of the body the transport carries — which is the thing being bounded.
+ */
+function jsonOfExactBytes(payload: unknown, targetBytes: number): string {
+  const base = JSON.stringify(payload);
+  const padding = targetBytes - Buffer.byteLength(base, "utf8");
+  if (padding < 0) {
+    throw new Error(`payload is already ${Buffer.byteLength(base, "utf8")} B > ${targetBytes} B`);
+  }
+  const body = `{${" ".repeat(padding)}${base.slice(1)}`;
+  if (Buffer.byteLength(body, "utf8") !== targetBytes) {
+    throw new Error(`padding failed: ${Buffer.byteLength(body, "utf8")} != ${targetBytes}`);
+  }
+  return body;
+}
+
+interface RawResponse {
+  status: number;
+  body: string;
+  json: () => unknown;
+}
+
+/**
+ * POST over a raw Node client so the test controls framing. `fetch` always computes and sends a
+ * `Content-Length` for a string body, which is precisely the header this route currently trusts,
+ * so the chunked case is unreachable through it.
+ *
+ * `chunked: true` omits Content-Length entirely (Node then uses `Transfer-Encoding: chunked`).
+ * `declaredLength` sends a Content-Length that need not match what is written — that is how the
+ * "a high declaration rejects without consuming the body" case is expressed.
+ * `end: false` leaves the request unfinished, so a response can only arrive if the server
+ * answered WITHOUT the full body.
+ */
+function postRaw(options: {
+  headers: Record<string, string>;
+  chunks: string[];
+  declaredLength?: number;
+  end?: boolean;
+  timeoutMs?: number;
+}): Promise<RawResponse> {
+  const { headers, chunks, declaredLength, end = true, timeoutMs = 30_000 } = options;
+  return new Promise<RawResponse>((resolve, reject) => {
+    const outgoing: Record<string, string> = { ...headers };
+    if (declaredLength !== undefined) outgoing["Content-Length"] = String(declaredLength);
+
+    // A bounded wait that FAILS rather than passing quietly: an absent response is the exact
+    // outcome these cases are trying to rule out, so it must never be mistaken for success.
+    // `timer` is assigned below and read only from callbacks (response end, request error, the
+    // timeout itself), every one of which runs after this synchronous body has finished — so it
+    // can never be observed unset.
+    const req = httpRequest(
+      {
+        host: "127.0.0.1",
+        port: Number(HTTP_TEST_PORT),
+        path: "/api/v1/codebases",
+        method: "POST",
+        headers: outgoing,
+      },
+      (res) => {
+        const parts: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => parts.push(chunk));
+        res.on("end", () => {
+          clearTimeout(timer);
+          req.destroy();
+          const body = Buffer.concat(parts).toString("utf8");
+          resolve({
+            status: res.statusCode ?? 0,
+            body,
+            json: () => JSON.parse(body),
+          });
+        });
+      }
+    );
+
+    const timer = setTimeout(() => {
+      req.destroy();
+      reject(
+        new Error(
+          `no response within ${timeoutMs}ms (declaredLength=${declaredLength ?? "none"}, ` +
+            `end=${end}, bytesWritten=${chunks.reduce((n, c) => n + Buffer.byteLength(c), 0)})`
+        )
+      );
+    }, timeoutMs);
+
+    req.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    for (const part of chunks) req.write(part);
+    if (end) req.end();
+  });
+}
+
+/** Split a body into `parts` chunks so the oversized cases genuinely stream. */
+function chunk(body: string, parts: number): string[] {
+  const size = Math.ceil(body.length / parts);
+  const out: string[] = [];
+  for (let i = 0; i < body.length; i += size) out.push(body.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Every scan-domain table the route's ingest owner can touch, scoped to ONE seeded team, in a
+ * stable order. Deliberately NOT a whole-database snapshot: authentication updates
+ * `api_keys.last_used_at` and the rate limiter writes its bucket on EVERY request including a
+ * rejected one, and those are explicitly allowed by the spec. What must not move is scan state.
+ */
+async function scanInventory(teamId: string) {
+  const admin = db();
+  const rows = async (table: string, cols: string) => {
+    const { data, error } = await admin
+      .from(table)
+      .select(cols)
+      .eq("team_id", teamId)
+      .order("id", { ascending: true });
+    if (error) throw new Error(`inventory ${table} failed: ${error.message}`);
+    return (data ?? []) as Record<string, unknown>[];
+  };
+
+  const items = await rows("items", "id, project_id, path, kind, content_sha256, access, member_id");
+  const itemIds = items.map((row) => row.id as string);
+  const { data: versions, error: versionError } = itemIds.length
+    ? await admin
+        .from("item_versions")
+        .select("id, item_id, content_sha256")
+        .in("item_id", itemIds)
+        .order("id", { ascending: true })
+    : { data: [], error: null };
+  if (versionError) throw new Error(`inventory item_versions failed: ${versionError.message}`);
+
+  const { data: auditRows, error: auditError } = await admin
+    .from("audit_log")
+    .select("id, action, target_type, target_id")
+    .eq("team_id", teamId)
+    .order("id", { ascending: true });
+  if (auditError) throw new Error(`inventory audit_log failed: ${auditError.message}`);
+  // Scan-domain audit only. Scoped by ACTION rather than by target id, because a rejected
+  // request that wrongly ingested would create target ids that did not exist before — an
+  // id-scoped comparison could not see them.
+  const scanAudit = (auditRows ?? []).filter((row) => {
+    const action = String((row as { action: string }).action);
+    return action === "codebase.scanned" || action.startsWith("item");
+  });
+
+  return {
+    codebases: await rows("codebases", "id, slug, full_name, last_scan_at"),
+    code_metrics: await rows("code_metrics", "id, codebase_id, head_sha, recent_commits, loc"),
+    code_contributions: await rows("code_contributions", "id, codebase_id, author_key, day, commits"),
+    github_issues: await rows("github_issues", "id, codebase_id, number, state"),
+    codebase_findings: await rows("codebase_findings", "id, codebase_id, fingerprint, status"),
+    codebase_finding_events: await rows("codebase_finding_events", "id, finding_id, event_type"),
+    items,
+    item_versions: (versions ?? []) as Record<string, unknown>[],
+    projects: await rows("projects", "id, slug, kind, last_synced_at, graph_group_id"),
+    project_context_units: await rows("project_context_units", "id, source_item_id, unit_key, state"),
+    project_context_memberships: await rows(
+      "project_context_memberships",
+      "id, project_id, context_unit_id, decision, valid_to"
+    ),
+    scan_ingest_runs: (await rows("ingest_runs", "id, source, trigger, ok, updated")).filter(
+      (row) => row.source === "scan"
+    ),
+    scan_audit: scanAudit,
+  };
+}
+
+async function seedTeamWithKey(): Promise<{ seed: Seed; key: string }> {
+  const seed = await seedTeam();
+  const { key } = await issueKeyFor(seed, "team");
+  return { seed, key };
+}
+
+describe("POST /api/v1/codebases — request bounds (HTTP)", () => {
+  // ——— AC17-02 / AC17-06: the byte bound is measured, not declared ———
+
+  it("admits a chunked body of exactly 2,400,000 bytes (the inclusive ceiling)", async () => {
+    const { seed, key } = await seedTeamWithKey();
+    const slug = uniqueSlug("at-limit");
+    const body = jsonOfExactBytes(scanPayload(slug, "a".repeat(40), commits(5)), MAX_BODY_BYTES);
+
+    const res = await postRaw({ headers: keyHeaders(key, seed.teamSlug), chunks: chunk(body, 24) });
+
+    expect(res.status).toBe(201);
+    expect((res.json() as { status: string }).status).toBe("ok");
+    // Non-vacuity: the accepted control proves the DB assertions in the rejection cases are
+    // reading a table that this route really does write.
+    const after = await scanInventory(seed.teamId);
+    expect(after.codebases.map((row) => row.slug)).toContain(slug);
+  });
+
+  it("rejects a chunked body of 2,400,001 bytes with the named 413, writing no scan state", async () => {
+    const { seed, key } = await seedTeamWithKey();
+    const slug = uniqueSlug("over-limit");
+    const before = await scanInventory(seed.teamId);
+    const body = jsonOfExactBytes(
+      scanPayload(slug, "b".repeat(40), commits(5)),
+      MAX_BODY_BYTES + 1
+    );
+
+    // No Content-Length: the header the current gate reads is simply absent, which is the whole
+    // point — a bound that trusts a declaration is not a bound.
+    const res = await postRaw({ headers: keyHeaders(key, seed.teamSlug), chunks: chunk(body, 24) });
+
+    expect(res.status).toBe(413);
+    const error = (res.json() as { error: { code: string; message: string } }).error;
+    expect(error.code).toBe("payload_too_large");
+    expect(error.message).toBe(BYTES_MESSAGE);
+
+    expect(await scanInventory(seed.teamId)).toEqual(before);
+  });
+
+  it("rejects a Content-Length above the ceiling before consuming the body", async () => {
+    const { seed, key } = await seedTeamWithKey();
+    const before = await scanInventory(seed.teamId);
+
+    // Declare more than the ceiling, write a token byte, and never finish the request. A
+    // response can therefore only arrive if the route rejected on the declaration alone — the
+    // "it is only an optimization" half of the spec's rule.
+    const res = await postRaw({
+      headers: keyHeaders(key, seed.teamSlug),
+      chunks: ["{"],
+      declaredLength: MAX_BODY_BYTES + 1,
+      end: false,
+      timeoutMs: 20_000,
+    });
+
+    expect(res.status).toBe(413);
+    const error = (res.json() as { error: { code: string; message: string } }).error;
+    expect(error.code).toBe("payload_too_large");
+    expect(error.message).toBe(BYTES_MESSAGE);
+    expect(await scanInventory(seed.teamId)).toEqual(before);
+  }, 30_000);
+
+  it("the declared-length and measured paths return the SAME 413 contract", async () => {
+    const { seed, key } = await seedTeamWithKey();
+    const slug = uniqueSlug("declared-over");
+    const before = await scanInventory(seed.teamId);
+    const body = jsonOfExactBytes(
+      scanPayload(slug, "c".repeat(40), commits(5)),
+      MAX_BODY_BYTES + 1
+    );
+
+    // The same oversized body, this time WITH an accurate Content-Length, so the early
+    // declaration check is what fires. Two code paths reject this request depending on how the
+    // client framed it; a caller must not be able to tell them apart from the response, or the
+    // "optimization" would be a second, undocumented contract.
+    //
+    // Deliberately NOT a spoofed low declaration: understating Content-Length changes HTTP
+    // framing itself, so a real socket cannot express "the header lies" without the transport
+    // truncating the body first. That case belongs to unit tests over a constructed Request.
+    const res = await postRaw({
+      headers: keyHeaders(key, seed.teamSlug),
+      chunks: chunk(body, 24),
+      declaredLength: Buffer.byteLength(body, "utf8"),
+    });
+    expect(res.status).toBe(413);
+    expect((res.json() as { error: { message: string } }).error.message).toBe(BYTES_MESSAGE);
+    expect(await scanInventory(seed.teamId)).toEqual(before);
+  });
+
+  // ——— AC17-06: the count bound over the wire ———
+
+  it("rejects 101 valid commits with the named 422, writing no scan state", async () => {
+    const { seed, key } = await seedTeamWithKey();
+    const slug = uniqueSlug("over-count");
+    const before = await scanInventory(seed.teamId);
+
+    const res = await fetch(CODEBASES_URL, {
+      method: "POST",
+      headers: keyHeaders(key, seed.teamSlug),
+      body: JSON.stringify(scanPayload(slug, "d".repeat(40), commits(101, "1"))),
+    });
+
+    expect(res.status).toBe(422);
+    const error = (await res.json()).error as { code: string; message: string };
+    expect(error.code).toBe("invalid_payload");
+    expect(error.message).toBe(COUNT_MESSAGE);
+
+    const after = await scanInventory(seed.teamId);
+    expect(after).toEqual(before);
+    // Named explicitly, because these are the two rows whose ABSENCE is the product claim:
+    // the rejected scan never became a codebase, and left no run to read in the runs log.
+    expect(after.codebases.map((row) => row.slug)).not.toContain(slug);
+    expect(after.scan_ingest_runs).toHaveLength(0);
+  });
+
+  // ——— AC17-05: existing outcomes keep their precedence ———
+
+  it("401 for a bad key and 403 for an external-tier key, both above the body bound", async () => {
+    const { seed } = await seedTeamWithKey();
+    const oversized = jsonOfExactBytes(
+      scanPayload(uniqueSlug("precedence"), "e".repeat(40), commits(101, "2")),
+      MAX_BODY_BYTES + 1
+    );
+    const before = await scanInventory(seed.teamId);
+
+    const unauthorized = await postRaw({
+      headers: {
+        Authorization: "Bearer aios_not_a_real_key",
+        "X-AIOS-Team": seed.teamSlug,
+        "Content-Type": "application/json",
+      },
+      chunks: chunk(oversized, 12),
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const { key: externalKey } = await issueKeyFor(seed, "external");
+    const forbidden = await postRaw({
+      headers: keyHeaders(externalKey, seed.teamSlug),
+      chunks: chunk(oversized, 12),
+    });
+    expect(forbidden.status).toBe(403);
+    expect((forbidden.json() as { error: { code: string } }).error.code).toBe("forbidden_tier");
+
+    // Neither auth failure is allowed to become a body-bound failure: an oversized request from
+    // a principal who may not post here must still say "you may not post here".
+    expect(await scanInventory(seed.teamId)).toEqual(before);
+  });
+
+  // ——— AC17-07: recovery, and what survives a rejected replacement ———
+
+  it("a rejected replacement leaves the accepted snapshot intact, and a corrected scan persists all 100 commits", async () => {
+    const { seed, key } = await seedTeamWithKey();
+    const slug = uniqueSlug("recovery");
+    const headSha = "1".repeat(40);
+    const headShaCorrected = "2".repeat(40);
+    const headers = keyHeaders(key, seed.teamSlug);
+
+    // 1. an ordinary accepted scan establishes real state to protect.
+    const seeded = await fetch(CODEBASES_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(scanPayload(slug, headSha, commits(3, "3"))),
+    });
+    expect(seeded.status).toBe(201);
+    const accepted = await scanInventory(seed.teamId);
+    expect(accepted.code_metrics).toHaveLength(1);
+
+    // 2. an over-count replacement of THE SAME (codebase, head_sha) — the case that would
+    //    otherwise replace the metrics row, because the upsert key is unchanged.
+    const rejected = await fetch(CODEBASES_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(scanPayload(slug, headSha, commits(101, "4"))),
+    });
+    expect(rejected.status).toBe(422);
+    expect(((await rejected.json()).error as { message: string }).message).toBe(COUNT_MESSAGE);
+
+    // 3. exact row equality: not "still has 3 commits", but "nothing moved at all".
+    expect(await scanInventory(seed.teamId)).toEqual(accepted);
+
+    // 4. neither rejection is transient, and the recovery is ONE complete smaller scan — never
+    //    two partial pushes, which the (codebase_id, head_sha) upsert would silently collapse.
+    const corrected = await fetch(CODEBASES_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(scanPayload(slug, headShaCorrected, commits(100, "5"))),
+    });
+    expect(corrected.status).toBe(201);
+
+    const after = await scanInventory(seed.teamId);
+    const correctedPoint = after.code_metrics.find((row) => row.head_sha === headShaCorrected);
+    expect(correctedPoint, "the corrected scan wrote no metrics point").toBeDefined();
+    const snapshot = correctedPoint!.recent_commits as unknown[];
+    expect(snapshot).toHaveLength(100);
+
+    // Every commit reached `items` at its own path — a partial success would show here as a
+    // short count, and the 100-element ceiling is worthless if it silently drops work.
+    const expectedPaths = commits(100, "5").map((c) => `commits/${slug}/${c.sha as string}.md`);
+    const actualPaths = after.items.map((row) => row.path as string);
+    for (const path of expectedPaths) expect(actualPaths).toContain(path);
+
+    // The first scan's point survived the whole sequence: this is a new point, not a rewrite.
+    expect(after.code_metrics.map((row) => row.head_sha).sort()).toEqual(
+      [headSha, headShaCorrected].sort()
+    );
+  }, 60_000);
+});

--- a/test/http/codebases-request-bounds.http.test.ts
+++ b/test/http/codebases-request-bounds.http.test.ts
@@ -178,25 +178,32 @@ function chunk(body: string, parts: number): string[] {
  * stable order. Deliberately NOT a whole-database snapshot: authentication updates
  * `api_keys.last_used_at` and the rate limiter writes its bucket on EVERY request including a
  * rejected one, and those are explicitly allowed by the spec. What must not move is scan state.
+ *
+ * Every row is read WHOLE (`*`), never as a column list. "No writes on rejection" is a claim
+ * about the row, and a projection can only ever prove that the columns someone thought to name
+ * did not move: a rejected request that rewrote a body, a frontmatter, a score, or any of the
+ * timestamps outside the list would still compare equal. The scope is one freshly seeded team,
+ * so the whole row costs nothing and is the only honest subject for "nothing moved at all".
  */
 async function scanInventory(teamId: string) {
   const admin = db();
-  const rows = async (table: string, cols: string) => {
+  const rows = async (table: string) => {
     const { data, error } = await admin
       .from(table)
-      .select(cols)
+      .select("*")
       .eq("team_id", teamId)
       .order("id", { ascending: true });
     if (error) throw new Error(`inventory ${table} failed: ${error.message}`);
     return (data ?? []) as Record<string, unknown>[];
   };
 
-  const items = await rows("items", "id, project_id, path, kind, content_sha256, access, member_id");
+  const items = await rows("items");
   const itemIds = items.map((row) => row.id as string);
+  // Scoped by item rather than by team: item_versions has no team_id of its own.
   const { data: versions, error: versionError } = itemIds.length
     ? await admin
         .from("item_versions")
-        .select("id, item_id, content_sha256")
+        .select("*")
         .in("item_id", itemIds)
         .order("id", { ascending: true })
     : { data: [], error: null };
@@ -204,7 +211,7 @@ async function scanInventory(teamId: string) {
 
   const { data: auditRows, error: auditError } = await admin
     .from("audit_log")
-    .select("id, action, target_type, target_id")
+    .select("*")
     .eq("team_id", teamId)
     .order("id", { ascending: true });
   if (auditError) throw new Error(`inventory audit_log failed: ${auditError.message}`);
@@ -217,23 +224,18 @@ async function scanInventory(teamId: string) {
   });
 
   return {
-    codebases: await rows("codebases", "id, slug, full_name, last_scan_at"),
-    code_metrics: await rows("code_metrics", "id, codebase_id, head_sha, recent_commits, loc"),
-    code_contributions: await rows("code_contributions", "id, codebase_id, author_key, day, commits"),
-    github_issues: await rows("github_issues", "id, codebase_id, number, state"),
-    codebase_findings: await rows("codebase_findings", "id, codebase_id, fingerprint, status"),
-    codebase_finding_events: await rows("codebase_finding_events", "id, finding_id, event_type"),
+    codebases: await rows("codebases"),
+    code_metrics: await rows("code_metrics"),
+    code_contributions: await rows("code_contributions"),
+    github_issues: await rows("github_issues"),
+    codebase_findings: await rows("codebase_findings"),
+    codebase_finding_events: await rows("codebase_finding_events"),
     items,
     item_versions: (versions ?? []) as Record<string, unknown>[],
-    projects: await rows("projects", "id, slug, kind, last_synced_at, graph_group_id"),
-    project_context_units: await rows("project_context_units", "id, source_item_id, unit_key, state"),
-    project_context_memberships: await rows(
-      "project_context_memberships",
-      "id, project_id, context_unit_id, decision, valid_to"
-    ),
-    scan_ingest_runs: (await rows("ingest_runs", "id, source, trigger, ok, updated")).filter(
-      (row) => row.source === "scan"
-    ),
+    projects: await rows("projects"),
+    project_context_units: await rows("project_context_units"),
+    project_context_memberships: await rows("project_context_memberships"),
+    scan_ingest_runs: (await rows("ingest_runs")).filter((row) => row.source === "scan"),
     scan_audit: scanAudit,
   };
 }
@@ -425,22 +427,29 @@ describe("POST /api/v1/codebases — request bounds (HTTP)", () => {
 
     // 4. neither rejection is transient, and the recovery is ONE complete smaller scan — never
     //    two partial pushes, which the (codebase_id, head_sha) upsert would silently collapse.
+    // ONE array, built once, submitted and then compared against — so the assertions below are
+    // about the commits this request actually carried, not about a second call that merely
+    // happens to be built the same way.
+    const correctedCommits = commits(100, "5");
     const corrected = await fetch(CODEBASES_URL, {
       method: "POST",
       headers,
-      body: JSON.stringify(scanPayload(slug, headShaCorrected, commits(100, "5"))),
+      body: JSON.stringify(scanPayload(slug, headShaCorrected, correctedCommits)),
     });
     expect(corrected.status).toBe(201);
 
     const after = await scanInventory(seed.teamId);
     const correctedPoint = after.code_metrics.find((row) => row.head_sha === headShaCorrected);
     expect(correctedPoint, "the corrected scan wrote no metrics point").toBeDefined();
-    const snapshot = correctedPoint!.recent_commits as unknown[];
-    expect(snapshot).toHaveLength(100);
+    // Deep equality, not a length: a count of 100 is equally satisfied by 100 truncated,
+    // reordered or substituted commits, and "one complete smaller scan" is a claim about the
+    // CONTENT surviving the round-trip. The ingest owner persists the parsed array verbatim, so
+    // the stored snapshot must be exactly what was sent, in order.
+    expect(correctedPoint!.recent_commits).toEqual(correctedCommits);
 
     // Every commit reached `items` at its own path — a partial success would show here as a
     // short count, and the 100-element ceiling is worthless if it silently drops work.
-    const expectedPaths = commits(100, "5").map((c) => `commits/${slug}/${c.sha as string}.md`);
+    const expectedPaths = correctedCommits.map((c) => `commits/${slug}/${c.sha as string}.md`);
     const actualPaths = after.items.map((row) => row.path as string);
     for (const path of expectedPaths) expect(actualPaths).toContain(path);
 


### PR DESCRIPTION
Direct clients could submit unbounded recent-commit lists, and chunked codebase scans bypassed the existing Content-Length-only size check. This change caps scans at 100 recent commits and 2,400,000 actual body bytes, returning actionable 422/413 responses before scan data is written. Authentication, team-tier and rate-limit precedence remain unchanged.

The separately versioned admission supplement is prepared in the companion aios-workspace change. That contract must merge to aios-workspace/main before this PR merges to staging, as explicitly approved. Member API version stays 1.23; the unrelated 1.24 identity feature is outside this slice.

Verification: 52 focused unit tests, 7 real HTTP/Postgres tests, 1,577 data-mechanics tests, 24 sidecar tests and 8 canonical contract tests passed. Production build, TypeScript, docs drift and scoped ESLint passed. Full unit run: 4,383 passed, one unrelated NDA-gate timeout; isolated retry passed all 21 tests. Existing lint warnings remain. Four data-mechanics tests skipped.

Spec: docs/design/auditfix17-request-bounds.md; deterministic SPEC_READY. Linear: https://linear.app/je4light/issue/AIO-1136/phase-a-lane-b-item-17-re-derive-and-enforce-bounded-api-batch-work

Models actually used: Astra medium specification/adjudication; Fable5.1 spec/code reviews; Opus5 high implementation. An additional Sol spec review completed before the user clarified review roles; no further Sol reviews or builder fallback. Fresh Astra high found two medium HTTP assertion gaps; Opus fixed complete-row comparisons and exact submitted/persisted commit equality. A fresh focused Astra high review returned CLEAR for da2fc4de. HTTP7/7,types,scopedlint reran successfully.

## Review — Reviewed by Fable5.1 and fresh GPT-6 Astra high — verdict CLEAR after two medium test gaps fixed and focused Astra re-review

Fable code review CLEAR on stable snapshot887195ef29a82a8d9a1a7097fba90d5bb952c566c90d2ba0055f2629a080357e. Its optional large chunked write-before-read client diagnostic is deferred: no stall or timeout bound was reproduced. The accepted release-only policy bounds application reads; transport cleanup remains runtime-owned. Earlier spec conditions were resolved; an inevitable cancellation/reset claim was refuted by actual adapter diagnostics, not treated as a reproduced defect.

Sibling request-admission routes (items/metrics/costs/subscriptions) are an explicitly unfiled Wave3 follow-up in the remediation plan. This is only AUDITFIX-17, not the complete PhaseA program.

Mutation runner outputs (verbatim):

count:

```text
mutate: REDDENED
  red: AC17-01 — metrics.recent_commits count bound rejects 101 otherwise-valid commits with the exact named message
  red: AC17-01 — metrics.recent_commits count bound counts duplicate SHAs — deduplication downstream is not an input-budget escape
  red: AC17-01 — metrics.recent_commits count bound counts commits with no usable sha — skipping downstream is not an escape either
  red: codebase request-admission supplement (revision 1) every published recent_commits boundary case matches the real schema's verdict
  red: codebase request-admission supplement (revision 1) the LITERAL 100/101 boundary behaves as published, whatever the file says
  red: codebase request-admission supplement (revision 1) the published 422 message is what a caller actually receives
  tests run: 17
```

bytes:

```text
mutate: REDDENED
  red: AC17-02 (reader) — the literal byte boundary rejects a chunked body of 2,400,001 bytes
  red: AC17-02 (reader) — the literal byte boundary a misleadingly LOW declaration cannot buy admission
  red: AC17-03 — the reader stops at the crossing chunk and lets go stops reading the moment the running total crosses the cap
  red: AC17-03 — the reader stops at the crossing chunk and lets go never parses the oversized prefix, even when the prefix is a complete document
  red: AC17-03 — the reader stops at the crossing chunk and lets go answers without waiting for EOF on a source that stays open
  red: AC17-03 — the reader stops at the crossing chunk and lets go leaves a real stream UNLOCKED and uncancelled after an overflow
  red: AC17-04 — decoding matches Request.json() counts BYTES, not characters
  tests run: 27
```

declared:

```text
mutate: REDDENED
  red: AC17-02 (reader) — the literal byte boundary rejects a Content-Length above the cap without reading a single byte
  tests run: 27
```

release:

```text
mutate: REDDENED
  red: AC17-03 — the reader stops at the crossing chunk and lets go stops reading the moment the running total crosses the cap
  red: AC17-03 — the reader stops at the crossing chunk and lets go answers without waiting for EOF on a source that stays open
  red: AC17-03 — the reader stops at the crossing chunk and lets go leaves a real stream UNLOCKED and uncancelled after an overflow
  red: AC17-03 — the reader stops at the crossing chunk and lets go leaves a real stream unlocked after a SUCCESSFUL read too
  red: AC17-03 — the reader stops at the crossing chunk and lets go releases the lock when the read itself fails, and reports an unreadable body
  tests run: 27
```

wiring:

```text
mutate: REDDENED
  red: POST /api/v1/codebases — admission precedence (AC17-05) an oversized body is refused with the named 413, before any scan work
  red: POST /api/v1/codebases — admission precedence (AC17-05) a Content-Length above the ceiling is refused without reading the body
  red: POST /api/v1/codebases — admission precedence (AC17-05) 101 commits are refused with the named 422, before any scan work
  red: POST /api/v1/codebases — admission precedence (AC17-05) a malformed body keeps the existing 422, not a new error class
  red: POST /api/v1/codebases — admission precedence (AC17-05) an ordinary scan at the ceiling still ingests and returns the 201 envelope
  tests run: 8
```

pin:

```text
mutate: REDDENED
  red: codebase request-admission supplement (revision 1) the vendored copy is byte-identical to the pinned canonical revision
  red: codebase request-admission supplement (revision 1) publishes the literal ceilings this server enforces
  tests run: 9
```

AIOS-Work: AUDITFIX-17

Final Brain commit: da2fc4de. Final snapshot:17422845f9f9e6b7efc4002942c392505e6bcb739eaa38c47cabb748ce02373c. Companion main4300ace integrated without overlapping task changes;15contract/test-discovery tests passed. Only rollout wording changed after final review; deterministic SPEC_READY and Linear exact attachment reverified.

Canonical companion: https://github.com/aiosbrain/aios-workspace/pull/683 (main first). Final Brain head104df839 adds only spec metadata/activation clarification; fresh Astra reviewed it CLEAR. Server implementation unchanged since da2fc4de.
